### PR TITLE
[Verilator] Revert recent changes that brake CI

### DIFF
--- a/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -49,9 +49,12 @@ void VerilatorSimCtrl::SetTop(VerilatedToplevel *top, CData *sig_clk,
 
 int VerilatorSimCtrl::Exec(int argc, char **argv) {
   bool exit_app = false;
-  bool good_cmdline = ParseCommandArgs(argc, argv, exit_app);
+  if (!ParseCommandArgs(argc, argv, exit_app)) {
+    return 1;
+  }
   if (exit_app) {
-    return good_cmdline ? 0 : 1;
+    // Successful exit requested by command argument parsing
+    return 0;
   }
 
   RunSimulation();
@@ -85,7 +88,6 @@ bool VerilatorSimCtrl::ParseCommandArgs(int argc, char **argv, bool &exit_app) {
         if (!tracing_possible_) {
           std::cerr << "ERROR: Tracing has not been enabled at compile time."
                     << std::endl;
-          exit_app = true;
           return false;
         }
         TraceOn();
@@ -99,7 +101,6 @@ bool VerilatorSimCtrl::ParseCommandArgs(int argc, char **argv, bool &exit_app) {
         break;
       case ':':  // missing argument
         std::cerr << "ERROR: Missing argument." << std::endl << std::endl;
-        exit_app = true;
         return false;
       case '?':
       default:;
@@ -114,7 +115,6 @@ bool VerilatorSimCtrl::ParseCommandArgs(int argc, char **argv, bool &exit_app) {
   // Parse arguments for all registered extensions
   for (auto it = extension_array_.begin(); it != extension_array_.end(); ++it) {
     if (!(*it)->ParseCLIArguments(argc, argv, exit_app)) {
-      exit_app = true;
       return false;
       if (exit_app) {
         return true;

--- a/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -47,17 +47,19 @@ void VerilatorSimCtrl::SetTop(VerilatedToplevel *top, CData *sig_clk,
   flags_ = flags;
 }
 
-std::pair<int, bool> VerilatorSimCtrl::Exec(int argc, char **argv) {
+int VerilatorSimCtrl::Exec(int argc, char **argv) {
   bool exit_app = false;
   bool good_cmdline = ParseCommandArgs(argc, argv, exit_app);
   if (exit_app) {
-    return std::make_pair(good_cmdline ? 0 : 1, false);
+    return good_cmdline ? 0 : 1;
   }
 
   RunSimulation();
 
-  int retcode = WasSimulationSuccessful() ? 0 : 1;
-  return std::make_pair(retcode, true);
+  if (!WasSimulationSuccessful()) {
+    return 1;
+  }
+  return 0;
 }
 
 bool VerilatorSimCtrl::ParseCommandArgs(int argc, char **argv, bool &exit_app) {

--- a/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.h
+++ b/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.h
@@ -49,11 +49,10 @@ class VerilatorSimCtrl {
    * 1. Parses a C-style set of command line arguments (see ParseCommandArgs())
    * 2. Runs the simulation (see RunSimulation())
    *
-   * @return a pair with main()-compatible process exit code (0 for success, 1
-   *         in case of an error) and a boolean flag telling the calling
-   *         function whether the simulation actually ran.
+   * @return a main()-compatible process exit code: 0 for success, 1 in case
+   *         of an error.
    */
-  std::pair<int, bool> Exec(int argc, char **argv);
+  int Exec(int argc, char **argv);
 
   /**
    * Parse command line arguments

--- a/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.h
+++ b/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.h
@@ -57,9 +57,7 @@ class VerilatorSimCtrl {
   /**
    * Parse command line arguments
    *
-   * Process all recognized command-line arguments from argc/argv. If a command
-   * line argument implies that we should exit immediately (like --help), sets
-   * exit_app. On failure, sets exit_app as well as returning false.
+   * Process all recognized command-line arguments from argc/argv.
    *
    * @param argc, argv Standard C command line arguments
    * @param exit_app Indicate that program should terminate

--- a/hw/ip/aes/pre_dv/aes_sbox_tb/cpp/aes_sbox_tb.cc
+++ b/hw/ip/aes/pre_dv/aes_sbox_tb/cpp/aes_sbox_tb.cc
@@ -2,14 +2,15 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "Vaes_sbox_tb.h"
+#include "verilated_toplevel.h"
+#include "verilator_sim_ctrl.h"
+
 #include <functional>
 #include <iostream>
 #include <signal.h>
 
-#include "Vaes_sbox_tb.h"
 #include "sim_ctrl_extension.h"
-#include "verilated_toplevel.h"
-#include "verilator_sim_ctrl.h"
 
 class AESSBoxTB : public SimCtrlExtension {
   using SimCtrlExtension::SimCtrlExtension;
@@ -54,7 +55,7 @@ int main(int argc, char **argv) {
             << std::endl;
 
   // Get pass / fail from Verilator
-  ret_code = simctrl.Exec(argc, argv).first;
+  ret_code = simctrl.Exec(argc, argv);
 
   return ret_code;
 }

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
@@ -131,11 +131,9 @@ int main(int argc, char **argv) {
             << "==================" << std::endl
             << std::endl;
 
-  auto pr = simctrl.Exec(argc, argv);
-  int ret_code = pr.first;
-  bool ran_simulation = pr.second;
+  int ret_code = simctrl.Exec(argc, argv);
 
-  if (ret_code != 0 || !ran_simulation) {
+  if (ret_code != 0) {
     return ret_code;
   }
 

--- a/hw/ip/prim/pre_dv/prim_sync_reqack/cpp/prim_sync_reqack_tb.cc
+++ b/hw/ip/prim/pre_dv/prim_sync_reqack/cpp/prim_sync_reqack_tb.cc
@@ -2,14 +2,15 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "Vprim_sync_reqack_tb.h"
+#include "verilated_toplevel.h"
+#include "verilator_sim_ctrl.h"
+
 #include <functional>
 #include <iostream>
 #include <signal.h>
 
-#include "Vprim_sync_reqack_tb.h"
 #include "sim_ctrl_extension.h"
-#include "verilated_toplevel.h"
-#include "verilator_sim_ctrl.h"
 
 class PrimSyncReqAckTB : public SimCtrlExtension {
   using SimCtrlExtension::SimCtrlExtension;
@@ -55,7 +56,7 @@ int main(int argc, char **argv) {
             << std::endl;
 
   // Get pass / fail from Verilator
-  ret_code = simctrl.Exec(argc, argv).first;
+  ret_code = simctrl.Exec(argc, argv);
 
   return ret_code;
 }

--- a/hw/top_earlgrey/top_earlgrey_verilator.cc
+++ b/hw/top_earlgrey/top_earlgrey_verilator.cc
@@ -37,5 +37,5 @@ int main(int argc, char **argv) {
             << "=================================" << std::endl
             << std::endl;
 
-  return simctrl.Exec(argc, argv).first;
+  return simctrl.Exec(argc, argv);
 }


### PR DESCRIPTION
This reverts commit 1d329c439f5584ce948152a969df7360426b83ed as it appears to break Verilator CI.