### PR TITLE
[sw] Add CRT assembly library

### DIFF
--- a/sw/device/boot_rom/meson.build
+++ b/sw/device/boot_rom/meson.build
@@ -45,6 +45,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
     link_depends: rom_link_deps,
     dependencies: [
       chip_info_h,
+      sw_lib_crt,
       sw_lib_runtime_hart,
       sw_lib_runtime_print,
       sw_lib_flash_ctrl,

--- a/sw/device/boot_rom/rom_crt.S
+++ b/sw/device/boot_rom/rom_crt.S
@@ -10,6 +10,9 @@
   // is allocated executable space in ROM by the linker.
   .section .crt, "ax"
 
+  .extern crt_section_clear
+  .extern crt_section_copy
+
 /**
  * Entry point after reset. This symbol is jumped to from the handler
  * for IRQ 0x80.
@@ -73,55 +76,42 @@ _start:
   .globl _start
 
   // Zero out the `.bss` segment.
-  //
-  // We use `t0` and `t1` to represent the start and end pointers
-  // of `.bss`.
-  la   t0, _bss_start
-  la   t1, _bss_end
-  bgeu t0, t1, bss_zero_loop_end
-bss_zero_loop:
-  sw    zero, 0(t0)
-  addi  t0, t0, 0x4
-  bltu  t0, t1, bss_zero_loop
-bss_zero_loop_end:
+  la   a0, _bss_start
+  la   a1, _bss_end
+  call crt_section_clear
 
   // Zero out the stack
   //
-  // We use `t0` and `t1` to represent the start and end pointers of the stack.
   // As the stack grows downwards and we zero going forwards the start pointer
   // starts as _stack_start and the end pointer at _stack_end.
-  la   t0, _stack_start
-  la   t1, _stack_end
-  bgeu t0, t1, stack_zero_loop_end
-stack_zero_loop:
-  sw    zero, 0(t0)
-  addi  t0, t0, 0x4
-  bltu  t0, t1, stack_zero_loop
-stack_zero_loop_end:
+  la   a0, _stack_start
+  la   a1, _stack_end
+  call crt_section_clear
 
   // Initialize the `.data` segment from the `.idata` segment.
-  //
-  // We use `t0` and `t1` to represent the start and end pointers
-  // of `.data`, `t2` to represent the start pointer of `.idata`
-  // (which has the same length as `.data`) and `t3` is a scratch
-  // register for the copy.
-  la   t0, _data_start
-  la   t1, _data_end
-  la   t2, _data_init_start
-  bgeu t0, t1, data_copy_loop_end
-data_copy_loop:
-  lw   t3, 0(t2)
-  sw   t3, 0(t0)
-  addi t0, t0, 0x4
-  addi t2, t2, 0x4
-  bltu t0, t1, data_copy_loop
-data_copy_loop_end:
+  la   a0, _data_start
+  la   a1, _data_end
+  la   a2, _data_init_start
+  call crt_section_copy
 
-  // Re-clobber all of the registers from above.
+  // Clobber all temporary registers.
   li t0, 0x0
   li t1, 0x0
   li t2, 0x0
   li t3, 0x0
+  li t4, 0x0
+  li t5, 0x0
+  li t6, 0x0
+
+  // Clobber all argument registers.
+  li a0, 0x0
+  li a1, 0x0
+  li a2, 0x0
+  li a3, 0x0
+  li a4, 0x0
+  li a5, 0x0
+  li a6, 0x0
+  li a7, 0x0
 
   // Jump into the C program entry point.
   call _boot_start

--- a/sw/device/exts/common/flash_crt.S
+++ b/sw/device/exts/common/flash_crt.S
@@ -21,6 +21,8 @@
   .extern abort
   .extern main
   .extern crt_interrupt_vector
+  .extern crt_section_clear
+  .extern crt_section_copy
 
 /**
  * Callable entry point for flash.
@@ -47,49 +49,20 @@ _start:
   csrw mtvec, t0
 
   // Zero out the `.bss` segment.
-  //
-  // We use `t0` and `t1` to represent the start and end pointers
-  // of `.bss`.
-  la   t0, _bss_start
-  la   t1, _bss_end
-  bgeu t0, t1, bss_zero_loop_end
-bss_zero_loop:
-  sw    zero, 0(t0)
-  addi  t0, t0, 0x4
-  bltu  t0, t1, bss_zero_loop
-bss_zero_loop_end:
+  la   a0, _bss_start
+  la   a1, _bss_end
+  call crt_section_clear
 
   // Zero out the stack
-  //
-  // We use `t0` and `t1` to represent the start and end pointers of the stack.
-  // As the stack grows downwards and we zero going forwards the start pointer
-  // starts as _stack_start and the end pointer at _stack_end.
-  la   t0, _stack_start
-  la   t1, _stack_end
-  bgeu t0, t1, stack_zero_loop_end
-stack_zero_loop:
-  sw    zero, 0(t0)
-  addi  t0, t0, 0x4
-  bltu  t0, t1, stack_zero_loop
-stack_zero_loop_end:
+  la   a0, _stack_start
+  la   a1, _stack_end
+  call crt_section_clear
 
   // Initialize the `.data` segment from the `.idata` segment.
-  //
-  // We use `t0` and `t1` to represent the start and end pointers
-  // of `.data`, `t2` to represent the start pointer of `.idata`
-  // (which has the same length as `.data`) and `t3` is a scratch
-  // register for the copy.
-  la   t0, _data_start
-  la   t1, _data_end
-  la   t2, _data_init_start
-  bgeu t0, t1, data_copy_loop_end
-data_copy_loop:
-  lw   t3, 0(t2)
-  sw   t3, 0(t0)
-  addi t0, t0, 0x4
-  addi t2, t2, 0x4
-  bltu t0, t1, data_copy_loop
-data_copy_loop_end:
+  la   a0, _data_start
+  la   a1, _data_end
+  la   a2, _data_init_start
+  call crt_section_copy
 
   // Call the functions in the `.init_array` section.
   //

--- a/sw/device/exts/common/meson.build
+++ b/sw/device/exts/common/meson.build
@@ -41,6 +41,7 @@ riscv_crt = declare_dependency(
   ],
   dependencies: [
     freestanding_headers,
+    sw_lib_crt,
     sw_lib_mem,
     sw_lib_irq,
     top_earlgrey,

--- a/sw/device/lib/crt/crt.S
+++ b/sw/device/lib/crt/crt.S
@@ -1,0 +1,134 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * CRT library
+ *
+ * Utility functions written in assembly that can be used before the C
+ * runtime has been initialized. These functions should not be used once
+ * the C runtime has been initialized.
+ */
+
+  // NOTE: The "ax" flag below is necessary to ensure that this section
+  // is allocated space in ROM by the linker.
+  .section .crt, "ax", @progbits
+
+/**
+ * Write zeros into the section bounded by the start and end pointers.
+ * The section must be word (4 byte) aligned. It is valid for the section
+ * to have a length of 0 (i.e. the start and end pointers may be equal).
+ *
+ * This function follows the standard ILP32 calling convention for arguments
+ * but does not require a valid stack pointer, thread pointer or global
+ * pointer.
+ *
+ * Clobbers a0 and t0.
+ *
+ * @param a0 pointer to start of section to clear (inclusive).
+ * @param a1 pointer to end of section to clear (exclusive).
+ */
+crt_section_clear:
+  .globl crt_section_clear
+  .type crt_section_clear, @function
+
+  // Check that start is before end.
+  bgeu a0, a1, L_clear_nothing
+
+  // Check that start and end are word aligned.
+  or   t0, a0, a1
+  andi t0, t0, 0x3
+  bnez t0, L_clear_error
+
+L_clear_loop:
+  // Write zero into section memory word-by-word.
+  // TODO: unroll
+  sw   zero, 0(a0)
+  addi a0, a0, 4
+  bltu a0, a1, L_clear_loop
+  ret
+
+L_clear_nothing:
+  // If section length is 0 just return. Otherwise end is before start
+  // which is invalid so trigger an error.
+  bne a0, a1, L_clear_error
+  ret
+
+L_clear_error:
+  unimp
+
+  // Set function size to allow disassembly.
+  .size crt_section_clear, .-crt_section_clear
+
+/**
+ * Copy data from the given source into the section bounded by the start and
+ * end pointers. Both the section and the source must be word (4 byte) aligned.
+ * It is valid for the section to have a length of 0 (i.e. the start and end
+ * pointers may be equal). The source is assumed to have the same length as the
+ * target section.
+ *
+ * The destination section and the source must not overlap.
+ *
+ * This function follows the standard ILP32 calling convention for arguments
+ * but does not require a valid stack pointer, thread pointer or global
+ * pointer.
+ *
+ * Clobbers a0, a2, t0 and t1.
+ *
+ * @param a0 pointer to start of destination section (inclusive).
+ * @param a1 pointer to end of destination section (exclusive).
+ * @param a2 pointer to source data (inclusive).
+ */
+crt_section_copy:
+  .global crt_section_copy
+  .type crt_section_copy, @function
+
+  // Check that start is before end.
+  bgeu a0, a1, L_copy_nothing
+
+  // Check that start, end and src are word aligned.
+  or   t0, a0, a1
+  or   t0, t0, a2
+  andi t0, t0, 0x3
+  bnez t0, L_copy_error
+
+  // Check that source does not destructively overlap destination
+  // (assuming a forwards copy).
+  //
+  // src  start          end
+  //  |     |             |
+  //  +-------------+     |
+  //  |   source    |     |
+  //  +-------------+     |
+  //        +-------------+
+  //        | destination |
+  //        +-------------+
+  //        |             |
+  //      start          end
+  //
+  // TODO: disallow all overlap since it indicates API misuse?
+  sub  t0, a0, a2           // (start - src) mod 2**32
+  sub  t1, a1, a0           // end - start
+  bltu t0, t1, L_copy_error
+
+L_copy_loop:
+  // Copy data from src into section word-by-word.
+  // TODO: unroll
+  lw   t0, 0(a2)
+  addi a2, a2, 4
+  sw   t0, 0(a0)
+  addi a0, a0, 4
+  bltu a0, a1, L_copy_loop
+  ret
+
+L_copy_nothing:
+  // If section length is 0 just return. Otherwise end is before start
+  // which is invalid so trigger an error.
+  bne a0, a1, L_copy_error
+  ret
+
+L_copy_error:
+  unimp
+
+  // Set function size to allow disassembly.
+  .size crt_section_copy, .-crt_section_copy

--- a/sw/device/lib/crt/meson.build
+++ b/sw/device/lib/crt/meson.build
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Assembly utility functions for initializing C runtime (sw_lib_crt).
+sw_lib_crt = declare_dependency(
+  link_with: static_library(
+    'crt_ot',
+    sources: ['crt.S'],
+  )
+)

--- a/sw/device/lib/meson.build
+++ b/sw/device/lib/meson.build
@@ -4,6 +4,7 @@
 
 subdir('base')
 subdir('arch')
+subdir('crt')
 subdir('dif')
 subdir('runtime')
 subdir('testing')

--- a/sw/device/mask_rom/mask_rom_start.S
+++ b/sw/device/mask_rom/mask_rom_start.S
@@ -171,98 +171,83 @@ _mask_rom_start_boot:
    */
 
   // Zero all writable registers except x2 (sp).
-  mv x1,  zero
+  li x1,  0x0
   // NOT x2 (sp) - We have already set it to the right value above.
-  mv x3,  zero
-  mv x4,  zero
-  mv x5,  zero
-  mv x6,  zero
-  mv x7,  zero
-  mv x8,  zero
-  mv x9,  zero
-  mv x10, zero
-  mv x11, zero
-  mv x12, zero
-  mv x13, zero
-  mv x14, zero
-  mv x15, zero
-  mv x16, zero
-  mv x17, zero
-  mv x18, zero
-  mv x19, zero
-  mv x20, zero
-  mv x21, zero
-  mv x22, zero
-  mv x23, zero
-  mv x24, zero
-  mv x25, zero
-  mv x26, zero
-  mv x27, zero
-  mv x28, zero
-  mv x29, zero
-  mv x30, zero
-  mv x31, zero
+  li x3,  0x0
+  li x4,  0x0
+  li x5,  0x0
+  li x6,  0x0
+  li x7,  0x0
+  li x8,  0x0
+  li x9,  0x0
+  li x10, 0x0
+  li x11, 0x0
+  li x12, 0x0
+  li x13, 0x0
+  li x14, 0x0
+  li x15, 0x0
+  li x16, 0x0
+  li x17, 0x0
+  li x18, 0x0
+  li x19, 0x0
+  li x20, 0x0
+  li x21, 0x0
+  li x22, 0x0
+  li x23, 0x0
+  li x24, 0x0
+  li x25, 0x0
+  li x26, 0x0
+  li x27, 0x0
+  li x28, 0x0
+  li x29, 0x0
+  li x30, 0x0
+  li x31, 0x0
+
+  .extern crt_section_clear
+  .extern crt_section_copy
 
   // TODO: Setup SRAM Scrambling
   // Temporarily: Zero out ram_main
-  //
-  // `t0` is the address to start zeroing at.
-  // `t1` is the address to stop zeroing at.
-  li   t0, TOP_EARLGREY_RAM_MAIN_BASE_ADDR
-  li   t1, (TOP_EARLGREY_RAM_MAIN_BASE_ADDR + TOP_EARLGREY_RAM_MAIN_SIZE_BYTES)
-  bgeu t0, t1, sram_zero_end
-sram_zero_loop:
-  // TODO: Unroll loop
-  sw   zero, 0x0(t0)
-  addi t0, t0, 0x4
-  bltu t0, t1, sram_zero_loop
-sram_zero_end:
+  li   a0, TOP_EARLGREY_RAM_MAIN_BASE_ADDR
+  li   a1, (TOP_EARLGREY_RAM_MAIN_BASE_ADDR + TOP_EARLGREY_RAM_MAIN_SIZE_BYTES)
+  call crt_section_clear
 
   /**
    * Setup C Runtime
    */
 
   // Initialize the `.data` section.
-  //
-  // `t0` is the start address of `.data` (in RAM).
-  // `t1` is the end address of `.data` (in RAM).
-  // `t2` is the start address of `.data` (in ROM).
-  // `t3` is a scratch register for the copy.
-  la   t0, _data_start
-  la   t1, _data_end
-  la   t2, _data_init_start
-  bgeu t0, t1, data_copy_loop_end
-data_copy_loop:
-  // TODO: Unroll this loop
-  lw   t3, 0x0(t2)
-  sw   t3, 0x0(t0)
-  addi t0, t0, 0x4
-  addi t2, t2, 0x4
-  bltu t0, t1, data_copy_loop
-data_copy_loop_end:
+  la   a0, _data_start
+  la   a1, _data_end
+  la   a2, _data_init_start
+  call crt_section_copy
 
   // Initialize the `.bss` section.
   //
   // We do this despite zeroing all of SRAM above, so that we still zero `.bss`
   // once we've enabled SRAM scrambling.
-  //
-  // `t0` is the address to start zeroing at.
-  // `t1` is the address to stop zeroing at.
-  la   t0, _bss_start
-  la   t1, _bss_end
-  bgeu t0, t1, bss_zero_end
-bss_zero_loop:
-  // TODO: Unroll loop
-  sw   zero, 0x0(t0)
-  addi t0, t0, 0x4
-  bltu t0, t1, bss_zero_loop
-bss_zero_end:
+  la   a0, _bss_start
+  la   a1, _bss_end
+  call crt_section_clear
 
-  // Re-clobber all of the registers used to Setup the C Runtime.
-  mv t0, zero
-  mv t1, zero
-  mv t2, zero
-  mv t3, zero
+  // Re-clobber all of the temporary registers (may have been used in calls).
+  li t0, 0x0
+  li t1, 0x0
+  li t2, 0x0
+  li t3, 0x0
+  li t4, 0x0
+  li t5, 0x0
+  li t6, 0x0
+
+  // Re-clobber all of the argument registers (may have been used in calls).
+  li a0, 0x0
+  li a1, 0x0
+  li a2, 0x0
+  li a3, 0x0
+  li a4, 0x0
+  li a5, 0x0
+  li a6, 0x0
+  li a7, 0x0
 
   // Setup global pointer.
   //

--- a/sw/device/mask_rom/meson.build
+++ b/sw/device/mask_rom/meson.build
@@ -27,6 +27,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
     dependencies: [
       chip_info_h,
       device_lib,
+      sw_lib_crt,
       rom_ext_manifest_parser
     ],
   )

