### PR TITLE
[ci] Don't generate binaries for top_englishbreakfast

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -280,35 +280,6 @@ jobs:
     parameters:
       artifact: sw_build
 
-- job: sw_build_englishbreakfast
-  displayName: Build Software for English Breakfast toplevel design
-  dependsOn: lint
-  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
-  pool:
-    vmImage: ubuntu-18.04
-  steps:
-  - template: ci/install-package-dependencies.yml
-  - bash: |
-      set -x
-      sudo util/get-toolchain.py \
-        --install-dir="$TOOLCHAIN_PATH" \
-        --release-version="$TOOLCHAIN_VERSION" \
-        --update
-    displayName: Install toolchain
-  - bash: |
-      . util/build_consts.sh
-      ./meson_init.sh -A
-      ./hw/top_englishbreakfast/util/prepare_sw.py
-      ninja -C "$OBJ_DIR" sw/device/boot_rom/boot_rom_export_fpga_nexysvideo
-      ninja -C "$OBJ_DIR" sw/device/boot_rom/boot_rom_export_sim_verilator
-      ninja -C "$OBJ_DIR" sw/device/sca/aes_serial/aes_serial_export_fpga_nexysvideo
-      ninja -C "$OBJ_DIR" sw/device/sca/aes_serial/aes_serial_export_sim_verilator
-      ninja -C "$OBJ_DIR" sw/device/examples/hello_world/hello_world_export_sim_verilator
-    displayName: Prepare software build and build embedded targets
-  - template: ci/upload-artifacts-template.yml
-    parameters:
-      artifact: sw_build_englishbreakfast
-
 # We continue building with GCC, despite defaulting to Clang. This is a copy of
 # `sw_build` with `meson_init.sh` configured with the GCC toolchain, instead of
 # the default toolchain.
@@ -519,7 +490,11 @@ jobs:
   dependsOn:
     - lint
     # The bootrom is built into the FPGA image at synthesis time.
-    - sw_build_englishbreakfast
+    # Currently, we can't have different versions of binaries in $BIN_DIR. Consequently, we are
+    # using the NexysVideo bootrom here and the resulting CW305 bitstream is not functional.
+    # By generating the CW305 bootrom binary we would break execute_fpga_tests executed on the
+    # NexysVideo.
+    - sw_build
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
   pool: ci-public
   timeoutInMinutes: 120 # 2 hours


### PR DESCRIPTION
It seems we can't have binaries for different tops in $BIN_DIR. Generating the bootrom binary for top_englishbreakfast seems to break the execution of tests on the NexysVideo FPGA board (top_earlgrey). This commit disables generation of binaries for top_englishbreakfast. At the moment, we can accept that the corresponding bitstream generated in CI is not functional.