### PR TITLE
[top] Remove hardcoded refs to top_earlgrey from SV templates

### DIFF
--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -103,7 +103,7 @@ module top_${top["name"]} #(
   import top_pkg::*;
   import tl_main_pkg::*;
   // Compile-time random constants
-  import top_earlgrey_rnd_cnst_pkg::*;
+  import top_${top["name"]}_rnd_cnst_pkg::*;
 
   // Signals
   logic [${num_mio_inputs + num_mio_inouts - 1}:0] mio_p2d;

--- a/hw/top_earlgrey/data/top_earlgrey_rnd_cnst_pkg.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey_rnd_cnst_pkg.sv.tpl
@@ -23,7 +23,7 @@ ${gencmd}
       numbits = 4*blockwidth
     return hexblocks
 %>
-package top_earlgrey_rnd_cnst_pkg;
+package top_${top["name"]}_rnd_cnst_pkg;
 
 % for m in top["module"]:
   % for p in filter(lambda p: p["randtype"] in ["data", "perm"], m["param_list"]):
@@ -41,4 +41,4 @@ package top_earlgrey_rnd_cnst_pkg;
 
   % endfor
 % endfor
-endpackage : top_earlgrey_rnd_cnst_pkg
+endpackage : top_${top["name"]}_rnd_cnst_pkg


### PR DESCRIPTION
Avoiding hardcoded references to `top_earlgrey` in such files will allow us to re-use them also for different top levels.

This PR has been factored out from #4329.