### PR TITLE
[dv] Add separate clock for EDN interface

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -62,12 +62,18 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
           cfg.m_alert_agent_cfg[alert_name]);
     end
 
-    // create edn pull agent and set cfg
+    // create edn pull agent, set cfg and set clk freq
     if (cfg.has_edn) begin
       m_edn_pull_agent = push_pull_agent#(.DeviceDataWidth(EDN_DATA_WIDTH))::type_id::create(
                          "m_edn_pull_agent", this);
       uvm_config_db#(push_pull_agent_cfg#(.DeviceDataWidth(EDN_DATA_WIDTH)))::set(
                      this, "m_edn_pull_agent", "cfg", cfg.m_edn_pull_agent_cfg);
+
+      if (!uvm_config_db#(virtual clk_rst_if)::get(this, "", "edn_clk_rst_vif",
+          cfg.edn_clk_rst_vif)) begin
+        `uvm_fatal(get_full_name(), "failed to get edn_clk_rst_vif from uvm_config_db")
+      end
+      cfg.clk_rst_vif.set_freq_mhz(cfg.edn_clk_freq_mhz);
     end
   endfunction
 

--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -8,9 +8,13 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   alert_esc_agent_cfg      m_alert_agent_cfg[string];
   push_pull_agent_cfg#(.DeviceDataWidth(EDN_DATA_WIDTH)) m_edn_pull_agent_cfg;
 
-  // common interfaces - intrrupts and alerts
+  // edn clk freq
+  rand clk_freq_mhz_e edn_clk_freq_mhz;
+
+  // common interfaces - intrrupts, alerts, edn clk
   intr_vif    intr_vif;
   devmode_vif devmode_vif;
+  virtual clk_rst_if  edn_clk_rst_vif;
 
   // en_devmode default sets to 1 because all IPs' devmode_i is tied off internally to 1
   // TODO: enable random drive devmode once design supports

--- a/hw/dv/sv/common_ifs/clk_rst_if.sv
+++ b/hw/dv/sv/common_ifs/clk_rst_if.sv
@@ -97,8 +97,8 @@ interface clk_rst_if #(
     end
   endfunction
 
-  // set the clk period in ns
-  function automatic void set_period_ns(int period_ps);
+  // set the clk period in ps
+  function automatic void set_period_ps(int period_ps);
     clk_period_ps = period_ps;
     clk_freq_mhz  = 1000_000 / clk_period_ps;
     recompute     = 1'b1;

--- a/hw/dv/sv/common_ifs/index.md
+++ b/hw/dv/sv/common_ifs/index.md
@@ -30,7 +30,7 @@ the frequency and duty cycle of the generated clock, use the following
 functions:
 * `set_freq_mhz` / `set_freq_khz`: set the clock frequency in MHz / KHz. This
   is 50MHz by default.
-* `set_period_ns`: set the clock period in nanoseconds. This is 20ns by default
+* `set_period_ps`: set the clock period in picoseconds. This is 20_000ps by default
   (giving a clock period of 50MHz).
 * `set_duty_cycle`: set the duty cycle (as a percentage: 1 - 99). This is 50 by
   default.

--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -514,6 +514,25 @@
   end
 `endif
 
+// Declare edn clock, reset and push_pull_if. Connect them and set edn_clk_rst_if and edn_if for
+// using them in env
+// Use this macro in tb.sv if the IP connects to a EDN interface
+// TODO, tie core reset with EDN reset for now
+`ifndef DV_EDN_IF_CONNECT
+`define DV_EDN_IF_CONNECT \
+  wire edn_rst_n = rst_n; \
+  wire edn_clk; \
+  clk_rst_if edn_clk_rst_if(.clk(edn_clk), .rst_n(edn_rst_n)); \
+  push_pull_if #(.DeviceDataWidth(cip_base_pkg::EDN_DATA_WIDTH)) edn_if(.clk(edn_clk), \
+                                                                        .rst_n(edn_rst_n)); \
+  initial begin \
+    edn_clk_rst_if.set_active(.drive_rst_n_val(0)); \
+    uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "edn_clk_rst_vif", edn_clk_rst_if); \
+    uvm_config_db#(virtual push_pull_if#(.DeviceDataWidth(cip_base_pkg::EDN_DATA_WIDTH)))::set \
+                   (null, "*env.m_edn_pull_agent*", "vif", edn_if); \
+  end
+`endif
+
 // Instantiates a covergroup in an interface or module.
 //
 // This macro assumes that a covergroup of the same name as the __CG_NAME arg is defined in the

--- a/hw/ip/keymgr/dv/tb.sv
+++ b/hw/ip/keymgr/dv/tb.sv
@@ -24,16 +24,18 @@ module tb;
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   keymgr_if keymgr_if(.clk(clk), .rst_n(rst_n));
   keymgr_kmac_intf keymgr_kmac_intf(.clk(clk), .rst_n(rst_n));
-  push_pull_if #(.DeviceDataWidth(cip_base_pkg::EDN_DATA_WIDTH)) edn_if(.clk(clk), .rst_n(rst_n));
 
   `DV_ALERT_IF_CONNECT
