### PR TITLE
[verilator] Only control the reset line when necessary

### DIFF
--- a/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -289,11 +289,16 @@ void VerilatorSimCtrl::Run() {
   time_begin_ = std::chrono::steady_clock::now();
   UnsetReset();
   Trace();
+
+  unsigned long start_reset_cycle_ = initial_reset_delay_cycles_;
+  unsigned long end_reset_cycle_ = start_reset_cycle_ + reset_duration_cycles_;
+
   while (1) {
-    if (time_ / 2 >= initial_reset_delay_cycles_) {
+    unsigned long cycle_ = time_ / 2;
+
+    if (cycle_ == start_reset_cycle_) {
       SetReset();
-    }
-    if (time_ / 2 >= reset_duration_cycles_ + initial_reset_delay_cycles_) {
+    } else if (cycle_ == end_reset_cycle_) {
       UnsetReset();
     }
 


### PR DESCRIPTION
The previous code was calling `SetReset()` and then `UnsetReset()` for
every cycle after the initial reset, which I noticed because I was
using a watchpoint to debug something else.

This seems a bit unnecessary, so this patch gets rid of that. It also
changes the logic to only call `SetReset()` and `UnsetReset()` on the
"edges". This should be equivalent, but it's a bit more obvious what's
going on.