### PR TITLE
[fpga] Use wildcard matching instead of hardcoded top_name in clocks.xdc

### DIFF
--- a/hw/top_earlgrey/data/clocks.xdc
+++ b/hw/top_earlgrey/data/clocks.xdc
@@ -14,15 +14,15 @@ set clks_48_unbuf [get_clocks -of_objects [get_pin clkgen/pll/CLKOUT1]]
 ## destination flops few enough.
 
 set u_pll clkgen/pll
-set u_div2 top_earlgrey/u_clkmgr/u_io_div2_div
+set u_div2 top_*/u_clkmgr/u_io_div2_div
 create_generated_clock -name clk_io_div2 -source [get_pin ${u_pll}/CLKOUT0] -divide_by 2 [get_pin ${u_div2}/u_clk_div_buf/gen_xilinx.u_impl_xilinx/bufg_i/O]
 
-set u_div4 top_earlgrey/u_clkmgr/u_io_div4_div
+set u_div4 top_*/u_clkmgr/u_io_div4_div
 create_generated_clock -name clk_io_div4 -source [get_pin ${u_pll}/CLKOUT0] -divide_by 4 [get_pin ${u_div4}/u_clk_div_buf/gen_xilinx.u_impl_xilinx/bufg_i/O]
 
 ## JTAG and SPI clocks
 create_clock -add -name jtag_tck    -period 100.00 -waveform {0 5} [get_nets jtag_tck_buf]
-create_clock -add -name clk_spi_in  -period 100.00 -waveform {0 5} [get_pin top_earlgrey/u_spi_device/u_clk_spi_in_buf/gen_xilinx.u_impl_xilinx/bufg_i/O]
-create_clock -add -name clk_spi_out -period 100.00 -waveform {0 5} [get_pin top_earlgrey/u_spi_device/u_clk_spi_out_buf/gen_xilinx.u_impl_xilinx/bufg_i/O]
+create_clock -add -name clk_spi_in  -period 100.00 -waveform {0 5} [get_pin top_*/u_spi_device/u_clk_spi_in_buf/gen_xilinx.u_impl_xilinx/bufg_i/O]
+create_clock -add -name clk_spi_out -period 100.00 -waveform {0 5} [get_pin top_*/u_spi_device/u_clk_spi_out_buf/gen_xilinx.u_impl_xilinx/bufg_i/O]
 
 set_clock_groups -group ${clks_10_unbuf} -group ${clks_48_unbuf} -group clk_io_div2 -group clk_io_div4 -group jtag_tck -group clk_spi_in -group clk_spi_out -asynchronous


### PR DESCRIPTION
Avoiding hardcoded references to `top_earlgrey` this file will allow us to re-use it also for different top levels.

This PR has been factored out from #4329.