### PR TITLE
Lower pyyaml requirements for faster builds

### DIFF
--- a/ci/install-package-dependencies.yml
+++ b/ci/install-package-dependencies.yml
@@ -64,7 +64,7 @@ steps:
       # version, which then fails to run.
       python3 -m pip install --user -U pip setuptools
 
-      pip3 install --user -U -r python-requirements.txt
+      pip3 install --user -r python-requirements.txt
 
       # Install Verible
       mkdir -p build/verible

--- a/hw/dv/tools/ralgen/ralgen.py
+++ b/hw/dv/tools/ralgen/ralgen.py
@@ -99,9 +99,7 @@ def main():
         f.write("CAPI=2:\n")
         yaml.dump(ral_pkg_core_text,
                   f,
-                  encoding="utf-8",
-                  default_flow_style=False,
-                  sort_keys=False)
+                  encoding="utf-8")
     print("RAL core file written to {}".format(ral_pkg_core_file))
 
 

--- a/hw/formal/tools/csr_assert_gen/csr_assert_gen.py
+++ b/hw/formal/tools/csr_assert_gen/csr_assert_gen.py
@@ -93,9 +93,7 @@ def main():
         f.write("CAPI=2:\n")
         yaml.dump(csr_assert_core_text,
                   f,
-                  encoding="utf-8",
-                  default_flow_style=False,
-                  sort_keys=False)
+                  encoding="utf-8")
     print("CSR assert core file written to {}".format(csr_assert_core_file))
 
 

--- a/hw/ip/prim/util/primgen.py
+++ b/hw/ip/prim/util/primgen.py
@@ -378,8 +378,6 @@ def _generate_abstract_impl(gapi):
         yaml.dump(abstract_prim_core,
                   f,
                   encoding="utf-8",
-                  default_flow_style=False,
-                  sort_keys=False,
                   Dumper=YamlDumper)
     print("Core file written to %s" % (abstract_prim_core_filepath, ))
 

--- a/hw/ip/rstmgr/util/rstmgr_gen_core.py
+++ b/hw/ip/rstmgr/util/rstmgr_gen_core.py
@@ -176,9 +176,7 @@ def main():
             f.write("CAPI=2:\n")
             yaml.dump(core['text'],
                       f,
-                      encoding="utf-8",
-                      default_flow_style=False,
-                      sort_keys=False)
+                      encoding="utf-8")
             print("core file written to {}".format(core['path']))
 
 

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -19,7 +19,7 @@ pyserial
 pygments
 pytest
 pytest-timeout
-pyyaml >= 5.1
+pyyaml
 tabulate
 yapf
 

--- a/util/topgen-fusesoc.py
+++ b/util/topgen-fusesoc.py
@@ -37,8 +37,6 @@ def write_core(core_filepath, generated_core):
         yaml.dump(generated_core,
                   f,
                   encoding="utf-8",
-                  default_flow_style=False,
-                  sort_keys=False,
                   Dumper=YamlDumper)
     print("Core file written to %s" % (core_filepath, ))
 


### PR DESCRIPTION
PyYAML is heavily used to dump and parse YAML files in FuseSoC. PyYAML can either use a pure Python implementation of the parser/dumper, or use the native libyaml library. The latter one is significantly faster (multiple times), and actually makes (in my experience) an observable difference when running FuseSoC (in our setup with primgen involved).

Up to now, we required a quite recent version of pyyaml which was only installable through pip; this version doesn't use the native libyaml library. In this PR, the version requirements are lowered by changing some code in a trivial way, which allows us to use the Ubuntu-packaged version of PyYAML again, which is compiled with the native libyaml library bindings.