### PR TITLE
[keymgr] keymgr input key valid checks

### DIFF
--- a/hw/ip/keymgr/doc/_index.md
+++ b/hw/ip/keymgr/doc/_index.md
@@ -246,8 +246,8 @@ Based on input from key manager control, this module selects the inputs for each
 
 ### Software Binding
 
-The identities flow employs an idea called [software binding](https://docs.opentitan.org/doc/security/specs/identities_and_root_keys/#software-binding) to ensure that a particular key derivation scheme is only reproducible for a given software configuration.
 
+The identities flow employs an idea called [software binding](https://docs.opentitan.org/doc/security/specs/identities_and_root_keys/#software-binding) to ensure that a particular key derivation scheme is only reproducible for a given software configuration.
 This software binding exists for every stage of key manager except for `OwnerKey`.
 The binding is created through the secure boot flow, where each stage sets the binding used for the next verified stage before advancing to it.
 In order to save on storage and not have a duplicate copy per stage, the software binding registers {{< regref SOFTWARE_BINDING >}} are shared between key manager stages.

--- a/hw/ip/keymgr/rtl/keymgr_input_checks.sv
+++ b/hw/ip/keymgr/rtl/keymgr_input_checks.sv
@@ -11,16 +11,44 @@
 module keymgr_input_checks import keymgr_pkg::*;(
   input [2**StageWidth-1:0][31:0] max_key_versions_i,
   input keymgr_stage_e stage_sel_i,
+  input hw_key_req_t key_i,
   input [31:0] key_version_i,
-  output logic key_version_good_o
+  input [KeyWidth-1:0] creator_seed_i,
+  input [KeyWidth-1:0] owner_seed_i,
+  input [DevIdWidth-1:0] devid_i,
+  input [HealthStateWidth-1:0] health_state_i,
+  output logic creator_seed_vld_o,
+  output logic owner_seed_vld_o,
+  output logic devid_vld_o,
+  output logic health_state_vld_o,
+  output logic key_version_vld_o,
+  output logic key_vld_o
 );
 
   logic [31:0] cur_max_key_version;
   assign cur_max_key_version = max_key_versions_i[stage_sel_i];
 
   // key version must be smaller than or equal to max version
-  assign key_version_good_o = key_version_i <= cur_max_key_version;
+  assign key_version_vld_o = key_version_i <= cur_max_key_version;
 
+  // general data check
+  assign creator_seed_vld_o = valid_chk(MaxWidth'(creator_seed_i));
+  assign owner_seed_vld_o = valid_chk(MaxWidth'(owner_seed_i));
+  assign devid_vld_o = valid_chk(MaxWidth'(devid_i));
+  assign health_state_vld_o = valid_chk(MaxWidth'(health_state_i));
+
+  // key check
+  logic unused_key_vld;
+  assign unused_key_vld = key_i.valid;
+  assign key_vld_o = valid_chk(MaxWidth'(key_i.key_share0)) &
+                     valid_chk(MaxWidth'(key_i.key_share1));
+
+  // checks for all 0's or all 1's of value
+  function automatic logic valid_chk (logic [MaxWidth-1:0] value);
+
+    return |value & ~&value;
+
+  endfunction // valid_chk
 
 
 endmodule // keymgr_input_checks

--- a/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
+++ b/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
@@ -15,7 +15,7 @@ module keymgr_kmac_if import keymgr_pkg::*;(
   input [AdvDataWidth-1:0] adv_data_i,
   input [IdDataWidth-1:0] id_data_i,
   input [GenDataWidth-1:0] gen_data_i,
-  input [3:0] inputs_invalid_i, // probably should break down into categories later
+  input [3:0] inputs_invalid_i,
   output logic inputs_invalid_o,
 
   // keymgr control to select appropriate inputs

--- a/hw/ip/keymgr/rtl/keymgr_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_pkg.sv
@@ -18,6 +18,7 @@ package keymgr_pkg;
   // These should be defined in another module's package
   parameter int HealthStateWidth = 128;
   parameter int DevIdWidth = 256;
+  parameter int MaxWidth = 256;
 
   // Default seeds
   // These are generated using random.org byte dumper

--- a/hw/ip/keymgr/rtl/keymgr_sideload_key.sv
+++ b/hw/ip/keymgr/rtl/keymgr_sideload_key.sv
@@ -10,6 +10,7 @@ module keymgr_sideload_key import keymgr_pkg::*;(
   input clk_i,
   input rst_ni,
   input en_i,
+  input set_en_i,
   input set_i,
   input clr_i,
   input [31:0] entropy_i,
@@ -42,7 +43,9 @@ module keymgr_sideload_key import keymgr_pkg::*;(
         key_q[i] <= {EntropyCopies{entropy_i}};
       end
     end else if (set_i) begin
-      key_q <= key_i;
+      for (int i = 0; i < Shares; i++) begin
+        key_q[i] <= set_en_i ? key_i[i] : {EntropyCopies{entropy_i}};
+      end
     end
   end
 


### PR DESCRIPTION
- Add additional data checks.
   - For advance calls, all hardware supplied data are checked for all 0's and all 1's
   - Keys are always checked for all 0's and all 1's
- De-couple internal key-state from sideload key
   - Do not overwrite sideload key with internal key, instead mux them out
- Split sideload / sw key update into two control signals
   - Control signals are generated using different control paths