### PR TITLE
[lc/otp/alerts] Place size-only buffers on all multibit signals

### DIFF
--- a/hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv
+++ b/hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv
@@ -28,6 +28,7 @@ module flash_ctrl_wrapper (
   input        lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_rd_en_i,
   input        lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_wr_en_i,
   input        lc_ctrl_pkg::lc_tx_t lc_seed_hw_rd_en_i,
+  input        lc_ctrl_pkg::lc_tx_t lc_dft_en_i,
   input        flash_ctrl_pkg::lc_flash_req_t lc_i,
   output       pwrmgr_pkg::pwr_flash_rsp_t pwrmgr_o,
   input        pwrmgr_pkg::pwr_flash_req_t pwrmgr_i,
@@ -113,17 +114,27 @@ module flash_ctrl_wrapper (
   );
 
   flash_phy u_flash_eflash (
-    .clk_i           (clk_i),
-    .rst_ni          (rst_ni),
-    .host_req_i      (flash_host_req),
-    .host_addr_i     (flash_host_addr),
-    .host_req_rdy_o  (flash_host_req_rdy),
-    .host_req_done_o (flash_host_req_done),
-    .host_rdata_o    (flash_host_rdata),
-    .flash_ctrl_i    (flash_ctrl_flash_req),
-    .flash_ctrl_o    (flash_ctrl_flash_rsp),
+    .clk_i,
+    .rst_ni,
+    .host_req_i             (flash_host_req     ),
+    .host_addr_i            (flash_host_addr    ),
+    .host_req_rdy_o         (flash_host_req_rdy ),
+    .host_req_done_o        (flash_host_req_done),
+    .host_rdata_o           (flash_host_rdata   ),
+    .host_rderr_o           ( ),
+    .flash_ctrl_i           (flash_ctrl_flash_req),
+    .flash_ctrl_o           (flash_ctrl_flash_rsp),
+    .scanmode_i             (1'b0),
+    .scan_rst_ni            (1'b0),
     .flash_power_ready_h_i,
-    .flash_power_down_h_i
+    .flash_power_down_h_i,
+    .flash_test_mode_a_i    (1'b0),
+    .flash_test_voltage_h_i (1'b0),
+    .lc_dft_en_i,
+    .tck_i                  (1'b0),
+    .tdi_i                  (1'b0),
+    .tms_i                  (1'b0),
+    .tdo_o                  ( )
   );
 
 endmodule

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -56,6 +56,7 @@ module tb;
     .lc_iso_part_sw_rd_en_i     (lc_ctrl_pkg::On),
     .lc_iso_part_sw_wr_en_i     (lc_ctrl_pkg::On),
     .lc_seed_hw_rd_en_i         (lc_ctrl_pkg::On),
+    .lc_dft_en_i                (lc_ctrl_pkg::Off),
     .lc_i                       (flash_ctrl_pkg::LC_FLASH_REQ_DEFAULT),
     .pwrmgr_o                   (pwrmgr_pkg::PWR_FLASH_RSP_DEFAULT),
     .pwrmgr_i                   (pwrmgr_pkg::PWR_FLASH_REQ_DEFAULT),

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
@@ -102,8 +102,8 @@ module lc_ctrl_fsm
   assign otp_prog_lc_cnt_o   = lc_cnt_q;
 
   // Conditional LC signal outputs
-  lc_tx_t lc_clk_byp_req_d, lc_clk_byp_req_q;
-  lc_tx_t lc_flash_rma_req_d, lc_flash_rma_req_q;
+  lc_tx_t lc_clk_byp_req_d, lc_clk_byp_req_q, lc_clk_byp_req;
+  lc_tx_t lc_flash_rma_req_d, lc_flash_rma_req_q, lc_flash_rma_req;
 
   `ASSERT_KNOWN(LcStateKnown_A,   lc_state_q   )
   `ASSERT_KNOWN(LcCntKnown_A,     lc_cnt_q     )
@@ -140,8 +140,8 @@ module lc_ctrl_fsm
     // The clock bypass and RMA signals remain asserted once set to ON.
     // Note that the remaining life cycle signals are decoded in
     // the lc_ctrl_signal_decode submodule.
-    lc_clk_byp_req_d   = lc_clk_byp_req_q;
-    lc_flash_rma_req_d = lc_flash_rma_req_q;
+    lc_clk_byp_req   = lc_clk_byp_req_q;
+    lc_flash_rma_req = lc_flash_rma_req_q;
 
     unique case (fsm_state_q)
       ///////////////////////////////////////////////////////////////////
@@ -183,7 +183,7 @@ module lc_ctrl_fsm
                                LcStTestLocked0,
                                LcStTestLocked1,
                                LcStTestLocked2}) begin
-          lc_clk_byp_req_d = On;
+          lc_clk_byp_req = On;
           if (lc_clk_byp_ack_i == On) begin
             fsm_state_d = CntIncrSt;
           end
@@ -252,7 +252,7 @@ module lc_ctrl_fsm
       // two times later below.
       FlashRmaSt: begin
         if (trans_target_i == DecLcStRma) begin
-          lc_flash_rma_req_d = On;
+          lc_flash_rma_req = On;
           if (lc_flash_rma_ack_i == On) begin
             fsm_state_d = TokenCheck0St;
           end
@@ -346,6 +346,15 @@ module lc_ctrl_fsm
     .rst_ni,
     .d_i ( fsm_state_d ),
     .q_o ( fsm_state_raw_q )
+  );
+
+  prim_lc_sender u_prim_lc_sender_clk_byp_req (
+    .lc_en_i(lc_clk_byp_req),
+    .lc_en_o(lc_clk_byp_req_d)
+  );
+  prim_lc_sender u_prim_lc_sender_flash_rma_req (
+    .lc_en_i(lc_flash_rma_req),
+    .lc_en_o(lc_flash_rma_req_d)
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
@@ -451,7 +460,7 @@ module lc_ctrl_fsm
   );
 
   // Conditional signals set by main FSM.
-  assign lc_clk_byp_req_o   = lc_clk_byp_req_q;
+  assign lc_clk_byp_req_o = lc_clk_byp_req_q;
   assign lc_flash_rma_req_o = lc_flash_rma_req_q;
 
   ////////////////

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_signal_decode.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_signal_decode.sv
@@ -44,38 +44,38 @@ module lc_ctrl_signal_decode
   // Signal Decoder Logic //
   //////////////////////////
 
-  lc_tx_t lc_dft_en_d, lc_dft_en_q;
-  lc_tx_t lc_nvm_debug_en_d, lc_nvm_debug_en_q;
-  lc_tx_t lc_hw_debug_en_d, lc_hw_debug_en_q;
-  lc_tx_t lc_cpu_en_d, lc_cpu_en_q;
-  lc_tx_t lc_creator_seed_sw_rw_en_d, lc_creator_seed_sw_rw_en_q;
-  lc_tx_t lc_owner_seed_sw_rw_en_d, lc_owner_seed_sw_rw_en_q;
-  lc_tx_t lc_iso_part_sw_rd_en_d, lc_iso_part_sw_rd_en_q;
-  lc_tx_t lc_iso_part_sw_wr_en_d, lc_iso_part_sw_wr_en_q;
-  lc_tx_t lc_seed_hw_rd_en_d, lc_seed_hw_rd_en_q;
-  lc_tx_t lc_keymgr_en_d, lc_keymgr_en_q;
-  lc_tx_t lc_escalate_en_d, lc_escalate_en_q;
+  lc_tx_t lc_dft_en_d, lc_dft_en_q, lc_dft_en;
+  lc_tx_t lc_nvm_debug_en_d, lc_nvm_debug_en_q, lc_nvm_debug_en;
+  lc_tx_t lc_hw_debug_en_d, lc_hw_debug_en_q, lc_hw_debug_en;
+  lc_tx_t lc_cpu_en_d, lc_cpu_en_q, lc_cpu_en;
+  lc_tx_t lc_creator_seed_sw_rw_en_d, lc_creator_seed_sw_rw_en_q, lc_creator_seed_sw_rw_en;
+  lc_tx_t lc_owner_seed_sw_rw_en_d, lc_owner_seed_sw_rw_en_q, lc_owner_seed_sw_rw_en;
+  lc_tx_t lc_iso_part_sw_rd_en_d, lc_iso_part_sw_rd_en_q, lc_iso_part_sw_rd_en;
+  lc_tx_t lc_iso_part_sw_wr_en_d, lc_iso_part_sw_wr_en_q, lc_iso_part_sw_wr_en;
+  lc_tx_t lc_seed_hw_rd_en_d, lc_seed_hw_rd_en_q, lc_seed_hw_rd_en;
+  lc_tx_t lc_keymgr_en_d, lc_keymgr_en_q, lc_keymgr_en;
+  lc_tx_t lc_escalate_en_d, lc_escalate_en_q, lc_escalate_en;
   lc_keymgr_div_t lc_keymgr_div_d, lc_keymgr_div_q;
 
   always_comb begin : p_lc_signal_decode
     // Life cycle control signal defaults
-    lc_dft_en_d                = Off;
-    lc_nvm_debug_en_d          = Off;
-    lc_hw_debug_en_d           = Off;
-    lc_cpu_en_d                = Off;
-    lc_creator_seed_sw_rw_en_d = Off;
-    lc_owner_seed_sw_rw_en_d   = Off;
-    lc_iso_part_sw_rd_en_d     = Off;
-    lc_iso_part_sw_wr_en_d     = Off;
-    lc_seed_hw_rd_en_d         = Off;
-    lc_keymgr_en_d             = Off;
-    lc_escalate_en_d           = Off;
+    lc_dft_en                = Off;
+    lc_nvm_debug_en          = Off;
+    lc_hw_debug_en           = Off;
+    lc_cpu_en                = Off;
+    lc_creator_seed_sw_rw_en = Off;
+    lc_owner_seed_sw_rw_en   = Off;
+    lc_iso_part_sw_rd_en     = Off;
+    lc_iso_part_sw_wr_en     = Off;
+    lc_seed_hw_rd_en         = Off;
+    lc_keymgr_en             = Off;
+    lc_escalate_en           = Off;
     // Set to invalid diversification value by default.
-    lc_keymgr_div_d            = RndCnstLcKeymgrDivInvalid;
+    lc_keymgr_div_d          = RndCnstLcKeymgrDivInvalid;
     // The escalation life cycle signal is always decoded, no matter
     // which state we currently are in.
     if (esc_wipe_secrets_i) begin
-      lc_escalate_en_d = On;
+      lc_escalate_en = On;
     end
 
     // Only broadcast during the following main FSM states
@@ -96,65 +96,65 @@ module lc_ctrl_signal_decode
         LcStTestUnlocked1,
         LcStTestUnlocked2,
         LcStTestUnlocked3: begin
-          lc_dft_en_d            = On;
-          lc_nvm_debug_en_d      = On;
-          lc_hw_debug_en_d       = On;
-          lc_cpu_en_d            = On;
-          lc_iso_part_sw_wr_en_d = On;
-          lc_keymgr_div_d        = RndCnstLcKeymgrDivTestDevRma;
+          lc_dft_en            = On;
+          lc_nvm_debug_en      = On;
+          lc_hw_debug_en       = On;
+          lc_cpu_en            = On;
+          lc_iso_part_sw_wr_en = On;
+          lc_keymgr_div_d      = RndCnstLcKeymgrDivTestDevRma;
         end
         ///////////////////////////////////////////////////////////////////
         // Enable production functions
         LcStProd, LcStProdEnd: begin
-          lc_cpu_en_d              = On;
-          lc_keymgr_en_d           = On;
-          lc_owner_seed_sw_rw_en_d = On;
-          lc_iso_part_sw_wr_en_d   = On;
-          lc_iso_part_sw_rd_en_d   = On;
-          lc_keymgr_div_d          = RndCnstLcKeymgrDivProduction;
+          lc_cpu_en              = On;
+          lc_keymgr_en           = On;
+          lc_owner_seed_sw_rw_en = On;
+          lc_iso_part_sw_wr_en   = On;
+          lc_iso_part_sw_rd_en   = On;
+          lc_keymgr_div_d        = RndCnstLcKeymgrDivProduction;
           // Only allow provisioning if the device has not yet been personalized.
           if (lc_id_state_i == LcIdBlank) begin
-            lc_creator_seed_sw_rw_en_d = On;
+            lc_creator_seed_sw_rw_en = On;
           end
           // Only allow hardware to consume the seeds once personalized.
           if (lc_id_state_i == LcIdPersonalized) begin
-            lc_seed_hw_rd_en_d = On;
+            lc_seed_hw_rd_en = On;
           end
 
         end
         ///////////////////////////////////////////////////////////////////
         // Same functions as PROD, but with additional debug functionality.
         LcStDev: begin
-          lc_hw_debug_en_d         = On;
-          lc_cpu_en_d              = On;
-          lc_keymgr_en_d           = On;
-          lc_owner_seed_sw_rw_en_d = On;
-          lc_iso_part_sw_wr_en_d   = On;
-          lc_iso_part_sw_rd_en_d   = On;
-          lc_keymgr_div_d          = RndCnstLcKeymgrDivTestDevRma;
+          lc_hw_debug_en         = On;
+          lc_cpu_en              = On;
+          lc_keymgr_en           = On;
+          lc_owner_seed_sw_rw_en = On;
+          lc_iso_part_sw_wr_en   = On;
+          lc_iso_part_sw_rd_en   = On;
+          lc_keymgr_div_d        = RndCnstLcKeymgrDivTestDevRma;
           // Only allow provisioning if the device has not yet been personalized.
           if (lc_id_state_i == LcIdBlank) begin
-            lc_creator_seed_sw_rw_en_d = On;
+            lc_creator_seed_sw_rw_en = On;
           end
           // Only allow hardware to consume the seeds once personalized.
           if (lc_id_state_i == LcIdPersonalized) begin
-            lc_seed_hw_rd_en_d = On;
+            lc_seed_hw_rd_en = On;
           end
         end
         ///////////////////////////////////////////////////////////////////
         // Enable all test and production functions.
         LcStRma: begin
-          lc_dft_en_d                = On;
-          lc_nvm_debug_en_d          = On;
-          lc_hw_debug_en_d           = On;
-          lc_cpu_en_d                = On;
-          lc_keymgr_en_d             = On;
-          lc_creator_seed_sw_rw_en_d = On;
-          lc_owner_seed_sw_rw_en_d   = On;
-          lc_iso_part_sw_wr_en_d     = On;
-          lc_iso_part_sw_rd_en_d     = On;
-          lc_seed_hw_rd_en_d         = On;
-          lc_keymgr_div_d            = RndCnstLcKeymgrDivTestDevRma;
+          lc_dft_en                = On;
+          lc_nvm_debug_en          = On;
+          lc_hw_debug_en           = On;
+          lc_cpu_en                = On;
+          lc_keymgr_en             = On;
+          lc_creator_seed_sw_rw_en = On;
+          lc_owner_seed_sw_rw_en   = On;
+          lc_iso_part_sw_wr_en     = On;
+          lc_iso_part_sw_rd_en     = On;
+          lc_seed_hw_rd_en         = On;
+          lc_keymgr_div_d          = RndCnstLcKeymgrDivTestDevRma;
         end
         ///////////////////////////////////////////////////////////////////
         // Invalid or scrapped life cycle state, do not assert
@@ -167,6 +167,51 @@ module lc_ctrl_signal_decode
   /////////////////////////////////
   // Control signal output flops //
   /////////////////////////////////
+
+  prim_lc_sender u_prim_lc_sender_dft_en (
+    .lc_en_i(lc_dft_en),
+    .lc_en_o(lc_dft_en_d)
+  );
+  prim_lc_sender u_prim_lc_sender_nvm_debug_en (
+    .lc_en_i(lc_nvm_debug_en),
+    .lc_en_o(lc_nvm_debug_en_d)
+  );
+  prim_lc_sender u_prim_lc_sender_hw_debug_en (
+    .lc_en_i(lc_hw_debug_en),
+    .lc_en_o(lc_hw_debug_en_d)
+  );
+  prim_lc_sender u_prim_lc_sender_cpu_en (
+    .lc_en_i(lc_cpu_en),
+    .lc_en_o(lc_cpu_en_d)
+  );
+  prim_lc_sender u_prim_lc_sender_creator_seed_sw_rw_en (
+    .lc_en_i(lc_creator_seed_sw_rw_en),
+    .lc_en_o(lc_creator_seed_sw_rw_en_d)
+  );
+  prim_lc_sender u_prim_lc_sender_owner_seed_sw_rw_en (
+    .lc_en_i(lc_owner_seed_sw_rw_en),
+    .lc_en_o(lc_owner_seed_sw_rw_en_d)
+  );
+  prim_lc_sender u_prim_lc_sender_iso_part_sw_rd_en (
+    .lc_en_i(lc_iso_part_sw_rd_en),
+    .lc_en_o(lc_iso_part_sw_rd_en_d)
+  );
+  prim_lc_sender u_prim_lc_sender_iso_part_sw_wr_en (
+    .lc_en_i(lc_iso_part_sw_wr_en),
+    .lc_en_o(lc_iso_part_sw_wr_en_d)
+  );
+  prim_lc_sender u_prim_lc_sender_seed_hw_rd_en (
+    .lc_en_i(lc_seed_hw_rd_en),
+    .lc_en_o(lc_seed_hw_rd_en_d)
+  );
+  prim_lc_sender u_prim_lc_sender_keymgr_en (
+    .lc_en_i(lc_keymgr_en),
+    .lc_en_o(lc_keymgr_en_d)
+  );
+  prim_lc_sender u_prim_lc_sender_escalate_en (
+    .lc_en_i(lc_escalate_en),
+    .lc_en_o(lc_escalate_en_d)
+  );
 
   assign lc_dft_en_o                = lc_dft_en_q;
   assign lc_nvm_debug_en_o          = lc_nvm_debug_en_q;

--- a/hw/ip/otp_ctrl/otp_ctrl.core
+++ b/hw/ip/otp_ctrl/otp_ctrl.core
@@ -15,6 +15,7 @@ filesets:
       - lowrisc:prim:otp
       - lowrisc:prim:lfsr
       - lowrisc:prim:lc_sync
+      - lowrisc:prim:buf
       - lowrisc:prim:secded
       - lowrisc:ip:pwrmgr_pkg
     files:

--- a/hw/ip/prim/lint/prim_buf.waiver
+++ b/hw/ip/prim/lint/prim_buf.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_buf
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_buf.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -15,6 +15,7 @@ filesets:
       - lowrisc:prim:pad_wrapper
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:clock_mux2
+      - lowrisc:prim:buf
       - lowrisc:prim:flop
       - lowrisc:prim:flop_2sync
     files:

--- a/hw/ip/prim/prim_buf.core
+++ b/hw/ip/prim/prim_buf.core
@@ -1,0 +1,50 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:buf"
+description: "Generic buffer"
+filesets:
+  primgen_dep:
+    depend:
+      - lowrisc:prim:prim_pkg
+      - lowrisc:prim:primgen
+
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_buf.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
+generate:
+  impl:
+    generator: primgen
+    parameters:
+      prim_name: buf
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - primgen_dep
+    generate:
+      - impl

--- a/hw/ip/prim/prim_lc_sender.core
+++ b/hw/ip/prim/prim_lc_sender.core
@@ -3,24 +3,31 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: "lowrisc:prim_xilinx:buf"
-description: "buffer"
+name: "lowrisc:prim:lc_sender:0.1"
+description: "Sender primitive for life cycle control signals."
 filesets:
   files_rtl:
+    depend:
+      - lowrisc:prim:assert
+      - lowrisc:prim:buf
+      - lowrisc:ip:lc_ctrl_pkg
     files:
-      - rtl/prim_xilinx_buf.sv
+      - rtl/prim_lc_sender.sv
     file_type: systemVerilogSource
 
   files_verilator_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
+    files:
     file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
+    files:
+      # - lint/prim_lc_sender.waiver
     file_type: waiver
 
   files_veriblelint_waiver:
@@ -30,9 +37,20 @@ filesets:
       - lowrisc:lint:comportable
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - tool_verilator   ? (files_verilator_waiver)
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
       - files_rtl
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/prim/prim_lc_sync.core
+++ b/hw/ip/prim/prim_lc_sync.core
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:prim:assert
       - lowrisc:prim:flop_2sync
-      - lowrisc:prim:clock_buf
+      - lowrisc:prim:lc_sender
       - lowrisc:ip:lc_ctrl_pkg
     files:
       - rtl/prim_lc_sync.sv

--- a/hw/ip/prim/rtl/prim_alert_receiver.sv
+++ b/hw/ip/prim/rtl/prim_alert_receiver.sv
@@ -63,13 +63,13 @@ module prim_alert_receiver
   ) i_decode_alert (
     .clk_i,
     .rst_ni,
-    .diff_pi  ( alert_tx_i.alert_p     ),
-    .diff_ni  ( alert_tx_i.alert_n     ),
-    .level_o  ( alert_level  ),
-    .rise_o   (              ),
-    .fall_o   (              ),
-    .event_o  (              ),
-    .sigint_o ( alert_sigint )
+    .diff_pi  ( alert_tx_i.alert_p ),
+    .diff_ni  ( alert_tx_i.alert_n ),
+    .level_o  ( alert_level        ),
+    .rise_o   (                    ),
+    .fall_o   (                    ),
+    .event_o  (                    ),
+    .sigint_o ( alert_sigint       )
   );
 
   /////////////////////////////////////////////////////
@@ -78,7 +78,8 @@ module prim_alert_receiver
   typedef enum logic [1:0] {Idle, HsAckWait, Pause0, Pause1} state_e;
   state_e state_d, state_q;
   logic ping_rise;
-  logic ping_tog_d, ping_tog_q, ack_d, ack_q;
+  logic ping_tog, ping_tog_dp, ping_tog_qp, ping_tog_dn, ping_tog_qn;
+  logic ack, ack_dp, ack_qp, ack_dn, ack_qn;
   logic ping_req_d, ping_req_q;
   logic ping_pending_d, ping_pending_q;
 
@@ -86,7 +87,25 @@ module prim_alert_receiver
   // signalling is performed by a level change event on the diff output
   assign ping_req_d  = ping_req_i;
   assign ping_rise  = ping_req_i && !ping_req_q;
-  assign ping_tog_d = (ping_rise) ? ~ping_tog_q : ping_tog_q;
+  assign ping_tog = (ping_rise) ? ~ping_tog_qp : ping_tog_qp;
+
+  // This prevents further tool optimizations of the differential signal.
+  prim_buf u_prim_buf_ack_p (
+    .in_i(ack),
+    .out_o(ack_dp)
+  );
+  prim_buf u_prim_buf_ack_n (
+    .in_i(~ack),
+    .out_o(ack_dn)
+  );
+  prim_buf u_prim_buf_ping_p (
+    .in_i(ping_tog),
+    .out_o(ping_tog_dp)
+  );
+  prim_buf u_prim_buf_ping_n (
+    .in_i(~ping_tog),
+    .out_o(ping_tog_dn)
+  );
 
   // the ping pending signal is used to in the FSM to distinguish whether the
   // incoming handshake shall be treated as an alert or a ping response.
@@ -96,10 +115,11 @@ module prim_alert_receiver
   assign ping_pending_d = ping_rise | ((~ping_ok_o) & ping_req_i & ping_pending_q);
 
   // diff pair outputs
-  assign alert_rx_o.ack_p  = ack_q;
-  assign alert_rx_o.ack_n  = ~ack_q;
-  assign alert_rx_o.ping_p = ping_tog_q;
-  assign alert_rx_o.ping_n = ~ping_tog_q;
+  assign alert_rx_o.ack_p = ack_qp;
+  assign alert_rx_o.ack_n = ack_qn;
+
+  assign alert_rx_o.ping_p = ping_tog_qp;
+  assign alert_rx_o.ping_n = ping_tog_qn;
 
   // this FSM receives the four phase handshakes from the alert receiver
   // note that the latency of the alert_p/n input diff pair is at least one
@@ -108,7 +128,7 @@ module prim_alert_receiver
   always_comb begin : p_fsm
     // default
     state_d      = state_q;
-    ack_d        = 1'b0;
+    ack          = 1'b0;
     ping_ok_o    = 1'b0;
     integ_fail_o = 1'b0;
     alert_o      = 1'b0;
@@ -118,7 +138,7 @@ module prim_alert_receiver
         // wait for handshake to be initiated
         if (alert_level) begin
           state_d = HsAckWait;
-          ack_d   = 1'b1;
+          ack     = 1'b1;
           // signal either an alert or ping received on the output
           if (ping_pending_q) begin
             ping_ok_o = 1'b1;
@@ -132,7 +152,7 @@ module prim_alert_receiver
         if (!alert_level) begin
           state_d  = Pause0;
         end else begin
-          ack_d    = 1'b1;
+          ack      = 1'b1;
         end
       end
       // pause cycles between back-to-back handshakes
@@ -144,7 +164,7 @@ module prim_alert_receiver
     // override in case of sigint
     if (alert_sigint) begin
       state_d      = Idle;
-      ack_d        = 1'b0;
+      ack          = 1'b0;
       ping_ok_o    = 1'b0;
       integ_fail_o = 1'b1;
       alert_o      = 1'b0;
@@ -154,14 +174,18 @@ module prim_alert_receiver
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_reg
     if (!rst_ni) begin
       state_q        <= Idle;
-      ack_q          <= 1'b0;
-      ping_tog_q     <= 1'b0;
+      ack_qp         <= 1'b0;
+      ack_qn         <= 1'b1;
+      ping_tog_qp    <= 1'b0;
+      ping_tog_qn    <= 1'b1;
       ping_req_q     <= 1'b0;
       ping_pending_q <= 1'b0;
     end else begin
       state_q        <= state_d;
-      ack_q          <= ack_d;
-      ping_tog_q     <= ping_tog_d;
+      ack_qp         <= ack_dp;
+      ack_qn         <= ack_dn;
+      ping_tog_qp    <= ping_tog_dp;
+      ping_tog_qn    <= ping_tog_dn;
       ping_req_q     <= ping_req_d;
       ping_pending_q <= ping_pending_d;
     end

--- a/hw/ip/prim/rtl/prim_alert_sender.sv
+++ b/hw/ip/prim/rtl/prim_alert_sender.sv
@@ -58,13 +58,13 @@ module prim_alert_sender
   ) i_decode_ping (
     .clk_i,
     .rst_ni,
-    .diff_pi  ( alert_rx_i.ping_p     ),
-    .diff_ni  ( alert_rx_i.ping_n     ),
-    .level_o  (             ),
-    .rise_o   (             ),
-    .fall_o   (             ),
-    .event_o  ( ping_event  ),
-    .sigint_o ( ping_sigint )
+    .diff_pi  ( alert_rx_i.ping_p ),
+    .diff_ni  ( alert_rx_i.ping_n ),
+    .level_o  (                   ),
+    .rise_o   (                   ),
+    .fall_o   (                   ),
+    .event_o  ( ping_event        ),
+    .sigint_o ( ping_sigint       )
   );
 
   logic ack_sigint, ack_level;
@@ -74,13 +74,13 @@ module prim_alert_sender
   ) i_decode_ack (
     .clk_i,
     .rst_ni,
-    .diff_pi  ( alert_rx_i.ack_p      ),
-    .diff_ni  ( alert_rx_i.ack_n      ),
-    .level_o  ( ack_level   ),
-    .rise_o   (             ),
-    .fall_o   (             ),
-    .event_o  (             ),
-    .sigint_o ( ack_sigint  )
+    .diff_pi  ( alert_rx_i.ack_p ),
+    .diff_ni  ( alert_rx_i.ack_n ),
+    .level_o  ( ack_level        ),
+    .rise_o   (                  ),
+    .fall_o   (                  ),
+    .event_o  (                  ),
+    .sigint_o ( ack_sigint       )
   );
 
 
@@ -98,10 +98,11 @@ module prim_alert_sender
     Pause1
     } state_e;
   state_e state_d, state_q;
-  logic alert_pq, alert_nq, alert_pd, alert_nd;
+  logic alert_p, alert_n, alert_pq, alert_nq, alert_pd, alert_nd;
   logic sigint_detected;
 
   assign sigint_detected = ack_sigint | ping_sigint;
+
 
   // diff pair output
   assign alert_tx_o.alert_p = alert_pq;
@@ -127,8 +128,8 @@ module prim_alert_sender
   always_comb begin : p_fsm
     // default
     state_d = state_q;
-    alert_pd   = 1'b0;
-    alert_nd   = 1'b1;
+    alert_p    = 1'b0;
+    alert_n    = 1'b1;
     ping_clr   = 1'b0;
     alert_clr  = 1'b0;
 
@@ -137,8 +138,8 @@ module prim_alert_sender
         // alert always takes precedence
         if (alert_req_i || alert_set_q || ping_event || ping_set_q) begin
           state_d   = (alert_req_i || alert_set_q) ? AlertHsPhase1 : PingHsPhase1;
-          alert_pd  = 1'b1;
-          alert_nd  = 1'b0;
+          alert_p   = 1'b1;
+          alert_n   = 1'b0;
         end
       end
       // waiting for ack from receiver
@@ -146,8 +147,8 @@ module prim_alert_sender
         if (ack_level) begin
           state_d  = AlertHsPhase2;
         end else begin
-          alert_pd = 1'b1;
-          alert_nd = 1'b0;
+          alert_p  = 1'b1;
+          alert_n  = 1'b0;
         end
       end
       // wait for deassertion of ack
@@ -162,8 +163,8 @@ module prim_alert_sender
         if (ack_level) begin
           state_d  = PingHsPhase2;
         end else begin
-          alert_pd = 1'b1;
-          alert_nd = 1'b0;
+          alert_p  = 1'b1;
+          alert_n  = 1'b0;
         end
       end
       // wait for deassertion of ack
@@ -192,8 +193,8 @@ module prim_alert_sender
         state_d  = Idle;
         if (sigint_detected) begin
           state_d  = SigInt;
-          alert_pd = ~alert_pq;
-          alert_nd = ~alert_pq;
+          alert_p  = ~alert_pq;
+          alert_n  = ~alert_pq;
         end
       end
       // catch parasitic states
@@ -202,12 +203,22 @@ module prim_alert_sender
     // bail out if a signal integrity issue has been detected
     if (sigint_detected && (state_q != SigInt)) begin
       state_d   = SigInt;
-      alert_pd  = 1'b0;
-      alert_nd  = 1'b0;
+      alert_p   = 1'b0;
+      alert_n   = 1'b0;
       ping_clr  = 1'b0;
       alert_clr = 1'b0;
     end
   end
+
+  // This prevents further tool optimizations of the differential signal.
+  prim_buf u_prim_buf_p (
+    .in_i(alert_p),
+    .out_o(alert_pd)
+  );
+  prim_buf u_prim_buf_n (
+    .in_i(alert_n),
+    .out_o(alert_nd)
+  );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_reg
     if (!rst_ni) begin

--- a/hw/ip/prim/rtl/prim_esc_receiver.sv
+++ b/hw/ip/prim/rtl/prim_esc_receiver.sv
@@ -57,17 +57,27 @@ module prim_esc_receiver
 
   typedef enum logic [2:0] {Idle, Check, PingResp, EscResp, SigInt} state_e;
   state_e state_d, state_q;
-  logic resp_pd, resp_pq, resp_nd, resp_nq;
+  logic resp_p, resp_pd, resp_pq;
+  logic resp_n, resp_nd, resp_nq;
+
+  // This prevents further tool optimizations of the differential signal.
+  prim_buf u_prim_buf_p (
+    .in_i(resp_p),
+    .out_o(resp_pd)
+  );
+  prim_buf u_prim_buf_n (
+    .in_i(resp_n),
+    .out_o(resp_nd)
+  );
 
   assign esc_rx_o.resp_p = resp_pq;
   assign esc_rx_o.resp_n = resp_nq;
 
-
   always_comb begin : p_fsm
     // default
     state_d  = state_q;
-    resp_pd  = 1'b0;
-    resp_nd  = 1'b1;
+    resp_p   = 1'b0;
+    resp_n   = 1'b1;
     esc_en_o = 1'b0;
 
     unique case (state_q)
@@ -75,8 +85,8 @@ module prim_esc_receiver
       Idle: begin
         if (esc_level) begin
           state_d = Check;
-          resp_pd = 1'b1;
-          resp_nd = 1'b0;
+          resp_p  = 1'b1;
+          resp_n  = 1'b0;
         end
       end
       // we decide here whether this is only a ping request or
@@ -92,8 +102,8 @@ module prim_esc_receiver
       // we got an escalation signal (pings cannot occur back to back)
       PingResp: begin
         state_d = Idle;
-        resp_pd = 1'b1;
-        resp_nd = 1'b0;
+        resp_p  = 1'b1;
+        resp_n  = 1'b0;
         if (esc_level) begin
           state_d  = EscResp;
           esc_en_o = 1'b1;
@@ -105,8 +115,8 @@ module prim_esc_receiver
         state_d = Idle;
         if (esc_level) begin
           state_d  = EscResp;
-          resp_pd  = ~resp_pq;
-          resp_nd  = resp_pq;
+          resp_p   = ~resp_pq;
+          resp_n   = resp_pq;
           esc_en_o = 1'b1;
         end
       end
@@ -119,8 +129,8 @@ module prim_esc_receiver
         state_d = Idle;
         if (sigint_detected) begin
           state_d = SigInt;
-          resp_pd = ~resp_pq;
-          resp_nd = ~resp_pq;
+          resp_p  = ~resp_pq;
+          resp_n  = ~resp_pq;
         end
       end
       default : state_d = Idle;
@@ -129,8 +139,8 @@ module prim_esc_receiver
     // bail out if a signal integrity issue has been detected
     if (sigint_detected && (state_q != SigInt)) begin
       state_d  = SigInt;
-      resp_pd  = 1'b0;
-      resp_nd  = 1'b0;
+      resp_p   = 1'b0;
+      resp_n   = 1'b0;
     end
   end
 

--- a/hw/ip/prim/rtl/prim_esc_sender.sv
+++ b/hw/ip/prim/rtl/prim_esc_sender.sv
@@ -71,8 +71,18 @@ module prim_esc_sender
 
   // ping enable is 1 cycle pulse
   // escalation pulse is always longer than 2 cycles
-  assign esc_tx_o.esc_p = esc_req_i | esc_req_q | (ping_req_d & ~ping_req_q);
-  assign esc_tx_o.esc_n = ~esc_tx_o.esc_p;
+  logic esc_p;
+  assign esc_p = esc_req_i | esc_req_q | (ping_req_d & ~ping_req_q);
+
+  // This prevents further tool optimizations of the differential signal.
+  prim_buf u_prim_buf_p (
+    .in_i(esc_p),
+    .out_o(esc_tx_o.esc_p)
+  );
+  prim_buf u_prim_buf_n (
+    .in_i(~esc_p),
+    .out_o(esc_tx_o.esc_n)
+  );
 
   //////////////
   // RX Logic //

--- a/hw/ip/prim/rtl/prim_lc_sender.sv
+++ b/hw/ip/prim/rtl/prim_lc_sender.sv
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Multibit life cycle signal sender module.
+//
+// This module is combinational and instantiates a hand-picked buffer cell
+// for each bit in the life cycle control signal such that tools do not
+// optimize the multibit encoding.
+
+`include "prim_assert.sv"
+
+module prim_lc_sender (
+  input  lc_ctrl_pkg::lc_tx_t lc_en_i,
+  output lc_ctrl_pkg::lc_tx_t lc_en_o
+);
+
+  logic [lc_ctrl_pkg::TxWidth-1:0] lc_en, lc_en_out;
+  assign lc_en = lc_ctrl_pkg::TxWidth'(lc_en_i);
+
+  for (genvar k = 0; k < lc_ctrl_pkg::TxWidth; k++) begin : gen_bits
+    prim_buf u_prim_buf (
+      .in_i(lc_en[k]),
+      .out_o(lc_en_out[k])
+    );
+  end
+
+  assign lc_en_o = lc_ctrl_pkg::lc_tx_t'(lc_en_out);
+
+endmodule : prim_lc_sender

--- a/hw/ip/prim/rtl/prim_lc_sync.sv
+++ b/hw/ip/prim/rtl/prim_lc_sync.sv
@@ -36,22 +36,39 @@ module prim_lc_sync #(
     .q_o(lc_en)
   );
 
-  logic [NumCopies-1:0][lc_ctrl_pkg::TxWidth-1:0] lc_en_copies;
   for (genvar j = 0; j < NumCopies; j++) begin : gen_buffs
-    for (genvar k = 0; k < lc_ctrl_pkg::TxWidth; k++) begin : gen_bits
-      // TODO: replace this with a normal buffer primitive, once available.
-      prim_clock_buf u_prim_clock_buf (
-        .clk_i(lc_en[k]),
-        .clk_o(lc_en_copies[j][k])
-      );
-    end
-    assign lc_en_o[j] = lc_ctrl_pkg::lc_tx_t'(lc_en_copies[j]);
+    prim_lc_sender u_prim_lc_sender (
+      .lc_en_i(lc_ctrl_pkg::lc_tx_t'(lc_en)),
+      .lc_en_o(lc_en_o[j])
+    );
   end
 
   ////////////////
   // Assertions //
   ////////////////
 
-  // TODO: add more assertions
+  // The outputs should be known at all times.
+  `ASSERT_KNOWN(OutputsKnown_A, lc_en_o)
+
+  // If the multibit signal is in a transient state, we expect it
+  // to be stable again within one clock cycle.
+  `ASSERT(CheckTransients_A,
+      !(lc_en_i inside {lc_ctrl_pkg::On, lc_ctrl_pkg::Off})
+      |=>
+      (lc_en_i inside {lc_ctrl_pkg::On, lc_ctrl_pkg::Off}))
+
+  // If a signal departs from passive state, we expect it to move to the active state
+  // with only one transient cycle in between.
+  `ASSERT(CheckTransients0_A,
+      $past(lc_en_i == lc_ctrl_pkg::Off) &&
+      !(lc_en_i inside {lc_ctrl_pkg::On, lc_ctrl_pkg::Off})
+      |=>
+      (lc_en_i == lc_ctrl_pkg::On))
+
+  `ASSERT(CheckTransients1_A,
+      $past(lc_en_i == lc_ctrl_pkg::On) &&
+      !(lc_en_i inside {lc_ctrl_pkg::On, lc_ctrl_pkg::Off})
+      |=>
+      (lc_en_i == lc_ctrl_pkg::Off))
 
 endmodule : prim_lc_sync

--- a/hw/ip/prim_generic/prim_generic_buf.core
+++ b/hw/ip/prim_generic/prim_generic_buf.core
@@ -1,0 +1,40 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_generic:buf"
+description: "buffer"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_generic_buf.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim_generic/rtl/prim_generic_buf.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_buf.sv
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+module prim_generic_buf (
+  input in_i,
+  output logic out_o
+);
+
+  assign out_o = in_i;
+
+endmodule : prim_generic_buf

--- a/hw/ip/prim_xilinx/prim_xilinx_buf.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_buf.core
@@ -1,0 +1,42 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_xilinx:buf"
+description: "buffer"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_xilinx_buf.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      #- lint/prim_xilinx_buf.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      #- lint/prim_xilinx_buf.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_buf.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_buf.sv
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module prim_xilinx_buf (
+  input in_i,
+  (* keep = "true" *) output logic out_o
+);
+
+  assign out_o = in_i;
+
+endmodule : prim_xilinx_buf


### PR DESCRIPTION
This places size only buffers on multibit signals such as

- differential alert and escalation signals
- life cycle signals
- OTP partition locks

to prevent synthesis tools from optimizing the encoding (these buffers receive a `size_only` attribute in the DC synthesis flow).

Signed-off-by: Michael Schaffner <msf@opentitan.org>