### PR TITLE
[sw] Update broken link to 'Exceptions and Interrupts' Ibex docs

### DIFF
--- a/sw/device/exts/common/ibex_interrupt_vectors.S
+++ b/sw/device/exts/common/ibex_interrupt_vectors.S
@@ -39,7 +39,7 @@
  * overlap the interrupt vector, which causes debugging confusion.
  *
  * More information about Ibex's interrupts can be found here:
- *   https://ibex-core.readthedocs.io/en/latest/exception_interrupts.html
+ *   https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
  */
   .balign 256
 crt_interrupt_vector:

--- a/sw/device/mask_rom/mask_rom_start.S
+++ b/sw/device/mask_rom/mask_rom_start.S
@@ -42,7 +42,7 @@
  * - Reset Handler (Entry 32)
  *
  * More information about Ibex's interrupts can be found here:
- *   https://ibex-core.readthedocs.io/en/latest/exception_interrupts.html
+ *   https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
  */
   .balign 256
   .globl _mask_rom_interrupt_vector

--- a/sw/device/rom_exts/rom_ext_start.S
+++ b/sw/device/rom_exts/rom_ext_start.S
@@ -40,7 +40,7 @@
  * - Reset Handler (Entry 32)
  *
  * More information about Ibex's interrupts can be found here:
- *   https://ibex-core.readthedocs.io/en/latest/exception_interrupts.html
+ *   https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
  */
   .balign 256
   .globl _rom_ext_interrupt_vector


### PR DESCRIPTION
The 'Exceptions and Interrupts' page has moved into the Ibex
Reference Guide.