### PR TITLE
[top / rv_core_ibex / rstmgr ] ibex / rstmgr crash dump hook-up

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr.hjson.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.hjson.tpl
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 <%
-
+  crash_dump_srcs = ['alert', 'cpu']
 %>
 
 # RSTMGR register template
@@ -88,6 +88,13 @@
       package: "alert_pkg",
     },
 
+    { struct:  "crashdump",
+      type:    "uni",
+      name:    "cpu_dump",
+      act:     "rcv",
+      package: "rv_core_ibex_pkg",
+    },
+
     // Exported resets
 % for intf in export_rsts:
     { struct:  "rstmgr_${intf}_out",
@@ -146,9 +153,10 @@
       ]
     },
 
-    { name: "ALERT_INFO_CTRL",
+    % for dump_src in crash_dump_srcs:
+    { name: "${dump_src.upper()}_INFO_CTRL",
       desc: '''
-            Alert info dump controls.
+            ${dump_src.capitalize()} info dump controls.
             ''',
       swaccess: "rw",
       hwaccess: "hro",
@@ -157,7 +165,7 @@
           name: "EN",
           hwaccess: "hrw",
           desc: '''
-            Enable alert dump to capture new information.
+            Enable ${dump_src} dump to capture new information.
             This field is automatically set to 0 upon system reset (even if rstmgr is not reset).
             '''
           resval: "0"
@@ -173,9 +181,9 @@
       ]
     },
 
