### PR TITLE
[prim] Teach verilator to recognise a clock gate

### DIFF
--- a/hw/ip/prim_generic/rtl/prim_generic_clock_gating.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_clock_gating.sv
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Common Library: Clock Gating cell
+//
+// The logic assumes that en_i is synchronized (so the instantiation site might need to put a
+// synchronizer before en_i).
 
 module prim_generic_clock_gating #(
   parameter bit NoFpgaGate = 1'b0 // this parameter has no function in generic
@@ -13,8 +16,7 @@ module prim_generic_clock_gating #(
   output logic clk_o
 );
 
-  // Assume en_i synchronized, if not put synchronizer prior to en_i
-  logic en_latch;
+  logic en_latch /* verilator clock_enable */;
   always_latch begin
     if (!clk_i) begin
       en_latch = en_i | test_en_i;


### PR DESCRIPTION
This avoids an UNOPTFLAT warning, and should speed up simulation a
bit. Quoting from the Verilator manual:

> The clock_enable attribute will cause the clock gate to be ignored
> in the scheduling algorithm, sometimes required for correct clock
> behavior, and always improving performance. It's also a good idea to
> enable the IMPERFECTSCH warning, to ensure all clock enables are
> properly recognized.

Adding the IMPERFECTSCH warning throws up LOTS of cases, unrelated to
this patch, so I'm not convinced that's worth doing at the moment (it
probably shows there are some low-hanging simulation performance
improvements though).
