### PR TITLE
[otbn] Run ISS and RTL in lock-step

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -38,7 +38,10 @@ struct ISSWrapper {
 
   // Run simulation for a single cycle. Return true if it is now
   // finished (ECALL or error).
-  std::pair<bool, uint32_t> step();
+  //
+  // If gen_trace is true, pass trace data to the (singleton)
+  // OtbnTraceChecker object.
+  std::pair<bool, uint32_t> step(bool gen_trace);
 
   // Read contents of the register file
   void get_regs(std::array<uint32_t, 32> *gprs, std::array<u256_t, 32> *wdrs);

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -104,14 +104,15 @@ module otbn_core_model
   // Extract particular bits of the status value.
   //
   //   [0]     running:      The ISS is currently running
-  //   [1]     failed_step:  Something went wrong when trying to start or step the ISS.
-  //   [2]     failed_cmp:   The consistency check at the end of run failed.
+  //   [1]     check_due:    The ISS just finished but still needs to check results
+  //   [2]     failed_step:  Something went wrong when trying to start or step the ISS.
+  //   [3]     failed_cmp:   The consistency check at the end of run failed.
   //   [31:16] raw_err_code: The code to expose as the ERR_CODE register
   //
 
-  bit failed_cmp, failed_step, running;
+  bit failed_cmp, failed_step, check_due, running;
   bit [15:0] raw_err_code;
-  assign {failed_cmp, failed_step, running} = status[2:0];
+  assign {failed_cmp, failed_step, check_due, running} = status[3:0];
   assign raw_err_code = status[31:16];
   assign err_code_o = err_code_e'(raw_err_code);
 
@@ -120,7 +121,7 @@ module otbn_core_model
       // Clear status (stop running, and forget any errors)
       status <= 0;
     end else begin
-      if (start_i | running) begin
+      if (start_i | running | check_due) begin
         status <= otbn_model_step(model_handle,
                                   ImemScope, ImemSizeWords,
                                   DmemScope, DmemSizeWords,

--- a/hw/ip/otbn/dv/model/otbn_model.core
+++ b/hw/ip/otbn/dv/model/otbn_model.core
@@ -10,10 +10,13 @@ filesets:
     depend:
       - lowrisc:ip:otbn_pkg
       - lowrisc:dv_verilator:memutil_dpi
+      - lowrisc:ip:otbn_tracer
     files:
       - otbn_model.cc: { file_type: cppSource }
       - iss_wrapper.cc: { file_type: cppSource }
       - iss_wrapper.h: { file_type: cppSource, is_include_file: true }
+      - otbn_trace_checker.h: { file_type: cppSource, is_include_file: true }
+      - otbn_trace_checker.cc: { file_type: cppSource }
       - otbn_core_model.sv
       - otbn_rf_snooper_if.sv
       - otbn_stack_snooper_if.sv

--- a/hw/ip/otbn/dv/model/otbn_trace_checker.cc
+++ b/hw/ip/otbn/dv/model/otbn_trace_checker.cc
@@ -1,0 +1,281 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "otbn_trace_checker.h"
+
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <memory>
+
+#include "otbn_trace_source.h"
+
+static std::unique_ptr<OtbnTraceChecker> trace_checker;
+
+OtbnTraceChecker::OtbnTraceChecker()
+    : rtl_pending_(false),
+      rtl_stall_(false),
+      iss_pending_(false),
+      done_(true),
+      seen_err_(false) {
+  OtbnTraceSource::get().AddListener(this);
+}
+
+OtbnTraceChecker::~OtbnTraceChecker() {
+  if (!done_) {
+    std::cerr
+        << ("WARNING: Destroying OtbnTraceChecker object with an "
+            "unfinished operation.\n");
+  }
+}
+
+OtbnTraceChecker &OtbnTraceChecker::get() {
+  if (!trace_checker) {
+    trace_checker.reset(new OtbnTraceChecker());
+  }
+  return *trace_checker;
+}
+
+void OtbnTraceChecker::AcceptTraceString(const std::string &trace,
+                                         unsigned int cycle_count) {
+  assert(!(rtl_pending_ && iss_pending_));
+
+  if (seen_err_)
+    return;
+
+  done_ = false;
+  TraceEntry trace_entry = TraceEntry::from_rtl_trace(trace);
+  if (trace_entry.hdr_.empty()) {
+    std::cerr << "ERROR: Invalid RTL trace entry with empty header:\n";
+    trace_entry.print("  ", std::cerr);
+    seen_err_ = true;
+    return;
+  }
+
+  // Unless something has gone very wrong, trace_entry.hdr_ will start with 'S'
+  // (stall) or 'E' (execute). We want to coalesce entries for an instruction
+  // here to avoid the ISS needing to figure out what write happens when on a
+  // multi-cycle instruction.
+  //
+  // We work on the basis that an instruction will appear as zero or more stall
+  // entries followed by an execution entry. When we see a stall entry, we
+  // merge it into rtl_stalled_entry_, setting rtl_stall_ to flag that it
+  // contains some information.
+  //
+  // When an execution entry comes up, we check it matches the pending stall
+  // entry and then merge all the fields together, finally setting
+  // rtl_pending_.
+  bool is_stall = trace_entry.hdr_[0] == 'S';
+  if (is_stall) {
+    if (rtl_stall_) {
+      // We already have a stall line. Make sure the headers match.
+      if (rtl_stalled_entry_.hdr_ != trace_entry.hdr_) {
+        std::cerr
+            << ("ERROR: Stall trace entry followed by "
+                "mis-matching stall.\n"
+                "  Existing stall entry was:\n");
+        rtl_stalled_entry_.print("    ", std::cerr);
+        std::cerr << "  New stall entry was:\n";
+        trace_entry.print("    ", std::cerr);
+        seen_err_ = true;
+        return;
+      }
+      rtl_stalled_entry_.take_writes(trace_entry);
+    } else {
+      // This is the first stall. Set the rtl_stall_ flag and save trace_entry.
+      rtl_stall_ = true;
+      rtl_stalled_entry_ = trace_entry;
+    }
+    return;
+  }
+
+  // This wasn't a stall entry. Check it's an execution.
+  if (trace_entry.hdr_[0] != 'E') {
+    std::cerr << "ERROR: Invalid RTL trace entry (neither S nor E):\n";
+    trace_entry.print("  ", std::cerr);
+    seen_err_ = true;
+    return;
+  }
+
+  // If had a stall before, merge in any writes from it, making sure the lines
+  // match.
+  if (rtl_stall_) {
+    if (trace_entry.hdr_.compare(1, std::string::npos, rtl_stalled_entry_.hdr_,
+                                 1, std::string::npos) != 0) {
+      std::cerr
+          << ("ERROR: Execution trace entry doesn't match stall:\n"
+              "  Stall entry was:\n");
+      rtl_stalled_entry_.print("    ", std::cerr);
+      std::cerr << "  Execution entry was:\n";
+      trace_entry.print("    ", std::cerr);
+      seen_err_ = true;
+      return;
+    }
+
+    trace_entry.take_writes(rtl_stalled_entry_);
+  }
+
+  // Check we don't already have a pending RTL execution entry
+  if (rtl_pending_) {
+    std::cerr
+        << ("ERROR: Two back-to-back RTL "
+            "trace entries with no ISS entry.\n"
+            "  First RTL entry was:\n");
+    rtl_entry_.print("    ", std::cerr);
+    std::cerr << "  Second RTL entry was:\n";
+    trace_entry.print("    ", std::cerr);
+    seen_err_ = true;
+    return;
+  }
+
+  rtl_pending_ = true;
+  rtl_stall_ = false;
+  rtl_entry_ = trace_entry;
+
+  if (!MatchPair()) {
+    seen_err_ = true;
+  }
+}
+
+bool OtbnTraceChecker::OnIssTrace(const std::vector<std::string> &lines) {
+  assert(!(rtl_pending_ && iss_pending_));
+
+  if (seen_err_) {
+    return false;
+  }
+
+  // Ignore STALL entries
+  if (lines.size() == 1 && lines[0] == "STALL") {
+    return true;
+  }
+
+  TraceEntry trace_entry = TraceEntry::from_iss_trace(lines);
+
+  done_ = false;
+  if (iss_pending_) {
+    std::cerr
+        << ("ERROR: Two back-to-back ISS "
+            "trace entries with no RTL entry.\n"
+            "  First ISS entry was:\n");
+    iss_entry_.print("    ", std::cerr);
+    std::cerr << "  Second ISS entry was:\n";
+    trace_entry.print("    ", std::cerr);
+    seen_err_ = true;
+    return false;
+  }
+  iss_pending_ = true;
+  iss_entry_ = trace_entry;
+
+  return MatchPair();
+}
+
+bool OtbnTraceChecker::Finish() {
+  assert(!(rtl_pending_ && iss_pending_));
+  done_ = true;
+  if (seen_err_) {
+    return false;
+  }
+  if (iss_pending_) {
+    std::cerr
+        << ("ERROR: Got to end of RTL operation, but there is no RTL "
+            "trace entry to match the pending ISS one:\n");
+    iss_entry_.print("    ", std::cerr);
+    seen_err_ = true;
+    return false;
+  }
+  if (rtl_pending_) {
+    std::cerr
+        << ("ERROR: Got to end of ISS operation, but there is no ISS "
+            "trace entry to match the pending RTL one:\n");
+    rtl_entry_.print("    ", std::cerr);
+    seen_err_ = true;
+    return false;
+  }
+  return true;
+}
+
+bool OtbnTraceChecker::MatchPair() {
+  if (!(rtl_pending_ && iss_pending_)) {
+    return true;
+  }
+  rtl_pending_ = false;
+  iss_pending_ = false;
+  if (!(rtl_entry_ == iss_entry_)) {
+    std::cerr
+        << ("ERROR: Mismatch between RTL and ISS trace entries.\n"
+            "  RTL entry is:\n");
+    rtl_entry_.print("    ", std::cerr);
+    std::cerr << "  ISS entry is:\n";
+    iss_entry_.print("    ", std::cerr);
+    seen_err_ = true;
+    return false;
+  }
+  return true;
+}
+
+OtbnTraceChecker::TraceEntry OtbnTraceChecker::TraceEntry::from_rtl_trace(
+    const std::string &trace) {
+  TraceEntry entry;
+
+  size_t eol = trace.find('\n');
+  entry.hdr_ = trace.substr(0, eol);
+
+  while (eol != std::string::npos) {
+    size_t bol = eol + 1;
+    eol = trace.find('\n', bol);
+    size_t line_len =
+        (eol == std::string::npos) ? std::string::npos : eol - bol;
+    std::string line = trace.substr(bol, line_len);
+    if (line.size() > 0 && line[0] == '>')
+      entry.writes_.push_back(line);
+  }
+  std::sort(entry.writes_.begin(), entry.writes_.end());
+
+  return entry;
+}
+
+OtbnTraceChecker::TraceEntry OtbnTraceChecker::TraceEntry::from_iss_trace(
+    const std::vector<std::string> &lines) {
+  TraceEntry entry;
+  if (!lines.empty()) {
+    entry.hdr_ = lines[0];
+  }
+  bool first = true;
+  for (const std::string &line : lines) {
+    if (first) {
+      entry.hdr_ = line;
+    } else {
+      // Ignore '!' lines (which are used to tell the simulation about external
+      // register changes, not tracked by the RTL core simulation)
+      bool is_bang = (line.size() > 0 && line[0] == '!');
+      if (!is_bang) {
+        entry.writes_.push_back(line);
+      }
+    }
+    first = false;
+  }
+  std::sort(entry.writes_.begin(), entry.writes_.end());
+  return entry;
+}
+
+bool OtbnTraceChecker::TraceEntry::operator==(const TraceEntry &other) const {
+  return hdr_ == other.hdr_ && writes_ == other.writes_;
+}
+
+void OtbnTraceChecker::TraceEntry::print(const std::string &indent,
+                                         std::ostream &os) const {
+  os << indent << hdr_ << "\n";
+  for (const std::string &write : writes_) {
+    os << indent << write << "\n";
+  }
+}
+
+void OtbnTraceChecker::TraceEntry::take_writes(const TraceEntry &other) {
+  if (!other.writes_.empty()) {
+    for (const std::string &write : other.writes_) {
+      writes_.push_back(write);
+    }
+    std::sort(writes_.begin(), writes_.end());
+  }
+}

--- a/hw/ip/otbn/dv/model/otbn_trace_checker.h
+++ b/hw/ip/otbn/dv/model/otbn_trace_checker.h
@@ -1,0 +1,100 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// A singleton class that listens to trace entries from the simulated core (as
+// an OtbnTraceListener) and compares them with the trace coming out of the
+// stepped ISS process.
+//
+// Trace entries from the simulated core appear as a result of DPI callbacks,
+// so there's no way to propagate errors when they appear. ISS trace entries
+// arrive through a synchronous interface, so the checker reports any mismatch
+// at that point.
+//
+// For example, if "RTL A" means "trace event A from RTL" and "ISS B" means
+// "trace event B from ISS" then the following is a correct series of trace
+// events:
+//
+//     RTL A; ISS A; ISS B; RTL B ...
+//
+// None of these are valid:
+//
+//     RTL A; RTL B; ...  (*)
+//     ISS A; ISS B; ...
+//     RTL A; ISS B; ...
+//
+// The only way that an invalid trace is not reported is if no ISS trace events
+// appear after the error. Trace (*), above, is an example of this. Another
+// example would be if the last trace events were one of:
+//
+//     ...; ISS A; RTL B
+//     ...; ISS A           (and nothing else)
+//
+// To catch these cases, the ISS simulation must call the Finish() method when
+// it is done (which checks there are no outstanding events missing).
+
+#include <iosfwd>
+#include <string>
+#include <vector>
+
+#include "otbn_trace_listener.h"
+
+class OtbnTraceChecker : public OtbnTraceListener {
+ public:
+  OtbnTraceChecker();
+  ~OtbnTraceChecker();
+
+  // Get the singleton object
+  static OtbnTraceChecker &get();
+
+  // Take a trace entry from the wrapped RTL. Any mismatch error is stored
+  // until the next call to an API function that can respond with the error.
+  void AcceptTraceString(const std::string &trace,
+                         unsigned int cycle_count) override;
+
+  // Take a trace entry from the wrapped ISS.
+  //
+  // Prints an error message to stderr and returns false on mismatch.
+  bool OnIssTrace(const std::vector<std::string> &lines);
+
+  // Call this when the ISS simulation completes an operation (on ECALL or
+  // error).
+  //
+  // Prints an error message to stderr and returns false if it detects a
+  // mismatch.
+  bool Finish();
+
+ private:
+  // If rtl_pending_ and iss_pending_ are not both true, return true
+  // immediately with no other change. Otherwise, compare the two pending trace
+  // entries. If they match, clear them both and return true. If not, print a
+  // message to stderr and return false.
+  bool MatchPair();
+
+  class TraceEntry {
+   public:
+    static TraceEntry from_rtl_trace(const std::string &trace);
+    static TraceEntry from_iss_trace(const std::vector<std::string> &lines);
+
+    bool operator==(const TraceEntry &other) const;
+    void print(const std::string &indent, std::ostream &os) const;
+
+    void take_writes(const TraceEntry &other);
+
+    std::string hdr_;
+    std::vector<std::string> writes_;
+  };
+
+  bool rtl_pending_;
+  bool rtl_stall_;
+  TraceEntry rtl_entry_;
+  TraceEntry rtl_stalled_entry_;
+
+  bool iss_pending_;
+  TraceEntry iss_entry_;
+
+  bool done_;
+  bool seen_err_;
+};

--- a/hw/ip/otbn/dv/otbnsim/sim/decode.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/decode.py
@@ -91,7 +91,7 @@ def _decode_word(word_off: int, word: int) -> OTBNInsn:
     # shifting, sign interpretation etc.)
     op_vals = cls.insn.enc_vals_to_op_vals(4 * word_off, enc_vals)
 
-    return cls(op_vals)
+    return cls(word, op_vals)
 
 
 def decode_bytes(data: bytes) -> List[OTBNInsn]:

--- a/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
@@ -25,6 +25,9 @@ class TraceExtRegChange(Trace):
                         ' (from HW)' if self.from_hw else '',
                         self.new_value))
 
