### PR TITLE
[dv/sram] add SRAM scrambling model for DV

### DIFF
--- a/hw/dv/sv/mem_bkdr_if/mem_bkdr_if.core
+++ b/hw/dv/sv/mem_bkdr_if/mem_bkdr_if.core
@@ -10,7 +10,10 @@ filesets:
     depend:
       - lowrisc:opentitan:bus_params_pkg
       - lowrisc:dv:dv_utils
+      - lowrisc:dv:crypto_dpi_prince:0.1
+      - lowrisc:prim:cipher_pkg:0.1
     files:
+      - sram_scrambler_pkg.sv
       - mem_bkdr_if.sv
     file_type: systemVerilogSource
 

--- a/hw/dv/sv/mem_bkdr_if/mem_bkdr_if.sv
+++ b/hw/dv/sv/mem_bkdr_if/mem_bkdr_if.sv
@@ -228,7 +228,7 @@ interface mem_bkdr_if #(parameter bit MEM_PARITY = 0,
     logic [7:0] rdata;
     logic [bus_params_pkg::BUS_AW-1:0] bus_addr;
 
-    logic rdata_arr[]      = new[8];
+    logic rdata_arr[]       = new[8];
     logic scrambled_addr[]  = new[mem_addr_width];
     logic sram_addr[]       = new[mem_addr_width];
     logic key_arr[]         = new[SRAM_KEY_WIDTH];
@@ -269,7 +269,7 @@ interface mem_bkdr_if #(parameter bit MEM_PARITY = 0,
     logic [15:0] rdata;
     logic [bus_params_pkg::BUS_AW-1:0] bus_addr;
 
-    logic rdata_arr[]     = new[16];
+    logic rdata_arr[]       = new[16];
     logic scrambled_addr[]  = new[mem_addr_width];
     logic sram_addr[]       = new[mem_addr_width];
     logic key_arr[]         = new[SRAM_KEY_WIDTH];
@@ -310,7 +310,7 @@ interface mem_bkdr_if #(parameter bit MEM_PARITY = 0,
     logic [31:0] rdata = '0;
     logic [bus_params_pkg::BUS_AW-1:0] bus_addr = '0;
 
-    logic rdata_arr[]     = new[32];
+    logic rdata_arr[]       = new[32];
     logic scrambled_addr[]  = new[mem_addr_width];
     logic sram_addr[]       = new[mem_addr_width];
     logic key_arr[]         = new[SRAM_KEY_WIDTH];
@@ -354,7 +354,7 @@ interface mem_bkdr_if #(parameter bit MEM_PARITY = 0,
     logic [63:0] rdata;
     logic [bus_params_pkg::BUS_AW-1:0] bus_addr = '0;
 
-    logic rdata_arr[]     = new[64];
+    logic rdata_arr[]       = new[64];
     logic scrambled_addr[]  = new[mem_addr_width];
     logic sram_addr[]       = new[mem_addr_width];
     logic key_arr[]         = new[SRAM_KEY_WIDTH];
@@ -397,7 +397,7 @@ interface mem_bkdr_if #(parameter bit MEM_PARITY = 0,
     logic [7:0] scrambled_data;
     logic [bus_params_pkg::BUS_AW-1:0] bus_addr = '0;
 
-    logic wdata_arr[]      = new[8];
+    logic wdata_arr[]       = new[8];
     logic scrambled_addr[]  = new[mem_addr_width];
     logic sram_addr[]       = new[mem_addr_width];
     logic key_arr[]         = new[SRAM_KEY_WIDTH];
@@ -438,7 +438,7 @@ interface mem_bkdr_if #(parameter bit MEM_PARITY = 0,
     logic [15:0] scrambled_data;
     logic [bus_params_pkg::BUS_AW-1:0] bus_addr = '0;
 
-    logic wdata_arr[]     = new[16];
+    logic wdata_arr[]       = new[16];
     logic scrambled_addr[]  = new[mem_addr_width];
     logic sram_addr[]       = new[mem_addr_width];
     logic key_arr[]         = new[SRAM_KEY_WIDTH];
@@ -479,7 +479,7 @@ interface mem_bkdr_if #(parameter bit MEM_PARITY = 0,
     logic [31:0] scrambled_data;
     logic [bus_params_pkg::BUS_AW-1:0] bus_addr = '0;
 
-    logic wdata_arr[]     = new[32];
+    logic wdata_arr[]       = new[32];
     logic scrambled_addr[]  = new[mem_addr_width];
     logic sram_addr[]       = new[mem_addr_width];
     logic key_arr[]         = new[SRAM_KEY_WIDTH];
@@ -520,7 +520,7 @@ interface mem_bkdr_if #(parameter bit MEM_PARITY = 0,
     logic [63:0] scrambled_data;
     logic [bus_params_pkg::BUS_AW-1:0] bus_addr = '0;
 
-    logic wdata_arr[]     = new[64];
+    logic wdata_arr[]       = new[64];
     logic scrambled_addr[]  = new[mem_addr_width];
     logic sram_addr[]       = new[mem_addr_width];
     logic key_arr[]         = new[SRAM_KEY_WIDTH];

--- a/hw/dv/sv/mem_bkdr_if/mem_bkdr_if.sv
+++ b/hw/dv/sv/mem_bkdr_if/mem_bkdr_if.sv
@@ -16,9 +16,28 @@
 // any parameter set and can be set into the uvm_config_db to allow us to manipulate the mem
 // contents from the testbench without having us to add heirarchy information, making the chip
 // testbench portable.
-interface mem_bkdr_if();
+//
+// The `MEM_PARITY` parameter is used to indicate whether the target memory uses parity checks.
+// If so, we need to take care to modify the read/write indices, as the total memory width will be
+// `mem_bytes_per_word * 8 + mem_bytes_per_word` as we have one parity bit per data byte.
+//
+// The `MEM_ECC` parameter is used to indicate whether the target memory uses an ECC implementation,
+// so we can ensure to usethe proper data encoding scheme.
+// TODO: ECC implementation has not been completed yet, only basic stub functionality is added for
+//       now.
+//
+// The `MEM_PARITY` and `MEM_ECC` parameters must not be set concurrently,
+// all resultant behavior is undefined.
+//
+// Note: The maximum data width currently supported by this interface is 64-bits (8 bytes).
+//       If support for wider memories is desired, it will need to be implemented.
+
+interface mem_bkdr_if #(parameter bit MEM_PARITY = 0,
+                        parameter bit MEM_ECC = 0) ();
   import uvm_pkg::*;
   import bus_params_pkg::BUS_AW;
+  import sram_scrambler_pkg::*;
+
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
@@ -30,28 +49,47 @@ interface mem_bkdr_if();
   `define MEM_ARR_PATH_SLICE gen_generic.u_impl_generic.mem
 `endif
 
+  // Represents the highest bit position of a data byte.
+  // If parity is enabled, it is 9 because we add a parity tag bit.
+  // If no parity, then no extra bits are added.
+  //
+  // TODO - need to update to hanies
+  localparam int MEM_BYTE_MSB = (MEM_PARITY) ? 9 : 8;
+
+  localparam int MAX_MEM_WIDTH = MEM_BYTE_MSB * 8;
+
   // derive memory specifics such as depth, width, addr_msb mem size etc.
   bit initialized;
   int mem_depth;
   int mem_width;
-  int mem_bytes_per_index;
+  int mem_bytes_per_word;
   int mem_size_bytes;
   int mem_addr_lsb;
+  int mem_addr_width;
+  int mem_byte_addr_width;
   string path = $sformatf("%m");
 
   function automatic void init();
