### PR TITLE
Revert "[otbn] Re-enable smoke test in CI"

### DIFF
--- a/test/systemtest/config.py
+++ b/test/systemtest/config.py
@@ -29,12 +29,13 @@ TEST_APPS_SELFCHECKING = [
         "binary_name": "dif_otbn_smoketest",
         "verilator_extra_args": ['+OTBN_USE_MODEL=0'],
     },
-    {
-        "name": "dif_otbn_smoketest_model",
-        "binary_name": "dif_otbn_smoketest",
-        "verilator_extra_args": ['+OTBN_USE_MODEL=1'],
-        "targets": ["sim_verilator"],
-    },
+# Using the model in CI isn't possible until #4097 is resolved.
+#    {
+#        "name": "dif_otbn_smoketest_model",
+#        "binary_name": "dif_otbn_smoketest",
+#        "verilator_extra_args": ['+OTBN_USE_MODEL=1'],
+#        "targets": ["sim_verilator"],
+#    },
     {
         "name": "dif_otp_ctrl_smoketest",
     },


### PR DESCRIPTION
This reverts commit 8438016. Unfortunately, the changes in commit
480c0deb0 (which passed CI before enabling the smoke test, but then
were merged afterwards) break things.

Let's disable the test for a bit: fixing it properly needs a couple of
patches to the ISS, which are pending but not yet merged.
