### PR TITLE
[usbuart] Fix usbuart for all the usb changes

### DIFF
--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
@@ -54,6 +54,7 @@ module usb_fs_nb_pe #(
   output logic [3:0]             in_ep_current_o, // Other signals addressed to this ep
   output logic                   in_ep_rollback_o, // Bad termination, rollback transaction
   output logic                   in_ep_xfr_end_o, // good termination, transaction complete
+  output logic                   in_ep_acked_o,   // good term, completed by ack (subset of xfr_end)
   output logic [PktW - 1:0]      in_ep_get_addr_o, // Offset requested (0..pktlen)
   output logic                   in_ep_data_get_o, // Accept data (get_addr advances too)
   output logic                   in_ep_newpkt_o, // New IN pkt start (with in_ep_current_o update)
@@ -138,6 +139,7 @@ module usb_fs_nb_pe #(
     .in_ep_current_o       (in_ep_current_o),
     .in_ep_rollback_o      (in_ep_rollback_o),
     .in_ep_xfr_end_o       (in_ep_xfr_end_o),
+    .in_ep_acked_o         (in_ep_acked_o),
     .in_ep_get_addr_o      (in_ep_get_addr_o),
     .in_ep_data_get_o      (in_ep_data_get_o),
     .in_ep_newpkt_o        (in_ep_newpkt_o),

--- a/hw/ip/usbdev/rtl/usbdev_usbif.sv
+++ b/hw/ip/usbdev/rtl/usbdev_usbif.sv
@@ -304,6 +304,7 @@ module usbdev_usbif  #(
     .in_ep_current_o       (in_ep_current),
     .in_ep_rollback_o      (link_in_err_o),
     .in_ep_xfr_end_o       (in_ep_xfr_end),
+    .in_ep_acked_o         (), // us xfr_end to include iso transactions
     .in_ep_get_addr_o      (in_ep_get_addr),
     .in_ep_data_get_o      (in_ep_data_get),
     .in_ep_newpkt_o        (in_ep_newpkt),

