### PR TITLE
[otp_ctrl/edn] Update EDN interface and KDI logic 

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -10,6 +10,13 @@
 
 { name: "otp_ctrl",
   clock_primary: "clk_i",
+  other_clock_list: [
+    "clk_edn_i"
+  ],
+  reset_primary: "rst_ni",
+  other_reset_list: [
+    "rst_edn_ni"
+  ]
   bus_device: "tlul",
   bus_host: "none",
 
@@ -475,12 +482,11 @@
       package: "otp_ctrl_pkg"
     }
     // EDN interface
-    { struct:  "otp_edn"
+    { struct:  "edn"
       type:    "req_rsp"
-      name:    "otp_edn"
+      name:    "edn"
       act:     "req"
-      default: "'0"
-      package: "otp_ctrl_pkg"
+      package: "edn_pkg"
     }
     // Power manager init command
     { struct:  "pwr_otp"

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -23,6 +23,13 @@
 %>
 { name: "otp_ctrl",
   clock_primary: "clk_i",
+  other_clock_list: [
+    "clk_edn_i"
+  ],
+  reset_primary: "rst_ni",
+  other_reset_list: [
+    "rst_edn_ni"
+  ]
   bus_device: "tlul",
   bus_host: "none",
 
@@ -192,12 +199,11 @@
       package: "otp_ctrl_pkg"
     }
     // EDN interface
-    { struct:  "otp_edn"
+    { struct:  "edn"
       type:    "req_rsp"
-      name:    "otp_edn"
+      name:    "edn"
       act:     "req"
-      default: "'0"
-      package: "otp_ctrl_pkg"
+      package: "edn_pkg"
     }
     // Power manager init command
     { struct:  "pwr_otp"

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -49,7 +49,6 @@ module tb;
   push_pull_if #(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_addr_if(.clk(clk), .rst_n(rst_n));
   push_pull_if #(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_data_if(.clk(clk), .rst_n(rst_n));
   push_pull_if #(.DeviceDataWidth(cip_base_pkg::EDN_DATA_WIDTH)) edn_if(.clk(clk), .rst_n(rst_n));
-  wire [30:0] edn_extra_data = 0; // TODO: temp align, will remove once design update
 
   pins_if #(OtpPwrIfWidth) pwr_otp_if(pwr_otp);
   // TODO: use standard req/rsp agent
@@ -69,6 +68,12 @@ module tb;
   otp_ctrl dut (
     .clk_i                      (clk        ),
     .rst_ni                     (rst_n      ),
+    // edn
+    // TODO: consider connecting this to a different clock.
+    .clk_edn_i                  (clk        ),
+    .rst_edn_ni                 (rst_n      ),
+    .edn_o                      (edn_if.req ),
+    .edn_i                      ({edn_if.ack, edn_if.d_data}),
 
     .tl_i                       (tl_if.h2d  ),
     .tl_o                       (tl_if.d2h  ),
@@ -81,10 +86,6 @@ module tb;
     // ast
     .otp_ast_pwr_seq_o          (ast_req),
     .otp_ast_pwr_seq_h_i        ('0),
-    // edn
-    .otp_edn_o                  (edn_if.req),
-    // TODO: temp padding 0s, will update once design align with EDN
-    .otp_edn_i                  ({edn_if.ack, edn_extra_data, edn_if.d_data}),
     // pwrmgr
     .pwr_otp_i                  (pwr_otp[OtpPwrInitReq]),
     .pwr_otp_o                  (pwr_otp[OtpPwrDoneRsp:OtpPwrIdleRsp]),

--- a/hw/ip/otp_ctrl/otp_ctrl.core
+++ b/hw/ip/otp_ctrl/otp_ctrl.core
@@ -17,7 +17,9 @@ filesets:
       - lowrisc:prim:lc_sync
       - lowrisc:prim:buf
       - lowrisc:prim:secded
+      - lowrisc:prim:edn_req
       - lowrisc:ip:pwrmgr_pkg
+      - lowrisc:ip:edn_pkg
     files:
       - rtl/otp_ctrl_reg_top.sv
       - rtl/otp_ctrl_ecc_reg.sv

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -134,20 +134,6 @@ package otp_ctrl_pkg;
     logic read_lock;  // Whether the partition is read lockable (via digest)
   } part_info_t;
 
-  ////////////////////////
-  // Typedefs for CSRNG //
-  ////////////////////////
-
-  // Bidirectional entropy requests for scramble key derivation.
-  typedef struct packed {
-    logic        req;
-  } otp_edn_req_t;
-
-  typedef struct packed {
-    logic                    ack;
-    logic [EdnDataWidth-1:0] data;
-  } otp_edn_rsp_t;
-
   ///////////////////////////////
   // Typedefs for LC Interface //
   ///////////////////////////////

--- a/hw/ip/prim/prim_edn_req.core
+++ b/hw/ip/prim/prim_edn_req.core
@@ -1,0 +1,21 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:edn_req:0.1"
+description: "EDN synchronization and word packing IP."
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:all
+      - lowrisc:prim:assert
+      - lowrisc:ip:edn_pkg
+    files:
+      - rtl/prim_edn_req.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/ip/prim/rtl/prim_edn_req.sv
+++ b/hw/ip/prim/rtl/prim_edn_req.sv
@@ -1,0 +1,70 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// This module can be used as a "gadget" to adapt the native 32bit width of the EDN network
+// locally to the width needed by the consuming logic. For example, a if the local consumer
+// needs 128bit, this module would request four 32 bit words from EDN and stack them accordingly.
+//
+// The module also uses a req/ack synchronizer to synchronize the EDN data over to the local
+// clock domain. Note that this assumes that the EDN data bus remains stable between subsequent
+// requests.
+//
+
+`include "prim_assert.sv"
+
+module prim_edn_req
+  import prim_alert_pkg::*;
+#(
+  parameter int OutWidth = 32
+) (
+  // Design side
+  input                       clk_i,
+  input                       rst_ni,
+  input                       req_i,
+  output                      ack_o,
+  output logic [OutWidth-1:0] data_o,
+  // EDN side
+  input                       clk_edn_i,
+  input                       rst_edn_ni,
+  output edn_pkg::edn_req_t   edn_o,
+  input  edn_pkg::edn_rsp_t   edn_i
+);
+
+  // TODO: swap this for prim_sync_reqack_data, once available.
+  logic word_ack;
+  prim_sync_reqack u_prim_sync_reqack (
+    .clk_src_i  ( clk_i         ),
+    .rst_src_ni ( rst_ni        ),
+    .clk_dst_i  ( clk_edn_i     ),
+    .rst_dst_ni ( rst_edn_ni    ),
+    .src_req_i  ( req_i         ),
+    .src_ack_o  ( word_ack      ),
+    .dst_req_o  ( edn_o.edn_req ),
+    .dst_ack_i  ( edn_i.edn_ack )
+  );
+
+  logic unused_edn_fips;
+  assign unused_edn_fips = edn_i.edn_fips;
+
+  prim_packer_fifo #(
+    .InW(edn_pkg::ENDPOINT_BUS_WIDTH),
+    .OutW(OutWidth)
+  ) u_prim_packer_fifo (
+    .clk_i,
+    .rst_ni,
+    .clr_i    ( 1'b0          ), // not needed
+    .wvalid_i ( word_ack      ),
+    .wdata_i  ( edn_i.edn_bus ),
+    // no need for backpressure since we're always ready to
+    // sink data at this point.
+    .wready_o (               ),
+    .rvalid_o ( ack_o         ),
+    .rdata_o  ( data_o        ),
+    // we're always ready to receive the packed output word
+    // at this point.
+    .rready_i ( 1'b1          ),
+    .depth_o  (               )
+  );
+
+endmodule : prim_edn_req

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -150,6 +150,7 @@
         clocks:
         {
           clk_io_div4_timers: io_div4
+          clk_main_timers: main
         }
       }
       {
@@ -1005,17 +1006,20 @@
       clock_srcs:
       {
         clk_i: io_div4
+        clk_edn_i: main
       }
       clock_group: timers
       reset_connections:
       {
         rst_ni: rstmgr_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]
+        rst_edn_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40130000
       clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_io_div4_timers
+        clk_edn_i: clkmgr_clocks.clk_main_timers
       }
       domain: "0"
       size: 0x4000
@@ -1188,12 +1192,11 @@
           index: -1
         }
         {
-          struct: otp_edn
+          struct: edn
           type: req_rsp
-          name: otp_edn
+          name: edn
           act: req
-          default: "'0"
-          package: otp_ctrl_pkg
+          package: edn_pkg
           inst_name: otp_ctrl
           index: -1
         }
@@ -8767,12 +8770,11 @@
         index: -1
       }
       {
-        struct: otp_edn
+        struct: edn
         type: req_rsp
-        name: otp_edn
+        name: edn
         act: req
-        default: "'0"
-        package: otp_ctrl_pkg
+        package: edn_pkg
         inst_name: otp_ctrl
         index: -1
       }

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -249,9 +249,9 @@
     },
     { name: "otp_ctrl",
       type: "otp_ctrl",
-      clock_srcs: {clk_i: "io_div4"},
+      clock_srcs: {clk_i: "io_div4", clk_edn_i: "main"},
       clock_group: "timers",
-      reset_connections: {rst_ni: "lc_io_div4"},
+      reset_connections: {rst_ni: "lc_io_div4", rst_edn_ni: "sys"},
       base_addr: "0x40130000",
     },
     { name: "lc_ctrl",
@@ -606,7 +606,7 @@
       'rv_core_ibex.crashdump'  : ['rstmgr.cpu_dump'],
       'csrng.entropy_src_hw_if' : ['entropy_src.entropy_src_hw_if'],
       // TODO see #4447
-      //'edn0.edn' : ['keymgr.edn'],
+      //'edn0.edn'              : ['keymgr.edn', 'otp_ctrl.edn'],
 
       // KeyMgr Sideload & KDF function
       'otp_ctrl.otp_keymgr_key': ['keymgr.otp_key'],

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -260,6 +260,7 @@ module clkmgr import clkmgr_pkg::*; (
   assign clocks_o.clk_io_div4_secure = clk_io_div4_root;
   assign clocks_o.clk_main_secure = clk_main_root;
   assign clocks_o.clk_io_div4_timers = clk_io_div4_root;
+  assign clocks_o.clk_main_timers = clk_main_root;
   assign clocks_o.clk_proc_main = clk_main_root;
 
   ////////////////////////////////////////////////////

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -36,6 +36,7 @@ package clkmgr_pkg;
   logic clk_io_div4_secure;
   logic clk_main_secure;
   logic clk_io_div4_timers;
+  logic clk_main_timers;
   logic clk_proc_main;
   logic clk_io_div4_peri;
   logic clk_usb_peri;

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -864,8 +864,8 @@ module top_earlgrey #(
       // Inter-module signals
       .otp_ast_pwr_seq_o(otp_ctrl_otp_ast_pwr_seq_o),
       .otp_ast_pwr_seq_h_i(otp_ctrl_otp_ast_pwr_seq_h_i),
-      .otp_edn_o(),
-      .otp_edn_i('0),
+      .edn_o(),
+      .edn_i(edn_pkg::EDN_RSP_DEFAULT),
       .pwr_otp_i(pwrmgr_pwr_otp_req),
       .pwr_otp_o(pwrmgr_pwr_otp_rsp),
       .lc_otp_program_i(lc_ctrl_lc_otp_program_req),
@@ -889,7 +889,9 @@ module top_earlgrey #(
       .tl_i(otp_ctrl_tl_req),
       .tl_o(otp_ctrl_tl_rsp),
       .clk_i (clkmgr_clocks.clk_io_div4_timers),
-      .rst_ni (rstmgr_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel])
+      .clk_edn_i (clkmgr_clocks.clk_main_timers),
+      .rst_ni (rstmgr_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]),
+      .rst_edn_ni (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel])
   );
 
   lc_ctrl #(


### PR DESCRIPTION
This adds a `prim_edn_req` gadget for synchronizing EDN data and adjusting the native 32bit EDN data to the local data width of the consumer via a `prim_packer` primitive.
Then, that primitive is instantiated in `otp_ctrl` and the top-level is adjusted accordingly.
