### PR TITLE
[lc_ctrl/otp_ctrl] Scripting update

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl_state.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_state.hjson
@@ -37,4 +37,17 @@
     min_hw       : 5,
     max_hw       : 17,
     min_hd       : 5
+
+    // LC token size in bit
+    token_size   : 128
+    tokens       : [
+        {
+            name:  "AllZeroToken"
+            value: "0x0"
+        }
+        {
+            name:  "RndCnstRawUnlockToken"
+            value: "<random>"
+        }
+    ]
 }

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -43,8 +43,6 @@ interface lc_ctrl_if(input clk, input rst_n);
     otp_i.error = 0;
     otp_i.state = lc_state;
     otp_i.count = lc_cnt;
-    otp_i.all_zero_token = 0;
-    otp_i.raw_unlock_token = 0;
     otp_i.test_unlock_token = 0;
     otp_i.test_exit_token = 0;
     otp_i.rma_token = 0;

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -13,6 +13,7 @@ interface lc_ctrl_if(input clk, input rst_n);
   logic prog_err; // TODO: remove once push-pull can constrain data
   otp_ctrl_pkg::otp_lc_data_t     otp_i;
   otp_ctrl_part_pkg::otp_hw_cfg_t otp_hw_cfg_i;
+  lc_ctrl_pkg::lc_token_t hashed_token;
 
   lc_ctrl_pkg::lc_tx_t lc_dft_en_o;
   lc_ctrl_pkg::lc_tx_t lc_nvm_debug_en_o;
@@ -54,6 +55,7 @@ interface lc_ctrl_if(input clk, input rst_n);
     clk_byp_ack_i = clk_byp_ack;
     flash_rma_ack_i = flash_rma_ack;
     prog_err = 0;
+    hashed_token = '0;
   endtask
 
   task automatic set_clk_byp_ack(lc_ctrl_pkg::lc_tx_t val);
@@ -64,4 +66,7 @@ interface lc_ctrl_if(input clk, input rst_n);
     flash_rma_ack_i = val;
   endtask
 
+  task automatic set_hashed_token(lc_ctrl_pkg::lc_token_t val);
+    hashed_token = val;
+  endtask
 endinterface

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
@@ -42,6 +42,10 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
         randomize_next_lc_state(dec_lc_state(lc_state));
         `uvm_info(`gfn, $sformatf("next_LC_state is %0s, input token is %0h", next_lc_state.name,
                                   token_val), UVM_DEBUG)
+        if (lc_state == LcStRaw && next_lc_state inside {DecLcStTestUnlocked0,
+            DecLcStTestUnlocked1, DecLcStTestUnlocked2, DecLcStTestUnlocked3}) begin
+          cfg.lc_ctrl_vif.set_hashed_token(lc_ctrl_state_pkg::RndCnstRawUnlockTokenHashed);
+        end
         sw_transition_req(next_lc_state, token_val, trans_success);
       end else begin
         // wait at least two clks for scb to finish checking lc outputs

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -43,7 +43,7 @@ module tb;
   assign otp_prog_rsp.ack = otp_prog_if.ack;
   assign otp_token_rsp.ack = otp_token_if.ack;
   // TODO: temp constraint to 0 because it has to equal to otp_lc_data_i tokens
