### PR TITLE
[prim_ram] Rearrange parity bit packing and fix wrong wmask settings

### DIFF
--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -132,7 +132,7 @@ module tb;
 
   // bind mem_bkdr_if
   `define OTP_CTRL_MEM_HIER \
-      dut.u_otp.gen_generic.u_impl_generic.i_prim_ram_1p_adv.u_mem.gen_generic.u_impl_generic
+      dut.u_otp.gen_generic.u_impl_generic.u_prim_ram_1p_adv.u_mem.gen_generic.u_impl_generic
 
   assign interrupts[OtpOperationDone] = intr_otp_operation_done;
   assign interrupts[OtpErr]           = intr_otp_error;

--- a/hw/ip/prim/rtl/prim_ram_1p_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_adv.sv
@@ -5,8 +5,8 @@
 // Single-Port SRAM Wrapper
 //
 // Supported configurations:
-// - ECC for 32b wide memories with no write mask
-//   (Width == 32 && DataBitsPerMask == 32).
+// - ECC for 32b and 64b wide memories with no write mask
+//   (Width == 32 or Width == 64, DataBitsPerMask is ignored).
 // - Byte parity if Width is a multiple of 8 bit and write masks have Byte
 //   granularity (DataBitsPerMask == 8).
 //
@@ -51,11 +51,6 @@ module prim_ram_1p_adv #(
 
   `ASSERT_INIT(CannotHaveEccAndParity_A, !(EnableParity && EnableECC))
 
-  // While we require DataBitsPerMask to be per Byte (8) at the interface in case Byte parity is
-  // enabled, we need to switch this to a per-bit mask locally such that we can individually enable
-  // the parity bits to be written alongside the data.
-  localparam int LocalDataBitsPerMask = (EnableParity) ? 1 : DataBitsPerMask;
-
   // Calculate ECC width
   localparam int ParWidth  = (EnableParity) ? Width/8 :
                              (!EnableECC)   ? 0 :
@@ -65,6 +60,13 @@ module prim_ram_1p_adv #(
                              (Width <=  57) ? 7 :
                              (Width <= 120) ? 8 : 8 ;
   localparam int TotalWidth = Width + ParWidth;
+
+  // If byte parity is enabled, the write enable bits are used to write memory colums
+  // with 8 + 1 = 9 bit width (data plus corresponding parity bit).
+  // If ECC is enabled, the DataBitsPerMask is ignored.
+  localparam int LocalDataBitsPerMask = (EnableParity) ? 9          :
+                                        (EnableECC)    ? TotalWidth :
+                                                         DataBitsPerMask;
 
   ////////////////////////////
   // RAM Primitive Instance //
@@ -154,19 +156,21 @@ module prim_ram_1p_adv #(
 
     always_comb begin : p_parity
       rerror_d = '0;
-      wmask_d[0+:Width] = wmask_i;
-      wdata_d[0+:Width] = wdata_i;
-
       for (int i = 0; i < Width/8; i ++) begin
+        // Data mapping. We have to make 8+1 = 9 bit groups
+        // that have the same write enable such that FPGA tools
+        // can map this correctly to BRAM resources.
+        wmask_d[i*9 +: 8] = wmask_i[i*8 +: 8];
+        wdata_d[i*9 +: 8] = wdata_i[i*8 +: 8];
+        rdata_d[i*8 +: 8] = rdata_sram[i*9 +: 8];
+
         // parity generation (odd parity)
-        wdata_d[Width + i] = ~(^wdata_i[i*8 +: 8]);
-        wmask_d[Width + i] = &wmask_i[i*8 +: 8];
+        wdata_d[i*9 + 8] = ~(^wdata_i[i*8 +: 8]);
+        wmask_d[i*9 + 8] = &wmask_i[i*8 +: 8];
         // parity decoding (errors are always uncorrectable)
-        rerror_d[1] |= ~(^{rdata_sram[i*8 +: 8], rdata_sram[Width + i]});
+        rerror_d[1] |= ~(^{rdata_sram[i*9 +: 8], rdata_sram[i*9 + 8]});
       end
     end
-
-    assign rdata_d  = rdata_sram[0+:Width];
   end else begin : gen_nosecded_noparity
     assign wmask_d = wmask_i;
     assign wdata_d = wdata_i;

