### PR TITLE
[otbn] Auto-generate decode information in ISA

### DIFF
--- a/hw/ip/otbn/data/base-insns.yml
+++ b/hw/ip/otbn/data/base-insns.yml
@@ -239,7 +239,11 @@
 - mnemonic: lw
   rv32i: true
   synopsis: Load Word
-  operands: [grd, offset, grs1]
+  operands:
+    - grd
+    - name: offset
+      abbrev: "off"
+    - grs1
   syntax: <grd>, <offset>(<grs1>)
   encoding:
     scheme: I
@@ -262,7 +266,11 @@
 - mnemonic: sw
   rv32i: true
   synopsis: Store Word
-  operands: [grs2, offset, grs1]
+  operands:
+    - grs2
+    - name: offset
+      abbrev: "off"
+    - grs1
   syntax: <grs2>, <offset>(<grs1>)
   encoding:
     scheme: S
@@ -289,6 +297,7 @@
     - grs2
     - &branch-offset-operand
       name: offset
+      abbrev: "off"
       pc-rel: true
       type: simm<<1
   straight-line: false
@@ -431,6 +440,7 @@
       doc: Name of the GPR containing the number of iterations
     - &bodysize-operand
       name: bodysize
+      abbrev: sz
       type: uimm+1
       doc: Number of instructions in the loop body
   straight-line: false

--- a/hw/ip/otbn/data/base-insns.yml
+++ b/hw/ip/otbn/data/base-insns.yml
@@ -374,14 +374,10 @@
   lsu:
     type: csr
     target: [csr]
-  decode: |
-    csr_num = UInt(csr)
-    d = UInt(grd)
-    s = UInt(grs1)
   operation: |
-    gpr_s_val = GPR[s]
-    GPR[d] = CSR[csr_num]
-    CSR[csr_num] |= gpr_s_val
+    gpr_s_val = GPR[grs1]
+    GPR[grd] = CSR[csr]
+    CSR[csr] |= gpr_s_val
 
 - mnemonic: csrrw
   rv32i: true
@@ -403,17 +399,13 @@
   lsu:
     type: csr
     target: [csr]
-  decode: |
-    csr_num = UInt(csr)
-    d = UInt(grd)
-    s = UInt(grs1)
   operation: |
-    gpr_s_val = GPR[s]
+    gpr_s_val = GPR[grs1]
 
     if d != 0:
-      GPR[d] = CSR[csr_num]
+      GPR[grd] = CSR[csr]
 
-    CSR[csr_num] = gpr_s_val
+    CSR[csr] = gpr_s_val
 
 - mnemonic: ecall
   rv32i: true

--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -34,19 +34,11 @@
     Adds two WDR values, writes the result to the destination WDR and updates
     flags. The content of the second source WDR can be shifted by an unsigned
     immediate before it is consumed by the operation.
-  decode: |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-
-    fg = DecodeFlagGroup(flag_group)
-    sb = UInt(shift_bits) // 8
-    st = DecodeShiftType(shift_type)
   operation: |
-    b_shifted = ShiftReg(b, st, sb)
-    (result, flags_out) = AddWithCarry(a, b_shifted, "0")
+    b_shifted = ShiftReg(wrs2, shift_type, shift_bits)
+    (result, flags_out) = AddWithCarry(wrs1, b_shifted, "0")
 
-    WDR[d] = result
+    WDR[wrd] = result
     FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnaf
@@ -68,19 +60,11 @@
     destination WDR, and updates the flags. The content of the second source
     WDR can be shifted by an unsigned immediate before it is consumed by the
     operation.
-  decode: |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-
-    fg = DecodeFlagGroup(flag_group)
-    sb = UInt(shift_bits) // 8
-    st = DecodeShiftType(shift_type)
   operation: |
-    b_shifted = ShiftReg(b, st, sb)
-    (result, flags_out) = AddWithCarry(a, b_shifted, FLAGS[flag_group].C)
+    b_shifted = ShiftReg(wrs2, shift_type, shift_bits)
+    (result, flags_out) = AddWithCarry(wrs1, b_shifted, FLAGS[flag_group].C)
 
-    WDR[d] = result
+    WDR[wrd] = result
     FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnaf
@@ -109,16 +93,10 @@
   doc: |
     Adds a zero-extended unsigned immediate to the value of a WDR, writes the
     result to the destination WDR, and updates the flags.
-  decode: |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-
-    fg = DecodeFlagGroup(flag_group)
-    i = ZeroExtend(imm, WLEN)
   operation: |
-    (result, flags_out) = AddWithCarry(a, i, "0")
+    (result, flags_out) = AddWithCarry(wrs1, imm, "0")
 
-    WDR[d] = result
+    WDR[wrd] = result
     FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnai
@@ -144,17 +122,13 @@
     The intermediate result is small enough if both inputs are less than `MOD`.
 
     Flags are not used or saved.
-  decode: |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
   operation: |
-    result = a + b
+    result = wrs1 + wrs2
 
     if result >= MOD:
       result = result - MOD
 
-    WDR[d] = result & ((1 << 256) - 1)
+    WDR[wrd] = result & ((1 << 256) - 1)
   encoding:
     scheme: bnam
     mapping:
@@ -211,23 +185,13 @@
     Multiplies two `WLEN/4` WDR values, shifts the product by `acc_shift_imm` bits, and adds the result to the accumulator.
 
     For versions of the instruction with writeback, see `BN.MULQACC.WO` and `BN.MULQACC.SO`.
