### PR TITLE
[dv/lc_ctrl] add esc sender agent to LC_ctrl tb

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
@@ -52,7 +52,7 @@ class alert_esc_agent extends dv_base_agent#(
       `uvm_fatal(`gfn, "failed to get alert_esc_if handle from uvm_config_db")
     end
     // get esc_en signal for esc_monitor
-    if (cfg.is_active && !cfg.is_alert) begin
+    if (cfg.is_active && !cfg.is_alert && cfg.if_mode == Device) begin
       if (!uvm_config_db#(virtual alert_esc_probe_if)::get(this, "", "probe_vif", cfg.probe_vif))
           begin
         `uvm_fatal(`gfn, "failed to get probe_vif handle from uvm_config_db")

--- a/hw/dv/sv/alert_esc_agent/esc_sender_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_sender_driver.sv
@@ -12,9 +12,30 @@ class esc_sender_driver extends alert_esc_base_driver;
 
   `uvm_component_new
 
+  virtual task reset_signals();
+    do_reset();
+    forever begin
+      @(negedge cfg.vif.rst_n);
+      under_reset = 1;
+      do_reset();
+      @(posedge cfg.vif.rst_n);
+      under_reset = 0;
+    end
+  endtask
+
   virtual task get_and_drive();
     // TODO
+    drive_esc();
   endtask : get_and_drive
 
+  virtual task drive_esc();
+    // TODO
+    wait(!under_reset);
+  endtask
+
+  virtual task do_reset();
+    cfg.vif.esc_tx_int.esc_p <= 1'b0;
+    cfg.vif.esc_tx_int.esc_n <= 1'b1;
+  endtask
 endclass : esc_sender_driver
 

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.sv
@@ -13,6 +13,9 @@ class lc_ctrl_env extends cip_base_env #(
   push_pull_agent#(.HostDataWidth(OTP_PROG_HDATA_WIDTH), .DeviceDataWidth(OTP_PROG_DDATA_WIDTH))
                    m_otp_prog_pull_agent;
   push_pull_agent#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)) m_otp_token_pull_agent;
+  alert_esc_agent m_esc_wipe_secrets_agent;
+  alert_esc_agent m_esc_scrap_state_agent;
+
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
@@ -25,6 +28,13 @@ class lc_ctrl_env extends cip_base_env #(
     if (!uvm_config_db#(lc_ctrl_vif)::get(this, "", "lc_ctrl_vif", cfg.lc_ctrl_vif)) begin
       `uvm_fatal(`gfn, "failed to get lc_ctrl_vif from uvm_config_db")
     end
+
+    m_esc_wipe_secrets_agent = alert_esc_agent::type_id::create("m_esc_wipe_secrets_agent", this);
+    uvm_config_db#(alert_esc_agent_cfg)::set(this, "m_esc_wipe_secrets_agent", "cfg",
+                                             cfg.m_esc_wipe_secrets_agent_cfg);
+    m_esc_scrap_state_agent = alert_esc_agent::type_id::create("m_esc_scrap_state_agent", this);
+    uvm_config_db#(alert_esc_agent_cfg)::set(this, "m_esc_scrap_state_agent", "cfg",
+                                             cfg.m_esc_scrap_state_agent_cfg);
 
     m_otp_prog_pull_agent = push_pull_agent#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),
         .DeviceDataWidth(OTP_PROG_DDATA_WIDTH))::type_id::create("m_otp_prog_pull_agent", this);
@@ -42,11 +52,17 @@ class lc_ctrl_env extends cip_base_env #(
     super.connect_phase(phase);
     virtual_sequencer.otp_prog_pull_sequencer_h = m_otp_prog_pull_agent.sequencer;
     virtual_sequencer.otp_token_pull_sequencer_h = m_otp_token_pull_agent.sequencer;
+    virtual_sequencer.esc_wipe_secrets_sequencer_h = m_esc_wipe_secrets_agent.sequencer;
+    virtual_sequencer.esc_scrap_state_sequencer_h = m_esc_scrap_state_agent.sequencer;
     if (cfg.en_scb) begin
       m_otp_prog_pull_agent.monitor.analysis_port.connect(
           scoreboard.otp_prog_fifo.analysis_export);
       m_otp_token_pull_agent.monitor.analysis_port.connect(
           scoreboard.otp_token_fifo.analysis_export);
+      m_esc_wipe_secrets_agent.monitor.analysis_port.connect(
+          scoreboard.esc_wipe_secrets_fifo.analysis_export);
+      m_esc_scrap_state_agent.monitor.analysis_port.connect(
+          scoreboard.esc_scrap_state_fifo.analysis_export);
     end
   endfunction
 

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
@@ -8,6 +8,8 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(lc_ctrl_reg_block));
   push_pull_agent_cfg#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),
                        .DeviceDataWidth(OTP_PROG_DDATA_WIDTH)) m_otp_prog_pull_agent_cfg;
   push_pull_agent_cfg#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)) m_otp_token_pull_agent_cfg;
+  alert_esc_agent_cfg m_esc_wipe_secrets_agent_cfg;
+  alert_esc_agent_cfg m_esc_scrap_state_agent_cfg;
 
   // ext interfaces
   pwr_lc_vif  pwr_lc_vif;
@@ -33,6 +35,16 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(lc_ctrl_reg_block));
     `DV_CHECK_RANDOMIZE_FATAL(m_otp_token_pull_agent_cfg)
     m_otp_token_pull_agent_cfg.agent_type = PullAgent;
     m_otp_token_pull_agent_cfg.if_mode    = Device;
+
+    m_esc_wipe_secrets_agent_cfg = alert_esc_agent_cfg::type_id::create(
+        "m_esc_wipe_secrets_agent_cfg");
+    `DV_CHECK_RANDOMIZE_FATAL(m_esc_wipe_secrets_agent_cfg)
+    m_esc_wipe_secrets_agent_cfg.is_alert = 0;
+
+    m_esc_scrap_state_agent_cfg = alert_esc_agent_cfg::type_id::create(
+        "m_esc_scrap_state_agent_cfg");
+    `DV_CHECK_RANDOMIZE_FATAL(m_esc_scrap_state_agent_cfg)
+    m_esc_scrap_state_agent_cfg.is_alert = 0;
   endfunction
 
 endclass

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
@@ -15,6 +15,7 @@ package lc_ctrl_env_pkg;
   import lc_ctrl_pkg::*;
   import otp_ctrl_pkg::*;
   import push_pull_agent_pkg::*;
+  import alert_esc_agent_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
@@ -17,6 +17,8 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
                         .DeviceDataWidth(OTP_PROG_DDATA_WIDTH))) otp_prog_fifo;
   uvm_tlm_analysis_fifo #(push_pull_item#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)))
                         otp_token_fifo;