--- a/hw/ip/prim/rtl/prim_ram_1p_scr.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_scr.sv
@@ -24,9 +24,8 @@
 `include "prim_assert.sv"
 
 module prim_ram_1p_scr #(
-  parameter  int Depth                = 512, // Needs to be a power of 2 if NumAddrScrRounds > 0.
-  parameter  int Width                = 256, // Needs to be byte aligned for parity
-  parameter  int DataBitsPerMask      = 8,   // Currently only 8 is supported
+  parameter  int Depth                = 16*1024, // Needs to be a power of 2 if NumAddrScrRounds > 0.
+  parameter  int Width                = 32, // Needs to be byte aligned for parity
   parameter  int CfgWidth             = 8,   // WTC, RTC, etc
 
   // Scrambling parameters. Note that this needs to be low-latency, hence we have to keep the
@@ -332,7 +331,7 @@ module prim_ram_1p_scr #(
   prim_ram_1p_adv #(
     .Depth(Depth),
     .Width(Width),
-    .DataBitsPerMask(DataBitsPerMask),
+    .DataBitsPerMask(8),
     .CfgW(CfgWidth),
     .EnableECC(1'b0),
     .EnableParity(1'b1), // We are using byte parity

--- a/hw/ip/prim/rtl/prim_ram_2p_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_2p_adv.sv
@@ -5,8 +5,8 @@
 // Dual-Port SRAM Wrapper
 //
 // Supported configurations:
-// - ECC for 32b wide memories with no write mask
-//   (Width == 32 && DataBitsPerMask == 32).
+// - ECC for 32b and 64b wide memories with no write mask
+//   (Width == 32 or Width == 64, DataBitsPerMask is ignored).
 // - Byte parity if Width is a multiple of 8 bit and write masks have Byte
 //   granularity (DataBitsPerMask == 8).
 //

--- a/hw/ip/prim/rtl/prim_ram_2p_async_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_2p_async_adv.sv
@@ -5,8 +5,8 @@
 // Asynchronous Dual-Port SRAM Wrapper
 //
 // Supported configurations:
-// - ECC for 32b wide memories with no write mask
-//   (Width == 32 && DataBitsPerMask == 32).
+// - ECC for 32b and 64b wide memories with no write mask
+//   (Width == 32 or Width == 64, DataBitsPerMask is ignored).
 // - Byte parity if Width is a multiple of 8 bit and write masks have Byte
 //   granularity (DataBitsPerMask == 8).
 //
@@ -62,11 +62,6 @@ module prim_ram_2p_async_adv #(
 
   `ASSERT_INIT(CannotHaveEccAndParity_A, !(EnableParity && EnableECC))
 
-  // While we require DataBitsPerMask to be per Byte (8) at the interface in case Byte parity is
-  // enabled, we need to switch this to a per-bit mask locally such that we can individually enable
-  // the parity bits to be written alongside the data.
-  localparam int LocalDataBitsPerMask = (EnableParity) ? 1 : DataBitsPerMask;
-
   // Calculate ECC width
   localparam int ParWidth  = (EnableParity) ? Width/8 :
                              (!EnableECC)   ? 0 :
@@ -76,6 +71,13 @@ module prim_ram_2p_async_adv #(
                              (Width <=  57) ? 7 :
                              (Width <= 120) ? 8 : 8 ;
   localparam int TotalWidth = Width + ParWidth;
+
+  // If byte parity is enabled, the write enable bits are used to write memory colums
+  // with 8 + 1 = 9 bit width (data plus corresponding parity bit).
+  // If ECC is enabled, the DataBitsPerMask is ignored.
+  localparam int LocalDataBitsPerMask = (EnableParity) ? 9          :
+                                        (EnableECC)    ? TotalWidth :
+                                                         DataBitsPerMask;
 
   ////////////////////////////
   // RAM Primitive Instance //
@@ -197,25 +199,27 @@ module prim_ram_2p_async_adv #(
     always_comb begin : p_parity
       a_rerror_d = '0;
       b_rerror_d = '0;
-      a_wmask_d[0+:Width] = a_wmask_i;
-      b_wmask_d[0+:Width] = b_wmask_i;
-      a_wdata_d[0+:Width] = a_wdata_i;
-      b_wdata_d[0+:Width] = b_wdata_i;
-
       for (int i = 0; i < Width/8; i ++) begin
+        // Data mapping. We have to make 8+1 = 9 bit groups
+        // that have the same write enable such that FPGA tools
+        // can map this correctly to BRAM resources.
+        a_wmask_d[i*9 +: 8] = a_wmask_i[i*8 +: 8];
+        a_wdata_d[i*9 +: 8] = a_wdata_i[i*8 +: 8];
+        a_rdata_d[i*8 +: 8] = a_rdata_sram[i*9 +: 8];
+        b_wmask_d[i*9 +: 8] = b_wmask_i[i*8 +: 8];
+        b_wdata_d[i*9 +: 8] = b_wdata_i[i*8 +: 8];
+        b_rdata_d[i*8 +: 8] = b_rdata_sram[i*9 +: 8];
+
         // parity generation (odd parity)
