### PR TITLE
[dv] GPIO smoke test enhancements for DV

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -177,7 +177,7 @@
     }
     {
       name: chip_dif_gpio_smoketest
-      uvm_test_seq: chip_sw_base_vseq
+      uvm_test_seq: chip_sw_gpio_smoke_vseq
       sw_images: ["sw/device/tests/dif_gpio_smoketest:1"]
       en_run_modes: ["sw_test_mode"]
     }

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -32,6 +32,7 @@ filesets:
       - seq_lib/chip_shadow_reg_errors_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_uart_tx_rx_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_gpio_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_gpio_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_spi_tx_rx_vseq.sv: {is_include_file: true}
       - autogen/alert_handler_env_pkg__params.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_smoke_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_smoke_vseq.sv
@@ -1,0 +1,69 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test vseq is paired with SW test `sw/device/tests/dif_gpio_smoketest.c`.
+class chip_sw_gpio_smoke_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_gpio_smoke_vseq)
+
+  // We override the SW symbol `kGpioVals` with our own set of random values.
+  localparam string sw_symbol_gpio_vals = "kGpioVals";
+  localparam uint timeout_ns = 2_000_000;
+
+  // Declared as int to match the SW test.
+  rand int gpio_vals[];
+  uint num_gpio_vals;
+  constraint gpio_vals_c {
+    gpio_vals.size() == num_gpio_vals;
+  }
+
+  `uvm_object_new
+
+  function void pre_randomize();
+    int addr;
+    // Find how many bytes the SW allocate for sw_symbol_gpio_vals, then convert to word size.
+    sw_symbol_get_addr_size({p_sequencer.cfg.sw_images[SwTypeTest], ".elf"},
+                            sw_symbol_gpio_vals, addr, num_gpio_vals);
+    num_gpio_vals /= 4;
+  endfunction
+
+  virtual task cpu_init();
+    super.cpu_init();
+    // Need to convert integer array to byte array.
+    sw_symbol_backdoor_overwrite(sw_symbol_gpio_vals, {<<byte{{<<int{gpio_vals}}}});
+  endtask
+
+  virtual task body();
+    super.body();
+
+    // Wait until we reach the SW test state.
+    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+
+    // Disable the default pulldown on GPIOs.
+    cfg.gpio_vif.set_pulldown_en({chip_env_pkg::NUM_GPIOS{1'b0}});
+
+    `uvm_info(`gfn, "Starting GPIO output test", UVM_LOW)
+    for (int i = 0; i < num_gpio_vals; i++) begin
+      `DV_SPINWAIT(wait(cfg.gpio_vif.pins === gpio_vals[i][NUM_GPIOS-1:0]);,
+                   $sformatf("Timed out waiting for GPIOs == %0h", gpio_vals[i][NUM_GPIOS-1:0]),
+                   timeout_ns,
+                  `gfn)
+    end
+
+    // Test walking 1s and 0s.
+    for (int i = 0; i < NUM_GPIOS; i++) begin
+      logic [NUM_GPIOS-1:0] exp_gpios = (1 << i);
+      `DV_SPINWAIT(wait(cfg.gpio_vif.pins === exp_gpios);,
+                   $sformatf("Timed out waiting for GPIOs == %0h", exp_gpios),
+                   timeout_ns,
+                  `gfn)
+
+      exp_gpios = ~exp_gpios;
+      `DV_SPINWAIT(wait(cfg.gpio_vif.pins === exp_gpios);,
+                   $sformatf("Timed out waiting for GPIOs == %0h", exp_gpios),
+                   timeout_ns,
+                  `gfn)
+    end
+  endtask
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -7,5 +7,6 @@
 `include "chip_shadow_reg_errors_vseq.sv"
 `include "chip_sw_base_vseq.sv"
 `include "chip_sw_uart_tx_rx_vseq.sv"
+`include "chip_sw_gpio_smoke_vseq.sv"
 `include "chip_sw_gpio_vseq.sv"
 `include "chip_sw_spi_tx_rx_vseq.sv"

--- a/sw/device/tests/dif/dif_gpio_smoketest.c
+++ b/sw/device/tests/dif/dif_gpio_smoketest.c
@@ -16,6 +16,17 @@ static dif_gpio_t gpio;
 const test_config_t kTestConfig;
 
 /**
+ * A known pattern written to GPIOs.
+ *
+ * On FPGA, these patterns are tested as-is. In DV, this symbol is overwritten
+ * by the testbench to test completely random patterns. This is done in
+ * `hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_smoke_vseq.sv`. The DV test
+ * also checks GPIO pin values at the chip periphery for correctness.
+ */
+static const uint32_t kGpioVals[] = {0xAAAAAAAA, 0x55555555, 0xA5A5A5A5,
+                                     0xFFFFFFFF, 0};
+
+/**
  * Pins to be tested.
  *
  * This test only uses pins 0-15 to be compatible with both FPGA and DV:
@@ -60,9 +71,8 @@ bool test_main(void) {
             &gpio) == kDifGpioOk);
   CHECK(dif_gpio_output_set_enabled_all(&gpio, kGpioMask) == kDifGpioOk);
 
-  const uint32_t kVals[] = {0xAAAAAAAA, 0x55555555, 0xA5A5A5A5, 0xFFFFFFFF, 0};
-  for (uint8_t i = 0; i < ARRAYSIZE(kVals); ++i) {
-    test_gpio_write(kVals[i]);
+  for (uint8_t i = 0; i < ARRAYSIZE(kGpioVals); ++i) {
+    test_gpio_write(kGpioVals[i]);
   }
 
   // Walking 1s and 0s. Iterates over every integer with one bit set and every


### PR DESCRIPTION
The first 2 commits can be ignored - they are already a part of #4484. The next 2 commits enhances the GPIO smoke test for DV - the commit 3 adds checks on the testbench side to prove what the SW wrote to the GPIOs is indeed what was seen. It also overwrites the `kGpioVals` symbol to randomize what the SW test writes, rather than write a fixed set of patterns. Commit 4 supports the changes in commit 3. 