--- a/hw/ip/usbuart/data/usbuart.hjson
+++ b/hw/ip/usbuart/data/usbuart.hjson
@@ -2,51 +2,127 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 { name: "usbuart",
-  clock_primary: "clk_fixed",
-  other_clock_list: [ "clk_48mhz" ]
+  clock_primary: "clk_i",
+  other_clock_list: [ "clk_usb_48mhz_i" ]
+  reset_primary: "rst_ni",
+  other_reset_list: [ "rst_usb_48mhz_ni" ]
   bus_device: "tlul",
   bus_host: "none",
   available_inout_list: [
-    { name: "usb_dp", desc: "USB data D+" }
-    { name: "usb_dm", desc: "USB data D-" }
+    { name: "d", desc: "USB data differential" }
+    { name: "dp", desc: "USB data D+" }
+    { name: "dn", desc: "USB data D-" }
   ],
   available_input_list: [
-    {  name: "usb_sense", desc: "USB host VBUS sense" }
+    {  name: "sense", desc: "USB host VBUS sense" }
   ],
   available_output_list: [
-    { name: "usb_pullup", desc: "USB FS pullup control" }
+    { name: "se0", desc: "USB single-ended zero link state" }
+    { name: "dp_pullup", desc: "USB D+ pullup control" }
+    { name: "dn_pullup", desc: "USB D- pullup control" }
+    { name: "tx_mode_se", desc: "USB single-ended transmit mode control" }
+    { name: "suspend", desc: "USB link suspend state" }
+  ],
+  inter_signal_list: [
+    { name:    "usb_ref_val",
+      type:    "uni",
+      act:     "req",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    }
+    { name:    "usb_ref_pulse",
+      type:    "uni",
+      act:     "req",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    }
+  ]
+  param_list: [
+    { name:    "NEndpoints",
+      type:    "int",
+      default: "12",
+      desc:    "Number of endpoints",
+      local:   "true"
+    }
   ],
   interrupt_list: [
-    { name: "tx_watermark"
-      desc: "raised if the transmit FIFO is past the highwater mark."}
-    { name: "rx_watermark"
-      desc: "raised if the receive FIFO is past the highwater mark."}
-    { name: "tx_overflow"
-      desc: "raised if the transmit FIFO has overflowed."}
-    { name: "rx_overflow"
-      desc: "raised if the receive FIFO has overflowed."}
-    { name: "rx_frame_err"
+    { name: "pkt_received"
+      desc: "UART tx_watermark: raised if the transmit FIFO is past the high-water mark."}
+    { name: "pkt_sent"
+      desc: "UART rx_watermark: raised if the receive FIFO is past the high-water mark."}
+    { name: "disconnected",
+      desc: "UART tx_empty: raised if the transmit FIFO has emptied and no transmit is ongoing."}
+    { name: "host_lost",
+      desc: "UART rx_overflow: raised if the receive FIFO has overflowed."}
+    { name: "link_reset",
       desc: '''
-            raised if a framing error has been detected on receive,
+            UART rx_frame_err: raised if a framing error has been detected on receive,
             which will never happen on the USB interface.
             '''}
-    { name: "rx_break_err"
+    { name: "link_suspend",
       desc: '''
-            raised if break condition has been detected on receive.
+            UART rx_break_err: raised if break condition has been detected on receive.
             This is done if either the host is not providing VBUS or has not
             provided a Start of Frame indication in 2.048ms.
             '''}
-    { name: "rx_timeout"
+    { name: "link_resume",
       desc: '''
-            raised if RX FIFO has characters remaining in the FIFO without being
-            retrieved for the programmed time period.
-            '''
+          UART rx_timeout: raised if RX FIFO has characters remaining in the FIFO without being
+          retrieved for the programmed time period.
+          '''
     }
-    { name: "rx_parity_err"
+    { name: "av_empty",
       desc: '''
-            raised if the receiver has detected a parity error,
+            UART rx_parity_err: raised if the receiver has detected a parity error,
             which will never happen on the USB interface.
             '''}
+    { name: "rx_full",
+      desc: '''
+            Dummy to meet usbdev.
+            '''
+    }
+    { name: "av_overflow",
+      desc: '''
+            Dummy to meet usbdev.
+            '''
+    }
+    { name: "link_in_err",
+      desc: '''
+            Dummy to meet usbdev.
+            '''
+    }
+    { name: "rx_crc_err",
+      desc: '''
+            Dummy to meet usbdev.
+            '''
+    }
+    { name: "rx_pid_err",
+      desc: '''
+            Dummy to meet usbdev.
+            '''
+    }
+    { name: "rx_bitstuff_err",
+      desc: '''
+            Dummy to meet usbdev.
+            '''
+    }
+    { name: "frame",
+      desc: '''
+            Dummy to meet usbdev.
+            '''
+    }
+    { name: "connected",
+      desc: '''
+            Dummy to meet usbdev.
+            '''
+    }
+    { name: "link_out_err",
+      desc: '''
+            Dummy to meet usbdev.
+            '''
+    }
   ]
   regwidth: "32",
   registers: [
@@ -136,18 +212,22 @@
         { bits: "2"
           name: "TXEMPTY"
           desc: "TX FIFO is empty"
+          resval: "1"
         }
         { bits: "3"
           name: "TXIDLE"
           desc: "TX is idle. At the moment this matches the TXEMPTY bit."
+          resval: "1"
         }
         { bits: "4"
           name: "RXIDLE"
           desc: "RX is idle. At the moment this matches the RXEMPTY bit."
+          resval: "1"
         }
         { bits: "5"
           name: "RXEMPTY"
           desc: "RX FIFO is empty"
+          resval: "1"
         }
       ]
     }
@@ -177,16 +257,22 @@
       hwqe:     "true",
       fields: [
         { bits: "0",
+          swaccess: "wo",
+          hwaccess: "hro",
           name: "RXRST",
-          desc: "RX fifo reset"
+          desc: "RX fifo reset. Write 1 to the register resets RX_FIFO. Read returns 0"
         }
         { bits: "1",
+          swaccess: "wo",
+          hwaccess: "hro",
           name: "TXRST",
-          desc: "TX fifo reset"
+          desc: "TX fifo reset. Write 1 to the register resets TX_FIFO. Read returns 0"
         }
         { bits: "4:2",
           name: "RXILVL",
-          desc: "Trigger level for RX interrupts",
+          desc: '''Trigger level for RX interrupts. If the FIFO depth is greater than or equal to
+                the setting, it raises rx_watermark interrupt.
+                ''',
           enum: [
             { value: "0",
               name: "rxlvl1",
@@ -208,16 +294,17 @@
               name: "rxlvl30",
               desc: "30 characters"
             },
-            // TODO expect generator to make others reserved
           ]
         }
         { bits: "6:5",
           name: "TXILVL",
-          desc: "Trigger level for TX interrupts",
+          desc: '''Trigger level for TX interrupts. If the FIFO depth is less than the setting, it
+                raises tx_watermark interrupt.
+                ''',
           enum: [
             { value: "0",
               name: "txlvl1",
-              desc: "1 character"
+              desc: "2 characters"
             },
             { value: "1",
               name: "txlvl4",
@@ -295,6 +382,29 @@
         }
       ]
     }
+    { name: "USBCTRL",
+      desc: "USB control",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "0",
+          name: "pinflip",
+          desc: "Set to swap D+ and D- pins"
+        }
+        { bits: "1",
+          name: "tx_diff",
+          desc: "Set to configure programmable PHY for differential mode (d and se0)"
+        }
+        { bits: "2",
+          name: "rx_diff",
+          desc: "Set to configure receiver for differential PHY"
+        }
+        { bits: "3",
+          name: "ref_disable",
+          desc: "Set to disable SOF reference pulses for clocking"
+        }
+      ]
+    }
     { name: "USBSTAT",
       desc: "USB Status",
       swaccess: "ro",
@@ -310,17 +420,34 @@
                 '''
         }
         {
-          bits: "14",
-          name: "host_timeout",
+          bits: "12",
+          name: "link_reset",
           desc: '''
-                Start of frame not received from host for 1s.
+                Link is in the reset state.
+                '''
+        }
+        {
+          bits: "13",
+          name: "link_suspend",
+          desc: '''
+                Link is in the suspend state.
+                '''
+        }
+        {
+          bits: "14",
+          name: "host_lost",
+          desc: '''
+                Start of frame not received from host for 4.096ms. This also triggers a
+                break interrupt. A SoF is required every 1ms on a functioning USB link.
+                Note that this bit (and break condition) will be set if the link is
+                suspended or in reset.
                 '''
         }
         {
           bits: "15",
-          name: "host_lost",
+          name: "pwr_sense",
           desc: '''
-                Start of frame not received from host for 2.048ms.
+                State of the VBUS sense pin (note this is not used by the hardware).
                 '''
         }
         {

--- a/hw/ip/usbuart/rtl/usb_serial_ctrl_ep.sv
+++ b/hw/ip/usbuart/rtl/usb_serial_ctrl_ep.sv
@@ -15,7 +15,8 @@ module usb_serial_ctrl_ep  #(
 ) (
   input              clk_i,
   input              rst_ni,
-  output logic [6:0] dev_addr,
+  input              link_reset_i,
+  output logic [6:0] dev_addr_o,
 
   ////////////////////////////
   // out endpoint interface //
@@ -71,7 +72,7 @@ module usb_serial_ctrl_ep  #(
   logic [6:0] dev_addr_int;
   logic [6:0] new_dev_addr;
 
-  assign dev_addr = dev_addr_int;
+  assign dev_addr_o = dev_addr_int;
 
   assign out_ep_stall_o = 1'b0;
   assign out_ep_full_o = 1'b0;
@@ -237,6 +238,10 @@ module usb_serial_ctrl_ep  #(
   assign dscr_type = usb_dscr_type_e'(wValue[15:8]);
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
+      dev_addr_int <= '0;
+      save_dev_addr <= 1'b0;
+      in_ep_stall_o <= 1'b0;
+    end else if (link_reset_i) begin
       dev_addr_int <= '0;
       save_dev_addr <= 1'b0;
       in_ep_stall_o <= 1'b0;

--- a/hw/ip/usbuart/rtl/usbuart.sv
+++ b/hw/ip/usbuart/rtl/usbuart.sv
@@ -6,38 +6,66 @@
 //
 
 module usbuart (
-  input        clk_i,
-  input        rst_ni, // Reset synchronized to clk_i
-  input        clk_usb_48mhz_i,
-  input        rst_usb_48mhz_ni, // Reset synchronized to clk_usb_48mhz_i
 
   // Bus Interface
+  input logic  clk_i,
+  input logic  rst_ni,
+  input logic  clk_usb_48mhz_i, // use usb_ prefix for signals in this clk
+  input logic  rst_usb_48mhz_ni, // async reset, with relase sync to clk_usb_48_mhz_i
+
+  // Register interface
   input        tlul_pkg::tl_h2d_t tl_i,
   output       tlul_pkg::tl_d2h_t tl_o,
 
-  // Generic IO
-  input        cio_usb_dp_i,
-  output logic cio_usb_dp_o,
-  output logic cio_usb_dp_en_o,
+  // Data inputs
+  input logic  cio_d_i, // differential
+  input logic  cio_dp_i, // single-ended, can be used in differential mode to detect SE0
+  input logic  cio_dn_i, // single-ended, can be used in differential mode to detect SE0
 
-  input        cio_usb_dn_i,
-  output logic cio_usb_dn_o,
-  output logic cio_usb_dn_en_o,
+  // Data outputs
+  output logic cio_d_o,
+  output logic cio_d_en_o,
+  output logic cio_dp_o,
+  output logic cio_dp_en_o,
+  output logic cio_dn_o,
+  output logic cio_dn_en_o,
 
-  input        cio_usb_sense_i,
+  // Non-data I/O
+  input logic  cio_sense_i,
+  output logic cio_se0_o,
+  output logic cio_se0_en_o,
+  output logic cio_dp_pullup_o,
+  output logic cio_dp_pullup_en_o,
+  output logic cio_dn_pullup_o,
+  output logic cio_dn_pullup_en_o,
+  output logic cio_suspend_o,
+  output logic cio_suspend_en_o,
+  output logic cio_tx_mode_se_o,
+  output logic cio_tx_mode_se_en_o,
 
-  output logic cio_pullup_o,
-  output logic cio_pullup_en_o,
+  // SOF reference for clock calibration
+  output logic usb_ref_val_o,
+  output logic usb_ref_pulse_o,
 
-  // Interrupts
-  output logic intr_tx_watermark_o ,
-  output logic intr_rx_watermark_o ,
-  output logic intr_tx_overflow_o ,
-  output logic intr_rx_overflow_o ,
-  output logic intr_rx_frame_err_o ,
-  output logic intr_rx_break_err_o ,
-  output logic intr_rx_timeout_o ,
-  output logic intr_rx_parity_err_o
+  // Interrupts -- for testing logic list needs to match udbdev, actual match uart
+  // The two lists are in the order they land in the register bits (bit 0 first)
+  output logic intr_pkt_received_o, // intr_tx_watermark_o
+  output logic intr_pkt_sent_o, // intr_rx_watermark_o
+  output logic intr_disconnected_o, // intr_tx_empty_o
+  output logic intr_host_lost_o, // intr_rx_overflow_o
+  output logic intr_link_reset_o, // intr_rx_frame_err_o
+  output logic intr_link_suspend_o, // intr_rx_break_err_o
+  output logic intr_link_resume_o, // intr_rx_timeout_o
+  output logic intr_av_empty_o, // intr_rx_parity_err_o
+  output logic intr_rx_full_o,
+  output logic intr_av_overflow_o,
+  output logic intr_link_in_err_o,
+  output logic intr_rx_crc_err_o,
+  output logic intr_rx_pid_err_o,
+  output logic intr_rx_bitstuff_err_o,
+  output logic intr_frame_o,
+  output logic intr_connected_o,
+  output logic intr_link_out_err_o
 );
 
   import usbuart_reg_pkg::*;
@@ -45,19 +73,67 @@ module usbuart (
   usbuart_reg2hw_t reg2hw;
   usbuart_hw2reg_t hw2reg;
 
+  // signals between iomux and core
+  logic usb_rx_d, usb_rx_dp, usb_rx_dn, usb_tx_d, usb_tx_se0, usb_tx_oe, usb_pwr_sense;
+  logic usb_pullup_en, usb_link_suspend;
+
   usbuart_reg_top u_reg (
     .clk_i,
     .rst_ni,
-    .tl_i,
-    .tl_o,
+
+    .tl_i (tl_i),
+    .tl_o (tl_o),
+
 
     .reg2hw,
     .hw2reg,
 
-    .devmode_i  (1'b1)
+    .devmode_i (1'b1)
   );
 
-  assign cio_pullup_o = 1'b1;
+
+  usbuart_iomux i_usbuart_iomux (
+    .clk_usb_48mhz_i        (clk_usb_48mhz_i),
+    .rst_usb_48mhz_ni       (rst_usb_48mhz_ni),
+
+    // Register interface
+    .pinflip_i              (reg2hw.usbctrl.pinflip.q),
+    .tx_diff_mode_i         (reg2hw.usbctrl.tx_diff.q),
+
+    // Chip IO
+    .cio_d_i                (cio_d_i),
+    .cio_dp_i               (cio_dp_i),
+    .cio_dn_i               (cio_dn_i),
+    .cio_d_o                (cio_d_o),
+    .cio_d_en_o             (cio_d_en_o),
+    .cio_dp_o               (cio_dp_o),
+    .cio_dp_en_o            (cio_dp_en_o),
+    .cio_dn_o               (cio_dn_o),
+    .cio_dn_en_o            (cio_dn_en_o),
+    .cio_se0_o              (cio_se0_o),
+    .cio_se0_en_o           (cio_se0_en_o),
+    .cio_sense_i            (cio_sense_i),
+    .cio_dp_pullup_o        (cio_dp_pullup_o),
+    .cio_dp_pullup_en_o     (cio_dp_pullup_en_o),
+    .cio_dn_pullup_o        (cio_dn_pullup_o),
+    .cio_dn_pullup_en_o     (cio_dn_pullup_en_o),
+    .cio_suspend_o          (cio_suspend_o),
+    .cio_suspend_en_o       (cio_suspend_en_o),
+    .cio_tx_mode_se_o       (cio_tx_mode_se_o),
+    .cio_tx_mode_se_en_o    (cio_tx_mode_se_en_o),
+
+    // Internal interface
+    .usb_rx_d_o             (usb_rx_d),
+    .usb_rx_dp_o            (usb_rx_dp),
+    .usb_rx_dn_o            (usb_rx_dn),
+    .usb_tx_d_i             (usb_tx_d),
+    .usb_tx_se0_i           (usb_tx_se0),
+    .usb_tx_oe_i            (usb_tx_oe),
+    .usb_pwr_sense_o        (usb_pwr_sense),
+    .usb_pullup_en_i        (usb_pullup_en),
+    .usb_suspend_i          (usb_link_suspend)
+  );
+
 
   usbuart_core usbuart_core (
     .clk_i,
@@ -67,24 +143,39 @@ module usbuart (
     .reg2hw,
     .hw2reg,
 
-    .cio_usb_sense_i     (cio_usb_sense_i),
+    // Internal interface
+    .usb_rx_d_i             (usb_rx_d),
+    .usb_rx_dp_i            (usb_rx_dp),
+    .usb_rx_dn_i            (usb_rx_dn),
+    .usb_tx_d_o             (usb_tx_d),
+    .usb_tx_se0_o           (usb_tx_se0),
+    .usb_tx_oe_o            (usb_tx_oe),
+    .usb_pwr_sense_i        (usb_pwr_sense),
+    .usb_pullup_en_o        (usb_pullup_en),
+    .usb_suspend_o          (usb_link_suspend),
 
-    .cio_usb_dp_i        (cio_usb_dp_i),
-    .cio_usb_dn_i        (cio_usb_dn_i),
-    .cio_usb_dp_o        (cio_usb_dp_o),
-    .cio_usb_dn_o        (cio_usb_dn_o),
-    .cio_usb_dp_en_o     (cio_usb_dp_en_o),
-    .cio_usb_dn_en_o     (cio_usb_dn_en_o),
-    .cio_usb_pullup_en_o (cio_pullup_en_o),
+    // SOF reference for clock calibration
+    .usb_ref_val_o          (usb_ref_val_o),
+    .usb_ref_pulse_o        (usb_ref_pulse_o),
 
-    .intr_tx_watermark_o  (intr_tx_watermark_o ),
-    .intr_rx_watermark_o  (intr_rx_watermark_o ),
-    .intr_tx_overflow_o   (intr_tx_overflow_o  ),
-    .intr_rx_overflow_o   (intr_rx_overflow_o  ),
-    .intr_rx_frame_err_o  (intr_rx_frame_err_o ),
-    .intr_rx_break_err_o  (intr_rx_break_err_o ),
-    .intr_rx_timeout_o    (intr_rx_timeout_o   ),
-    .intr_rx_parity_err_o (intr_rx_parity_err_o)
+    // Interrupts
+    .intr_pkt_received_o    (intr_pkt_received_o),
+    .intr_pkt_sent_o        (intr_pkt_sent_o),
+    .intr_disconnected_o    (intr_disconnected_o),
+    .intr_host_lost_o       (intr_host_lost_o),
+    .intr_link_reset_o      (intr_link_reset_o),
+    .intr_link_suspend_o    (intr_link_suspend_o),
+    .intr_link_resume_o     (intr_link_resume_o),
+    .intr_av_empty_o        (intr_av_empty_o),
+    .intr_rx_full_o         (intr_rx_full_o),
+    .intr_av_overflow_o     (intr_av_overflow_o),
+    .intr_link_in_err_o     (intr_link_in_err_o),
+    .intr_rx_crc_err_o      (intr_rx_crc_err_o),
+    .intr_rx_pid_err_o      (intr_rx_pid_err_o),
+    .intr_rx_bitstuff_err_o (intr_rx_bitstuff_err_o),
+    .intr_frame_o           (intr_frame_o),
+    .intr_connected_o       (intr_connected_o),
+    .intr_link_out_err_o    (intr_link_out_err_o)
   );
 
 endmodule // usbuart

--- a/hw/ip/usbuart/rtl/usbuart_core.sv
+++ b/hw/ip/usbuart/rtl/usbuart_core.sv
@@ -6,48 +6,64 @@
 //
 
 module usbuart_core (
-  input        clk_i,
-  input        rst_ni,
-  input        clk_usb_48mhz_i,
-  input        rst_usb_48mhz_ni,
+  input logic  clk_i,
+  input logic  rst_ni,
+  input logic  clk_usb_48mhz_i,
+  input logic  rst_usb_48mhz_ni,
 
   input        usbuart_reg_pkg::usbuart_reg2hw_t reg2hw,
   output       usbuart_reg_pkg::usbuart_hw2reg_t hw2reg,
 
-  input        cio_usb_dp_i,
-  output logic cio_usb_dp_o,
-  output logic cio_usb_dp_en_o,
+  input logic  usb_rx_d_i,
+  input logic  usb_rx_dp_i,
+  input logic  usb_rx_dn_i,
+  output logic usb_tx_d_o,
+  output logic usb_tx_se0_o,
+  output logic usb_tx_oe_o,
+  input logic  usb_pwr_sense_i,
+  output logic usb_pullup_en_o,
+  output logic usb_suspend_o,
 
-  input        cio_usb_dn_i,
-  output logic cio_usb_dn_o,
-  output logic cio_usb_dn_en_o,
+  // SOF reference for clock calibration
+  output logic usb_ref_val_o,
+  output logic usb_ref_pulse_o,
 
-  input        cio_usb_sense_i,
-
-  output logic cio_usb_pullup_en_o,
-
-  output logic intr_tx_watermark_o,
-  output logic intr_rx_watermark_o,
-  output logic intr_tx_overflow_o,
-  output logic intr_rx_overflow_o,
-  output logic intr_rx_frame_err_o,
-  output logic intr_rx_break_err_o,
-  output logic intr_rx_timeout_o,
-  output logic intr_rx_parity_err_o
+  // Interrupts -- for testing logic list needs to match udbdev, actual match uart
+  // The two lists are in the order they land in the register bits (bit 0 first)
+  output logic intr_pkt_received_o, // intr_tx_watermark_o
+  output logic intr_pkt_sent_o, // intr_rx_watermark_o
+  output logic intr_disconnected_o, // intr_tx_empty_o
+  output logic intr_host_lost_o, // intr_rx_overflow_o
+  output logic intr_link_reset_o, // intr_rx_frame_err_o
+  output logic intr_link_suspend_o, // intr_rx_break_err_o
+  output logic intr_link_resume_o, // intr_rx_timeout_o
+  output logic intr_av_empty_o, // intr_rx_parity_err_o
+  output logic intr_rx_full_o,
+  output logic intr_av_overflow_o,
+  output logic intr_link_in_err_o,
+  output logic intr_rx_crc_err_o,
+  output logic intr_rx_pid_err_o,
+  output logic intr_rx_bitstuff_err_o,
+  output logic intr_frame_o,
+  output logic intr_connected_o,
+  output logic intr_link_out_err_o
 );
 
   import usbuart_reg_pkg::*;
 
-  logic [7:0]    uart_rdata;
-  logic          tx_fifo_rst_n, rx_fifo_rst_n;
+  localparam int       FifoDepth = 32;
+
+  // width of param and signal should match
+  localparam bit [5:0] FifoDepthForRegCompare = 6'(FifoDepth);
   logic [5:0]    tx_fifo_depth, rx_fifo_depth;
   logic [5:0]    rx_fifo_depth_prev;
+
+  logic [7:0]    uart_rdata;
   // rx timeout interrupt
   logic [23:0]   rx_timeout_count, rx_timeout_count_next, uart_rxto_val;
   logic          rx_fifo_depth_changed, uart_rxto_en;
 
   logic          tx_enable, rx_enable;
-  logic          sys_loopback;
   logic          uart_fifo_rxrst, uart_fifo_txrst;
   logic [2:0]    uart_fifo_rxilvl;
   logic [1:0]    uart_fifo_txilvl;
@@ -55,53 +71,31 @@ module usbuart_core (
   logic [7:0]    usb_tx_fifo_rdata;
   logic          usb_tx_rready, usb_if_tx_read, usb_tx_rvalid;
   logic          tx_fifo_wready;
-  logic          lb_data_move;
+  logic          usb_lb_data_move;
   logic [7:0]    usb_rx_fifo_wdata;
   logic [7:0]    usb_if_rx_fifo_wdata;
   logic          usb_rx_wvalid, usb_if_rx_write;
   logic          rx_fifo_rvalid, usb_rx_wready;
-  logic          event_tx_watermark, event_rx_watermark, event_tx_overflow, event_rx_overflow;
-  logic          event_rx_frame_err, event_rx_break_err, event_rx_timeout, event_rx_parity_err;
-  logic          host_lost, host_timeout;
-  logic          usb_pullup_en;
+  logic          usb_host_lost, usb_link_reset;
+  logic          sys_pwr_sense, sys_rx_oflw, sys_host_lost, sys_link_reset, sys_link_suspend;
+  logic [10:0]   usb_frame, sys_frame;
+  logic          event_tx_watermark, event_rx_watermark, event_tx_empty, event_rx_overflow;
+  logic          event_rx_frame_err, event_rx_break_err, event_rx_timeout;
+  logic          event_rx_parity_err;
 
-  assign tx_enable     = reg2hw.ctrl.tx.q;
-  assign rx_enable     = reg2hw.ctrl.rx.q;
-  assign sys_loopback  = reg2hw.ctrl.slpbk.q;
-  assign usb_pullup_en = tx_enable | rx_enable;
+
+  assign tx_enable       = reg2hw.ctrl.tx.q;
+  assign rx_enable       = reg2hw.ctrl.rx.q;
+
+  // Note: this goes to an async pin so ok register is in sys clock domain
+  assign usb_pullup_en_o = tx_enable | rx_enable;
 
   logic [3:0]    unused_ctrl_q;
   assign unused_ctrl_q = {reg2hw.ctrl.nf.q, reg2hw.ctrl.llpbk.q, reg2hw.ctrl.parity_en.q,
                           reg2hw.ctrl.parity_odd.q};
 
-  // 4 cycle reset pulse
-  logic [2:0]    rxres_cnt;
-  logic [2:0]    txres_cnt;
-  logic          uart_start_rxrst, uart_start_txrst;
-
-  assign uart_start_rxrst  = reg2hw.fifo_ctrl.rxrst.q & reg2hw.fifo_ctrl.rxrst.qe;
-  assign uart_start_txrst  = reg2hw.fifo_ctrl.txrst.q & reg2hw.fifo_ctrl.txrst.qe;
-  assign uart_fifo_rxrst  = ~rxres_cnt[2];
-  assign uart_fifo_txrst  = ~txres_cnt[2];
-
-  always_ff @(posedge clk_i or negedge rst_ni)
-      begin
-        if (!rst_ni) begin
-            txres_cnt <= 3'h0;
-            rxres_cnt <= 3'h0;
-        end else begin
-          if (uart_start_txrst) begin
-            txres_cnt <= 3'b0;
-          end else if (uart_fifo_txrst) begin
-            txres_cnt <= txres_cnt + 1;
-          end
-          if (uart_start_rxrst) begin
-            rxres_cnt <= 3'b0;
-          end else if (uart_fifo_rxrst) begin
-            rxres_cnt <= rxres_cnt + 1;
-          end
-        end // else: !if(!rst_ni)
-      end // always_ff @ (posedge clk_i or negedge rst_ni)
+  assign uart_fifo_rxrst  = reg2hw.fifo_ctrl.rxrst.q & reg2hw.fifo_ctrl.rxrst.qe;
+  assign uart_fifo_txrst  = reg2hw.fifo_ctrl.txrst.q & reg2hw.fifo_ctrl.txrst.qe;
 
   assign uart_fifo_rxilvl = reg2hw.fifo_ctrl.rxilvl.q;
   assign uart_fifo_txilvl = reg2hw.fifo_ctrl.txilvl.q;
@@ -121,24 +115,32 @@ module usbuart_core (
   assign unused_rdata_q = reg2hw.rdata.q;
 
   assign hw2reg.status.rxempty.d     = ~rx_fifo_rvalid;
-  assign hw2reg.status.rxidle.d      = ~rx_fifo_rvalid; // TODO
-  assign hw2reg.status.txidle.d      = ~usb_tx_rvalid;  // TODO
-  assign hw2reg.status.txempty.d     = ~usb_tx_rvalid;
-  assign hw2reg.status.rxfull.d      = ~usb_rx_wready;
+  assign hw2reg.status.rxidle.d      = ~rx_fifo_rvalid;        // ignore pkt being received
+  assign hw2reg.status.txidle.d      = (tx_fifo_depth == '0);  // TODO: ignores packet tail
+  assign hw2reg.status.txempty.d     = (tx_fifo_depth == '0);
+  assign hw2reg.status.rxfull.d      = (rx_fifo_depth == FifoDepthForRegCompare);
   assign hw2reg.status.txfull.d      = ~tx_fifo_wready;
 
   assign hw2reg.fifo_status.txlvl.d  = tx_fifo_depth;
   assign hw2reg.fifo_status.rxlvl.d  = rx_fifo_depth;
 
-  // resets are self-clearing, so need to update FIFO_CTRL
-  assign hw2reg.fifo_ctrl.rxrst.de = reg2hw.fifo_ctrl.rxrst.q;
-  assign hw2reg.fifo_ctrl.rxrst.d  = 1'b0;
-  assign hw2reg.fifo_ctrl.txrst.de = reg2hw.fifo_ctrl.txrst.q;
-  assign hw2reg.fifo_ctrl.txrst.d  = 1'b0;
+  // TODO: not sure why these are hrw rather than hro but that is what uart does
   assign hw2reg.fifo_ctrl.rxilvl.de = 1'b0;
   assign hw2reg.fifo_ctrl.rxilvl.d  = 3'h0;
   assign hw2reg.fifo_ctrl.txilvl.de = 1'b0;
   assign hw2reg.fifo_ctrl.txilvl.d  = 2'h0;
+
+
+  // sys clk -> USB clk (arguably these are set once at init so don't need sync)
+  logic usb_ref_disable, usb_rx_diff, usb_slpbk;
+  prim_flop_2sync #(
+    .Width      (3)
+  ) cdc_sys_to_usb_ctrl (
+    .clk_i  (clk_usb_48mhz_i),
+    .rst_ni (rst_usb_48mhz_ni),
+    .d_i    ({reg2hw.usbctrl.ref_disable.q, reg2hw.usbctrl.rx_diff.q, reg2hw.ctrl.slpbk.q}),
+    .q_o    ({usb_ref_disable,              usb_rx_diff,              usb_slpbk})
+  );
 
 
   //              NCO 16x Baud Generator
@@ -161,127 +163,179 @@ module usbuart_core (
   // TX Logic //
   //////////////
 
-  // TODO: This is not a safe way to create a reset signal
-  assign tx_fifo_rst_n = rst_usb_48mhz_ni & ~uart_fifo_txrst;
+  // Don't really reset the fifo when the register bit is set, fake by draining (in usb domain)
+  logic usb_fifo_txrst, usb_tx_rvalid_raw;
+  logic usb_tx_rst_pop_d, usb_tx_rst_pop_q;
+  prim_pulse_sync sync_txrst (
+    .clk_src_i   (clk_i),
+    .clk_dst_i   (clk_usb_48mhz_i),
+    .rst_src_ni  (rst_ni),
+    .rst_dst_ni  (rst_usb_48mhz_ni),
+    .src_pulse_i (uart_fifo_txrst),
+    .dst_pulse_o (usb_fifo_txrst)
+  );
+
+  // if there is anything valid then pop each clock cycle
+  assign usb_tx_rst_pop_d = (usb_tx_rst_pop_q | usb_fifo_txrst) & usb_tx_rvalid_raw;
+  always_ff @(posedge clk_usb_48mhz_i or negedge rst_usb_48mhz_ni) begin
+    if (!rst_usb_48mhz_ni) begin
+      usb_tx_rst_pop_q <= 1'b0;
+    end else begin
+      usb_tx_rst_pop_q <= usb_tx_rst_pop_d;
+    end
+  end
 
   // Character fifo also crosses to USB clock domain
   //`$dfifo_uart_tx->mname()`
   prim_fifo_async #(
     .Width(8),
-    .Depth(32)
+    .Depth(FifoDepth)
   ) usbuart_txfifo (
     .clk_wr_i  (clk_i),
-    .rst_wr_ni (tx_fifo_rst_n),
-    .wvalid_i  (reg2hw.wdata.qe),
+    .rst_wr_ni (rst_ni),
+    .wvalid_i  (reg2hw.wdata.qe), // need to block if resetting is active
     .wready_o  (tx_fifo_wready),
     .wdata_i   (reg2hw.wdata.q),
     .wdepth_o  (tx_fifo_depth),
 
     .clk_rd_i  (clk_usb_48mhz_i),
-    .rst_rd_ni (tx_fifo_rst_n), // CDC: rely on it being there a long time
-    .rvalid_o  (usb_tx_rvalid),
-    .rready_i  (usb_tx_rready),
+    .rst_rd_ni (rst_usb_48mhz_ni),
+    .rvalid_o  (usb_tx_rvalid_raw),
+    .rready_i  (usb_tx_rready | usb_tx_rst_pop_d),
     .rdata_o   (usb_tx_fifo_rdata),
     .rdepth_o  () // only using empty
   );
 
+  // never show valid if the fifo is being reset
+  assign usb_tx_rvalid = usb_tx_rvalid_raw & ~usb_tx_rst_pop_d;
+
   //////////////
   // RX Logic //
   //////////////
-  logic usb_rx_oflw;
+  logic usb_rx_oflw, rx_fifo_rvalid_raw;
 
-  // TODO: This is not a safe way to create a reset signal
-  assign rx_fifo_rst_n = rst_usb_48mhz_ni & ~uart_fifo_rxrst;
+  // Don't really reset the fifo when the register bit is set, fake by draining it
+  // if there is anything valid then pop each clock cycle
+  logic rx_rst_pop_d, rx_rst_pop_q;
+
+  assign rx_rst_pop_d = (rx_rst_pop_q | uart_fifo_rxrst) & rx_fifo_rvalid_raw;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rx_rst_pop_q <= 1'b0;
+    end else begin
+      rx_rst_pop_q <= rx_rst_pop_d;
+    end
+  end
 
   //`$dfifo_uart_rx->mname()`
   prim_fifo_async #(
     .Width(8),
-    .Depth(32)
+    .Depth(FifoDepth)
   ) usbuart_rxfifo (
     .clk_wr_i  (clk_usb_48mhz_i),
-    .rst_wr_ni (rx_fifo_rst_n),  // CDC: rely on it being there a long time
+    .rst_wr_ni (rst_usb_48mhz_ni),
     .wvalid_i  (usb_rx_wvalid),
     .wready_o  (usb_rx_wready),
     .wdata_i   (usb_rx_fifo_wdata),
     .wdepth_o  (), // only using full
 
     .clk_rd_i  (clk_i),
-    .rst_rd_ni (rx_fifo_rst_n),
-    .rvalid_o  (rx_fifo_rvalid),
-    .rready_i  (reg2hw.rdata.re),
+    .rst_rd_ni (rst_ni),
+    .rvalid_o  (rx_fifo_rvalid_raw),
+    .rready_i  (reg2hw.rdata.re | rx_rst_pop_d),
     .rdata_o   (uart_rdata),
     .rdepth_o  (rx_fifo_depth)
   );
 
+  // never show valid if the fifo is being reset
+  assign rx_fifo_rvalid = rx_fifo_rvalid_raw & ~rx_rst_pop_d;
 
   // Sys loopback is done at the bottom of the fifos
   // TODO could do line loopback in a similar way at top of fifos?
   always_ff @(posedge clk_usb_48mhz_i) begin
-    lb_data_move <= sys_loopback & usb_tx_rvalid & usb_rx_wready & ~lb_data_move;
+    usb_lb_data_move <= usb_slpbk & usb_tx_rvalid & usb_rx_wready & ~usb_lb_data_move;
   end
-  assign usb_tx_rready     = sys_loopback ? lb_data_move      : usb_if_tx_read;
-  assign usb_rx_wvalid     = sys_loopback ? lb_data_move      : usb_if_rx_write;
-  assign usb_rx_fifo_wdata = sys_loopback ? usb_tx_fifo_rdata : usb_if_rx_fifo_wdata;
-
-  logic usb_rx_d;
-  logic usb_rx_se0;
-  logic usb_tx_d;
-  logic usb_tx_se0;
-  logic usb_tx_oe;
+  assign usb_tx_rready     = usb_slpbk ? usb_lb_data_move  : usb_if_tx_read;
+  assign usb_rx_wvalid     = usb_slpbk ? usb_lb_data_move  : usb_if_rx_write;
+  assign usb_rx_fifo_wdata = usb_slpbk ? usb_tx_fifo_rdata : usb_if_rx_fifo_wdata;
 
   usbuart_usbif usbuart_usbif (
-    .clk_48mhz_i (clk_usb_48mhz_i),
-    .rst_ni      (rst_usb_48mhz_ni & cio_usb_sense_i), // TODO: This is not a safe way to create a
-                                                       // reset signal
+    .clk_48mhz_i       (clk_usb_48mhz_i),
+    .rst_ni            (rst_usb_48mhz_ni),
 
-    .usb_d_i                (usb_rx_d),
-    .usb_se0_i              (usb_rx_se0),
-    .usb_d_o                (usb_tx_d),
-    .usb_se0_o              (usb_tx_se0),
-    .usb_oe_o               (usb_tx_oe),
+    .usb_d_i           (usb_rx_d_i),
+    .usb_dp_i          (usb_rx_dp_i),
+    .usb_dn_i          (usb_rx_dn_i),
+    .usb_d_o           (usb_tx_d_o),
+    .usb_se0_o         (usb_tx_se0_o),
+    .usb_oe_o          (usb_tx_oe_o),
+    .rx_diff_mode_i    (usb_rx_diff),
+    // SOF reference for clock calibration
+    .usb_ref_disable_i (usb_ref_disable),
+    .usb_ref_val_o     (usb_ref_val_o),
+    .usb_ref_pulse_o   (usb_ref_pulse_o),
 
     // Fifo used to communicate with system
     // fake tx always empty and rx never full when in internal loopback
-    .tx_empty       (~usb_tx_rvalid & ~sys_loopback),
-    .rx_full        (~usb_rx_wready & ~sys_loopback),
-    .tx_read        (usb_if_tx_read),
-    .rx_write       (usb_if_rx_write),
-    .rx_err         (usb_rx_oflw), // RX overflow
-    .rx_fifo_wdata  (usb_if_rx_fifo_wdata),
-    .tx_fifo_rdata  (usb_tx_fifo_rdata),
-    .status_frame_o (hw2reg.usbstat.frame.d),
-    .status_host_lost_o (host_lost),
-    .status_host_timeout_o (host_timeout),
-    .status_device_address_o (hw2reg.usbstat.device_address.d),
-    .parity_o       (hw2reg.usbparam.parity_req.d),
-    .baud_o         (hw2reg.usbparam.baud_req.d)
+    .tx_empty          (~usb_tx_rvalid & ~usb_slpbk),
+    .rx_full           (~usb_rx_wready & ~usb_slpbk),
+    .tx_read           (usb_if_tx_read),
+    .rx_write          (usb_if_rx_write),
+    .rx_err            (usb_rx_oflw), // RX overflow
+    .rx_fifo_wdata     (usb_if_rx_fifo_wdata),
+    .tx_fifo_rdata     (usb_tx_fifo_rdata),
+    .frame_o           (usb_frame),
+    .host_lost_o       (usb_host_lost),
+    .link_reset_o      (usb_link_reset),
+    .link_suspend_o    (usb_suspend_o),
+    .device_address_o  (hw2reg.usbstat.device_address.d),  // CDC: these are static after init
+    .parity_o          (hw2reg.usbparam.parity_req.d),  // CDC: these are static after init
+    .baud_o            (hw2reg.usbparam.baud_req.d)  // CDC: these are static after init
     );
-  assign hw2reg.usbstat.host_lost.d = host_lost;
-  assign hw2reg.usbstat.host_timeout.d = host_timeout;
 
   ////////////////////////
   // Interrupt & Status //
   ////////////////////////
+  logic           tx_watermark_d, tx_watermark_prev_q;
+  logic           rx_watermark_d, rx_watermark_prev_q;
 
-  always_comb
+  // Because the USB will poll at discrete intervals will not have the same
+  // issue with empty as in the UART case, the first write of a burst will sit in the
+  // fifo until the next polling interval.
+  assign event_tx_empty  = (tx_fifo_depth == 0);
+
+  always_comb begin
     unique case(uart_fifo_txilvl)
-      2'h0:       event_tx_watermark = (tx_fifo_depth >= 6'd1);
-      2'h1:       event_tx_watermark = (tx_fifo_depth >= 6'd4);
-      2'h2:       event_tx_watermark = (tx_fifo_depth >= 6'd8);
-      default:    event_tx_watermark = (tx_fifo_depth >= 6'd16);
-      endcase
+      2'h0:       tx_watermark_d = (tx_fifo_depth < 6'd2);
+      2'h1:       tx_watermark_d = (tx_fifo_depth < 6'd4);
+      2'h2:       tx_watermark_d = (tx_fifo_depth < 6'd8);
+      default:    tx_watermark_d = (tx_fifo_depth < 6'd16);
+    endcase
+  end
+  assign event_tx_watermark = tx_watermark_d & ~tx_watermark_prev_q;
 
-
-  always_comb
+  always_comb begin
     unique case(uart_fifo_rxilvl)
-      3'h0:       event_rx_watermark = (rx_fifo_depth >= 6'd1);
-      3'h1:       event_rx_watermark = (rx_fifo_depth >= 6'd4);
-      3'h2:       event_rx_watermark = (rx_fifo_depth >= 6'd8);
-      3'h3:       event_rx_watermark = (rx_fifo_depth >= 6'd16);
-      3'h4:       event_rx_watermark = (rx_fifo_depth >= 6'd30);
-      default:    event_rx_watermark = 1'b0;
-      endcase
+      3'h0:       rx_watermark_d = (rx_fifo_depth >= 6'd1);
+      3'h1:       rx_watermark_d = (rx_fifo_depth >= 6'd4);
+      3'h2:       rx_watermark_d = (rx_fifo_depth >= 6'd8);
+      3'h3:       rx_watermark_d = (rx_fifo_depth >= 6'd16);
+      3'h4:       rx_watermark_d = (rx_fifo_depth >= 6'd30);
+      default:    rx_watermark_d = 1'b0;
+    endcase
+  end
 