-  decode: |
-    zero_accumulator = DecodeMulqaccZeroacc(zero_acc)
-
-    d = None
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-
-    d_hwsel = None
-    a_qwsel = DecodeQuarterWordSelect(wrs1_qwsel)
-    b_qwsel = DecodeQuarterWordSelect(wrs2_qwsel)
   operation: |
-    a_qw = GetQuarterWord(a, a_qwsel)
-    b_qw = GetQuarterWord(b, b_qwsel)
+    a_qw = GetQuarterWord(wrs1, wrs1_qwsel)
+    b_qw = GetQuarterWord(wrs2, wrs2_qwsel)
 
     mul_res = a_qw * b_qw
 
-    if zero_accumulator:
+    if zero_acc:
       ACC = 0
 
     ACC = ACC + (mul_res << acc_shift_imm)
@@ -265,33 +229,21 @@
     Multiplies two `WLEN/4` WDR values, shifts the product by `acc_shift_imm` bits, and adds the result to the accumulator.
     Writes the resulting accumulator to `wrd`.
     Updates the M, L and Z flags of `flag_group`.
-  decode: |
-    zero_accumulator = DecodeMulqaccZeroacc(zero_acc)
-
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-
-    d_hwsel = None
-    a_qwsel = DecodeQuarterWordSelect(wrs1_qwsel)
-    b_qwsel = DecodeQuarterWordSelect(wrs2_qwsel)
-
-    fg = DecodeFlagGroup(flag_group)
   operation: |
-    a_qw = GetQuarterWord(a, a_qwsel)
-    b_qw = GetQuarterWord(b, b_qwsel)
+    a_qw = GetQuarterWord(wrs1, wrs1_qwsel)
+    b_qw = GetQuarterWord(wrs2, wrs2_qwsel)
 
     mul_res = a_qw * b_qw
 
-    if zero_accumulator:
+    if zero_acc:
       ACC = 0
 
     ACC = ACC + (mul_res << acc_shift_imm)
 
-    WDR[d] = ACC
-    FLAGS[fg].M = ACC[WLEN-1]
-    FLAGS[fg].L = ACC[0]
-    FLAGS[fg].Z = (ACC == 0)
+    WDR[wrd] = ACC
+    FLAGS[flag_group].M = ACC[WLEN-1]
+    FLAGS[flag_group].L = ACC[0]
+    FLAGS[flag_group].Z = (ACC == 0)
   encoding:
     scheme: bnaq
     mapping:
@@ -339,25 +291,13 @@
     If `wrd_hwsel` is one (so the instruction is updating the upper half-word of `wrd`), it updates the `M` and `Z` flags and leaves `L` unchanged.
     The `M` flag is set iff the top bit of the shifted-out result is zero.
     The `Z` flag is left unchanged if the shifted-out result is zero and cleared if not.
-  decode: |
-    zero_accumulator = DecodeMulqaccZeroacc(zero_acc)
-
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-
-    d_hwsel = DecodeHalfWordSelect(wrd_hwsel)
-    a_qwsel = DecodeQuarterWordSelect(wrs1_qwsel)
-    b_qwsel = DecodeQuarterWordSelect(wrs2_qwsel)
-
-    fg = DecodeFlagGroup(flag_group)
   operation: |
-    a_qw = GetQuarterWord(a, a_qwsel)
-    b_qw = GetQuarterWord(b, b_qwsel)
+    a_qw = GetQuarterWord(wrs1, wrs1_qwsel)
+    b_qw = GetQuarterWord(wrs2, wrs2_qwsel)
 
     mul_res = a_qw * b_qw
 
-    if zero_accumulator:
+    if zero_acc:
       ACC = 0
 
     ACC = ACC + (mul_res << acc_shift_imm)
@@ -365,15 +305,15 @@
     shifted = ACC[WLEN/2-1:0]
     ACC = ACC >> (WLEN/2)
 
-    if d_hwsel == 'L':
-      WDR[d][WLEN/2-1:0] = shifted
-      FLAGS[fg].L = shifted[0]
-      FLAGS[fg].Z = (shifted == 0)
-    elif d_hwsel == 'U':
-      WDR[d][WLEN-1:WLEN/2] = shifted
-      FLAGS[fg].M = shifted[WLEN/2-1]
+    if wrd_hwsel == 'L':
+      WDR[wrd][WLEN/2-1:0] = shifted
+      FLAGS[flag_group].L = shifted[0]
+      FLAGS[flag_group].Z = (shifted == 0)
+    elif wrd_hwsel == 'U':
+      WDR[wrd][WLEN-1:WLEN/2] = shifted
+      FLAGS[flag_group].M = shifted[WLEN/2-1]
       if (shifted != 0):
-        FLAGS[fg].Z = 0
+        FLAGS[flag_group].Z = 0
   encoding:
     scheme: bnaq
     mapping:
@@ -404,19 +344,11 @@
   doc: |
     Subtracts the second WDR value from the first one, writes the result to the destination WDR and updates flags.
     The content of the second source WDR can be shifted by an unsigned immediate before it is consumed by the operation.
-  decode: &bn-sub-decode |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-
-    fg = DecodeFlagGroup(flag_group)
-    sb = UInt(shift_bits) // 8
-    st = DecodeShiftType(shift_type)
   operation: |
