### PR TITLE
[aes] Fix lint errors related to unused clock and reset signals

### DIFF
--- a/hw/ip/aes/lint/aes.waiver
+++ b/hw/ip/aes/lint/aes.waiver
@@ -5,3 +5,15 @@
 # waiver file for aes
 waive -rules COMBO_READ_WRITE -location {aes_key_expand.sv} -regexp {'regular\[[0-9]+\]\[2:1|4:2|6:5\]' is read from within the same combinational process block} \
       -comment "regular[*] is assigned in a for loop, regular[*][1|2|5] depends on regular[*][0|1|4]"
+
+waive -rules {CLOCK_USE} -location {aes_cipher_core.sv} -regexp {clk_i' is connected to 'aes_sub_bytes' port} \
+      -comment "when using fully combinational S-Box implementations, no clock is used inside aes_sub_bytes"
+
+waive -rules {CLOCK_USE} -location {aes_key_expand.sv} -regexp {clk_i' is connected to 'aes_sbox' port} \
+      -comment "when using fully combinational S-Box implementations, no clock is used inside aes_sbox"
+
+waive -rules {RESET_USE} -location {aes_cipher_core.sv} -regexp {'rst_ni' is connected to 'aes_sub_bytes' port} \
+      -comment "when using fully combinational S-Box implementations, no reset is used inside aes_sub_bytes"
+
+waive -rules {RESET_USE} -location {aes_key_expand.sv} -regexp {'rst_ni' is connected to 'aes_sbox' port} \
+       -comment "when using fully combinational S-Box implementations, no reset is used inside aes_sbox"


### PR DESCRIPTION
If fully combinational S-Box implementations are used, these signals are unused.