### PR TITLE
[kmac] Add EDN synchronizer

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -4,6 +4,9 @@
 
 { name: "kmac"
   clock_primary: "clk_i"
+  other_clock_list: [ "clk_edn_i" ]
+  reset_primary: "rst_ni",
+  other_reset_list: [ "rst_edn_ni" ]
   bus_device: "tlul"
   bus_host: "none"
 

--- a/hw/ip/kmac/kmac.core
+++ b/hw/ip/kmac/kmac.core
@@ -15,6 +15,7 @@ filesets:
       - lowrisc:ip:keymgr_pkg
       - lowrisc:ip:sha3
       - lowrisc:ip:edn_pkg
+      - lowrisc:prim:edn_req
     files:
       - rtl/kmac_pkg.sv
       - rtl/kmac_core.sv

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3960,17 +3960,20 @@
       clock_srcs:
       {
         clk_i: main
+        clk_edn_i: main
       }
       clock_group: trans
       reset_connections:
       {
         rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
+        rst_edn_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x41120000
       clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_kmac
+        clk_edn_i: clkmgr_clocks.clk_main_kmac
       }
       domain: "0"
       size: 0x1000

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -385,9 +385,9 @@
     },
     { name: "kmac"
       type: "kmac"
-      clock_srcs: {clk_i: "main"}
+      clock_srcs: {clk_i: "main", clk_edn_i: "main"}
       clock_group: "trans"
-      reset_connections: {rst_ni: "sys"}
+      reset_connections: {rst_ni: "sys", rst_edn_ni: "sys"}
       base_addr: "0x41120000"
     },
     { name: "keymgr",

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1303,7 +1303,9 @@ module top_earlgrey #(
       .tl_i(kmac_tl_req),
       .tl_o(kmac_tl_rsp),
       .clk_i (clkmgr_clocks.clk_main_kmac),
-      .rst_ni (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel])
+      .clk_edn_i (clkmgr_clocks.clk_main_kmac),
+      .rst_ni (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
+      .rst_edn_ni (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel])
   );
 
   keymgr #(


### PR DESCRIPTION
This PR adds newly introduced `prim_edn_req` primitive into KMAC Entropy interface.

This requires to define EDN clock (it is synchronous to KMAC clock) in KMAC, which results in re-generating TOP.
