### PR TITLE
[kmac/dv] Fix CSR test failure

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -407,6 +407,9 @@
           If 0, the entropy module waits the EDN response always. If EDN does
           not respond in this configuration, the software shall reset the IP.
           '''
+          tags: [// Writing this timer may cause EDN wait timeout, which triggers a SVA error
+                 // We will do that in functional tests
+                 "excl:CsrNonInitTests:CsrExclWrite"]
         }
       ]
     } // R: ENTROPY_PERIOD


### PR DESCRIPTION
Encountered some failures when running CI. After debug this, I found this timer
shouldn't be written in CSR test, otherwise, it may cause SVA errors.

This would also fix some of the errors in chip_csr_rw.

@udinator if you have a chance, please clean up failures for KMAC CSR tests as sometimes they may appear in CI tests.

Signed-off-by: Weicai Yang <weicai@google.com>