### PR TITLE
[dv/otp] add seq for lc_token req

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
@@ -17,6 +17,7 @@ class otp_ctrl_env extends cip_base_env #(
   push_pull_agent#(.DeviceDataWidth(FLASH_DATA_SIZE)) m_flash_addr_pull_agent;
   push_pull_agent#(.DeviceDataWidth(FLASH_DATA_SIZE)) m_flash_data_pull_agent;
   push_pull_agent#(.DeviceDataWidth(1), .HostDataWidth(LC_PROG_DATA_SIZE)) m_lc_prog_pull_agent;
+  push_pull_agent#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)) m_lc_token_pull_agent;
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
@@ -51,6 +52,12 @@ class otp_ctrl_env extends cip_base_env #(
         ::type_id::create("m_lc_prog_pull_agent", this);
     uvm_config_db#(push_pull_agent_cfg#(.HostDataWidth(LC_PROG_DATA_SIZE), .DeviceDataWidth(1)))::
         set(this, "m_lc_prog_pull_agent", "cfg", cfg.m_lc_prog_pull_agent_cfg);
+
+    // build lc-otp token pull agent
+    m_lc_token_pull_agent = push_pull_agent#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth))
+        ::type_id::create("m_lc_token_pull_agent", this);
+    uvm_config_db#(push_pull_agent_cfg#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)))::
+        set(this, "m_lc_token_pull_agent", "cfg", cfg.m_lc_token_pull_agent_cfg);
 
     // config power manager pin
     if (!uvm_config_db#(pwr_otp_vif)::get(this, "", "pwr_otp_vif", cfg.pwr_otp_vif)) begin
@@ -101,11 +108,13 @@ class otp_ctrl_env extends cip_base_env #(
     virtual_sequencer.flash_addr_pull_sequencer_h = m_flash_addr_pull_agent.sequencer;
     virtual_sequencer.flash_data_pull_sequencer_h = m_flash_data_pull_agent.sequencer;
     virtual_sequencer.lc_prog_pull_sequencer_h    = m_lc_prog_pull_agent.sequencer;
+    virtual_sequencer.lc_token_pull_sequencer_h   = m_lc_token_pull_agent.sequencer;
     if (cfg.en_scb) begin
       m_otbn_pull_agent.monitor.analysis_port.connect(scoreboard.otbn_fifo.analysis_export);
       m_flash_addr_pull_agent.monitor.analysis_port.connect(scoreboard.flash_addr_fifo.analysis_export);
       m_flash_data_pull_agent.monitor.analysis_port.connect(scoreboard.flash_data_fifo.analysis_export);
       m_lc_prog_pull_agent.monitor.analysis_port.connect(scoreboard.lc_prog_fifo.analysis_export);
+      m_lc_token_pull_agent.monitor.analysis_port.connect(scoreboard.lc_token_fifo.analysis_export);
     end
   endfunction
 

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -10,6 +10,7 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
   rand push_pull_agent_cfg#(.DeviceDataWidth(FLASH_DATA_SIZE)) m_flash_data_pull_agent_cfg;
   rand push_pull_agent_cfg#(.DeviceDataWidth(FLASH_DATA_SIZE)) m_flash_addr_pull_agent_cfg;
   rand push_pull_agent_cfg#(.DeviceDataWidth(1), .HostDataWidth(LC_PROG_DATA_SIZE)) m_lc_prog_pull_agent_cfg;
+  rand push_pull_agent_cfg#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)) m_lc_token_pull_agent_cfg;
 
   // ext interfaces
   pwr_otp_vif                  pwr_otp_vif;
@@ -54,6 +55,11 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
     m_lc_prog_pull_agent_cfg = push_pull_agent_cfg#(.HostDataWidth(LC_PROG_DATA_SIZE),
                                .DeviceDataWidth(1))::type_id::create("m_lc_prog_pull_agent_cfg");
     m_lc_prog_pull_agent_cfg.agent_type = PullAgent;
+
+    m_lc_token_pull_agent_cfg = push_pull_agent_cfg#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth))::
+                                type_id::create("m_lc_token_pull_agent_cfg");
+    m_lc_token_pull_agent_cfg.agent_type = PullAgent;
+    m_lc_token_pull_agent_cfg.in_bidirectional_mode = 1;
 
     // set num_interrupts & num_alerts
     begin

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -29,6 +29,8 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
   uvm_tlm_analysis_fifo #(push_pull_item#(.DeviceDataWidth(FLASH_DATA_SIZE))) flash_data_fifo;
   uvm_tlm_analysis_fifo #(push_pull_item#(.DeviceDataWidth(1), .HostDataWidth(LC_PROG_DATA_SIZE)))
                         lc_prog_fifo;
+  uvm_tlm_analysis_fifo #(push_pull_item#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)))
+                        lc_token_fifo;
 
   // local queues to hold incoming packets pending comparison
 
@@ -43,6 +45,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
     flash_addr_fifo = new("flash_addr_fifo", this);
     flash_data_fifo = new("flash_data_fifo", this);
     lc_prog_fifo    = new("lc_prog_fifo", this);
