### PR TITLE
[dv/csr_excl] Fix VCS warning

### DIFF
--- a/hw/dv/sv/dv_base_reg/csr_excl_item.sv
+++ b/hw/dv/sv/dv_base_reg/csr_excl_item.sv
@@ -32,7 +32,7 @@ class csr_excl_item extends uvm_object;
       `uvm_fatal(`gfn, $sformatf("add %s exclusion without a test", obj))
     end
 
-    if (!exclusions.exists(obj)) exclusions[obj] = '{default:0};
+    if (!exclusions.exists(obj)) exclusions[obj] = '{default:CsrNoExcl};
     val = csr_excl_type | exclusions[obj].csr_excl_type;
     test = csr_test_type | exclusions[obj].csr_test_type;
     exclusions[obj].csr_excl_type = csr_excl_type_e'(val);


### PR DESCRIPTION
In csr_excl_item.sv currently there is a xcelium warning for assigning
enum type directly to 0.
This PR fixed it by directly using the enum default type.

Signed-off-by: Cindy Chen <chencindy@google.com>