### PR TITLE
[cleanup] Mass replace tabs with spaces

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src_testplan.hjson
+++ b/hw/ip/entropy_src/data/entropy_src_testplan.hjson
@@ -11,7 +11,10 @@
   entries: [
     {
       name: smoke
-      desc: '''Enable entropy_src in LFSR mode, wait for interrupt, verify entropy for power-on seed.'''
+      desc: '''
+            Enable entropy_src in LFSR mode, wait for interrupt, verify entropy
+            for power-on seed.
+            '''
       milestone: V1
       tests: ["entropy_src_smoke"]
     }
@@ -29,7 +32,7 @@
       name: firmware_mode
       desc: '''
             Verify health_checks aren't active
-	    Verify bypass active
+            Verify bypass active
             Verify read FIFO
             - Random FIFO depths
             '''
@@ -42,8 +45,8 @@
             Verify LFSR entropy matches predicted
             - Random seeds
             - Random rng activity
-	    - Random rates
-	    Verify FIPS bits match predicted
+            - Random rates
+            - Verify FIPS bits match predicted
             '''
       milestone: V2
       tests: []
@@ -53,9 +56,9 @@
       desc: '''
             Verify rng entropy
             - Random FIFO depths
-	    - Random rates
-            Verify rng single_bit_mode for all bit_selector values
-	    Verify FIPS bits match predicted
+            - Random rates
+            - Verify rng single_bit_mode for all bit_selector values
+      Verify FIPS bits match predicted
             '''
       milestone: V2
       tests: []
@@ -64,16 +67,16 @@
       name: health_checks
       desc: '''
             Verify AdaptProp, RepCnt, RepCntSym, Bucket, Markov health check results match predicted.
-	    - Generate passing and failing raw entropy streams
-	    - Random window sizes
-	    - Default and random hi/lo bypass/fips thresholds
-	    - Enables/fail counts/clears
-	    Verify hi/lo bypass/fips watermarks
-            Verify External health check behaves as predicted
-	    - Verify outputs match internal reg values/entropy bus
-	    - Pulse inputs and verify captured
-	    Verify health testing stops when no demand for entropy
-	    '''
+            - Generate passing and failing raw entropy streams
+            - Random window sizes
+            - Default and random hi/lo bypass/fips thresholds
+            - Enables/fail counts/clears
+            - Verify hi/lo bypass/fips watermarks
+            - Verify External health check behaves as predicted
+            - Verify outputs match internal reg values/entropy bus
+            - Pulse inputs and verify captured
+            - Verify health testing stops when no demand for entropy
+            '''
       milestone: V2
       tests: []
     }
@@ -81,8 +84,8 @@
       name: conditioning
       desc: '''
             Verify genbits in bypass mode as predicted.
-	    Verify genbits after shah3 conditioning as predicted.
-	    '''
+            Verify genbits after shah3 conditioning as predicted.
+            '''
       milestone: V2
       tests: []
     }
@@ -92,7 +95,7 @@
             Verify es_entropy_valid interrupt asserts as predicted.
             Verify es_health_test_failed interrupt asserts as predicted.
             Verify es_fifo_err interrupt asserts as predicted.
-	    '''
+            '''
       milestone: V2
       tests: []
     }
@@ -100,15 +103,16 @@
       name: alerts
       desc: '''
             Verify es_alert_count_met asserts as expected.
-	    '''
+            '''
       milestone: V2
       tests: []
     }
     {
       name: stress_all
       desc: '''
-            Combine the individual test points while injecting TL errors and running CSR tests in parallel.
-	    '''
+            Combine the individual test points while injecting TL errors and
+            running CSR tests in parallel.
+            '''
       milestone: V2
       tests: ["entropy_src_stress_all"]
     }
@@ -116,7 +120,7 @@
       name: fifo_errs
       desc: '''
             Verify they never occur with asserts
-	    '''
+            '''
       milestone: V2
       tests: []
     }

--- a/hw/ip/otbn/dv/otbnsim/test/simple/insns/bnlid.s
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/insns/bnlid.s
@@ -21,8 +21,8 @@
 
   /*
     Check wrapping and incrementing on the grd side. Set x3 to 32+2 and load
-	with increment from address 0x40. We should get data from 0x40 in w2 and x3
-	should equal 3
+    with increment from address 0x40. We should get data from 0x40 in w2 and x3
+    should equal 3
   */
   addi      x3, x0, 34
   bn.lid    x3++, 64(x0)

--- a/hw/ip/otp_ctrl/doc/_index.md
+++ b/hw/ip/otp_ctrl/doc/_index.md
@@ -29,14 +29,14 @@ Together, the OTP controller and IP provide secure one-time-programming function
 ## Features
 
 - Multiple logical partitions of the underlying OTP IP
