### PR TITLE
[dvsim] Copy repo to scratch area and reference everything from {proj_root}

### DIFF
--- a/hw/data/common_project_cfg.hjson
+++ b/hw/data/common_project_cfg.hjson
@@ -8,9 +8,13 @@
   results_server:   reports.opentitan.org
 
   // Default directory structure for the output
-  scratch_base_path:  "{scratch_root}/{dut}.{flow}.{tool}"
-  scratch_path:       "{scratch_base_path}/{branch}"
-  tool_srcs_dir:      "{scratch_path}/{tool}"
+  scratch_base_path:  "{scratch_root}/{branch}"
+  scratch_path:       "{scratch_base_path}/{dut}-{flow}-{tool}"
+
+  exports: [
+    { SCRATCH_PATH: "{scratch_path}" },
+    { proj_root: "{proj_root}" }
+  ]
 
   // Results server stuff - indicate what command to use to copy over the results.
   // Workaround for gsutil to fall back to using python2.7.

--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -3,10 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   flow:             sim
-  flow_makefile:    "{dv_root}/tools/dvsim/sim.mk"
-
   // Where to find DV code
   dv_root:          "{proj_root}/hw/dv"
+  flow_makefile:    "{dv_root}/tools/dvsim/sim.mk"
 
   import_cfgs:      ["{proj_root}/hw/data/common_project_cfg.hjson",
                      "{dv_root}/tools/dvsim/common_modes.hjson",
@@ -70,8 +69,7 @@
 
   // Default list of things to export to shell
   exports: [
-    { SCRATCH_BASE_PATH: "{scratch_base_path}" },
-    { TOOL_SRCS_DIR: "{tool_srcs_dir}" },
+    { dv_root: "{dv_root}" },
     { SIMULATOR: "{tool}" },
     { WAVES: "{waves}" },
     { DUT_TOP: "{dut}" },
@@ -129,27 +127,20 @@
     }
   ]
 
-  // Add waves.tcl to the set of sources to be copied over to
-  // {tool_srcs_dir}. This can be sourced by the tool-specific TCL
-  // script to set up wave dumping.
-  tool_srcs:  ["{dv_root}/tools/sim.tcl",
-               "{dv_root}/tools/common.tcl",
-               "{dv_root}/tools/waves.tcl"]
-
   // Project defaults for VCS
   vcs_cov_cfg_file: "{{build_mode}_vcs_cov_cfg_file}"
-  vcs_unr_cfg_file: "{tool_srcs_dir}/unr.cfg"
-  vcs_cov_excl_files: ["{tool_srcs_dir}/common_cov_excl.el"]
+  vcs_unr_cfg_file: "{dv_root}/tools/vcs/unr.cfg"
+  vcs_cov_excl_files: ["{dv_root}/tools/vcs/common_cov_excl.el"]
 
   // Build-specific coverage cfg files for VCS.
-  default_vcs_cov_cfg_file: "-cm_hier {tool_srcs_dir}/cover.cfg"
-  cover_reg_top_vcs_cov_cfg_file: "-cm_hier {tool_srcs_dir}/cover_reg_top.cfg"
+  default_vcs_cov_cfg_file: "-cm_hier {dv_root}/tools/vcs/cover.cfg"
+  cover_reg_top_vcs_cov_cfg_file: "-cm_hier {dv_root}/tools/vcs/cover_reg_top.cfg"
 
   // Project defaults for Xcelium
   // xcelium_cov_cfg_file: "{{build_mode}_xcelium_cov_cfg_file}"
-  // xcelium_cov_refine_files: ["{tool_srcs_dir}/common_cov.vRefine"]
+  // xcelium_cov_refine_files: ["{dv_root}/tools/xcelium/common_cov.vRefine"]
 
   // Build-specific coverage cfg files for Xcelium.
-  // default_xcelium_cov_cfg_file: "-covfile {tool_srcs_dir}/cover.ccf"
-  // cover_reg_top_xcelium_cov_cfg_file: "-covfile {tool_srcs_dir}/cover_reg_top.ccf"
+  // default_xcelium_cov_cfg_file: "-covfile {dv_root}/tools/xcelium/cover.ccf"
+  // cover_reg_top_xcelium_cov_cfg_file: "-covfile {dv_root}/tools/xcelium/cover_reg_top.ccf"
 }

--- a/hw/dv/tools/dvsim/dsim.hjson
+++ b/hw/dv/tools/dvsim/dsim.hjson
@@ -5,12 +5,6 @@
   build_cmd:  "{job_prefix} dsim"
   run_cmd:    "{job_prefix} dsim"
 
