### PR TITLE
[kmac] Reverse the PREFIX order

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -484,7 +484,7 @@
               800-185 specification.
 
               Order of Prefix is:
-              prefix[end:0] := {PREFIX0, PREFIX1, ... }
+              prefix[end:0] := {PREFIX(N-1), ..., PREFIX(1), PREFIX(0) }
 
               The registers are allowed to be updated when the engine is in Idle state.
               If the engine computes the hash, it discards any attempts to update the secret keys

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -195,7 +195,7 @@ module kmac
   // Function-name N and Customization input string S
   always_comb begin
     for (int i = 0 ; i < NumWordsPrefix; i++) begin
-      ns_prefix[32*i+:32] = reg2hw.prefix[NumWordsPrefix-1 - i].q;
+      ns_prefix[32*i+:32] = reg2hw.prefix[i].q;
     end
   end
 


### PR DESCRIPTION
Changed the !!PREFIX register order in little-endian way.

@gkelly @moidx As KMAC internals operate in little-endian, @udinator and I think merging PREFIX registers opposite way than HMAC is more natural. Could you please comment?