### PR TITLE
[ci] Fail CI on broken FPGA runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -550,9 +550,6 @@ jobs:
         --log-cli-level=DEBUG \
         --test-run-title="Run system tests on Nexys Video FPGA board" \
         --napoleon-docstrings
-    # FPGA CI is using new infrastructure. Do not fail CI until we have more
-    # experience with it.
-    continueOnError: true
     displayName: Execute tests
 
 - job: deploy_release_artifacts


### PR DESCRIPTION
When we introduced the CI runs on FPGAs we downgraded failures to
warnings to ensure that infrastructure problems wouldn't disrupt the
development workflow. The infrastructure has shown to be stable now and
is actually catching real bugs, so we can make the warning an error
again to raise visibility.