### PR TITLE
[otp] scb checking for lc_token and small typo fix

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
@@ -291,7 +291,7 @@ module otp_ctrl_scrmbl import otp_ctrl_pkg::*; #(
               key_state_sel  = SelDigestConst;
               data_state_en  = 1'b1;
               key_state_en   = 1'b1;
-              is_first_d     = 1'b1;
+              is_first_d     = 1'b0;
               digest_mode_d  = StandardMode;
               sel_d          = sel_i;
             end


### PR DESCRIPTION
This PR has two commits:

1. For DV, add checking logic in scb for OTP unlock_token checks.
2. For RTL, fix a tiny typo reported in issue #4586 .

Signed-off-by: Cindy Chen <chencindy@google.com>