+
+  // edn_clk, edn_rst_n and edn_if are defined and driven in below macro
+  `DV_EDN_IF_CONNECT
 
   // dut
   keymgr dut (
     .clk_i                (clk        ),
     .rst_ni               (rst_n      ),
-    .clk_edn_i            (clk        ),
-    .rst_edn_ni           (rst_n      ),
+    .clk_edn_i            (edn_clk    ),
+    .rst_edn_ni           (edn_rst_n  ),
     .aes_key_o            (keymgr_if.aes_key),
     .hmac_key_o           (keymgr_if.hmac_key),
     .kmac_key_o           (keymgr_if.kmac_key),
@@ -51,7 +53,6 @@ module tb;
     .alert_tx_o           (alert_tx   ),
     .tl_i                 (tl_if.h2d  ),
     .tl_o                 (tl_if.d2h  )
-    // TODO: add remaining IOs and hook them
   );
 
   initial begin
@@ -70,8 +71,6 @@ module tb;
     uvm_config_db#(virtual keymgr_if)::set(null, "*.env", "keymgr_vif", keymgr_if);
     uvm_config_db#(virtual keymgr_kmac_intf)::set(null,
                    "*env.m_keymgr_kmac_agent*", "vif", keymgr_kmac_intf);
-    uvm_config_db#(virtual push_pull_if#(.DeviceDataWidth(cip_base_pkg::EDN_DATA_WIDTH)))::set
-                   (null, "*env.m_edn_pull_agent*", "vif", edn_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end

--- a/hw/ip/kmac/dv/env/kmac_env_cfg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cfg.sv
@@ -14,6 +14,7 @@ class kmac_env_cfg extends cip_base_env_cfg #(.RAL_T(kmac_reg_block));
   `uvm_object_new
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
+    has_edn = 1;
     super.initialize(csr_base_addr);
 
     // set num_interrupts & num_alerts

--- a/hw/ip/kmac/dv/tb.sv
+++ b/hw/ip/kmac/dv/tb.sv
@@ -36,6 +36,9 @@ module tb;
 
   kmac_sideload_if sideload_if();
 