+    lc_token_fifo   = new("lc_token_fifo", this);
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_virtual_sequencer.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_virtual_sequencer.sv
@@ -10,10 +10,11 @@ class otp_ctrl_virtual_sequencer extends cip_base_virtual_sequencer #(
 
   `uvm_component_new
 
-  push_pull_sequencer#(.DeviceDataWidth(SRAM_DATA_SIZE))  sram_pull_sequencer_h[NumSramKeyReqSlots];
-  push_pull_sequencer#(.DeviceDataWidth(OTBN_DATA_SIZE))  otbn_pull_sequencer_h;
+  push_pull_sequencer#(.DeviceDataWidth(SRAM_DATA_SIZE)) sram_pull_sequencer_h[NumSramKeyReqSlots];
+  push_pull_sequencer#(.DeviceDataWidth(OTBN_DATA_SIZE)) otbn_pull_sequencer_h;
   push_pull_sequencer#(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_data_pull_sequencer_h;
   push_pull_sequencer#(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_addr_pull_sequencer_h;
+  push_pull_sequencer#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)) lc_token_pull_sequencer_h;
   push_pull_sequencer#(.DeviceDataWidth(1), .HostDataWidth(LC_PROG_DATA_SIZE))
                        lc_prog_pull_sequencer_h;
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -188,6 +188,13 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     `uvm_send(lc_prog_pull_seq)
   endtask
 
+  virtual task req_lc_token();
+    push_pull_host_seq#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)) lc_token_pull_seq;
+    `uvm_create_on(lc_token_pull_seq, p_sequencer.lc_token_pull_sequencer_h);
+    `DV_CHECK_RANDOMIZE_FATAL(lc_token_pull_seq)
+    `uvm_send(lc_token_pull_seq)
+  endtask
+
   // first two or three LSB bits of DAI address can be randomized based on if it is secret
   virtual function bit [TL_AW-1:0] randomize_dai_addr(bit [TL_AW-1:0] dai_addr);
     if (is_secret(dai_addr)) begin

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -121,7 +121,10 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
       // check digest
       check_digests();
 
-      if (do_lc_trans) req_lc_transition();
+      if (do_lc_trans) begin
+        req_lc_transition();
+        req_lc_token();
+      end
     end
 
   endtask : body

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -31,15 +31,17 @@ module tb;
 
   //TODO: use push-pull agent once support
   wire otp_ctrl_pkg::otp_ast_req_t        ast_req;
-  wire otp_ctrl_pkg::lc_otp_token_rsp_t   otp_token;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
   pins_if #(1) devmode_if(devmode);
 
+  // lc_otp interfaces
   push_pull_if #(.HostDataWidth(LC_PROG_DATA_SIZE), .DeviceDataWidth(1))
                  lc_prog_if(.clk(clk), .rst_n(rst_n));
+  push_pull_if #(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)) lc_token_if(.clk(clk), .rst_n(rst_n));
+
   push_pull_if #(.DeviceDataWidth(SRAM_DATA_SIZE))
                  sram_if[NumSramKeyReqSlots](.clk(clk), .rst_n(rst_n));
   push_pull_if #(.DeviceDataWidth(OTBN_DATA_SIZE)) otbn_if(.clk(clk), .rst_n(rst_n));
@@ -87,8 +89,8 @@ module tb;
     // lc
     .lc_otp_program_i           ({lc_prog_if.req, lc_prog_if.h_data}),
     .lc_otp_program_o           ({lc_prog_if.d_data, lc_prog_if.ack}),
-    .lc_otp_token_i             ('0),
-    .lc_otp_token_o             (otp_token),
+    .lc_otp_token_i             ({lc_token_if.req, lc_token_if.h_data}),
+    .lc_otp_token_o             ({lc_token_if.ack, lc_token_if.d_data}),
     .lc_creator_seed_sw_rw_en_i (lc_creator_seed_sw_rw_en),
     .lc_seed_hw_rd_en_i         (lc_seed_hw_rd_en),
     .lc_dft_en_i                (lc_dft_en),
@@ -152,6 +154,8 @@ module tb;
                    set(null, "*env.m_edn_pull_agent*", "vif", edn_if);
     uvm_config_db#(virtual push_pull_if#(.HostDataWidth(LC_PROG_DATA_SIZE), .DeviceDataWidth(1)))::
                    set(null, "*env.m_lc_prog_pull_agent*", "vif", lc_prog_if);
+    uvm_config_db#(virtual push_pull_if#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)))::
+                   set(null, "*env.m_lc_token_pull_agent*", "vif", lc_token_if);
 
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(pwr_otp_vif)::set(null, "*.env", "pwr_otp_vif", pwr_otp_if);


### PR DESCRIPTION
This PR add a push-pull agent for lc_token req, and add sequence to send lc_token req.
scb checking for the correctness of the encoded token will come in next PR.

Signed-off-by: Cindy Chen <chencindy@google.com>