+  assign event_rx_watermark = rx_watermark_d & ~rx_watermark_prev_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      tx_watermark_prev_q  <= 1'b1; // by default watermark condition is true
+      rx_watermark_prev_q  <= 1'b0; // by default watermark condition is false
+    end else begin
+      tx_watermark_prev_q  <= tx_watermark_d;
+      rx_watermark_prev_q  <= rx_watermark_d;
+    end
+  end
 
   // rx timeout interrupt
   assign uart_rxto_en  = reg2hw.timeout_ctrl.en.q;
@@ -316,174 +370,259 @@ module usbuart_core (
       rx_fifo_depth_prev  <= rx_fifo_depth;
     end
 
-  logic sys_usb_sense; // USB sense synced to clk_i
+  // synced to clk_i
 
-  assign event_rx_overflow  = usb_rx_oflw; // TODO CDC
-  assign event_tx_overflow  = reg2hw.wdata.qe & (~tx_fifo_wready);
-  assign event_rx_break_err = ~sys_usb_sense |
-                              (reg2hw.ctrl.rxblvl.q == 0) ? host_lost : host_timeout;
+  prim_pulse_sync sync_rx_oflw (
+    .clk_src_i   (clk_usb_48mhz_i),
+    .clk_dst_i   (clk_i),
+    .rst_src_ni  (rst_usb_48mhz_ni),
+    .rst_dst_ni  (rst_ni),
+    .src_pulse_i (usb_rx_oflw),
+    .dst_pulse_o (sys_rx_oflw)
+  );
+
+  prim_flop_2sync #(
+    .Width (15) // frame is 11 bits
+  ) cdc_usb_to_sys (
+    .clk_i  (clk_i),
+    .rst_ni (rst_ni),
+    .d_i    ({usb_pwr_sense_i, usb_host_lost, usb_link_reset, usb_suspend_o,    usb_frame}),
+    .q_o    ({sys_pwr_sense,   sys_host_lost, sys_link_reset, sys_link_suspend, sys_frame})
+  );
+
+  assign hw2reg.usbstat.host_lost.d = sys_host_lost;
+  assign hw2reg.usbstat.link_reset.d = sys_link_reset;
+  assign hw2reg.usbstat.link_suspend.d = sys_link_suspend;
+  assign hw2reg.usbstat.pwr_sense.d = sys_pwr_sense;
+  assign hw2reg.usbstat.frame.d = sys_frame;
+
+  assign event_rx_overflow  = sys_rx_oflw;
+  assign event_rx_break_err = sys_host_lost;
   assign event_rx_frame_err = 0; // TODO is there a related USB error?
   assign event_rx_parity_err = 0; // TODO is there a related USB error?
 
-  // instantiate interrupt hardware primitives
+  // Interrupt regiser bolierplate below this point
+  // Note: event uses UART terminology but interrupt matches USBDEV
 
-  prim_intr_hw #(.Width(1)) intr_hw_tx_watermark (
+  prim_intr_hw #(.Width(1)) intr_hw_pkt_received (
     .clk_i,
     .rst_ni,
     .event_intr_i           (event_tx_watermark),
-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.tx_watermark.q),
-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.tx_watermark.q),
-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.tx_watermark.qe),
-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.tx_watermark.q),
-    .hw2reg_intr_state_de_o (hw2reg.intr_state.tx_watermark.de),
-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.tx_watermark.d),
-    .intr_o                 (intr_tx_watermark_o)
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.pkt_received.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.pkt_received.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.pkt_received.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.pkt_received.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.pkt_received.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.pkt_received.d),
+    .intr_o                 (intr_pkt_received_o)
   );
 
-  prim_intr_hw #(.Width(1)) intr_hw_rx_watermark (
+  prim_intr_hw #(.Width(1)) intr_hw_pkt_sent (
     .clk_i,
     .rst_ni,
     .event_intr_i           (event_rx_watermark),
-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.rx_watermark.q),
-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.rx_watermark.q),
-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.rx_watermark.qe),
-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.rx_watermark.q),
-    .hw2reg_intr_state_de_o (hw2reg.intr_state.rx_watermark.de),
-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.rx_watermark.d),
-    .intr_o                 (intr_rx_watermark_o)
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.pkt_sent.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.pkt_sent.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.pkt_sent.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.pkt_sent.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.pkt_sent.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.pkt_sent.d),
+    .intr_o                 (intr_pkt_sent_o)
   );
 
-  prim_intr_hw #(.Width(1)) intr_hw_tx_overflow (
+  prim_intr_hw #(.Width(1)) intr_disconnected (
     .clk_i,
     .rst_ni,
-    .event_intr_i           (event_tx_overflow),
-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.tx_overflow.q),
-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.tx_overflow.q),
-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.tx_overflow.qe),
-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.tx_overflow.q),
-    .hw2reg_intr_state_de_o (hw2reg.intr_state.tx_overflow.de),
-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.tx_overflow.d),
-    .intr_o                 (intr_tx_overflow_o)
+    .event_intr_i           (event_tx_empty),
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.disconnected.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.disconnected.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.disconnected.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.disconnected.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.disconnected.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.disconnected.d),
+    .intr_o                 (intr_disconnected_o)
   );
 
-  prim_intr_hw #(.Width(1)) intr_hw_rx_overflow (
+  prim_intr_hw #(.Width(1)) intr_connected (
+    .clk_i,
+    .rst_ni,
+    .event_intr_i           (1'b0),
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.connected.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.connected.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.connected.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.connected.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.connected.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.connected.d),
+    .intr_o                 (intr_connected_o)
+  );
+
+  prim_intr_hw #(.Width(1)) intr_host_lost (
     .clk_i,
     .rst_ni,
     .event_intr_i           (event_rx_overflow),
-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.rx_overflow.q),
-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.rx_overflow.q),
-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.rx_overflow.qe),
-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.rx_overflow.q),
-    .hw2reg_intr_state_de_o (hw2reg.intr_state.rx_overflow.de),
-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.rx_overflow.d),
-    .intr_o                 (intr_rx_overflow_o)
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.host_lost.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.host_lost.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.host_lost.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.host_lost.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.host_lost.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.host_lost.d),
+    .intr_o                 (intr_host_lost_o)
   );
 
-  prim_intr_hw #(.Width(1)) intr_hw_rx_frame_err (
+  prim_intr_hw #(.Width(1)) intr_link_reset (
     .clk_i,
     .rst_ni,
     .event_intr_i           (event_rx_frame_err),
-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.rx_frame_err.q),
-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.rx_frame_err.q),
-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.rx_frame_err.qe),
-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.rx_frame_err.q),
-    .hw2reg_intr_state_de_o (hw2reg.intr_state.rx_frame_err.de),
-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.rx_frame_err.d),
-    .intr_o                 (intr_rx_frame_err_o)
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.link_reset.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.link_reset.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.link_reset.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.link_reset.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.link_reset.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.link_reset.d),
+    .intr_o                 (intr_link_reset_o)
   );
 
-  prim_intr_hw #(.Width(1)) intr_hw_rx_break_err (
+  prim_intr_hw #(.Width(1)) intr_link_suspend (
     .clk_i,
     .rst_ni,
     .event_intr_i           (event_rx_break_err),
-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.rx_break_err.q),
-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.rx_break_err.q),
-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.rx_break_err.qe),
-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.rx_break_err.q),
-    .hw2reg_intr_state_de_o (hw2reg.intr_state.rx_break_err.de),
-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.rx_break_err.d),
-    .intr_o                 (intr_rx_break_err_o)
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.link_suspend.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.link_suspend.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.link_suspend.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.link_suspend.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.link_suspend.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.link_suspend.d),
+    .intr_o                 (intr_link_suspend_o)
   );
 
-  prim_intr_hw #(.Width(1)) intr_hw_rx_timeout (
+  prim_intr_hw #(.Width(1)) intr_link_resume (
     .clk_i,
     .rst_ni,
     .event_intr_i           (event_rx_timeout),
-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.rx_timeout.q),
-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.rx_timeout.q),
-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.rx_timeout.qe),
-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.rx_timeout.q),
-    .hw2reg_intr_state_de_o (hw2reg.intr_state.rx_timeout.de),
-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.rx_timeout.d),
-    .intr_o                 (intr_rx_timeout_o)
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.link_resume.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.link_resume.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.link_resume.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.link_resume.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.link_resume.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.link_resume.d),
+    .intr_o                 (intr_link_resume_o)
   );
 
-  prim_intr_hw #(.Width(1)) intr_hw_rx_parity_err (
+  prim_intr_hw #(.Width(1)) intr_av_empty (
     .clk_i,
     .rst_ni,
     .event_intr_i           (event_rx_parity_err),
