### PR TITLE
[kmac] Revise Endianess in the Message FIFO

### DIFF
--- a/hw/ip/kmac/rtl/kmac_msgfifo.sv
+++ b/hw/ip/kmac/rtl/kmac_msgfifo.sv
@@ -117,15 +117,13 @@ module kmac_msgfifo
     .flush_done_o (packer_flush_done)
   );
 
-  // Convert packer wdata and wmask to FIFO struct
-  // As packer packs to right, it converts the data here again
-  // TODO: Is it true internal SHA3 is big-endian same as HMAC?
-  assign fifo_wdata.data = conv_endian64(packer_wdata, 1'b1);
-  always_comb begin
-    for (int i = 0 ; i < OutWidth/8 ; i++) begin
-      fifo_wdata.strb[i] = packer_wmask[8*(OutWidth/8-i-1)];
-    end
-  end
+  // Assign packer wdata and wmask to FIFO struct
+  // In contrast to HMAC case, KMAC SHA3 operates in little-endian. MSG fifo is
+  // converted into 3-D form so the endianess here is not a problem.
+  assign fifo_wdata = '{
+    data: packer_wdata,
+    strb: packer_wmask
+  } ;
 
   // MsgFIFO
   prim_fifo_sync #(


### PR DESCRIPTION
Problem:

    When the software writes partially and proceed the SHA3, the
    assertion inside sha3pad module fires. The assertion is to check
    when it is partial, the MSB of the strobe is always 0.

The strob and the data in partial completion was not expected value.
lower bytes of the message and lower bits of the strobe are 0 rather
than MSB as 0.

The data in between prim_packer and prim_fifo inside kmac_msgfifo module
was swapped always. The code was derived from HMAC.

It is correct to swap the data in HMAC. HMAC implements the hashing
logic in big-endian way. So the lower most bytes should be placed at the
higher most byte.

In KMAC, the message in SHA3 hashing module is converted into 3-D cube
form. The conversion logic assumes the data to be little-endian. Bit 0
is the actual bit 0 in the SHA3 specification. So, no need to convert
again.

This commit is to fix the issue above by assigning the data without
endian conversion.

The issue is reported by @udinator