+    def rtl_trace(self) -> str:
+        return '! otbn.{}: {:#010x}'.format(self.name, self.new_value)
+
 
 class RGField:
     '''A wrapper around a field in a register as parsed by reggen'''

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -33,8 +33,8 @@ class ADDI(RV32RegImm):
 class LUI(OTBNInsn):
     insn = insn_for_mnemonic('lui', 2)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.grd = op_vals['grd']
         self.imm = op_vals['imm']
 
@@ -173,8 +173,8 @@ class XORI(RV32RegImm):
 class LW(OTBNInsn):
     insn = insn_for_mnemonic('lw', 3)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.grd = op_vals['grd']
         self.offset = op_vals['offset']
         self.grs1 = op_vals['grs1']
@@ -189,8 +189,8 @@ class LW(OTBNInsn):
 class SW(OTBNInsn):
     insn = insn_for_mnemonic('sw', 3)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.grs2 = op_vals['grs2']
         self.offset = op_vals['offset']
         self.grs1 = op_vals['grs1']
@@ -206,8 +206,8 @@ class BEQ(OTBNInsn):
     insn = insn_for_mnemonic('beq', 3)
     affects_control = True
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.grs1 = op_vals['grs1']
         self.grs2 = op_vals['grs2']
         self.offset = op_vals['offset']
