### PR TITLE
[sw/device/examples] Fix hello world examples

### DIFF
--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -22,7 +22,7 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
 
 // These just for the '/' printout
-#define USBDEV_BASE_ADDR 0x40150000
+#define USBDEV_BASE_ADDR TOP_EARLGREY_USBDEV_BASE_ADDR
 #include "usbdev_regs.h"  // Generated.
 
 #define REG32(add) *((volatile uint32_t *)(add))
@@ -121,7 +121,8 @@ int main(int argc, char **argv) {
 
   CHECK(dif_spi_device_init(
             (dif_spi_device_params_t){
-                .base_addr = mmio_region_from_addr(0x40020000),
+                .base_addr =
+                    mmio_region_from_addr(TOP_EARLGREY_SPI_DEVICE_BASE_ADDR),
             },
             &spi) == kDifSpiDeviceOk);
   CHECK(dif_spi_device_configure(
@@ -136,7 +137,7 @@ int main(int argc, char **argv) {
                   }) == kDifSpiDeviceOk);
 
   dif_gpio_params_t gpio_params = {
-      .base_addr = mmio_region_from_addr(0x40010000),
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR),
   };
   CHECK(dif_gpio_init(gpio_params, &gpio) == kDifGpioOk);
   // Enable GPIO: 0-7 and 16 is input; 8-15 is output.

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -38,7 +38,8 @@ int main(int argc, char **argv) {
 
   CHECK(dif_spi_device_init(
             (dif_spi_device_params_t){
-                .base_addr = mmio_region_from_addr(0x40020000),
+                .base_addr =
+                    mmio_region_from_addr(TOP_EARLGREY_SPI_DEVICE_BASE_ADDR),
             },
             &spi) == kDifSpiDeviceOk);
   CHECK(dif_spi_device_configure(
@@ -53,7 +54,7 @@ int main(int argc, char **argv) {
                   }) == kDifSpiDeviceOk);
 
   dif_gpio_params_t gpio_params = {
-      .base_addr = mmio_region_from_addr(0x40010000),
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR),
   };
   CHECK(dif_gpio_init(gpio_params, &gpio) == kDifGpioOk);
   // Enable GPIO: 0-7 and 16 is input; 8-15 is output.


### PR DESCRIPTION
The base addresses of some peripherals were updated in d5a1e4b.
This broke the hello world examples because they used hardcoded
addresses. This change uses the relevant constants defined in the
top_earlgrey header instead.