-  // Indicate the tool specific helper sources - these are copied over to the
-  // {tool_srcs_dir} before running the simulation.
-  // TODO, there is no dsim tool file, point to vcs for now to avoid error from script
-  // tool_srcs: ["{dv_root}/tools/dsim/*"]
-
-
   build_opts: ["-work {build_dir}/dsim_out",
                "-genimage image",
                "-sv",
@@ -59,13 +53,13 @@
   // Merging coverage.
   // "cov_db_dirs" is a special variable that appends all build directories in use.
   // It is constructed by the tool itself.
-  cov_merge_dir:    "{scratch_base_path}/cov_merge"
+  cov_merge_dir:    "{scratch_path}/cov_merge"
   cov_merge_db_dir: "{cov_merge_dir}/merged.vdb"
   cov_merge_cmd:    "{job_prefix} urg"
   cov_merge_opts:   []
 
   // Generate coverage reports in text as well as html.
-  cov_report_dir:   "{scratch_base_path}/cov_report"
+  cov_report_dir:   "{scratch_path}/cov_report"
   cov_report_cmd:   "{job_prefix} urg"
   cov_report_opts:  []
   cov_report_txt:   "{cov_report_dir}/dashboard.txt"
@@ -73,7 +67,7 @@
 
   // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
   // GUI for visual analysis.
-  cov_analyze_dir:  "{scratch_base_path}/cov_analyze"
+  cov_analyze_dir:  "{scratch_path}/cov_analyze"
   cov_analyze_cmd:  "{job_prefix} verdi"
   cov_analyze_opts: ["-cov",
                      "-covdir {cov_merge_db_dir}",

--- a/hw/dv/tools/dvsim/riviera.hjson
+++ b/hw/dv/tools/dvsim/riviera.hjson
@@ -5,10 +5,6 @@
   build_cmd:  "vlib work && {job_prefix} vlog"
   run_cmd:    "{job_prefix} vsim"
 
-  // Indicate the tool specific helper sources - these are copied over to the
-  // {tool_srcs_dir} before running the simulation.
-  tool_srcs:  ["{dv_root}/tools/riviera/*"]
-
   build_opts: ["-timescale 1ns/1ps",
                "+incdir+\"{RIVIERA_HOME}/vlib/uvm-1.2/src\"",
                "\"{RIVIERA_HOME}/vlib/uvm-1.2/src/uvm_pkg.sv\"",
@@ -31,7 +27,7 @@
   supported_wave_formats: []
 
   // Default tcl script used when running the sim. Override if needed.
-  run_script: "{tool_srcs_dir}/riviera_run.do"
+  run_script: "{dv_root}/tools/riviera/riviera_run.do"
 
   // Coverage related.
   // TODO: These options have to be filled in.
@@ -45,20 +41,20 @@
   // Merging coverage.
   // "cov_db_dirs" is a special variable that appends all build directories in use.
   // It is constructed by the tool itself.
-  cov_merge_dir:    "{scratch_base_path}/cov_merge"
+  cov_merge_dir:    "{scratch_path}/cov_merge"
   cov_merge_db_dir: ""
   cov_merge_cmd:    ""
   cov_merge_opts:   []
 
   // Generate covreage reports in text as well as html.
-  cov_report_dir:       "{scratch_base_path}/cov_report"
+  cov_report_dir:       "{scratch_path}/cov_report"
   cov_report_cmd:       ""
   cov_report_opts:      []
   cov_report_dashboard: ""
 
   // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
   // GUI for visual analysis.
-  cov_analyze_dir:  "{scratch_base_path}/cov_analyze"
+  cov_analyze_dir:  "{scratch_path}/cov_analyze"
   cov_analyze_cmd:  ""
   cov_analyze_opts: []
 
@@ -90,8 +86,8 @@
       is_sim_mode: 1
       build_opts: []
     }
-	{
     // TODO: Add build and run options to enable zero delay loop detection.
+    {
       name: riviera_loopdetect
       is_sim_mode: 1
       build_opts: []

--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -4,7 +4,6 @@
 
 .DEFAULT_GOAL := all
 
-LOCK_TOOL_SRCS_DIR ?= flock --timeout 3600 ${tool_srcs_dir} --command
 LOCK_SW_BUILD_DIR  ?= flock --timeout 3600 ${sw_build_dir} --command
 
 all: build run
@@ -14,14 +13,7 @@ all: build run
 ###############################
 build: build_result
 
-prep_tool_srcs:
-	@echo "[make]: prep_tool_srcs"
-	mkdir -p ${tool_srcs_dir}
-ifneq (${tool_srcs},)
-	${LOCK_TOOL_SRCS_DIR} "cp -Ru ${tool_srcs} ${tool_srcs_dir}/."
-endif
-
-pre_build: prep_tool_srcs
+pre_build:
 	@echo "[make]: pre_build"
 	mkdir -p ${build_dir}
 ifneq (${pre_build_cmds},)
@@ -34,11 +26,11 @@ ifneq (${sv_flist_gen_cmd},)
 	cd ${build_dir} && ${sv_flist_gen_cmd} ${sv_flist_gen_opts}
 endif
 
-build_tb: gen_sv_flist
-	@echo "[make]: build the testbench"
+do_build: gen_sv_flist
+	@echo "[make]: build"
 	cd ${sv_flist_gen_dir} && ${build_cmd} ${build_opts}
 
-post_build: build_tb
+post_build: do_build
 	@echo "[make]: post_build"
 ifneq (${post_build_cmds},)
 	cd ${build_dir} && ${post_build_cmds}
@@ -49,7 +41,7 @@ build_result: post_build
 
 run: run_result
 
-pre_run: prep_tool_srcs
+pre_run:
 	@echo "[make]: pre_run"
 	mkdir -p ${run_dir}
 ifneq (${pre_run_cmds},)
@@ -138,24 +130,23 @@ cov_report:
 	${cov_report_cmd} ${cov_report_opts}
 
 # Open coverage tool to review and create report or exclusion file.
-cov_analyze: prep_tool_srcs
+cov_analyze:
 	@echo "[make]: cov_analyze"
 	${cov_analyze_cmd} ${cov_analyze_opts}
 
 .PHONY: build \
-				prep_tool_srcs \
-				pre_build \
-				gen_sv_flist \
-				build_tb \
-				post_build \
-				build_result \
-				run \
-				pre_run \
-				sw_build \
-				simulate \
-				post_run \
-				run_result \
-				debug_waves \
-				cov_merge \
-				cov_analyze \
-				cov_report
+        pre_build \
+        gen_sv_flist \
+        do_build \
+        post_build \
+        build_result \
+        run \
+        pre_run \
+        sw_build \
+        simulate \
+        post_run \
+        run_result \
+        debug_waves \
+        cov_merge \
+        cov_analyze \
+        cov_report

--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -6,10 +6,6 @@
   build_ex:   "{build_dir}/simv"
   run_cmd:    "{job_prefix} {build_ex}"
 
-  // Indicate the tool specific helper sources - these are copied over to the
-  // {tool_srcs_dir} before running the simulation.
-  tool_srcs:  ["{dv_root}/tools/vcs/*"]
-
   build_opts: ["-sverilog -full64 -licqueue -kdb -ntb_opts uvm-1.2",
                "-timescale=1ns/1ps",
                "-Mdir={build_ex}.csrc",
@@ -109,7 +105,7 @@
   supported_wave_formats: ["fsdb", "vpd"]
 
   // Default tcl script used when running the sim. Override if needed.
-  run_script: "{tool_srcs_dir}/sim.tcl"
+  run_script: "{dv_root}/tools/sim.tcl"
 
   // Coverage related.
   cov_db_dir: "{scratch_path}/coverage/{build_mode}.vdb"
@@ -122,7 +118,7 @@
   // Merging coverage.
   // "cov_db_dirs" is a special variable that appends all build directories in use.
   // It is constructed by the tool itself.
-  cov_merge_dir:    "{scratch_base_path}/cov_merge"
+  cov_merge_dir:    "{scratch_path}/cov_merge"
   cov_merge_db_dir: "{cov_merge_dir}/merged.vdb"
   cov_merge_cmd:    "{job_prefix} urg"
   cov_merge_opts:   ["-full64",
@@ -138,7 +134,7 @@
                      "-dbname {cov_merge_db_dir}"]
 
   // Generate coverage reports in text as well as html.
-  cov_report_dir:       "{scratch_base_path}/cov_report"
+  cov_report_dir:       "{scratch_path}/cov_report"
   cov_report_cmd:       "{job_prefix} urg"
   cov_report_opts:      ["-full64",
                         "+urg+lic+wait",
@@ -154,7 +150,7 @@
   // UNR related.
   // All code coverage, assert isn't supported
   cov_unr_metrics: "line+cond+fsm+tgl+branch"
-  cov_unr_dir:     "{scratch_base_path}/cov_unr"
+  cov_unr_dir:     "{scratch_path}/cov_unr"
 
   cov_unr_common_build_opts: ["-sverilog -full64 -licqueue -ntb_opts uvm-1.2",
                               "-timescale=1ns/1ps"]
@@ -187,7 +183,7 @@
 
   // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
   // GUI for visual analysis.
-  cov_analyze_dir:  "{scratch_base_path}/cov_analyze"
+  cov_analyze_dir:  "{scratch_path}/cov_analyze"
   cov_analyze_cmd:  "{job_prefix} verdi"
   cov_analyze_opts: ["-cov",
                      "-covdir {cov_merge_db_dir}",
@@ -261,7 +257,7 @@
     {
       name: vcs_xprop
       is_sim_mode: 1
-      build_opts: ["-xprop={tool_srcs_dir}/xprop.cfg"]
+      build_opts: ["-xprop={dv_root}/tools/vcs/xprop.cfg"]
     }
     {
       name: vcs_profile

--- a/hw/dv/tools/dvsim/verilator.hjson
+++ b/hw/dv/tools/dvsim/verilator.hjson
@@ -47,11 +47,6 @@
   ex_name:    "{eval_cmd} echo \"{fusesoc_core}\" | cut -d: -f3"
   run_cmd:    "{build_dir}/sim-verilator/V{ex_name}"
 
-  // Indicate the tool specific helper sources - these are copied over to the
-  // {tool_srcs_dir} before running the simulation.
-  // TODO: none at the moment.
-  tool_srcs:  []
-
   // TODO: Verilator has a few useful build switches. Need to figure out how to
   // pass them via FuseSoC.
 

--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -5,10 +5,6 @@
   build_cmd:  "{job_prefix} xrun"
   run_cmd:    "{job_prefix} xrun"
 
-  // Indicate the tool specific helper sources - these are copied over to the
-  // {tool_srcs_dir} before running the simulation.
-  tool_srcs:  ["{dv_root}/tools/xcelium/*"]
-
   build_opts: ["-elaborate -64bit -access +r -sv",
                "-licqueue",
                // TODO: duplicate primitives between OT and Ibex #1231
@@ -65,7 +61,7 @@
   supported_wave_formats: ["shm", "fsdb", "vcd"]
 
   // Default tcl script used when running the sim. Override if needed.
-  run_script: "{tool_srcs_dir}/sim.tcl"
+  run_script: "{dv_root}/tools/sim.tcl"
 
   // Coverage related.
   // By default, collect all coverage metrics: block:expr:fsm:toggle:functional.
@@ -90,26 +86,26 @@
 
   // Merging coverage.
   // It is constructed by the tool itself.
-  cov_merge_dir:    "{scratch_base_path}/cov_merge"
+  cov_merge_dir:    "{scratch_path}/cov_merge"
   cov_merge_db_dir: "{cov_merge_dir}/merged"
   cov_merge_cmd:    "{job_prefix} imc"
   cov_merge_opts:   ["-64bit",
                      "-licqueue",
-                     "-exec {tool_srcs_dir}/cov_merge.tcl"]
+                     "-exec {dv_root}/tools/xcelium/cov_merge.tcl"]
 
   // Generate covreage reports in text as well as html.
-  cov_report_dir:   "{scratch_base_path}/cov_report"
+  cov_report_dir:   "{scratch_path}/cov_report"
   cov_report_cmd:   "{job_prefix} imc"
   cov_report_opts:  ["-64bit",
                      "-licqueue",
-                     "-exec {tool_srcs_dir}/cov_report.tcl",
+                     "-exec {dv_root}/tools/xcelium/cov_report.tcl",
                      "{xcelium_cov_refine_files}"]
   cov_report_txt:   "{cov_report_dir}/cov_report.txt"
   cov_report_page:  "index.html"
 
   // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
   // GUI for visual analysis.
-  cov_analyze_dir:  "{scratch_base_path}/cov_analyze"
+  cov_analyze_dir:  "{scratch_path}/cov_analyze"
   cov_analyze_cmd:  "{job_prefix} imc"
   cov_analyze_opts: ["-gui",
                      "-64bit",

--- a/hw/dv/tools/sim.tcl
+++ b/hw/dv/tools/sim.tcl
@@ -6,16 +6,16 @@
 # VCS syntax: -ucli -do <this file>
 # Xcelium syntax: -input <this file>
 
-set tool_srcs_dir ""
-if {[info exists ::env(TOOL_SRCS_DIR)]} {
-  set tool_srcs_dir "$::env(TOOL_SRCS_DIR)"
+set dv_root ""
+if {[info exists ::env(dv_root)]} {
+  set dv_root "$::env(dv_root)"
 } else {
-  puts "ERROR: Script run without TOOL_SRCS_DIR environment variable."
+  puts "ERROR: Script run without dv_root environment variable."
   quit
 }
 
-source "${tool_srcs_dir}/common.tcl"
-source "${tool_srcs_dir}/waves.tcl"
+source "${dv_root}/tools/common.tcl"
+source "${dv_root}/tools/waves.tcl"
 
 run
 quit

--- a/hw/dv/tools/vcs/unr.cfg
+++ b/hw/dv/tools/vcs/unr.cfg
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
--covInput $SCRATCH_BASE_PATH/cov_merge/merged.vdb
+-covInput $SCRATCH_PATH/cov_merge/merged.vdb
 -covDUT $dut_instance
 
 # Provide the clock specification
@@ -14,10 +14,10 @@
 # -blackBoxes -type design *
 
 # Include common el file, so that it doesn't generate reviewed common exclusions
--covEL $TOOL_SRCS_DIR/common_cov_excl.el
+-covEL $dv_root/tools/vcs/common_cov_excl.el
 
 # Name of the generated exclusion file
--save_exclusion $SCRATCH_BASE_PATH/cov_unr/unr_exclude.el
+-save_exclusion $SCRATCH_PATH/cov_unr/unr_exclude.el
 
 # Enables verbose reporting in addition to summary reporting.
 -verboseReport

--- a/hw/formal/tools/dvsim/common_fpv_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_fpv_cfg.hjson
@@ -3,11 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   flow:             fpv
-  flow_makefile:    "{proj_root}/hw/formal/tools/dvsim/fpv.mk"
+  fpv_root:         "{proj_root}/hw/formal"
+  flow_makefile:    "{fpv_root}/tools/dvsim/fpv.mk"
 
   import_cfgs:      [// common server configuration for results upload
                      "{proj_root}/hw/data/common_project_cfg.hjson",
-                     "{proj_root}/hw/formal/tools/{tool}/{tool}.hjson"]
+                     "{fpv_root}/tools/{tool}/{tool}.hjson"]
 
   tool:             "jaspergold"
 
@@ -29,16 +30,13 @@
                       "--setup {fusesoc_core}"]
   sv_flist_gen_dir:  "{build_dir}/formal-icarus"
 
-  // Indicate the tool specific helper sources
-  tool_srcs: ["{proj_root}/hw/formal/tools/{tool}/fpv.tcl"]
-
   // Vars that need to exported to the env
   exports: [
     { FPV_TOP: "{dut}" },
     { COV: "{cov}" }
   ]
 
-  report_cmd:  "python3 {proj_root}/hw/formal/tools/{tool}/parse-fpv-report.py"
+  report_cmd:  "python3 {fpv_root}/tools/{tool}/parse-fpv-report.py"
   report_opts: ["--logpath={build_dir}/fpv.log",
                 "--reppath={build_dir}/results.hjson",
                 "--cov={cov}",

--- a/hw/formal/tools/dvsim/fpv.mk
+++ b/hw/formal/tools/dvsim/fpv.mk
@@ -1,6 +1,7 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL := all
 
 all: build
@@ -8,35 +9,36 @@ all: build
 ###################
 ## build targets ##
 ###################
-build: compile_result
+build: build_result
 
 gen_sv_flist:
 	@echo "[make]: gen_sv_flist"
 	cd ${build_dir} && ${sv_flist_gen_cmd} ${sv_flist_gen_opts}
 
-pre_compile: gen_sv_flist
-	@echo "[make]: pre_compile"
+pre_build: gen_sv_flist
+	@echo "[make]: pre_build"
 	mkdir -p ${build_dir}
-	env | sort > ${build_dir}/env_vars
-	cp -Ru ${tool_srcs} ${sv_flist_gen_dir}
+ifneq (${pre_build_cmds},)
+	cd ${build_dir} && ${pre_build_cmds}
+endif
 
-compile: pre_compile
-	@echo "[make]: compile"
-	# we check the status in the parse script below
+do_build: pre_build
+	@echo "[make]: do_build"
 	cd ${sv_flist_gen_dir} && ${build_cmd} ${build_opts} 2>&1 | tee ${build_dir}/fpv.log
 
-post_compile: compile
-	@echo "[make]: post_compile"
+post_build: do_build
+	@echo "[make]: post_build"
+ifneq (${post_build_cmds},)
+	cd ${build_dir} && ${post_build_cmds}
+endif
 
-# Parse out result
-compile_result: post_compile
-	@echo "[make]: compile_result"
+build_result: post_build
+	@echo "[make]: build_result"
 	${report_cmd} ${report_opts}
 
-.PHONY: \
-	build \
-	run \
-	pre_compile \
-	compile \
-	post_compile \
-	compile_result
+.PHONY: build \
+        gen_sv_flist \
+        pre_build \
+        do_build \
+        post_build \
+        build_result

--- a/hw/ip/aes/syn/aes_syn_cfg.hjson
+++ b/hw/ip/aes/syn/aes_syn_cfg.hjson
@@ -12,8 +12,7 @@
                 "{proj_root}/hw/syn/tools/dvsim/common_syn_cfg.hjson"]
 
   // Timing constraints for this module
-  sdc_path: "{proj_root}/hw/ip/aes/syn/"
-  sdc_file: "constraints.sdc"
+  sdc_file: "{proj_root}/hw/ip/aes/syn/constraints.sdc"
 
   // Configuration for result parser script
   area_depth: 1

--- a/hw/ip/alert_handler/dv/alert_handler_generic_sim_cfg.hjson
+++ b/hw/ip/alert_handler/dv/alert_handler_generic_sim_cfg.hjson
@@ -36,13 +36,7 @@
   reseed: 50
 
   // Add ALERT_HANDLER specific exclusion files.
-
-  // Add excl files to tool_srcs so that it gets copied over to the scratch area.
-  tool_srcs: ["{proj_root}/hw/ip/alert_handler/dv/cov/alert_handler_cov_excl.el"]
-
-  // Refer to the excl file with vcs_cov_excl_files var with the rel path from tool_srcs_dir
-  // so the VCS can find it.
-  vcs_cov_excl_files: ["{tool_srcs_dir}/alert_handler_cov_excl.el"]
+  vcs_cov_excl_files: ["{proj_root}/hw/ip/alert_handler/dv/cov/alert_handler_cov_excl.el"]
 
   // Default UVM test and seq class name.
   uvm_test: alert_handler_base_test

--- a/hw/ip/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/ip/gpio/dv/gpio_sim_cfg.hjson
@@ -43,13 +43,7 @@
   uvm_test_seq: gpio_base_vseq
 
   // Add GPIO specific exclusion files.
-
-  // Add excl files to tool_srcs so that it gets copied over to the scratch area.
-  tool_srcs: ["{proj_root}/hw/ip/gpio/dv/cov/gpio_cov_excl.el"]
-
-  // Refer to the excl file with vcs_cov_excl_files var with the rel path from tool_srcs_dir
-  // so the VCS can find it.
-  vcs_cov_excl_files: ["{tool_srcs_dir}/gpio_cov_excl.el"]
+  vcs_cov_excl_files: ["{proj_root}/hw/ip/gpio/dv/cov/gpio_cov_excl.el"]
 
   // List of test specifications.
   tests: [

--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -39,13 +39,7 @@
   reseed: 50
 
   // Add HMAC specific exclusion files.
-
-  // Add excl files to tool_srcs so that it gets copied over to the scratch area.
-  tool_srcs: ["{proj_root}/hw/ip/hmac/dv/cov/hmac_cov_excl.el"]
-
-  // Refer to the excl file with vcs_cov_excl_files var with the rel path from tool_srcs_dir
-  // so the VCS can find it.
-  vcs_cov_excl_files: ["{tool_srcs_dir}/hmac_cov_excl.el"]
+  vcs_cov_excl_files: ["{proj_root}/hw/ip/hmac/dv/cov/hmac_cov_excl.el"]
 
   // Default UVM test and seq class name.
   uvm_test: hmac_base_test

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -41,8 +41,8 @@
   // Need to override the default output directory
   overrides: [
     {
-      name: scratch_base_path
-      value: "{scratch_root}/{variant}.{flow}.{tool}"
+      name: scratch_path
+      value: "{scratch_base_path}/{variant}-{flow}-{tool}"
     }
   ]
 

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -21,6 +21,9 @@ name:
   // Testplan hjson file.
   testplan: "{proj_root}/hw/ip/otbn/data/otbn_testplan.hjson"
 
+  exports: [
+    { REPO_TOP: "{proj_root}" },
+  ]
 
   // Import additional common sim cfg files.
   // TODO: remove imported cfgs that do not apply.

--- a/hw/ip/otbn/syn/otbn_syn_cfg.hjson
+++ b/hw/ip/otbn/syn/otbn_syn_cfg.hjson
@@ -12,8 +12,7 @@
                 "{proj_root}/hw/syn/tools/dvsim/common_syn_cfg.hjson"]
 
   // Timing constraints for this module
-  sdc_path: "{proj_root}/hw/ip/otbn/syn/"
-  sdc_file: "constraints.sdc"
+  sdc_file: "{proj_root}/hw/ip/otbn/syn/constraints.sdc"
 
   // Configuration for result parser script
   area_depth: 1

--- a/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson
@@ -23,13 +23,8 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
-  // Add the coverage configuration and exclusion files so they get copied
-  // over to the scratch area.
-  tool_srcs: ["{proj_root}/hw/ip/prim/dv/prim_lfsr/data/prim_lfsr_cover.cfg",
-              "{proj_root}/hw/ip/prim/dv/prim_lfsr/data/prim_lfsr_cover_assert.cfg",
-              "{proj_root}/hw/ip/prim/dv/prim_lfsr/data/prim_lfsr_cov_excl.el"]
-
-  vcs_cov_excl_files: ["{tool_srcs_dir}/prim_lfsr_cov_excl.el"]
+  // Add PRIM_LSFR specific exclusion files.
+  vcs_cov_excl_files: ["{proj_root}/hw/ip/prim/dv/prim_lfsr/data/prim_lfsr_cov_excl.el"]
 
   build_modes: [
     {
@@ -44,8 +39,8 @@
 
   // dw_8 is only used for "smoke" sims, so coverage collection is not needed.
   prim_lfsr_dw_8_vcs_cov_cfg_file: ""
-  prim_lfsr_dw_24_vcs_cov_cfg_file: "-cm_hier {tool_srcs_dir}/prim_lfsr_cover.cfg"
-  vcs_cov_assert_cfg_file: "-cm_assert_hier {tool_srcs_dir}/prim_lfsr_cover_assert.cfg"
+  prim_lfsr_dw_24_vcs_cov_cfg_file: "-cm_hier {proj_root}/hw/ip/prim/dv/prim_lfsr/data/prim_lfsr_cover.cfg"
+  vcs_cov_assert_cfg_file: "-cm_assert_hier {proj_root}/hw/ip/prim/dv/prim_lfsr/data/prim_lfsr_cover_assert.cfg"
 
   prim_lfsr_dw_8_xcelium_cov_cfg_file: ""
   prim_lfsr_dw_24_xcelium_cov_cfg_file: ""

--- a/hw/ip/prim/dv/prim_present/prim_present_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_present/prim_present_sim_cfg.hjson
@@ -26,13 +26,10 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
-  // Add these to tool_srcs so that they get copied over.
-  tool_srcs: ["{proj_root}/hw/ip/prim/dv/prim_present/data/prim_present_cover.cfg"]
-
   overrides: [
     {
       name: vcs_cov_cfg_file
-      value: "-cm_hier {tool_srcs_dir}/prim_present_cover.cfg"
+      value: "-cm_hier {proj_root}/hw/ip/prim/dv/prim_present/data/prim_present_cover.cfg"
     }
   ]
 

--- a/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson
@@ -23,12 +23,10 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
-  tool_srcs: ["{proj_root}/hw/ip/prim/dv/prim_prince/data/prim_prince_cover.cfg"]
-
   overrides: [
     {
       name: vcs_cov_cfg_file
-      value: "-cm_hier {tool_srcs_dir}/prim_prince_cover.cfg"
+      value: "-cm_hier {proj_root}/hw/ip/prim/dv/prim_prince/data/prim_prince_cover.cfg"
     }
   ]
 

--- a/hw/ip/rv_core_ibex/syn/rv_core_ibex_syn_cfg.hjson
+++ b/hw/ip/rv_core_ibex/syn/rv_core_ibex_syn_cfg.hjson
@@ -12,7 +12,5 @@
                 "{proj_root}/hw/syn/tools/dvsim/common_syn_cfg.hjson"]
 
   // Timing constraints for this module
-  sdc_path: "{proj_root}/hw/ip/rv_core_ibex/syn"
-  sdc_file: "constraints.sdc"
-
+  sdc_file: "{proj_root}/hw/ip/rv_core_ibex/syn/constraints.sdc"
  }

--- a/hw/ip/tlul/generic_dv/xbar_sim_cfg.hjson
+++ b/hw/ip/tlul/generic_dv/xbar_sim_cfg.hjson
@@ -23,9 +23,6 @@
   // Set the path to testplan md file as it's not in the default location.
   testplan_doc_path: "hw/ip/tlul/doc/dv/#testplan"
 
-  // Add xbar specific exclusion files.
-  vcs_cov_excl_files: ["{tool_srcs_dir}/xbar_cov_excl.el"]
-
   // Import additional common sim cfg files.
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",

--- a/hw/ip/uart/dv/uart_sim_cfg.hjson
+++ b/hw/ip/uart/dv/uart_sim_cfg.hjson
@@ -43,13 +43,7 @@
   uvm_test_seq: uart_base_vseq
 
   // Add UART specific exclusion files.
-
-  // Add excl files to tool_srcs so that it gets copied over to the scratch area.
-  tool_srcs: ["{proj_root}/hw/ip/uart/dv/cov/uart_cov_excl.el"]
-
-  // Refer to the excl file with vcs_cov_excl_files var with the rel path from tool_srcs_dir
-  // so the VCS can find it.
-  vcs_cov_excl_files: ["{tool_srcs_dir}/uart_cov_excl.el"]
+  vcs_cov_excl_files: ["{proj_root}/hw/ip/uart/dv/cov/uart_cov_excl.el"]
 
   // List of test specifications.
   tests: [

--- a/hw/lint/tools/dvsim/ascentlint.hjson
+++ b/hw/lint/tools/dvsim/ascentlint.hjson
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-    // Ascentlint-specific results parsing script that is called after running lint
-    report_cmd: "{proj_root}/hw/lint/tools/{tool}/parse-lint-report.py "
-    report_opts: ["--repdir={build_dir}/lint-{tool}",
-                  "--outdir={build_dir}"]
+  tool: "ascentlint"
+
+  // Ascentlint-specific results parsing script that is called after running lint
+  report_cmd: "{lint_root}/tools/{tool}/parse-lint-report.py "
+  report_opts: ["--repdir={build_dir}/lint-{tool}",
+                "--outdir={build_dir}"]
 }

--- a/hw/lint/tools/dvsim/common_lint_cfg.hjson
+++ b/hw/lint/tools/dvsim/common_lint_cfg.hjson
@@ -3,12 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   flow:             lint
-  flow_makefile:    "{proj_root}/hw/lint/tools/dvsim/lint.mk"
+  lint_root:        "{proj_root}/hw/lint"
+  flow_makefile:    "{lint_root}/tools/dvsim/lint.mk"
 
   import_cfgs:      [// common server configuration for results upload
                      "{proj_root}/hw/data/common_project_cfg.hjson"
                      // tool-specific configuration
-                     "{proj_root}/hw/lint/tools/dvsim/{tool}.hjson"]
+                     "{lint_root}/tools/dvsim/{tool}.hjson"]
 
   // Name of the DUT / top-level to be run through lint
   dut:        "{name}"
@@ -30,5 +31,4 @@
   sv_flist_gen_cmd:   ""
   sv_flist_gen_opts:  []
   sv_flist_gen_dir:   ""
-  tool_srcs:          []
 }

--- a/hw/lint/tools/dvsim/lint.mk
+++ b/hw/lint/tools/dvsim/lint.mk
@@ -1,6 +1,7 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL := all
 
 all: build
@@ -8,30 +9,31 @@ all: build
 ###################
 ## build targets ##
 ###################
-build: compile_result
+build: build_result
 
-pre_compile:
-	@echo "[make]: pre_compile"
-	mkdir -p ${build_dir} && env | sort > ${build_dir}/env_vars
-	mkdir -p ${tool_srcs_dir}
-	-cp -Ru ${tool_srcs} ${tool_srcs_dir}
+pre_build:
+	@echo "[make]: pre_build"
+	mkdir -p ${build_dir}
+ifneq (${pre_build_cmds},)
+	cd ${build_dir} && ${pre_build_cmds}
+endif
 
-compile: pre_compile
-	@echo "[make]: compile"
-	# we check the status in the parse script below
+do_build: pre_build
+	@echo "[make]: do_build"
 	-cd ${build_dir} && ${build_cmd} ${build_opts} 2>&1 | tee ${build_log}
 
-post_compile: compile
-	@echo "[make]: post_compile"
+post_build: do_build
+	@echo "[make]: post_build"
+ifneq (${post_build_cmds},)
+	cd ${build_dir} && ${post_build_cmds}
+endif
 
-# Parse out result
-compile_result: post_compile
-	@echo "[make]: compile_result"
+build_result: post_build
+	@echo "[make]: build_result"
 	${report_cmd} ${report_opts}
 
 .PHONY: build \
-	run \
-	pre_compile \
-	compile \
-	post_compile \
-	compile_result
+        pre_build \
+        do_build \
+        post_build \
+        build_result

--- a/hw/lint/tools/dvsim/veriblelint.hjson
+++ b/hw/lint/tools/dvsim/veriblelint.hjson
@@ -2,12 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-    // TODO(#1342): switch over to native structured tool output, once supported by Verible
-    // Verible lint-specific results parsing script that is called after running lint
-    report_cmd: "{proj_root}/hw/lint/tools/{tool}/parse-lint-report.py "
-    report_opts: ["--repdir={build_dir}",
-                  "--outdir={build_dir}"]
+  tool: "veriblelint"
 
-    // This customizes the report format for style lint
-    is_style_lint: True
+  // TODO(#1342): switch over to native structured tool output, once supported by Verible
+  // Verible lint-specific results parsing script that is called after running lint
+  report_cmd: "{lint_root}/tools/{tool}/parse-lint-report.py "
+  report_opts: ["--repdir={build_dir}",
+                "--outdir={build_dir}"]
+
+  // This customizes the report format for style lint
+  is_style_lint: True
 }

--- a/hw/lint/tools/dvsim/verilator.hjson
+++ b/hw/lint/tools/dvsim/verilator.hjson
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-    // Verilator lint-specific results parsing script that is called after running lint
-    report_cmd: "{proj_root}/hw/lint/tools/{tool}/parse-lint-report.py "
-    report_opts: ["--logpath={build_dir}/lint.log",
-                  "--reppath={build_dir}/results.hjson"]
+  tool: "verilator"
+
+  // Verilator lint-specific results parsing script that is called after running lint
+  report_cmd: "{lint_root}/tools/{tool}/parse-lint-report.py "
+  report_opts: ["--logpath={build_dir}/lint.log",
+                "--reppath={build_dir}/results.hjson"]
 }

--- a/hw/syn/tools/dc/run-syn.tcl
+++ b/hw/syn/tools/dc/run-syn.tcl
@@ -8,9 +8,26 @@
 ##  PREPARE FLOW   ##
 #####################
 
-# tool setup
-set CONFIG_PATH "./"
-source ${CONFIG_PATH}/setup.tcl
+set syn_root ""
+if {[info exists ::env(syn_root)]} {
+  set syn_root "$::env(syn_root)"
+} else {
+  puts "ERROR: Script run without syn_root environment variable."
+  quit
+}
+
+set foundry_root ""
+if {[info exists ::env(foundry_root)]} {
+  set foundry_root "$::env(foundry_root)"
+} else {
+  puts "ERROR: Script run without foundry_root environment variable."
+  quit
+}
+
+# Tool setup.
+# TODO: The below path assumes a certain directory structure in the foundry area which does not
+# exist in the open repo.
+source ${foundry_root}/syn/dc/setup.tcl
 
 # if in interactive mode, do not exit at the end of the script
 if { [info exists ::env(INTERACTIVE)] } {

--- a/hw/syn/tools/dvsim/common_syn_cfg.hjson
+++ b/hw/syn/tools/dvsim/common_syn_cfg.hjson
@@ -3,14 +3,20 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   flow:             syn
-  flow_makefile:    "{proj_root}/hw/syn/tools/dvsim/syn.mk"
+  syn_root:         "{proj_root}/hw/syn"
+  flow_makefile:    "{syn_root}/tools/dvsim/syn.mk"
+
+  // TODO: the path below is used to refer to the foundry area which does not exist in the open
+  // repo. This forces the closed "foundry" repo to be placed in that area. This might be subject to
+  // change in future.
+  foundry_root:     "{proj_root}/hw/foundry"
 
   import_cfgs:      [// common server configuration for results upload
                      // TODO: check whether this config file can be aligned such that it can
                      // be reused among different flow types
                      // "{proj_root}/hw/dv/tools/dvsim/fusesoc.hjson",
                      "{proj_root}/hw/data/common_project_cfg.hjson",
-                     "{proj_root}/hw/syn/tools/dvsim/{tool}.hjson"]
+                     "{syn_root}/tools/dvsim/{tool}.hjson"]
 
   // Default directory structure for the output
   dut:              "{name}"
@@ -34,4 +40,9 @@
                        "{fusesoc_core}"]
   sv_flist_gen_dir:   "{build_dir}/syn-icarus"
   sv_flist:           "{sv_flist_gen_dir}/{fusesoc_core_}.scr"
+
+  exports: [
+    { syn_root: "{syn_root}" },
+    { foundry_root: "{foundry_root}" },
+  ]
 }

--- a/hw/syn/tools/dvsim/dc.hjson
+++ b/hw/syn/tools/dvsim/dc.hjson
@@ -2,14 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  // The tool sources include the technology setup file,
-  // the main synthesis run script and the constraints file
-  tool_srcs: ["{proj_root}/hw/foundry/syn/{tool}/setup.tcl"
-              "{proj_root}/hw/foundry/syn/{tool}/lib-setup.tcl"
-              "{proj_root}/hw/foundry/syn/{tool}/ram-macros-setup.tcl"
-              "{proj_root}/hw/syn/tools/{tool}/run-syn.tcl"
-              "{sdc_path}/{sdc_file}"]
-
   // Environment variables that are needed in the synthesis script
   exports: [
     { DUT:        "{dut}" },
@@ -20,10 +12,10 @@
 
   // Tool invocation
   build_cmd:  "{job_prefix} dc_shell-xg-t "
-  build_opts: ["-f run-syn.tcl"]
+  build_opts: ["-f {syn_root}/tools/dc/run-syn.tcl"]
 
   // DC-specific results parsing script that is called after running synthesis
-  report_cmd: "{proj_root}/hw/syn/tools/{tool}/parse-syn-report.py --depth {area_depth}"
+  report_cmd: "{syn_root}/tools/dc/parse-syn-report.py --depth {area_depth}"
   report_opts: ["--dut {dut}",
                 "--logpath {build_dir} ",
                 "--reppath {build_dir}/REPORTS",

--- a/hw/syn/tools/dvsim/syn.mk
+++ b/hw/syn/tools/dvsim/syn.mk
@@ -1,6 +1,7 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL := all
 
 all: build
@@ -8,33 +9,36 @@ all: build
 ###################
 ## build targets ##
 ###################
-build: compile_result
+build: build_result
 
 gen_sv_flist:
 	@echo "[make]: gen_sv_flist"
 	cd ${build_dir} && ${sv_flist_gen_cmd} ${sv_flist_gen_opts}
 
-pre_compile: gen_sv_flist
-	@echo "[make]: pre_compile"
-	mkdir -p ${build_dir} && env | sort > ${build_dir}/env_vars
-	-cp -Ru ${tool_srcs} ${sv_flist_gen_dir}
+pre_build: gen_sv_flist
+	@echo "[make]: pre_build"
+	mkdir -p ${build_dir}
+ifneq (${pre_build_cmds},)
+	cd ${build_dir} && ${pre_build_cmds}
+endif
 
-compile: pre_compile
-	@echo "[make]: compile"
-	# we check the status in the parse script below
+do_build: pre_build
+	@echo "[make]: do_build"
 	cd ${sv_flist_gen_dir} && ${build_cmd} ${build_opts} 2>&1 | tee ${build_log}
 
-post_compile: compile
-	@echo "[make]: post_compile"
+post_build: do_build
+	@echo "[make]: post_build"
+ifneq (${post_build_cmds},)
+	cd ${build_dir} && ${post_build_cmds}
+endif
 
-# Parse out result
-compile_result: post_compile
-	@echo "[make]: compile_result"
+build_result: post_build
+	@echo "[make]: build_result"
 	${report_cmd} ${report_opts}
 
 .PHONY: build \
-	gen_sv_flist \
-	pre_compile \
-	compile \
-	post_compile \
-	compile_result
+        gen_sv_flist \
+        pre_build \
+        do_build \
+        post_build \
+        build_result

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -54,14 +54,14 @@
     // IPs. See `hw/dv/tools/dvsim/common_sim_cfg.hjson` for the default value.
     {
       name: default_vcs_cov_cfg_file
-      value: "-cm_hier {tool_srcs_dir}/chip_cover.cfg"
+      value: "-cm_hier {proj_root}/hw/top_earlgrey/dv/cov/chip_cover.cfg"
     }
     // Used by 'cover_reg_top' only builds - we only cover the *_reg_top of
     // the non-pre-verified modules at the chip level. See
     // `hw/dv/tools/dvsim//common_sim_cfg.hjson` for the default value.
     {
       name: cover_reg_top_vcs_cov_cfg_file
-      value: "-cm_hier {tool_srcs_dir}/chip_cover_reg_top.cfg"
+      value: "-cm_hier {proj_root)/hw/top_earlgrey/dv/cov/chip_cover_reg_top.cfg"
     }
 
     // This defaults to 'ip' in `hw/data/common_project_cfg.hjson`.
@@ -73,10 +73,7 @@
 
   // Set the vcs_cov_assert_hier to supply the chip specific assertion coverage
   // hierarchies.
-  vcs_cov_assert_hier: "-cm_assert_hier {tool_srcs_dir}/chip_assert_cover.cfg"
-
-  // Add these to tool_srcs so that they get copied over.
-  tool_srcs: ["{proj_root}/hw/top_earlgrey/dv/cov/*"]
+  vcs_cov_assert_hier: "-cm_assert_hier {proj_root}/hw/top_earlgrey/dv/cov/chip_assert_cover.cfg"
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 1

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson
@@ -12,8 +12,8 @@
   // Testplan hjson file.
   testplan: "{proj_root}/hw/top_earlgrey/ip/{dut}/data/autogen/{dut}_testplan.hjson"
 
-  // Add excl files to tool_srcs so that it gets copied over to the scratch area.
-  tool_srcs: ["{proj_root}/hw/top_earlgrey/ip/{dut}/dv/cov/xbar_cov_excl.el"]
+  // Add xbar_main specific exclusion files.
+  vcs_cov_excl_files: ["{proj_root}/hw/top_earlgrey/ip/{dut}/dv/cov/xbar_cov_excl.el"]
 
   // Import additional common sim cfg files.
   import_cfgs: [// xbar common sim cfg file

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson
@@ -12,8 +12,8 @@
   // Testplan hjson file.
   testplan: "{proj_root}/hw/top_earlgrey/ip/{dut}/data/autogen/{dut}_testplan.hjson"
 
-  // Add excl files to tool_srcs so that it gets copied over to the scratch area.
-  tool_srcs: ["{proj_root}/hw/top_earlgrey/ip/{dut}/dv/cov/xbar_cov_excl.el"]
+  // Add xbar_peri specific exclusion files.
+  vcs_cov_excl_files: ["{proj_root}/hw/top_earlgrey/ip/{dut}/dv/cov/xbar_cov_excl.el"]
 
   // Import additional common sim cfg files.
   import_cfgs: [// xbar common sim cfg file

--- a/hw/top_earlgrey/syn/top_earlgrey_syn_cfg.hjson
+++ b/hw/top_earlgrey/syn/top_earlgrey_syn_cfg.hjson
@@ -20,13 +20,10 @@
   ]
 
   // Timing constraints for this module
-  sdc_path: "{proj_root}/hw/top_earlgrey/syn"
-  sdc_file: "constraints.sdc"
+  sdc_file: "{proj_root}/hw/top_earlgrey/syn/constraints.sdc"
 
   // Technology specific timing constraints for this module
-  foundry_sdc_path: "{proj_root}/hw/foundry/top_earlgrey/syn"
-  foundry_sdc_file: "foundry.constraints.sdc"
-  tool_srcs: ["{foundry_sdc_path}/{foundry_sdc_file}"]
+  foundry_sdc_file: "{proj_root}/hw/foundry/top_earlgrey/syn/foundry.constraints.sdc"
 
   // Configuration for result parser script
   area_depth: 1

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -654,8 +654,7 @@ class CompileSim(Deploy):
 
         self.mandatory_cmd_attrs.update({
             # tool srcs
-            "tool_srcs": False,
-            "tool_srcs_dir": False,
+            "proj_root": False,
 
             # Flist gen
             "sv_flist_gen_cmd": False,
@@ -717,8 +716,7 @@ class CompileOneShot(Deploy):
 
         self.mandatory_cmd_attrs.update({
             # tool srcs
-            "tool_srcs": False,
-            "tool_srcs_dir": False,
+            "proj_root": False,
 
             # Flist gen
             "sv_flist_gen_cmd": False,
@@ -727,8 +725,10 @@ class CompileOneShot(Deploy):
 
             # Build
             "build_dir": False,
+            "pre_build_cmds": False,
             "build_cmd": False,
             "build_opts": False,
+            "post_build_cmds": False,
             "build_log": False,
 
             # Report processing
@@ -775,8 +775,6 @@ class RunTest(Deploy):
 
         self.mandatory_cmd_attrs.update({
             # tool srcs
-            "tool_srcs": False,
-            "tool_srcs_dir": False,
             "proj_root": False,
             "uvm_test": False,
             "uvm_test_seq": False,
@@ -866,8 +864,7 @@ class CovUnr(Deploy):
         self.target = "cov_unr"
         self.mandatory_cmd_attrs.update({
             # tool srcs
-            "tool_srcs": False,
-            "tool_srcs_dir": False,
+            "proj_root": False,
 
             # Need to generate filelist based on build mode
             "sv_flist_gen_cmd": False,
@@ -1066,8 +1063,7 @@ class CovAnalyze(Deploy):
 
         self.mandatory_cmd_attrs.update({
             # tool srcs
-            "tool_srcs": False,
-            "tool_srcs_dir": False,
+            "proj_root": False,
             "cov_analyze_cmd": False,
             "cov_analyze_opts": False
         })

--- a/util/tlgen/xbar.sim_cfg.hjson.tpl
+++ b/util/tlgen/xbar.sim_cfg.hjson.tpl
@@ -12,8 +12,8 @@
   // Testplan hjson file.
   testplan: "{proj_root}/${xbar.ip_path}/data/autogen/{dut}_testplan.hjson"
 
-  // Add excl files to tool_srcs so that it gets copied over to the scratch area.
-  tool_srcs: ["{proj_root}/${xbar.ip_path}/dv/cov/xbar_cov_excl.el"]
+  // Add xbar_${xbar.name} specific exclusion files.
+  vcs_cov_excl_files: ["{proj_root}/${xbar.ip_path}/dv/cov/xbar_cov_excl.el"]
 
   // Import additional common sim cfg files.
   import_cfgs: [// xbar common sim cfg file


### PR DESCRIPTION
This change enables the remote compute servers running EDA jobs at Google have access to the entire repo. 

Previously, sources the tools required access to were passed to the HJson list `tool_srcs`. Those sources would then get copied over to the `tool` directory in the scratch area so that they were accessible from there. This is unfortunately too limiting. OTBN has a usecase where the ISS is run in lock-step with the simulation and requires Python scripts to be available. Python scripts may be dependent on other Python scripts and other sources, making it difficult to track individual sources that need to be copied over. 

In these set of changes, we just simply copy over the entire repo so that that limitation is gone. Copying is done ONLY if `DVSIM_REMOTE_DISPATCH` env variable is defined in the user's workspace AND the chosen scratch space is outside the repo_top. The copying is done in the first commit. The subsequent commits are changes made to dv, fpv, lint and synthesis respectively to support this change. 

