### PR TITLE
[keymgr/dv] Add keymgr_invalid_kmac_input_vseq

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_env.core
+++ b/hw/ip/keymgr/dv/env/keymgr_env.core
@@ -27,6 +27,7 @@ filesets:
       - seq_lib/keymgr_cfgen_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_direct_to_disabled_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_lc_disable_vseq.sv: {is_include_file: true}
+      - seq_lib/keymgr_invalid_kmac_input_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_invalid_kmac_input_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_invalid_kmac_input_vseq.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test Invalid_kmac_input error by setting key_version > current_max_key_ver
+class keymgr_invalid_kmac_input_vseq extends keymgr_random_vseq;
+  `uvm_object_utils(keymgr_invalid_kmac_input_vseq)
+  `uvm_object_new
+
+  // enable key_version error with 1/3 chance
+  constraint is_key_version_err_c {
+    is_key_version_err dist {0 :/ 2, 1 :/ 1};
+  }
+
+endclass : keymgr_invalid_kmac_input_vseq

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_random_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_random_vseq.sv
@@ -48,8 +48,14 @@ class keymgr_random_vseq extends keymgr_sideload_vseq;
         ? max_creator_key_ver_val : (current_state == keymgr_pkg::StOwnerIntKey)
         ? max_owner_int_key_ver_val : (current_state == keymgr_pkg::StOwnerKey)
         ? max_owner_key_ver_val : '1;
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(is_key_version_err)
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(key_version_val,
-                                       !is_key_version_err -> key_version_val <= max_key_ver_val;)
+                                       if (is_key_version_err) {
+                                         max_key_ver_val != '1 -> key_version_val > max_key_ver_val;
+                                       } else {
+                                         key_version_val <= max_key_ver_val;
+                                       })
+    ral.key_version.set(key_version_val);
     csr_update(ral.key_version);
   endtask : write_random_sw_content
 

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_vseq_list.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_vseq_list.sv
@@ -10,3 +10,4 @@
 `include "keymgr_cfgen_vseq.sv"
 `include "keymgr_direct_to_disabled_vseq.sv"
 `include "keymgr_lc_disable_vseq.sv"
+`include "keymgr_invalid_kmac_input_vseq.sv"

--- a/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
+++ b/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
@@ -80,6 +80,11 @@
       name: keymgr_lc_disable
       uvm_test_seq: keymgr_lc_disable_vseq
     }
+
+    {
+      name: keymgr_invalid_kmac_input
+      uvm_test_seq: keymgr_invalid_kmac_input_vseq
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
Update scb accordingly for key version error
also fix `is_key_version_err` is always 0 in random_vseq

Signed-off-by: Weicai Yang <weicai@google.com>