@@ -223,8 +223,8 @@ class BNE(OTBNInsn):
     insn = insn_for_mnemonic('bne', 3)
     affects_control = True
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.grs1 = op_vals['grs1']
         self.grs2 = op_vals['grs2']
         self.offset = op_vals['offset']
@@ -240,8 +240,8 @@ class JAL(OTBNInsn):
     insn = insn_for_mnemonic('jal', 2)
     affects_control = True
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.grd = op_vals['grd']
         self.offset = op_vals['offset']
 
@@ -255,8 +255,8 @@ class JALR(OTBNInsn):
     insn = insn_for_mnemonic('jalr', 3)
     affects_control = True
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.grd = op_vals['grd']
         self.grs1 = op_vals['grs1']
         self.offset = op_vals['offset']
@@ -272,8 +272,8 @@ class JALR(OTBNInsn):
 class CSRRS(OTBNInsn):
     insn = insn_for_mnemonic('csrrs', 3)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.grd = op_vals['grd']
         self.csr = op_vals['csr']
         self.grs1 = op_vals['grs1']
@@ -290,8 +290,8 @@ class CSRRS(OTBNInsn):
 class CSRRW(OTBNInsn):
     insn = insn_for_mnemonic('csrrw', 3)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.grd = op_vals['grd']
         self.csr = op_vals['csr']
         self.grs1 = op_vals['grs1']
@@ -309,8 +309,8 @@ class CSRRW(OTBNInsn):
 class ECALL(OTBNInsn):
     insn = insn_for_mnemonic('ecall', 0)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         pass
 
     def execute(self, state: OTBNState) -> None:
