### PR TITLE
[otbn] Add support for loop error handling to ISS and document the loop instructions

### DIFF
--- a/hw/ip/otbn/data/base-insns.yml
+++ b/hw/ip/otbn/data/base-insns.yml
@@ -442,15 +442,19 @@
       type: uimm+1
       doc: Number of instructions in the loop body
   straight-line: false
-  note: &loop-note |
-    The LOOP and LOOPI instructions are under-specified, and improvements
-    to them are being discussed. See
-    https://github.com/lowRISC/opentitan/issues/2496 for up-to-date
-    information.
   doc: |
     Repeats a sequence of code multiple times. The number of iterations is
     read from `grs`, treated as an unsigned value. The number of
     instructions in the loop is given in the `bodysize` immediate.
+
+    The `LOOP` instruction doesn't support a zero iteration count.
+    If the value in `grs` is zero, OTBN stops with the `ErrCodeLoop` error.
+    Starting a loop pushes an entry on to the loop stack.
+    If the stack is already full, OTBN stops with the `ErrCodeLoop` error.
+
+    There are also conditions on the code inside a loop.
+    A `LOOP`, `LOOPI`, jump or branch instruction may not appear as the last instruction in a loop.
+    OTBN will stop on that instruction with the `ErrCodeLoop` error.
   encoding:
     scheme: loop
     mapping:
@@ -465,12 +469,18 @@
       doc: Number of iterations
     - *bodysize-operand
   straight-line: false
-  note: *loop-note
   doc: |
     Repeats a sequence of code multiple times. The `iterations`
     unsigned immediate operand gives the number of iterations and
     the `bodysize` unsigned immediate operand gives the number of
     instructions in the body.
+
+    Starting a loop pushes an entry on to the loop stack.
+    If the stack is already full, OTBN stops with the `ErrCodeLoop` error.
+
+    There are also conditions on the code inside a loop.
+    A `LOOP`, `LOOPI`, jump or branch instruction may not appear as the last instruction in a loop.
+    OTBN will stop on that instruction with the `ErrCodeLoop` error.
   encoding:
     scheme: loopi
     mapping:

--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -356,9 +356,10 @@ The `L`, `M`, and `Z` flags are determined based on the result of the operation 
 
 ### Loop Stack
 
-The LOOP instruction allows for nested loops; the active loops are stored on the loop stack.
-Each loop stack entry is a tuple of loop count, start address, and end address.
-The number of entries in the loop stack is implementation-dependent.
+OTBN has two instructions for hardware-assisted loops: [`LOOP`]({{< relref "hw/ip/otbn/doc/isa#loop" >}}) and [`LOOPI`]({{< relref "hw/ip/otbn/doc/isa#loopi" >}}).
+Both use the same state for tracking control flow.
+This is a stack of tuples containing a loop count, start address and end address.
+The stack has a maximum depth of eight and the top of the stack is the current loop.
 
 # Theory of Operations
 

--- a/hw/ip/otbn/dv/otbnsim/sim/alert.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/alert.py
@@ -4,11 +4,17 @@
 
 from typing import Optional
 
-# A copy of the list of error codes. This also appears in otbn.hjson and
+# A copy of the list of error codes. This also appears in the documentation and
 # otbn_pkg.sv: we should probably be generating them from the hjson every time.
-ERR_CODE_NO_ERROR = 0
-ERR_CODE_BAD_DATA_ADDR = 1
-ERR_CODE_CALL_STACK = 2
+ERR_CODE_NO_ERROR = 0x0
+ERR_CODE_BAD_DATA_ADDR = 0x1
+ERR_CODE_BAD_INSN_ADDR = 0x2
+ERR_CODE_CALL_STACK = 0x3
+ERR_CODE_ILLEGAL_INSN = 0x4
+ERR_CODE_LOOP = 0x5
+ERR_CODE_FATAL_IMEM = 0x80
+ERR_CODE_FATAL_DMEM = 0x81
+ERR_CODE_FATAL_REG = 0x82
 
 
 class Alert(Exception):
@@ -24,3 +30,15 @@ class Alert(Exception):
     def error_code(self) -> int:
         assert self.err_code is not None
         return self.err_code