--- a/sw/device/rom_exts/meson.build
+++ b/sw/device/rom_exts/meson.build
@@ -88,6 +88,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
       link_depends: slot_link_args[1],
       dependencies: [
         device_lib,
+        sw_lib_crt,
         sw_lib_dif_uart,
         sw_lib_runtime_hart,
         sw_lib_runtime_print,

--- a/sw/device/rom_exts/rom_ext_start.S
+++ b/sw/device/rom_exts/rom_ext_start.S
@@ -183,50 +183,43 @@ _rom_ext_start_boot:
    */
 
   /**
-   * Initialize the `.data` section.
-   *
-   * `t0` is the start address of `.data` (in RAM).
-   * `t1` is the end address of `.data` (in RAM).
-   * `t2` is the start address of `.data` (in ROM).
-   * `t3` is a scratch register for the copy.
+   * Initialize the `.data` section in RAM from ROM.
    */
-  la   t0, _data_start
-  la   t1, _data_end
-  la   t2, _data_init_start
-  bgeu t0, t1, data_copy_loop_end
-data_copy_loop:
-  // TODO: Unroll this loop
-  lw   t3, 0x0(t2)
-  sw   t3, 0x0(t0)
-  addi t0, t0, 0x4
-  addi t2, t2, 0x4
-  bltu t0, t1, data_copy_loop
-data_copy_loop_end:
+  la   a0, _data_start
+  la   a1, _data_end
+  la   a2, _data_init_start
+  .extern crt_section_copy
+  call crt_section_copy
 
   /**
    * Initialize the `.bss` section.
    *
    * We do this despite zeroing all of SRAM above, so that we still zero `.bss`
    * once we've enabled SRAM scrambling.
-   *
-   * `t0` is the address to start zeroing at.
-   * `t1` is the address to stop zeroing at.
    */
-  la   t0, _bss_start
-  la   t1, _bss_end
-  bgeu t0, t1, bss_zero_end
-bss_zero_loop:
-  // TODO: Unroll loop
-  sw   zero, 0x0(t0)
-  addi t0, t0, 0x4
-  bltu t0, t1, bss_zero_loop
-bss_zero_end:
+  la   a0, _bss_start
+  la   a1, _bss_end
+  .extern crt_section_clear
+  call crt_section_clear
 
-  // Re-clobber all of the registers used to Setup the C Runtime.
-  mv t0, zero
-  mv t1, zero
-  mv t2, zero
-  mv t3, zero
+  // Re-clobber all of the temporary registers.
+  li t0, 0x0
+  li t1, 0x0
+  li t2, 0x0
+  li t3, 0x0
+  li t4, 0x0
+  li t5, 0x0
+  li t6, 0x0
+
+  // Re-clobber all of the argument registers.
+  li a0, 0x0
+  li a1, 0x0
+  li a2, 0x0
+  li a3, 0x0
+  li a4, 0x0
+  li a5, 0x0
+  li a6, 0x0
+  li a7, 0x0
 
   /**
    * Setup global pointer.


### PR DESCRIPTION
Create a new library containing assembly functions for use when
initializing the C runtime.

For now it contains two basic helper functions:
 * crt_section_copy: copy data into a section
 * crt_section_clear: zero the data in a section

Over time we can move more functionality into this library on a
case-by-case basis.