### PR TITLE
[dv] Auto-gen byte write for RAL

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -4139,6 +4139,7 @@
       type: ram_1p
       base_addr: 0x10000000
       size: 0x10000
+      byte_write: "true"
       inter_signal_list:
       [
         {
@@ -4176,6 +4177,7 @@
       type: ram_1p
       base_addr: 0x18000000
       size: 0x1000
+      byte_write: "true"
       inter_signal_list:
       [
         {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -413,6 +413,7 @@
       type: "ram_1p",
       base_addr: "0x10000000",
       size: "0x10000"
+      byte_write: "true",
       inter_signal_list: [
         { struct: "tl"
           package: "tlul_pkg"
@@ -430,6 +431,7 @@
       type: "ram_1p",
       base_addr: "0x18000000",
       size: "0x1000",
+      byte_write: "true",
       inter_signal_list: [
         { struct: "tl"
           package: "tlul_pkg"

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -120,11 +120,6 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
   protected virtual function void apply_ral_fixes();
     // Out of reset, the link is in disconnected state.
     ral.usbdev.intr_state.disconnected.set_reset(1'b1);
-
-    // ram_main mem and hmac mem support partial write
-    ral.ram_main.set_mem_partial_write_support(1);
-    ral.ram_ret.set_mem_partial_write_support(1);
-    ral.hmac.msg_fifo.set_mem_partial_write_support(1);
   endfunction
 
   // Parse a space-separated list of sw_images supplied as a string.

--- a/util/reggen/data.py
+++ b/util/reggen/data.py
@@ -175,6 +175,7 @@ class MultiReg(Reg):
 class Window():
     def __init__(self):
         self.base_addr = 0
+        self.byte_write = 0
         self.limit_addr = 0
         self.n_bits = 0
         self.tags = []

--- a/util/reggen/gen_rtl.py
+++ b/util/reggen/gen_rtl.py
@@ -114,6 +114,7 @@ def parse_win(obj, width):
     win = Window()
     win.name = obj["name"]
     win.base_addr = obj["genoffset"]
+    win.byte_write = obj["genbyte-write"]
     win.limit_addr = obj["genoffset"] + int(obj["items"]) * (width // 8)
     win.dvrights = obj["swaccess"]
     win.n_bits = obj["genvalidbits"]

--- a/util/reggen/uvm_reg.sv.tpl
+++ b/util/reggen/uvm_reg.sv.tpl
@@ -160,6 +160,9 @@ package ${block.name}_ral_pkg;
                  string           access = "${mem_right}",
                  int              has_coverage = UVM_NO_COVERAGE);
       super.new(name, size, n_bits, access, has_coverage);
+    % if w.byte_write:
+      set_mem_partial_write_support(1);
+    % endif
     endfunction : new
 
   endclass : ${gen_dv.mcname(block, w)}

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -815,6 +815,8 @@ def generate_top_ral(top, ip_objs, out_path):
             mem.name = item["name"]
             mem.base_addr = int(item["base_addr"], 0)
             mem.limit_addr = int(item["base_addr"], 0) + int(item["size"], 0)
+            mem.byte_write = ('byte_write' in item and
+                              item["byte_write"].lower() == "true")
             if "swaccess" in item.keys():
                 mem.dvrights = item["swaccess"]
             else:

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -379,7 +379,8 @@ def generate_pinmux_and_padctrl(top, out_path):
     data_path.mkdir(parents=True, exist_ok=True)
 
     # Template path
-    tpl_path = Path(__file__).resolve().parent / '../hw/ip/pinmux/data/pinmux.hjson.tpl'
+    tpl_path = Path(
+        __file__).resolve().parent / '../hw/ip/pinmux/data/pinmux.hjson.tpl'
 
     # Generate register package and RTLs
     gencmd = ("// util/topgen.py -t hw/top_{topname}/data/top_{topname}.hjson "
@@ -434,7 +435,8 @@ def generate_pinmux_and_padctrl(top, out_path):
     data_path.mkdir(parents=True, exist_ok=True)
 
     # Template path
-    tpl_path = Path(__file__).resolve().parent / '../hw/ip/padctrl/data/padctrl.hjson.tpl'
+    tpl_path = Path(
+        __file__).resolve().parent / '../hw/ip/padctrl/data/padctrl.hjson.tpl'
 
     # Generate register package and RTLs
     gencmd = ("// util/topgen.py -t hw/top_{topname}/data/top_{topname}.hjson "
@@ -779,8 +781,8 @@ def generate_top_only(top_only_list, out_path, topname):
     log.info("Generating top only modules")
 
     for ip in top_only_list:
-        hjson_path = Path(__file__).resolve().parent / "../hw/top_{}/ip/{}/data/{}.hjson".format(
-            topname, ip, ip)
+        hjson_path = Path(__file__).resolve(
+        ).parent / "../hw/top_{}/ip/{}/data/{}.hjson".format(topname, ip, ip)
         genrtl_dir = out_path / "ip/{}/rtl".format(ip)
         genrtl_dir.mkdir(parents=True, exist_ok=True)
         log.info("Generating top modules {}, hjson: {}, output: {}".format(
@@ -1013,10 +1015,10 @@ def main():
             # validation, use the template in hw/ip/{ip_name}/data .
             if x.stem in generated_list and not x.is_file():
                 hjson_file = ip_dir / "{}/data/{}.hjson".format(x.stem, x.stem)
-                log.info("Auto-generated hjson %s does not yet exist. "
-                         % str(x) +
-                         "Falling back to template %s for initial validation."
-                         % str(hjson_file))
+                log.info(
+                    "Auto-generated hjson %s does not yet exist. " % str(x) +
+                    "Falling back to template %s for initial validation." %
+                    str(hjson_file))
             else:
                 hjson_file = x
 


### PR DESCRIPTION
Without this update, we need to manually set partial write support for the
mem that supports it. If not, will see failure in tl_errors test.
Make it automatic to save time to debug this kind of issue

first commit is just to run lintpy to fix style, can skip reviewing it.
    
Signed-off-by: Weicai Yang <weicai@google.com>