-    b_shifted = ShiftReg(b, st, sb)
-    (result, flags_out) = SubtractWithBorrow(a, b_shifted, 0)
+    b_shifted = ShiftReg(wrs2, shift_type, shift_bits)
+    (result, flags_out) = SubtractWithBorrow(wrs1, b_shifted, 0)
 
-    WDR[d] = result
+    WDR[wrd] = result
     FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnaf
@@ -436,12 +368,11 @@
   doc: |
     Subtracts the second WDR value and the Carry from the first one, writes the result to the destination WDR, and updates the flags.
     The content of the second source WDR can be shifted by an unsigned immediate before it is consumed by the operation.
-  decode: *bn-sub-decode
   operation: |
-    b_shifted = ShiftReg(b, st, sb)
-    (result, flags_out) = SubtractWithBorrow(a, b_shifted, FLAGS[flag_group].C)
+    b_shifted = ShiftReg(wrs2, shift_type, shift_bits)
+    (result, flags_out) = SubtractWithBorrow(wrs1, b_shifted, FLAGS[flag_group].C)
 
-    WDR[d] = result
+    WDR[wrd] = result
     FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnaf
@@ -469,16 +400,10 @@
   doc: |
     Subtracts a zero-extended unsigned immediate from the value of a WDR,
     writes the result to the destination WDR, and updates the flags.
-  decode: |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-
-    fg = DecodeFlagGroup(flag_group)
-    i = ZeroExtend(imm, WLEN)
   operation: |
-    (result, flags_out) = SubtractWithBorrow(a, i, 0)
+    (result, flags_out) = SubtractWithBorrow(wrs1, imm, 0)
 
-    WDR[d] = result
+    WDR[wrd] = result
     FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnai
@@ -504,17 +429,13 @@
     This is guaranteed if both inputs are less than `MOD`.
 
     Flags are not used or saved.
-  decode: |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
   operation: |
-    result = a - b
+    result = wrs1 - wrs2
 
     if result < 0:
       result = MOD + result
 
-    WDR[d] = result & ((1 << 256) - 1)
+    WDR[wrd] = result & ((1 << 256) - 1)
   encoding:
     scheme: bnam
     mapping:
@@ -543,19 +464,11 @@
     Takes the values stored in registers referenced by `wrs1` and `wrs2` and stores the result in the register referenced by `wrd`.
     The content of the second source register can be shifted by an immediate before it is consumed by the operation.
     The M, L and Z flags in flag group 0 are updated with the result of the operation.
-  decode: &bn-and-decode |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-
-    sb = UInt(shift_bits) // 8
-    st = DecodeShiftType(shift_type)
-    fg = DecodeFlagGroup(flag_group)
   operation: |
-    b_shifted = ShiftReg(b, st, sb)
-    result = a & b_shifted
+    b_shifted = ShiftReg(wrs2, shift_type, shift_bits)
+    result = wrs1 & b_shifted
 
-    WDR[d] = result
+    WDR[wrd] = result
     flags_out = FlagsForResult(result)
     FLAGS[flag_group] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[flag_group].C}
   encoding:
@@ -578,12 +491,11 @@
     Takes the values stored in WDRs referenced by `wrs1` and `wrs2` and stores the result in the WDR referenced by `wrd`.
     The content of the second source WDR can be shifted by an immediate before it is consumed by the operation.
     The M, L and Z flags in flag group 0 are updated with the result of the operation.
-  decode: *bn-and-decode
   operation: |
-    b_shifted = ShiftReg(b, st, sb)
-    result = a | b_shifted
+    b_shifted = ShiftReg(wrs2, shift_type, shift_bits)
+    result = wrs1 | b_shifted
 
-    WDR[d] = result
+    WDR[wrd] = result
     flags_out = FlagsForResult(result)
     FLAGS[flag_group] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[flag_group].C}
   encoding:
@@ -613,18 +525,11 @@
     Negates the value in `wrs` and stores the result in the register referenced by `wrd`.
     The source value can be shifted by an immediate before it is consumed by the operation.
     The M, L and Z flags in flag group 0 are updated with the result of the operation.
-  decode: |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-
-    sb = UInt(shift_bits) // 8
-    st = DecodeShiftType(shift_type)
-    fg = DecodeFlagGroup(flag_group)
   operation: |
-    a_shifted = ShiftReg(a, st, sb)
+    a_shifted = ShiftReg(wrs1, shift_type, shift_bits)
     result = ~a_shifted
 
-    WDR[d] = result
+    WDR[wrd] = result
     flags_out = FlagsForResult(result)
     FLAGS[flag_group] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[flag_group].C}
   encoding:
@@ -646,12 +551,11 @@
     Takes the values stored in WDRs referenced by `wrs1` and `wrs2` and stores the result in the WDR referenced by `wrd`.
     The content of the second source WDR can be shifted by an immediate before it is consumed by the operation.
     The M, L and Z flags in flag group 0 are updated with the result of the operation.
-  decode: *bn-and-decode
   operation: |
-    b_shifted = ShiftReg(b, st, sb)
-    result = a ^ b_shifted
+    b_shifted = ShiftReg(wrs2, shift_type, shift_bits)
+    result = wrs1 ^ b_shifted
 
