### PR TITLE
[edn/rtl] endpoint hold data for async requestors

### DIFF
--- a/hw/ip/edn/doc/_index.md
+++ b/hw/ip/edn/doc/_index.md
@@ -199,18 +199,18 @@ See the [CSRNG IP]({{< relref "hw/ip/csrng/doc" >}}) waveform section for the CS
 ##### Peripheral Hardware Interface - Req/Ack
 The following waveform shows an example of how the peripheral hardware interface works.
 This example shows the case where the boot-time mode in the ENTROPY_SRC block is enabled.
+This example also shows the case where the next request will change the prior data by popping the data FIFO.
 
 {{< wavejson >}}
 {signal: [
-   {name: 'clk'           , wave: 'p...|.........|.......'},
-   {name: 'edn_enable'    , wave: '01..|.........|.......'},
-   {name: 'edn_req'       , wave: '0..1|..01.0..1|.....0.'},
-   {name: 'edn_ack'       , wave: '0...|.10.10...|....10.'},
-   {name: 'edn_bus[31:0]' , wave: '0...|.30.30...|....30.', data: ['es0','es1','es2']},
-   {name: 'edn_fips'      , wave: '0...|....10...|....10.'},
+   {name: 'clk'           , wave: 'p...|...........|......'},
+   {name: 'edn_enable'    , wave: '01..|...........|......'},
+   {name: 'edn_req'       , wave: '0..1|..0..1.0...|1.0...'},
+   {name: 'edn_ack'       , wave: '0...|.10...10...|.10...'},
+   {name: 'edn_bus[31:0]' , wave: '0...|3....3.....|3.....', data: ['es0','es1','es2']},
+   {name: 'edn_fips'      , wave: '0...|...........|......'},
  {},
-]}
-{{< /wavejson >}}
+]}{{< /wavejson >}}
 
 # Programmers Guide
 

--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -112,7 +112,6 @@ module edn_core import edn_pkg::*; #(
   logic                               sfifo_gencmd_not_full;
   logic                               sfifo_gencmd_not_empty;
 
-
   // flops
   logic [31:0]                        cs_cmd_req_q, cs_cmd_req_d;
   logic                               cs_cmd_req_vld_q, cs_cmd_req_vld_d;
@@ -513,7 +512,7 @@ module edn_core import edn_pkg::*; #(
 
     // gate returned data
     assign edn_o[i].edn_ack = packer_ep_ack[i];
-    assign edn_o[i].edn_bus = packer_ep_ack[i] ? packer_ep_rdata[i] : '0;
+    assign edn_o[i].edn_bus = packer_ep_rdata[i];
 
     edn_ack_sm u_edn_ack_sm_ep (
       .clk_i            (clk_i),


### PR DESCRIPTION
Hold returned data N cycles after the ack is pulsed.
Waveform documentation has also been updated.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>