### PR TITLE
[kmac] Entropy Generation logic

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -261,15 +261,19 @@
           fetch the entropy and run.
           '''
           hwaccess: "hrw"
-         } // f: entropy_ready
-         { bits: "25"
-           name: err_processed
-           desc: '''When error occurs and one of the state machine stays at
-                  Error handling state, SW may process the error based on
-                  ERR_CODE, then let FSM back to the reset state
-                 '''
-           hwaccess: "hrw"
-         } // f: err_processed
+          tags: [// Randomly write mem will cause this reg updated by design
+                 "excl:CsrNonInitTests:CsrExclCheck"]
+        } // f: entropy_ready
+        { bits: "25"
+          name: err_processed
+          desc: '''When error occurs and one of the state machine stays at
+                 Error handling state, SW may process the error based on
+                 ERR_CODE, then let FSM back to the reset state
+                '''
+          hwaccess: "hrw"
+          tags: [// Randomly write mem will cause this reg updated by design
+                 "excl:CsrNonInitTests:CsrExclCheck"]
+        } // f: err_processed
       ]
     } // R: CFG
     { name: "CMD"

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -213,6 +213,63 @@
                 Key Derivation Function (KDF).
                 '''
         } // f: sideload
+        { bits: "17:16"
+          name: entropy_mode
+          desc: '''Entropy Mode
+
+          Software selects the entropy source with this field. In EdnMode,
+          the entropy generator sends requests to EDN to get the entropy. The
+          received entropy is fed into internal LFSR.
+
+          In SwMode, the software should update the internal LFSR seed
+          through !!ENTROPY_SEED_LOWER and !!ENTROPY_SEED_UPPER.
+          '''
+
+          enum: [
+            { value: "0"
+              name: "idle_mode"
+              desc: '''At reset state, the entropy mode is Idle mode. It does
+              not operate in this mode.
+              '''
+            }
+            { value: "1"
+              name: "edn_mode"
+              desc: "Entropy generator module fetches entropy from EDN"
+            }
+            { value: "2"
+              name: "sw_mode"
+              desc: '''Software update the internal entropy via register
+              interface'''
+            }
+          ]
+        } // f: entropy_mode
+        { bits: "19"
+          name: entropy_fast_process
+          desc: '''Entropy Fast process mode.
+
+          If 1, entropy logic uses garbage data while not processing the KMAC
+          key block. It will re-use previous entropy value and will not
+          expand the entropy when it is consumed. Only it refreshes the
+          entropy while processing the secret key block.
+          '''
+        } // f: entropy_fast_process
+        { bits: "24"
+          name: entropy_ready
+          desc: '''Entropy Ready status.
+
+          Software sets this field to allow the entropy generator in KMAC to
+          fetch the entropy and run.
+          '''
+          hwaccess: "hrw"
+         } // f: entropy_ready
+         { bits: "25"
+           name: err_processed
+           desc: '''When error occurs and one of the state machine stays at
+                  Error handling state, SW may process the error based on
+                  ERR_CODE, then let FSM back to the reset state
+                 '''
+           hwaccess: "hrw"
+         } // f: err_processed
       ]
     } // R: CFG
     { name: "CMD"
@@ -315,23 +372,34 @@
       ]
     } // R: STATUS
     { name: "ENTROPY_PERIOD"
-      desc: '''Entropy Refresh Period.
-
-      This register determines the refresh period. The value is the number of
-      clock cycles. In every entropy period, the entropy generation logic in
-      KMAC requests new entropy to EDN and feed the value into LFSR seed.
-
-      If 0, the entropy generation logic does not refresh its seed. The
-      software manually updates the seed by writing into "ENTROPY_SEED"
-      registers.
+      desc: '''Entropy Timer Periods.
       '''
       swaccess: "rw"
       hwaccess: "hro"
       regwen: "CFG_REGWEN"
       fields: [
-        { bits: "31:0"
-          name: "period"
-          desc: "entropy period in clock cycles"
+        { bits: "15:0"
+          name: "entropy_timer"
+          desc: '''Entropy period in clock cycles This register determines
+          the refresh period. The value is the number of clock cycles. In
+          every entropy period, the entropy generation logic in KMAC requests
+          new entropy to EDN and feed the value into LFSR seed.
+
+          If 0, the entropy generation logic does not refresh its seed. The
+          software manually updates the seed by writing into "ENTROPY_SEED"
+          registers. '''
+        }
+        { bits: "31:16"
+          name: "wait_timer"
+          desc: '''EDN request wait timer.
+
+          The entropy module in KMAC waits up to this field in clock cycles
+          after it sends request to EDN module. If the timer expires, the
+          entropy module moves to an error state and notifies to the system.
+
+          If 0, the entropy module waits the EDN response always. If EDN does
+          not respond in this configuration, the software shall reset the IP.
+          '''
         }
       ]
     } // R: ENTROPY_PERIOD
@@ -355,8 +423,9 @@
     { name: "ENTROPY_SEED_UPPER"
       desc: '''Entropy Seed [63:32].
 
-      Everytime when the software writes into this register, LFSR is reseeded
-      with the value of {ENTROPY_SEED_UPPER, ENTROPY_SEED_LOWER}.
+      Everytime when the software writes into !!ENTROPY_SEED_LOWER register,
+      LFSR is reseeded with the value of {ENTROPY_SEED_UPPER,
+      ENTROPY_SEED_LOWER}.
       '''
       swaccess: "rw"
       hwaccess: "hro"

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -20,7 +20,7 @@
   ]
   param_list: [
     { name:    "EnMasking"
-      type:    "int"
+      type:    "bit"
       default: "0"
       desc:    '''
         Disable(0) or enable(1) first-order masking of Keccak round.

--- a/hw/ip/kmac/fpv/tb/sha3_fpv.sv
+++ b/hw/ip/kmac/fpv/tb/sha3_fpv.sv
@@ -6,7 +6,7 @@ module sha3_fpv
   import sha3_pkg::*;
 #(
   // Enable Masked Keccak if 1
-  parameter  int EnMasking = 0,
+  parameter  bit EnMasking = 0,
   localparam int Share = (EnMasking) ? 2 : 1
 )(
   input clk_i,

--- a/hw/ip/kmac/fpv/tb/sha3pad_fpv.sv
+++ b/hw/ip/kmac/fpv/tb/sha3pad_fpv.sv
@@ -6,7 +6,7 @@
 module sha3pad_fpv
   import sha3_pkg::*;
 #(
-  parameter int EnMasking = 0,
+  parameter  bit EnMasking = 0,
   localparam int Share = (EnMasking) ? 2 : 1
 ) (
   input clk_i,

--- a/hw/ip/kmac/kmac.core
+++ b/hw/ip/kmac/kmac.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:prim:all
       - lowrisc:prim:prim_dom_and_2share
+      - lowrisc:prim:lfsr
       - lowrisc:prim:assert
       - lowrisc:ip:tlul
       - lowrisc:ip:keymgr_pkg

--- a/hw/ip/kmac/rtl/keccak_round.sv
+++ b/hw/ip/kmac/rtl/keccak_round.sv
@@ -22,7 +22,7 @@ module keccak_round #(
   localparam int DInAddr  = $clog2(DInEntry),
 
   // Control parameters
-  parameter  int EnMasking = 0,  // Enable secure hardening
+  parameter  bit EnMasking = 0,  // Enable secure hardening
   localparam int Share     = EnMasking ? 2 : 1,
 
   // If ReuseShare is not 0, the logic will use unused sheet as an entropy

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -11,13 +11,13 @@ module kmac
 #(
   // EnMasking: Enable masking security hardening inside keccak_round
   // If it is enabled, the result digest will be two set of 1600bit.
-  parameter int EnMasking = 0,
+  parameter bit EnMasking = 1,
 
   // ReuseShare: If set, keccak_round logic only consumes small portion of
   // entropy, not 1600bit of entropy at every round. It uses adjacent shares
   // as entropy inside Domain-Oriented Masking AND logic.
   // This parameter only affects when `EnMasking` is set.
-  parameter int ReuseShare = 0
+  parameter bit ReuseShare = 0
 ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/kmac/rtl/kmac_core.sv
+++ b/hw/ip/kmac/rtl/kmac_core.sv
@@ -11,7 +11,7 @@ module kmac_core
 #(
   // EnMasking: Enable masking security hardening inside keccak_round
   // If it is enabled, the result digest will be two set of 1600bit.
-  parameter  int EnMasking = 0,
+  parameter  bit EnMasking = 0,
   localparam int Share = (EnMasking) ? 2 : 1 // derived parameter
 ) (
   input clk_i,

--- a/hw/ip/kmac/rtl/kmac_entropy.sv
+++ b/hw/ip/kmac/rtl/kmac_entropy.sv
@@ -4,6 +4,8 @@
 //
 // KMAC Entropy Generation module
 
+`include "prim_assert.sv"
+
 module kmac_entropy
   import kmac_pkg::*;
 (
@@ -15,7 +17,7 @@ module kmac_entropy
   input  edn_pkg::edn_rsp_t entropy_i,
 
   // Entropy to internal
-  output                        rand_valid_o,
+  output logic                  rand_valid_o,
   output [sha3_pkg::StateW-1:0] rand_data_o,
   input                         rand_consumed_i,
 
@@ -24,35 +26,523 @@ module kmac_entropy
   input in_keyblock_i,
 
   // Configurations
-  //// Entropy refresh period in clk cycles
-  input [31:0] refresh_period_i,
+  input entropy_mode_e mode_i,
+  //// SW sets ready bit when EDN is ready to accept requests through its app.
+  //// interface.
+  input entropy_ready_i,
 
   //// SW update of seed
   input        seed_update_i,
-  input [63:0] seed_data_i
+  input [63:0] seed_data_i,
+
+  //// Timer limit value
+  //// If value is 0, timer is disabled
+  input [EntropyTimerW-1:0] entropy_timer_limit_i,
+  input [EdnWaitTimerW-1:0] wait_timer_limit_i,
+
+  // Error output
+  output err_t err_o,
+  input        err_processed_i
 );
+
+  /////////////////
+  // Definitions //
+  /////////////////
+
+  // Timer Widths are defined in kmac_pkg
+
+  // storage width
+  localparam int unsigned EntropyLfsrW    = 64;
+  localparam int unsigned EntropyStorageW = 320;
+  localparam int unsigned EntropyMultiply = sha3_pkg::StateW / EntropyStorageW;
+  `ASSERT_INIT(StorageNoRemainder_A, (sha3_pkg::StateW%EntropyStorageW) == 0)
+  `ASSERT_INIT(LfsrNoRemainder_A, (EntropyStorageW%EntropyLfsrW) == 0)
+
+  localparam int unsigned StorageEntries = EntropyStorageW / EntropyLfsrW ;
+  localparam int unsigned StorageIndexW = $clog2(StorageEntries);
+
+  // States
+  typedef enum logic [3:0] {
+    // Reset: Reset state. The entropy is not ready. The state machine should
+    // get new entropy from EDN or the seed should be feeded by the software.
+    StRandReset,
+
+    // The seed is fed into LFSR and the entropy is ready. It means the
+    // rand_valid is asserted with valid data. It takes a few steps to reach
+    // this state from StRandIdle.
+    StRandReady,
+
+    // EDN interface: Send request and receive
+    // RandEdnReq state can be transit from StRandReset or from StRandReady
+    //
+    // Reset --> EdnReq:
+    //     If entropy source module is ready, the software sets a bit in CFG
+    //     also sets the entropy mode to EdnMode. Then this FSM moves to EdnReq
+    //     to initialize LFSR seed.
+    //
+    // Ready --> EdnReq:
+    //     1. If a mode is configured as to update entropy everytime it is
+    //        consumed, then the FSM moves from Ready to EdnReq to refresh seed
+    //     2. If the software enabled EDN timer and the timer is expired and
+    //        also the KMAC is processing the key block, the FSM moves to
+    //        EdnReq to refresh seed
+    //     3. If a KMAC operation is completed, the FSM also refreshes the LFSR
+    //        seed to prepare next KMAC op or wipe out operation.
+    StRandEdn,
+
+    // Sw Seed: If mode is set to manual mode, This entropy module needs initial
+    // seed from the software. It waits the seed update signal to expand initial
+    // entropy
+    StSwSeedWait,
+
+    // Expand: The SW or EDN provides 64-bit entropy (seed). In this state, this
+    // entropy generator expands the 64-bit entropy into 320-bit entropy using
+    // LFSR. Then it expands 320-bit pseudo random entropy into 1600-bit by
+    // replicating the PR entropy five times w/ compile-time shuffling scheme.
+    StRandExpand,
+
+    // ErrWaitExpired: If Edn timer expires, FSM moves to this state and wait
+    // the software response. Software should switch to manual mode then disable
+    // the timer (to 0) and update the seed via register interface.
+    StRandErrWaitExpired,
+
+    // ErrNoValidMode: If SW sets entropy ready but the mode is not either
+    // Manual Mode nor EdnMode, this logic reports to SW with
+    // NoValidEntropyMode.
+    StRandErrIncorrectMode,
+
+    // Err: After the error is reported, FSM sits in Err state ignoring all the
+    // requests. It does not generate new entropy and drops the entropy valid
+    // signal.
+    //
+    // SW sets err_processed signal to clear the error. The software should
+    // clear the entropy ready signal before clear the error interrupt so that
+    // the FSM sits in StRandReset state not moving forward with incorrect
+    // configurations.
+    StRandErr
+  } rand_st_e;
 
   /////////////
   // Signals //
   /////////////
 
-  // TODO: Implement logics
-  logic unused_in_progress, unused_in_keyblock;
-  assign unused_in_progress = in_progress_i;
-  assign unused_in_keyblock = in_keyblock_i;
+  // Timers
+  // "Entropy Timer": While in operation, if this entropy timer is enabled, FSM
+  //   fetches new entropy from LFSR when the timer is expired.
+  //
+  // "Wait Timer": This timer is in active when FSM sends entropy request to EDN
+  //   If EDN does not return the entropy data until the timer expired, FSM
+  //   moves to error state and report the error to the system.
 
-  logic [31:0] unused_refresh_period;
-  assign unused_refresh_period = refresh_period_i;
+  typedef enum logic [1:0] {
+    NoTimer      = 2'h 0,
+    EntropyTimer = 2'h 1,
+    EdnWaitTimer = 2'h 2
+  } timer_sel_e;
+  timer_sel_e timer_sel;
 
-  logic unused_seed_update;
-  logic [63:0] unused_seed_data;
-  assign unused_seed_update = seed_update_i;
-  assign unused_seed_data = seed_data_i;
+  localparam int unsigned TimerW = (EntropyTimerW > EdnWaitTimerW)
+                                 ? EntropyTimerW : EdnWaitTimerW;
+  logic timer_enable, timer_update, timer_expired;
+  logic [TimerW-1:0] timer_limit;
+  logic [TimerW-1:0] timer_value;
 
-  assign rand_valid_o = 1'b 1;
-  assign rand_data_o = '0;
+  // LFSR
+  //// SW configures to use EDN or SEED register as a LFSR seed
+  logic lfsr_seed_en;
+  logic [EntropyLfsrW-1:0] lfsr_seed;
+  logic lfsr_en;
+  logic [EntropyLfsrW-1:0] lfsr_data;
 
-  assign entropy_o = '{default: '0};
+  // storage
+  logic storage_update;
+  logic storage_idx_clear;
+  logic storage_filled;
+
+  // in_progress: check if in_progress de-asserted. It means hashing operation
+  // is completed. Entropy logic refreshes seed and prepare new entropy.
+  // de-asserting in_progress sets in_progress_deasserted, then when FSM moves
+  // to StRandEdn, it clears the de-assertion. This is to not miss the
+  // deassertion event.
+  logic in_progress_deasserted, in_progress_clear, in_progress_d;
+
+  // Entropy valid signal
+  // FSM set and clear the valid signal, rand_consume signal clear the valid
+  // signal. Split the set, clear to make entropy valid while FSM is processing
+  // other tasks.
+  logic rand_valid_set, rand_valid_clear;
+
+  // unused signals
+  logic unused_edn_fips;
+  assign unused_edn_fips = entropy_i.edn_fips;
+
+  //////////////
+  // Datapath //
+  //////////////
+
+  // Timers ===================================================================
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      timer_value <= '0;
+    end else if (timer_update) begin
+      timer_value <= timer_limit;
+    end else if (timer_expired) begin
+      timer_value <= '0; // keep the value
+    end else if (timer_enable && |timer_value) begin // if non-zero timer v
+      timer_value <= timer_value - 1'b 1;
+    end
+  end
+
+  // select timer
+  always_comb begin
+    timer_limit = '0;
+    unique case (timer_sel)
+      EntropyTimer: timer_limit = TimerW'(entropy_timer_limit_i);
+      EdnWaitTimer: timer_limit = TimerW'(wait_timer_limit_i);
+      default: timer_limit = '0; // NoTimer
+    endcase
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      timer_expired <= 1'b 0;
+    end else if (timer_update) begin
+      timer_expired <= 1'b 0;
+    end else if (timer_enable && (timer_value == '0)) begin
+      timer_expired <= 1'b 1;
+    end
+  end
+  // Timers -------------------------------------------------------------------
+
+
+  // LFSR =====================================================================
+  //// FSM controls the seed enable signal `lfsr_seed_en`.
+  //// Seed selection
+  always_comb begin
+    unique case (mode_i)
+      EntropyModeNone: lfsr_seed = '0;
+      // TODO: Check EDN Bus width
+      EntropyModeEdn:  lfsr_seed = {2{entropy_i.edn_bus}};
+      EntropyModeSw:   lfsr_seed = seed_data_i;
+      default:         lfsr_seed = '0;
+    endcase
+  end
+  `ASSERT_KNOWN(ModeKnown_A, mode_i)
+
+  prim_lfsr #(
+    .LfsrDw(EntropyLfsrW),
+    .EntropyDw(EntropyLfsrW),
+    .StateOutDw(EntropyLfsrW)
+  ) u_lfsr (
+    .clk_i,
+    .rst_ni,
+    .seed_en_i(lfsr_seed_en),
+    .seed_i   (lfsr_seed),
+    .lfsr_en_i(lfsr_en),
+    .entropy_i('0),        // Does not use additional entropy while operating
+    .state_o  (lfsr_data)  // (partial) LFSR state output StateOutDw
+  );
+  // LFSR ---------------------------------------------------------------------
+
+  // 320-bit storage ==========================================================
+  logic [EntropyStorageW-1:0] entropy_storage;
+  logic [StorageIndexW-1:0] storage_idx;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      entropy_storage <= '0;
+    end else if (storage_update) begin
+      for (int unsigned i = 0 ; i < StorageEntries ; i++) begin
+        if (StorageIndexW'(i) == storage_idx) begin
+          entropy_storage[i*EntropyLfsrW+:EntropyLfsrW] <= lfsr_data;
+        end
+      end
+    end
+    // TODO: Should the consumed entropy be discarded?
+  end
+
+  //// Index
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      storage_idx <= '0;
+    end else if (storage_idx_clear) begin
+      storage_idx <= '0;
+    end else if (storage_filled) begin
+      storage_idx <= storage_idx;
+    end else if (storage_update) begin
+      storage_idx <= storage_idx + 1'b 1;
+    end
+  end
+
+  assign storage_filled = (storage_idx == StorageIndexW'(StorageEntries));
+  // 320-bit storage ----------------------------------------------------------
+
+  // Storage expands to StateW ================================================
+  // May adopt fancy shuffling scheme to obsfucate
+  // Or, convert the 320bit to sheet then multiply then unroll into 1600bit
+  assign rand_data_o = {EntropyMultiply{entropy_storage}};
+
+  // entropy valid
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rand_valid_o <= 1'b 0;
+    end else if (rand_valid_set) begin
+      rand_valid_o <= 1'b 1;
+    end else if (rand_valid_clear || rand_consumed_i) begin
+      rand_valid_o <= 1'b 0;
+    end
+  end
+
+  `ASSUME(ConsumeNotAseertWhenNotReady_M, rand_consumed_i |-> rand_valid_o)
+
+  // Storage expands to StateW ------------------------------------------------
+
+  // In Process Logic =========================================================
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      in_progress_d <= 1'b 0;
+    end else begin
+      in_progress_d <= in_progress_i;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      in_progress_deasserted <= 1'b 0;
+    end else if (in_progress_d && !in_progress_i && (mode_i == EntropyModeEdn)) begin
+      in_progress_deasserted <= 1'b 1;
+    end else if (in_progress_clear) begin
+      in_progress_deasserted <= 1'b 0;
+    end
+  end
+  // In Process Logic ---------------------------------------------------------
+
+  ///////////////////
+  // State Machine //
+  ///////////////////
+
+  rand_st_e st, st_d;
+
+  // State FF
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      st <= StRandReset;
+    end else begin
+      st <= st_d;
+    end
+  end
+
+  // State: Next State and Output Logic
+  always_comb begin
+    st_d = StRandReset;
+
+    // Default Timer values
+    timer_enable = 1'b 0;
+    timer_update = 1'b 0;
+    timer_sel    = NoTimer;
+
+    // EDN request
+    entropy_o = '{edn_req: 1'b 0};
+
+    // rand is valid when this logic expands the entropy.
+    // FSM sets the valid signal, the signal is cleared by `consume` signal
+    // or FSM clear signal.
+    // Why split the signal to set and clear?
+    // FSM only set the signal to make entropy valid while processing other
+    // tasks such as EDN request.
+    rand_valid_set   = 1'b 0;
+    rand_valid_clear = 1'b 0;
+
+    // lfsr_en: Let LFSR run
+    // To save power, this logic enables LFSR when it needs entropy expansion.
+    // TODO: Check if random LFSR run while staying in ready state to obsfucate
+    // LFSR value?
+    lfsr_en = 1'b 0;
+
+    // lfsr_seed_en: Signal to update LFSR seed
+    // LFSR seed can be updated by EDN or SW.
+    lfsr_seed_en = 1'b 0;
+
+    // Entropy Storage control signals
+    storage_idx_clear = 1'b 0;
+    storage_update    = 1'b 0;
+
+    in_progress_clear = 1'b 0;
+
+    // Error
+    err_o = '{valid: 1'b 0, code: ErrNone, info: '0};
+
+    unique case (st)
+      StRandReset: begin
+        if (entropy_ready_i) begin
+          // SW has configured KMAC
+          unique case (mode_i)
+            EntropyModeSw: begin
+              st_d = StSwSeedWait;
+            end
+
+            EntropyModeEdn: begin
+              st_d = StRandEdn;
+
+              // Timer reset
+              timer_sel = EdnWaitTimer;
+              timer_update = 1'b 1;
+            end
+
+            default: begin
+              // EntropyModeNone or other values
+              // Error. No valid mode given, report to SW
+              st_d = StRandErrIncorrectMode;
+            end
+          endcase
+        end else begin
+          st_d = StRandReset;
+        end
+      end
+
+      StRandReady: begin
+        timer_enable = 1'b 1; // If limit is zero, timer won't work
+
+        if (rand_consumed_i) begin
+          st_d = StRandExpand;
+
+          lfsr_en           = 1'b 1;
+          storage_idx_clear = 1'b 1;
+
+          rand_valid_clear = 1'b 1;
+        end else if (mode_i == EntropyModeEdn) begin
+          if (in_keyblock_i && timer_expired && |entropy_timer_limit_i) begin
+            // Timer count is non-zero and timer expired
+            st_d = StRandEdn;
+
+            timer_update = 1'b 1;
+            timer_sel    = EdnWaitTimer;
+
+          end else if (in_progress_deasserted) begin
+            // hashing operation is completed, refresh the entropy and stop
+            st_d = StRandEdn;
+
+            in_progress_clear = 1'b 1;
+
+            timer_update = 1'b 1;
+            timer_sel    = EdnWaitTimer;
+          end else begin
+            st_d = StRandReady;
+          end
+        end else begin
+          st_d = StRandReady;
+        end
+      end
+
+      StRandEdn: begin
+        // Send request
+        entropy_o = '{edn_req: 1'b 1};
+
+        // Wait timer
+        timer_enable = 1'b 1;
+
+        if (timer_expired && |wait_timer_limit_i) begin
+          // If timer count is non-zero and expired;
+          st_d = StRandErrWaitExpired;
+
+        end else if (entropy_i.edn_ack) begin
+          st_d = StRandExpand;
+
+          lfsr_en = 1'b 1;
+          lfsr_seed_en = 1'b 1;
+
+          rand_valid_clear = 1'b 1;
+
+          storage_idx_clear = 1'b 1;
+          // TODO: check fips?
+        end else begin
+          st_d = StRandEdn;
+        end
+      end
+
+      StSwSeedWait: begin
+        if (seed_update_i) begin
+          st_d = StRandExpand;
+
+          lfsr_en = 1'b 1;
+          lfsr_seed_en = 1'b 1;
+
+          rand_valid_clear = 1'b 1;
+
+          storage_idx_clear = 1'b 1;
+        end else begin
+          st_d = StSwSeedWait;
+        end
+      end
+
+      StRandExpand: begin
+        lfsr_en = 1'b 1;
+        if (storage_filled) begin
+          st_d = StRandReady;
+
+          storage_update = 1'b 0;
+
+          rand_valid_set = 1'b 1;
+
+          // Based on the timer value, either reset the timer or just move
+          if (mode_i == EntropyModeEdn && |entropy_timer_limit_i) begin
+            timer_sel = EntropyTimer;
+            timer_update = 1'b 1;
+          end
+        end else begin
+          st_d = StRandExpand;
+
+          storage_update = 1'b 1;
+        end
+      end
+
+      StRandErrWaitExpired: begin
+        st_d = StRandErr;
+
+        err_o = '{ valid: 1'b 1,
+                   code: ErrWaitTimerExpired,
+                   info: 24'(timer_value)
+                 };
+      end
+
+      StRandErrIncorrectMode: begin
+        st_d = StRandErr;
+
+        err_o = '{ valid: 1'b 1,
+                   code: ErrIncorrectEntropyMode,
+                   info: 24'(mode_i)
+                 };
+      end
+
+      StRandErr: begin
+        // Keep entropy signal valid to complete current hashing even with error
+        rand_valid_set = 1'b 1;
+
+        if (err_processed_i) begin
+          st_d = StRandReset;
+
+          // TODO: Reset as much as
+        end else begin
+          st_d = StRandErr;
+        end
+
+      end
+
+      default: begin
+        st_d = StRandReset;
+      end
+    endcase
+  end
+  `ASSERT_KNOWN(RandStKnown_A, st)
+
+  ////////////////
+  // Assertions //
+  ////////////////
+
+  // entropy storage cannot be exceed the Entry number.
+  // filled is asserted when the storage index meets the Entry number.
+  // So, if filled, no update signal shall be asserted
+  `ASSERT(StorageIdxInBound_A, storage_filled |-> !storage_update)
 
 endmodule : kmac_entropy
 

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -82,6 +82,17 @@ package kmac_pkg;
     CmdDone      = 4'b 1000
   } kmac_cmd_e;
 
+  // Timer
+  parameter int unsigned EntropyTimerW = 16;
+  parameter int unsigned EdnWaitTimerW = 16;
+
+  // Entropy Mode Selection : Should be matched to register package Enum value
+  typedef enum logic [1:0] {
+    EntropyModeNone = 2'h 0,
+    EntropyModeEdn  = 2'h 1,
+    EntropyModeSw   = 2'h 2
+  } entropy_mode_e;
+
   ////////////////////
   // Error Handling //
   ////////////////////
@@ -108,7 +119,15 @@ package kmac_pkg;
 
     // ErrSwPushWrongCmd
     //  - Sw writes any command except CmdStart when Idle.
-    ErrSwPushedWrongCmd = 8'h 03
+    ErrSwPushedWrongCmd = 8'h 03,
+
+    // ErrWaitTimerExpired
+    // Entropy Wait timer expired. Something wrong on EDN i/f
+    ErrWaitTimerExpired = 8'h 04,
+
+    // ErrIncorrectEntropyMode
+    // Incorrect Entropy mode when entropy is ready
+    ErrIncorrectEntropyMode = 8'h 05
   } err_code_e;
 
   typedef struct packed {

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -71,6 +71,18 @@ package kmac_reg_pkg;
     struct packed {
       logic        q;
     } sideload;
+    struct packed {
+      logic [1:0]  q;
+    } entropy_mode;
+    struct packed {
+      logic        q;
+    } entropy_fast_process;
+    struct packed {
+      logic        q;
+    } entropy_ready;
+    struct packed {
+      logic        q;
+    } err_processed;
   } kmac_reg2hw_cfg_reg_t;
 
   typedef struct packed {
@@ -79,7 +91,12 @@ package kmac_reg_pkg;
   } kmac_reg2hw_cmd_reg_t;
 
   typedef struct packed {
-    logic [31:0] q;
+    struct packed {
+      logic [15:0] q;
+    } entropy_timer;
+    struct packed {
+      logic [15:0] q;
+    } wait_timer;
   } kmac_reg2hw_entropy_period_reg_t;
 
   typedef struct packed {
@@ -133,6 +150,17 @@ package kmac_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        d;
+      logic        de;
+    } entropy_ready;
+    struct packed {
+      logic        d;
+      logic        de;
+    } err_processed;
+  } kmac_hw2reg_cfg_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        d;
     } sha3_idle;
     struct packed {
       logic        d;
@@ -161,10 +189,10 @@ package kmac_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    kmac_reg2hw_intr_state_reg_t intr_state; // [1534:1532]
-    kmac_reg2hw_intr_enable_reg_t intr_enable; // [1531:1529]
-    kmac_reg2hw_intr_test_reg_t intr_test; // [1528:1523]
-    kmac_reg2hw_cfg_reg_t cfg; // [1522:1514]
+    kmac_reg2hw_intr_state_reg_t intr_state; // [1539:1537]
+    kmac_reg2hw_intr_enable_reg_t intr_enable; // [1536:1534]
+    kmac_reg2hw_intr_test_reg_t intr_test; // [1533:1528]
+    kmac_reg2hw_cfg_reg_t cfg; // [1527:1514]
     kmac_reg2hw_cmd_reg_t cmd; // [1513:1509]
     kmac_reg2hw_entropy_period_reg_t entropy_period; // [1508:1477]
     kmac_reg2hw_entropy_seed_lower_reg_t entropy_seed_lower; // [1476:1444]
@@ -179,8 +207,9 @@ package kmac_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    kmac_hw2reg_intr_state_reg_t intr_state; // [49:44]
-    kmac_hw2reg_cfg_regwen_reg_t cfg_regwen; // [43:43]
+    kmac_hw2reg_intr_state_reg_t intr_state; // [53:48]
+    kmac_hw2reg_cfg_regwen_reg_t cfg_regwen; // [47:47]
+    kmac_hw2reg_cfg_reg_t cfg; // [46:43]
     kmac_hw2reg_status_reg_t status; // [42:33]
     kmac_hw2reg_err_code_reg_t err_code; // [32:0]
   } kmac_hw2reg_t;
@@ -313,7 +342,7 @@ package kmac_reg_pkg;
     4'b 0001, // index[ 1] KMAC_INTR_ENABLE
     4'b 0001, // index[ 2] KMAC_INTR_TEST
     4'b 0001, // index[ 3] KMAC_CFG_REGWEN
-    4'b 0011, // index[ 4] KMAC_CFG
+    4'b 1111, // index[ 4] KMAC_CFG
     4'b 0001, // index[ 5] KMAC_CMD
     4'b 0011, // index[ 6] KMAC_STATUS
     4'b 1111, // index[ 7] KMAC_ENTROPY_PERIOD

--- a/hw/ip/kmac/rtl/sha3.sv
+++ b/hw/ip/kmac/rtl/sha3.sv
@@ -12,14 +12,14 @@ module sha3
   import sha3_pkg::*;
 #(
   // Enable Masked Keccak if 1
-  parameter  int EnMasking = 0,
+  parameter  bit EnMasking = 0,
   // derived parameter
   localparam int Share = (EnMasking) ? 2 : 1,
 
   // Configurations
   // Decide if implements Re-use the adjacent shares as entropy
   // in DOM AND logic
-  parameter int ReuseShare = 0
+  parameter bit ReuseShare = 0
 ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/kmac/rtl/sha3.sv
+++ b/hw/ip/kmac/rtl/sha3.sv
@@ -55,6 +55,10 @@ module sha3
   output logic absorbed_o,
   output logic squeezing_o,
 
+  // Indicate of one block processed. KMAC main state tracks the progression
+  // based on this signal.
+  output logic block_processed_o,
+
   output sha3_st_e sha3_fsm_o,
 
   // digest output
@@ -129,6 +133,8 @@ module sha3
 
   // Squeezing output
   assign squeezing_o = squeezing;
+
+  assign block_processed_o = keccak_complete;
 
   // State connection
   assign state_valid_o = state_valid;

--- a/hw/ip/kmac/rtl/sha3pad.sv
+++ b/hw/ip/kmac/rtl/sha3pad.sv
@@ -9,7 +9,7 @@
 module sha3pad
   import sha3_pkg::*;
 #(
-  parameter int EnMasking = 0,
+  parameter  bit EnMasking = 0,
   localparam int Share = (EnMasking) ? 2 : 1
 ) (
   input clk_i,

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3983,7 +3983,7 @@
       [
         {
           name: EnMasking
-          type: int
+          type: bit
           default: "0"
           desc:
             '''

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -16,7 +16,7 @@ module top_earlgrey #(
   parameter aes_pkg::sbox_impl_e AesSBoxImpl = aes_pkg::SBoxImplCanrightMaskedNoreuse,
   parameter int unsigned SecAesStartTriggerDelay = 0,
   parameter bit SecAesAllowForcingMasks = 1'b0,
-  parameter int KmacEnMasking = 0,
+  parameter bit KmacEnMasking = 0,
   parameter int KmacReuseShare = 0,
   parameter aes_pkg::sbox_impl_e CsrngSBoxImpl = aes_pkg::SBoxImplLut,
   parameter otbn_pkg::regfile_e OtbnRegFile = otbn_pkg::RegFileFF,


### PR DESCRIPTION
This PR implements Entropy Generation logic inside KMAC. Currently this PR is in draft. After checking it on FPV, I will change this for code review.

It adds a few register fields to control entropy module. The `mode` field configures if the entropy module updates its LFSR seed by sw or from EDN. `entropy_ready` and `err_processed` fields are self-clear registers. those value are read 0 always to not affect the FSM after error has been processed. (for example, if entropy ready remains 1, if error occurs and the software sets err_processed, the state machine goes to reset then moves to seed update without any wait)

The entropy logic recevied 64 bit from software but 32 bit from EDN as of now. I hope EDN to support 64bit to update wide LFSR. Or we could reduce the LFSR to 32 bit ( @cdgori  could you please comment ? )

The LFSR is only in active when the entropy needs to be updated (by consumption or timer expire). Not sure this introduces security concerns.

After entropy logic packs 320 bits of entropy, it expands 320bit to 1600 bit. It just duplicates the bits into 1600 bit. As @tjaychen  mentioned, 320 bit is to cover one sheet operation used in Chi. If okay, we also could reduce this to smaller to accelerate the Secret Key block process.

FYI, current PR does not implement `in_progress` nor `in_block` yet. I am working on it.

Related FSM sheet: https://docs.google.com/spreadsheets/d/1C0ASTmSz0c_I7dZ82nAzdn7U9TaL4Wcd2gNxV4DJEyk/edit?pli=1#gid=1127598758