### PR TITLE
[otbn] Ensure the RIG always picks aligned jumps

### DIFF
--- a/hw/ip/otbn/util/rig/gens/jump.py
+++ b/hw/ip/otbn/util/rig/gens/jump.py
@@ -109,6 +109,7 @@ class Jump(SnippetGen):
         if tgt is None:
             return None
         assert tgt_min <= tgt <= tgt_max
+        assert tgt & 3 == 0
 
         # Adjust again for base_addr: we pick the offset from there
         op_val = tgt - base_addr

--- a/hw/ip/otbn/util/rig/program.py
+++ b/hw/ip/otbn/util/rig/program.py
@@ -346,6 +346,13 @@ class Program:
 
         '''
 
+        # Round tgt_min and tgt_max inwards to multiples of 4 (because
+        # instructions always have to be word aligned)
+        if tgt_min is not None:
+            tgt_min = (tgt_min + 3) & ~3
+        if tgt_max is not None:
+            tgt_max = tgt_max & ~3
+
         # To pick the targets, we start by choosing a "gap" between existing
         # sections in which they should land. To do *that*, we start by making
         # a list of all the gaps between sections in ascending order of base


### PR DESCRIPTION
The choice of jump target is made in `Program.pick_branch_targets`,
which was mostly careful to always pick aligned addresses. However, it
didn't correctly handle its `tgt_min/tgt_max` arguments, which might not
be aligned.

Fixes overnight failure which you can reproduce by running `hw/ip/otbn/util/otbn-rig gen --size 100 --seed 2217570224`.