### PR TITLE
[aes] Add reset to data, IV, state and key registers

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -266,7 +266,7 @@
       ]
       tags: [// Updated by the HW.
              // Updates based on writes to other regs.
-             // No reset but sync clear with random data.
+             // These registers are reset to 0, but the reset also triggers internal operations that clear these registers with pseudo-random data shortly afterwards (See Trigger Register).
              // Exclude from init and write-read checks.
              "excl:CsrAllTests:CsrExclCheck"]
       }

--- a/hw/ip/aes/doc/checklist.md
+++ b/hw/ip/aes/doc/checklist.md
@@ -51,7 +51,7 @@ Code Quality  | [CDC_SETUP][]           | Not Started |
 Code Quality  | [FPGA_TIMING][]         | Not Started |
 Code Quality  | [CDC_SYNCMACRO][]       | Not Started |
 Security      | [SEC_CM_IMPLEMENTED][]  | Not Started |
-Security      | [SEC_NON_RESET_FLOPS][] | Not Started |
+Security      | [SEC_NON_RESET_FLOPS][] | Done        |
 Security      | [SEC_SHADOW_REGS][]     | Not Started |
 Security      | [SEC_RND_CNST][]        | Not Started |
 

--- a/hw/ip/aes/rtl/aes_cipher_core.sv
+++ b/hw/ip/aes/rtl/aes_cipher_core.sv
@@ -218,8 +218,10 @@ module aes_cipher_core import aes_pkg::*;
     endcase
   end
 
-  always_ff @(posedge clk_i) begin : state_reg
-    if (state_we) begin
+  always_ff @(posedge clk_i or negedge rst_ni) begin : state_reg
+    if (!rst_ni) begin
+      state_q <= '{default: '0};
+    end else if (state_we) begin
       state_q <= state_d;
     end
   end
@@ -351,8 +353,10 @@ module aes_cipher_core import aes_pkg::*;
     endcase
   end
 
-  always_ff @(posedge clk_i) begin : key_full_reg
-    if (key_full_we) begin
+  always_ff @(posedge clk_i or negedge rst_ni) begin : key_full_reg
+    if (!rst_ni) begin
+      key_full_q <= '{default: '0};
+    end else if (key_full_we) begin
       key_full_q <= key_full_d;
     end
   end
@@ -366,8 +370,10 @@ module aes_cipher_core import aes_pkg::*;
     endcase
   end
 
-  always_ff @(posedge clk_i) begin : key_dec_reg
-    if (key_dec_we) begin
+  always_ff @(posedge clk_i or negedge rst_ni) begin : key_dec_reg
+    if (!rst_ni) begin
+      key_dec_q <= '{default: '0};
+    end else if (key_dec_we) begin
       key_dec_q <= key_dec_d;
     end
   end

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -206,10 +206,12 @@ module aes_core
     endcase
   end
 
-  always_ff @(posedge clk_i) begin : key_init_reg
+  always_ff @(posedge clk_i or negedge rst_ni) begin : key_init_reg
     for (int s=0; s<2; s++) begin
       for (int i=0; i<8; i++) begin
-        if (key_init_we[s][i]) begin
+        if (!rst_ni) begin
+          key_init_q[s][i] <= '0;
+        end else if (key_init_we[s][i]) begin
           key_init_q[s][i] <= key_init_d[s][i];
         end
       end
@@ -229,9 +231,11 @@ module aes_core
     endcase
   end
 
-  always_ff @(posedge clk_i) begin : iv_reg
+  always_ff @(posedge clk_i or negedge rst_ni) begin : iv_reg
     for (int i=0; i<8; i++) begin
-      if (iv_we[i]) begin
+      if (!rst_ni) begin
+        iv_q[i] <= '0;
+      end else if (iv_we[i]) begin
         iv_q[i] <= iv_d[i];
       end
     end
@@ -246,8 +250,10 @@ module aes_core
     endcase
   end
 
-  always_ff @(posedge clk_i) begin : data_in_prev_reg
-    if (data_in_prev_we) begin
+  always_ff @(posedge clk_i or negedge rst_ni) begin : data_in_prev_reg
+    if (!rst_ni) begin
+      data_in_prev_q <= '0;
+    end else if (data_in_prev_we) begin
       data_in_prev_q <= data_in_prev_d;
     end
   end
@@ -567,8 +573,10 @@ module aes_core
   // Outputs //
   /////////////
 
-  always_ff @(posedge clk_i) begin : data_out_reg
-    if (data_out_we) begin
+  always_ff @(posedge clk_i or negedge rst_ni) begin : data_out_reg
+    if (!rst_ni) begin
+      data_out_q <= '0;
+    end else if (data_out_we) begin
       data_out_q <= data_out_d;
     end
   end


### PR DESCRIPTION
We originally removed the reset from those registers as part of lowRISC/OpenTitan#1845 to avoid Hamming weight leakage of potentially sensitive assests during targeted reset glitch attacks.

When discussing the pros and cons of non-reset vs. reset flops later on, we have concluded that in the case of AES reset flops should be used for the following reasons:
- In the hardened AES implementation, key and state values are stored in multiple shares. Neither the Hamming weights of the individual shares nor the summed Hamming weight are proportional to the Hamming weight of the secret asset.
- Input/ouput data and IV values are (currently) not stored in multiple shares but these are less critical as they are used only once. Further, they are stored in banks of 32 bits leaving a larger hypothesis space compared to when glitching e.g. an 8-bit register into reset. In addition, they could potentially also be extracted when being transferred over the TL-UL bus.

Therefore, this commit re-adds resets to data, IV, state and key registers. Upon reset, we keep clearing the registers with random data.

See lowRISC/OpenTitan#2603 for more information on the non-reset vs. reset flop rationale.