-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.rx_parity_err.q),
-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.rx_parity_err.q),
-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.rx_parity_err.qe),
-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.rx_parity_err.q),
-    .hw2reg_intr_state_de_o (hw2reg.intr_state.rx_parity_err.de),
-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.rx_parity_err.d),
-    .intr_o                 (intr_rx_parity_err_o)
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.av_empty.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.av_empty.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.av_empty.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.av_empty.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.av_empty.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.av_empty.d),
+    .intr_o                 (intr_av_empty_o)
   );
 
-  /////////////////////////////////
-  // USB IO Muxing               //
-  /////////////////////////////////
-  logic cio_oe;
-
-  // Static configuration
-  usbdev_reg_pkg::usbdev_reg2hw_phy_config_reg_t usb_phy_config;
-  assign usb_phy_config.rx_differential_mode.q   = 1'b0;
-  assign usb_phy_config.tx_differential_mode.q   = 1'b0;
-  assign usb_phy_config.pinflip.q                = 1'b0;
-  assign usb_phy_config.eop_single_bit.q         = 1'b1;
-  assign usb_phy_config.override_pwr_sense_en.q  = 1'b0;
-  assign usb_phy_config.override_pwr_sense_val.q = 1'b0;
-  assign usb_phy_config.usb_ref_disable.q        = 1'b0;
-  assign usb_phy_config.tx_osc_test_mode.q       = 1'b0;
-
-  usbdev_iomux i_usbdev_iomux (
-    .clk_i                  ( clk_i                  ),
-    .rst_ni                 ( rst_ni                 ),
-    .clk_usb_48mhz_i        ( clk_usb_48mhz_i        ),
-    .rst_usb_48mhz_ni       ( rst_usb_48mhz_ni       ),
-
-    // Register interface
-    .sys_reg2hw_config_i    ( usb_phy_config         ),
-    .sys_usb_sense_o        ( sys_usb_sense          ),
-
-    // Chip IO
-    .cio_usb_d_i            ( 1'b0                   ),
-    .cio_usb_dp_i           ( cio_usb_dp_i           ),
-    .cio_usb_dn_i           ( cio_usb_dn_i           ),
-    .cio_usb_d_o            (                        ),
-    .cio_usb_se0_o          (                        ),
-    .cio_usb_dp_o           ( cio_usb_dp_o           ),
-    .cio_usb_dn_o           ( cio_usb_dn_o           ),
-    .cio_usb_oe_o           ( cio_oe                 ),
-    .cio_usb_tx_mode_se_o   (                        ),
-    .cio_usb_sense_i        ( cio_usb_sense_i        ),
-    .cio_usb_dp_pullup_en_o ( cio_usb_pullup_en_o    ),
-    .cio_usb_dn_pullup_en_o (                        ),
-    .cio_usb_suspend_o      (                        ),
-
-    // Internal interface
-    .usb_rx_d_o             ( usb_rx_d               ),
-    .usb_rx_se0_o           ( usb_rx_se0             ),
-    .usb_tx_d_i             ( usb_tx_d               ),
-    .usb_tx_se0_i           ( usb_tx_se0             ),
-    .usb_tx_oe_i            ( usb_tx_oe              ),
-    .usb_pwr_sense_o        (                        ),
-    .usb_pullup_en_i        ( usb_pullup_en          ),
-    .usb_suspend_i          ( 1'b0                   )  // not used
+  prim_intr_hw #(.Width(1)) intr_rx_full (
+    .clk_i,
+    .rst_ni,
+    .event_intr_i           (1'b0),
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.rx_full.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.rx_full.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.rx_full.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.rx_full.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.rx_full.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.rx_full.d),
+    .intr_o                 (intr_rx_full_o)
   );
 
-  assign cio_usb_dp_en_o = cio_oe;
-  assign cio_usb_dn_en_o = cio_oe;
+  prim_intr_hw #(.Width(1)) intr_av_overflow (
+    .clk_i,
+    .rst_ni,
+    .event_intr_i           (1'b0),
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.av_overflow.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.av_overflow.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.av_overflow.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.av_overflow.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.av_overflow.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.av_overflow.d),
+    .intr_o                 (intr_av_overflow_o)
+  );
+
+  prim_intr_hw #(.Width(1)) intr_link_in_err (
+    .clk_i,
+    .rst_ni,
+    .event_intr_i           (1'b0),
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.link_in_err.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.link_in_err.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.link_in_err.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.link_in_err.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.link_in_err.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.link_in_err.d),
+    .intr_o                 (intr_link_in_err_o)
+  );
+
+  prim_intr_hw #(.Width(1)) intr_link_out_err (
+    .clk_i,
+    .rst_ni,
+    .event_intr_i           (1'b0),
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.link_out_err.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.link_out_err.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.link_out_err.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.link_out_err.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.link_out_err.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.link_out_err.d),
+    .intr_o                 (intr_link_out_err_o)
+  );
+
+  prim_intr_hw #(.Width(1)) intr_rx_crc_err (
+    .clk_i,
+    .rst_ni,
+    .event_intr_i           (1'b0),
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.rx_crc_err.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.rx_crc_err.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.rx_crc_err.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.rx_crc_err.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.rx_crc_err.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.rx_crc_err.d),
+    .intr_o                 (intr_rx_crc_err_o)
+  );
+
+  prim_intr_hw #(.Width(1)) intr_rx_pid_err (
+    .clk_i,
+    .rst_ni,
+    .event_intr_i           (1'b0),
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.rx_pid_err.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.rx_pid_err.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.rx_pid_err.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.rx_pid_err.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.rx_pid_err.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.rx_pid_err.d),
+    .intr_o                 (intr_rx_pid_err_o)
+  );
+
+  prim_intr_hw #(.Width(1)) intr_rx_bitstuff_err (
+    .clk_i,
+    .rst_ni,
+    .event_intr_i           (1'b0),
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.rx_bitstuff_err.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.rx_bitstuff_err.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.rx_bitstuff_err.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.rx_bitstuff_err.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.rx_bitstuff_err.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.rx_bitstuff_err.d),
+    .intr_o                 (intr_rx_bitstuff_err_o)
+  );
+
+  prim_intr_hw #(.Width(1)) intr_frame (
+    .clk_i,
+    .rst_ni,
+    .event_intr_i           (1'b0),
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.frame.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.frame.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.frame.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.frame.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.frame.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.frame.d),
+    .intr_o                 (intr_frame_o)
+  );
 
 endmodule

--- a/hw/ip/usbuart/rtl/usbuart_iomux.sv
+++ b/hw/ip/usbuart/rtl/usbuart_iomux.sv
@@ -1,0 +1,153 @@
+// Copyright lowRISC contributors.
+// Copyright ETH Zurich.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// USB IO Mux
+//
+// Muxes the USB IO signals from register access, differential signaling, single-ended signaling
+// and swaps D+/D- if configured. The incomming signals are also muxed and synchronized to the
+// corresponding clock domain.
+
+module usbuart_iomux
+(
+  input logic  clk_usb_48mhz_i, // use usb_ prefix for signals in this clk
+  input logic  rst_usb_48mhz_ni,
+
+  // Register interface (system clk)
+  input logic  pinflip_i,
+  input logic  tx_diff_mode_i,
+
+  // External USB Interface(s) (async)
+  // Data outputs
+  input logic  cio_d_i,
+  input logic  cio_dp_i,
+  input logic  cio_dn_i,
+  output logic cio_d_o,
+  output logic cio_d_en_o,
+  output logic cio_dp_o,
+  output logic cio_dp_en_o,
+  output logic cio_dn_o,
+  output logic cio_dn_en_o,
+  output logic cio_se0_o,
+  output logic cio_se0_en_o,
+
+  // Non-data I/O
+  input logic  cio_sense_i,
+  output logic cio_dp_pullup_o,
+  output logic cio_dp_pullup_en_o,
+  output logic cio_dn_pullup_o,
+  output logic cio_dn_pullup_en_o,
+  output logic cio_suspend_o,
+  output logic cio_suspend_en_o,
+  output logic cio_tx_mode_se_o,
+  output logic cio_tx_mode_se_en_o,
+
+
+  // Internal USB Interface (usb clk)
+  output logic usb_rx_d_o,
+  output logic usb_rx_dp_o,
+  output logic usb_rx_dn_o,
+  input logic  usb_tx_d_i,
+  input logic  usb_tx_se0_i,
+  input logic  usb_tx_oe_i,
+  output logic usb_pwr_sense_o,
+  input logic  usb_pullup_en_i,
+  input logic  usb_suspend_i
+);
+
+  logic cio_usb_d_flipped;
+  logic cio_usb_dp, cio_usb_dn, cio_usb_d;
+  logic usb_pinflip, usb_tx_diff_mode;
+
+  //////////
+  // CDCs //
+  //////////
+
+
+  // USB input pins (to usbclk)
+  prim_flop_2sync #(
+    .Width (4)
+  ) cdc_io_to_usb (
+    .clk_i  (clk_usb_48mhz_i),
+    .rst_ni (rst_usb_48mhz_ni),
+    .d_i    ({cio_dp_i,
+              cio_dn_i,
+              cio_d_i,
+              cio_sense_i}),
+    .q_o    ({cio_usb_dp,
+              cio_usb_dn,
+              cio_usb_d,
+              usb_pwr_sense_o})
+  );
+
+  // These are config bits so basically static. Could prob get away without CDC
+  prim_flop_2sync #(
+    .Width (2)
+  ) cdc_sys_to_usb (
+    .clk_i  (clk_usb_48mhz_i),
+    .rst_ni (rst_usb_48mhz_ni),
+    .d_i    ({pinflip_i,
+              tx_diff_mode_i}),
+    .q_o    ({usb_pinflip,
+              usb_tx_diff_mode})
+  );
+
+  ////////////////////////
+  // USB output pin mux //
+  ////////////////////////
+
+
+  // D+/D- can be swapped based on a config register.
+  // The data just gets inverted, the pullup gets moved to dn if pinflip is set
+  assign cio_usb_d_flipped = usb_tx_d_i ^ usb_pinflip;
+  assign cio_dp_pullup_en_o = usb_pullup_en_i & ~usb_pinflip;
+  assign cio_dn_pullup_en_o = usb_pullup_en_i &  usb_pinflip;
+
+  assign cio_tx_mode_se_o = ~usb_tx_diff_mode;
+
+  // simplified version for usbuart -- always generate dp, dn rather than park at 0
+  // will work with single ended only phy or diffferential only PHY
+  // only case where register needs setting is for PHY that switches based on cio_usb_tx_mdoe_se
+  // (this is basically an and gate...)
+  always_comb begin : proc_drive_out
+    if (usb_tx_se0_i) begin
+      cio_dp_o = 1'b0;
+      cio_dn_o = 1'b0;
+    end else begin
+      cio_dp_o = cio_usb_d_flipped;
+      cio_dn_o = ~cio_usb_d_flipped;
+    end
+  end
+  assign cio_d_o = cio_usb_d_flipped;
+  assign cio_se0_o = usb_tx_se0_i;
+  assign cio_suspend_o = usb_suspend_i;
+
+  ///////////////////////
+  // USB input pin mux //
+  ///////////////////////
+
+  // D+/D- can be swapped based on a config register.
+  assign usb_rx_dp_o = usb_pinflip ?  cio_usb_dn : cio_usb_dp;
+  assign usb_rx_dn_o = usb_pinflip ?  cio_usb_dp : cio_usb_dn;
+  assign usb_rx_d_o  = usb_pinflip ? ~cio_usb_d  : cio_usb_d;
+
+  ////////////////////////
+  // USB Output Enables //
+  ////////////////////////
+
+  // Data outputs
+  assign cio_d_en_o  = usb_tx_oe_i;
+  assign cio_dp_en_o = usb_tx_oe_i;
+  assign cio_dn_en_o = usb_tx_oe_i;
+
+  // Non-data outputs - always enabled.
+  assign cio_se0_en_o        = 1'b1;
+  assign cio_suspend_en_o    = 1'b1;
+  assign cio_tx_mode_se_en_o = 1'b1;
+
+  // Pullup, data always set
+  assign cio_dp_pullup_o     = 1'b1;
+  assign cio_dn_pullup_o     = 1'b1;
+
+endmodule

--- a/hw/ip/usbuart/rtl/usbuart_reg_pkg.sv
+++ b/hw/ip/usbuart/rtl/usbuart_reg_pkg.sv
@@ -6,96 +6,189 @@
 
 package usbuart_reg_pkg;
 
+  // Param list
+  parameter int NEndpoints = 12;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////
   typedef struct packed {
     struct packed {
       logic        q;
-    } tx_watermark;
+    } pkt_received;
     struct packed {
       logic        q;
-    } rx_watermark;
+    } pkt_sent;
     struct packed {
       logic        q;
-    } tx_overflow;
+    } disconnected;
     struct packed {
       logic        q;
-    } rx_overflow;
+    } host_lost;
     struct packed {
       logic        q;
-    } rx_frame_err;
+    } link_reset;
     struct packed {
       logic        q;
-    } rx_break_err;
+    } link_suspend;
     struct packed {
       logic        q;
-    } rx_timeout;
+    } link_resume;
     struct packed {
       logic        q;
-    } rx_parity_err;
+    } av_empty;
+    struct packed {
+      logic        q;
+    } rx_full;
+    struct packed {
+      logic        q;
+    } av_overflow;
+    struct packed {
+      logic        q;
+    } link_in_err;
+    struct packed {
+      logic        q;
+    } rx_crc_err;
+    struct packed {
+      logic        q;
+    } rx_pid_err;
+    struct packed {
+      logic        q;
+    } rx_bitstuff_err;
+    struct packed {
+      logic        q;
+    } frame;
+    struct packed {
+      logic        q;
+    } connected;
+    struct packed {
+      logic        q;
+    } link_out_err;
   } usbuart_reg2hw_intr_state_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
-    } tx_watermark;
+    } pkt_received;
     struct packed {
       logic        q;
-    } rx_watermark;
+    } pkt_sent;
     struct packed {
       logic        q;
-    } tx_overflow;
+    } disconnected;
     struct packed {
       logic        q;
-    } rx_overflow;
+    } host_lost;
     struct packed {
       logic        q;
-    } rx_frame_err;
+    } link_reset;
     struct packed {
       logic        q;
-    } rx_break_err;
+    } link_suspend;
     struct packed {
       logic        q;
-    } rx_timeout;
+    } link_resume;
     struct packed {
       logic        q;
-    } rx_parity_err;
+    } av_empty;
+    struct packed {
+      logic        q;
+    } rx_full;
+    struct packed {
+      logic        q;
+    } av_overflow;
+    struct packed {
+      logic        q;
+    } link_in_err;
+    struct packed {
+      logic        q;
+    } rx_crc_err;
+    struct packed {
+      logic        q;
+    } rx_pid_err;
+    struct packed {
+      logic        q;
+    } rx_bitstuff_err;
+    struct packed {
+      logic        q;
+    } frame;
+    struct packed {
+      logic        q;
+    } connected;
+    struct packed {
+      logic        q;
+    } link_out_err;
   } usbuart_reg2hw_intr_enable_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
       logic        qe;
-    } tx_watermark;
+    } pkt_received;
     struct packed {
       logic        q;
       logic        qe;
-    } rx_watermark;
+    } pkt_sent;
     struct packed {
       logic        q;
       logic        qe;
-    } tx_overflow;
+    } disconnected;
     struct packed {
       logic        q;
       logic        qe;
-    } rx_overflow;
+    } host_lost;
     struct packed {
       logic        q;
       logic        qe;
-    } rx_frame_err;
+    } link_reset;
     struct packed {
       logic        q;
       logic        qe;
-    } rx_break_err;
+    } link_suspend;
     struct packed {
       logic        q;
       logic        qe;
-    } rx_timeout;
+    } link_resume;
     struct packed {
       logic        q;
       logic        qe;
-    } rx_parity_err;
+    } av_empty;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } rx_full;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } av_overflow;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } link_in_err;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } rx_crc_err;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } rx_pid_err;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } rx_bitstuff_err;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } frame;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } connected;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } link_out_err;
   } usbuart_reg2hw_intr_test_reg_t;
 
   typedef struct packed {
@@ -175,40 +268,91 @@ package usbuart_reg_pkg;
     } en;
   } usbuart_reg2hw_timeout_ctrl_reg_t;
 
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } pinflip;
+    struct packed {
+      logic        q;
+    } tx_diff;
+    struct packed {
+      logic        q;
+    } rx_diff;
+    struct packed {
+      logic        q;
+    } ref_disable;
+  } usbuart_reg2hw_usbctrl_reg_t;
+
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } tx_watermark;
+    } pkt_received;
     struct packed {
       logic        d;
       logic        de;
-    } rx_watermark;
+    } pkt_sent;
     struct packed {
       logic        d;
       logic        de;
-    } tx_overflow;
+    } disconnected;
     struct packed {
       logic        d;
       logic        de;
-    } rx_overflow;
+    } host_lost;
     struct packed {
       logic        d;
       logic        de;
-    } rx_frame_err;
+    } link_reset;
     struct packed {
       logic        d;
       logic        de;
-    } rx_break_err;
+    } link_suspend;
     struct packed {
       logic        d;
       logic        de;
-    } rx_timeout;
+    } link_resume;
     struct packed {
       logic        d;
       logic        de;
-    } rx_parity_err;
+    } av_empty;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rx_full;
+    struct packed {
+      logic        d;
+      logic        de;
+    } av_overflow;
+    struct packed {
+      logic        d;
+      logic        de;
+    } link_in_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rx_crc_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rx_pid_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rx_bitstuff_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } frame;
+    struct packed {
+      logic        d;
+      logic        de;
+    } connected;
+    struct packed {
+      logic        d;
+      logic        de;
+    } link_out_err;
   } usbuart_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
@@ -238,14 +382,6 @@ package usbuart_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic        d;
-      logic        de;
-    } rxrst;
-    struct packed {
-      logic        d;
-      logic        de;
-    } txrst;
-    struct packed {
       logic [2:0]  d;
       logic        de;
     } rxilvl;
