### PR TITLE
[lc_ctrl] Reduce number of diversification groups to 3

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -28,31 +28,19 @@
 
   param_list: [
     // Random netlist constants
-    { name:      "RndCnstLcKeymgrDivInv",
+    { name:      "RndCnstLcKeymgrDivInvalid",
       desc:      "Compile-time random bits for lc state group diversification value",
       type:      "lc_ctrl_pkg::lc_keymgr_div_t",
       randcount: "64",
       randtype:  "data",
     }
-    { name:      "RndCnstLcKeymgrDivTest",
+    { name:      "RndCnstLcKeymgrDivTestDevRma",
       desc:      "Compile-time random bits for lc state group diversification value",
       type:      "lc_ctrl_pkg::lc_keymgr_div_t",
       randcount: "64",
       randtype:  "data",
     }
-    { name:      "RndCnstLcKeymgrDivProd",
-      desc:      "Compile-time random bits for lc state group diversification value",
-      type:      "lc_ctrl_pkg::lc_keymgr_div_t",
-      randcount: "64",
-      randtype:  "data",
-    }
-    { name:      "RndCnstLcKeymgrDivDev",
-      desc:      "Compile-time random bits for lc state group diversification value",
-      type:      "lc_ctrl_pkg::lc_keymgr_div_t",
-      randcount: "64",
-      randtype:  "data",
-    }
-    { name:      "RndCnstLcKeymgrDivRma",
+    { name:      "RndCnstLcKeymgrDivProduction",
       desc:      "Compile-time random bits for lc state group diversification value",
       type:      "lc_ctrl_pkg::lc_keymgr_div_t",
       randcount: "64",

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -16,11 +16,9 @@ module lc_ctrl
   // Idcode value for the JTAG.
   parameter logic [31:0]          IdcodeValue  = 32'h00000001,
   // Random netlist constants
-  parameter lc_keymgr_div_t RndCnstLcKeymgrDivInv  = LcKeymgrDivWidth'(0),
-  parameter lc_keymgr_div_t RndCnstLcKeymgrDivTest = LcKeymgrDivWidth'(1),
-  parameter lc_keymgr_div_t RndCnstLcKeymgrDivProd = LcKeymgrDivWidth'(2),
-  parameter lc_keymgr_div_t RndCnstLcKeymgrDivDev  = LcKeymgrDivWidth'(3),
-  parameter lc_keymgr_div_t RndCnstLcKeymgrDivRma  = LcKeymgrDivWidth'(4)
+  parameter lc_keymgr_div_t RndCnstLcKeymgrDivInvalid    = LcKeymgrDivWidth'(0),
+  parameter lc_keymgr_div_t RndCnstLcKeymgrDivTestDevRma = LcKeymgrDivWidth'(1),
+  parameter lc_keymgr_div_t RndCnstLcKeymgrDivProduction = LcKeymgrDivWidth'(2)
 ) (
   input                                              clk_i,
   input                                              rst_ni,
@@ -464,11 +462,9 @@ module lc_ctrl
   assign lc_flash_rma_seed_o = transition_token_q[RmaSeedWidth-1:0];
 
   lc_ctrl_fsm #(
-    .RndCnstLcKeymgrDivInv  ( RndCnstLcKeymgrDivInv  ),
-    .RndCnstLcKeymgrDivTest ( RndCnstLcKeymgrDivTest ),
-    .RndCnstLcKeymgrDivProd ( RndCnstLcKeymgrDivProd ),
-    .RndCnstLcKeymgrDivDev  ( RndCnstLcKeymgrDivDev  ),
-    .RndCnstLcKeymgrDivRma  ( RndCnstLcKeymgrDivRma  )
+    .RndCnstLcKeymgrDivInvalid    ( RndCnstLcKeymgrDivInvalid    ),
+    .RndCnstLcKeymgrDivTestDevRma ( RndCnstLcKeymgrDivTestDevRma ),
+    .RndCnstLcKeymgrDivProduction ( RndCnstLcKeymgrDivProduction )
   ) u_lc_ctrl_fsm (
     .clk_i,
     .rst_ni,

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
@@ -7,11 +7,9 @@
 module lc_ctrl_fsm
   import lc_ctrl_pkg::*;
 #(// Random netlist constants
-  parameter lc_keymgr_div_t RndCnstLcKeymgrDivInv  = LcKeymgrDivWidth'(0),
-  parameter lc_keymgr_div_t RndCnstLcKeymgrDivTest = LcKeymgrDivWidth'(1),
-  parameter lc_keymgr_div_t RndCnstLcKeymgrDivProd = LcKeymgrDivWidth'(2),
-  parameter lc_keymgr_div_t RndCnstLcKeymgrDivDev  = LcKeymgrDivWidth'(3),
-  parameter lc_keymgr_div_t RndCnstLcKeymgrDivRma  = LcKeymgrDivWidth'(4)
+  parameter lc_keymgr_div_t RndCnstLcKeymgrDivInvalid    = LcKeymgrDivWidth'(0),
+  parameter lc_keymgr_div_t RndCnstLcKeymgrDivTestDevRma = LcKeymgrDivWidth'(1),
+  parameter lc_keymgr_div_t RndCnstLcKeymgrDivProduction = LcKeymgrDivWidth'(2)
 ) (
   // This module is combinational, but we
   // need the clock and reset for the assertions.
@@ -423,11 +421,9 @@ module lc_ctrl_fsm
 
   // LC signal decoder and broadcasting logic.
   lc_ctrl_signal_decode #(
-    .RndCnstLcKeymgrDivInv  ( RndCnstLcKeymgrDivInv  ),
-    .RndCnstLcKeymgrDivTest ( RndCnstLcKeymgrDivTest ),
-    .RndCnstLcKeymgrDivProd ( RndCnstLcKeymgrDivProd ),
-    .RndCnstLcKeymgrDivDev  ( RndCnstLcKeymgrDivDev  ),
-    .RndCnstLcKeymgrDivRma  ( RndCnstLcKeymgrDivRma  )
+    .RndCnstLcKeymgrDivInvalid    ( RndCnstLcKeymgrDivInvalid    ),
+    .RndCnstLcKeymgrDivTestDevRma ( RndCnstLcKeymgrDivTestDevRma ),
+    .RndCnstLcKeymgrDivProduction ( RndCnstLcKeymgrDivProduction )
   ) u_lc_ctrl_signal_decode (
     .clk_i,
     .rst_ni,

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_signal_decode.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_signal_decode.sv
@@ -9,16 +9,12 @@ module lc_ctrl_signal_decode
 #(
   // Random netlist constants
   // SCRAP, RAW, TEST_LOCKED*, INVALID
-  parameter lc_keymgr_div_t RndCnstLcKeymgrDivInv  = LcKeymgrDivWidth'(0),
-  // TEST_UNLOCKED*
-  parameter lc_keymgr_div_t RndCnstLcKeymgrDivTest = LcKeymgrDivWidth'(1),
+  parameter lc_keymgr_div_t RndCnstLcKeymgrDivInvalid    = LcKeymgrDivWidth'(0),
+  // TEST_UNLOCKED*, DEV, RMA
+  parameter lc_keymgr_div_t RndCnstLcKeymgrDivTestDevRma = LcKeymgrDivWidth'(1),
   // PROD, PROD_END
-  parameter lc_keymgr_div_t RndCnstLcKeymgrDivProd = LcKeymgrDivWidth'(2),
-  // DEV
-  parameter lc_keymgr_div_t RndCnstLcKeymgrDivDev  = LcKeymgrDivWidth'(3),
-  // RMA
-  parameter lc_keymgr_div_t RndCnstLcKeymgrDivRma  = LcKeymgrDivWidth'(4)
-) (
+  parameter lc_keymgr_div_t RndCnstLcKeymgrDivProduction = LcKeymgrDivWidth'(2)
+  ) (
   input                  clk_i,
   input                  rst_ni,
   // Life cycle state vector.
@@ -69,7 +65,7 @@ module lc_ctrl_signal_decode
     lc_keymgr_en_d       = Off;
     lc_escalate_en_d     = Off;
     // Set to invalid diversification value by default.
-    lc_keymgr_div_d      = RndCnstLcKeymgrDivInv;
+    lc_keymgr_div_d      = RndCnstLcKeymgrDivInvalid;
     // The escalation life cycle signal is always decoded, no matter
     // which state we currently are in.
     if (esc_wipe_secrets_i) begin
@@ -98,7 +94,7 @@ module lc_ctrl_signal_decode
           lc_nvm_debug_en_d = On;
           lc_hw_debug_en_d  = On;
           lc_cpu_en_d       = On;
-          lc_keymgr_div_d   = RndCnstLcKeymgrDivTest;
+          lc_keymgr_div_d      = RndCnstLcKeymgrDivTestDevRma;
           lc_iso_flash_wr_en_d = On;
         end
         ///////////////////////////////////////////////////////////////////
@@ -107,7 +103,7 @@ module lc_ctrl_signal_decode
           lc_cpu_en_d          = On;
           lc_keymgr_en_d       = On;
           lc_provision_rd_en_d = On;
-          lc_keymgr_div_d      = RndCnstLcKeymgrDivProd;
+          lc_keymgr_div_d      = RndCnstLcKeymgrDivProduction;
           // Only allow provisioning if the defice has not yet been personalized.
           if (lc_id_state_i == LcIdBlank) begin
             lc_provision_wr_en_d = On;
@@ -120,7 +116,7 @@ module lc_ctrl_signal_decode
           lc_cpu_en_d          = On;
           lc_keymgr_en_d       = On;
           lc_provision_rd_en_d = On;
-          lc_keymgr_div_d      = RndCnstLcKeymgrDivDev;
+          lc_keymgr_div_d      = RndCnstLcKeymgrDivTestDevRma;
           // Only allow provisioning if the defice has not yet been personalized.
           if (lc_id_state_i == LcIdBlank) begin
             lc_provision_wr_en_d = On;
@@ -135,7 +131,7 @@ module lc_ctrl_signal_decode
           lc_cpu_en_d          = On;
           lc_keymgr_en_d       = On;
           lc_provision_rd_en_d = On;
-          lc_keymgr_div_d      = RndCnstLcKeymgrDivRma;
+          lc_keymgr_div_d      = RndCnstLcKeymgrDivTestDevRma;
           // Only allow provisioning if the defice has not yet been personalized.
           if (lc_id_state_i == LcIdBlank) begin
             lc_provision_wr_en_d = On;
@@ -175,7 +171,7 @@ module lc_ctrl_signal_decode
       lc_iso_flash_wr_en_q <= Off;
       lc_keymgr_en_q       <= Off;
       lc_escalate_en_q     <= Off;
-      lc_keymgr_div_q      <= RndCnstLcKeymgrDivInv;
+      lc_keymgr_div_q      <= RndCnstLcKeymgrDivInvalid;
     end else begin
       lc_dft_en_q          <= lc_dft_en_d;
       lc_nvm_debug_en_q    <= lc_nvm_debug_en_d;
@@ -196,16 +192,10 @@ module lc_ctrl_signal_decode
 
   // Need to make sure that the random netlist constants
   // are unique.
-  `ASSERT_INIT(LcKeymgrDivUnique0_A, !(RndCnstLcKeymgrDivInv  inside {RndCnstLcKeymgrDivTest,
-                                                                      RndCnstLcKeymgrDivProd,
-                                                                      RndCnstLcKeymgrDivDev,
-                                                                      RndCnstLcKeymgrDivRma}))
-  `ASSERT_INIT(LcKeymgrDivUnique1_A, !(RndCnstLcKeymgrDivTest inside {RndCnstLcKeymgrDivProd,
-                                                                      RndCnstLcKeymgrDivDev,
-                                                                      RndCnstLcKeymgrDivRma}))
-  `ASSERT_INIT(LcKeymgrDivUnique2_A, !(RndCnstLcKeymgrDivProd inside {RndCnstLcKeymgrDivDev,
-                                                                      RndCnstLcKeymgrDivRma}))
-  `ASSERT_INIT(LcKeymgrDivUnique3_A, !(RndCnstLcKeymgrDivDev  inside {RndCnstLcKeymgrDivRma}))
+  `ASSERT_INIT(LcKeymgrDivUnique0_A,
+      !(RndCnstLcKeymgrDivInvalid inside {RndCnstLcKeymgrDivTestDevRma,
+                                          RndCnstLcKeymgrDivProduction}))
+  `ASSERT_INIT(LcKeymgrDivUnique1_A, RndCnstLcKeymgrDivProduction != RndCnstLcKeymgrDivTestDevRma)
 
   `ASSERT(SignalsAreOffWhenNotEnabled_A,
       !lc_state_valid_i
@@ -218,7 +208,7 @@ module lc_ctrl_signal_decode
       lc_provision_rd_en_o == Off &&
       lc_keymgr_en_o == Off &&
       lc_dft_en_o == Off &&
-      lc_keymgr_div_o == RndCnstLcKeymgrDivInv)
+      lc_keymgr_div_o == RndCnstLcKeymgrDivInvalid)
 
   `ASSERT(EscalationAlwaysDecoded_A,
       (lc_escalate_en_o == On) == $past(esc_wipe_secrets_i))


### PR DESCRIPTION
This further narrows the number of diversification groups from 5 to 3 as discussed in #4443.

Signed-off-by: Michael Schaffner <msf@opentitan.org>