### PR TITLE
[aes] Parameterize LFSR default seeds and perms

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -57,29 +57,47 @@
       local:   "false",
       expose:  "true"
     },
-    { name:    "SeedClearing",
-      type:    "logic [aes_pkg::WidthPRDClearing-1:0]",
-      default: "aes_pkg::DefaultSeedClearing",
+    { name:    "AlertAsyncOn",
+      type:    "logic [aes_reg_pkg::NumAlerts-1:0]",
+      default: "{aes_reg_pkg::NumAlerts{1'b1}}",
+      desc:    '''
+        One bit per alert specifying whether the corresponding sender in the AES module and the receiver in the alert handler are in the same clock domain (0) or whether there is an asynchronous boundary in between (1).
+      '''
+      local:   "false",
+      expose:  "false"
+    },
+    { name:    "RndCnstClearingLfsrSeed",
+      type:    "aes_pkg::clearing_lfsr_seed_t",
+      default: "aes_pkg::RndCnstClearingLfsrSeedDefault",
       desc:    '''
         Default seed of the PRNG used for register clearing.
       '''
       local:   "false",
       expose:  "false"
     },
-    { name:    "SeedMasking",
-      type:    "logic [aes_pkg::WidthPRDMasking-1:0]",
-      default: "aes_pkg::DefaultSeedMasking",
+    { name:    "RndCnstClearingLfsrPerm",
+      type:    "aes_pkg::clearing_lfsr_perm_t",
+      default: "aes_pkg::RndCnstClearingLfsrPermDefault",
+      desc:    '''
+        Permutation applied to the LFSR of the PRNG used for clearing.
+      '''
+      local:   "false",
+      expose:  "false"
+    },
+    { name:    "RndCnstMaskingLfsrSeed",
+      type:    "aes_pkg::masking_lfsr_seed_t",
+      default: "aes_pkg::RndCnstMaskingLfsrSeedDefault",
       desc:    '''
         Default seed of the PRNG used for masking.
       '''
       local:   "false",
       expose:  "false"
     },
-    { name:    "AlertAsyncOn",
-      type:    "logic [aes_reg_pkg::NumAlerts-1:0]",
-      default: "{aes_reg_pkg::NumAlerts{1'b1}}",
+    { name:    "RndCnstMskgChunkLfsrPerm",
+      type:    "aes_pkg::mskg_chunk_lfsr_perm_t",
+      default: "aes_pkg::RndCnstMskgChunkLfsrPermDefault",
       desc:    '''
-        One bit per alert specifying whether the corresponding sender in the AES module and the receiver in the alert handler are in the same clock domain (0) or whether there is an asynchronous boundary in between (1).
+        Permutation applied to the LFSR chunks of the PRNG used for masking.
       '''
       local:   "false",
       expose:  "false"

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -25,9 +25,11 @@ module aes
   parameter bit          SecAllowForcingMasks  = 0, // Allow forcing masks to 0 using
                                                     // FORCE_ZERO_MASK bit in Control Register.
                                                     // Useful for SCA only.
-  parameter logic [WidthPRDClearing-1:0] SeedClearing = DefaultSeedClearing,
-  parameter logic  [WidthPRDMasking-1:0] SeedMasking  = DefaultSeedMasking,
-  parameter logic        [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  parameter clearing_lfsr_seed_t   RndCnstClearingLfsrSeed  = RndCnstClearingLfsrSeedDefault,
+  parameter clearing_lfsr_perm_t   RndCnstClearingLfsrPerm  = RndCnstClearingLfsrPermDefault,
+  parameter masking_lfsr_seed_t    RndCnstMaskingLfsrSeed   = RndCnstMaskingLfsrSeedDefault,
+  parameter mskg_chunk_lfsr_perm_t RndCnstMskgChunkLfsrPerm = RndCnstMskgChunkLfsrPermDefault
 ) (
   input  logic                                      clk_i,
   input  logic                                      rst_ni,
@@ -70,31 +72,33 @@ module aes
   );
 
   aes_core #(
-    .AES192Enable         ( AES192Enable         ),
-    .Masking              ( Masking              ),
-    .SBoxImpl             ( SBoxImpl             ),
-    .SecStartTriggerDelay ( SecStartTriggerDelay ),
-    .SecAllowForcingMasks ( SecAllowForcingMasks ),
-    .SeedClearing         ( SeedClearing         ),
-    .SeedMasking          ( SeedMasking          )
+    .AES192Enable             ( AES192Enable             ),
+    .Masking                  ( Masking                  ),
+    .SBoxImpl                 ( SBoxImpl                 ),
+    .SecStartTriggerDelay     ( SecStartTriggerDelay     ),
+    .SecAllowForcingMasks     ( SecAllowForcingMasks     ),
+    .RndCnstClearingLfsrSeed  ( RndCnstClearingLfsrSeed  ),
+    .RndCnstClearingLfsrPerm  ( RndCnstClearingLfsrPerm  ),
+    .RndCnstMaskingLfsrSeed   ( RndCnstMaskingLfsrSeed   ),
+    .RndCnstMskgChunkLfsrPerm ( RndCnstMskgChunkLfsrPerm )
   ) u_aes_core (
-    .clk_i                  ( clk_i               ),
-    .rst_ni                 ( rst_ni              ),
+    .clk_i                  ( clk_i                          ),
+    .rst_ni                 ( rst_ni                         ),
 
     // TODO: This still needs to be connected to the entropy source.
     // See https://github.com/lowRISC/opentitan/issues/1005
-    .entropy_clearing_req_o (                     ),
-    .entropy_clearing_ack_i ( 1'b1                ),
-    .entropy_clearing_i     ( DefaultSeedClearing ),
-    .entropy_masking_req_o  (                     ),
-    .entropy_masking_ack_i  ( 1'b1                ),
-    .entropy_masking_i      ( DefaultSeedMasking  ),
+    .entropy_clearing_req_o (                                ),
+    .entropy_clearing_ack_i ( 1'b1                           ),
+    .entropy_clearing_i     ( RndCnstClearingLfsrSeedDefault ),
+    .entropy_masking_req_o  (                                ),
+    .entropy_masking_ack_i  ( 1'b1                           ),
+    .entropy_masking_i      ( RndCnstMaskingLfsrSeedDefault  ),
 
-    .ctrl_err_update_o      ( alert[0]            ),
-    .ctrl_err_storage_o     ( alert[1]            ),
+    .ctrl_err_update_o      ( alert[0]                       ),
+    .ctrl_err_storage_o     ( alert[1]                       ),
 
-    .reg2hw                 ( reg2hw              ),
-    .hw2reg                 ( hw2reg              )
+    .reg2hw                 ( reg2hw                         ),
+    .hw2reg                 ( hw2reg                         )
   );
 
   assign idle_o = hw2reg.status.idle.d;

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -18,8 +18,10 @@ module aes_core
 
   localparam int         NumShares            = Masking ? 2 : 1, // derived parameter
 
-  parameter logic [WidthPRDClearing-1:0] SeedClearing = DefaultSeedClearing,
-  parameter logic  [WidthPRDMasking-1:0] SeedMasking  = DefaultSeedMasking
+  parameter clearing_lfsr_seed_t   RndCnstClearingLfsrSeed  = RndCnstClearingLfsrSeedDefault,
+  parameter clearing_lfsr_perm_t   RndCnstClearingLfsrPerm  = RndCnstClearingLfsrPermDefault,
+  parameter masking_lfsr_seed_t    RndCnstMaskingLfsrSeed   = RndCnstMaskingLfsrSeedDefault,
+  parameter mskg_chunk_lfsr_perm_t RndCnstMskgChunkLfsrPerm = RndCnstMskgChunkLfsrPermDefault
 ) (
   input  logic                        clk_i,
   input  logic                        rst_ni,
@@ -130,8 +132,9 @@ module aes_core
 
   // The clearing PRNG provides pseudo-random data for register clearing purposes.
   aes_prng_clearing #(
-    .Width       ( WidthPRDClearing ),
-    .DefaultSeed ( SeedClearing     )
+    .Width           ( WidthPRDClearing        ),
+    .RndCnstLfsrSeed ( RndCnstClearingLfsrSeed ),
+    .RndCnstLfsrPerm ( RndCnstClearingLfsrPerm )
   ) u_aes_prng_clearing (
     .clk_i         ( clk_i                  ),
     .rst_ni        ( rst_ni                 ),
@@ -320,11 +323,12 @@ module aes_core
 
   // Cipher core
   aes_cipher_core #(
-    .AES192Enable         ( AES192Enable         ),
-    .Masking              ( Masking              ),
-    .SBoxImpl             ( SBoxImpl             ),
-    .SecAllowForcingMasks ( SecAllowForcingMasks ),
-    .SeedMasking          ( SeedMasking          )
+    .AES192Enable             ( AES192Enable             ),
+    .Masking                  ( Masking                  ),
+    .SBoxImpl                 ( SBoxImpl                 ),
+    .SecAllowForcingMasks     ( SecAllowForcingMasks     ),
+    .RndCnstMaskingLfsrSeed   ( RndCnstMaskingLfsrSeed   ),
+    .RndCnstMskgChunkLfsrPerm ( RndCnstMskgChunkLfsrPerm )
   ) u_aes_cipher_core (
     .clk_i              ( clk_i                      ),
     .rst_ni             ( rst_ni                     ),

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -16,10 +16,29 @@ parameter int unsigned WidthPRDMasking  = WidthPRDData + WidthPRDKey;
 
 parameter int unsigned ChunkSizePRDMasking = WidthPRDMasking/10;
 
-// Default seeds for pseudo-random number generators
-parameter logic [WidthPRDClearing-1:0] DefaultSeedClearing = 64'hFEDCBA9876543210;
-parameter logic  [WidthPRDMasking-1:0] DefaultSeedMasking  = {36'ha, 36'h9, 36'h8, 36'h7, 36'h6,
-                                                              36'h5, 36'h4, 36'h3, 36'h2, 36'h1};
+// Clearing PRNG default LFSR seed and permutation
+// These LFSR parameters have been generated with
+// $ hw/ip/prim/util/gen-lfsr-seed.py --width 64 --seed 31468618 --prefix "Clearing"
+parameter int ClearingLfsrWidth = 64;
+typedef logic [ClearingLfsrWidth-1:0] clearing_lfsr_seed_t;
+typedef logic [ClearingLfsrWidth-1:0][$clog2(ClearingLfsrWidth)-1:0] clearing_lfsr_perm_t;
+parameter clearing_lfsr_seed_t RndCnstClearingLfsrSeedDefault = 64'hc32d580f74f1713a;
+parameter clearing_lfsr_perm_t RndCnstClearingLfsrPermDefault = {
+  128'hb33fdfc81deb6292c21f8a3102585067,
+  256'h9c2f4be1bbe937b4b7c9d7f4e57568d99c8ae291a899143e0d8459d31b143223
+};
+
+// Masking PRNG default LFSR seed and permutation
+// We use a single seed that is split down into chunks internally. All LFSR chunks use the same
+// permutation.
+// These LFSR parameters have been generated with
+// $ hw/ip/prim/util/gen-lfsr-seed.py --width 360 --seed 31468618 --prefix "Masking"
+parameter int MaskingLfsrWidth = 360;
+typedef logic [MaskingLfsrWidth-1:0] masking_lfsr_seed_t;
+parameter masking_lfsr_seed_t RndCnstMaskingLfsrSeedDefault = {
+  180'h5ae9b31605f9077a6b758a442031e1c4616ea343ec153,
+  180'h282a30c132b5723c5a4cf4743b3c7c32d580f74f1713a
+};
 
 // These LFSR parameters have been generated with
 // $ hw/ip/prim/util/gen-lfsr-seed.py --width 36 --seed 31468618 --prefix "MskgChunk"

--- a/hw/ip/aes/rtl/aes_prng_masking.sv
+++ b/hw/ip/aes/rtl/aes_prng_masking.sv
@@ -26,8 +26,8 @@ module aes_prng_masking import aes_pkg::*;
   parameter  bit          SecAllowForcingMasks  = 0, // Allow forcing masks to 0 using
                                                      // force_zero_masks_i. Useful for SCA only.
 
-  // The chunks must not be initialized to 0. Every chunk should get a different seed.
-  parameter logic [NumChunks-1:0][ChunkSize-1:0] DefaultSeed = {NumChunks{ChunkSize'(1)}}
+  parameter masking_lfsr_seed_t    RndCnstLfsrSeed      = RndCnstMaskingLfsrSeedDefault,
+  parameter mskg_chunk_lfsr_perm_t RndCnstChunkLfsrPerm = RndCnstMskgChunkLfsrPermDefault
 ) (
   input  logic             clk_i,
   input  logic             rst_ni,
@@ -87,12 +87,12 @@ module aes_prng_masking import aes_pkg::*;
     assign prng_seed[c] = entropy_i[c * ChunkSize +: ChunkSize];
 
     prim_lfsr #(
-      .LfsrType    ( "GAL_XOR"                       ),
-      .LfsrDw      ( ChunkSize                       ),
-      .StateOutDw  ( ChunkSize                       ),
-      .DefaultSeed ( DefaultSeed[c]                  ),
-      .StatePermEn ( 1'b1                            ),
-      .StatePerm   ( RndCnstMskgChunkLfsrPermDefault )
+      .LfsrType    ( "GAL_XOR"                                   ),
+      .LfsrDw      ( ChunkSize                                   ),
+      .StateOutDw  ( ChunkSize                                   ),
+      .DefaultSeed ( RndCnstLfsrSeed[c * ChunkSize +: ChunkSize] ),
+      .StatePermEn ( 1'b1                                        ),
+      .StatePerm   ( RndCnstChunkLfsrPerm                        )
     ) u_lfsr_chunk (
       .clk_i     ( clk_i         ),
       .rst_ni    ( rst_ni        ),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2582,28 +2582,6 @@
           name_top: SecAesAllowForcingMasks
         }
         {
-          name: SeedClearing
-          type: logic [aes_pkg::WidthPRDClearing-1:0]
-          default: aes_pkg::DefaultSeedClearing
-          desc: Default seed of the PRNG used for register clearing.
-          local: "false"
-          expose: "false"
-          randcount: "0"
-          randtype: none
-          name_top: AesSeedClearing
-        }
-        {
-          name: SeedMasking
-          type: logic [aes_pkg::WidthPRDMasking-1:0]
-          default: aes_pkg::DefaultSeedMasking
-          desc: Default seed of the PRNG used for masking.
-          local: "false"
-          expose: "false"
-          randcount: "0"
-          randtype: none
-          name_top: AesSeedMasking
-        }
-        {
           name: AlertAsyncOn
           type: logic [aes_reg_pkg::NumAlerts-1:0]
           default: "{aes_reg_pkg::NumAlerts{1'b1}}"
@@ -2613,6 +2591,50 @@
           randcount: "0"
           randtype: none
           name_top: AesAlertAsyncOn
+        }
+        {
+          name: RndCnstClearingLfsrSeed
+          type: aes_pkg::clearing_lfsr_seed_t
+          default: aes_pkg::RndCnstClearingLfsrSeedDefault
+          desc: Default seed of the PRNG used for register clearing.
+          local: "false"
+          expose: "false"
+          randcount: "0"
+          randtype: none
+          name_top: RndCnstAesClearingLfsrSeed
+        }
+        {
+          name: RndCnstClearingLfsrPerm
+          type: aes_pkg::clearing_lfsr_perm_t
+          default: aes_pkg::RndCnstClearingLfsrPermDefault
+          desc: Permutation applied to the LFSR of the PRNG used for clearing.
+          local: "false"
+          expose: "false"
+          randcount: "0"
+          randtype: none
+          name_top: RndCnstAesClearingLfsrPerm
+        }
+        {
+          name: RndCnstMaskingLfsrSeed
+          type: aes_pkg::masking_lfsr_seed_t
+          default: aes_pkg::RndCnstMaskingLfsrSeedDefault
+          desc: Default seed of the PRNG used for masking.
+          local: "false"
+          expose: "false"
+          randcount: "0"
+          randtype: none
+          name_top: RndCnstAesMaskingLfsrSeed
+        }
+        {
+          name: RndCnstMskgChunkLfsrPerm
+          type: aes_pkg::mskg_chunk_lfsr_perm_t
+          default: aes_pkg::RndCnstMskgChunkLfsrPermDefault
+          desc: Permutation applied to the LFSR chunks of the PRNG used for masking.
+          local: "false"
+          expose: "false"
+          randcount: "0"
+          randtype: none
+          name_top: RndCnstAesMskgChunkLfsrPerm
         }
       ]
       interrupt_list: []

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1051,9 +1051,11 @@ module top_earlgrey #(
     .SBoxImpl(AesSBoxImpl),
     .SecStartTriggerDelay(SecAesStartTriggerDelay),
     .SecAllowForcingMasks(SecAesAllowForcingMasks),
-    .SeedClearing(aes_pkg::DefaultSeedClearing),
-    .SeedMasking(aes_pkg::DefaultSeedMasking),
-    .AlertAsyncOn({aes_reg_pkg::NumAlerts{1'b1}})
+    .AlertAsyncOn({aes_reg_pkg::NumAlerts{1'b1}}),
+    .RndCnstClearingLfsrSeed(aes_pkg::RndCnstClearingLfsrSeedDefault),
+    .RndCnstClearingLfsrPerm(aes_pkg::RndCnstClearingLfsrPermDefault),
+    .RndCnstMaskingLfsrSeed(aes_pkg::RndCnstMaskingLfsrSeedDefault),
+    .RndCnstMskgChunkLfsrPerm(aes_pkg::RndCnstMskgChunkLfsrPermDefault)
   ) u_aes (
 
       // [9]: ctrl_err_update


### PR DESCRIPTION
This PR changes how the LFSR default seeds and permutations for the clearing and masking PRNG of AES are generated and propagated. In line with other OpenTitan IPs, we now use the `gen-lfsr-seed.py` script. The values are exposed as IP parameters.

We do not yet expose them to the top-level/`top_pkg.sv` as the type declarations and dimensions are likely to change in the process of SCA hardening. This allows to continue the SCA hardening work without constantly updating the top level.