+    // Check that both MEM_PARITY and MEM_ECC are not concurrently enabled
+    `DV_CHECK_FATAL((MEM_PARITY && MEM_ECC) == 0,
+        "Cannot enable both parity checks and ECC",
+        path)
     if (!initialized) begin
       mem_depth = $size(`MEM_ARR_PATH_SLICE);
       mem_width = $bits(`MEM_ARR_PATH_SLICE) / mem_depth;
-      mem_bytes_per_index = mem_width / 8;
-      mem_size_bytes = mem_depth * mem_bytes_per_index;
-      mem_addr_lsb = $clog2(mem_bytes_per_index);
+      mem_bytes_per_word = mem_width / MEM_BYTE_MSB;
+      mem_size_bytes = mem_depth * mem_bytes_per_word;
+      mem_addr_lsb = $clog2(mem_bytes_per_word);
+      mem_addr_width = $clog2(mem_depth);
+      mem_byte_addr_width = mem_addr_width + mem_addr_lsb;
       `uvm_info(path, $sformatf("mem_depth = %0d", mem_depth), UVM_HIGH)
+      `uvm_info(path, $sformatf("mem_addr_width =  %0d", mem_addr_width), UVM_HIGH)
       `uvm_info(path, $sformatf("mem_width = %0d", mem_width), UVM_HIGH)
-      `uvm_info(path, $sformatf("mem_bytes_per_index = %0d", mem_bytes_per_index), UVM_HIGH)
+      `uvm_info(path, $sformatf("mem_bytes_per_word = %0d", mem_bytes_per_word), UVM_HIGH)
       `uvm_info(path, $sformatf("mem_size_bytes = %0d", mem_size_bytes), UVM_HIGH)
       `uvm_info(path, $sformatf("mem_addr_lsb = %0d", mem_addr_lsb), UVM_HIGH)
-      `DV_CHECK_LE_FATAL(mem_bytes_per_index, 8, "mem data width > 8 bytes is not supported", path)
+      `uvm_info(path, $sformatf("mem_byte_msb = %0d", MEM_BYTE_MSB), UVM_HIGH)
+      `DV_CHECK_LE_FATAL(mem_bytes_per_word, 8, "mem data width > 8 bytes is not supported", path)
       initialized = 1'b1;
     end
   endfunction
@@ -71,39 +109,19 @@ interface mem_bkdr_if();
   function automatic logic [7:0] read8(input bit [bus_params_pkg::BUS_AW-1:0] addr);
     if (is_addr_valid(addr)) begin
       int mem_index = addr >> mem_addr_lsb;
-      logic [63:0] mem_data = `MEM_ARR_PATH_SLICE[mem_index];
-      case (mem_bytes_per_index)
+      bit [MAX_MEM_WIDTH-1:0] mem_data = `MEM_ARR_PATH_SLICE[mem_index];
+      case (mem_bytes_per_word)
         1: begin
           return mem_data[7:0];
         end
         2: begin
-          case (addr[0])
-            1'b0:  return mem_data[7:0];
-            1'b1:  return mem_data[15:8];
-            default: ;
-          endcase
+          return mem_data[addr[0] * MEM_BYTE_MSB +: 8];
         end
         4: begin
-          case (addr[1:0])
-            2'b00:  return mem_data[7:0];
-            2'b01:  return mem_data[15:8];
-            2'b10:  return mem_data[23:16];
-            2'b11:  return mem_data[31:24];
-            default: ;
-          endcase
+          return mem_data[addr[1:0] * MEM_BYTE_MSB +: 8];
         end
         8: begin
-          case (addr[2:0])
-            3'b000:  return mem_data[7:0];
-            3'b001:  return mem_data[15:8];
-            3'b010:  return mem_data[23:16];
-            3'b011:  return mem_data[31:24];
-            3'b100:  return mem_data[39:32];
-            3'b101:  return mem_data[47:40];
-            3'b110:  return mem_data[55:48];
-            3'b111:  return mem_data[63:56];
-            default: ;
-          endcase
+          return mem_data[addr[2:0] * MEM_BYTE_MSB +: 8];
         end
         default: ;
       endcase
@@ -114,33 +132,7 @@ interface mem_bkdr_if();
   function automatic logic [15:0] read16(input bit [bus_params_pkg::BUS_AW-1:0] addr);
     `DV_CHECK_EQ_FATAL(addr[0], '0, $sformatf("addr 0x%0h not 16-bit aligned", addr), path)
     if (is_addr_valid(addr)) begin
-      int mem_index = addr >> mem_addr_lsb;
-      logic [63:0] mem_data = `MEM_ARR_PATH_SLICE[mem_index];
-      case (mem_bytes_per_index)
-        1: begin
-          return {read8(addr + 1), mem_data[7:0]};
-        end
-        2: begin
-          return mem_data[15:0];
-        end
-        4: begin
-          case (addr[1])
-            1'b0:  return mem_data[15:0];
-            1'b1:  return mem_data[31:16];
-            default: ;
-          endcase
-        end
-        8: begin
-          case (addr[2:1])
-            2'b00:  return mem_data[15:0];
-            2'b01:  return mem_data[31:16];
-            2'b10:  return mem_data[47:32];
-            2'b11:  return mem_data[63:48];
-            default: ;
-          endcase
-        end
-        default: ;
-      endcase
+      return {read8(addr + 1), read8(addr)};
     end
     return 'x;
   endfunction
@@ -148,72 +140,52 @@ interface mem_bkdr_if();
   function automatic logic [31:0] read32(input bit [bus_params_pkg::BUS_AW-1:0] addr);
     `DV_CHECK_EQ_FATAL(addr[1:0], '0, $sformatf("addr 0x%0h not 32-bit aligned", addr), path)
     if (is_addr_valid(addr)) begin
-      int mem_index = addr >> mem_addr_lsb;
-      logic [63:0] mem_data = `MEM_ARR_PATH_SLICE[mem_index];
-      case (mem_bytes_per_index)
-        1: begin
-          return {read16(addr + 2), read8(addr + 1), mem_data[7:0]};
-        end
-        2: begin
-          return {read16(addr + 2), mem_data[15:0]};
-        end
-        4: begin
-          return mem_data[31:0];
-        end
-        8: begin
-          case (addr[2])
-            1'b0:  return mem_data[31:0];
-            1'b1:  return mem_data[63:32];
-            default: ;
-          endcase
-        end
-        default: ;
-      endcase
+      return {read16(addr + 2), read16(addr)};
     end
     return 'x;
   endfunction
 
   function automatic logic [63:0] read64(input bit [bus_params_pkg::BUS_AW-1:0] addr);
     `DV_CHECK_EQ_FATAL(addr[2:0], '0, $sformatf("addr 0x%0h not 64-bit aligned", addr), path)
-    return {read32(addr + 4), read32(addr)};
+    if (is_addr_valid(addr)) begin
+      return {read32(addr + 4), read32(addr)};
+    end
+    return 'x;
   endfunction
 
   function automatic void write8(input bit [bus_params_pkg::BUS_AW-1:0] addr, input bit [7:0] data);
     if (is_addr_valid(addr)) begin
       int mem_index = addr >> mem_addr_lsb;
-      bit [63:0] rw_data = `MEM_ARR_PATH_SLICE[mem_index];
-      case (mem_bytes_per_index)
+      bit [MAX_MEM_WIDTH-1:0] rw_data = `MEM_ARR_PATH_SLICE[mem_index];
+      // Note that if memory parity checks are enabled,
+      // we have to write the correct parity bit as well.
+      // Odd parity is used, rather than even parity checking.
+      //
+      // TODO: odd/even parity checks could be made configurable.
+      case (mem_bytes_per_word)
         1: begin
-          rw_data[7:0] = data;
+          rw_data[0 +: 8] = data;
+          if (MEM_PARITY) begin
+            rw_data[0 + 8] = ~(^data);
+          end
         end
         2: begin
-          case (addr[0])
-            1'b0:  rw_data[7:0] = data;
-            1'b1:  rw_data[15:8] = data;
-            default: ;
-          endcase
+          rw_data[addr[0] * MEM_BYTE_MSB +: 8] = data;
+          if (MEM_PARITY) begin
+            rw_data[addr[0] * MEM_BYTE_MSB + 8] = ~(^data);
+          end
         end
         4: begin
-          case (addr[1:0])
-            2'b00:  rw_data[7:0] = data;
-            2'b01:  rw_data[15:8] = data;
-            2'b10:  rw_data[23:16] = data;
-            2'b11:  rw_data[31:24] = data;
-            default: ;
-          endcase
+          rw_data[addr[1:0] * MEM_BYTE_MSB +: 8] = data;
+          if (MEM_PARITY) begin
+            rw_data[addr[1:0] * MEM_BYTE_MSB + 8] = ~(^data);
+          end
         end
         8: begin
-          case (addr[2:0])
-            3'b000: rw_data[7:0] = data;
-            3'b001: rw_data[15:8] = data;
-            3'b010: rw_data[23:16] = data;
-            3'b011: rw_data[31:24] = data;
-            3'b100: rw_data[39:32] = data;
-            3'b101: rw_data[47:40] = data;
-            3'b110: rw_data[55:48] = data;
-            3'b111: rw_data[63:56] = data;
-            default: ;
-          endcase
+          rw_data[addr[2:0] * MEM_BYTE_MSB +: 8] = data;
+          if (MEM_PARITY) begin
+            rw_data[addr[2:0] * MEM_BYTE_MSB + 8] = ~(^data);
+          end
         end
         default: ;
       endcase
@@ -225,35 +197,8 @@ interface mem_bkdr_if();
                                   input bit [15:0] data);
     `DV_CHECK_EQ_FATAL(addr[0], '0, $sformatf("addr 0x%0h not 16-bit aligned", addr), path)
     if (is_addr_valid(addr)) begin
-      int mem_index = addr >> mem_addr_lsb;
-      bit [63:0] rw_data = `MEM_ARR_PATH_SLICE[mem_index];
-      case (mem_bytes_per_index)
-        1: begin
-          rw_data[7:0] = data[7:0];
-          write8(addr + 1, data[15:8]);
-        end
-        2: begin
-          rw_data[15:0] = data;
-        end
-        4: begin
-          case (addr[1])
-            1'b0: rw_data[15:0] = data;
-            1'b1: rw_data[31:16] = data;
-            default: ;
-          endcase
-        end
-        8: begin
-          case (addr[2:1])
-            2'b00:  rw_data[15:0] = data;
-            2'b01:  rw_data[32:16] = data;
-            2'b10:  rw_data[47:32] = data;
-            2'b11:  rw_data[63:48] = data;
-            default: ;
-          endcase
-        end
-        default: ;
-      endcase
-      `MEM_ARR_PATH_SLICE[mem_index] = rw_data;
+      write8(addr, data[7:0]);
+      write8(addr + 1, data[15:8]);
     end
   endfunction
 
@@ -261,31 +206,8 @@ interface mem_bkdr_if();
                                   input bit [31:0] data);
     `DV_CHECK_EQ_FATAL(addr[1:0], '0, $sformatf("addr 0x%0h not 32-bit aligned", addr), path)
     if (is_addr_valid(addr)) begin
-      int mem_index = addr >> mem_addr_lsb;
-      bit [63:0] rw_data = `MEM_ARR_PATH_SLICE[mem_index];
-      case (mem_bytes_per_index)
-        1: begin
-          rw_data[7:0] = data[7:0];
-          write8(addr + 1, data[15:8]);
-          write16(addr + 2, data[31:16]);
-        end
-        2: begin
-          rw_data[15:0] = data[15:0];
-          write16(addr + 2, data[31:16]);
-        end
-        4: begin
-          rw_data[31:0] = data;
-        end
-        8: begin
-          case (addr[2])
-            1'b0:  rw_data[31:0] = data;
-            1'b1:  rw_data[63:32] = data;
-            default: ;
-          endcase
-        end
-        default: ;
-      endcase
-      `MEM_ARR_PATH_SLICE[mem_index] = rw_data;
+      write16(addr, data[15:0]);
+      write16(addr + 2, data[31:16]);
     end
   endfunction
 
@@ -294,6 +216,342 @@ interface mem_bkdr_if();
     `DV_CHECK_EQ_FATAL(addr[2:0], '0, $sformatf("addr 0x%0h not 64-bit aligned", addr), path)
     write32(addr, data[31:0]);
     write32(addr + 4, data[63:32]);
+  endfunction
+
+  ///////////////////////////////////////////////////////////
+  // Wrapper functions for encrypted read/write operations //
+  ///////////////////////////////////////////////////////////
+
+  function automatic logic [7:0] sram_encrypt_read8(input logic [bus_params_pkg::BUS_AW-1:0] addr,
+                                                    input logic [SRAM_KEY_WIDTH-1:0]         key,
+                                                    input logic [SRAM_BLOCK_WIDTH-1:0]       nonce);
+    logic [7:0] rdata;
+    logic [bus_params_pkg::BUS_AW-1:0] bus_addr;
+
+    logic rdata_arr[]      = new[8];
+    logic scrambled_addr[]  = new[mem_addr_width];
+    logic sram_addr[]       = new[mem_addr_width];
+    logic key_arr[]         = new[SRAM_KEY_WIDTH];
+    logic nonce_arr[]       = new[SRAM_BLOCK_WIDTH];
+
+    key_arr   = {<< {key}};
+    nonce_arr = {<< {nonce}};
+
+    for (int i = 0; i < mem_addr_width; i++) begin
+      sram_addr[i] = addr[mem_addr_lsb + i];
+    end
+
+    // Calculate the scrambled address
+    scrambled_addr = sram_scrambler_pkg::encrypt_sram_addr(sram_addr, mem_addr_width, nonce_arr);
+
+    // Construct bus representation of the address
+    for (int i = 0; i < mem_addr_lsb; i++) begin
+      bus_addr[i] = addr[i];
+    end
+    for (int i = 0; i < mem_addr_width; i++) begin
+      bus_addr[mem_addr_lsb + i] = scrambled_addr[i];
+    end
+
+    // Read memory, and return the decrypted data
+    rdata = read8(bus_addr);
+    rdata_arr = {<< {rdata}};
+
+    rdata_arr = sram_scrambler_pkg::decrypt_sram_data(rdata_arr, 8,
+                                                      sram_addr, mem_addr_width,
+                                                      key_arr, nonce_arr);
+    rdata = {<< {rdata_arr}};
+    return rdata;
+  endfunction
+
+  function automatic logic [15:0] sram_encrypt_read16(input logic [bus_params_pkg::BUS_AW-1:0] addr,
+                                                      input logic [SRAM_KEY_WIDTH-1:0]         key,
+                                                      input logic [SRAM_BLOCK_WIDTH-1:0]       nonce);
+    logic [15:0] rdata;
+    logic [bus_params_pkg::BUS_AW-1:0] bus_addr;
+
+    logic rdata_arr[]     = new[16];
+    logic scrambled_addr[]  = new[mem_addr_width];
+    logic sram_addr[]       = new[mem_addr_width];
+    logic key_arr[]         = new[SRAM_KEY_WIDTH];
+    logic nonce_arr[]       = new[SRAM_BLOCK_WIDTH];
+
+    key_arr   = {<< {key}};
+    nonce_arr = {<< {nonce}};
+
+    for (int i = 0; i < mem_addr_width; i++) begin
+      sram_addr[i] = addr[mem_addr_lsb + i];
+    end
+
+    // Calculate the scrambled address
+    scrambled_addr = sram_scrambler_pkg::encrypt_sram_addr(sram_addr, mem_addr_width, nonce_arr);
+
+    // Construct bus representation of the address
+    for (int i = 0; i < mem_addr_lsb; i++) begin
+      bus_addr[i] = addr[i];
+    end
+    for (int i = 0; i < mem_addr_width; i++) begin
+      bus_addr[mem_addr_lsb + i] = scrambled_addr[i];
+    end
+
+    // Read memory and return the decrypted data
+    rdata = read16(bus_addr);
+    rdata_arr = {<< {rdata}};
+
+    rdata_arr = sram_scrambler_pkg::decrypt_sram_data(rdata_arr, 16,
+                                                      sram_addr, mem_addr_width,
+                                                      key_arr, nonce_arr);
+    rdata = {<< {rdata_arr}};
+    return rdata;
+  endfunction
+
+  function automatic logic [31:0] sram_encrypt_read32(input logic [bus_params_pkg::BUS_AW-1:0] addr,
+                                                      input logic [SRAM_KEY_WIDTH-1:0]         key,
+                                                      input logic [SRAM_BLOCK_WIDTH-1:0]       nonce);
+    logic [31:0] rdata = '0;
+    logic [bus_params_pkg::BUS_AW-1:0] bus_addr = '0;
+
+    logic rdata_arr[]     = new[32];
+    logic scrambled_addr[]  = new[mem_addr_width];
+    logic sram_addr[]       = new[mem_addr_width];
+    logic key_arr[]         = new[SRAM_KEY_WIDTH];
+    logic nonce_arr[]       = new[SRAM_BLOCK_WIDTH];
+
+    key_arr   = {<< {key}};
+    nonce_arr = {<< {nonce}};
+
+    for (int i = 0; i < mem_addr_width; i++) begin
+      sram_addr[i] = addr[mem_addr_lsb + i];
+    end
+
+    // Calculate the scrambled address
+    scrambled_addr = sram_scrambler_pkg::encrypt_sram_addr(sram_addr, mem_addr_width, nonce_arr);
+
+    // Construct bus representation of the address
+    for (int i = 0; i < mem_addr_lsb; i++) begin
+      bus_addr[i] = addr[i];
+    end
+    for (int i = 0; i < mem_addr_width; i++) begin
+      bus_addr[mem_addr_lsb + i] = scrambled_addr[i];
+    end
+
+    `uvm_info(path, $sformatf("bus_addr: 0x%0x", bus_addr), UVM_HIGH)
+
+    // Read memory and return the decrypted data
+    rdata = read32(bus_addr);
+    rdata_arr = {<< {rdata}};
+
+    rdata_arr = sram_scrambler_pkg::decrypt_sram_data(rdata_arr, 32,
+                                                      sram_addr, mem_addr_width,
+                                                      key_arr, nonce_arr);
+    rdata = {<< {rdata_arr}};
+    return rdata;
+
+  endfunction
+
+  function automatic logic [63:0] sram_encrypt_read64(input logic [bus_params_pkg::BUS_AW-1:0] addr,
+                                                      input logic [SRAM_KEY_WIDTH-1:0]         key,
+                                                      input logic [SRAM_BLOCK_WIDTH-1:0]       nonce);
+    logic [63:0] rdata;
+    logic [bus_params_pkg::BUS_AW-1:0] bus_addr = '0;
+
+    logic rdata_arr[]     = new[64];
+    logic scrambled_addr[]  = new[mem_addr_width];
+    logic sram_addr[]       = new[mem_addr_width];
+    logic key_arr[]         = new[SRAM_KEY_WIDTH];
+    logic nonce_arr[]       = new[SRAM_BLOCK_WIDTH];
+
+    key_arr   = {<< {key}};
+    nonce_arr = {<< {nonce}};
+
+    for (int i = 0; i < mem_addr_width; i++) begin
+      sram_addr[i] = addr[mem_addr_lsb + i];
+    end
+
+    // Calculate the scrambled address
+    scrambled_addr = sram_scrambler_pkg::encrypt_sram_addr(sram_addr, mem_addr_width, nonce_arr);
+
+    // Construct bus representation of the address
+    for (int i = 0; i < mem_addr_lsb; i++) begin
+      bus_addr[i] = addr[i];
+    end
+    for (int i = 0; i < mem_addr_width; i++) begin
+      bus_addr[mem_addr_lsb + i] = scrambled_addr[i];
+    end
+
+    // Read memory and return the decrypted data
+    rdata = read64(bus_addr);
+    rdata_arr = {<< {rdata}};
+
+    rdata_arr = sram_scrambler_pkg::decrypt_sram_data(rdata_arr, 64,
+                                                      sram_addr, mem_addr_width,
+                                                      key_arr, nonce_arr);
+    rdata = {<< {rdata_arr}};
+    return rdata;
+
+  endfunction
+
+  function automatic void sram_encrypt_write8(input logic [bus_params_pkg::BUS_AW-1:0] addr,
+                                              input logic [7:0]                        data,
+                                              input logic [SRAM_KEY_WIDTH-1:0]         key,
+                                              input logic [SRAM_BLOCK_WIDTH-1:0]       nonce);
+    logic [7:0] scrambled_data;
+    logic [bus_params_pkg::BUS_AW-1:0] bus_addr = '0;
+
+    logic wdata_arr[]      = new[8];
+    logic scrambled_addr[]  = new[mem_addr_width];
+    logic sram_addr[]       = new[mem_addr_width];
+    logic key_arr[]         = new[SRAM_KEY_WIDTH];
+    logic nonce_arr[]       = new[SRAM_BLOCK_WIDTH];
+
+    key_arr   = {<< {key}};
+    nonce_arr = {<< {nonce}};
+
+    for (int i = 0; i < mem_addr_width; i++) begin
+      sram_addr[i] = addr[mem_addr_lsb + i];
+    end
+
+    // Calculate the scrambled address
+    scrambled_addr = sram_scrambler_pkg::encrypt_sram_addr(sram_addr, mem_addr_width, nonce_arr);
+
+    // Calculate the scrambled data
+    wdata_arr = {<< {data}};
+    wdata_arr = sram_scrambler_pkg::encrypt_sram_data(wdata_arr, 8,
+                                                      sram_addr, mem_addr_width,
+                                                      key_arr, nonce_arr);
+    // Construct bus representation of the address
+    for (int i = 0; i < mem_addr_lsb; i++) begin
+      bus_addr[i] = addr[i];
+    end
+    for (int i = 0; i < mem_addr_width; i++) begin
+      bus_addr[mem_addr_lsb + i] = scrambled_addr[i];
+    end
+
+    // Write the scrambled data to memory
+    scrambled_data = {<< {wdata_arr}};
+    write8(bus_addr, scrambled_data);
+  endfunction
+
+  function automatic void sram_encrypt_write16(input logic [bus_params_pkg::BUS_AW-1:0] addr,
+                                               input logic [15:0]                       data,
+                                               input logic [SRAM_KEY_WIDTH-1:0]         key,
+                                               input logic [SRAM_BLOCK_WIDTH-1:0]       nonce);
+    logic [15:0] scrambled_data;
+    logic [bus_params_pkg::BUS_AW-1:0] bus_addr = '0;
+
+    logic wdata_arr[]     = new[16];
+    logic scrambled_addr[]  = new[mem_addr_width];
+    logic sram_addr[]       = new[mem_addr_width];
+    logic key_arr[]         = new[SRAM_KEY_WIDTH];
+    logic nonce_arr[]       = new[SRAM_BLOCK_WIDTH];
+
+    key_arr   = {<< {key}};
+    nonce_arr = {<< {nonce}};
+
+    for (int i = 0; i < mem_addr_width; i++) begin
+      sram_addr[i] = addr[mem_addr_lsb + i];
+    end
+
+    // Calculate the scrambled address
+    scrambled_addr = sram_scrambler_pkg::encrypt_sram_addr(sram_addr, mem_addr_width, nonce_arr);
+
+    // Calculate the scrambled data
+    wdata_arr = {<< {data}};
+    wdata_arr = sram_scrambler_pkg::encrypt_sram_data(wdata_arr, 16,
+                                                      sram_addr, mem_addr_width,
+                                                      key_arr, nonce_arr);
+    // Construct bus representation of the address
+    for (int i = 0; i < mem_addr_lsb; i++) begin
+      bus_addr[i] = addr[i];
+    end
+    for (int i = 0; i < mem_addr_width; i++) begin
+      bus_addr[mem_addr_lsb + i] = scrambled_addr[i];
+    end
+
+    // Write the scrambled data to memory
+    scrambled_data = {<< {wdata_arr}};
+    write16(bus_addr, scrambled_data);
+  endfunction
+
+  function automatic void sram_encrypt_write32(input logic [bus_params_pkg::BUS_AW-1:0] addr,
+                                               input logic [31:0]                       data,
+                                               input logic [SRAM_KEY_WIDTH-1:0]         key,
+                                               input logic [SRAM_BLOCK_WIDTH-1:0]       nonce);
+    logic [31:0] scrambled_data;
+    logic [bus_params_pkg::BUS_AW-1:0] bus_addr = '0;
+
+    logic wdata_arr[]     = new[32];
+    logic scrambled_addr[]  = new[mem_addr_width];
+    logic sram_addr[]       = new[mem_addr_width];
+    logic key_arr[]         = new[SRAM_KEY_WIDTH];
+    logic nonce_arr[]       = new[SRAM_BLOCK_WIDTH];
+
+    key_arr   = {<< {key}};
+    nonce_arr = {<< {nonce}};
+
+    for (int i = 0; i < mem_addr_width; i++) begin
+      sram_addr[i] = addr[mem_addr_lsb + i];
+    end
+
+    // Calculate the scrambled address
+    scrambled_addr = sram_scrambler_pkg::encrypt_sram_addr(sram_addr, mem_addr_width, nonce_arr);
+
+    // Calculate the scrambled data
+    wdata_arr = {<< {data}};
+    wdata_arr = sram_scrambler_pkg::encrypt_sram_data(wdata_arr, 32,
+                                                      sram_addr, mem_addr_width,
+                                                      key_arr, nonce_arr);
+    // Construct bus representation of the address
+    for (int i = 0; i < mem_addr_lsb; i++) begin
+      bus_addr[i] = addr[i];
+    end
+    for (int i = 0; i < mem_addr_width; i++) begin
+      bus_addr[mem_addr_lsb + i] = scrambled_addr[i];
+    end
+
+    // Write the scrambled data to memory
+    scrambled_data = {<< {wdata_arr}};
+    write32(bus_addr, scrambled_data);
+  endfunction
+
+  function automatic void sram_encrypt_write64(input logic [bus_params_pkg::BUS_AW-1:0] addr,
+                                               input logic [63:0]                       data,
+                                               input logic [SRAM_KEY_WIDTH-1:0]         key,
+                                               input logic [SRAM_BLOCK_WIDTH-1:0]       nonce);
+    logic [63:0] scrambled_data;
+    logic [bus_params_pkg::BUS_AW-1:0] bus_addr = '0;
+
+    logic wdata_arr[]     = new[64];
+    logic scrambled_addr[]  = new[mem_addr_width];
+    logic sram_addr[]       = new[mem_addr_width];
+    logic key_arr[]         = new[SRAM_KEY_WIDTH];
+    logic nonce_arr[]       = new[SRAM_BLOCK_WIDTH];
+
+    key_arr   = {<< {key}};
+    nonce_arr = {<< {nonce}};
+
+    for (int i = 0; i < mem_addr_width; i++) begin
+      sram_addr[i] = addr[mem_addr_lsb + i];
+    end
+
+    // Calculate the scrambled address
+    scrambled_addr = sram_scrambler_pkg::encrypt_sram_addr(sram_addr, mem_addr_width, nonce_arr);
+
+    // Calculate the scrambled data
+    wdata_arr = {<< {data}};
+    wdata_arr = sram_scrambler_pkg::encrypt_sram_data(wdata_arr, 64,
+                                                      sram_addr, mem_addr_width,
+                                                      key_arr, nonce_arr);
+    // Construct bus representation of the address
+    for (int i = 0; i < mem_addr_lsb; i++) begin
+      bus_addr[i] = addr[i];
+    end
+    for (int i = 0; i < mem_addr_width; i++) begin
+      bus_addr[mem_addr_lsb + i] = scrambled_addr[i];
+    end
+
+    // Write the scrambled data to memory
+    scrambled_data = {<< {wdata_arr}};
+    write64(bus_addr, scrambled_data);
   endfunction
 
   // check if input file is read/writable
@@ -337,20 +595,49 @@ interface mem_bkdr_if();
   function automatic void clear_mem();
     init();
     `uvm_info(path, "Clear memory", UVM_LOW)
-    `MEM_ARR_PATH_SLICE = '{default:'0};
+    if (MEM_PARITY) begin
+      // Have to manually loop over memory and clear to avoid overwriting any parity bits.
+      for (int i = 0; i < mem_size_bytes; i++) begin
+        write8(i, '0);
+      end
+    end
+    // TODO - temporary workaround until ECC encoding is implemented
+    if (MEM_ECC) begin
+      `MEM_ARR_PATH_SLICE = '{default:'0};
+    end
   endfunction // clr_mem
 
   function automatic void set_mem();
     init();
     `uvm_info(path, "Set memory", UVM_LOW)
-    `MEM_ARR_PATH_SLICE = '{default:'1};
+    if (MEM_PARITY) begin
+      // Have to manually loop over memory and set to avoid overwriting any parity bits.
+      for (int i = 0; i < mem_size_bytes; i++) begin
+        write8(i, '1);
+      end
+    end
+    // TODO - temporary workaround until ECC encoding is implemented
+    if (MEM_ECC) begin
+      `MEM_ARR_PATH_SLICE = '{default:'1};
+    end
   endfunction
 
   // randomize the memory
   function automatic void randomize_mem();
+    logic [7:0] rand_val;
     init();
     `uvm_info(path, "Randomizing mem contents", UVM_LOW)
-    foreach (`MEM_ARR_PATH_SLICE[i]) `MEM_ARR_PATH_SLICE[i] = {$urandom, $urandom};
+    if (MEM_PARITY) begin
+      // Have to manually loop over memory and randomize to avoid overwriting any parity bits.
+      for (int i = 0; i < mem_size_bytes; i++) begin
+        `DV_CHECK_STD_RANDOMIZE_FATAL(rand_val, "Randomization failed!", path)
+        write8(i, rand_val);
+      end
+    end
+    // TODO - temporary workaround until ECC encoding is implemented
+    if (MEM_ECC) begin
+      foreach (`MEM_ARR_PATH_SLICE[i]) `DV_CHECK_STD_RANDOMIZE_FATAL(`MEM_ARR_PATH_SLICE[i], , path)
+    end
   endfunction
 
   // invalidate the memory.

--- a/hw/dv/sv/mem_bkdr_if/sram_scrambler_pkg.sv
+++ b/hw/dv/sv/mem_bkdr_if/sram_scrambler_pkg.sv
@@ -1,0 +1,289 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+////////////////////////////////////////////
+// SRAM address and data scrambling logic //
+///////////////////////////////////////////
+//
+// There are a few general things to note here:
+//
+// - SRAM data scrambling relies on a reduced-round PRINCE cipher, plus a custom substitution
+//   and permutation network loosely based off of PRESENT.
+//
+// - SRAM address scrambling relies solely on the custom substitution and permutation network.
+//
+// - The custom subst/perm network used for data scrambling operates at byte granularity,
+//   while for address scrambling it operates at a granularity of the address width.
+//
+// - For DV purposes we can safely rely on the PRESENT sboxes, as nightly regressions are
+//   completely passing plus the sboxes in `prim_cipher_pkg` are copied directly from the
+//   PRESENT specifications.
+//   This has the side effect of allowing us to avoid duplication of the sboxes, which lowers the
+//   probability of an error in translation.
+
+package sram_scrambler_pkg;
+
+  import uvm_pkg::*;
+  import bus_params_pkg::BUS_AW;
+  import crypto_dpi_prince_pkg::*;
+  import prim_cipher_pkg::*;
+
+  `include "uvm_macros.svh"
+
+  string path = "sram_scrambler_pkg";
+
+  // Fixed key size - PRINCE cipher operates on a 128-bit key,
+  // and the same key is used for all parallel cipher instances.
+  parameter int SRAM_KEY_WIDTH = 128;
+
+  // Fixed data block size - PRINCE cipher operates on 64-bit data blocks.
+  parameter int SRAM_BLOCK_WIDTH = 64;
+
+  parameter int NUM_ROUNDS = 2;
+
+  // Create a generic typedef for dynamic array of logic to be able to return these values.
+  typedef logic state_t[];
+
+  // The sboxes operate on nibbles.
+  //
+  // If `WIDTH % 4 != 0`, the uppermost bits will get shifted to lower positions
+  // during either the `flip_vector` or `perm_layer` stage of the network,
+  // so it is guaranted that all bits will eventually go through an sbox.
+  function automatic state_t sbox_layer(state_t state, int width, bit inv);
+    logic state_out[] = new[width](state);
+    logic [3:0] sbox_in;
+    logic [3:0] sbox_out;
+    for (int i = 0; i < width / 4; i++) begin
+      // `with` syntax is currently unsupported by Verible,
+      // uncomment once support has been added
+      //
+      //sbox_in = {<< {state with [i*4 +: 4]}};
+      for (int j = 0; j < 4; j++) begin
+        sbox_in[j] = state[i*4 + j];
+      end
+
+      if (inv) begin
+        sbox_out = prim_cipher_pkg::PRESENT_SBOX4_INV[sbox_in];
+      end else begin
+        sbox_out = prim_cipher_pkg::PRESENT_SBOX4[sbox_in];
+      end
+
+      for (int j = 0; j < 4; j++) begin
+        state_out[i*4 + j] = sbox_out[j];
+      end
+    end
+    return state_out;
+  endfunction : sbox_layer
+
+  // Reverse the input bit vector.
+  function automatic state_t flip_vector(state_t state);
+    return {<< {state}};
+  endfunction : flip_vector
+
+  // Permutation layer - all even indexed bits move to the lower half,
+  // and all odd indexed bits move to the top half.
+  function automatic state_t perm_layer(state_t state, int width, bit inv);
+    logic state_out[] = new[width];
+    for (int i = 0; i < width / 2; i++) begin
+      if (inv) begin
+        state_out[i * 2]          = state[i];
+        state_out[i * 2 + 1]      = state[i + width / 2];
+      end else begin
+        state_out[i]              = state[i * 2];
+        state_out[i + width / 2]  = state[i * 2 + 1];
+      end
+    end
+    return state_out;
+  endfunction : perm_layer
+
+  // Performs NUM_ROUNDS full encryption rounds
+  function automatic state_t sp_encrypt(state_t data, int width, state_t key);
+    logic state[] = new[width](data);
+    for (int i = 0; i < NUM_ROUNDS; i++) begin
+      // xor the data and key
+      for (int j = 0; j < width; j++) begin
+        state[j] = state[j] ^ key[j];
+      end
+      // sbox layer
+      state = sbox_layer(state, width, 0);
+      // flip the bit vector
+      state = flip_vector(state);
+      // permutation layer
+      state = perm_layer(state, width, 0);
+    end
+    // final xor
+    for (int i = 0; i < width; i++) begin
+      state[i] = state[i] ^ key[i];
+    end
+    return state;
+  endfunction : sp_encrypt
+
+  // Performs NUM_ROUNDS full decryption rounds
+  function automatic state_t sp_decrypt(state_t data, int width, state_t key);
+    logic state[] = new[width](data);
+    for (int i = 0; i < NUM_ROUNDS; i++) begin
+      // xor data and key
+      for (int j = 0; j < width; j++) begin
+        state[j] = state[j] ^ key[j];
+      end
+      // permutation layer
+      state = perm_layer(state, width, 1);
+      // flip bit vector
+      state = flip_vector(state);
+      // sbox layer
+      state = sbox_layer(state, width, 1'b1);
+    end
+    // final xor
+    for (int i = 0; i < width; i++) begin
+      state[i] = state[i] ^ key[i];
+    end
+    return state;
+  endfunction : sp_decrypt
+
+  // Generates the 64-bit keystream that is XORed with the data to obtain a ciphertext.
+  // Assumes that the data is at most 64 bits wide.
+  //
+  // Should not be called directly.
+  function automatic state_t gen_keystream(logic addr[], int addr_width,
+                                           logic key[], logic nonce[]);
+    logic [NUM_ROUNDS-1:0][SRAM_BLOCK_WIDTH-1:0] prince_result_arr;
+
+    logic [SRAM_BLOCK_WIDTH-1:0]  prince_plaintext;
+    logic [SRAM_KEY_WIDTH-1:0]    prince_key;
+    logic [SRAM_BLOCK_WIDTH-1:0]  prince_result;
+
+    logic iv[]      = new[SRAM_BLOCK_WIDTH];
+    logic key_out[] = new[SRAM_BLOCK_WIDTH];
+
+    // IV is composed of nonce concatenated with address
+    for (int i = 0; i < addr_width; i++) begin
+      iv[i] = addr[i];
+    end
+    for (int i = 0; i < SRAM_BLOCK_WIDTH - addr_width; i++) begin
+      iv[addr_width + i] = nonce[i];
+    end
+
+    //for (int i = 0; i < SRAM_BLOCK_WIDTH - addr_width; i++) begin
+    //  iv[addr_width + i] = nonce[i];
+    //end
+
+    // convert arrays to packed vectors before invoking prince DPI model
+    prince_plaintext = {<< {iv}};
+    // `with` syntax is currently unsupported by Verible,
+    // uncomment once support has been added
+    //
+    // prince_key = {<< {key with [0 +: SRAM_KEY_WIDTH]}};
+    for (int i = 0; i < SRAM_KEY_WIDTH; i++) begin
+      prince_key[i] = key[i];
+    end
+
+    crypto_dpi_prince_pkg::sv_dpi_prince_encrypt(.plaintext(prince_plaintext),
+                                                 .key(prince_key),
+                                                 .old_key_schedule(0),
+                                                 .ciphertext(prince_result_arr));
+    prince_result = prince_result_arr[NUM_ROUNDS-1];
+
+    key_out = {<< {prince_result}};
+
+    return key_out;
+  endfunction : gen_keystream
+
+  // Encrypts the target SRAM address using the custom S&P network.
+  function automatic state_t encrypt_sram_addr(logic addr[], int addr_width,
+                                               logic full_nonce[]);
+
+    logic nonce[] = new[addr_width];
+    logic encrypted_addr[] = new[addr_width];
+
+    // The address encryption nonce is the same width as the address,
+    // and is constructed from the top addr_width bits of the full nonce.
+    //
+    // `with` syntax is currently unsupported by Verible,
+    // uncomment once support has been added
+    //
+    // nonce = {>> {full_nonce with [SRAM_BLOCK_WIDTH - addr_width +: addr_width]}};
+    for (int i = 0; i < addr_width; i++) begin
+      nonce[i] = full_nonce[SRAM_BLOCK_WIDTH - addr_width + i];
+    end
+
+    encrypted_addr = sp_encrypt(addr, addr_width, nonce);
+    return encrypted_addr;
+
+  endfunction : encrypt_sram_addr
+
+  // SRAM data encryption is more involved, we need to run 2 rounds of PRINCE on the nonce and key
+  // and then XOR the result with the data.
+  //
+  // After that, the XORed data neeeds to them be passed through the S&P network one byte at a time.
+  //
+  // TODO: We currently do not support data size of >64bits.
+  function automatic state_t encrypt_sram_data(logic data[], int data_width,
+                                               logic addr[], int addr_width,
+                                               logic key[], logic nonce[]);
+    // Generate the keystream
+    logic keystream[] = new[SRAM_BLOCK_WIDTH];
+    logic data_enc[] = new[data_width];
+    logic byte_to_enc[] = new[8];
+    logic enc_byte[] = new[8];
+    logic zero_key[] = new[8];
+
+    // the key used for byte diffusion is all-zero.
+    for (int i = 0; i < zero_key.size(); i++) begin
+      zero_key[i] = '0;
+    end
+
+    // Generate the keystream
+    keystream = gen_keystream(addr, addr_width, key, nonce);
+
+    // XOR keystream with input data
+    // Assumes data width <= 64.
+    for (int i = 0; i < data_width; i++) begin
+      data_enc[i] = data[i] ^ keystream[i];
+    end
+
+    // pass each byte of the encoded result through the subst/perm network
+    for (int i = 0; i < data_width / 8; i++) begin
+      byte_to_enc = data_enc[i*8 +: 8];
+      enc_byte = sp_encrypt(byte_to_enc, 8, zero_key);
+      data_enc[i*8 +: 8] = enc_byte;
+    end
+
+    return data_enc;
+
+  endfunction : encrypt_sram_data
+
+  function automatic state_t decrypt_sram_data(logic data[], int data_width,
+                                               logic addr[], int addr_width,
+                                               logic key[], logic nonce[]);
+    logic keystream[] = new[SRAM_BLOCK_WIDTH];
+    logic data_dec[] = new[data_width];
+    logic byte_to_dec[] = new[8];
+    logic dec_byte[] = new[8];
+    logic zero_key[] = new[8];
+
+    // the key used for byte diffusion is all-zero.
+    for (int i = 0; i < zero_key.size(); i++) begin
+      zero_key[i] = '0;
+    end
+
+    // Generate the keystream
+    keystream = gen_keystream(addr, addr_width, key, nonce);
+
+    // pass each byte of the data through the subst/perm network
+    for (int i = 0; i < data_width / 8; i++) begin
+      byte_to_dec = data[i*8 +: 8];
+      dec_byte = sp_decrypt(byte_to_dec, 8, zero_key);
+      data_dec[i*8 +: 8] = dec_byte;
+    end
+
+    // XOR result data with the keystream
+    for (int i = 0; i < data_width; i++) begin
+      data_dec[i] = data_dec[i] ^ keystream[i];
+    end
+
+    return data_dec;
+
+  endfunction : decrypt_sram_data
+
+endpackage : sram_scrambler_pkg

--- a/hw/dv/sv/mem_bkdr_if/sram_scrambler_pkg.sv
+++ b/hw/dv/sv/mem_bkdr_if/sram_scrambler_pkg.sv
@@ -84,7 +84,7 @@ package sram_scrambler_pkg;
   // Permutation layer - all even indexed bits move to the lower half,
   // and all odd indexed bits move to the top half.
   function automatic state_t perm_layer(state_t state, int width, bit inv);
-    logic state_out[] = new[width];
+    logic state_out[] = new[width](state);
     for (int i = 0; i < width / 2; i++) begin
       if (inv) begin
         state_out[i * 2]          = state[i];

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -30,7 +30,9 @@ package flash_ctrl_env_pkg;
   parameter uint FlashNumBusWordsPerBank  = FlashNumBusWords / flash_ctrl_pkg::NumBanks;
   parameter uint FlashNumBusWordsPerPage  = FlashNumBusWordsPerBank / flash_ctrl_pkg::PagesPerBank;
 
-  parameter uint FlashDataByteWidth       = $clog2(flash_ctrl_pkg::DataWidth / 8);
+  parameter uint FlashBankBytesPerWord    = flash_ctrl_pkg::DataWidth / 8;
+
+  parameter uint FlashDataByteWidth       = $clog2(FlashBankBytesPerWord);
   parameter uint FlashWordLineWidth       = $clog2(flash_ctrl_pkg::WordsPerPage);
   parameter uint FlashPageWidth           = $clog2(flash_ctrl_pkg::PagesPerBank);
   parameter uint FlashBankWidth           = $clog2(flash_ctrl_pkg::NumBanks);
@@ -88,7 +90,8 @@ package flash_ctrl_env_pkg;
     bit [TL_AW-1:0] addr;       // starting addr for the op
   } flash_op_t;
 
-  typedef virtual mem_bkdr_if mem_bkdr_vif;
+  // 8 bytes per word of flash memory
+  typedef virtual mem_bkdr_if #(.MEM_BYTES_PER_WORD(8)) mem_bkdr_vif;
 
   // functions
 

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -90,8 +90,7 @@ package flash_ctrl_env_pkg;
     bit [TL_AW-1:0] addr;       // starting addr for the op
   } flash_op_t;
 
-  // 8 bytes per word of flash memory
-  typedef virtual mem_bkdr_if #(.MEM_BYTES_PER_WORD(8)) mem_bkdr_vif;
+  typedef virtual mem_bkdr_if mem_bkdr_vif;
 
   // functions
 

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -121,13 +121,13 @@ package otp_ctrl_env_pkg;
     OtpCheckPendingIdx
   } otp_status_e;
 
-  typedef enum bit [1:0] {
+typedef enum bit [1:0] {
     OtpNoEccErr,
     OtpEccCorrErr,
     OtpEccUncorrErr
   } otp_ecc_err_e;
 
-  typedef virtual mem_bkdr_if mem_bkdr_vif;
+  typedef virtual mem_bkdr_if #(.MEM_ECC(1)) mem_bkdr_vif;
   typedef virtual otp_ctrl_if otp_ctrl_vif;
 
   // functions

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -133,7 +133,7 @@ module tb;
   assign interrupts[OtpOperationDone] = intr_otp_operation_done;
   assign interrupts[OtpErr]           = intr_otp_error;
 
-  bind `OTP_CTRL_MEM_HIER mem_bkdr_if mem_bkdr_if();
+  bind `OTP_CTRL_MEM_HIER mem_bkdr_if #(.MEM_ECC(1)) mem_bkdr_if();
 
   initial begin
     // drive clk and rst_n from clk_if

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -18,6 +18,7 @@ filesets:
       - lowrisc:prim:buf
       - lowrisc:prim:flop
       - lowrisc:prim:flop_2sync
+      - lowrisc:prim:cipher_pkg:0.1
     files:
       - rtl/prim_clock_gating_sync.sv
       - rtl/prim_alert_pkg.sv
@@ -39,7 +40,6 @@ filesets:
       - rtl/prim_keccak.sv
       - rtl/prim_packer.sv
       - rtl/prim_packer_fifo.sv
-      - rtl/prim_cipher_pkg.sv
       - rtl/prim_present.sv
       - rtl/prim_prince.sv
       - rtl/prim_subst_perm.sv

--- a/hw/ip/prim/prim_cipher_pkg.core
+++ b/hw/ip/prim/prim_cipher_pkg.core
@@ -1,0 +1,17 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:cipher_pkg:0.1"
+description: "PRINCE and PRESENT block cipher package"
+filesets:
+  files_dv:
+    files:
+      - rtl/prim_cipher_pkg.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_pkg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_pkg.sv
@@ -16,6 +16,7 @@ package sram_ctrl_env_pkg;
   import sram_ctrl_pkg::*;
   import otp_ctrl_pkg::*;
   import lc_ctrl_pkg::*;
+  import crypto_dpi_prince_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -30,10 +31,9 @@ package sram_ctrl_env_pkg;
   parameter int KDI_DATA_SIZE = 1 + otp_ctrl_pkg::SramKeyWidth + otp_ctrl_pkg::SramNonceWidth;
 
   // types
-  typedef virtual mem_bkdr_if mem_bkdr_vif;
+  typedef virtual mem_bkdr_if #(.MEM_ADDR_WIDTH(`SRAM_ADDR_WIDTH),
+                                .MEM_BYTES_PER_WORD(`SRAM_DATA_WIDTH >> 3)) mem_bkdr_vif;
   typedef virtual sram_ctrl_lc_if lc_vif;
-
-  // functions
 
   // package sources
   `include "sram_ctrl_env_cfg.sv"

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -51,11 +51,11 @@
   build_modes: [
     {
       name: sram_ctrl_main
-      build_opts: ["+define+ADDR_BITS=14", "+define+WIDTH=32"]
+      build_opts: ["+define+SRAM_ADDR_WIDTH=14", "+define+SRAM_DATA_WIDTH=32"]
     }
     {
       name: sram_ctrl_ret
-      build_opts: ["+define+ADDR_BITS=10", "+define+WIDTH=32"]
+      build_opts: ["+define+SRAM_ADDR_WIDTH=10", "+define+SRAM_DATA_WIDTH=32"]
     }
   ]
 

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -48,11 +48,42 @@ class chip_env extends cip_base_env #(
       `uvm_fatal(`gfn, "failed to get rst_n_mon_vif from uvm_config_db")
     end
 
-    foreach (cfg.mem_bkdr_vifs[mem]) begin
-      if (!uvm_config_db#(mem_bkdr_vif)::get(this, "", $sformatf("mem_bkdr_vifs[%0s]", mem.name),
-                                             cfg.mem_bkdr_vifs[mem])) begin
-        `uvm_fatal(`gfn, $sformatf("failed to get mem_bkdr_vifs[%0s] from uvm_config_db", mem.name))
-      end
+    if (!uvm_config_db#(mem_bkdr_vif)::get(this, "", "rom_bkdr_vif", cfg.rom_bkdr_vif)) begin
+      `uvm_fatal(`gfn, "failed to get rom_bkdr_vif from uvm_config_db")
+    end
+
+    if (!uvm_config_db#(parity_mem_bkdr_vif)::get(this, "", "ram_main_bkdr_vif",
+        cfg.ram_main_bkdr_vif)) begin
+      `uvm_fatal(`gfn, "failed to get ram_main_bkdr_vif from uvm_config_db")
+    end
+
+    if (!uvm_config_db#(parity_mem_bkdr_vif)::get(this, "", "ram_ret_bkdr_vif",
+        cfg.ram_ret_bkdr_vif)) begin
+      `uvm_fatal(`gfn, "failed to get ram_ret_bkdr_vif from uvm_config_db")
+    end
+
+    if (!uvm_config_db#(mem_bkdr_vif)::get(this, "", "flash_bank0_bkdr_vif",
+        cfg.flash_bank0_bkdr_vif)) begin
+      `uvm_fatal(`gfn, "failed to get flash_bank0_bkdr_vif from uvm_config_db")
+    end
+
+    if (!uvm_config_db#(mem_bkdr_vif)::get(this, "", "flash_bank1_bkdr_vif",
+        cfg.flash_bank1_bkdr_vif)) begin
+      `uvm_fatal(`gfn, "failed to get flash_bank1_bkdr_vif from uvm_config_db")
+    end
+
+    if (!uvm_config_db#(mem_bkdr_vif)::get(this, "", "flash_info0_bkdr_vif",
+        cfg.flash_info0_bkdr_vif)) begin
+      `uvm_fatal(`gfn, "failed to get flash_info0_bkdr_vif from uvm_config_db")
+    end
+
+    if (!uvm_config_db#(mem_bkdr_vif)::get(this, "", "flash_info1_bkdr_vif",
+        cfg.flash_info1_bkdr_vif)) begin
+      `uvm_fatal(`gfn, "failed to get flash_info1_bkdr_vif from uvm_config_db")
+    end
+
+    if (!uvm_config_db#(ecc_mem_bkdr_vif)::get(this, "", "otp_bkdr_vif", cfg.otp_bkdr_vif)) begin
+      `uvm_fatal(`gfn, "failed to get otp_bkdr_vif from uvm_config_db")
     end
 
     // get the handle to the sw log monitor for available sw_images.

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -20,11 +20,20 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
   // chip top interfaces
   virtual clk_rst_if  usb_clk_rst_vif;
   gpio_vif            gpio_vif;
