### PR TITLE
[aes] Add support for multi-cycle S-Box implementations

### DIFF
--- a/hw/ip/aes/rtl/aes_sbox.sv
+++ b/hw/ip/aes/rtl/aes_sbox.sv
@@ -8,6 +8,11 @@ module aes_sbox import aes_pkg::*;
 #(
   parameter sbox_impl_e SBoxImpl = SBoxImplLut
 ) (
+  input  logic                    clk_i,
+  input  logic                    rst_ni,
+  input  logic                    en_i,
+  output logic                    out_req_o,
+  input  logic                    out_ack_i,
   input  ciph_op_e                op_i,
   input  logic              [7:0] data_i,
   input  logic              [7:0] in_mask_i,
@@ -20,10 +25,16 @@ module aes_sbox import aes_pkg::*;
   localparam bit SBoxMasked = (SBoxImpl == SBoxImplCanrightMasked ||
                                SBoxImpl == SBoxImplCanrightMaskedNoreuse) ? 1'b1 : 1'b0;
 
+  localparam bit SBoxSingleCycle = 1'b1;
+
   if (!SBoxMasked) begin : gen_sbox_unmasked
-    // Tie off unused mask and PRD inputs.
+    // Tie off unused inputs.
+    logic                    unused_clk;
+    logic                    unused_rst;
     logic             [15:0] unused_masks;
     logic [WidthPRDSBox-1:0] unused_prd;
+    assign unused_clk   = clk_i;
+    assign unused_rst   = rst_ni;
     assign unused_masks = {in_mask_i, out_mask_i};
     assign unused_prd   = prd_masking_i;
 
@@ -43,6 +54,12 @@ module aes_sbox import aes_pkg::*;
   end else begin : gen_sbox_masked
 
     if (SBoxImpl == SBoxImplCanrightMaskedNoreuse) begin : gen_sbox_canright_masked_noreuse
+      // Tie off unused inputs.
+      logic unused_clk;
+      logic unused_rst;
+      assign unused_clk = clk_i;
+      assign unused_rst = rst_ni;
+
       aes_sbox_canright_masked_noreuse u_aes_sbox (
         .op_i,
         .data_i,
@@ -52,8 +69,12 @@ module aes_sbox import aes_pkg::*;
         .data_o
       );
     end else begin : gen_sbox_canright_masked // SBoxImpl == SBoxImplCanrightMasked
-      // Tie of unused PRD inputs.
+      // Tie off unused inputs.
+      logic                    unused_clk;
+      logic                    unused_rst;
       logic [WidthPRDSBox-1:0] unused_prd;
+      assign unused_clk = clk_i;
+      assign unused_rst = rst_ni;
       assign unused_prd = prd_masking_i;
 
       aes_sbox_canright_masked u_aes_sbox (
@@ -64,6 +85,34 @@ module aes_sbox import aes_pkg::*;
         .data_o
       );
     end
+  end
+
+  if (SBoxSingleCycle) begin : gen_req_singlecycle
+    // Tie off unused inputs.
+    logic unused_out_ack;
+    assign unused_out_ack = out_ack_i;
+
+    // Signal that we have valid output right away.
+    assign out_req_o = en_i;
+  end else begin : gen_req_multicycle
+
+    // All currently implemented S-Boxes allow for single-cycle operation. Future S-Box
+    // implementations may require multiple clock cycles. The counter below is for mimicking such
+    // implementations. It's for testing purposes only.
+
+    // Counter register
+    logic [2:0] count_d, count_q;
+    assign count_d = (out_req_o && out_ack_i) ? '0                :
+                     out_req_o                ? count_q           :
+                     en_i                     ? count_q + 3'b001 : count_q;
+    always_ff @(posedge clk_i or negedge rst_ni) begin : reg_count
+      if (!rst_ni) begin
+        count_q <= '0;
+      end else begin
+        count_q <= count_d;
+      end
+    end
+    assign out_req_o = en_i & count_q == 3'b111;
   end
 
 endmodule

--- a/hw/ip/aes/rtl/aes_sub_bytes.sv
+++ b/hw/ip/aes/rtl/aes_sub_bytes.sv
@@ -8,6 +8,11 @@ module aes_sub_bytes import aes_pkg::*;
 #(
   parameter sbox_impl_e SBoxImpl = SBoxImplLut
 ) (
+  input  logic                              clk_i,
+  input  logic                              rst_ni,
+  input  logic                              en_i,
+  output logic                              out_req_o,
+  input  logic                              out_ack_i,
   input  ciph_op_e                          op_i,
   input  logic              [3:0][3:0][7:0] data_i,
   input  logic              [3:0][3:0][7:0] in_mask_i,
@@ -16,12 +21,22 @@ module aes_sub_bytes import aes_pkg::*;
   output logic              [3:0][3:0][7:0] data_o
 );
 
-  // Individually substitute bytes
+  logic [3:0][3:0] out_req;
+
+  // Collect REQ signals.
+  assign out_req_o = &out_req;
+
+  // Individually substitute bytes.
   for (genvar j = 0; j < 4; j++) begin : gen_sbox_j
     for (genvar i = 0; i < 4; i++) begin : gen_sbox_i
       aes_sbox #(
         .SBoxImpl ( SBoxImpl )
       ) u_aes_sbox_ij (
+        .clk_i         ( clk_i               ),
+        .rst_ni        ( rst_ni              ),
+        .en_i          ( en_i                ),
+        .out_req_o     ( out_req[i][j]       ),
+        .out_ack_i     ( out_ack_i           ),
         .op_i          ( op_i                ),
         .data_i        ( data_i[i][j]        ),
         .in_mask_i     ( in_mask_i[i][j]     ),


### PR DESCRIPTION
This PR lays the ground work for multi-cycle S-Boxes required for SCA hardening.

This is achieved by adding input enable signals as well as output req/ack handshake signals between the cipher core controller and the SubBytes and KeyExpand blocks (both contain several S-Boxes). For the currently implemented single-cycle S-Boxes nothing changes, the newly added signals have static values in this case.

Note: this PR contains quite some whitespace changes. For the review, I recommend to hide these in the GitHub interface.