### PR TITLE
[aes] Add SVAs to check correct extraction of the masking PRNG output

### DIFF
--- a/hw/ip/aes/rtl/aes_cipher_core.sv
+++ b/hw/ip/aes/rtl/aes_cipher_core.sv
@@ -495,4 +495,14 @@ module aes_cipher_core import aes_pkg::*;
   `ASSERT_KNOWN(AesKeyWordsSelKnown, key_words_sel)
   `ASSERT_KNOWN(AesRoundKeySelKnown, round_key_sel)
 
+  // Make sure the output of the masking PRNG is properly extracted without creating overlaps
+  // of masks and PRD distributed to the individual S-Boxes.
+  logic [WidthPRDMasking-1:0] unused_prd_masking;
+  for (genvar i = 0; i < 4; i++) begin : gen_unused_prd_masking
+    assign unused_prd_masking[i * WidthPRDRow +: WidthPRDRow] =
+        aes_sb_out_mask_prd_concat(sb_out_mask[i], prd_sub_bytes[i]);
+  end
+  assign unused_prd_masking[WidthPRDMasking-1 -: WidthPRDKey] = prd_key_expand;
+  `ASSERT(AesMskgPrdExtraction, prd_masking == unused_prd_masking)
+
 endmodule

--- a/hw/ip/aes/rtl/aes_key_expand.sv
+++ b/hw/ip/aes/rtl/aes_key_expand.sv
@@ -390,4 +390,10 @@ module aes_key_expand import aes_pkg::*;
       AES_256
       })
 
+  // Make sure the output of the masking PRNG is properly extracted without creating overlaps
+  // of masks and PRD distributed to the individual S-Boxes.
+  logic [WidthPRDKey-1:0] unused_prd_masking;
+  assign unused_prd_masking = aes_sb_out_mask_prd_concat(sw_out_mask, sw_prd);
+  `ASSERT(AesMskgPrdExtraction, prd_masking_i == unused_prd_masking)
+
 endmodule

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -252,6 +252,10 @@ function automatic logic [7:0] aes_mvm(
   return vec_c;
 endfunction
 
+// Functions for extracting  SubBytes output masks and additional pseudo-random data (PRD) from the
+// output of the masking PRNG on a row basis. We have:
+// prng_output = { prd_key_expand, ... , sb_prd[4], sb_out_mask[4], sb_prd[0], sb_out_mask[0] }
+
 // Extract one row of output masks for SubBytes from PRNG output. The output mask is in the LSBs of
 // each segment.
 function automatic logic [3:0][7:0] aes_sb_out_mask_get(logic [4*(8+WidthPRDSBox)-1:0] in);
@@ -269,6 +273,20 @@ function automatic logic [3:0][WidthPRDSBox-1:0] aes_sb_prd_get(logic [4*(8+Widt
     sb_prd[i] = in[i*(8+WidthPRDSBox)+8 +: WidthPRDSBox];
   end
   return sb_prd;
+endfunction
+
+// Undo extraction of output masks and PRD for SubBytes for one row. This can be used to verify
+// proper extraction (no overlap of masks and PRD, no unused PRNG output).
+function automatic logic [4*(8+WidthPRDSBox)-1:0] aes_sb_out_mask_prd_concat(
+  logic              [3:0][7:0] sb_out_mask,
+  logic [3:0][WidthPRDSBox-1:0] sb_prd
+);
+  logic [4*(8+WidthPRDSBox)-1:0] sb_out_mask_prd;
+  for (int i=0; i<4; i++) begin
+    sb_out_mask_prd[i*(8+WidthPRDSBox)   +: 8]            = sb_out_mask[i];
+    sb_out_mask_prd[i*(8+WidthPRDSBox)+8 +: WidthPRDSBox] = sb_prd[i];
+  end
+  return sb_out_mask_prd;
 endfunction
 
 endpackage


### PR DESCRIPTION
The output masks and further pseudo-random data (PRD) for the individual S-Boxes is extracted from the PRNG output. If this extraction is not done correctly, multiple S-Boxes might use the same output masks or PRD which could be exploited during SCA.

This PR adds a check for that by repacking the output masks and PRD and comparing that with the original PRNG output during simulation.

This is related to https://github.com/lowRISC/opentitan/pull/4185#discussion_r538752905 .