-  mem_bkdr_vif        mem_bkdr_vifs[chip_mem_e];
   virtual pins_if#(1) srst_n_vif;
   virtual pins_if#(1) jtag_spi_n_vif;
   virtual pins_if#(1) bootstrap_vif;
   virtual pins_if#(1) rst_n_mon_vif;
+
+  // mem backdoors
+  mem_bkdr_vif        rom_bkdr_vif;
+  parity_mem_bkdr_vif ram_main_bkdr_vif;
+  parity_mem_bkdr_vif ram_ret_bkdr_vif;
+  mem_bkdr_vif        flash_bank0_bkdr_vif;
+  mem_bkdr_vif        flash_bank1_bkdr_vif;
+  mem_bkdr_vif        flash_info0_bkdr_vif;
+  mem_bkdr_vif        flash_info1_bkdr_vif;
+  ecc_mem_bkdr_vif    otp_bkdr_vif;
 
   // sw related
   // Directory from where to pick up the SW test images -default to PWD {run_dir}.
@@ -77,14 +86,6 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
   `uvm_object_new
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
-    chip_mem_e mems[] = {Rom,
-                         RamMain,
-                         RamRet,
-                         FlashBank0,
-                         FlashBank1,
-                         FlashBank0Info,
-                         FlashBank1Info,
-                         Otp};
 
     has_devmode = 0;
     list_of_alerts = chip_env_pkg::LIST_OF_ALERTS;
@@ -103,11 +104,6 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
 
     // create spi agent config obj
     m_spi_agent_cfg = spi_agent_cfg::type_id::create("m_spi_agent_cfg");
-
-    // initialize the mem_bkdr_if vifs we want for this chip
-    foreach (mems[mem]) begin
-      mem_bkdr_vifs[mems[mem]] = null;
-    end
 
     // By default, assume SW images in PWD with these generic names.
     sw_images[SwTypeRom] = "./rom";

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -7,6 +7,8 @@ package chip_env_pkg;
   import uvm_pkg::*;
   import top_pkg::*;
   import flash_ctrl_pkg::*;
+  import otp_ctrl_pkg::*;
+  import sram_ctrl_pkg::*;
   import dv_utils_pkg::*;
   import dv_base_reg_pkg::*;
   import csr_utils_pkg::*;
@@ -40,9 +42,13 @@ package chip_env_pkg;
   parameter bit [TL_AW-1:0] SW_DV_LOG_ADDR          = SW_DV_START_ADDR + 4;
 
   typedef virtual pins_if #(NUM_GPIOS)  gpio_vif;
-  typedef virtual mem_bkdr_if           mem_bkdr_vif;
   typedef virtual sw_logger_if          sw_logger_vif;
   typedef virtual sw_test_status_if     sw_test_status_vif;
+
+  // backdoors
+  typedef virtual mem_bkdr_if mem_bkdr_vif;
+  typedef virtual mem_bkdr_if #(.MEM_PARITY(1)) parity_mem_bkdr_vif;
+  typedef virtual mem_bkdr_if #(.MEM_ECC(1)) ecc_mem_bkdr_vif;
 
   // Types of memories in the chip.
   typedef enum {

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -48,10 +48,10 @@ class chip_base_vseq extends cip_base_vseq #(
     // Initialize gpio pin default states
     cfg.gpio_vif.set_pulldown_en({chip_env_pkg::NUM_GPIOS{1'b1}});
     // Initialize flash seeds
-    cfg.mem_bkdr_vifs[FlashBank0Info].set_mem();
-    cfg.mem_bkdr_vifs[FlashBank1Info].set_mem();
+    cfg.flash_info0_bkdr_vif.set_mem();
+    cfg.flash_info1_bkdr_vif.set_mem();
     // Bring the chip out of reset.
-    cfg.mem_bkdr_vifs[Otp].clear_mem();
+    cfg.otp_bkdr_vif.clear_mem();
     super.dut_init(reset_kind);
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -33,7 +33,7 @@ class chip_common_vseq extends chip_base_vseq;
 
   virtual task apply_reset(string kind = "HARD");
     super.apply_reset(kind);
-    cfg.mem_bkdr_vifs[Otp].clear_mem();
+    cfg.otp_bkdr_vif.clear_mem();
     wait (cfg.rst_n_mon_vif.pins[0] === 1);
     cfg.clk_rst_vif.wait_clks(100);
   endtask

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -76,13 +76,13 @@ module tb;
 
   // backdoors
   bind `ROM_HIER mem_bkdr_if rom_mem_bkdr_if();
