### PR TITLE
[otbn] Pass stall signal to call stack to avoid double-pop

### DIFF
--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -55,6 +55,7 @@ module otbn_controller
   output logic [4:0]   rf_base_rd_addr_b_o,
   output logic         rf_base_rd_en_b_o,
   input  logic [31:0]  rf_base_rd_data_b_i,
+  output logic         rf_base_rd_commit_o,
 
   input  logic         rf_base_call_stack_err_i,
 
@@ -369,6 +370,7 @@ module otbn_controller
     rf_base_rd_addr_b_o = insn_dec_base_i.b;
     rf_base_rd_en_b_o   = insn_dec_base_i.rf_ren_b & insn_valid_i;
     rf_base_wr_addr_o   = insn_dec_base_i.d;
+    rf_base_rd_commit_o = !stall;
 
     if (insn_dec_shared_i.subset == InsnSubsetBignum) begin
       unique case (1'b1)

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -89,6 +89,7 @@ module otbn_core
   logic [4:0]   rf_base_rd_addr_b;
   logic         rf_base_rd_en_b;
   logic [31:0]  rf_base_rd_data_b;
+  logic         rf_base_rd_commit;
   logic         rf_base_call_stack_err;
 
   alu_base_operation_t  alu_base_operation;
@@ -228,6 +229,7 @@ module otbn_core
     .rf_base_rd_addr_b_o      (rf_base_rd_addr_b),
     .rf_base_rd_en_b_o        (rf_base_rd_en_b),
     .rf_base_rd_data_b_i      (rf_base_rd_data_b),
+    .rf_base_rd_commit_o      (rf_base_rd_commit),
     .rf_base_call_stack_err_i (rf_base_call_stack_err),
 
     // To/from bignunm register file
@@ -322,6 +324,7 @@ module otbn_core
     .rd_addr_b_i (rf_base_rd_addr_b),
     .rd_en_b_i   (rf_base_rd_en_b),
     .rd_data_b_o (rf_base_rd_data_b),
+    .rd_commit_i (rf_base_rd_commit),
 
     .call_stack_err_o (rf_base_call_stack_err)
   );

--- a/hw/ip/otbn/rtl/otbn_rf_base.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_base.sv
@@ -34,6 +34,7 @@ module otbn_rf_base
   input  logic [4:0]   rd_addr_b_i,
   input  logic         rd_en_b_i,
   output logic [31:0]  rd_data_b_o,
+  input  logic         rd_commit_i,
 
   output logic         call_stack_err_o
 );
@@ -60,7 +61,7 @@ module otbn_rf_base
 
   assign pop_stack_a = rd_en_a_i & (rd_addr_a_i == CallStackRegIndex[4:0]);
   assign pop_stack_b = rd_en_b_i & (rd_addr_b_i == CallStackRegIndex[4:0]);
-  assign pop_stack   = pop_stack_a | pop_stack_b;
+  assign pop_stack   = rd_commit_i & (pop_stack_a | pop_stack_b);
 
   assign push_stack = wr_en_i & (wr_addr_i == CallStackRegIndex[4:0]);
 


### PR DESCRIPTION
This avoids a problem with instruction sequences like

    addi    x1, x0, 0
    addi    x1, x0, 1
    bn.lid  x1, 0(x0)
    ecall

Without a fix like this one, the controller holds the read enable for
`x1` high for both cycles of the stalling `bn.lid` instruction, resulting
in a double pop.

@GregAC and I talked about the bug on Slack earlier. I think he's got another fix in mind which doesn't need the stall signal to be piped around the design. But this gets things working again for me locally, so I thought I should push it up as one way to fix things.

Closes #4722 (but maybe there's a better way to do it).