-        a_wdata_d[Width + i] = ~(^a_wdata_i[i*8 +: 8]);
-        b_wdata_d[Width + i] = ~(^b_wdata_i[i*8 +: 8]);
-        a_wmask_d[Width + i] = &a_wmask_i[i*8 +: 8];
-        b_wmask_d[Width + i] = &b_wmask_i[i*8 +: 8];
+        a_wdata_d[i*9 + 8] = ~(^a_wdata_i[i*8 +: 8]);
+        a_wmask_d[i*9 + 8] = &a_wmask_i[i*8 +: 8];
+        b_wdata_d[i*9 + 8] = ~(^b_wdata_i[i*8 +: 8]);
+        b_wmask_d[i*9 + 8] = &b_wmask_i[i*8 +: 8];
         // parity decoding (errors are always uncorrectable)
-        a_rerror_d[1] |= ~(^{a_rdata_sram[i*8 +: 8], a_rdata_sram[Width + i]});
-        b_rerror_d[1] |= ~(^{b_rdata_sram[i*8 +: 8], b_rdata_sram[Width + i]});
+        a_rerror_d[1] |= ~(^{a_rdata_sram[i*9 +: 8], a_rdata_sram[i*9 + 8]});
+        b_rerror_d[1] |= ~(^{b_rdata_sram[i*9 +: 8], b_rdata_sram[i*9 + 8]});
       end
     end
-
-    assign a_rdata_d  = a_rdata_sram[0+:Width];
-    assign b_rdata_d  = b_rdata_sram[0+:Width];
   end else begin : gen_nosecded_noparity
     assign a_wmask_d  = a_wmask_i;
     assign b_wmask_d  = b_wmask_i;

--- a/hw/ip/prim_generic/rtl/prim_generic_otp.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_otp.sv
@@ -280,7 +280,7 @@ module prim_generic_otp #(
     .EnableECC            (1'b1),
     .EnableInputPipeline  (1),
     .EnableOutputPipeline (1)
-  ) i_prim_ram_1p_adv (
+  ) u_prim_ram_1p_adv (
     .clk_i,
     .rst_ni,
     .req_i    ( req            ),

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -675,6 +675,7 @@ module usbdev (
   prim_ram_2p_async_adv #(
     .Depth (SramDepth),
     .Width (SramDw),    // 32 x 512 --> 2kB
+    .DataBitsPerMask(SramDw),
     .CfgW  (8),
 
     .EnableECC           (0), // No Protection

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -349,7 +349,6 @@ module top_${top["name"]} #(
   prim_ram_1p_scr #(
     .Width(${data_width}),
     .Depth(${sram_depth}),
-    .DataBitsPerMask(8),
     .CfgWidth(8)
   ) u_ram1p_${m["name"]} (
     % for key in clocks:

--- a/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
+++ b/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
@@ -24,5 +24,5 @@
 // in the future, this needs to be upgraded to support all info types
 `define FLASH0_INFO_HIER   `FLASH_BANK0.gen_info_types[0].u_info_mem
 `define FLASH1_INFO_HIER   `FLASH_BANK1.gen_info_types[0].u_info_mem
-`define OTP_MEM_HIER       `CHIP_HIER.u_otp_ctrl.u_otp.gen_generic.u_impl_generic.i_prim_ram_1p_adv.\
+`define OTP_MEM_HIER       `CHIP_HIER.u_otp_ctrl.u_otp.gen_generic.u_impl_generic.u_prim_ram_1p_adv.\
                            u_mem.gen_generic.u_impl_generic

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -594,7 +594,6 @@ module top_earlgrey #(
   prim_ram_1p_scr #(
     .Width(32),
     .Depth(16384),
-    .DataBitsPerMask(8),
     .CfgWidth(8)
   ) u_ram1p_ram_main (
     .clk_i   (clkmgr_clocks.clk_main_infra),
@@ -654,7 +653,6 @@ module top_earlgrey #(
   prim_ram_1p_scr #(
     .Width(32),
     .Depth(1024),
-    .DataBitsPerMask(8),
     .CfgWidth(8)
   ) u_ram1p_ram_ret (
     .clk_i   (clkmgr_clocks.clk_io_div4_infra),


### PR DESCRIPTION
This ensures that 1) memories not using per-bit or per-byte wmask have the correct DataBitsPerMask setting, and 2) that memories with byte parity employ the correct data + parity bit packing order such that these memories can be efficiently mapped onto FPGA block rams.

This fix reduces BRAM utilization on NexysVideo from ~80% to ~65%.

Fix #4670.

Signed-off-by: Michael Schaffner <msf@opentitan.org>