### PR TITLE
[prim_edn_req] Fix protocol violation, enable use of prim_sync_reqack_data

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -546,6 +546,7 @@ module otp_ctrl
     .req_i      ( edn_req  ),
     .ack_o      ( edn_ack  ),
     .data_o     ( edn_data ),
+    .fips_o     (          ), // unused
     .clk_edn_i,
     .rst_edn_ni,
     .edn_o,

--- a/hw/ip/prim/rtl/prim_edn_req.sv
+++ b/hw/ip/prim/rtl/prim_edn_req.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // This module can be used as a "gadget" to adapt the native 32bit width of the EDN network
-// locally to the width needed by the consuming logic. For example, a if the local consumer
+// locally to the width needed by the consuming logic. For example, if the local consumer
 // needs 128bit, this module would request four 32 bit words from EDN and stack them accordingly.
 //
 // The module also uses a req/ack synchronizer to synchronize the EDN data over to the local
@@ -22,8 +22,9 @@ module prim_edn_req
   input                       clk_i,
   input                       rst_ni,
   input                       req_i,
-  output                      ack_o,
+  output logic                ack_o,
   output logic [OutWidth-1:0] data_o,
+  output logic                fips_o,
   // EDN side
   input                       clk_edn_i,
   input                       rst_edn_ni,
@@ -36,25 +37,23 @@ module prim_edn_req
   assign word_req = req_i & ~ack_o;
 
   logic [edn_pkg::ENDPOINT_BUS_WIDTH-1:0] word_data;
+  logic word_fips;
   prim_sync_reqack_data #(
     .Width(edn_pkg::ENDPOINT_BUS_WIDTH),
     .DataSrc2Dst(1'b0),
     .DataReg(1'b0)
   ) u_prim_sync_reqack_data (
-    .clk_src_i  ( clk_i         ),
-    .rst_src_ni ( rst_ni        ),
-    .clk_dst_i  ( clk_edn_i     ),
-    .rst_dst_ni ( rst_edn_ni    ),
-    .src_req_i  ( word_req      ),
-    .src_ack_o  ( word_ack      ),
-    .dst_req_o  ( edn_o.edn_req ),
-    .dst_ack_i  ( edn_i.edn_ack ),
-    .data_i     ( edn_i.edn_bus ),
-    .data_o     ( word_data     )
+    .clk_src_i  ( clk_i                           ),
+    .rst_src_ni ( rst_ni                          ),
+    .clk_dst_i  ( clk_edn_i                       ),
+    .rst_dst_ni ( rst_edn_ni                      ),
+    .src_req_i  ( word_req                        ),
+    .src_ack_o  ( word_ack                        ),
+    .dst_req_o  ( edn_o.edn_req                   ),
+    .dst_ack_i  ( edn_i.edn_ack                   ),
+    .data_i     ( {edn_i.edn_fips, edn_i.edn_bus} ),
+    .data_o     ( {word_fips,      word_data}     )
   );
-
-  logic unused_edn_fips;
-  assign unused_edn_fips = edn_i.edn_fips;
 
   prim_packer_fifo #(
     .InW(edn_pkg::ENDPOINT_BUS_WIDTH),
@@ -75,5 +74,20 @@ module prim_edn_req
     .rready_i ( 1'b1          ),
     .depth_o  (               )
   );
+
+  // Need to track if any of the packed words has been generated with a pre-FIPS seed, i.e., has
+  // fips == 1'b0.
+  logic fips_d, fips_q;
+  assign fips_d = (req_i && ack_o) ? 1'b1               : // clear
+                  (word_ack)       ? fips_q & word_fips : // accumulate
+                                     fips_q;              // keep
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      fips_q <= 1'b1;
+    end else begin
+      fips_q <= fips_d;
+    end
+  end
+  assign fips_o = fips_q;
 
 endmodule : prim_edn_req

--- a/hw/ip/prim/rtl/prim_edn_req.sv
+++ b/hw/ip/prim/rtl/prim_edn_req.sv
@@ -35,8 +35,12 @@ module prim_edn_req
   logic word_req, word_ack;
   assign word_req = req_i & ~ack_o;
 
-  // TODO: swap this for prim_sync_reqack_data, once available.
-  prim_sync_reqack u_prim_sync_reqack (
+  logic [edn_pkg::ENDPOINT_BUS_WIDTH-1:0] word_data;
+  prim_sync_reqack_data #(
+    .Width(edn_pkg::ENDPOINT_BUS_WIDTH),
+    .DataSrc2Dst(1'b0),
+    .DataReg(1'b0)
+  ) u_prim_sync_reqack_data (
     .clk_src_i  ( clk_i         ),
     .rst_src_ni ( rst_ni        ),
     .clk_dst_i  ( clk_edn_i     ),
@@ -44,7 +48,9 @@ module prim_edn_req
     .src_req_i  ( word_req      ),
     .src_ack_o  ( word_ack      ),
     .dst_req_o  ( edn_o.edn_req ),
-    .dst_ack_i  ( edn_i.edn_ack )
+    .dst_ack_i  ( edn_i.edn_ack ),
+    .data_i     ( edn_i.edn_bus ),
+    .data_o     ( word_data     )
   );
 
   logic unused_edn_fips;
@@ -58,7 +64,7 @@ module prim_edn_req
     .rst_ni,
     .clr_i    ( 1'b0          ), // not needed
     .wvalid_i ( word_ack      ),
-    .wdata_i  ( edn_i.edn_bus ),
+    .wdata_i  ( word_data     ),
     // no need for backpressure since we're always ready to
     // sink data at this point.
     .wready_o (               ),

--- a/hw/ip/prim/rtl/prim_edn_req.sv
+++ b/hw/ip/prim/rtl/prim_edn_req.sv
@@ -31,14 +31,17 @@ module prim_edn_req
   input  edn_pkg::edn_rsp_t   edn_i
 );
 
+  // Stop requesting words from EDN once desired amount of data is available.
+  logic word_req, word_ack;
+  assign word_req = req_i & ~ack_o;
+
   // TODO: swap this for prim_sync_reqack_data, once available.
-  logic word_ack;
   prim_sync_reqack u_prim_sync_reqack (
     .clk_src_i  ( clk_i         ),
     .rst_src_ni ( rst_ni        ),
     .clk_dst_i  ( clk_edn_i     ),
     .rst_dst_ni ( rst_edn_ni    ),
-    .src_req_i  ( req_i         ),
+    .src_req_i  ( word_req      ),
     .src_ack_o  ( word_ack      ),
     .dst_req_o  ( edn_o.edn_req ),
     .dst_ack_i  ( edn_i.edn_ack )


### PR DESCRIPTION
This PR contains two commits:
1. The first commit fixes a protocol violation. Without this commit, the `req_i` signal is directly forwarded to the handshake synchronizer and de-asserted 1 cycle after receiving the last ACK. This means the handshake synchronizer sees a REQ without having sufficient time to ACK. The fix implemented in this PR is to not forward the REQ whenever the packer FIFO has valid data output.
2. The second commit instantiates the `prim_sync_reqack_data` primitive that also feeds the data through the synchronizer prim. This will allow to waive all CDC violations in one place.