### PR TITLE
[dvsim] Fix revision hyperlink

### DIFF
--- a/hw/data/common_project_cfg.hjson
+++ b/hw/data/common_project_cfg.hjson
@@ -31,7 +31,7 @@
   revision: '''{eval_cmd}
             COMMIT_L=`git rev-parse HEAD`; \
             COMMIT_S=`git rev-parse --short HEAD`; \
-            echo "Revision: [\`$COMMIT_S\`]({repo_server}/tree/$COMMIT_L)";
+            echo "Revision: [\`$COMMIT_S\`]({results_server_url_prefix}{repo_server}/tree/$COMMIT_L)";
             '''
 
   // The current design level


### PR DESCRIPTION
add `https://` otherwise, when we click in the website, it becomes
https://reports.opentitan.org/hw/ip/spi_device/dv/2020.12.10_13.42.20/github.com/lowrisc/opentitan/tree/22d577b88cea101d6d20794542c2db06c5d5f2bf

can try it [here](https://reports.opentitan.org/hw/ip/spi_device/dv/2020.12.10_13.42.20/results.html)
Signed-off-by: Weicai Yang <weicai@google.com>