### PR TITLE
[kmac] Revise the endianness in KMAC

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -185,15 +185,14 @@
         } // f: mode
         { bits: "8"
           name: "msg_endianness"
-          desc: '''Message and Secret Key Endianness.
+          desc: '''Message Endianness.
 
-                Convert TL-UL write data[31:0] to big-endian style
-                {d[7:0], d[15:8], ...}
+                If 1, Convert TL-UL write data[31:0] to {d[7:0], d[15:8], ...}
 
                 0: Little-endian. Keep input value as it is
                 1: Big-endian. Convert incoming value
                 '''
-          resval: "1"
+          resval: "0"
         } // f: msg_endianness
         { bits: "9"
           name: "state_endianness"

--- a/hw/ip/kmac/doc/_index.md
+++ b/hw/ip/kmac/doc/_index.md
@@ -304,6 +304,24 @@ After the software reads all the digest values, it issues Done command to !!CMD 
 Done command clears the Keccak state, FSM in SHA3 and KMAC, and a few internal variables.
 Secret key and other software programmed values won't be reset.
 
+
+## Endianness
+
+This KMAC HWIP operates in little-endian.
+Internal SHA3 hashing engine receives in 64-bit granularity.
+The data written to SHA3 is assumed to be little endian.
+
+The software may write/read the data in big-endian order if !!CFG.msg_endianness or !!CFG.state_endianness is set.
+If the endianness bit is 1, the data is assumed to be big-endian.
+So, the internal logic byte-swap the data.
+For example, when the software writes `0xDEADBEEF` with endianness as 1, the logic converts it to `0xEFBEADDE` then writes into MSG_FIFO.
+
+The software managed secret key, and the prefix are always little-endian values.
+For example, if the software configures the function name `N` in KMAC operation, it writes `encode_string("KMAC")`.
+The `encode_string("KMAC")` represents `0x01 0x20 0x4b 0x4d 0x41 0x43` in byte order.
+The software writes `0x4d4b2001` into !!PREFIX0 and `0x????4341` into !!PREFIX1 .
+Upper 2 bytes can vary depending on the customization input string `S`.
+
 ## KMAC/SHA3 context switching
 
 This version of KMAC/SHA3 HWIP _does not_ support the software context switching.

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -474,12 +474,12 @@ module kmac
   assign tlram_rerror = '0;
 
   // Convert endian here
-  //    prim_packer always packs to the right, but SHA engine assumes incoming
-  //    to be big-endian, [31:24] comes first. So, the data is reverted after
-  //    prim_packer before the message fifo. here to reverse if not big-endian
-  //    before pushing to the packer.
-  assign tlram_wdata_endian = conv_endian32(tlram_wdata, ~reg2hw.cfg.msg_endianness.q);
-  assign tlram_wmask_endian = conv_endian32(tlram_wmask, ~reg2hw.cfg.msg_endianness.q);
+  //    prim_packer always packs to the right(bit0). If the input DWORD is
+  //    big-endian, it needs to be swapped to little-endian to maintain the
+  //    order. Internal SHA3(Keccak) runs in little-endian in contrast to HMAC
+  //    So, no endian-swap after prim_packer.
+  assign tlram_wdata_endian = conv_endian32(tlram_wdata, reg2hw.cfg.msg_endianness.q);
+  assign tlram_wmask_endian = conv_endian32(tlram_wmask, reg2hw.cfg.msg_endianness.q);
 
   // TL Adapter
   tlul_adapter_sram #(

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -598,7 +598,7 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h0)
   ) u_cfg_msg_endianness (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),


### PR DESCRIPTION
Previous commit 00310851134f35124264a55458a9fc9b1e48d645 fixed the
ordering issue. Based on the update, the KMAC top is revised w.r.t the
reverted endianness in MSG_FIFO.

The CFG.msg_endianness represents little-endian if the value is 0.
The KMAC top, however, byte-swapped the TL input data and mask if 0.

Also, the msg_endianness describes the value to affect secret keys. So,
the design is updated accordingly.