### PR TITLE
[pwrmgr] Move fsm enum defs to pkg

### DIFF
--- a/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
@@ -183,5 +183,36 @@ package pwrmgr_pkg;
     LowPower = 1'b1
   } low_power_hint_e;
 
+  // fast fsm state enum
+  typedef enum logic [4:0] {
+    FastPwrStateLowPower,
+    FastPwrStateEnableClocks,
+    FastPwrStateReleaseLcRst,
+    FastPwrStateOtpInit,
+    FastPwrStateLcInit,
+    FastPwrStateFlashInit,
+    FastPwrStateAckPwrUp,
+    FastPwrStateActive,
+    FastPwrStateDisClks,
+    FastPwrStateFallThrough,
+    FastPwrStateNvmIdleChk,
+    FastPwrStateLowPowerPrep,
+    FastPwrStateNvmShutDown,
+    FastPwrStateResetPrep,
+    FastPwrStateReqPwrDn
+  } fast_pwr_state_e;
+
+  // slow fsm state enum
+  typedef enum logic [3:0] {
+    SlowPwrStateReset,
+    SlowPwrStateLowPower,
+    SlowPwrStateMainPowerOn,
+    SlowPwrStateClocksOn,
+    SlowPwrStateReqPwrUp,
+    SlowPwrStateIdle,
+    SlowPwrStateAckPwrDn,
+    SlowPwrStateClocksOff,
+    SlowPwrStateMainPowerOff
+  } slow_pwr_state_e;
 
 endpackage // pwrmgr_pkg


### PR DESCRIPTION
Doing this to enable probing and monitoring fsm state in DV.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>