-    { name: "ALERT_INFO_ATTR",
+    { name: "${dump_src.upper()}_INFO_ATTR",
       desc: '''
-            Alert info dump attributes.
+            ${dump_src.capitalize()} info dump attributes.
             ''',
       swaccess: "ro",
       hwaccess: "hwo",
@@ -186,7 +194,7 @@
           swaccess: "ro",
           hwaccess: "hwo",
           desc: '''
-            The number of 32-bit values contained in the alert info dump.
+            The number of 32-bit values contained in the ${dump_src} info dump.
             '''
           resval: "0",
           tags: [// This field only reflects the status of the design, thus the
@@ -196,10 +204,10 @@
       ]
     },
 
-    { name: "ALERT_INFO",
+    { name: "${dump_src.upper()}_INFO",
       desc: '''
-              Alert dump information prior to last reset.
-              Which value read is controlled by the ALERT_INFO_CTRL register.
+              ${dump_src.capitalize()} dump information prior to last reset.
+              Which value read is controlled by the !${dump_src.upper()}_INFO_CTRL register.
             ''',
       swaccess: "ro",
       hwaccess: "hwo",
@@ -208,13 +216,13 @@
         { bits: "31:0",
           name: "VALUE",
           desc: '''
-            The current 32-bit value of alert crash dump.
+            The current 32-bit value of crash dump.
             '''
           resval: "0",
         },
       ]
     },
-
+    % endfor
 
 
     ########################

--- a/hw/ip/rstmgr/rstmgr.core
+++ b/hw/ip/rstmgr/rstmgr.core
@@ -15,6 +15,7 @@ filesets:
     files:
       - rtl/rstmgr_ctrl.sv
       - rtl/rstmgr_por.sv
+      - rtl/rstmgr_crash_info.sv
       - fileset_ip ? (rtl/rstmgr.sv)
     file_type: systemVerilogSource
 

--- a/hw/ip/rstmgr/rstmgr_pkg.core
+++ b/hw/ip/rstmgr/rstmgr_pkg.core
@@ -12,9 +12,10 @@ filesets:
       - lowrisc:ip:rstmgr_reg
       - lowrisc:ip:alert_handler_reg
       - lowrisc:ip:alert_handler_component
-      - fileset_top ? (lowrisc:systems:rstmgr_pkg)
+      - lowrisc:ip:rv_core_ibex_pkg
+      - "fileset_top ? (lowrisc:systems:rstmgr_pkg)"
     files:
-      - fileset_ip ? (rtl/rstmgr_pkg.sv)
+      - "fileset_ip ? (rtl/rstmgr_pkg.sv)"
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/rstmgr/rtl/rstmgr_crash_info.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_crash_info.sv
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+// This module implements the crash dump functionality
+
+`include "prim_assert.sv"
+
+module rstmgr_crash_info
+  import rstmgr_pkg::*;
+  import rstmgr_reg_pkg::IdxWidth;
+  import rstmgr_reg_pkg::RdWidth;
+#(
+  parameter int CrashDumpWidth = 32,
+  localparam int CrashRemainder = CrashDumpWidth % RdWidth > 0 ? 1 : 0,
+  localparam int CrashStoreSlot = CrashDumpWidth / RdWidth + CrashRemainder,
+  localparam int SlotCntWidth   = $clog2(CrashStoreSlot)
+) (
+  input clk_i,
+  input rst_ni,
+  input [CrashDumpWidth-1:0] dump_i,
+  input dump_capture_i,
+  input [IdxWidth-1:0] slot_sel_i,
+  output logic [IdxWidth-1:0] slots_cnt_o,
+  output logic [RdWidth-1:0] slot_o
+);
+
+  localparam int TotalWidth = CrashStoreSlot * RdWidth;
+  logic [2**SlotCntWidth-1:0][RdWidth-1:0] slots;
+  logic [CrashStoreSlot-1:0][RdWidth-1:0] slots_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      slots_q <= '0;
+    end else if (dump_capture_i) begin
+      slots_q <= TotalWidth'(dump_i);
+    end
+  end
+
+  always_comb begin
+    slots = '0;
+    slots[CrashStoreSlot-1:0] = slots_q;
+  end
+
+  assign slots_cnt_o = CrashStoreSlot;
+  assign slot_o = slots[slot_sel_i[SlotCntWidth-1:0]];
+
+  if (SlotCntWidth < IdxWidth) begin : gen_tieoffs
+    logic [IdxWidth-SlotCntWidth-1:0] unused_idx;
+    assign unused_idx = slot_sel_i[IdxWidth-1:SlotCntWidth];
+  end
+
+  // Make sure the crash dump isn't excessively large
+  `ASSERT_INIT(CntWidth_A, SlotCntWidth <= IdxWidth)
+
+endmodule // rstmgr_crash_info

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -8,7 +8,7 @@
  * 32 bit RISC-V core supporting the RV32I + optionally EMC instruction sets.
  * Instruction and data bus are 32 bit wide TileLink-UL (TL-UL).
  */
-module rv_core_ibex #(
+module rv_core_ibex import rv_core_ibex_pkg::*; #(
   parameter bit                 PMPEnable         = 1'b0,
   parameter int unsigned        PMPGranularity    = 0,
   parameter int unsigned        PMPNumRegions     = 4,
@@ -60,6 +60,9 @@ module rv_core_ibex #(
 
   // Debug Interface
   input  logic        debug_req_i,
+
+  // Crash dump information
+  output crashdump_t  crash_dump_o,
 
   // CPU Control Signals
   input  logic        fetch_enable_i,
@@ -319,6 +322,10 @@ module rv_core_ibex #(
     .spare_req_o (),
     .spare_rsp_i (1'b0),
     .spare_rsp_o ());
+
+
+  //hardwire crashdump for now
+  assign crash_dump_o = '0;
 
   //
   // Interception point for connecting simulation SRAM by disconnecting the tl_d output. The

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_pkg.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_pkg.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package rv_core_ibex_pkg;
+
+  typedef struct packed {
+    logic [top_pkg::TL_AW-1:0] last_pc_fetched;
+    logic [top_pkg::TL_AW-1:0] last_pc_retired;
+    logic [top_pkg::TL_AW-1:0] last_instr_addr;
+    logic [top_pkg::TL_AW-1:0] last_data_addr;
+  } crashdump_t;
+
+endpackage : rv_core_ibex_pkg

--- a/hw/ip/rv_core_ibex/rv_core_ibex.core
+++ b/hw/ip/rv_core_ibex/rv_core_ibex.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:prim:clock_gating
       - lowrisc:ip:tlul
       - lowrisc:tlul:adapter_host
+      - lowrisc:ip:rv_core_ibex_pkg
     files:
       - rtl/rv_core_ibex.sv
     file_type: systemVerilogSource
@@ -86,4 +87,3 @@ targets:
     default_tool: icarus
     parameters:
       - SYNTHESIS=true
-

--- a/hw/ip/rv_core_ibex/rv_core_ibex_pkg.core
+++ b/hw/ip/rv_core_ibex/rv_core_ibex_pkg.core
@@ -1,0 +1,18 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:ip:rv_core_ibex_pkg:0.1"
+description: "Package file for ibex wrapper"
+
+filesets:
+  files_rtl:
+    depend:
+    files:
+      - rtl/rv_core_ibex_pkg.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -380,6 +380,19 @@
           top_signame: alert_handler_esc_rx
           index: 0
         }
