### PR TITLE
[dv/otp] OTP_CTRL dai lock sequence

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -78,7 +78,7 @@
             operations are locked correctly, and check if the `AccessError` is set.
             '''
       milestone: V2
-      tests: []
+      tests: ["otp_ctrl_dai_lock"]
     }
     {
       name: interface_key_check

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -25,6 +25,7 @@ filesets:
       - seq_lib/otp_ctrl_wake_up_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_lc_vseq.sv: {is_include_file: true}
+      - seq_lib/otp_ctrl_dai_lock_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -16,6 +16,11 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
   // LC partition does not have digest
   bit [SCRAMBLE_DATA_SIZE-1:0] digests[NumPart-1];
 
+  // This bit is used for DAI interface to mark if the read access is valid.
+  bit dai_read_valid;
+  // This two bits are local values stored for sw partitions' read lock registers.
+  bit [1:0] sw_read_lock;
+
   // TLM agent fifos
   uvm_tlm_analysis_fifo #(push_pull_item#(.DeviceDataWidth(SRAM_DATA_SIZE)))
                         sram_fifo[NumSramKeyReqSlots];
@@ -58,6 +63,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
           bit [SCRAMBLE_DATA_SIZE-1:0] data = descramble_data(0, 0);
           otp_a   = '{default:0};
           digests = '{default:0};
+          sw_read_lock = 0;
           // secret partitions have been scrambled before writing to OTP.
           // here calculate the pre-srambled raw data when clearing internal OTP to all 0s.
           for (int i = SECRET0_START_ADDR; i <= SECRET0_END_ADDR; i++) begin
@@ -102,8 +108,9 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
         {[SW_WINDOW_BASE_ADDR : SW_WINDOW_BASE_ADDR + SW_WINDOW_SIZE]}) begin
       if (data_phase_read) begin
         bit [TL_AW-1:0] dai_addr = (csr_addr & addr_mask - SW_WINDOW_BASE_ADDR) >> 2;
-        `DV_CHECK_EQ(item.d_data, otp_a[dai_addr],
-                     $sformatf("mem read mismatch at addr %0h", dai_addr))
+        int part_idx = get_part_index(dai_addr);
+        bit [TL_DW-1:0] exp_val = sw_read_lock[part_idx] ? 0 : otp_a[dai_addr];
+        `DV_CHECK_EQ(item.d_data, exp_val, $sformatf("mem read mismatch at addr %0h", dai_addr))
       end
       return;
     // TEST ACCESS window
@@ -136,31 +143,45 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
         do_read_check = 1'b0;
         // FIXME
       end
-      // FIXME
-      "status": do_read_check = 1'b0;
       "direct_access_cmd": begin
         if (addr_phase_write && ral.direct_access_regwen.get_mirrored_value()) begin
           // here only normalize to 2 lsb, if is secret, will be reduced further
           bit [TL_AW-1:0] dai_addr = ral.direct_access_address.get_mirrored_value() >> 2 << 2;
+          int part_idx = get_part_index(dai_addr);
           case (item.a_data)
-            DaiDigest: cal_digest_val(get_part_index(dai_addr));
+            DaiDigest: cal_digest_val(part_idx);
             DaiRead: begin
-              // TODO: currently do nothing
+              // SW partitions write read_lock_csr can lock read access
+              // Secret partitions cal digest can also lock read access
+              if ((part_idx inside {CreatorSwCfgIdx, OwnerSwCfgIdx} && sw_read_lock[part_idx]) ||
+                  (is_secret(dai_addr) && digests[part_idx] != 0)) begin
+                predict_status_err(.dai_err(1));
+                dai_read_valid = 0;
+              end else begin
+                void'(ral.status.predict(OtpDaiIdle));
+                dai_read_valid = 1;
+              end
             end
             DaiWrite: begin
-              // write digest
-              if (dai_addr inside {CreatorSwCfgDigestOffset, OwnerSwCfgDigestOffset}) begin
-                digests[get_part_index(dai_addr)] =
-                        {ral.direct_access_wdata_1.get_mirrored_value(),
-                         ral.direct_access_wdata_0.get_mirrored_value()};
-              // write OTP memory
+              // check if write locked
+              if (digests[part_idx] != 0) begin
+                predict_status_err(.dai_err(1));
               end else begin
-                bit[TL_AW-1:0] normalized_dai_addr = get_normalized_dai_addr();
-                otp_a[normalized_dai_addr] = ral.direct_access_wdata_0.get_mirrored_value();
-                if (is_secret(dai_addr)) begin
-                  otp_a[normalized_dai_addr + 1] = ral.direct_access_wdata_1.get_mirrored_value();
+                void'(ral.status.predict(OtpDaiIdle));
+                // write digest
+                if (dai_addr inside {CreatorSwCfgDigestOffset, OwnerSwCfgDigestOffset}) begin
+                  digests[part_idx] = {ral.direct_access_wdata_1.get_mirrored_value(),
+                                       ral.direct_access_wdata_0.get_mirrored_value()};
+                // write OTP memory
+                end else begin
+                  bit[TL_AW-1:0] normalized_dai_addr = get_normalized_dai_addr();
+                  otp_a[normalized_dai_addr] = ral.direct_access_wdata_0.get_mirrored_value();
+                  if (is_secret(dai_addr)) begin
+                    otp_a[normalized_dai_addr + 1] = ral.direct_access_wdata_1.
+                                                     get_mirrored_value();
+                  end
+                  // TODO: LC partition, raise status error
                 end
-                // TODO: LC partition, raise status error
               end
             end
             default: begin
@@ -174,23 +195,31 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
         if (data_phase_read && ral.direct_access_regwen.get_mirrored_value()) begin
           bit [TL_AW-1:0] dai_addr = get_normalized_dai_addr();
           if (csr.get_name() == "direct_access_rdata_0") begin
-            `DV_CHECK_EQ(item.d_data, otp_a[dai_addr],
+            bit [TL_DW-1:0] exp_val = dai_read_valid ? otp_a[dai_addr] : 0;
+            `DV_CHECK_EQ(item.d_data, exp_val,
                          $sformatf("DAI read mismatch at addr %0h", dai_addr))
             do_read_check = 0;
           end else begin
             if (is_secret(ral.direct_access_address.get_mirrored_value())) begin
-            `DV_CHECK_EQ(item.d_data, otp_a[dai_addr + 1],
-                         $sformatf("DAI read mismatch at addr %0h", dai_addr + 1))
+              bit [TL_DW-1:0] exp_val = dai_read_valid ? otp_a[dai_addr + 1] : 0;
+              `DV_CHECK_EQ(item.d_data, exp_val,
+                           $sformatf("DAI read mismatch at addr %0h", dai_addr + 1))
               do_read_check = 0;
             end
           end
         end
       end
+      "creator_sw_cfg_read_lock": begin
+        if (item.d_data == 1) sw_read_lock[CreatorSwCfgIdx] = 1;
+      end
+      "owner_sw_cfg_read_lock": begin
+        if (item.d_data == 1) sw_read_lock[OwnerSwCfgIdx] = 1;
+      end
       "hw_cfg_digest_0", "hw_cfg_digest_1", "", "secret0_digest_0", "secret0_digest_1",
       "secret1_digest_0", "secret1_digest_1", "secret2_digest_0", "secret2_digest_1",
       "creator_sw_cfg_digest_0", "creator_sw_cfg_digest_1", "owner_sw_cfg_digest_0",
       "owner_sw_cfg_digest_1", "direct_access_regwen", "direct_access_wdata_0",
-      "direct_access_wdata_1", "direct_access_address": begin
+      "direct_access_wdata_1", "direct_access_address", "status": begin
         // Do nothing
       end
       default: begin
@@ -213,6 +242,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
     // reset local fifos queues and variables
     // digest values are updated after a power cycle
     predict_digest_csrs();
+    void'(ral.status.predict(OtpDaiIdle));
   endfunction
 
   // predict digest registers
@@ -260,16 +290,18 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
     int             array_size;
     real            key_factor  = SCRAMBLE_KEY_SIZE / TL_DW;
 
+    if (digests[part_idx] != 0 ||
+        part_idx inside {CreatorSwCfgIdx, OwnerSwCfgIdx, LifeCycleIdx}) begin
+      predict_status_err(.dai_err(1));
+      return;
+    end else begin
+      void'(ral.status.predict(OtpDaiIdle));
+    end
     case (part_idx)
       HwCfgIdx:   mem_q = otp_a[HW_CFG_START_ADDR:HW_CFG_END_ADDR];
       Secret0Idx: mem_q = otp_a[SECRET0_START_ADDR:SECRET0_END_ADDR];
       Secret1Idx: mem_q = otp_a[SECRET1_START_ADDR:SECRET1_END_ADDR];
       Secret2Idx: mem_q = otp_a[SECRET2_START_ADDR:SECRET2_END_ADDR];
-      CreatorSwCfgIdx, OwnerSwCfgIdx, LifeCycleIdx: begin
-        // access error
-        bit [TL_DW-1:0] status_val = OtpDaiErr || (1'b1 << part_idx);
-        void'(ral.status.predict(status_val));
-      end
       default: begin
         `uvm_fatal(`gfn, $sformatf("Access unexpected partition %0d", part_idx))
       end
@@ -339,5 +371,10 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
   function bit [TL_AW-1:0] get_normalized_dai_addr();
     bit [TL_DW-1:0] dai_addr = ral.direct_access_address.get_mirrored_value();
     get_normalized_dai_addr = is_secret(dai_addr) ? dai_addr >> 3 << 1 : dai_addr >> 2;
+  endfunction
+
+  virtual function void predict_status_err(bit dai_err, int part_idx = 0);
+    void'(ral.intr_state.otp_error.predict(.value(1)));
+    if (dai_err) void'(ral.status.predict(OtpDaiErr | OtpDaiIdle));
   endfunction
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// otp_ctrl_dai_lock_vseq is developed to read/write lock DAI interface by partitions, and request
+// read/write access to check if correct status and error code is triggered
+class otp_ctrl_dai_lock_vseq extends otp_ctrl_smoke_vseq;
+  `uvm_object_utils(otp_ctrl_dai_lock_vseq)
+
+  `uvm_object_new
+
+  // enable access_err for each cycle
+  constraint no_access_err_c {access_locked_parts == 1;}
+
+endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -13,10 +13,13 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
   bit do_lc_trans;
 
+  rand bit                           access_locked_parts;
   rand bit [TL_AW-1:0]               dai_addr;
   rand bit [TL_DW-1:0]               wdata0, wdata1;
   rand int                           num_dai_op;
   rand otp_ctrl_part_pkg::part_idx_e part_idx;
+
+  constraint no_access_err_c {access_locked_parts == 0;}
 
   // LC partition does not allow DAI access
   constraint partition_index_c {
@@ -55,14 +58,18 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
   task body();
     for (int i = 1; i <= num_trans; i++) begin
-      `uvm_info(`gfn, $sformatf("starting seq %0d/%0d", i, num_trans), UVM_MEDIUM)
-      do_otp_ctrl_init = 1;
-      if (i > 1) dut_init();
-      do_otp_ctrl_init = 0;
+      bit [TL_DW-1:0] tlul_val;
+      `uvm_info(`gfn, $sformatf("starting seq %0d/%0d", i, num_trans), UVM_LOW)
 
-      // after otp-init done, check status
-      cfg.clk_rst_vif.wait_clks(1);
-      csr_rd_check(.ptr(ral.status), .compare_value(OtpDaiIdle));
+      // to avoid access locked OTP partions, issue reset and clear the OTP memory to all 0.
+      if (access_locked_parts == 0) begin
+        do_otp_ctrl_init = 1;
+        if (i > 1) dut_init();
+        // after otp-init done, check status
+        cfg.clk_rst_vif.wait_clks(1);
+        csr_rd_check(.ptr(ral.status), .compare_value(OtpDaiIdle));
+      end
+      do_otp_ctrl_init = 0;
 
       // get sram keys
       req_all_sram_keys();
@@ -75,7 +82,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
       req_flash_data();
 
       for (int i = 0; i < num_dai_op; i++) begin
-        bit [TL_DW-1:0] rdata0, rdata1, tlul_rdata;
+        bit [TL_DW-1:0] rdata0, rdata1;
         `uvm_info(`gfn, $sformatf("starting dai access seq %0d/%0d", i, num_dai_op), UVM_DEBUG)
         `DV_CHECK_RANDOMIZE_FATAL(this)
 
@@ -96,18 +103,19 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
           // random issue reset, OTP content should not be cleared
           if ($urandom_range(0, 1)) dut_init();
-          tl_access(.addr(tlul_addr), .write(0), .data(tlul_rdata), .blocking(1));
+          tl_access(.addr(tlul_addr), .write(0), .data(tlul_val), .blocking(1));
         end
-      end
 
-      // check no error
-      csr_rd_check(.ptr(ral.status), .compare_value(OtpDaiIdle));
+        if ($urandom_range(0, 1)) csr_rd(.ptr(ral.status), .value(tlul_val));
+      end
 
       // lock HW digests
       `uvm_info(`gfn, "Trigger HW digest calculation", UVM_HIGH)
       cal_hw_digests();
+      if ($urandom_range(0, 1)) csr_rd(.ptr(ral.status), .value(tlul_val));
       write_sw_digests();
-      csr_rd_check(.ptr(ral.status), .compare_value(OtpDaiIdle));
+      if ($urandom_range(0, 1)) csr_rd(.ptr(ral.status), .value(tlul_val));
+      write_sw_rd_locks();
       dut_init();
 
       // check digest

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
@@ -7,3 +7,4 @@
 `include "otp_ctrl_smoke_vseq.sv"
 `include "otp_ctrl_common_vseq.sv"
 `include "otp_ctrl_lc_vseq.sv"
+`include "otp_ctrl_dai_lock_vseq.sv"

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -65,7 +65,11 @@
       uvm_test_seq: otp_ctrl_lc_vseq
     }
 
-    // TODO: add more tests here
+    {
+      name: otp_ctrl_dai_lock
+      uvm_test_seq: otp_ctrl_dai_lock_vseq
+    }
+
   ]
 
   // List of regressions.


### PR DESCRIPTION
This sequence lock each partition of OTP's DAI interface by:
1. Trigger digest
2. Write rd_lock_reg for SW partitions
Then access read/write/digest cal, to ensure data cannot be accessed and
corresponding status reg is set correctly.

Next step will work on the error code.

Signed-off-by: Cindy Chen <chencindy@google.com>