-    WDR[d] = result
+    WDR[wrd] = result
     flags_out = FlagsForResult(result)
     FLAGS[flag_group] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[flag_group].C}
   encoding:
@@ -683,13 +587,8 @@
   doc: |
     Concatenates the content of WDRs referenced by `wrs1` and `wrs2` (`wrs1` forms the upper part), shifts it right by an immediate value and truncates to WLEN bit.
     The result is stored in the WDR referenced by `wrd`.
-  decode: |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-    shift_bit = Uint(imm)
   operation: |
-    WDR[d] = (((a << WLEN) | b) >> shift_bit)[WLEN-1:0]
+    WDR[wrd] = (((wrs1 << WLEN) | wrs2) >> imm)[WLEN-1:0]
   encoding:
     scheme: bnr
     mapping:
@@ -721,16 +620,10 @@
     <wrd>, <wrs1>, <wrs2>, [FG<flag_group>.]<flag>
   doc: |
     Returns in the destination WDR the value of the first source WDR if the flag in the chosen flag group is set, otherwise returns the value of the second source WDR.
-  decode: |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-    fg = DecodeFlagGroup(flag_group)
-    flag = DecodeFlag(flag)
   operation: |
-    flag_is_set = FLAGS[fg].get(flag)
+    flag_is_set = FLAGS[flag_group].get(flag)
 
-    WDR[d] = wrs1 if flag_is_set else wrs2
+    WDR[wrd] = wrs1 if flag_is_set else wrs2
   encoding:
     scheme: bns
     mapping:
@@ -755,16 +648,9 @@
   doc: |
     Subtracts the second WDR value from the first one and updates flags.
     This instruction is identical to BN.SUB, except that no result register is written.
-  decode: &bn-cmp-decode |
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-
-    fg = DecodeFlagGroup(flag_group)
-    sb = UInt(shift_bits) // 8
-    st = DecodeShiftType(shift_type)
   operation: |
-    b_shifted = ShiftReg(b, st, sb)
-    (, flags_out) = SubtractWithBorrow(a, b_shifted, 0)
+    b_shifted = ShiftReg(wrs2, shift_type, shift_bits)
+    (, flags_out) = SubtractWithBorrow(wrs1, b_shifted, 0)
 
     FLAGS[flag_group] = flags_out
   encoding:
@@ -784,9 +670,8 @@
   doc: |
     Subtracts the second WDR value from the first one and updates flags.
     This instruction is identical to BN.SUBB, except that no result register is written.
-  decode: *bn-cmp-decode
   operation: |
-    (, flags_out) = SubtractWithBorrow(a, b, FLAGS[flag_group].C)
+    (, flags_out) = SubtractWithBorrow(wrs1, wrs2, FLAGS[flag_group].C)
 
     FLAGS[flag_group] = flags_out
   encoding:
@@ -843,13 +728,9 @@
     The memory address must be aligned to WLEN bits.
     Any address that is unaligned or is above the top of memory will result in an error (with error code `ErrCodeBadDataAddr`).
   cycles: 2
-  decode: |
-    rd = UInt(grd)
-    rs1 = UInt(grs1)
-    offset = UInt(offset)
   operation: |
-    mem_addr = GPR[rs1] + offset
-    wdr_dest = GPR[rd]
+    mem_addr = GPR[grs1] + offset
+    wdr_dest = GPR[grd]
 
     assert not (grs1_inc and grd_inc)  # prevented in encoding
     if mem_addr % (WLEN / 8) or mem_addr + WLEN > DMEM_SIZE:
@@ -860,9 +741,9 @@
     WDR[wdr_dest] = LoadWlenWordFromMemory(mem_index)
 
     if grs1_inc:
-        GPR[rs1] = GPR[rs1] + (WLEN / 8)
+        GPR[grs1] = GPR[grs1] + (WLEN / 8)
     if grd_inc:
-        GPR[rd] = (GPR[rd] + 1) & 0x1f
+        GPR[grd] = (GPR[grd] + 1) & 0x1f
   lsu:
     type: mem-load
     target: [offset, grs1]
@@ -916,13 +797,9 @@
 
     The memory address must be aligned to WLEN bits.
     Any address that is unaligned or is above the top of memory will result in an error (with error code `ErrCodeBadDataAddr`).
-  decode: |
-    rs1 = UInt(grs1)
-    rs2 = UInt(grs2)
-    offset = UInt(offset)
   operation: |
-    mem_addr = GPR[rs1] + offset
-    wdr_src = GPR[rs2]
+    mem_addr = GPR[grs1] + offset
+    wdr_src = GPR[grs2]
 
     assert not (grs1_inc and grd_inc)  # prevented in encoding
     if mem_addr % (WLEN / 8) or mem_addr + WLEN > DMEM_SIZE:
@@ -933,9 +810,9 @@
     StoreWlenWordToMemory(mem_index, WDR[wdr_src])
 
     if grs1_inc:
-        GPR[rs1] = GPR[rs1] + (WLEN / 8)
+        GPR[grs1] = GPR[grs1] + (WLEN / 8)
     if grs2_inc:
-        GPR[rs2] = (GPR[rs2] + 1) & 0x1f
+        GPR[grs2] = (GPR[grs2] + 1) & 0x1f
   lsu:
     type: mem-store
     target: [offset, grs1]
@@ -953,10 +830,7 @@
 - mnemonic: bn.mov
   synopsis: Copy content between WDRs (direct addressing)
   operands: [wrd, wrs]
