### PR TITLE
[otp] lci interface assertion related fix

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_lci.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_lci.sv
@@ -139,7 +139,6 @@ module otp_ctrl_lci
       // If the write data contains a 0 bit in a position where a bit has already been
       // programmed to 1 before, the OTP errors out.
       WriteSt: begin
-        // Check whether the OTP word is nonzero.
         otp_req_o = 1'b1;
         otp_cmd_o = OtpWrite;
         if (otp_gnt_i) begin
@@ -218,7 +217,7 @@ module otp_ctrl_lci
 
   logic [NumLcOtpWords-1:0][OtpWidth-1:0] data;
   assign data        = {lc_count_i, lc_state_i};
-  assign otp_wdata_o = OtpIfWidth'(data[cnt_q]);
+  assign otp_wdata_o = (otp_req_o) ? OtpIfWidth'(data[cnt_q]) : '0;
 
   logic unused_rdata;
   assign unused_rdata = ^otp_rdata_i;

--- a/hw/ip/prim_generic/rtl/prim_generic_otp.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_otp.sv
@@ -295,7 +295,7 @@ module prim_generic_otp #(
   );
 
   // Currently it is assumed that no wrap arounds can occur.
-  `ASSERT(NoWrapArounds_A, addr >= addr_q)
+  `ASSERT(NoWrapArounds_A, req |-> (addr >= addr_q))
 
   //////////
   // Regs //


### PR DESCRIPTION
As documented in PR #4488. Thanks Michael for pointing out the fix for the two
reported assertion issues:

1. Fix lci data known assertion error, by using a mux to select using
otp_lc_program_i data or using all 0s.
2. Fix prim_generic_otp wrap round assertions by gating it with `req`.

Signed-off-by: Cindy Chen <chencindy@google.com>