### PR TITLE
[edn/dv] Add edn_pull agent in cip and add auto-gen script to config edn 

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -6,6 +6,7 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   // ext component cfgs
   rand tl_agent_cfg        m_tl_agent_cfg;
   rand alert_esc_agent_cfg m_alert_agent_cfg[string];
+  rand push_pull_agent_cfg#(.DeviceDataWidth(EDN_DATA_WIDTH)) m_edn_pull_agent_cfg;
 
   // common interfaces - intrrupts and alerts
   intr_vif    intr_vif;
@@ -15,6 +16,7 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   // TODO: enable random drive devmode once design supports
   bit  has_devmode = 1;
   bit  en_devmode = 1;
+  bit  has_edn = 0;
 
   uint num_interrupts;
 
@@ -43,7 +45,6 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
 
       foreach(list_of_alerts[i]) begin
         string alert_name = list_of_alerts[i];
-
         // create alert_esc_agent_cfg if the module has alerts
         m_alert_agent_cfg[alert_name] = alert_esc_agent_cfg::type_id::create("m_alert_agent_cfg");
         m_alert_agent_cfg[alert_name].if_mode = dv_utils_pkg::Device;
@@ -54,6 +55,13 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
           m_alert_agent_cfg[alert_name].alert_delay_max = 0;
         end
       end
+    end
+
+    if (has_edn) begin
+      m_edn_pull_agent_cfg = push_pull_agent_cfg#(.DeviceDataWidth(EDN_DATA_WIDTH))::type_id::
+                             create("m_edn_pull_agent_cfg");
+      m_edn_pull_agent_cfg.agent_type = PullAgent;
+      m_edn_pull_agent_cfg.if_mode    = Device;
     end
   endfunction
 

--- a/hw/dv/sv/cip_lib/cip_base_pkg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_pkg.sv
@@ -12,6 +12,7 @@ package cip_base_pkg;
   import dv_base_reg_pkg::*;
   import tl_agent_pkg::*;
   import alert_esc_agent_pkg::*;
+  import push_pull_agent_pkg::*;
   import mem_model_pkg::*;
 
   // macro includes
@@ -20,6 +21,7 @@ package cip_base_pkg;
 
   // package variables
   string msg_id = "cip_base_pkg";
