### PR TITLE
[util] Adapt flash size reduce/check scripts for changes in flash params

### DIFF
--- a/hw/top_earlgrey/util/opentitan_earlgrey_flash_size_check.py
+++ b/hw/top_earlgrey/util/opentitan_earlgrey_flash_size_check.py
@@ -29,7 +29,7 @@ def main():
     # Check for the following regular expressions in the following source files.
     files = ["flash_ctrl_reg_pkg.sv", "tl_main_pkg.sv"]
     match = [
-        r"parameter\s+int\s+RegPagesPerBank\s*=\s*32;",
+        r"parameter\s+int\s+RegPagesPerBank\s*=\s*16;",
         r"localparam\s+logic\s*\[\s*31\s*:\s*0\s*\]\s+ADDR_MASK_EFLASH\s*=\s*32'h\s*0000ffff;"
     ]
 

--- a/hw/top_earlgrey/util/opentitan_earlgrey_flash_size_reduce.py
+++ b/hw/top_earlgrey/util/opentitan_earlgrey_flash_size_reduce.py
@@ -51,10 +51,10 @@ def main():
          hjson_file.write(orighdr + hjson.dumps(cfg, hjson_file))
 
     # update value
-    log.info("Updating flash pages_per_bank to 32")
+    log.info("Updating flash pages_per_bank to 16")
     for mem in cfg["memory"]:
         if mem['type'] == 'eflash':
-            mem['pages_per_bank'] = 32
+            mem['pages_per_bank'] = 16
 
     # write back updated hjson
     with open(top_hjson, "w") as hjson_file:


### PR DESCRIPTION
We've recently changed the flash parametrization in lowRISC/OpenTitan#4534. This PR adapts the flash size reduce/check scripts required for smaller FPGAs accordingly.

This fixes lowRISC/OpenTitan#4638.