### PR TITLE
[dv/test_vectors_pkg] Switch to use str_utils_pkg

### DIFF
--- a/hw/dv/sv/test_vectors/test_vectors.core
+++ b/hw/dv/sv/test_vectors/test_vectors.core
@@ -6,6 +6,8 @@ name: "lowrisc:dv:test_vectors"
 description: "parse test vectors files and output an array of structures with parsed info"
 filesets:
   files_dv:
+    depend:
+      - lowrisc:dv:str_utils
     files:
       - test_vectors_pkg.sv
       - vectors/hmac/HMAC_RFC4868.rsp: {is_include_file: true}


### PR DESCRIPTION
This PR updates the test_vectors_pkg to make use of the new
str_utils_pkg methods, with the exception of `str_to_bytes` function as
we still need a custom implementation.

Signed-off-by: Udi Jonnalagadda <udij@google.com>