### PR TITLE
[otbn dv] Include missing header file

### DIFF
--- a/hw/ip/otbn/dv/tracer/cpp/log_trace_listener.cc
+++ b/hw/ip/otbn/dv/tracer/cpp/log_trace_listener.cc
@@ -6,6 +6,7 @@
 #include <iomanip>
 #include <ios>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 
 #include "log_trace_listener.h"


### PR DESCRIPTION
Without this, OTBN and oddly, chip level sims fail (at Google) with the following
error:

```console
scratch/rstmgr-test/top_earlgrey_asic-sim-vcs/default/sim-vcs/../src/lowrisc_ip_otbn_tracer_0/cpp/log_trace_listener.cc: In constructor 'LogTraceListener::LogTraceListener(const string&)':
scratch/rstmgr-test/top_earlgrey_asic-sim-vcs/default/sim-vcs/../src/lowrisc_ip_otbn_tracer_0/cpp/log_trace_listener.cc:18:11: error: 'runtime_error' is not a member of 'std'
     throw std::runtime_error(oss.str());
```

Signed-off-by: Srikrishna Iyer <sriyer@google.com>