### PR TITLE
Aes bug fix updated environment for some corner cases found with aes clear test

### DIFF
--- a/hw/ip/aes/data/aes_testplan.hjson
+++ b/hw/ip/aes/data/aes_testplan.hjson
@@ -41,7 +41,7 @@
       desc: '''
            Randomly select key length to verify all supported key lengths are working.'''
            milestone: V2
-      tests: ["aes_stress", "aes_smoke", "aes_config_error", "aes_clear"]
+      tests: ["aes_stress", "aes_smoke", "aes_config_error"]
     }
     {
       name: back2back
@@ -49,7 +49,7 @@
            Randomly select the spacing between consecutive messages and blocks from 0 - n clock cycles.
            The distribution will be weighted toward no and small gaps (0-10 cycles) but will also cover larger gaps.'''
       milestone: V2
-      tests: ["aes_b2b", "aes_stress", "aes_clear"]
+      tests: ["aes_b2b", "aes_stress"]
     }
     {
       name: backpressure
@@ -64,7 +64,7 @@
         Run multiple messages in a random mix of encryption / decryption.
         Each message should select its mode randomly.'''
       milestone: V2
-      tests: ["aes_stress", "aes_smoke", "aes_config_error", "aes_clear"]
+      tests: ["aes_stress", "aes_smoke", "aes_config_error"]
     }
     {
       name: failure_test
@@ -85,7 +85,7 @@
             Exercise trigger and clear registers at random times to make sure we handle the different cornercases correctly.
             Example of a cornercases clearing data input or data output before the data is consumed or the DUT finishes an operation.'''
       milestone: V2
-      tests: ["aes_clear"]
+      tests: []
     }
     {
       name: nist_test_vectors

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -86,6 +86,9 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
   int                clear_reg_pct              = 0;
 
 
+  // keep track of how many packets was split
+  int                split_cnt                  = 0;
+
 
   // rand variables
   // 0: C model 1: OPEN_SSL/BORING_SSL

--- a/hw/ip/aes/dv/env/aes_seq_item.sv
+++ b/hw/ip/aes/dv/env/aes_seq_item.sv
@@ -54,7 +54,7 @@ class aes_seq_item extends uvm_sequence_item;
 
 
   // used by the checker
-  bit [3:0][31:0] data_out;
+  bit [3:0][31:0] data_out            ='0;
   // set if data should be fixed and not randomized
   bit             fixed_data          = 0;
   // if set unused key bytes will be forced to 0 - controlled from test
@@ -192,6 +192,7 @@ class aes_seq_item extends uvm_sequence_item;
   // if ret_celan = 1
   // return 1 if all or none of the registers have been written
   function bit iv_clean(bit ret_clean, bit clear);
+    `uvm_info(`gfn, $sformatf("\n\t ----| IV status %b ", iv_vld), UVM_MEDIUM)
     if (clear) begin
       if (clear_reg_w_rand) begin
         iv = {4{$urandom()}};


### PR DESCRIPTION
The aes clear test found some corners where the environment didn't behave correctly.
this has spawned an issue #4653 to remove some of these untestable corners.

while debugging this I found a few other issues and some code that could be optimized which I have done in this PR.
Ithe last of the two commits removes the Clear test from regression until it can be run again.

also updates message_cnt to good_cnt as it only counts seen-good packages