+        {
+          struct: crashdump
+          type: uni
+          name: crashdump
+          act: req
+          package: rv_core_ibex_pkg
+          inst_name: rv_core_ibex
+          width: 1
+          default: ""
+          top_type: broadcast
+          top_signame: rv_core_ibex_crashdump
+          index: -1
+        }
       ]
     }
   ]
@@ -2405,6 +2418,18 @@
           width: 1
           default: ""
           top_signame: alert_handler_crashdump
+          index: -1
+        }
+        {
+          struct: crashdump
+          type: uni
+          name: cpu_dump
+          act: rcv
+          package: rv_core_ibex_pkg
+          inst_name: rstmgr
+          width: 1
+          default: ""
+          top_signame: rv_core_ibex_crashdump
           index: -1
         }
         {
@@ -5227,6 +5252,10 @@
       pwrmgr.pwr_lc:
       [
         lc_ctrl.pwr_lc
+      ]
+      rv_core_ibex.crashdump:
+      [
+        rstmgr.cpu_dump
       ]
       otp_ctrl.otp_keymgr_key:
       [
@@ -9142,6 +9171,18 @@
         index: -1
       }
       {
+        struct: crashdump
+        type: uni
+        name: cpu_dump
+        act: rcv
+        package: rv_core_ibex_pkg
+        inst_name: rstmgr
+        width: 1
+        default: ""
+        top_signame: rv_core_ibex_crashdump
+        index: -1
+      }
+      {
         struct: rstmgr_ast_out
         type: uni
         name: resets_ast
@@ -10605,6 +10646,19 @@
         top_signame: alert_handler_esc_rx
         index: 0
       }
+      {
+        struct: crashdump
+        type: uni
+        name: crashdump
+        act: req
+        package: rv_core_ibex_pkg
+        inst_name: rv_core_ibex
+        width: 1
+        default: ""
+        top_type: broadcast
+        top_signame: rv_core_ibex_crashdump
+        index: -1
+      }
     ]
     external:
     [
@@ -11007,6 +11061,14 @@
         signame: pwrmgr_pwr_lc_rsp
         width: 1
         type: req_rsp
+        default: ""
+      }
+      {
+        package: rv_core_ibex_pkg
+        struct: crashdump
+        signame: rv_core_ibex_crashdump
+        width: 1
+        type: uni
         default: ""
       }
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -183,6 +183,13 @@
           act:     "req",
           package: "prim_esc_pkg",
         },
+
+        { struct:  "crashdump",
+          type:    "uni",
+          name:    "crashdump",
+          act:     "req",
+          package: "rv_core_ibex_pkg",
+        },
       ],
     }
 
@@ -563,6 +570,7 @@
       'pwrmgr.pwr_lc'           : ['lc_ctrl.pwr_lc'],
       'flash_ctrl.keymgr'       : ['keymgr.flash'],
       'alert_handler.crashdump' : ['rstmgr.alert_dump'],
+      'rv_core_ibex.crashdump'  : ['rstmgr.cpu_dump'],
       'csrng.entropy_src_hw_if' : ['entropy_src.entropy_src_hw_if'],
       // TODO see #4447
       //'edn0.edn' : ['keymgr.edn'],

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -245,6 +245,8 @@ module top_${top["name"]} #(
     .esc_rx_o             (alert_handler_esc_rx[0]),
     // debug interface
     .debug_req_i          (debug_req),
+    // crash dump interface
+    .crash_dump_o         (rv_core_ibex_crashdump),
     // CPU control signals
     .fetch_enable_i       (1'b1),
     .core_sleep_o         (pwrmgr_pwr_cpu.core_sleeping)

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -95,6 +95,13 @@
       package: "alert_pkg",
     },
 
