### PR TITLE
[dv/lc_ctrl] connect lc outputs

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.sv
@@ -10,6 +10,9 @@ class lc_ctrl_env extends cip_base_env #(
   );
   `uvm_component_utils(lc_ctrl_env)
 
+  push_pull_agent#(.HostDataWidth(OTP_PROG_HDATA_WIDTH), .DeviceDataWidth(OTP_PROG_DDATA_WIDTH))
+                   m_otp_prog_pull_agent;
+  push_pull_agent#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)) m_otp_token_pull_agent;
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
@@ -22,10 +25,29 @@ class lc_ctrl_env extends cip_base_env #(
     if (!uvm_config_db#(lc_ctrl_vif)::get(this, "", "lc_ctrl_vif", cfg.lc_ctrl_vif)) begin
       `uvm_fatal(`gfn, "failed to get lc_ctrl_vif from uvm_config_db")
     end
+
+    m_otp_prog_pull_agent = push_pull_agent#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),
+        .DeviceDataWidth(OTP_PROG_DDATA_WIDTH))::type_id::create("m_otp_prog_pull_agent", this);
+    uvm_config_db#(push_pull_agent_cfg#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),
+        .DeviceDataWidth(OTP_PROG_DDATA_WIDTH)))::set(this, "m_otp_prog_pull_agent", "cfg",
+        cfg.m_otp_prog_pull_agent_cfg);
+
+    m_otp_token_pull_agent = push_pull_agent#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth))::type_id::
+        create("m_otp_token_pull_agent", this);
+    uvm_config_db#(push_pull_agent_cfg#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)))::set(this,
+        "m_otp_token_pull_agent", "cfg", cfg.m_otp_token_pull_agent_cfg);
   endfunction
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
+    virtual_sequencer.otp_prog_pull_sequencer_h = m_otp_prog_pull_agent.sequencer;
+    virtual_sequencer.otp_token_pull_sequencer_h = m_otp_token_pull_agent.sequencer;
+    if (cfg.en_scb) begin
+      m_otp_prog_pull_agent.monitor.analysis_port.connect(
+          scoreboard.otp_prog_fifo.analysis_export);
+      m_otp_token_pull_agent.monitor.analysis_port.connect(
+          scoreboard.otp_token_fifo.analysis_export);
+    end
   endfunction
 
 endclass

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
@@ -5,6 +5,10 @@
 class lc_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(lc_ctrl_reg_block));
 
   // ext component cfgs
+  push_pull_agent_cfg#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),
+                       .DeviceDataWidth(OTP_PROG_DDATA_WIDTH)) m_otp_prog_pull_agent_cfg;
+  push_pull_agent_cfg#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)) m_otp_token_pull_agent_cfg;
+
   // ext interfaces
   pwr_lc_vif  pwr_lc_vif;
   lc_ctrl_vif lc_ctrl_vif;
@@ -17,6 +21,18 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(lc_ctrl_reg_block));
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = lc_ctrl_env_pkg::LIST_OF_ALERTS;
     super.initialize(csr_base_addr);
+
+    m_otp_prog_pull_agent_cfg = push_pull_agent_cfg#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),
+        .DeviceDataWidth(OTP_PROG_DDATA_WIDTH))::type_id::create("m_otp_prog_pull_agent_cfg");
+    `DV_CHECK_RANDOMIZE_FATAL(m_otp_prog_pull_agent_cfg)
+    m_otp_prog_pull_agent_cfg.agent_type = PullAgent;
+    m_otp_prog_pull_agent_cfg.if_mode    = Device;
+
+    m_otp_token_pull_agent_cfg = push_pull_agent_cfg#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth))
+        ::type_id::create("m_otp_token_pull_agent_cfg");
+    `DV_CHECK_RANDOMIZE_FATAL(m_otp_token_pull_agent_cfg)
+    m_otp_token_pull_agent_cfg.agent_type = PullAgent;
+    m_otp_token_pull_agent_cfg.if_mode    = Device;
   endfunction
 
 endclass

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
@@ -14,6 +14,7 @@ package lc_ctrl_env_pkg;
   import lc_ctrl_ral_pkg::*;
   import lc_ctrl_pkg::*;
   import otp_ctrl_pkg::*;
+  import push_pull_agent_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -24,6 +25,11 @@ package lc_ctrl_env_pkg;
   parameter uint   NUM_ALERTS = 2;
   parameter uint   CLAIM_TRANS_VAL = 'ha5;
   parameter uint   NUM_STATES = 16;
+
+  // lc_otp_program host data width: lc_state_e width + lc_cnt_e width
+  parameter uint OTP_PROG_HDATA_WIDTH = lc_ctrl_pkg::LcStateWidth + lc_ctrl_pkg::LcCountWidth;
+  // TODO: temp set to 0, once push-pull agent can constraint data, it will set to 1 for error bit
+  parameter uint OTP_PROG_DDATA_WIDTH = 0;
 
   typedef struct packed {
     lc_ctrl_pkg::lc_tx_e lc_dft_en_o;

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -24,6 +24,8 @@ interface lc_ctrl_if(input clk, input rst_n);
   lc_ctrl_pkg::lc_tx_t lc_keymgr_en_o;
   lc_ctrl_pkg::lc_tx_t lc_escalate_en_o;
 
+  lc_ctrl_pkg::lc_keymgr_div_t lc_keymgr_div_o;
+
   task automatic init(lc_ctrl_pkg::lc_state_e lc_state = LcStRaw,
                       lc_ctrl_pkg::lc_cnt_e   lc_cnt = LcCntRaw);
     otp_i.valid = 1;

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
@@ -11,7 +11,12 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
 
   // local variables
   bit is_personalized = 0;
+
   // TLM agent fifos
+  uvm_tlm_analysis_fifo #(push_pull_item#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),
+                        .DeviceDataWidth(OTP_PROG_DDATA_WIDTH))) otp_prog_fifo;
+  uvm_tlm_analysis_fifo #(push_pull_item#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)))
+                        otp_token_fifo;
 
   // local queues to hold incoming packets pending comparison
 
@@ -19,6 +24,8 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
+    otp_prog_fifo = new("otp_prog_fifo", this);
+    otp_token_fifo = new("otp_token_fifo", this);
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_virtual_sequencer.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_virtual_sequencer.sv
@@ -8,6 +8,10 @@ class lc_ctrl_virtual_sequencer extends cip_base_virtual_sequencer #(
   );
   `uvm_component_utils(lc_ctrl_virtual_sequencer)
 
+  push_pull_sequencer#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),
+                       .DeviceDataWidth(OTP_PROG_DDATA_WIDTH)) otp_prog_pull_sequencer_h;
+
+  push_pull_sequencer#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)) otp_token_pull_sequencer_h;
 
   `uvm_component_new
 

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -90,7 +90,7 @@ module tb;
     .lc_flash_rma_req_o         (),
     .lc_flash_rma_ack_i         (lc_ctrl_pkg::Off),
 
-    .lc_keymgr_div_o            (),
+    .lc_keymgr_div_o            (lc_ctrl_if.lc_keymgr_div_o),
 
     .otp_hw_cfg_i               (lc_ctrl_if.otp_hw_cfg_i)
   );


### PR DESCRIPTION
This PR has two commits:
1. Connect LC_OTP interface with two push-pull agents: one for otp_program, and one for otp_token.
    There are still some TODOs remaining because push-pull agent current does not support constraints for h_data or d_data.
2. Connect keymgr_div_o output to lc_ctrl_if for the ease of checking data in scb later.