-  bind `RAM_MAIN_HIER mem_bkdr_if ram_mem_bkdr_if();
-  bind `RAM_RET_HIER mem_bkdr_if ram_mem_bkdr_if();
+  bind `RAM_MAIN_HIER mem_bkdr_if #(.MEM_PARITY(1)) ram_mem_bkdr_if();
+  bind `RAM_RET_HIER mem_bkdr_if #(.MEM_PARITY(1)) ram_mem_bkdr_if();
   bind `FLASH0_MEM_HIER mem_bkdr_if flash0_mem_bkdr_if();
   bind `FLASH1_MEM_HIER mem_bkdr_if flash1_mem_bkdr_if();
   bind `FLASH0_INFO_HIER mem_bkdr_if flash0_info_bkdr_if();
   bind `FLASH1_INFO_HIER mem_bkdr_if flash1_info_bkdr_if();
-  bind `OTP_MEM_HIER mem_bkdr_if otp_bkdr_if();
+  bind `OTP_MEM_HIER mem_bkdr_if #(.MEM_ECC(1)) otp_bkdr_if();
 
   // TODO: the external clk is currently not connected.
   // We will need to feed this in via a muxed pin, once that function implemented.
@@ -272,22 +272,22 @@ module tb;
         null, "*.env", "rst_n_mon_vif", rst_n_mon_if);
 
     // Backdoors
