### PR TITLE
[dv/lc_ctrl] fix csr_mem_rw_with_rand_reset failure

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
@@ -39,12 +39,23 @@ class lc_ctrl_base_vseq extends cip_base_vseq #(
   endtask
 
   // setup basic lc_ctrl features
-  virtual task lc_ctrl_init();
-    `DV_CHECK_RANDOMIZE_FATAL(this)
+  virtual task lc_ctrl_init(bit rand_otp_i = 1);
     cfg.pwr_lc_vif.drive_pin(LcPwrInitReq, 1);
+    if (rand_otp_i) begin
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+    end else begin
+      lc_state = LcStRaw;
+      lc_cnt = LcCntRaw;
+    end
     cfg.lc_ctrl_vif.init(lc_state, lc_cnt);
     wait(cfg.pwr_lc_vif.pins[LcPwrDoneRsp] == 1);
     cfg.pwr_lc_vif.drive_pin(LcPwrInitReq, 0);
+  endtask
+
+  // some registers won't set to default value until otp_init is done
+  virtual task read_and_check_all_csrs_after_reset();
+    lc_ctrl_init(0);
+    super.read_and_check_all_csrs_after_reset();
   endtask
 
   virtual task sw_transition_req(bit [TL_DW-1:0] next_lc_state, bit [TL_DW*3-1:0] token_val);

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -57,6 +57,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     // drive dft_en pins to access the test_access memory
     cfg.lc_dft_en_vif.drive(lc_ctrl_pkg::On);
     otp_pwr_init();
+    super.read_and_check_all_csrs_after_reset();
   endtask
 
   // this task triggers an OTP write sequence via the DAI interface


### PR DESCRIPTION
LC_CTRL has a similar issue as otp_ctrl that after issuing reset, to
start the LC_ctrl we need initilize lc_ctrl with external input from
pwrmgr and otp_ctrl. So in csr_mem_rw_with_rand_reset test, it won't
pass unless initialization is done.
Similar to OTP_CTRL, the fix is override
`read_and_check_all_csrs_after_reset` with init sequence.
This PR also fixes the issue in OTP_CTRL that did not call super in
`read_and_check_all_csrs_after_reset`.

Signed-off-by: Cindy Chen <chencindy@google.com>