### PR TITLE
[ast] Move clkmgr dependency from wrapper package into wrapper

### DIFF
--- a/hw/top_earlgrey/ip/ast/ast.core
+++ b/hw/top_earlgrey/ip/ast/ast.core
@@ -3,7 +3,8 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:systems:ast:0.1"
-description: "Analog Sensor Top generic views"
+description: "Analog sensor top (AST) generic views"
+
 filesets:
   files_rtl:
     depend:

--- a/hw/top_earlgrey/ip/ast/ast_wrapper.core
+++ b/hw/top_earlgrey/ip/ast/ast_wrapper.core
@@ -3,14 +3,20 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:systems:ast_wrapper:0.1"
-description: "ast wrapper"
+description: "Analog sensor top (AST) wrapper"
+
 filesets:
   files_rtl:
     depend:
+      - lowrisc:prim:assert
+      - lowrisc:tlul:headers
       - lowrisc:systems:ast_wrapper_pkg
       - lowrisc:systems:ast
-      - lowrisc:ip:entropy_src
-      - lowrisc:prim:clock_buf
+      - lowrisc:systems:sensor_ctrl_reg
+      - lowrisc:ip:clkmgr_pkg
+      - lowrisc:ip:pwrmgr_pkg
+      - lowrisc:ip:rstmgr_pkg
+      - lowrisc:ip:entropy_src_pkg
     files:
       - rtl/ast_wrapper.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip/ast/ast_wrapper_pkg.core
+++ b/hw/top_earlgrey/ip/ast/ast_wrapper_pkg.core
@@ -2,14 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-
 name: "lowrisc:systems:ast_wrapper_pkg"
-description: "ast wrapper package"
+description: "Analog sensor top (AST) wrapper package"
+
 filesets:
   files_rtl:
     depend:
-      - lowrisc:ip:pwrmgr_pkg
-      - lowrisc:top_earlgrey:clkmgr
       - lowrisc:constants:top_pkg
     files:
       - rtl/ast_wrapper_pkg.sv


### PR DESCRIPTION
The package does not really depend on clkmgr but only the wrapper does.

This PR has been factored out from #4329.