-  decode: |
-    s = UInt(wrs)
-    d = UInt(wrd)
-  operation: WDR[d] = WDR[s]
+  operation: WDR[wrd] = WDR[wrs]
   encoding:
     scheme: bnmov
     mapping:
@@ -993,17 +867,13 @@
 
     - If `grd_inc` is set, `grd` is updated to be `(*grd + 1) & 0x1f`.
     - If `grs_inc` is set, `grs` is updated to be `(*grs + 1) & 0x1f`.
-
-  decode: |
-    s = UInt(grs)
-    d = UInt(grd)
   operation: |
-    WDR[GPR[d]] = WDR[GPR[s]]
+    WDR[GPR[grd]] = WDR[GPR[grs]]
 
     if grs_inc:
-      GPR[s] = GPR[s] + 1
+      GPR[grs] = GPR[grs] + 1
     if grd_inc:
-      GPR[d] = GPR[d] + 1
+      GPR[grd] = GPR[grd] + 1
   encoding:
     scheme: bnmovr
     mapping:

--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -16,16 +16,19 @@
       doc: Name of the second source WDR
     - &bn-shift-type-operand
       name: shift_type
+      abbrev: st
       type: enum(<<, >>)
       doc: |
         The direction of an optional shift applied to `<wrs2>`.
     - &bn-shift-bits-operand
       name: shift_bits
+      abbrev: sb
       type: uimm5<<3
       doc: |
         Number of bits by which to shift `<wrs2>`. Defaults to 0.
     - &bn-flag-group-operand
       name: flag_group
+      abbrev: fg
       type: uimm1
       doc: Flag group to use. Defaults to 0.
   syntax: &bn-add-syntax |
@@ -143,6 +146,7 @@
   operands:
     - &mulqacc-zero-acc
       name: zero_acc
+      abbrev: za
       type: option(.Z)
       doc: Zero the accumulator before accumulating the multiply result.
     - &mulqacc-wrs1
@@ -150,6 +154,7 @@
       doc: First source WDR
     - &mulqacc-wrs1-qwsel
       name: wrs1_qwsel
+      abbrev: q1
       type: uimm2
       doc: |
         Quarter-word select for `<wrs1>`.
@@ -164,6 +169,7 @@
       doc: Second source WDR
     - &mulqacc-wrs2-qwsel
       name: wrs2_qwsel
+      abbrev: q2
       type: uimm2
       doc: |
         Quarter-word select for `<wrs2>`.
@@ -175,6 +181,7 @@
         - `3`: Select `wrs1[WLEN-1:WLEN/4*3]` (most significant quarter-word)
     - &mulqacc-acc-shift-imm
       name: acc_shift_imm
+      abbrev: shift
       type: uimm2<<6
       doc: |
         The number of bits to shift the `WLEN/2`-bit multiply result before accumulating.
@@ -264,6 +271,7 @@
     - *mulqacc-zero-acc
     - *mulqacc-wrd
     - name: wrd_hwsel
+      abbrev: dh
       type: enum(L,U)
       doc: |
         Half-word select for `<wrd>`.
@@ -698,16 +706,19 @@
         Name of the GPR containing the memory byte address.
         The value contained in the referenced GPR must be WLEN-aligned.
     - name: offset
+      abbrev: "off"
       doc: |
         Offset value.
         Must be WLEN-aligned.
       type: simm<<5
     - name: grs1_inc
+      abbrev: inc1
       type: option(++)
       doc: |
         Increment the value in `<grs1>` by WLEN/8 (one word).
         Cannot be specified together with `grd_inc`.
     - name: grd_inc
+      abbrev: incd
       type: option(++)
       doc: |
         Increment the value in `<grd>` by one.
@@ -768,17 +779,20 @@
     - name: grs2
       doc: Name of the GPR referencing the source WDR.
     - name: offset
+      abbrev: "off"
       doc: |
         Offset value.
         Must be WLEN-aligned.
       type: simm<<5
     - name: grs1_inc
       type: option(++)
+      abbrev: inc1
       doc: |
         Increment the value in `<grs1>` by WLEN/8 (one word).
         Cannot be specified together with `grs2_inc`.
     - name: grs2_inc
       type: option(++)
+      abbrev: inc2
       doc: |
         Increment the value in `<grs2>` by one.
         Cannot be specified together with `grs1_inc`.

--- a/hw/ip/otbn/data/insns.yml
+++ b/hw/ip/otbn/data/insns.yml
@@ -92,6 +92,10 @@ encoding-schemes: enc-schemes.yml
 #
 #  name:      The name of the operand. Required and must be unique.
 #
+#  abbrev:    An optional shortened name for the operand. If given, it
+#             must not match the short name or full name of any other
+#             operand.
+#
 #  type:      The type of the operand. A string. If this can be figured out
 #             from the operand name, it is optional. See below for a list of
 #             possible operand types and the rules for recognising them

--- a/hw/ip/otbn/doc/isa.md
+++ b/hw/ip/otbn/doc/isa.md
@@ -12,6 +12,27 @@ It also includes a hardware call stack and hardware loop instructions.
 The big number subset is designed to operate on 256b WDRs.
 It doesn't include any control flow instructions, and just supports load/store, logical and arithmetic operations.
 
