### PR TITLE
[otbn] Fix address range check for narrow loads and stores

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/dmem.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/dmem.py
@@ -181,7 +181,7 @@ class Dmem:
         if addr & 3:
             raise BadAddrError('narrow load', addr,
                                'address is not 4-byte aligned')
-        if (addr + 31) // 32 >= len(self.data):
+        if (addr + 3) // 32 >= len(self.data):
             raise BadAddrError('narrow load', addr,
                                'address is above the top of dmem')
 
@@ -203,7 +203,7 @@ class Dmem:
         if addr & 3:
             raise BadAddrError('narrow load', addr,
                                'address is not 4-byte aligned')
-        if (addr + 31) // 32 >= len(self.data):
+        if (addr + 3) // 32 >= len(self.data):
             raise BadAddrError('narrow load', addr,
                                'address is above the top of dmem')
 


### PR DESCRIPTION
Dividing by 32 here converts from "address" to "32-byte word". We
should add 3 to the address before dividing, so that we're getting the
word corresponding to the top byte of the load or store. (In practice,
this doesn't actually do anything because addr is 4-byte aligned, but
it can't hurt to be explicit).

Before this patch, we were adding 31 instead (copy-pasted from the
wide load and store methods above), which causes an error if you try
to load or store 32 bits to e.g. `0xff4.`