@@ -322,8 +322,8 @@ class LOOP(OTBNInsn):
     insn = insn_for_mnemonic('loop', 2)
     affects_control = True
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.grs = op_vals['grs']
         self.bodysize = op_vals['bodysize']
 
@@ -340,8 +340,8 @@ class LOOPI(OTBNInsn):
     insn = insn_for_mnemonic('loopi', 2)
     affects_control = True
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.iterations = op_vals['iterations']
         self.bodysize = op_vals['bodysize']
 
@@ -352,8 +352,8 @@ class LOOPI(OTBNInsn):
 class BNADD(OTBNInsn):
     insn = insn_for_mnemonic('bn.add', 6)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wrd = op_vals['wrd']
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
@@ -374,8 +374,8 @@ class BNADD(OTBNInsn):
 class BNADDC(OTBNInsn):
     insn = insn_for_mnemonic('bn.addc', 6)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wrd = op_vals['wrd']
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
@@ -397,8 +397,8 @@ class BNADDC(OTBNInsn):
 class BNADDI(OTBNInsn):
     insn = insn_for_mnemonic('bn.addi', 4)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wrd = op_vals['wrd']
         self.wrs = op_vals['wrs']
         self.imm = op_vals['imm']
@@ -416,8 +416,8 @@ class BNADDI(OTBNInsn):
 class BNADDM(OTBNInsn):
     insn = insn_for_mnemonic('bn.addm', 3)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wrd = op_vals['wrd']
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
@@ -438,8 +438,8 @@ class BNADDM(OTBNInsn):
 class BNMULQACC(OTBNInsn):
     insn = insn_for_mnemonic('bn.mulqacc', 6)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.zero_acc = op_vals['zero_acc']
         self.wrs1 = op_vals['wrs1']
         self.wrs1_qwsel = op_vals['wrs1_qwsel']
@@ -466,8 +466,8 @@ class BNMULQACC(OTBNInsn):
 class BNMULQACCWO(OTBNInsn):
     insn = insn_for_mnemonic('bn.mulqacc.wo', 8)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.zero_acc = op_vals['zero_acc']
         self.wrd = op_vals['wrd']
         self.wrs1 = op_vals['wrs1']
@@ -498,8 +498,8 @@ class BNMULQACCWO(OTBNInsn):
 class BNMULQACCSO(OTBNInsn):
     insn = insn_for_mnemonic('bn.mulqacc.so', 9)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.zero_acc = op_vals['zero_acc']
         self.wrd = op_vals['wrd']
         self.wrd_hwsel = op_vals['wrd_hwsel']
@@ -545,8 +545,8 @@ class BNMULQACCSO(OTBNInsn):
 class BNSUB(OTBNInsn):
     insn = insn_for_mnemonic('bn.sub', 6)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wrd = op_vals['wrd']
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
@@ -567,8 +567,8 @@ class BNSUB(OTBNInsn):
 class BNSUBB(OTBNInsn):
     insn = insn_for_mnemonic('bn.subb', 6)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wrd = op_vals['wrd']
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
@@ -590,8 +590,8 @@ class BNSUBB(OTBNInsn):
 class BNSUBI(OTBNInsn):
     insn = insn_for_mnemonic('bn.subi', 4)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wrd = op_vals['wrd']
         self.wrs = op_vals['wrs']
         self.imm = op_vals['imm']
@@ -609,8 +609,8 @@ class BNSUBI(OTBNInsn):
 class BNSUBM(OTBNInsn):
     insn = insn_for_mnemonic('bn.subm', 3)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wrd = op_vals['wrd']
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
@@ -632,8 +632,8 @@ class BNSUBM(OTBNInsn):
 class BNAND(OTBNInsn):
     insn = insn_for_mnemonic('bn.and', 6)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wrd = op_vals['wrd']
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
@@ -654,8 +654,8 @@ class BNAND(OTBNInsn):
 class BNOR(OTBNInsn):
     insn = insn_for_mnemonic('bn.or', 6)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wrd = op_vals['wrd']
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
@@ -676,8 +676,8 @@ class BNOR(OTBNInsn):
 class BNNOT(OTBNInsn):
     insn = insn_for_mnemonic('bn.not', 5)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wrd = op_vals['wrd']
         self.wrs = op_vals['wrs']
         self.shift_type = op_vals['shift_type']
@@ -696,8 +696,8 @@ class BNNOT(OTBNInsn):
 class BNXOR(OTBNInsn):
     insn = insn_for_mnemonic('bn.xor', 6)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wrd = op_vals['wrd']
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
@@ -718,8 +718,8 @@ class BNXOR(OTBNInsn):
 class BNRSHI(OTBNInsn):
     insn = insn_for_mnemonic('bn.rshi', 4)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wrd = op_vals['wrd']
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
@@ -736,8 +736,8 @@ class BNRSHI(OTBNInsn):
 class BNRSEL(OTBNInsn):
     insn = insn_for_mnemonic('bn.sel', 5)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wrd = op_vals['wrd']
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
@@ -754,8 +754,8 @@ class BNRSEL(OTBNInsn):
 class BNCMP(OTBNInsn):
     insn = insn_for_mnemonic('bn.cmp', 5)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
         self.shift_type = op_vals['shift_type']
@@ -774,8 +774,8 @@ class BNCMP(OTBNInsn):
 class BNCMPB(OTBNInsn):
     insn = insn_for_mnemonic('bn.cmpb', 5)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
         self.shift_type = op_vals['shift_type']
@@ -795,8 +795,8 @@ class BNCMPB(OTBNInsn):
 class BNLID(OTBNInsn):
     insn = insn_for_mnemonic('bn.lid', 5)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.grd = op_vals['grd']
         self.grd_inc = op_vals['grd_inc']
         self.offset = op_vals['offset']
@@ -824,8 +824,8 @@ class BNLID(OTBNInsn):
 class BNSID(OTBNInsn):
     insn = insn_for_mnemonic('bn.sid', 5)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.grs2 = op_vals['grs2']
         self.grs2_inc = op_vals['grs2_inc']
         self.offset = op_vals['offset']
@@ -854,8 +854,8 @@ class BNSID(OTBNInsn):
 class BNMOV(OTBNInsn):
     insn = insn_for_mnemonic('bn.mov', 2)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wrd = op_vals['wrd']
         self.wrs = op_vals['wrs']
 
@@ -867,8 +867,8 @@ class BNMOV(OTBNInsn):
 class BNMOVR(OTBNInsn):
     insn = insn_for_mnemonic('bn.movr', 4)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.grd = op_vals['grd']
         self.grd_inc = op_vals['grd_inc']
         self.grs = op_vals['grs']