+    { struct:  "crashdump",
+      type:    "uni",
+      name:    "cpu_dump",
+      act:     "rcv",
+      package: "rv_core_ibex_pkg",
+    },
+
     // Exported resets
     { struct:  "rstmgr_ast_out",
       type:    "uni",
@@ -204,7 +211,7 @@
     { name: "ALERT_INFO",
       desc: '''
               Alert dump information prior to last reset.
-              Which value read is controlled by the ALERT_INFO_CTRL register.
+              Which value read is controlled by the !ALERT_INFO_CTRL register.
             ''',
       swaccess: "ro",
       hwaccess: "hwo",
@@ -213,13 +220,80 @@
         { bits: "31:0",
           name: "VALUE",
           desc: '''
-            The current 32-bit value of alert crash dump.
+            The current 32-bit value of crash dump.
             '''
           resval: "0",
         },
       ]
     },
+    { name: "CPU_INFO_CTRL",
+      desc: '''
+            Cpu info dump controls.
+            ''',
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "0",
+          name: "EN",
+          hwaccess: "hrw",
+          desc: '''
+            Enable cpu dump to capture new information.
+            This field is automatically set to 0 upon system reset (even if rstmgr is not reset).
+            '''
+          resval: "0"
+        },
 
+        { bits: "4+IdxWidth-1:4",
+          name: "INDEX",
+          desc: '''
+            Controls which 32-bit value to read.
+            '''
+          resval: "0"
+        },
+      ]
+    },
+
+    { name: "CPU_INFO_ATTR",
+      desc: '''
+            Cpu info dump attributes.
+            ''',
+      swaccess: "ro",
+      hwaccess: "hwo",
+      hwext: "true",
+      fields: [
+        { bits: "IdxWidth-1:0",
+          name: "CNT_AVAIL",
+          swaccess: "ro",
+          hwaccess: "hwo",
+          desc: '''
+            The number of 32-bit values contained in the cpu info dump.
+            '''
+          resval: "0",
+          tags: [// This field only reflects the status of the design, thus the
+                 // default value is likely to change and not remain 0
+                 "excl:CsrAllTests:CsrExclCheck"]
+        },
+      ]
+    },
+
+    { name: "CPU_INFO",
+      desc: '''
+              Cpu dump information prior to last reset.
+              Which value read is controlled by the !CPU_INFO_CTRL register.
+            ''',
+      swaccess: "ro",
+      hwaccess: "hwo",
+      hwext: "true",
+      fields: [
+        { bits: "31:0",
+          name: "VALUE",
+          desc: '''
+            The current 32-bit value of crash dump.
+            '''
+          resval: "0",
+        },
+      ]
+    },
 
 
     # Templated registers for software control

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -9,8 +9,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // This module is the overall reset manager wrapper
-// TODO: This module is only a draft implementation that covers most of the rstmgr
-// functoinality but is incomplete
 
 `include "prim_assert.sv"
 
@@ -42,6 +40,9 @@ module rstmgr import rstmgr_pkg::*; (
 
   // Interface to alert handler
   input alert_pkg::alert_crashdump_t alert_dump_i,
+
+  // Interface to cpu crash dump
+  input rv_core_ibex_pkg::crashdump_t cpu_dump_i,
 
   // dft bypass
   input scan_rst_ni,
@@ -562,6 +563,43 @@ module rstmgr import rstmgr_pkg::*; (
   assign hw2reg.reset_info.hw_req.d  = pwr_i.rstreqs | reg2hw.reset_info.hw_req.q;
   assign hw2reg.reset_info.hw_req.de = rst_hw_req;
 
+  ////////////////////////////////////////////////////
+  // Crash info capture                             //
+  ////////////////////////////////////////////////////
+
+  logic dump_capture;
+  assign dump_capture =  rst_hw_req | rst_ndm | rst_low_power;
+
+  rstmgr_crash_info #(
+    .CrashDumpWidth($bits(alert_pkg::alert_crashdump_t))
+  ) u_alert_info (
+    .clk_i,
+    .rst_ni,
+    .dump_i(alert_dump_i),
+    .dump_capture_i(dump_capture & reg2hw.alert_info_ctrl.en.q),
+    .slot_sel_i(reg2hw.alert_info_ctrl.index.q),
+    .slots_cnt_o(hw2reg.alert_info_attr.d),
+    .slot_o(hw2reg.alert_info.d)
+  );
+
+  rstmgr_crash_info #(
+    .CrashDumpWidth($bits(rv_core_ibex_pkg::crashdump_t))
+  ) u_cpu_info (
+    .clk_i,
+    .rst_ni,
+    .dump_i(cpu_dump_i),
+    .dump_capture_i(dump_capture & reg2hw.cpu_info_ctrl.en.q),
+    .slot_sel_i(reg2hw.cpu_info_ctrl.index.q),
+    .slots_cnt_o(hw2reg.cpu_info_attr.d),
+    .slot_o(hw2reg.cpu_info.d)
+  );
+
+  // once dump is captured, no more information is captured until
+  // re-eanbled by software.
+  assign hw2reg.alert_info_ctrl.en.d  = 1'b0;
+  assign hw2reg.alert_info_ctrl.en.de = dump_capture;
+  assign hw2reg.cpu_info_ctrl.en.d  = 1'b0;
+  assign hw2reg.cpu_info_ctrl.en.de = dump_capture;
 
   ////////////////////////////////////////////////////
   // Exported resets                                //
@@ -570,59 +608,12 @@ module rstmgr import rstmgr_pkg::*; (
   assign resets_ast_o.rst_ast_usbdev_sys_io_div4_n = resets_o.rst_sys_io_div4_n;
   assign resets_ast_o.rst_ast_usbdev_usb_n = resets_o.rst_usb_n;
 
-  ////////////////////////////////////////////////////
-  // Crash info capture                             //
-  ////////////////////////////////////////////////////
-  localparam int CrashRemainder = $bits(alert_pkg::alert_crashdump_t) % RdWidth > 0 ? 1 : 0;
-  localparam int CrashStoreSlot = $bits(alert_pkg::alert_crashdump_t) / RdWidth +
-      CrashRemainder;
-  localparam int TotalWidth     = CrashStoreSlot * RdWidth;
-  localparam int SlotCntWidth   = $clog2(CrashStoreSlot);
 
-  logic dump_capture;
-  logic [2**SlotCntWidth-1:0][RdWidth-1:0] slots;
-  logic [CrashStoreSlot-1:0][RdWidth-1:0] slots_q;
-
-  // capture on any legal reset request
-  assign dump_capture = reg2hw.alert_info_ctrl.en.q &
-                        (rst_hw_req | rst_ndm | rst_low_power);
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      slots_q <= '0;
-    end else if (dump_capture) begin
-      slots_q <= TotalWidth'(alert_dump_i);
-    end
-  end
-
-  always_comb begin
-    slots = '0;
-    slots[CrashStoreSlot-1:0] = slots_q;
-  end
-
-  // once dump is captured, no more information is captured until
-  // re-eanbled by software.
-  assign hw2reg.alert_info_ctrl.en.d  = 1'b0;
-  assign hw2reg.alert_info_ctrl.en.de = dump_capture;
-
-  // number of segments to read
-  assign hw2reg.alert_info_attr.d = CrashStoreSlot;
-
-  // the actual dump data
-  assign hw2reg.alert_info.d = slots[reg2hw.alert_info_ctrl.index.q[SlotCntWidth-1:0]];
-
-  if (SlotCntWidth < IdxWidth) begin : gen_tieoffs
-    logic [IdxWidth-SlotCntWidth-1:0] unused_idx;
-    assign unused_idx = reg2hw.alert_info_ctrl.index.q[IdxWidth-1:SlotCntWidth];
-  end
 
 
   ////////////////////////////////////////////////////
   // Assertions                                     //
   ////////////////////////////////////////////////////
-
-  // Make sure the crash dump isn't excessively large
-  `ASSERT_INIT(CntWidth_A, SlotCntWidth <= IdxWidth)
 
   // when upstream resets, downstream must also reset
 

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
@@ -31,6 +31,15 @@ package rstmgr_reg_pkg;
   } rstmgr_reg2hw_alert_info_ctrl_reg_t;
 
   typedef struct packed {
+    struct packed {
+      logic        q;
+    } en;
+    struct packed {
+      logic [3:0]  q;
+    } index;
+  } rstmgr_reg2hw_cpu_info_ctrl_reg_t;
+
+  typedef struct packed {
     logic        q;
   } rstmgr_reg2hw_sw_rst_regen_mreg_t;
 