+  uvm_tlm_analysis_fifo #(alert_esc_seq_item) esc_wipe_secrets_fifo;
+  uvm_tlm_analysis_fifo #(alert_esc_seq_item) esc_scrap_state_fifo;
 
   // local queues to hold incoming packets pending comparison
 
@@ -26,6 +28,8 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
     super.build_phase(phase);
     otp_prog_fifo = new("otp_prog_fifo", this);
     otp_token_fifo = new("otp_token_fifo", this);
+    esc_wipe_secrets_fifo = new("esc_wipe_secrets_fifo", this);
+    esc_scrap_state_fifo = new("esc_scrap_state_fifo", this);
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_virtual_sequencer.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_virtual_sequencer.sv
@@ -9,9 +9,11 @@ class lc_ctrl_virtual_sequencer extends cip_base_virtual_sequencer #(
   `uvm_component_utils(lc_ctrl_virtual_sequencer)
 
   push_pull_sequencer#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),
-                       .DeviceDataWidth(OTP_PROG_DDATA_WIDTH)) otp_prog_pull_sequencer_h;
-
+                       .DeviceDataWidth(OTP_PROG_DDATA_WIDTH))    otp_prog_pull_sequencer_h;
   push_pull_sequencer#(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)) otp_token_pull_sequencer_h;
+
+  alert_esc_sequencer esc_wipe_secrets_sequencer_h;
+  alert_esc_sequencer esc_scrap_state_sequencer_h;
 
   `uvm_component_new
 

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -28,6 +28,8 @@ module tb;
   pins_if #(LcPwrIfWidth) pwr_lc_if(pwr_lc);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   lc_ctrl_if lc_ctrl_if(.clk(clk), .rst_n(rst_n));
+  alert_esc_if esc_wipe_secrets_if(.clk(clk), .rst_n(rst_n));
+  alert_esc_if esc_scrap_state_if(.clk(clk), .rst_n(rst_n));
   push_pull_if #(.HostDataWidth(OTP_PROG_HDATA_WIDTH), .DeviceDataWidth(OTP_PROG_DDATA_WIDTH))
                otp_prog_if(.clk(clk), .rst_n(rst_n));
   push_pull_if #(.HostDataWidth(lc_ctrl_pkg::LcTokenWidth)) otp_token_if(.clk(clk), .rst_n(rst_n));
@@ -55,10 +57,10 @@ module tb;
     .jtag_o                     (),
     .scanmode_i                 (1'b0     ),
 
-    .esc_wipe_secrets_tx_i      ({2'b01}),
-    .esc_wipe_secrets_rx_o      (),
-    .esc_scrap_state_tx_i       ({2'b01}),
-    .esc_scrap_state_rx_o       (),
+    .esc_wipe_secrets_tx_i      (esc_wipe_secrets_if.esc_tx),
+    .esc_wipe_secrets_rx_o      (esc_wipe_secrets_if.esc_rx),
+    .esc_scrap_state_tx_i       (esc_scrap_state_if.esc_tx),
+    .esc_scrap_state_rx_o       (esc_scrap_state_if.esc_rx),
 
     .pwr_lc_i                   (pwr_lc[LcPwrInitReq]),
     .pwr_lc_o                   (pwr_lc[LcPwrDoneRsp:LcPwrIdleRsp]),
@@ -104,6 +106,11 @@ module tb;
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(pwr_lc_vif)::set(null, "*.env", "pwr_lc_vif", pwr_lc_if);
     uvm_config_db#(virtual lc_ctrl_if)::set(null, "*.env", "lc_ctrl_vif", lc_ctrl_if);
+
+    uvm_config_db#(virtual alert_esc_if)::set(null, "*env.m_esc_wipe_secrets_agent*", "vif",
+                                              esc_wipe_secrets_if);
+    uvm_config_db#(virtual alert_esc_if)::set(null, "*env.m_esc_scrap_state_agent*", "vif",
+                                              esc_scrap_state_if);
 
     uvm_config_db#(virtual push_pull_if#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),
                                          .DeviceDataWidth(OTP_PROG_DDATA_WIDTH)))::


### PR DESCRIPTION
This PR has two commits:
1. Add alert_esc_agent's esc_sender mode to lc_ctrl
2. Add basic support for alert_esc_agent to support esc_sender mode.
It will need more work to actually drive esc sequences.