### PR TITLE
[keymgr] Updates for software binding and associated enable

### DIFF
--- a/hw/ip/keymgr/data/keymgr.hjson
+++ b/hw/ip/keymgr/data/keymgr.hjson
@@ -136,12 +136,6 @@
       randtype:  "data",
     },
 
-    { name: "NumRomExtReg",
-      desc: "Number of Registers for ROM_ext descriptor",
-      type: "int",
-      default: "4",
-      local: "true"
-    },
     { name: "NumInReg",
       desc: "Number of Registers for SW inputs (SW binding / keyID / Salt)",
       type: "int",
@@ -304,58 +298,37 @@
       ]
     },
 
-    { name: "ROM_EXT_DESC_EN",
-      desc: "Register write enable for ROM_EXT_DESC",
-      swaccess: "rw0c",
-      hwaccess: "none",
-      fields: [
-        { bits: "1:0",
-          name: "EN",
-          resval: "2"
-          desc: '''
-            ROM_ext descriptor configure enable.
-            All values except for 2 are interpreted as configuration disable.
-          '''
-        },
-      ]
-    },
-    { multireg: {
-        cname: "KEYMGR",
-        name: "ROM_EXT_DESC",
-        desc: '''
-          ROM_ext descriptor.
-          This value must be representative of the current ROM_ext contents.
-          For example, this could be a truncated hash of the ROM_ext
-        ''',
-        count: "NumRomExtReg",
-        swaccess: "rw",
-        hwaccess: "hro",
-        fields: [
-            { bits: "31:0",
-              name: "VAL",
-              desc: '''
-                Software binding value
-              ''',
-              resval: "0"
-            },
-        ],
-      },
-    },
-
     // The following can potentially be replaced by a RAM if it gets too large
     // Currently there are 32b * NumInReg * 3 bits for inputs
     //                     32b * NumOutReg * 2 (if key shares desired) for outputs
     //                     32b * NumOutReg * NumCryptos * 2 (if key shares desired) for hidden key bus
     // This totals to over 2kb of storage
