### PR TITLE
[otbn] Set err_code correctly when not building model

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -498,7 +498,7 @@ module otbn
       .start_i (start),
       .done_o  (done),
 
-      .err_code_o (err_code_rtl),
+      .err_code_o (err_code),
 
       .start_addr_i  (start_addr),
 


### PR DESCRIPTION
The `err_code_rtl` signal is only defined and used in the other branch,
where it gets muxed with `err_code_model`.

I spotted this because I was glancing through the AscentLint report from last night. It would be nice to clean up the other errors so that we can assume something has gone wrong whenever the box isn't green.