### PR TITLE
[kmac] Connect only one bit per 8bit in packer mask

### DIFF
--- a/hw/ip/kmac/rtl/kmac_msgfifo.sv
+++ b/hw/ip/kmac/rtl/kmac_msgfifo.sv
@@ -120,10 +120,13 @@ module kmac_msgfifo
   // Assign packer wdata and wmask to FIFO struct
   // In contrast to HMAC case, KMAC SHA3 operates in little-endian. MSG fifo is
   // converted into 3-D form so the endianess here is not a problem.
-  assign fifo_wdata = '{
-    data: packer_wdata,
-    strb: packer_wmask
-  } ;
+  assign fifo_wdata.data = packer_wdata;
+  always_comb begin
+    fifo_wdata.strb = '0;
+    for (int i = 0 ; i < OutWidth/8 ; i++) begin
+      fifo_wdata.strb[i] = packer_wmask[8*i];
+    end
+  end
 
   // MsgFIFO
   prim_fifo_sync #(


### PR DESCRIPTION
The previous fix 003108511 removed the endian conversion logic and
directly connects the packer outputs to fifo_wdata struct.

The strobe in the fifo struct is byte strobe but the revised logic only
directly assigned the 64bit packer mask into 8bit byte strobe.

This commit is to connect only LSB in a byte to fifo strobe signal.