### PR TITLE
[i2c, rtl] SDA Interference fix

### DIFF
--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -342,7 +342,7 @@ module i2c_fsm (
         host_idle_o = 1'b1;
         sda_temp = 1'b1;
         scl_temp = 1'b1;
-        if (sda_i == 0) event_sda_interference_o = 1'b1;
+        if (host_enable_i && sda_i == 0) event_sda_interference_o = 1'b1;
         if (!target_address0_i && !target_mask0_i && !target_address1_i && !target_mask1_i) begin
           acq_fifo_wvalid_o = 1'b0;
         end


### PR DESCRIPTION
In Idle state, event_sda_interference will be raised only if host is enabled
Fix is needed for PR 4180

Signed-off-by: Igor Kouznetsov <igor.kouznetsov@wdc.com>