### PR TITLE
[dv/lc_ctrl] add rma and clk_byp response

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -24,10 +24,18 @@ interface lc_ctrl_if(input clk, input rst_n);
   lc_ctrl_pkg::lc_tx_t lc_keymgr_en_o;
   lc_ctrl_pkg::lc_tx_t lc_escalate_en_o;
 
-  lc_ctrl_pkg::lc_keymgr_div_t lc_keymgr_div_o;
+  lc_ctrl_pkg::lc_tx_t clk_byp_req_o;
+  lc_ctrl_pkg::lc_tx_t clk_byp_ack_i;
+  lc_ctrl_pkg::lc_tx_t flash_rma_req_o;
+  lc_ctrl_pkg::lc_tx_t flash_rma_ack_i;
+
+  lc_ctrl_pkg::lc_keymgr_div_t     keymgr_div_o;
+  lc_ctrl_pkg::lc_flash_rma_seed_t flash_rma_seed_o;
 
   task automatic init(lc_ctrl_pkg::lc_state_e lc_state = LcStRaw,
-                      lc_ctrl_pkg::lc_cnt_e   lc_cnt = LcCntRaw);
+                      lc_ctrl_pkg::lc_cnt_e   lc_cnt = LcCntRaw,
+                      lc_ctrl_pkg::lc_tx_t    clk_byp_ack = lc_ctrl_pkg::Off,
+                      lc_ctrl_pkg::lc_tx_t    flash_rma_ack = lc_ctrl_pkg::Off);
     otp_i.valid = 1;
     otp_i.state = lc_state;
     otp_i.count = lc_cnt;
@@ -40,6 +48,17 @@ interface lc_ctrl_if(input clk, input rst_n);
 
     otp_hw_cfg_i.valid = lc_ctrl_pkg::Off;
     otp_hw_cfg_i.data = 0;
+
+    clk_byp_ack_i = clk_byp_ack;
+    flash_rma_ack_i = flash_rma_ack;
+  endtask
+
+  task automatic set_clk_byp_ack(lc_ctrl_pkg::lc_tx_t val);
+    clk_byp_ack_i = val;
+  endtask
+
+  task automatic set_flash_rma_ack(lc_ctrl_pkg::lc_tx_t val);
+    flash_rma_ack_i = val;
   endtask
 
 endinterface

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
@@ -58,6 +58,44 @@ class lc_ctrl_base_vseq extends cip_base_vseq #(
     super.read_and_check_all_csrs_after_reset();
   endtask
 
