### PR TITLE
[dv/lc_ctrl] lc_ctrl_sim.hjson and uvmdvgen update

### DIFF
--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -29,10 +29,11 @@
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
+                "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
+                // TODO: temp commented out stress_test
+                // "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
 
   // Add additional tops for simulation.
   sim_tops: ["lc_ctrl_bind"]

--- a/util/uvmdvgen/sim_cfg.hjson.tpl
+++ b/util/uvmdvgen/sim_cfg.hjson.tpl
@@ -38,6 +38,9 @@
 % if has_interrupts:
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
 % endif
+% if has_alerts:
+                "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
+% endif
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 % else:


### PR DESCRIPTION
1. Enable lc_ctrl alert_test vseq, and temp comment out stress_test until
support it.
2. It also adds alert_test to uvmdvgen, so it will automatically
included in bring up if has_alerts is set to 1.

Passing alert_test for lc_ctrl is based on #4559

Signed-off-by: Cindy Chen <chencindy@google.com>