### PR TITLE
[otbn] Correct ordering in flag enum

### DIFF
--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -343,16 +343,16 @@ Each flag is a single bit.
 - `C` (Carry flag).
   Set to 1 an overflow occurred in the last arithmetic instruction.
 
-- `L` (LSb flag).
-  The least significant bit of the result of the last arithmetic or shift instruction.
-
 - `M` (MSb flag)
   The most significant bit of the result of the last arithmetic or shift instruction.
+
+- `L` (LSb flag).
+  The least significant bit of the result of the last arithmetic or shift instruction.
 
 - `Z` (Zero Flag)
   Set to 1 if the result of the last operation was zero; otherwise 0.
 
-The `L`, `M`, and `Z` flags are determined based on the result of the operation as it is written back into the result register, without considering the overflow bit.
+The `M`, `L`, and `Z` flags are determined based on the result of the operation as it is written back into the result register, without considering the overflow bit.
 
 ### Loop Stack
 

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -217,8 +217,8 @@ package otbn_pkg;
 
   typedef enum logic [$clog2(FlagsWidth)-1:0] {
     FlagC = 'd0,
-    FlagL = 'd1,
-    FlagM = 'd2,
+    FlagM = 'd1,
+    FlagL = 'd2,
     FlagZ = 'd3
   } flag_e;
 


### PR DESCRIPTION
There's been a bit of confusion over the last couple of months about
the order (CMLZ or CLMZ). We came down on the former, but this enum
was still backwards.

Also, reorder the list of flags in the documentation to match. (It
wasn't technically wrong, but it's probably less confusing if it's the
same as everything else).