+  virtual task run_clk_byp_rsp_nonblocking(bit has_err = 0);
+    fork
+      forever begin
+        lc_ctrl_pkg::lc_tx_t rsp;
+        wait(cfg.lc_ctrl_vif.clk_byp_req_o == lc_ctrl_pkg::On);
+        rsp = (has_err) ? $urandom_range(0, 1) ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off :
+                          lc_ctrl_pkg::On;
+        cfg.clk_rst_vif.wait_clks($urandom_range(0, 20));
+        cfg.lc_ctrl_vif.set_clk_byp_ack(rsp);
+
+        wait (cfg.lc_ctrl_vif.clk_byp_req_o != lc_ctrl_pkg::On);
+        rsp = (has_err) ? $urandom_range(0, 1) ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off :
+                          lc_ctrl_pkg::Off;
+        cfg.clk_rst_vif.wait_clks($urandom_range(0, 20));
+        cfg.lc_ctrl_vif.set_clk_byp_ack(rsp);
+      end
+    join_none
+  endtask
+
+  virtual task run_flash_rma_rsp_nonblocking(bit has_err = 0);
+    fork
+      forever begin
+        lc_ctrl_pkg::lc_tx_t rsp;
+        wait(cfg.lc_ctrl_vif.flash_rma_req_o == lc_ctrl_pkg::On);
+        rsp = (has_err) ? $urandom_range(0, 1) ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off :
+                          lc_ctrl_pkg::On;
+        cfg.clk_rst_vif.wait_clks($urandom_range(0, 20));
+        cfg.lc_ctrl_vif.set_flash_rma_ack(rsp);
+
+        wait (cfg.lc_ctrl_vif.flash_rma_req_o != lc_ctrl_pkg::On);
+        rsp = (has_err) ? $urandom_range(0, 1) ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off :
+                          lc_ctrl_pkg::Off;
+        cfg.clk_rst_vif.wait_clks($urandom_range(0, 20));
+        cfg.lc_ctrl_vif.set_flash_rma_ack(rsp);
+      end
+    join_none
+  endtask
+
   virtual task sw_transition_req(bit [TL_DW-1:0] next_lc_state, bit [TL_DW*3-1:0] token_val);
     csr_wr(ral.claim_transition_if, CLAIM_TRANS_VAL);
     csr_wr(ral.transition_target, next_lc_state);

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
@@ -8,13 +8,23 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
 
   `uvm_object_new
 
+  rand bit clk_byp_error_rsp;
+  rand bit flash_rma_error_rsp;
   dec_lc_state_e next_lc_state;
 
   constraint lc_cnt_c {
     lc_state != LcStRaw -> lc_cnt != LcCntRaw;
   }
 
+  constraint no_err_rsps_c {
+    clk_byp_error_rsp   == 0;
+    flash_rma_error_rsp == 0;
+  }
+
   task body();
+    run_clk_byp_rsp_nonblocking(clk_byp_error_rsp);
+    run_flash_rma_rsp_nonblocking(flash_rma_error_rsp);
+
     for (int i = 1; i <= num_trans; i++) begin
       if (i != 1) dut_init();
       `uvm_info(`gfn, $sformatf("starting seq %0d/%0d, init LC_state is %0s, LC_cnt is %0s",
@@ -43,8 +53,7 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
   // need to randomize here because associative array's index cannot be a rand input in constraint
   virtual function void randomize_next_lc_state(dec_lc_state_e curr_lc_state);
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(next_lc_state,
-        // TODO: temp constraint for no DecLcStRma
-        next_lc_state inside {VALID_NEXT_STATES[curr_lc_state]}; next_lc_state != DecLcStRma;)
+        next_lc_state inside {VALID_NEXT_STATES[curr_lc_state]};)
   endfunction
 
 endclass : lc_ctrl_smoke_vseq

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -83,14 +83,14 @@ module tb;
     .lc_keymgr_en_o             (lc_ctrl_if.lc_keymgr_en_o),
     .lc_escalate_en_o           (lc_ctrl_if.lc_escalate_en_o),
 
-    .lc_clk_byp_req_o           (),
-    .lc_clk_byp_ack_i           (lc_ctrl_pkg::On),
+    .lc_clk_byp_req_o           (lc_ctrl_if.clk_byp_req_o),
+    .lc_clk_byp_ack_i           (lc_ctrl_if.clk_byp_ack_i),
 
-    .lc_flash_rma_seed_o        (),
-    .lc_flash_rma_req_o         (),
-    .lc_flash_rma_ack_i         (lc_ctrl_pkg::Off),
+    .lc_flash_rma_seed_o        (lc_ctrl_if.flash_rma_seed_o),
+    .lc_flash_rma_req_o         (lc_ctrl_if.flash_rma_req_o),
+    .lc_flash_rma_ack_i         (lc_ctrl_if.flash_rma_ack_i),
 
-    .lc_keymgr_div_o            (lc_ctrl_if.lc_keymgr_div_o),
+    .lc_keymgr_div_o            (lc_ctrl_if.keymgr_div_o),
 
     .otp_hw_cfg_i               (lc_ctrl_if.otp_hw_cfg_i)
   );


### PR DESCRIPTION
This PR adds rsp sequence to rma and clk_byp requests.
The response includes an error bit that can cause error cases in
response. The error case will be used in later sequence.

Signed-off-by: Cindy Chen <chencindy@google.com>