### PR TITLE
[otbn] Don't double-start OTBN in otbn_top_sim

### DIFF
--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -21,7 +21,10 @@ module otbn_top_sim (
   logic      otbn_done_d, otbn_done_q;
   err_code_e otbn_err_code_d, otbn_err_code_q;
   logic      otbn_start;
-  logic      otbn_start_done;
+
+  // Intialise otbn_start_done to 1 so that we only signal otbn_start after we have seen a reset. If
+  // you don't do this, we start OTBN before the reset, which can generate confusing trace messages.
+  logic      otbn_start_done = 1'b1;
 
   // Instruction memory (IMEM) signals
   logic                     imem_req;


### PR DESCRIPTION
Otherwise there's just enough time before the reset to get some very
confusing trace messages, which cause mismatches with the ISS.