+    { name: "SW_BINDING_EN",
+      desc: "Register write enable for SOFTWARE_BINDING",
+      swaccess: "rw0c",
+      hwaccess: "hwo",
+      fields: [
+        { bits: "0",
+          name: "EN",
+          resval: "1"
+          desc: '''
+            Software binding register write enable.
+            This is locked by software and unlocked by hardware upon a successful advance call.
+          '''
+        },
+      ]
+    },
 
     { multireg: {
         cname: "KEYMGR",
-        name: "SOFTWARE_BINDING",
-        regwen: "CFGEN",
+        name: "SW_BINDING",
+        regwen: "SW_BINDING_EN",
         desc: '''
           Software binding input to key manager.
-          This register is non-lockable and shared between various software stages.
-          This binding value is not considered secret.
+          This register is lockable and shared between key manager stages.
+          This binding value is not considered secret, however its integrity is very important.
+
+          The software binding is locked by software and unlocked by hardware upon a successful advance operation.
         ''',
         count: "NumInReg",
         swaccess: "rw",

--- a/hw/ip/keymgr/rtl/keymgr_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_ctrl.sv
@@ -23,6 +23,7 @@ module keymgr_ctrl import keymgr_pkg::*;(
   output logic data_valid_o,
   output logic wipe_key_o,
   output keymgr_working_state_e working_state_o,
+  output logic sw_binding_unlock_o,
 
   // Data input
   input  otp_ctrl_pkg::otp_keymgr_key_t root_key_i,
@@ -105,6 +106,9 @@ module keymgr_ctrl import keymgr_pkg::*;(
   assign id_en_o    = op_accepted & gen_id_sel;
   assign gen_en_o   = op_accepted & gen_out_sel;
   assign load_key_o = adv_en_o & !adv_en_q;
+
+  // unlock sw binding configuration whenever an advance call is made without errors
+  assign sw_binding_unlock_o = adv_en_o & op_done_o & ~|error_o;
 
   // check incoming kmac data validity
   // also check inputs used during compute

--- a/hw/ip/keymgr/rtl/keymgr_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_pkg.sv
@@ -11,7 +11,7 @@ package keymgr_pkg;
   parameter int DigestWidth = 128;     // uses truncated hash
   parameter int KmacDataIfWidth = 64;  // KMAC interface data width
   parameter int KeyMgrStages = 3;      // Number of key manager stages (creator, ownerInt, owner)
-  parameter int RomExtDescWidth = 128; // Size of rom_ext hash, truncated
+  parameter int SwBindingWidth = 128; // Size of rom_ext hash, truncated
   parameter int Shares = 2; // number of key shares
   parameter int EdnWidth = edn_pkg::ENDPOINT_BUS_WIDTH;
 
@@ -49,7 +49,7 @@ package keymgr_pkg;
 
   // Width calculations
   // These are the largest calculations in use across all stages
-  parameter int AdvDataWidth = RomExtDescWidth + 2*KeyWidth + DevIdWidth + HealthStateWidth;
+  parameter int AdvDataWidth = SwBindingWidth + 2*KeyWidth + DevIdWidth + HealthStateWidth;
   parameter int IdDataWidth = KeyWidth;
   // key version + salt + key ID + constant
   parameter int GenDataWidth = 32 + 128 + KeyWidth;

--- a/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
@@ -7,7 +7,6 @@
 package keymgr_reg_pkg;
 
   // Param list
-  parameter int NumRomExtReg = 4;
   parameter int NumInReg = 4;
   parameter int NumOutReg = 8;
   parameter int NumKeyVersion = 1;
@@ -74,11 +73,7 @@ package keymgr_reg_pkg;
 
   typedef struct packed {
     logic [31:0] q;
-  } keymgr_reg2hw_rom_ext_desc_mreg_t;
-
-  typedef struct packed {
-    logic [31:0] q;
-  } keymgr_reg2hw_software_binding_mreg_t;
+  } keymgr_reg2hw_sw_binding_mreg_t;
 
   typedef struct packed {
     logic [31:0] q;
@@ -139,6 +134,11 @@ package keymgr_reg_pkg;
   } keymgr_hw2reg_control_reg_t;
 
   typedef struct packed {
+    logic        d;
+    logic        de;
+  } keymgr_hw2reg_sw_binding_en_reg_t;
+
+  typedef struct packed {
     logic [31:0] d;
     logic        de;
   } keymgr_hw2reg_sw_share0_output_mreg_t;
@@ -182,14 +182,13 @@ package keymgr_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    keymgr_reg2hw_intr_state_reg_t intr_state; // [549:548]
-    keymgr_reg2hw_intr_enable_reg_t intr_enable; // [547:546]
-    keymgr_reg2hw_intr_test_reg_t intr_test; // [545:542]
-    keymgr_reg2hw_alert_test_reg_t alert_test; // [541:538]
-    keymgr_reg2hw_control_reg_t control; // [537:532]
-    keymgr_reg2hw_reseed_interval_reg_t reseed_interval; // [531:516]
-    keymgr_reg2hw_rom_ext_desc_mreg_t [3:0] rom_ext_desc; // [515:388]
-    keymgr_reg2hw_software_binding_mreg_t [3:0] software_binding; // [387:260]
+    keymgr_reg2hw_intr_state_reg_t intr_state; // [421:420]
+    keymgr_reg2hw_intr_enable_reg_t intr_enable; // [419:418]
+    keymgr_reg2hw_intr_test_reg_t intr_test; // [417:414]
+    keymgr_reg2hw_alert_test_reg_t alert_test; // [413:410]
+    keymgr_reg2hw_control_reg_t control; // [409:404]
+    keymgr_reg2hw_reseed_interval_reg_t reseed_interval; // [403:388]
+    keymgr_reg2hw_sw_binding_mreg_t [3:0] sw_binding; // [387:260]
     keymgr_reg2hw_salt_mreg_t [3:0] salt; // [259:132]
     keymgr_reg2hw_key_version_mreg_t [0:0] key_version; // [131:100]
     keymgr_reg2hw_max_creator_key_ver_reg_t max_creator_key_ver; // [99:68]
@@ -202,9 +201,10 @@ package keymgr_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    keymgr_hw2reg_intr_state_reg_t intr_state; // [549:546]
-    keymgr_hw2reg_cfgen_reg_t cfgen; // [545:545]
-    keymgr_hw2reg_control_reg_t control; // [544:543]
+    keymgr_hw2reg_intr_state_reg_t intr_state; // [551:548]
+    keymgr_hw2reg_cfgen_reg_t cfgen; // [547:547]
+    keymgr_hw2reg_control_reg_t control; // [546:545]
+    keymgr_hw2reg_sw_binding_en_reg_t sw_binding_en; // [544:543]
     keymgr_hw2reg_sw_share0_output_mreg_t [7:0] sw_share0_output; // [542:279]
     keymgr_hw2reg_sw_share1_output_mreg_t [7:0] sw_share1_output; // [278:15]
     keymgr_hw2reg_working_state_reg_t working_state; // [14:11]
@@ -220,45 +220,41 @@ package keymgr_reg_pkg;
   parameter logic [7:0] KEYMGR_CFGEN_OFFSET = 8'h 10;
   parameter logic [7:0] KEYMGR_CONTROL_OFFSET = 8'h 14;
   parameter logic [7:0] KEYMGR_RESEED_INTERVAL_OFFSET = 8'h 18;
-  parameter logic [7:0] KEYMGR_ROM_EXT_DESC_EN_OFFSET = 8'h 1c;
-  parameter logic [7:0] KEYMGR_ROM_EXT_DESC_0_OFFSET = 8'h 20;
-  parameter logic [7:0] KEYMGR_ROM_EXT_DESC_1_OFFSET = 8'h 24;
-  parameter logic [7:0] KEYMGR_ROM_EXT_DESC_2_OFFSET = 8'h 28;
-  parameter logic [7:0] KEYMGR_ROM_EXT_DESC_3_OFFSET = 8'h 2c;
-  parameter logic [7:0] KEYMGR_SOFTWARE_BINDING_0_OFFSET = 8'h 30;
-  parameter logic [7:0] KEYMGR_SOFTWARE_BINDING_1_OFFSET = 8'h 34;
-  parameter logic [7:0] KEYMGR_SOFTWARE_BINDING_2_OFFSET = 8'h 38;
-  parameter logic [7:0] KEYMGR_SOFTWARE_BINDING_3_OFFSET = 8'h 3c;
-  parameter logic [7:0] KEYMGR_SALT_0_OFFSET = 8'h 40;
-  parameter logic [7:0] KEYMGR_SALT_1_OFFSET = 8'h 44;
-  parameter logic [7:0] KEYMGR_SALT_2_OFFSET = 8'h 48;
-  parameter logic [7:0] KEYMGR_SALT_3_OFFSET = 8'h 4c;
-  parameter logic [7:0] KEYMGR_KEY_VERSION_OFFSET = 8'h 50;
-  parameter logic [7:0] KEYMGR_MAX_CREATOR_KEY_VER_EN_OFFSET = 8'h 54;
-  parameter logic [7:0] KEYMGR_MAX_CREATOR_KEY_VER_OFFSET = 8'h 58;
-  parameter logic [7:0] KEYMGR_MAX_OWNER_INT_KEY_VER_EN_OFFSET = 8'h 5c;
-  parameter logic [7:0] KEYMGR_MAX_OWNER_INT_KEY_VER_OFFSET = 8'h 60;
-  parameter logic [7:0] KEYMGR_MAX_OWNER_KEY_VER_EN_OFFSET = 8'h 64;
-  parameter logic [7:0] KEYMGR_MAX_OWNER_KEY_VER_OFFSET = 8'h 68;
-  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_0_OFFSET = 8'h 6c;
-  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_1_OFFSET = 8'h 70;
-  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_2_OFFSET = 8'h 74;
-  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_3_OFFSET = 8'h 78;
-  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_4_OFFSET = 8'h 7c;
-  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_5_OFFSET = 8'h 80;
-  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_6_OFFSET = 8'h 84;
-  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_7_OFFSET = 8'h 88;
-  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_0_OFFSET = 8'h 8c;
-  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_1_OFFSET = 8'h 90;
-  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_2_OFFSET = 8'h 94;
-  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_3_OFFSET = 8'h 98;
-  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_4_OFFSET = 8'h 9c;
-  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_5_OFFSET = 8'h a0;
-  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_6_OFFSET = 8'h a4;
-  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_7_OFFSET = 8'h a8;
-  parameter logic [7:0] KEYMGR_WORKING_STATE_OFFSET = 8'h ac;
-  parameter logic [7:0] KEYMGR_OP_STATUS_OFFSET = 8'h b0;
-  parameter logic [7:0] KEYMGR_ERR_CODE_OFFSET = 8'h b4;
+  parameter logic [7:0] KEYMGR_SW_BINDING_EN_OFFSET = 8'h 1c;
+  parameter logic [7:0] KEYMGR_SW_BINDING_0_OFFSET = 8'h 20;
+  parameter logic [7:0] KEYMGR_SW_BINDING_1_OFFSET = 8'h 24;
+  parameter logic [7:0] KEYMGR_SW_BINDING_2_OFFSET = 8'h 28;
+  parameter logic [7:0] KEYMGR_SW_BINDING_3_OFFSET = 8'h 2c;
+  parameter logic [7:0] KEYMGR_SALT_0_OFFSET = 8'h 30;
+  parameter logic [7:0] KEYMGR_SALT_1_OFFSET = 8'h 34;
+  parameter logic [7:0] KEYMGR_SALT_2_OFFSET = 8'h 38;
+  parameter logic [7:0] KEYMGR_SALT_3_OFFSET = 8'h 3c;
+  parameter logic [7:0] KEYMGR_KEY_VERSION_OFFSET = 8'h 40;
+  parameter logic [7:0] KEYMGR_MAX_CREATOR_KEY_VER_EN_OFFSET = 8'h 44;
+  parameter logic [7:0] KEYMGR_MAX_CREATOR_KEY_VER_OFFSET = 8'h 48;
+  parameter logic [7:0] KEYMGR_MAX_OWNER_INT_KEY_VER_EN_OFFSET = 8'h 4c;
+  parameter logic [7:0] KEYMGR_MAX_OWNER_INT_KEY_VER_OFFSET = 8'h 50;
+  parameter logic [7:0] KEYMGR_MAX_OWNER_KEY_VER_EN_OFFSET = 8'h 54;
+  parameter logic [7:0] KEYMGR_MAX_OWNER_KEY_VER_OFFSET = 8'h 58;
+  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_0_OFFSET = 8'h 5c;
+  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_1_OFFSET = 8'h 60;
+  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_2_OFFSET = 8'h 64;
+  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_3_OFFSET = 8'h 68;
+  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_4_OFFSET = 8'h 6c;
+  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_5_OFFSET = 8'h 70;
+  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_6_OFFSET = 8'h 74;
+  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_7_OFFSET = 8'h 78;
+  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_0_OFFSET = 8'h 7c;
+  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_1_OFFSET = 8'h 80;
+  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_2_OFFSET = 8'h 84;
+  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_3_OFFSET = 8'h 88;
+  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_4_OFFSET = 8'h 8c;
+  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_5_OFFSET = 8'h 90;
+  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_6_OFFSET = 8'h 94;
+  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_7_OFFSET = 8'h 98;
+  parameter logic [7:0] KEYMGR_WORKING_STATE_OFFSET = 8'h 9c;
+  parameter logic [7:0] KEYMGR_OP_STATUS_OFFSET = 8'h a0;
+  parameter logic [7:0] KEYMGR_ERR_CODE_OFFSET = 8'h a4;
 
 
   // Register Index
@@ -270,15 +266,11 @@ package keymgr_reg_pkg;
     KEYMGR_CFGEN,
     KEYMGR_CONTROL,
     KEYMGR_RESEED_INTERVAL,
-    KEYMGR_ROM_EXT_DESC_EN,
-    KEYMGR_ROM_EXT_DESC_0,
-    KEYMGR_ROM_EXT_DESC_1,
-    KEYMGR_ROM_EXT_DESC_2,
-    KEYMGR_ROM_EXT_DESC_3,
-    KEYMGR_SOFTWARE_BINDING_0,
-    KEYMGR_SOFTWARE_BINDING_1,
-    KEYMGR_SOFTWARE_BINDING_2,
-    KEYMGR_SOFTWARE_BINDING_3,
+    KEYMGR_SW_BINDING_EN,
+    KEYMGR_SW_BINDING_0,
+    KEYMGR_SW_BINDING_1,
+    KEYMGR_SW_BINDING_2,
+    KEYMGR_SW_BINDING_3,
     KEYMGR_SALT_0,
     KEYMGR_SALT_1,
     KEYMGR_SALT_2,
@@ -312,7 +304,7 @@ package keymgr_reg_pkg;
   } keymgr_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] KEYMGR_PERMIT [46] = '{
+  parameter logic [3:0] KEYMGR_PERMIT [42] = '{
     4'b 0001, // index[ 0] KEYMGR_INTR_STATE
     4'b 0001, // index[ 1] KEYMGR_INTR_ENABLE
     4'b 0001, // index[ 2] KEYMGR_INTR_TEST
@@ -320,45 +312,41 @@ package keymgr_reg_pkg;
     4'b 0001, // index[ 4] KEYMGR_CFGEN
     4'b 0011, // index[ 5] KEYMGR_CONTROL
     4'b 0011, // index[ 6] KEYMGR_RESEED_INTERVAL
-    4'b 0001, // index[ 7] KEYMGR_ROM_EXT_DESC_EN
-    4'b 1111, // index[ 8] KEYMGR_ROM_EXT_DESC_0
-    4'b 1111, // index[ 9] KEYMGR_ROM_EXT_DESC_1
-    4'b 1111, // index[10] KEYMGR_ROM_EXT_DESC_2
-    4'b 1111, // index[11] KEYMGR_ROM_EXT_DESC_3
-    4'b 1111, // index[12] KEYMGR_SOFTWARE_BINDING_0
-    4'b 1111, // index[13] KEYMGR_SOFTWARE_BINDING_1
-    4'b 1111, // index[14] KEYMGR_SOFTWARE_BINDING_2
-    4'b 1111, // index[15] KEYMGR_SOFTWARE_BINDING_3
-    4'b 1111, // index[16] KEYMGR_SALT_0
-    4'b 1111, // index[17] KEYMGR_SALT_1
-    4'b 1111, // index[18] KEYMGR_SALT_2
-    4'b 1111, // index[19] KEYMGR_SALT_3
-    4'b 1111, // index[20] KEYMGR_KEY_VERSION
-    4'b 0001, // index[21] KEYMGR_MAX_CREATOR_KEY_VER_EN
-    4'b 1111, // index[22] KEYMGR_MAX_CREATOR_KEY_VER
-    4'b 0001, // index[23] KEYMGR_MAX_OWNER_INT_KEY_VER_EN
-    4'b 1111, // index[24] KEYMGR_MAX_OWNER_INT_KEY_VER
-    4'b 0001, // index[25] KEYMGR_MAX_OWNER_KEY_VER_EN
-    4'b 1111, // index[26] KEYMGR_MAX_OWNER_KEY_VER
-    4'b 1111, // index[27] KEYMGR_SW_SHARE0_OUTPUT_0
-    4'b 1111, // index[28] KEYMGR_SW_SHARE0_OUTPUT_1
-    4'b 1111, // index[29] KEYMGR_SW_SHARE0_OUTPUT_2
-    4'b 1111, // index[30] KEYMGR_SW_SHARE0_OUTPUT_3
-    4'b 1111, // index[31] KEYMGR_SW_SHARE0_OUTPUT_4
-    4'b 1111, // index[32] KEYMGR_SW_SHARE0_OUTPUT_5
-    4'b 1111, // index[33] KEYMGR_SW_SHARE0_OUTPUT_6
-    4'b 1111, // index[34] KEYMGR_SW_SHARE0_OUTPUT_7
-    4'b 1111, // index[35] KEYMGR_SW_SHARE1_OUTPUT_0
-    4'b 1111, // index[36] KEYMGR_SW_SHARE1_OUTPUT_1
-    4'b 1111, // index[37] KEYMGR_SW_SHARE1_OUTPUT_2
-    4'b 1111, // index[38] KEYMGR_SW_SHARE1_OUTPUT_3
-    4'b 1111, // index[39] KEYMGR_SW_SHARE1_OUTPUT_4
-    4'b 1111, // index[40] KEYMGR_SW_SHARE1_OUTPUT_5
-    4'b 1111, // index[41] KEYMGR_SW_SHARE1_OUTPUT_6
-    4'b 1111, // index[42] KEYMGR_SW_SHARE1_OUTPUT_7
-    4'b 0001, // index[43] KEYMGR_WORKING_STATE
-    4'b 0001, // index[44] KEYMGR_OP_STATUS
-    4'b 0001  // index[45] KEYMGR_ERR_CODE
+    4'b 0001, // index[ 7] KEYMGR_SW_BINDING_EN
+    4'b 1111, // index[ 8] KEYMGR_SW_BINDING_0
+    4'b 1111, // index[ 9] KEYMGR_SW_BINDING_1
+    4'b 1111, // index[10] KEYMGR_SW_BINDING_2
+    4'b 1111, // index[11] KEYMGR_SW_BINDING_3
+    4'b 1111, // index[12] KEYMGR_SALT_0
+    4'b 1111, // index[13] KEYMGR_SALT_1
+    4'b 1111, // index[14] KEYMGR_SALT_2
+    4'b 1111, // index[15] KEYMGR_SALT_3
+    4'b 1111, // index[16] KEYMGR_KEY_VERSION
+    4'b 0001, // index[17] KEYMGR_MAX_CREATOR_KEY_VER_EN
+    4'b 1111, // index[18] KEYMGR_MAX_CREATOR_KEY_VER
+    4'b 0001, // index[19] KEYMGR_MAX_OWNER_INT_KEY_VER_EN
+    4'b 1111, // index[20] KEYMGR_MAX_OWNER_INT_KEY_VER
+    4'b 0001, // index[21] KEYMGR_MAX_OWNER_KEY_VER_EN
+    4'b 1111, // index[22] KEYMGR_MAX_OWNER_KEY_VER
+    4'b 1111, // index[23] KEYMGR_SW_SHARE0_OUTPUT_0
+    4'b 1111, // index[24] KEYMGR_SW_SHARE0_OUTPUT_1
+    4'b 1111, // index[25] KEYMGR_SW_SHARE0_OUTPUT_2
+    4'b 1111, // index[26] KEYMGR_SW_SHARE0_OUTPUT_3
+    4'b 1111, // index[27] KEYMGR_SW_SHARE0_OUTPUT_4
+    4'b 1111, // index[28] KEYMGR_SW_SHARE0_OUTPUT_5
+    4'b 1111, // index[29] KEYMGR_SW_SHARE0_OUTPUT_6
+    4'b 1111, // index[30] KEYMGR_SW_SHARE0_OUTPUT_7
+    4'b 1111, // index[31] KEYMGR_SW_SHARE1_OUTPUT_0
+    4'b 1111, // index[32] KEYMGR_SW_SHARE1_OUTPUT_1
+    4'b 1111, // index[33] KEYMGR_SW_SHARE1_OUTPUT_2
+    4'b 1111, // index[34] KEYMGR_SW_SHARE1_OUTPUT_3
+    4'b 1111, // index[35] KEYMGR_SW_SHARE1_OUTPUT_4
+    4'b 1111, // index[36] KEYMGR_SW_SHARE1_OUTPUT_5
+    4'b 1111, // index[37] KEYMGR_SW_SHARE1_OUTPUT_6
+    4'b 1111, // index[38] KEYMGR_SW_SHARE1_OUTPUT_7
+    4'b 0001, // index[39] KEYMGR_WORKING_STATE
+    4'b 0001, // index[40] KEYMGR_OP_STATUS
+    4'b 0001  // index[41] KEYMGR_ERR_CODE
   };
 endpackage
 

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -105,33 +105,21 @@ module keymgr_reg_top (
   logic [15:0] reseed_interval_qs;
   logic [15:0] reseed_interval_wd;
   logic reseed_interval_we;
-  logic [1:0] rom_ext_desc_en_qs;
-  logic [1:0] rom_ext_desc_en_wd;
-  logic rom_ext_desc_en_we;
-  logic [31:0] rom_ext_desc_0_qs;
-  logic [31:0] rom_ext_desc_0_wd;
-  logic rom_ext_desc_0_we;
-  logic [31:0] rom_ext_desc_1_qs;
-  logic [31:0] rom_ext_desc_1_wd;
-  logic rom_ext_desc_1_we;
-  logic [31:0] rom_ext_desc_2_qs;
-  logic [31:0] rom_ext_desc_2_wd;
-  logic rom_ext_desc_2_we;
-  logic [31:0] rom_ext_desc_3_qs;
-  logic [31:0] rom_ext_desc_3_wd;
-  logic rom_ext_desc_3_we;
-  logic [31:0] software_binding_0_qs;
-  logic [31:0] software_binding_0_wd;
-  logic software_binding_0_we;
-  logic [31:0] software_binding_1_qs;
-  logic [31:0] software_binding_1_wd;
-  logic software_binding_1_we;
-  logic [31:0] software_binding_2_qs;
-  logic [31:0] software_binding_2_wd;
-  logic software_binding_2_we;
-  logic [31:0] software_binding_3_qs;
-  logic [31:0] software_binding_3_wd;
-  logic software_binding_3_we;
+  logic sw_binding_en_qs;
+  logic sw_binding_en_wd;
+  logic sw_binding_en_we;
+  logic [31:0] sw_binding_0_qs;
+  logic [31:0] sw_binding_0_wd;
+  logic sw_binding_0_we;
+  logic [31:0] sw_binding_1_qs;
+  logic [31:0] sw_binding_1_wd;
+  logic sw_binding_1_we;
+  logic [31:0] sw_binding_2_qs;
+  logic [31:0] sw_binding_2_wd;
+  logic sw_binding_2_we;
+  logic [31:0] sw_binding_3_qs;
+  logic [31:0] sw_binding_3_wd;
+  logic sw_binding_3_we;
   logic [31:0] salt_0_qs;
   logic [31:0] salt_0_wd;
   logic salt_0_we;
@@ -526,158 +514,48 @@ module keymgr_reg_top (
   );
 
 
-  // R[rom_ext_desc_en]: V(False)
+  // R[sw_binding_en]: V(False)
 
   prim_subreg #(
-    .DW      (2),
+    .DW      (1),
     .SWACCESS("W0C"),
-    .RESVAL  (2'h2)
-  ) u_rom_ext_desc_en (
+    .RESVAL  (1'h1)
+  ) u_sw_binding_en (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (rom_ext_desc_en_we),
-    .wd     (rom_ext_desc_en_wd),
+    .we     (sw_binding_en_we),
+    .wd     (sw_binding_en_wd),
 
     // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
+    .de     (hw2reg.sw_binding_en.de),
+    .d      (hw2reg.sw_binding_en.d ),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (rom_ext_desc_en_qs)
+    .qs     (sw_binding_en_qs)
   );
 
 
 
-  // Subregister 0 of Multireg rom_ext_desc
-  // R[rom_ext_desc_0]: V(False)
+  // Subregister 0 of Multireg sw_binding
+  // R[sw_binding_0]: V(False)
 
   prim_subreg #(
     .DW      (32),
     .SWACCESS("RW"),
     .RESVAL  (32'h0)
-  ) u_rom_ext_desc_0 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (rom_ext_desc_0_we),
-    .wd     (rom_ext_desc_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.rom_ext_desc[0].q ),
-
-    // to register interface (read)
-    .qs     (rom_ext_desc_0_qs)
-  );
-
-  // Subregister 1 of Multireg rom_ext_desc
-  // R[rom_ext_desc_1]: V(False)
-
-  prim_subreg #(
-    .DW      (32),
-    .SWACCESS("RW"),
-    .RESVAL  (32'h0)
-  ) u_rom_ext_desc_1 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (rom_ext_desc_1_we),
-    .wd     (rom_ext_desc_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.rom_ext_desc[1].q ),
-
-    // to register interface (read)
-    .qs     (rom_ext_desc_1_qs)
-  );
-
-  // Subregister 2 of Multireg rom_ext_desc
-  // R[rom_ext_desc_2]: V(False)
-
-  prim_subreg #(
-    .DW      (32),
-    .SWACCESS("RW"),
-    .RESVAL  (32'h0)
-  ) u_rom_ext_desc_2 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (rom_ext_desc_2_we),
-    .wd     (rom_ext_desc_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.rom_ext_desc[2].q ),
-
-    // to register interface (read)
-    .qs     (rom_ext_desc_2_qs)
-  );
-
-  // Subregister 3 of Multireg rom_ext_desc
-  // R[rom_ext_desc_3]: V(False)
-
-  prim_subreg #(
-    .DW      (32),
-    .SWACCESS("RW"),
-    .RESVAL  (32'h0)
-  ) u_rom_ext_desc_3 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (rom_ext_desc_3_we),
-    .wd     (rom_ext_desc_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.rom_ext_desc[3].q ),
-
-    // to register interface (read)
-    .qs     (rom_ext_desc_3_qs)
-  );
-
-
-
-  // Subregister 0 of Multireg software_binding
-  // R[software_binding_0]: V(False)
-
-  prim_subreg #(
-    .DW      (32),
-    .SWACCESS("RW"),
-    .RESVAL  (32'h0)
-  ) u_software_binding_0 (
+  ) u_sw_binding_0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (software_binding_0_we & cfgen_qs),
-    .wd     (software_binding_0_wd),
+    .we     (sw_binding_0_we & sw_binding_en_qs),
+    .wd     (sw_binding_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -685,26 +563,26 @@ module keymgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.software_binding[0].q ),
+    .q      (reg2hw.sw_binding[0].q ),
 
     // to register interface (read)
