### PR TITLE
[lc_ctrl/otp_ctrl] Precompute hashed versions of global tokens

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -15,6 +15,8 @@ interface lc_ctrl_if(input clk, input rst_n);
     otp_i.valid = 1;
     otp_i.state = lc_state;
     otp_i.count = lc_cnt;
+    otp_i.all_zero_token = 0;
+    otp_i.raw_unlock_token = 0;
     otp_i.test_unlock_token = 0;
     otp_i.test_exit_token = 0;
     otp_i.rma_token = 0;

--- a/hw/ip/lc_ctrl/lint/lc_ctrl.waiver
+++ b/hw/ip/lc_ctrl/lint/lc_ctrl.waiver
@@ -4,3 +4,5 @@
 #
 # waiver file for LC controller
 
+waive -rules CONST_FF -location {lc_ctrl_signal_decode.sv} -regexp {Flip-flop 'lc_keymgr_div_q\[.*\]' is driven by constant zeros.*} \
+      -comment {Some of these bits may be constantly zero, depending on the RndCnst parameters.}

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -479,6 +479,8 @@ module lc_ctrl
     .lc_state_i             ( otp_lc_data_i.state             ),
     .lc_id_state_i          ( otp_lc_data_i.id_state          ),
     .lc_cnt_i               ( otp_lc_data_i.count             ),
+    .all_zero_token_i       ( otp_lc_data_i.all_zero_token    ),
+    .raw_unlock_token_i     ( otp_lc_data_i.raw_unlock_token  ),
     .test_unlock_token_i    ( otp_lc_data_i.test_unlock_token ),
     .test_exit_token_i      ( otp_lc_data_i.test_exit_token   ),
     .rma_token_i            ( otp_lc_data_i.rma_token         ),

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
@@ -27,7 +27,9 @@ module lc_ctrl_fsm
   input  lc_state_e             lc_state_i,
   input  lc_id_state_e          lc_id_state_i,
   input  lc_cnt_e               lc_cnt_i,
-  // Token input from OTP.
+  // Token input from OTP (these are all hash post-images).
+  input  lc_token_t             all_zero_token_i,
+  input  lc_token_t             raw_unlock_token_i,
   input  lc_token_t             test_unlock_token_i,
   input  lc_token_t             test_exit_token_i,
   input  lc_token_t             rma_token_i,
@@ -378,8 +380,8 @@ module lc_ctrl_fsm
   logic [TokenIdxWidth-1:0] token_idx;
   always_comb begin : p_token_assign
     hashed_tokens = '0;
-    hashed_tokens[ZeroTokenIdx]       = AllZeroTokenHashed;
-    hashed_tokens[RawUnlockTokenIdx]  = RawUnlockTokenHashed;
+    hashed_tokens[ZeroTokenIdx]       = all_zero_token_i;
+    hashed_tokens[RawUnlockTokenIdx]  = raw_unlock_token_i;
     hashed_tokens[TestUnlockTokenIdx] = test_unlock_token_i;
     hashed_tokens[TestExitTokenIdx]   = test_exit_token_i;
     hashed_tokens[RmaTokenIdx]        = rma_token_i;

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv
@@ -184,10 +184,6 @@ package lc_ctrl_pkg;
     InvalidTokenIdx    = 3'h5
   } token_idx_e;
 
-  // TODO: precompute these values (probably have to do that in OTP at elab time).
-  parameter logic [LcTokenWidth-1:0] RawUnlockTokenHashed = '0;
-  parameter logic [LcTokenWidth-1:0] AllZeroTokenHashed = '0;
-
   ////////////////////////////////
   // Typedefs for LC Interfaces //
   ////////////////////////////////

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -76,6 +76,12 @@
       randcount: "513",  // 2*256+1
       randtype:  "data", // randomize randcount databits
     }
+    { name:      "RndCnstRawUnlockToken",
+      desc:      "Compile-time random value for RAW unlock token.",
+      type:      "lc_ctrl_pkg::lc_token_t"
+      randcount: "128",
+      randtype:  "data", // randomize randcount databits
+    }
     // Normal parameters
     { name: "NumSramKeyReqSlots",
       desc: "Number of key slots",

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -89,6 +89,12 @@
       randcount: "513",  // 2*256+1
       randtype:  "data", // randomize randcount databits
     }
