### PR TITLE
[otp_ctrl] Two small fix related otp_ctrl kdi/lci interface

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -1041,7 +1041,7 @@ end else if (PartInfo[k].variant == LifeCycle) begin : gen_lifecycle
   assign otp_hw_cfg_o.valid = (part_init_done[HwCfgIdx]) ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off;
   assign otp_hw_cfg_o.data = otp_hw_cfg_data_t'(part_buf_data[HwCfgOffset +: HwCfgSize]);
   // Root keys
-  assign otp_keymgr_key_o.valid = part_init_done[Secret2Idx];
+  assign otp_keymgr_key_o.valid = part_digest[Secret2Idx] != '0;
   assign otp_keymgr_key_o.key_share0 = (lc_seed_hw_rd_en == lc_ctrl_pkg::On) ?
                                        part_buf_data[CreatorRootKeyShare0Offset +:
                                                      CreatorRootKeyShare0Size] :
@@ -1054,7 +1054,7 @@ end else if (PartInfo[k].variant == LifeCycle) begin : gen_lifecycle
                                                       CreatorRootKeyShare1Size*8];
 
   // Scrambling Keys
-  assign scrmbl_key_seed_valid = part_init_done[Secret1Idx];
+  assign scrmbl_key_seed_valid = part_digest[Secret1Idx] != '0;
   assign sram_data_key_seed    = part_buf_data[SramDataKeySeedOffset +:
                                                SramDataKeySeedSize];
   assign flash_data_key_seed   = part_buf_data[FlashDataKeySeedOffset +:

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_lci.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_lci.sv
@@ -129,6 +129,7 @@ module otp_ctrl_lci
       ///////////////////////////////////////////////////////////////////
       // Wait for a request from the life cycle controller
       IdleSt: begin
+        lci_idle_o = 1'b1;
         if (lc_req_i) begin
           state_d = WriteSt;
           cnt_clr = 1'b1;


### PR DESCRIPTION
This PR has two commits:
1. In otp_ctrl's lci interface, adds the logic to set `lci_idle_o` to 1 at IdleSt.
2. In otp_ctrl's kdi interface, the `valid` output should be set when the partition is locked, not when it is initialized.

Signed-off-by: Cindy Chen <chencindy@google.com>