@@ -274,10 +410,16 @@ package usbuart_reg_pkg;
     } frame;
     struct packed {
       logic        d;
-    } host_timeout;
+    } link_reset;
+    struct packed {
+      logic        d;
+    } link_suspend;
     struct packed {
       logic        d;
     } host_lost;
+    struct packed {
+      logic        d;
+    } pwr_sense;
     struct packed {
       logic [6:0]  d;
     } device_address;
@@ -297,28 +439,29 @@ package usbuart_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    usbuart_reg2hw_intr_state_reg_t intr_state; // [112:105]
-    usbuart_reg2hw_intr_enable_reg_t intr_enable; // [104:97]
-    usbuart_reg2hw_intr_test_reg_t intr_test; // [96:81]
-    usbuart_reg2hw_ctrl_reg_t ctrl; // [80:56]
-    usbuart_reg2hw_rdata_reg_t rdata; // [55:47]
-    usbuart_reg2hw_wdata_reg_t wdata; // [46:38]
-    usbuart_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [37:27]
-    usbuart_reg2hw_ovrd_reg_t ovrd; // [26:25]
-    usbuart_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [24:0]
+    usbuart_reg2hw_intr_state_reg_t intr_state; // [152:136]
+    usbuart_reg2hw_intr_enable_reg_t intr_enable; // [135:119]
+    usbuart_reg2hw_intr_test_reg_t intr_test; // [118:85]
+    usbuart_reg2hw_ctrl_reg_t ctrl; // [84:60]
+    usbuart_reg2hw_rdata_reg_t rdata; // [59:51]
+    usbuart_reg2hw_wdata_reg_t wdata; // [50:42]
+    usbuart_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [41:31]
+    usbuart_reg2hw_ovrd_reg_t ovrd; // [30:29]
+    usbuart_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [28:4]
+    usbuart_reg2hw_usbctrl_reg_t usbctrl; // [3:0]
   } usbuart_reg2hw_t;
 
   ///////////////////////////////////////
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    usbuart_hw2reg_intr_state_reg_t intr_state; // [106:91]
-    usbuart_hw2reg_status_reg_t status; // [90:85]
-    usbuart_hw2reg_rdata_reg_t rdata; // [84:77]
-    usbuart_hw2reg_fifo_ctrl_reg_t fifo_ctrl; // [76:66]
-    usbuart_hw2reg_fifo_status_reg_t fifo_status; // [65:54]
-    usbuart_hw2reg_val_reg_t val; // [53:38]
-    usbuart_hw2reg_usbstat_reg_t usbstat; // [37:18]
+    usbuart_hw2reg_intr_state_reg_t intr_state; // [122:89]
+    usbuart_hw2reg_status_reg_t status; // [88:83]
+    usbuart_hw2reg_rdata_reg_t rdata; // [82:75]
+    usbuart_hw2reg_fifo_ctrl_reg_t fifo_ctrl; // [74:68]
+    usbuart_hw2reg_fifo_status_reg_t fifo_status; // [67:56]
+    usbuart_hw2reg_val_reg_t val; // [55:40]
+    usbuart_hw2reg_usbstat_reg_t usbstat; // [39:18]
     usbuart_hw2reg_usbparam_reg_t usbparam; // [17:0]
   } usbuart_hw2reg_t;
 
@@ -335,8 +478,9 @@ package usbuart_reg_pkg;
   parameter logic [5:0] USBUART_OVRD_OFFSET = 6'h 24;
   parameter logic [5:0] USBUART_VAL_OFFSET = 6'h 28;
   parameter logic [5:0] USBUART_TIMEOUT_CTRL_OFFSET = 6'h 2c;
-  parameter logic [5:0] USBUART_USBSTAT_OFFSET = 6'h 30;
-  parameter logic [5:0] USBUART_USBPARAM_OFFSET = 6'h 34;
+  parameter logic [5:0] USBUART_USBCTRL_OFFSET = 6'h 30;
+  parameter logic [5:0] USBUART_USBSTAT_OFFSET = 6'h 34;
+  parameter logic [5:0] USBUART_USBPARAM_OFFSET = 6'h 38;
 
 
   // Register Index
@@ -353,15 +497,16 @@ package usbuart_reg_pkg;
     USBUART_OVRD,
     USBUART_VAL,
     USBUART_TIMEOUT_CTRL,
+    USBUART_USBCTRL,
     USBUART_USBSTAT,
     USBUART_USBPARAM
   } usbuart_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] USBUART_PERMIT [14] = '{
-    4'b 0001, // index[ 0] USBUART_INTR_STATE
-    4'b 0001, // index[ 1] USBUART_INTR_ENABLE
-    4'b 0001, // index[ 2] USBUART_INTR_TEST
+  parameter logic [3:0] USBUART_PERMIT [15] = '{
+    4'b 0111, // index[ 0] USBUART_INTR_STATE
+    4'b 0111, // index[ 1] USBUART_INTR_ENABLE
+    4'b 0111, // index[ 2] USBUART_INTR_TEST
     4'b 1111, // index[ 3] USBUART_CTRL
     4'b 0001, // index[ 4] USBUART_STATUS
     4'b 0001, // index[ 5] USBUART_RDATA
@@ -371,8 +516,9 @@ package usbuart_reg_pkg;
     4'b 0001, // index[ 9] USBUART_OVRD
     4'b 0011, // index[10] USBUART_VAL
     4'b 1111, // index[11] USBUART_TIMEOUT_CTRL
-    4'b 0111, // index[12] USBUART_USBSTAT
-    4'b 0111  // index[13] USBUART_USBPARAM
+    4'b 0001, // index[12] USBUART_USBCTRL
+    4'b 0111, // index[13] USBUART_USBSTAT
+    4'b 0111  // index[14] USBUART_USBPARAM
   };
 endpackage
 

--- a/hw/ip/usbuart/rtl/usbuart_reg_top.sv
+++ b/hw/ip/usbuart/rtl/usbuart_reg_top.sv
@@ -71,70 +71,142 @@ module usbuart_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
-  logic intr_state_tx_watermark_qs;
-  logic intr_state_tx_watermark_wd;
-  logic intr_state_tx_watermark_we;
-  logic intr_state_rx_watermark_qs;
-  logic intr_state_rx_watermark_wd;
-  logic intr_state_rx_watermark_we;
-  logic intr_state_tx_overflow_qs;
-  logic intr_state_tx_overflow_wd;
-  logic intr_state_tx_overflow_we;
-  logic intr_state_rx_overflow_qs;
-  logic intr_state_rx_overflow_wd;
-  logic intr_state_rx_overflow_we;
-  logic intr_state_rx_frame_err_qs;
-  logic intr_state_rx_frame_err_wd;
-  logic intr_state_rx_frame_err_we;
-  logic intr_state_rx_break_err_qs;
-  logic intr_state_rx_break_err_wd;
-  logic intr_state_rx_break_err_we;
-  logic intr_state_rx_timeout_qs;
-  logic intr_state_rx_timeout_wd;
-  logic intr_state_rx_timeout_we;
-  logic intr_state_rx_parity_err_qs;
-  logic intr_state_rx_parity_err_wd;
-  logic intr_state_rx_parity_err_we;
-  logic intr_enable_tx_watermark_qs;
-  logic intr_enable_tx_watermark_wd;
-  logic intr_enable_tx_watermark_we;
-  logic intr_enable_rx_watermark_qs;
-  logic intr_enable_rx_watermark_wd;
-  logic intr_enable_rx_watermark_we;
-  logic intr_enable_tx_overflow_qs;
-  logic intr_enable_tx_overflow_wd;
-  logic intr_enable_tx_overflow_we;
-  logic intr_enable_rx_overflow_qs;
-  logic intr_enable_rx_overflow_wd;
-  logic intr_enable_rx_overflow_we;
-  logic intr_enable_rx_frame_err_qs;
-  logic intr_enable_rx_frame_err_wd;
-  logic intr_enable_rx_frame_err_we;
-  logic intr_enable_rx_break_err_qs;
-  logic intr_enable_rx_break_err_wd;
-  logic intr_enable_rx_break_err_we;
-  logic intr_enable_rx_timeout_qs;
-  logic intr_enable_rx_timeout_wd;
-  logic intr_enable_rx_timeout_we;
-  logic intr_enable_rx_parity_err_qs;
-  logic intr_enable_rx_parity_err_wd;
-  logic intr_enable_rx_parity_err_we;
-  logic intr_test_tx_watermark_wd;
-  logic intr_test_tx_watermark_we;
-  logic intr_test_rx_watermark_wd;
-  logic intr_test_rx_watermark_we;
-  logic intr_test_tx_overflow_wd;
-  logic intr_test_tx_overflow_we;
-  logic intr_test_rx_overflow_wd;
-  logic intr_test_rx_overflow_we;
-  logic intr_test_rx_frame_err_wd;
-  logic intr_test_rx_frame_err_we;
-  logic intr_test_rx_break_err_wd;
-  logic intr_test_rx_break_err_we;
-  logic intr_test_rx_timeout_wd;
-  logic intr_test_rx_timeout_we;
-  logic intr_test_rx_parity_err_wd;
-  logic intr_test_rx_parity_err_we;
+  logic intr_state_pkt_received_qs;
+  logic intr_state_pkt_received_wd;
+  logic intr_state_pkt_received_we;
+  logic intr_state_pkt_sent_qs;
+  logic intr_state_pkt_sent_wd;
+  logic intr_state_pkt_sent_we;
+  logic intr_state_disconnected_qs;
+  logic intr_state_disconnected_wd;
+  logic intr_state_disconnected_we;
+  logic intr_state_host_lost_qs;
+  logic intr_state_host_lost_wd;
+  logic intr_state_host_lost_we;
+  logic intr_state_link_reset_qs;
+  logic intr_state_link_reset_wd;
+  logic intr_state_link_reset_we;
+  logic intr_state_link_suspend_qs;
+  logic intr_state_link_suspend_wd;
+  logic intr_state_link_suspend_we;
+  logic intr_state_link_resume_qs;
+  logic intr_state_link_resume_wd;
+  logic intr_state_link_resume_we;
+  logic intr_state_av_empty_qs;
+  logic intr_state_av_empty_wd;
+  logic intr_state_av_empty_we;
+  logic intr_state_rx_full_qs;
+  logic intr_state_rx_full_wd;
+  logic intr_state_rx_full_we;
+  logic intr_state_av_overflow_qs;
+  logic intr_state_av_overflow_wd;
+  logic intr_state_av_overflow_we;
+  logic intr_state_link_in_err_qs;
+  logic intr_state_link_in_err_wd;
+  logic intr_state_link_in_err_we;
+  logic intr_state_rx_crc_err_qs;
+  logic intr_state_rx_crc_err_wd;
+  logic intr_state_rx_crc_err_we;
+  logic intr_state_rx_pid_err_qs;
+  logic intr_state_rx_pid_err_wd;
+  logic intr_state_rx_pid_err_we;
+  logic intr_state_rx_bitstuff_err_qs;
+  logic intr_state_rx_bitstuff_err_wd;
+  logic intr_state_rx_bitstuff_err_we;
+  logic intr_state_frame_qs;
+  logic intr_state_frame_wd;
+  logic intr_state_frame_we;
+  logic intr_state_connected_qs;
+  logic intr_state_connected_wd;
+  logic intr_state_connected_we;
+  logic intr_state_link_out_err_qs;
+  logic intr_state_link_out_err_wd;
+  logic intr_state_link_out_err_we;
+  logic intr_enable_pkt_received_qs;
+  logic intr_enable_pkt_received_wd;
+  logic intr_enable_pkt_received_we;
+  logic intr_enable_pkt_sent_qs;
+  logic intr_enable_pkt_sent_wd;
+  logic intr_enable_pkt_sent_we;
+  logic intr_enable_disconnected_qs;
+  logic intr_enable_disconnected_wd;
+  logic intr_enable_disconnected_we;
+  logic intr_enable_host_lost_qs;
+  logic intr_enable_host_lost_wd;
+  logic intr_enable_host_lost_we;
+  logic intr_enable_link_reset_qs;
+  logic intr_enable_link_reset_wd;
+  logic intr_enable_link_reset_we;
+  logic intr_enable_link_suspend_qs;
+  logic intr_enable_link_suspend_wd;
+  logic intr_enable_link_suspend_we;
+  logic intr_enable_link_resume_qs;
+  logic intr_enable_link_resume_wd;
+  logic intr_enable_link_resume_we;
+  logic intr_enable_av_empty_qs;
+  logic intr_enable_av_empty_wd;
+  logic intr_enable_av_empty_we;
+  logic intr_enable_rx_full_qs;
+  logic intr_enable_rx_full_wd;
+  logic intr_enable_rx_full_we;
+  logic intr_enable_av_overflow_qs;
+  logic intr_enable_av_overflow_wd;
+  logic intr_enable_av_overflow_we;
+  logic intr_enable_link_in_err_qs;
+  logic intr_enable_link_in_err_wd;
+  logic intr_enable_link_in_err_we;
+  logic intr_enable_rx_crc_err_qs;
+  logic intr_enable_rx_crc_err_wd;
+  logic intr_enable_rx_crc_err_we;
+  logic intr_enable_rx_pid_err_qs;
+  logic intr_enable_rx_pid_err_wd;
+  logic intr_enable_rx_pid_err_we;
+  logic intr_enable_rx_bitstuff_err_qs;
+  logic intr_enable_rx_bitstuff_err_wd;
+  logic intr_enable_rx_bitstuff_err_we;
+  logic intr_enable_frame_qs;
+  logic intr_enable_frame_wd;
+  logic intr_enable_frame_we;
+  logic intr_enable_connected_qs;
+  logic intr_enable_connected_wd;
+  logic intr_enable_connected_we;
+  logic intr_enable_link_out_err_qs;
+  logic intr_enable_link_out_err_wd;
+  logic intr_enable_link_out_err_we;
+  logic intr_test_pkt_received_wd;
+  logic intr_test_pkt_received_we;
+  logic intr_test_pkt_sent_wd;
+  logic intr_test_pkt_sent_we;
+  logic intr_test_disconnected_wd;
+  logic intr_test_disconnected_we;
+  logic intr_test_host_lost_wd;
+  logic intr_test_host_lost_we;
+  logic intr_test_link_reset_wd;
+  logic intr_test_link_reset_we;
+  logic intr_test_link_suspend_wd;
+  logic intr_test_link_suspend_we;
+  logic intr_test_link_resume_wd;
+  logic intr_test_link_resume_we;
+  logic intr_test_av_empty_wd;
+  logic intr_test_av_empty_we;
+  logic intr_test_rx_full_wd;
+  logic intr_test_rx_full_we;
+  logic intr_test_av_overflow_wd;
+  logic intr_test_av_overflow_we;
+  logic intr_test_link_in_err_wd;
+  logic intr_test_link_in_err_we;
+  logic intr_test_rx_crc_err_wd;
+  logic intr_test_rx_crc_err_we;
+  logic intr_test_rx_pid_err_wd;
+  logic intr_test_rx_pid_err_we;
+  logic intr_test_rx_bitstuff_err_wd;
+  logic intr_test_rx_bitstuff_err_we;
+  logic intr_test_frame_wd;
+  logic intr_test_frame_we;
+  logic intr_test_connected_wd;
+  logic intr_test_connected_we;
+  logic intr_test_link_out_err_wd;
+  logic intr_test_link_out_err_we;
   logic ctrl_tx_qs;
   logic ctrl_tx_wd;
   logic ctrl_tx_we;
@@ -178,10 +250,8 @@ module usbuart_reg_top (
   logic rdata_re;
   logic [7:0] wdata_wd;
   logic wdata_we;
-  logic fifo_ctrl_rxrst_qs;
   logic fifo_ctrl_rxrst_wd;
   logic fifo_ctrl_rxrst_we;
-  logic fifo_ctrl_txrst_qs;
   logic fifo_ctrl_txrst_wd;
   logic fifo_ctrl_txrst_we;
   logic [2:0] fifo_ctrl_rxilvl_qs;
@@ -208,12 +278,28 @@ module usbuart_reg_top (
   logic timeout_ctrl_en_qs;
   logic timeout_ctrl_en_wd;
   logic timeout_ctrl_en_we;
+  logic usbctrl_pinflip_qs;
+  logic usbctrl_pinflip_wd;
+  logic usbctrl_pinflip_we;
+  logic usbctrl_tx_diff_qs;
+  logic usbctrl_tx_diff_wd;
+  logic usbctrl_tx_diff_we;
+  logic usbctrl_rx_diff_qs;
+  logic usbctrl_rx_diff_wd;
+  logic usbctrl_rx_diff_we;
+  logic usbctrl_ref_disable_qs;
+  logic usbctrl_ref_disable_wd;
+  logic usbctrl_ref_disable_we;
   logic [10:0] usbstat_frame_qs;
   logic usbstat_frame_re;
-  logic usbstat_host_timeout_qs;
-  logic usbstat_host_timeout_re;
+  logic usbstat_link_reset_qs;
+  logic usbstat_link_reset_re;
+  logic usbstat_link_suspend_qs;
+  logic usbstat_link_suspend_re;
   logic usbstat_host_lost_qs;
   logic usbstat_host_lost_re;
+  logic usbstat_pwr_sense_qs;
+  logic usbstat_pwr_sense_re;
   logic [6:0] usbstat_device_address_qs;
   logic usbstat_device_address_re;
   logic [15:0] usbparam_baud_req_qs;
@@ -224,228 +310,462 @@ module usbuart_reg_top (
   // Register instances
   // R[intr_state]: V(False)
 
-  //   F[tx_watermark]: 0:0
+  //   F[pkt_received]: 0:0
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W1C"),
     .RESVAL  (1'h0)
-  ) u_intr_state_tx_watermark (
+  ) u_intr_state_pkt_received (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_state_tx_watermark_we),
-    .wd     (intr_state_tx_watermark_wd),
+    .we     (intr_state_pkt_received_we),
+    .wd     (intr_state_pkt_received_wd),
 
     // from internal hardware
-    .de     (hw2reg.intr_state.tx_watermark.de),
-    .d      (hw2reg.intr_state.tx_watermark.d ),
+    .de     (hw2reg.intr_state.pkt_received.de),
+    .d      (hw2reg.intr_state.pkt_received.d ),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_state.tx_watermark.q ),
+    .q      (reg2hw.intr_state.pkt_received.q ),
 
     // to register interface (read)
-    .qs     (intr_state_tx_watermark_qs)
+    .qs     (intr_state_pkt_received_qs)
   );
 
 
-  //   F[rx_watermark]: 1:1
+  //   F[pkt_sent]: 1:1
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W1C"),
     .RESVAL  (1'h0)
-  ) u_intr_state_rx_watermark (
+  ) u_intr_state_pkt_sent (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_state_rx_watermark_we),
-    .wd     (intr_state_rx_watermark_wd),
+    .we     (intr_state_pkt_sent_we),
+    .wd     (intr_state_pkt_sent_wd),
 
     // from internal hardware
-    .de     (hw2reg.intr_state.rx_watermark.de),
-    .d      (hw2reg.intr_state.rx_watermark.d ),
+    .de     (hw2reg.intr_state.pkt_sent.de),
+    .d      (hw2reg.intr_state.pkt_sent.d ),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_state.rx_watermark.q ),
+    .q      (reg2hw.intr_state.pkt_sent.q ),
 
     // to register interface (read)
