### PR TITLE
[dv] Fix regression compile error

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -34,7 +34,7 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
         cfg.m_alert_agent_cfg[i].alert_delay_max = 0;
       end
 
-      cfg.m_edn_pull_agent_cfg.zero_delays = 1;
+      if (cfg.has_edn) cfg.m_edn_pull_agent_cfg.zero_delays = 1;
     end
 
     // get vifs


### PR DESCRIPTION
Some regression has compile error due to `cip_env` null object for
edn_agent_cfg. This happened if cfg.zero_delay is randomized to 1, or set to 1. 
This PR fix it by adding a gating logic `has_edn` before assigning zero_delay to it.

Signed-off-by: Cindy Chen <chencindy@google.com>