+  // edn_clk, edn_rst_n and edn_if is defined and driven in below macro
+  `DV_EDN_IF_CONNECT
+
   // dut
   kmac #(.EnMasking(`EN_MASKING), .ReuseShare(`REUSE_SHARE)) dut (
     .clk_i                (clk                      ),
@@ -60,12 +63,18 @@ module tb;
     .intr_kmac_err_o      (intr_kmac_err            ),
 
     // Idle interface
-    .idle_o               (idle                     )
+    .idle_o               (idle                     ),
 
     // TODO: hook up interfaces for:
     //
     // 1) KDF
     // 2) csrng/edn
+
+    // edn
+    .clk_edn_i                  (edn_clk    ),
+    .rst_edn_ni                 (edn_rst_n  ),
+    .entropy_o                  (edn_if.req ),
+    .entropy_i                  ({edn_if.ack, edn_if.d_data})
   );
 
   // Interface assignments

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -48,7 +48,6 @@ module tb;
   push_pull_if #(.DeviceDataWidth(OTBN_DATA_SIZE)) otbn_if(.clk(clk), .rst_n(rst_n));
   push_pull_if #(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_addr_if(.clk(clk), .rst_n(rst_n));
   push_pull_if #(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_data_if(.clk(clk), .rst_n(rst_n));
-  push_pull_if #(.DeviceDataWidth(cip_base_pkg::EDN_DATA_WIDTH)) edn_if(.clk(clk), .rst_n(rst_n));
 
   pins_if #(OtpPwrIfWidth) pwr_otp_if(pwr_otp);
   // TODO: use standard req/rsp agent
@@ -64,14 +63,16 @@ module tb;
 
   `DV_ALERT_IF_CONNECT
 
+  // edn_clk, edn_rst_n and edn_if are defined and driven in below macro
+  `DV_EDN_IF_CONNECT
+
   // dut
   otp_ctrl dut (
     .clk_i                      (clk        ),
     .rst_ni                     (rst_n      ),
     // edn
-    // TODO: consider connecting this to a different clock.
-    .clk_edn_i                  (clk        ),
-    .rst_edn_ni                 (rst_n      ),
+    .clk_edn_i                  (edn_clk    ),
+    .rst_edn_ni                 (edn_rst_n  ),
     .edn_o                      (edn_if.req ),
     .edn_i                      ({edn_if.ack, edn_if.d_data}),
 
@@ -154,8 +155,6 @@ module tb;
                    "*env.m_flash_data_pull_agent*", "vif", flash_data_if);
     uvm_config_db#(virtual push_pull_if#(.DeviceDataWidth(FLASH_DATA_SIZE)))::set(null,
                    "*env.m_flash_addr_pull_agent*", "vif", flash_addr_if);
-    uvm_config_db#(virtual push_pull_if#(.DeviceDataWidth(cip_base_pkg::EDN_DATA_WIDTH)))::
-                   set(null, "*env.m_edn_pull_agent*", "vif", edn_if);
     uvm_config_db#(virtual push_pull_if#(.HostDataWidth(LC_PROG_DATA_SIZE), .DeviceDataWidth(1)))::
                    set(null, "*env.m_lc_prog_pull_agent*", "vif", lc_prog_if);
     uvm_config_db#(virtual push_pull_if#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)))::

--- a/hw/ip/prim/dv/prim_lfsr/tb/prim_lfsr_tb.sv
+++ b/hw/ip/prim/dv/prim_lfsr/tb/prim_lfsr_tb.sv
@@ -166,7 +166,7 @@ module prim_lfsr_tb;
     lfsr_en = '0;
     err     = '0;
 
-    main_clk.set_period_ns(ClkPeriod);
+    main_clk.set_period_ps(ClkPeriod);
     main_clk.set_active();
     main_clk.apply_reset();
 

--- a/hw/ip/prim/dv/prim_prince/tb/prim_prince_tb.sv
+++ b/hw/ip/prim/dv/prim_prince/tb/prim_prince_tb.sv
@@ -237,7 +237,7 @@ module prim_prince_tb;
     bit [KeyWidth/2-1:0] k0, k1;
     bit [DataWidth-1:0] plaintext;
 
-    clk_if.set_period_ns(ClkPeriod);
+    clk_if.set_period_ps(ClkPeriod);
     clk_if.set_active();
     clk_if.apply_reset();
     $timeformat(-12, 0, " ps", 12);

--- a/hw/ip/prim/rtl/prim_sync_reqack_data.sv
+++ b/hw/ip/prim/rtl/prim_sync_reqack_data.sv
@@ -97,7 +97,7 @@ module prim_sync_reqack_data #(
     // DST domain shall not change data while waiting for SRC domain to latch it (together with
     // receiving ACK). Assert that the data is stable +/- 2 SRC cycles around the SRC handshake.
     `ASSERT(SyncReqAckDataHoldDst2Src,
-        src_req_i && src_ack_o |-> $past(data_o,2) == data_o && $stable(data_o) [*3],
+        src_req_i && src_ack_o |-> $past(data_o,2) == data_o && $stable(data_o) [*2],
         clk_src_i, !rst_src_ni)
   end
 

--- a/util/uvmdvgen/tb.sv.tpl
+++ b/util/uvmdvgen/tb.sv.tpl
@@ -33,12 +33,13 @@ module tb;
 % for agent in env_agents:
   ${agent}_if ${agent}_if();
 % endfor
-% if has_edn:
-  push_pull_if #(.DeviceDataWidth(cip_base_pkg::EDN_DATA_WIDTH)) edn_if(.clk(clk), .rst_n(rst_n));
-% endif
 
 % if has_alerts:
   `DV_ALERT_IF_CONNECT
+% endif
+% if has_edn:
+  // edn_clk, edn_rst_n and edn_if are defined and driven in below macro
+  `DV_EDN_IF_CONNECT
 % endif
 
   // dut
@@ -54,6 +55,8 @@ module tb;
     .alert_tx_o           (alert_tx )${"," if has_edn else ""}
   % endif
   % if has_edn:
+    .clk_edn_i            (edn_clk    ),
+    .rst_edn_ni           (edn_rst_n  ),
     .edn_o                (edn_if.req),
     .edn_i                ({edn_if.ack, edn_if.d_data})
   % endif
@@ -75,10 +78,6 @@ module tb;
 % for agent in env_agents:
     uvm_config_db#(virtual ${agent}_if)::set(null, "*.env.m_${agent}_agent*", "vif", ${agent}_if);
 % endfor
-% if has_edn:
-    uvm_config_db#(virtual push_pull_if#(.DeviceDataWidth(cip_base_pkg::EDN_DATA_WIDTH)))::set
-                   (null, "*env.m_edn_pull_agent*", "vif", edn_if);
-% endif
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end


### PR DESCRIPTION
EDN interface is using a separate clock. Add this clock in cip lib
Create a macro for easily connecting EDN in tb
Currently tie EDN reset to core reset.

Signed-off-by: Weicai Yang <weicai@google.com>