### PR TITLE
[dv/lc_ctrl] add scb checking for lc_state and cnt

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
@@ -139,6 +139,29 @@ package lc_ctrl_env_pkg;
     endcase
   endfunction
 
+  function automatic int dec_lc_cnt(lc_cnt_e curr_cnt);
+    case (curr_cnt)
+      LcCntRaw: return 0;
+      LcCnt1  : return 1;
+      LcCnt2  : return 2;
+      LcCnt3  : return 3;
+      LcCnt4  : return 4;
+      LcCnt5  : return 5;
+      LcCnt6  : return 6;
+      LcCnt7  : return 7;
+      LcCnt8  : return 8;
+      LcCnt9  : return 9;
+      LcCnt10 : return 10;
+      LcCnt11 : return 11;
+      LcCnt12 : return 12;
+      LcCnt13 : return 13;
+      LcCnt14 : return 14;
+      LcCnt15 : return 15;
+      LcCnt16 : return 16;
+      default: `uvm_fatal("lc_env_pkg", $sformatf("unknown lc_cnt 0x%0h", curr_cnt))
+    endcase
+  endfunction
+
   // package sources
   `include "lc_ctrl_env_cfg.sv"
   `include "lc_ctrl_env_cov.sv"

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
@@ -68,4 +68,11 @@ class lc_ctrl_base_vseq extends cip_base_vseq #(
     csr_spinwait(ral.status.transition_successful, 1);
   endtask
 
+  // checking of these two CSRs are done in scb
+  virtual task rd_lc_state_and_cnt_csrs();
+    bit [TL_DW-1:0] val;
+    csr_rd(ral.lc_state, val);
+    csr_rd(ral.lc_transition_cnt, val);
+  endtask
+
 endclass : lc_ctrl_base_vseq

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
@@ -20,6 +20,11 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
       `uvm_info(`gfn, $sformatf("starting seq %0d/%0d, init LC_state is %0s, LC_cnt is %0s",
                                 i, num_trans, lc_state.name, lc_cnt.name), UVM_MEDIUM)
 
+      if ($urandom_range(0, 1)) begin
+        csr_rd_check(.ptr(ral.status.ready), .compare_value(1));
+        rd_lc_state_and_cnt_csrs();
+      end
+
       // SW transition request
       if (valid_state_for_trans(lc_state) && lc_cnt != LcCnt16) begin
         bit [TL_DW*3-1:0] token_val = {$urandom(), $urandom(), $urandom()};


### PR DESCRIPTION
1. Add scb checking for lc_state and lc_transition_cnt CSRs.
2. Remove interrupt related logic in lc_scb because lc_ctrl does not
have interrupt.

Signed-off-by: Cindy Chen <chencindy@google.com>