### PR TITLE
[fpv] add missing IPs to FPV batch script

### DIFF
--- a/hw/ip/csrng/dv/sva/csrng_sva.core
+++ b/hw/ip/csrng/dv/sva/csrng_sva.core
@@ -13,6 +13,10 @@ filesets:
       - csrng_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:csrng
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,15 @@ generate:
       depend: lowrisc:ip:csrng
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: csrng

--- a/hw/ip/edn/dv/sva/edn_sva.core
+++ b/hw/ip/edn/dv/sva/edn_sva.core
@@ -13,6 +13,10 @@ filesets:
       - edn_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:edn
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,15 @@ generate:
       depend: lowrisc:ip:edn
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: edn

--- a/hw/ip/kmac/dv/sva/kmac_sva.core
+++ b/hw/ip/kmac/dv/sva/kmac_sva.core
@@ -13,6 +13,10 @@ filesets:
       - kmac_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:kmac
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,15 @@ generate:
       depend: lowrisc:ip:kmac
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: kmac

--- a/hw/ip/otbn/dv/uvm/sva/otbn_sva.core
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_sva.core
@@ -13,6 +13,10 @@ filesets:
       - otbn_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:otbn
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,15 @@ generate:
       depend: lowrisc:ip:otbn
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: otbn

--- a/hw/ip/pattgen/dv/sva/pattgen_sva.core
+++ b/hw/ip/pattgen/dv/sva/pattgen_sva.core
@@ -13,6 +13,10 @@ filesets:
       - pattgen_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:pattgen
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,14 @@ generate:
       depend: lowrisc:ip:pattgen
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: pattgen

--- a/hw/top_earlgrey/fpv/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/fpv/top_earlgrey_fpv_cfgs.hjson
@@ -116,6 +116,18 @@
                cov: false
              }
              {
+               name: csrng
+               fusesoc_core: lowrisc:dv:csrng_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
+             }
+             {
+               name: edn
+               fusesoc_core: lowrisc:dv:edn_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
+             }
+             {
                name: entropy_src
                fusesoc_core: lowrisc:dv:entropy_src_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
@@ -146,6 +158,12 @@
                cov: false
              }
              {
+               name: pattgen
+               fusesoc_core: lowrisc:dv:pattgen_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
+             }
+             {
                name: keymgr
                fusesoc_core: lowrisc:dv:keymgr_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
@@ -164,6 +182,12 @@
                cov: false
              }
              {
+               name: otbn
+               fusesoc_core: lowrisc:dv:otbn_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
+             }
+             {
                name: rv_timer
                fusesoc_core: lowrisc:dv:rv_timer_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
@@ -172,6 +196,12 @@
              {
                name: spi_device
                fusesoc_core: lowrisc:dv:spi_device_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
+             }
+             {
+               name: sram_ctrl
+               fusesoc_core: lowrisc:dv:sram_ctrl_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                cov: false
              }


### PR DESCRIPTION
This PR adds some missing IPs to the FPV batch script. Note that IPs
like clkmgr and rstmgr have not been added because they do not have a
block level dv testbench. I will add them in a coming PR.

Signed-off-by: Cindy Chen <chencindy@google.com>