### PR TITLE
[dv/otp_ctrl] otp_ctrl access blank addr error sequence

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -117,7 +117,7 @@
             - If error is unrecoverable, ensure that OTP entered terminal state
             '''
       milestone: V2
-      tests: []
+      tests: ["otp_ctrl_macro_errs"]
     }
     {
       name: otp_ctrl_errors

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -26,6 +26,7 @@ filesets:
       - seq_lib/otp_ctrl_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_lc_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_dai_lock_vseq.sv: {is_include_file: true}
+      - seq_lib/otp_ctrl_macro_errs_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -64,7 +64,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
     forever begin
       @(posedge cfg.pwr_otp_vif.pins[OtpPwrInitReq]) begin
         if (cfg.backdoor_clear_mem) begin
-          bit [SCRAMBLE_DATA_SIZE-1:0] data = descramble_data(0, 0);
+          bit [SCRAMBLE_DATA_SIZE-1:0] data = descramble_data(0, Secret0Idx);
           otp_a   = '{default:0};
           digests = '{default:0};
           sw_read_lock = 0;
@@ -74,12 +74,12 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
             otp_a[i] = ((i - SECRET0_START_ADDR) % 2) ? data[SCRAMBLE_DATA_SIZE-1:TL_DW] :
                                                         data[TL_DW-1:0];
           end
-          data = descramble_data(0, 1);
+          data = descramble_data(0, Secret1Idx);
           for (int i = SECRET1_START_ADDR; i <= SECRET1_END_ADDR; i++) begin
             otp_a[i] = ((i - SECRET1_START_ADDR) % 2) ? data[SCRAMBLE_DATA_SIZE-1:TL_DW] :
                                                         data[TL_DW-1:0];
           end
-          data = descramble_data(0, 2);
+          data = descramble_data(0, Secret2Idx);
           for (int i = SECRET2_START_ADDR; i <= SECRET2_END_ADDR; i++) begin
             otp_a[i] = ((i - SECRET2_START_ADDR) % 2) ? data[SCRAMBLE_DATA_SIZE-1:TL_DW] :
                                                         data[TL_DW-1:0];
@@ -194,9 +194,21 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
                 // write OTP memory
                 end else begin
                   bit[TL_AW-1:0] normalized_dai_addr = get_normalized_dai_addr();
-                  otp_a[normalized_dai_addr] = `gmv(ral.direct_access_wdata_0);
-                  if (is_secret(dai_addr)) begin
-                    otp_a[normalized_dai_addr + 1] = `gmv(ral.direct_access_wdata_1);
+                  if (!is_secret(dai_addr)) begin
+                    if (otp_a[normalized_dai_addr] == 0) begin
+                      otp_a[normalized_dai_addr] = `gmv(ral.direct_access_wdata_0);
+                    end else begin
+                      predict_status_err(1);
+                    end
+                  end else begin
+                    bit [SCRAMBLE_DATA_SIZE-1:0] secret_data = {otp_a[normalized_dai_addr + 1],
+                                                                otp_a[normalized_dai_addr]};
+                    if (scramble_data(secret_data, part_idx) == 0) begin
+                      otp_a[normalized_dai_addr] = `gmv(ral.direct_access_wdata_0);
+                      otp_a[normalized_dai_addr + 1] = `gmv(ral.direct_access_wdata_1);
+                    end else begin
+                      predict_status_err(1);
+                    end
                   end
                   // TODO: LC partition, raise status error
                 end
@@ -332,7 +344,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
       bit [TL_DW-1:0] scrambled_mem_q[$];
       for (int i = 0; i < array_size/2; i++) begin
         bit [SCRAMBLE_DATA_SIZE-1:0] scrambled_data;
-        scrambled_data = scramble_data({mem_q[i*2+1], mem_q[i*2]}, part_idx - Secret0Idx);
+        scrambled_data = scramble_data({mem_q[i*2+1], mem_q[i*2]}, part_idx);
         scrambled_mem_q.push_back(scrambled_data[TL_DW-1:0]);
         scrambled_mem_q.push_back(scrambled_data[SCRAMBLE_DATA_SIZE-1:TL_DW]);
       end
@@ -368,7 +380,8 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
 
   // when secret data write into otp_array, it will be scrambled
   function bit [SCRAMBLE_DATA_SIZE-1:0] scramble_data(bit [SCRAMBLE_DATA_SIZE-1:0] input_data,
-                                                      int secret_idx);
+                                                      int part_idx);
+    int secret_idx = part_idx - Secret0Idx;
     bit [NUM_ROUND-1:0][SCRAMBLE_DATA_SIZE-1:0] output_data;
     crypto_dpi_present_pkg::sv_dpi_present_encrypt(input_data,
                                                    RndCnstKeyDefault[secret_idx],
@@ -379,7 +392,8 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
 
   // when secret data read out of otp_array, it will be descrambled
   function bit [SCRAMBLE_DATA_SIZE-1:0] descramble_data(bit [SCRAMBLE_DATA_SIZE-1:0] input_data,
-                                                        int secret_idx);
+                                                        int part_idx);
+    int secret_idx = part_idx - Secret0Idx;
     bit [NUM_ROUND-1:0][SCRAMBLE_DATA_SIZE-1:0] output_data;
     crypto_dpi_present_pkg::sv_dpi_present_decrypt(input_data,
                                                    RndCnstKeyDefault[secret_idx],
@@ -396,7 +410,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
                                                 bit [SCRAMBLE_KEY_SIZE-1:0]  key,
                                                 bit [SCRAMBLE_KEY_SIZE-1:0]  final_const);
     bit [NUM_ROUND-1:0] [SCRAMBLE_DATA_SIZE-1:0] enc_array;
-    bit  [SCRAMBLE_DATA_SIZE-1:0] intermediate_state;
+    bit [SCRAMBLE_DATA_SIZE-1:0] intermediate_state;
     crypto_dpi_present_pkg::sv_dpi_present_encrypt(data, key, key_size_80, enc_array);
     // XOR the previous state into the digest result according to the Davies-Meyer scheme.
     intermediate_state = data ^ enc_array[NUM_ROUND-1];

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -163,9 +163,9 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
         // FIXME
       end
       "direct_access_cmd": begin
-        if (addr_phase_write && ral.direct_access_regwen.get_mirrored_value()) begin
+        if (addr_phase_write && `gmv(ral.direct_access_regwen)) begin
           // here only normalize to 2 lsb, if is secret, will be reduced further
-          bit [TL_AW-1:0] dai_addr = ral.direct_access_address.get_mirrored_value() >> 2 << 2;
+          bit [TL_AW-1:0] dai_addr = `gmv(ral.direct_access_address) >> 2 << 2;
           int part_idx = get_part_index(dai_addr);
           case (item.a_data)
             DaiDigest: cal_digest_val(part_idx);
@@ -189,15 +189,14 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
                 void'(ral.status.predict(OtpDaiIdle));
                 // write digest
                 if (dai_addr inside {CreatorSwCfgDigestOffset, OwnerSwCfgDigestOffset}) begin
-                  digests[part_idx] = {ral.direct_access_wdata_1.get_mirrored_value(),
-                                       ral.direct_access_wdata_0.get_mirrored_value()};
+                  digests[part_idx] = {`gmv(ral.direct_access_wdata_1),
+                                       `gmv(ral.direct_access_wdata_0)};
                 // write OTP memory
                 end else begin
                   bit[TL_AW-1:0] normalized_dai_addr = get_normalized_dai_addr();
-                  otp_a[normalized_dai_addr] = ral.direct_access_wdata_0.get_mirrored_value();
+                  otp_a[normalized_dai_addr] = `gmv(ral.direct_access_wdata_0);
                   if (is_secret(dai_addr)) begin
-                    otp_a[normalized_dai_addr + 1] = ral.direct_access_wdata_1.
-                                                     get_mirrored_value();
+                    otp_a[normalized_dai_addr + 1] = `gmv(ral.direct_access_wdata_1);
                   end
                   // TODO: LC partition, raise status error
                 end
@@ -211,7 +210,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
       end
       "direct_access_rdata_0", "direct_access_rdata_1": begin
         // TODO: need to check last cmd is READ
-        if (data_phase_read && ral.direct_access_regwen.get_mirrored_value()) begin
+        if (data_phase_read && `gmv(ral.direct_access_regwen)) begin
           bit [TL_AW-1:0] dai_addr = get_normalized_dai_addr();
           if (csr.get_name() == "direct_access_rdata_0") begin
             bit [TL_DW-1:0] exp_val = dai_read_valid ? otp_a[dai_addr] : 0;
@@ -219,7 +218,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
                          $sformatf("DAI read mismatch at addr %0h", dai_addr))
             do_read_check = 0;
           end else begin
-            if (is_secret(ral.direct_access_address.get_mirrored_value())) begin
+            if (is_secret(`gmv(ral.direct_access_address))) begin
               bit [TL_DW-1:0] exp_val = dai_read_valid ? otp_a[dai_addr + 1] : 0;
               `DV_CHECK_EQ(item.d_data, exp_val,
                            $sformatf("DAI read mismatch at addr %0h", dai_addr + 1))
@@ -408,7 +407,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
   endfunction
 
   function bit [TL_AW-1:0] get_normalized_dai_addr();
-    bit [TL_DW-1:0] dai_addr = ral.direct_access_address.get_mirrored_value();
+    bit [TL_DW-1:0] dai_addr = `gmv(ral.direct_access_address);
     get_normalized_dai_addr = is_secret(dai_addr) ? dai_addr >> 3 << 1 : dai_addr >> 2;
   endfunction
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_errs_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_errs_vseq.sv
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// otp_ctrl_marco_errs_vseq is developed to randomly read/write to any address within OTP:
+// - A writeblank error will be triggered if write to a non-empty address
+// - An access error will be triggered if write to lc partition via DAI interface, or if DAI write
+//   to digest addrs for non-sw partitions
+class otp_ctrl_macro_errs_vseq extends otp_ctrl_smoke_vseq;
+  `uvm_object_utils(otp_ctrl_macro_errs_vseq)
+
+  `uvm_object_new
+
+  constraint num_iterations_c {
+    num_trans  inside {[1:5]};
+    num_dai_op inside {[100:500]};
+  }
+
+  virtual task pre_start();
+    super.pre_start();
+    // TODO: enable this once support
+    // this.partition_index_c.constraint_mode(0);
+    // this.dai_wr_legal_addr_c.constraint_mode(0);
+    this.dai_wr_blank_addr_c.constraint_mode(0);
+    collect_used_addr = 0;
+  endtask
+
+endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -24,11 +24,9 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
   // LC partition does not allow DAI access
   constraint partition_index_c {
     part_idx inside {[CreatorSwCfgIdx:Secret2Idx]};
-    part_idx != HwCfgIdx;
   }
 
-  constraint dai_addr_c {
-    dai_addr inside {used_dai_addr_q} == 0;
+  constraint dai_wr_legal_addr_c {
     if (part_idx == CreatorSwCfgIdx) dai_addr inside `PART_ADDR_RANGE(CreatorSwCfgIdx);
     if (part_idx == OwnerSwCfgIdx)   dai_addr inside `PART_ADDR_RANGE(OwnerSwCfgIdx);
     if (part_idx == HwCfgIdx)        dai_addr inside `PART_ADDR_RANGE(HwCfgIdx);
@@ -36,7 +34,10 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
     if (part_idx == Secret1Idx)      dai_addr inside `PART_ADDR_RANGE(Secret1Idx);
     if (part_idx == Secret2Idx)      dai_addr inside `PART_ADDR_RANGE(Secret2Idx);
     if (part_idx == LifeCycleIdx)    dai_addr inside `PART_ADDR_RANGE(LifeCycleIdx);
+  }
 
+  constraint dai_wr_blank_addr_c {
+    dai_addr inside {used_dai_addr_q} == 0;
     dai_addr % 4 == 0;
     if (part_idx inside {[Secret0Idx:Secret2Idx]}) dai_addr % 8 == 0;
   }

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -12,6 +12,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
   `uvm_object_new
 
   bit do_lc_trans;
+  bit collect_used_addr = 1;
 
   rand bit                           access_locked_parts;
   rand bit [TL_AW-1:0]               dai_addr;
@@ -91,7 +92,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
         // OTP write via DAI
         if ($urandom_range(0, 1)) begin
           dai_wr(dai_addr, wdata0, wdata1);
-          used_dai_addr_q.push_back(dai_addr);
+          if (collect_used_addr) used_dai_addr_q.push_back(dai_addr);
         end
 
         if ($urandom_range(0, 1)) begin

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
@@ -8,3 +8,4 @@
 `include "otp_ctrl_common_vseq.sv"
 `include "otp_ctrl_lc_vseq.sv"
 `include "otp_ctrl_dai_lock_vseq.sv"
+`include "otp_ctrl_macro_errs_vseq.sv"

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -70,6 +70,11 @@
       uvm_test_seq: otp_ctrl_dai_lock_vseq
     }
 
+    {
+      name: otp_ctrl_macro_errs
+      uvm_test_seq: otp_ctrl_macro_errs_vseq
+    }
+
   ]
 
   // List of regressions.


### PR DESCRIPTION
This PR has two commits:
1. Clean up otp_ctrl tb: use macro `gmv` instead of full function name.
   Remove unnecessary constraints. 
2. Add sequence `otp_ctrl_macro_errs`. This PR only adds the access blank address errors, other macro errors will be added with coming PRs.