-    .qs     (software_binding_0_qs)
+    .qs     (sw_binding_0_qs)
   );
 
-  // Subregister 1 of Multireg software_binding
-  // R[software_binding_1]: V(False)
+  // Subregister 1 of Multireg sw_binding
+  // R[sw_binding_1]: V(False)
 
   prim_subreg #(
     .DW      (32),
     .SWACCESS("RW"),
     .RESVAL  (32'h0)
-  ) u_software_binding_1 (
+  ) u_sw_binding_1 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (software_binding_1_we & cfgen_qs),
-    .wd     (software_binding_1_wd),
+    .we     (sw_binding_1_we & sw_binding_en_qs),
+    .wd     (sw_binding_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -712,26 +590,26 @@ module keymgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.software_binding[1].q ),
+    .q      (reg2hw.sw_binding[1].q ),
 
     // to register interface (read)
-    .qs     (software_binding_1_qs)
+    .qs     (sw_binding_1_qs)
   );
 
-  // Subregister 2 of Multireg software_binding
-  // R[software_binding_2]: V(False)
+  // Subregister 2 of Multireg sw_binding
+  // R[sw_binding_2]: V(False)
 
   prim_subreg #(
     .DW      (32),
     .SWACCESS("RW"),
     .RESVAL  (32'h0)
-  ) u_software_binding_2 (
+  ) u_sw_binding_2 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (software_binding_2_we & cfgen_qs),
-    .wd     (software_binding_2_wd),
+    .we     (sw_binding_2_we & sw_binding_en_qs),
+    .wd     (sw_binding_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -739,26 +617,26 @@ module keymgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.software_binding[2].q ),
+    .q      (reg2hw.sw_binding[2].q ),
 
     // to register interface (read)