+    { name:      "RndCnstRawUnlockToken",
+      desc:      "Compile-time random value for RAW unlock token.",
+      type:      "lc_ctrl_pkg::lc_token_t"
+      randcount: "128",
+      randtype:  "data", // randomize randcount databits
+    }
     // Normal parameters
     { name: "NumSramKeyReqSlots",
       desc: "Number of key slots",

--- a/hw/ip/otp_ctrl/otp_ctrl.core
+++ b/hw/ip/otp_ctrl/otp_ctrl.core
@@ -21,6 +21,7 @@ filesets:
       - rtl/otp_ctrl_reg_top.sv
       - rtl/otp_ctrl_ecc_reg.sv
       - rtl/otp_ctrl_scrmbl.sv
+      - rtl/otp_ctrl_token_const.sv
       - rtl/otp_ctrl_lfsr_timer.sv
       - rtl/otp_ctrl_part_unbuf.sv
       - rtl/otp_ctrl_part_buf.sv

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -15,12 +15,13 @@ module otp_ctrl
   // Enable asynchronous transitions on alerts.
   parameter logic [NumAlerts-1:0] AlertAsyncOn      = {NumAlerts{1'b1}},
   // Compile time random constants, to be overriden by topgen.
-  parameter lfsr_seed_t          RndCnstLfsrSeed    = RndCnstLfsrSeedDefault,
-  parameter lfsr_perm_t          RndCnstLfsrPerm    = RndCnstLfsrPermDefault,
-  parameter key_array_t          RndCnstKey         = RndCnstKeyDefault,
-  parameter digest_const_array_t RndCnstDigestConst = RndCnstDigestConstDefault,
-  parameter digest_iv_array_t    RndCnstDigestIV    = RndCnstDigestIVDefault,
-  parameter otp_keymgr_key_t     RndCnstKeyMgrKey   = RndCnstKeyMgrKeyDefault
+  parameter lfsr_seed_t             RndCnstLfsrSeed       = RndCnstLfsrSeedDefault,
+  parameter lfsr_perm_t             RndCnstLfsrPerm       = RndCnstLfsrPermDefault,
+  parameter key_array_t             RndCnstKey            = RndCnstKeyDefault,
+  parameter digest_const_array_t    RndCnstDigestConst    = RndCnstDigestConstDefault,
+  parameter digest_iv_array_t       RndCnstDigestIV       = RndCnstDigestIVDefault,
+  parameter otp_keymgr_key_t        RndCnstKeyMgrKey      = RndCnstKeyMgrKeyDefault,
+  parameter lc_ctrl_pkg::lc_token_t RndCnstRawUnlockToken = RndCnstRawUnlockTokenDefault
 ) (
   input                                              clk_i,
   input                                              rst_ni,
@@ -686,6 +687,19 @@ module otp_ctrl
     part_scrmbl_req_ready[scrmbl_mtx_idx] = scrmbl_arb_req_ready;
     part_scrmbl_rsp_valid[scrmbl_mtx_idx] = scrmbl_arb_rsp_valid;
   end
+
+  /////////////////////////////////////////////
+  // Static fife cycle token precomputations //
+  /////////////////////////////////////////////
+
+  otp_ctrl_token_const #(
+    .RndCnstDigestConst    ( RndCnstDigestConst    ),
+    .RndCnstDigestIV       ( RndCnstDigestIV       ),
+    .RndCnstRawUnlockToken ( RndCnstRawUnlockToken )
+  ) u_otp_ctrl_token_const (
+    .all_zero_token_hashed_o   ( otp_lc_data_o.all_zero_token   ),
+    .raw_unlock_token_hashed_o ( otp_lc_data_o.raw_unlock_token )
+  );
 
   /////////////////////////////
   // Direct Access Interface //

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -164,6 +164,9 @@ package otp_ctrl_pkg;
     logic                      valid;
     lc_ctrl_pkg::lc_state_e    state;
     lc_ctrl_pkg::lc_cnt_e      count;
+    // These are all hash post-images
+    lc_ctrl_pkg::lc_token_t    all_zero_token;
+    lc_ctrl_pkg::lc_token_t    raw_unlock_token;
     lc_ctrl_pkg::lc_token_t    test_unlock_token;
     lc_ctrl_pkg::lc_token_t    test_exit_token;
     lc_ctrl_pkg::lc_token_t    rma_token;
@@ -338,5 +341,8 @@ package otp_ctrl_pkg;
     key_share0: 256'h091833106d26f6539ddf1d7446cece22d564d879f720163881849d2e3530f361,
     key_share1: 256'h0ce300e36f30349fefa3ab17def703f17b6a074dd54581f5deb9a3c47fb2177f
   };
+
+  parameter lc_ctrl_pkg::lc_token_t RndCnstRawUnlockTokenDefault =
+    128'hcbbd013ff15eba2f3065461eeb88463e;
 
 endpackage : otp_ctrl_pkg

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_token_const.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_token_const.sv
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This module contains the hash post-image constants for the all-zero and raw unlock tokens.
+// This implementation relies on constant propagation to precompute these constants from the
+// random netlist constants at compile time, and hence does not contain any "real" logic.
+
+module otp_ctrl_token_const import otp_ctrl_pkg::*; #(
+  // Compile time random constants, to be overriden by topgen.
+  parameter digest_const_array_t    RndCnstDigestConst    = RndCnstDigestConstDefault,
+  parameter digest_iv_array_t       RndCnstDigestIV       = RndCnstDigestIVDefault,
+  parameter lc_ctrl_pkg::lc_token_t RndCnstRawUnlockToken = RndCnstRawUnlockTokenDefault
+) (
+  output lc_ctrl_pkg::lc_token_t all_zero_token_hashed_o,
+  output lc_ctrl_pkg::lc_token_t raw_unlock_token_hashed_o
+);
+
+  localparam int NumHashes = 2;
+  localparam int AllZeroIdx = 0;
+  localparam int RawUnlockIdx = 1;
+
+  logic [NumHashes-1:0][1:0][ScrmblKeyWidth-1:0]   data;
+  logic [NumHashes-1:0][4:0][ScrmblBlockWidth-1:0] state;
+
+  // First digest is for the all zero token, the second is for the raw unlock token.
+  assign data[AllZeroIdx][0] = '0;
+  assign data[RawUnlockIdx][0] = RndCnstRawUnlockToken;
+
+  // Repeat for all precomputed hashes.
+  for (genvar j = 0; j < NumHashes; j++) begin : gen_hashes
+    // Initialize all hashes with digest IV.
+    assign state[j][0] = RndCnstDigestIV[LcRawDigest];
+    // Second data block is always the digest finalization constant.
+    assign data[j][1]  = RndCnstDigestConst[LcRawDigest];
+
+    // Each hash takes four invocations, see diagram c) on
+    // https://docs.opentitan.org/hw/ip/otp_ctrl/doc/index.html#scrambling-datapath
+    for (genvar k = 0; k < 4; k++) begin : gen_invocations
+      // This relies on constant propagation to
+      // statically precompute the hashed token values.
+      prim_present #(
+        .KeyWidth(128),
+        .NumRounds(NumPresentRounds)
+      ) u_prim_present_enc_0 (
+        .data_i ( state[j][k]   ),
+        .key_i  ( data[j][k%2]  ),
+        .idx_i  ( 5'h1          ),
+        .data_o ( state[j][k+1] ),
+        .key_o  ( ),
+        .idx_o  ( )
+      );
+    end
+  end
+
+  // Concatenate the two 64bit hash results to form the final digests.
+  assign all_zero_token_hashed_o   = {state[AllZeroIdx][4],   state[AllZeroIdx][2]};
+  assign raw_unlock_token_hashed_o = {state[RawUnlockIdx][4], state[RawUnlockIdx][2]};
+
+endmodule : otp_ctrl_token_const

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1051,6 +1051,18 @@
           name_top: RndCnstOtpCtrlKeyMgrKey
           randwidth: 513
         }
