### PR TITLE
[keymgr/dv] Change polling cfgen to wait for 2 cycles

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -207,7 +207,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
 
         if (addr_phase_read) begin
           addr_phase_cfgen = current_op_status == keymgr_pkg::OpWip;
-        end else if (addr_phase_write) begin
+        end else if (data_phase_read) begin
           `DV_CHECK_EQ(item.d_data, addr_phase_cfgen)
         end
       end

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -27,9 +27,9 @@ class keymgr_base_vseq extends cip_base_vseq #(
     super.dut_init();
     cfg.keymgr_vif.init();
 
-    // design synchronizes life cycle value from async domain to update cfg_en
-    // wait until cfg_en=1, otherwise some register programming will be gated
-    csr_spinwait(.ptr(ral.cfgen), .exp_data(1'b1));
+    // Add 2 cycles for design to synchronize life cycle value from async domain to update cfg_en
+    // otherwise, some register programming will be gated
+    cfg.clk_rst_vif.wait_clks(2);
 
     if (do_keymgr_init) keymgr_init();
   endtask


### PR DESCRIPTION
As Cindy pointed out, if polling cfgen during synchronizing, scb need to
handle those 2 cycles when value is changing. Use 2 cycles delay to avoid
special handle in scb
Also fix a typo at checking cfgen value

Fix for #4589
Signed-off-by: Weicai Yang <weicai@google.com>