### PR TITLE
[dv/lc_ctrl] testplan and add to V1 status

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.prj.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.prj.hjson
@@ -5,11 +5,11 @@
 {
     name:               "lc_ctrl",
     design_spec:        "hw/ip/lc_ctrl/doc",
-    dv_doc:            "",
-    hw_checklist:       "",
+    dv_doc:             "hw/ip/lc_ctrl/doc/dv",
+    hw_checklist:       "hw/ip/lc_ctrl/doc/checklist",
     version:            "0.1",
     life_stage:         "L1",
     design_stage:       "D1",
-    verification_stage: "V0",
+    verification_stage: "V1",
     notes:              "",
 }

--- a/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
@@ -4,8 +4,7 @@
 {
   name: "lc_ctrl"
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
   entries: [
     {

--- a/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name: "lc_ctrl"
-  // TODO: remove the common testplans if not applicable
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
@@ -12,21 +11,136 @@
     {
       name: smoke
       desc: '''
-            Smoke test accessing a major datapath within the lc_ctrl.
+            Smoke test accessing lc_ctrl state transition datapath.
 
             **Stimulus**:
-            - TBD
+            - Initialize lc_ctrl by sending pwrmgr req and otp_ctrl valid random data
+            - Request a valid next LC state by writing CSRs: `transition_target`,
+              `transition_token*`, and `transition_cmd`
 
             **Checks**:
-            - TBD
+            - After lc_ctrl initialization finishes, check lc_ctrl broadcast outputs, check
+              the value of lc_state and lc_transition_cnt CSRs, and check device_id and id_state
+              CSRs
+            - After lc_ctrl state transition request, check status to ensure the transition is
+              valid and successful
+            - Check token matching for both conditional and unconditional requests
+            - Once the transition is successful, check lc_ctrl broadcast outputs are all turned off
             '''
       milestone: V1
       tests: ["lc_ctrl_smoke"]
     }
     {
-      name: feature1
-      desc: '''Add more test entries here like above.'''
-      milestone: V1
+      name: state_post_trans
+      desc: '''
+            This test is based on smoke test.
+            After smoke sequence, this test adds additional lc_state transition request before
+            issuing reset. This should happen regardless if the transition is successful.
+            Use scoreboard to ensure lc_ctrl ignores this additional lc_state transition request
+            and check state count.
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: regwen_during_op
+      desc: '''
+            `Transition_regwen` is RO register and it gates bunch of write access of other
+            registers.
+
+            **Checks**:
+            - Check `transition_regwen` register is set to 1 during lc_state transition request
+            - Check that accessing its locked CSRs is gated during the transition operation
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: lc_prog_failure
+      desc: '''
+            This test checks lc_program failure by setting the error bit after otp program request.
+
+            **Checks**:
+            - Check if status register reflects the correct error bit
+            - Check if lc_program_failure alert is triggered
+            - Check if lc_state moves to escalation state
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: lc_state_failure
+      desc: '''
+            This test checks lc_state failure by:
+            - Driving invalid data to lc_ctrl input `otp_lc_data_i` fields `lc_state` and `lc_cnt`
+            - Backdoor changing lc_ctrl FSM's to invalid value
+            For invalid value, the testbench will test using random value and valid `A/B/C/D`
+            values with different orders.
+
+            **Checks**:
+            - Check if status register reflects the correct error bit
+            - Check if lc_state_failure alert is triggered
+            - Check if lc_state moves to escalation state
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: lc_errors
+      desc: '''
+            This test randomly executes the error senarios:
+            - Otp_ctrl input lc_trans_cnt reaches 16
+            - Lc_ctrl state transition request is invalid
+            - Input LC token does not match the output from otp_ctrl
+            - Flash rma responses to lc_ctrl request with error
+            - LC clock bypass responses with error
+            - Input otp_lc_data's error bit is set to 1
+            Note that all the above scenarios except the last one requires a reset to recover.
+
+            **Checks**:
+            - Check if status register reflects the correct error bit
+            - Check if lc_state moves to correct exit state
+            - Check if lc_trans_cnt is incremented
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: security_escalation
+      desc: '''
+            This test checks two security escalation responses:
+            1. Wipe secrets: permanently asserts lc_escalate_en signal
+            2. Scrap state: lc_ctrl moves to escalation state, check the state will be cleared up
+               upon next power cycle
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: jtag_access
+      desc: '''
+            This test checks jtag debug interface in lc_ctrl.
+            This test will use both JTAG TAP and TLUL to access the CSR space.
+            All above CSR sequences should be accessible via both interfaces.
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: jtag_priority
+      desc: '''
+            This test covers a corner case in JTAG and TLUL interfaces.
+
+            **Stimulus**:
+            - Issue mux_claim operation from TLUL and JTAG interfaces at the same time
+
+            **Checks**:
+            - Ensure TAP interface has the priority
+            - Ensure right after the mux_claim operation, the non-prioritized interface returns 0
+              from the CSR readings. This checking ensures there is no token leakage between
+              interfaces
+            '''
+      milestone: V2
       tests: []
     }
   ]

--- a/hw/ip/lc_ctrl/doc/checklist.md
+++ b/hw/ip/lc_ctrl/doc/checklist.md
@@ -115,28 +115,28 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Not Started | [LC_CTRL DV document]({{<relref "hw/ip/lc_ctrl/doc/dv" >}})
-Documentation | [DV_PLAN_COMPLETED][]                 | Not Started | [LC_CTRL DV plan]({{<relref "hw/ip/lc_ctrl/doc/dv/index.md#dv_plan" >}})
-Testbench     | [TB_TOP_CREATED][]                    | Not Started |
-Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Not Started |
-Testbench     | [SIM_TB_ENV_CREATED][]                | Not Started |
-Testbench     | [SIM_RAL_MODEL_GEN_AUTOMATED][]       | Not Started |
-Testbench     | [CSR_CHECK_GEN_AUTOMATED][]           | Not Started |
-Testbench     | [TB_GEN_AUTOMATED][]                  | Not Started |
-Tests         | [SIM_SMOKE_TEST_PASSING][]            | Not Started |
-Tests         | [SIM_CSR_MEM_TEST_SUITE_PASSING][]    | Not Started |
-Tests         | [FPV_MAIN_ASSERTIONS_PROVEN][]        | Not Started |
-Tool Setup    | [SIM_ALT_TOOL_SETUP][]                | Not Started |
-Regression    | [SIM_SMOKE_REGRESSION_SETUP][]        | Not Started |
-Regression    | [SIM_NIGHTLY_REGRESSION_SETUP][]      | Not Started |
-Regression    | [FPV_REGRESSION_SETUP][]              | Not Started |
-Coverage      | [SIM_COVERAGE_MODEL_ADDED][]          | Not Started |
-Code Quality  | [TB_LINT_SETUP][]                     | Not Started |
-Integration   | [PRE_VERIFIED_SUB_MODULES_V1][]       | Not Started |
-Review        | [DESIGN_SPEC_REVIEWED][]              | Not Started |
-Review        | [DV_PLAN_REVIEWED][]                  | Not Started |
-Review        | [STD_TEST_CATEGORIES_PLANNED][]       | Not Started | Exception (?)
-Review        | [V2_CHECKLIST_SCOPED][]               | Not Started |
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [LC_CTRL DV document]({{<relref "hw/ip/lc_ctrl/doc/dv" >}})
+Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [LC_CTRL DV plan]({{<relref "hw/ip/lc_ctrl/doc/dv/index.md#dv_plan" >}})
+Testbench     | [TB_TOP_CREATED][]                    | Done        |
+Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
+Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |
+Testbench     | [SIM_RAL_MODEL_GEN_AUTOMATED][]       | Done        |
+Testbench     | [CSR_CHECK_GEN_AUTOMATED][]           | Done        |
+Testbench     | [TB_GEN_AUTOMATED][]                  | Done        |
+Tests         | [SIM_SMOKE_TEST_PASSING][]            | Done        |
+Tests         | [SIM_CSR_MEM_TEST_SUITE_PASSING][]    | Done        |
+Tests         | [FPV_MAIN_ASSERTIONS_PROVEN][]        | N/A         |
+Tool Setup    | [SIM_ALT_TOOL_SETUP][]                | Done        |
+Regression    | [SIM_SMOKE_REGRESSION_SETUP][]        | Done        |
+Regression    | [SIM_NIGHTLY_REGRESSION_SETUP][]      | Done        |
+Regression    | [FPV_REGRESSION_SETUP][]              | N/A         |
+Coverage      | [SIM_COVERAGE_MODEL_ADDED][]          | Done        |
+Code Quality  | [TB_LINT_SETUP][]                     | Done        |
+Integration   | [PRE_VERIFIED_SUB_MODULES_V1][]       | N/A         | Exception for IP modules
+Review        | [DESIGN_SPEC_REVIEWED][]              | Done        |
+Review        | [DV_PLAN_REVIEWED][]                  | Done        |
+Review        | [STD_TEST_CATEGORIES_PLANNED][]       | Done        | Exception (Security, Power)
+Review        | [V2_CHECKLIST_SCOPED][]               | Done        |
 
 [DV_DOC_DRAFT_COMPLETED]:             {{<relref "/doc/project/checklist.md#dv_doc_draft_completed" >}}
 [DV_PLAN_COMPLETED]:                  {{<relref "/doc/project/checklist.md#dv_plan_completed" >}}

--- a/hw/ip/lc_ctrl/doc/dv/index.md
+++ b/hw/ip/lc_ctrl/doc/dv/index.md
@@ -114,5 +114,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
 ```
 
 ## DV plan
-<!-- TODO: uncomment the line below after adding the DV plan -->
-{{</* testplan "hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson" */>}}
+{{< testplan "hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson" >}}

--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -29,7 +29,6 @@
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
                 // TODO: temp commented out stress_test

--- a/hw/ip/otp_ctrl/data/otp_ctrl.prj.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.prj.hjson
@@ -5,7 +5,7 @@
 {
     name:               "otp_ctrl",
     design_spec:        "hw/ip/otp_ctrl/doc",
-    dv_doc:            "hw/ip/otp_ctrl/doc/dv",
+    dv_doc:             "hw/ip/otp_ctrl/doc/dv",
     hw_checklist:       "hw/ip/otp_ctrl/doc/checklist",
     sw_checklist:       "sw/device/lib/dif/dif_otp_ctrl",
     version:            "0.1",


### PR DESCRIPTION
This PR has three commits to move LC_CTRL to V1 status:
1. Add a testplan.
2. Remove the interrupts and memory tests within testplan and lc_ctrl_sim_cfg.hjson
3. Update checklist.