### PR TITLE
[fpv] Fix jaspergold run script

### DIFF
--- a/hw/formal/tools/jaspergold/jaspergold.hjson
+++ b/hw/formal/tools/jaspergold/jaspergold.hjson
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   build_cmd: "{job_prefix} jg"
-  build_opts: ["-batch fpv.tcl",
+  build_opts: ["-batch {fpv_root}/tools/{tool}/fpv.tcl",
                "-proj jgproject",
                "-allow_unsupported_OS",
                "-command exit"]


### PR DESCRIPTION
Fix jaspergold script error by adding an absolute path to fpv.tcl file.

Signed-off-by: Cindy Chen <chencindy@google.com>