@@ -71,6 +80,21 @@ package rstmgr_reg_pkg;
   } rstmgr_hw2reg_alert_info_reg_t;
 
   typedef struct packed {
+    struct packed {
+      logic        d;
+      logic        de;
+    } en;
+  } rstmgr_hw2reg_cpu_info_ctrl_reg_t;
+
+  typedef struct packed {
+    logic [3:0]  d;
+  } rstmgr_hw2reg_cpu_info_attr_reg_t;
+
+  typedef struct packed {
+    logic [31:0] d;
+  } rstmgr_hw2reg_cpu_info_reg_t;
+
+  typedef struct packed {
     logic        d;
   } rstmgr_hw2reg_sw_rst_ctrl_n_mreg_t;
 
@@ -79,8 +103,9 @@ package rstmgr_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    rstmgr_reg2hw_reset_info_reg_t reset_info; // [12:11]
-    rstmgr_reg2hw_alert_info_ctrl_reg_t alert_info_ctrl; // [10:6]
+    rstmgr_reg2hw_reset_info_reg_t reset_info; // [17:16]
+    rstmgr_reg2hw_alert_info_ctrl_reg_t alert_info_ctrl; // [15:11]
+    rstmgr_reg2hw_cpu_info_ctrl_reg_t cpu_info_ctrl; // [10:6]
     rstmgr_reg2hw_sw_rst_regen_mreg_t [1:0] sw_rst_regen; // [5:4]
     rstmgr_reg2hw_sw_rst_ctrl_n_mreg_t [1:0] sw_rst_ctrl_n; // [3:0]
   } rstmgr_reg2hw_t;
