### PR TITLE
[dvsim] Fix publish report path

### DIFF
--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -124,6 +124,10 @@ class FlowCfg():
             for entry in self.use_cfgs:
                 self._load_child_cfg(entry, mk_config)
 
+        if self.rel_path == "":
+            self.rel_path = os.path.dirname(self.flow_cfg_file).replace(
+                self.proj_root + '/', '')
+
         # Process overrides before substituting wildcards
         self._process_overrides()
 
@@ -131,10 +135,6 @@ class FlowCfg():
         # after merging the hjson but before expansion, they can override
         # _expand and add the code at the start.
         self._expand()
-
-        if self.rel_path == "":
-            self.rel_path = os.path.dirname(self.flow_cfg_file).replace(
-                self.proj_root + '/', '')
 
         # Run any final checks
         self._post_init()


### PR DESCRIPTION

Move `self.rel_path` before `self._process_overrides()` to fix
`rel_path` is empty in hjson file

Fix below highlighted path
VERBOSE: [FlowCfg] CLOUDSDK_PYTHON=/usr/bin/python2.7 /usr/bin/gsutil cp /edascratch/weicai-opentitan/ot/uart.sim.vcs/try_publish/results_Mon.12.14.20__06.57.39PM.html gs://reports.opentitan.org/**hw/ip/uart/dv**/latest/results.html;

Signed-off-by: Weicai Yang <weicai@google.com>