+  parameter uint EDN_DATA_WIDTH = 33; // 32 bits data, 1 bit fips
 
   typedef enum {
     err_update,

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -15,6 +15,9 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   // Alert_fifo to notify scb if DUT sends an alert
   uvm_tlm_analysis_fifo #(alert_esc_seq_item) alert_fifos[string];
 
+  // EDN fifo
+  uvm_tlm_analysis_fifo #(push_pull_item#(.DeviceDataWidth(EDN_DATA_WIDTH))) edn_fifo;
+
   mem_model#() exp_mem;
 
   `uvm_component_new
@@ -27,6 +30,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
       string alert_name = cfg.list_of_alerts[i];
       alert_fifos[alert_name] = new($sformatf("alert_fifo[%s]", alert_name), this);
     end
+    if (cfg.has_edn) edn_fifo = new("edn_fifo", this);
     exp_mem = mem_model#()::type_id::create("exp_mem", this);
   endfunction
 

--- a/hw/dv/sv/cip_lib/cip_base_virtual_sequencer.sv
+++ b/hw/dv/sv/cip_lib/cip_base_virtual_sequencer.sv
@@ -9,6 +9,7 @@ class cip_base_virtual_sequencer #(type CFG_T = cip_base_env_cfg,
 
   tl_sequencer        tl_sequencer_h;
   alert_esc_sequencer alert_esc_sequencer_h[string];
+  push_pull_sequencer#(.DeviceDataWidth(EDN_DATA_WIDTH)) edn_pull_sequencer_h;
 
   `uvm_component_new
 

--- a/hw/dv/sv/cip_lib/cip_lib.core
+++ b/hw/dv/sv/cip_lib/cip_lib.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:dv:dv_lib
       - lowrisc:dv:tl_agent
       - lowrisc:dv:alert_esc_agent
+      - lowrisc:dv:push_pull_agent
       - lowrisc:dv:dv_base_reg
       - lowrisc:dv:mem_model
       - lowrisc:opentitan:bus_params_pkg

--- a/hw/ip/keymgr/dv/env/keymgr_env.core
+++ b/hw/ip/keymgr/dv/env/keymgr_env.core
@@ -9,7 +9,6 @@ filesets:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
-      - lowrisc:dv:push_pull_agent
       - lowrisc:dv:keymgr_kmac_agent
     files:
       - keymgr_if.sv

--- a/hw/ip/keymgr/dv/env/keymgr_env.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env.sv
@@ -13,7 +13,6 @@ class keymgr_env extends cip_base_env #(
   `uvm_component_new
 
   keymgr_kmac_agent m_keymgr_kmac_agent;
-  push_pull_agent#(.DeviceDataWidth(EDN_DATA_SIZE)) m_edn_pull_agent;
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
@@ -26,18 +25,10 @@ class keymgr_env extends cip_base_env #(
     if (!uvm_config_db#(keymgr_vif)::get(this, "", "keymgr_vif", cfg.keymgr_vif)) begin
       `uvm_fatal(`gfn, "failed to get keymgr_vif from uvm_config_db")
     end
-
-    // build edn-otp push agent
-    m_edn_pull_agent = push_pull_agent#(.DeviceDataWidth(EDN_DATA_SIZE))::type_id::create("m_edn_pull_agent",
-                                                                          this);
-    uvm_config_db#(push_pull_agent_cfg#(.DeviceDataWidth(EDN_DATA_SIZE)))::set(
-      this, "m_edn_pull_agent", "cfg", cfg.m_edn_pull_agent_cfg);
   endfunction
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
-    virtual_sequencer.edn_pull_sequencer_h = m_edn_pull_agent.sequencer;
-    m_edn_pull_agent.monitor.req_port.connect(scoreboard.edn_fifo.analysis_export);
   endfunction
 
 endclass

--- a/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
@@ -5,7 +5,6 @@
 class keymgr_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_reg_block));
 
   rand keymgr_kmac_agent_cfg m_keymgr_kmac_agent_cfg;
-  rand push_pull_agent_cfg#(.DeviceDataWidth(EDN_DATA_SIZE)) m_edn_pull_agent_cfg;
 
   // interface for input data from LC, OTP and flash
   keymgr_vif keymgr_vif;
@@ -17,14 +16,11 @@ class keymgr_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_reg_block));
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = keymgr_env_pkg::LIST_OF_ALERTS;
+    has_edn = 1;
     super.initialize(csr_base_addr);
 
     m_keymgr_kmac_agent_cfg = keymgr_kmac_agent_cfg::type_id::create("m_keymgr_kmac_agent_cfg");
     m_keymgr_kmac_agent_cfg.if_mode = dv_utils_pkg::Device;
-    m_edn_pull_agent_cfg = push_pull_agent_cfg#(.DeviceDataWidth(EDN_DATA_SIZE))::type_id::create
-                           ("m_edn_pull_agent_cfg");
-    m_edn_pull_agent_cfg.agent_type = PullAgent;
-    m_edn_pull_agent_cfg.if_mode    = Device;
 
     // set num_interrupts & num_alerts
     begin

--- a/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
@@ -11,7 +11,6 @@ package keymgr_env_pkg;
   import tl_agent_pkg::*;
   import cip_base_pkg::*;
   import csr_utils_pkg::*;
-  import push_pull_agent_pkg::*;
   import keymgr_ral_pkg::*;
   import keymgr_kmac_agent_pkg::*;
 
@@ -32,8 +31,6 @@ package keymgr_env_pkg;
       keymgr_pkg::StCreatorRootKey,
       keymgr_pkg::StOwnerIntKey,
       keymgr_pkg::StOwnerKey};
-
-  parameter uint EDN_DATA_SIZE = edn_pkg::ENDPOINT_BUS_WIDTH + 1;
 
   typedef virtual keymgr_if keymgr_vif;
   typedef enum {

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -12,7 +12,6 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
   // local variables
 
   // TLM agent fifos
-  uvm_tlm_analysis_fifo #(push_pull_item#(.DeviceDataWidth(EDN_DATA_SIZE))) edn_fifo;
 
   // local queues to hold incoming packets pending comparison
 
@@ -20,7 +19,6 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    edn_fifo = new("edn_fifo", this);
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/keymgr/dv/env/keymgr_virtual_sequencer.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_virtual_sequencer.sv
@@ -10,6 +10,5 @@ class keymgr_virtual_sequencer extends cip_base_virtual_sequencer #(
 
 
   `uvm_component_new
-  push_pull_sequencer#(.DeviceDataWidth(EDN_DATA_SIZE)) edn_pull_sequencer_h;
 
 endclass

--- a/hw/ip/keymgr/dv/tb.sv
+++ b/hw/ip/keymgr/dv/tb.sv
@@ -8,7 +8,6 @@ module tb;
   import dv_utils_pkg::*;
   import keymgr_env_pkg::*;
   import keymgr_test_pkg::*;
-  import push_pull_agent_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -25,7 +24,7 @@ module tb;
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   keymgr_if keymgr_if(.clk(clk), .rst_n(rst_n));
   keymgr_kmac_intf keymgr_kmac_intf(.clk(clk), .rst_n(rst_n));
-  push_pull_if #(.DeviceDataWidth(EDN_DATA_SIZE)) edn_if(.clk(clk), .rst_n(rst_n));
+  push_pull_if #(.DeviceDataWidth(cip_base_pkg::EDN_DATA_WIDTH)) edn_if(.clk(clk), .rst_n(rst_n));
 
   `DV_ALERT_IF_CONNECT
 
@@ -65,8 +64,8 @@ module tb;
     uvm_config_db#(virtual keymgr_if)::set(null, "*.env", "keymgr_vif", keymgr_if);
     uvm_config_db#(virtual keymgr_kmac_intf)::set(null,
                    "*env.m_keymgr_kmac_agent*", "vif", keymgr_kmac_intf);
-    uvm_config_db#(virtual push_pull_if#(.DeviceDataWidth(EDN_DATA_SIZE)))::set(null,
-                   "*env.m_edn_pull_agent*", "vif", edn_if);
+    uvm_config_db#(virtual push_pull_if#(.DeviceDataWidth(cip_base_pkg::EDN_DATA_WIDTH)))::set
+                   (null, "*env.m_edn_pull_agent*", "vif", edn_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -10,7 +10,6 @@ filesets:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
       - lowrisc:dv:mem_bkdr_if
-      - lowrisc:dv:push_pull_agent
       - lowrisc:dv:crypto_dpi_present
     files:
       - otp_ctrl_env_pkg.sv

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
@@ -16,7 +16,6 @@ class otp_ctrl_env extends cip_base_env #(
   push_pull_agent#(.DeviceDataWidth(OTBN_DATA_SIZE))  m_otbn_pull_agent;
   push_pull_agent#(.DeviceDataWidth(FLASH_DATA_SIZE)) m_flash_addr_pull_agent;
   push_pull_agent#(.DeviceDataWidth(FLASH_DATA_SIZE)) m_flash_data_pull_agent;
-  push_pull_agent#(.DeviceDataWidth(EDN_DATA_SIZE))   m_edn_pull_agent;
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
@@ -45,12 +44,6 @@ class otp_ctrl_env extends cip_base_env #(
         "m_flash_data_pull_agent", this);
     uvm_config_db#(push_pull_agent_cfg#(.DeviceDataWidth(FLASH_DATA_SIZE)))::set(this, "m_flash_data_pull_agent",
         "cfg", cfg.m_flash_data_pull_agent_cfg);
-
-    // build edn-otp push agent
-    m_edn_pull_agent = push_pull_agent#(.DeviceDataWidth(EDN_DATA_SIZE))::type_id::create("m_edn_pull_agent",
-                                                                          this);
-    uvm_config_db#(push_pull_agent_cfg#(.DeviceDataWidth(EDN_DATA_SIZE)))::set(
-      this, "m_edn_pull_agent", "cfg", cfg.m_edn_pull_agent_cfg);
 
     // config power manager pin
     if (!uvm_config_db#(pwr_otp_vif)::get(this, "", "pwr_otp_vif", cfg.pwr_otp_vif)) begin
@@ -92,12 +85,10 @@ class otp_ctrl_env extends cip_base_env #(
     virtual_sequencer.otbn_pull_sequencer_h       = m_otbn_pull_agent.sequencer;
     virtual_sequencer.flash_addr_pull_sequencer_h = m_flash_addr_pull_agent.sequencer;
     virtual_sequencer.flash_data_pull_sequencer_h = m_flash_data_pull_agent.sequencer;
-    virtual_sequencer.edn_pull_sequencer_h        = m_edn_pull_agent.sequencer;
     if (cfg.en_scb) begin
       m_otbn_pull_agent.monitor.req_port.connect(scoreboard.otbn_fifo.analysis_export);
       m_flash_addr_pull_agent.monitor.req_port.connect(scoreboard.flash_addr_fifo.analysis_export);
       m_flash_data_pull_agent.monitor.req_port.connect(scoreboard.flash_data_fifo.analysis_export);
-      m_edn_pull_agent.monitor.req_port.connect(scoreboard.edn_fifo.analysis_export);
     end
   endfunction
 

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -9,7 +9,6 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
   rand push_pull_agent_cfg#(.DeviceDataWidth(OTBN_DATA_SIZE))  m_otbn_pull_agent_cfg;
   rand push_pull_agent_cfg#(.DeviceDataWidth(FLASH_DATA_SIZE)) m_flash_data_pull_agent_cfg;
   rand push_pull_agent_cfg#(.DeviceDataWidth(FLASH_DATA_SIZE)) m_flash_addr_pull_agent_cfg;
-  rand push_pull_agent_cfg#(.DeviceDataWidth(EDN_DATA_SIZE))   m_edn_pull_agent_cfg;
 
   // ext interfaces
   pwr_otp_vif              pwr_otp_vif;
@@ -27,6 +26,7 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = otp_ctrl_env_pkg::LIST_OF_ALERTS;
+    has_edn = 1;
     super.initialize(csr_base_addr);
 
     // create push_pull agent config obj
@@ -46,12 +46,6 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
     m_flash_addr_pull_agent_cfg = push_pull_agent_cfg#(.DeviceDataWidth(FLASH_DATA_SIZE))::type_id::create
                                   ("m_flash_addr_pull_agent_cfg");
     m_flash_addr_pull_agent_cfg.agent_type = PullAgent;
-
-    m_edn_pull_agent_cfg = push_pull_agent_cfg#(.DeviceDataWidth(EDN_DATA_SIZE))::type_id::create
-                           ("m_edn_pull_agent_cfg");
-    m_edn_pull_agent_cfg.agent_type = PullAgent;
-    m_edn_pull_agent_cfg.if_mode    = Device;
-
 
     // set num_interrupts & num_alerts
     begin

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -67,8 +67,6 @@ package otp_ctrl_env_pkg;
   parameter uint OTBN_DATA_SIZE  = 1 + OtbnKeyWidth + OtbnNonceWidth;
   // flash rsp data has 1 bit for seed_valid, the rest are for key
   parameter uint FLASH_DATA_SIZE = 1 + FlashKeyWidth;
-  // edn rsp data are key width
-  parameter uint EDN_DATA_SIZE   = EdnDataWidth;
 
   // scramble related parameters
   parameter uint SCRAMBLE_DATA_SIZE = 64;

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -22,7 +22,6 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
   uvm_tlm_analysis_fifo #(push_pull_item#(.DeviceDataWidth(OTBN_DATA_SIZE)))  otbn_fifo;
   uvm_tlm_analysis_fifo #(push_pull_item#(.DeviceDataWidth(FLASH_DATA_SIZE))) flash_addr_fifo;
   uvm_tlm_analysis_fifo #(push_pull_item#(.DeviceDataWidth(FLASH_DATA_SIZE))) flash_data_fifo;
-  uvm_tlm_analysis_fifo #(push_pull_item#(.DeviceDataWidth(EDN_DATA_SIZE)))   edn_fifo;
 
   // local queues to hold incoming packets pending comparison
 
@@ -36,7 +35,6 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
     otbn_fifo       = new("otbn_fifo", this);
     flash_addr_fifo = new("flash_addr_fifo", this);
     flash_data_fifo = new("flash_data_fifo", this);
-    edn_fifo        = new("edn_fifo", this);
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_virtual_sequencer.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_virtual_sequencer.sv
@@ -14,5 +14,4 @@ class otp_ctrl_virtual_sequencer extends cip_base_virtual_sequencer #(
   push_pull_sequencer#(.DeviceDataWidth(OTBN_DATA_SIZE))  otbn_pull_sequencer_h;
   push_pull_sequencer#(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_data_pull_sequencer_h;
   push_pull_sequencer#(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_addr_pull_sequencer_h;
-  push_pull_sequencer#(.DeviceDataWidth(EDN_DATA_SIZE))   edn_pull_sequencer_h;
 endclass

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -8,7 +8,6 @@ module tb;
   import dv_utils_pkg::*;
   import otp_ctrl_env_pkg::*;
   import otp_ctrl_test_pkg::*;
-  import push_pull_agent_pkg::*;
   import otp_ctrl_reg_pkg::*;
   import lc_ctrl_pkg::*;
 
@@ -45,7 +44,8 @@ module tb;
   push_pull_if #(.DeviceDataWidth(OTBN_DATA_SIZE))  otbn_if(.clk(clk), .rst_n(rst_n));
   push_pull_if #(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_addr_if(.clk(clk), .rst_n(rst_n));
   push_pull_if #(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_data_if(.clk(clk), .rst_n(rst_n));
-  push_pull_if #(.DeviceDataWidth(EDN_DATA_SIZE))   edn_if(.clk(clk), .rst_n(rst_n));
+  push_pull_if #(.DeviceDataWidth(cip_base_pkg::EDN_DATA_WIDTH)) edn_if(.clk(clk), .rst_n(rst_n));
+  wire [30:0] edn_extra_data = 0; // TODO: temp align, will remove once design update
 
   pins_if #(OtpPwrIfWidth) pwr_otp_if(pwr_otp);
   // TODO: use standard req/rsp agent
@@ -76,7 +76,8 @@ module tb;
     .otp_ast_pwr_seq_h_i       ('0),
     // edn
     .otp_edn_o                 (edn_if.req),
-    .otp_edn_i                 ({edn_if.ack, edn_if.d_data}),
+    // TODO: temp padding 0s, will update once design align with EDN
+    .otp_edn_i                 ({edn_if.ack, edn_extra_data, edn_if.d_data}),
     // pwrmgr
     .pwr_otp_i                 (pwr_otp[OtpPwrInitReq]),
     .pwr_otp_o                 (pwr_otp[OtpPwrDoneRsp:OtpPwrIdleRsp]),
@@ -143,8 +144,8 @@ module tb;
                    "*env.m_flash_data_pull_agent*", "vif", flash_data_if);
     uvm_config_db#(virtual push_pull_if#(.DeviceDataWidth(FLASH_DATA_SIZE)))::set(null,
                    "*env.m_flash_addr_pull_agent*", "vif", flash_addr_if);
-    uvm_config_db#(virtual push_pull_if#(.DeviceDataWidth(EDN_DATA_SIZE)))::set(null,
-                   "*env.m_edn_pull_agent*", "vif", edn_if);
+    uvm_config_db#(virtual push_pull_if#(.DeviceDataWidth(cip_base_pkg::EDN_DATA_WIDTH)))::set
+                  (null, "*env.m_edn_pull_agent*", "vif", edn_if);
 
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(pwr_otp_vif)::set(null, "*.env", "pwr_otp_vif", pwr_otp_if);

--- a/util/uvmdvgen/env_cfg.sv.tpl
+++ b/util/uvmdvgen/env_cfg.sv.tpl
@@ -27,6 +27,9 @@ class ${name}_env_cfg extends dv_base_env_cfg;
 % if has_alerts:
     list_of_alerts = ${name}_env_pkg::LIST_OF_ALERTS;
 % endif
+% if has_edn:
+    cfg.has_edn = 1;
+% endif
 % if has_ral:
     super.initialize(csr_base_addr);
 % endif

--- a/util/uvmdvgen/gen_env.py
+++ b/util/uvmdvgen/gen_env.py
@@ -12,8 +12,8 @@ from pkg_resources import resource_filename
 from uvmdvgen import VENDOR_DEFAULT
 
 
-def gen_env(name, is_cip, has_ral, has_interrupts, has_alerts, env_agents,
-            root_dir, vendor):
+def gen_env(name, is_cip, has_ral, has_interrupts, has_alerts, has_edn,
+            env_agents, root_dir, vendor):
     # yapf: disable
     # 4-tuple - sub-path, ip name, class name, file ext
     env_srcs = [('dv/env',          name + '_', 'env_cfg',            '.sv'),
@@ -79,6 +79,7 @@ def gen_env(name, is_cip, has_ral, has_interrupts, has_alerts, env_agents,
                                has_ral=has_ral,
                                has_interrupts=has_interrupts,
                                has_alerts=has_alerts,
+                               has_edn=has_edn,
                                env_agents=env_agents,
                                vendor=vendor))
             except Exception as e:

--- a/util/uvmdvgen/uvmdvgen.py
+++ b/util/uvmdvgen/uvmdvgen.py
@@ -75,6 +75,13 @@ def main():
         help="""CIP has alerts. Create alerts interface in tb""")
 
     parser.add_argument(
+        "-he",
+        "--has-edn",
+        default=False,
+        action='store_true',
+        help="""CIP has EDN connection. Create edn pull interface in tb""")
+
+    parser.add_argument(
         "-ea",
         "--env-agents",
         nargs="+",
@@ -134,8 +141,8 @@ def main():
         if not args.env_agents:
             args.env_agents = []
         gen_env.gen_env(args.name, args.is_cip, args.has_ral,
-                        args.has_interrupts, args.has_alerts, args.env_agents,
-                        args.env_outdir, args.vendor)
+                        args.has_interrupts, args.has_alerts, args.has_edn,
+                        args.env_agents, args.env_outdir, args.vendor)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR has two commits:
1. Add edn_pull_agent creation and configuration in `cip_lib`.
   This commit also remove the existing code in `keymgr` and `otp_ctrl`, and use the one in `cip_lib`.
   Note that current otp_ctrl design config the edn connection port with a different width (64 instead of 32). Since it is a low priority fix, DV temp patched it to avoid X prop.

2. Add a switch "has_edn" in uvmdvgen, to add configs in `tb.sv` and `IP_env_cfg.sv` to help config the edn_pull agent easily.