### PR TITLE
Revert "Add Pattgen to EarlGrey"

### DIFF
--- a/hw/ip/pattgen/dv/tb.sv
+++ b/hw/ip/pattgen/dv/tb.sv
@@ -38,10 +38,10 @@ module tb;
     .tl_i                 (tl_if.h2d     ),
     .tl_o                 (tl_if.d2h     ),
 
-    .cio_pda0_tx_o        (pda_tx_o[0]   ),
-    .cio_pcl0_tx_o        (pcl_tx_o[0]   ),
-    .cio_pda1_tx_o        (pda_tx_o[1]   ),
-    .cio_pcl1_tx_o        (pcl_tx_o[1]   ),
+    .pda0_tx_o            (pda_tx_o[0]   ),
+    .pcl0_tx_o            (pcl_tx_o[0]   ),
+    .pda1_tx_o            (pda_tx_o[1]   ),
+    .pcl1_tx_o            (pcl_tx_o[1]   ),
     .intr_done_ch0_o      (intr_done_ch0 ),
     .intr_done_ch1_o      (intr_done_ch1 )
   );

--- a/hw/ip/pattgen/rtl/pattgen.sv
+++ b/hw/ip/pattgen/rtl/pattgen.sv
@@ -13,23 +13,14 @@ module pattgen
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
 
-  output logic cio_pda0_tx_o,
-  output logic cio_pda0_tx_en_o,
-  output logic cio_pcl0_tx_o,
-  output logic cio_pcl0_tx_en_o,
-  output logic cio_pda1_tx_o,
-  output logic cio_pda1_tx_en_o,
-  output logic cio_pcl1_tx_o,
-  output logic cio_pcl1_tx_en_o,
+  output logic pda0_tx_o,
+  output logic pcl0_tx_o,
+  output logic pda1_tx_o,
+  output logic pcl1_tx_o,
 
   output logic intr_done_ch0_o,
   output logic intr_done_ch1_o
 );
-
-  assign cio_pda0_tx_en_o = 1'b1;
-  assign cio_pcl0_tx_en_o = 1'b1;
-  assign cio_pda1_tx_en_o = 1'b1;
-  assign cio_pcl1_tx_en_o = 1'b1;
 
   pattgen_reg2hw_t reg2hw;
   pattgen_hw2reg_t hw2reg;
@@ -50,10 +41,10 @@ module pattgen
     .reg2hw,
     .hw2reg,
 
-    .pda0_tx_o(cio_pda0_tx_o),
-    .pcl0_tx_o(cio_pcl0_tx_o),
-    .pda1_tx_o(cio_pda1_tx_o),
-    .pcl1_tx_o(cio_pcl1_tx_o),
+    .pda0_tx_o,
+    .pcl0_tx_o,
+    .pda1_tx_o,
+    .pcl1_tx_o,
 
     .intr_done_ch0_o,
     .intr_done_ch1_o
@@ -61,10 +52,10 @@ module pattgen
 
   `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid)
   `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready)
-  `ASSERT_KNOWN(Pcl0TxKnownO_A, cio_pcl0_tx_o)
-  `ASSERT_KNOWN(Pda0TxKnownO_A, cio_pda0_tx_o)
-  `ASSERT_KNOWN(Pcl1TxKnownO_A, cio_pcl1_tx_o)
-  `ASSERT_KNOWN(Pda1TxKnownO_A, cio_pda1_tx_o)
+  `ASSERT_KNOWN(Pcl0TxKnownO_A, pcl0_tx_o)
+  `ASSERT_KNOWN(Pda0TxKnownO_A, pda0_tx_o)
+  `ASSERT_KNOWN(Pcl1TxKnownO_A, pcl1_tx_o)
+  `ASSERT_KNOWN(Pda1TxKnownO_A, pda1_tx_o)
   `ASSERT_KNOWN(IntrCh0DoneKnownO_A, intr_done_ch0_o)
   `ASSERT_KNOWN(IntrCh1DoneKnownO_A, intr_done_ch1_o)
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -727,248 +727,6 @@
       ]
     }
     {
-      name: i2c
-      type: i2c
-      clock_srcs:
-      {
-        clk_i: io_div4
-      }
-      clock_group: peri
-      reset_connections:
-      {
-        rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
-      }
-      base_addr: 0x40080000
-      clock_reset_export: []
-      clock_connections:
-      {
-        clk_i: clkmgr_clocks.clk_io_div4_peri
-      }
-      domain: "0"
-      size: 0x1000
-      bus_device: tlul
-      bus_host: none
-      available_input_list: []
-      available_output_list: []
-      available_inout_list:
-      [
-        {
-          name: sda
-          width: 1
-          type: inout
-        }
-        {
-          name: scl
-          width: 1
-          type: inout
-        }
-      ]
-      param_list: []
-      interrupt_list:
-      [
-        {
-          name: fmt_watermark
-          width: 1
-          bits: "0"
-          bitinfo:
-          [
-            1
-            1
-            0
-          ]
-          type: interrupt
-        }
-        {
-          name: rx_watermark
-          width: 1
-          bits: "1"
-          bitinfo:
-          [
-            2
-            1
-            1
-          ]
-          type: interrupt
-        }
-        {
-          name: fmt_overflow
-          width: 1
-          bits: "2"
-          bitinfo:
-          [
-            4
-            1
-            2
-          ]
-          type: interrupt
-        }
-        {
-          name: rx_overflow
-          width: 1
-          bits: "3"
-          bitinfo:
-          [
-            8
-            1
-            3
-          ]
-          type: interrupt
-        }
-        {
-          name: nak
-          width: 1
-          bits: "4"
-          bitinfo:
-          [
-            16
-            1
-            4
-          ]
-          type: interrupt
-        }
-        {
-          name: scl_interference
-          width: 1
-          bits: "5"
-          bitinfo:
-          [
-            32
-            1
-            5
-          ]
-          type: interrupt
-        }
-        {
-          name: sda_interference
-          width: 1
-          bits: "6"
-          bitinfo:
-          [
-            64
-            1
-            6
-          ]
-          type: interrupt
-        }
-        {
-          name: stretch_timeout
-          width: 1
-          bits: "7"
-          bitinfo:
-          [
-            128
-            1
-            7
-          ]
-          type: interrupt
-        }
-        {
-          name: sda_unstable
-          width: 1
-          bits: "8"
-          bitinfo:
-          [
-            256
-            1
-            8
-          ]
-          type: interrupt
-        }
-        {
-          name: trans_complete
-          width: 1
-          bits: "9"
-          bitinfo:
-          [
-            512
-            1
-            9
-          ]
-          type: interrupt
-        }
-        {
-          name: tx_empty
-          width: 1
-          bits: "10"
-          bitinfo:
-          [
-            1024
-            1
-            10
-          ]
-          type: interrupt
-        }
-        {
-          name: tx_nonempty
-          width: 1
-          bits: "11"
-          bitinfo:
-          [
-            2048
-            1
-            11
-          ]
-          type: interrupt
-        }
-        {
-          name: tx_overflow
-          width: 1
-          bits: "12"
-          bitinfo:
-          [
-            4096
-            1
-            12
-          ]
-          type: interrupt
-        }
-        {
-          name: acq_overflow
-          width: 1
-          bits: "13"
-          bitinfo:
-          [
-            8192
-            1
-            13
-          ]
-          type: interrupt
-        }
-        {
-          name: ack_stop
-          width: 1
-          bits: "14"
-          bitinfo:
-          [
-            16384
-            1
-            14
-          ]
-          type: interrupt
-        }
-      ]
-      alert_list: []
-      wakeup_list: []
-      reset_request_list: []
-      scan: "false"
-      scan_reset: "false"
-      inter_signal_list:
-      [
-        {
-          struct: tl
-          package: tlul_pkg
-          type: req_rsp
-          act: rsp
-          name: tl
-          inst_name: i2c
-          width: 1
-          default: ""
-          top_signame: i2c_tl
-          index: -1
-        }
-      ]
-    }
-    {
       name: pattgen
       type: pattgen
       clock_srcs:
@@ -4940,10 +4698,6 @@
       [
         peri.tl_spi_device
       ]
-      i2c.tl:
-      [
-        peri.tl_i2c
-      ]
       rv_timer.tl:
       [
         peri.tl_rv_timer
@@ -5810,7 +5564,6 @@
           sensor_ctrl
           ast_wrapper
           pattgen
-          i2c
         ]
       }
       nodes:
@@ -5873,24 +5626,6 @@
           [
             {
               base_addr: 0x40050000
-              size_byte: 0x1000
-            }
-          ]
-          xbar: false
-          stub: false
-          pipeline_byp: "true"
-        }
-        {
-          name: i2c
-          type: device
-          clock: clk_peri_i
-          reset: rst_peri_ni
-          pipeline: "false"
-          inst_type: i2c
-          addr_range:
-          [
-            {
-              base_addr: 0x40080000
               size_byte: 0x1000
             }
           ]
@@ -6133,18 +5868,6 @@
         {
           struct: tl
           type: req_rsp
-          name: tl_i2c
-          act: req
-          package: tlul_pkg
-          inst_name: peri
-          width: 1
-          default: ""
-          top_signame: i2c_tl
-          index: -1
-        }
-        {
-          struct: tl
-          type: req_rsp
           name: tl_rv_timer
           act: req
           package: tlul_pkg
@@ -6281,7 +6004,6 @@
     keymgr
     kmac
     pattgen
-    i2c
   ]
   interrupt:
   [
@@ -7026,201 +6748,6 @@
       type: interrupt
       module_name: pattgen
     }
-    {
-      name: i2c_fmt_watermark
-      width: 1
-      bits: "0"
-      bitinfo:
-      [
-        1
-        1
-        0
-      ]
-      type: interrupt
-      module_name: i2c
-    }
-    {
-      name: i2c_rx_watermark
-      width: 1
-      bits: "1"
-      bitinfo:
-      [
-        2
-        1
-        1
-      ]
-      type: interrupt
-      module_name: i2c
-    }
-    {
-      name: i2c_fmt_overflow
-      width: 1
-      bits: "2"
-      bitinfo:
-      [
-        4
-        1
-        2
-      ]
-      type: interrupt
-      module_name: i2c
-    }
-    {
-      name: i2c_rx_overflow
-      width: 1
-      bits: "3"
-      bitinfo:
-      [
-        8
-        1
-        3
-      ]
-      type: interrupt
-      module_name: i2c
-    }
-    {
-      name: i2c_nak
-      width: 1
-      bits: "4"
-      bitinfo:
-      [
-        16
-        1
-        4
-      ]
-      type: interrupt
-      module_name: i2c
-    }
-    {
-      name: i2c_scl_interference
-      width: 1
-      bits: "5"
-      bitinfo:
-      [
-        32
-        1
-        5
-      ]
-      type: interrupt
-      module_name: i2c
-    }
-    {
-      name: i2c_sda_interference
-      width: 1
-      bits: "6"
-      bitinfo:
-      [
-        64
-        1
-        6
-      ]
-      type: interrupt
-      module_name: i2c
-    }
-    {
-      name: i2c_stretch_timeout
-      width: 1
-      bits: "7"
-      bitinfo:
-      [
-        128
-        1
-        7
-      ]
-      type: interrupt
-      module_name: i2c
-    }
-    {
-      name: i2c_sda_unstable
-      width: 1
-      bits: "8"
-      bitinfo:
-      [
-        256
-        1
-        8
-      ]
-      type: interrupt
-      module_name: i2c
-    }
-    {
-      name: i2c_trans_complete
-      width: 1
-      bits: "9"
-      bitinfo:
-      [
-        512
-        1
-        9
-      ]
-      type: interrupt
-      module_name: i2c
-    }
-    {
-      name: i2c_tx_empty
-      width: 1
-      bits: "10"
-      bitinfo:
-      [
-        1024
-        1
-        10
-      ]
-      type: interrupt
-      module_name: i2c
-    }
-    {
-      name: i2c_tx_nonempty
-      width: 1
-      bits: "11"
-      bitinfo:
-      [
-        2048
-        1
-        11
-      ]
-      type: interrupt
-      module_name: i2c
-    }
-    {
-      name: i2c_tx_overflow
-      width: 1
-      bits: "12"
-      bitinfo:
-      [
-        4096
-        1
-        12
-      ]
-      type: interrupt
-      module_name: i2c
-    }
-    {
-      name: i2c_acq_overflow
-      width: 1
-      bits: "13"
-      bitinfo:
-      [
-        8192
-        1
-        13
-      ]
-      type: interrupt
-      module_name: i2c
-    }
-    {
-      name: i2c_ack_stop
-      width: 1
-      bits: "14"
-      bitinfo:
-      [
-        16384
-        1
-        14
-      ]
-      type: interrupt
-      module_name: i2c
-    }
   ]
   alert_module:
   [
@@ -7504,7 +7031,6 @@
       uart
       gpio
       pattgen
-      i2c
     ]
     nc_modules:
     [
@@ -7747,18 +7273,6 @@
         type: inout
         module_name: gpio
       }
-      {
-        name: i2c_sda
-        width: 1
-        type: inout
-        module_name: i2c
-      }
-      {
-        name: i2c_scl
-        width: 1
-        type: inout
-        module_name: i2c
-      }
     ]
   }
   padctrl:
@@ -7896,18 +7410,6 @@
         width: 1
         default: ""
         top_signame: spi_device_tl
-        index: -1
-      }
-      {
-        struct: tl
-        package: tlul_pkg
-        type: req_rsp
-        act: rsp
-        name: tl
-        inst_name: i2c
-        width: 1
-        default: ""
-        top_signame: i2c_tl
         index: -1
       }
       {
@@ -9635,18 +9137,6 @@
       {
         struct: tl
         type: req_rsp
-        name: tl_i2c
-        act: req
-        package: tlul_pkg
-        inst_name: peri
-        width: 1
-        default: ""
-        top_signame: i2c_tl
-        index: -1
-      }
-      {
-        struct: tl
-        type: req_rsp
         name: tl_rv_timer
         act: req
         package: tlul_pkg
@@ -10517,22 +10007,6 @@
         package: tlul_pkg
         struct: tl_d2h
         signame: spi_device_tl_rsp
-        width: 1
-        type: req_rsp
-        default: ""
-      }
-      {
-        package: tlul_pkg
-        struct: tl_h2d
-        signame: i2c_tl_req
-        width: 1
-        type: req_rsp
-        default: ""
-      }
-      {
-        package: tlul_pkg
-        struct: tl_d2h
-        signame: i2c_tl_rsp
         width: 1
         type: req_rsp
         default: ""

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -727,102 +727,6 @@
       ]
     }
     {
-      name: pattgen
-      type: pattgen
-      clock_srcs:
-      {
-        clk_i: io_div4
-      }
-      clock_group: peri
-      reset_connections:
-      {
-        rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
-      }
-      base_addr: 0x400e0000
-      clock_reset_export: []
-      clock_connections:
-      {
-        clk_i: clkmgr_clocks.clk_io_div4_peri
-      }
-      domain: "0"
-      size: 0x1000
-      bus_device: tlul
-      bus_host: none
-      available_input_list: []
-      available_output_list:
-      [
-        {
-          name: pda0_tx
-          width: 1
-          type: output
-        }
-        {
-          name: pcl0_tx
-          width: 1
-          type: output
-        }
-        {
-          name: pda1_tx
-          width: 1
-          type: output
-        }
-        {
-          name: pcl1_tx
-          width: 1
-          type: output
-        }
-      ]
-      available_inout_list: []
-      param_list: []
-      interrupt_list:
-      [
-        {
-          name: done_ch0
-          width: 1
-          bits: "0"
-          bitinfo:
-          [
-            1
-            1
-            0
-          ]
-          type: interrupt
-        }
-        {
-          name: done_ch1
-          width: 1
-          bits: "1"
-          bitinfo:
-          [
-            2
-            1
-            1
-          ]
-          type: interrupt
-        }
-      ]
-      alert_list: []
-      wakeup_list: []
-      reset_request_list: []
-      scan: "false"
-      scan_reset: "false"
-      inter_signal_list:
-      [
-        {
-          struct: tl
-          package: tlul_pkg
-          type: req_rsp
-          act: rsp
-          name: tl
-          inst_name: pattgen
-          width: 1
-          default: ""
-          top_signame: pattgen_tl
-          index: -1
-        }
-      ]
-    }
-    {
       name: rv_timer
       type: rv_timer
       clock_srcs:
@@ -4730,10 +4634,6 @@
       [
         peri.tl_sensor_ctrl
       ]
-      pattgen.tl:
-      [
-        peri.tl_pattgen
-      ]
     }
     top:
     [
@@ -5563,7 +5463,6 @@
           otp_ctrl
           sensor_ctrl
           ast_wrapper
-          pattgen
         ]
       }
       nodes:
@@ -5794,24 +5693,6 @@
           xbar: false
           pipeline_byp: "true"
         }
-        {
-          name: pattgen
-          type: device
-          clock: clk_peri_i
-          reset: rst_peri_ni
-          pipeline: "false"
-          inst_type: pattgen
-          addr_range:
-          [
-            {
-              base_addr: 0x400e0000
-              size_byte: 0x1000
-            }
-          ]
-          xbar: false
-          stub: false
-          pipeline_byp: "true"
-        }
       ]
       clock: clk_peri_i
       type: xbar
@@ -5974,18 +5855,6 @@
           top_signame: ast_tl
           index: -1
         }
-        {
-          struct: tl
-          type: req_rsp
-          name: tl_pattgen
-          act: req
-          package: tlul_pkg
-          inst_name: peri
-          width: 1
-          default: ""
-          top_signame: pattgen_tl
-          index: -1
-        }
       ]
     }
   ]
@@ -6003,7 +5872,6 @@
     otbn
     keymgr
     kmac
-    pattgen
   ]
   interrupt:
   [
@@ -6722,32 +6590,6 @@
       type: interrupt
       module_name: kmac
     }
-    {
-      name: pattgen_done_ch0
-      width: 1
-      bits: "0"
-      bitinfo:
-      [
-        1
-        1
-        0
-      ]
-      type: interrupt
-      module_name: pattgen
-    }
-    {
-      name: pattgen_done_ch1
-      width: 1
-      bits: "1"
-      bitinfo:
-      [
-        2
-        1
-        1
-      ]
-      type: interrupt
-      module_name: pattgen
-    }
   ]
   alert_module:
   [
@@ -7030,7 +6872,6 @@
     [
       uart
       gpio
-      pattgen
     ]
     nc_modules:
     [
@@ -7238,33 +7079,7 @@
       }
     ]
     inputs: []
-    outputs:
-    [
-      {
-        name: pattgen_pda0_tx
-        width: 1
-        type: output
-        module_name: pattgen
-      }
-      {
-        name: pattgen_pcl0_tx
-        width: 1
-        type: output
-        module_name: pattgen
-      }
-      {
-        name: pattgen_pda1_tx
-        width: 1
-        type: output
-        module_name: pattgen
-      }
-      {
-        name: pattgen_pcl1_tx
-        width: 1
-        type: output
-        module_name: pattgen
-      }
-    ]
+    outputs: []
     inouts:
     [
       {
@@ -7410,18 +7225,6 @@
         width: 1
         default: ""
         top_signame: spi_device_tl
-        index: -1
-      }
-      {
-        struct: tl
-        package: tlul_pkg
-        type: req_rsp
-        act: rsp
-        name: tl
-        inst_name: pattgen
-        width: 1
-        default: ""
-        top_signame: pattgen_tl
         index: -1
       }
       {
@@ -9243,18 +9046,6 @@
         top_signame: ast_tl
         index: -1
       }
-      {
-        struct: tl
-        type: req_rsp
-        name: tl_pattgen
-        act: req
-        package: tlul_pkg
-        inst_name: peri
-        width: 1
-        default: ""
-        top_signame: pattgen_tl
-        index: -1
-      }
     ]
     external:
     [
@@ -10135,22 +9926,6 @@
         package: tlul_pkg
         struct: tl_d2h
         signame: sensor_ctrl_tl_rsp
-        width: 1
-        type: req_rsp
-        default: ""
-      }
-      {
-        package: tlul_pkg
-        struct: tl_h2d
-        signame: pattgen_tl_req
-        width: 1
-        type: req_rsp
-        default: ""
-      }
-      {
-        package: tlul_pkg
-        struct: tl_d2h
-        signame: pattgen_tl_rsp
         width: 1
         type: req_rsp
         default: ""

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -197,13 +197,6 @@
       reset_connections: {rst_ni: "spi_device"},
       base_addr: "0x40050000",
     },
-    { name: "i2c",
-      type: "i2c",
-      clock_srcs: {clk_i: "io_div4"},
-      clock_group: "peri",
-      reset_connections: {rst_ni: "sys_io_div4"},
-      base_addr: "0x40080000",
-    },
     { name: "pattgen",
       type: "pattgen",
       clock_srcs: {clk_i: "io_div4"},
@@ -609,7 +602,7 @@
   // first item goes to LSB of the interrupt source
   interrupt_module: ["gpio", "uart", "spi_device", "flash_ctrl",
                      "hmac", "alert_handler", "nmi_gen", "usbdev", "pwrmgr",
-                     "otbn", "keymgr", "kmac", "pattgen", "i2c" ]
+                     "otbn", "keymgr", "kmac", "pattgen" ]
 
   // RV_PLIC has two searching algorithm internally to pick the most highest priority interrupt
   // source. "sequential" is smaller but slower, "matrix" is larger but faster.
@@ -652,7 +645,7 @@
     //  between the modules and the IO PADS.
     //  If `mio_modules` aren't defined, it uses all remaining modules from
     //  module list except defined in `dio_modules`.
-    mio_modules: ["uart", "gpio", "pattgen", "i2c"]
+    mio_modules: ["uart", "gpio", "pattgen"]
 
     // If any module isn't defined in above two lists, its inputs will be tied
     //  to 0, and the output/OE signals will be floating (or connected to

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -197,13 +197,6 @@
       reset_connections: {rst_ni: "spi_device"},
       base_addr: "0x40050000",
     },
-    { name: "pattgen",
-      type: "pattgen",
-      clock_srcs: {clk_i: "io_div4"},
-      clock_group: "peri",
-      reset_connections: {rst_ni: "sys_io_div4"},
-      base_addr: "0x400e0000",
-    },
     { name: "rv_timer",
       type: "rv_timer",
       clock_srcs: {clk_i: "io_div4"},
@@ -602,7 +595,7 @@
   // first item goes to LSB of the interrupt source
   interrupt_module: ["gpio", "uart", "spi_device", "flash_ctrl",
                      "hmac", "alert_handler", "nmi_gen", "usbdev", "pwrmgr",
-                     "otbn", "keymgr", "kmac", "pattgen" ]
+                     "otbn", "keymgr", "kmac" ]
 
   // RV_PLIC has two searching algorithm internally to pick the most highest priority interrupt
   // source. "sequential" is smaller but slower, "matrix" is larger but faster.
@@ -645,7 +638,7 @@
     //  between the modules and the IO PADS.
     //  If `mio_modules` aren't defined, it uses all remaining modules from
     //  module list except defined in `dio_modules`.
-    mio_modules: ["uart", "gpio", "pattgen"]
+    mio_modules: ["uart", "gpio"]
 
     // If any module isn't defined in above two lists, its inputs will be tied
     //  to 0, and the output/OE signals will be floating (or connected to

--- a/hw/top_earlgrey/data/xbar_peri.hjson
+++ b/hw/top_earlgrey/data/xbar_peri.hjson
@@ -33,12 +33,6 @@
       reset:     "rst_peri_ni",
       pipeline: "false"
     },
-    { name:      "i2c",
-      type:      "device",
-      clock:     "clk_peri_i",
-      reset:     "rst_peri_ni",
-      pipeline:  "false"
-    },
     { name:      "rv_timer",
       type:      "device",
       clock:     "clk_peri_i",
@@ -110,6 +104,6 @@
   ],
   connections: {
     main:  ["uart", "gpio", "spi_device", "rv_timer", "usbdev", "pwrmgr", "rstmgr", "clkmgr",
-            "ram_ret", "otp_ctrl", "sensor_ctrl", "ast_wrapper", "pattgen", "i2c"],
+            "ram_ret", "otp_ctrl", "sensor_ctrl", "ast_wrapper", "pattgen"],
   },
 }

--- a/hw/top_earlgrey/data/xbar_peri.hjson
+++ b/hw/top_earlgrey/data/xbar_peri.hjson
@@ -95,15 +95,9 @@
         }
       ]
     },
-    { name:      "pattgen",
-      type:      "device",
-      clock:     "clk_peri_i",
-      reset:     "rst_peri_ni",
-      pipeline:  "false",
-    },
   ],
   connections: {
     main:  ["uart", "gpio", "spi_device", "rv_timer", "usbdev", "pwrmgr", "rstmgr", "clkmgr",
-            "ram_ret", "otp_ctrl", "sensor_ctrl", "ast_wrapper", "pattgen"],
+            "ram_ret", "otp_ctrl", "sensor_ctrl", "ast_wrapper"],
   },
 }

--- a/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
@@ -55,7 +55,6 @@ tl_if keymgr_tl_if(clk_main, rst_n);
 tl_if uart_tl_if(clk_io_div4, rst_n);
 tl_if gpio_tl_if(clk_io_div4, rst_n);
 tl_if spi_device_tl_if(clk_io_div4, rst_n);
-tl_if i2c_tl_if(clk_io_div4, rst_n);
 tl_if rv_timer_tl_if(clk_io_div4, rst_n);
 tl_if usbdev_tl_if(clk_io_div4, rst_n);
 tl_if pwrmgr_tl_if(clk_io_div4, rst_n);
@@ -116,7 +115,6 @@ initial begin
     `DRIVE_CHIP_TL_DEVICE_IF(uart, uart, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(gpio, gpio, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(spi_device, spi_device, tl)
-    `DRIVE_CHIP_TL_DEVICE_IF(i2c, i2c, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(rv_timer, rv_timer, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(usbdev, usbdev, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(pwrmgr, pwrmgr, tl)

--- a/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
@@ -64,7 +64,6 @@ tl_if ram_ret_tl_if(clk_io_div4, rst_n);
 tl_if otp_ctrl_tl_if(clk_io_div4, rst_n);
 tl_if sensor_ctrl_tl_if(clk_io_div4, rst_n);
 tl_if ast_wrapper_tl_if(clk_io_div4, rst_n);
-tl_if pattgen_tl_if(clk_io_div4, rst_n);
 
 initial begin
   bit xbar_mode;
@@ -124,7 +123,6 @@ initial begin
     `DRIVE_CHIP_TL_DEVICE_IF(otp_ctrl, otp_ctrl, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(sensor_ctrl, sensor_ctrl, tl)
     `DRIVE_CHIP_TL_EXT_DEVICE_IF(ast_wrapper, ast_tl)
-    `DRIVE_CHIP_TL_DEVICE_IF(pattgen, pattgen, tl)
   end
 end
 

--- a/hw/top_earlgrey/dv/autogen/xbar_env_pkg__params.sv
+++ b/hw/top_earlgrey/dv/autogen/xbar_env_pkg__params.sv
@@ -73,9 +73,6 @@ tl_device_t xbar_devices[$] = '{
     '{"spi_device", '{
         '{32'h40050000, 32'h40050fff}
     }},
-    '{"i2c", '{
-        '{32'h40080000, 32'h40080fff}
-    }},
     '{"rv_timer", '{
         '{32'h40100000, 32'h40100fff}
     }},
@@ -133,7 +130,6 @@ tl_host_t xbar_hosts[$] = '{
         "sensor_ctrl",
         "ast_wrapper",
         "pattgen",
-        "i2c",
         "flash_ctrl",
         "aes",
         "entropy_src",
@@ -167,7 +163,6 @@ tl_host_t xbar_hosts[$] = '{
         "sensor_ctrl",
         "ast_wrapper",
         "pattgen",
-        "i2c",
         "flash_ctrl",
         "aes",
         "entropy_src",

--- a/hw/top_earlgrey/dv/autogen/xbar_env_pkg__params.sv
+++ b/hw/top_earlgrey/dv/autogen/xbar_env_pkg__params.sv
@@ -99,9 +99,6 @@ tl_device_t xbar_devices[$] = '{
     }},
     '{"ast_wrapper", '{
         '{32'h40180000, 32'h40180fff}
-    }},
-    '{"pattgen", '{
-        '{32'h400e0000, 32'h400e0fff}
     }}};
 
   // List of Xbar hosts
@@ -129,7 +126,6 @@ tl_host_t xbar_hosts[$] = '{
         "otp_ctrl",
         "sensor_ctrl",
         "ast_wrapper",
-        "pattgen",
         "flash_ctrl",
         "aes",
         "entropy_src",
@@ -162,7 +158,6 @@ tl_host_t xbar_hosts[$] = '{
         "otp_ctrl",
         "sensor_ctrl",
         "ast_wrapper",
-        "pattgen",
         "flash_ctrl",
         "aes",
         "entropy_src",

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -88,13 +88,13 @@
     { name: "NMioPeriphIn",
       desc: "Number of muxed peripheral inputs",
       type: "int",
-      default: "34",
+      default: "32",
       local: "true"
     },
     { name: "NMioPeriphOut",
       desc: "Number of muxed peripheral outputs",
       type: "int",
-      default: "38",
+      default: "36",
       local: "true"
     },
     { name: "NMioPads",

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -94,7 +94,7 @@
     { name: "NMioPeriphOut",
       desc: "Number of muxed peripheral outputs",
       type: "int",
-      default: "36",
+      default: "32",
       local: "true"
     },
     { name: "NMioPads",

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
@@ -7,8 +7,8 @@
 package pinmux_reg_pkg;
 
   // Param list
-  parameter int NMioPeriphIn = 34;
-  parameter int NMioPeriphOut = 38;
+  parameter int NMioPeriphIn = 32;
+  parameter int NMioPeriphOut = 36;
   parameter int NMioPads = 32;
   parameter int NDioPads = 15;
   parameter int NWkupDetect = 8;
@@ -77,7 +77,7 @@ package pinmux_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    pinmux_reg2hw_periph_insel_mreg_t [33:0] periph_insel; // [672:469]
+    pinmux_reg2hw_periph_insel_mreg_t [31:0] periph_insel; // [660:469]
     pinmux_reg2hw_mio_outsel_mreg_t [31:0] mio_outsel; // [468:277]
     pinmux_reg2hw_mio_out_sleep_val_mreg_t [31:0] mio_out_sleep_val; // [276:213]
     pinmux_reg2hw_dio_out_sleep_val_mreg_t [14:0] dio_out_sleep_val; // [212:168]
@@ -176,7 +176,7 @@ package pinmux_reg_pkg;
     4'b 1111, // index[ 4] PINMUX_PERIPH_INSEL_3
     4'b 1111, // index[ 5] PINMUX_PERIPH_INSEL_4
     4'b 1111, // index[ 6] PINMUX_PERIPH_INSEL_5
-    4'b 0111, // index[ 7] PINMUX_PERIPH_INSEL_6
+    4'b 0011, // index[ 7] PINMUX_PERIPH_INSEL_6
     4'b 1111, // index[ 8] PINMUX_MIO_OUTSEL_0
     4'b 1111, // index[ 9] PINMUX_MIO_OUTSEL_1
     4'b 1111, // index[10] PINMUX_MIO_OUTSEL_2

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
@@ -8,7 +8,7 @@ package pinmux_reg_pkg;
 
   // Param list
   parameter int NMioPeriphIn = 32;
-  parameter int NMioPeriphOut = 36;
+  parameter int NMioPeriphOut = 32;
   parameter int NMioPads = 32;
   parameter int NDioPads = 15;
   parameter int NWkupDetect = 8;

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
@@ -170,12 +170,6 @@ module pinmux_reg_top (
   logic [5:0] periph_insel_6_in_31_qs;
   logic [5:0] periph_insel_6_in_31_wd;
   logic periph_insel_6_in_31_we;
-  logic [5:0] periph_insel_6_in_32_qs;
-  logic [5:0] periph_insel_6_in_32_wd;
-  logic periph_insel_6_in_32_we;
-  logic [5:0] periph_insel_6_in_33_qs;
-  logic [5:0] periph_insel_6_in_33_wd;
-  logic periph_insel_6_in_33_we;
   logic [5:0] mio_outsel_0_out_0_qs;
   logic [5:0] mio_outsel_0_out_0_wd;
   logic mio_outsel_0_out_0_we;
@@ -1484,58 +1478,6 @@ module pinmux_reg_top (
 
     // to register interface (read)
     .qs     (periph_insel_6_in_31_qs)
-  );
-
-
-  // F[in_32]: 17:12
-  prim_subreg #(
-    .DW      (6),
-    .SWACCESS("RW"),
-    .RESVAL  (6'h0)
-  ) u_periph_insel_6_in_32 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (periph_insel_6_in_32_we & regen_qs),
-    .wd     (periph_insel_6_in_32_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.periph_insel[32].q ),
-
-    // to register interface (read)
-    .qs     (periph_insel_6_in_32_qs)
-  );
-
-
-  // F[in_33]: 23:18
-  prim_subreg #(
-    .DW      (6),
-    .SWACCESS("RW"),
-    .RESVAL  (6'h0)
-  ) u_periph_insel_6_in_33 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (periph_insel_6_in_33_we & regen_qs),
-    .wd     (periph_insel_6_in_33_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.periph_insel[33].q ),
-
-    // to register interface (read)
-    .qs     (periph_insel_6_in_33_qs)
   );
 
 
@@ -5085,12 +5027,6 @@ module pinmux_reg_top (
   assign periph_insel_6_in_31_we = addr_hit[7] & reg_we & ~wr_err;
   assign periph_insel_6_in_31_wd = reg_wdata[11:6];
 
-  assign periph_insel_6_in_32_we = addr_hit[7] & reg_we & ~wr_err;
-  assign periph_insel_6_in_32_wd = reg_wdata[17:12];
-
-  assign periph_insel_6_in_33_we = addr_hit[7] & reg_we & ~wr_err;
-  assign periph_insel_6_in_33_wd = reg_wdata[23:18];
-
   assign mio_outsel_0_out_0_we = addr_hit[8] & reg_we & ~wr_err;
   assign mio_outsel_0_out_0_wd = reg_wdata[5:0];
 
@@ -5578,8 +5514,6 @@ module pinmux_reg_top (
       addr_hit[7]: begin
         reg_rdata_next[5:0] = periph_insel_6_in_30_qs;
         reg_rdata_next[11:6] = periph_insel_6_in_31_qs;
-        reg_rdata_next[17:12] = periph_insel_6_in_32_qs;
-        reg_rdata_next[23:18] = periph_insel_6_in_33_qs;
       end
 
       addr_hit[8]: begin

--- a/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
+++ b/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
@@ -25,7 +25,7 @@
     { name: "NumSrc",
       desc: "Number of interrupt sources",
       type: "int",
-      default: "104",
+      default: "89",
       local: "true"
     },
     { name: "NumTarget",
@@ -775,126 +775,6 @@
     }
     { name: "PRIO88",
       desc: "Interrupt Source 88 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO89",
-      desc: "Interrupt Source 89 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO90",
-      desc: "Interrupt Source 90 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO91",
-      desc: "Interrupt Source 91 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO92",
-      desc: "Interrupt Source 92 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO93",
-      desc: "Interrupt Source 93 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO94",
-      desc: "Interrupt Source 94 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO95",
-      desc: "Interrupt Source 95 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO96",
-      desc: "Interrupt Source 96 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO97",
-      desc: "Interrupt Source 97 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO98",
-      desc: "Interrupt Source 98 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO99",
-      desc: "Interrupt Source 99 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO100",
-      desc: "Interrupt Source 100 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO101",
-      desc: "Interrupt Source 101 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO102",
-      desc: "Interrupt Source 102 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO103",
-      desc: "Interrupt Source 103 Priority",
       swaccess: "rw",
       hwaccess: "hro",
       fields: [

--- a/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
+++ b/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
@@ -25,7 +25,7 @@
     { name: "NumSrc",
       desc: "Number of interrupt sources",
       type: "int",
-      default: "89",
+      default: "87",
       local: "true"
     },
     { name: "NumTarget",
@@ -759,22 +759,6 @@
     }
     { name: "PRIO86",
       desc: "Interrupt Source 86 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO87",
-      desc: "Interrupt Source 87 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO88",
-      desc: "Interrupt Source 88 Priority",
       swaccess: "rw",
       hwaccess: "hro",
       fields: [

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
@@ -183,26 +183,11 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   assign prio[86] = reg2hw.prio86.q;
   assign prio[87] = reg2hw.prio87.q;
   assign prio[88] = reg2hw.prio88.q;
-  assign prio[89] = reg2hw.prio89.q;
-  assign prio[90] = reg2hw.prio90.q;
-  assign prio[91] = reg2hw.prio91.q;
-  assign prio[92] = reg2hw.prio92.q;
-  assign prio[93] = reg2hw.prio93.q;
-  assign prio[94] = reg2hw.prio94.q;
-  assign prio[95] = reg2hw.prio95.q;
-  assign prio[96] = reg2hw.prio96.q;
-  assign prio[97] = reg2hw.prio97.q;
-  assign prio[98] = reg2hw.prio98.q;
-  assign prio[99] = reg2hw.prio99.q;
-  assign prio[100] = reg2hw.prio100.q;
-  assign prio[101] = reg2hw.prio101.q;
-  assign prio[102] = reg2hw.prio102.q;
-  assign prio[103] = reg2hw.prio103.q;
 
   //////////////////////
   // Interrupt Enable //
   //////////////////////
-  for (genvar s = 0; s < 104; s++) begin : gen_ie0
+  for (genvar s = 0; s < 89; s++) begin : gen_ie0
     assign ie[0][s] = reg2hw.ie0[s].q;
   end
 
@@ -228,7 +213,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ////////
   // IP //
   ////////
-  for (genvar s = 0; s < 104; s++) begin : gen_ip
+  for (genvar s = 0; s < 89; s++) begin : gen_ip
     assign hw2reg.ip[s].de = 1'b1; // Always write
     assign hw2reg.ip[s].d  = ip[s];
   end
@@ -236,7 +221,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ///////////////////////////////////
   // Detection:: 0: Level, 1: Edge //
   ///////////////////////////////////
-  for (genvar s = 0; s < 104; s++) begin : gen_le
+  for (genvar s = 0; s < 89; s++) begin : gen_le
     assign le[s] = reg2hw.le[s].q;
   end
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
@@ -181,13 +181,11 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   assign prio[84] = reg2hw.prio84.q;
   assign prio[85] = reg2hw.prio85.q;
   assign prio[86] = reg2hw.prio86.q;
-  assign prio[87] = reg2hw.prio87.q;
-  assign prio[88] = reg2hw.prio88.q;
 
   //////////////////////
   // Interrupt Enable //
   //////////////////////
-  for (genvar s = 0; s < 89; s++) begin : gen_ie0
+  for (genvar s = 0; s < 87; s++) begin : gen_ie0
     assign ie[0][s] = reg2hw.ie0[s].q;
   end
 
@@ -213,7 +211,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ////////
   // IP //
   ////////
-  for (genvar s = 0; s < 89; s++) begin : gen_ip
+  for (genvar s = 0; s < 87; s++) begin : gen_ip
     assign hw2reg.ip[s].de = 1'b1; // Always write
     assign hw2reg.ip[s].d  = ip[s];
   end
@@ -221,7 +219,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ///////////////////////////////////
   // Detection:: 0: Level, 1: Edge //
   ///////////////////////////////////
-  for (genvar s = 0; s < 89; s++) begin : gen_le
+  for (genvar s = 0; s < 87; s++) begin : gen_le
     assign le[s] = reg2hw.le[s].q;
   end
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
@@ -7,7 +7,7 @@
 package rv_plic_reg_pkg;
 
   // Param list
-  parameter int NumSrc = 104;
+  parameter int NumSrc = 89;
   parameter int NumTarget = 1;
   parameter int PrioWidth = 2;
 
@@ -375,66 +375,6 @@ package rv_plic_reg_pkg;
   } rv_plic_reg2hw_prio88_reg_t;
 
   typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio89_reg_t;
-
-  typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio90_reg_t;
-
-  typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio91_reg_t;
-
-  typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio92_reg_t;
-
-  typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio93_reg_t;
-
-  typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio94_reg_t;
-
-  typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio95_reg_t;
-
-  typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio96_reg_t;
-
-  typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio97_reg_t;
-
-  typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio98_reg_t;
-
-  typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio99_reg_t;
-
-  typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio100_reg_t;
-
-  typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio101_reg_t;
-
-  typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio102_reg_t;
-
-  typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio103_reg_t;
-
-  typedef struct packed {
     logic        q;
   } rv_plic_reg2hw_ie0_mreg_t;
 
@@ -467,112 +407,97 @@ package rv_plic_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_plic_reg2hw_le_mreg_t [103:0] le; // [427:324]
-    rv_plic_reg2hw_prio0_reg_t prio0; // [323:322]
-    rv_plic_reg2hw_prio1_reg_t prio1; // [321:320]
-    rv_plic_reg2hw_prio2_reg_t prio2; // [319:318]
-    rv_plic_reg2hw_prio3_reg_t prio3; // [317:316]
-    rv_plic_reg2hw_prio4_reg_t prio4; // [315:314]
-    rv_plic_reg2hw_prio5_reg_t prio5; // [313:312]
-    rv_plic_reg2hw_prio6_reg_t prio6; // [311:310]
-    rv_plic_reg2hw_prio7_reg_t prio7; // [309:308]
-    rv_plic_reg2hw_prio8_reg_t prio8; // [307:306]
-    rv_plic_reg2hw_prio9_reg_t prio9; // [305:304]
-    rv_plic_reg2hw_prio10_reg_t prio10; // [303:302]
-    rv_plic_reg2hw_prio11_reg_t prio11; // [301:300]
-    rv_plic_reg2hw_prio12_reg_t prio12; // [299:298]
-    rv_plic_reg2hw_prio13_reg_t prio13; // [297:296]
-    rv_plic_reg2hw_prio14_reg_t prio14; // [295:294]
-    rv_plic_reg2hw_prio15_reg_t prio15; // [293:292]
-    rv_plic_reg2hw_prio16_reg_t prio16; // [291:290]
-    rv_plic_reg2hw_prio17_reg_t prio17; // [289:288]
-    rv_plic_reg2hw_prio18_reg_t prio18; // [287:286]
-    rv_plic_reg2hw_prio19_reg_t prio19; // [285:284]
-    rv_plic_reg2hw_prio20_reg_t prio20; // [283:282]
-    rv_plic_reg2hw_prio21_reg_t prio21; // [281:280]
-    rv_plic_reg2hw_prio22_reg_t prio22; // [279:278]
-    rv_plic_reg2hw_prio23_reg_t prio23; // [277:276]
-    rv_plic_reg2hw_prio24_reg_t prio24; // [275:274]
-    rv_plic_reg2hw_prio25_reg_t prio25; // [273:272]
-    rv_plic_reg2hw_prio26_reg_t prio26; // [271:270]
-    rv_plic_reg2hw_prio27_reg_t prio27; // [269:268]
-    rv_plic_reg2hw_prio28_reg_t prio28; // [267:266]
-    rv_plic_reg2hw_prio29_reg_t prio29; // [265:264]
-    rv_plic_reg2hw_prio30_reg_t prio30; // [263:262]
-    rv_plic_reg2hw_prio31_reg_t prio31; // [261:260]
-    rv_plic_reg2hw_prio32_reg_t prio32; // [259:258]
-    rv_plic_reg2hw_prio33_reg_t prio33; // [257:256]
-    rv_plic_reg2hw_prio34_reg_t prio34; // [255:254]
-    rv_plic_reg2hw_prio35_reg_t prio35; // [253:252]
-    rv_plic_reg2hw_prio36_reg_t prio36; // [251:250]
-    rv_plic_reg2hw_prio37_reg_t prio37; // [249:248]
-    rv_plic_reg2hw_prio38_reg_t prio38; // [247:246]
-    rv_plic_reg2hw_prio39_reg_t prio39; // [245:244]
-    rv_plic_reg2hw_prio40_reg_t prio40; // [243:242]
-    rv_plic_reg2hw_prio41_reg_t prio41; // [241:240]
-    rv_plic_reg2hw_prio42_reg_t prio42; // [239:238]
-    rv_plic_reg2hw_prio43_reg_t prio43; // [237:236]
-    rv_plic_reg2hw_prio44_reg_t prio44; // [235:234]
-    rv_plic_reg2hw_prio45_reg_t prio45; // [233:232]
-    rv_plic_reg2hw_prio46_reg_t prio46; // [231:230]
-    rv_plic_reg2hw_prio47_reg_t prio47; // [229:228]
-    rv_plic_reg2hw_prio48_reg_t prio48; // [227:226]
-    rv_plic_reg2hw_prio49_reg_t prio49; // [225:224]
-    rv_plic_reg2hw_prio50_reg_t prio50; // [223:222]
-    rv_plic_reg2hw_prio51_reg_t prio51; // [221:220]
-    rv_plic_reg2hw_prio52_reg_t prio52; // [219:218]
-    rv_plic_reg2hw_prio53_reg_t prio53; // [217:216]
-    rv_plic_reg2hw_prio54_reg_t prio54; // [215:214]
-    rv_plic_reg2hw_prio55_reg_t prio55; // [213:212]
-    rv_plic_reg2hw_prio56_reg_t prio56; // [211:210]
-    rv_plic_reg2hw_prio57_reg_t prio57; // [209:208]
-    rv_plic_reg2hw_prio58_reg_t prio58; // [207:206]
-    rv_plic_reg2hw_prio59_reg_t prio59; // [205:204]
-    rv_plic_reg2hw_prio60_reg_t prio60; // [203:202]
-    rv_plic_reg2hw_prio61_reg_t prio61; // [201:200]
-    rv_plic_reg2hw_prio62_reg_t prio62; // [199:198]
-    rv_plic_reg2hw_prio63_reg_t prio63; // [197:196]
-    rv_plic_reg2hw_prio64_reg_t prio64; // [195:194]
-    rv_plic_reg2hw_prio65_reg_t prio65; // [193:192]
-    rv_plic_reg2hw_prio66_reg_t prio66; // [191:190]
-    rv_plic_reg2hw_prio67_reg_t prio67; // [189:188]
-    rv_plic_reg2hw_prio68_reg_t prio68; // [187:186]
-    rv_plic_reg2hw_prio69_reg_t prio69; // [185:184]
-    rv_plic_reg2hw_prio70_reg_t prio70; // [183:182]
-    rv_plic_reg2hw_prio71_reg_t prio71; // [181:180]
-    rv_plic_reg2hw_prio72_reg_t prio72; // [179:178]
-    rv_plic_reg2hw_prio73_reg_t prio73; // [177:176]
-    rv_plic_reg2hw_prio74_reg_t prio74; // [175:174]
-    rv_plic_reg2hw_prio75_reg_t prio75; // [173:172]
-    rv_plic_reg2hw_prio76_reg_t prio76; // [171:170]
-    rv_plic_reg2hw_prio77_reg_t prio77; // [169:168]
-    rv_plic_reg2hw_prio78_reg_t prio78; // [167:166]
-    rv_plic_reg2hw_prio79_reg_t prio79; // [165:164]
-    rv_plic_reg2hw_prio80_reg_t prio80; // [163:162]
-    rv_plic_reg2hw_prio81_reg_t prio81; // [161:160]
-    rv_plic_reg2hw_prio82_reg_t prio82; // [159:158]
-    rv_plic_reg2hw_prio83_reg_t prio83; // [157:156]
-    rv_plic_reg2hw_prio84_reg_t prio84; // [155:154]
-    rv_plic_reg2hw_prio85_reg_t prio85; // [153:152]
-    rv_plic_reg2hw_prio86_reg_t prio86; // [151:150]
-    rv_plic_reg2hw_prio87_reg_t prio87; // [149:148]
-    rv_plic_reg2hw_prio88_reg_t prio88; // [147:146]
-    rv_plic_reg2hw_prio89_reg_t prio89; // [145:144]
-    rv_plic_reg2hw_prio90_reg_t prio90; // [143:142]
-    rv_plic_reg2hw_prio91_reg_t prio91; // [141:140]
-    rv_plic_reg2hw_prio92_reg_t prio92; // [139:138]
-    rv_plic_reg2hw_prio93_reg_t prio93; // [137:136]
-    rv_plic_reg2hw_prio94_reg_t prio94; // [135:134]
-    rv_plic_reg2hw_prio95_reg_t prio95; // [133:132]
-    rv_plic_reg2hw_prio96_reg_t prio96; // [131:130]
-    rv_plic_reg2hw_prio97_reg_t prio97; // [129:128]
-    rv_plic_reg2hw_prio98_reg_t prio98; // [127:126]
-    rv_plic_reg2hw_prio99_reg_t prio99; // [125:124]
-    rv_plic_reg2hw_prio100_reg_t prio100; // [123:122]
-    rv_plic_reg2hw_prio101_reg_t prio101; // [121:120]
-    rv_plic_reg2hw_prio102_reg_t prio102; // [119:118]
-    rv_plic_reg2hw_prio103_reg_t prio103; // [117:116]
-    rv_plic_reg2hw_ie0_mreg_t [103:0] ie0; // [115:12]
+    rv_plic_reg2hw_le_mreg_t [88:0] le; // [367:279]
+    rv_plic_reg2hw_prio0_reg_t prio0; // [278:277]
+    rv_plic_reg2hw_prio1_reg_t prio1; // [276:275]
+    rv_plic_reg2hw_prio2_reg_t prio2; // [274:273]
+    rv_plic_reg2hw_prio3_reg_t prio3; // [272:271]
+    rv_plic_reg2hw_prio4_reg_t prio4; // [270:269]
+    rv_plic_reg2hw_prio5_reg_t prio5; // [268:267]
+    rv_plic_reg2hw_prio6_reg_t prio6; // [266:265]
+    rv_plic_reg2hw_prio7_reg_t prio7; // [264:263]
+    rv_plic_reg2hw_prio8_reg_t prio8; // [262:261]
+    rv_plic_reg2hw_prio9_reg_t prio9; // [260:259]
+    rv_plic_reg2hw_prio10_reg_t prio10; // [258:257]
+    rv_plic_reg2hw_prio11_reg_t prio11; // [256:255]
+    rv_plic_reg2hw_prio12_reg_t prio12; // [254:253]
+    rv_plic_reg2hw_prio13_reg_t prio13; // [252:251]
+    rv_plic_reg2hw_prio14_reg_t prio14; // [250:249]
+    rv_plic_reg2hw_prio15_reg_t prio15; // [248:247]
+    rv_plic_reg2hw_prio16_reg_t prio16; // [246:245]
+    rv_plic_reg2hw_prio17_reg_t prio17; // [244:243]
+    rv_plic_reg2hw_prio18_reg_t prio18; // [242:241]
+    rv_plic_reg2hw_prio19_reg_t prio19; // [240:239]
+    rv_plic_reg2hw_prio20_reg_t prio20; // [238:237]
+    rv_plic_reg2hw_prio21_reg_t prio21; // [236:235]
+    rv_plic_reg2hw_prio22_reg_t prio22; // [234:233]
+    rv_plic_reg2hw_prio23_reg_t prio23; // [232:231]
+    rv_plic_reg2hw_prio24_reg_t prio24; // [230:229]
+    rv_plic_reg2hw_prio25_reg_t prio25; // [228:227]
+    rv_plic_reg2hw_prio26_reg_t prio26; // [226:225]
+    rv_plic_reg2hw_prio27_reg_t prio27; // [224:223]
+    rv_plic_reg2hw_prio28_reg_t prio28; // [222:221]
+    rv_plic_reg2hw_prio29_reg_t prio29; // [220:219]
+    rv_plic_reg2hw_prio30_reg_t prio30; // [218:217]
+    rv_plic_reg2hw_prio31_reg_t prio31; // [216:215]
+    rv_plic_reg2hw_prio32_reg_t prio32; // [214:213]
+    rv_plic_reg2hw_prio33_reg_t prio33; // [212:211]
+    rv_plic_reg2hw_prio34_reg_t prio34; // [210:209]
+    rv_plic_reg2hw_prio35_reg_t prio35; // [208:207]
+    rv_plic_reg2hw_prio36_reg_t prio36; // [206:205]
+    rv_plic_reg2hw_prio37_reg_t prio37; // [204:203]
+    rv_plic_reg2hw_prio38_reg_t prio38; // [202:201]
+    rv_plic_reg2hw_prio39_reg_t prio39; // [200:199]
+    rv_plic_reg2hw_prio40_reg_t prio40; // [198:197]
+    rv_plic_reg2hw_prio41_reg_t prio41; // [196:195]
+    rv_plic_reg2hw_prio42_reg_t prio42; // [194:193]
+    rv_plic_reg2hw_prio43_reg_t prio43; // [192:191]
+    rv_plic_reg2hw_prio44_reg_t prio44; // [190:189]
+    rv_plic_reg2hw_prio45_reg_t prio45; // [188:187]
+    rv_plic_reg2hw_prio46_reg_t prio46; // [186:185]
+    rv_plic_reg2hw_prio47_reg_t prio47; // [184:183]
+    rv_plic_reg2hw_prio48_reg_t prio48; // [182:181]
+    rv_plic_reg2hw_prio49_reg_t prio49; // [180:179]
+    rv_plic_reg2hw_prio50_reg_t prio50; // [178:177]
+    rv_plic_reg2hw_prio51_reg_t prio51; // [176:175]
+    rv_plic_reg2hw_prio52_reg_t prio52; // [174:173]
+    rv_plic_reg2hw_prio53_reg_t prio53; // [172:171]
+    rv_plic_reg2hw_prio54_reg_t prio54; // [170:169]
+    rv_plic_reg2hw_prio55_reg_t prio55; // [168:167]
+    rv_plic_reg2hw_prio56_reg_t prio56; // [166:165]
+    rv_plic_reg2hw_prio57_reg_t prio57; // [164:163]
+    rv_plic_reg2hw_prio58_reg_t prio58; // [162:161]
+    rv_plic_reg2hw_prio59_reg_t prio59; // [160:159]
+    rv_plic_reg2hw_prio60_reg_t prio60; // [158:157]
+    rv_plic_reg2hw_prio61_reg_t prio61; // [156:155]
+    rv_plic_reg2hw_prio62_reg_t prio62; // [154:153]
+    rv_plic_reg2hw_prio63_reg_t prio63; // [152:151]
+    rv_plic_reg2hw_prio64_reg_t prio64; // [150:149]
+    rv_plic_reg2hw_prio65_reg_t prio65; // [148:147]
+    rv_plic_reg2hw_prio66_reg_t prio66; // [146:145]
+    rv_plic_reg2hw_prio67_reg_t prio67; // [144:143]
+    rv_plic_reg2hw_prio68_reg_t prio68; // [142:141]
+    rv_plic_reg2hw_prio69_reg_t prio69; // [140:139]
+    rv_plic_reg2hw_prio70_reg_t prio70; // [138:137]
+    rv_plic_reg2hw_prio71_reg_t prio71; // [136:135]
+    rv_plic_reg2hw_prio72_reg_t prio72; // [134:133]
+    rv_plic_reg2hw_prio73_reg_t prio73; // [132:131]
+    rv_plic_reg2hw_prio74_reg_t prio74; // [130:129]
+    rv_plic_reg2hw_prio75_reg_t prio75; // [128:127]
+    rv_plic_reg2hw_prio76_reg_t prio76; // [126:125]
+    rv_plic_reg2hw_prio77_reg_t prio77; // [124:123]
+    rv_plic_reg2hw_prio78_reg_t prio78; // [122:121]
+    rv_plic_reg2hw_prio79_reg_t prio79; // [120:119]
+    rv_plic_reg2hw_prio80_reg_t prio80; // [118:117]
+    rv_plic_reg2hw_prio81_reg_t prio81; // [116:115]
+    rv_plic_reg2hw_prio82_reg_t prio82; // [114:113]
+    rv_plic_reg2hw_prio83_reg_t prio83; // [112:111]
+    rv_plic_reg2hw_prio84_reg_t prio84; // [110:109]
+    rv_plic_reg2hw_prio85_reg_t prio85; // [108:107]
+    rv_plic_reg2hw_prio86_reg_t prio86; // [106:105]
+    rv_plic_reg2hw_prio87_reg_t prio87; // [104:103]
+    rv_plic_reg2hw_prio88_reg_t prio88; // [102:101]
+    rv_plic_reg2hw_ie0_mreg_t [88:0] ie0; // [100:12]
     rv_plic_reg2hw_threshold0_reg_t threshold0; // [11:10]
     rv_plic_reg2hw_cc0_reg_t cc0; // [9:1]
     rv_plic_reg2hw_msip0_reg_t msip0; // [0:0]
@@ -582,7 +507,7 @@ package rv_plic_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_plic_hw2reg_ip_mreg_t [103:0] ip; // [214:7]
+    rv_plic_hw2reg_ip_mreg_t [88:0] ip; // [184:7]
     rv_plic_hw2reg_cc0_reg_t cc0; // [6:0]
   } rv_plic_hw2reg_t;
 
@@ -590,122 +515,104 @@ package rv_plic_reg_pkg;
   parameter logic [9:0] RV_PLIC_IP_0_OFFSET = 10'h 0;
   parameter logic [9:0] RV_PLIC_IP_1_OFFSET = 10'h 4;
   parameter logic [9:0] RV_PLIC_IP_2_OFFSET = 10'h 8;
-  parameter logic [9:0] RV_PLIC_IP_3_OFFSET = 10'h c;
-  parameter logic [9:0] RV_PLIC_LE_0_OFFSET = 10'h 10;
-  parameter logic [9:0] RV_PLIC_LE_1_OFFSET = 10'h 14;
-  parameter logic [9:0] RV_PLIC_LE_2_OFFSET = 10'h 18;
-  parameter logic [9:0] RV_PLIC_LE_3_OFFSET = 10'h 1c;
-  parameter logic [9:0] RV_PLIC_PRIO0_OFFSET = 10'h 20;
-  parameter logic [9:0] RV_PLIC_PRIO1_OFFSET = 10'h 24;
-  parameter logic [9:0] RV_PLIC_PRIO2_OFFSET = 10'h 28;
-  parameter logic [9:0] RV_PLIC_PRIO3_OFFSET = 10'h 2c;
-  parameter logic [9:0] RV_PLIC_PRIO4_OFFSET = 10'h 30;
-  parameter logic [9:0] RV_PLIC_PRIO5_OFFSET = 10'h 34;
-  parameter logic [9:0] RV_PLIC_PRIO6_OFFSET = 10'h 38;
-  parameter logic [9:0] RV_PLIC_PRIO7_OFFSET = 10'h 3c;
-  parameter logic [9:0] RV_PLIC_PRIO8_OFFSET = 10'h 40;
-  parameter logic [9:0] RV_PLIC_PRIO9_OFFSET = 10'h 44;
-  parameter logic [9:0] RV_PLIC_PRIO10_OFFSET = 10'h 48;
-  parameter logic [9:0] RV_PLIC_PRIO11_OFFSET = 10'h 4c;
-  parameter logic [9:0] RV_PLIC_PRIO12_OFFSET = 10'h 50;
-  parameter logic [9:0] RV_PLIC_PRIO13_OFFSET = 10'h 54;
-  parameter logic [9:0] RV_PLIC_PRIO14_OFFSET = 10'h 58;
-  parameter logic [9:0] RV_PLIC_PRIO15_OFFSET = 10'h 5c;
-  parameter logic [9:0] RV_PLIC_PRIO16_OFFSET = 10'h 60;
-  parameter logic [9:0] RV_PLIC_PRIO17_OFFSET = 10'h 64;
-  parameter logic [9:0] RV_PLIC_PRIO18_OFFSET = 10'h 68;
-  parameter logic [9:0] RV_PLIC_PRIO19_OFFSET = 10'h 6c;
-  parameter logic [9:0] RV_PLIC_PRIO20_OFFSET = 10'h 70;
-  parameter logic [9:0] RV_PLIC_PRIO21_OFFSET = 10'h 74;
-  parameter logic [9:0] RV_PLIC_PRIO22_OFFSET = 10'h 78;
-  parameter logic [9:0] RV_PLIC_PRIO23_OFFSET = 10'h 7c;
-  parameter logic [9:0] RV_PLIC_PRIO24_OFFSET = 10'h 80;
-  parameter logic [9:0] RV_PLIC_PRIO25_OFFSET = 10'h 84;
-  parameter logic [9:0] RV_PLIC_PRIO26_OFFSET = 10'h 88;
-  parameter logic [9:0] RV_PLIC_PRIO27_OFFSET = 10'h 8c;
-  parameter logic [9:0] RV_PLIC_PRIO28_OFFSET = 10'h 90;
-  parameter logic [9:0] RV_PLIC_PRIO29_OFFSET = 10'h 94;
-  parameter logic [9:0] RV_PLIC_PRIO30_OFFSET = 10'h 98;
-  parameter logic [9:0] RV_PLIC_PRIO31_OFFSET = 10'h 9c;
-  parameter logic [9:0] RV_PLIC_PRIO32_OFFSET = 10'h a0;
-  parameter logic [9:0] RV_PLIC_PRIO33_OFFSET = 10'h a4;
-  parameter logic [9:0] RV_PLIC_PRIO34_OFFSET = 10'h a8;
-  parameter logic [9:0] RV_PLIC_PRIO35_OFFSET = 10'h ac;
-  parameter logic [9:0] RV_PLIC_PRIO36_OFFSET = 10'h b0;
-  parameter logic [9:0] RV_PLIC_PRIO37_OFFSET = 10'h b4;
-  parameter logic [9:0] RV_PLIC_PRIO38_OFFSET = 10'h b8;
-  parameter logic [9:0] RV_PLIC_PRIO39_OFFSET = 10'h bc;
-  parameter logic [9:0] RV_PLIC_PRIO40_OFFSET = 10'h c0;
-  parameter logic [9:0] RV_PLIC_PRIO41_OFFSET = 10'h c4;
-  parameter logic [9:0] RV_PLIC_PRIO42_OFFSET = 10'h c8;
-  parameter logic [9:0] RV_PLIC_PRIO43_OFFSET = 10'h cc;
-  parameter logic [9:0] RV_PLIC_PRIO44_OFFSET = 10'h d0;
-  parameter logic [9:0] RV_PLIC_PRIO45_OFFSET = 10'h d4;
-  parameter logic [9:0] RV_PLIC_PRIO46_OFFSET = 10'h d8;
-  parameter logic [9:0] RV_PLIC_PRIO47_OFFSET = 10'h dc;
-  parameter logic [9:0] RV_PLIC_PRIO48_OFFSET = 10'h e0;
-  parameter logic [9:0] RV_PLIC_PRIO49_OFFSET = 10'h e4;
-  parameter logic [9:0] RV_PLIC_PRIO50_OFFSET = 10'h e8;
-  parameter logic [9:0] RV_PLIC_PRIO51_OFFSET = 10'h ec;
-  parameter logic [9:0] RV_PLIC_PRIO52_OFFSET = 10'h f0;
-  parameter logic [9:0] RV_PLIC_PRIO53_OFFSET = 10'h f4;
-  parameter logic [9:0] RV_PLIC_PRIO54_OFFSET = 10'h f8;
-  parameter logic [9:0] RV_PLIC_PRIO55_OFFSET = 10'h fc;
-  parameter logic [9:0] RV_PLIC_PRIO56_OFFSET = 10'h 100;
-  parameter logic [9:0] RV_PLIC_PRIO57_OFFSET = 10'h 104;
-  parameter logic [9:0] RV_PLIC_PRIO58_OFFSET = 10'h 108;
-  parameter logic [9:0] RV_PLIC_PRIO59_OFFSET = 10'h 10c;
-  parameter logic [9:0] RV_PLIC_PRIO60_OFFSET = 10'h 110;
-  parameter logic [9:0] RV_PLIC_PRIO61_OFFSET = 10'h 114;
-  parameter logic [9:0] RV_PLIC_PRIO62_OFFSET = 10'h 118;
-  parameter logic [9:0] RV_PLIC_PRIO63_OFFSET = 10'h 11c;
-  parameter logic [9:0] RV_PLIC_PRIO64_OFFSET = 10'h 120;
-  parameter logic [9:0] RV_PLIC_PRIO65_OFFSET = 10'h 124;
-  parameter logic [9:0] RV_PLIC_PRIO66_OFFSET = 10'h 128;
-  parameter logic [9:0] RV_PLIC_PRIO67_OFFSET = 10'h 12c;
-  parameter logic [9:0] RV_PLIC_PRIO68_OFFSET = 10'h 130;
-  parameter logic [9:0] RV_PLIC_PRIO69_OFFSET = 10'h 134;
-  parameter logic [9:0] RV_PLIC_PRIO70_OFFSET = 10'h 138;
-  parameter logic [9:0] RV_PLIC_PRIO71_OFFSET = 10'h 13c;
-  parameter logic [9:0] RV_PLIC_PRIO72_OFFSET = 10'h 140;
-  parameter logic [9:0] RV_PLIC_PRIO73_OFFSET = 10'h 144;
-  parameter logic [9:0] RV_PLIC_PRIO74_OFFSET = 10'h 148;
-  parameter logic [9:0] RV_PLIC_PRIO75_OFFSET = 10'h 14c;
-  parameter logic [9:0] RV_PLIC_PRIO76_OFFSET = 10'h 150;
-  parameter logic [9:0] RV_PLIC_PRIO77_OFFSET = 10'h 154;
-  parameter logic [9:0] RV_PLIC_PRIO78_OFFSET = 10'h 158;
-  parameter logic [9:0] RV_PLIC_PRIO79_OFFSET = 10'h 15c;
-  parameter logic [9:0] RV_PLIC_PRIO80_OFFSET = 10'h 160;
-  parameter logic [9:0] RV_PLIC_PRIO81_OFFSET = 10'h 164;
-  parameter logic [9:0] RV_PLIC_PRIO82_OFFSET = 10'h 168;
-  parameter logic [9:0] RV_PLIC_PRIO83_OFFSET = 10'h 16c;
-  parameter logic [9:0] RV_PLIC_PRIO84_OFFSET = 10'h 170;
-  parameter logic [9:0] RV_PLIC_PRIO85_OFFSET = 10'h 174;
-  parameter logic [9:0] RV_PLIC_PRIO86_OFFSET = 10'h 178;
-  parameter logic [9:0] RV_PLIC_PRIO87_OFFSET = 10'h 17c;
-  parameter logic [9:0] RV_PLIC_PRIO88_OFFSET = 10'h 180;
-  parameter logic [9:0] RV_PLIC_PRIO89_OFFSET = 10'h 184;
-  parameter logic [9:0] RV_PLIC_PRIO90_OFFSET = 10'h 188;
-  parameter logic [9:0] RV_PLIC_PRIO91_OFFSET = 10'h 18c;
-  parameter logic [9:0] RV_PLIC_PRIO92_OFFSET = 10'h 190;
-  parameter logic [9:0] RV_PLIC_PRIO93_OFFSET = 10'h 194;
-  parameter logic [9:0] RV_PLIC_PRIO94_OFFSET = 10'h 198;
-  parameter logic [9:0] RV_PLIC_PRIO95_OFFSET = 10'h 19c;
-  parameter logic [9:0] RV_PLIC_PRIO96_OFFSET = 10'h 1a0;
-  parameter logic [9:0] RV_PLIC_PRIO97_OFFSET = 10'h 1a4;
-  parameter logic [9:0] RV_PLIC_PRIO98_OFFSET = 10'h 1a8;
-  parameter logic [9:0] RV_PLIC_PRIO99_OFFSET = 10'h 1ac;
-  parameter logic [9:0] RV_PLIC_PRIO100_OFFSET = 10'h 1b0;
-  parameter logic [9:0] RV_PLIC_PRIO101_OFFSET = 10'h 1b4;
-  parameter logic [9:0] RV_PLIC_PRIO102_OFFSET = 10'h 1b8;
-  parameter logic [9:0] RV_PLIC_PRIO103_OFFSET = 10'h 1bc;
+  parameter logic [9:0] RV_PLIC_LE_0_OFFSET = 10'h c;
+  parameter logic [9:0] RV_PLIC_LE_1_OFFSET = 10'h 10;
+  parameter logic [9:0] RV_PLIC_LE_2_OFFSET = 10'h 14;
+  parameter logic [9:0] RV_PLIC_PRIO0_OFFSET = 10'h 18;
+  parameter logic [9:0] RV_PLIC_PRIO1_OFFSET = 10'h 1c;
+  parameter logic [9:0] RV_PLIC_PRIO2_OFFSET = 10'h 20;
+  parameter logic [9:0] RV_PLIC_PRIO3_OFFSET = 10'h 24;
+  parameter logic [9:0] RV_PLIC_PRIO4_OFFSET = 10'h 28;
+  parameter logic [9:0] RV_PLIC_PRIO5_OFFSET = 10'h 2c;
+  parameter logic [9:0] RV_PLIC_PRIO6_OFFSET = 10'h 30;
+  parameter logic [9:0] RV_PLIC_PRIO7_OFFSET = 10'h 34;
+  parameter logic [9:0] RV_PLIC_PRIO8_OFFSET = 10'h 38;
+  parameter logic [9:0] RV_PLIC_PRIO9_OFFSET = 10'h 3c;
+  parameter logic [9:0] RV_PLIC_PRIO10_OFFSET = 10'h 40;
+  parameter logic [9:0] RV_PLIC_PRIO11_OFFSET = 10'h 44;
+  parameter logic [9:0] RV_PLIC_PRIO12_OFFSET = 10'h 48;
+  parameter logic [9:0] RV_PLIC_PRIO13_OFFSET = 10'h 4c;
+  parameter logic [9:0] RV_PLIC_PRIO14_OFFSET = 10'h 50;
+  parameter logic [9:0] RV_PLIC_PRIO15_OFFSET = 10'h 54;
+  parameter logic [9:0] RV_PLIC_PRIO16_OFFSET = 10'h 58;
+  parameter logic [9:0] RV_PLIC_PRIO17_OFFSET = 10'h 5c;
+  parameter logic [9:0] RV_PLIC_PRIO18_OFFSET = 10'h 60;
+  parameter logic [9:0] RV_PLIC_PRIO19_OFFSET = 10'h 64;
+  parameter logic [9:0] RV_PLIC_PRIO20_OFFSET = 10'h 68;
+  parameter logic [9:0] RV_PLIC_PRIO21_OFFSET = 10'h 6c;
+  parameter logic [9:0] RV_PLIC_PRIO22_OFFSET = 10'h 70;
+  parameter logic [9:0] RV_PLIC_PRIO23_OFFSET = 10'h 74;
+  parameter logic [9:0] RV_PLIC_PRIO24_OFFSET = 10'h 78;
+  parameter logic [9:0] RV_PLIC_PRIO25_OFFSET = 10'h 7c;
+  parameter logic [9:0] RV_PLIC_PRIO26_OFFSET = 10'h 80;
+  parameter logic [9:0] RV_PLIC_PRIO27_OFFSET = 10'h 84;
+  parameter logic [9:0] RV_PLIC_PRIO28_OFFSET = 10'h 88;
+  parameter logic [9:0] RV_PLIC_PRIO29_OFFSET = 10'h 8c;
+  parameter logic [9:0] RV_PLIC_PRIO30_OFFSET = 10'h 90;
+  parameter logic [9:0] RV_PLIC_PRIO31_OFFSET = 10'h 94;
+  parameter logic [9:0] RV_PLIC_PRIO32_OFFSET = 10'h 98;
+  parameter logic [9:0] RV_PLIC_PRIO33_OFFSET = 10'h 9c;
+  parameter logic [9:0] RV_PLIC_PRIO34_OFFSET = 10'h a0;
+  parameter logic [9:0] RV_PLIC_PRIO35_OFFSET = 10'h a4;
+  parameter logic [9:0] RV_PLIC_PRIO36_OFFSET = 10'h a8;
+  parameter logic [9:0] RV_PLIC_PRIO37_OFFSET = 10'h ac;
+  parameter logic [9:0] RV_PLIC_PRIO38_OFFSET = 10'h b0;
+  parameter logic [9:0] RV_PLIC_PRIO39_OFFSET = 10'h b4;
+  parameter logic [9:0] RV_PLIC_PRIO40_OFFSET = 10'h b8;
+  parameter logic [9:0] RV_PLIC_PRIO41_OFFSET = 10'h bc;
+  parameter logic [9:0] RV_PLIC_PRIO42_OFFSET = 10'h c0;
+  parameter logic [9:0] RV_PLIC_PRIO43_OFFSET = 10'h c4;
+  parameter logic [9:0] RV_PLIC_PRIO44_OFFSET = 10'h c8;
+  parameter logic [9:0] RV_PLIC_PRIO45_OFFSET = 10'h cc;
+  parameter logic [9:0] RV_PLIC_PRIO46_OFFSET = 10'h d0;
+  parameter logic [9:0] RV_PLIC_PRIO47_OFFSET = 10'h d4;
+  parameter logic [9:0] RV_PLIC_PRIO48_OFFSET = 10'h d8;
+  parameter logic [9:0] RV_PLIC_PRIO49_OFFSET = 10'h dc;
+  parameter logic [9:0] RV_PLIC_PRIO50_OFFSET = 10'h e0;
+  parameter logic [9:0] RV_PLIC_PRIO51_OFFSET = 10'h e4;
+  parameter logic [9:0] RV_PLIC_PRIO52_OFFSET = 10'h e8;
+  parameter logic [9:0] RV_PLIC_PRIO53_OFFSET = 10'h ec;
+  parameter logic [9:0] RV_PLIC_PRIO54_OFFSET = 10'h f0;
+  parameter logic [9:0] RV_PLIC_PRIO55_OFFSET = 10'h f4;
+  parameter logic [9:0] RV_PLIC_PRIO56_OFFSET = 10'h f8;
+  parameter logic [9:0] RV_PLIC_PRIO57_OFFSET = 10'h fc;
+  parameter logic [9:0] RV_PLIC_PRIO58_OFFSET = 10'h 100;
+  parameter logic [9:0] RV_PLIC_PRIO59_OFFSET = 10'h 104;
+  parameter logic [9:0] RV_PLIC_PRIO60_OFFSET = 10'h 108;
+  parameter logic [9:0] RV_PLIC_PRIO61_OFFSET = 10'h 10c;
+  parameter logic [9:0] RV_PLIC_PRIO62_OFFSET = 10'h 110;
+  parameter logic [9:0] RV_PLIC_PRIO63_OFFSET = 10'h 114;
+  parameter logic [9:0] RV_PLIC_PRIO64_OFFSET = 10'h 118;
+  parameter logic [9:0] RV_PLIC_PRIO65_OFFSET = 10'h 11c;
+  parameter logic [9:0] RV_PLIC_PRIO66_OFFSET = 10'h 120;
+  parameter logic [9:0] RV_PLIC_PRIO67_OFFSET = 10'h 124;
+  parameter logic [9:0] RV_PLIC_PRIO68_OFFSET = 10'h 128;
+  parameter logic [9:0] RV_PLIC_PRIO69_OFFSET = 10'h 12c;
+  parameter logic [9:0] RV_PLIC_PRIO70_OFFSET = 10'h 130;
+  parameter logic [9:0] RV_PLIC_PRIO71_OFFSET = 10'h 134;
+  parameter logic [9:0] RV_PLIC_PRIO72_OFFSET = 10'h 138;
+  parameter logic [9:0] RV_PLIC_PRIO73_OFFSET = 10'h 13c;
+  parameter logic [9:0] RV_PLIC_PRIO74_OFFSET = 10'h 140;
+  parameter logic [9:0] RV_PLIC_PRIO75_OFFSET = 10'h 144;
+  parameter logic [9:0] RV_PLIC_PRIO76_OFFSET = 10'h 148;
+  parameter logic [9:0] RV_PLIC_PRIO77_OFFSET = 10'h 14c;
+  parameter logic [9:0] RV_PLIC_PRIO78_OFFSET = 10'h 150;
+  parameter logic [9:0] RV_PLIC_PRIO79_OFFSET = 10'h 154;
+  parameter logic [9:0] RV_PLIC_PRIO80_OFFSET = 10'h 158;
+  parameter logic [9:0] RV_PLIC_PRIO81_OFFSET = 10'h 15c;
+  parameter logic [9:0] RV_PLIC_PRIO82_OFFSET = 10'h 160;
+  parameter logic [9:0] RV_PLIC_PRIO83_OFFSET = 10'h 164;
+  parameter logic [9:0] RV_PLIC_PRIO84_OFFSET = 10'h 168;
+  parameter logic [9:0] RV_PLIC_PRIO85_OFFSET = 10'h 16c;
+  parameter logic [9:0] RV_PLIC_PRIO86_OFFSET = 10'h 170;
+  parameter logic [9:0] RV_PLIC_PRIO87_OFFSET = 10'h 174;
+  parameter logic [9:0] RV_PLIC_PRIO88_OFFSET = 10'h 178;
   parameter logic [9:0] RV_PLIC_IE0_0_OFFSET = 10'h 200;
   parameter logic [9:0] RV_PLIC_IE0_1_OFFSET = 10'h 204;
   parameter logic [9:0] RV_PLIC_IE0_2_OFFSET = 10'h 208;
-  parameter logic [9:0] RV_PLIC_IE0_3_OFFSET = 10'h 20c;
-  parameter logic [9:0] RV_PLIC_THRESHOLD0_OFFSET = 10'h 210;
-  parameter logic [9:0] RV_PLIC_CC0_OFFSET = 10'h 214;
-  parameter logic [9:0] RV_PLIC_MSIP0_OFFSET = 10'h 218;
+  parameter logic [9:0] RV_PLIC_THRESHOLD0_OFFSET = 10'h 20c;
+  parameter logic [9:0] RV_PLIC_CC0_OFFSET = 10'h 210;
+  parameter logic [9:0] RV_PLIC_MSIP0_OFFSET = 10'h 214;
 
 
   // Register Index
@@ -713,11 +620,9 @@ package rv_plic_reg_pkg;
     RV_PLIC_IP_0,
     RV_PLIC_IP_1,
     RV_PLIC_IP_2,
-    RV_PLIC_IP_3,
     RV_PLIC_LE_0,
     RV_PLIC_LE_1,
     RV_PLIC_LE_2,
-    RV_PLIC_LE_3,
     RV_PLIC_PRIO0,
     RV_PLIC_PRIO1,
     RV_PLIC_PRIO2,
@@ -807,151 +712,117 @@ package rv_plic_reg_pkg;
     RV_PLIC_PRIO86,
     RV_PLIC_PRIO87,
     RV_PLIC_PRIO88,
-    RV_PLIC_PRIO89,
-    RV_PLIC_PRIO90,
-    RV_PLIC_PRIO91,
-    RV_PLIC_PRIO92,
-    RV_PLIC_PRIO93,
-    RV_PLIC_PRIO94,
-    RV_PLIC_PRIO95,
-    RV_PLIC_PRIO96,
-    RV_PLIC_PRIO97,
-    RV_PLIC_PRIO98,
-    RV_PLIC_PRIO99,
-    RV_PLIC_PRIO100,
-    RV_PLIC_PRIO101,
-    RV_PLIC_PRIO102,
-    RV_PLIC_PRIO103,
     RV_PLIC_IE0_0,
     RV_PLIC_IE0_1,
     RV_PLIC_IE0_2,
-    RV_PLIC_IE0_3,
     RV_PLIC_THRESHOLD0,
     RV_PLIC_CC0,
     RV_PLIC_MSIP0
   } rv_plic_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] RV_PLIC_PERMIT [119] = '{
+  parameter logic [3:0] RV_PLIC_PERMIT [101] = '{
     4'b 1111, // index[  0] RV_PLIC_IP_0
     4'b 1111, // index[  1] RV_PLIC_IP_1
     4'b 1111, // index[  2] RV_PLIC_IP_2
-    4'b 0001, // index[  3] RV_PLIC_IP_3
-    4'b 1111, // index[  4] RV_PLIC_LE_0
-    4'b 1111, // index[  5] RV_PLIC_LE_1
-    4'b 1111, // index[  6] RV_PLIC_LE_2
-    4'b 0001, // index[  7] RV_PLIC_LE_3
-    4'b 0001, // index[  8] RV_PLIC_PRIO0
-    4'b 0001, // index[  9] RV_PLIC_PRIO1
-    4'b 0001, // index[ 10] RV_PLIC_PRIO2
-    4'b 0001, // index[ 11] RV_PLIC_PRIO3
-    4'b 0001, // index[ 12] RV_PLIC_PRIO4
-    4'b 0001, // index[ 13] RV_PLIC_PRIO5
-    4'b 0001, // index[ 14] RV_PLIC_PRIO6
-    4'b 0001, // index[ 15] RV_PLIC_PRIO7
-    4'b 0001, // index[ 16] RV_PLIC_PRIO8
-    4'b 0001, // index[ 17] RV_PLIC_PRIO9
-    4'b 0001, // index[ 18] RV_PLIC_PRIO10
-    4'b 0001, // index[ 19] RV_PLIC_PRIO11
-    4'b 0001, // index[ 20] RV_PLIC_PRIO12
-    4'b 0001, // index[ 21] RV_PLIC_PRIO13
-    4'b 0001, // index[ 22] RV_PLIC_PRIO14
-    4'b 0001, // index[ 23] RV_PLIC_PRIO15
-    4'b 0001, // index[ 24] RV_PLIC_PRIO16
-    4'b 0001, // index[ 25] RV_PLIC_PRIO17
-    4'b 0001, // index[ 26] RV_PLIC_PRIO18
-    4'b 0001, // index[ 27] RV_PLIC_PRIO19
-    4'b 0001, // index[ 28] RV_PLIC_PRIO20
-    4'b 0001, // index[ 29] RV_PLIC_PRIO21
-    4'b 0001, // index[ 30] RV_PLIC_PRIO22
-    4'b 0001, // index[ 31] RV_PLIC_PRIO23
-    4'b 0001, // index[ 32] RV_PLIC_PRIO24
-    4'b 0001, // index[ 33] RV_PLIC_PRIO25
-    4'b 0001, // index[ 34] RV_PLIC_PRIO26
-    4'b 0001, // index[ 35] RV_PLIC_PRIO27
-    4'b 0001, // index[ 36] RV_PLIC_PRIO28
-    4'b 0001, // index[ 37] RV_PLIC_PRIO29
-    4'b 0001, // index[ 38] RV_PLIC_PRIO30
-    4'b 0001, // index[ 39] RV_PLIC_PRIO31
-    4'b 0001, // index[ 40] RV_PLIC_PRIO32
-    4'b 0001, // index[ 41] RV_PLIC_PRIO33
-    4'b 0001, // index[ 42] RV_PLIC_PRIO34
-    4'b 0001, // index[ 43] RV_PLIC_PRIO35
-    4'b 0001, // index[ 44] RV_PLIC_PRIO36
-    4'b 0001, // index[ 45] RV_PLIC_PRIO37
-    4'b 0001, // index[ 46] RV_PLIC_PRIO38
-    4'b 0001, // index[ 47] RV_PLIC_PRIO39
-    4'b 0001, // index[ 48] RV_PLIC_PRIO40
-    4'b 0001, // index[ 49] RV_PLIC_PRIO41
-    4'b 0001, // index[ 50] RV_PLIC_PRIO42
-    4'b 0001, // index[ 51] RV_PLIC_PRIO43
-    4'b 0001, // index[ 52] RV_PLIC_PRIO44
-    4'b 0001, // index[ 53] RV_PLIC_PRIO45
-    4'b 0001, // index[ 54] RV_PLIC_PRIO46
-    4'b 0001, // index[ 55] RV_PLIC_PRIO47
-    4'b 0001, // index[ 56] RV_PLIC_PRIO48
-    4'b 0001, // index[ 57] RV_PLIC_PRIO49
-    4'b 0001, // index[ 58] RV_PLIC_PRIO50
-    4'b 0001, // index[ 59] RV_PLIC_PRIO51
-    4'b 0001, // index[ 60] RV_PLIC_PRIO52
-    4'b 0001, // index[ 61] RV_PLIC_PRIO53
-    4'b 0001, // index[ 62] RV_PLIC_PRIO54
-    4'b 0001, // index[ 63] RV_PLIC_PRIO55
-    4'b 0001, // index[ 64] RV_PLIC_PRIO56
-    4'b 0001, // index[ 65] RV_PLIC_PRIO57
-    4'b 0001, // index[ 66] RV_PLIC_PRIO58
-    4'b 0001, // index[ 67] RV_PLIC_PRIO59
-    4'b 0001, // index[ 68] RV_PLIC_PRIO60
-    4'b 0001, // index[ 69] RV_PLIC_PRIO61
-    4'b 0001, // index[ 70] RV_PLIC_PRIO62
-    4'b 0001, // index[ 71] RV_PLIC_PRIO63
-    4'b 0001, // index[ 72] RV_PLIC_PRIO64
-    4'b 0001, // index[ 73] RV_PLIC_PRIO65
-    4'b 0001, // index[ 74] RV_PLIC_PRIO66
-    4'b 0001, // index[ 75] RV_PLIC_PRIO67
-    4'b 0001, // index[ 76] RV_PLIC_PRIO68
-    4'b 0001, // index[ 77] RV_PLIC_PRIO69
-    4'b 0001, // index[ 78] RV_PLIC_PRIO70
-    4'b 0001, // index[ 79] RV_PLIC_PRIO71
-    4'b 0001, // index[ 80] RV_PLIC_PRIO72
-    4'b 0001, // index[ 81] RV_PLIC_PRIO73
-    4'b 0001, // index[ 82] RV_PLIC_PRIO74
-    4'b 0001, // index[ 83] RV_PLIC_PRIO75
-    4'b 0001, // index[ 84] RV_PLIC_PRIO76
-    4'b 0001, // index[ 85] RV_PLIC_PRIO77
-    4'b 0001, // index[ 86] RV_PLIC_PRIO78
-    4'b 0001, // index[ 87] RV_PLIC_PRIO79
-    4'b 0001, // index[ 88] RV_PLIC_PRIO80
-    4'b 0001, // index[ 89] RV_PLIC_PRIO81
-    4'b 0001, // index[ 90] RV_PLIC_PRIO82
-    4'b 0001, // index[ 91] RV_PLIC_PRIO83
-    4'b 0001, // index[ 92] RV_PLIC_PRIO84
-    4'b 0001, // index[ 93] RV_PLIC_PRIO85
-    4'b 0001, // index[ 94] RV_PLIC_PRIO86
-    4'b 0001, // index[ 95] RV_PLIC_PRIO87
-    4'b 0001, // index[ 96] RV_PLIC_PRIO88
-    4'b 0001, // index[ 97] RV_PLIC_PRIO89
-    4'b 0001, // index[ 98] RV_PLIC_PRIO90
-    4'b 0001, // index[ 99] RV_PLIC_PRIO91
-    4'b 0001, // index[100] RV_PLIC_PRIO92
-    4'b 0001, // index[101] RV_PLIC_PRIO93
-    4'b 0001, // index[102] RV_PLIC_PRIO94
-    4'b 0001, // index[103] RV_PLIC_PRIO95
-    4'b 0001, // index[104] RV_PLIC_PRIO96
-    4'b 0001, // index[105] RV_PLIC_PRIO97
-    4'b 0001, // index[106] RV_PLIC_PRIO98
-    4'b 0001, // index[107] RV_PLIC_PRIO99
-    4'b 0001, // index[108] RV_PLIC_PRIO100
-    4'b 0001, // index[109] RV_PLIC_PRIO101
-    4'b 0001, // index[110] RV_PLIC_PRIO102
-    4'b 0001, // index[111] RV_PLIC_PRIO103
-    4'b 1111, // index[112] RV_PLIC_IE0_0
-    4'b 1111, // index[113] RV_PLIC_IE0_1
-    4'b 1111, // index[114] RV_PLIC_IE0_2
-    4'b 0001, // index[115] RV_PLIC_IE0_3
-    4'b 0001, // index[116] RV_PLIC_THRESHOLD0
-    4'b 0001, // index[117] RV_PLIC_CC0
-    4'b 0001  // index[118] RV_PLIC_MSIP0
+    4'b 1111, // index[  3] RV_PLIC_LE_0
+    4'b 1111, // index[  4] RV_PLIC_LE_1
+    4'b 1111, // index[  5] RV_PLIC_LE_2
+    4'b 0001, // index[  6] RV_PLIC_PRIO0
+    4'b 0001, // index[  7] RV_PLIC_PRIO1
+    4'b 0001, // index[  8] RV_PLIC_PRIO2
+    4'b 0001, // index[  9] RV_PLIC_PRIO3
+    4'b 0001, // index[ 10] RV_PLIC_PRIO4
+    4'b 0001, // index[ 11] RV_PLIC_PRIO5
+    4'b 0001, // index[ 12] RV_PLIC_PRIO6
+    4'b 0001, // index[ 13] RV_PLIC_PRIO7
+    4'b 0001, // index[ 14] RV_PLIC_PRIO8
+    4'b 0001, // index[ 15] RV_PLIC_PRIO9
+    4'b 0001, // index[ 16] RV_PLIC_PRIO10
+    4'b 0001, // index[ 17] RV_PLIC_PRIO11
+    4'b 0001, // index[ 18] RV_PLIC_PRIO12
+    4'b 0001, // index[ 19] RV_PLIC_PRIO13
+    4'b 0001, // index[ 20] RV_PLIC_PRIO14
+    4'b 0001, // index[ 21] RV_PLIC_PRIO15
+    4'b 0001, // index[ 22] RV_PLIC_PRIO16
+    4'b 0001, // index[ 23] RV_PLIC_PRIO17
+    4'b 0001, // index[ 24] RV_PLIC_PRIO18
+    4'b 0001, // index[ 25] RV_PLIC_PRIO19
+    4'b 0001, // index[ 26] RV_PLIC_PRIO20
+    4'b 0001, // index[ 27] RV_PLIC_PRIO21
+    4'b 0001, // index[ 28] RV_PLIC_PRIO22
+    4'b 0001, // index[ 29] RV_PLIC_PRIO23
+    4'b 0001, // index[ 30] RV_PLIC_PRIO24
+    4'b 0001, // index[ 31] RV_PLIC_PRIO25
+    4'b 0001, // index[ 32] RV_PLIC_PRIO26
+    4'b 0001, // index[ 33] RV_PLIC_PRIO27
+    4'b 0001, // index[ 34] RV_PLIC_PRIO28
+    4'b 0001, // index[ 35] RV_PLIC_PRIO29
+    4'b 0001, // index[ 36] RV_PLIC_PRIO30
+    4'b 0001, // index[ 37] RV_PLIC_PRIO31
+    4'b 0001, // index[ 38] RV_PLIC_PRIO32
+    4'b 0001, // index[ 39] RV_PLIC_PRIO33
+    4'b 0001, // index[ 40] RV_PLIC_PRIO34
+    4'b 0001, // index[ 41] RV_PLIC_PRIO35
+    4'b 0001, // index[ 42] RV_PLIC_PRIO36
+    4'b 0001, // index[ 43] RV_PLIC_PRIO37
+    4'b 0001, // index[ 44] RV_PLIC_PRIO38
+    4'b 0001, // index[ 45] RV_PLIC_PRIO39
+    4'b 0001, // index[ 46] RV_PLIC_PRIO40
+    4'b 0001, // index[ 47] RV_PLIC_PRIO41
+    4'b 0001, // index[ 48] RV_PLIC_PRIO42
+    4'b 0001, // index[ 49] RV_PLIC_PRIO43
+    4'b 0001, // index[ 50] RV_PLIC_PRIO44
+    4'b 0001, // index[ 51] RV_PLIC_PRIO45
+    4'b 0001, // index[ 52] RV_PLIC_PRIO46
+    4'b 0001, // index[ 53] RV_PLIC_PRIO47
+    4'b 0001, // index[ 54] RV_PLIC_PRIO48
+    4'b 0001, // index[ 55] RV_PLIC_PRIO49
+    4'b 0001, // index[ 56] RV_PLIC_PRIO50
+    4'b 0001, // index[ 57] RV_PLIC_PRIO51
+    4'b 0001, // index[ 58] RV_PLIC_PRIO52
+    4'b 0001, // index[ 59] RV_PLIC_PRIO53
+    4'b 0001, // index[ 60] RV_PLIC_PRIO54
+    4'b 0001, // index[ 61] RV_PLIC_PRIO55
+    4'b 0001, // index[ 62] RV_PLIC_PRIO56
+    4'b 0001, // index[ 63] RV_PLIC_PRIO57
+    4'b 0001, // index[ 64] RV_PLIC_PRIO58
+    4'b 0001, // index[ 65] RV_PLIC_PRIO59
+    4'b 0001, // index[ 66] RV_PLIC_PRIO60
+    4'b 0001, // index[ 67] RV_PLIC_PRIO61
+    4'b 0001, // index[ 68] RV_PLIC_PRIO62
+    4'b 0001, // index[ 69] RV_PLIC_PRIO63
+    4'b 0001, // index[ 70] RV_PLIC_PRIO64
+    4'b 0001, // index[ 71] RV_PLIC_PRIO65
+    4'b 0001, // index[ 72] RV_PLIC_PRIO66
+    4'b 0001, // index[ 73] RV_PLIC_PRIO67
+    4'b 0001, // index[ 74] RV_PLIC_PRIO68
+    4'b 0001, // index[ 75] RV_PLIC_PRIO69
+    4'b 0001, // index[ 76] RV_PLIC_PRIO70
+    4'b 0001, // index[ 77] RV_PLIC_PRIO71
+    4'b 0001, // index[ 78] RV_PLIC_PRIO72
+    4'b 0001, // index[ 79] RV_PLIC_PRIO73
+    4'b 0001, // index[ 80] RV_PLIC_PRIO74
+    4'b 0001, // index[ 81] RV_PLIC_PRIO75
+    4'b 0001, // index[ 82] RV_PLIC_PRIO76
+    4'b 0001, // index[ 83] RV_PLIC_PRIO77
+    4'b 0001, // index[ 84] RV_PLIC_PRIO78
+    4'b 0001, // index[ 85] RV_PLIC_PRIO79
+    4'b 0001, // index[ 86] RV_PLIC_PRIO80
+    4'b 0001, // index[ 87] RV_PLIC_PRIO81
+    4'b 0001, // index[ 88] RV_PLIC_PRIO82
+    4'b 0001, // index[ 89] RV_PLIC_PRIO83
+    4'b 0001, // index[ 90] RV_PLIC_PRIO84
+    4'b 0001, // index[ 91] RV_PLIC_PRIO85
+    4'b 0001, // index[ 92] RV_PLIC_PRIO86
+    4'b 0001, // index[ 93] RV_PLIC_PRIO87
+    4'b 0001, // index[ 94] RV_PLIC_PRIO88
+    4'b 1111, // index[ 95] RV_PLIC_IE0_0
+    4'b 1111, // index[ 96] RV_PLIC_IE0_1
+    4'b 1111, // index[ 97] RV_PLIC_IE0_2
+    4'b 0001, // index[ 98] RV_PLIC_THRESHOLD0
+    4'b 0001, // index[ 99] RV_PLIC_CC0
+    4'b 0001  // index[100] RV_PLIC_MSIP0
   };
 endpackage
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
@@ -7,7 +7,7 @@
 package rv_plic_reg_pkg;
 
   // Param list
-  parameter int NumSrc = 89;
+  parameter int NumSrc = 87;
   parameter int NumTarget = 1;
   parameter int PrioWidth = 2;
 
@@ -367,14 +367,6 @@ package rv_plic_reg_pkg;
   } rv_plic_reg2hw_prio86_reg_t;
 
   typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio87_reg_t;
-
-  typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio88_reg_t;
-
-  typedef struct packed {
     logic        q;
   } rv_plic_reg2hw_ie0_mreg_t;
 
@@ -407,97 +399,95 @@ package rv_plic_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_plic_reg2hw_le_mreg_t [88:0] le; // [367:279]
-    rv_plic_reg2hw_prio0_reg_t prio0; // [278:277]
-    rv_plic_reg2hw_prio1_reg_t prio1; // [276:275]
-    rv_plic_reg2hw_prio2_reg_t prio2; // [274:273]
-    rv_plic_reg2hw_prio3_reg_t prio3; // [272:271]
-    rv_plic_reg2hw_prio4_reg_t prio4; // [270:269]
-    rv_plic_reg2hw_prio5_reg_t prio5; // [268:267]
-    rv_plic_reg2hw_prio6_reg_t prio6; // [266:265]
-    rv_plic_reg2hw_prio7_reg_t prio7; // [264:263]
-    rv_plic_reg2hw_prio8_reg_t prio8; // [262:261]
-    rv_plic_reg2hw_prio9_reg_t prio9; // [260:259]
-    rv_plic_reg2hw_prio10_reg_t prio10; // [258:257]
-    rv_plic_reg2hw_prio11_reg_t prio11; // [256:255]
-    rv_plic_reg2hw_prio12_reg_t prio12; // [254:253]
-    rv_plic_reg2hw_prio13_reg_t prio13; // [252:251]
-    rv_plic_reg2hw_prio14_reg_t prio14; // [250:249]
-    rv_plic_reg2hw_prio15_reg_t prio15; // [248:247]
-    rv_plic_reg2hw_prio16_reg_t prio16; // [246:245]
-    rv_plic_reg2hw_prio17_reg_t prio17; // [244:243]
-    rv_plic_reg2hw_prio18_reg_t prio18; // [242:241]
-    rv_plic_reg2hw_prio19_reg_t prio19; // [240:239]
-    rv_plic_reg2hw_prio20_reg_t prio20; // [238:237]
-    rv_plic_reg2hw_prio21_reg_t prio21; // [236:235]
-    rv_plic_reg2hw_prio22_reg_t prio22; // [234:233]
-    rv_plic_reg2hw_prio23_reg_t prio23; // [232:231]
-    rv_plic_reg2hw_prio24_reg_t prio24; // [230:229]
-    rv_plic_reg2hw_prio25_reg_t prio25; // [228:227]
-    rv_plic_reg2hw_prio26_reg_t prio26; // [226:225]
-    rv_plic_reg2hw_prio27_reg_t prio27; // [224:223]
-    rv_plic_reg2hw_prio28_reg_t prio28; // [222:221]
-    rv_plic_reg2hw_prio29_reg_t prio29; // [220:219]
-    rv_plic_reg2hw_prio30_reg_t prio30; // [218:217]
-    rv_plic_reg2hw_prio31_reg_t prio31; // [216:215]
-    rv_plic_reg2hw_prio32_reg_t prio32; // [214:213]
-    rv_plic_reg2hw_prio33_reg_t prio33; // [212:211]
-    rv_plic_reg2hw_prio34_reg_t prio34; // [210:209]
-    rv_plic_reg2hw_prio35_reg_t prio35; // [208:207]
-    rv_plic_reg2hw_prio36_reg_t prio36; // [206:205]
-    rv_plic_reg2hw_prio37_reg_t prio37; // [204:203]
-    rv_plic_reg2hw_prio38_reg_t prio38; // [202:201]
-    rv_plic_reg2hw_prio39_reg_t prio39; // [200:199]
-    rv_plic_reg2hw_prio40_reg_t prio40; // [198:197]
-    rv_plic_reg2hw_prio41_reg_t prio41; // [196:195]
-    rv_plic_reg2hw_prio42_reg_t prio42; // [194:193]
-    rv_plic_reg2hw_prio43_reg_t prio43; // [192:191]
-    rv_plic_reg2hw_prio44_reg_t prio44; // [190:189]
-    rv_plic_reg2hw_prio45_reg_t prio45; // [188:187]
-    rv_plic_reg2hw_prio46_reg_t prio46; // [186:185]
-    rv_plic_reg2hw_prio47_reg_t prio47; // [184:183]
-    rv_plic_reg2hw_prio48_reg_t prio48; // [182:181]
-    rv_plic_reg2hw_prio49_reg_t prio49; // [180:179]
-    rv_plic_reg2hw_prio50_reg_t prio50; // [178:177]
-    rv_plic_reg2hw_prio51_reg_t prio51; // [176:175]
-    rv_plic_reg2hw_prio52_reg_t prio52; // [174:173]
-    rv_plic_reg2hw_prio53_reg_t prio53; // [172:171]
-    rv_plic_reg2hw_prio54_reg_t prio54; // [170:169]
-    rv_plic_reg2hw_prio55_reg_t prio55; // [168:167]
-    rv_plic_reg2hw_prio56_reg_t prio56; // [166:165]
-    rv_plic_reg2hw_prio57_reg_t prio57; // [164:163]
-    rv_plic_reg2hw_prio58_reg_t prio58; // [162:161]
-    rv_plic_reg2hw_prio59_reg_t prio59; // [160:159]
-    rv_plic_reg2hw_prio60_reg_t prio60; // [158:157]
-    rv_plic_reg2hw_prio61_reg_t prio61; // [156:155]
-    rv_plic_reg2hw_prio62_reg_t prio62; // [154:153]
-    rv_plic_reg2hw_prio63_reg_t prio63; // [152:151]
-    rv_plic_reg2hw_prio64_reg_t prio64; // [150:149]
-    rv_plic_reg2hw_prio65_reg_t prio65; // [148:147]
-    rv_plic_reg2hw_prio66_reg_t prio66; // [146:145]
-    rv_plic_reg2hw_prio67_reg_t prio67; // [144:143]
-    rv_plic_reg2hw_prio68_reg_t prio68; // [142:141]
-    rv_plic_reg2hw_prio69_reg_t prio69; // [140:139]
-    rv_plic_reg2hw_prio70_reg_t prio70; // [138:137]
-    rv_plic_reg2hw_prio71_reg_t prio71; // [136:135]
-    rv_plic_reg2hw_prio72_reg_t prio72; // [134:133]
-    rv_plic_reg2hw_prio73_reg_t prio73; // [132:131]
-    rv_plic_reg2hw_prio74_reg_t prio74; // [130:129]
-    rv_plic_reg2hw_prio75_reg_t prio75; // [128:127]
-    rv_plic_reg2hw_prio76_reg_t prio76; // [126:125]
-    rv_plic_reg2hw_prio77_reg_t prio77; // [124:123]
-    rv_plic_reg2hw_prio78_reg_t prio78; // [122:121]
-    rv_plic_reg2hw_prio79_reg_t prio79; // [120:119]
-    rv_plic_reg2hw_prio80_reg_t prio80; // [118:117]
-    rv_plic_reg2hw_prio81_reg_t prio81; // [116:115]
-    rv_plic_reg2hw_prio82_reg_t prio82; // [114:113]
-    rv_plic_reg2hw_prio83_reg_t prio83; // [112:111]
-    rv_plic_reg2hw_prio84_reg_t prio84; // [110:109]
-    rv_plic_reg2hw_prio85_reg_t prio85; // [108:107]
-    rv_plic_reg2hw_prio86_reg_t prio86; // [106:105]
-    rv_plic_reg2hw_prio87_reg_t prio87; // [104:103]
-    rv_plic_reg2hw_prio88_reg_t prio88; // [102:101]
-    rv_plic_reg2hw_ie0_mreg_t [88:0] ie0; // [100:12]
+    rv_plic_reg2hw_le_mreg_t [86:0] le; // [359:273]
+    rv_plic_reg2hw_prio0_reg_t prio0; // [272:271]
+    rv_plic_reg2hw_prio1_reg_t prio1; // [270:269]
+    rv_plic_reg2hw_prio2_reg_t prio2; // [268:267]
+    rv_plic_reg2hw_prio3_reg_t prio3; // [266:265]
+    rv_plic_reg2hw_prio4_reg_t prio4; // [264:263]
+    rv_plic_reg2hw_prio5_reg_t prio5; // [262:261]
+    rv_plic_reg2hw_prio6_reg_t prio6; // [260:259]
+    rv_plic_reg2hw_prio7_reg_t prio7; // [258:257]
+    rv_plic_reg2hw_prio8_reg_t prio8; // [256:255]
+    rv_plic_reg2hw_prio9_reg_t prio9; // [254:253]
+    rv_plic_reg2hw_prio10_reg_t prio10; // [252:251]
+    rv_plic_reg2hw_prio11_reg_t prio11; // [250:249]
+    rv_plic_reg2hw_prio12_reg_t prio12; // [248:247]
+    rv_plic_reg2hw_prio13_reg_t prio13; // [246:245]
+    rv_plic_reg2hw_prio14_reg_t prio14; // [244:243]
+    rv_plic_reg2hw_prio15_reg_t prio15; // [242:241]
+    rv_plic_reg2hw_prio16_reg_t prio16; // [240:239]
+    rv_plic_reg2hw_prio17_reg_t prio17; // [238:237]
+    rv_plic_reg2hw_prio18_reg_t prio18; // [236:235]
+    rv_plic_reg2hw_prio19_reg_t prio19; // [234:233]
+    rv_plic_reg2hw_prio20_reg_t prio20; // [232:231]
+    rv_plic_reg2hw_prio21_reg_t prio21; // [230:229]
+    rv_plic_reg2hw_prio22_reg_t prio22; // [228:227]
+    rv_plic_reg2hw_prio23_reg_t prio23; // [226:225]
+    rv_plic_reg2hw_prio24_reg_t prio24; // [224:223]
+    rv_plic_reg2hw_prio25_reg_t prio25; // [222:221]
+    rv_plic_reg2hw_prio26_reg_t prio26; // [220:219]
+    rv_plic_reg2hw_prio27_reg_t prio27; // [218:217]
+    rv_plic_reg2hw_prio28_reg_t prio28; // [216:215]
+    rv_plic_reg2hw_prio29_reg_t prio29; // [214:213]
+    rv_plic_reg2hw_prio30_reg_t prio30; // [212:211]
+    rv_plic_reg2hw_prio31_reg_t prio31; // [210:209]
+    rv_plic_reg2hw_prio32_reg_t prio32; // [208:207]
+    rv_plic_reg2hw_prio33_reg_t prio33; // [206:205]
+    rv_plic_reg2hw_prio34_reg_t prio34; // [204:203]
+    rv_plic_reg2hw_prio35_reg_t prio35; // [202:201]
+    rv_plic_reg2hw_prio36_reg_t prio36; // [200:199]
+    rv_plic_reg2hw_prio37_reg_t prio37; // [198:197]
+    rv_plic_reg2hw_prio38_reg_t prio38; // [196:195]
+    rv_plic_reg2hw_prio39_reg_t prio39; // [194:193]
+    rv_plic_reg2hw_prio40_reg_t prio40; // [192:191]
+    rv_plic_reg2hw_prio41_reg_t prio41; // [190:189]
+    rv_plic_reg2hw_prio42_reg_t prio42; // [188:187]
+    rv_plic_reg2hw_prio43_reg_t prio43; // [186:185]
+    rv_plic_reg2hw_prio44_reg_t prio44; // [184:183]
+    rv_plic_reg2hw_prio45_reg_t prio45; // [182:181]
+    rv_plic_reg2hw_prio46_reg_t prio46; // [180:179]
+    rv_plic_reg2hw_prio47_reg_t prio47; // [178:177]
+    rv_plic_reg2hw_prio48_reg_t prio48; // [176:175]
+    rv_plic_reg2hw_prio49_reg_t prio49; // [174:173]
+    rv_plic_reg2hw_prio50_reg_t prio50; // [172:171]
+    rv_plic_reg2hw_prio51_reg_t prio51; // [170:169]
+    rv_plic_reg2hw_prio52_reg_t prio52; // [168:167]
+    rv_plic_reg2hw_prio53_reg_t prio53; // [166:165]
+    rv_plic_reg2hw_prio54_reg_t prio54; // [164:163]
+    rv_plic_reg2hw_prio55_reg_t prio55; // [162:161]
+    rv_plic_reg2hw_prio56_reg_t prio56; // [160:159]
+    rv_plic_reg2hw_prio57_reg_t prio57; // [158:157]
+    rv_plic_reg2hw_prio58_reg_t prio58; // [156:155]
+    rv_plic_reg2hw_prio59_reg_t prio59; // [154:153]
+    rv_plic_reg2hw_prio60_reg_t prio60; // [152:151]
+    rv_plic_reg2hw_prio61_reg_t prio61; // [150:149]
+    rv_plic_reg2hw_prio62_reg_t prio62; // [148:147]
+    rv_plic_reg2hw_prio63_reg_t prio63; // [146:145]
+    rv_plic_reg2hw_prio64_reg_t prio64; // [144:143]
+    rv_plic_reg2hw_prio65_reg_t prio65; // [142:141]
+    rv_plic_reg2hw_prio66_reg_t prio66; // [140:139]
+    rv_plic_reg2hw_prio67_reg_t prio67; // [138:137]
+    rv_plic_reg2hw_prio68_reg_t prio68; // [136:135]
+    rv_plic_reg2hw_prio69_reg_t prio69; // [134:133]
+    rv_plic_reg2hw_prio70_reg_t prio70; // [132:131]
+    rv_plic_reg2hw_prio71_reg_t prio71; // [130:129]
+    rv_plic_reg2hw_prio72_reg_t prio72; // [128:127]
+    rv_plic_reg2hw_prio73_reg_t prio73; // [126:125]
+    rv_plic_reg2hw_prio74_reg_t prio74; // [124:123]
+    rv_plic_reg2hw_prio75_reg_t prio75; // [122:121]
+    rv_plic_reg2hw_prio76_reg_t prio76; // [120:119]
+    rv_plic_reg2hw_prio77_reg_t prio77; // [118:117]
+    rv_plic_reg2hw_prio78_reg_t prio78; // [116:115]
+    rv_plic_reg2hw_prio79_reg_t prio79; // [114:113]
+    rv_plic_reg2hw_prio80_reg_t prio80; // [112:111]
+    rv_plic_reg2hw_prio81_reg_t prio81; // [110:109]
+    rv_plic_reg2hw_prio82_reg_t prio82; // [108:107]
+    rv_plic_reg2hw_prio83_reg_t prio83; // [106:105]
+    rv_plic_reg2hw_prio84_reg_t prio84; // [104:103]
+    rv_plic_reg2hw_prio85_reg_t prio85; // [102:101]
+    rv_plic_reg2hw_prio86_reg_t prio86; // [100:99]
+    rv_plic_reg2hw_ie0_mreg_t [86:0] ie0; // [98:12]
     rv_plic_reg2hw_threshold0_reg_t threshold0; // [11:10]
     rv_plic_reg2hw_cc0_reg_t cc0; // [9:1]
     rv_plic_reg2hw_msip0_reg_t msip0; // [0:0]
@@ -507,7 +497,7 @@ package rv_plic_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_plic_hw2reg_ip_mreg_t [88:0] ip; // [184:7]
+    rv_plic_hw2reg_ip_mreg_t [86:0] ip; // [180:7]
     rv_plic_hw2reg_cc0_reg_t cc0; // [6:0]
   } rv_plic_hw2reg_t;
 
@@ -605,8 +595,6 @@ package rv_plic_reg_pkg;
   parameter logic [9:0] RV_PLIC_PRIO84_OFFSET = 10'h 168;
   parameter logic [9:0] RV_PLIC_PRIO85_OFFSET = 10'h 16c;
   parameter logic [9:0] RV_PLIC_PRIO86_OFFSET = 10'h 170;
-  parameter logic [9:0] RV_PLIC_PRIO87_OFFSET = 10'h 174;
-  parameter logic [9:0] RV_PLIC_PRIO88_OFFSET = 10'h 178;
   parameter logic [9:0] RV_PLIC_IE0_0_OFFSET = 10'h 200;
   parameter logic [9:0] RV_PLIC_IE0_1_OFFSET = 10'h 204;
   parameter logic [9:0] RV_PLIC_IE0_2_OFFSET = 10'h 208;
@@ -710,8 +698,6 @@ package rv_plic_reg_pkg;
     RV_PLIC_PRIO84,
     RV_PLIC_PRIO85,
     RV_PLIC_PRIO86,
-    RV_PLIC_PRIO87,
-    RV_PLIC_PRIO88,
     RV_PLIC_IE0_0,
     RV_PLIC_IE0_1,
     RV_PLIC_IE0_2,
@@ -721,108 +707,106 @@ package rv_plic_reg_pkg;
   } rv_plic_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] RV_PLIC_PERMIT [101] = '{
-    4'b 1111, // index[  0] RV_PLIC_IP_0
-    4'b 1111, // index[  1] RV_PLIC_IP_1
-    4'b 1111, // index[  2] RV_PLIC_IP_2
-    4'b 1111, // index[  3] RV_PLIC_LE_0
-    4'b 1111, // index[  4] RV_PLIC_LE_1
-    4'b 1111, // index[  5] RV_PLIC_LE_2
-    4'b 0001, // index[  6] RV_PLIC_PRIO0
-    4'b 0001, // index[  7] RV_PLIC_PRIO1
-    4'b 0001, // index[  8] RV_PLIC_PRIO2
-    4'b 0001, // index[  9] RV_PLIC_PRIO3
-    4'b 0001, // index[ 10] RV_PLIC_PRIO4
-    4'b 0001, // index[ 11] RV_PLIC_PRIO5
-    4'b 0001, // index[ 12] RV_PLIC_PRIO6
-    4'b 0001, // index[ 13] RV_PLIC_PRIO7
-    4'b 0001, // index[ 14] RV_PLIC_PRIO8
-    4'b 0001, // index[ 15] RV_PLIC_PRIO9
-    4'b 0001, // index[ 16] RV_PLIC_PRIO10
-    4'b 0001, // index[ 17] RV_PLIC_PRIO11
-    4'b 0001, // index[ 18] RV_PLIC_PRIO12
-    4'b 0001, // index[ 19] RV_PLIC_PRIO13
-    4'b 0001, // index[ 20] RV_PLIC_PRIO14
-    4'b 0001, // index[ 21] RV_PLIC_PRIO15
-    4'b 0001, // index[ 22] RV_PLIC_PRIO16
-    4'b 0001, // index[ 23] RV_PLIC_PRIO17
-    4'b 0001, // index[ 24] RV_PLIC_PRIO18
-    4'b 0001, // index[ 25] RV_PLIC_PRIO19
-    4'b 0001, // index[ 26] RV_PLIC_PRIO20
-    4'b 0001, // index[ 27] RV_PLIC_PRIO21
-    4'b 0001, // index[ 28] RV_PLIC_PRIO22
-    4'b 0001, // index[ 29] RV_PLIC_PRIO23
-    4'b 0001, // index[ 30] RV_PLIC_PRIO24
-    4'b 0001, // index[ 31] RV_PLIC_PRIO25
-    4'b 0001, // index[ 32] RV_PLIC_PRIO26
-    4'b 0001, // index[ 33] RV_PLIC_PRIO27
-    4'b 0001, // index[ 34] RV_PLIC_PRIO28
-    4'b 0001, // index[ 35] RV_PLIC_PRIO29
-    4'b 0001, // index[ 36] RV_PLIC_PRIO30
-    4'b 0001, // index[ 37] RV_PLIC_PRIO31
-    4'b 0001, // index[ 38] RV_PLIC_PRIO32
-    4'b 0001, // index[ 39] RV_PLIC_PRIO33
-    4'b 0001, // index[ 40] RV_PLIC_PRIO34
-    4'b 0001, // index[ 41] RV_PLIC_PRIO35
-    4'b 0001, // index[ 42] RV_PLIC_PRIO36
-    4'b 0001, // index[ 43] RV_PLIC_PRIO37
-    4'b 0001, // index[ 44] RV_PLIC_PRIO38
-    4'b 0001, // index[ 45] RV_PLIC_PRIO39
-    4'b 0001, // index[ 46] RV_PLIC_PRIO40
-    4'b 0001, // index[ 47] RV_PLIC_PRIO41
-    4'b 0001, // index[ 48] RV_PLIC_PRIO42
-    4'b 0001, // index[ 49] RV_PLIC_PRIO43
-    4'b 0001, // index[ 50] RV_PLIC_PRIO44
-    4'b 0001, // index[ 51] RV_PLIC_PRIO45
-    4'b 0001, // index[ 52] RV_PLIC_PRIO46
-    4'b 0001, // index[ 53] RV_PLIC_PRIO47
-    4'b 0001, // index[ 54] RV_PLIC_PRIO48
-    4'b 0001, // index[ 55] RV_PLIC_PRIO49
-    4'b 0001, // index[ 56] RV_PLIC_PRIO50
-    4'b 0001, // index[ 57] RV_PLIC_PRIO51
-    4'b 0001, // index[ 58] RV_PLIC_PRIO52
-    4'b 0001, // index[ 59] RV_PLIC_PRIO53
-    4'b 0001, // index[ 60] RV_PLIC_PRIO54
-    4'b 0001, // index[ 61] RV_PLIC_PRIO55
-    4'b 0001, // index[ 62] RV_PLIC_PRIO56
-    4'b 0001, // index[ 63] RV_PLIC_PRIO57
-    4'b 0001, // index[ 64] RV_PLIC_PRIO58
-    4'b 0001, // index[ 65] RV_PLIC_PRIO59
-    4'b 0001, // index[ 66] RV_PLIC_PRIO60
-    4'b 0001, // index[ 67] RV_PLIC_PRIO61
-    4'b 0001, // index[ 68] RV_PLIC_PRIO62
-    4'b 0001, // index[ 69] RV_PLIC_PRIO63
-    4'b 0001, // index[ 70] RV_PLIC_PRIO64
-    4'b 0001, // index[ 71] RV_PLIC_PRIO65
-    4'b 0001, // index[ 72] RV_PLIC_PRIO66
-    4'b 0001, // index[ 73] RV_PLIC_PRIO67
-    4'b 0001, // index[ 74] RV_PLIC_PRIO68
-    4'b 0001, // index[ 75] RV_PLIC_PRIO69
-    4'b 0001, // index[ 76] RV_PLIC_PRIO70
-    4'b 0001, // index[ 77] RV_PLIC_PRIO71
-    4'b 0001, // index[ 78] RV_PLIC_PRIO72
-    4'b 0001, // index[ 79] RV_PLIC_PRIO73
-    4'b 0001, // index[ 80] RV_PLIC_PRIO74
-    4'b 0001, // index[ 81] RV_PLIC_PRIO75
-    4'b 0001, // index[ 82] RV_PLIC_PRIO76
-    4'b 0001, // index[ 83] RV_PLIC_PRIO77
-    4'b 0001, // index[ 84] RV_PLIC_PRIO78
-    4'b 0001, // index[ 85] RV_PLIC_PRIO79
-    4'b 0001, // index[ 86] RV_PLIC_PRIO80
-    4'b 0001, // index[ 87] RV_PLIC_PRIO81
-    4'b 0001, // index[ 88] RV_PLIC_PRIO82
-    4'b 0001, // index[ 89] RV_PLIC_PRIO83
-    4'b 0001, // index[ 90] RV_PLIC_PRIO84
-    4'b 0001, // index[ 91] RV_PLIC_PRIO85
-    4'b 0001, // index[ 92] RV_PLIC_PRIO86
-    4'b 0001, // index[ 93] RV_PLIC_PRIO87
-    4'b 0001, // index[ 94] RV_PLIC_PRIO88
-    4'b 1111, // index[ 95] RV_PLIC_IE0_0
-    4'b 1111, // index[ 96] RV_PLIC_IE0_1
-    4'b 1111, // index[ 97] RV_PLIC_IE0_2
-    4'b 0001, // index[ 98] RV_PLIC_THRESHOLD0
-    4'b 0001, // index[ 99] RV_PLIC_CC0
-    4'b 0001  // index[100] RV_PLIC_MSIP0
+  parameter logic [3:0] RV_PLIC_PERMIT [99] = '{
+    4'b 1111, // index[ 0] RV_PLIC_IP_0
+    4'b 1111, // index[ 1] RV_PLIC_IP_1
+    4'b 0111, // index[ 2] RV_PLIC_IP_2
+    4'b 1111, // index[ 3] RV_PLIC_LE_0
+    4'b 1111, // index[ 4] RV_PLIC_LE_1
+    4'b 0111, // index[ 5] RV_PLIC_LE_2
+    4'b 0001, // index[ 6] RV_PLIC_PRIO0
+    4'b 0001, // index[ 7] RV_PLIC_PRIO1
+    4'b 0001, // index[ 8] RV_PLIC_PRIO2
+    4'b 0001, // index[ 9] RV_PLIC_PRIO3
+    4'b 0001, // index[10] RV_PLIC_PRIO4
+    4'b 0001, // index[11] RV_PLIC_PRIO5
+    4'b 0001, // index[12] RV_PLIC_PRIO6
+    4'b 0001, // index[13] RV_PLIC_PRIO7
+    4'b 0001, // index[14] RV_PLIC_PRIO8
+    4'b 0001, // index[15] RV_PLIC_PRIO9
+    4'b 0001, // index[16] RV_PLIC_PRIO10
+    4'b 0001, // index[17] RV_PLIC_PRIO11
+    4'b 0001, // index[18] RV_PLIC_PRIO12
+    4'b 0001, // index[19] RV_PLIC_PRIO13
+    4'b 0001, // index[20] RV_PLIC_PRIO14
+    4'b 0001, // index[21] RV_PLIC_PRIO15
+    4'b 0001, // index[22] RV_PLIC_PRIO16
+    4'b 0001, // index[23] RV_PLIC_PRIO17
+    4'b 0001, // index[24] RV_PLIC_PRIO18
+    4'b 0001, // index[25] RV_PLIC_PRIO19
+    4'b 0001, // index[26] RV_PLIC_PRIO20
+    4'b 0001, // index[27] RV_PLIC_PRIO21
+    4'b 0001, // index[28] RV_PLIC_PRIO22
+    4'b 0001, // index[29] RV_PLIC_PRIO23
+    4'b 0001, // index[30] RV_PLIC_PRIO24
+    4'b 0001, // index[31] RV_PLIC_PRIO25
+    4'b 0001, // index[32] RV_PLIC_PRIO26
+    4'b 0001, // index[33] RV_PLIC_PRIO27
+    4'b 0001, // index[34] RV_PLIC_PRIO28
+    4'b 0001, // index[35] RV_PLIC_PRIO29
+    4'b 0001, // index[36] RV_PLIC_PRIO30
+    4'b 0001, // index[37] RV_PLIC_PRIO31
+    4'b 0001, // index[38] RV_PLIC_PRIO32
+    4'b 0001, // index[39] RV_PLIC_PRIO33
+    4'b 0001, // index[40] RV_PLIC_PRIO34
+    4'b 0001, // index[41] RV_PLIC_PRIO35
+    4'b 0001, // index[42] RV_PLIC_PRIO36
+    4'b 0001, // index[43] RV_PLIC_PRIO37
+    4'b 0001, // index[44] RV_PLIC_PRIO38
+    4'b 0001, // index[45] RV_PLIC_PRIO39
+    4'b 0001, // index[46] RV_PLIC_PRIO40
+    4'b 0001, // index[47] RV_PLIC_PRIO41
+    4'b 0001, // index[48] RV_PLIC_PRIO42
+    4'b 0001, // index[49] RV_PLIC_PRIO43
+    4'b 0001, // index[50] RV_PLIC_PRIO44
+    4'b 0001, // index[51] RV_PLIC_PRIO45
+    4'b 0001, // index[52] RV_PLIC_PRIO46
+    4'b 0001, // index[53] RV_PLIC_PRIO47
+    4'b 0001, // index[54] RV_PLIC_PRIO48
+    4'b 0001, // index[55] RV_PLIC_PRIO49
+    4'b 0001, // index[56] RV_PLIC_PRIO50
+    4'b 0001, // index[57] RV_PLIC_PRIO51
+    4'b 0001, // index[58] RV_PLIC_PRIO52
+    4'b 0001, // index[59] RV_PLIC_PRIO53
+    4'b 0001, // index[60] RV_PLIC_PRIO54
+    4'b 0001, // index[61] RV_PLIC_PRIO55
+    4'b 0001, // index[62] RV_PLIC_PRIO56
+    4'b 0001, // index[63] RV_PLIC_PRIO57
+    4'b 0001, // index[64] RV_PLIC_PRIO58
+    4'b 0001, // index[65] RV_PLIC_PRIO59
+    4'b 0001, // index[66] RV_PLIC_PRIO60
+    4'b 0001, // index[67] RV_PLIC_PRIO61
+    4'b 0001, // index[68] RV_PLIC_PRIO62
+    4'b 0001, // index[69] RV_PLIC_PRIO63
+    4'b 0001, // index[70] RV_PLIC_PRIO64
+    4'b 0001, // index[71] RV_PLIC_PRIO65
+    4'b 0001, // index[72] RV_PLIC_PRIO66
+    4'b 0001, // index[73] RV_PLIC_PRIO67
+    4'b 0001, // index[74] RV_PLIC_PRIO68
+    4'b 0001, // index[75] RV_PLIC_PRIO69
+    4'b 0001, // index[76] RV_PLIC_PRIO70
+    4'b 0001, // index[77] RV_PLIC_PRIO71
+    4'b 0001, // index[78] RV_PLIC_PRIO72
+    4'b 0001, // index[79] RV_PLIC_PRIO73
+    4'b 0001, // index[80] RV_PLIC_PRIO74
+    4'b 0001, // index[81] RV_PLIC_PRIO75
+    4'b 0001, // index[82] RV_PLIC_PRIO76
+    4'b 0001, // index[83] RV_PLIC_PRIO77
+    4'b 0001, // index[84] RV_PLIC_PRIO78
+    4'b 0001, // index[85] RV_PLIC_PRIO79
+    4'b 0001, // index[86] RV_PLIC_PRIO80
+    4'b 0001, // index[87] RV_PLIC_PRIO81
+    4'b 0001, // index[88] RV_PLIC_PRIO82
+    4'b 0001, // index[89] RV_PLIC_PRIO83
+    4'b 0001, // index[90] RV_PLIC_PRIO84
+    4'b 0001, // index[91] RV_PLIC_PRIO85
+    4'b 0001, // index[92] RV_PLIC_PRIO86
+    4'b 1111, // index[93] RV_PLIC_IE0_0
+    4'b 1111, // index[94] RV_PLIC_IE0_1
+    4'b 0111, // index[95] RV_PLIC_IE0_2
+    4'b 0001, // index[96] RV_PLIC_THRESHOLD0
+    4'b 0001, // index[97] RV_PLIC_CC0
+    4'b 0001  // index[98] RV_PLIC_MSIP0
   };
 endpackage
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
@@ -160,21 +160,6 @@ module rv_plic_reg_top (
   logic ip_2_p_86_qs;
   logic ip_2_p_87_qs;
   logic ip_2_p_88_qs;
-  logic ip_2_p_89_qs;
-  logic ip_2_p_90_qs;
-  logic ip_2_p_91_qs;
-  logic ip_2_p_92_qs;
-  logic ip_2_p_93_qs;
-  logic ip_2_p_94_qs;
-  logic ip_2_p_95_qs;
-  logic ip_3_p_96_qs;
-  logic ip_3_p_97_qs;
-  logic ip_3_p_98_qs;
-  logic ip_3_p_99_qs;
-  logic ip_3_p_100_qs;
-  logic ip_3_p_101_qs;
-  logic ip_3_p_102_qs;
-  logic ip_3_p_103_qs;
   logic le_0_le_0_qs;
   logic le_0_le_0_wd;
   logic le_0_le_0_we;
@@ -442,51 +427,6 @@ module rv_plic_reg_top (
   logic le_2_le_88_qs;
   logic le_2_le_88_wd;
   logic le_2_le_88_we;
-  logic le_2_le_89_qs;
-  logic le_2_le_89_wd;
-  logic le_2_le_89_we;
-  logic le_2_le_90_qs;
-  logic le_2_le_90_wd;
-  logic le_2_le_90_we;
-  logic le_2_le_91_qs;
-  logic le_2_le_91_wd;
-  logic le_2_le_91_we;
-  logic le_2_le_92_qs;
-  logic le_2_le_92_wd;
-  logic le_2_le_92_we;
-  logic le_2_le_93_qs;
-  logic le_2_le_93_wd;
-  logic le_2_le_93_we;
-  logic le_2_le_94_qs;
-  logic le_2_le_94_wd;
-  logic le_2_le_94_we;
-  logic le_2_le_95_qs;
-  logic le_2_le_95_wd;
-  logic le_2_le_95_we;
-  logic le_3_le_96_qs;
-  logic le_3_le_96_wd;
-  logic le_3_le_96_we;
-  logic le_3_le_97_qs;
-  logic le_3_le_97_wd;
-  logic le_3_le_97_we;
-  logic le_3_le_98_qs;
-  logic le_3_le_98_wd;
-  logic le_3_le_98_we;
-  logic le_3_le_99_qs;
-  logic le_3_le_99_wd;
-  logic le_3_le_99_we;
-  logic le_3_le_100_qs;
-  logic le_3_le_100_wd;
-  logic le_3_le_100_we;
-  logic le_3_le_101_qs;
-  logic le_3_le_101_wd;
-  logic le_3_le_101_we;
-  logic le_3_le_102_qs;
-  logic le_3_le_102_wd;
-  logic le_3_le_102_we;
-  logic le_3_le_103_qs;
-  logic le_3_le_103_wd;
-  logic le_3_le_103_we;
   logic [1:0] prio0_qs;
   logic [1:0] prio0_wd;
   logic prio0_we;
@@ -754,51 +694,6 @@ module rv_plic_reg_top (
   logic [1:0] prio88_qs;
   logic [1:0] prio88_wd;
   logic prio88_we;
-  logic [1:0] prio89_qs;
-  logic [1:0] prio89_wd;
-  logic prio89_we;
-  logic [1:0] prio90_qs;
-  logic [1:0] prio90_wd;
-  logic prio90_we;
-  logic [1:0] prio91_qs;
-  logic [1:0] prio91_wd;
-  logic prio91_we;
-  logic [1:0] prio92_qs;
-  logic [1:0] prio92_wd;
-  logic prio92_we;
-  logic [1:0] prio93_qs;
-  logic [1:0] prio93_wd;
-  logic prio93_we;
-  logic [1:0] prio94_qs;
-  logic [1:0] prio94_wd;
-  logic prio94_we;
-  logic [1:0] prio95_qs;
-  logic [1:0] prio95_wd;
-  logic prio95_we;
-  logic [1:0] prio96_qs;
-  logic [1:0] prio96_wd;
-  logic prio96_we;
-  logic [1:0] prio97_qs;
-  logic [1:0] prio97_wd;
-  logic prio97_we;
-  logic [1:0] prio98_qs;
-  logic [1:0] prio98_wd;
-  logic prio98_we;
-  logic [1:0] prio99_qs;
-  logic [1:0] prio99_wd;
-  logic prio99_we;
-  logic [1:0] prio100_qs;
-  logic [1:0] prio100_wd;
-  logic prio100_we;
-  logic [1:0] prio101_qs;
-  logic [1:0] prio101_wd;
-  logic prio101_we;
-  logic [1:0] prio102_qs;
-  logic [1:0] prio102_wd;
-  logic prio102_we;
-  logic [1:0] prio103_qs;
-  logic [1:0] prio103_wd;
-  logic prio103_we;
   logic ie0_0_e_0_qs;
   logic ie0_0_e_0_wd;
   logic ie0_0_e_0_we;
@@ -1066,51 +961,6 @@ module rv_plic_reg_top (
   logic ie0_2_e_88_qs;
   logic ie0_2_e_88_wd;
   logic ie0_2_e_88_we;
-  logic ie0_2_e_89_qs;
-  logic ie0_2_e_89_wd;
-  logic ie0_2_e_89_we;
-  logic ie0_2_e_90_qs;
-  logic ie0_2_e_90_wd;
-  logic ie0_2_e_90_we;
-  logic ie0_2_e_91_qs;
-  logic ie0_2_e_91_wd;
-  logic ie0_2_e_91_we;
-  logic ie0_2_e_92_qs;
-  logic ie0_2_e_92_wd;
-  logic ie0_2_e_92_we;
-  logic ie0_2_e_93_qs;
-  logic ie0_2_e_93_wd;
-  logic ie0_2_e_93_we;
-  logic ie0_2_e_94_qs;
-  logic ie0_2_e_94_wd;
-  logic ie0_2_e_94_we;
-  logic ie0_2_e_95_qs;
-  logic ie0_2_e_95_wd;
-  logic ie0_2_e_95_we;
-  logic ie0_3_e_96_qs;
-  logic ie0_3_e_96_wd;
-  logic ie0_3_e_96_we;
-  logic ie0_3_e_97_qs;
-  logic ie0_3_e_97_wd;
-  logic ie0_3_e_97_we;
-  logic ie0_3_e_98_qs;
-  logic ie0_3_e_98_wd;
-  logic ie0_3_e_98_we;
-  logic ie0_3_e_99_qs;
-  logic ie0_3_e_99_wd;
-  logic ie0_3_e_99_we;
-  logic ie0_3_e_100_qs;
-  logic ie0_3_e_100_wd;
-  logic ie0_3_e_100_we;
-  logic ie0_3_e_101_qs;
-  logic ie0_3_e_101_wd;
-  logic ie0_3_e_101_we;
-  logic ie0_3_e_102_qs;
-  logic ie0_3_e_102_wd;
-  logic ie0_3_e_102_we;
-  logic ie0_3_e_103_qs;
-  logic ie0_3_e_103_wd;
-  logic ie0_3_e_103_we;
   logic [1:0] threshold0_qs;
   logic [1:0] threshold0_wd;
   logic threshold0_we;
@@ -3355,384 +3205,6 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (ip_2_p_88_qs)
-  );
-
-
-  // F[p_89]: 25:25
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_2_p_89 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[89].de),
-    .d      (hw2reg.ip[89].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_2_p_89_qs)
-  );
-
-
-  // F[p_90]: 26:26
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_2_p_90 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[90].de),
-    .d      (hw2reg.ip[90].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_2_p_90_qs)
-  );
-
-
-  // F[p_91]: 27:27
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_2_p_91 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[91].de),
-    .d      (hw2reg.ip[91].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_2_p_91_qs)
-  );
-
-
-  // F[p_92]: 28:28
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_2_p_92 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[92].de),
-    .d      (hw2reg.ip[92].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_2_p_92_qs)
-  );
-
-
-  // F[p_93]: 29:29
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_2_p_93 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[93].de),
-    .d      (hw2reg.ip[93].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_2_p_93_qs)
-  );
-
-
-  // F[p_94]: 30:30
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_2_p_94 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[94].de),
-    .d      (hw2reg.ip[94].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_2_p_94_qs)
-  );
-
-
-  // F[p_95]: 31:31
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_2_p_95 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[95].de),
-    .d      (hw2reg.ip[95].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_2_p_95_qs)
-  );
-
-
-  // Subregister 96 of Multireg ip
-  // R[ip_3]: V(False)
-
-  // F[p_96]: 0:0
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_3_p_96 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[96].de),
-    .d      (hw2reg.ip[96].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_3_p_96_qs)
-  );
-
-
-  // F[p_97]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_3_p_97 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[97].de),
-    .d      (hw2reg.ip[97].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_3_p_97_qs)
-  );
-
-
-  // F[p_98]: 2:2
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_3_p_98 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[98].de),
-    .d      (hw2reg.ip[98].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_3_p_98_qs)
-  );
-
-
-  // F[p_99]: 3:3
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_3_p_99 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[99].de),
-    .d      (hw2reg.ip[99].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_3_p_99_qs)
-  );
-
-
-  // F[p_100]: 4:4
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_3_p_100 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[100].de),
-    .d      (hw2reg.ip[100].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_3_p_100_qs)
-  );
-
-
-  // F[p_101]: 5:5
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_3_p_101 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[101].de),
-    .d      (hw2reg.ip[101].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_3_p_101_qs)
-  );
-
-
-  // F[p_102]: 6:6
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_3_p_102 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[102].de),
-    .d      (hw2reg.ip[102].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_3_p_102_qs)
-  );
-
-
-  // F[p_103]: 7:7
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_3_p_103 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[103].de),
-    .d      (hw2reg.ip[103].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_3_p_103_qs)
   );
 
 
@@ -6058,399 +5530,6 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (le_2_le_88_qs)
-  );
-
-
-  // F[le_89]: 25:25
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_2_le_89 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_2_le_89_we),
-    .wd     (le_2_le_89_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[89].q ),
-
-    // to register interface (read)
-    .qs     (le_2_le_89_qs)
-  );
-
-
-  // F[le_90]: 26:26
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_2_le_90 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_2_le_90_we),
-    .wd     (le_2_le_90_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[90].q ),
-
-    // to register interface (read)
-    .qs     (le_2_le_90_qs)
-  );
-
-
-  // F[le_91]: 27:27
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_2_le_91 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_2_le_91_we),
-    .wd     (le_2_le_91_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[91].q ),
-
-    // to register interface (read)
-    .qs     (le_2_le_91_qs)
-  );
-
-
-  // F[le_92]: 28:28
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_2_le_92 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_2_le_92_we),
-    .wd     (le_2_le_92_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[92].q ),
-
-    // to register interface (read)
-    .qs     (le_2_le_92_qs)
-  );
-
-
-  // F[le_93]: 29:29
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_2_le_93 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_2_le_93_we),
-    .wd     (le_2_le_93_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[93].q ),
-
-    // to register interface (read)
-    .qs     (le_2_le_93_qs)
-  );
-
-
-  // F[le_94]: 30:30
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_2_le_94 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_2_le_94_we),
-    .wd     (le_2_le_94_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[94].q ),
-
-    // to register interface (read)
-    .qs     (le_2_le_94_qs)
-  );
-
-
-  // F[le_95]: 31:31
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_2_le_95 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_2_le_95_we),
-    .wd     (le_2_le_95_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[95].q ),
-
-    // to register interface (read)
-    .qs     (le_2_le_95_qs)
-  );
-
-
-  // Subregister 96 of Multireg le
-  // R[le_3]: V(False)
-
-  // F[le_96]: 0:0
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_3_le_96 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_3_le_96_we),
-    .wd     (le_3_le_96_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[96].q ),
-
-    // to register interface (read)
-    .qs     (le_3_le_96_qs)
-  );
-
-
-  // F[le_97]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_3_le_97 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_3_le_97_we),
-    .wd     (le_3_le_97_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[97].q ),
-
-    // to register interface (read)
-    .qs     (le_3_le_97_qs)
-  );
-
-
-  // F[le_98]: 2:2
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_3_le_98 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_3_le_98_we),
-    .wd     (le_3_le_98_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[98].q ),
-
-    // to register interface (read)
-    .qs     (le_3_le_98_qs)
-  );
-
-
-  // F[le_99]: 3:3
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_3_le_99 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_3_le_99_we),
-    .wd     (le_3_le_99_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[99].q ),
-
-    // to register interface (read)
-    .qs     (le_3_le_99_qs)
-  );
-
-
-  // F[le_100]: 4:4
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_3_le_100 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_3_le_100_we),
-    .wd     (le_3_le_100_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[100].q ),
-
-    // to register interface (read)
-    .qs     (le_3_le_100_qs)
-  );
-
-
-  // F[le_101]: 5:5
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_3_le_101 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_3_le_101_we),
-    .wd     (le_3_le_101_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[101].q ),
-
-    // to register interface (read)
-    .qs     (le_3_le_101_qs)
-  );
-
-
-  // F[le_102]: 6:6
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_3_le_102 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_3_le_102_we),
-    .wd     (le_3_le_102_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[102].q ),
-
-    // to register interface (read)
-    .qs     (le_3_le_102_qs)
-  );
-
-
-  // F[le_103]: 7:7
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_3_le_103 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_3_le_103_we),
-    .wd     (le_3_le_103_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[103].q ),
-
-    // to register interface (read)
-    .qs     (le_3_le_103_qs)
   );
 
 
@@ -8858,411 +7937,6 @@ module rv_plic_reg_top (
   );
 
 
-  // R[prio89]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio89 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio89_we),
-    .wd     (prio89_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio89.q ),
-
-    // to register interface (read)
-    .qs     (prio89_qs)
-  );
-
-
-  // R[prio90]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio90 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio90_we),
-    .wd     (prio90_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio90.q ),
-
-    // to register interface (read)
-    .qs     (prio90_qs)
-  );
-
-
-  // R[prio91]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio91 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio91_we),
-    .wd     (prio91_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio91.q ),
-
-    // to register interface (read)
-    .qs     (prio91_qs)
-  );
-
-
-  // R[prio92]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio92 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio92_we),
-    .wd     (prio92_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio92.q ),
-
-    // to register interface (read)
-    .qs     (prio92_qs)
-  );
-
-
-  // R[prio93]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio93 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio93_we),
-    .wd     (prio93_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio93.q ),
-
-    // to register interface (read)
-    .qs     (prio93_qs)
-  );
-
-
-  // R[prio94]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio94 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio94_we),
-    .wd     (prio94_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio94.q ),
-
-    // to register interface (read)
-    .qs     (prio94_qs)
-  );
-
-
-  // R[prio95]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio95 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio95_we),
-    .wd     (prio95_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio95.q ),
-
-    // to register interface (read)
-    .qs     (prio95_qs)
-  );
-
-
-  // R[prio96]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio96 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio96_we),
-    .wd     (prio96_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio96.q ),
-
-    // to register interface (read)
-    .qs     (prio96_qs)
-  );
-
-
-  // R[prio97]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio97 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio97_we),
-    .wd     (prio97_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio97.q ),
-
-    // to register interface (read)
-    .qs     (prio97_qs)
-  );
-
-
-  // R[prio98]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio98 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio98_we),
-    .wd     (prio98_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio98.q ),
-
-    // to register interface (read)
-    .qs     (prio98_qs)
-  );
-
-
-  // R[prio99]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio99 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio99_we),
-    .wd     (prio99_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio99.q ),
-
-    // to register interface (read)
-    .qs     (prio99_qs)
-  );
-
-
-  // R[prio100]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio100 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio100_we),
-    .wd     (prio100_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio100.q ),
-
-    // to register interface (read)
-    .qs     (prio100_qs)
-  );
-
-
-  // R[prio101]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio101 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio101_we),
-    .wd     (prio101_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio101.q ),
-
-    // to register interface (read)
-    .qs     (prio101_qs)
-  );
-
-
-  // R[prio102]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio102 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio102_we),
-    .wd     (prio102_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio102.q ),
-
-    // to register interface (read)
-    .qs     (prio102_qs)
-  );
-
-
-  // R[prio103]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio103 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio103_we),
-    .wd     (prio103_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio103.q ),
-
-    // to register interface (read)
-    .qs     (prio103_qs)
-  );
-
-
 
   // Subregister 0 of Multireg ie0
   // R[ie0_0]: V(False)
@@ -11587,399 +10261,6 @@ module rv_plic_reg_top (
   );
 
 
-  // F[e_89]: 25:25
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_2_e_89 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_2_e_89_we),
-    .wd     (ie0_2_e_89_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[89].q ),
-
-    // to register interface (read)
-    .qs     (ie0_2_e_89_qs)
-  );
-
-
-  // F[e_90]: 26:26
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_2_e_90 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_2_e_90_we),
-    .wd     (ie0_2_e_90_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[90].q ),
-
-    // to register interface (read)
-    .qs     (ie0_2_e_90_qs)
-  );
-
-
-  // F[e_91]: 27:27
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_2_e_91 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_2_e_91_we),
-    .wd     (ie0_2_e_91_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[91].q ),
-
-    // to register interface (read)
-    .qs     (ie0_2_e_91_qs)
-  );
-
-
-  // F[e_92]: 28:28
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_2_e_92 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_2_e_92_we),
-    .wd     (ie0_2_e_92_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[92].q ),
-
-    // to register interface (read)
-    .qs     (ie0_2_e_92_qs)
-  );
-
-
-  // F[e_93]: 29:29
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_2_e_93 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_2_e_93_we),
-    .wd     (ie0_2_e_93_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[93].q ),
-
-    // to register interface (read)
-    .qs     (ie0_2_e_93_qs)
-  );
-
-
-  // F[e_94]: 30:30
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_2_e_94 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_2_e_94_we),
-    .wd     (ie0_2_e_94_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[94].q ),
-
-    // to register interface (read)
-    .qs     (ie0_2_e_94_qs)
-  );
-
-
-  // F[e_95]: 31:31
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_2_e_95 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_2_e_95_we),
-    .wd     (ie0_2_e_95_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[95].q ),
-
-    // to register interface (read)
-    .qs     (ie0_2_e_95_qs)
-  );
-
-
-  // Subregister 96 of Multireg ie0
-  // R[ie0_3]: V(False)
-
-  // F[e_96]: 0:0
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_3_e_96 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_3_e_96_we),
-    .wd     (ie0_3_e_96_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[96].q ),
-
-    // to register interface (read)
-    .qs     (ie0_3_e_96_qs)
-  );
-
-
-  // F[e_97]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_3_e_97 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_3_e_97_we),
-    .wd     (ie0_3_e_97_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[97].q ),
-
-    // to register interface (read)
-    .qs     (ie0_3_e_97_qs)
-  );
-
-
-  // F[e_98]: 2:2
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_3_e_98 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_3_e_98_we),
-    .wd     (ie0_3_e_98_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[98].q ),
-
-    // to register interface (read)
-    .qs     (ie0_3_e_98_qs)
-  );
-
-
-  // F[e_99]: 3:3
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_3_e_99 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_3_e_99_we),
-    .wd     (ie0_3_e_99_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[99].q ),
-
-    // to register interface (read)
-    .qs     (ie0_3_e_99_qs)
-  );
-
-
-  // F[e_100]: 4:4
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_3_e_100 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_3_e_100_we),
-    .wd     (ie0_3_e_100_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[100].q ),
-
-    // to register interface (read)
-    .qs     (ie0_3_e_100_qs)
-  );
-
-
-  // F[e_101]: 5:5
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_3_e_101 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_3_e_101_we),
-    .wd     (ie0_3_e_101_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[101].q ),
-
-    // to register interface (read)
-    .qs     (ie0_3_e_101_qs)
-  );
-
-
-  // F[e_102]: 6:6
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_3_e_102 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_3_e_102_we),
-    .wd     (ie0_3_e_102_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[102].q ),
-
-    // to register interface (read)
-    .qs     (ie0_3_e_102_qs)
-  );
-
-
-  // F[e_103]: 7:7
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_3_e_103 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_3_e_103_we),
-    .wd     (ie0_3_e_103_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[103].q ),
-
-    // to register interface (read)
-    .qs     (ie0_3_e_103_qs)
-  );
-
-
 
   // R[threshold0]: V(False)
 
@@ -12053,128 +10334,110 @@ module rv_plic_reg_top (
 
 
 
-  logic [118:0] addr_hit;
+  logic [100:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[  0] = (reg_addr == RV_PLIC_IP_0_OFFSET);
     addr_hit[  1] = (reg_addr == RV_PLIC_IP_1_OFFSET);
     addr_hit[  2] = (reg_addr == RV_PLIC_IP_2_OFFSET);
-    addr_hit[  3] = (reg_addr == RV_PLIC_IP_3_OFFSET);
-    addr_hit[  4] = (reg_addr == RV_PLIC_LE_0_OFFSET);
-    addr_hit[  5] = (reg_addr == RV_PLIC_LE_1_OFFSET);
-    addr_hit[  6] = (reg_addr == RV_PLIC_LE_2_OFFSET);
-    addr_hit[  7] = (reg_addr == RV_PLIC_LE_3_OFFSET);
-    addr_hit[  8] = (reg_addr == RV_PLIC_PRIO0_OFFSET);
-    addr_hit[  9] = (reg_addr == RV_PLIC_PRIO1_OFFSET);
-    addr_hit[ 10] = (reg_addr == RV_PLIC_PRIO2_OFFSET);
-    addr_hit[ 11] = (reg_addr == RV_PLIC_PRIO3_OFFSET);
-    addr_hit[ 12] = (reg_addr == RV_PLIC_PRIO4_OFFSET);
-    addr_hit[ 13] = (reg_addr == RV_PLIC_PRIO5_OFFSET);
-    addr_hit[ 14] = (reg_addr == RV_PLIC_PRIO6_OFFSET);
-    addr_hit[ 15] = (reg_addr == RV_PLIC_PRIO7_OFFSET);
-    addr_hit[ 16] = (reg_addr == RV_PLIC_PRIO8_OFFSET);
-    addr_hit[ 17] = (reg_addr == RV_PLIC_PRIO9_OFFSET);
-    addr_hit[ 18] = (reg_addr == RV_PLIC_PRIO10_OFFSET);
-    addr_hit[ 19] = (reg_addr == RV_PLIC_PRIO11_OFFSET);
-    addr_hit[ 20] = (reg_addr == RV_PLIC_PRIO12_OFFSET);
-    addr_hit[ 21] = (reg_addr == RV_PLIC_PRIO13_OFFSET);
-    addr_hit[ 22] = (reg_addr == RV_PLIC_PRIO14_OFFSET);
-    addr_hit[ 23] = (reg_addr == RV_PLIC_PRIO15_OFFSET);
-    addr_hit[ 24] = (reg_addr == RV_PLIC_PRIO16_OFFSET);
-    addr_hit[ 25] = (reg_addr == RV_PLIC_PRIO17_OFFSET);
-    addr_hit[ 26] = (reg_addr == RV_PLIC_PRIO18_OFFSET);
-    addr_hit[ 27] = (reg_addr == RV_PLIC_PRIO19_OFFSET);
-    addr_hit[ 28] = (reg_addr == RV_PLIC_PRIO20_OFFSET);
-    addr_hit[ 29] = (reg_addr == RV_PLIC_PRIO21_OFFSET);
-    addr_hit[ 30] = (reg_addr == RV_PLIC_PRIO22_OFFSET);
-    addr_hit[ 31] = (reg_addr == RV_PLIC_PRIO23_OFFSET);
-    addr_hit[ 32] = (reg_addr == RV_PLIC_PRIO24_OFFSET);
-    addr_hit[ 33] = (reg_addr == RV_PLIC_PRIO25_OFFSET);
-    addr_hit[ 34] = (reg_addr == RV_PLIC_PRIO26_OFFSET);
-    addr_hit[ 35] = (reg_addr == RV_PLIC_PRIO27_OFFSET);
-    addr_hit[ 36] = (reg_addr == RV_PLIC_PRIO28_OFFSET);
-    addr_hit[ 37] = (reg_addr == RV_PLIC_PRIO29_OFFSET);
-    addr_hit[ 38] = (reg_addr == RV_PLIC_PRIO30_OFFSET);
-    addr_hit[ 39] = (reg_addr == RV_PLIC_PRIO31_OFFSET);
-    addr_hit[ 40] = (reg_addr == RV_PLIC_PRIO32_OFFSET);
-    addr_hit[ 41] = (reg_addr == RV_PLIC_PRIO33_OFFSET);
-    addr_hit[ 42] = (reg_addr == RV_PLIC_PRIO34_OFFSET);
-    addr_hit[ 43] = (reg_addr == RV_PLIC_PRIO35_OFFSET);
-    addr_hit[ 44] = (reg_addr == RV_PLIC_PRIO36_OFFSET);
-    addr_hit[ 45] = (reg_addr == RV_PLIC_PRIO37_OFFSET);
-    addr_hit[ 46] = (reg_addr == RV_PLIC_PRIO38_OFFSET);
-    addr_hit[ 47] = (reg_addr == RV_PLIC_PRIO39_OFFSET);
-    addr_hit[ 48] = (reg_addr == RV_PLIC_PRIO40_OFFSET);
-    addr_hit[ 49] = (reg_addr == RV_PLIC_PRIO41_OFFSET);
-    addr_hit[ 50] = (reg_addr == RV_PLIC_PRIO42_OFFSET);
-    addr_hit[ 51] = (reg_addr == RV_PLIC_PRIO43_OFFSET);
-    addr_hit[ 52] = (reg_addr == RV_PLIC_PRIO44_OFFSET);
-    addr_hit[ 53] = (reg_addr == RV_PLIC_PRIO45_OFFSET);
-    addr_hit[ 54] = (reg_addr == RV_PLIC_PRIO46_OFFSET);
-    addr_hit[ 55] = (reg_addr == RV_PLIC_PRIO47_OFFSET);
-    addr_hit[ 56] = (reg_addr == RV_PLIC_PRIO48_OFFSET);
-    addr_hit[ 57] = (reg_addr == RV_PLIC_PRIO49_OFFSET);
-    addr_hit[ 58] = (reg_addr == RV_PLIC_PRIO50_OFFSET);
-    addr_hit[ 59] = (reg_addr == RV_PLIC_PRIO51_OFFSET);
-    addr_hit[ 60] = (reg_addr == RV_PLIC_PRIO52_OFFSET);
-    addr_hit[ 61] = (reg_addr == RV_PLIC_PRIO53_OFFSET);
-    addr_hit[ 62] = (reg_addr == RV_PLIC_PRIO54_OFFSET);
-    addr_hit[ 63] = (reg_addr == RV_PLIC_PRIO55_OFFSET);
-    addr_hit[ 64] = (reg_addr == RV_PLIC_PRIO56_OFFSET);
-    addr_hit[ 65] = (reg_addr == RV_PLIC_PRIO57_OFFSET);
-    addr_hit[ 66] = (reg_addr == RV_PLIC_PRIO58_OFFSET);
-    addr_hit[ 67] = (reg_addr == RV_PLIC_PRIO59_OFFSET);
-    addr_hit[ 68] = (reg_addr == RV_PLIC_PRIO60_OFFSET);
-    addr_hit[ 69] = (reg_addr == RV_PLIC_PRIO61_OFFSET);
-    addr_hit[ 70] = (reg_addr == RV_PLIC_PRIO62_OFFSET);
-    addr_hit[ 71] = (reg_addr == RV_PLIC_PRIO63_OFFSET);
-    addr_hit[ 72] = (reg_addr == RV_PLIC_PRIO64_OFFSET);
-    addr_hit[ 73] = (reg_addr == RV_PLIC_PRIO65_OFFSET);
-    addr_hit[ 74] = (reg_addr == RV_PLIC_PRIO66_OFFSET);
-    addr_hit[ 75] = (reg_addr == RV_PLIC_PRIO67_OFFSET);
-    addr_hit[ 76] = (reg_addr == RV_PLIC_PRIO68_OFFSET);
-    addr_hit[ 77] = (reg_addr == RV_PLIC_PRIO69_OFFSET);
-    addr_hit[ 78] = (reg_addr == RV_PLIC_PRIO70_OFFSET);
-    addr_hit[ 79] = (reg_addr == RV_PLIC_PRIO71_OFFSET);
-    addr_hit[ 80] = (reg_addr == RV_PLIC_PRIO72_OFFSET);
-    addr_hit[ 81] = (reg_addr == RV_PLIC_PRIO73_OFFSET);
-    addr_hit[ 82] = (reg_addr == RV_PLIC_PRIO74_OFFSET);
-    addr_hit[ 83] = (reg_addr == RV_PLIC_PRIO75_OFFSET);
-    addr_hit[ 84] = (reg_addr == RV_PLIC_PRIO76_OFFSET);
-    addr_hit[ 85] = (reg_addr == RV_PLIC_PRIO77_OFFSET);
-    addr_hit[ 86] = (reg_addr == RV_PLIC_PRIO78_OFFSET);
-    addr_hit[ 87] = (reg_addr == RV_PLIC_PRIO79_OFFSET);
-    addr_hit[ 88] = (reg_addr == RV_PLIC_PRIO80_OFFSET);
-    addr_hit[ 89] = (reg_addr == RV_PLIC_PRIO81_OFFSET);
-    addr_hit[ 90] = (reg_addr == RV_PLIC_PRIO82_OFFSET);
-    addr_hit[ 91] = (reg_addr == RV_PLIC_PRIO83_OFFSET);
-    addr_hit[ 92] = (reg_addr == RV_PLIC_PRIO84_OFFSET);
-    addr_hit[ 93] = (reg_addr == RV_PLIC_PRIO85_OFFSET);
-    addr_hit[ 94] = (reg_addr == RV_PLIC_PRIO86_OFFSET);
-    addr_hit[ 95] = (reg_addr == RV_PLIC_PRIO87_OFFSET);
-    addr_hit[ 96] = (reg_addr == RV_PLIC_PRIO88_OFFSET);
-    addr_hit[ 97] = (reg_addr == RV_PLIC_PRIO89_OFFSET);
-    addr_hit[ 98] = (reg_addr == RV_PLIC_PRIO90_OFFSET);
-    addr_hit[ 99] = (reg_addr == RV_PLIC_PRIO91_OFFSET);
-    addr_hit[100] = (reg_addr == RV_PLIC_PRIO92_OFFSET);
-    addr_hit[101] = (reg_addr == RV_PLIC_PRIO93_OFFSET);
-    addr_hit[102] = (reg_addr == RV_PLIC_PRIO94_OFFSET);
-    addr_hit[103] = (reg_addr == RV_PLIC_PRIO95_OFFSET);
-    addr_hit[104] = (reg_addr == RV_PLIC_PRIO96_OFFSET);
-    addr_hit[105] = (reg_addr == RV_PLIC_PRIO97_OFFSET);
-    addr_hit[106] = (reg_addr == RV_PLIC_PRIO98_OFFSET);
-    addr_hit[107] = (reg_addr == RV_PLIC_PRIO99_OFFSET);
-    addr_hit[108] = (reg_addr == RV_PLIC_PRIO100_OFFSET);
-    addr_hit[109] = (reg_addr == RV_PLIC_PRIO101_OFFSET);
-    addr_hit[110] = (reg_addr == RV_PLIC_PRIO102_OFFSET);
-    addr_hit[111] = (reg_addr == RV_PLIC_PRIO103_OFFSET);
-    addr_hit[112] = (reg_addr == RV_PLIC_IE0_0_OFFSET);
-    addr_hit[113] = (reg_addr == RV_PLIC_IE0_1_OFFSET);
-    addr_hit[114] = (reg_addr == RV_PLIC_IE0_2_OFFSET);
-    addr_hit[115] = (reg_addr == RV_PLIC_IE0_3_OFFSET);
-    addr_hit[116] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
-    addr_hit[117] = (reg_addr == RV_PLIC_CC0_OFFSET);
-    addr_hit[118] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
+    addr_hit[  3] = (reg_addr == RV_PLIC_LE_0_OFFSET);
+    addr_hit[  4] = (reg_addr == RV_PLIC_LE_1_OFFSET);
+    addr_hit[  5] = (reg_addr == RV_PLIC_LE_2_OFFSET);
+    addr_hit[  6] = (reg_addr == RV_PLIC_PRIO0_OFFSET);
+    addr_hit[  7] = (reg_addr == RV_PLIC_PRIO1_OFFSET);
+    addr_hit[  8] = (reg_addr == RV_PLIC_PRIO2_OFFSET);
+    addr_hit[  9] = (reg_addr == RV_PLIC_PRIO3_OFFSET);
+    addr_hit[ 10] = (reg_addr == RV_PLIC_PRIO4_OFFSET);
+    addr_hit[ 11] = (reg_addr == RV_PLIC_PRIO5_OFFSET);
+    addr_hit[ 12] = (reg_addr == RV_PLIC_PRIO6_OFFSET);
+    addr_hit[ 13] = (reg_addr == RV_PLIC_PRIO7_OFFSET);
+    addr_hit[ 14] = (reg_addr == RV_PLIC_PRIO8_OFFSET);
+    addr_hit[ 15] = (reg_addr == RV_PLIC_PRIO9_OFFSET);
+    addr_hit[ 16] = (reg_addr == RV_PLIC_PRIO10_OFFSET);
+    addr_hit[ 17] = (reg_addr == RV_PLIC_PRIO11_OFFSET);
+    addr_hit[ 18] = (reg_addr == RV_PLIC_PRIO12_OFFSET);
+    addr_hit[ 19] = (reg_addr == RV_PLIC_PRIO13_OFFSET);
+    addr_hit[ 20] = (reg_addr == RV_PLIC_PRIO14_OFFSET);
+    addr_hit[ 21] = (reg_addr == RV_PLIC_PRIO15_OFFSET);
+    addr_hit[ 22] = (reg_addr == RV_PLIC_PRIO16_OFFSET);
+    addr_hit[ 23] = (reg_addr == RV_PLIC_PRIO17_OFFSET);
+    addr_hit[ 24] = (reg_addr == RV_PLIC_PRIO18_OFFSET);
+    addr_hit[ 25] = (reg_addr == RV_PLIC_PRIO19_OFFSET);
+    addr_hit[ 26] = (reg_addr == RV_PLIC_PRIO20_OFFSET);
+    addr_hit[ 27] = (reg_addr == RV_PLIC_PRIO21_OFFSET);
+    addr_hit[ 28] = (reg_addr == RV_PLIC_PRIO22_OFFSET);
+    addr_hit[ 29] = (reg_addr == RV_PLIC_PRIO23_OFFSET);
+    addr_hit[ 30] = (reg_addr == RV_PLIC_PRIO24_OFFSET);
+    addr_hit[ 31] = (reg_addr == RV_PLIC_PRIO25_OFFSET);
+    addr_hit[ 32] = (reg_addr == RV_PLIC_PRIO26_OFFSET);
+    addr_hit[ 33] = (reg_addr == RV_PLIC_PRIO27_OFFSET);
+    addr_hit[ 34] = (reg_addr == RV_PLIC_PRIO28_OFFSET);
+    addr_hit[ 35] = (reg_addr == RV_PLIC_PRIO29_OFFSET);
+    addr_hit[ 36] = (reg_addr == RV_PLIC_PRIO30_OFFSET);
+    addr_hit[ 37] = (reg_addr == RV_PLIC_PRIO31_OFFSET);
+    addr_hit[ 38] = (reg_addr == RV_PLIC_PRIO32_OFFSET);
+    addr_hit[ 39] = (reg_addr == RV_PLIC_PRIO33_OFFSET);
+    addr_hit[ 40] = (reg_addr == RV_PLIC_PRIO34_OFFSET);
+    addr_hit[ 41] = (reg_addr == RV_PLIC_PRIO35_OFFSET);
+    addr_hit[ 42] = (reg_addr == RV_PLIC_PRIO36_OFFSET);
+    addr_hit[ 43] = (reg_addr == RV_PLIC_PRIO37_OFFSET);
+    addr_hit[ 44] = (reg_addr == RV_PLIC_PRIO38_OFFSET);
+    addr_hit[ 45] = (reg_addr == RV_PLIC_PRIO39_OFFSET);
+    addr_hit[ 46] = (reg_addr == RV_PLIC_PRIO40_OFFSET);
+    addr_hit[ 47] = (reg_addr == RV_PLIC_PRIO41_OFFSET);
+    addr_hit[ 48] = (reg_addr == RV_PLIC_PRIO42_OFFSET);
+    addr_hit[ 49] = (reg_addr == RV_PLIC_PRIO43_OFFSET);
+    addr_hit[ 50] = (reg_addr == RV_PLIC_PRIO44_OFFSET);
+    addr_hit[ 51] = (reg_addr == RV_PLIC_PRIO45_OFFSET);
+    addr_hit[ 52] = (reg_addr == RV_PLIC_PRIO46_OFFSET);
+    addr_hit[ 53] = (reg_addr == RV_PLIC_PRIO47_OFFSET);
+    addr_hit[ 54] = (reg_addr == RV_PLIC_PRIO48_OFFSET);
+    addr_hit[ 55] = (reg_addr == RV_PLIC_PRIO49_OFFSET);
+    addr_hit[ 56] = (reg_addr == RV_PLIC_PRIO50_OFFSET);
+    addr_hit[ 57] = (reg_addr == RV_PLIC_PRIO51_OFFSET);
+    addr_hit[ 58] = (reg_addr == RV_PLIC_PRIO52_OFFSET);
+    addr_hit[ 59] = (reg_addr == RV_PLIC_PRIO53_OFFSET);
+    addr_hit[ 60] = (reg_addr == RV_PLIC_PRIO54_OFFSET);
+    addr_hit[ 61] = (reg_addr == RV_PLIC_PRIO55_OFFSET);
+    addr_hit[ 62] = (reg_addr == RV_PLIC_PRIO56_OFFSET);
+    addr_hit[ 63] = (reg_addr == RV_PLIC_PRIO57_OFFSET);
+    addr_hit[ 64] = (reg_addr == RV_PLIC_PRIO58_OFFSET);
+    addr_hit[ 65] = (reg_addr == RV_PLIC_PRIO59_OFFSET);
+    addr_hit[ 66] = (reg_addr == RV_PLIC_PRIO60_OFFSET);
+    addr_hit[ 67] = (reg_addr == RV_PLIC_PRIO61_OFFSET);
+    addr_hit[ 68] = (reg_addr == RV_PLIC_PRIO62_OFFSET);
+    addr_hit[ 69] = (reg_addr == RV_PLIC_PRIO63_OFFSET);
+    addr_hit[ 70] = (reg_addr == RV_PLIC_PRIO64_OFFSET);
+    addr_hit[ 71] = (reg_addr == RV_PLIC_PRIO65_OFFSET);
+    addr_hit[ 72] = (reg_addr == RV_PLIC_PRIO66_OFFSET);
+    addr_hit[ 73] = (reg_addr == RV_PLIC_PRIO67_OFFSET);
+    addr_hit[ 74] = (reg_addr == RV_PLIC_PRIO68_OFFSET);
+    addr_hit[ 75] = (reg_addr == RV_PLIC_PRIO69_OFFSET);
+    addr_hit[ 76] = (reg_addr == RV_PLIC_PRIO70_OFFSET);
+    addr_hit[ 77] = (reg_addr == RV_PLIC_PRIO71_OFFSET);
+    addr_hit[ 78] = (reg_addr == RV_PLIC_PRIO72_OFFSET);
+    addr_hit[ 79] = (reg_addr == RV_PLIC_PRIO73_OFFSET);
+    addr_hit[ 80] = (reg_addr == RV_PLIC_PRIO74_OFFSET);
+    addr_hit[ 81] = (reg_addr == RV_PLIC_PRIO75_OFFSET);
+    addr_hit[ 82] = (reg_addr == RV_PLIC_PRIO76_OFFSET);
+    addr_hit[ 83] = (reg_addr == RV_PLIC_PRIO77_OFFSET);
+    addr_hit[ 84] = (reg_addr == RV_PLIC_PRIO78_OFFSET);
+    addr_hit[ 85] = (reg_addr == RV_PLIC_PRIO79_OFFSET);
+    addr_hit[ 86] = (reg_addr == RV_PLIC_PRIO80_OFFSET);
+    addr_hit[ 87] = (reg_addr == RV_PLIC_PRIO81_OFFSET);
+    addr_hit[ 88] = (reg_addr == RV_PLIC_PRIO82_OFFSET);
+    addr_hit[ 89] = (reg_addr == RV_PLIC_PRIO83_OFFSET);
+    addr_hit[ 90] = (reg_addr == RV_PLIC_PRIO84_OFFSET);
+    addr_hit[ 91] = (reg_addr == RV_PLIC_PRIO85_OFFSET);
+    addr_hit[ 92] = (reg_addr == RV_PLIC_PRIO86_OFFSET);
+    addr_hit[ 93] = (reg_addr == RV_PLIC_PRIO87_OFFSET);
+    addr_hit[ 94] = (reg_addr == RV_PLIC_PRIO88_OFFSET);
+    addr_hit[ 95] = (reg_addr == RV_PLIC_IE0_0_OFFSET);
+    addr_hit[ 96] = (reg_addr == RV_PLIC_IE0_1_OFFSET);
+    addr_hit[ 97] = (reg_addr == RV_PLIC_IE0_2_OFFSET);
+    addr_hit[ 98] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
+    addr_hit[ 99] = (reg_addr == RV_PLIC_CC0_OFFSET);
+    addr_hit[100] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -12283,24 +10546,6 @@ module rv_plic_reg_top (
     if (addr_hit[ 98] && reg_we && (RV_PLIC_PERMIT[ 98] != (RV_PLIC_PERMIT[ 98] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[ 99] && reg_we && (RV_PLIC_PERMIT[ 99] != (RV_PLIC_PERMIT[ 99] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[100] && reg_we && (RV_PLIC_PERMIT[100] != (RV_PLIC_PERMIT[100] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[101] && reg_we && (RV_PLIC_PERMIT[101] != (RV_PLIC_PERMIT[101] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[102] && reg_we && (RV_PLIC_PERMIT[102] != (RV_PLIC_PERMIT[102] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[103] && reg_we && (RV_PLIC_PERMIT[103] != (RV_PLIC_PERMIT[103] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[104] && reg_we && (RV_PLIC_PERMIT[104] != (RV_PLIC_PERMIT[104] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[105] && reg_we && (RV_PLIC_PERMIT[105] != (RV_PLIC_PERMIT[105] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[106] && reg_we && (RV_PLIC_PERMIT[106] != (RV_PLIC_PERMIT[106] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[107] && reg_we && (RV_PLIC_PERMIT[107] != (RV_PLIC_PERMIT[107] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[108] && reg_we && (RV_PLIC_PERMIT[108] != (RV_PLIC_PERMIT[108] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[109] && reg_we && (RV_PLIC_PERMIT[109] != (RV_PLIC_PERMIT[109] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[110] && reg_we && (RV_PLIC_PERMIT[110] != (RV_PLIC_PERMIT[110] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[111] && reg_we && (RV_PLIC_PERMIT[111] != (RV_PLIC_PERMIT[111] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[112] && reg_we && (RV_PLIC_PERMIT[112] != (RV_PLIC_PERMIT[112] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[113] && reg_we && (RV_PLIC_PERMIT[113] != (RV_PLIC_PERMIT[113] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[114] && reg_we && (RV_PLIC_PERMIT[114] != (RV_PLIC_PERMIT[114] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[115] && reg_we && (RV_PLIC_PERMIT[115] != (RV_PLIC_PERMIT[115] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[116] && reg_we && (RV_PLIC_PERMIT[116] != (RV_PLIC_PERMIT[116] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[117] && reg_we && (RV_PLIC_PERMIT[117] != (RV_PLIC_PERMIT[117] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[118] && reg_we && (RV_PLIC_PERMIT[118] != (RV_PLIC_PERMIT[118] & reg_be))) wr_err = 1'b1 ;
   end
 
 
@@ -12392,965 +10637,815 @@ module rv_plic_reg_top (
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  assign le_0_le_0_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_0_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_0_wd = reg_wdata[0];
 
-  assign le_0_le_1_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_1_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_1_wd = reg_wdata[1];
 
-  assign le_0_le_2_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_2_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_2_wd = reg_wdata[2];
 
-  assign le_0_le_3_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_3_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_3_wd = reg_wdata[3];
 
-  assign le_0_le_4_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_4_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_4_wd = reg_wdata[4];
 
-  assign le_0_le_5_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_5_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_5_wd = reg_wdata[5];
 
-  assign le_0_le_6_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_6_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_6_wd = reg_wdata[6];
 
-  assign le_0_le_7_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_7_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_7_wd = reg_wdata[7];
 
-  assign le_0_le_8_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_8_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_8_wd = reg_wdata[8];
 
-  assign le_0_le_9_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_9_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_9_wd = reg_wdata[9];
 
-  assign le_0_le_10_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_10_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_10_wd = reg_wdata[10];
 
-  assign le_0_le_11_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_11_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_11_wd = reg_wdata[11];
 
-  assign le_0_le_12_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_12_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_12_wd = reg_wdata[12];
 
-  assign le_0_le_13_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_13_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_13_wd = reg_wdata[13];
 
-  assign le_0_le_14_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_14_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_14_wd = reg_wdata[14];
 
-  assign le_0_le_15_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_15_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_15_wd = reg_wdata[15];
 
-  assign le_0_le_16_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_16_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_16_wd = reg_wdata[16];
 
-  assign le_0_le_17_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_17_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_17_wd = reg_wdata[17];
 
-  assign le_0_le_18_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_18_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_18_wd = reg_wdata[18];
 
-  assign le_0_le_19_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_19_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_19_wd = reg_wdata[19];
 
-  assign le_0_le_20_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_20_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_20_wd = reg_wdata[20];
 
-  assign le_0_le_21_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_21_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_21_wd = reg_wdata[21];
 
-  assign le_0_le_22_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_22_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_22_wd = reg_wdata[22];
 
-  assign le_0_le_23_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_23_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_23_wd = reg_wdata[23];
 
-  assign le_0_le_24_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_24_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_24_wd = reg_wdata[24];
 
-  assign le_0_le_25_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_25_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_25_wd = reg_wdata[25];
 
-  assign le_0_le_26_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_26_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_26_wd = reg_wdata[26];
 
-  assign le_0_le_27_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_27_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_27_wd = reg_wdata[27];
 
-  assign le_0_le_28_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_28_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_28_wd = reg_wdata[28];
 
-  assign le_0_le_29_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_29_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_29_wd = reg_wdata[29];
 
-  assign le_0_le_30_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_30_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_30_wd = reg_wdata[30];
 
-  assign le_0_le_31_we = addr_hit[4] & reg_we & ~wr_err;
+  assign le_0_le_31_we = addr_hit[3] & reg_we & ~wr_err;
   assign le_0_le_31_wd = reg_wdata[31];
 
-  assign le_1_le_32_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_32_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_32_wd = reg_wdata[0];
 
-  assign le_1_le_33_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_33_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_33_wd = reg_wdata[1];
 
-  assign le_1_le_34_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_34_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_34_wd = reg_wdata[2];
 
-  assign le_1_le_35_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_35_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_35_wd = reg_wdata[3];
 
-  assign le_1_le_36_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_36_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_36_wd = reg_wdata[4];
 
-  assign le_1_le_37_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_37_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_37_wd = reg_wdata[5];
 
-  assign le_1_le_38_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_38_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_38_wd = reg_wdata[6];
 
-  assign le_1_le_39_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_39_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_39_wd = reg_wdata[7];
 
-  assign le_1_le_40_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_40_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_40_wd = reg_wdata[8];
 
-  assign le_1_le_41_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_41_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_41_wd = reg_wdata[9];
 
-  assign le_1_le_42_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_42_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_42_wd = reg_wdata[10];
 
-  assign le_1_le_43_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_43_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_43_wd = reg_wdata[11];
 
-  assign le_1_le_44_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_44_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_44_wd = reg_wdata[12];
 
-  assign le_1_le_45_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_45_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_45_wd = reg_wdata[13];
 
-  assign le_1_le_46_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_46_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_46_wd = reg_wdata[14];
 
-  assign le_1_le_47_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_47_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_47_wd = reg_wdata[15];
 
-  assign le_1_le_48_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_48_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_48_wd = reg_wdata[16];
 
-  assign le_1_le_49_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_49_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_49_wd = reg_wdata[17];
 
-  assign le_1_le_50_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_50_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_50_wd = reg_wdata[18];
 
-  assign le_1_le_51_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_51_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_51_wd = reg_wdata[19];
 
-  assign le_1_le_52_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_52_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_52_wd = reg_wdata[20];
 
-  assign le_1_le_53_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_53_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_53_wd = reg_wdata[21];
 
-  assign le_1_le_54_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_54_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_54_wd = reg_wdata[22];
 
-  assign le_1_le_55_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_55_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_55_wd = reg_wdata[23];
 
-  assign le_1_le_56_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_56_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_56_wd = reg_wdata[24];
 
-  assign le_1_le_57_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_57_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_57_wd = reg_wdata[25];
 
-  assign le_1_le_58_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_58_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_58_wd = reg_wdata[26];
 
-  assign le_1_le_59_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_59_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_59_wd = reg_wdata[27];
 
-  assign le_1_le_60_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_60_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_60_wd = reg_wdata[28];
 
-  assign le_1_le_61_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_61_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_61_wd = reg_wdata[29];
 
-  assign le_1_le_62_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_62_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_62_wd = reg_wdata[30];
 
-  assign le_1_le_63_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_1_le_63_we = addr_hit[4] & reg_we & ~wr_err;
   assign le_1_le_63_wd = reg_wdata[31];
 
-  assign le_2_le_64_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_64_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_64_wd = reg_wdata[0];
 
-  assign le_2_le_65_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_65_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_65_wd = reg_wdata[1];
 
-  assign le_2_le_66_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_66_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_66_wd = reg_wdata[2];
 
-  assign le_2_le_67_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_67_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_67_wd = reg_wdata[3];
 
-  assign le_2_le_68_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_68_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_68_wd = reg_wdata[4];
 
-  assign le_2_le_69_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_69_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_69_wd = reg_wdata[5];
 
-  assign le_2_le_70_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_70_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_70_wd = reg_wdata[6];
 
-  assign le_2_le_71_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_71_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_71_wd = reg_wdata[7];
 
-  assign le_2_le_72_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_72_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_72_wd = reg_wdata[8];
 
-  assign le_2_le_73_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_73_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_73_wd = reg_wdata[9];
 
-  assign le_2_le_74_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_74_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_74_wd = reg_wdata[10];
 
-  assign le_2_le_75_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_75_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_75_wd = reg_wdata[11];
 
-  assign le_2_le_76_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_76_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_76_wd = reg_wdata[12];
 
-  assign le_2_le_77_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_77_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_77_wd = reg_wdata[13];
 
-  assign le_2_le_78_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_78_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_78_wd = reg_wdata[14];
 
-  assign le_2_le_79_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_79_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_79_wd = reg_wdata[15];
 
-  assign le_2_le_80_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_80_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_80_wd = reg_wdata[16];
 
-  assign le_2_le_81_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_81_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_81_wd = reg_wdata[17];
 
-  assign le_2_le_82_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_82_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_82_wd = reg_wdata[18];
 
-  assign le_2_le_83_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_83_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_83_wd = reg_wdata[19];
 
-  assign le_2_le_84_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_84_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_84_wd = reg_wdata[20];
 
-  assign le_2_le_85_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_85_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_85_wd = reg_wdata[21];
 
-  assign le_2_le_86_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_86_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_86_wd = reg_wdata[22];
 
-  assign le_2_le_87_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_87_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_87_wd = reg_wdata[23];
 
-  assign le_2_le_88_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_2_le_88_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_88_wd = reg_wdata[24];
 
-  assign le_2_le_89_we = addr_hit[6] & reg_we & ~wr_err;
-  assign le_2_le_89_wd = reg_wdata[25];
-
-  assign le_2_le_90_we = addr_hit[6] & reg_we & ~wr_err;
-  assign le_2_le_90_wd = reg_wdata[26];
-
-  assign le_2_le_91_we = addr_hit[6] & reg_we & ~wr_err;
-  assign le_2_le_91_wd = reg_wdata[27];
-
-  assign le_2_le_92_we = addr_hit[6] & reg_we & ~wr_err;
-  assign le_2_le_92_wd = reg_wdata[28];
-
-  assign le_2_le_93_we = addr_hit[6] & reg_we & ~wr_err;
-  assign le_2_le_93_wd = reg_wdata[29];
-
-  assign le_2_le_94_we = addr_hit[6] & reg_we & ~wr_err;
-  assign le_2_le_94_wd = reg_wdata[30];
-
-  assign le_2_le_95_we = addr_hit[6] & reg_we & ~wr_err;
-  assign le_2_le_95_wd = reg_wdata[31];
-
-  assign le_3_le_96_we = addr_hit[7] & reg_we & ~wr_err;
-  assign le_3_le_96_wd = reg_wdata[0];
-
-  assign le_3_le_97_we = addr_hit[7] & reg_we & ~wr_err;
-  assign le_3_le_97_wd = reg_wdata[1];
-
-  assign le_3_le_98_we = addr_hit[7] & reg_we & ~wr_err;
-  assign le_3_le_98_wd = reg_wdata[2];
-
-  assign le_3_le_99_we = addr_hit[7] & reg_we & ~wr_err;
-  assign le_3_le_99_wd = reg_wdata[3];
-
-  assign le_3_le_100_we = addr_hit[7] & reg_we & ~wr_err;
-  assign le_3_le_100_wd = reg_wdata[4];
-
-  assign le_3_le_101_we = addr_hit[7] & reg_we & ~wr_err;
-  assign le_3_le_101_wd = reg_wdata[5];
-
-  assign le_3_le_102_we = addr_hit[7] & reg_we & ~wr_err;
-  assign le_3_le_102_wd = reg_wdata[6];
-
-  assign le_3_le_103_we = addr_hit[7] & reg_we & ~wr_err;
-  assign le_3_le_103_wd = reg_wdata[7];
-
-  assign prio0_we = addr_hit[8] & reg_we & ~wr_err;
+  assign prio0_we = addr_hit[6] & reg_we & ~wr_err;
   assign prio0_wd = reg_wdata[1:0];
 
-  assign prio1_we = addr_hit[9] & reg_we & ~wr_err;
+  assign prio1_we = addr_hit[7] & reg_we & ~wr_err;
   assign prio1_wd = reg_wdata[1:0];
 
-  assign prio2_we = addr_hit[10] & reg_we & ~wr_err;
+  assign prio2_we = addr_hit[8] & reg_we & ~wr_err;
   assign prio2_wd = reg_wdata[1:0];
 
-  assign prio3_we = addr_hit[11] & reg_we & ~wr_err;
+  assign prio3_we = addr_hit[9] & reg_we & ~wr_err;
   assign prio3_wd = reg_wdata[1:0];
 
-  assign prio4_we = addr_hit[12] & reg_we & ~wr_err;
+  assign prio4_we = addr_hit[10] & reg_we & ~wr_err;
   assign prio4_wd = reg_wdata[1:0];
 
-  assign prio5_we = addr_hit[13] & reg_we & ~wr_err;
+  assign prio5_we = addr_hit[11] & reg_we & ~wr_err;
   assign prio5_wd = reg_wdata[1:0];
 
-  assign prio6_we = addr_hit[14] & reg_we & ~wr_err;
+  assign prio6_we = addr_hit[12] & reg_we & ~wr_err;
   assign prio6_wd = reg_wdata[1:0];
 
-  assign prio7_we = addr_hit[15] & reg_we & ~wr_err;
+  assign prio7_we = addr_hit[13] & reg_we & ~wr_err;
   assign prio7_wd = reg_wdata[1:0];
 
-  assign prio8_we = addr_hit[16] & reg_we & ~wr_err;
+  assign prio8_we = addr_hit[14] & reg_we & ~wr_err;
   assign prio8_wd = reg_wdata[1:0];
 
-  assign prio9_we = addr_hit[17] & reg_we & ~wr_err;
+  assign prio9_we = addr_hit[15] & reg_we & ~wr_err;
   assign prio9_wd = reg_wdata[1:0];
 
-  assign prio10_we = addr_hit[18] & reg_we & ~wr_err;
+  assign prio10_we = addr_hit[16] & reg_we & ~wr_err;
   assign prio10_wd = reg_wdata[1:0];
 
-  assign prio11_we = addr_hit[19] & reg_we & ~wr_err;
+  assign prio11_we = addr_hit[17] & reg_we & ~wr_err;
   assign prio11_wd = reg_wdata[1:0];
 
-  assign prio12_we = addr_hit[20] & reg_we & ~wr_err;
+  assign prio12_we = addr_hit[18] & reg_we & ~wr_err;
   assign prio12_wd = reg_wdata[1:0];
 
-  assign prio13_we = addr_hit[21] & reg_we & ~wr_err;
+  assign prio13_we = addr_hit[19] & reg_we & ~wr_err;
   assign prio13_wd = reg_wdata[1:0];
 
-  assign prio14_we = addr_hit[22] & reg_we & ~wr_err;
+  assign prio14_we = addr_hit[20] & reg_we & ~wr_err;
   assign prio14_wd = reg_wdata[1:0];
 
-  assign prio15_we = addr_hit[23] & reg_we & ~wr_err;
+  assign prio15_we = addr_hit[21] & reg_we & ~wr_err;
   assign prio15_wd = reg_wdata[1:0];
 
-  assign prio16_we = addr_hit[24] & reg_we & ~wr_err;
+  assign prio16_we = addr_hit[22] & reg_we & ~wr_err;
   assign prio16_wd = reg_wdata[1:0];
 
-  assign prio17_we = addr_hit[25] & reg_we & ~wr_err;
+  assign prio17_we = addr_hit[23] & reg_we & ~wr_err;
   assign prio17_wd = reg_wdata[1:0];
 
-  assign prio18_we = addr_hit[26] & reg_we & ~wr_err;
+  assign prio18_we = addr_hit[24] & reg_we & ~wr_err;
   assign prio18_wd = reg_wdata[1:0];
 
-  assign prio19_we = addr_hit[27] & reg_we & ~wr_err;
+  assign prio19_we = addr_hit[25] & reg_we & ~wr_err;
   assign prio19_wd = reg_wdata[1:0];
 
-  assign prio20_we = addr_hit[28] & reg_we & ~wr_err;
+  assign prio20_we = addr_hit[26] & reg_we & ~wr_err;
   assign prio20_wd = reg_wdata[1:0];
 
-  assign prio21_we = addr_hit[29] & reg_we & ~wr_err;
+  assign prio21_we = addr_hit[27] & reg_we & ~wr_err;
   assign prio21_wd = reg_wdata[1:0];
 
-  assign prio22_we = addr_hit[30] & reg_we & ~wr_err;
+  assign prio22_we = addr_hit[28] & reg_we & ~wr_err;
   assign prio22_wd = reg_wdata[1:0];
 
-  assign prio23_we = addr_hit[31] & reg_we & ~wr_err;
+  assign prio23_we = addr_hit[29] & reg_we & ~wr_err;
   assign prio23_wd = reg_wdata[1:0];
 
-  assign prio24_we = addr_hit[32] & reg_we & ~wr_err;
+  assign prio24_we = addr_hit[30] & reg_we & ~wr_err;
   assign prio24_wd = reg_wdata[1:0];
 
-  assign prio25_we = addr_hit[33] & reg_we & ~wr_err;
+  assign prio25_we = addr_hit[31] & reg_we & ~wr_err;
   assign prio25_wd = reg_wdata[1:0];
 
-  assign prio26_we = addr_hit[34] & reg_we & ~wr_err;
+  assign prio26_we = addr_hit[32] & reg_we & ~wr_err;
   assign prio26_wd = reg_wdata[1:0];
 
-  assign prio27_we = addr_hit[35] & reg_we & ~wr_err;
+  assign prio27_we = addr_hit[33] & reg_we & ~wr_err;
   assign prio27_wd = reg_wdata[1:0];
 
-  assign prio28_we = addr_hit[36] & reg_we & ~wr_err;
+  assign prio28_we = addr_hit[34] & reg_we & ~wr_err;
   assign prio28_wd = reg_wdata[1:0];
 
-  assign prio29_we = addr_hit[37] & reg_we & ~wr_err;
+  assign prio29_we = addr_hit[35] & reg_we & ~wr_err;
   assign prio29_wd = reg_wdata[1:0];
 
-  assign prio30_we = addr_hit[38] & reg_we & ~wr_err;
+  assign prio30_we = addr_hit[36] & reg_we & ~wr_err;
   assign prio30_wd = reg_wdata[1:0];
 
-  assign prio31_we = addr_hit[39] & reg_we & ~wr_err;
+  assign prio31_we = addr_hit[37] & reg_we & ~wr_err;
   assign prio31_wd = reg_wdata[1:0];
 
-  assign prio32_we = addr_hit[40] & reg_we & ~wr_err;
+  assign prio32_we = addr_hit[38] & reg_we & ~wr_err;
   assign prio32_wd = reg_wdata[1:0];
 
-  assign prio33_we = addr_hit[41] & reg_we & ~wr_err;
+  assign prio33_we = addr_hit[39] & reg_we & ~wr_err;
   assign prio33_wd = reg_wdata[1:0];
 
-  assign prio34_we = addr_hit[42] & reg_we & ~wr_err;
+  assign prio34_we = addr_hit[40] & reg_we & ~wr_err;
   assign prio34_wd = reg_wdata[1:0];
 
-  assign prio35_we = addr_hit[43] & reg_we & ~wr_err;
+  assign prio35_we = addr_hit[41] & reg_we & ~wr_err;
   assign prio35_wd = reg_wdata[1:0];
 
-  assign prio36_we = addr_hit[44] & reg_we & ~wr_err;
+  assign prio36_we = addr_hit[42] & reg_we & ~wr_err;
   assign prio36_wd = reg_wdata[1:0];
 
-  assign prio37_we = addr_hit[45] & reg_we & ~wr_err;
+  assign prio37_we = addr_hit[43] & reg_we & ~wr_err;
   assign prio37_wd = reg_wdata[1:0];
 
-  assign prio38_we = addr_hit[46] & reg_we & ~wr_err;
+  assign prio38_we = addr_hit[44] & reg_we & ~wr_err;
   assign prio38_wd = reg_wdata[1:0];
 
-  assign prio39_we = addr_hit[47] & reg_we & ~wr_err;
+  assign prio39_we = addr_hit[45] & reg_we & ~wr_err;
   assign prio39_wd = reg_wdata[1:0];
 
-  assign prio40_we = addr_hit[48] & reg_we & ~wr_err;
+  assign prio40_we = addr_hit[46] & reg_we & ~wr_err;
   assign prio40_wd = reg_wdata[1:0];
 
-  assign prio41_we = addr_hit[49] & reg_we & ~wr_err;
+  assign prio41_we = addr_hit[47] & reg_we & ~wr_err;
   assign prio41_wd = reg_wdata[1:0];
 
-  assign prio42_we = addr_hit[50] & reg_we & ~wr_err;
+  assign prio42_we = addr_hit[48] & reg_we & ~wr_err;
   assign prio42_wd = reg_wdata[1:0];
 
-  assign prio43_we = addr_hit[51] & reg_we & ~wr_err;
+  assign prio43_we = addr_hit[49] & reg_we & ~wr_err;
   assign prio43_wd = reg_wdata[1:0];
 
-  assign prio44_we = addr_hit[52] & reg_we & ~wr_err;
+  assign prio44_we = addr_hit[50] & reg_we & ~wr_err;
   assign prio44_wd = reg_wdata[1:0];
 
-  assign prio45_we = addr_hit[53] & reg_we & ~wr_err;
+  assign prio45_we = addr_hit[51] & reg_we & ~wr_err;
   assign prio45_wd = reg_wdata[1:0];
 
-  assign prio46_we = addr_hit[54] & reg_we & ~wr_err;
+  assign prio46_we = addr_hit[52] & reg_we & ~wr_err;
   assign prio46_wd = reg_wdata[1:0];
 
-  assign prio47_we = addr_hit[55] & reg_we & ~wr_err;
+  assign prio47_we = addr_hit[53] & reg_we & ~wr_err;
   assign prio47_wd = reg_wdata[1:0];
 
-  assign prio48_we = addr_hit[56] & reg_we & ~wr_err;
+  assign prio48_we = addr_hit[54] & reg_we & ~wr_err;
   assign prio48_wd = reg_wdata[1:0];
 
-  assign prio49_we = addr_hit[57] & reg_we & ~wr_err;
+  assign prio49_we = addr_hit[55] & reg_we & ~wr_err;
   assign prio49_wd = reg_wdata[1:0];
 
-  assign prio50_we = addr_hit[58] & reg_we & ~wr_err;
+  assign prio50_we = addr_hit[56] & reg_we & ~wr_err;
   assign prio50_wd = reg_wdata[1:0];
 
-  assign prio51_we = addr_hit[59] & reg_we & ~wr_err;
+  assign prio51_we = addr_hit[57] & reg_we & ~wr_err;
   assign prio51_wd = reg_wdata[1:0];
 
-  assign prio52_we = addr_hit[60] & reg_we & ~wr_err;
+  assign prio52_we = addr_hit[58] & reg_we & ~wr_err;
   assign prio52_wd = reg_wdata[1:0];
 
-  assign prio53_we = addr_hit[61] & reg_we & ~wr_err;
+  assign prio53_we = addr_hit[59] & reg_we & ~wr_err;
   assign prio53_wd = reg_wdata[1:0];
 
-  assign prio54_we = addr_hit[62] & reg_we & ~wr_err;
+  assign prio54_we = addr_hit[60] & reg_we & ~wr_err;
   assign prio54_wd = reg_wdata[1:0];
 
-  assign prio55_we = addr_hit[63] & reg_we & ~wr_err;
+  assign prio55_we = addr_hit[61] & reg_we & ~wr_err;
   assign prio55_wd = reg_wdata[1:0];
 
-  assign prio56_we = addr_hit[64] & reg_we & ~wr_err;
+  assign prio56_we = addr_hit[62] & reg_we & ~wr_err;
   assign prio56_wd = reg_wdata[1:0];
 
-  assign prio57_we = addr_hit[65] & reg_we & ~wr_err;
+  assign prio57_we = addr_hit[63] & reg_we & ~wr_err;
   assign prio57_wd = reg_wdata[1:0];
 
-  assign prio58_we = addr_hit[66] & reg_we & ~wr_err;
+  assign prio58_we = addr_hit[64] & reg_we & ~wr_err;
   assign prio58_wd = reg_wdata[1:0];
 
-  assign prio59_we = addr_hit[67] & reg_we & ~wr_err;
+  assign prio59_we = addr_hit[65] & reg_we & ~wr_err;
   assign prio59_wd = reg_wdata[1:0];
 
-  assign prio60_we = addr_hit[68] & reg_we & ~wr_err;
+  assign prio60_we = addr_hit[66] & reg_we & ~wr_err;
   assign prio60_wd = reg_wdata[1:0];
 
-  assign prio61_we = addr_hit[69] & reg_we & ~wr_err;
+  assign prio61_we = addr_hit[67] & reg_we & ~wr_err;
   assign prio61_wd = reg_wdata[1:0];
 
-  assign prio62_we = addr_hit[70] & reg_we & ~wr_err;
+  assign prio62_we = addr_hit[68] & reg_we & ~wr_err;
   assign prio62_wd = reg_wdata[1:0];
 
-  assign prio63_we = addr_hit[71] & reg_we & ~wr_err;
+  assign prio63_we = addr_hit[69] & reg_we & ~wr_err;
   assign prio63_wd = reg_wdata[1:0];
 
-  assign prio64_we = addr_hit[72] & reg_we & ~wr_err;
+  assign prio64_we = addr_hit[70] & reg_we & ~wr_err;
   assign prio64_wd = reg_wdata[1:0];
 
-  assign prio65_we = addr_hit[73] & reg_we & ~wr_err;
+  assign prio65_we = addr_hit[71] & reg_we & ~wr_err;
   assign prio65_wd = reg_wdata[1:0];
 
-  assign prio66_we = addr_hit[74] & reg_we & ~wr_err;
+  assign prio66_we = addr_hit[72] & reg_we & ~wr_err;
   assign prio66_wd = reg_wdata[1:0];
 
-  assign prio67_we = addr_hit[75] & reg_we & ~wr_err;
+  assign prio67_we = addr_hit[73] & reg_we & ~wr_err;
   assign prio67_wd = reg_wdata[1:0];
 
-  assign prio68_we = addr_hit[76] & reg_we & ~wr_err;
+  assign prio68_we = addr_hit[74] & reg_we & ~wr_err;
   assign prio68_wd = reg_wdata[1:0];
 
-  assign prio69_we = addr_hit[77] & reg_we & ~wr_err;
+  assign prio69_we = addr_hit[75] & reg_we & ~wr_err;
   assign prio69_wd = reg_wdata[1:0];
 
-  assign prio70_we = addr_hit[78] & reg_we & ~wr_err;
+  assign prio70_we = addr_hit[76] & reg_we & ~wr_err;
   assign prio70_wd = reg_wdata[1:0];
 
-  assign prio71_we = addr_hit[79] & reg_we & ~wr_err;
+  assign prio71_we = addr_hit[77] & reg_we & ~wr_err;
   assign prio71_wd = reg_wdata[1:0];
 
-  assign prio72_we = addr_hit[80] & reg_we & ~wr_err;
+  assign prio72_we = addr_hit[78] & reg_we & ~wr_err;
   assign prio72_wd = reg_wdata[1:0];
 
-  assign prio73_we = addr_hit[81] & reg_we & ~wr_err;
+  assign prio73_we = addr_hit[79] & reg_we & ~wr_err;
   assign prio73_wd = reg_wdata[1:0];
 
-  assign prio74_we = addr_hit[82] & reg_we & ~wr_err;
+  assign prio74_we = addr_hit[80] & reg_we & ~wr_err;
   assign prio74_wd = reg_wdata[1:0];
 
-  assign prio75_we = addr_hit[83] & reg_we & ~wr_err;
+  assign prio75_we = addr_hit[81] & reg_we & ~wr_err;
   assign prio75_wd = reg_wdata[1:0];
 
-  assign prio76_we = addr_hit[84] & reg_we & ~wr_err;
+  assign prio76_we = addr_hit[82] & reg_we & ~wr_err;
   assign prio76_wd = reg_wdata[1:0];
 
-  assign prio77_we = addr_hit[85] & reg_we & ~wr_err;
+  assign prio77_we = addr_hit[83] & reg_we & ~wr_err;
   assign prio77_wd = reg_wdata[1:0];
 
-  assign prio78_we = addr_hit[86] & reg_we & ~wr_err;
+  assign prio78_we = addr_hit[84] & reg_we & ~wr_err;
   assign prio78_wd = reg_wdata[1:0];
 
-  assign prio79_we = addr_hit[87] & reg_we & ~wr_err;
+  assign prio79_we = addr_hit[85] & reg_we & ~wr_err;
   assign prio79_wd = reg_wdata[1:0];
 
-  assign prio80_we = addr_hit[88] & reg_we & ~wr_err;
+  assign prio80_we = addr_hit[86] & reg_we & ~wr_err;
   assign prio80_wd = reg_wdata[1:0];
 
-  assign prio81_we = addr_hit[89] & reg_we & ~wr_err;
+  assign prio81_we = addr_hit[87] & reg_we & ~wr_err;
   assign prio81_wd = reg_wdata[1:0];
 
-  assign prio82_we = addr_hit[90] & reg_we & ~wr_err;
+  assign prio82_we = addr_hit[88] & reg_we & ~wr_err;
   assign prio82_wd = reg_wdata[1:0];
 
-  assign prio83_we = addr_hit[91] & reg_we & ~wr_err;
+  assign prio83_we = addr_hit[89] & reg_we & ~wr_err;
   assign prio83_wd = reg_wdata[1:0];
 
-  assign prio84_we = addr_hit[92] & reg_we & ~wr_err;
+  assign prio84_we = addr_hit[90] & reg_we & ~wr_err;
   assign prio84_wd = reg_wdata[1:0];
 
-  assign prio85_we = addr_hit[93] & reg_we & ~wr_err;
+  assign prio85_we = addr_hit[91] & reg_we & ~wr_err;
   assign prio85_wd = reg_wdata[1:0];
 
-  assign prio86_we = addr_hit[94] & reg_we & ~wr_err;
+  assign prio86_we = addr_hit[92] & reg_we & ~wr_err;
   assign prio86_wd = reg_wdata[1:0];
 
-  assign prio87_we = addr_hit[95] & reg_we & ~wr_err;
+  assign prio87_we = addr_hit[93] & reg_we & ~wr_err;
   assign prio87_wd = reg_wdata[1:0];
 
-  assign prio88_we = addr_hit[96] & reg_we & ~wr_err;
+  assign prio88_we = addr_hit[94] & reg_we & ~wr_err;
   assign prio88_wd = reg_wdata[1:0];
 
-  assign prio89_we = addr_hit[97] & reg_we & ~wr_err;
-  assign prio89_wd = reg_wdata[1:0];
-
-  assign prio90_we = addr_hit[98] & reg_we & ~wr_err;
-  assign prio90_wd = reg_wdata[1:0];
-
-  assign prio91_we = addr_hit[99] & reg_we & ~wr_err;
-  assign prio91_wd = reg_wdata[1:0];
-
-  assign prio92_we = addr_hit[100] & reg_we & ~wr_err;
-  assign prio92_wd = reg_wdata[1:0];
-
-  assign prio93_we = addr_hit[101] & reg_we & ~wr_err;
-  assign prio93_wd = reg_wdata[1:0];
-
-  assign prio94_we = addr_hit[102] & reg_we & ~wr_err;
-  assign prio94_wd = reg_wdata[1:0];
-
-  assign prio95_we = addr_hit[103] & reg_we & ~wr_err;
-  assign prio95_wd = reg_wdata[1:0];
-
-  assign prio96_we = addr_hit[104] & reg_we & ~wr_err;
-  assign prio96_wd = reg_wdata[1:0];
-
-  assign prio97_we = addr_hit[105] & reg_we & ~wr_err;
-  assign prio97_wd = reg_wdata[1:0];
-
-  assign prio98_we = addr_hit[106] & reg_we & ~wr_err;
-  assign prio98_wd = reg_wdata[1:0];
-
-  assign prio99_we = addr_hit[107] & reg_we & ~wr_err;
-  assign prio99_wd = reg_wdata[1:0];
-
-  assign prio100_we = addr_hit[108] & reg_we & ~wr_err;
-  assign prio100_wd = reg_wdata[1:0];
-
-  assign prio101_we = addr_hit[109] & reg_we & ~wr_err;
-  assign prio101_wd = reg_wdata[1:0];
-
-  assign prio102_we = addr_hit[110] & reg_we & ~wr_err;
-  assign prio102_wd = reg_wdata[1:0];
-
-  assign prio103_we = addr_hit[111] & reg_we & ~wr_err;
-  assign prio103_wd = reg_wdata[1:0];
-
-  assign ie0_0_e_0_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_0_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_0_wd = reg_wdata[0];
 
-  assign ie0_0_e_1_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_1_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_1_wd = reg_wdata[1];
 
-  assign ie0_0_e_2_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_2_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_2_wd = reg_wdata[2];
 
-  assign ie0_0_e_3_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_3_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_3_wd = reg_wdata[3];
 
-  assign ie0_0_e_4_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_4_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_4_wd = reg_wdata[4];
 
-  assign ie0_0_e_5_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_5_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_5_wd = reg_wdata[5];
 
-  assign ie0_0_e_6_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_6_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_6_wd = reg_wdata[6];
 
-  assign ie0_0_e_7_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_7_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_7_wd = reg_wdata[7];
 
-  assign ie0_0_e_8_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_8_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_8_wd = reg_wdata[8];
 
-  assign ie0_0_e_9_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_9_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_9_wd = reg_wdata[9];
 
-  assign ie0_0_e_10_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_10_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_10_wd = reg_wdata[10];
 
-  assign ie0_0_e_11_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_11_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_11_wd = reg_wdata[11];
 
-  assign ie0_0_e_12_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_12_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_12_wd = reg_wdata[12];
 
-  assign ie0_0_e_13_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_13_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_13_wd = reg_wdata[13];
 
-  assign ie0_0_e_14_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_14_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_14_wd = reg_wdata[14];
 
-  assign ie0_0_e_15_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_15_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_15_wd = reg_wdata[15];
 
-  assign ie0_0_e_16_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_16_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_16_wd = reg_wdata[16];
 
-  assign ie0_0_e_17_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_17_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_17_wd = reg_wdata[17];
 
-  assign ie0_0_e_18_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_18_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_18_wd = reg_wdata[18];
 
-  assign ie0_0_e_19_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_19_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_19_wd = reg_wdata[19];
 
-  assign ie0_0_e_20_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_20_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_20_wd = reg_wdata[20];
 
-  assign ie0_0_e_21_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_21_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_21_wd = reg_wdata[21];
 
-  assign ie0_0_e_22_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_22_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_22_wd = reg_wdata[22];
 
-  assign ie0_0_e_23_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_23_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_23_wd = reg_wdata[23];
 
-  assign ie0_0_e_24_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_24_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_24_wd = reg_wdata[24];
 
-  assign ie0_0_e_25_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_25_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_25_wd = reg_wdata[25];
 
-  assign ie0_0_e_26_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_26_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_26_wd = reg_wdata[26];
 
-  assign ie0_0_e_27_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_27_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_27_wd = reg_wdata[27];
 
-  assign ie0_0_e_28_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_28_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_28_wd = reg_wdata[28];
 
-  assign ie0_0_e_29_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_29_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_29_wd = reg_wdata[29];
 
-  assign ie0_0_e_30_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_30_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_30_wd = reg_wdata[30];
 
-  assign ie0_0_e_31_we = addr_hit[112] & reg_we & ~wr_err;
+  assign ie0_0_e_31_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_0_e_31_wd = reg_wdata[31];
 
-  assign ie0_1_e_32_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_32_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_32_wd = reg_wdata[0];
 
-  assign ie0_1_e_33_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_33_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_33_wd = reg_wdata[1];
 
-  assign ie0_1_e_34_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_34_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_34_wd = reg_wdata[2];
 
-  assign ie0_1_e_35_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_35_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_35_wd = reg_wdata[3];
 
-  assign ie0_1_e_36_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_36_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_36_wd = reg_wdata[4];
 
-  assign ie0_1_e_37_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_37_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_37_wd = reg_wdata[5];
 
-  assign ie0_1_e_38_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_38_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_38_wd = reg_wdata[6];
 
-  assign ie0_1_e_39_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_39_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_39_wd = reg_wdata[7];
 
-  assign ie0_1_e_40_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_40_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_40_wd = reg_wdata[8];
 
-  assign ie0_1_e_41_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_41_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_41_wd = reg_wdata[9];
 
-  assign ie0_1_e_42_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_42_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_42_wd = reg_wdata[10];
 
-  assign ie0_1_e_43_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_43_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_43_wd = reg_wdata[11];
 
-  assign ie0_1_e_44_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_44_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_44_wd = reg_wdata[12];
 
-  assign ie0_1_e_45_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_45_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_45_wd = reg_wdata[13];
 
-  assign ie0_1_e_46_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_46_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_46_wd = reg_wdata[14];
 
-  assign ie0_1_e_47_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_47_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_47_wd = reg_wdata[15];
 
-  assign ie0_1_e_48_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_48_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_48_wd = reg_wdata[16];
 
-  assign ie0_1_e_49_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_49_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_49_wd = reg_wdata[17];
 
-  assign ie0_1_e_50_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_50_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_50_wd = reg_wdata[18];
 
-  assign ie0_1_e_51_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_51_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_51_wd = reg_wdata[19];
 
-  assign ie0_1_e_52_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_52_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_52_wd = reg_wdata[20];
 
-  assign ie0_1_e_53_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_53_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_53_wd = reg_wdata[21];
 
-  assign ie0_1_e_54_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_54_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_54_wd = reg_wdata[22];
 
-  assign ie0_1_e_55_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_55_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_55_wd = reg_wdata[23];
 
-  assign ie0_1_e_56_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_56_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_56_wd = reg_wdata[24];
 
-  assign ie0_1_e_57_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_57_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_57_wd = reg_wdata[25];
 
-  assign ie0_1_e_58_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_58_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_58_wd = reg_wdata[26];
 
-  assign ie0_1_e_59_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_59_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_59_wd = reg_wdata[27];
 
-  assign ie0_1_e_60_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_60_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_60_wd = reg_wdata[28];
 
-  assign ie0_1_e_61_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_61_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_61_wd = reg_wdata[29];
 
-  assign ie0_1_e_62_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_62_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_62_wd = reg_wdata[30];
 
-  assign ie0_1_e_63_we = addr_hit[113] & reg_we & ~wr_err;
+  assign ie0_1_e_63_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_1_e_63_wd = reg_wdata[31];
 
-  assign ie0_2_e_64_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_64_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_64_wd = reg_wdata[0];
 
-  assign ie0_2_e_65_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_65_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_65_wd = reg_wdata[1];
 
-  assign ie0_2_e_66_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_66_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_66_wd = reg_wdata[2];
 
-  assign ie0_2_e_67_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_67_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_67_wd = reg_wdata[3];
 
-  assign ie0_2_e_68_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_68_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_68_wd = reg_wdata[4];
 
-  assign ie0_2_e_69_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_69_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_69_wd = reg_wdata[5];
 
-  assign ie0_2_e_70_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_70_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_70_wd = reg_wdata[6];
 
-  assign ie0_2_e_71_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_71_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_71_wd = reg_wdata[7];
 
-  assign ie0_2_e_72_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_72_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_72_wd = reg_wdata[8];
 
-  assign ie0_2_e_73_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_73_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_73_wd = reg_wdata[9];
 
-  assign ie0_2_e_74_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_74_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_74_wd = reg_wdata[10];
 
-  assign ie0_2_e_75_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_75_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_75_wd = reg_wdata[11];
 
-  assign ie0_2_e_76_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_76_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_76_wd = reg_wdata[12];
 
-  assign ie0_2_e_77_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_77_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_77_wd = reg_wdata[13];
 
-  assign ie0_2_e_78_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_78_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_78_wd = reg_wdata[14];
 
-  assign ie0_2_e_79_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_79_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_79_wd = reg_wdata[15];
 
-  assign ie0_2_e_80_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_80_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_80_wd = reg_wdata[16];
 
-  assign ie0_2_e_81_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_81_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_81_wd = reg_wdata[17];
 
-  assign ie0_2_e_82_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_82_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_82_wd = reg_wdata[18];
 
-  assign ie0_2_e_83_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_83_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_83_wd = reg_wdata[19];
 
-  assign ie0_2_e_84_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_84_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_84_wd = reg_wdata[20];
 
-  assign ie0_2_e_85_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_85_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_85_wd = reg_wdata[21];
 
-  assign ie0_2_e_86_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_86_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_86_wd = reg_wdata[22];
 
-  assign ie0_2_e_87_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_87_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_87_wd = reg_wdata[23];
 
-  assign ie0_2_e_88_we = addr_hit[114] & reg_we & ~wr_err;
+  assign ie0_2_e_88_we = addr_hit[97] & reg_we & ~wr_err;
   assign ie0_2_e_88_wd = reg_wdata[24];
 
-  assign ie0_2_e_89_we = addr_hit[114] & reg_we & ~wr_err;
-  assign ie0_2_e_89_wd = reg_wdata[25];
-
-  assign ie0_2_e_90_we = addr_hit[114] & reg_we & ~wr_err;
-  assign ie0_2_e_90_wd = reg_wdata[26];
-
-  assign ie0_2_e_91_we = addr_hit[114] & reg_we & ~wr_err;
-  assign ie0_2_e_91_wd = reg_wdata[27];
-
-  assign ie0_2_e_92_we = addr_hit[114] & reg_we & ~wr_err;
-  assign ie0_2_e_92_wd = reg_wdata[28];
-
-  assign ie0_2_e_93_we = addr_hit[114] & reg_we & ~wr_err;
-  assign ie0_2_e_93_wd = reg_wdata[29];
-
-  assign ie0_2_e_94_we = addr_hit[114] & reg_we & ~wr_err;
-  assign ie0_2_e_94_wd = reg_wdata[30];
-
-  assign ie0_2_e_95_we = addr_hit[114] & reg_we & ~wr_err;
-  assign ie0_2_e_95_wd = reg_wdata[31];
-
-  assign ie0_3_e_96_we = addr_hit[115] & reg_we & ~wr_err;
-  assign ie0_3_e_96_wd = reg_wdata[0];
-
-  assign ie0_3_e_97_we = addr_hit[115] & reg_we & ~wr_err;
-  assign ie0_3_e_97_wd = reg_wdata[1];
-
-  assign ie0_3_e_98_we = addr_hit[115] & reg_we & ~wr_err;
-  assign ie0_3_e_98_wd = reg_wdata[2];
-
-  assign ie0_3_e_99_we = addr_hit[115] & reg_we & ~wr_err;
-  assign ie0_3_e_99_wd = reg_wdata[3];
-
-  assign ie0_3_e_100_we = addr_hit[115] & reg_we & ~wr_err;
-  assign ie0_3_e_100_wd = reg_wdata[4];
-
-  assign ie0_3_e_101_we = addr_hit[115] & reg_we & ~wr_err;
-  assign ie0_3_e_101_wd = reg_wdata[5];
-
-  assign ie0_3_e_102_we = addr_hit[115] & reg_we & ~wr_err;
-  assign ie0_3_e_102_wd = reg_wdata[6];
-
-  assign ie0_3_e_103_we = addr_hit[115] & reg_we & ~wr_err;
-  assign ie0_3_e_103_wd = reg_wdata[7];
-
-  assign threshold0_we = addr_hit[116] & reg_we & ~wr_err;
+  assign threshold0_we = addr_hit[98] & reg_we & ~wr_err;
   assign threshold0_wd = reg_wdata[1:0];
 
-  assign cc0_we = addr_hit[117] & reg_we & ~wr_err;
+  assign cc0_we = addr_hit[99] & reg_we & ~wr_err;
   assign cc0_wd = reg_wdata[6:0];
-  assign cc0_re = addr_hit[117] && reg_re;
+  assign cc0_re = addr_hit[99] && reg_re;
 
-  assign msip0_we = addr_hit[118] & reg_we & ~wr_err;
+  assign msip0_we = addr_hit[100] & reg_we & ~wr_err;
   assign msip0_wd = reg_wdata[0];
 
   // Read data return
@@ -13453,27 +11548,9 @@ module rv_plic_reg_top (
         reg_rdata_next[22] = ip_2_p_86_qs;
         reg_rdata_next[23] = ip_2_p_87_qs;
         reg_rdata_next[24] = ip_2_p_88_qs;
-        reg_rdata_next[25] = ip_2_p_89_qs;
-        reg_rdata_next[26] = ip_2_p_90_qs;
-        reg_rdata_next[27] = ip_2_p_91_qs;
-        reg_rdata_next[28] = ip_2_p_92_qs;
-        reg_rdata_next[29] = ip_2_p_93_qs;
-        reg_rdata_next[30] = ip_2_p_94_qs;
-        reg_rdata_next[31] = ip_2_p_95_qs;
       end
 
       addr_hit[3]: begin
-        reg_rdata_next[0] = ip_3_p_96_qs;
-        reg_rdata_next[1] = ip_3_p_97_qs;
-        reg_rdata_next[2] = ip_3_p_98_qs;
-        reg_rdata_next[3] = ip_3_p_99_qs;
-        reg_rdata_next[4] = ip_3_p_100_qs;
-        reg_rdata_next[5] = ip_3_p_101_qs;
-        reg_rdata_next[6] = ip_3_p_102_qs;
-        reg_rdata_next[7] = ip_3_p_103_qs;
-      end
-
-      addr_hit[4]: begin
         reg_rdata_next[0] = le_0_le_0_qs;
         reg_rdata_next[1] = le_0_le_1_qs;
         reg_rdata_next[2] = le_0_le_2_qs;
@@ -13508,7 +11585,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = le_0_le_31_qs;
       end
 
-      addr_hit[5]: begin
+      addr_hit[4]: begin
         reg_rdata_next[0] = le_1_le_32_qs;
         reg_rdata_next[1] = le_1_le_33_qs;
         reg_rdata_next[2] = le_1_le_34_qs;
@@ -13543,7 +11620,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = le_1_le_63_qs;
       end
 
-      addr_hit[6]: begin
+      addr_hit[5]: begin
         reg_rdata_next[0] = le_2_le_64_qs;
         reg_rdata_next[1] = le_2_le_65_qs;
         reg_rdata_next[2] = le_2_le_66_qs;
@@ -13569,443 +11646,365 @@ module rv_plic_reg_top (
         reg_rdata_next[22] = le_2_le_86_qs;
         reg_rdata_next[23] = le_2_le_87_qs;
         reg_rdata_next[24] = le_2_le_88_qs;
-        reg_rdata_next[25] = le_2_le_89_qs;
-        reg_rdata_next[26] = le_2_le_90_qs;
-        reg_rdata_next[27] = le_2_le_91_qs;
-        reg_rdata_next[28] = le_2_le_92_qs;
-        reg_rdata_next[29] = le_2_le_93_qs;
-        reg_rdata_next[30] = le_2_le_94_qs;
-        reg_rdata_next[31] = le_2_le_95_qs;
       end
 
-      addr_hit[7]: begin
-        reg_rdata_next[0] = le_3_le_96_qs;
-        reg_rdata_next[1] = le_3_le_97_qs;
-        reg_rdata_next[2] = le_3_le_98_qs;
-        reg_rdata_next[3] = le_3_le_99_qs;
-        reg_rdata_next[4] = le_3_le_100_qs;
-        reg_rdata_next[5] = le_3_le_101_qs;
-        reg_rdata_next[6] = le_3_le_102_qs;
-        reg_rdata_next[7] = le_3_le_103_qs;
-      end
-
-      addr_hit[8]: begin
+      addr_hit[6]: begin
         reg_rdata_next[1:0] = prio0_qs;
       end
 
-      addr_hit[9]: begin
+      addr_hit[7]: begin
         reg_rdata_next[1:0] = prio1_qs;
       end
 
-      addr_hit[10]: begin
+      addr_hit[8]: begin
         reg_rdata_next[1:0] = prio2_qs;
       end
 
-      addr_hit[11]: begin
+      addr_hit[9]: begin
         reg_rdata_next[1:0] = prio3_qs;
       end
 
-      addr_hit[12]: begin
+      addr_hit[10]: begin
         reg_rdata_next[1:0] = prio4_qs;
       end
 
-      addr_hit[13]: begin
+      addr_hit[11]: begin
         reg_rdata_next[1:0] = prio5_qs;
       end
 
-      addr_hit[14]: begin
+      addr_hit[12]: begin
         reg_rdata_next[1:0] = prio6_qs;
       end
 
-      addr_hit[15]: begin
+      addr_hit[13]: begin
         reg_rdata_next[1:0] = prio7_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[14]: begin
         reg_rdata_next[1:0] = prio8_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[15]: begin
         reg_rdata_next[1:0] = prio9_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[16]: begin
         reg_rdata_next[1:0] = prio10_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[17]: begin
         reg_rdata_next[1:0] = prio11_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[18]: begin
         reg_rdata_next[1:0] = prio12_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[19]: begin
         reg_rdata_next[1:0] = prio13_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[20]: begin
         reg_rdata_next[1:0] = prio14_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[21]: begin
         reg_rdata_next[1:0] = prio15_qs;
       end
 
-      addr_hit[24]: begin
+      addr_hit[22]: begin
         reg_rdata_next[1:0] = prio16_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[23]: begin
         reg_rdata_next[1:0] = prio17_qs;
       end
 
-      addr_hit[26]: begin
+      addr_hit[24]: begin
         reg_rdata_next[1:0] = prio18_qs;
       end
 
-      addr_hit[27]: begin
+      addr_hit[25]: begin
         reg_rdata_next[1:0] = prio19_qs;
       end
 
-      addr_hit[28]: begin
+      addr_hit[26]: begin
         reg_rdata_next[1:0] = prio20_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[27]: begin
         reg_rdata_next[1:0] = prio21_qs;
       end
 
-      addr_hit[30]: begin
+      addr_hit[28]: begin
         reg_rdata_next[1:0] = prio22_qs;
       end
 
-      addr_hit[31]: begin
+      addr_hit[29]: begin
         reg_rdata_next[1:0] = prio23_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[30]: begin
         reg_rdata_next[1:0] = prio24_qs;
       end
 
-      addr_hit[33]: begin
+      addr_hit[31]: begin
         reg_rdata_next[1:0] = prio25_qs;
       end
 
-      addr_hit[34]: begin
+      addr_hit[32]: begin
         reg_rdata_next[1:0] = prio26_qs;
       end
 
-      addr_hit[35]: begin
+      addr_hit[33]: begin
         reg_rdata_next[1:0] = prio27_qs;
       end
 
-      addr_hit[36]: begin
+      addr_hit[34]: begin
         reg_rdata_next[1:0] = prio28_qs;
       end
 
-      addr_hit[37]: begin
+      addr_hit[35]: begin
         reg_rdata_next[1:0] = prio29_qs;
       end
 
-      addr_hit[38]: begin
+      addr_hit[36]: begin
         reg_rdata_next[1:0] = prio30_qs;
       end
 
-      addr_hit[39]: begin
+      addr_hit[37]: begin
         reg_rdata_next[1:0] = prio31_qs;
       end
 
-      addr_hit[40]: begin
+      addr_hit[38]: begin
         reg_rdata_next[1:0] = prio32_qs;
       end
 
-      addr_hit[41]: begin
+      addr_hit[39]: begin
         reg_rdata_next[1:0] = prio33_qs;
       end
 
-      addr_hit[42]: begin
+      addr_hit[40]: begin
         reg_rdata_next[1:0] = prio34_qs;
       end
 
-      addr_hit[43]: begin
+      addr_hit[41]: begin
         reg_rdata_next[1:0] = prio35_qs;
       end
 
-      addr_hit[44]: begin
+      addr_hit[42]: begin
         reg_rdata_next[1:0] = prio36_qs;
       end
 
-      addr_hit[45]: begin
+      addr_hit[43]: begin
         reg_rdata_next[1:0] = prio37_qs;
       end
 
-      addr_hit[46]: begin
+      addr_hit[44]: begin
         reg_rdata_next[1:0] = prio38_qs;
       end
 
-      addr_hit[47]: begin
+      addr_hit[45]: begin
         reg_rdata_next[1:0] = prio39_qs;
       end
 
-      addr_hit[48]: begin
+      addr_hit[46]: begin
         reg_rdata_next[1:0] = prio40_qs;
       end
 
-      addr_hit[49]: begin
+      addr_hit[47]: begin
         reg_rdata_next[1:0] = prio41_qs;
       end
 
-      addr_hit[50]: begin
+      addr_hit[48]: begin
         reg_rdata_next[1:0] = prio42_qs;
       end
 
-      addr_hit[51]: begin
+      addr_hit[49]: begin
         reg_rdata_next[1:0] = prio43_qs;
       end
 
-      addr_hit[52]: begin
+      addr_hit[50]: begin
         reg_rdata_next[1:0] = prio44_qs;
       end
 
-      addr_hit[53]: begin
+      addr_hit[51]: begin
         reg_rdata_next[1:0] = prio45_qs;
       end
 
-      addr_hit[54]: begin
+      addr_hit[52]: begin
         reg_rdata_next[1:0] = prio46_qs;
       end
 
-      addr_hit[55]: begin
+      addr_hit[53]: begin
         reg_rdata_next[1:0] = prio47_qs;
       end
 
-      addr_hit[56]: begin
+      addr_hit[54]: begin
         reg_rdata_next[1:0] = prio48_qs;
       end
 
-      addr_hit[57]: begin
+      addr_hit[55]: begin
         reg_rdata_next[1:0] = prio49_qs;
       end
 
-      addr_hit[58]: begin
+      addr_hit[56]: begin
         reg_rdata_next[1:0] = prio50_qs;
       end
 
-      addr_hit[59]: begin
+      addr_hit[57]: begin
         reg_rdata_next[1:0] = prio51_qs;
       end
 
-      addr_hit[60]: begin
+      addr_hit[58]: begin
         reg_rdata_next[1:0] = prio52_qs;
       end
 
-      addr_hit[61]: begin
+      addr_hit[59]: begin
         reg_rdata_next[1:0] = prio53_qs;
       end
 
-      addr_hit[62]: begin
+      addr_hit[60]: begin
         reg_rdata_next[1:0] = prio54_qs;
       end
 
-      addr_hit[63]: begin
+      addr_hit[61]: begin
         reg_rdata_next[1:0] = prio55_qs;
       end
 
-      addr_hit[64]: begin
+      addr_hit[62]: begin
         reg_rdata_next[1:0] = prio56_qs;
       end
 
-      addr_hit[65]: begin
+      addr_hit[63]: begin
         reg_rdata_next[1:0] = prio57_qs;
       end
 
-      addr_hit[66]: begin
+      addr_hit[64]: begin
         reg_rdata_next[1:0] = prio58_qs;
       end
 
-      addr_hit[67]: begin
+      addr_hit[65]: begin
         reg_rdata_next[1:0] = prio59_qs;
       end
 
-      addr_hit[68]: begin
+      addr_hit[66]: begin
         reg_rdata_next[1:0] = prio60_qs;
       end
 
-      addr_hit[69]: begin
+      addr_hit[67]: begin
         reg_rdata_next[1:0] = prio61_qs;
       end
 
-      addr_hit[70]: begin
+      addr_hit[68]: begin
         reg_rdata_next[1:0] = prio62_qs;
       end
 
-      addr_hit[71]: begin
+      addr_hit[69]: begin
         reg_rdata_next[1:0] = prio63_qs;
       end
 
-      addr_hit[72]: begin
+      addr_hit[70]: begin
         reg_rdata_next[1:0] = prio64_qs;
       end
 
-      addr_hit[73]: begin
+      addr_hit[71]: begin
         reg_rdata_next[1:0] = prio65_qs;
       end
 
-      addr_hit[74]: begin
+      addr_hit[72]: begin
         reg_rdata_next[1:0] = prio66_qs;
       end
 
-      addr_hit[75]: begin
+      addr_hit[73]: begin
         reg_rdata_next[1:0] = prio67_qs;
       end
 
-      addr_hit[76]: begin
+      addr_hit[74]: begin
         reg_rdata_next[1:0] = prio68_qs;
       end
 
-      addr_hit[77]: begin
+      addr_hit[75]: begin
         reg_rdata_next[1:0] = prio69_qs;
       end
 
-      addr_hit[78]: begin
+      addr_hit[76]: begin
         reg_rdata_next[1:0] = prio70_qs;
       end
 
-      addr_hit[79]: begin
+      addr_hit[77]: begin
         reg_rdata_next[1:0] = prio71_qs;
       end
 
-      addr_hit[80]: begin
+      addr_hit[78]: begin
         reg_rdata_next[1:0] = prio72_qs;
       end
 
-      addr_hit[81]: begin
+      addr_hit[79]: begin
         reg_rdata_next[1:0] = prio73_qs;
       end
 
-      addr_hit[82]: begin
+      addr_hit[80]: begin
         reg_rdata_next[1:0] = prio74_qs;
       end
 
-      addr_hit[83]: begin
+      addr_hit[81]: begin
         reg_rdata_next[1:0] = prio75_qs;
       end
 
-      addr_hit[84]: begin
+      addr_hit[82]: begin
         reg_rdata_next[1:0] = prio76_qs;
       end
 
-      addr_hit[85]: begin
+      addr_hit[83]: begin
         reg_rdata_next[1:0] = prio77_qs;
       end
 
-      addr_hit[86]: begin
+      addr_hit[84]: begin
         reg_rdata_next[1:0] = prio78_qs;
       end
 
-      addr_hit[87]: begin
+      addr_hit[85]: begin
         reg_rdata_next[1:0] = prio79_qs;
       end
 
-      addr_hit[88]: begin
+      addr_hit[86]: begin
         reg_rdata_next[1:0] = prio80_qs;
       end
 
-      addr_hit[89]: begin
+      addr_hit[87]: begin
         reg_rdata_next[1:0] = prio81_qs;
       end
 
-      addr_hit[90]: begin
+      addr_hit[88]: begin
         reg_rdata_next[1:0] = prio82_qs;
       end
 
-      addr_hit[91]: begin
+      addr_hit[89]: begin
         reg_rdata_next[1:0] = prio83_qs;
       end
 
-      addr_hit[92]: begin
+      addr_hit[90]: begin
         reg_rdata_next[1:0] = prio84_qs;
       end
 
-      addr_hit[93]: begin
+      addr_hit[91]: begin
         reg_rdata_next[1:0] = prio85_qs;
       end
 
-      addr_hit[94]: begin
+      addr_hit[92]: begin
         reg_rdata_next[1:0] = prio86_qs;
       end
 
-      addr_hit[95]: begin
+      addr_hit[93]: begin
         reg_rdata_next[1:0] = prio87_qs;
       end
 
-      addr_hit[96]: begin
+      addr_hit[94]: begin
         reg_rdata_next[1:0] = prio88_qs;
       end
 
-      addr_hit[97]: begin
-        reg_rdata_next[1:0] = prio89_qs;
-      end
-
-      addr_hit[98]: begin
-        reg_rdata_next[1:0] = prio90_qs;
-      end
-
-      addr_hit[99]: begin
-        reg_rdata_next[1:0] = prio91_qs;
-      end
-
-      addr_hit[100]: begin
-        reg_rdata_next[1:0] = prio92_qs;
-      end
-
-      addr_hit[101]: begin
-        reg_rdata_next[1:0] = prio93_qs;
-      end
-
-      addr_hit[102]: begin
-        reg_rdata_next[1:0] = prio94_qs;
-      end
-
-      addr_hit[103]: begin
-        reg_rdata_next[1:0] = prio95_qs;
-      end
-
-      addr_hit[104]: begin
-        reg_rdata_next[1:0] = prio96_qs;
-      end
-
-      addr_hit[105]: begin
-        reg_rdata_next[1:0] = prio97_qs;
-      end
-
-      addr_hit[106]: begin
-        reg_rdata_next[1:0] = prio98_qs;
-      end
-
-      addr_hit[107]: begin
-        reg_rdata_next[1:0] = prio99_qs;
-      end
-
-      addr_hit[108]: begin
-        reg_rdata_next[1:0] = prio100_qs;
-      end
-
-      addr_hit[109]: begin
-        reg_rdata_next[1:0] = prio101_qs;
-      end
-
-      addr_hit[110]: begin
-        reg_rdata_next[1:0] = prio102_qs;
-      end
-
-      addr_hit[111]: begin
-        reg_rdata_next[1:0] = prio103_qs;
-      end
-
-      addr_hit[112]: begin
+      addr_hit[95]: begin
         reg_rdata_next[0] = ie0_0_e_0_qs;
         reg_rdata_next[1] = ie0_0_e_1_qs;
         reg_rdata_next[2] = ie0_0_e_2_qs;
@@ -14040,7 +12039,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_0_e_31_qs;
       end
 
-      addr_hit[113]: begin
+      addr_hit[96]: begin
         reg_rdata_next[0] = ie0_1_e_32_qs;
         reg_rdata_next[1] = ie0_1_e_33_qs;
         reg_rdata_next[2] = ie0_1_e_34_qs;
@@ -14075,7 +12074,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_1_e_63_qs;
       end
 
-      addr_hit[114]: begin
+      addr_hit[97]: begin
         reg_rdata_next[0] = ie0_2_e_64_qs;
         reg_rdata_next[1] = ie0_2_e_65_qs;
         reg_rdata_next[2] = ie0_2_e_66_qs;
@@ -14101,35 +12100,17 @@ module rv_plic_reg_top (
         reg_rdata_next[22] = ie0_2_e_86_qs;
         reg_rdata_next[23] = ie0_2_e_87_qs;
         reg_rdata_next[24] = ie0_2_e_88_qs;
-        reg_rdata_next[25] = ie0_2_e_89_qs;
-        reg_rdata_next[26] = ie0_2_e_90_qs;
-        reg_rdata_next[27] = ie0_2_e_91_qs;
-        reg_rdata_next[28] = ie0_2_e_92_qs;
-        reg_rdata_next[29] = ie0_2_e_93_qs;
-        reg_rdata_next[30] = ie0_2_e_94_qs;
-        reg_rdata_next[31] = ie0_2_e_95_qs;
       end
 
-      addr_hit[115]: begin
-        reg_rdata_next[0] = ie0_3_e_96_qs;
-        reg_rdata_next[1] = ie0_3_e_97_qs;
-        reg_rdata_next[2] = ie0_3_e_98_qs;
-        reg_rdata_next[3] = ie0_3_e_99_qs;
-        reg_rdata_next[4] = ie0_3_e_100_qs;
-        reg_rdata_next[5] = ie0_3_e_101_qs;
-        reg_rdata_next[6] = ie0_3_e_102_qs;
-        reg_rdata_next[7] = ie0_3_e_103_qs;
-      end
-
-      addr_hit[116]: begin
+      addr_hit[98]: begin
         reg_rdata_next[1:0] = threshold0_qs;
       end
 
-      addr_hit[117]: begin
+      addr_hit[99]: begin
         reg_rdata_next[6:0] = cc0_qs;
       end
 
-      addr_hit[118]: begin
+      addr_hit[100]: begin
         reg_rdata_next[0] = msip0_qs;
       end
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
@@ -158,8 +158,6 @@ module rv_plic_reg_top (
   logic ip_2_p_84_qs;
   logic ip_2_p_85_qs;
   logic ip_2_p_86_qs;
-  logic ip_2_p_87_qs;
-  logic ip_2_p_88_qs;
   logic le_0_le_0_qs;
   logic le_0_le_0_wd;
   logic le_0_le_0_we;
@@ -421,12 +419,6 @@ module rv_plic_reg_top (
   logic le_2_le_86_qs;
   logic le_2_le_86_wd;
   logic le_2_le_86_we;
-  logic le_2_le_87_qs;
-  logic le_2_le_87_wd;
-  logic le_2_le_87_we;
-  logic le_2_le_88_qs;
-  logic le_2_le_88_wd;
-  logic le_2_le_88_we;
   logic [1:0] prio0_qs;
   logic [1:0] prio0_wd;
   logic prio0_we;
@@ -688,12 +680,6 @@ module rv_plic_reg_top (
   logic [1:0] prio86_qs;
   logic [1:0] prio86_wd;
   logic prio86_we;
-  logic [1:0] prio87_qs;
-  logic [1:0] prio87_wd;
-  logic prio87_we;
-  logic [1:0] prio88_qs;
-  logic [1:0] prio88_wd;
-  logic prio88_we;
   logic ie0_0_e_0_qs;
   logic ie0_0_e_0_wd;
   logic ie0_0_e_0_we;
@@ -955,12 +941,6 @@ module rv_plic_reg_top (
   logic ie0_2_e_86_qs;
   logic ie0_2_e_86_wd;
   logic ie0_2_e_86_we;
-  logic ie0_2_e_87_qs;
-  logic ie0_2_e_87_wd;
-  logic ie0_2_e_87_we;
-  logic ie0_2_e_88_qs;
-  logic ie0_2_e_88_wd;
-  logic ie0_2_e_88_we;
   logic [1:0] threshold0_qs;
   logic [1:0] threshold0_wd;
   logic threshold0_we;
@@ -3155,56 +3135,6 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (ip_2_p_86_qs)
-  );
-
-
-  // F[p_87]: 23:23
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_2_p_87 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[87].de),
-    .d      (hw2reg.ip[87].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_2_p_87_qs)
-  );
-
-
-  // F[p_88]: 24:24
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_2_p_88 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[88].de),
-    .d      (hw2reg.ip[88].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_2_p_88_qs)
   );
 
 
@@ -5478,58 +5408,6 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (le_2_le_86_qs)
-  );
-
-
-  // F[le_87]: 23:23
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_2_le_87 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_2_le_87_we),
-    .wd     (le_2_le_87_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[87].q ),
-
-    // to register interface (read)
-    .qs     (le_2_le_87_qs)
-  );
-
-
-  // F[le_88]: 24:24
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_2_le_88 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_2_le_88_we),
-    .wd     (le_2_le_88_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[88].q ),
-
-    // to register interface (read)
-    .qs     (le_2_le_88_qs)
   );
 
 
@@ -7883,60 +7761,6 @@ module rv_plic_reg_top (
   );
 
 
-  // R[prio87]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio87 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio87_we),
-    .wd     (prio87_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio87.q ),
-
-    // to register interface (read)
-    .qs     (prio87_qs)
-  );
-
-
-  // R[prio88]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio88 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio88_we),
-    .wd     (prio88_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio88.q ),
-
-    // to register interface (read)
-    .qs     (prio88_qs)
-  );
-
-
 
   // Subregister 0 of Multireg ie0
   // R[ie0_0]: V(False)
@@ -10209,58 +10033,6 @@ module rv_plic_reg_top (
   );
 
 
-  // F[e_87]: 23:23
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_2_e_87 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_2_e_87_we),
-    .wd     (ie0_2_e_87_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[87].q ),
-
-    // to register interface (read)
-    .qs     (ie0_2_e_87_qs)
-  );
-
-
-  // F[e_88]: 24:24
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_2_e_88 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_2_e_88_we),
-    .wd     (ie0_2_e_88_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[88].q ),
-
-    // to register interface (read)
-    .qs     (ie0_2_e_88_qs)
-  );
-
-
 
   // R[threshold0]: V(False)
 
@@ -10334,110 +10106,108 @@ module rv_plic_reg_top (
 
 
 
-  logic [100:0] addr_hit;
+  logic [98:0] addr_hit;
   always_comb begin
     addr_hit = '0;
-    addr_hit[  0] = (reg_addr == RV_PLIC_IP_0_OFFSET);
-    addr_hit[  1] = (reg_addr == RV_PLIC_IP_1_OFFSET);
-    addr_hit[  2] = (reg_addr == RV_PLIC_IP_2_OFFSET);
-    addr_hit[  3] = (reg_addr == RV_PLIC_LE_0_OFFSET);
-    addr_hit[  4] = (reg_addr == RV_PLIC_LE_1_OFFSET);
-    addr_hit[  5] = (reg_addr == RV_PLIC_LE_2_OFFSET);
-    addr_hit[  6] = (reg_addr == RV_PLIC_PRIO0_OFFSET);
-    addr_hit[  7] = (reg_addr == RV_PLIC_PRIO1_OFFSET);
-    addr_hit[  8] = (reg_addr == RV_PLIC_PRIO2_OFFSET);
-    addr_hit[  9] = (reg_addr == RV_PLIC_PRIO3_OFFSET);
-    addr_hit[ 10] = (reg_addr == RV_PLIC_PRIO4_OFFSET);
-    addr_hit[ 11] = (reg_addr == RV_PLIC_PRIO5_OFFSET);
-    addr_hit[ 12] = (reg_addr == RV_PLIC_PRIO6_OFFSET);
-    addr_hit[ 13] = (reg_addr == RV_PLIC_PRIO7_OFFSET);
-    addr_hit[ 14] = (reg_addr == RV_PLIC_PRIO8_OFFSET);
-    addr_hit[ 15] = (reg_addr == RV_PLIC_PRIO9_OFFSET);
-    addr_hit[ 16] = (reg_addr == RV_PLIC_PRIO10_OFFSET);
-    addr_hit[ 17] = (reg_addr == RV_PLIC_PRIO11_OFFSET);
-    addr_hit[ 18] = (reg_addr == RV_PLIC_PRIO12_OFFSET);
-    addr_hit[ 19] = (reg_addr == RV_PLIC_PRIO13_OFFSET);
-    addr_hit[ 20] = (reg_addr == RV_PLIC_PRIO14_OFFSET);
-    addr_hit[ 21] = (reg_addr == RV_PLIC_PRIO15_OFFSET);
-    addr_hit[ 22] = (reg_addr == RV_PLIC_PRIO16_OFFSET);
-    addr_hit[ 23] = (reg_addr == RV_PLIC_PRIO17_OFFSET);
-    addr_hit[ 24] = (reg_addr == RV_PLIC_PRIO18_OFFSET);
-    addr_hit[ 25] = (reg_addr == RV_PLIC_PRIO19_OFFSET);
-    addr_hit[ 26] = (reg_addr == RV_PLIC_PRIO20_OFFSET);
-    addr_hit[ 27] = (reg_addr == RV_PLIC_PRIO21_OFFSET);
-    addr_hit[ 28] = (reg_addr == RV_PLIC_PRIO22_OFFSET);
-    addr_hit[ 29] = (reg_addr == RV_PLIC_PRIO23_OFFSET);
-    addr_hit[ 30] = (reg_addr == RV_PLIC_PRIO24_OFFSET);
-    addr_hit[ 31] = (reg_addr == RV_PLIC_PRIO25_OFFSET);
-    addr_hit[ 32] = (reg_addr == RV_PLIC_PRIO26_OFFSET);
-    addr_hit[ 33] = (reg_addr == RV_PLIC_PRIO27_OFFSET);
-    addr_hit[ 34] = (reg_addr == RV_PLIC_PRIO28_OFFSET);
-    addr_hit[ 35] = (reg_addr == RV_PLIC_PRIO29_OFFSET);
-    addr_hit[ 36] = (reg_addr == RV_PLIC_PRIO30_OFFSET);
-    addr_hit[ 37] = (reg_addr == RV_PLIC_PRIO31_OFFSET);
-    addr_hit[ 38] = (reg_addr == RV_PLIC_PRIO32_OFFSET);
-    addr_hit[ 39] = (reg_addr == RV_PLIC_PRIO33_OFFSET);
-    addr_hit[ 40] = (reg_addr == RV_PLIC_PRIO34_OFFSET);
-    addr_hit[ 41] = (reg_addr == RV_PLIC_PRIO35_OFFSET);
-    addr_hit[ 42] = (reg_addr == RV_PLIC_PRIO36_OFFSET);
-    addr_hit[ 43] = (reg_addr == RV_PLIC_PRIO37_OFFSET);
-    addr_hit[ 44] = (reg_addr == RV_PLIC_PRIO38_OFFSET);
-    addr_hit[ 45] = (reg_addr == RV_PLIC_PRIO39_OFFSET);
-    addr_hit[ 46] = (reg_addr == RV_PLIC_PRIO40_OFFSET);
-    addr_hit[ 47] = (reg_addr == RV_PLIC_PRIO41_OFFSET);
-    addr_hit[ 48] = (reg_addr == RV_PLIC_PRIO42_OFFSET);
-    addr_hit[ 49] = (reg_addr == RV_PLIC_PRIO43_OFFSET);
-    addr_hit[ 50] = (reg_addr == RV_PLIC_PRIO44_OFFSET);
-    addr_hit[ 51] = (reg_addr == RV_PLIC_PRIO45_OFFSET);
-    addr_hit[ 52] = (reg_addr == RV_PLIC_PRIO46_OFFSET);
-    addr_hit[ 53] = (reg_addr == RV_PLIC_PRIO47_OFFSET);
-    addr_hit[ 54] = (reg_addr == RV_PLIC_PRIO48_OFFSET);
-    addr_hit[ 55] = (reg_addr == RV_PLIC_PRIO49_OFFSET);
-    addr_hit[ 56] = (reg_addr == RV_PLIC_PRIO50_OFFSET);
-    addr_hit[ 57] = (reg_addr == RV_PLIC_PRIO51_OFFSET);
-    addr_hit[ 58] = (reg_addr == RV_PLIC_PRIO52_OFFSET);
-    addr_hit[ 59] = (reg_addr == RV_PLIC_PRIO53_OFFSET);
-    addr_hit[ 60] = (reg_addr == RV_PLIC_PRIO54_OFFSET);
-    addr_hit[ 61] = (reg_addr == RV_PLIC_PRIO55_OFFSET);
-    addr_hit[ 62] = (reg_addr == RV_PLIC_PRIO56_OFFSET);
-    addr_hit[ 63] = (reg_addr == RV_PLIC_PRIO57_OFFSET);
-    addr_hit[ 64] = (reg_addr == RV_PLIC_PRIO58_OFFSET);
-    addr_hit[ 65] = (reg_addr == RV_PLIC_PRIO59_OFFSET);
-    addr_hit[ 66] = (reg_addr == RV_PLIC_PRIO60_OFFSET);
-    addr_hit[ 67] = (reg_addr == RV_PLIC_PRIO61_OFFSET);
-    addr_hit[ 68] = (reg_addr == RV_PLIC_PRIO62_OFFSET);
-    addr_hit[ 69] = (reg_addr == RV_PLIC_PRIO63_OFFSET);
-    addr_hit[ 70] = (reg_addr == RV_PLIC_PRIO64_OFFSET);
-    addr_hit[ 71] = (reg_addr == RV_PLIC_PRIO65_OFFSET);
-    addr_hit[ 72] = (reg_addr == RV_PLIC_PRIO66_OFFSET);
-    addr_hit[ 73] = (reg_addr == RV_PLIC_PRIO67_OFFSET);
-    addr_hit[ 74] = (reg_addr == RV_PLIC_PRIO68_OFFSET);
-    addr_hit[ 75] = (reg_addr == RV_PLIC_PRIO69_OFFSET);
-    addr_hit[ 76] = (reg_addr == RV_PLIC_PRIO70_OFFSET);
-    addr_hit[ 77] = (reg_addr == RV_PLIC_PRIO71_OFFSET);
-    addr_hit[ 78] = (reg_addr == RV_PLIC_PRIO72_OFFSET);
-    addr_hit[ 79] = (reg_addr == RV_PLIC_PRIO73_OFFSET);
-    addr_hit[ 80] = (reg_addr == RV_PLIC_PRIO74_OFFSET);
-    addr_hit[ 81] = (reg_addr == RV_PLIC_PRIO75_OFFSET);
-    addr_hit[ 82] = (reg_addr == RV_PLIC_PRIO76_OFFSET);
-    addr_hit[ 83] = (reg_addr == RV_PLIC_PRIO77_OFFSET);
-    addr_hit[ 84] = (reg_addr == RV_PLIC_PRIO78_OFFSET);
-    addr_hit[ 85] = (reg_addr == RV_PLIC_PRIO79_OFFSET);
-    addr_hit[ 86] = (reg_addr == RV_PLIC_PRIO80_OFFSET);
-    addr_hit[ 87] = (reg_addr == RV_PLIC_PRIO81_OFFSET);
-    addr_hit[ 88] = (reg_addr == RV_PLIC_PRIO82_OFFSET);
-    addr_hit[ 89] = (reg_addr == RV_PLIC_PRIO83_OFFSET);
-    addr_hit[ 90] = (reg_addr == RV_PLIC_PRIO84_OFFSET);
-    addr_hit[ 91] = (reg_addr == RV_PLIC_PRIO85_OFFSET);
-    addr_hit[ 92] = (reg_addr == RV_PLIC_PRIO86_OFFSET);
-    addr_hit[ 93] = (reg_addr == RV_PLIC_PRIO87_OFFSET);
-    addr_hit[ 94] = (reg_addr == RV_PLIC_PRIO88_OFFSET);
-    addr_hit[ 95] = (reg_addr == RV_PLIC_IE0_0_OFFSET);
-    addr_hit[ 96] = (reg_addr == RV_PLIC_IE0_1_OFFSET);
-    addr_hit[ 97] = (reg_addr == RV_PLIC_IE0_2_OFFSET);
-    addr_hit[ 98] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
-    addr_hit[ 99] = (reg_addr == RV_PLIC_CC0_OFFSET);
-    addr_hit[100] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
+    addr_hit[ 0] = (reg_addr == RV_PLIC_IP_0_OFFSET);
+    addr_hit[ 1] = (reg_addr == RV_PLIC_IP_1_OFFSET);
+    addr_hit[ 2] = (reg_addr == RV_PLIC_IP_2_OFFSET);
+    addr_hit[ 3] = (reg_addr == RV_PLIC_LE_0_OFFSET);
+    addr_hit[ 4] = (reg_addr == RV_PLIC_LE_1_OFFSET);
+    addr_hit[ 5] = (reg_addr == RV_PLIC_LE_2_OFFSET);
+    addr_hit[ 6] = (reg_addr == RV_PLIC_PRIO0_OFFSET);
+    addr_hit[ 7] = (reg_addr == RV_PLIC_PRIO1_OFFSET);
+    addr_hit[ 8] = (reg_addr == RV_PLIC_PRIO2_OFFSET);
+    addr_hit[ 9] = (reg_addr == RV_PLIC_PRIO3_OFFSET);
+    addr_hit[10] = (reg_addr == RV_PLIC_PRIO4_OFFSET);
+    addr_hit[11] = (reg_addr == RV_PLIC_PRIO5_OFFSET);
+    addr_hit[12] = (reg_addr == RV_PLIC_PRIO6_OFFSET);
+    addr_hit[13] = (reg_addr == RV_PLIC_PRIO7_OFFSET);
+    addr_hit[14] = (reg_addr == RV_PLIC_PRIO8_OFFSET);
+    addr_hit[15] = (reg_addr == RV_PLIC_PRIO9_OFFSET);
+    addr_hit[16] = (reg_addr == RV_PLIC_PRIO10_OFFSET);
+    addr_hit[17] = (reg_addr == RV_PLIC_PRIO11_OFFSET);
+    addr_hit[18] = (reg_addr == RV_PLIC_PRIO12_OFFSET);
+    addr_hit[19] = (reg_addr == RV_PLIC_PRIO13_OFFSET);
+    addr_hit[20] = (reg_addr == RV_PLIC_PRIO14_OFFSET);
+    addr_hit[21] = (reg_addr == RV_PLIC_PRIO15_OFFSET);
+    addr_hit[22] = (reg_addr == RV_PLIC_PRIO16_OFFSET);
+    addr_hit[23] = (reg_addr == RV_PLIC_PRIO17_OFFSET);
+    addr_hit[24] = (reg_addr == RV_PLIC_PRIO18_OFFSET);
+    addr_hit[25] = (reg_addr == RV_PLIC_PRIO19_OFFSET);
+    addr_hit[26] = (reg_addr == RV_PLIC_PRIO20_OFFSET);
+    addr_hit[27] = (reg_addr == RV_PLIC_PRIO21_OFFSET);
+    addr_hit[28] = (reg_addr == RV_PLIC_PRIO22_OFFSET);
+    addr_hit[29] = (reg_addr == RV_PLIC_PRIO23_OFFSET);
+    addr_hit[30] = (reg_addr == RV_PLIC_PRIO24_OFFSET);
+    addr_hit[31] = (reg_addr == RV_PLIC_PRIO25_OFFSET);
+    addr_hit[32] = (reg_addr == RV_PLIC_PRIO26_OFFSET);
+    addr_hit[33] = (reg_addr == RV_PLIC_PRIO27_OFFSET);
+    addr_hit[34] = (reg_addr == RV_PLIC_PRIO28_OFFSET);
+    addr_hit[35] = (reg_addr == RV_PLIC_PRIO29_OFFSET);
+    addr_hit[36] = (reg_addr == RV_PLIC_PRIO30_OFFSET);
+    addr_hit[37] = (reg_addr == RV_PLIC_PRIO31_OFFSET);
+    addr_hit[38] = (reg_addr == RV_PLIC_PRIO32_OFFSET);
+    addr_hit[39] = (reg_addr == RV_PLIC_PRIO33_OFFSET);
+    addr_hit[40] = (reg_addr == RV_PLIC_PRIO34_OFFSET);
+    addr_hit[41] = (reg_addr == RV_PLIC_PRIO35_OFFSET);
+    addr_hit[42] = (reg_addr == RV_PLIC_PRIO36_OFFSET);
+    addr_hit[43] = (reg_addr == RV_PLIC_PRIO37_OFFSET);
+    addr_hit[44] = (reg_addr == RV_PLIC_PRIO38_OFFSET);
+    addr_hit[45] = (reg_addr == RV_PLIC_PRIO39_OFFSET);
+    addr_hit[46] = (reg_addr == RV_PLIC_PRIO40_OFFSET);
+    addr_hit[47] = (reg_addr == RV_PLIC_PRIO41_OFFSET);
+    addr_hit[48] = (reg_addr == RV_PLIC_PRIO42_OFFSET);
+    addr_hit[49] = (reg_addr == RV_PLIC_PRIO43_OFFSET);
+    addr_hit[50] = (reg_addr == RV_PLIC_PRIO44_OFFSET);
+    addr_hit[51] = (reg_addr == RV_PLIC_PRIO45_OFFSET);
+    addr_hit[52] = (reg_addr == RV_PLIC_PRIO46_OFFSET);
+    addr_hit[53] = (reg_addr == RV_PLIC_PRIO47_OFFSET);
+    addr_hit[54] = (reg_addr == RV_PLIC_PRIO48_OFFSET);
+    addr_hit[55] = (reg_addr == RV_PLIC_PRIO49_OFFSET);
+    addr_hit[56] = (reg_addr == RV_PLIC_PRIO50_OFFSET);
+    addr_hit[57] = (reg_addr == RV_PLIC_PRIO51_OFFSET);
+    addr_hit[58] = (reg_addr == RV_PLIC_PRIO52_OFFSET);
+    addr_hit[59] = (reg_addr == RV_PLIC_PRIO53_OFFSET);
+    addr_hit[60] = (reg_addr == RV_PLIC_PRIO54_OFFSET);
+    addr_hit[61] = (reg_addr == RV_PLIC_PRIO55_OFFSET);
+    addr_hit[62] = (reg_addr == RV_PLIC_PRIO56_OFFSET);
+    addr_hit[63] = (reg_addr == RV_PLIC_PRIO57_OFFSET);
+    addr_hit[64] = (reg_addr == RV_PLIC_PRIO58_OFFSET);
+    addr_hit[65] = (reg_addr == RV_PLIC_PRIO59_OFFSET);
+    addr_hit[66] = (reg_addr == RV_PLIC_PRIO60_OFFSET);
+    addr_hit[67] = (reg_addr == RV_PLIC_PRIO61_OFFSET);
+    addr_hit[68] = (reg_addr == RV_PLIC_PRIO62_OFFSET);
+    addr_hit[69] = (reg_addr == RV_PLIC_PRIO63_OFFSET);
+    addr_hit[70] = (reg_addr == RV_PLIC_PRIO64_OFFSET);
+    addr_hit[71] = (reg_addr == RV_PLIC_PRIO65_OFFSET);
+    addr_hit[72] = (reg_addr == RV_PLIC_PRIO66_OFFSET);
+    addr_hit[73] = (reg_addr == RV_PLIC_PRIO67_OFFSET);
+    addr_hit[74] = (reg_addr == RV_PLIC_PRIO68_OFFSET);
+    addr_hit[75] = (reg_addr == RV_PLIC_PRIO69_OFFSET);
+    addr_hit[76] = (reg_addr == RV_PLIC_PRIO70_OFFSET);
+    addr_hit[77] = (reg_addr == RV_PLIC_PRIO71_OFFSET);
+    addr_hit[78] = (reg_addr == RV_PLIC_PRIO72_OFFSET);
+    addr_hit[79] = (reg_addr == RV_PLIC_PRIO73_OFFSET);
+    addr_hit[80] = (reg_addr == RV_PLIC_PRIO74_OFFSET);
+    addr_hit[81] = (reg_addr == RV_PLIC_PRIO75_OFFSET);
+    addr_hit[82] = (reg_addr == RV_PLIC_PRIO76_OFFSET);
+    addr_hit[83] = (reg_addr == RV_PLIC_PRIO77_OFFSET);
+    addr_hit[84] = (reg_addr == RV_PLIC_PRIO78_OFFSET);
+    addr_hit[85] = (reg_addr == RV_PLIC_PRIO79_OFFSET);
+    addr_hit[86] = (reg_addr == RV_PLIC_PRIO80_OFFSET);
+    addr_hit[87] = (reg_addr == RV_PLIC_PRIO81_OFFSET);
+    addr_hit[88] = (reg_addr == RV_PLIC_PRIO82_OFFSET);
+    addr_hit[89] = (reg_addr == RV_PLIC_PRIO83_OFFSET);
+    addr_hit[90] = (reg_addr == RV_PLIC_PRIO84_OFFSET);
+    addr_hit[91] = (reg_addr == RV_PLIC_PRIO85_OFFSET);
+    addr_hit[92] = (reg_addr == RV_PLIC_PRIO86_OFFSET);
+    addr_hit[93] = (reg_addr == RV_PLIC_IE0_0_OFFSET);
+    addr_hit[94] = (reg_addr == RV_PLIC_IE0_1_OFFSET);
+    addr_hit[95] = (reg_addr == RV_PLIC_IE0_2_OFFSET);
+    addr_hit[96] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
+    addr_hit[97] = (reg_addr == RV_PLIC_CC0_OFFSET);
+    addr_hit[98] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -10445,110 +10215,106 @@ module rv_plic_reg_top (
   // Check sub-word write is permitted
   always_comb begin
     wr_err = 1'b0;
-    if (addr_hit[  0] && reg_we && (RV_PLIC_PERMIT[  0] != (RV_PLIC_PERMIT[  0] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[  1] && reg_we && (RV_PLIC_PERMIT[  1] != (RV_PLIC_PERMIT[  1] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[  2] && reg_we && (RV_PLIC_PERMIT[  2] != (RV_PLIC_PERMIT[  2] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[  3] && reg_we && (RV_PLIC_PERMIT[  3] != (RV_PLIC_PERMIT[  3] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[  4] && reg_we && (RV_PLIC_PERMIT[  4] != (RV_PLIC_PERMIT[  4] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[  5] && reg_we && (RV_PLIC_PERMIT[  5] != (RV_PLIC_PERMIT[  5] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[  6] && reg_we && (RV_PLIC_PERMIT[  6] != (RV_PLIC_PERMIT[  6] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[  7] && reg_we && (RV_PLIC_PERMIT[  7] != (RV_PLIC_PERMIT[  7] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[  8] && reg_we && (RV_PLIC_PERMIT[  8] != (RV_PLIC_PERMIT[  8] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[  9] && reg_we && (RV_PLIC_PERMIT[  9] != (RV_PLIC_PERMIT[  9] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 10] && reg_we && (RV_PLIC_PERMIT[ 10] != (RV_PLIC_PERMIT[ 10] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 11] && reg_we && (RV_PLIC_PERMIT[ 11] != (RV_PLIC_PERMIT[ 11] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 12] && reg_we && (RV_PLIC_PERMIT[ 12] != (RV_PLIC_PERMIT[ 12] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 13] && reg_we && (RV_PLIC_PERMIT[ 13] != (RV_PLIC_PERMIT[ 13] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 14] && reg_we && (RV_PLIC_PERMIT[ 14] != (RV_PLIC_PERMIT[ 14] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 15] && reg_we && (RV_PLIC_PERMIT[ 15] != (RV_PLIC_PERMIT[ 15] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 16] && reg_we && (RV_PLIC_PERMIT[ 16] != (RV_PLIC_PERMIT[ 16] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 17] && reg_we && (RV_PLIC_PERMIT[ 17] != (RV_PLIC_PERMIT[ 17] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 18] && reg_we && (RV_PLIC_PERMIT[ 18] != (RV_PLIC_PERMIT[ 18] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 19] && reg_we && (RV_PLIC_PERMIT[ 19] != (RV_PLIC_PERMIT[ 19] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 20] && reg_we && (RV_PLIC_PERMIT[ 20] != (RV_PLIC_PERMIT[ 20] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 21] && reg_we && (RV_PLIC_PERMIT[ 21] != (RV_PLIC_PERMIT[ 21] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 22] && reg_we && (RV_PLIC_PERMIT[ 22] != (RV_PLIC_PERMIT[ 22] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 23] && reg_we && (RV_PLIC_PERMIT[ 23] != (RV_PLIC_PERMIT[ 23] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 24] && reg_we && (RV_PLIC_PERMIT[ 24] != (RV_PLIC_PERMIT[ 24] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 25] && reg_we && (RV_PLIC_PERMIT[ 25] != (RV_PLIC_PERMIT[ 25] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 26] && reg_we && (RV_PLIC_PERMIT[ 26] != (RV_PLIC_PERMIT[ 26] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 27] && reg_we && (RV_PLIC_PERMIT[ 27] != (RV_PLIC_PERMIT[ 27] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 28] && reg_we && (RV_PLIC_PERMIT[ 28] != (RV_PLIC_PERMIT[ 28] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 29] && reg_we && (RV_PLIC_PERMIT[ 29] != (RV_PLIC_PERMIT[ 29] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 30] && reg_we && (RV_PLIC_PERMIT[ 30] != (RV_PLIC_PERMIT[ 30] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 31] && reg_we && (RV_PLIC_PERMIT[ 31] != (RV_PLIC_PERMIT[ 31] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 32] && reg_we && (RV_PLIC_PERMIT[ 32] != (RV_PLIC_PERMIT[ 32] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 33] && reg_we && (RV_PLIC_PERMIT[ 33] != (RV_PLIC_PERMIT[ 33] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 34] && reg_we && (RV_PLIC_PERMIT[ 34] != (RV_PLIC_PERMIT[ 34] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 35] && reg_we && (RV_PLIC_PERMIT[ 35] != (RV_PLIC_PERMIT[ 35] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 36] && reg_we && (RV_PLIC_PERMIT[ 36] != (RV_PLIC_PERMIT[ 36] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 37] && reg_we && (RV_PLIC_PERMIT[ 37] != (RV_PLIC_PERMIT[ 37] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 38] && reg_we && (RV_PLIC_PERMIT[ 38] != (RV_PLIC_PERMIT[ 38] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 39] && reg_we && (RV_PLIC_PERMIT[ 39] != (RV_PLIC_PERMIT[ 39] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 40] && reg_we && (RV_PLIC_PERMIT[ 40] != (RV_PLIC_PERMIT[ 40] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 41] && reg_we && (RV_PLIC_PERMIT[ 41] != (RV_PLIC_PERMIT[ 41] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 42] && reg_we && (RV_PLIC_PERMIT[ 42] != (RV_PLIC_PERMIT[ 42] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 43] && reg_we && (RV_PLIC_PERMIT[ 43] != (RV_PLIC_PERMIT[ 43] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 44] && reg_we && (RV_PLIC_PERMIT[ 44] != (RV_PLIC_PERMIT[ 44] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 45] && reg_we && (RV_PLIC_PERMIT[ 45] != (RV_PLIC_PERMIT[ 45] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 46] && reg_we && (RV_PLIC_PERMIT[ 46] != (RV_PLIC_PERMIT[ 46] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 47] && reg_we && (RV_PLIC_PERMIT[ 47] != (RV_PLIC_PERMIT[ 47] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 48] && reg_we && (RV_PLIC_PERMIT[ 48] != (RV_PLIC_PERMIT[ 48] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 49] && reg_we && (RV_PLIC_PERMIT[ 49] != (RV_PLIC_PERMIT[ 49] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 50] && reg_we && (RV_PLIC_PERMIT[ 50] != (RV_PLIC_PERMIT[ 50] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 51] && reg_we && (RV_PLIC_PERMIT[ 51] != (RV_PLIC_PERMIT[ 51] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 52] && reg_we && (RV_PLIC_PERMIT[ 52] != (RV_PLIC_PERMIT[ 52] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 53] && reg_we && (RV_PLIC_PERMIT[ 53] != (RV_PLIC_PERMIT[ 53] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 54] && reg_we && (RV_PLIC_PERMIT[ 54] != (RV_PLIC_PERMIT[ 54] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 55] && reg_we && (RV_PLIC_PERMIT[ 55] != (RV_PLIC_PERMIT[ 55] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 56] && reg_we && (RV_PLIC_PERMIT[ 56] != (RV_PLIC_PERMIT[ 56] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 57] && reg_we && (RV_PLIC_PERMIT[ 57] != (RV_PLIC_PERMIT[ 57] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 58] && reg_we && (RV_PLIC_PERMIT[ 58] != (RV_PLIC_PERMIT[ 58] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 59] && reg_we && (RV_PLIC_PERMIT[ 59] != (RV_PLIC_PERMIT[ 59] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 60] && reg_we && (RV_PLIC_PERMIT[ 60] != (RV_PLIC_PERMIT[ 60] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 61] && reg_we && (RV_PLIC_PERMIT[ 61] != (RV_PLIC_PERMIT[ 61] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 62] && reg_we && (RV_PLIC_PERMIT[ 62] != (RV_PLIC_PERMIT[ 62] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 63] && reg_we && (RV_PLIC_PERMIT[ 63] != (RV_PLIC_PERMIT[ 63] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 64] && reg_we && (RV_PLIC_PERMIT[ 64] != (RV_PLIC_PERMIT[ 64] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 65] && reg_we && (RV_PLIC_PERMIT[ 65] != (RV_PLIC_PERMIT[ 65] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 66] && reg_we && (RV_PLIC_PERMIT[ 66] != (RV_PLIC_PERMIT[ 66] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 67] && reg_we && (RV_PLIC_PERMIT[ 67] != (RV_PLIC_PERMIT[ 67] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 68] && reg_we && (RV_PLIC_PERMIT[ 68] != (RV_PLIC_PERMIT[ 68] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 69] && reg_we && (RV_PLIC_PERMIT[ 69] != (RV_PLIC_PERMIT[ 69] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 70] && reg_we && (RV_PLIC_PERMIT[ 70] != (RV_PLIC_PERMIT[ 70] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 71] && reg_we && (RV_PLIC_PERMIT[ 71] != (RV_PLIC_PERMIT[ 71] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 72] && reg_we && (RV_PLIC_PERMIT[ 72] != (RV_PLIC_PERMIT[ 72] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 73] && reg_we && (RV_PLIC_PERMIT[ 73] != (RV_PLIC_PERMIT[ 73] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 74] && reg_we && (RV_PLIC_PERMIT[ 74] != (RV_PLIC_PERMIT[ 74] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 75] && reg_we && (RV_PLIC_PERMIT[ 75] != (RV_PLIC_PERMIT[ 75] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 76] && reg_we && (RV_PLIC_PERMIT[ 76] != (RV_PLIC_PERMIT[ 76] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 77] && reg_we && (RV_PLIC_PERMIT[ 77] != (RV_PLIC_PERMIT[ 77] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 78] && reg_we && (RV_PLIC_PERMIT[ 78] != (RV_PLIC_PERMIT[ 78] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 79] && reg_we && (RV_PLIC_PERMIT[ 79] != (RV_PLIC_PERMIT[ 79] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 80] && reg_we && (RV_PLIC_PERMIT[ 80] != (RV_PLIC_PERMIT[ 80] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 81] && reg_we && (RV_PLIC_PERMIT[ 81] != (RV_PLIC_PERMIT[ 81] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 82] && reg_we && (RV_PLIC_PERMIT[ 82] != (RV_PLIC_PERMIT[ 82] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 83] && reg_we && (RV_PLIC_PERMIT[ 83] != (RV_PLIC_PERMIT[ 83] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 84] && reg_we && (RV_PLIC_PERMIT[ 84] != (RV_PLIC_PERMIT[ 84] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 85] && reg_we && (RV_PLIC_PERMIT[ 85] != (RV_PLIC_PERMIT[ 85] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 86] && reg_we && (RV_PLIC_PERMIT[ 86] != (RV_PLIC_PERMIT[ 86] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 87] && reg_we && (RV_PLIC_PERMIT[ 87] != (RV_PLIC_PERMIT[ 87] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 88] && reg_we && (RV_PLIC_PERMIT[ 88] != (RV_PLIC_PERMIT[ 88] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 89] && reg_we && (RV_PLIC_PERMIT[ 89] != (RV_PLIC_PERMIT[ 89] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 90] && reg_we && (RV_PLIC_PERMIT[ 90] != (RV_PLIC_PERMIT[ 90] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 91] && reg_we && (RV_PLIC_PERMIT[ 91] != (RV_PLIC_PERMIT[ 91] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 92] && reg_we && (RV_PLIC_PERMIT[ 92] != (RV_PLIC_PERMIT[ 92] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 93] && reg_we && (RV_PLIC_PERMIT[ 93] != (RV_PLIC_PERMIT[ 93] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 94] && reg_we && (RV_PLIC_PERMIT[ 94] != (RV_PLIC_PERMIT[ 94] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 95] && reg_we && (RV_PLIC_PERMIT[ 95] != (RV_PLIC_PERMIT[ 95] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 96] && reg_we && (RV_PLIC_PERMIT[ 96] != (RV_PLIC_PERMIT[ 96] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 97] && reg_we && (RV_PLIC_PERMIT[ 97] != (RV_PLIC_PERMIT[ 97] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 98] && reg_we && (RV_PLIC_PERMIT[ 98] != (RV_PLIC_PERMIT[ 98] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 99] && reg_we && (RV_PLIC_PERMIT[ 99] != (RV_PLIC_PERMIT[ 99] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[100] && reg_we && (RV_PLIC_PERMIT[100] != (RV_PLIC_PERMIT[100] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 0] && reg_we && (RV_PLIC_PERMIT[ 0] != (RV_PLIC_PERMIT[ 0] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 1] && reg_we && (RV_PLIC_PERMIT[ 1] != (RV_PLIC_PERMIT[ 1] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 2] && reg_we && (RV_PLIC_PERMIT[ 2] != (RV_PLIC_PERMIT[ 2] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 3] && reg_we && (RV_PLIC_PERMIT[ 3] != (RV_PLIC_PERMIT[ 3] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 4] && reg_we && (RV_PLIC_PERMIT[ 4] != (RV_PLIC_PERMIT[ 4] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 5] && reg_we && (RV_PLIC_PERMIT[ 5] != (RV_PLIC_PERMIT[ 5] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 6] && reg_we && (RV_PLIC_PERMIT[ 6] != (RV_PLIC_PERMIT[ 6] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 7] && reg_we && (RV_PLIC_PERMIT[ 7] != (RV_PLIC_PERMIT[ 7] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 8] && reg_we && (RV_PLIC_PERMIT[ 8] != (RV_PLIC_PERMIT[ 8] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 9] && reg_we && (RV_PLIC_PERMIT[ 9] != (RV_PLIC_PERMIT[ 9] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[10] && reg_we && (RV_PLIC_PERMIT[10] != (RV_PLIC_PERMIT[10] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[11] && reg_we && (RV_PLIC_PERMIT[11] != (RV_PLIC_PERMIT[11] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[12] && reg_we && (RV_PLIC_PERMIT[12] != (RV_PLIC_PERMIT[12] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[13] && reg_we && (RV_PLIC_PERMIT[13] != (RV_PLIC_PERMIT[13] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[14] && reg_we && (RV_PLIC_PERMIT[14] != (RV_PLIC_PERMIT[14] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[15] && reg_we && (RV_PLIC_PERMIT[15] != (RV_PLIC_PERMIT[15] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[16] && reg_we && (RV_PLIC_PERMIT[16] != (RV_PLIC_PERMIT[16] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[17] && reg_we && (RV_PLIC_PERMIT[17] != (RV_PLIC_PERMIT[17] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[18] && reg_we && (RV_PLIC_PERMIT[18] != (RV_PLIC_PERMIT[18] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[19] && reg_we && (RV_PLIC_PERMIT[19] != (RV_PLIC_PERMIT[19] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[20] && reg_we && (RV_PLIC_PERMIT[20] != (RV_PLIC_PERMIT[20] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[21] && reg_we && (RV_PLIC_PERMIT[21] != (RV_PLIC_PERMIT[21] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[22] && reg_we && (RV_PLIC_PERMIT[22] != (RV_PLIC_PERMIT[22] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[23] && reg_we && (RV_PLIC_PERMIT[23] != (RV_PLIC_PERMIT[23] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[24] && reg_we && (RV_PLIC_PERMIT[24] != (RV_PLIC_PERMIT[24] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[25] && reg_we && (RV_PLIC_PERMIT[25] != (RV_PLIC_PERMIT[25] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[26] && reg_we && (RV_PLIC_PERMIT[26] != (RV_PLIC_PERMIT[26] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[27] && reg_we && (RV_PLIC_PERMIT[27] != (RV_PLIC_PERMIT[27] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[28] && reg_we && (RV_PLIC_PERMIT[28] != (RV_PLIC_PERMIT[28] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[29] && reg_we && (RV_PLIC_PERMIT[29] != (RV_PLIC_PERMIT[29] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[30] && reg_we && (RV_PLIC_PERMIT[30] != (RV_PLIC_PERMIT[30] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[31] && reg_we && (RV_PLIC_PERMIT[31] != (RV_PLIC_PERMIT[31] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[32] && reg_we && (RV_PLIC_PERMIT[32] != (RV_PLIC_PERMIT[32] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[33] && reg_we && (RV_PLIC_PERMIT[33] != (RV_PLIC_PERMIT[33] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[34] && reg_we && (RV_PLIC_PERMIT[34] != (RV_PLIC_PERMIT[34] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[35] && reg_we && (RV_PLIC_PERMIT[35] != (RV_PLIC_PERMIT[35] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[36] && reg_we && (RV_PLIC_PERMIT[36] != (RV_PLIC_PERMIT[36] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[37] && reg_we && (RV_PLIC_PERMIT[37] != (RV_PLIC_PERMIT[37] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[38] && reg_we && (RV_PLIC_PERMIT[38] != (RV_PLIC_PERMIT[38] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[39] && reg_we && (RV_PLIC_PERMIT[39] != (RV_PLIC_PERMIT[39] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[40] && reg_we && (RV_PLIC_PERMIT[40] != (RV_PLIC_PERMIT[40] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[41] && reg_we && (RV_PLIC_PERMIT[41] != (RV_PLIC_PERMIT[41] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[42] && reg_we && (RV_PLIC_PERMIT[42] != (RV_PLIC_PERMIT[42] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[43] && reg_we && (RV_PLIC_PERMIT[43] != (RV_PLIC_PERMIT[43] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[44] && reg_we && (RV_PLIC_PERMIT[44] != (RV_PLIC_PERMIT[44] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[45] && reg_we && (RV_PLIC_PERMIT[45] != (RV_PLIC_PERMIT[45] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[46] && reg_we && (RV_PLIC_PERMIT[46] != (RV_PLIC_PERMIT[46] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[47] && reg_we && (RV_PLIC_PERMIT[47] != (RV_PLIC_PERMIT[47] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[48] && reg_we && (RV_PLIC_PERMIT[48] != (RV_PLIC_PERMIT[48] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[49] && reg_we && (RV_PLIC_PERMIT[49] != (RV_PLIC_PERMIT[49] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[50] && reg_we && (RV_PLIC_PERMIT[50] != (RV_PLIC_PERMIT[50] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[51] && reg_we && (RV_PLIC_PERMIT[51] != (RV_PLIC_PERMIT[51] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[52] && reg_we && (RV_PLIC_PERMIT[52] != (RV_PLIC_PERMIT[52] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[53] && reg_we && (RV_PLIC_PERMIT[53] != (RV_PLIC_PERMIT[53] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[54] && reg_we && (RV_PLIC_PERMIT[54] != (RV_PLIC_PERMIT[54] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[55] && reg_we && (RV_PLIC_PERMIT[55] != (RV_PLIC_PERMIT[55] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[56] && reg_we && (RV_PLIC_PERMIT[56] != (RV_PLIC_PERMIT[56] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[57] && reg_we && (RV_PLIC_PERMIT[57] != (RV_PLIC_PERMIT[57] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[58] && reg_we && (RV_PLIC_PERMIT[58] != (RV_PLIC_PERMIT[58] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[59] && reg_we && (RV_PLIC_PERMIT[59] != (RV_PLIC_PERMIT[59] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[60] && reg_we && (RV_PLIC_PERMIT[60] != (RV_PLIC_PERMIT[60] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[61] && reg_we && (RV_PLIC_PERMIT[61] != (RV_PLIC_PERMIT[61] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[62] && reg_we && (RV_PLIC_PERMIT[62] != (RV_PLIC_PERMIT[62] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[63] && reg_we && (RV_PLIC_PERMIT[63] != (RV_PLIC_PERMIT[63] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[64] && reg_we && (RV_PLIC_PERMIT[64] != (RV_PLIC_PERMIT[64] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[65] && reg_we && (RV_PLIC_PERMIT[65] != (RV_PLIC_PERMIT[65] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[66] && reg_we && (RV_PLIC_PERMIT[66] != (RV_PLIC_PERMIT[66] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[67] && reg_we && (RV_PLIC_PERMIT[67] != (RV_PLIC_PERMIT[67] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[68] && reg_we && (RV_PLIC_PERMIT[68] != (RV_PLIC_PERMIT[68] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[69] && reg_we && (RV_PLIC_PERMIT[69] != (RV_PLIC_PERMIT[69] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[70] && reg_we && (RV_PLIC_PERMIT[70] != (RV_PLIC_PERMIT[70] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[71] && reg_we && (RV_PLIC_PERMIT[71] != (RV_PLIC_PERMIT[71] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[72] && reg_we && (RV_PLIC_PERMIT[72] != (RV_PLIC_PERMIT[72] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[73] && reg_we && (RV_PLIC_PERMIT[73] != (RV_PLIC_PERMIT[73] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[74] && reg_we && (RV_PLIC_PERMIT[74] != (RV_PLIC_PERMIT[74] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[75] && reg_we && (RV_PLIC_PERMIT[75] != (RV_PLIC_PERMIT[75] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[76] && reg_we && (RV_PLIC_PERMIT[76] != (RV_PLIC_PERMIT[76] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[77] && reg_we && (RV_PLIC_PERMIT[77] != (RV_PLIC_PERMIT[77] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[78] && reg_we && (RV_PLIC_PERMIT[78] != (RV_PLIC_PERMIT[78] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[79] && reg_we && (RV_PLIC_PERMIT[79] != (RV_PLIC_PERMIT[79] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[80] && reg_we && (RV_PLIC_PERMIT[80] != (RV_PLIC_PERMIT[80] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[81] && reg_we && (RV_PLIC_PERMIT[81] != (RV_PLIC_PERMIT[81] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[82] && reg_we && (RV_PLIC_PERMIT[82] != (RV_PLIC_PERMIT[82] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[83] && reg_we && (RV_PLIC_PERMIT[83] != (RV_PLIC_PERMIT[83] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[84] && reg_we && (RV_PLIC_PERMIT[84] != (RV_PLIC_PERMIT[84] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[85] && reg_we && (RV_PLIC_PERMIT[85] != (RV_PLIC_PERMIT[85] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[86] && reg_we && (RV_PLIC_PERMIT[86] != (RV_PLIC_PERMIT[86] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[87] && reg_we && (RV_PLIC_PERMIT[87] != (RV_PLIC_PERMIT[87] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[88] && reg_we && (RV_PLIC_PERMIT[88] != (RV_PLIC_PERMIT[88] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[89] && reg_we && (RV_PLIC_PERMIT[89] != (RV_PLIC_PERMIT[89] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[90] && reg_we && (RV_PLIC_PERMIT[90] != (RV_PLIC_PERMIT[90] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[91] && reg_we && (RV_PLIC_PERMIT[91] != (RV_PLIC_PERMIT[91] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[92] && reg_we && (RV_PLIC_PERMIT[92] != (RV_PLIC_PERMIT[92] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[93] && reg_we && (RV_PLIC_PERMIT[93] != (RV_PLIC_PERMIT[93] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[94] && reg_we && (RV_PLIC_PERMIT[94] != (RV_PLIC_PERMIT[94] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[95] && reg_we && (RV_PLIC_PERMIT[95] != (RV_PLIC_PERMIT[95] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[96] && reg_we && (RV_PLIC_PERMIT[96] != (RV_PLIC_PERMIT[96] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[97] && reg_we && (RV_PLIC_PERMIT[97] != (RV_PLIC_PERMIT[97] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[98] && reg_we && (RV_PLIC_PERMIT[98] != (RV_PLIC_PERMIT[98] & reg_be))) wr_err = 1'b1 ;
   end
-
-
 
 
 
@@ -10898,12 +10664,6 @@ module rv_plic_reg_top (
   assign le_2_le_86_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_86_wd = reg_wdata[22];
 
-  assign le_2_le_87_we = addr_hit[5] & reg_we & ~wr_err;
-  assign le_2_le_87_wd = reg_wdata[23];
-
-  assign le_2_le_88_we = addr_hit[5] & reg_we & ~wr_err;
-  assign le_2_le_88_wd = reg_wdata[24];
-
   assign prio0_we = addr_hit[6] & reg_we & ~wr_err;
   assign prio0_wd = reg_wdata[1:0];
 
@@ -11165,287 +10925,275 @@ module rv_plic_reg_top (
   assign prio86_we = addr_hit[92] & reg_we & ~wr_err;
   assign prio86_wd = reg_wdata[1:0];
 
-  assign prio87_we = addr_hit[93] & reg_we & ~wr_err;
-  assign prio87_wd = reg_wdata[1:0];
-
-  assign prio88_we = addr_hit[94] & reg_we & ~wr_err;
-  assign prio88_wd = reg_wdata[1:0];
-
-  assign ie0_0_e_0_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_0_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_0_wd = reg_wdata[0];
 
-  assign ie0_0_e_1_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_1_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_1_wd = reg_wdata[1];
 
-  assign ie0_0_e_2_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_2_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_2_wd = reg_wdata[2];
 
-  assign ie0_0_e_3_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_3_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_3_wd = reg_wdata[3];
 
-  assign ie0_0_e_4_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_4_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_4_wd = reg_wdata[4];
 
-  assign ie0_0_e_5_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_5_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_5_wd = reg_wdata[5];
 
-  assign ie0_0_e_6_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_6_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_6_wd = reg_wdata[6];
 
-  assign ie0_0_e_7_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_7_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_7_wd = reg_wdata[7];
 
-  assign ie0_0_e_8_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_8_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_8_wd = reg_wdata[8];
 
-  assign ie0_0_e_9_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_9_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_9_wd = reg_wdata[9];
 
-  assign ie0_0_e_10_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_10_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_10_wd = reg_wdata[10];
 
-  assign ie0_0_e_11_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_11_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_11_wd = reg_wdata[11];
 
-  assign ie0_0_e_12_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_12_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_12_wd = reg_wdata[12];
 
-  assign ie0_0_e_13_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_13_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_13_wd = reg_wdata[13];
 
-  assign ie0_0_e_14_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_14_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_14_wd = reg_wdata[14];
 
-  assign ie0_0_e_15_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_15_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_15_wd = reg_wdata[15];
 
-  assign ie0_0_e_16_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_16_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_16_wd = reg_wdata[16];
 
-  assign ie0_0_e_17_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_17_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_17_wd = reg_wdata[17];
 
-  assign ie0_0_e_18_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_18_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_18_wd = reg_wdata[18];
 
-  assign ie0_0_e_19_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_19_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_19_wd = reg_wdata[19];
 
-  assign ie0_0_e_20_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_20_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_20_wd = reg_wdata[20];
 
-  assign ie0_0_e_21_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_21_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_21_wd = reg_wdata[21];
 
-  assign ie0_0_e_22_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_22_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_22_wd = reg_wdata[22];
 
-  assign ie0_0_e_23_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_23_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_23_wd = reg_wdata[23];
 
-  assign ie0_0_e_24_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_24_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_24_wd = reg_wdata[24];
 
-  assign ie0_0_e_25_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_25_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_25_wd = reg_wdata[25];
 
-  assign ie0_0_e_26_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_26_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_26_wd = reg_wdata[26];
 
-  assign ie0_0_e_27_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_27_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_27_wd = reg_wdata[27];
 
-  assign ie0_0_e_28_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_28_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_28_wd = reg_wdata[28];
 
-  assign ie0_0_e_29_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_29_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_29_wd = reg_wdata[29];
 
-  assign ie0_0_e_30_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_30_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_30_wd = reg_wdata[30];
 
-  assign ie0_0_e_31_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_0_e_31_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_31_wd = reg_wdata[31];
 
-  assign ie0_1_e_32_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_32_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_32_wd = reg_wdata[0];
 
-  assign ie0_1_e_33_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_33_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_33_wd = reg_wdata[1];
 
-  assign ie0_1_e_34_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_34_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_34_wd = reg_wdata[2];
 
-  assign ie0_1_e_35_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_35_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_35_wd = reg_wdata[3];
 
-  assign ie0_1_e_36_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_36_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_36_wd = reg_wdata[4];
 
-  assign ie0_1_e_37_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_37_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_37_wd = reg_wdata[5];
 
-  assign ie0_1_e_38_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_38_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_38_wd = reg_wdata[6];
 
-  assign ie0_1_e_39_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_39_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_39_wd = reg_wdata[7];
 
-  assign ie0_1_e_40_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_40_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_40_wd = reg_wdata[8];
 
-  assign ie0_1_e_41_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_41_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_41_wd = reg_wdata[9];
 
-  assign ie0_1_e_42_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_42_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_42_wd = reg_wdata[10];
 
-  assign ie0_1_e_43_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_43_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_43_wd = reg_wdata[11];
 
-  assign ie0_1_e_44_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_44_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_44_wd = reg_wdata[12];
 
-  assign ie0_1_e_45_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_45_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_45_wd = reg_wdata[13];
 
-  assign ie0_1_e_46_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_46_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_46_wd = reg_wdata[14];
 
-  assign ie0_1_e_47_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_47_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_47_wd = reg_wdata[15];
 
-  assign ie0_1_e_48_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_48_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_48_wd = reg_wdata[16];
 
-  assign ie0_1_e_49_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_49_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_49_wd = reg_wdata[17];
 
-  assign ie0_1_e_50_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_50_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_50_wd = reg_wdata[18];
 
-  assign ie0_1_e_51_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_51_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_51_wd = reg_wdata[19];
 
-  assign ie0_1_e_52_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_52_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_52_wd = reg_wdata[20];
 
-  assign ie0_1_e_53_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_53_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_53_wd = reg_wdata[21];
 
-  assign ie0_1_e_54_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_54_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_54_wd = reg_wdata[22];
 
-  assign ie0_1_e_55_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_55_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_55_wd = reg_wdata[23];
 
-  assign ie0_1_e_56_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_56_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_56_wd = reg_wdata[24];
 
-  assign ie0_1_e_57_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_57_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_57_wd = reg_wdata[25];
 
-  assign ie0_1_e_58_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_58_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_58_wd = reg_wdata[26];
 
-  assign ie0_1_e_59_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_59_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_59_wd = reg_wdata[27];
 
-  assign ie0_1_e_60_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_60_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_60_wd = reg_wdata[28];
 
-  assign ie0_1_e_61_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_61_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_61_wd = reg_wdata[29];
 
-  assign ie0_1_e_62_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_62_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_62_wd = reg_wdata[30];
 
-  assign ie0_1_e_63_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_1_e_63_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_63_wd = reg_wdata[31];
 
-  assign ie0_2_e_64_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_64_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_64_wd = reg_wdata[0];
 
-  assign ie0_2_e_65_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_65_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_65_wd = reg_wdata[1];
 
-  assign ie0_2_e_66_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_66_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_66_wd = reg_wdata[2];
 
-  assign ie0_2_e_67_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_67_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_67_wd = reg_wdata[3];
 
-  assign ie0_2_e_68_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_68_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_68_wd = reg_wdata[4];
 
-  assign ie0_2_e_69_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_69_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_69_wd = reg_wdata[5];
 
-  assign ie0_2_e_70_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_70_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_70_wd = reg_wdata[6];
 
-  assign ie0_2_e_71_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_71_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_71_wd = reg_wdata[7];
 
-  assign ie0_2_e_72_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_72_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_72_wd = reg_wdata[8];
 
-  assign ie0_2_e_73_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_73_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_73_wd = reg_wdata[9];
 
-  assign ie0_2_e_74_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_74_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_74_wd = reg_wdata[10];
 
-  assign ie0_2_e_75_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_75_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_75_wd = reg_wdata[11];
 
-  assign ie0_2_e_76_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_76_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_76_wd = reg_wdata[12];
 
-  assign ie0_2_e_77_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_77_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_77_wd = reg_wdata[13];
 
-  assign ie0_2_e_78_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_78_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_78_wd = reg_wdata[14];
 
-  assign ie0_2_e_79_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_79_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_79_wd = reg_wdata[15];
 
-  assign ie0_2_e_80_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_80_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_80_wd = reg_wdata[16];
 
-  assign ie0_2_e_81_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_81_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_81_wd = reg_wdata[17];
 
-  assign ie0_2_e_82_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_82_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_82_wd = reg_wdata[18];
 
-  assign ie0_2_e_83_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_83_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_83_wd = reg_wdata[19];
 
-  assign ie0_2_e_84_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_84_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_84_wd = reg_wdata[20];
 
-  assign ie0_2_e_85_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_85_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_85_wd = reg_wdata[21];
 
-  assign ie0_2_e_86_we = addr_hit[97] & reg_we & ~wr_err;
+  assign ie0_2_e_86_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_86_wd = reg_wdata[22];
 
-  assign ie0_2_e_87_we = addr_hit[97] & reg_we & ~wr_err;
-  assign ie0_2_e_87_wd = reg_wdata[23];
-
-  assign ie0_2_e_88_we = addr_hit[97] & reg_we & ~wr_err;
-  assign ie0_2_e_88_wd = reg_wdata[24];
-
-  assign threshold0_we = addr_hit[98] & reg_we & ~wr_err;
+  assign threshold0_we = addr_hit[96] & reg_we & ~wr_err;
   assign threshold0_wd = reg_wdata[1:0];
 
-  assign cc0_we = addr_hit[99] & reg_we & ~wr_err;
+  assign cc0_we = addr_hit[97] & reg_we & ~wr_err;
   assign cc0_wd = reg_wdata[6:0];
-  assign cc0_re = addr_hit[99] && reg_re;
+  assign cc0_re = addr_hit[97] && reg_re;
 
-  assign msip0_we = addr_hit[100] & reg_we & ~wr_err;
+  assign msip0_we = addr_hit[98] & reg_we & ~wr_err;
   assign msip0_wd = reg_wdata[0];
 
   // Read data return
@@ -11546,8 +11294,6 @@ module rv_plic_reg_top (
         reg_rdata_next[20] = ip_2_p_84_qs;
         reg_rdata_next[21] = ip_2_p_85_qs;
         reg_rdata_next[22] = ip_2_p_86_qs;
-        reg_rdata_next[23] = ip_2_p_87_qs;
-        reg_rdata_next[24] = ip_2_p_88_qs;
       end
 
       addr_hit[3]: begin
@@ -11644,8 +11390,6 @@ module rv_plic_reg_top (
         reg_rdata_next[20] = le_2_le_84_qs;
         reg_rdata_next[21] = le_2_le_85_qs;
         reg_rdata_next[22] = le_2_le_86_qs;
-        reg_rdata_next[23] = le_2_le_87_qs;
-        reg_rdata_next[24] = le_2_le_88_qs;
       end
 
       addr_hit[6]: begin
@@ -11997,14 +11741,6 @@ module rv_plic_reg_top (
       end
 
       addr_hit[93]: begin
-        reg_rdata_next[1:0] = prio87_qs;
-      end
-
-      addr_hit[94]: begin
-        reg_rdata_next[1:0] = prio88_qs;
-      end
-
-      addr_hit[95]: begin
         reg_rdata_next[0] = ie0_0_e_0_qs;
         reg_rdata_next[1] = ie0_0_e_1_qs;
         reg_rdata_next[2] = ie0_0_e_2_qs;
@@ -12039,7 +11775,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_0_e_31_qs;
       end
 
-      addr_hit[96]: begin
+      addr_hit[94]: begin
         reg_rdata_next[0] = ie0_1_e_32_qs;
         reg_rdata_next[1] = ie0_1_e_33_qs;
         reg_rdata_next[2] = ie0_1_e_34_qs;
@@ -12074,7 +11810,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_1_e_63_qs;
       end
 
-      addr_hit[97]: begin
+      addr_hit[95]: begin
         reg_rdata_next[0] = ie0_2_e_64_qs;
         reg_rdata_next[1] = ie0_2_e_65_qs;
         reg_rdata_next[2] = ie0_2_e_66_qs;
@@ -12098,19 +11834,17 @@ module rv_plic_reg_top (
         reg_rdata_next[20] = ie0_2_e_84_qs;
         reg_rdata_next[21] = ie0_2_e_85_qs;
         reg_rdata_next[22] = ie0_2_e_86_qs;
-        reg_rdata_next[23] = ie0_2_e_87_qs;
-        reg_rdata_next[24] = ie0_2_e_88_qs;
       end
 
-      addr_hit[98]: begin
+      addr_hit[96]: begin
         reg_rdata_next[1:0] = threshold0_qs;
       end
 
-      addr_hit[99]: begin
+      addr_hit[97]: begin
         reg_rdata_next[6:0] = cc0_qs;
       end
 
-      addr_hit[100]: begin
+      addr_hit[98]: begin
         reg_rdata_next[0] = msip0_qs;
       end
 

--- a/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
@@ -41,7 +41,6 @@
       sensor_ctrl
       ast_wrapper
       pattgen
-      i2c
     ]
   }
   nodes:
@@ -104,24 +103,6 @@
       [
         {
           base_addr: 0x40050000
-          size_byte: 0x1000
-        }
-      ]
-      xbar: false
-      stub: false
-      pipeline_byp: "true"
-    }
-    {
-      name: i2c
-      type: device
-      clock: clk_peri_i
-      reset: rst_peri_ni
-      pipeline: "false"
-      inst_type: i2c
-      addr_range:
-      [
-        {
-          base_addr: 0x40080000
           size_byte: 0x1000
         }
       ]

--- a/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
@@ -40,7 +40,6 @@
       otp_ctrl
       sensor_ctrl
       ast_wrapper
-      pattgen
     ]
   }
   nodes:
@@ -269,24 +268,6 @@
         }
       ]
       xbar: false
-      pipeline_byp: "true"
-    }
-    {
-      name: pattgen
-      type: device
-      clock: clk_peri_i
-      reset: rst_peri_ni
-      pipeline: "false"
-      inst_type: pattgen
-      addr_range:
-      [
-        {
-          base_addr: 0x400e0000
-          size_byte: 0x1000
-        }
-      ]
-      xbar: false
-      stub: false
       pipeline_byp: "true"
     }
   ]

--- a/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.hjson
@@ -39,12 +39,6 @@
     }
     { struct: "tl"
       type:   "req_rsp"
-      name:   "tl_i2c"
-      act:    "req"
-      package: "tlul_pkg"
-    }
-    { struct: "tl"
-      type:   "req_rsp"
       name:   "tl_rv_timer"
       act:    "req"
       package: "tlul_pkg"

--- a/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.hjson
@@ -91,11 +91,5 @@
       act:    "req"
       package: "tlul_pkg"
     }
-    { struct: "tl"
-      type:   "req_rsp"
-      name:   "tl_pattgen"
-      act:    "req"
-      package: "tlul_pkg"
-    }
   ]
 }

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/tb__xbar_connect.sv
@@ -20,7 +20,6 @@ initial force dut.rst_peri_ni = rst_n;
 `CONNECT_TL_DEVICE_IF(uart, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(gpio, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(spi_device, dut, clk_peri_i, rst_n)
-`CONNECT_TL_DEVICE_IF(i2c, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(rv_timer, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(usbdev, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(pwrmgr, dut, clk_peri_i, rst_n)

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/tb__xbar_connect.sv
@@ -29,4 +29,3 @@ initial force dut.rst_peri_ni = rst_n;
 `CONNECT_TL_DEVICE_IF(otp_ctrl, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(sensor_ctrl, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(ast_wrapper, dut, clk_peri_i, rst_n)
-`CONNECT_TL_DEVICE_IF(pattgen, dut, clk_peri_i, rst_n)

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_env_pkg__params.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_env_pkg__params.sv
@@ -16,9 +16,6 @@ tl_device_t xbar_devices[$] = '{
     '{"spi_device", '{
         '{32'h40050000, 32'h40050fff}
     }},
-    '{"i2c", '{
-        '{32'h40080000, 32'h40080fff}
-    }},
     '{"rv_timer", '{
         '{32'h40100000, 32'h40100fff}
     }},
@@ -65,6 +62,5 @@ tl_host_t xbar_hosts[$] = '{
         "otp_ctrl",
         "sensor_ctrl",
         "ast_wrapper",
-        "pattgen",
-        "i2c"}}
+        "pattgen"}}
 };

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_env_pkg__params.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_env_pkg__params.sv
@@ -42,9 +42,6 @@ tl_device_t xbar_devices[$] = '{
     }},
     '{"ast_wrapper", '{
         '{32'h40180000, 32'h40180fff}
-    }},
-    '{"pattgen", '{
-        '{32'h400e0000, 32'h400e0fff}
 }}};
 
   // List of Xbar hosts
@@ -61,6 +58,5 @@ tl_host_t xbar_hosts[$] = '{
         "ram_ret",
         "otp_ctrl",
         "sensor_ctrl",
-        "ast_wrapper",
-        "pattgen"}}
+        "ast_wrapper"}}
 };

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_bind.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_bind.sv
@@ -32,12 +32,6 @@ module xbar_peri_bind;
     .h2d    (tl_spi_device_o),
     .d2h    (tl_spi_device_i)
   );
-  bind xbar_peri tlul_assert #(.EndpointType("Host")) tlul_assert_device_i2c (
-    .clk_i  (clk_peri_i),
-    .rst_ni (rst_peri_ni),
-    .h2d    (tl_i2c_o),
-    .d2h    (tl_i2c_i)
-  );
   bind xbar_peri tlul_assert #(.EndpointType("Host")) tlul_assert_device_rv_timer (
     .clk_i  (clk_peri_i),
     .rst_ni (rst_peri_ni),

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_bind.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_bind.sv
@@ -86,11 +86,5 @@ module xbar_peri_bind;
     .h2d    (tl_ast_wrapper_o),
     .d2h    (tl_ast_wrapper_i)
   );
-  bind xbar_peri tlul_assert #(.EndpointType("Host")) tlul_assert_device_pattgen (
-    .clk_i  (clk_peri_i),
-    .rst_ni (rst_peri_ni),
-    .h2d    (tl_pattgen_o),
-    .d2h    (tl_pattgen_i)
-  );
 
 endmodule

--- a/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/tl_peri_pkg.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/tl_peri_pkg.sv
@@ -9,7 +9,6 @@ package tl_peri_pkg;
   localparam logic [31:0] ADDR_SPACE_UART        = 32'h 40000000;
   localparam logic [31:0] ADDR_SPACE_GPIO        = 32'h 40040000;
   localparam logic [31:0] ADDR_SPACE_SPI_DEVICE  = 32'h 40050000;
-  localparam logic [31:0] ADDR_SPACE_I2C         = 32'h 40080000;
   localparam logic [31:0] ADDR_SPACE_RV_TIMER    = 32'h 40100000;
   localparam logic [31:0] ADDR_SPACE_USBDEV      = 32'h 40500000;
   localparam logic [31:0] ADDR_SPACE_PWRMGR      = 32'h 40400000;
@@ -24,7 +23,6 @@ package tl_peri_pkg;
   localparam logic [31:0] ADDR_MASK_UART        = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_GPIO        = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_SPI_DEVICE  = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_I2C         = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_RV_TIMER    = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_USBDEV      = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_PWRMGR      = 32'h 00000fff;
@@ -37,23 +35,22 @@ package tl_peri_pkg;
   localparam logic [31:0] ADDR_MASK_PATTGEN     = 32'h 00000fff;
 
   localparam int N_HOST   = 1;
-  localparam int N_DEVICE = 14;
+  localparam int N_DEVICE = 13;
 
   typedef enum int {
     TlUart = 0,
     TlGpio = 1,
     TlSpiDevice = 2,
-    TlI2C = 3,
-    TlRvTimer = 4,
-    TlUsbdev = 5,
-    TlPwrmgr = 6,
-    TlRstmgr = 7,
-    TlClkmgr = 8,
-    TlRamRet = 9,
-    TlOtpCtrl = 10,
-    TlSensorCtrl = 11,
-    TlAstWrapper = 12,
-    TlPattgen = 13
+    TlRvTimer = 3,
+    TlUsbdev = 4,
+    TlPwrmgr = 5,
+    TlRstmgr = 6,
+    TlClkmgr = 7,
+    TlRamRet = 8,
+    TlOtpCtrl = 9,
+    TlSensorCtrl = 10,
+    TlAstWrapper = 11,
+    TlPattgen = 12
   } tl_device_e;
 
   typedef enum int {

--- a/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/tl_peri_pkg.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/tl_peri_pkg.sv
@@ -18,7 +18,6 @@ package tl_peri_pkg;
   localparam logic [31:0] ADDR_SPACE_OTP_CTRL    = 32'h 40130000;
   localparam logic [31:0] ADDR_SPACE_SENSOR_CTRL = 32'h 40110000;
   localparam logic [31:0] ADDR_SPACE_AST_WRAPPER = 32'h 40180000;
-  localparam logic [31:0] ADDR_SPACE_PATTGEN     = 32'h 400e0000;
 
   localparam logic [31:0] ADDR_MASK_UART        = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_GPIO        = 32'h 00000fff;
@@ -32,10 +31,9 @@ package tl_peri_pkg;
   localparam logic [31:0] ADDR_MASK_OTP_CTRL    = 32'h 00003fff;
   localparam logic [31:0] ADDR_MASK_SENSOR_CTRL = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_AST_WRAPPER = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_PATTGEN     = 32'h 00000fff;
 
   localparam int N_HOST   = 1;
-  localparam int N_DEVICE = 13;
+  localparam int N_DEVICE = 12;
 
   typedef enum int {
     TlUart = 0,
@@ -49,8 +47,7 @@ package tl_peri_pkg;
     TlRamRet = 8,
     TlOtpCtrl = 9,
     TlSensorCtrl = 10,
-    TlAstWrapper = 11,
-    TlPattgen = 12
+    TlAstWrapper = 11
   } tl_device_e;
 
   typedef enum int {

--- a/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/xbar_peri.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/xbar_peri.sv
@@ -7,7 +7,7 @@
 //
 // Interconnect
 // main
-//   -> s1n_15
+//   -> s1n_14
 //     -> uart
 //     -> gpio
 //     -> spi_device
@@ -21,7 +21,6 @@
 //     -> sensor_ctrl
 //     -> ast_wrapper
 //     -> pattgen
-//     -> i2c
 
 module xbar_peri (
   input clk_peri_i,
@@ -38,8 +37,6 @@ module xbar_peri (
   input  tlul_pkg::tl_d2h_t tl_gpio_i,
   output tlul_pkg::tl_h2d_t tl_spi_device_o,
   input  tlul_pkg::tl_d2h_t tl_spi_device_i,
-  output tlul_pkg::tl_h2d_t tl_i2c_o,
-  input  tlul_pkg::tl_d2h_t tl_i2c_i,
   output tlul_pkg::tl_h2d_t tl_rv_timer_o,
   input  tlul_pkg::tl_d2h_t tl_rv_timer_i,
   output tlul_pkg::tl_h2d_t tl_usbdev_o,
@@ -72,107 +69,101 @@ module xbar_peri (
   logic unused_scanmode;
   assign unused_scanmode = scanmode_i;
 
-  tl_h2d_t tl_s1n_15_us_h2d ;
-  tl_d2h_t tl_s1n_15_us_d2h ;
+  tl_h2d_t tl_s1n_14_us_h2d ;
+  tl_d2h_t tl_s1n_14_us_d2h ;
 
 
-  tl_h2d_t tl_s1n_15_ds_h2d [14];
-  tl_d2h_t tl_s1n_15_ds_d2h [14];
+  tl_h2d_t tl_s1n_14_ds_h2d [13];
+  tl_d2h_t tl_s1n_14_ds_d2h [13];
 
   // Create steering signal
-  logic [3:0] dev_sel_s1n_15;
+  logic [3:0] dev_sel_s1n_14;
 
 
 
-  assign tl_uart_o = tl_s1n_15_ds_h2d[0];
-  assign tl_s1n_15_ds_d2h[0] = tl_uart_i;
+  assign tl_uart_o = tl_s1n_14_ds_h2d[0];
+  assign tl_s1n_14_ds_d2h[0] = tl_uart_i;
 
-  assign tl_gpio_o = tl_s1n_15_ds_h2d[1];
-  assign tl_s1n_15_ds_d2h[1] = tl_gpio_i;
+  assign tl_gpio_o = tl_s1n_14_ds_h2d[1];
+  assign tl_s1n_14_ds_d2h[1] = tl_gpio_i;
 
-  assign tl_spi_device_o = tl_s1n_15_ds_h2d[2];
-  assign tl_s1n_15_ds_d2h[2] = tl_spi_device_i;
+  assign tl_spi_device_o = tl_s1n_14_ds_h2d[2];
+  assign tl_s1n_14_ds_d2h[2] = tl_spi_device_i;
 
-  assign tl_rv_timer_o = tl_s1n_15_ds_h2d[3];
-  assign tl_s1n_15_ds_d2h[3] = tl_rv_timer_i;
+  assign tl_rv_timer_o = tl_s1n_14_ds_h2d[3];
+  assign tl_s1n_14_ds_d2h[3] = tl_rv_timer_i;
 
-  assign tl_usbdev_o = tl_s1n_15_ds_h2d[4];
-  assign tl_s1n_15_ds_d2h[4] = tl_usbdev_i;
+  assign tl_usbdev_o = tl_s1n_14_ds_h2d[4];
+  assign tl_s1n_14_ds_d2h[4] = tl_usbdev_i;
 
-  assign tl_pwrmgr_o = tl_s1n_15_ds_h2d[5];
-  assign tl_s1n_15_ds_d2h[5] = tl_pwrmgr_i;
+  assign tl_pwrmgr_o = tl_s1n_14_ds_h2d[5];
+  assign tl_s1n_14_ds_d2h[5] = tl_pwrmgr_i;
 
-  assign tl_rstmgr_o = tl_s1n_15_ds_h2d[6];
-  assign tl_s1n_15_ds_d2h[6] = tl_rstmgr_i;
+  assign tl_rstmgr_o = tl_s1n_14_ds_h2d[6];
+  assign tl_s1n_14_ds_d2h[6] = tl_rstmgr_i;
 
-  assign tl_clkmgr_o = tl_s1n_15_ds_h2d[7];
-  assign tl_s1n_15_ds_d2h[7] = tl_clkmgr_i;
+  assign tl_clkmgr_o = tl_s1n_14_ds_h2d[7];
+  assign tl_s1n_14_ds_d2h[7] = tl_clkmgr_i;
 
-  assign tl_ram_ret_o = tl_s1n_15_ds_h2d[8];
-  assign tl_s1n_15_ds_d2h[8] = tl_ram_ret_i;
+  assign tl_ram_ret_o = tl_s1n_14_ds_h2d[8];
+  assign tl_s1n_14_ds_d2h[8] = tl_ram_ret_i;
 
-  assign tl_otp_ctrl_o = tl_s1n_15_ds_h2d[9];
-  assign tl_s1n_15_ds_d2h[9] = tl_otp_ctrl_i;
+  assign tl_otp_ctrl_o = tl_s1n_14_ds_h2d[9];
+  assign tl_s1n_14_ds_d2h[9] = tl_otp_ctrl_i;
 
-  assign tl_sensor_ctrl_o = tl_s1n_15_ds_h2d[10];
-  assign tl_s1n_15_ds_d2h[10] = tl_sensor_ctrl_i;
+  assign tl_sensor_ctrl_o = tl_s1n_14_ds_h2d[10];
+  assign tl_s1n_14_ds_d2h[10] = tl_sensor_ctrl_i;
 
-  assign tl_ast_wrapper_o = tl_s1n_15_ds_h2d[11];
-  assign tl_s1n_15_ds_d2h[11] = tl_ast_wrapper_i;
+  assign tl_ast_wrapper_o = tl_s1n_14_ds_h2d[11];
+  assign tl_s1n_14_ds_d2h[11] = tl_ast_wrapper_i;
 
-  assign tl_pattgen_o = tl_s1n_15_ds_h2d[12];
-  assign tl_s1n_15_ds_d2h[12] = tl_pattgen_i;
+  assign tl_pattgen_o = tl_s1n_14_ds_h2d[12];
+  assign tl_s1n_14_ds_d2h[12] = tl_pattgen_i;
 
-  assign tl_i2c_o = tl_s1n_15_ds_h2d[13];
-  assign tl_s1n_15_ds_d2h[13] = tl_i2c_i;
-
-  assign tl_s1n_15_us_h2d = tl_main_i;
-  assign tl_main_o = tl_s1n_15_us_d2h;
+  assign tl_s1n_14_us_h2d = tl_main_i;
+  assign tl_main_o = tl_s1n_14_us_d2h;
 
   always_comb begin
     // default steering to generate error response if address is not within the range
-    dev_sel_s1n_15 = 4'd14;
-    if ((tl_s1n_15_us_h2d.a_address & ~(ADDR_MASK_UART)) == ADDR_SPACE_UART) begin
-      dev_sel_s1n_15 = 4'd0;
+    dev_sel_s1n_14 = 4'd13;
+    if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_UART)) == ADDR_SPACE_UART) begin
+      dev_sel_s1n_14 = 4'd0;
 
-    end else if ((tl_s1n_15_us_h2d.a_address & ~(ADDR_MASK_GPIO)) == ADDR_SPACE_GPIO) begin
-      dev_sel_s1n_15 = 4'd1;
+    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_GPIO)) == ADDR_SPACE_GPIO) begin
+      dev_sel_s1n_14 = 4'd1;
 
-    end else if ((tl_s1n_15_us_h2d.a_address & ~(ADDR_MASK_SPI_DEVICE)) == ADDR_SPACE_SPI_DEVICE) begin
-      dev_sel_s1n_15 = 4'd2;
+    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_SPI_DEVICE)) == ADDR_SPACE_SPI_DEVICE) begin
+      dev_sel_s1n_14 = 4'd2;
 
-    end else if ((tl_s1n_15_us_h2d.a_address & ~(ADDR_MASK_RV_TIMER)) == ADDR_SPACE_RV_TIMER) begin
-      dev_sel_s1n_15 = 4'd3;
+    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_RV_TIMER)) == ADDR_SPACE_RV_TIMER) begin
+      dev_sel_s1n_14 = 4'd3;
 
-    end else if ((tl_s1n_15_us_h2d.a_address & ~(ADDR_MASK_USBDEV)) == ADDR_SPACE_USBDEV) begin
-      dev_sel_s1n_15 = 4'd4;
+    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_USBDEV)) == ADDR_SPACE_USBDEV) begin
+      dev_sel_s1n_14 = 4'd4;
 
-    end else if ((tl_s1n_15_us_h2d.a_address & ~(ADDR_MASK_PWRMGR)) == ADDR_SPACE_PWRMGR) begin
-      dev_sel_s1n_15 = 4'd5;
+    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_PWRMGR)) == ADDR_SPACE_PWRMGR) begin
+      dev_sel_s1n_14 = 4'd5;
 
-    end else if ((tl_s1n_15_us_h2d.a_address & ~(ADDR_MASK_RSTMGR)) == ADDR_SPACE_RSTMGR) begin
-      dev_sel_s1n_15 = 4'd6;
+    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_RSTMGR)) == ADDR_SPACE_RSTMGR) begin
+      dev_sel_s1n_14 = 4'd6;
 
-    end else if ((tl_s1n_15_us_h2d.a_address & ~(ADDR_MASK_CLKMGR)) == ADDR_SPACE_CLKMGR) begin
-      dev_sel_s1n_15 = 4'd7;
+    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_CLKMGR)) == ADDR_SPACE_CLKMGR) begin
+      dev_sel_s1n_14 = 4'd7;
 
-    end else if ((tl_s1n_15_us_h2d.a_address & ~(ADDR_MASK_RAM_RET)) == ADDR_SPACE_RAM_RET) begin
-      dev_sel_s1n_15 = 4'd8;
+    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_RAM_RET)) == ADDR_SPACE_RAM_RET) begin
+      dev_sel_s1n_14 = 4'd8;
 
-    end else if ((tl_s1n_15_us_h2d.a_address & ~(ADDR_MASK_OTP_CTRL)) == ADDR_SPACE_OTP_CTRL) begin
-      dev_sel_s1n_15 = 4'd9;
+    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_OTP_CTRL)) == ADDR_SPACE_OTP_CTRL) begin
+      dev_sel_s1n_14 = 4'd9;
 
-    end else if ((tl_s1n_15_us_h2d.a_address & ~(ADDR_MASK_SENSOR_CTRL)) == ADDR_SPACE_SENSOR_CTRL) begin
-      dev_sel_s1n_15 = 4'd10;
+    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_SENSOR_CTRL)) == ADDR_SPACE_SENSOR_CTRL) begin
+      dev_sel_s1n_14 = 4'd10;
 
-    end else if ((tl_s1n_15_us_h2d.a_address & ~(ADDR_MASK_AST_WRAPPER)) == ADDR_SPACE_AST_WRAPPER) begin
-      dev_sel_s1n_15 = 4'd11;
+    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_AST_WRAPPER)) == ADDR_SPACE_AST_WRAPPER) begin
+      dev_sel_s1n_14 = 4'd11;
 
-    end else if ((tl_s1n_15_us_h2d.a_address & ~(ADDR_MASK_PATTGEN)) == ADDR_SPACE_PATTGEN) begin
-      dev_sel_s1n_15 = 4'd12;
-
-    end else if ((tl_s1n_15_us_h2d.a_address & ~(ADDR_MASK_I2C)) == ADDR_SPACE_I2C) begin
-      dev_sel_s1n_15 = 4'd13;
+    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_PATTGEN)) == ADDR_SPACE_PATTGEN) begin
+      dev_sel_s1n_14 = 4'd12;
 end
   end
 
@@ -181,17 +172,17 @@ end
   tlul_socket_1n #(
     .HReqDepth (4'h0),
     .HRspDepth (4'h0),
-    .DReqDepth (56'h0),
-    .DRspDepth (56'h0),
-    .N         (14)
-  ) u_s1n_15 (
+    .DReqDepth (52'h0),
+    .DRspDepth (52'h0),
+    .N         (13)
+  ) u_s1n_14 (
     .clk_i        (clk_peri_i),
     .rst_ni       (rst_peri_ni),
-    .tl_h_i       (tl_s1n_15_us_h2d),
-    .tl_h_o       (tl_s1n_15_us_d2h),
-    .tl_d_o       (tl_s1n_15_ds_h2d),
-    .tl_d_i       (tl_s1n_15_ds_d2h),
-    .dev_select_i (dev_sel_s1n_15)
+    .tl_h_i       (tl_s1n_14_us_h2d),
+    .tl_h_o       (tl_s1n_14_us_d2h),
+    .tl_d_o       (tl_s1n_14_ds_h2d),
+    .tl_d_i       (tl_s1n_14_ds_d2h),
+    .dev_select_i (dev_sel_s1n_14)
   );
 
 endmodule

--- a/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/xbar_peri.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/xbar_peri.sv
@@ -7,7 +7,7 @@
 //
 // Interconnect
 // main
-//   -> s1n_14
+//   -> s1n_13
 //     -> uart
 //     -> gpio
 //     -> spi_device
@@ -20,7 +20,6 @@
 //     -> otp_ctrl
 //     -> sensor_ctrl
 //     -> ast_wrapper
-//     -> pattgen
 
 module xbar_peri (
   input clk_peri_i,
@@ -55,8 +54,6 @@ module xbar_peri (
   input  tlul_pkg::tl_d2h_t tl_sensor_ctrl_i,
   output tlul_pkg::tl_h2d_t tl_ast_wrapper_o,
   input  tlul_pkg::tl_d2h_t tl_ast_wrapper_i,
-  output tlul_pkg::tl_h2d_t tl_pattgen_o,
-  input  tlul_pkg::tl_d2h_t tl_pattgen_i,
 
   input scanmode_i
 );
@@ -69,101 +66,95 @@ module xbar_peri (
   logic unused_scanmode;
   assign unused_scanmode = scanmode_i;
 
-  tl_h2d_t tl_s1n_14_us_h2d ;
-  tl_d2h_t tl_s1n_14_us_d2h ;
+  tl_h2d_t tl_s1n_13_us_h2d ;
+  tl_d2h_t tl_s1n_13_us_d2h ;
 
 
-  tl_h2d_t tl_s1n_14_ds_h2d [13];
-  tl_d2h_t tl_s1n_14_ds_d2h [13];
+  tl_h2d_t tl_s1n_13_ds_h2d [12];
+  tl_d2h_t tl_s1n_13_ds_d2h [12];
 
   // Create steering signal
-  logic [3:0] dev_sel_s1n_14;
+  logic [3:0] dev_sel_s1n_13;
 
 
 
-  assign tl_uart_o = tl_s1n_14_ds_h2d[0];
-  assign tl_s1n_14_ds_d2h[0] = tl_uart_i;
+  assign tl_uart_o = tl_s1n_13_ds_h2d[0];
+  assign tl_s1n_13_ds_d2h[0] = tl_uart_i;
 
-  assign tl_gpio_o = tl_s1n_14_ds_h2d[1];
-  assign tl_s1n_14_ds_d2h[1] = tl_gpio_i;
+  assign tl_gpio_o = tl_s1n_13_ds_h2d[1];
+  assign tl_s1n_13_ds_d2h[1] = tl_gpio_i;
 
-  assign tl_spi_device_o = tl_s1n_14_ds_h2d[2];
-  assign tl_s1n_14_ds_d2h[2] = tl_spi_device_i;
+  assign tl_spi_device_o = tl_s1n_13_ds_h2d[2];
+  assign tl_s1n_13_ds_d2h[2] = tl_spi_device_i;
 
-  assign tl_rv_timer_o = tl_s1n_14_ds_h2d[3];
-  assign tl_s1n_14_ds_d2h[3] = tl_rv_timer_i;
+  assign tl_rv_timer_o = tl_s1n_13_ds_h2d[3];
+  assign tl_s1n_13_ds_d2h[3] = tl_rv_timer_i;
 
-  assign tl_usbdev_o = tl_s1n_14_ds_h2d[4];
-  assign tl_s1n_14_ds_d2h[4] = tl_usbdev_i;
+  assign tl_usbdev_o = tl_s1n_13_ds_h2d[4];
+  assign tl_s1n_13_ds_d2h[4] = tl_usbdev_i;
 
-  assign tl_pwrmgr_o = tl_s1n_14_ds_h2d[5];
-  assign tl_s1n_14_ds_d2h[5] = tl_pwrmgr_i;
+  assign tl_pwrmgr_o = tl_s1n_13_ds_h2d[5];
+  assign tl_s1n_13_ds_d2h[5] = tl_pwrmgr_i;
 
-  assign tl_rstmgr_o = tl_s1n_14_ds_h2d[6];
-  assign tl_s1n_14_ds_d2h[6] = tl_rstmgr_i;
+  assign tl_rstmgr_o = tl_s1n_13_ds_h2d[6];
+  assign tl_s1n_13_ds_d2h[6] = tl_rstmgr_i;
 
-  assign tl_clkmgr_o = tl_s1n_14_ds_h2d[7];
-  assign tl_s1n_14_ds_d2h[7] = tl_clkmgr_i;
+  assign tl_clkmgr_o = tl_s1n_13_ds_h2d[7];
+  assign tl_s1n_13_ds_d2h[7] = tl_clkmgr_i;
 
-  assign tl_ram_ret_o = tl_s1n_14_ds_h2d[8];
-  assign tl_s1n_14_ds_d2h[8] = tl_ram_ret_i;
+  assign tl_ram_ret_o = tl_s1n_13_ds_h2d[8];
+  assign tl_s1n_13_ds_d2h[8] = tl_ram_ret_i;
 
-  assign tl_otp_ctrl_o = tl_s1n_14_ds_h2d[9];
-  assign tl_s1n_14_ds_d2h[9] = tl_otp_ctrl_i;
+  assign tl_otp_ctrl_o = tl_s1n_13_ds_h2d[9];
+  assign tl_s1n_13_ds_d2h[9] = tl_otp_ctrl_i;
 
-  assign tl_sensor_ctrl_o = tl_s1n_14_ds_h2d[10];
-  assign tl_s1n_14_ds_d2h[10] = tl_sensor_ctrl_i;
+  assign tl_sensor_ctrl_o = tl_s1n_13_ds_h2d[10];
+  assign tl_s1n_13_ds_d2h[10] = tl_sensor_ctrl_i;
 
-  assign tl_ast_wrapper_o = tl_s1n_14_ds_h2d[11];
-  assign tl_s1n_14_ds_d2h[11] = tl_ast_wrapper_i;
+  assign tl_ast_wrapper_o = tl_s1n_13_ds_h2d[11];
+  assign tl_s1n_13_ds_d2h[11] = tl_ast_wrapper_i;
 
-  assign tl_pattgen_o = tl_s1n_14_ds_h2d[12];
-  assign tl_s1n_14_ds_d2h[12] = tl_pattgen_i;
-
-  assign tl_s1n_14_us_h2d = tl_main_i;
-  assign tl_main_o = tl_s1n_14_us_d2h;
+  assign tl_s1n_13_us_h2d = tl_main_i;
+  assign tl_main_o = tl_s1n_13_us_d2h;
 
   always_comb begin
     // default steering to generate error response if address is not within the range
-    dev_sel_s1n_14 = 4'd13;
-    if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_UART)) == ADDR_SPACE_UART) begin
-      dev_sel_s1n_14 = 4'd0;
+    dev_sel_s1n_13 = 4'd12;
+    if ((tl_s1n_13_us_h2d.a_address & ~(ADDR_MASK_UART)) == ADDR_SPACE_UART) begin
+      dev_sel_s1n_13 = 4'd0;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_GPIO)) == ADDR_SPACE_GPIO) begin
-      dev_sel_s1n_14 = 4'd1;
+    end else if ((tl_s1n_13_us_h2d.a_address & ~(ADDR_MASK_GPIO)) == ADDR_SPACE_GPIO) begin
+      dev_sel_s1n_13 = 4'd1;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_SPI_DEVICE)) == ADDR_SPACE_SPI_DEVICE) begin
-      dev_sel_s1n_14 = 4'd2;
+    end else if ((tl_s1n_13_us_h2d.a_address & ~(ADDR_MASK_SPI_DEVICE)) == ADDR_SPACE_SPI_DEVICE) begin
+      dev_sel_s1n_13 = 4'd2;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_RV_TIMER)) == ADDR_SPACE_RV_TIMER) begin
-      dev_sel_s1n_14 = 4'd3;
+    end else if ((tl_s1n_13_us_h2d.a_address & ~(ADDR_MASK_RV_TIMER)) == ADDR_SPACE_RV_TIMER) begin
+      dev_sel_s1n_13 = 4'd3;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_USBDEV)) == ADDR_SPACE_USBDEV) begin
-      dev_sel_s1n_14 = 4'd4;
+    end else if ((tl_s1n_13_us_h2d.a_address & ~(ADDR_MASK_USBDEV)) == ADDR_SPACE_USBDEV) begin
+      dev_sel_s1n_13 = 4'd4;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_PWRMGR)) == ADDR_SPACE_PWRMGR) begin
-      dev_sel_s1n_14 = 4'd5;
+    end else if ((tl_s1n_13_us_h2d.a_address & ~(ADDR_MASK_PWRMGR)) == ADDR_SPACE_PWRMGR) begin
+      dev_sel_s1n_13 = 4'd5;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_RSTMGR)) == ADDR_SPACE_RSTMGR) begin
-      dev_sel_s1n_14 = 4'd6;
+    end else if ((tl_s1n_13_us_h2d.a_address & ~(ADDR_MASK_RSTMGR)) == ADDR_SPACE_RSTMGR) begin
+      dev_sel_s1n_13 = 4'd6;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_CLKMGR)) == ADDR_SPACE_CLKMGR) begin
-      dev_sel_s1n_14 = 4'd7;
+    end else if ((tl_s1n_13_us_h2d.a_address & ~(ADDR_MASK_CLKMGR)) == ADDR_SPACE_CLKMGR) begin
+      dev_sel_s1n_13 = 4'd7;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_RAM_RET)) == ADDR_SPACE_RAM_RET) begin
-      dev_sel_s1n_14 = 4'd8;
+    end else if ((tl_s1n_13_us_h2d.a_address & ~(ADDR_MASK_RAM_RET)) == ADDR_SPACE_RAM_RET) begin
+      dev_sel_s1n_13 = 4'd8;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_OTP_CTRL)) == ADDR_SPACE_OTP_CTRL) begin
-      dev_sel_s1n_14 = 4'd9;
+    end else if ((tl_s1n_13_us_h2d.a_address & ~(ADDR_MASK_OTP_CTRL)) == ADDR_SPACE_OTP_CTRL) begin
+      dev_sel_s1n_13 = 4'd9;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_SENSOR_CTRL)) == ADDR_SPACE_SENSOR_CTRL) begin
-      dev_sel_s1n_14 = 4'd10;
+    end else if ((tl_s1n_13_us_h2d.a_address & ~(ADDR_MASK_SENSOR_CTRL)) == ADDR_SPACE_SENSOR_CTRL) begin
+      dev_sel_s1n_13 = 4'd10;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_AST_WRAPPER)) == ADDR_SPACE_AST_WRAPPER) begin
-      dev_sel_s1n_14 = 4'd11;
-
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_PATTGEN)) == ADDR_SPACE_PATTGEN) begin
-      dev_sel_s1n_14 = 4'd12;
+    end else if ((tl_s1n_13_us_h2d.a_address & ~(ADDR_MASK_AST_WRAPPER)) == ADDR_SPACE_AST_WRAPPER) begin
+      dev_sel_s1n_13 = 4'd11;
 end
   end
 
@@ -172,17 +163,17 @@ end
   tlul_socket_1n #(
     .HReqDepth (4'h0),
     .HRspDepth (4'h0),
-    .DReqDepth (52'h0),
-    .DRspDepth (52'h0),
-    .N         (13)
-  ) u_s1n_14 (
+    .DReqDepth (48'h0),
+    .DRspDepth (48'h0),
+    .N         (12)
+  ) u_s1n_13 (
     .clk_i        (clk_peri_i),
     .rst_ni       (rst_peri_ni),
-    .tl_h_i       (tl_s1n_14_us_h2d),
-    .tl_h_o       (tl_s1n_14_us_d2h),
-    .tl_d_o       (tl_s1n_14_ds_h2d),
-    .tl_d_i       (tl_s1n_14_ds_d2h),
-    .dev_select_i (dev_sel_s1n_14)
+    .tl_h_i       (tl_s1n_13_us_h2d),
+    .tl_h_o       (tl_s1n_13_us_d2h),
+    .tl_d_o       (tl_s1n_13_ds_h2d),
+    .tl_d_i       (tl_s1n_13_ds_d2h),
+    .dev_select_i (dev_sel_s1n_13)
   );
 
 endmodule

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -99,9 +99,9 @@ module top_earlgrey #(
   import top_earlgrey_rnd_cnst_pkg::*;
 
   // Signals
-  logic [33:0] mio_p2d;
-  logic [37:0] mio_d2p;
-  logic [37:0] mio_d2p_en;
+  logic [31:0] mio_p2d;
+  logic [35:0] mio_d2p;
+  logic [35:0] mio_d2p_en;
   logic [14:0] dio_p2d;
   logic [14:0] dio_d2p;
   logic [14:0] dio_d2p_en;
@@ -119,13 +119,6 @@ module top_earlgrey #(
   logic        cio_spi_device_sdi_p2d;
   logic        cio_spi_device_sdo_d2p;
   logic        cio_spi_device_sdo_en_d2p;
-  // i2c
-  logic        cio_i2c_sda_p2d;
-  logic        cio_i2c_scl_p2d;
-  logic        cio_i2c_sda_d2p;
-  logic        cio_i2c_sda_en_d2p;
-  logic        cio_i2c_scl_d2p;
-  logic        cio_i2c_scl_en_d2p;
   // pattgen
   logic        cio_pattgen_pda0_tx_d2p;
   logic        cio_pattgen_pda0_tx_en_d2p;
@@ -179,7 +172,7 @@ module top_earlgrey #(
   // otbn
 
 
-  logic [103:0]  intr_vector;
+  logic [88:0]  intr_vector;
   // Interrupt source list
   logic intr_uart_tx_watermark;
   logic intr_uart_rx_watermark;
@@ -196,21 +189,6 @@ module top_earlgrey #(
   logic intr_spi_device_rxerr;
   logic intr_spi_device_rxoverflow;
   logic intr_spi_device_txunderflow;
-  logic intr_i2c_fmt_watermark;
-  logic intr_i2c_rx_watermark;
-  logic intr_i2c_fmt_overflow;
-  logic intr_i2c_rx_overflow;
-  logic intr_i2c_nak;
-  logic intr_i2c_scl_interference;
-  logic intr_i2c_sda_interference;
-  logic intr_i2c_stretch_timeout;
-  logic intr_i2c_sda_unstable;
-  logic intr_i2c_trans_complete;
-  logic intr_i2c_tx_empty;
-  logic intr_i2c_tx_nonempty;
-  logic intr_i2c_tx_overflow;
-  logic intr_i2c_acq_overflow;
-  logic intr_i2c_ack_stop;
   logic intr_pattgen_done_ch0;
   logic intr_pattgen_done_ch1;
   logic intr_rv_timer_timer_expired_0_0;
@@ -356,8 +334,6 @@ module top_earlgrey #(
   tlul_pkg::tl_d2h_t       gpio_tl_rsp;
   tlul_pkg::tl_h2d_t       spi_device_tl_req;
   tlul_pkg::tl_d2h_t       spi_device_tl_rsp;
-  tlul_pkg::tl_h2d_t       i2c_tl_req;
-  tlul_pkg::tl_d2h_t       i2c_tl_rsp;
   tlul_pkg::tl_h2d_t       rv_timer_tl_req;
   tlul_pkg::tl_d2h_t       rv_timer_tl_rsp;
   tlul_pkg::tl_h2d_t       usbdev_tl_req;
@@ -788,42 +764,6 @@ module top_earlgrey #(
       .scanmode_i   (scanmode_i),
       .clk_i (clkmgr_clocks.clk_io_div4_peri),
       .rst_ni (rstmgr_resets.rst_spi_device_n[rstmgr_pkg::Domain0Sel])
-  );
-
-  i2c u_i2c (
-
-      // Input
-      .cio_sda_i    (cio_i2c_sda_p2d),
-      .cio_scl_i    (cio_i2c_scl_p2d),
-
-      // Output
-      .cio_sda_o    (cio_i2c_sda_d2p),
-      .cio_sda_en_o (cio_i2c_sda_en_d2p),
-      .cio_scl_o    (cio_i2c_scl_d2p),
-      .cio_scl_en_o (cio_i2c_scl_en_d2p),
-
-      // Interrupt
-      .intr_fmt_watermark_o    (intr_i2c_fmt_watermark),
-      .intr_rx_watermark_o     (intr_i2c_rx_watermark),
-      .intr_fmt_overflow_o     (intr_i2c_fmt_overflow),
-      .intr_rx_overflow_o      (intr_i2c_rx_overflow),
-      .intr_nak_o              (intr_i2c_nak),
-      .intr_scl_interference_o (intr_i2c_scl_interference),
-      .intr_sda_interference_o (intr_i2c_sda_interference),
-      .intr_stretch_timeout_o  (intr_i2c_stretch_timeout),
-      .intr_sda_unstable_o     (intr_i2c_sda_unstable),
-      .intr_trans_complete_o   (intr_i2c_trans_complete),
-      .intr_tx_empty_o         (intr_i2c_tx_empty),
-      .intr_tx_nonempty_o      (intr_i2c_tx_nonempty),
-      .intr_tx_overflow_o      (intr_i2c_tx_overflow),
-      .intr_acq_overflow_o     (intr_i2c_acq_overflow),
-      .intr_ack_stop_o         (intr_i2c_ack_stop),
-
-      // Inter-module signals
-      .tl_i(i2c_tl_req),
-      .tl_o(i2c_tl_rsp),
-      .clk_i (clkmgr_clocks.clk_io_div4_peri),
-      .rst_ni (rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel])
   );
 
   pattgen u_pattgen (
@@ -1410,21 +1350,6 @@ module top_earlgrey #(
 
   // interrupt assignments
   assign intr_vector = {
-      intr_i2c_ack_stop,
-      intr_i2c_acq_overflow,
-      intr_i2c_tx_overflow,
-      intr_i2c_tx_nonempty,
-      intr_i2c_tx_empty,
-      intr_i2c_trans_complete,
-      intr_i2c_sda_unstable,
-      intr_i2c_stretch_timeout,
-      intr_i2c_sda_interference,
-      intr_i2c_scl_interference,
-      intr_i2c_nak,
-      intr_i2c_rx_overflow,
-      intr_i2c_fmt_overflow,
-      intr_i2c_rx_watermark,
-      intr_i2c_fmt_watermark,
       intr_pattgen_done_ch1,
       intr_pattgen_done_ch0,
       intr_kmac_kmac_err,
@@ -1607,10 +1532,6 @@ module top_earlgrey #(
     .tl_spi_device_o(spi_device_tl_req),
     .tl_spi_device_i(spi_device_tl_rsp),
 
-    // port: tl_i2c
-    .tl_i2c_o(i2c_tl_req),
-    .tl_i2c_i(i2c_tl_rsp),
-
     // port: tl_rv_timer
     .tl_rv_timer_o(rv_timer_tl_req),
     .tl_rv_timer_i(rv_timer_tl_rsp),
@@ -1658,8 +1579,6 @@ module top_earlgrey #(
   // Pinmux connections
   assign mio_d2p = {
     cio_gpio_gpio_d2p,
-    cio_i2c_sda_d2p,
-    cio_i2c_scl_d2p,
     cio_pattgen_pda0_tx_d2p,
     cio_pattgen_pcl0_tx_d2p,
     cio_pattgen_pda1_tx_d2p,
@@ -1667,17 +1586,13 @@ module top_earlgrey #(
   };
   assign mio_d2p_en = {
     cio_gpio_gpio_en_d2p,
-    cio_i2c_sda_en_d2p,
-    cio_i2c_scl_en_d2p,
     cio_pattgen_pda0_tx_en_d2p,
     cio_pattgen_pcl0_tx_en_d2p,
     cio_pattgen_pda1_tx_en_d2p,
     cio_pattgen_pcl1_tx_en_d2p
   };
   assign {
-    cio_gpio_gpio_p2d,
-    cio_i2c_sda_p2d,
-    cio_i2c_scl_p2d
+    cio_gpio_gpio_p2d
   } = mio_p2d;
 
   // Dedicated IO connections

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -100,8 +100,8 @@ module top_earlgrey #(
 
   // Signals
   logic [31:0] mio_p2d;
-  logic [35:0] mio_d2p;
-  logic [35:0] mio_d2p_en;
+  logic [31:0] mio_d2p;
+  logic [31:0] mio_d2p_en;
   logic [14:0] dio_p2d;
   logic [14:0] dio_d2p;
   logic [14:0] dio_d2p_en;
@@ -119,15 +119,6 @@ module top_earlgrey #(
   logic        cio_spi_device_sdi_p2d;
   logic        cio_spi_device_sdo_d2p;
   logic        cio_spi_device_sdo_en_d2p;
-  // pattgen
-  logic        cio_pattgen_pda0_tx_d2p;
-  logic        cio_pattgen_pda0_tx_en_d2p;
-  logic        cio_pattgen_pcl0_tx_d2p;
-  logic        cio_pattgen_pcl0_tx_en_d2p;
-  logic        cio_pattgen_pda1_tx_d2p;
-  logic        cio_pattgen_pda1_tx_en_d2p;
-  logic        cio_pattgen_pcl1_tx_d2p;
-  logic        cio_pattgen_pcl1_tx_en_d2p;
   // rv_timer
   // sensor_ctrl
   // otp_ctrl
@@ -172,7 +163,7 @@ module top_earlgrey #(
   // otbn
 
 
-  logic [88:0]  intr_vector;
+  logic [86:0]  intr_vector;
   // Interrupt source list
   logic intr_uart_tx_watermark;
   logic intr_uart_rx_watermark;
@@ -189,8 +180,6 @@ module top_earlgrey #(
   logic intr_spi_device_rxerr;
   logic intr_spi_device_rxoverflow;
   logic intr_spi_device_txunderflow;
-  logic intr_pattgen_done_ch0;
-  logic intr_pattgen_done_ch1;
   logic intr_rv_timer_timer_expired_0_0;
   logic intr_otp_ctrl_otp_operation_done;
   logic intr_otp_ctrl_otp_error;
@@ -350,8 +339,6 @@ module top_earlgrey #(
   tlul_pkg::tl_d2h_t       otp_ctrl_tl_rsp;
   tlul_pkg::tl_h2d_t       sensor_ctrl_tl_req;
   tlul_pkg::tl_d2h_t       sensor_ctrl_tl_rsp;
-  tlul_pkg::tl_h2d_t       pattgen_tl_req;
-  tlul_pkg::tl_d2h_t       pattgen_tl_rsp;
   rstmgr_pkg::rstmgr_out_t       rstmgr_resets;
   rstmgr_pkg::rstmgr_cpu_t       rstmgr_cpu;
   pwrmgr_pkg::pwr_cpu_t       pwrmgr_pwr_cpu;
@@ -764,29 +751,6 @@ module top_earlgrey #(
       .scanmode_i   (scanmode_i),
       .clk_i (clkmgr_clocks.clk_io_div4_peri),
       .rst_ni (rstmgr_resets.rst_spi_device_n[rstmgr_pkg::Domain0Sel])
-  );
-
-  pattgen u_pattgen (
-
-      // Output
-      .cio_pda0_tx_o    (cio_pattgen_pda0_tx_d2p),
-      .cio_pda0_tx_en_o (cio_pattgen_pda0_tx_en_d2p),
-      .cio_pcl0_tx_o    (cio_pattgen_pcl0_tx_d2p),
-      .cio_pcl0_tx_en_o (cio_pattgen_pcl0_tx_en_d2p),
-      .cio_pda1_tx_o    (cio_pattgen_pda1_tx_d2p),
-      .cio_pda1_tx_en_o (cio_pattgen_pda1_tx_en_d2p),
-      .cio_pcl1_tx_o    (cio_pattgen_pcl1_tx_d2p),
-      .cio_pcl1_tx_en_o (cio_pattgen_pcl1_tx_en_d2p),
-
-      // Interrupt
-      .intr_done_ch0_o (intr_pattgen_done_ch0),
-      .intr_done_ch1_o (intr_pattgen_done_ch1),
-
-      // Inter-module signals
-      .tl_i(pattgen_tl_req),
-      .tl_o(pattgen_tl_rsp),
-      .clk_i (clkmgr_clocks.clk_io_div4_peri),
-      .rst_ni (rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel])
   );
 
   rv_timer u_rv_timer (
@@ -1350,8 +1314,6 @@ module top_earlgrey #(
 
   // interrupt assignments
   assign intr_vector = {
-      intr_pattgen_done_ch1,
-      intr_pattgen_done_ch0,
       intr_kmac_kmac_err,
       intr_kmac_fifo_empty,
       intr_kmac_kmac_done,
@@ -1568,28 +1530,16 @@ module top_earlgrey #(
     .tl_ast_wrapper_o(ast_tl_req_o),
     .tl_ast_wrapper_i(ast_tl_rsp_i),
 
-    // port: tl_pattgen
-    .tl_pattgen_o(pattgen_tl_req),
-    .tl_pattgen_i(pattgen_tl_rsp),
-
 
     .scanmode_i
   );
 
   // Pinmux connections
   assign mio_d2p = {
-    cio_gpio_gpio_d2p,
-    cio_pattgen_pda0_tx_d2p,
-    cio_pattgen_pcl0_tx_d2p,
-    cio_pattgen_pda1_tx_d2p,
-    cio_pattgen_pcl1_tx_d2p
+    cio_gpio_gpio_d2p
   };
   assign mio_d2p_en = {
-    cio_gpio_gpio_en_d2p,
-    cio_pattgen_pda0_tx_en_d2p,
-    cio_pattgen_pcl0_tx_en_d2p,
-    cio_pattgen_pda1_tx_en_d2p,
-    cio_pattgen_pcl1_tx_en_d2p
+    cio_gpio_gpio_en_d2p
   };
   assign {
     cio_gpio_gpio_p2d

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
@@ -42,16 +42,6 @@ package top_earlgrey_pkg;
   parameter int unsigned TOP_EARLGREY_SPI_DEVICE_SIZE_BYTES = 32'h1000;
 
   /**
-   * Peripheral base address for i2c in top earlgrey.
-   */
-  parameter int unsigned TOP_EARLGREY_I2C_BASE_ADDR = 32'h40080000;
-
-  /**
-   * Peripheral size in bytes for i2c in top earlgrey.
-   */
-  parameter int unsigned TOP_EARLGREY_I2C_SIZE_BYTES = 32'h1000;
-
-  /**
    * Peripheral base address for pattgen in top earlgrey.
    */
   parameter int unsigned TOP_EARLGREY_PATTGEN_BASE_ADDR = 32'h400e0000;

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
@@ -42,16 +42,6 @@ package top_earlgrey_pkg;
   parameter int unsigned TOP_EARLGREY_SPI_DEVICE_SIZE_BYTES = 32'h1000;
 
   /**
-   * Peripheral base address for pattgen in top earlgrey.
-   */
-  parameter int unsigned TOP_EARLGREY_PATTGEN_BASE_ADDR = 32'h400e0000;
-
-  /**
-   * Peripheral size in bytes for pattgen in top earlgrey.
-   */
-  parameter int unsigned TOP_EARLGREY_PATTGEN_SIZE_BYTES = 32'h1000;
-
-  /**
    * Peripheral base address for rv_timer in top earlgrey.
    */
   parameter int unsigned TOP_EARLGREY_RV_TIMER_BASE_ADDR = 32'h40100000;

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.c
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.c
@@ -11,7 +11,7 @@
  * `top_earlgrey_plic_peripheral_t`.
  */
 const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[104] = {
+    top_earlgrey_plic_interrupt_for_peripheral[89] = {
   [kTopEarlgreyPlicIrqIdNone] = kTopEarlgreyPlicPeripheralUnknown,
   [kTopEarlgreyPlicIrqIdGpioGpio0] = kTopEarlgreyPlicPeripheralGpio,
   [kTopEarlgreyPlicIrqIdGpioGpio1] = kTopEarlgreyPlicPeripheralGpio,
@@ -101,21 +101,6 @@ const top_earlgrey_plic_peripheral_t
   [kTopEarlgreyPlicIrqIdKmacKmacErr] = kTopEarlgreyPlicPeripheralKmac,
   [kTopEarlgreyPlicIrqIdPattgenDoneCh0] = kTopEarlgreyPlicPeripheralPattgen,
   [kTopEarlgreyPlicIrqIdPattgenDoneCh1] = kTopEarlgreyPlicPeripheralPattgen,
-  [kTopEarlgreyPlicIrqIdI2cFmtWatermark] = kTopEarlgreyPlicPeripheralI2c,
-  [kTopEarlgreyPlicIrqIdI2cRxWatermark] = kTopEarlgreyPlicPeripheralI2c,
-  [kTopEarlgreyPlicIrqIdI2cFmtOverflow] = kTopEarlgreyPlicPeripheralI2c,
-  [kTopEarlgreyPlicIrqIdI2cRxOverflow] = kTopEarlgreyPlicPeripheralI2c,
-  [kTopEarlgreyPlicIrqIdI2cNak] = kTopEarlgreyPlicPeripheralI2c,
-  [kTopEarlgreyPlicIrqIdI2cSclInterference] = kTopEarlgreyPlicPeripheralI2c,
-  [kTopEarlgreyPlicIrqIdI2cSdaInterference] = kTopEarlgreyPlicPeripheralI2c,
-  [kTopEarlgreyPlicIrqIdI2cStretchTimeout] = kTopEarlgreyPlicPeripheralI2c,
-  [kTopEarlgreyPlicIrqIdI2cSdaUnstable] = kTopEarlgreyPlicPeripheralI2c,
-  [kTopEarlgreyPlicIrqIdI2cTransComplete] = kTopEarlgreyPlicPeripheralI2c,
-  [kTopEarlgreyPlicIrqIdI2cTxEmpty] = kTopEarlgreyPlicPeripheralI2c,
-  [kTopEarlgreyPlicIrqIdI2cTxNonempty] = kTopEarlgreyPlicPeripheralI2c,
-  [kTopEarlgreyPlicIrqIdI2cTxOverflow] = kTopEarlgreyPlicPeripheralI2c,
-  [kTopEarlgreyPlicIrqIdI2cAcqOverflow] = kTopEarlgreyPlicPeripheralI2c,
-  [kTopEarlgreyPlicIrqIdI2cAckStop] = kTopEarlgreyPlicPeripheralI2c,
 };
 
 

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.c
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.c
@@ -11,7 +11,7 @@
  * `top_earlgrey_plic_peripheral_t`.
  */
 const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[89] = {
+    top_earlgrey_plic_interrupt_for_peripheral[87] = {
   [kTopEarlgreyPlicIrqIdNone] = kTopEarlgreyPlicPeripheralUnknown,
   [kTopEarlgreyPlicIrqIdGpioGpio0] = kTopEarlgreyPlicPeripheralGpio,
   [kTopEarlgreyPlicIrqIdGpioGpio1] = kTopEarlgreyPlicPeripheralGpio,
@@ -99,8 +99,6 @@ const top_earlgrey_plic_peripheral_t
   [kTopEarlgreyPlicIrqIdKmacKmacDone] = kTopEarlgreyPlicPeripheralKmac,
   [kTopEarlgreyPlicIrqIdKmacFifoEmpty] = kTopEarlgreyPlicPeripheralKmac,
   [kTopEarlgreyPlicIrqIdKmacKmacErr] = kTopEarlgreyPlicPeripheralKmac,
-  [kTopEarlgreyPlicIrqIdPattgenDoneCh0] = kTopEarlgreyPlicPeripheralPattgen,
-  [kTopEarlgreyPlicIrqIdPattgenDoneCh1] = kTopEarlgreyPlicPeripheralPattgen,
 };
 
 

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -80,24 +80,6 @@ extern "C" {
 #define TOP_EARLGREY_SPI_DEVICE_SIZE_BYTES 0x1000u
 
 /**
- * Peripheral base address for i2c in top earlgrey.
- *
- * This should be used with #mmio_region_from_addr to access the memory-mapped
- * registers associated with the peripheral (usually via a DIF).
- */
-#define TOP_EARLGREY_I2C_BASE_ADDR 0x40080000u
-
-/**
- * Peripheral size for i2c in top earlgrey.
- *
- * This is the size (in bytes) of the peripheral's reserved memory area. All
- * memory-mapped registers associated with this peripheral should have an
- * address between #TOP_EARLGREY_I2C_BASE_ADDR and
- * `TOP_EARLGREY_I2C_BASE_ADDR + TOP_EARLGREY_I2C_SIZE_BYTES`.
- */
-#define TOP_EARLGREY_I2C_SIZE_BYTES 0x1000u
-
-/**
  * Peripheral base address for pattgen in top earlgrey.
  *
  * This should be used with #mmio_region_from_addr to access the memory-mapped
@@ -574,8 +556,7 @@ typedef enum top_earlgrey_plic_peripheral {
   kTopEarlgreyPlicPeripheralKeymgr = 11, /**< keymgr */
   kTopEarlgreyPlicPeripheralKmac = 12, /**< kmac */
   kTopEarlgreyPlicPeripheralPattgen = 13, /**< pattgen */
-  kTopEarlgreyPlicPeripheralI2c = 14, /**< i2c */
-  kTopEarlgreyPlicPeripheralLast = 14, /**< \internal Final PLIC peripheral */
+  kTopEarlgreyPlicPeripheralLast = 13, /**< \internal Final PLIC peripheral */
 } top_earlgrey_plic_peripheral_t;
 
 /**
@@ -674,22 +655,7 @@ typedef enum top_earlgrey_plic_irq_id {
   kTopEarlgreyPlicIrqIdKmacKmacErr = 86, /**< kmac_kmac_err */
   kTopEarlgreyPlicIrqIdPattgenDoneCh0 = 87, /**< pattgen_done_ch0 */
   kTopEarlgreyPlicIrqIdPattgenDoneCh1 = 88, /**< pattgen_done_ch1 */
-  kTopEarlgreyPlicIrqIdI2cFmtWatermark = 89, /**< i2c_fmt_watermark */
-  kTopEarlgreyPlicIrqIdI2cRxWatermark = 90, /**< i2c_rx_watermark */
-  kTopEarlgreyPlicIrqIdI2cFmtOverflow = 91, /**< i2c_fmt_overflow */
-  kTopEarlgreyPlicIrqIdI2cRxOverflow = 92, /**< i2c_rx_overflow */
-  kTopEarlgreyPlicIrqIdI2cNak = 93, /**< i2c_nak */
-  kTopEarlgreyPlicIrqIdI2cSclInterference = 94, /**< i2c_scl_interference */
-  kTopEarlgreyPlicIrqIdI2cSdaInterference = 95, /**< i2c_sda_interference */
-  kTopEarlgreyPlicIrqIdI2cStretchTimeout = 96, /**< i2c_stretch_timeout */
-  kTopEarlgreyPlicIrqIdI2cSdaUnstable = 97, /**< i2c_sda_unstable */
-  kTopEarlgreyPlicIrqIdI2cTransComplete = 98, /**< i2c_trans_complete */
-  kTopEarlgreyPlicIrqIdI2cTxEmpty = 99, /**< i2c_tx_empty */
-  kTopEarlgreyPlicIrqIdI2cTxNonempty = 100, /**< i2c_tx_nonempty */
-  kTopEarlgreyPlicIrqIdI2cTxOverflow = 101, /**< i2c_tx_overflow */
-  kTopEarlgreyPlicIrqIdI2cAcqOverflow = 102, /**< i2c_acq_overflow */
-  kTopEarlgreyPlicIrqIdI2cAckStop = 103, /**< i2c_ack_stop */
-  kTopEarlgreyPlicIrqIdLast = 103, /**< \internal The Last Valid Interrupt ID. */
+  kTopEarlgreyPlicIrqIdLast = 88, /**< \internal The Last Valid Interrupt ID. */
 } top_earlgrey_plic_irq_id_t;
 
 /**
@@ -699,7 +665,7 @@ typedef enum top_earlgrey_plic_irq_id {
  * `top_earlgrey_plic_peripheral_t`.
  */
 extern const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[104];
+    top_earlgrey_plic_interrupt_for_peripheral[89];
 
 /**
  * PLIC Interrupt Target.
@@ -809,9 +775,7 @@ typedef enum top_earlgrey_pinmux_peripheral_in {
   kTopEarlgreyPinmuxPeripheralInGpioGpio29 = 29, /**< gpio_gpio 29 */
   kTopEarlgreyPinmuxPeripheralInGpioGpio30 = 30, /**< gpio_gpio 30 */
   kTopEarlgreyPinmuxPeripheralInGpioGpio31 = 31, /**< gpio_gpio 31 */
-  kTopEarlgreyPinmuxPeripheralInI2cSda = 32, /**< i2c_sda */
-  kTopEarlgreyPinmuxPeripheralInI2cScl = 33, /**< i2c_scl */
-  kTopEarlgreyPinmuxPeripheralInLast = 33, /**< \internal Last valid peripheral input */
+  kTopEarlgreyPinmuxPeripheralInLast = 31, /**< \internal Last valid peripheral input */
 } top_earlgrey_pinmux_peripheral_in_t;
 
 /**
@@ -933,13 +897,11 @@ typedef enum top_earlgrey_pinmux_outsel {
   kTopEarlgreyPinmuxOutselGpioGpio29 = 32, /**< gpio_gpio 29 */
   kTopEarlgreyPinmuxOutselGpioGpio30 = 33, /**< gpio_gpio 30 */
   kTopEarlgreyPinmuxOutselGpioGpio31 = 34, /**< gpio_gpio 31 */
-  kTopEarlgreyPinmuxOutselI2cSda = 35, /**< i2c_sda */
-  kTopEarlgreyPinmuxOutselI2cScl = 36, /**< i2c_scl */
-  kTopEarlgreyPinmuxOutselPattgenPda0Tx = 37, /**< pattgen_pda0_tx */
-  kTopEarlgreyPinmuxOutselPattgenPcl0Tx = 38, /**< pattgen_pcl0_tx */
-  kTopEarlgreyPinmuxOutselPattgenPda1Tx = 39, /**< pattgen_pda1_tx */
-  kTopEarlgreyPinmuxOutselPattgenPcl1Tx = 40, /**< pattgen_pcl1_tx */
-  kTopEarlgreyPinmuxOutselLast = 40, /**< \internal Last valid outsel value */
+  kTopEarlgreyPinmuxOutselPattgenPda0Tx = 35, /**< pattgen_pda0_tx */
+  kTopEarlgreyPinmuxOutselPattgenPcl0Tx = 36, /**< pattgen_pcl0_tx */
+  kTopEarlgreyPinmuxOutselPattgenPda1Tx = 37, /**< pattgen_pda1_tx */
+  kTopEarlgreyPinmuxOutselPattgenPcl1Tx = 38, /**< pattgen_pcl1_tx */
+  kTopEarlgreyPinmuxOutselLast = 38, /**< \internal Last valid outsel value */
 } top_earlgrey_pinmux_outsel_t;
 
 /**

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -80,24 +80,6 @@ extern "C" {
 #define TOP_EARLGREY_SPI_DEVICE_SIZE_BYTES 0x1000u
 
 /**
- * Peripheral base address for pattgen in top earlgrey.
- *
- * This should be used with #mmio_region_from_addr to access the memory-mapped
- * registers associated with the peripheral (usually via a DIF).
- */
-#define TOP_EARLGREY_PATTGEN_BASE_ADDR 0x400e0000u
-
-/**
- * Peripheral size for pattgen in top earlgrey.
- *
- * This is the size (in bytes) of the peripheral's reserved memory area. All
- * memory-mapped registers associated with this peripheral should have an
- * address between #TOP_EARLGREY_PATTGEN_BASE_ADDR and
- * `TOP_EARLGREY_PATTGEN_BASE_ADDR + TOP_EARLGREY_PATTGEN_SIZE_BYTES`.
- */
-#define TOP_EARLGREY_PATTGEN_SIZE_BYTES 0x1000u
-
-/**
  * Peripheral base address for rv_timer in top earlgrey.
  *
  * This should be used with #mmio_region_from_addr to access the memory-mapped
@@ -555,8 +537,7 @@ typedef enum top_earlgrey_plic_peripheral {
   kTopEarlgreyPlicPeripheralOtbn = 10, /**< otbn */
   kTopEarlgreyPlicPeripheralKeymgr = 11, /**< keymgr */
   kTopEarlgreyPlicPeripheralKmac = 12, /**< kmac */
-  kTopEarlgreyPlicPeripheralPattgen = 13, /**< pattgen */
-  kTopEarlgreyPlicPeripheralLast = 13, /**< \internal Final PLIC peripheral */
+  kTopEarlgreyPlicPeripheralLast = 12, /**< \internal Final PLIC peripheral */
 } top_earlgrey_plic_peripheral_t;
 
 /**
@@ -653,9 +634,7 @@ typedef enum top_earlgrey_plic_irq_id {
   kTopEarlgreyPlicIrqIdKmacKmacDone = 84, /**< kmac_kmac_done */
   kTopEarlgreyPlicIrqIdKmacFifoEmpty = 85, /**< kmac_fifo_empty */
   kTopEarlgreyPlicIrqIdKmacKmacErr = 86, /**< kmac_kmac_err */
-  kTopEarlgreyPlicIrqIdPattgenDoneCh0 = 87, /**< pattgen_done_ch0 */
-  kTopEarlgreyPlicIrqIdPattgenDoneCh1 = 88, /**< pattgen_done_ch1 */
-  kTopEarlgreyPlicIrqIdLast = 88, /**< \internal The Last Valid Interrupt ID. */
+  kTopEarlgreyPlicIrqIdLast = 86, /**< \internal The Last Valid Interrupt ID. */
 } top_earlgrey_plic_irq_id_t;
 
 /**
@@ -665,7 +644,7 @@ typedef enum top_earlgrey_plic_irq_id {
  * `top_earlgrey_plic_peripheral_t`.
  */
 extern const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[89];
+    top_earlgrey_plic_interrupt_for_peripheral[87];
 
 /**
  * PLIC Interrupt Target.
@@ -897,11 +876,7 @@ typedef enum top_earlgrey_pinmux_outsel {
   kTopEarlgreyPinmuxOutselGpioGpio29 = 32, /**< gpio_gpio 29 */
   kTopEarlgreyPinmuxOutselGpioGpio30 = 33, /**< gpio_gpio 30 */
   kTopEarlgreyPinmuxOutselGpioGpio31 = 34, /**< gpio_gpio 31 */
-  kTopEarlgreyPinmuxOutselPattgenPda0Tx = 35, /**< pattgen_pda0_tx */
-  kTopEarlgreyPinmuxOutselPattgenPcl0Tx = 36, /**< pattgen_pcl0_tx */
-  kTopEarlgreyPinmuxOutselPattgenPda1Tx = 37, /**< pattgen_pda1_tx */
-  kTopEarlgreyPinmuxOutselPattgenPcl1Tx = 38, /**< pattgen_pcl1_tx */
-  kTopEarlgreyPinmuxOutselLast = 38, /**< \internal Last valid outsel value */
+  kTopEarlgreyPinmuxOutselLast = 34, /**< \internal Last valid outsel value */
 } top_earlgrey_pinmux_outsel_t;
 
 /**

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -42,7 +42,6 @@ filesets:
       - lowrisc:ip:rstmgr
       - lowrisc:ip:pwrmgr
       - lowrisc:ip:pattgen
-      - lowrisc:ip:i2c
       - lowrisc:systems:sensor_ctrl
       - lowrisc:systems:ast_wrapper_pkg
       - lowrisc:tlul:headers

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -41,7 +41,6 @@ filesets:
       - lowrisc:top_earlgrey:xbar_peri
       - lowrisc:ip:rstmgr
       - lowrisc:ip:pwrmgr
-      - lowrisc:ip:pattgen
       - lowrisc:systems:sensor_ctrl
       - lowrisc:systems:ast_wrapper_pkg
       - lowrisc:tlul:headers

--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -16,7 +16,7 @@
 // If either of these static assertions fail, then the assumptions in this DIF
 // implementation should be revisited. In particular, `kPlicTargets`
 // may need updating,
-_Static_assert(RV_PLIC_PARAM_NUMSRC == 104,
+_Static_assert(RV_PLIC_PARAM_NUMSRC == 89,
                "PLIC instantiation parameters have changed.");
 _Static_assert(RV_PLIC_PARAM_NUMTARGET == 1,
                "PLIC instantiation parameters have changed.");

--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -16,7 +16,7 @@
 // If either of these static assertions fail, then the assumptions in this DIF
 // implementation should be revisited. In particular, `kPlicTargets`
 // may need updating,
-_Static_assert(RV_PLIC_PARAM_NUMSRC == 89,
+_Static_assert(RV_PLIC_PARAM_NUMSRC == 87,
                "PLIC instantiation parameters have changed.");
 _Static_assert(RV_PLIC_PARAM_NUMTARGET == 1,
                "PLIC instantiation parameters have changed.");

--- a/sw/device/tests/dif/dif_plic_unittest.cc
+++ b/sw/device/tests/dif/dif_plic_unittest.cc
@@ -35,13 +35,11 @@ class InitTest : public PlicTest {
     EXPECT_WRITE32(RV_PLIC_IE0_0_REG_OFFSET, 0);
     EXPECT_WRITE32(RV_PLIC_IE0_1_REG_OFFSET, 0);
     EXPECT_WRITE32(RV_PLIC_IE0_2_REG_OFFSET, 0);
-    EXPECT_WRITE32(RV_PLIC_IE0_3_REG_OFFSET, 0);
 
     // Level/edge multireg.
     EXPECT_WRITE32(RV_PLIC_LE_0_REG_OFFSET, 0);
     EXPECT_WRITE32(RV_PLIC_LE_1_REG_OFFSET, 0);
     EXPECT_WRITE32(RV_PLIC_LE_2_REG_OFFSET, 0);
-    EXPECT_WRITE32(RV_PLIC_LE_3_REG_OFFSET, 0);
 
     // Priority registers.
     for (int i = 0; i < RV_PLIC_PARAM_NUMSRC; ++i) {
@@ -98,22 +96,19 @@ class IrqTest : public PlicTest {
       kEnableRegisters{{
           {RV_PLIC_IE0_0_REG_OFFSET, RV_PLIC_IE0_0_E_31_BIT},
           {RV_PLIC_IE0_1_REG_OFFSET, RV_PLIC_IE0_1_E_63_BIT},
-          {RV_PLIC_IE0_2_REG_OFFSET, RV_PLIC_IE0_2_E_95_BIT},
-          {RV_PLIC_IE0_3_REG_OFFSET, RV_PLIC_IE0_3_E_103_BIT},
+          {RV_PLIC_IE0_2_REG_OFFSET, RV_PLIC_IE0_2_E_88_BIT},
       }};
   static constexpr std::array<Register, RV_PLIC_LE_MULTIREG_COUNT>
       kTriggerRegisters{{
           {RV_PLIC_LE_0_REG_OFFSET, RV_PLIC_LE_0_LE_31_BIT},
           {RV_PLIC_LE_1_REG_OFFSET, RV_PLIC_LE_1_LE_63_BIT},
-          {RV_PLIC_LE_2_REG_OFFSET, RV_PLIC_LE_2_LE_95_BIT},
-          {RV_PLIC_LE_3_REG_OFFSET, RV_PLIC_LE_3_LE_103_BIT},
+          {RV_PLIC_LE_2_REG_OFFSET, RV_PLIC_LE_2_LE_88_BIT},
       }};
   static constexpr std::array<Register, RV_PLIC_IP_MULTIREG_COUNT>
       kPendingRegisters{{
           {RV_PLIC_IP_0_REG_OFFSET, RV_PLIC_IP_0_P_31_BIT},
           {RV_PLIC_IP_1_REG_OFFSET, RV_PLIC_IP_1_P_63_BIT},
-          {RV_PLIC_IP_2_REG_OFFSET, RV_PLIC_IP_2_P_95_BIT},
-          {RV_PLIC_IP_3_REG_OFFSET, RV_PLIC_IP_3_P_103_BIT},
+          {RV_PLIC_IP_2_REG_OFFSET, RV_PLIC_IP_2_P_88_BIT},
       }};
 
   // Set enable/disable multireg expectations, one bit per call.
@@ -142,12 +137,9 @@ class IrqTest : public PlicTest {
   }
 };
 
-constexpr std::array<IrqTest::Register, RV_PLIC_IE0_MULTIREG_COUNT>
-    IrqTest::kEnableRegisters;
-constexpr std::array<IrqTest::Register, RV_PLIC_LE_MULTIREG_COUNT>
-    IrqTest::kTriggerRegisters;
-constexpr std::array<IrqTest::Register, RV_PLIC_IP_MULTIREG_COUNT>
-    IrqTest::kPendingRegisters;
+constexpr std::array<IrqTest::Register, 3> IrqTest::kEnableRegisters;
+constexpr std::array<IrqTest::Register, 3> IrqTest::kTriggerRegisters;
+constexpr std::array<IrqTest::Register, 3> IrqTest::kPendingRegisters;
 
 class IrqEnableSetTest : public IrqTest {};
 

--- a/sw/device/tests/dif/dif_plic_unittest.cc
+++ b/sw/device/tests/dif/dif_plic_unittest.cc
@@ -96,19 +96,19 @@ class IrqTest : public PlicTest {
       kEnableRegisters{{
           {RV_PLIC_IE0_0_REG_OFFSET, RV_PLIC_IE0_0_E_31_BIT},
           {RV_PLIC_IE0_1_REG_OFFSET, RV_PLIC_IE0_1_E_63_BIT},
-          {RV_PLIC_IE0_2_REG_OFFSET, RV_PLIC_IE0_2_E_88_BIT},
+          {RV_PLIC_IE0_2_REG_OFFSET, RV_PLIC_IE0_2_E_86_BIT},
       }};
   static constexpr std::array<Register, RV_PLIC_LE_MULTIREG_COUNT>
       kTriggerRegisters{{
           {RV_PLIC_LE_0_REG_OFFSET, RV_PLIC_LE_0_LE_31_BIT},
           {RV_PLIC_LE_1_REG_OFFSET, RV_PLIC_LE_1_LE_63_BIT},
-          {RV_PLIC_LE_2_REG_OFFSET, RV_PLIC_LE_2_LE_88_BIT},
+          {RV_PLIC_LE_2_REG_OFFSET, RV_PLIC_LE_2_LE_86_BIT},
       }};
   static constexpr std::array<Register, RV_PLIC_IP_MULTIREG_COUNT>
       kPendingRegisters{{
           {RV_PLIC_IP_0_REG_OFFSET, RV_PLIC_IP_0_P_31_BIT},
           {RV_PLIC_IP_1_REG_OFFSET, RV_PLIC_IP_1_P_63_BIT},
-          {RV_PLIC_IP_2_REG_OFFSET, RV_PLIC_IP_2_P_88_BIT},
+          {RV_PLIC_IP_2_REG_OFFSET, RV_PLIC_IP_2_P_86_BIT},
       }};
 
   // Set enable/disable multireg expectations, one bit per call.


### PR DESCRIPTION
Revert PR #4155 for breaking at least the GPIO smoke test on FPGAs (dif_gpio_smoketest): the test never returns PASS. (PR test results: https://dev.azure.com/lowrisc/opentitan/_build/results?buildId=29086&view=ms.vss-test-web.build-test-results-tab&runId=7536&resultId=100013&paneView=debug).


Additionally, on master, spiflash is now broken. Test results:
* https://dev.azure.com/lowrisc/opentitan/_build/results?buildId=29102&view=ms.vss-test-web.build-test-results-tab
* https://dev.azure.com/lowrisc/opentitan/_build/results?buildId=29102&view=logs&j=ada8d0d5-374c-54af-e066-9fea9971ff58&t=9288f196-a6ed-526c-1bd6-d39e19de2ebc

CI did catch this issue, but doesn't return an error at the moment for FPGA CI, as we did want to ensure that the infrastructure is stable enough first. That is clearly the case now and I'll follow up with a PR to convert the current CI warning into an error, which makes it easier to see. (now at #4557) 

@martin-lueker: To land this change again, please open a new PR from the original branch and include a fix for the failing test. Reach out to the SW team if you need help with that. Also, please ensure that each commit is resulting in a buildable opentitan repository; in this case, include the "autogen" changes in the commit that changes related things. You can do so just before merging to make reviewing easier.

I didn't fully debug this, but it looks like the PR CI (running against an older master version) did only have the gpio smoke test problem, and then merging into master we potentially collided with another change with then caused all of spiflash to break (probably a pinout issue?).