+In the instruction documentation that follows, each instruction has a syntax example.
+For example, the `SW` instruction has syntax:
+```
+  SW <grs2>, <offset>(<grs1>)
+```
+This means that it takes three operands, called `grs2`, `offset` and `grs1`.
+These operands are further documented in a table.
+Immediate operands like `offset` show their valid range of values.
+
+In the pseudo-code in the Operation sections, all operands have integer values.
+These values come from the encoded bits in the instruction and the operand table describes exactly how.
+The `signed()` and `unsigned()` functions denote signed and unsigned extension from raw bits to an integer.
+Signed values are encoded 2's complement.
+Some operands are encoded PC-relative and have their absolute values when they appear in the Operation section.
+To show this, the operand table's description includes `PC` to denote the current value of the program counter as an integer.
+
+Below the table of operands is an encoding table.
+This shows how the 32 bits of the instruction word are filled in.
+Ranges of bits that map to an operand are named (in capitals) and those names are used in the operand table.
+For example, the `SW` instruction's `offset` operand is split across two ranges of bits (31:25 and 11:7) called `OFF_1` and `OFF_0`, respectively.
+
 <!-- Documentation for the instructions in the ISA. Generated from ../data/insns.yml. -->
 # Base Instruction Subset
 

--- a/hw/ip/otbn/util/shared/insn_yaml.py
+++ b/hw/ip/otbn/util/shared/insn_yaml.py
@@ -27,7 +27,7 @@ class Insn:
                         ['mnemonic', 'operands'],
                         ['group', 'rv32i', 'synopsis',
                          'syntax', 'doc', 'note', 'trailing-doc',
-                         'decode', 'operation', 'encoding', 'glued-ops',
+                         'operation', 'encoding', 'glued-ops',
                          'literal-pseudo-op', 'python-pseudo-op', 'lsu',
                          'straight-line', 'cycles'])
 
@@ -73,7 +73,6 @@ class Insn:
         self.doc = get_optional_str(yd, 'doc', what)
         self.note = get_optional_str(yd, 'note', what)
         self.trailing_doc = get_optional_str(yd, 'trailing-doc', what)
-        self.decode = get_optional_str(yd, 'decode', what)
         self.operation = get_optional_str(yd, 'operation', what)
 
         raw_syntax = get_optional_str(yd, 'syntax', what)

--- a/hw/ip/otbn/util/shared/insn_yaml.py
+++ b/hw/ip/otbn/util/shared/insn_yaml.py
@@ -53,6 +53,19 @@ class Insn:
                                           self.operands,
                                           lambda op: op.name)
 
+        # The call to index_list has checked that operand names are distinct.
+        # We also need to check that no operand abbreviation clashes with
+        # anything else.
+        operand_names = set(self.name_to_operand.keys())
+        for op in self.operands:
+            if op.abbrev is not None:
+                if op.abbrev in operand_names:
+                    raise ValueError('The name {!r} appears as an operand or '
+                                     'abbreviation more than once for '
+                                     'instruction {!r}.'
+                                     .format(op.abbrev, self.mnemonic))
+                operand_names.add(op.abbrev)
+
         if self.encoding is not None:
             # If we have an encoding, we passed it to the Operand constructors
             # above. This ensured that each operand has a field. However, it's

--- a/hw/ip/otbn/util/shared/operand.py
+++ b/hw/ip/otbn/util/shared/operand.py
@@ -548,9 +548,8 @@ class EnumOperandType(OperandType):
 
     def markdown_doc(self) -> Optional[str]:
         # Override from OperandType base class
-        parts = ['Syntax table:\n\n'
-                 '| Syntax | Value of immediate |\n'
-                 '|--------|--------------------|\n']
+        parts = ['| Assembly Syntax | Value |\n'
+                 '|-----------------|-------|\n']
         for idx, item in enumerate(self.items):
             parts.append('| `{}` | `{}` |\n'
                          .format(item, idx))

--- a/hw/ip/otbn/util/yaml_to_doc.py
+++ b/hw/ip/otbn/util/yaml_to_doc.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Optional, TextIO, Tuple
 from shared.bool_literal import BoolLiteral
 from shared.encoding import Encoding
 from shared.insn_yaml import Insn, InsnsFile, InsnGroup, load_file
-from shared.operand import Operand
+from shared.operand import EnumOperandType, OptionOperandType, Operand
 
 _O2EDicts = Tuple[Dict[str, List[str]], Dict[int, str]]
 
@@ -301,11 +301,35 @@ def render_insn(insn: Insn, heading_level: int) -> str:
     # Show operation pseudo-code if given
     if insn.operation is not None:
         parts.append('{} Operation\n\n'
-                     '```python3\n'
+                     .format('#' * (heading_level + 1)))
+
+        # Add a handy header to remind readers that enum operands and option
+        # operands are referred to by their integer values.
+        not_num_ops = []
+        for operand in insn.operands:
+            if ((isinstance(operand.op_type, EnumOperandType) or
+                 isinstance(operand.op_type, OptionOperandType))):
+                not_num_ops.append(operand.name)
+
+        if not_num_ops:
+            if len(not_num_ops) == 1:
+                op_str = ('operand `{}` is referred to by its'
+                          .format(not_num_ops[0]))
+            else:
+                op_str = ('operands {} and `{}` are referred to by their'
+                          .format(', '.join('`{}`'.format(e)
+                                            for e in not_num_ops[:-1]),
+                                  not_num_ops[-1]))
+
+            parts.append('In the listing below, {} integer value.\n'
+                         'The operand table above shows how this corresponds '
+                         'to assembly syntax.\n\n'
+                         .format(op_str))
+
+        parts.append('```python3\n'
                      '{}\n'
                      '```\n\n'
-                     .format('#' * (heading_level + 1),
-                             insn.operation))
+                     .format(insn.operation))
     return ''.join(parts)
 
 