@@ -896,8 +896,8 @@ class BNMOVR(OTBNInsn):
 class BNWSRR(OTBNInsn):
     insn = insn_for_mnemonic('bn.wsrr', 2)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wrd = op_vals['wrd']
         self.wsr = op_vals['wsr']
 
@@ -909,8 +909,8 @@ class BNWSRR(OTBNInsn):
 class BNWSRW(OTBNInsn):
     insn = insn_for_mnemonic('bn.wsrw', 2)
 
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.wsr = op_vals['wsr']
         self.wrs = op_vals['wrs']
 

--- a/hw/ip/otbn/dv/otbnsim/sim/isa.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/isa.py
@@ -74,7 +74,8 @@ class OTBNInsn:
     # a loop).
     affects_control = False
 
-    def __init__(self, op_vals: Dict[str, int]):
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        self.raw = raw
         self.op_vals = op_vals
 
         # Memoized disassembly for this instruction. We store the PC at which
@@ -105,8 +106,8 @@ class OTBNInsn:
 
 class RV32RegReg(OTBNInsn):
     '''A general class for register-register insns from the RV32I ISA'''
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.grd = op_vals['grd']
         self.grs1 = op_vals['grs1']
         self.grs2 = op_vals['grs2']
@@ -114,8 +115,8 @@ class RV32RegReg(OTBNInsn):
 
 class RV32RegImm(OTBNInsn):
     '''A general class for register-immediate insns from the RV32I ISA'''
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.grd = op_vals['grd']
         self.grs1 = op_vals['grs1']
         self.imm = op_vals['imm']
@@ -123,8 +124,8 @@ class RV32RegImm(OTBNInsn):
 
 class RV32ImmShift(OTBNInsn):
     '''A general class for immediate shift insns from the RV32I ISA'''
-    def __init__(self, op_vals: Dict[str, int]):
-        super().__init__(op_vals)
+    def __init__(self, raw: int, op_vals: Dict[str, int]):
+        super().__init__(raw, op_vals)
         self.grd = op_vals['grd']
         self.grs1 = op_vals['grs1']
         self.shamt = op_vals['shamt']