@@ -89,20 +114,26 @@ package rstmgr_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    rstmgr_hw2reg_reset_info_reg_t reset_info; // [46:40]
-    rstmgr_hw2reg_alert_info_ctrl_reg_t alert_info_ctrl; // [39:38]
-    rstmgr_hw2reg_alert_info_attr_reg_t alert_info_attr; // [37:34]
-    rstmgr_hw2reg_alert_info_reg_t alert_info; // [33:2]
+    rstmgr_hw2reg_reset_info_reg_t reset_info; // [84:78]
+    rstmgr_hw2reg_alert_info_ctrl_reg_t alert_info_ctrl; // [77:76]
+    rstmgr_hw2reg_alert_info_attr_reg_t alert_info_attr; // [75:72]
+    rstmgr_hw2reg_alert_info_reg_t alert_info; // [71:40]
+    rstmgr_hw2reg_cpu_info_ctrl_reg_t cpu_info_ctrl; // [39:38]
+    rstmgr_hw2reg_cpu_info_attr_reg_t cpu_info_attr; // [37:34]
+    rstmgr_hw2reg_cpu_info_reg_t cpu_info; // [33:2]
     rstmgr_hw2reg_sw_rst_ctrl_n_mreg_t [1:0] sw_rst_ctrl_n; // [1:0]
   } rstmgr_hw2reg_t;
 
   // Register Address
-  parameter logic [4:0] RSTMGR_RESET_INFO_OFFSET = 5'h 0;
-  parameter logic [4:0] RSTMGR_ALERT_INFO_CTRL_OFFSET = 5'h 4;
-  parameter logic [4:0] RSTMGR_ALERT_INFO_ATTR_OFFSET = 5'h 8;
-  parameter logic [4:0] RSTMGR_ALERT_INFO_OFFSET = 5'h c;
-  parameter logic [4:0] RSTMGR_SW_RST_REGEN_OFFSET = 5'h 10;
-  parameter logic [4:0] RSTMGR_SW_RST_CTRL_N_OFFSET = 5'h 14;
+  parameter logic [5:0] RSTMGR_RESET_INFO_OFFSET = 6'h 0;
+  parameter logic [5:0] RSTMGR_ALERT_INFO_CTRL_OFFSET = 6'h 4;
+  parameter logic [5:0] RSTMGR_ALERT_INFO_ATTR_OFFSET = 6'h 8;
+  parameter logic [5:0] RSTMGR_ALERT_INFO_OFFSET = 6'h c;
+  parameter logic [5:0] RSTMGR_CPU_INFO_CTRL_OFFSET = 6'h 10;
+  parameter logic [5:0] RSTMGR_CPU_INFO_ATTR_OFFSET = 6'h 14;
+  parameter logic [5:0] RSTMGR_CPU_INFO_OFFSET = 6'h 18;
+  parameter logic [5:0] RSTMGR_SW_RST_REGEN_OFFSET = 6'h 1c;
+  parameter logic [5:0] RSTMGR_SW_RST_CTRL_N_OFFSET = 6'h 20;
 
 
   // Register Index