-    .qs     (intr_state_rx_watermark_qs)
+    .qs     (intr_state_pkt_sent_qs)
   );
 
 
-  //   F[tx_overflow]: 2:2
+  //   F[disconnected]: 2:2
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W1C"),
     .RESVAL  (1'h0)
-  ) u_intr_state_tx_overflow (
+  ) u_intr_state_disconnected (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_state_tx_overflow_we),
-    .wd     (intr_state_tx_overflow_wd),
+    .we     (intr_state_disconnected_we),
+    .wd     (intr_state_disconnected_wd),
 
     // from internal hardware
-    .de     (hw2reg.intr_state.tx_overflow.de),
-    .d      (hw2reg.intr_state.tx_overflow.d ),
+    .de     (hw2reg.intr_state.disconnected.de),
+    .d      (hw2reg.intr_state.disconnected.d ),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_state.tx_overflow.q ),
+    .q      (reg2hw.intr_state.disconnected.q ),
 
     // to register interface (read)
-    .qs     (intr_state_tx_overflow_qs)
+    .qs     (intr_state_disconnected_qs)
   );
 
 
-  //   F[rx_overflow]: 3:3
+  //   F[host_lost]: 3:3
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W1C"),
     .RESVAL  (1'h0)
-  ) u_intr_state_rx_overflow (
+  ) u_intr_state_host_lost (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_state_rx_overflow_we),
-    .wd     (intr_state_rx_overflow_wd),
+    .we     (intr_state_host_lost_we),
+    .wd     (intr_state_host_lost_wd),
 
     // from internal hardware
-    .de     (hw2reg.intr_state.rx_overflow.de),
-    .d      (hw2reg.intr_state.rx_overflow.d ),
+    .de     (hw2reg.intr_state.host_lost.de),
+    .d      (hw2reg.intr_state.host_lost.d ),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_state.rx_overflow.q ),
+    .q      (reg2hw.intr_state.host_lost.q ),
 
     // to register interface (read)
-    .qs     (intr_state_rx_overflow_qs)
+    .qs     (intr_state_host_lost_qs)
   );
 
 
-  //   F[rx_frame_err]: 4:4
+  //   F[link_reset]: 4:4
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W1C"),
     .RESVAL  (1'h0)
-  ) u_intr_state_rx_frame_err (
+  ) u_intr_state_link_reset (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_state_rx_frame_err_we),
-    .wd     (intr_state_rx_frame_err_wd),
+    .we     (intr_state_link_reset_we),
+    .wd     (intr_state_link_reset_wd),
 
     // from internal hardware
-    .de     (hw2reg.intr_state.rx_frame_err.de),
-    .d      (hw2reg.intr_state.rx_frame_err.d ),
+    .de     (hw2reg.intr_state.link_reset.de),
+    .d      (hw2reg.intr_state.link_reset.d ),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_state.rx_frame_err.q ),
+    .q      (reg2hw.intr_state.link_reset.q ),
 
     // to register interface (read)
-    .qs     (intr_state_rx_frame_err_qs)
+    .qs     (intr_state_link_reset_qs)
   );
 
 
-  //   F[rx_break_err]: 5:5
+  //   F[link_suspend]: 5:5
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W1C"),
     .RESVAL  (1'h0)
-  ) u_intr_state_rx_break_err (
+  ) u_intr_state_link_suspend (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_state_rx_break_err_we),
-    .wd     (intr_state_rx_break_err_wd),
+    .we     (intr_state_link_suspend_we),
+    .wd     (intr_state_link_suspend_wd),
 
     // from internal hardware
-    .de     (hw2reg.intr_state.rx_break_err.de),
-    .d      (hw2reg.intr_state.rx_break_err.d ),
+    .de     (hw2reg.intr_state.link_suspend.de),
+    .d      (hw2reg.intr_state.link_suspend.d ),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_state.rx_break_err.q ),
+    .q      (reg2hw.intr_state.link_suspend.q ),
 
     // to register interface (read)
-    .qs     (intr_state_rx_break_err_qs)
+    .qs     (intr_state_link_suspend_qs)
   );
 
 
-  //   F[rx_timeout]: 6:6
+  //   F[link_resume]: 6:6
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W1C"),
     .RESVAL  (1'h0)
-  ) u_intr_state_rx_timeout (
+  ) u_intr_state_link_resume (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_state_rx_timeout_we),
-    .wd     (intr_state_rx_timeout_wd),
+    .we     (intr_state_link_resume_we),
+    .wd     (intr_state_link_resume_wd),
 
     // from internal hardware
-    .de     (hw2reg.intr_state.rx_timeout.de),
-    .d      (hw2reg.intr_state.rx_timeout.d ),
+    .de     (hw2reg.intr_state.link_resume.de),
+    .d      (hw2reg.intr_state.link_resume.d ),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_state.rx_timeout.q ),
+    .q      (reg2hw.intr_state.link_resume.q ),
 
     // to register interface (read)
-    .qs     (intr_state_rx_timeout_qs)
+    .qs     (intr_state_link_resume_qs)
   );
 
 
-  //   F[rx_parity_err]: 7:7
+  //   F[av_empty]: 7:7
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W1C"),
     .RESVAL  (1'h0)
-  ) u_intr_state_rx_parity_err (
+  ) u_intr_state_av_empty (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_state_rx_parity_err_we),
-    .wd     (intr_state_rx_parity_err_wd),
+    .we     (intr_state_av_empty_we),
+    .wd     (intr_state_av_empty_wd),
 
     // from internal hardware
-    .de     (hw2reg.intr_state.rx_parity_err.de),
-    .d      (hw2reg.intr_state.rx_parity_err.d ),
+    .de     (hw2reg.intr_state.av_empty.de),
+    .d      (hw2reg.intr_state.av_empty.d ),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_state.rx_parity_err.q ),
+    .q      (reg2hw.intr_state.av_empty.q ),
 
     // to register interface (read)
-    .qs     (intr_state_rx_parity_err_qs)
+    .qs     (intr_state_av_empty_qs)
+  );
+
+
+  //   F[rx_full]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_intr_state_rx_full (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_state_rx_full_we),
+    .wd     (intr_state_rx_full_wd),
+
+    // from internal hardware
+    .de     (hw2reg.intr_state.rx_full.de),
+    .d      (hw2reg.intr_state.rx_full.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_state.rx_full.q ),
+
+    // to register interface (read)
+    .qs     (intr_state_rx_full_qs)
+  );
+
+
+  //   F[av_overflow]: 9:9
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_intr_state_av_overflow (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_state_av_overflow_we),
+    .wd     (intr_state_av_overflow_wd),
+
+    // from internal hardware
+    .de     (hw2reg.intr_state.av_overflow.de),
+    .d      (hw2reg.intr_state.av_overflow.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_state.av_overflow.q ),
+
+    // to register interface (read)
+    .qs     (intr_state_av_overflow_qs)
+  );
+
+
+  //   F[link_in_err]: 10:10
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_intr_state_link_in_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_state_link_in_err_we),
+    .wd     (intr_state_link_in_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.intr_state.link_in_err.de),
+    .d      (hw2reg.intr_state.link_in_err.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_state.link_in_err.q ),
+
+    // to register interface (read)
+    .qs     (intr_state_link_in_err_qs)
+  );
+
+
+  //   F[rx_crc_err]: 11:11
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_intr_state_rx_crc_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_state_rx_crc_err_we),
+    .wd     (intr_state_rx_crc_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.intr_state.rx_crc_err.de),
+    .d      (hw2reg.intr_state.rx_crc_err.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_state.rx_crc_err.q ),
+
+    // to register interface (read)
+    .qs     (intr_state_rx_crc_err_qs)
+  );
+
+
+  //   F[rx_pid_err]: 12:12
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_intr_state_rx_pid_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_state_rx_pid_err_we),
+    .wd     (intr_state_rx_pid_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.intr_state.rx_pid_err.de),
+    .d      (hw2reg.intr_state.rx_pid_err.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_state.rx_pid_err.q ),
+
+    // to register interface (read)
+    .qs     (intr_state_rx_pid_err_qs)
+  );
+
+
+  //   F[rx_bitstuff_err]: 13:13
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_intr_state_rx_bitstuff_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_state_rx_bitstuff_err_we),
+    .wd     (intr_state_rx_bitstuff_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.intr_state.rx_bitstuff_err.de),
+    .d      (hw2reg.intr_state.rx_bitstuff_err.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_state.rx_bitstuff_err.q ),
+
+    // to register interface (read)
+    .qs     (intr_state_rx_bitstuff_err_qs)
+  );
+
+
+  //   F[frame]: 14:14
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_intr_state_frame (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_state_frame_we),
+    .wd     (intr_state_frame_wd),
+
+    // from internal hardware
+    .de     (hw2reg.intr_state.frame.de),
+    .d      (hw2reg.intr_state.frame.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_state.frame.q ),
+
+    // to register interface (read)
+    .qs     (intr_state_frame_qs)
+  );
+
+
+  //   F[connected]: 15:15
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_intr_state_connected (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_state_connected_we),
+    .wd     (intr_state_connected_wd),
+
+    // from internal hardware
+    .de     (hw2reg.intr_state.connected.de),
+    .d      (hw2reg.intr_state.connected.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_state.connected.q ),
+
+    // to register interface (read)
+    .qs     (intr_state_connected_qs)
+  );
+
+
+  //   F[link_out_err]: 16:16
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_intr_state_link_out_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_state_link_out_err_we),
+    .wd     (intr_state_link_out_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.intr_state.link_out_err.de),
+    .d      (hw2reg.intr_state.link_out_err.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_state.link_out_err.q ),
+
+    // to register interface (read)
+    .qs     (intr_state_link_out_err_qs)
   );
 
 
   // R[intr_enable]: V(False)
 
-  //   F[tx_watermark]: 0:0
+  //   F[pkt_received]: 0:0
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h0)
-  ) u_intr_enable_tx_watermark (
+  ) u_intr_enable_pkt_received (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_enable_tx_watermark_we),
-    .wd     (intr_enable_tx_watermark_wd),
+    .we     (intr_enable_pkt_received_we),
+    .wd     (intr_enable_pkt_received_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -453,25 +773,25 @@ module usbuart_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_enable.tx_watermark.q ),
+    .q      (reg2hw.intr_enable.pkt_received.q ),
 
     // to register interface (read)
-    .qs     (intr_enable_tx_watermark_qs)
+    .qs     (intr_enable_pkt_received_qs)
   );
 
 
-  //   F[rx_watermark]: 1:1
+  //   F[pkt_sent]: 1:1
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h0)
-  ) u_intr_enable_rx_watermark (
+  ) u_intr_enable_pkt_sent (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_enable_rx_watermark_we),
-    .wd     (intr_enable_rx_watermark_wd),
+    .we     (intr_enable_pkt_sent_we),
+    .wd     (intr_enable_pkt_sent_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -479,25 +799,25 @@ module usbuart_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_enable.rx_watermark.q ),
+    .q      (reg2hw.intr_enable.pkt_sent.q ),
 
     // to register interface (read)
-    .qs     (intr_enable_rx_watermark_qs)
+    .qs     (intr_enable_pkt_sent_qs)
   );
 
 
-  //   F[tx_overflow]: 2:2
+  //   F[disconnected]: 2:2
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h0)
-  ) u_intr_enable_tx_overflow (
+  ) u_intr_enable_disconnected (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_enable_tx_overflow_we),
-    .wd     (intr_enable_tx_overflow_wd),
+    .we     (intr_enable_disconnected_we),
+    .wd     (intr_enable_disconnected_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -505,25 +825,25 @@ module usbuart_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_enable.tx_overflow.q ),
+    .q      (reg2hw.intr_enable.disconnected.q ),
 
     // to register interface (read)
-    .qs     (intr_enable_tx_overflow_qs)
+    .qs     (intr_enable_disconnected_qs)
   );
 
 
-  //   F[rx_overflow]: 3:3
+  //   F[host_lost]: 3:3
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h0)
-  ) u_intr_enable_rx_overflow (
+  ) u_intr_enable_host_lost (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_enable_rx_overflow_we),
-    .wd     (intr_enable_rx_overflow_wd),
+    .we     (intr_enable_host_lost_we),
+    .wd     (intr_enable_host_lost_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -531,25 +851,25 @@ module usbuart_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_enable.rx_overflow.q ),
+    .q      (reg2hw.intr_enable.host_lost.q ),
 
     // to register interface (read)
-    .qs     (intr_enable_rx_overflow_qs)
+    .qs     (intr_enable_host_lost_qs)
   );
 
 
-  //   F[rx_frame_err]: 4:4
+  //   F[link_reset]: 4:4
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h0)
-  ) u_intr_enable_rx_frame_err (
+  ) u_intr_enable_link_reset (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_enable_rx_frame_err_we),
-    .wd     (intr_enable_rx_frame_err_wd),
+    .we     (intr_enable_link_reset_we),
+    .wd     (intr_enable_link_reset_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -557,25 +877,25 @@ module usbuart_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_enable.rx_frame_err.q ),
+    .q      (reg2hw.intr_enable.link_reset.q ),
 
     // to register interface (read)
-    .qs     (intr_enable_rx_frame_err_qs)
+    .qs     (intr_enable_link_reset_qs)
   );
 
 
-  //   F[rx_break_err]: 5:5
+  //   F[link_suspend]: 5:5
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h0)
-  ) u_intr_enable_rx_break_err (
+  ) u_intr_enable_link_suspend (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_enable_rx_break_err_we),
-    .wd     (intr_enable_rx_break_err_wd),
+    .we     (intr_enable_link_suspend_we),
+    .wd     (intr_enable_link_suspend_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -583,25 +903,25 @@ module usbuart_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_enable.rx_break_err.q ),
+    .q      (reg2hw.intr_enable.link_suspend.q ),
 
     // to register interface (read)
-    .qs     (intr_enable_rx_break_err_qs)
+    .qs     (intr_enable_link_suspend_qs)
   );
 
 
-  //   F[rx_timeout]: 6:6
+  //   F[link_resume]: 6:6
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h0)
-  ) u_intr_enable_rx_timeout (
+  ) u_intr_enable_link_resume (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_enable_rx_timeout_we),
-    .wd     (intr_enable_rx_timeout_wd),
+    .we     (intr_enable_link_resume_we),
+    .wd     (intr_enable_link_resume_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -609,25 +929,25 @@ module usbuart_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_enable.rx_timeout.q ),
+    .q      (reg2hw.intr_enable.link_resume.q ),
 
     // to register interface (read)
-    .qs     (intr_enable_rx_timeout_qs)
+    .qs     (intr_enable_link_resume_qs)
   );
 
 
-  //   F[rx_parity_err]: 7:7
+  //   F[av_empty]: 7:7
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h0)
-  ) u_intr_enable_rx_parity_err (
+  ) u_intr_enable_av_empty (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_enable_rx_parity_err_we),
-    .wd     (intr_enable_rx_parity_err_wd),
+    .we     (intr_enable_av_empty_we),
+    .wd     (intr_enable_av_empty_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -635,131 +955,500 @@ module usbuart_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_enable.rx_parity_err.q ),
+    .q      (reg2hw.intr_enable.av_empty.q ),
 
     // to register interface (read)
