### PR TITLE
[ci] Fix setuptools install problems in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -394,7 +394,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.hasOTBNChanges'], '1'))
   pool:
     vmImage: ubuntu-18.04
-  timeoutInMinutes: 5
+  timeoutInMinutes: 10
   steps:
   - template: ci/install-package-dependencies.yml
   - bash: |

--- a/ci/install-package-dependencies.yml
+++ b/ci/install-package-dependencies.yml
@@ -57,22 +57,12 @@ steps:
       # appropriate bin directory to the PATH
       export PATH=$HOME/.local/bin:$PATH
 
-      # Explicitly installing six is a workaround for pip dependency resolution:
-      # six is already installed as system package with a version below the
-      # required one.  Explicitly installing six through pip gets us a supported
-      # version.
-      #
       # Explicitly updating pip and setuptools is required to have these tools
       # properly parse Python-version metadata, which some packages uses to
       # specify that an older version of a package must be used for a certain
       # Python version. If that information is not read, pip installs the latest
       # version, which then fails to run.
-      python3 -m pip install --user -U pip six
-
-      # There's been a bit of a kerfuffle about setuptools version 50, which
-      # breaks importing distutils on Debian/Ubuntu systems. Make sure we don't
-      # pick it up until the dust has settled and things work again.
-      pip3 install --user -U 'setuptools < 50.0.0'
+      python3 -m pip install --user -U pip setuptools
 
       pip3 install --user -U -r python-requirements.txt
 

--- a/ci/install-package-dependencies.yml
+++ b/ci/install-package-dependencies.yml
@@ -67,7 +67,7 @@ steps:
       # specify that an older version of a package must be used for a certain
       # Python version. If that information is not read, pip installs the latest
       # version, which then fails to run.
-      pip3 install --user -U pip six
+      python3 -m pip install --user -U pip six
 
       # There's been a bit of a kerfuffle about setuptools version 50, which
       # breaks importing distutils on Debian/Ubuntu systems. Make sure we don't


### PR DESCRIPTION
CI currently installs a lot of version of setuptools until it finds a suitable one. This PR does some cleanups, and also removes the pin to setuptools < 50, which isn't necessary any more (as we have found out on Ibex, where we did a similar change in https://github.com/lowRISC/ibex/pull/1208).