--- a/hw/ip/otbn/util/yaml_to_doc.py
+++ b/hw/ip/otbn/util/yaml_to_doc.py
@@ -8,15 +8,18 @@
 import argparse
 import os
 import sys
-from typing import Dict, List, TextIO
+from typing import Dict, List, Optional, TextIO, Tuple
 
 from shared.bool_literal import BoolLiteral
 from shared.encoding import Encoding
 from shared.insn_yaml import Insn, InsnsFile, InsnGroup, load_file
-from shared.operand import ImmOperandType, Operand
+from shared.operand import Operand
+
+_O2EDicts = Tuple[Dict[str, List[str]], Dict[int, str]]
 
 
-def render_operand_row(operand: Operand) -> str:
+def render_operand_row(operand: Operand,
+                       op_ranges: Optional[List[str]]) -> str:
     '''Generate the single row of a markdown table for an operand'''
 
     # This is in <tr><td> form, but we want to embed arbitrary markup (and
@@ -25,7 +28,7 @@ def render_operand_row(operand: Operand) -> str:
     # flavoured markdown switch back to "markdown mode" for the contents.
     parts = []
     parts.append('<tr><td>\n\n')
-    parts.append('`<{}>`'.format(operand.name))
+    parts.append('`{}`'.format(operand.name))
     parts.append('\n\n</td><td>')
 
     # The "description" cell contains any documentation supplied in the file,
@@ -41,11 +44,17 @@ def render_operand_row(operand: Operand) -> str:
             parts.append('\n\n')
             parts.append(ot_doc)
 
+        if op_ranges is not None:
+            parts.append('\n\n')
+            dec_str = operand.op_type.describe_decode(op_ranges)
+            parts.append('Decode as `{}`\n\n'.format(dec_str))
+
     parts.append('\n\n</td></tr>')
     return ''.join(parts)
 
 
-def render_operand_table(insn: Insn) -> str:
+def render_operand_table(operands: List[Operand],
+                         o2e: Optional[Dict[str, List[str]]]) -> str:
     '''Generate the operand table for an instruction'''
 
     # We have to generate this in <tr><td> form because we want to put
@@ -53,18 +62,27 @@ def render_operand_table(insn: Insn) -> str:
     # support inline elements).
     parts = []
     parts.append('<table><thead>'
-                 '<tr><th>Assembly symbol</th><th>Description</th></tr>'
+                 '<tr><th>Operand</th><th>Description</th></tr>'
                  '</thead>'
                  '<tbody>')
-    for operand in insn.operands:
-        parts.append(render_operand_row(operand))
+    for operand in operands:
+        if o2e is None:
+            op_ranges = None
+        else:
+            op_ranges = o2e.get(operand.name)
+            # If we had an encoding, it should have encoded every operand, so
+            # name_op_enc_fields should have picked up operand.
+            assert op_ranges is not None
+
+        parts.append(render_operand_row(operand, op_ranges))
+
     parts.append('</tbody></table>\n\n')
     return ''.join(parts)
 
 
 def render_encoding(mnemonic: str,
-                    name_to_operand: Dict[str, Operand],
-                    encoding: Encoding) -> str:
+                    encoding: Encoding,
+                    e2o: Dict[int, str]) -> str:
     '''Generate a table displaying an instruction encoding'''
     parts = []
     parts.append('<table style="font-size: 75%">')