-    .qs     (intr_enable_rx_parity_err_qs)
+    .qs     (intr_enable_av_empty_qs)
+  );
+
+
+  //   F[rx_full]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_intr_enable_rx_full (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_enable_rx_full_we),
+    .wd     (intr_enable_rx_full_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_enable.rx_full.q ),
+
+    // to register interface (read)
+    .qs     (intr_enable_rx_full_qs)
+  );
+
+
+  //   F[av_overflow]: 9:9
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_intr_enable_av_overflow (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_enable_av_overflow_we),
+    .wd     (intr_enable_av_overflow_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_enable.av_overflow.q ),
+
+    // to register interface (read)
+    .qs     (intr_enable_av_overflow_qs)
+  );
+
+
+  //   F[link_in_err]: 10:10
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_intr_enable_link_in_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_enable_link_in_err_we),
+    .wd     (intr_enable_link_in_err_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_enable.link_in_err.q ),
+
+    // to register interface (read)
+    .qs     (intr_enable_link_in_err_qs)
+  );
+
+
+  //   F[rx_crc_err]: 11:11
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_intr_enable_rx_crc_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_enable_rx_crc_err_we),
+    .wd     (intr_enable_rx_crc_err_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_enable.rx_crc_err.q ),
+
+    // to register interface (read)
+    .qs     (intr_enable_rx_crc_err_qs)
+  );
+
+
+  //   F[rx_pid_err]: 12:12
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_intr_enable_rx_pid_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_enable_rx_pid_err_we),
+    .wd     (intr_enable_rx_pid_err_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_enable.rx_pid_err.q ),
+
+    // to register interface (read)
+    .qs     (intr_enable_rx_pid_err_qs)
+  );
+
+
+  //   F[rx_bitstuff_err]: 13:13
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_intr_enable_rx_bitstuff_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_enable_rx_bitstuff_err_we),
+    .wd     (intr_enable_rx_bitstuff_err_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_enable.rx_bitstuff_err.q ),
+
+    // to register interface (read)
+    .qs     (intr_enable_rx_bitstuff_err_qs)
+  );
+
+
+  //   F[frame]: 14:14
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_intr_enable_frame (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_enable_frame_we),
+    .wd     (intr_enable_frame_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_enable.frame.q ),
+
+    // to register interface (read)
+    .qs     (intr_enable_frame_qs)
+  );
+
+
+  //   F[connected]: 15:15
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_intr_enable_connected (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_enable_connected_we),
+    .wd     (intr_enable_connected_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_enable.connected.q ),
+
+    // to register interface (read)
+    .qs     (intr_enable_connected_qs)
+  );
+
+
+  //   F[link_out_err]: 16:16
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_intr_enable_link_out_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_enable_link_out_err_we),
+    .wd     (intr_enable_link_out_err_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_enable.link_out_err.q ),
+
+    // to register interface (read)
+    .qs     (intr_enable_link_out_err_qs)
   );
 
 
   // R[intr_test]: V(True)
 
