### PR TITLE
[keymgr/dv] Fix regression failures

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -242,11 +242,15 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
         // Check in this block
         do_read_check = 1'b0;
 
-        if (addr_phase_read) begin
-          addr_phase_cfgen = current_op_status != keymgr_pkg::OpWip &&
-                             cfg.keymgr_vif.keymgr_en == lc_ctrl_pkg::On;
-        end else if (data_phase_read) begin
-          `DV_CHECK_EQ(item.d_data, addr_phase_cfgen)
+        // skip checking cfgen value when it's advance OP in Reset, as it's hard to know what exact
+        // time OP will complete
+        if (current_state != keymgr_pkg::StReset || current_op_status != keymgr_pkg::OpWip) begin
+          if (addr_phase_read) begin
+            addr_phase_cfgen = current_op_status != keymgr_pkg::OpWip &&
+                               cfg.keymgr_vif.keymgr_en == lc_ctrl_pkg::On;
+          end else if (data_phase_read) begin
+            `DV_CHECK_EQ(item.d_data, addr_phase_cfgen)
+          end
         end
       end
       "control": begin

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_random_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_random_vseq.sv
@@ -7,18 +7,7 @@ class keymgr_random_vseq extends keymgr_sideload_vseq;
   `uvm_object_utils(keymgr_random_vseq)
   `uvm_object_new
 
-  rand bit is_key_version_err;
-
-  constraint is_key_version_err_c {
-    is_key_version_err == 0;
-  }
-
   task write_random_sw_content();
-    bit [TL_DW-1:0] key_version_val;
-    bit [TL_DW-1:0] max_creator_key_ver_val;
-    bit [TL_DW-1:0] max_owner_int_key_ver_val;
-    bit [TL_DW-1:0] max_owner_key_ver_val;
-    bit [TL_DW-1:0] max_key_ver_val;
     uvm_reg         csr_update_q[$];
 
     csr_random_n_add_to_q(ral.sw_binding_0, csr_update_q);
@@ -37,26 +26,10 @@ class keymgr_random_vseq extends keymgr_sideload_vseq;
     csr_random_n_add_to_q(ral.max_creator_key_ver_en, csr_update_q);
     csr_random_n_add_to_q(ral.max_owner_int_key_ver_en, csr_update_q);
     csr_random_n_add_to_q(ral.max_owner_key_ver_en, csr_update_q);
+    csr_random_n_add_to_q(ral.key_version, csr_update_q);
 
     csr_update_q.shuffle();
     foreach (csr_update_q[i]) csr_update(csr_update_q[i]);
-
-    max_creator_key_ver_val   = `gmv(ral.max_creator_key_ver);
-    max_owner_int_key_ver_val = `gmv(ral.max_owner_int_key_ver);
-    max_owner_key_ver_val     = `gmv(ral.max_owner_key_ver);
-    max_key_ver_val = (current_state == keymgr_pkg::StCreatorRootKey)
-        ? max_creator_key_ver_val : (current_state == keymgr_pkg::StOwnerIntKey)
-        ? max_owner_int_key_ver_val : (current_state == keymgr_pkg::StOwnerKey)
-        ? max_owner_key_ver_val : '1;
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(is_key_version_err)
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(key_version_val,
-                                       if (is_key_version_err) {
-                                         max_key_ver_val != '1 -> key_version_val > max_key_ver_val;
-                                       } else {
-                                         key_version_val <= max_key_ver_val;
-                                       })
-    ral.key_version.set(key_version_val);
-    csr_update(ral.key_version);
   endtask : write_random_sw_content
 
   task csr_random_n_add_to_q(uvm_reg csr, ref uvm_reg csr_q[$]);


### PR DESCRIPTION
1. Fix key_version not updated after moving into new state, which
triggers unexpected error
2. Fix cfgen checking at StReset

Signed-off-by: Weicai Yang <weicai@google.com>