### PR TITLE
[dv] Update EDN have chance to use large delay

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -28,6 +28,13 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
       cfg.m_tl_agent_cfg.a_ready_delay_max = 0;
       cfg.m_tl_agent_cfg.d_ready_delay_min = 0;
       cfg.m_tl_agent_cfg.d_ready_delay_max = 0;
+
+      foreach (cfg.m_alert_agent_cfg[i]) begin
+        cfg.m_alert_agent_cfg[i].alert_delay_min = 0;
+        cfg.m_alert_agent_cfg[i].alert_delay_max = 0;
+      end
+
+      cfg.m_edn_pull_agent_cfg.zero_delays = 1;
     end
 
     // get vifs

--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -5,8 +5,8 @@
 class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg #(RAL_T);
   // ext component cfgs
   rand tl_agent_cfg        m_tl_agent_cfg;
-  rand alert_esc_agent_cfg m_alert_agent_cfg[string];
-  rand push_pull_agent_cfg#(.DeviceDataWidth(EDN_DATA_WIDTH)) m_edn_pull_agent_cfg;
+  alert_esc_agent_cfg      m_alert_agent_cfg[string];
+  push_pull_agent_cfg#(.DeviceDataWidth(EDN_DATA_WIDTH)) m_edn_pull_agent_cfg;
 
   // common interfaces - intrrupts and alerts
   intr_vif    intr_vif;
@@ -47,19 +47,17 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
         string alert_name = list_of_alerts[i];
         // create alert_esc_agent_cfg if the module has alerts
         m_alert_agent_cfg[alert_name] = alert_esc_agent_cfg::type_id::create("m_alert_agent_cfg");
+        `DV_CHECK_RANDOMIZE_FATAL(m_alert_agent_cfg[alert_name])
         m_alert_agent_cfg[alert_name].if_mode = dv_utils_pkg::Device;
         m_alert_agent_cfg[alert_name].is_async = 1; // default async_on, can override this
         m_alert_agent_cfg[alert_name].en_ping_cov = 0;
-        if (zero_delays) begin
-          m_alert_agent_cfg[alert_name].alert_delay_min = 0;
-          m_alert_agent_cfg[alert_name].alert_delay_max = 0;
-        end
       end
     end
 
     if (has_edn) begin
       m_edn_pull_agent_cfg = push_pull_agent_cfg#(.DeviceDataWidth(EDN_DATA_WIDTH))::type_id::
                              create("m_edn_pull_agent_cfg");
+      `DV_CHECK_RANDOMIZE_FATAL(m_edn_pull_agent_cfg)
       m_edn_pull_agent_cfg.agent_type = PullAgent;
       m_edn_pull_agent_cfg.if_mode    = Device;
     end

--- a/hw/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
@@ -18,18 +18,38 @@ class push_pull_agent_cfg #(parameter int HostDataWidth = 32,
   bit in_bidirectional_mode = 1'b0;
 
   // Device-side delay range for both Push/Pull protocols.
-  int unsigned device_delay_min = 0;
-  int unsigned device_delay_max = 10;
+  rand int unsigned device_delay_min;
+  rand int unsigned device_delay_max;
+  rand int unsigned large_device_delay_max_weight = 10; // max 100
 
   // Host-side delay range for both Push/Pull protocols.
-  int unsigned host_delay_min = 0;
-  int unsigned host_delay_max = 10;
+  rand int unsigned host_delay_min;
+  rand int unsigned host_delay_max;
+  rand int unsigned large_host_delay_max_weight = 10; // max 100
 
   // Enables/disable all protocol delays.
   rand bit zero_delays;
 
   // Enable starting the device sequence by default if configured in Device mode.
   bit start_default_device_seq = 1;
+
+  constraint device_delay_min_c {
+    device_delay_min == 0;
+  }
+
+  constraint device_delay_max_c {
+    device_delay_max dist {1000 :/ large_device_delay_max_weight,
+                           100  :/ 100 - large_device_delay_max_weight};
+  }
+
+  constraint host_delay_min_c {
+    host_delay_min == 0;
+  }
+
+  constraint host_delay_max_c {
+    host_delay_max dist {1000 :/ large_host_delay_max_weight,
+                         100  :/ 100 - large_host_delay_max_weight};
+  }
 
   // Bias randomization in favor of enabling zero delays less often.
   constraint zero_delays_c {


### PR DESCRIPTION
1. Make delay_max/min to rand and add knob to control large delay
2. Fix that objects in cip_base_env_cfg can't be randomized before it's
created
3. Fix zero_delays usage. It's set at the end of test build phase, we 
should use iti at env build phase or later

Fixed #4536.

Signed-off-by: Weicai Yang <weicai@google.com>