-  //   F[tx_watermark]: 0:0
+  //   F[pkt_received]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_intr_test_tx_watermark (
+  ) u_intr_test_pkt_received (
     .re     (1'b0),
-    .we     (intr_test_tx_watermark_we),
-    .wd     (intr_test_tx_watermark_wd),
+    .we     (intr_test_pkt_received_we),
+    .wd     (intr_test_pkt_received_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.tx_watermark.qe),
-    .q      (reg2hw.intr_test.tx_watermark.q ),
+    .qe     (reg2hw.intr_test.pkt_received.qe),
+    .q      (reg2hw.intr_test.pkt_received.q ),
     .qs     ()
   );
 
 
-  //   F[rx_watermark]: 1:1
+  //   F[pkt_sent]: 1:1
   prim_subreg_ext #(
     .DW    (1)
-  ) u_intr_test_rx_watermark (
+  ) u_intr_test_pkt_sent (
     .re     (1'b0),
-    .we     (intr_test_rx_watermark_we),
-    .wd     (intr_test_rx_watermark_wd),
+    .we     (intr_test_pkt_sent_we),
+    .wd     (intr_test_pkt_sent_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_watermark.qe),
-    .q      (reg2hw.intr_test.rx_watermark.q ),
+    .qe     (reg2hw.intr_test.pkt_sent.qe),
+    .q      (reg2hw.intr_test.pkt_sent.q ),
     .qs     ()
   );
 
 
-  //   F[tx_overflow]: 2:2
+  //   F[disconnected]: 2:2
   prim_subreg_ext #(
     .DW    (1)
-  ) u_intr_test_tx_overflow (
+  ) u_intr_test_disconnected (
     .re     (1'b0),
-    .we     (intr_test_tx_overflow_we),
-    .wd     (intr_test_tx_overflow_wd),
+    .we     (intr_test_disconnected_we),
+    .wd     (intr_test_disconnected_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.tx_overflow.qe),
-    .q      (reg2hw.intr_test.tx_overflow.q ),
+    .qe     (reg2hw.intr_test.disconnected.qe),
+    .q      (reg2hw.intr_test.disconnected.q ),
     .qs     ()
   );
 
 
-  //   F[rx_overflow]: 3:3
+  //   F[host_lost]: 3:3
   prim_subreg_ext #(
     .DW    (1)
-  ) u_intr_test_rx_overflow (
+  ) u_intr_test_host_lost (
     .re     (1'b0),
-    .we     (intr_test_rx_overflow_we),
-    .wd     (intr_test_rx_overflow_wd),
+    .we     (intr_test_host_lost_we),
+    .wd     (intr_test_host_lost_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_overflow.qe),
-    .q      (reg2hw.intr_test.rx_overflow.q ),
+    .qe     (reg2hw.intr_test.host_lost.qe),
+    .q      (reg2hw.intr_test.host_lost.q ),
     .qs     ()
   );
 
 
-  //   F[rx_frame_err]: 4:4
+  //   F[link_reset]: 4:4
   prim_subreg_ext #(
     .DW    (1)
-  ) u_intr_test_rx_frame_err (
+  ) u_intr_test_link_reset (
     .re     (1'b0),
-    .we     (intr_test_rx_frame_err_we),
-    .wd     (intr_test_rx_frame_err_wd),
+    .we     (intr_test_link_reset_we),
+    .wd     (intr_test_link_reset_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_frame_err.qe),
-    .q      (reg2hw.intr_test.rx_frame_err.q ),
+    .qe     (reg2hw.intr_test.link_reset.qe),
+    .q      (reg2hw.intr_test.link_reset.q ),
     .qs     ()
   );
 
 
-  //   F[rx_break_err]: 5:5
+  //   F[link_suspend]: 5:5
   prim_subreg_ext #(
     .DW    (1)
-  ) u_intr_test_rx_break_err (
+  ) u_intr_test_link_suspend (
     .re     (1'b0),
-    .we     (intr_test_rx_break_err_we),
-    .wd     (intr_test_rx_break_err_wd),
+    .we     (intr_test_link_suspend_we),
+    .wd     (intr_test_link_suspend_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_break_err.qe),
-    .q      (reg2hw.intr_test.rx_break_err.q ),
+    .qe     (reg2hw.intr_test.link_suspend.qe),
+    .q      (reg2hw.intr_test.link_suspend.q ),
     .qs     ()
   );
 
 
-  //   F[rx_timeout]: 6:6
+  //   F[link_resume]: 6:6
   prim_subreg_ext #(
     .DW    (1)
-  ) u_intr_test_rx_timeout (
+  ) u_intr_test_link_resume (
     .re     (1'b0),
-    .we     (intr_test_rx_timeout_we),
-    .wd     (intr_test_rx_timeout_wd),
+    .we     (intr_test_link_resume_we),
+    .wd     (intr_test_link_resume_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_timeout.qe),
-    .q      (reg2hw.intr_test.rx_timeout.q ),
+    .qe     (reg2hw.intr_test.link_resume.qe),
+    .q      (reg2hw.intr_test.link_resume.q ),
     .qs     ()
   );
 
 
-  //   F[rx_parity_err]: 7:7
+  //   F[av_empty]: 7:7
   prim_subreg_ext #(
     .DW    (1)
-  ) u_intr_test_rx_parity_err (
+  ) u_intr_test_av_empty (
     .re     (1'b0),
-    .we     (intr_test_rx_parity_err_we),
-    .wd     (intr_test_rx_parity_err_wd),
+    .we     (intr_test_av_empty_we),
+    .wd     (intr_test_av_empty_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_parity_err.qe),
-    .q      (reg2hw.intr_test.rx_parity_err.q ),
+    .qe     (reg2hw.intr_test.av_empty.qe),
+    .q      (reg2hw.intr_test.av_empty.q ),
+    .qs     ()
+  );
+
+
+  //   F[rx_full]: 8:8
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_intr_test_rx_full (
+    .re     (1'b0),
+    .we     (intr_test_rx_full_we),
+    .wd     (intr_test_rx_full_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.intr_test.rx_full.qe),
+    .q      (reg2hw.intr_test.rx_full.q ),
+    .qs     ()
+  );
+
+
+  //   F[av_overflow]: 9:9
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_intr_test_av_overflow (
+    .re     (1'b0),
+    .we     (intr_test_av_overflow_we),
+    .wd     (intr_test_av_overflow_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.intr_test.av_overflow.qe),
+    .q      (reg2hw.intr_test.av_overflow.q ),
+    .qs     ()
+  );
+
+
+  //   F[link_in_err]: 10:10
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_intr_test_link_in_err (
+    .re     (1'b0),
+    .we     (intr_test_link_in_err_we),
+    .wd     (intr_test_link_in_err_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.intr_test.link_in_err.qe),
+    .q      (reg2hw.intr_test.link_in_err.q ),
+    .qs     ()
+  );
+
+
+  //   F[rx_crc_err]: 11:11
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_intr_test_rx_crc_err (
+    .re     (1'b0),
+    .we     (intr_test_rx_crc_err_we),
+    .wd     (intr_test_rx_crc_err_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.intr_test.rx_crc_err.qe),
+    .q      (reg2hw.intr_test.rx_crc_err.q ),
+    .qs     ()
+  );
+
+
+  //   F[rx_pid_err]: 12:12
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_intr_test_rx_pid_err (
+    .re     (1'b0),
+    .we     (intr_test_rx_pid_err_we),
+    .wd     (intr_test_rx_pid_err_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.intr_test.rx_pid_err.qe),
+    .q      (reg2hw.intr_test.rx_pid_err.q ),
+    .qs     ()
+  );
+
+
+  //   F[rx_bitstuff_err]: 13:13
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_intr_test_rx_bitstuff_err (
+    .re     (1'b0),
+    .we     (intr_test_rx_bitstuff_err_we),
+    .wd     (intr_test_rx_bitstuff_err_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.intr_test.rx_bitstuff_err.qe),
+    .q      (reg2hw.intr_test.rx_bitstuff_err.q ),
+    .qs     ()
+  );
+
+
+  //   F[frame]: 14:14
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_intr_test_frame (
+    .re     (1'b0),
+    .we     (intr_test_frame_we),
+    .wd     (intr_test_frame_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.intr_test.frame.qe),
+    .q      (reg2hw.intr_test.frame.q ),
+    .qs     ()
+  );
+
+
+  //   F[connected]: 15:15
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_intr_test_connected (
+    .re     (1'b0),
+    .we     (intr_test_connected_we),
+    .wd     (intr_test_connected_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.intr_test.connected.qe),
+    .q      (reg2hw.intr_test.connected.q ),
+    .qs     ()
+  );
+
+
+  //   F[link_out_err]: 16:16
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_intr_test_link_out_err (
+    .re     (1'b0),
+    .we     (intr_test_link_out_err_we),
+    .wd     (intr_test_link_out_err_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.intr_test.link_out_err.qe),
+    .q      (reg2hw.intr_test.link_out_err.q ),
     .qs     ()
   );
 
@@ -1139,7 +1828,7 @@ module usbuart_reg_top (
   //   F[rxrst]: 0:0
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("RW"),
+    .SWACCESS("WO"),
     .RESVAL  (1'h0)
   ) u_fifo_ctrl_rxrst (
     .clk_i   (clk_i    ),
@@ -1150,22 +1839,21 @@ module usbuart_reg_top (
     .wd     (fifo_ctrl_rxrst_wd),
 
     // from internal hardware
-    .de     (hw2reg.fifo_ctrl.rxrst.de),
-    .d      (hw2reg.fifo_ctrl.rxrst.d ),
+    .de     (1'b0),
+    .d      ('0  ),
 
     // to internal hardware
     .qe     (reg2hw.fifo_ctrl.rxrst.qe),
     .q      (reg2hw.fifo_ctrl.rxrst.q ),
 
-    // to register interface (read)
-    .qs     (fifo_ctrl_rxrst_qs)
+    .qs     ()
   );
 
 
   //   F[txrst]: 1:1
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("RW"),
+    .SWACCESS("WO"),
     .RESVAL  (1'h0)
   ) u_fifo_ctrl_txrst (
     .clk_i   (clk_i    ),
@@ -1176,15 +1864,14 @@ module usbuart_reg_top (
     .wd     (fifo_ctrl_txrst_wd),
 
     // from internal hardware
-    .de     (hw2reg.fifo_ctrl.txrst.de),
-    .d      (hw2reg.fifo_ctrl.txrst.d ),
+    .de     (1'b0),
+    .d      ('0  ),
 
     // to internal hardware
     .qe     (reg2hw.fifo_ctrl.txrst.qe),
     .q      (reg2hw.fifo_ctrl.txrst.q ),
 
-    // to register interface (read)
-    .qs     (fifo_ctrl_txrst_qs)
+    .qs     ()
   );
 
 
@@ -1396,6 +2083,112 @@ module usbuart_reg_top (
   );
 
 
+  // R[usbctrl]: V(False)
+
+  //   F[pinflip]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_usbctrl_pinflip (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (usbctrl_pinflip_we),
+    .wd     (usbctrl_pinflip_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.usbctrl.pinflip.q ),
+
+    // to register interface (read)
+    .qs     (usbctrl_pinflip_qs)
+  );
+
+
+  //   F[tx_diff]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_usbctrl_tx_diff (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (usbctrl_tx_diff_we),
+    .wd     (usbctrl_tx_diff_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.usbctrl.tx_diff.q ),
+
+    // to register interface (read)
+    .qs     (usbctrl_tx_diff_qs)
+  );
+
+
+  //   F[rx_diff]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_usbctrl_rx_diff (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (usbctrl_rx_diff_we),
+    .wd     (usbctrl_rx_diff_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.usbctrl.rx_diff.q ),
+
+    // to register interface (read)
+    .qs     (usbctrl_rx_diff_qs)
+  );
+
+
+  //   F[ref_disable]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_usbctrl_ref_disable (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (usbctrl_ref_disable_we),
+    .wd     (usbctrl_ref_disable_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.usbctrl.ref_disable.q ),
+
+    // to register interface (read)
+    .qs     (usbctrl_ref_disable_qs)
+  );
+
+
   // R[usbstat]: V(True)
 
   //   F[frame]: 10:0
@@ -1413,22 +2206,37 @@ module usbuart_reg_top (
   );
 
 
-  //   F[host_timeout]: 14:14
+  //   F[link_reset]: 12:12
   prim_subreg_ext #(
     .DW    (1)
-  ) u_usbstat_host_timeout (
-    .re     (usbstat_host_timeout_re),
+  ) u_usbstat_link_reset (
+    .re     (usbstat_link_reset_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.usbstat.host_timeout.d),
+    .d      (hw2reg.usbstat.link_reset.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (usbstat_host_timeout_qs)
+    .qs     (usbstat_link_reset_qs)
   );
 
 
-  //   F[host_lost]: 15:15
+  //   F[link_suspend]: 13:13
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_usbstat_link_suspend (
+    .re     (usbstat_link_suspend_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.usbstat.link_suspend.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (usbstat_link_suspend_qs)
+  );
+
+
+  //   F[host_lost]: 14:14
   prim_subreg_ext #(
     .DW    (1)
   ) u_usbstat_host_lost (
@@ -1440,6 +2248,21 @@ module usbuart_reg_top (
     .qe     (),
     .q      (),
     .qs     (usbstat_host_lost_qs)
+  );
+
+
+  //   F[pwr_sense]: 15:15
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_usbstat_pwr_sense (
+    .re     (usbstat_pwr_sense_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.usbstat.pwr_sense.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (usbstat_pwr_sense_qs)
   );
 
 
@@ -1492,7 +2315,7 @@ module usbuart_reg_top (
 
 
 
-  logic [13:0] addr_hit;
+  logic [14:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == USBUART_INTR_STATE_OFFSET);
@@ -1507,8 +2330,9 @@ module usbuart_reg_top (
     addr_hit[ 9] = (reg_addr == USBUART_OVRD_OFFSET);
     addr_hit[10] = (reg_addr == USBUART_VAL_OFFSET);
     addr_hit[11] = (reg_addr == USBUART_TIMEOUT_CTRL_OFFSET);
-    addr_hit[12] = (reg_addr == USBUART_USBSTAT_OFFSET);
-    addr_hit[13] = (reg_addr == USBUART_USBPARAM_OFFSET);
+    addr_hit[12] = (reg_addr == USBUART_USBCTRL_OFFSET);
+    addr_hit[13] = (reg_addr == USBUART_USBSTAT_OFFSET);
+    addr_hit[14] = (reg_addr == USBUART_USBPARAM_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1530,79 +2354,161 @@ module usbuart_reg_top (
     if (addr_hit[11] && reg_we && (USBUART_PERMIT[11] != (USBUART_PERMIT[11] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[12] && reg_we && (USBUART_PERMIT[12] != (USBUART_PERMIT[12] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[13] && reg_we && (USBUART_PERMIT[13] != (USBUART_PERMIT[13] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[14] && reg_we && (USBUART_PERMIT[14] != (USBUART_PERMIT[14] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_tx_watermark_we = addr_hit[0] & reg_we & ~wr_err;
-  assign intr_state_tx_watermark_wd = reg_wdata[0];
+  assign intr_state_pkt_received_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_pkt_received_wd = reg_wdata[0];
 
-  assign intr_state_rx_watermark_we = addr_hit[0] & reg_we & ~wr_err;
-  assign intr_state_rx_watermark_wd = reg_wdata[1];
+  assign intr_state_pkt_sent_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_pkt_sent_wd = reg_wdata[1];
 
-  assign intr_state_tx_overflow_we = addr_hit[0] & reg_we & ~wr_err;
-  assign intr_state_tx_overflow_wd = reg_wdata[2];
+  assign intr_state_disconnected_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_disconnected_wd = reg_wdata[2];
 
-  assign intr_state_rx_overflow_we = addr_hit[0] & reg_we & ~wr_err;
-  assign intr_state_rx_overflow_wd = reg_wdata[3];
+  assign intr_state_host_lost_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_host_lost_wd = reg_wdata[3];
 
-  assign intr_state_rx_frame_err_we = addr_hit[0] & reg_we & ~wr_err;
-  assign intr_state_rx_frame_err_wd = reg_wdata[4];
+  assign intr_state_link_reset_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_link_reset_wd = reg_wdata[4];
 
-  assign intr_state_rx_break_err_we = addr_hit[0] & reg_we & ~wr_err;
-  assign intr_state_rx_break_err_wd = reg_wdata[5];
+  assign intr_state_link_suspend_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_link_suspend_wd = reg_wdata[5];
 
-  assign intr_state_rx_timeout_we = addr_hit[0] & reg_we & ~wr_err;
-  assign intr_state_rx_timeout_wd = reg_wdata[6];
+  assign intr_state_link_resume_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_link_resume_wd = reg_wdata[6];
 
-  assign intr_state_rx_parity_err_we = addr_hit[0] & reg_we & ~wr_err;
-  assign intr_state_rx_parity_err_wd = reg_wdata[7];
+  assign intr_state_av_empty_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_av_empty_wd = reg_wdata[7];
 
-  assign intr_enable_tx_watermark_we = addr_hit[1] & reg_we & ~wr_err;
-  assign intr_enable_tx_watermark_wd = reg_wdata[0];
+  assign intr_state_rx_full_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_full_wd = reg_wdata[8];
 
-  assign intr_enable_rx_watermark_we = addr_hit[1] & reg_we & ~wr_err;
-  assign intr_enable_rx_watermark_wd = reg_wdata[1];
+  assign intr_state_av_overflow_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_av_overflow_wd = reg_wdata[9];
 
-  assign intr_enable_tx_overflow_we = addr_hit[1] & reg_we & ~wr_err;
-  assign intr_enable_tx_overflow_wd = reg_wdata[2];
+  assign intr_state_link_in_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_link_in_err_wd = reg_wdata[10];
 
-  assign intr_enable_rx_overflow_we = addr_hit[1] & reg_we & ~wr_err;
-  assign intr_enable_rx_overflow_wd = reg_wdata[3];
+  assign intr_state_rx_crc_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_crc_err_wd = reg_wdata[11];
 
-  assign intr_enable_rx_frame_err_we = addr_hit[1] & reg_we & ~wr_err;
-  assign intr_enable_rx_frame_err_wd = reg_wdata[4];
+  assign intr_state_rx_pid_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_pid_err_wd = reg_wdata[12];
 
-  assign intr_enable_rx_break_err_we = addr_hit[1] & reg_we & ~wr_err;
-  assign intr_enable_rx_break_err_wd = reg_wdata[5];
+  assign intr_state_rx_bitstuff_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_bitstuff_err_wd = reg_wdata[13];
 
-  assign intr_enable_rx_timeout_we = addr_hit[1] & reg_we & ~wr_err;
-  assign intr_enable_rx_timeout_wd = reg_wdata[6];
+  assign intr_state_frame_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_frame_wd = reg_wdata[14];
 
-  assign intr_enable_rx_parity_err_we = addr_hit[1] & reg_we & ~wr_err;
-  assign intr_enable_rx_parity_err_wd = reg_wdata[7];
+  assign intr_state_connected_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_connected_wd = reg_wdata[15];
 
-  assign intr_test_tx_watermark_we = addr_hit[2] & reg_we & ~wr_err;
-  assign intr_test_tx_watermark_wd = reg_wdata[0];
+  assign intr_state_link_out_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_link_out_err_wd = reg_wdata[16];
 
-  assign intr_test_rx_watermark_we = addr_hit[2] & reg_we & ~wr_err;
-  assign intr_test_rx_watermark_wd = reg_wdata[1];
+  assign intr_enable_pkt_received_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_pkt_received_wd = reg_wdata[0];
 
-  assign intr_test_tx_overflow_we = addr_hit[2] & reg_we & ~wr_err;
-  assign intr_test_tx_overflow_wd = reg_wdata[2];
+  assign intr_enable_pkt_sent_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_pkt_sent_wd = reg_wdata[1];
 
-  assign intr_test_rx_overflow_we = addr_hit[2] & reg_we & ~wr_err;
-  assign intr_test_rx_overflow_wd = reg_wdata[3];
+  assign intr_enable_disconnected_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_disconnected_wd = reg_wdata[2];
 
-  assign intr_test_rx_frame_err_we = addr_hit[2] & reg_we & ~wr_err;
-  assign intr_test_rx_frame_err_wd = reg_wdata[4];
+  assign intr_enable_host_lost_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_host_lost_wd = reg_wdata[3];
 
-  assign intr_test_rx_break_err_we = addr_hit[2] & reg_we & ~wr_err;
-  assign intr_test_rx_break_err_wd = reg_wdata[5];
+  assign intr_enable_link_reset_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_link_reset_wd = reg_wdata[4];
 
-  assign intr_test_rx_timeout_we = addr_hit[2] & reg_we & ~wr_err;
-  assign intr_test_rx_timeout_wd = reg_wdata[6];
+  assign intr_enable_link_suspend_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_link_suspend_wd = reg_wdata[5];
 
-  assign intr_test_rx_parity_err_we = addr_hit[2] & reg_we & ~wr_err;
-  assign intr_test_rx_parity_err_wd = reg_wdata[7];
+  assign intr_enable_link_resume_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_link_resume_wd = reg_wdata[6];
+
+  assign intr_enable_av_empty_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_av_empty_wd = reg_wdata[7];
+
+  assign intr_enable_rx_full_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_full_wd = reg_wdata[8];
+
+  assign intr_enable_av_overflow_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_av_overflow_wd = reg_wdata[9];
+
+  assign intr_enable_link_in_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_link_in_err_wd = reg_wdata[10];
+
+  assign intr_enable_rx_crc_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_crc_err_wd = reg_wdata[11];
+
+  assign intr_enable_rx_pid_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_pid_err_wd = reg_wdata[12];
+
+  assign intr_enable_rx_bitstuff_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_bitstuff_err_wd = reg_wdata[13];
+
+  assign intr_enable_frame_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_frame_wd = reg_wdata[14];
+
+  assign intr_enable_connected_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_connected_wd = reg_wdata[15];
+
+  assign intr_enable_link_out_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_link_out_err_wd = reg_wdata[16];
+
+  assign intr_test_pkt_received_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_pkt_received_wd = reg_wdata[0];
+
+  assign intr_test_pkt_sent_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_pkt_sent_wd = reg_wdata[1];
+
+  assign intr_test_disconnected_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_disconnected_wd = reg_wdata[2];
+
+  assign intr_test_host_lost_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_host_lost_wd = reg_wdata[3];
+
+  assign intr_test_link_reset_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_link_reset_wd = reg_wdata[4];
+
+  assign intr_test_link_suspend_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_link_suspend_wd = reg_wdata[5];
+
+  assign intr_test_link_resume_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_link_resume_wd = reg_wdata[6];
+
+  assign intr_test_av_empty_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_av_empty_wd = reg_wdata[7];
+
+  assign intr_test_rx_full_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_full_wd = reg_wdata[8];
+
+  assign intr_test_av_overflow_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_av_overflow_wd = reg_wdata[9];
+
+  assign intr_test_link_in_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_link_in_err_wd = reg_wdata[10];
+
+  assign intr_test_rx_crc_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_crc_err_wd = reg_wdata[11];
+
+  assign intr_test_rx_pid_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_pid_err_wd = reg_wdata[12];
+
+  assign intr_test_rx_bitstuff_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_bitstuff_err_wd = reg_wdata[13];
+
+  assign intr_test_frame_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_frame_wd = reg_wdata[14];
+
+  assign intr_test_connected_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_connected_wd = reg_wdata[15];
+
+  assign intr_test_link_out_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_link_out_err_wd = reg_wdata[16];
 
   assign ctrl_tx_we = addr_hit[3] & reg_we & ~wr_err;
   assign ctrl_tx_wd = reg_wdata[0];
@@ -1678,42 +2584,76 @@ module usbuart_reg_top (
   assign timeout_ctrl_en_we = addr_hit[11] & reg_we & ~wr_err;
   assign timeout_ctrl_en_wd = reg_wdata[31];
 
-  assign usbstat_frame_re = addr_hit[12] && reg_re;
+  assign usbctrl_pinflip_we = addr_hit[12] & reg_we & ~wr_err;
+  assign usbctrl_pinflip_wd = reg_wdata[0];
 
-  assign usbstat_host_timeout_re = addr_hit[12] && reg_re;
+  assign usbctrl_tx_diff_we = addr_hit[12] & reg_we & ~wr_err;
+  assign usbctrl_tx_diff_wd = reg_wdata[1];
 
-  assign usbstat_host_lost_re = addr_hit[12] && reg_re;
+  assign usbctrl_rx_diff_we = addr_hit[12] & reg_we & ~wr_err;
+  assign usbctrl_rx_diff_wd = reg_wdata[2];
 
-  assign usbstat_device_address_re = addr_hit[12] && reg_re;
+  assign usbctrl_ref_disable_we = addr_hit[12] & reg_we & ~wr_err;
+  assign usbctrl_ref_disable_wd = reg_wdata[3];
 
-  assign usbparam_baud_req_re = addr_hit[13] && reg_re;
+  assign usbstat_frame_re = addr_hit[13] && reg_re;
 
-  assign usbparam_parity_req_re = addr_hit[13] && reg_re;
+  assign usbstat_link_reset_re = addr_hit[13] && reg_re;
+
+  assign usbstat_link_suspend_re = addr_hit[13] && reg_re;
+
+  assign usbstat_host_lost_re = addr_hit[13] && reg_re;
+
+  assign usbstat_pwr_sense_re = addr_hit[13] && reg_re;
+
+  assign usbstat_device_address_re = addr_hit[13] && reg_re;
+
+  assign usbparam_baud_req_re = addr_hit[14] && reg_re;
+
+  assign usbparam_parity_req_re = addr_hit[14] && reg_re;
 
   // Read data return
   always_comb begin
     reg_rdata_next = '0;
     unique case (1'b1)
       addr_hit[0]: begin
-        reg_rdata_next[0] = intr_state_tx_watermark_qs;
-        reg_rdata_next[1] = intr_state_rx_watermark_qs;
-        reg_rdata_next[2] = intr_state_tx_overflow_qs;
-        reg_rdata_next[3] = intr_state_rx_overflow_qs;
-        reg_rdata_next[4] = intr_state_rx_frame_err_qs;
-        reg_rdata_next[5] = intr_state_rx_break_err_qs;
-        reg_rdata_next[6] = intr_state_rx_timeout_qs;
-        reg_rdata_next[7] = intr_state_rx_parity_err_qs;
+        reg_rdata_next[0] = intr_state_pkt_received_qs;
+        reg_rdata_next[1] = intr_state_pkt_sent_qs;
+        reg_rdata_next[2] = intr_state_disconnected_qs;
+        reg_rdata_next[3] = intr_state_host_lost_qs;
+        reg_rdata_next[4] = intr_state_link_reset_qs;
+        reg_rdata_next[5] = intr_state_link_suspend_qs;
+        reg_rdata_next[6] = intr_state_link_resume_qs;
+        reg_rdata_next[7] = intr_state_av_empty_qs;
+        reg_rdata_next[8] = intr_state_rx_full_qs;
+        reg_rdata_next[9] = intr_state_av_overflow_qs;
+        reg_rdata_next[10] = intr_state_link_in_err_qs;
+        reg_rdata_next[11] = intr_state_rx_crc_err_qs;
+        reg_rdata_next[12] = intr_state_rx_pid_err_qs;
+        reg_rdata_next[13] = intr_state_rx_bitstuff_err_qs;
+        reg_rdata_next[14] = intr_state_frame_qs;
+        reg_rdata_next[15] = intr_state_connected_qs;
+        reg_rdata_next[16] = intr_state_link_out_err_qs;
       end
 
       addr_hit[1]: begin
-        reg_rdata_next[0] = intr_enable_tx_watermark_qs;
-        reg_rdata_next[1] = intr_enable_rx_watermark_qs;
-        reg_rdata_next[2] = intr_enable_tx_overflow_qs;
-        reg_rdata_next[3] = intr_enable_rx_overflow_qs;
-        reg_rdata_next[4] = intr_enable_rx_frame_err_qs;
-        reg_rdata_next[5] = intr_enable_rx_break_err_qs;
-        reg_rdata_next[6] = intr_enable_rx_timeout_qs;
-        reg_rdata_next[7] = intr_enable_rx_parity_err_qs;
+        reg_rdata_next[0] = intr_enable_pkt_received_qs;
+        reg_rdata_next[1] = intr_enable_pkt_sent_qs;
+        reg_rdata_next[2] = intr_enable_disconnected_qs;
+        reg_rdata_next[3] = intr_enable_host_lost_qs;
+        reg_rdata_next[4] = intr_enable_link_reset_qs;
+        reg_rdata_next[5] = intr_enable_link_suspend_qs;
+        reg_rdata_next[6] = intr_enable_link_resume_qs;
+        reg_rdata_next[7] = intr_enable_av_empty_qs;
+        reg_rdata_next[8] = intr_enable_rx_full_qs;
+        reg_rdata_next[9] = intr_enable_av_overflow_qs;
+        reg_rdata_next[10] = intr_enable_link_in_err_qs;
+        reg_rdata_next[11] = intr_enable_rx_crc_err_qs;
+        reg_rdata_next[12] = intr_enable_rx_pid_err_qs;
+        reg_rdata_next[13] = intr_enable_rx_bitstuff_err_qs;
+        reg_rdata_next[14] = intr_enable_frame_qs;
+        reg_rdata_next[15] = intr_enable_connected_qs;
+        reg_rdata_next[16] = intr_enable_link_out_err_qs;
       end
 
       addr_hit[2]: begin
@@ -1725,6 +2665,15 @@ module usbuart_reg_top (
         reg_rdata_next[5] = '0;
         reg_rdata_next[6] = '0;
         reg_rdata_next[7] = '0;
+        reg_rdata_next[8] = '0;
+        reg_rdata_next[9] = '0;
+        reg_rdata_next[10] = '0;
+        reg_rdata_next[11] = '0;
+        reg_rdata_next[12] = '0;
+        reg_rdata_next[13] = '0;
+        reg_rdata_next[14] = '0;
+        reg_rdata_next[15] = '0;
+        reg_rdata_next[16] = '0;
       end
 
       addr_hit[3]: begin
@@ -1757,8 +2706,8 @@ module usbuart_reg_top (
       end
 
       addr_hit[7]: begin
-        reg_rdata_next[0] = fifo_ctrl_rxrst_qs;
-        reg_rdata_next[1] = fifo_ctrl_txrst_qs;
+        reg_rdata_next[0] = '0;
+        reg_rdata_next[1] = '0;
         reg_rdata_next[4:2] = fifo_ctrl_rxilvl_qs;
         reg_rdata_next[6:5] = fifo_ctrl_txilvl_qs;
       end
@@ -1783,13 +2732,22 @@ module usbuart_reg_top (
       end
 
       addr_hit[12]: begin
-        reg_rdata_next[10:0] = usbstat_frame_qs;
-        reg_rdata_next[14] = usbstat_host_timeout_qs;
-        reg_rdata_next[15] = usbstat_host_lost_qs;
-        reg_rdata_next[22:16] = usbstat_device_address_qs;
+        reg_rdata_next[0] = usbctrl_pinflip_qs;
+        reg_rdata_next[1] = usbctrl_tx_diff_qs;
+        reg_rdata_next[2] = usbctrl_rx_diff_qs;
+        reg_rdata_next[3] = usbctrl_ref_disable_qs;
       end
 
       addr_hit[13]: begin
+        reg_rdata_next[10:0] = usbstat_frame_qs;
+        reg_rdata_next[12] = usbstat_link_reset_qs;
+        reg_rdata_next[13] = usbstat_link_suspend_qs;
+        reg_rdata_next[14] = usbstat_host_lost_qs;
+        reg_rdata_next[15] = usbstat_pwr_sense_qs;
+        reg_rdata_next[22:16] = usbstat_device_address_qs;
+      end
+
+      addr_hit[14]: begin
         reg_rdata_next[15:0] = usbparam_baud_req_qs;
         reg_rdata_next[17:16] = usbparam_parity_req_qs;
       end

--- a/hw/ip/usbuart/usbuart.core
+++ b/hw/ip/usbuart/usbuart.core
@@ -10,12 +10,12 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:ip:tlul
       - lowrisc:ip:usb_fs_nb_pe
-      - lowrisc:ip:usbdev
     files:
       - rtl/usbuart_reg_pkg.sv
       - rtl/usbuart_reg_top.sv
       - rtl/usbuart_core.sv
       - rtl/usbuart_usbif.sv
+      - rtl/usbuart_iomux.sv
       - rtl/usb_serial_fifo_ep.sv
       - rtl/usb_serial_ctrl_ep.sv
       - rtl/usbuart.sv
@@ -83,5 +83,3 @@ targets:
         mode: lint-only
         verilator_options:
           - "-Wall"
-
-

--- a/util/licence-checker.hjson
+++ b/util/licence-checker.hjson
@@ -29,6 +29,7 @@
     # Manually checked, files contain additional copyright header lines
     'hw/ip/usb_fs_nb_pe/rtl/*',
     'hw/ip/usbdev/rtl/usbdev_iomux.sv',
+    'hw/ip/usbuart/rtl/usbuart_iomux.sv',
     'hw/ip/usbuart/rtl/usb_serial_*_ep.sv',
 
     ## Software Exclusions


### PR DESCRIPTION
Convert usbuart to have same verilog interface as usbdev and
same register interface as uart with additional USB registers

Simple test can be done by hacking the existing top_earlgrey to slot
the usbuart in rather than usbdev.
- Replace usbdev with usbuart in autogen/top_earlgrey.sv
- Replace usbdev with usbuart in top_earlgrey.core
- Change uart base_addr in hello_world to TOP_EARLGREY_USBDEV_BASE_ADDR

Passes verible and verilator lint checks.

Runs in verilator simulation (reading usb0.log output to see hello_world
messages are received by the host and the Hi!Hi! is echoed.)

Runs on Nexysvideo FPGA board.

Signed-off-by: Mark Hayter <mark.hayter@gmail.com>