@@ -97,31 +115,12 @@ def render_encoding(mnemonic: str,
                     by_msb[lsb + idx] = (1, '' if desc == 'x' else desc)
             continue
 
-        # Otherwise this field's value is an operand name
+        # Otherwise this field's value is an operand name. name_op_enc_fields
+        # should have added the MSBs of its ranges to e2o.
         assert isinstance(field.value, str)
-        operand_name = field.value
-
-        # Figure out whether there's any shifting going on.
-        op_type = name_to_operand[operand_name].op_type
-        shift = op_type.shift if isinstance(op_type, ImmOperandType) else 0
-
-        # If there is only one range (and no shifting), that's easy.
-        if len(scheme_field.bits.ranges) == 1 and shift == 0:
-            msb, lsb = scheme_field.bits.ranges[0]
-            by_msb[msb] = (msb - lsb + 1, operand_name)
-            continue
-
-        # Otherwise, we have to split up the operand into things like "foo[8:5]"
-        bits_seen = 0
         for msb, lsb in scheme_field.bits.ranges:
-            val_msb = shift + scheme_field.bits.width - 1 - bits_seen
-            val_lsb = val_msb - msb + lsb
-            bits_seen += msb - lsb + 1
-            if msb == lsb:
-                desc = '{}[{}]'.format(operand_name, val_msb)
-            else:
-                desc = '{}[{}:{}]'.format(operand_name, val_msb, val_lsb)
-            by_msb[msb] = (msb - lsb + 1, desc)
+            assert msb in e2o
+            by_msb[msb] = (msb - lsb + 1, e2o[msb])
 
     parts.append('<tr>')
     parts.append('<td>{}</td>'.format(mnemonic.upper()))
@@ -155,6 +154,70 @@ def render_literal_pseudo_op(rewrite: List[str]) -> str:
         parts.append('\n')
     parts.append('```\n\n')
     return ''.join(parts)
+
+
+def name_op_enc_fields(encoding: Encoding) -> _O2EDicts:
+    '''Name the encoding fields corresponding to operators
+
+    In the generated documentation, we name encoding fields based on the
+    operand that the encode. For example, if the operand "foo" is encoded in a
+    field, the field will be labelled "FOO" in the table. If the field is split
+    over multiple bit ranges, they will be labelled like "FOO_0", "FOO_1" etc,
+    counting from the LSB.
+
+    Returns a pair of dicts: (o2e, e2o). o2e maps an operand name to the list
+    of (our names for) encoding fields that contribute to it, MSB first. e2o
+    maps the MSB of a bit range in an encoding field to the name that should
+    appear for that range in the documentation.
+
+    In the example above, o2e['foo'] = ["FOO_1", "FOO_0"]. Suppose that the
+    upper range of bits for the encoding field for 'foo' had MSB 10. Then
+    e2o[10] = 'FOO_1'.
+
+    '''
+    o2e = {}  # type: Dict[str, List[str]]
+    e2o = {}  # type: Dict[int, str]
+
+    for field_name, field in encoding.fields.items():
+        # Ignore literal values: these don't correspond to operands
+        if isinstance(field.value, BoolLiteral):
+            continue
+
+        # Otherwise this field's value is an operand name
+        assert isinstance(field.value, str)
+        operand_name = field.value
+
+        # An encoding should never use an operand more than once
+        assert operand_name not in o2e
+
+        # There should always be at least one bit range for the field
+        scheme_field = field.scheme_field
+        assert scheme_field.bits.ranges
+
+        # If there is just one bit range, we generate a single named range by
+        # capitalizing the operand name.
+        if len(scheme_field.bits.ranges) == 1:
+            msb = scheme_field.bits.ranges[0][0]
+            assert msb not in e2o
+            range_name = operand_name.upper()
+            o2e[operand_name] = [range_name]
+            e2o[msb] = range_name
+            continue
+
+        # Otherwise, we need to label the operands. Sorting ranges ensures that
+        # they appear LSB-first.
+        o2e_list = []
+        range_basename = operand_name.upper()
+        for idx, (msb, lsb) in enumerate(sorted(scheme_field.bits.ranges)):
+            range_name = '{}_{}'.format(range_basename, idx)
+            o2e_list.append(range_name)
+            assert msb not in e2o
+            e2o[msb] = range_name
+        # We want to store o2e_list MSB-first, so reverse it here.
+        o2e_list.reverse()
+        o2e[operand_name] = o2e_list
+
+    return (o2e, e2o)
 
 
 def render_insn(insn: Insn, heading_level: int) -> str:
@@ -212,29 +275,28 @@ def render_insn(insn: Insn, heading_level: int) -> str:
         parts.append(insn.trailing_doc)
         parts.append('\n\n')
 
-    # Show the operand table if at least one operand has an associated
-    # description.
-    if any(op.doc is not None for op in insn.operands):
-        parts.append(render_operand_table(insn))
+    is_pseudo = insn.literal_pseudo_op or insn.python_pseudo_op
+
+    # If we have an encoding, match up encoding fields with operands
+    if is_pseudo or insn.encoding is None:
+        o2e = None
+        e2o = None
+    else:
+        o2e, e2o = name_op_enc_fields(insn.encoding)
+
+    # Show the operand table if there is at least one operand and this isn't a
+    # pseudo-op.
+    if insn.operands and not is_pseudo:
+        parts.append(render_operand_table(insn.operands, o2e))
 
     # Show encoding if we have one
-    if insn.encoding is not None:
-        parts.append(render_encoding(insn.mnemonic,
-                                     insn.name_to_operand,
-                                     insn.encoding))
+    if e2o is not None:
+        assert insn.encoding is not None
+        parts.append(render_encoding(insn.mnemonic, insn.encoding, e2o))
 
     # If this is a pseudo-op with a literal translation, show it
     if insn.literal_pseudo_op is not None:
         parts.append(render_literal_pseudo_op(insn.literal_pseudo_op))
-
-    # Show decode pseudo-code if given
-    if insn.decode is not None:
-        parts.append('{} Decode\n\n'
-                     '```python3\n'
-                     '{}\n'
-                     '```\n\n'
-                     .format('#' * (heading_level + 1),
-                             insn.decode))
 
     # Show operation pseudo-code if given
     if insn.operation is not None:


### PR DESCRIPTION
Remove the (slightly bit-rotted) manual decode information and
automatically generate the relevant information in the operand tables.
The results look like

ADD's grd operand:

    insn[11:7]

ANDI's imm operand:

    sign_extend(insn[31:20])

SW's offset operand:

    sign_extend({insn[31:25],insn[11:7]})

BEQ's offset operand:

    sign_extend(PC + {insn[31],insn[7],insn[30:25],insn[11:8],1'b0})

LOOP's bodysize operand:

    insn[31:20] + 1

The big YAML changes are removing the decode blocks and renaming the
variables in the "operation" pseudo-code to match the operand names.

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>