### PR TITLE
[doc/lc_ctrl] Minor fixes in LC_CTRL tables

### DIFF
--- a/hw/ip/lc_ctrl/doc/lc_ctrl_access_signals_table.md
+++ b/hw/ip/lc_ctrl/doc/lc_ctrl_access_signals_table.md
@@ -36,7 +36,7 @@
   </tr>
   <tr>
     <td style="text-align:left">RMA</td>
-    <td>Y*</td><td>Y</td><td>Y*</td><td>Y</td><td>Y</td>
+    <td>Y</td><td>Y</td><td>Y</td><td>Y</td><td>Y</td>
   </tr>
   <tr>
     <td style="text-align:left">SCRAP</td>

--- a/hw/ip/lc_ctrl/doc/lc_ctrl_otp_accessibility.md
+++ b/hw/ip/lc_ctrl/doc/lc_ctrl_otp_accessibility.md
@@ -16,7 +16,7 @@
 <td>no</td>
 <td>no</td>
 <td>yes</td>
-<td rowspan="2">Advanced only by HW. Not that these two items are exposed in decoded form in the life cycle controller CSRs.</td>
+<td rowspan="2">Advanced only by HW. Note that these two items are exposed in decoded form in the life cycle controller CSRs.</td>
 </tr>
 <tr>
 <td>LC_TRANSITION_CNT</td>


### PR DESCRIPTION
1. For RMA mode, all output should be enabled regardless of the device
is personalized or not. So remove the asterisks.

2. Fix typo Not that -> Note that.

Signed-off-by: Cindy Chen <chencindy@google.com>