### PR TITLE
[otbn] Add support for BN.LID, BN.MOVR and csr/wsr instructions to RIG

### DIFF
--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -968,6 +968,10 @@
   operands:
     - name: grd
       doc: Name of the GPR containing the destination WDR.
+      # The grd register is read to pick the WDR that should be written, so
+      # it's sort of logically a destination (hence the name) but should be
+      # treated as a source by tools like the random instruction generator.
+      type: grs
     - name: grs
       doc: Name of the GPR referencing the source WDR.
     - name: grd_inc

--- a/hw/ip/otbn/util/otbn-rig
+++ b/hw/ip/otbn/util/otbn-rig
@@ -92,7 +92,7 @@ def asm_main(args: argparse.Namespace) -> int:
                     for idx, x in enumerate(json_snippets)]
     except ValueError as err:
         print('Failed to parse snippets from {!r}: {}'
-              .format(args.snippets, err),
+              .format(args.snippets.name, err),
               file=sys.stderr)
         return 1
 

--- a/hw/ip/otbn/util/rig/gens/straight_line_insn.py
+++ b/hw/ip/otbn/util/rig/gens/straight_line_insn.py
@@ -379,12 +379,16 @@ class StraightLineInsn(SnippetGen):
         # Ask the model to try to find a target we can use. If this is a load
         # or a CSR operation, it will have to be an address that already has an
         # architectural value. If a store, it can be any address in range.
+        #
+        # We cheat a bit for WSR stores. These don't actually load a value, but
+        # we still want to make sure we pick a valid WSR index, so we claim we
+        # loaded one anyway.
         lsu_type_to_info = {
             'mem-load': ('dmem', True),
             'mem-store': ('dmem', False),
             'csr': ('csr', True),
             'wsr-load': ('wsr', True),
-            'wsr-store': ('wsr', False)
+            'wsr-store': ('wsr', True)
         }
         assert set(lsu_type_to_info.keys()) == set(LSUDesc.TYPES)
         mem_type, loads_value = lsu_type_to_info[insn.lsu.lsu_type]

--- a/hw/ip/otbn/util/shared/operand.py
+++ b/hw/ip/otbn/util/shared/operand.py
@@ -170,8 +170,6 @@ class RegOperandType(OperandType):
     TYPE_FMTS = {
         'gpr': (5, 'x'),
         'wdr': (5, 'w'),
-        'csr': (12, None),
-        'wsr': (8, None)
     }
 
     def __init__(self, reg_type: str, is_dest: bool) -> None:
@@ -558,8 +556,6 @@ def parse_operand_type(fmt: str,
         'grd': ('gpr', True),
         'wrs': ('wdr', False),
         'wrd': ('wdr', True),
-        'csr': ('csr', True),
-        'wsr': ('wsr', True)
     }
     reg_match = reg_fmts.get(fmt)
     if reg_match is not None:
@@ -570,6 +566,18 @@ def parse_operand_type(fmt: str,
                              .format(what, fmt))
         reg_type, is_dest = reg_match
         return RegOperandType.make(reg_type, is_dest, what, scheme_field)
+
+    # CSR and WSR indices. These are treated like unsigned immediates, with
+    # width 12 and 8, respectively.
+    xsr_fmts = {
+        'csr': 12,
+        'wsr': 8
+    }
+    xsr_match = xsr_fmts.get(fmt)
+    if xsr_match is not None:
+        assert not pc_rel
+        return ImmOperandType.make(xsr_match, 0, 0, False, False,
+                                   what, scheme_field)
 
     # Immediates
     for base, signed in [('simm', True), ('uimm', False)]:


### PR DESCRIPTION
This works, but will generate some exciting errors when you run the resulting programs (known bugs: BN.MOV implementation  (#4721); double x1 pop for loads (#4722); ISS/RTL mismatch for BN.LID wrapping (#4727)).

EDIT: All those bugs are fixed, so the resulting instruction streams might actually work! :-)