-    uvm_config_db#(virtual mem_bkdr_if)::set(
-        null, "*.env", "mem_bkdr_vifs[Rom]", `ROM_HIER.rom_mem_bkdr_if);
-    uvm_config_db#(virtual mem_bkdr_if)::set(
-        null, "*.env", "mem_bkdr_vifs[RamMain]", `RAM_MAIN_HIER.ram_mem_bkdr_if);
-    uvm_config_db#(virtual mem_bkdr_if)::set(
-        null, "*.env", "mem_bkdr_vifs[RamRet]", `RAM_RET_HIER.ram_mem_bkdr_if);
-    uvm_config_db#(virtual mem_bkdr_if)::set(
-        null, "*.env", "mem_bkdr_vifs[FlashBank0]", `FLASH0_MEM_HIER.flash0_mem_bkdr_if);
-    uvm_config_db#(virtual mem_bkdr_if)::set(
-        null, "*.env", "mem_bkdr_vifs[FlashBank1]", `FLASH1_MEM_HIER.flash1_mem_bkdr_if);
-    uvm_config_db#(virtual mem_bkdr_if)::set(
-        null, "*.env", "mem_bkdr_vifs[FlashBank0Info]", `FLASH0_INFO_HIER.flash0_info_bkdr_if);
-    uvm_config_db#(virtual mem_bkdr_if)::set(
-        null, "*.env", "mem_bkdr_vifs[FlashBank1Info]", `FLASH1_INFO_HIER.flash1_info_bkdr_if);
-    uvm_config_db#(virtual mem_bkdr_if)::set(
-        null, "*.env", "mem_bkdr_vifs[Otp]", `OTP_MEM_HIER.otp_bkdr_if);
+    uvm_config_db#(mem_bkdr_vif)::set(
+        null, "*.env", "rom_bkdr_vif", `ROM_HIER.rom_mem_bkdr_if);
+    uvm_config_db#(parity_mem_bkdr_vif)::set(
+        null, "*.env", "ram_main_bkdr_vif", `RAM_MAIN_HIER.ram_mem_bkdr_if);
+    uvm_config_db#(parity_mem_bkdr_vif)::set(
+        null, "*.env", "ram_ret_bkdr_vif", `RAM_RET_HIER.ram_mem_bkdr_if);
+    uvm_config_db#(mem_bkdr_vif)::set(
+        null, "*.env", "flash_bank0_bkdr_vif", `FLASH0_MEM_HIER.flash0_mem_bkdr_if);
+    uvm_config_db#(mem_bkdr_vif)::set(
+        null, "*.env", "flash_bank1_bkdr_vif", `FLASH1_MEM_HIER.flash1_mem_bkdr_if);
+    uvm_config_db#(mem_bkdr_vif)::set(
+        null, "*.env", "flash_info0_bkdr_vif", `FLASH0_INFO_HIER.flash0_info_bkdr_if);
+    uvm_config_db#(mem_bkdr_vif)::set(
+        null, "*.env", "flash_info1_bkdr_vif", `FLASH1_INFO_HIER.flash1_info_bkdr_if);
+    uvm_config_db#(ecc_mem_bkdr_vif)::set(
+        null, "*.env", "otp_bkdr_vif", `OTP_MEM_HIER.otp_bkdr_if);
 
     // SW logger and test status interfaces.
     uvm_config_db#(virtual sw_test_status_if)::set(


### PR DESCRIPTION
This PR adds a DV golden model for the scrambling mechanisms used by the
SRAM to scramble both addresses and data.

The main feature is a custom substitution/permutation network similar to
the PRESENT block cipher, which is added to the `sram_ctrl_env_pkg`.

Data scrambling uses the PRINCE block cipher as well, so the existing
DPI model is imported and re-used here.

As a side-note, I've tested the memory encryption functions locally,
and everything seems to be working correctly.

This PR also updates the parameter names/values in the SRAM testbench to match
the updated `mem_bkdr_if`.

Support for memory parity and ECC is also added here.
Parity calculations are fully supported, and will be calculated on writes, but
ECC encoding is stubbed out for now (will be fully implemented later).

Signed-off-by: Udi Jonnalagadda <udij@google.com>