### PR TITLE
[otbn] Wrap bn.movr increments modulo 32

### DIFF
--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -984,7 +984,12 @@
     <grd>[<grd_inc>], <grs>[<grs_inc>]
   doc: |
     Copies WDR contents between registers with indirect addressing.
-    Optionally, either the source or the destination register address can be incremented by 1.
+
+    After the operation, either the value in the GPR `grd`, or the value in `grs` can be optionally incremented.
+
+    - If `grd_inc` is set, `grd` is updated to be `(*grd + 1) & 0x1f`.
+    - If `grs_inc` is set, `grs` is updated to be `(*grs + 1) & 0x1f`.
+
   decode: |
     s = UInt(grs)
     d = UInt(grd)

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -886,11 +886,11 @@ class BNMOVR(OTBNInsn):
         state.wdrs.get_reg(wrd).write_unsigned(value)
 
         if self.grd_inc:
-            new_grd_val = (grd_val + 1) & ((1 << 32) - 1)
+            new_grd_val = (grd_val + 1) & 0x1f
             state.gprs.get_reg(self.grd).write_unsigned(new_grd_val)
 
         if self.grs_inc:
-            new_grs_val = (grs_val + 1) & ((1 << 32) - 1)
+            new_grs_val = (grs_val + 1) & 0x1f
             state.gprs.get_reg(self.grs).write_unsigned(new_grs_val)
 
 


### PR DESCRIPTION
This is what the RTL did already. Make the spec match the equivalent
documentation for `bn.lid` and update the ISS to match.

Fixes #4736.