### PR TITLE
[csrng/rtl] switch to lc_hw_debug_en for lifecycle input

### DIFF
--- a/hw/ip/csrng/csrng.core
+++ b/hw/ip/csrng/csrng.core
@@ -10,7 +10,7 @@ filesets:
       - lowrisc:constants:top_pkg
       - lowrisc:prim:all
       - lowrisc:prim:assert
-      - lowrisc:prim:multibit_sync
+      - lowrisc:prim:lc_sync
       - lowrisc:ip:tlul
       - lowrisc:ip:aes
       - lowrisc:ip:csrng_pkg

--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -53,7 +53,7 @@
     }
     { struct:  "lc_tx"
       type:    "uni"
-      name:    "lc_dft_en"
+      name:    "lc_hw_debug_en"
       act:     "rcv"
       default: "lc_ctrl_pkg::Off"
       package: "lc_ctrl_pkg"

--- a/hw/ip/csrng/rtl/csrng.sv
+++ b/hw/ip/csrng/rtl/csrng.sv
@@ -21,7 +21,7 @@ module csrng import csrng_pkg::*; #(
   input logic efuse_sw_app_enable_i,
 
   // Lifecycle broadcast inputs
-  input  lc_ctrl_pkg::lc_tx_t  lc_dft_en_i,
+  input  lc_ctrl_pkg::lc_tx_t  lc_hw_debug_en_i,
 
   // Entropy Interface
   output entropy_src_pkg::entropy_src_hw_if_req_t entropy_src_hw_if_o,
@@ -66,7 +66,7 @@ module csrng import csrng_pkg::*; #(
 
     // misc inputs
     .efuse_sw_app_enable_i,
-    .lc_dft_en_i,
+    .lc_hw_debug_en_i,
 
     // Entropy Interface
     .entropy_src_hw_if_o,

--- a/hw/ip/csrng/rtl/csrng_block_encrypt.sv
+++ b/hw/ip/csrng/rtl/csrng_block_encrypt.sv
@@ -18,7 +18,7 @@ module csrng_block_encrypt #(
    // update interface
   input logic                block_encrypt_bypass_i,
   input logic                block_encrypt_enable_i,
-  input lc_ctrl_pkg::lc_tx_t block_encrypt_lc_dft_en_i,
+  input logic                block_encrypt_lc_hw_debug_not_on_i,
   input logic                block_encrypt_req_i,
   output logic               block_encrypt_rdy_o,
   input logic [KeyLen-1:0]   block_encrypt_key_i,
@@ -74,20 +74,7 @@ module csrng_block_encrypt #(
   // aes cipher core lifecycle enable
   //--------------------------------------------
 
-  lc_ctrl_pkg::lc_tx_t lc_dft_en;
-
-  prim_multibit_sync #(
-    .Width(lc_ctrl_pkg::TxWidth),
-    .NumChecks (2),
-    .ResetValue(lc_ctrl_pkg::TxWidth'(lc_ctrl_pkg::Off))
-  ) u_prim_multibit_sync (
-    .clk_i,
-    .rst_ni,
-    .data_i (block_encrypt_lc_dft_en_i),
-    .data_o (lc_dft_en)
-  );
-
-  assign aes_cipher_core_enable = (!block_encrypt_bypass_i) || (lc_dft_en != lc_ctrl_pkg::On);
+  assign aes_cipher_core_enable = (!block_encrypt_bypass_i) || block_encrypt_lc_hw_debug_not_on_i;
 
   //--------------------------------------------
   // aes cipher core

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -20,7 +20,7 @@ module csrng_core import csrng_pkg::*; #(
   input efuse_sw_app_enable_i,
 
   // Lifecycle broadcast inputs
-  input  lc_ctrl_pkg::lc_tx_t  lc_dft_en_i,
+  input  lc_ctrl_pkg::lc_tx_t  lc_hw_debug_en_i,
 
   // Entropy Interface
   output entropy_src_pkg::entropy_src_hw_if_req_t entropy_src_hw_if_o,
@@ -257,6 +257,7 @@ module csrng_core import csrng_pkg::*; #(
   logic                    genbits_stage_fips_sw;
 
   logic [14:0]             hw_exception_sts;
+  logic                    lc_hw_debug_not_on;
 
   // flops
   logic [2:0]  acmd_q, acmd_d;
@@ -965,6 +966,27 @@ module csrng_core import csrng_pkg::*; #(
 
 
   //-------------------------------------
+  // life cycle logic
+  //-------------------------------------
+  // The chip level life cycle control
+  // provide control logic to determine
+  // how certain debug features are controlled.
+
+  lc_ctrl_pkg::lc_tx_t lc_hw_debug_en_out;
+
+  prim_lc_sync #(
+    .NumCopies(1)
+  ) u_prim_lc_sync (
+    .clk_i,
+    .rst_ni,
+    .lc_en_i(lc_hw_debug_en_i),
+    .lc_en_o(lc_hw_debug_en_out)
+  );
+
+  assign      lc_hw_debug_not_on = (lc_hw_debug_en_out != lc_ctrl_pkg::On);
+
+
+  //-------------------------------------
   // csrng_block_encrypt instantiation
   //-------------------------------------
   // The csrng_block_encrypt is shared
@@ -985,7 +1007,7 @@ module csrng_core import csrng_pkg::*; #(
     .rst_ni(rst_ni),
     .block_encrypt_bypass_i(!aes_cipher_enable),
     .block_encrypt_enable_i(cs_enable),
-    .block_encrypt_lc_dft_en_i(lc_dft_en_i),
+    .block_encrypt_lc_hw_debug_not_on_i(lc_hw_debug_not_on),
     .block_encrypt_req_i(benblk_arb_vld),
     .block_encrypt_rdy_o(benblk_arb_rdy),
     .block_encrypt_key_i(benblk_arb_key),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3457,7 +3457,7 @@
         {
           struct: lc_tx
           type: uni
-          name: lc_dft_en
+          name: lc_hw_debug_en
           act: rcv
           default: lc_ctrl_pkg::Off
           package: lc_ctrl_pkg
@@ -8262,7 +8262,7 @@
       {
         struct: lc_tx
         type: uni
-        name: lc_dft_en
+        name: lc_hw_debug_en
         act: rcv
         default: lc_ctrl_pkg::Off
         package: lc_ctrl_pkg

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1180,7 +1180,7 @@ module top_earlgrey #(
       .entropy_src_hw_if_o(csrng_entropy_src_hw_if_req),
       .entropy_src_hw_if_i(csrng_entropy_src_hw_if_rsp),
       .efuse_sw_app_enable_i('0),
-      .lc_dft_en_i(lc_ctrl_pkg::Off),
+      .lc_hw_debug_en_i(lc_ctrl_pkg::Off),
       .tl_i(csrng_tl_req),
       .tl_o(csrng_tl_rsp),
       .clk_i (clkmgr_clocks.clk_main_secure),


### PR DESCRIPTION
Converted to the prim_lc_sync module version of this function.
Removed all lint complaints.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>