### PR TITLE
[fpv/rv_dm] remove old FPV code

### DIFF
--- a/hw/ip/rv_dm/rv_dm.core
+++ b/hw/ip/rv_dm/rv_dm.core
@@ -41,11 +41,6 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
 
-  files_formal:
-    files:
-      - dv/tb/rv_dm_bind.sv
-    file_type: systemVerilogSource
-
 parameters:
   NrHarts:
     datatype: int
@@ -63,14 +58,7 @@ targets:
       - tool_verilator   ? (files_verilator_waiver)
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
-      - target_formal    ? (files_formal)
       - files_rtl
-    toplevel: rv_dm
-
-  formal:
-    filesets:
-      - files_rtl
-      - files_formal
     toplevel: rv_dm
 
   lint:


### PR DESCRIPTION
In rv_dm core file, it still refers to old `dv/tb/rv_dm_bind.sv` file.
This PR removes the old method to avoid compile error.

Signed-off-by: Cindy Chen <chencindy@google.com>