### PR TITLE
[otbn] Use .+123 syntax where possible for relative operands

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/isa.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/isa.py
@@ -93,7 +93,7 @@ class OTBNInsn:
             assert pc == old_pc
             return old_disasm
 
-        disasm = self.insn.disassemble(self.op_vals, 12)
+        disasm = self.insn.disassemble(pc, self.op_vals, 12)
         self._disasm = (pc, disasm)
         return disasm
 

--- a/hw/ip/otbn/util/otbn-as
+++ b/hw/ip/otbn/util/otbn-as
@@ -489,7 +489,7 @@ def expand_li(where: str, op_to_expr: Dict[str, Optional[str]]) -> List[str]:
                            'operand is wrong: {}'
                            .format(where, err))
 
-    grd_txt = gpr_type.op_val_to_str(grd_op_val)
+    grd_txt = gpr_type.op_val_to_str(grd_op_val, None)
 
     try:
         imm_int = int(imm, 0)

--- a/hw/ip/otbn/util/otbn-objdump
+++ b/hw/ip/otbn/util/otbn-objdump
@@ -97,7 +97,7 @@ def transform_disasm_line(line: str,
 
     # Similarly, we know we have a syntax (again, get_insn_masks requires it).
     # The rendering of the fields is done by the syntax object.
-    return match.group(1) + insn.disassemble(op_vals, 7)
+    return match.group(1) + insn.disassemble(pc, op_vals, 7)
 
 
 def get_insn_masks(insns_file: InsnsFile) -> List[Tuple[int, int, Insn]]:

--- a/hw/ip/otbn/util/rig/program.py
+++ b/hw/ip/otbn/util/rig/program.py
@@ -46,7 +46,7 @@ class ProgInsn:
             assert op_val is not None
             op_vals[operand.name] = op_val
 
-        return self.insn.disassemble(op_vals, 14)
+        return self.insn.disassemble(cur_pc, op_vals, 14)
 
     def to_json(self) -> object:
         '''Serialize to an object that can be written as JSON'''

--- a/hw/ip/otbn/util/shared/insn_yaml.py
+++ b/hw/ip/otbn/util/shared/insn_yaml.py
@@ -172,6 +172,7 @@ class Insn:
         return op_vals
 
     def disassemble(self,
+                    cur_pc: int,
                     op_vals: Dict[str, int],
                     mnem_width: int) -> str:
         '''Return disassembly for this instruction
@@ -186,7 +187,7 @@ class Insn:
 
         return (padded_mnem +
                 ('' if self.glued_ops else ' ') +
-                self.syntax.render(op_vals, self.name_to_operand))
+                self.syntax.render(cur_pc, op_vals, self.name_to_operand))
 
 
 def find_ambiguous_encodings(insns: List[Insn]) -> List[Tuple[str, str, int]]:


### PR DESCRIPTION
The binutils RISC-V assembler does magic things for instructions like

    bne x0, x1, 256

and expands them to something like:

    beq x0, x1, .+8
    jal 256

This plays havoc with the random instruction generator, but can be
avoided by explicitly writing

    bne x0, x1, .+128

(assuming the PC was 128).
