### PR TITLE
[ci] Show logs of Vivado runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -481,6 +481,15 @@ jobs:
       cp "$OBJ_DIR/hw/synth-vivado/lowrisc_systems_top_earlgrey_nexysvideo_0.1.bit" \
         "$BIN_DIR/hw/top_earlgrey"
     displayName: Build bitstream with Vivado
+  - bash: |
+      . util/build_consts.sh
+      echo Synthesis log
+      cat $OBJ_DIR/hw/synth-vivado/lowrisc_systems_top_earlgrey_nexysvideo_0.1.runs/synth_1/runme.log || true
+
+      echo Implementation log
+      cat $OBJ_DIR/hw/synth-vivado/lowrisc_systems_top_earlgrey_nexysvideo_0.1.runs/impl_1/runme.log || true
+    condition: always()
+    displayName: Display synthesis and implementation logs
   - template: ci/upload-artifacts-template.yml
     parameters:
       artifact: top_earlgrey_nexysvideo


### PR DESCRIPTION
We do get failing Vivado runs occasionally. The implementation log is
normally also dumped to STDOUT and visible in Azure Pipelines; the
syntheis log isn't, however. Make CI runs a bit easier to diagnose by
dumping both logs to STDOUT.