### PR TITLE
[kmac] Fix cSHAKE

### DIFF
--- a/hw/ip/kmac/rtl/sha3pad.sv
+++ b/hw/ip/kmac/rtl/sha3pad.sv
@@ -322,6 +322,8 @@ module sha3pad
       end
 
       StPrefixWait: begin
+        sel_mux = MuxPrefix;
+
         if (keccak_complete_i) begin
           st_d = StMessage;
         end else begin
@@ -569,7 +571,7 @@ module sha3pad
       MuxZeroEnd: msg_ready_o = 1'b 0;
 
       // MuxNone
-      default: msg_ready_o = 1'b 1;
+      default: msg_ready_o = 1'b 0;
     endcase
   end
 
@@ -800,7 +802,7 @@ module sha3pad
   // if partial write comes and is acked, then no more msg_valid_i until
   // next message
   `ASSUME(PartialEndOfMsg_M,
-    keccak_ack && msg_partial |=>
+    msg_valid_i && msg_ready_o && msg_partial |=>
       !msg_valid_i ##[1:$] $stable(msg_valid_i) ##1 process_latched,
     clk_i, !rst_ni)
 


### PR DESCRIPTION
[kmac] Fix cSHAKE mux selection issue
    
    In cSHAKE/KMAC mode, the state machine changes internal mux selection in
    SHA3 padding logic from MuxPrefix to MuxNone while waiting the prefix
    block process completion. It results in asserting msg_ready then the
    next block (secret key) was received without processing it.
    
    This commit fixes the issue above by changing MuxNone ready output to 0
    and FSM to select MuxPrefix while in PrefixWait state.