### PR TITLE
[kmac] Latch the output data from state

### DIFF
--- a/hw/ip/kmac/rtl/kmac_staterd.sv
+++ b/hw/ip/kmac/rtl/kmac_staterd.sv
@@ -76,7 +76,13 @@ module kmac_staterd
     .rerror_i (tlram_rerror)
   );
 
-  assign tlram_rdata = conv_endian32(tlram_rdata_endian, endian_swap_i);
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      tlram_rdata <= '0;
+    end else if (tlram_req & ~tlram_we) begin
+      tlram_rdata <= conv_endian32(tlram_rdata_endian, endian_swap_i);
+    end
+  end
 
   // Always grant
   assign tlram_gnt = tlram_req & ~tlram_we;


### PR DESCRIPTION
Problem:

    The software reads unknown data or all-zero from state window.

The `tlram_rdata` is connected to tlram_rdata_endian. the latter is a
muxed signal from the internal Keccak state registers. The mux selection
signal is the input TL-UL address.

As the address only valid when the request is asserted, the selection
signal becomes unknown or incorrect value when the state module returns
the read data.

This commit is to fix the bug by latching the tlram_rdata. There's
another solution to latch the address selectino only when it is valid.
The latter consumes less registers as address bit width is smaller than
the return data but creates a little bit more ambiguous logic so that
drops the readability.

The issue is reported by @udinator