### PR TITLE
[otbn] Add to/clarify loop information to docs

### DIFF
--- a/hw/ip/otbn/data/base-insns.yml
+++ b/hw/ip/otbn/data/base-insns.yml
@@ -443,18 +443,19 @@
       doc: Number of instructions in the loop body
   straight-line: false
   doc: |
-    Repeats a sequence of code multiple times. The number of iterations is
-    read from `grs`, treated as an unsigned value. The number of
-    instructions in the loop is given in the `bodysize` immediate.
+    Repeats a sequence of code multiple times.
+    The number of iterations is read from `grs`, treated as an unsigned value.
+    The number of instructions in the loop is given in the `bodysize` immediate.
 
     The `LOOP` instruction doesn't support a zero iteration count.
     If the value in `grs` is zero, OTBN stops with the `ErrCodeLoop` error.
-    Starting a loop pushes an entry on to the loop stack.
+    Starting a loop pushes an entry on to the [loop stack](../#loop-stack).
     If the stack is already full, OTBN stops with the `ErrCodeLoop` error.
 
-    There are also conditions on the code inside a loop.
-    A `LOOP`, `LOOPI`, jump or branch instruction may not appear as the last instruction in a loop.
+    `LOOP`, `LOOPI`, jump and branch instructions are all permitted inside a loop but may not appear as the last instruction in a loop.
     OTBN will stop on that instruction with the `ErrCodeLoop` error.
+
+    For more information on how to correctly use `LOOP` see [loop nesting](../#loop-nesting).
   encoding:
     scheme: loop
     mapping:
@@ -470,17 +471,19 @@
     - *bodysize-operand
   straight-line: false
   doc: |
-    Repeats a sequence of code multiple times. The `iterations`
-    unsigned immediate operand gives the number of iterations and
-    the `bodysize` unsigned immediate operand gives the number of
-    instructions in the body.
+    Repeats a sequence of code multiple times.
+    The number of iterations is given in the `iterations` immediate.
+    The number of instructions in the loop is given in the `bodysize` immediate.
 
-    Starting a loop pushes an entry on to the loop stack.
+    The `LOOPI` instruction doesn't support a zero iteration count.
+    If the value of `iterations` is zero, OTBN stops with the `ErrCodeLoop` error.
+    Starting a loop pushes an entry on to the [loop stack](../#loop-stack).
     If the stack is already full, OTBN stops with the `ErrCodeLoop` error.
 
-    There are also conditions on the code inside a loop.
-    A `LOOP`, `LOOPI`, jump or branch instruction may not appear as the last instruction in a loop.
+    `LOOP`, `LOOPI`, jump and branch instructions are all permitted inside a loop but may not appear as the last instruction in a loop.
     OTBN will stop on that instruction with the `ErrCodeLoop` error.
+
+    For more information on how to correctly use `LOOPI` see [loop nesting](../#loop-nesting).
   encoding:
     scheme: loopi
     mapping:

--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -361,6 +361,72 @@ Both use the same state for tracking control flow.
 This is a stack of tuples containing a loop count, start address and end address.
 The stack has a maximum depth of eight and the top of the stack is the current loop.
 
+### Loop nesting
+
+OTBN permits loop nesting and branches and jumps inside loops.
+However, it doesn't have support for early termination of loops: there's no way to pop an entry from the loop stack without executing the last instruction of the loop the correct number of times.
+It can also only pop one level of the loop stack per instruction.
+
+To avoid polluting the loop stack or avoid surprising behaviour, the programmer must ensure that:
+* Even if there are branches and jumps within a loop body, the final instruction of the loop body gets executed exactly once per iteration.
+* Nested loops have distinct end addresses.
+* The end instruction of an outer loop is not executed before an inner loop finishes.
+
+OTBN does not detect these conditions being violated, so no error will be signalled should they occur.
+
+(Note indentation in the code examples is for clarity and has no functional impact).
+
+The following loops are *well nested*:
+
+```
+LOOP x2, 3
+  LOOP x3, 1
+    ADDI x4, x4, 1
+  # The NOP ensures that the outer and inner loops end on different instructions
+  NOP
+
+# Both inner and outer loops call some_fn, which returns to
+# the body of the loop
+LOOP x2, 5
+  JAL x1, some_fn
+  LOOP x3, 2
+    JAL x1, some_fn
+    ADDI x4, x4, 1
+  NOP
+
+# Control flow leaves the immediate body of the outer loop but eventually 
+# returns to it
+LOOP x2, 4
+  BEQ x4, x5, some_label
+branch_back:
+  LOOP x3, 1
+    ADDI x6, x6, 1
+  NOP
+
+some_label:
+  ...
+  JAL x0, branch_back
+```
+
+The following loops are not well nested:
+
+```
+# Both loops end on the same instruction
+LOOP x2, 2
+  LOOP x3, 1
+    ADDI x4, x4, 1
+
+# Inner loop jumps into outer loop body (executing the outer loop end
+# instruction before the inner loop has finished)
+LOOP x2, 5
+  LOOP x3, 3
+    ADDI x4, x4 ,1
+    BEQ  x4, x5, outer_body
+    ADD  x6, x7, x8
+outer_body:
+  SUBI  x9, x9, 1
+```
+
 # Theory of Operations
 
 ## Block Diagram


### PR DESCRIPTION
* Formatting of the doc string is corrected (one sentence per line)
* Zero iterations in `LOOPI` also results in error
* Add guidance on how loop nesting works
* Make it explicit that branches/jumps are allowed in loops excepting
  the last instruction.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>