### PR TITLE
[dv/otp_ctrl] fix test_access mem_test regression failure

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
@@ -15,7 +15,8 @@ class otp_ctrl_common_vseq extends otp_ctrl_base_vseq;
     // drive dft_en pins to access the test_access memory
     cfg.lc_dft_en_vif.drive(lc_ctrl_pkg::On);
     // once turn on lc_dft_en regiser, will need some time to update the state register
-    cfg.clk_rst_vif.wait_clks(2);
+    // two clock cycles for lc_async mode, one clock cycle for driving dft_en
+    cfg.clk_rst_vif.wait_clks(3);
   endtask
 
   task post_start();


### PR DESCRIPTION
Regression failed on otp_ctrl mem_walk test because test_access cannot
be accessed until dft_en is set to ON. To set dft_en, tb drives the
dft_en pin, and RTL goes to lc_sync module, which at least take three
clock cycles.

Signed-off-by: Cindy Chen <chencindy@google.com>