@@ -111,18 +142,24 @@ package rstmgr_reg_pkg;
     RSTMGR_ALERT_INFO_CTRL,
     RSTMGR_ALERT_INFO_ATTR,
     RSTMGR_ALERT_INFO,
+    RSTMGR_CPU_INFO_CTRL,
+    RSTMGR_CPU_INFO_ATTR,
+    RSTMGR_CPU_INFO,
     RSTMGR_SW_RST_REGEN,
     RSTMGR_SW_RST_CTRL_N
   } rstmgr_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] RSTMGR_PERMIT [6] = '{
+  parameter logic [3:0] RSTMGR_PERMIT [9] = '{
     4'b 0001, // index[0] RSTMGR_RESET_INFO
     4'b 0001, // index[1] RSTMGR_ALERT_INFO_CTRL
     4'b 0001, // index[2] RSTMGR_ALERT_INFO_ATTR
     4'b 1111, // index[3] RSTMGR_ALERT_INFO
-    4'b 0001, // index[4] RSTMGR_SW_RST_REGEN
-    4'b 0001  // index[5] RSTMGR_SW_RST_CTRL_N
+    4'b 0001, // index[4] RSTMGR_CPU_INFO_CTRL
+    4'b 0001, // index[5] RSTMGR_CPU_INFO_ATTR
+    4'b 1111, // index[6] RSTMGR_CPU_INFO
+    4'b 0001, // index[7] RSTMGR_SW_RST_REGEN
+    4'b 0001  // index[8] RSTMGR_SW_RST_CTRL_N
   };
 endpackage
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -276,6 +276,7 @@ module top_earlgrey #(
   pwrmgr_pkg::pwr_otp_rsp_t       pwrmgr_pwr_otp_rsp;
   pwrmgr_pkg::pwr_lc_req_t       pwrmgr_pwr_lc_req;
   pwrmgr_pkg::pwr_lc_rsp_t       pwrmgr_pwr_lc_rsp;
+  rv_core_ibex_pkg::crashdump_t       rv_core_ibex_crashdump;
   otp_ctrl_pkg::otp_keymgr_key_t       otp_ctrl_otp_keymgr_key;
   keymgr_pkg::hw_key_req_t       keymgr_kmac_key;
   keymgr_pkg::kmac_data_req_t       keymgr_kmac_data_req;
@@ -452,6 +453,8 @@ module top_earlgrey #(
     .esc_rx_o             (alert_handler_esc_rx[0]),
     // debug interface
     .debug_req_i          (debug_req),
+    // crash dump interface
+    .crash_dump_o         (rv_core_ibex_crashdump),
     // CPU control signals
     .fetch_enable_i       (1'b1),
     .core_sleep_o         (pwrmgr_pwr_cpu.core_sleeping)
@@ -999,6 +1002,7 @@ module top_earlgrey #(
       .ast_i(rstmgr_ast_i),
       .cpu_i(rstmgr_cpu),
       .alert_dump_i(alert_handler_crashdump),
+      .cpu_dump_i(rv_core_ibex_crashdump),
       .resets_ast_o(rsts_ast_o),
       .tl_i(rstmgr_tl_req),
       .tl_o(rstmgr_tl_rsp),


### PR DESCRIPTION
Adds top level stitching for eventually hooking up the crash dump information. 
See #4618 

Review last two commits only, the others will be rebased away. 