-	- Each partition is lockable and integrity checked
-	- Integrity digests are stored alongside each logical bank
+  - Each partition is lockable and integrity checked
+  - Integrity digests are stored alongside each logical bank
 - Periodic / persistent checks of OTP values
-	- Periodic checks of shadowed content vs digests
-	- Periodic checks of OTP stored content and shadowed content
-	- Persistent checks for immediate errors
+  - Periodic checks of shadowed content vs digests
+  - Periodic checks of OTP stored content and shadowed content
+  - Persistent checks for immediate errors
 - Separate life cycle partition and interface to life cycle controller
-	- Supports life cycle functions, but cannot be integrity locked
+  - Supports life cycle functions, but cannot be integrity locked
 - Lightweight scrambling of secret OTP partition using a global netlist constant
 - Lightweight ephemeral key derivation function for RAM scrambling mechanisms
 - Lightweight key derivation function for FLASH scrambling mechanism

--- a/hw/ip/prim/doc/prim_present.md
+++ b/hw/ip/prim/doc/prim_present.md
@@ -72,9 +72,9 @@ round_keys = key_derivation(key_i, idx_i);
 state = data_i;
 
 for (int i=0; i < NumRounds; i++) {
-	state = state ^ round_keys[i];
-	state = sbox4_layer(state);
-	state = perm_layer(state);
+  state = state ^ round_keys[i];
+  state = sbox4_layer(state);
+  state = perm_layer(state);
 }
 
 data_o = state ^ round_keys[NumRounds-1];

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -226,8 +226,8 @@
           name: "sense",
           desc: '''
                 Reflects the state of the sense pin.
-		1 indicates that the host is providing VBUS.
-		Note that this bit always shows the state of the actual pin and does not take account of the override control.
+                1 indicates that the host is providing VBUS.
+                Note that this bit always shows the state of the actual pin and does not take account of the override control.
                 '''
         }
         {
@@ -502,7 +502,7 @@
     }
     { name: "phy_pins_sense",
       desc: '''
-            USB PHY pins sense. 
+            USB PHY pins sense.
             This register can be used to read out the state of the USB device inputs and outputs from software.
             This is designed to be used for debugging purposes or during chip testing.
             '''

--- a/hw/syn/tools/dc/run-syn.tcl
+++ b/hw/syn/tools/dc/run-syn.tcl
@@ -31,9 +31,9 @@ source ${foundry_root}/syn/dc/setup.tcl
 
 # if in interactive mode, do not exit at the end of the script
 if { [info exists ::env(INTERACTIVE)] } {
-    set RUN_INTERACTIVE 1
+  set RUN_INTERACTIVE 1
 } else {
-	set RUN_INTERACTIVE 0
+  set RUN_INTERACTIVE 0
 }
 
 # path to directory containing the source list file
@@ -70,12 +70,9 @@ saif_map -start
 ###The following variable helps verification when there are differences between DC and FM while inferring logical hierarchies
 set_app_var hdlin_enable_hier_map true
 
-
-
 #######################
 ##  DESIGN SOURCES  ###
 #######################
-
 
 # this PRIM_DEFAULT_IMPL selects the appropriate technology by defining
 # PRIM_DEFAULT_IMPL=prim_pkg::Impl<tech identifier>
@@ -191,5 +188,5 @@ saif_map -type ptpx -write_map ${RESULTDIR}/${DUT}.mapped.SAIF.namemap
 # write_file -format verilog -hierarchy -output "${VLOGDIR}/flat.v"
 
 if { $RUN_INTERACTIVE == 0 } {
-    exit
+  exit
 }

--- a/hw/syn/tools/dc/sweep.tcl
+++ b/hw/syn/tools/dc/sweep.tcl
@@ -56,63 +56,63 @@ set OUT_DEL 0.0
 ###########################
 
 foreach TCK $TCK_SWEEP {
-	###########################
-	##   ELABORATE DESIGN    ##
-	###########################
+  ###########################
+  ##   ELABORATE DESIGN    ##
+  ###########################
 
-	# delete previous designs.
-	remove_design -designs
-	sh rm -rf $WORKLIB/*
+  # delete previous designs.
+  remove_design -designs
+  sh rm -rf $WORKLIB/*
 
-	analyze -define ${DEFINE} -format sv ${SRC}   > "${REPDIR}/${DUT}_${TCK}_analyze.rpt"
-	elaborate  ${DUT} -parameters ${PARAMS}       > "${REPDIR}/${DUT}_${TCK}_elab.rpt"
-	link                                          > "${REPDIR}/${DUT}_${TCK}_link.rpt"
-	check_design                                  > "${REPDIR}/${DUT}_${TCK}_check.rpt"
+  analyze -define ${DEFINE} -format sv ${SRC}   > "${REPDIR}/${DUT}_${TCK}_analyze.rpt"
+  elaborate  ${DUT} -parameters ${PARAMS}       > "${REPDIR}/${DUT}_${TCK}_elab.rpt"
+  link                                          > "${REPDIR}/${DUT}_${TCK}_link.rpt"
+  check_design                                  > "${REPDIR}/${DUT}_${TCK}_check.rpt"
 
-	write_file -format ddc -hierarchy -output "${DDCDIR}/${DUT}_${TCK}_elab.ddc"
-	write_file -format verilog -hierarchy -output "${DDCDIR}/${DUT}_${TCK}_elab.v"
+  write_file -format ddc -hierarchy -output "${DDCDIR}/${DUT}_${TCK}_elab.ddc"
+  write_file -format verilog -hierarchy -output "${DDCDIR}/${DUT}_${TCK}_elab.v"
 
-	###########################
-	##   APPLY CONSTRAINTS   ##
-	###########################
+  ###########################
+  ##   APPLY CONSTRAINTS   ##
+  ###########################
 
-	# timing constraint in ns
-	# set timing to 250 MHz
-	set DELAY   ${TCK}
+  # timing constraint in ns
+  # set timing to 250 MHz
+  set DELAY   ${TCK}
 
-	create_clock ${CLK_PIN} -period ${TCK}
+  create_clock ${CLK_PIN} -period ${TCK}
 
-	set_ideal_network ${CLK_PIN}
-	set_ideal_network ${RST_PIN}
+  set_ideal_network ${CLK_PIN}
+  set_ideal_network ${RST_PIN}
 
-	set_max_delay ${DELAY} -from [all_inputs] -to [all_outputs]
-	set_input_delay ${IN_DEL} [remove_from_collection [all_inputs] {${CLK_PIN}}] -clock ${CLK_PIN}
-	set_output_delay ${OUT_DEL}  [all_outputs] -clock ${CLK_PIN}
+  set_max_delay ${DELAY} -from [all_inputs] -to [all_outputs]
+  set_input_delay ${IN_DEL} [remove_from_collection [all_inputs] {${CLK_PIN}}] -clock ${CLK_PIN}
+  set_output_delay ${OUT_DEL}  [all_outputs] -clock ${CLK_PIN}
 
-	set_driving_cell  -no_design_rule -lib_cell ${DRIVING_CELL} -pin X [all_inputs]
-	set_load [load_of ${LOAD_LIB}/${LOAD_CELL}/A] [all_outputs]
+  set_driving_cell  -no_design_rule -lib_cell ${DRIVING_CELL} -pin X [all_inputs]
+  set_load [load_of ${LOAD_LIB}/${LOAD_CELL}/A] [all_outputs]
 
-	######################
-	##    MAP DESIGN    ##
-	######################
+  ######################
+  ##    MAP DESIGN    ##
+  ######################
 
-	compile_ultra -gate_clock -scan  > "${REPDIR}/${DUT}_${TCK}_compile.rpt"
+  compile_ultra -gate_clock -scan  > "${REPDIR}/${DUT}_${TCK}_compile.rpt"
 
-	#################
-	##   REPORTS   ##
-	#################
+  #################
+  ##   REPORTS   ##
+  #################
 
-	report_timing -nosplit               > "${REPDIR}/${DUT}_${TCK}_timing.rpt"
-	report_area -hier -nosplit           > "${REPDIR}/${DUT}_${TCK}_area.rpt"
-	report_constraints -all_violators    > "${REPDIR}/${DUT}_${TCK}_constraints.rpt"
+  report_timing -nosplit               > "${REPDIR}/${DUT}_${TCK}_timing.rpt"
+  report_area -hier -nosplit           > "${REPDIR}/${DUT}_${TCK}_area.rpt"
+  report_constraints -all_violators    > "${REPDIR}/${DUT}_${TCK}_constraints.rpt"
 
-	report_timing -nosplit -nworst 1000 -input -net -trans -cap > "${REPDIR}/${DUT}_${TCK}_timing_long.rpt"
+  report_timing -nosplit -nworst 1000 -input -net -trans -cap > "${REPDIR}/${DUT}_${TCK}_timing_long.rpt"
 
-	#################
-	##   NETLIST   ##
-	#################
+  #################
+  ##   NETLIST   ##
+  #################
 
-	change_names -rules verilog -hierarchy
-	write_file -format ddc     -hierarchy -output "${DDCDIR}/${DUT}_${TCK}_mapped.ddc"
-	write_file -format verilog -hierarchy -output "${VLOGDIR}/${DUT}_${TCK}_mapped.v"
+  change_names -rules verilog -hierarchy
+  write_file -format ddc     -hierarchy -output "${DDCDIR}/${DUT}_${TCK}_mapped.ddc"
+  write_file -format verilog -hierarchy -output "${VLOGDIR}/${DUT}_${TCK}_mapped.v"
 }

--- a/site/docs/layouts/partials/head.html
+++ b/site/docs/layouts/partials/head.html
@@ -14,12 +14,12 @@
   <meta property="twitter:description" content="OpenTitan Documentation">
   <meta name="twitter:card" content="summary_large_image">
 
-	<link rel="apple-touch-icon" sizes="180x180" href="https://opentitan.org/apple-touch-icon.png">
-	<link rel="icon" type="image/png" sizes="32x32" href="https://opentitan.org/favicon-32x32.png">
-	<link rel="icon" type="image/png" sizes="16x16" href="https://opentitan.org/favicon-16x16.png">
-	<link rel="shortcut icon" href="https://opentitan.org/favicon.ico">
-	<meta name="msapplication-TileColor" content="#c27bcf">
-	<meta name="theme-color" content="#ffffff">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://opentitan.org/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://opentitan.org/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://opentitan.org/favicon-16x16.png">
+  <link rel="shortcut icon" href="https://opentitan.org/favicon.ico">
+  <meta name="msapplication-TileColor" content="#c27bcf">
+  <meta name="theme-color" content="#ffffff">
 
   <link href="https://fonts.googleapis.com/css?family=Livvic:300|Ubuntu:400,700&display=swap" rel="stylesheet">
   <title>{{ if .Title }}{{ .Title }} | {{ end }}OpenTitan Documentation</title>

--- a/site/landing/assets/scss/_benefits.scss
+++ b/site/landing/assets/scss/_benefits.scss
@@ -91,14 +91,14 @@
 }
 
 @keyframes rot {
-	from {
-		transform: rotate(0deg)
-		           translate(-3em)
-		           rotate(0deg);
-	}
-	to {
-		transform: rotate(360deg)
-		           translate(-3em)
-		           rotate(-360deg);
-	}
+  from {
+    transform: rotate(0deg)
+               translate(-3em)
+               rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg)
+               translate(-3em)
+               rotate(-360deg);
+  }
 }

--- a/site/landing/content/usage-policy.md
+++ b/site/landing/content/usage-policy.md
@@ -43,11 +43,11 @@ aliases:
 4. This website is intended only to give you information about us and our
    products and services. We do not intend, through this website:
 
-	1. make you any promises;
+  1. make you any promises;
 
-	1. make any contractual offer to you;
+  1. make any contractual offer to you;
 
-	1. supply any products or services to you.
+  1. supply any products or services to you.
 
 5. You have our permission to browse this website and in so doing make use of
    its content through a web browser. Unless we explicitly say otherwise, you
@@ -118,14 +118,14 @@ aliases:
      duties under data protection law), we have no liability to you connected
      with your use of our website. For example, we are not liable for
 
-	1. any missing or inaccurate content;
+  1. any missing or inaccurate content;
 
-	1. any unavailability of the website;
+  1. any unavailability of the website;
 
   1. any incompatibility of this website with any particular browser or browser
      plugin; or
 
-	1. economic loss or other loss of turnover, profit, business or goodwill.
+  1. economic loss or other loss of turnover, profit, business or goodwill.
 
 1. These terms are to be interpreted in accordance with English law and the
    courts of England shall have jurisdiction to settle any disputes arising

--- a/sw/otbn/code-snippets/loop.s
+++ b/sw/otbn/code-snippets/loop.s
@@ -14,13 +14,13 @@
     addi x3, x3, -1
 
     /* At this point, we've incremented x3 by 2-1 = 1 on each of three
-	   loop iterations, so x3 should equal 3. */
+       loop iterations, so x3 should equal 3. */
 
     loopi 5, 1
     addi x3, x3, -3
 
     /* Now we've run a loop that decrements x3 by 3 on each of
-	   five loop iterations, so it should now equal 3-15 = -12. */
+       five loop iterations, so it should now equal 3-15 = -12. */
 
     loop x2, 3
     loopi 4, 1
@@ -28,6 +28,6 @@
     nop
 
     /* The nested loop runs 3 * 4 times, incrementing by 2 each
-	iteration. So x3 should now equal -12 + 2*12 = 12. */
+       iteration. So x3 should now equal -12 + 2*12 = 12. */
 
     ecall


### PR DESCRIPTION
Mass search and replace of tabs with 2 spaces. This makes diffs easier. This is done on the entire repo. Image files, vendor directories and Makefiles are skipped. 

Signed-off-by: Srikrishna Iyer <sriyer@google.com>