### PR TITLE
[dv/top] Fix VCS warning for cover cfg file

### DIFF
--- a/hw/top_earlgrey/dv/cov/chip_cover_reg_top.cfg
+++ b/hw/top_earlgrey/dv/cov/chip_cover_reg_top.cfg
@@ -13,7 +13,7 @@
 +tree tb.dut.top_earlgrey.u_rv_plic.u_reg
 
 // Only cover the TL interface of all sub-modules.
-+node tb.dut.top_earlgrey.u_*.tl_*
++node tb.dut top_earlgrey.u_*.tl_*
 
 // TODO: Add TL interface of top_earlgrey and AST when available.
 


### PR DESCRIPTION
Fix for below warning. The syntax for struct is slightly different

> Warning-[VCM-HFUFR] Hier Config: regions not found
>   In the '-cm_hier' configuration file, pattern "+node ---
>   tb.dut.top_earlgrey.u_*.tl_*" did not match any pattern.
>   Please check the entry at line number "16" in hier config file
>   "/edascratch/weicai-opentitan/ot/rerun_top2/repo_top/hw/top_earlgrey/dv/cov/chip_cover_reg_top.cfg".
>   If the unmatched pattern is a design unit which is present in a verilog
>   library or present under a celldefine directive and you want VCS to consider
>   it for coverage, then please pass "-cm_libs yv+celldefine".

Signed-off-by: Weicai Yang <weicai@google.com>