-  assign otp_token_rsp.hashed_token = 0;
+  assign otp_token_rsp.hashed_token = lc_ctrl_if.hashed_token;
 
   // dut
   lc_ctrl dut (

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -10,6 +10,7 @@
 module lc_ctrl
   import lc_ctrl_pkg::*;
   import lc_ctrl_reg_pkg::*;
+  import lc_ctrl_state_pkg::*;
 #(
   // Enable asynchronous transitions on alerts.
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
@@ -482,8 +483,6 @@ module lc_ctrl
     .lc_state_i             ( otp_lc_data_i.state             ),
     .lc_id_state_i          ( otp_lc_data_i.id_state          ),
     .lc_cnt_i               ( otp_lc_data_i.count             ),
-    .all_zero_token_i       ( otp_lc_data_i.all_zero_token    ),
-    .raw_unlock_token_i     ( otp_lc_data_i.raw_unlock_token  ),
     .test_unlock_token_i    ( otp_lc_data_i.test_unlock_token ),
     .test_exit_token_i      ( otp_lc_data_i.test_exit_token   ),
     .rma_token_i            ( otp_lc_data_i.rma_token         ),

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
@@ -6,6 +6,7 @@
 
 module lc_ctrl_fsm
   import lc_ctrl_pkg::*;
+  import lc_ctrl_state_pkg::*;
 #(// Random netlist constants
   parameter lc_keymgr_div_t RndCnstLcKeymgrDivInvalid    = LcKeymgrDivWidth'(0),
   parameter lc_keymgr_div_t RndCnstLcKeymgrDivTestDevRma = LcKeymgrDivWidth'(1),
@@ -28,8 +29,6 @@ module lc_ctrl_fsm
   input  lc_id_state_e          lc_id_state_i,
   input  lc_cnt_e               lc_cnt_i,
   // Token input from OTP (these are all hash post-images).
-  input  lc_token_t             all_zero_token_i,
-  input  lc_token_t             raw_unlock_token_i,
   input  lc_token_t             test_unlock_token_i,
   input  lc_token_t             test_exit_token_i,
   input  lc_token_t             rma_token_i,
@@ -111,7 +110,7 @@ module lc_ctrl_fsm
   `ASSERT_KNOWN(FsmStateKnown_A,  fsm_state_q  )
 
   // Hashed token to compare against.
-  logic [LcTokenWidth-1:0] hashed_token_mux;
+  lc_token_t hashed_token_mux;
 
   always_comb begin : p_fsm
     // FSM default state assignments.
@@ -383,12 +382,12 @@ module lc_ctrl_fsm
   // Note that we always perform a token comparison, even in case of
   // unconditional transitions. In the case of unconditional tokens
   // we just pass an all-zero constant through the hashing function.
-  logic [2**TokenIdxWidth-1:0][LcTokenWidth-1:0] hashed_tokens;
+  lc_token_t [2**TokenIdxWidth-1:0] hashed_tokens;
   logic [TokenIdxWidth-1:0] token_idx;
   always_comb begin : p_token_assign
     hashed_tokens = '0;
-    hashed_tokens[ZeroTokenIdx]       = all_zero_token_i;
-    hashed_tokens[RawUnlockTokenIdx]  = raw_unlock_token_i;
+    hashed_tokens[ZeroTokenIdx]       = AllZeroTokenHashed;
+    hashed_tokens[RawUnlockTokenIdx]  = RndCnstRawUnlockTokenHashed;
     hashed_tokens[TestUnlockTokenIdx] = test_unlock_token_i;
     hashed_tokens[TestExitTokenIdx]   = test_exit_token_i;
     hashed_tokens[RmaTokenIdx]        = rma_token_i;

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv
@@ -13,7 +13,6 @@ package lc_ctrl_pkg;
   /////////////////////////////////
 
   parameter int LcValueWidth = 16;
-  parameter int LcTokenWidth = 128;
   parameter int NumLcStateValues = 12;
   parameter int LcStateWidth = NumLcStateValues * LcValueWidth;
   parameter int NumLcCountValues = 16;
@@ -24,6 +23,7 @@ package lc_ctrl_pkg;
   parameter int LcIdStateWidth = LcValueWidth;
   parameter int DecLcIdStateWidth = 2;
 
+  parameter int LcTokenWidth = 128;
   typedef logic [LcTokenWidth-1:0] lc_token_t;
 
   typedef enum logic [LcStateWidth-1:0] {

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv
@@ -10,6 +10,11 @@
 //
 package lc_ctrl_state_pkg;
 
+
+  /////////////////////////////////////////////
+  // Life cycle manufacturing state encoding //
+  /////////////////////////////////////////////
+
   // These values have been generated such that they are incrementally writeable with respect
   // to the ECC polynomial specified. The values are used to define the life cycle manufacturing
   // state and transition counter encoding in lc_ctrl_pkg.sv.
@@ -144,5 +149,22 @@ package lc_ctrl_state_pkg;
   parameter logic [15:0] E0 = 16'b1111010010011100; // ECC: 6'b000100
   parameter logic [15:0] F0 = 16'b1111011110111110; // ECC: 6'b101100
 
+
+  ///////////////////////////////////////////
+  // Hashed RAW unlock and all-zero tokens //
+  ///////////////////////////////////////////
+
+  parameter logic [127:0] AllZeroToken = {
+    128'h0
+  };
+  parameter logic [127:0] RndCnstRawUnlockToken = {
+    128'hF7968F592FD0C739C407F369AEBEB941
+  };
+  parameter logic [127:0] AllZeroTokenHashed = {
+    128'h0
+  };
+  parameter logic [127:0] RndCnstRawUnlockTokenHashed = {
+    128'hF7968F592FD0C739C407F369AEBEB941
+  };
 
 endpackage : lc_ctrl_state_pkg

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv.tpl
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv.tpl
@@ -13,6 +13,11 @@ package lc_ctrl_state_pkg;
 data_width = lc_st_enc.config['secded']['data_width']
 ecc_width  = lc_st_enc.config['secded']['ecc_width']
 %>
+
+  /////////////////////////////////////////////
+  // Life cycle manufacturing state encoding //
+  /////////////////////////////////////////////
+
   // These values have been generated such that they are incrementally writeable with respect
   // to the ECC polynomial specified. The values are used to define the life cycle manufacturing
   // state and transition counter encoding in lc_ctrl_pkg.sv.
@@ -54,6 +59,16 @@ ecc_width  = lc_st_enc.config['secded']['ecc_width']
   parameter logic [${data_width-1}:0] E${loop.index} = ${data_width}'b${word[0][ecc_width:]}; // ECC: ${ecc_width}'b${word[0][0:ecc_width]}
   parameter logic [${data_width-1}:0] F${loop.index} = ${data_width}'b${word[1][ecc_width:]}; // ECC: ${ecc_width}'b${word[1][0:ecc_width]}
 
+% endfor
+
+  ///////////////////////////////////////////
+  // Hashed RAW unlock and all-zero tokens //
+  ///////////////////////////////////////////
+<% token_size = lc_st_enc.config['token_size'] %>
+% for token in lc_st_enc.config['tokens']:
+  parameter logic [${token_size-1}:0] ${token['name']} = {
+    ${"{0:}'h{1:0X}".format(token_size, token['value'])}
+  };
 % endfor
 
 endpackage : lc_ctrl_state_pkg

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -59,30 +59,6 @@
       randcount: "40",
       randtype:  "perm", // random permutation for randcount elements
     }
-    { name:      "RndCnstKey",
-      desc:      "Compile-time random scrambling keys",
-      type:      "otp_ctrl_pkg::key_array_t"
-      randcount: "384",  // 3*128
-      randtype:  "data", // randomize randcount databits
-    }
-    { name:      "RndCnstDigestConst",
-      desc:      "Compile-time random digest constant",
-      type:      "otp_ctrl_pkg::digest_const_array_t"
-      randcount: "640",  // 5*128
-      randtype:  "data", // randomize randcount databits
-    }
-    { name:      "RndCnstDigestIV",
-      desc:      "Compile-time random digest IV",
-      type:      "otp_ctrl_pkg::digest_iv_array_t"
-      randcount: "320",  // 5*64
-      randtype:  "data", // randomize randcount databits
-    }
-    { name:      "RndCnstRawUnlockToken",
-      desc:      "Compile-time random value for RAW unlock token.",
-      type:      "lc_ctrl_pkg::lc_token_t"
-      randcount: "128",
-      randtype:  "data", // randomize randcount databits
-    }
     // Normal parameters
     { name: "NumSramKeyReqSlots",
       desc: "Number of key slots",

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -72,30 +72,6 @@
       randcount: "40",
       randtype:  "perm", // random permutation for randcount elements
     }
-    { name:      "RndCnstKey",
-      desc:      "Compile-time random scrambling keys",
-      type:      "otp_ctrl_pkg::key_array_t"
-      randcount: "384",  // 3*128
-      randtype:  "data", // randomize randcount databits
-    }
-    { name:      "RndCnstDigestConst",
-      desc:      "Compile-time random digest constant",
-      type:      "otp_ctrl_pkg::digest_const_array_t"
-      randcount: "640",  // 5*128
-      randtype:  "data", // randomize randcount databits
-    }
-    { name:      "RndCnstDigestIV",
-      desc:      "Compile-time random digest IV",
-      type:      "otp_ctrl_pkg::digest_iv_array_t"
-      randcount: "320",  // 5*64
-      randtype:  "data", // randomize randcount databits
-    }
-    { name:      "RndCnstRawUnlockToken",
-      desc:      "Compile-time random value for RAW unlock token.",
-      type:      "lc_ctrl_pkg::lc_token_t"
-      randcount: "128",
-      randtype:  "data", // randomize randcount databits
-    }
     // Normal parameters
     { name: "NumSramKeyReqSlots",
       desc: "Number of key slots",

--- a/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
@@ -22,6 +22,58 @@
         width: "2", // bytes
         depth: "1024"
     }
+
+    // Definition of scrambling and digest constants and keys.
+    scrambling: {
+        key_size:  "16",
+        iv_size:   "8",
+        cnst_size: "16",
+        keys: [
+            {
+                name:  "Secret0Key",
+                value: "<random>",
+            }
+            {
+                name:  "Secret1Key",
+                value: "<random>",
+            }
+            {
+                name:  "Secret2Key",
+                value: "<random>",
+            }
+        ]
+        digests: [
+            // This is the consistency digest used by all partitions.
+            {
+                name:       "CnstyDigest",
+                iv_value:   "<random>",
+                cnst_value: "<random>",
+            }
+            // The other digest configurations below are used for
+            // key derivation and token hashing.
+            {
+                name:       "LcRawDigest",
+                iv_value:   "<random>",
+                cnst_value: "<random>",
+            }
+            {
+                name:       "FlashDataKey",
+                iv_value:   "<random>",
+                cnst_value: "<random>",
+            }
+            {
+                name:       "FlashAddrKey",
+                iv_value:   "<random>",
+                cnst_value: "<random>",
+            }
+            {
+                name:       "SramDataKey",
+                iv_value:   "<random>",
+                cnst_value: "<random>",
+            }
+        ]
+    }
+
     // The enumeration order below defines the address map of the OTP controller,
     // if the offsets are not defined explicitly via the "offset" key.
     // Note that the digest items are added automatically to the address map.
@@ -89,7 +141,7 @@
                     // Default value to be output in case partition has not
                     // initialized or is in error state. If not specified,
                     // a value of '0 will be used.
-                    inv_default: "{256{1'b1}}",
+                    inv_default: "<random>",
                 }
                 {
                     name: "HW_CFG_CONTENT",
@@ -118,12 +170,12 @@
                     // This will generate a random default to be output in
                     // case partition has not initialized or is in error state.
                     // If not specified, a value of '0 will be used.
-                    rand_inv_default: "True",
+                    inv_default: "<random>",
                     size: "16"
                 }
                 {
                     name: "TEST_EXIT_TOKEN",
-                    rand_inv_default: "True",
+                    inv_default: "<random>",
                     size: "16"
                 }
             ],
@@ -144,17 +196,17 @@
             items: [
                 {
                     name: "FLASH_ADDR_KEY_SEED",
-                    rand_inv_default: "True",
+                    inv_default: "<random>",
                     size: "32"
                 }
                 {
                     name: "FLASH_DATA_KEY_SEED",
-                    rand_inv_default: "True",
+                    inv_default: "<random>",
                     size: "32"
                 }
                 {
                     name: "SRAM_DATA_KEY_SEED",
-                    rand_inv_default: "True",
+                    inv_default: "<random>",
                     size: "16"
                 }
             ],
@@ -176,17 +228,17 @@
             items: [
                 {
                     name: "RMA_TOKEN",
-                    rand_inv_default: "True",
+                    inv_default: "<random>",
                     size: "16"
                 }
                 {
                     name: "CREATOR_ROOT_KEY_SHARE0",
-                    rand_inv_default: "True",
+                    inv_default: "<random>",
                     size: "32"
                 }
                 {
                     name: "CREATOR_ROOT_KEY_SHARE1",
-                    rand_inv_default: "True",
+                    inv_default: "<random>",
                     size: "32"
                 }
             ],

--- a/hw/ip/otp_ctrl/otp_ctrl.core
+++ b/hw/ip/otp_ctrl/otp_ctrl.core
@@ -24,7 +24,6 @@ filesets:
       - rtl/otp_ctrl_reg_top.sv
       - rtl/otp_ctrl_ecc_reg.sv
       - rtl/otp_ctrl_scrmbl.sv
-      - rtl/otp_ctrl_token_const.sv
       - rtl/otp_ctrl_lfsr_timer.sv
       - rtl/otp_ctrl_part_unbuf.sv
       - rtl/otp_ctrl_part_buf.sv

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -13,14 +13,10 @@ module otp_ctrl
   import otp_ctrl_part_pkg::*;
 #(
   // Enable asynchronous transitions on alerts.
-  parameter logic [NumAlerts-1:0] AlertAsyncOn      = {NumAlerts{1'b1}},
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
   // Compile time random constants, to be overriden by topgen.
-  parameter lfsr_seed_t             RndCnstLfsrSeed       = RndCnstLfsrSeedDefault,
-  parameter lfsr_perm_t             RndCnstLfsrPerm       = RndCnstLfsrPermDefault,
-  parameter key_array_t             RndCnstKey            = RndCnstKeyDefault,
-  parameter digest_const_array_t    RndCnstDigestConst    = RndCnstDigestConstDefault,
-  parameter digest_iv_array_t       RndCnstDigestIV       = RndCnstDigestIVDefault,
-  parameter lc_ctrl_pkg::lc_token_t RndCnstRawUnlockToken = RndCnstRawUnlockTokenDefault,
+  parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault,
+  parameter lfsr_perm_t RndCnstLfsrPerm = RndCnstLfsrPermDefault,
   // Hexfile file to initialize the OTP macro.
   // Note that the hexdump needs to account for ECC.
   parameter MemInitFile = ""
@@ -717,11 +713,7 @@ module otp_ctrl
   logic scrmbl_arb_req_ready, scrmbl_arb_rsp_valid;
   logic [NumAgents-1:0] part_scrmbl_req_ready, part_scrmbl_rsp_valid;
 
-  otp_ctrl_scrmbl #(
-    .RndCnstKey(RndCnstKey),
-    .RndCnstDigestConst(RndCnstDigestConst),
-    .RndCnstDigestIV(RndCnstDigestIV)
-  ) u_scrmbl (
+  otp_ctrl_scrmbl u_scrmbl (
     .clk_i,
     .rst_ni,
     .cmd_i         ( scrmbl_req_bundle.cmd       ),
@@ -743,19 +735,6 @@ module otp_ctrl
     part_scrmbl_req_ready[scrmbl_mtx_idx] = scrmbl_arb_req_ready;
     part_scrmbl_rsp_valid[scrmbl_mtx_idx] = scrmbl_arb_rsp_valid;
   end
-
-  /////////////////////////////////////////////
-  // Static fife cycle token precomputations //
-  /////////////////////////////////////////////
-
-  otp_ctrl_token_const #(
-    .RndCnstDigestConst    ( RndCnstDigestConst    ),
-    .RndCnstDigestIV       ( RndCnstDigestIV       ),
-    .RndCnstRawUnlockToken ( RndCnstRawUnlockToken )
-  ) u_otp_ctrl_token_const (
-    .all_zero_token_hashed_o   ( otp_lc_data_o.all_zero_token   ),
-    .raw_unlock_token_hashed_o ( otp_lc_data_o.raw_unlock_token )
-  );
 
   /////////////////////////////
   // Direct Access Interface //

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
@@ -10,6 +10,7 @@
 module otp_ctrl_kdi
   import otp_ctrl_pkg::*;
   import otp_ctrl_reg_pkg::*;
+  import otp_ctrl_part_pkg::*;
 (
   input                                              clk_i,
   input                                              rst_ni,

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_lci.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_lci.sv
@@ -10,6 +10,7 @@
 module otp_ctrl_lci
   import otp_ctrl_pkg::*;
   import otp_ctrl_reg_pkg::*;
+  import otp_ctrl_part_pkg::*;
 #(
   // Lifecycle partition information
   parameter part_info_t Info = part_info_t'(0)

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -10,6 +10,7 @@
 module otp_ctrl_part_buf
   import otp_ctrl_pkg::*;
   import otp_ctrl_reg_pkg::*;
+  import otp_ctrl_part_pkg::*;
 #(
   // Partition information.
   parameter part_info_t             Info = part_info_t'(0),

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv.tpl
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv.tpl
@@ -10,20 +10,112 @@
 //
 <%
   def PascalCase(inp):
+    # if input is in snake case format
+    # or ALLCAPS
     oup = ''
-    upper = True
-    for k in inp.lower():
-      if k == '_':
-        upper = True
-      else:
-        oup += k.upper() if upper else k
-        upper = False
+    if '_' in inp or inp == inp.upper():
+      upper = True
+      for k in inp:
+        if k == '_':
+          upper = True
+        else:
+          oup += k.upper() if upper else k.lower()
+          upper = False
+    # assume its a possibly PascalCased string.
+    # just make sure the first char is capitalized.
+    else:
+      oup = inp[0].upper()
+      if len(inp) > 1:
+        oup += inp[1:]
+
     return oup
+
 %>
 package otp_ctrl_part_pkg;
 
+  import prim_util_pkg::vbits;
   import otp_ctrl_reg_pkg::*;
   import otp_ctrl_pkg::*;
+
+  ////////////////////////////////////
+  // Scrambling Constants and Types //
+  ////////////////////////////////////
+
+  parameter int NumScrmblKeys = ${len(otp_mmap.config["scrambling"]["keys"])};
+  parameter int NumDigestSets = ${len(otp_mmap.config["scrambling"]["digests"])};
+  parameter int ConstSelWidth = (NumScrmblKeys > NumDigestSets) ?
+                                vbits(NumScrmblKeys) :
+                                vbits(NumDigestSets);
+
+  typedef enum logic [ConstSelWidth-1:0] {
+    StandardMode,
+    ChainedMode
+  } digest_mode_e;
+
+  typedef logic [NumScrmblKeys-1:0][ScrmblKeyWidth-1:0] key_array_t;
+  typedef logic [NumDigestSets-1:0][ScrmblKeyWidth-1:0] digest_const_array_t;
+  typedef logic [NumDigestSets-1:0][ScrmblBlockWidth-1:0] digest_iv_array_t;
+
+  typedef enum logic [ConstSelWidth-1:0] {
+% for key in otp_mmap.config["scrambling"]["keys"]:
+    ${PascalCase(key["name"])}${"" if loop.last else ","}
+% endfor
+  } key_sel_e;
+
+  typedef enum logic [ConstSelWidth-1:0] {
+% for dig in otp_mmap.config["scrambling"]["digests"]:
+    ${PascalCase(dig["name"])}${"" if loop.last else ","}
+% endfor
+  } digest_sel_e;
+
+  parameter key_array_t RndCnstKey = {
+% for key in otp_mmap.config["scrambling"]["keys"][::-1]:
+    ${"{0:}'h{1:0X}".format(otp_mmap.config["scrambling"]["key_size"] * 8, key["value"])}${"" if loop.last else ","}
+% endfor
+  };
+
+  // Note: digest set 0 is used for computing the partition digests. Constants at
+  // higher indices are used to compute the scrambling keys.
+  parameter digest_const_array_t RndCnstDigestConst = {
+% for dig in otp_mmap.config["scrambling"]["digests"][::-1]:
+    ${"{0:}'h{1:0X}".format(otp_mmap.config["scrambling"]["cnst_size"] * 8, dig["cnst_value"])}${"" if loop.last else ","}
+% endfor
+  };
+
+  parameter digest_iv_array_t RndCnstDigestIV = {
+% for dig in otp_mmap.config["scrambling"]["digests"][::-1]:
+    ${"{0:}'h{1:0X}".format(otp_mmap.config["scrambling"]["iv_size"] * 8, dig["iv_value"])}${"" if loop.last else ","}
+% endfor
+  };
+
+
+  /////////////////////////////////////
+  // Typedefs for Partition Metadata //
+  /////////////////////////////////////
+
+  typedef enum logic [1:0] {
+    Unbuffered,
+    Buffered,
+    LifeCycle
+  } part_variant_e;
+
+  typedef struct packed {
+    part_variant_e variant;
+    // Offset and size within the OTP array, in Bytes.
+    logic [OtpByteAddrWidth-1:0] offset;
+    logic [OtpByteAddrWidth-1:0] size;
+    // Key index to use for scrambling.
+    key_sel_e key_sel;
+    // Attributes
+    logic secret;     // Whether the partition is secret (and hence scrambled)
+    logic hw_digest;  // Whether the partition has a hardware digest
+    logic write_lock; // Whether the partition is write lockable (via digest)
+    logic read_lock;  // Whether the partition is read lockable (via digest)
+  } part_info_t;
+
+  ////////////////////////
+  // Partition Metadata //
+  ////////////////////////
 
   localparam part_info_t PartInfo [NumPart] = '{
 % for part in otp_mmap.config["partitions"]:
@@ -77,9 +169,8 @@ package otp_ctrl_part_pkg;
   % for k, part in enumerate(otp_mmap.config["partitions"][::-1]):
     ${int(part["size"])*8}'({
     % for item in part["items"][::-1]:
-      ${item["inv_default"]}${("\n    })," if k < len(otp_mmap.config["partitions"])-1 else "\n    })});") if loop.last else ","}
+      ${"{}'h{:0X}".format(item["size"] * 8, item["inv_default"])}${("\n    })," if k < len(otp_mmap.config["partitions"])-1 else "\n    })});") if loop.last else ","}
     % endfor
   % endfor
-
 
 endpackage : otp_ctrl_part_pkg

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -10,6 +10,7 @@
 module otp_ctrl_part_unbuf
   import otp_ctrl_pkg::*;
   import otp_ctrl_reg_pkg::*;
+  import otp_ctrl_part_pkg::*;
 #(
   // Partition information.
   parameter part_info_t Info = part_info_t'(0)

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -85,55 +85,6 @@ package otp_ctrl_pkg;
     DigestFinalize
   } otp_scrmbl_cmd_e;
 
-  parameter int NumScrmblKeys = 3;
-  parameter int NumDigestSets = 5;
-  parameter int ConstSelWidth = (NumScrmblKeys > NumDigestSets) ?
-                                vbits(NumScrmblKeys) :
-                                vbits(NumDigestSets);
-
-  typedef enum logic [ConstSelWidth-1:0] {
-    Secret0Key,
-    Secret1Key,
-    Secret2Key
-  } key_sel_e;
-
-  typedef enum logic [ConstSelWidth-1:0] {
-    CnstyDigest,
-    LcRawDigest,
-    FlashDataKey,
-    FlashAddrKey,
-    SramDataKey
-  } digest_sel_e;
-
-  typedef enum logic [ConstSelWidth-1:0] {
-    StandardMode,
-    ChainedMode
-  } digest_mode_e;
-
-  /////////////////////////////////////
-  // Typedefs for Partition Metadata //
-  /////////////////////////////////////
-
-  typedef enum logic [1:0] {
-    Unbuffered,
-    Buffered,
-    LifeCycle
-  } part_variant_e;
-
-  typedef struct packed {
-    part_variant_e variant;
-    // Offset and size within the OTP array, in Bytes.
-    logic [OtpByteAddrWidth-1:0] offset;
-    logic [OtpByteAddrWidth-1:0] size;
-    // Key index to use for scrambling.
-    key_sel_e key_sel;
-    // Attributes
-    logic secret;     // Whether the partition is secret (and hence scrambled)
-    logic hw_digest;  // Whether the partition has a hardware digest
-    logic write_lock; // Whether the partition is write lockable (via digest)
-    logic read_lock;  // Whether the partition is read lockable (via digest)
-  } part_info_t;
-
   ///////////////////////////////
   // Typedefs for LC Interface //
   ///////////////////////////////
@@ -144,8 +95,6 @@ package otp_ctrl_pkg;
     lc_ctrl_pkg::lc_state_e    state;
     lc_ctrl_pkg::lc_cnt_e      count;
     // These are all hash post-images
-    lc_ctrl_pkg::lc_token_t    all_zero_token;
-    lc_ctrl_pkg::lc_token_t    raw_unlock_token;
     lc_ctrl_pkg::lc_token_t    test_unlock_token;
     lc_ctrl_pkg::lc_token_t    test_exit_token;
     lc_ctrl_pkg::lc_token_t    rma_token;
@@ -158,8 +107,6 @@ package otp_ctrl_pkg;
     error: 1'b0,
     state: lc_ctrl_pkg::LcStRaw,
     count: lc_ctrl_pkg::LcCntRaw,
-    all_zero_token: '0,
-    raw_unlock_token: '0,
     test_unlock_token: '0,
     test_exit_token: '0,
     rma_token: '0,
@@ -301,36 +248,5 @@ package otp_ctrl_pkg;
   localparam lfsr_seed_t RndCnstLfsrSeedDefault = 40'h453d28ea98;
   localparam lfsr_perm_t RndCnstLfsrPermDefault =
       240'h4235171482c225f79289b32181a0163a760355d3447063d16661e44c12a5;
-
-
-  typedef logic [NumScrmblKeys-1:0][ScrmblKeyWidth-1:0] key_array_t;
-  parameter key_array_t RndCnstKeyDefault = {
-    128'h047288e1a65c839dae610bbbdf8c4525,
-    128'h38fe59a71a91a65636573a6513784e3b,
-    128'h4f48dcc45ace0770e9135bda73e56344
-  };
-
-  // Note: digest set 0 is used for computing the partition digests. Constants at
-  // higher indices are used to compute the scrambling keys.
-  typedef logic [NumDigestSets-1:0][ScrmblKeyWidth-1:0] digest_const_array_t;
-  parameter digest_const_array_t RndCnstDigestConstDefault = {
-    128'h9d40106e2dc2346ec96d61f0cc5295c7,
-    128'hafed2aa5c3284c01d71103edab1d8953,
-    128'h8a14fe0c08f8a3a190dd32c05f208474,
-    128'h9e6fac4ba15a3bce29d05a3e9e2d0846,
-    128'h3a0c6051392e00ef24073627319555b8
-  };
-
-  typedef logic [NumDigestSets-1:0][ScrmblBlockWidth-1:0] digest_iv_array_t;
-  parameter digest_iv_array_t RndCnstDigestIVDefault = {
-    64'ha5af72c1b813aec4,
-    64'h5d7aacd1db316407,
-    64'hd0ec83b7fe6ae2ae,
-    64'hc2993a0ea64e312d,
-    64'h899aac2ab7d91479
-  };
-
-  parameter lc_ctrl_pkg::lc_token_t RndCnstRawUnlockTokenDefault =
-    128'hcbbd013ff15eba2f3065461eeb88463e;
 
 endpackage : otp_ctrl_pkg

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
@@ -68,12 +68,10 @@
 //             - http://www.lightweightcrypto.org/present/present_ches2007.pdf
 //
 
-module otp_ctrl_scrmbl import otp_ctrl_pkg::*; #(
-  // Compile time random constants, to be overriden by topgen.
-  parameter key_array_t          RndCnstKey         = RndCnstKeyDefault,
-  parameter digest_const_array_t RndCnstDigestConst = RndCnstDigestConstDefault,
-  parameter digest_iv_array_t    RndCnstDigestIV    = RndCnstDigestIVDefault
-) (
+module otp_ctrl_scrmbl
+  import otp_ctrl_pkg::*;
+  import otp_ctrl_part_pkg::*;
+(
   input                               clk_i,
   input                               rst_ni,
   // input data and command

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1054,54 +1054,6 @@
           name_top: RndCnstOtpCtrlLfsrPerm
           randwidth: 240
         }
-        {
-          name: RndCnstKey
-          desc: Compile-time random scrambling keys
-          type: otp_ctrl_pkg::key_array_t
-          randcount: "384"
-          randtype: data
-          local: "false"
-          default: 0x79ee911ce801484ba8373086f9dd4eee6faf88f22bccd612d1c09f5c02b2c8d1fdb92558e2d9c5d24440722325a93144
-          expose: "false"
-          name_top: RndCnstOtpCtrlKey
-          randwidth: 384
-        }
-        {
-          name: RndCnstDigestConst
-          desc: Compile-time random digest constant
-          type: otp_ctrl_pkg::digest_const_array_t
-          randcount: "640"
-          randtype: data
-          local: "false"
-          default: 0xce7d846469a3b8e35a6bd38295bd2fb366b3d62126c75eeaeb93d32f5cbc77463c91917516d51a2fa4400adc2669e2530ee2a465fd4dabcbd877afb6bcfeed7e03a0b091dc41d062dd10ca2d7b93136f
-          expose: "false"
-          name_top: RndCnstOtpCtrlDigestConst
-          randwidth: 640
-        }
-        {
-          name: RndCnstDigestIV
-          desc: Compile-time random digest IV
-          type: otp_ctrl_pkg::digest_iv_array_t
-          randcount: "320"
-          randtype: data
-          local: "false"
-          default: 0xb77f07ff3d7297200d5ab25561af49c696466a983e5346826a43628219e5a91389b9fe0d3b818e46
-          expose: "false"
-          name_top: RndCnstOtpCtrlDigestIV
-          randwidth: 320
-        }
-        {
-          name: RndCnstRawUnlockToken
-          desc: Compile-time random value for RAW unlock token.
-          type: lc_ctrl_pkg::lc_token_t
-          randcount: "128"
-          randtype: data
-          local: "false"
-          default: 0xde094ca8f1435f85e0f7489a309cbe57
-          expose: "false"
-          name_top: RndCnstOtpCtrlRawUnlockToken
-          randwidth: 128
-        }
       ]
       interrupt_list:
       [

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -846,11 +846,7 @@ module top_earlgrey #(
 
   otp_ctrl #(
     .RndCnstLfsrSeed(RndCnstOtpCtrlLfsrSeed),
-    .RndCnstLfsrPerm(RndCnstOtpCtrlLfsrPerm),
-    .RndCnstKey(RndCnstOtpCtrlKey),
-    .RndCnstDigestConst(RndCnstOtpCtrlDigestConst),
-    .RndCnstDigestIV(RndCnstOtpCtrlDigestIV),
-    .RndCnstRawUnlockToken(RndCnstOtpCtrlRawUnlockToken)
+    .RndCnstLfsrPerm(RndCnstOtpCtrlLfsrPerm)
   ) u_otp_ctrl (
 
       // Interrupt

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -26,30 +26,6 @@ package top_earlgrey_rnd_cnst_pkg;
     240'h5D294061E29A7C404F4593035A19097666E37072064153623855022D39E0
   };
 
-  // Compile-time random scrambling keys
-  parameter otp_ctrl_pkg::key_array_t RndCnstOtpCtrlKey = {
-    128'h79EE911CE801484BA8373086F9DD4EEE,
-    256'h6FAF88F22BCCD612D1C09F5C02B2C8D1FDB92558E2D9C5D24440722325A93144
-  };
-
-  // Compile-time random digest constant
-  parameter otp_ctrl_pkg::digest_const_array_t RndCnstOtpCtrlDigestConst = {
-    128'hCE7D846469A3B8E35A6BD38295BD2FB3,
-    256'h66B3D62126C75EEAEB93D32F5CBC77463C91917516D51A2FA4400ADC2669E253,
-    256'h0EE2A465FD4DABCBD877AFB6BCFEED7E03A0B091DC41D062DD10CA2D7B93136F
-  };
-
-  // Compile-time random digest IV
-  parameter otp_ctrl_pkg::digest_iv_array_t RndCnstOtpCtrlDigestIV = {
-    64'hB77F07FF3D729720,
-    256'h0D5AB25561AF49C696466A983E5346826A43628219E5A91389B9FE0D3B818E46
-  };
-
-  // Compile-time random value for RAW unlock token.
-  parameter lc_ctrl_pkg::lc_token_t RndCnstOtpCtrlRawUnlockToken = {
-    128'hDE094CA8F1435F85E0F7489A309CBE57
-  };
-
   ////////////////////////////////////////////
   // lc_ctrl
   ////////////////////////////////////////////

--- a/util/design/lib/OtpMemMap.py
+++ b/util/design/lib/OtpMemMap.py
@@ -11,10 +11,209 @@ import random
 from math import ceil, log2
 
 from tabulate import tabulate
-from lib.common import check_bool, check_int
+from lib.common import check_bool, check_int, random_or_hexvalue
 
 DIGEST_SUFFIX = "_DIGEST"
 DIGEST_SIZE = 8
+
+
+def _validate_otp(otp):
+    '''Validate OTP entry'''
+    otp.setdefault("depth", "1024")
+    otp.setdefault("width", "2")
+    otp["depth"] = check_int(otp["depth"])
+    otp["width"] = check_int(otp["width"])
+    otp["size"] = otp["depth"] * otp["width"]
+    otp["addr_width"] = ceil(log2(check_int(otp["depth"])))
+    otp["byte_addr_width"] = ceil(log2(otp["size"]))
+
+
+def _validate_scrambling(scr):
+    '''Validate SCrambling entry'''
+    scr.setdefault("key_size", "16")
+    scr.setdefault("iv_size", "8")
+    scr.setdefault("cnst_size", "16")
+    scr["key_size"] = check_int(scr["key_size"])
+    scr["iv_size"] = check_int(scr["iv_size"])
+    scr["cnst_size"] = check_int(scr["cnst_size"])
+
+    if "keys" not in scr:
+        log.error("Missing key configuration.")
+        exit(1)
+    if "digests" not in scr:
+        log.error("Missing digest configuration.")
+        exit(1)
+
+    for key in scr["keys"]:
+        key.setdefault("name", "unknown_key_name")
+        key.setdefault("value", "<random>")
+        random_or_hexvalue(key, "value", scr["key_size"] * 8)
+
+    for dig in scr["digests"]:
+        dig.setdefault("name", "unknown_key_name")
+        dig.setdefault("iv_value", "<random>")
+        dig.setdefault("cnst_value", "<random>")
+        random_or_hexvalue(dig, "iv_value", scr["iv_size"] * 8)
+        random_or_hexvalue(dig, "cnst_value", scr["cnst_size"] * 8)
+
+
+def _validate_part(part, offset, key_names):
+    '''Validates a partition within the OTP memory map'''
+    part.setdefault("offset", offset)
+    part.setdefault("name", "unknown_name")
+    part.setdefault("variant", "Unbuffered")
+    part.setdefault("size", "0")
+    part.setdefault("secret", "false")
+    part.setdefault("sw_digest", "false")
+    part.setdefault("hw_digest", "false")
+    part.setdefault("write_lock", "none")
+    part.setdefault("read_lock", "none")
+    part.setdefault("key_sel", "NoKey")
+    log.info("Partition {} at offset {} with size {}".format(
+        part["name"], part["offset"], part["size"]))
+
+    # Make sure these are boolean types (simplifies the mako templates)
+    part["secret"] = check_bool(part["secret"])
+    part["sw_digest"] = check_bool(part["sw_digest"])
+    part["hw_digest"] = check_bool(part["hw_digest"])
+    part["bkout_type"] = check_bool(part["bkout_type"])
+
+    # Make sure this has integer type.
+    part["size"] = check_int(part["size"])
+
+    # basic checks
+    if part["variant"] not in ["Unbuffered", "Buffered", "LifeCycle"]:
+        log.error("Invalid partition type {}".format(part["variant"]))
+        exit(1)
+
+    if part["key_sel"] not in (["NoKey"] + key_names):
+        log.error("Invalid key sel {}".format(part["key_sel"]))
+        exit(1)
+
+    if check_bool(part["secret"]) and part["key_sel"] == "NoKey":
+        log.error(
+            "A secret partition needs a key select value other than NoKey"
+        )
+        exit(1)
+
+    if part["write_lock"].lower() not in ["digest", "csr", "none"]:
+        log.error("Invalid value for write_lock")
+        exit(1)
+
+    if part["read_lock"].lower() not in ["digest", "csr", "none"]:
+        log.error("Invalid value for read_lock")
+        exit(1)
+
+    if part["sw_digest"] and part["hw_digest"]:
+        log.error(
+            "Partition cannot support both a SW and a HW digest at the same time."
+        )
+        exit(1)
+
+    if part["variant"] == "Unbuffered" and not part["sw_digest"]:
+        log.error(
+            "Unbuffered partitions without digest are not supported at the moment."
+        )
+        exit(1)
+
+    if not part["sw_digest"] and not part["hw_digest"]:
+        if part["write_lock"].lower(
+        ) == "digest" or part["read_lock"].lower() == "digest":
+            log.error(
+                "A partition can only be write/read lockable if it has a hw or sw digest."
+            )
+            exit(1)
+
+    if check_int(part["offset"]) % 8:
+        log.error("Partition offset must be 64bit aligned")
+        exit(1)
+
+    if check_int(part["size"]) % 8:
+        log.error("Partition size must be 64bit aligned")
+        exit(1)
+
+    if len(part["items"]) == 0:
+        log.warning("Partition does not contain any items.")
+
+
+def _validate_item(item, offset):
+    '''Validates an item within a partition'''
+    item.setdefault("name", "unknown_name")
+    item.setdefault("size", "0")
+    item.setdefault("isdigest", "false")
+    item.setdefault("offset", offset)
+
+    # Make sure this has integer type.
+    item["size"] = check_int(item["size"])
+
+    # Generate random constant to be used when partition has
+    # not been initialized yet or when it is in error state.
+    random_or_hexvalue(item, "inv_default", check_int(item["size"]) * 8)
+
+
+def _validate_mmap(config):
+    '''Validate the memory map configuration'''
+
+    # Get valid key names.
+    key_names = []
+    for key in config["scrambling"]["keys"]:
+        key_names.append(key["name"])
+
+    offset = 0
+    num_part = 0
+    for part in config["partitions"]:
+        num_part += 1
+        _validate_part(part, offset, key_names)
+
+        # Loop over items within a partition
+        for item in part["items"]:
+            _validate_item(item, offset)
+            log.info("> Item {} at offset {} with size {}".format(
+                item["name"], offset, item["size"]))
+            offset += check_int(item["size"])
+
+        # Place digest at the end of a partition.
+        if part["sw_digest"] or part["hw_digest"]:
+            part["items"].append({
+                "name":
+                part["name"] + DIGEST_SUFFIX,
+                "size":
+                DIGEST_SIZE,
+                "offset":
+                check_int(part["offset"]) + check_int(part["size"]) -
+                DIGEST_SIZE,
+                "isdigest":
+                "True",
+                "inv_default": "<random>"
+            })
+            # Randomize the digest default.
+            random_or_hexvalue(part["items"][-1], "inv_default", DIGEST_SIZE * 8)
+
+            log.info("> Adding digest {} at offset {} with size {}".format(
+                part["name"] + DIGEST_SUFFIX, offset, DIGEST_SIZE))
+            offset += DIGEST_SIZE
+
+        # check offsets and size
+        if offset > check_int(part["offset"]) + check_int(part["size"]):
+            log.error("Not enough space in partitition "
+                      "{} to accommodate all items. Bytes available "
+                      "= {}, bytes requested = {}".format(
+                          part["name"], part["size"],
+                          offset - part["offset"]))
+            exit(1)
+
+        offset = check_int(part["offset"]) + check_int(part["size"])
+
+    if offset > config["otp"]["size"]:
+        log.error(
+            "OTP is not big enough to store all partitions. "
+            "Bytes available {}, bytes required {}",
+            config["otp"]["size"], offset)
+        exit(1)
+
+    log.info("Total number of partitions: {}".format(num_part))
+    log.info("Bytes available in OTP: {}".format(config["otp"]["size"]))
+    log.info("Bytes required for partitions: {}".format(offset))
 
 
 class OtpMemMap():
@@ -37,161 +236,28 @@ class OtpMemMap():
         # Initialize RNG.
         random.seed(int(config['seed']))
 
-        offset = 0
-        num_part = 0
-        for part in config["partitions"]:
-            num_part += 1
-            # Defaults
-            part.setdefault("offset", offset)
-            part.setdefault("name", "unknown_name")
-            part.setdefault("variant", "Unbuffered")
-            part.setdefault("size", "0")
-            part.setdefault("secret", "false")
-            part.setdefault("sw_digest", "false")
-            part.setdefault("hw_digest", "false")
-            part.setdefault("write_lock", "none")
-            part.setdefault("read_lock", "none")
-            part.setdefault("key_sel", "NoKey")
-            log.info("Partition {} at offset {} with size {}".format(
-                part["name"], part["offset"], part["size"]))
-
-            # make sure these are boolean types (simplifies the mako templates)
-            part["secret"] = check_bool(part["secret"])
-            part["sw_digest"] = check_bool(part["sw_digest"])
-            part["hw_digest"] = check_bool(part["hw_digest"])
-            part["bkout_type"] = check_bool(part["bkout_type"])
-
-            # basic checks
-            if part["variant"] not in ["Unbuffered", "Buffered", "LifeCycle"]:
-                log.error("Invalid partition type {}".format(part["variant"]))
-                exit(1)
-
-            if part["key_sel"] not in [
-                    "NoKey", "Secret0Key", "Secret1Key", "Secret2Key"
-            ]:
-                log.error("Invalid key sel {}".format(part["key_sel"]))
-                exit(1)
-
-            if check_bool(part["secret"]) and part["key_sel"] == "NoKey":
-                log.error(
-                    "A secret partition needs a key select value other than NoKey"
-                )
-                exit(1)
-
-            if part["write_lock"].lower() not in ["digest", "csr", "none"]:
-                log.error("Invalid value for write_lock")
-                exit(1)
-
-            if part["read_lock"].lower() not in ["digest", "csr", "none"]:
-                log.error("Invalid value for read_lock")
-                exit(1)
-
-            if part["sw_digest"] and part["hw_digest"]:
-                log.error(
-                    "Partition cannot support both a SW and a HW digest at the same time."
-                )
-                exit(1)
-
-            if part["variant"] == "Unbuffered" and not part["sw_digest"]:
-                log.error(
-                    "Unbuffered partitions without digest are not supported at the moment."
-                )
-                exit(1)
-
-            if not part["sw_digest"] and not part["hw_digest"]:
-                if part["write_lock"].lower(
-                ) == "digest" or part["read_lock"].lower() == "digest":
-                    log.error(
-                        "A partition can only be write/read lockable if it has a hw or sw digest."
-                    )
-                    exit(1)
-
-            if check_int(part["offset"]) % 8:
-                log.error("Partition offset must be 64bit aligned")
-                exit(1)
-
-            if check_int(part["size"]) % 8:
-                log.error("Partition size must be 64bit aligned")
-                exit(1)
-
-            # Loop over items within a partition
-            for item in part["items"]:
-                item.setdefault("name", "unknown_name")
-                item.setdefault("size", "0")
-                item.setdefault("isdigest", "false")
-                item.setdefault("offset", offset)
-                # Generate random constant to be used when partition has
-                # not been initialized yet or when it is in error state.
-                if check_bool(item.setdefault("rand_inv_default", "false")):
-                    inv_default = random.getrandbits(
-                        check_int(item["size"]) * 8)
-                else:
-                    inv_default = 0
-                item.setdefault(
-                    "inv_default", "{}'h{:0X}".format(
-                        check_int(item["size"]) * 8, inv_default))
-                log.info("> Item {} at offset {} with size {}".format(
-                    item["name"], offset, item["size"]))
-                offset += check_int(item["size"])
-
-            # Place digest at the end of a partition.
-            if part["sw_digest"] or part["hw_digest"]:
-                part["items"].append({
-                    "name":
-                    part["name"] + DIGEST_SUFFIX,
-                    "size":
-                    DIGEST_SIZE,
-                    "offset":
-                    check_int(part["offset"]) + check_int(part["size"]) -
-                    DIGEST_SIZE,
-                    "isdigest":
-                    "True",
-                    "inv_default":
-                    "{256{1'b1}}"
-                })
-
-                log.info("> Adding digest {} at offset {} with size {}".format(
-                    part["name"] + DIGEST_SUFFIX, offset, DIGEST_SIZE))
-                offset += DIGEST_SIZE
-
-            if len(part["items"]) == 0:
-                log.warning("Partition does not contain any items.")
-
-            # check offsets and size
-            if offset > check_int(part["offset"]) + check_int(part["size"]):
-                log.error("Not enough space in partitition "
-                          "{} to accommodate all items. Bytes available "
-                          "= {}, bytes requested = {}".format(
-                              part["name"], part["size"],
-                              offset - part["offset"]))
-                exit(1)
-
-            offset = check_int(part["offset"]) + check_int(part["size"])
-
-        otp_size = check_int(config["otp"]["depth"]) * check_int(
-            config["otp"]["width"])
-        config["otp"]["size"] = otp_size
-        config["otp"]["addr_width"] = ceil(
-            log2(check_int(config["otp"]["depth"])))
-        config["otp"]["byte_addr_width"] = ceil(log2(check_int(otp_size)))
-
-        if offset > otp_size:
-            log.error(
-                "OTP is not big enough to store all partitions. "
-                "Bytes available {}, bytes required {}",
-                otp_size, offset)
+        if "otp" not in config:
+            log.error("Missing otp configuration.")
+            exit(1)
+        if "scrambling" not in config:
+            log.error("Missing scrambling configuration.")
+            exit(1)
+        if "partitions" not in config:
+            log.error("Missing partition configuration.")
             exit(1)
 
-        log.info("Total number of partitions: {}".format(num_part))
-        log.info("Bytes available in OTP: {}".format(otp_size))
-        log.info("Bytes required for partitions: {}".format(offset))
+        # Validate OTP info.
+        _validate_otp(config["otp"])
+        # Validate scrambling info.
+        _validate_scrambling(config["scrambling"])
+        # Validate memory map.
+        _validate_mmap(config)
 
         self.config = config
 
         log.info('')
         log.info('Successfully parsed and translated OTP memory map.')
         log.info('')
-
 
     def create_partitions_table(self):
         header = [

--- a/util/design/lib/common.py
+++ b/util/design/lib/common.py
@@ -204,3 +204,26 @@ def scatter_bits(mask, bits):
             j += 1
 
     return scatterword
+
+
+def random_or_hexvalue(dict_obj, key, num_bits):
+    '''Convert hex value at "key" to an integer or draw a random number.'''
+
+    # Initialize to default if this key does not exist.
+    dict_obj.setdefault(key, '0x0')
+
+    # Generate a random number of requested size in this case.
+    if dict_obj[key] == '<random>':
+        dict_obj[key] = random.getrandbits(num_bits)
+    # Otherwise attempt to convert this number to an int.
+    # Check that the range is correct.
+    else:
+        try:
+            dict_obj[key] = int(dict_obj[key], 16)
+            if dict_obj[key] >= 2**num_bits:
+                log.error('Value is out of range.')
+                exit(1)
+        except ValueError:
+            log.error('Invalid value "{}". Must be hex or "<random>".'
+                      .format(dict_obj[key]))
+            exit(1)


### PR DESCRIPTION
Note that this change depends on #4787 - only the last 3 commits are relevant.
 
 -------


This moves the OTP scrambling constant generation (for keys and digests) into the memory map generation script instead of using the topgen RndCnt mechanism.

Likewise, the generation of the RAW unlock token is moved into the life cycle state generation script.

These changes have a couple of advantages later on:
- The scrambling keys are conveniently available in the OTP memory map configuration, which eases generation of the OTP preload image later on.
- The RAW unlock token does not have to be "statically" hashed in RTL, but can be hashed in Python as a reprocessing step before dumping it into the template.
- It will be easier to replace the token hashing algo with KMAC later on.

Note that we do not expect to have multiple instances of the OTP or life cycle controllers in our top-level, hence moving away from the RndCnst