+
+
+class LoopError(Alert):
+    '''Raised when doing something wrong with a LOOP/LOOPI'''
+
+    err_code = ERR_CODE_LOOP
+
+    def __init__(self, what: str):
+        self.what = what
+
+    def __str__(self) -> str:
+        return 'Loop error: {}'.format(self.what)

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -4,6 +4,7 @@
 
 from typing import Dict
 
+from .alert import LoopError
 from .flags import FlagReg
 from .isa import (OTBNInsn, RV32RegReg, RV32RegImm, RV32ImmShift,
                   insn_for_mnemonic, logical_byte_shift)
@@ -203,6 +204,7 @@ class SW(OTBNInsn):
 
 class BEQ(OTBNInsn):
     insn = insn_for_mnemonic('beq', 3)
+    affects_control = True
 
     def __init__(self, op_vals: Dict[str, int]):
         super().__init__(op_vals)
@@ -219,6 +221,7 @@ class BEQ(OTBNInsn):
 
 class BNE(OTBNInsn):
     insn = insn_for_mnemonic('bne', 3)
+    affects_control = True
 
     def __init__(self, op_vals: Dict[str, int]):
         super().__init__(op_vals)
@@ -235,6 +238,7 @@ class BNE(OTBNInsn):
 
 class JAL(OTBNInsn):
     insn = insn_for_mnemonic('jal', 2)
+    affects_control = True
 
     def __init__(self, op_vals: Dict[str, int]):
         super().__init__(op_vals)
@@ -249,6 +253,7 @@ class JAL(OTBNInsn):
 
 class JALR(OTBNInsn):
     insn = insn_for_mnemonic('jalr', 3)
+    affects_control = True
 
     def __init__(self, op_vals: Dict[str, int]):
         super().__init__(op_vals)
@@ -315,6 +320,7 @@ class ECALL(OTBNInsn):
 
 class LOOP(OTBNInsn):
     insn = insn_for_mnemonic('loop', 2)
+    affects_control = True
 
     def __init__(self, op_vals: Dict[str, int]):
         super().__init__(op_vals)
@@ -323,11 +329,16 @@ class LOOP(OTBNInsn):
 
     def execute(self, state: OTBNState) -> None:
         num_iters = state.gprs.get_reg(self.grs).read_unsigned()
+        if num_iters == 0:
+            raise LoopError('loop count in x{} was zero'
+                            .format(self.grs))
+
         state.loop_start(num_iters, self.bodysize)
 
 
 class LOOPI(OTBNInsn):
     insn = insn_for_mnemonic('loopi', 2)
+    affects_control = True
 
     def __init__(self, op_vals: Dict[str, int]):
         super().__init__(op_vals)

--- a/hw/ip/otbn/dv/otbnsim/sim/isa.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/isa.py
@@ -69,6 +69,11 @@ class OTBNInsn:
     # instruction.
     insn = DummyInsn()  # type: Insn
 
+    # A class variable that is set by Insn subclasses that represent
+    # instructions that affect control flow (and are not allowed at the end of
+    # a loop).
+    affects_control = False
+
     def __init__(self, op_vals: Dict[str, int]):
         self.op_vals = op_vals
 

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -68,6 +68,7 @@ class OTBNSim:
                 if insn.insn.cycles > 1:
                     self.state.add_stall_cycles(insn.insn.cycles - 1)
 
+                self.state.pre_insn(insn.affects_control)
                 insn.execute(self.state)
                 self.state.post_insn()
 

--- a/hw/ip/otbn/dv/otbnsim/test/simple/loop-end-loop/expected.txt
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/loop-end-loop/expected.txt
@@ -1,0 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+x2 = 1
+x3 = 1
+x4 = 0

--- a/hw/ip/otbn/dv/otbnsim/test/simple/loop-end-loop/loop-end-loop.s
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/loop-end-loop/loop-end-loop.s
@@ -1,0 +1,15 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+  /* Check that we trigger an error if a loop ends with another loop instruction */
+  addi  x2, x0, 1
+
+  loopi 1, 2
+   addi  x3, x0, 1
+   loopi 1, 1
+
+  /* We shouldn't get here */
+  nop
+  addi  x4, x0, 1
+  ecall