--- a/hw/ip/otbn/dv/otbnsim/sim/reg.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/reg.py
@@ -17,6 +17,10 @@ class TraceRegister(Trace):
         fmt_str = '{{}} = 0x{{:0{}x}}'.format(self.width // 4)
         return fmt_str.format(self.name, self.new_value)
 
+    def rtl_trace(self) -> str:
+        return '> {}: {}'.format(self.name,
+                                 Trace.hex_value(self.new_value, self.width))
+
 
 class Reg:
     def __init__(self,
@@ -102,7 +106,7 @@ class RegFile:
             assert 0 <= idx < len(self._registers)
             next_val = self.get_reg(idx).read_next()
             assert next_val is not None
-            ret.append(TraceRegister(self._name_pfx + str(idx),
+            ret.append(TraceRegister('{}{:02}'.format(self._name_pfx, idx),
                                      self._width,
                                      next_val))
         return ret

--- a/hw/ip/otbn/dv/otbnsim/sim/trace.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/trace.py
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Optional
+
 
 class Trace:
     '''An object that can cause a trace entry'''
@@ -13,6 +15,34 @@ class Trace:
 
         '''
         raise NotImplementedError()
+
+    def rtl_trace(self) -> Optional[str]:
+        '''Return a representation of the entry for RTL tracing
+
+        This is used by the stepped interface (which gets compared with the RTL
+        model). Return None if the RTL trace doesn't have an entry for this
+        item (the default behaviour).
+
+        '''
+        return None
+
+    @staticmethod
+    def hex_value(value: int, bit_width: int) -> str:
+        '''Render a hex value in the format expected by RTL tracing'''
+        if bit_width == 32:
+            return '{:#010x}'.format(value)
+
+        num_words = (bit_width + 31) // 32
+        mask32 = (1 << 32) - 1
+        # Collect up words, LSB first
+        words = []
+        for idx in range(num_words):
+            lsb = 32 * idx
+            word = (value >> lsb) & mask32
+            top_width = (bit_width - lsb + 3) // 4
+            fmt_str = '{{:0{}x}}'.format(min(8, top_width))
+            words.append(fmt_str.format(word))
+        return '0x' + '_'.join(reversed(words))
 
 
 class TracePC(Trace):

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -15,6 +15,10 @@ class TraceWSR(Trace):
     def trace(self) -> str:
         return '{} = {:#x}'.format(self.wsr_name, self.new_value)
 
+    def rtl_trace(self) -> str:
+        return '> {}: {}'.format(self.wsr_name,
+                                 Trace.hex_value(self.new_value, 256))
+
 
 class WSR:
     '''Models a Wide Status Register'''

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -87,14 +87,20 @@ def on_step(sim: OTBNSim, args: List[str]) -> None:
         raise ValueError('step expects zero arguments. Got {}.'
                          .format(args))
 
-    pc = int(sim.state.pc)
-
+    pc = sim.state.pc
     assert 0 == pc & 3
+
     insn, changes = sim.step(verbose=False)
-    disasm = '(not running)' if insn is None else insn.disassemble(pc)
-    print('EXEC {:#08x}:     {}'.format(pc, disasm))
-    for trace in changes:
-        print('  {}'.format(trace.trace()))
+
+    if insn is None:
+        hdr = 'STALL'
+    else:
+        hdr = 'E PC: {:#010x}, insn: {:#010x}'.format(pc, insn.raw)
+    print(hdr)
+    for change in changes:
+        entry = change.rtl_trace()
+        if entry is not None:
+            print(entry)
 
 
 def on_run(sim: OTBNSim, args: List[str]) -> None:

--- a/hw/ip/otbn/dv/tracer/README.md
+++ b/hw/ip/otbn/dv/tracer/README.md
@@ -1,7 +1,7 @@
 # OTBN Tracer
 
 The tracer consists of a module (`otbn_tracer.sv`) and an interface
-(`otbn_trace_intf.sv`). The interface is responsible for directly probing the
+(`otbn_trace_if.sv`). The interface is responsible for directly probing the
 design and implementing any basic tracking logic that is required. The module
 takes an instance of this interface and uses it to produce trace data.
 
@@ -11,10 +11,10 @@ environment provides its implementation). Each call to
 `accept_otbn_trace_string` provides a trace record and a cycle count. There is
 at most one call per cycle. Further details are below.
 
-A typical setup would bind an instantiation of `otbn_trace_intf` and
-`otbn_tracer` into `otbn_core` passing the `otbn_trace_intf` instance into the
+A typical setup would bind an instantiation of `otbn_trace_if` and
+`otbn_tracer` into `otbn_core` passing the `otbn_trace_if` instance into the
 `otbn_tracer` instance. However this is no need for `otbn_tracer` to be bound
-into `otbn_core` provided it is given a `otbn_trace_intf` instance.
+into `otbn_core` provided it is given a `otbn_trace_if` instance.
 
 ## Trace Format
 

--- a/hw/ip/otbn/dv/tracer/README.md
+++ b/hw/ip/otbn/dv/tracer/README.md
@@ -139,3 +139,10 @@ is produced giving the full mask and data
 ```
 W [0x00000080]: Mask ERR Mask: 0xfffff800_0000ffff_ffffffff_00000000_00000000_00000000_00000000_00000000 Data: 0xcccccccc_bbbbbbbb_aaaaaaaa_facefeed_deadbeef_cafed00d_baadf00d_1234abcd
 ```
+
+## Using with dvsim
+
+To use this code, depend on the core file. If you're using dvsim,
+you'll also need to include `otbn_tracer_sim_opts.hjson` in your
+simulator configuration and add `"{tool}_otbn_tracer_build_opts"` to
+the `en_build_modes` variable.

--- a/hw/ip/otbn/dv/tracer/cpp/log_trace_listener.h
+++ b/hw/ip/otbn/dv/tracer/cpp/log_trace_listener.h
@@ -7,10 +7,11 @@
 
 #include <fstream>
 #include <string>
+
 #include "otbn_trace_listener.h"
 
 /**
- * An OTBNTraceListener that dumps the trace to a log file, with some minimal
+ * An OtbnTraceListener that dumps the trace to a log file, with some minimal
  * pretty printing.
  *
  * It examines the first line of any trace output, expecting it to be an 'E' or
@@ -22,7 +23,7 @@
  * line that gives the cycle count and dumps the rest of the trace indented by
  * four spaces.
  */
-class LogTraceListener : public OTBNTraceListener {
+class LogTraceListener : public OtbnTraceListener {
  private:
   std::ofstream trace_log;
 

--- a/hw/ip/otbn/dv/tracer/cpp/otbn_trace_listener.h
+++ b/hw/ip/otbn/dv/tracer/cpp/otbn_trace_listener.h
@@ -14,7 +14,7 @@
  * simulation that hosts the tracer is responsible for setting up listeners and
  * routing the DPI `accept_otbn_trace_string` calls to them.
  */
-class OTBNTraceListener {
+class OtbnTraceListener {
  public:
   /**
    * Helper function to split an OTBN trace output up into individual lines.
@@ -43,7 +43,7 @@ class OTBNTraceListener {
    */
   virtual void AcceptTraceString(const std::string &trace,
                                  unsigned int cycle_count) = 0;
-  virtual ~OTBNTraceListener() {}
+  virtual ~OtbnTraceListener() {}
 };
 
 #endif  // OPENTITAN_HW_IP_OTBN_DV_TRACER_CPP_OTBN_TRACE_LISTENER_H_

--- a/hw/ip/otbn/dv/tracer/cpp/otbn_trace_source.cc
+++ b/hw/ip/otbn/dv/tracer/cpp/otbn_trace_source.cc
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "otbn_trace_source.h"
+
+#include <algorithm>
+#include <cassert>
+#include <memory>
+
+static std::unique_ptr<OtbnTraceSource> trace_source;
+
+OtbnTraceSource &OtbnTraceSource::get() {
+  if (!trace_source) {
+    trace_source.reset(new OtbnTraceSource());
+  }
+  return *trace_source;
+}
+
+void OtbnTraceSource::AddListener(OtbnTraceListener *listener) {
+  listeners_.push_back(listener);
+}
+
+void OtbnTraceSource::RemoveListener(const OtbnTraceListener *listener) {
+  auto it = std::find(listeners_.begin(), listeners_.end(), listener);
+  assert(it != listeners_.end());
+  listeners_.erase(it);
+}
+
+void OtbnTraceSource::Broadcast(const std::string &trace,
+                                unsigned cycle_count) {
+  for (OtbnTraceListener *listener : listeners_) {
+    listener->AcceptTraceString(trace, cycle_count);
+  }
+}
+
+extern "C" void accept_otbn_trace_string(const char *trace,
+                                         unsigned int cycle_count) {
+  assert(trace != nullptr);
+  OtbnTraceSource::get().Broadcast(trace, cycle_count);
+}

--- a/hw/ip/otbn/dv/tracer/cpp/otbn_trace_source.h
+++ b/hw/ip/otbn/dv/tracer/cpp/otbn_trace_source.h
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+
+#include "otbn_trace_listener.h"
+
+// A source for simulation trace data.
+//
+// This is a singleton class, which will be constructed on the first call to
+// get() or the first trace data that comes back from the simulation.
+//
+// The object is in charge of taking trace data from the simulation (which is
+// sent by calling the accept_otbn_trace_string DPI function) and passing it
+// out to registered listeners.
+
+class OtbnTraceSource {
+ public:
+  // Get the (singleton) OtbnTraceSource object
+  static OtbnTraceSource &get();
+
+  // Add a listener to the source
+  void AddListener(OtbnTraceListener *listener);
+
+  // Remove a listener from the source
+  void RemoveListener(const OtbnTraceListener *listener);
+
+  // Send a trace string to all listeners
+  void Broadcast(const std::string &trace, unsigned cycle_count);
+
+ private:
+  std::vector<OtbnTraceListener *> listeners_;
+};

--- a/hw/ip/otbn/dv/tracer/lint/otbn_tracer_waivers.vlt
+++ b/hw/ip/otbn/dv/tracer/lint/otbn_tracer_waivers.vlt
@@ -7,8 +7,8 @@
 lint_off -rule BLKSEQ -file "*/otbn_tracer.sv" -match "*Blocking assignments (=) in sequential (flop or latch) block*"
 
 // Flag ISPR (3) has its own trace signals due to special handling
-lint_off -rule UNDRIVEN -file "*/otbn_trace_intf.sv" -match "*Bits of signal are not driven: 'ispr_*'[3]*"
+lint_off -rule UNDRIVEN -file "*/otbn_trace_if.sv" -match "*Bits of signal are not driven: 'ispr_*'[3]*"
 
-lint_off -rule UNUSED -file "*/otbn_trace_intf.sv" -match "*Bits of signal are not used: 'dmem_addr_o'*"
-lint_off -rule UNUSED -file "*/otbn_trace_intf.sv" -match "*Bits of signal are not used: 'insn_dec_shared'*"
-lint_off -rule UNUSED -file "*/otbn_trace_intf.sv" -match "*Bits of signal are not used: 'alu_bignum_operation'*"
+lint_off -rule UNUSED -file "*/otbn_trace_if.sv" -match "*Bits of signal are not used: 'dmem_addr_o'*"
+lint_off -rule UNUSED -file "*/otbn_trace_if.sv" -match "*Bits of signal are not used: 'insn_dec_shared'*"
+lint_off -rule UNUSED -file "*/otbn_trace_if.sv" -match "*Bits of signal are not used: 'alu_bignum_operation'*"

--- a/hw/ip/otbn/dv/tracer/otbn_tracer.core
+++ b/hw/ip/otbn/dv/tracer/otbn_tracer.core
@@ -16,7 +16,7 @@ filesets:
       - cpp/log_trace_listener.h: { is_include_file: true, file_type: cppSource }
       - cpp/log_trace_listener.cc: { file_type: cppSource }
       - rtl/otbn_tracer.sv: { file_type: systemVerilogSource }
-      - rtl/otbn_trace_intf.sv: { file_type: systemVerilogSource }
+      - rtl/otbn_trace_if.sv: { file_type: systemVerilogSource }
   files_verilator_waiver:
     files:
       - lint/otbn_tracer_waivers.vlt

--- a/hw/ip/otbn/dv/tracer/otbn_tracer.core
+++ b/hw/ip/otbn/dv/tracer/otbn_tracer.core
@@ -11,6 +11,8 @@ filesets:
       - lowrisc:ip:otbn_pkg
     files:
       - cpp/otbn_trace_listener.h: { is_include_file: true, file_type: cppSource }
+      - cpp/otbn_trace_source.h: { is_include_file: true, file_type: cppSource }
+      - cpp/otbn_trace_source.cc: { file_type: cppSource }
       - cpp/log_trace_listener.h: { is_include_file: true, file_type: cppSource }
       - cpp/log_trace_listener.cc: { file_type: cppSource }
       - rtl/otbn_tracer.sv: { file_type: systemVerilogSource }

--- a/hw/ip/otbn/dv/tracer/otbn_tracer_sim_opts.hjson
+++ b/hw/ip/otbn/dv/tracer/otbn_tracer_sim_opts.hjson
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Additional build-time options needed to compile C++ sources in
+  // simulators such as VCS and Xcelium for anything that uses
+  // otbn_tracer.
+  otbn_tracer_inc_dir: "{build_dir}/src/lowrisc_ip_otbn_tracer_0/cpp"
+
+  build_modes: [
+    {
+      name: vcs_otbn_tracer_build_opts
+      build_opts: ["-CFLAGS -I{otbn_tracer_inc_dir}"]
+    }
+    {
+      name: xcelium_otbn_tracer_build_opts
+      build_opts: ["-I{otbn_tracer_inc_dir}"]
+    }
+  ]
+}

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -22,7 +22,8 @@
  *    otbn_core.  Whatever binds the interface into otbn_core is responsible for connecting these
  *    up, e.g. using a wildcard '.*'.
  */
-interface otbn_trace_intf #(
+interface otbn_trace_if
+#(
   parameter int ImemAddrWidth,
   parameter int DmemAddrWidth,
   parameter otbn_pkg::regfile_e RegFile = otbn_pkg::RegFileFF
@@ -42,9 +43,9 @@ interface otbn_trace_intf #(
   input logic [31:0] rf_base_rd_data_b,
   input logic [31:0] rf_base_wr_data,
 
-  input logic [WdrAw-1:0] rf_bignum_rd_addr_a,
-  input logic [WdrAw-1:0] rf_bignum_rd_addr_b,
-  input logic [WdrAw-1:0] rf_bignum_wr_addr,
+  input logic [otbn_pkg::WdrAw-1:0] rf_bignum_rd_addr_a,
+  input logic [otbn_pkg::WdrAw-1:0] rf_bignum_rd_addr_b,
+  input logic [otbn_pkg::WdrAw-1:0] rf_bignum_wr_addr,
 
   input logic [otbn_pkg::WLEN-1:0] rf_bignum_rd_data_a,
   input logic [otbn_pkg::WLEN-1:0] rf_bignum_rd_data_b,

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
@@ -113,7 +113,7 @@ module otbn_tracer
                                             otbn_trace.rf_base_rd_data_b));
     end
 
-    if (otbn_trace.rf_base_wr_en) begin
+    if (otbn_trace.rf_base_wr_en && otbn_trace.rf_base_wr_addr != 0) begin
       output_trace(RegWritePrefix, $sformatf("x%02d: 0x%08x", otbn_trace.rf_base_wr_addr,
                                              otbn_trace.rf_base_wr_data));
     end

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
@@ -4,7 +4,7 @@
 
 /**
  * Tracer module for OTBN. This produces a multi-line string as trace output at most once every
- * cycle and provides it to the simulation environment via a DPI call. It uses `otbn_trace_intf` to
+ * cycle and provides it to the simulation environment via a DPI call. It uses `otbn_trace_if` to
  * get the information it needs. For further information see `hw/ip/otbn/dv/tracer/README.md`.
  */
 module otbn_tracer
@@ -12,7 +12,7 @@ module otbn_tracer
   input  logic  clk_i,
   input  logic  rst_ni,
 
-  otbn_trace_intf otbn_trace
+  otbn_trace_if otbn_trace
 );
   import otbn_pkg::*;
 
@@ -87,9 +87,8 @@ module otbn_tracer
       IsprAcc: return "ACC";
       IsprRnd: return "RND";
       IsprFlags: return "FLAGS";
+      default: return "UNKNOWN_ISPR";
     endcase
-
-    return "UNKNOWN_ISPR";
   endfunction
 
   // Format flag information into a string

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -30,8 +30,9 @@ name:
   import_cfgs: [
       // Project wide common sim cfg file
       "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
-      // Config file to pull in the correct flags for otbn_memutil
+      // Config files to get the correct flags for otbn_memutil and otbn_tracer
       "{proj_root}/hw/ip/otbn/dv/memutil/otbn_memutil_sim_opts.hjson",
+      "{proj_root}/hw/ip/otbn/dv/tracer/otbn_tracer_sim_opts.hjson",
       // Common CIP test lists
       "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
       "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
@@ -39,8 +40,9 @@ name:
       "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"
   ]
 
-  // Add options needed to compile against otbn_memutil
-  en_build_modes: ["{tool}_otbn_memutil_build_opts"]
+  // Add options needed to compile against otbn_memutil and otbn_tracer
+  en_build_modes: ["{tool}_otbn_memutil_build_opts",
+                   "{tool}_otbn_tracer_build_opts"]
 
   // Add additional tops for simulation.
   sim_tops: ["otbn_bind"]

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -53,6 +53,13 @@ module tb;
 
   );
 
+  bind otbn_core otbn_trace_if #(
+    .ImemAddrWidth (ImemAddrWidth),
+    .DmemAddrWidth (DmemAddrWidth)
+  ) i_otbn_trace_if (.*);
+
+  bind otbn_core otbn_tracer u_otbn_tracer(.*, .otbn_trace(i_otbn_trace_if));
+
   // OTBN model, wrapping an ISS.
   //
   // Note that we pull the "start" signal out of the DUT. This is because it's much more difficult

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
@@ -21,13 +21,13 @@
 #include "verilator_memutil.h"
 #include "verilator_sim_ctrl.h"
 
-std::vector<OTBNTraceListener *> otbn_trace_listeners;
+std::vector<OtbnTraceListener *> otbn_trace_listeners;
 
-void AddOTBNTraceListener(OTBNTraceListener *l) {
+void AddOtbnTraceListener(OtbnTraceListener *l) {
   otbn_trace_listeners.push_back(l);
 }
 
-void RemoveOTBNTraceListener(OTBNTraceListener *l) {
+void RemoveOtbnTraceListener(OtbnTraceListener *l) {
   auto l_iter =
       std::find(otbn_trace_listeners.begin(), otbn_trace_listeners.end(), l);
 
@@ -59,14 +59,14 @@ extern void accept_otbn_trace_string(const char *trace,
  * it sets up a LogTraceListener that will dump out the trace to the given log
  * file
  */
-class OTBNTraceUtil : public SimCtrlExtension {
+class OtbnTraceUtil : public SimCtrlExtension {
  private:
   std::unique_ptr<LogTraceListener> log_trace_listener_;
 
   bool SetupTraceLog(const std::string &log_filename) {
     try {
       log_trace_listener_ = std::make_unique<LogTraceListener>(log_filename);
-      AddOTBNTraceListener(log_trace_listener_.get());
+      AddOtbnTraceListener(log_trace_listener_.get());
       return true;
     } catch (const std::runtime_error &err) {
       std::cerr << "ERROR: Failed to set up trace log: " << err.what()
@@ -113,13 +113,13 @@ class OTBNTraceUtil : public SimCtrlExtension {
     return true;
   }
 
-  ~OTBNTraceUtil() { RemoveOTBNTraceListener(log_trace_listener_.get()); }
+  ~OtbnTraceUtil() { RemoveOtbnTraceListener(log_trace_listener_.get()); }
 };
 
 int main(int argc, char **argv) {
   otbn_top_sim top;
   VerilatorMemUtil memutil(new OtbnMemUtil("TOP.otbn_top_sim"));
-  OTBNTraceUtil traceutil;
+  OtbnTraceUtil traceutil;
 
   VerilatorSimCtrl &simctrl = VerilatorSimCtrl::GetInstance();
   simctrl.SetTop(&top, &top.IO_CLK, &top.IO_RST_N,

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
@@ -12,6 +12,7 @@
 
 #include "log_trace_listener.h"
 #include "otbn_memutil.h"
+#include "otbn_trace_checker.h"
 #include "otbn_trace_source.h"
 #include "verilated_toplevel.h"
 #include "verilator_memutil.h"
@@ -91,6 +92,7 @@ class OtbnTraceUtil : public SimCtrlExtension {
 
 int main(int argc, char **argv) {
   otbn_top_sim top;
+
   VerilatorMemUtil memutil(new OtbnMemUtil("TOP.otbn_top_sim"));
   OtbnTraceUtil traceutil;
 

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -73,8 +73,8 @@ module otbn_top_sim (
     .dmem_rerror_i ( dmem_rerror     )
   );
 
-  bind otbn_core otbn_trace_intf #(.ImemAddrWidth, .DmemAddrWidth) i_otbn_trace_intf (.*);
-  bind otbn_core otbn_tracer u_otbn_tracer(.*, .otbn_trace(i_otbn_trace_intf));
+  bind otbn_core otbn_trace_if #(.ImemAddrWidth, .DmemAddrWidth) i_otbn_trace_if (.*);
+  bind otbn_core otbn_tracer u_otbn_tracer(.*, .otbn_trace(i_otbn_trace_if));
 
   // Pulse otbn_start for 1 cycle immediately out of reset.
   // Flop `done_o` from otbn_core to match up with model done signal.

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -36,8 +36,9 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 // xbar tests
                 "{proj_root}/hw/ip/tlul/generic_dv/xbar_tests.hjson",
-                // Config file to pull in the correct flags for otbn_memutil
-                "{proj_root}/hw/ip/otbn/dv/memutil/otbn_memutil_sim_opts.hjson"
+                // Config files to get the correct flags for otbn_memutil and otbn_tracer
+                "{proj_root}/hw/ip/otbn/dv/memutil/otbn_memutil_sim_opts.hjson",
+                "{proj_root}/hw/ip/otbn/dv/tracer/otbn_tracer_sim_opts.hjson",
                 ]
 
   // Override existing project defaults to supply chip-specific values.
@@ -95,8 +96,9 @@
     }
   ]
 
-  // Add options needed to compile against otbn_memutil
-  en_build_modes: ["{tool}_otbn_memutil_build_opts"]
+  // Add options needed to compile against otbn_memutil and otbn_tracer
+  en_build_modes: ["{tool}_otbn_memutil_build_opts",
+                   "{tool}_otbn_tracer_build_opts"]
 
   // Add run modes.
   run_modes: [


### PR DESCRIPTION
This patch set teaches the ISS to spit out traces that look like the RTL and teaches the model (the C++/SV that wraps the ISS) to compare the two.

The first 8 patches are tidy-ups and bug fixes; patch 9 is the feature. If the last patch is going to take a while to review, I can split out the first 8 (but I thought it was probably easiest just to bundle everything up for now).

Fixes #4339.