### PR TITLE
[lc_ctrl] Add OTP partition error bit that is accessible via TAP

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -364,6 +364,15 @@
                 automatically to ESCALATE and raise an lc_state_failure alert.
                 '''
         }
+        { bits: "8"
+          name: "OTP_PARTITION_ERROR"
+          desc: '''
+                This bit is set to 1 if the life cycle partition in OTP is in error state.
+                This bit is intended for production testing during the RAW life cycle state,
+                where the OTP control and status registers are not accessible.
+                This error does not trigger an alert in the life cycle controller.
+                '''
+        }
       ]
     }
 

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -39,6 +39,7 @@ interface lc_ctrl_if(input clk, input rst_n);
                       lc_ctrl_pkg::lc_tx_t    clk_byp_ack = lc_ctrl_pkg::Off,
                       lc_ctrl_pkg::lc_tx_t    flash_rma_ack = lc_ctrl_pkg::Off);
     otp_i.valid = 1;
+    otp_i.error = 0;
     otp_i.state = lc_state;
     otp_i.count = lc_cnt;
     otp_i.all_zero_token = 0;

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -210,6 +210,7 @@ module lc_ctrl
   logic          flash_rma_error_d, flash_rma_error_q;
   logic          otp_prog_error_d, otp_prog_error_q;
   logic          state_invalid_error_d, state_invalid_error_q;
+  logic          otp_part_error_q;
   logic [7:0]    sw_claim_transition_if_d, sw_claim_transition_if_q;
   logic [7:0]    tap_claim_transition_if_d, tap_claim_transition_if_q;
   logic          transition_cmd;
@@ -237,6 +238,7 @@ module lc_ctrl
     hw2reg.status.flash_rma_error        = flash_rma_error_q;
     hw2reg.status.otp_error              = otp_prog_error_q;
     hw2reg.status.state_error            = state_invalid_error_q;
+    hw2reg.status.otp_partition_error    = otp_part_error_q;
     hw2reg.lc_state                      = dec_lc_state;
     hw2reg.lc_transition_cnt             = dec_lc_cnt;
     hw2reg.lc_id_state                   = dec_lc_id_state;
@@ -324,6 +326,7 @@ module lc_ctrl
       tap_claim_transition_if_q <= '0;
       transition_token_q        <= '0;
       transition_target_q       <= DecLcStRaw;
+      otp_part_error_q          <= '0;
     end else begin
       // All status and error bits are terminal and require a reset cycle.
       trans_success_q           <= trans_success_d        | trans_success_q;
@@ -333,6 +336,7 @@ module lc_ctrl
       flash_rma_error_q         <= flash_rma_error_d      | flash_rma_error_q;
       otp_prog_error_q          <= otp_prog_error_d       | otp_prog_error_q;
       state_invalid_error_q     <= state_invalid_error_d  | state_invalid_error_q;
+      otp_part_error_q          <= otp_lc_data_i.error    | otp_part_error_q;
       // Other regs, gated by mutex further below.
       sw_claim_transition_if_q  <= sw_claim_transition_if_d;
       tap_claim_transition_if_q <= tap_claim_transition_if_d;

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
@@ -74,6 +74,9 @@ package lc_ctrl_reg_pkg;
     struct packed {
       logic        d;
     } state_error;
+    struct packed {
+      logic        d;
+    } otp_partition_error;
   } lc_ctrl_hw2reg_status_reg_t;
 
   typedef struct packed {
@@ -124,7 +127,7 @@ package lc_ctrl_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    lc_ctrl_hw2reg_status_reg_t status; // [415:408]
+    lc_ctrl_hw2reg_status_reg_t status; // [416:408]
     lc_ctrl_hw2reg_claim_transition_if_reg_t claim_transition_if; // [407:400]
     lc_ctrl_hw2reg_transition_regwen_reg_t transition_regwen; // [399:399]
     lc_ctrl_hw2reg_transition_token_mreg_t [3:0] transition_token; // [398:271]
@@ -187,7 +190,7 @@ package lc_ctrl_reg_pkg;
   // Register width information to check illegal writes
   parameter logic [3:0] LC_CTRL_PERMIT [21] = '{
     4'b 0001, // index[ 0] LC_CTRL_ALERT_TEST
-    4'b 0001, // index[ 1] LC_CTRL_STATUS
+    4'b 0011, // index[ 1] LC_CTRL_STATUS
     4'b 0001, // index[ 2] LC_CTRL_CLAIM_TRANSITION_IF
     4'b 0001, // index[ 3] LC_CTRL_TRANSITION_REGWEN
     4'b 0001, // index[ 4] LC_CTRL_TRANSITION_CMD

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
@@ -91,6 +91,8 @@ module lc_ctrl_reg_top (
   logic status_otp_error_re;
   logic status_state_error_qs;
   logic status_state_error_re;
+  logic status_otp_partition_error_qs;
+  logic status_otp_partition_error_re;
   logic [7:0] claim_transition_if_qs;
   logic [7:0] claim_transition_if_wd;
   logic claim_transition_if_we;
@@ -294,6 +296,21 @@ module lc_ctrl_reg_top (
     .qe     (),
     .q      (),
     .qs     (status_state_error_qs)
+  );
+
+
+  //   F[otp_partition_error]: 8:8
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_status_otp_partition_error (
+    .re     (status_otp_partition_error_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.status.otp_partition_error.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (status_otp_partition_error_qs)
   );
 
 
@@ -689,6 +706,8 @@ module lc_ctrl_reg_top (
 
   assign status_state_error_re = addr_hit[1] && reg_re;
 
+  assign status_otp_partition_error_re = addr_hit[1] && reg_re;
+
   assign claim_transition_if_we = addr_hit[2] & reg_we & ~wr_err;
   assign claim_transition_if_wd = reg_wdata[7:0];
   assign claim_transition_if_re = addr_hit[2] && reg_re;
@@ -758,6 +777,7 @@ module lc_ctrl_reg_top (
         reg_rdata_next[5] = status_flash_rma_error_qs;
         reg_rdata_next[6] = status_otp_error_qs;
         reg_rdata_next[7] = status_state_error_qs;
+        reg_rdata_next[8] = status_otp_partition_error_qs;
       end
 
       addr_hit[2]: begin

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -1144,6 +1144,10 @@ end else if (PartInfo[k].variant == LifeCycle) begin : gen_lifecycle
 
   // Assert life cycle state valid signal only when all partitions have initialized.
   assign otp_lc_data_o.valid    = &part_init_done;
+  // Signal whether there are any errors in the life cycle partition (both correctable and
+  // uncorrectable ones). This bit is made available via the JTAG TAP, which is useful for
+  // production testing in RAW life cycle state where the OTP regs are not accessible.
+  assign otp_lc_data_o.error    = |part_error[LifeCycleIdx];
 
   // Not all bits of part_buf_data are used here.
   logic unused_buf_data;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -140,6 +140,7 @@ package otp_ctrl_pkg;
 
   typedef struct packed {
     logic                      valid;
+    logic                      error;
     lc_ctrl_pkg::lc_state_e    state;
     lc_ctrl_pkg::lc_cnt_e      count;
     // These are all hash post-images
@@ -154,6 +155,7 @@ package otp_ctrl_pkg;
   // Default for dangling connection
   parameter otp_lc_data_t OTP_LC_DATA_DEFAULT = '{
     valid: 1'b1,
+    error: 1'b0,
     state: '0,
     count: '0,
     all_zero_token: '0,


### PR DESCRIPTION
The `OTP_PARTITION_ERROR` bit is intended to ease production testing, since the life cycle partition is not readable via the TL-UL test interface and the DAI.
It flags any error encountered in the life cycle partition, including correctable and uncorrectable ECC errors.
Hence, this bit combined with the `STATE_ERROR` bit can be used to perform an implicit "blank check" of the OTP array in RAW state, before performing the RAW unlock sequence.

Signed-off-by: Michael Schaffner <msf@opentitan.org>