--- a/hw/ip/otbn/dv/otbnsim/test/simple/loop-overflow/expected.txt
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/loop-overflow/expected.txt
@@ -1,0 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+x2 = 1
+x3 = 0
+x4 = 4

--- a/hw/ip/otbn/dv/otbnsim/test/simple/loop-overflow/loop-overflow.s
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/loop-overflow/loop-overflow.s
@@ -1,0 +1,52 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+  /* An example that overflows the loop stack. We check the depth
+     exactly by running an 8-deep loop first (which should work) and
+     then 9 deep, which should fail.
+
+   */
+  addi  x2, x0, 0
+  addi  x3, x0, 0
+  addi  x4, x0, 4
+
+  loopi 1, 15
+   loopi 1, 13
+    loopi 1, 11
+     loopi 1, 9
+      loopi 1, 7
+       loopi 1, 5
+        loopi 1, 3
+         loopi 1, 1
+          addi x2, x2, 1
+         nop
+        nop
+       nop
+      nop
+     nop
+    nop
+   nop
+
+  loopi 1, 17
+   loopi 1, 15
+    loopi 1, 13
+     loopi 1, 11
+      loopi 1, 9
+       loopi 1, 7
+        loopi 1, 5
+         loopi 1, 3
+          loopi 1, 1
+           addi x3, x3, 1
+          nop
+         nop
+        nop
+       nop
+      nop
+     nop
+    nop
+   nop
+
+  /* We shouldn't get here */
+  addi  x4, x0, 40
+  ecall

--- a/hw/ip/otbn/dv/otbnsim/test/simple/loop-zero/expected.txt
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/loop-zero/expected.txt
@@ -1,0 +1,6 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+x2 = 1
+x3 = 0

--- a/hw/ip/otbn/dv/otbnsim/test/simple/loop-zero/loop-zero.s
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/loop-zero/loop-zero.s
@@ -1,0 +1,14 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+  /* Check that a zero count on a loop triggers an error. */
+  addi  x2, x0, 1
+  addi  x3, x0, 0
+
+  loop x3, 1
+   addi x2, x2, 1
+
+  /* We shouldn't get here */
+  addi x2, x2, 2
+  ecall

--- a/hw/ip/otbn/dv/otbnsim/test/simple/loops/expected.txt
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/loops/expected.txt
@@ -1,0 +1,6 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+x2 = 52
+x3 = 3

--- a/hw/ip/otbn/dv/otbnsim/test/simple/loops/loops.s
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/loops/loops.s
@@ -1,0 +1,33 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+  /* A basic example of using loop / loopi instructions to increment a
+     counter
+
+     In C-like pseudo-code, this would be:
+
+       x2 = 0;
+       x3 = 3;
+
+       for (int i = 0; i < 4; ++i) {
+         x2 += 10;
+         for (int j = 0; j < x3; ++j) {
+           x2 += 1;
+         }
+       }
+
+     The outer loop executes 4 times and the inner loop executes 3 times
+     on each iteration, so we increment x2 by 4*(10 + 3*1) = 52.
+
+   */
+  addi    x2, x0, 0
+  addi    x3, x0, 3
+
+  loopi  4, 4
+   addi   x2, x2, 10
+   loop   x3, 1
+    addi   x2, x2, 1
+   nop
+
+  ecall

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -43,6 +43,9 @@ package otbn_pkg;
   } regfile_e;
 
   // Error codes
+  //
+  // Note: This list is duplicated in the documentation (../doc/_index.md), the ISS
+  // (../dv/otbnsim/sim/alert.py), and the DIF. If updating it here, update those too.
   typedef enum logic [31:0] {
     ErrCodeNoError     = 32'h00,
     ErrCodeBadDataAddr = 32'h01,


### PR DESCRIPTION
The first patch updates the documentation for the loop instructions (@GregAC: Can you glance through this to check it matches what you think they do?).

The second patch teaches the ISS to cope with loop errors. This is a bit finicky because the ISS used to handle loops with a count of 1 differently from the RTL (we pushed to the stack if there was at least one back-edge). The code should now behave the same.

The third patch writes some tests to trigger each of the loop error conditions. The giant nested loops found several bugs in the previous patch, so I'm glad I wrote them!