+        {
+          name: RndCnstRawUnlockToken
+          desc: Compile-time random value for RAW unlock token.
+          type: lc_ctrl_pkg::lc_token_t
+          randcount: "128"
+          randtype: data
+          local: "false"
+          default: 0xaeb2691c0738f30d9006289a1d7d9d0c
+          expose: "false"
+          name_top: RndCnstOtpCtrlRawUnlockToken
+          randwidth: 128
+        }
       ]
       interrupt_list:
       [

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -818,7 +818,8 @@ module top_earlgrey #(
     .RndCnstKey(RndCnstOtpCtrlKey),
     .RndCnstDigestConst(RndCnstOtpCtrlDigestConst),
     .RndCnstDigestIV(RndCnstOtpCtrlDigestIV),
-    .RndCnstKeyMgrKey(RndCnstOtpCtrlKeyMgrKey)
+    .RndCnstKeyMgrKey(RndCnstOtpCtrlKeyMgrKey),
+    .RndCnstRawUnlockToken(RndCnstOtpCtrlRawUnlockToken)
   ) u_otp_ctrl (
 
       // Interrupt

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -52,6 +52,11 @@ package top_earlgrey_rnd_cnst_pkg;
     256'hB49BAC9198BD1FF344C5DA2242D290BEDE094CA8F1435F85E0F7489A309CBE57
   };
 
+  // Compile-time random value for RAW unlock token.
+  parameter lc_ctrl_pkg::lc_token_t RndCnstOtpCtrlRawUnlockToken = {
+    128'hAEB2691C0738F30D9006289A1D7D9D0C
+  };
+
   ////////////////////////////////////////////
   // lc_ctrl
   ////////////////////////////////////////////


### PR DESCRIPTION
This precomputes hashed versions of the all-zero and RAW unlock token using the PRINCE primitive.
This solution relies on constant propagation to fold the logic into constants at elab time.