-    .qs     (software_binding_2_qs)
+    .qs     (sw_binding_2_qs)
   );
 
-  // Subregister 3 of Multireg software_binding
-  // R[software_binding_3]: V(False)
+  // Subregister 3 of Multireg sw_binding
+  // R[sw_binding_3]: V(False)
 
   prim_subreg #(
     .DW      (32),
     .SWACCESS("RW"),
     .RESVAL  (32'h0)
-  ) u_software_binding_3 (
+  ) u_sw_binding_3 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (software_binding_3_we & cfgen_qs),
-    .wd     (software_binding_3_wd),
+    .we     (sw_binding_3_we & sw_binding_en_qs),
+    .wd     (sw_binding_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -766,10 +644,10 @@ module keymgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.software_binding[3].q ),
+    .q      (reg2hw.sw_binding[3].q ),
 
     // to register interface (read)
-    .qs     (software_binding_3_qs)
+    .qs     (sw_binding_3_qs)
   );
 
 
@@ -1671,7 +1549,7 @@ module keymgr_reg_top (
 
 
 
-  logic [45:0] addr_hit;
+  logic [41:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == KEYMGR_INTR_STATE_OFFSET);
@@ -1681,45 +1559,41 @@ module keymgr_reg_top (
     addr_hit[ 4] = (reg_addr == KEYMGR_CFGEN_OFFSET);
     addr_hit[ 5] = (reg_addr == KEYMGR_CONTROL_OFFSET);
     addr_hit[ 6] = (reg_addr == KEYMGR_RESEED_INTERVAL_OFFSET);
-    addr_hit[ 7] = (reg_addr == KEYMGR_ROM_EXT_DESC_EN_OFFSET);
-    addr_hit[ 8] = (reg_addr == KEYMGR_ROM_EXT_DESC_0_OFFSET);
-    addr_hit[ 9] = (reg_addr == KEYMGR_ROM_EXT_DESC_1_OFFSET);
-    addr_hit[10] = (reg_addr == KEYMGR_ROM_EXT_DESC_2_OFFSET);
-    addr_hit[11] = (reg_addr == KEYMGR_ROM_EXT_DESC_3_OFFSET);
-    addr_hit[12] = (reg_addr == KEYMGR_SOFTWARE_BINDING_0_OFFSET);
-    addr_hit[13] = (reg_addr == KEYMGR_SOFTWARE_BINDING_1_OFFSET);
-    addr_hit[14] = (reg_addr == KEYMGR_SOFTWARE_BINDING_2_OFFSET);
-    addr_hit[15] = (reg_addr == KEYMGR_SOFTWARE_BINDING_3_OFFSET);
-    addr_hit[16] = (reg_addr == KEYMGR_SALT_0_OFFSET);
-    addr_hit[17] = (reg_addr == KEYMGR_SALT_1_OFFSET);
-    addr_hit[18] = (reg_addr == KEYMGR_SALT_2_OFFSET);
-    addr_hit[19] = (reg_addr == KEYMGR_SALT_3_OFFSET);
-    addr_hit[20] = (reg_addr == KEYMGR_KEY_VERSION_OFFSET);
-    addr_hit[21] = (reg_addr == KEYMGR_MAX_CREATOR_KEY_VER_EN_OFFSET);
-    addr_hit[22] = (reg_addr == KEYMGR_MAX_CREATOR_KEY_VER_OFFSET);
-    addr_hit[23] = (reg_addr == KEYMGR_MAX_OWNER_INT_KEY_VER_EN_OFFSET);
-    addr_hit[24] = (reg_addr == KEYMGR_MAX_OWNER_INT_KEY_VER_OFFSET);
-    addr_hit[25] = (reg_addr == KEYMGR_MAX_OWNER_KEY_VER_EN_OFFSET);
-    addr_hit[26] = (reg_addr == KEYMGR_MAX_OWNER_KEY_VER_OFFSET);
-    addr_hit[27] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_0_OFFSET);
-    addr_hit[28] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_1_OFFSET);
-    addr_hit[29] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_2_OFFSET);
-    addr_hit[30] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_3_OFFSET);
-    addr_hit[31] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_4_OFFSET);
-    addr_hit[32] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_5_OFFSET);
-    addr_hit[33] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_6_OFFSET);
-    addr_hit[34] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_7_OFFSET);
-    addr_hit[35] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_0_OFFSET);
-    addr_hit[36] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_1_OFFSET);
-    addr_hit[37] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_2_OFFSET);
-    addr_hit[38] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_3_OFFSET);
-    addr_hit[39] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_4_OFFSET);
-    addr_hit[40] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_5_OFFSET);
-    addr_hit[41] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_6_OFFSET);
-    addr_hit[42] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_7_OFFSET);
-    addr_hit[43] = (reg_addr == KEYMGR_WORKING_STATE_OFFSET);
-    addr_hit[44] = (reg_addr == KEYMGR_OP_STATUS_OFFSET);
-    addr_hit[45] = (reg_addr == KEYMGR_ERR_CODE_OFFSET);
+    addr_hit[ 7] = (reg_addr == KEYMGR_SW_BINDING_EN_OFFSET);
+    addr_hit[ 8] = (reg_addr == KEYMGR_SW_BINDING_0_OFFSET);
+    addr_hit[ 9] = (reg_addr == KEYMGR_SW_BINDING_1_OFFSET);
+    addr_hit[10] = (reg_addr == KEYMGR_SW_BINDING_2_OFFSET);
+    addr_hit[11] = (reg_addr == KEYMGR_SW_BINDING_3_OFFSET);
+    addr_hit[12] = (reg_addr == KEYMGR_SALT_0_OFFSET);
+    addr_hit[13] = (reg_addr == KEYMGR_SALT_1_OFFSET);
+    addr_hit[14] = (reg_addr == KEYMGR_SALT_2_OFFSET);
+    addr_hit[15] = (reg_addr == KEYMGR_SALT_3_OFFSET);
+    addr_hit[16] = (reg_addr == KEYMGR_KEY_VERSION_OFFSET);
+    addr_hit[17] = (reg_addr == KEYMGR_MAX_CREATOR_KEY_VER_EN_OFFSET);
+    addr_hit[18] = (reg_addr == KEYMGR_MAX_CREATOR_KEY_VER_OFFSET);
+    addr_hit[19] = (reg_addr == KEYMGR_MAX_OWNER_INT_KEY_VER_EN_OFFSET);
+    addr_hit[20] = (reg_addr == KEYMGR_MAX_OWNER_INT_KEY_VER_OFFSET);
+    addr_hit[21] = (reg_addr == KEYMGR_MAX_OWNER_KEY_VER_EN_OFFSET);
+    addr_hit[22] = (reg_addr == KEYMGR_MAX_OWNER_KEY_VER_OFFSET);
+    addr_hit[23] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_0_OFFSET);
+    addr_hit[24] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_1_OFFSET);
+    addr_hit[25] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_2_OFFSET);
+    addr_hit[26] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_3_OFFSET);
+    addr_hit[27] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_4_OFFSET);
+    addr_hit[28] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_5_OFFSET);
+    addr_hit[29] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_6_OFFSET);
+    addr_hit[30] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_7_OFFSET);
+    addr_hit[31] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_0_OFFSET);
+    addr_hit[32] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_1_OFFSET);
+    addr_hit[33] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_2_OFFSET);
+    addr_hit[34] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_3_OFFSET);
+    addr_hit[35] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_4_OFFSET);
+    addr_hit[36] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_5_OFFSET);
+    addr_hit[37] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_6_OFFSET);
+    addr_hit[38] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_7_OFFSET);
+    addr_hit[39] = (reg_addr == KEYMGR_WORKING_STATE_OFFSET);
+    addr_hit[40] = (reg_addr == KEYMGR_OP_STATUS_OFFSET);
+    addr_hit[41] = (reg_addr == KEYMGR_ERR_CODE_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1769,10 +1643,6 @@ module keymgr_reg_top (
     if (addr_hit[39] && reg_we && (KEYMGR_PERMIT[39] != (KEYMGR_PERMIT[39] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[40] && reg_we && (KEYMGR_PERMIT[40] != (KEYMGR_PERMIT[40] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[41] && reg_we && (KEYMGR_PERMIT[41] != (KEYMGR_PERMIT[41] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[42] && reg_we && (KEYMGR_PERMIT[42] != (KEYMGR_PERMIT[42] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[43] && reg_we && (KEYMGR_PERMIT[43] != (KEYMGR_PERMIT[43] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[44] && reg_we && (KEYMGR_PERMIT[44] != (KEYMGR_PERMIT[44] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[45] && reg_we && (KEYMGR_PERMIT[45] != (KEYMGR_PERMIT[45] & reg_be))) wr_err = 1'b1 ;
   end
 
   assign intr_state_op_done_we = addr_hit[0] & reg_we & ~wr_err;
@@ -1813,128 +1683,116 @@ module keymgr_reg_top (
   assign reseed_interval_we = addr_hit[6] & reg_we & ~wr_err;
   assign reseed_interval_wd = reg_wdata[15:0];
 
-  assign rom_ext_desc_en_we = addr_hit[7] & reg_we & ~wr_err;
-  assign rom_ext_desc_en_wd = reg_wdata[1:0];
+  assign sw_binding_en_we = addr_hit[7] & reg_we & ~wr_err;
+  assign sw_binding_en_wd = reg_wdata[0];
 
-  assign rom_ext_desc_0_we = addr_hit[8] & reg_we & ~wr_err;
-  assign rom_ext_desc_0_wd = reg_wdata[31:0];
+  assign sw_binding_0_we = addr_hit[8] & reg_we & ~wr_err;
+  assign sw_binding_0_wd = reg_wdata[31:0];
 
-  assign rom_ext_desc_1_we = addr_hit[9] & reg_we & ~wr_err;
-  assign rom_ext_desc_1_wd = reg_wdata[31:0];
+  assign sw_binding_1_we = addr_hit[9] & reg_we & ~wr_err;
+  assign sw_binding_1_wd = reg_wdata[31:0];
 
-  assign rom_ext_desc_2_we = addr_hit[10] & reg_we & ~wr_err;
-  assign rom_ext_desc_2_wd = reg_wdata[31:0];
+  assign sw_binding_2_we = addr_hit[10] & reg_we & ~wr_err;
+  assign sw_binding_2_wd = reg_wdata[31:0];
 
-  assign rom_ext_desc_3_we = addr_hit[11] & reg_we & ~wr_err;
-  assign rom_ext_desc_3_wd = reg_wdata[31:0];
+  assign sw_binding_3_we = addr_hit[11] & reg_we & ~wr_err;
+  assign sw_binding_3_wd = reg_wdata[31:0];
 
-  assign software_binding_0_we = addr_hit[12] & reg_we & ~wr_err;
-  assign software_binding_0_wd = reg_wdata[31:0];
-
-  assign software_binding_1_we = addr_hit[13] & reg_we & ~wr_err;
-  assign software_binding_1_wd = reg_wdata[31:0];
-
-  assign software_binding_2_we = addr_hit[14] & reg_we & ~wr_err;
-  assign software_binding_2_wd = reg_wdata[31:0];
-
-  assign software_binding_3_we = addr_hit[15] & reg_we & ~wr_err;
-  assign software_binding_3_wd = reg_wdata[31:0];
-
-  assign salt_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign salt_0_we = addr_hit[12] & reg_we & ~wr_err;
   assign salt_0_wd = reg_wdata[31:0];
 
-  assign salt_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign salt_1_we = addr_hit[13] & reg_we & ~wr_err;
   assign salt_1_wd = reg_wdata[31:0];
 
-  assign salt_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign salt_2_we = addr_hit[14] & reg_we & ~wr_err;
   assign salt_2_wd = reg_wdata[31:0];
 
-  assign salt_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign salt_3_we = addr_hit[15] & reg_we & ~wr_err;
   assign salt_3_wd = reg_wdata[31:0];
 
-  assign key_version_we = addr_hit[20] & reg_we & ~wr_err;
+  assign key_version_we = addr_hit[16] & reg_we & ~wr_err;
   assign key_version_wd = reg_wdata[31:0];
 
-  assign max_creator_key_ver_en_we = addr_hit[21] & reg_we & ~wr_err;
+  assign max_creator_key_ver_en_we = addr_hit[17] & reg_we & ~wr_err;
   assign max_creator_key_ver_en_wd = reg_wdata[0];
 
-  assign max_creator_key_ver_we = addr_hit[22] & reg_we & ~wr_err;
+  assign max_creator_key_ver_we = addr_hit[18] & reg_we & ~wr_err;
   assign max_creator_key_ver_wd = reg_wdata[31:0];
 
-  assign max_owner_int_key_ver_en_we = addr_hit[23] & reg_we & ~wr_err;
+  assign max_owner_int_key_ver_en_we = addr_hit[19] & reg_we & ~wr_err;
   assign max_owner_int_key_ver_en_wd = reg_wdata[0];
 
-  assign max_owner_int_key_ver_we = addr_hit[24] & reg_we & ~wr_err;
+  assign max_owner_int_key_ver_we = addr_hit[20] & reg_we & ~wr_err;
   assign max_owner_int_key_ver_wd = reg_wdata[31:0];
 
-  assign max_owner_key_ver_en_we = addr_hit[25] & reg_we & ~wr_err;
+  assign max_owner_key_ver_en_we = addr_hit[21] & reg_we & ~wr_err;
   assign max_owner_key_ver_en_wd = reg_wdata[0];
 
-  assign max_owner_key_ver_we = addr_hit[26] & reg_we & ~wr_err;
+  assign max_owner_key_ver_we = addr_hit[22] & reg_we & ~wr_err;
   assign max_owner_key_ver_wd = reg_wdata[31:0];
 
-  assign sw_share0_output_0_we = addr_hit[27] & reg_re;
+  assign sw_share0_output_0_we = addr_hit[23] & reg_re;
   assign sw_share0_output_0_wd = '1;
 
-  assign sw_share0_output_1_we = addr_hit[28] & reg_re;
+  assign sw_share0_output_1_we = addr_hit[24] & reg_re;
   assign sw_share0_output_1_wd = '1;
 
-  assign sw_share0_output_2_we = addr_hit[29] & reg_re;
+  assign sw_share0_output_2_we = addr_hit[25] & reg_re;
   assign sw_share0_output_2_wd = '1;
 
-  assign sw_share0_output_3_we = addr_hit[30] & reg_re;
+  assign sw_share0_output_3_we = addr_hit[26] & reg_re;
   assign sw_share0_output_3_wd = '1;
 
-  assign sw_share0_output_4_we = addr_hit[31] & reg_re;
+  assign sw_share0_output_4_we = addr_hit[27] & reg_re;
   assign sw_share0_output_4_wd = '1;
 
-  assign sw_share0_output_5_we = addr_hit[32] & reg_re;
+  assign sw_share0_output_5_we = addr_hit[28] & reg_re;
   assign sw_share0_output_5_wd = '1;
 
-  assign sw_share0_output_6_we = addr_hit[33] & reg_re;
+  assign sw_share0_output_6_we = addr_hit[29] & reg_re;
   assign sw_share0_output_6_wd = '1;
 
-  assign sw_share0_output_7_we = addr_hit[34] & reg_re;
+  assign sw_share0_output_7_we = addr_hit[30] & reg_re;
   assign sw_share0_output_7_wd = '1;
 
-  assign sw_share1_output_0_we = addr_hit[35] & reg_re;
+  assign sw_share1_output_0_we = addr_hit[31] & reg_re;
   assign sw_share1_output_0_wd = '1;
 
-  assign sw_share1_output_1_we = addr_hit[36] & reg_re;
+  assign sw_share1_output_1_we = addr_hit[32] & reg_re;
   assign sw_share1_output_1_wd = '1;
 
-  assign sw_share1_output_2_we = addr_hit[37] & reg_re;
+  assign sw_share1_output_2_we = addr_hit[33] & reg_re;
   assign sw_share1_output_2_wd = '1;
 
-  assign sw_share1_output_3_we = addr_hit[38] & reg_re;
+  assign sw_share1_output_3_we = addr_hit[34] & reg_re;
   assign sw_share1_output_3_wd = '1;
 
-  assign sw_share1_output_4_we = addr_hit[39] & reg_re;
+  assign sw_share1_output_4_we = addr_hit[35] & reg_re;
   assign sw_share1_output_4_wd = '1;
 
-  assign sw_share1_output_5_we = addr_hit[40] & reg_re;
+  assign sw_share1_output_5_we = addr_hit[36] & reg_re;
   assign sw_share1_output_5_wd = '1;
 
-  assign sw_share1_output_6_we = addr_hit[41] & reg_re;
+  assign sw_share1_output_6_we = addr_hit[37] & reg_re;
   assign sw_share1_output_6_wd = '1;
 
-  assign sw_share1_output_7_we = addr_hit[42] & reg_re;
+  assign sw_share1_output_7_we = addr_hit[38] & reg_re;
   assign sw_share1_output_7_wd = '1;
 
 
-  assign op_status_we = addr_hit[44] & reg_we & ~wr_err;
+  assign op_status_we = addr_hit[40] & reg_we & ~wr_err;
   assign op_status_wd = reg_wdata[1:0];
 
-  assign err_code_invalid_op_we = addr_hit[45] & reg_we & ~wr_err;
+  assign err_code_invalid_op_we = addr_hit[41] & reg_we & ~wr_err;
   assign err_code_invalid_op_wd = reg_wdata[0];
 
-  assign err_code_invalid_cmd_we = addr_hit[45] & reg_we & ~wr_err;
+  assign err_code_invalid_cmd_we = addr_hit[41] & reg_we & ~wr_err;
   assign err_code_invalid_cmd_wd = reg_wdata[1];
 
-  assign err_code_invalid_kmac_input_we = addr_hit[45] & reg_we & ~wr_err;
+  assign err_code_invalid_kmac_input_we = addr_hit[41] & reg_we & ~wr_err;
   assign err_code_invalid_kmac_input_wd = reg_wdata[2];
 
-  assign err_code_invalid_kmac_data_we = addr_hit[45] & reg_we & ~wr_err;
+  assign err_code_invalid_kmac_data_we = addr_hit[41] & reg_we & ~wr_err;
   assign err_code_invalid_kmac_data_wd = reg_wdata[3];
 
   // Read data return
@@ -1976,158 +1834,142 @@ module keymgr_reg_top (
       end
 
       addr_hit[7]: begin
-        reg_rdata_next[1:0] = rom_ext_desc_en_qs;
+        reg_rdata_next[0] = sw_binding_en_qs;
       end
 
       addr_hit[8]: begin
-        reg_rdata_next[31:0] = rom_ext_desc_0_qs;
+        reg_rdata_next[31:0] = sw_binding_0_qs;
       end
 
       addr_hit[9]: begin
-        reg_rdata_next[31:0] = rom_ext_desc_1_qs;
+        reg_rdata_next[31:0] = sw_binding_1_qs;
       end
 
       addr_hit[10]: begin
-        reg_rdata_next[31:0] = rom_ext_desc_2_qs;
+        reg_rdata_next[31:0] = sw_binding_2_qs;
       end
 
       addr_hit[11]: begin
-        reg_rdata_next[31:0] = rom_ext_desc_3_qs;
+        reg_rdata_next[31:0] = sw_binding_3_qs;
       end
 
       addr_hit[12]: begin
-        reg_rdata_next[31:0] = software_binding_0_qs;
-      end
-
-      addr_hit[13]: begin
-        reg_rdata_next[31:0] = software_binding_1_qs;
-      end
-
-      addr_hit[14]: begin
-        reg_rdata_next[31:0] = software_binding_2_qs;
-      end
-
-      addr_hit[15]: begin
-        reg_rdata_next[31:0] = software_binding_3_qs;
-      end
-
-      addr_hit[16]: begin
         reg_rdata_next[31:0] = salt_0_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[13]: begin
         reg_rdata_next[31:0] = salt_1_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[14]: begin
         reg_rdata_next[31:0] = salt_2_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[15]: begin
         reg_rdata_next[31:0] = salt_3_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[16]: begin
         reg_rdata_next[31:0] = key_version_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[17]: begin
         reg_rdata_next[0] = max_creator_key_ver_en_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[18]: begin
         reg_rdata_next[31:0] = max_creator_key_ver_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[19]: begin
         reg_rdata_next[0] = max_owner_int_key_ver_en_qs;
       end
 
-      addr_hit[24]: begin
+      addr_hit[20]: begin
         reg_rdata_next[31:0] = max_owner_int_key_ver_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[21]: begin
         reg_rdata_next[0] = max_owner_key_ver_en_qs;
       end
 
-      addr_hit[26]: begin
+      addr_hit[22]: begin
         reg_rdata_next[31:0] = max_owner_key_ver_qs;
       end
 
-      addr_hit[27]: begin
+      addr_hit[23]: begin
         reg_rdata_next[31:0] = sw_share0_output_0_qs;
       end
 
-      addr_hit[28]: begin
+      addr_hit[24]: begin
         reg_rdata_next[31:0] = sw_share0_output_1_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[25]: begin
         reg_rdata_next[31:0] = sw_share0_output_2_qs;
       end
 
-      addr_hit[30]: begin
+      addr_hit[26]: begin
         reg_rdata_next[31:0] = sw_share0_output_3_qs;
       end
 
-      addr_hit[31]: begin
+      addr_hit[27]: begin
         reg_rdata_next[31:0] = sw_share0_output_4_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[28]: begin
         reg_rdata_next[31:0] = sw_share0_output_5_qs;
       end
 
-      addr_hit[33]: begin
+      addr_hit[29]: begin
         reg_rdata_next[31:0] = sw_share0_output_6_qs;
       end
 
-      addr_hit[34]: begin
+      addr_hit[30]: begin
         reg_rdata_next[31:0] = sw_share0_output_7_qs;
       end
 
-      addr_hit[35]: begin
+      addr_hit[31]: begin
         reg_rdata_next[31:0] = sw_share1_output_0_qs;
       end
 
-      addr_hit[36]: begin
+      addr_hit[32]: begin
         reg_rdata_next[31:0] = sw_share1_output_1_qs;
       end
 
-      addr_hit[37]: begin
+      addr_hit[33]: begin
         reg_rdata_next[31:0] = sw_share1_output_2_qs;
       end
 
-      addr_hit[38]: begin
+      addr_hit[34]: begin
         reg_rdata_next[31:0] = sw_share1_output_3_qs;
       end
 
-      addr_hit[39]: begin
+      addr_hit[35]: begin
         reg_rdata_next[31:0] = sw_share1_output_4_qs;
       end
 
-      addr_hit[40]: begin
+      addr_hit[36]: begin
         reg_rdata_next[31:0] = sw_share1_output_5_qs;
       end
 
-      addr_hit[41]: begin
+      addr_hit[37]: begin
         reg_rdata_next[31:0] = sw_share1_output_6_qs;
       end
 
-      addr_hit[42]: begin
+      addr_hit[38]: begin
         reg_rdata_next[31:0] = sw_share1_output_7_qs;
       end
 
-      addr_hit[43]: begin
+      addr_hit[39]: begin
         reg_rdata_next[2:0] = working_state_qs;
       end
 
-      addr_hit[44]: begin
+      addr_hit[40]: begin
         reg_rdata_next[1:0] = op_status_qs;
       end
 
-      addr_hit[45]: begin
+      addr_hit[41]: begin
         reg_rdata_next[0] = err_code_invalid_op_qs;
         reg_rdata_next[1] = err_code_invalid_cmd_qs;
         reg_rdata_next[2] = err_code_invalid_kmac_input_qs;


### PR DESCRIPTION
Please only review the last 2 commits.
The first 2 commits are from a different PR. 

I completely forgot @moidx and I had discussed this and that `ROM_EXT_DESC` can actually be implemented through software binding (the language is also in the spec).

So i've completely deprecated `ROM_EXT_DESC` and am just using software binding now with hardware unlock on successful advance calls.

This will also allow ROM to just lock the binding and wait for later stages to actually make the advance call. 
One thing we will need to consider is whether we should also allow ROM to disable "generation" operations during ROM stage, so that ROM_ext is not able to generate identities seeds that are exclusive to ROM. 