### PR TITLE
[keymgr/dv] Fix CSR failure

### DIFF
--- a/hw/ip/keymgr/data/keymgr.hjson
+++ b/hw/ip/keymgr/data/keymgr.hjson
@@ -369,6 +369,8 @@
           '''
         },
       ]
+      tags: [// when it's set, it can't be modified until the next advance operation completes
+             "excl:CsrNonInitTests:CsrExclWrite"]
     },
 
     { multireg: {


### PR DESCRIPTION
fix #4755
Exclude writing to binding_en as it's locked until next advance

Signed-off-by: Weicai Yang <weicai@google.com>