### PR TITLE
[dv/otp_ctrl] Add checkings for flash addr and data keys

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
@@ -104,7 +104,8 @@ class otp_ctrl_env extends cip_base_env #(
     for (int i = 0; i < NumSramKeyReqSlots; i++) begin
       virtual_sequencer.sram_pull_sequencer_h[i] = m_sram_pull_agent[i].sequencer;
       if (cfg.en_scb) begin
-        m_sram_pull_agent[i].monitor.analysis_port.connect(scoreboard.sram_fifo[i].analysis_export);
+        m_sram_pull_agent[i].monitor.analysis_port.connect(
+            scoreboard.sram_fifos[i].analysis_export);
       end
     end
 
@@ -115,10 +116,13 @@ class otp_ctrl_env extends cip_base_env #(
     virtual_sequencer.lc_token_pull_sequencer_h   = m_lc_token_pull_agent.sequencer;
     if (cfg.en_scb) begin
       m_otbn_pull_agent.monitor.analysis_port.connect(scoreboard.otbn_fifo.analysis_export);
-      m_flash_addr_pull_agent.monitor.analysis_port.connect(scoreboard.flash_addr_fifo.analysis_export);
-      m_flash_data_pull_agent.monitor.analysis_port.connect(scoreboard.flash_data_fifo.analysis_export);
+      m_flash_addr_pull_agent.monitor.analysis_port.connect(
+          scoreboard.flash_addr_fifo.analysis_export);
+      m_flash_data_pull_agent.monitor.analysis_port.connect(
+          scoreboard.flash_data_fifo.analysis_export);
       m_lc_prog_pull_agent.monitor.analysis_port.connect(scoreboard.lc_prog_fifo.analysis_export);
-      m_lc_token_pull_agent.monitor.analysis_port.connect(scoreboard.lc_token_fifo.analysis_export);
+      m_lc_token_pull_agent.monitor.analysis_port.connect(
+          scoreboard.lc_token_fifo.analysis_export);
     end
   endfunction
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -162,14 +162,14 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     `uvm_send(otbn_pull_seq)
   endtask
 
-  virtual task req_flash_addr();
+  virtual task req_flash_addr_key();
     push_pull_host_seq#(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_addr_pull_seq;
     `uvm_create_on(flash_addr_pull_seq, p_sequencer.flash_addr_pull_sequencer_h);
     `DV_CHECK_RANDOMIZE_FATAL(flash_addr_pull_seq)
     `uvm_send(flash_addr_pull_seq)
   endtask
 
-  virtual task req_flash_data();
+  virtual task req_flash_data_key();
     push_pull_host_seq#(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_data_pull_seq;
     `uvm_create_on(flash_data_pull_seq, p_sequencer.flash_data_pull_sequencer_h);
     `DV_CHECK_RANDOMIZE_FATAL(flash_data_pull_seq)

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -78,8 +78,8 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
       req_otbn_key();
 
       // get flash addr and data
-      req_flash_addr();
-      req_flash_data();
+      req_flash_addr_key();
+      req_flash_data_key();
 
       // get sram keys
       req_all_sram_keys();


### PR DESCRIPTION
This PR adds checkings in scb for Flash addr and data keys
This PR also changes a few hard-coded value to enums, and updated a few
variable/task namings.

Signed-off-by: Cindy Chen <chencindy@google.com>