### PR TITLE
[dv/otp_ctrl] Fix otp_ctrl_dai_lock randomization failure

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -59,7 +59,14 @@ package otp_ctrl_env_pkg;
 
   // TODO: did not count for LC partition
   parameter uint OTP_ARRAY_SIZE = (CreatorSwCfgSize + OwnerSwCfgSize + HwCfgSize + Secret0Size +
-                                   Secret1Size + Secret2Size)/ (TL_DW / 8);
+                                   Secret1Size + Secret2Size) / (TL_DW / 8);
+
+  // Total num of valid dai address, secret partitions have a granulity of 8, the rest have
+  // a granulity of 4.
+  parameter uint DAI_ADDR_SIZE =
+      (CreatorSwCfgContentSize + OwnerSwCfgContentSize + HwCfgContentSize) / 4 +
+      // secret partitions does not have content size, so use total size
+      (Secret0Size + Secret1Size + Secret2Size) / 8 - 3;
 
   // sram rsp data has 1 bit for seed_valid, the rest are for key and nonce
   parameter uint SRAM_DATA_SIZE = 1 + SramKeyWidth + SramNonceWidth;

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
@@ -12,4 +12,8 @@ class otp_ctrl_dai_lock_vseq extends otp_ctrl_smoke_vseq;
   // enable access_err for each cycle
   constraint no_access_err_c {access_locked_parts == 1;}
 
+  // access locked means no memory clear, constraint to ensure there are enough dai address
+  constraint num_iterations_up_to_num_valid_addr_c {
+    num_trans * num_dai_op <= DAI_ADDR_SIZE;
+  }
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -41,9 +41,10 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
     if (part_idx inside {[Secret0Idx:Secret2Idx]}) dai_addr % 8 == 0;
   }
 
-  constraint num_dai_op_c {num_dai_op inside {[1:50]};}
-
-  constraint num_trans_c {num_trans inside {[1:20]};}
+  constraint num_iterations_c {
+    num_trans  inside {[1:20]};
+    num_dai_op inside {[1:50]};
+  }
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);


### PR DESCRIPTION
In nightly regression, some otp_ctrl_dai_lock sequence has randomization
failure. The reason is because dai_write ran out of address.
There are total 467 writtable address within OTP DAI access. And
dai_lock sequence does not enable mem_clear, so could not rewrite any of
the address.
This PR fix it by adding a constraint to num total address can be
written.

Signed-off-by: Cindy Chen <chencindy@google.com>