### PR TITLE
[reggen, dv] Add ability to set DV register prefix

### DIFF
--- a/hw/dv/tools/ralgen/README.md
+++ b/hw/dv/tools/ralgen/README.md
@@ -15,6 +15,10 @@ The adjoining `ralgen.core` file registers the `ralgen` generator. The FuseSoC
 core file that 'calls' the generator adds it as a dependency. When calling the
 generator, the following parameters are set:
 * **name (mandatory)**: Name of the RAL package (typically, same is the IP).
+* **dv_base_prefix (optional)**: The prefix added to the base classes from
+  which the register classes are derived. Set this option to derive the register
+  classes not from the default `dv_base_reg`, but from user defined custom
+  class definitions.
 * **ip_hjson**: Path to the hjson specification written for an IP which includes
   the register descriptions. This needs to be a valid input for `reggen`.
 * **top_hjson**: Path to the hjson specification for a top level design. This
@@ -30,7 +34,9 @@ generate:
     generator: ralgen
     parameters:
       name: <name>
-      <ip_hjson|top_hjson>: <path-to-hjson-spec>
+      ip_hjson|top_hjson: <path-to-hjson-spec>
+      [dv_base_prefix: my_base]
+
 
 targets:
   default:
@@ -63,11 +69,15 @@ the `name` parameter to derive the
 [VLNV](https://fusesoc.readthedocs.io/en/master/user/overview.html#core-naming-rules)
 name for the generated core file.
 
-The generated core file adds **`lowrisc:dv:dv_lib`** as a dependency for the
-generated RAL package. This is required because our DV register block, register
-and field models are derived from the
+The generated core file adds **`lowrisc:dv:dv_base_reg`** as a dependency for
+the generated RAL package. This is required because our DV register block,
+register and field models are derived from the
 [DV library]({{< relref "hw/dv/sv/dv_lib/README.md" >}}) of classes. This
-ensures the right compilation order is maintained.
+ensures the right compilation order is maintained. If the `dv_base_prefix`
+argument is set, then it adds **`lowrisc:dv:my_base_reg`** as an extra
+dependency, where `my_base` is the value of the argument as shown in the
+example above. This core file and the associated sources are assumed to be
+available in the provided FuseSoC search paths.
 
 ## Limitations
 

--- a/hw/dv/tools/ralgen/ralgen.py
+++ b/hw/dv/tools/ralgen/ralgen.py
@@ -49,6 +49,7 @@ def main():
     name = gapi['parameters'].get('name')
     ip_hjson = gapi['parameters'].get('ip_hjson')
     top_hjson = gapi['parameters'].get('top_hjson')
+    dv_base_prefix = gapi['parameters'].get('dv_base_prefix')
     if not name or (bool(ip_hjson) == bool(top_hjson)):
         print("Error: ralgen requires the \"name\" and exactly one of "
               "{\"ip_hjson\" and \"top_hjson\"} parameters to be set.")
@@ -65,6 +66,11 @@ def main():
         cmd = os.path.join(util_path, "topgen.py")
         args = [cmd, "-r", "-o", ".", "-t", ral_spec]
 
+    depends = ["lowrisc:dv:dv_base_reg"]
+    if dv_base_prefix and dv_base_prefix != "dv_base":
+        args.extend(["--dv-base-prefix", dv_base_prefix])
+        depends.append("lowrisc:dv:{}_reg".format(dv_base_prefix))
+
     try:
         subprocess.run(args, check=True)
     except subprocess.CalledProcessError as e:
@@ -77,9 +83,7 @@ def main():
         'name': "lowrisc:dv:{}_ral_pkg".format(name),
         'filesets': {
             'files_dv': {
-                'depend': [
-                    "lowrisc:dv:dv_base_reg",
-                ],
+                'depend': depends,
                 'files': [
                     ral_pkg_file,
                 ],

--- a/util/reggen/README.md
+++ b/util/reggen/README.md
@@ -59,8 +59,44 @@ $ cd $REPO_TOP/util
 $ mkdir /tmp/dv
 $ ./regtool.py -s -t /tmp/dv ../hw/ip/uart/data/uart.hjson
 $ ls /tmp/dv
-    uart_reg_block.sv
+    uart_ral_pkg.sv
 ```
+
+By default, the generated block, register and field models are derived from
+`dv_base_reg` classes provided at `hw/dv/sv/dv_base_reg`. If required, the user
+can supply the `--dv-base-prefix my_base` switch to have the models derive from
+a custom, user-defined RAL classes instead:
+
+```console
+$ cd $REPO_TOP/util
+$ mkdir /tmp/dv
+$ ./regtool.py -s -t /tmp/dv ../hw/ip/uart/data/uart.hjson \
+  --dv-base-prefix my_base
+$ ls /tmp/dv
+    uart_ral_pkg.sv
+```
+
+This makes the following assumptions:
+- A FuseSoC core file aggregating the `my_base` RAL classes with the VLNV
+  name `lowrisc:dv:my_base_reg` is provided in the cores search path.
+- These custom classes are derived from the corresponding `dv_base_reg` classes
+  and have the following names:
+  - `my_base_reg_pkg.sv`: The RAL package that includes the below sources
+  - `my_base_reg_block.sv`: The register block abstraction
+  - `my_base_reg.sv`: The register abstraction
+  - `my_base_reg_field.sv`: The register field abstraction
+  - `my_base_mem.sv`: The memory abstraction
+- If any of the above class specializations is not needed, it can be
+  `typedef`'ed in `my_base_reg_pkg`:
+  ```systemverilog
+  package my_base_reg_pkg;
+    import dv_base_reg_pkg::*;
+    typedef dv_base_reg_field my_base_reg_field;
+    typedef dv_base_mem my_base_mem;
+    `include "my_base_reg.sv"
+    `include "my_base_reg_block.sv"
+  endpackage
+  ```
 
 The following shows an example of how to generate a FPV csr read write assertion
 module from a register description:

--- a/util/reggen/gen_dv.py
+++ b/util/reggen/gen_dv.py
@@ -39,12 +39,12 @@ def sv_base_addr(b, inst):
     return "{}'h{:x}".format(b.width, b.base_addr[inst])
 
 
-def gen_dv(obj, outdir):
+def gen_dv(obj, dv_base_prefix, outdir):
     '''Generate DV files using a raw dict object parsed from hjson'''
-    gen_ral(json_to_reg(obj), outdir)
+    gen_ral(json_to_reg(obj), dv_base_prefix, outdir)
 
 
-def gen_ral(block, outdir):
+def gen_ral(block, dv_base_prefix, outdir):
     '''Generate DV RAL model from a gen_rtl.Block specification'''
 
     # Read template
@@ -54,6 +54,7 @@ def gen_ral(block, outdir):
     # Expand template
     try:
         to_write = uvm_reg_tpl.render(block=block,
+                                      dv_base_prefix=dv_base_prefix,
                                       HwAccess=HwAccess,
                                       SwRdAccess=SwRdAccess,
                                       SwWrAccess=SwWrAccess)

--- a/util/reggen/uvm_reg.sv.tpl
+++ b/util/reggen/uvm_reg.sv.tpl
@@ -22,6 +22,9 @@ package ${block.name}_ral_pkg;
   // dep packages
   import uvm_pkg::*;
   import dv_base_reg_pkg::*;
+% if dv_base_prefix != "dv_base":
+  import ${dv_base_prefix}_reg_pkg::*;
+% endif
 % for b in block.blocks:
   import ${b.name}_ral_pkg::*;
 % endfor
@@ -46,10 +49,10 @@ package ${block.name}_ral_pkg;
   reg_shadowed = r.shadowed
 %>\
   // Class: ${gen_dv.rcname(block, r)}
-  class ${gen_dv.rcname(block, r)} extends dv_base_reg;
+  class ${gen_dv.rcname(block, r)} extends ${dv_base_prefix}_reg;
     // fields
 % for f in r.fields:
-    rand dv_base_reg_field ${f.name};
+    rand ${dv_base_prefix}_reg_field ${f.name};
 % endfor
 
     `uvm_object_utils(${gen_dv.rcname(block, r)})
@@ -85,7 +88,7 @@ package ${block.name}_ral_pkg;
   else:
     reg_field_name = reg_name + "_" + f.name
 %>\
-      ${f.name} = dv_base_reg_field::type_id::create("${f.name}");
+      ${f.name} = ${dv_base_prefix}_reg_field::type_id::create("${f.name}");
       ${f.name}.configure(
         .parent(this),
         .size(${field_size}),
@@ -150,7 +153,7 @@ package ${block.name}_ral_pkg;
   mem_size = int((w.limit_addr - w.base_addr) / (mem_n_bits / 8))
 %>\
   // Class: ${gen_dv.mcname(block, w)}
-  class ${gen_dv.mcname(block, w)} extends dv_base_mem;
+  class ${gen_dv.mcname(block, w)} extends ${dv_base_prefix}_mem;
 
     `uvm_object_utils(${gen_dv.mcname(block, w)})
 
@@ -169,7 +172,7 @@ package ${block.name}_ral_pkg;
 
 % endfor
   // Class: ${gen_dv.bcname(block)}
-  class ${gen_dv.bcname(block)} extends dv_base_reg_block;
+  class ${gen_dv.bcname(block)} extends ${dv_base_prefix}_reg_block;
 % if block.blocks:
     // sub blocks
 % endif

--- a/util/regtool.py
+++ b/util/regtool.py
@@ -71,6 +71,10 @@ def main():
                         '-t',
                         help='Target directory for generated RTL; '
                         'tool uses ../rtl if blank.')
+    parser.add_argument('--dv-base-prefix',
+                        default='dv_base',
+                        help='Prefix for the DV register classes from which '
+                        'the register models are derived.')
     parser.add_argument('--outfile',
                         '-o',
                         type=argparse.FileType('w'),
@@ -191,7 +195,7 @@ def main():
             gen_rtl.gen_rtl(obj, outdir)
             return 0
         if format == 'dv':
-            gen_dv.gen_dv(obj, outdir)
+            gen_dv.gen_dv(obj, args.dv_base_prefix, outdir)
             return 0
         if format == 'fpv':
             gen_fpv.gen_fpv(obj, outdir)

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -797,7 +797,7 @@ def generate_top_only(top_only_list, out_path, topname):
             gen_rtl.gen_rtl(hjson_obj, str(genrtl_dir))
 
 
-def generate_top_ral(top, ip_objs, out_path):
+def generate_top_ral(top, ip_objs, dv_base_prefix, out_path):
     # construct top ral block
     top_block = gen_rtl.Block()
     top_block.name = "chip"
@@ -835,7 +835,7 @@ def generate_top_ral(top, ip_objs, out_path):
     top_block.wins.sort(key=lambda win: win.base_addr)
 
     # generate the top ral model with template
-    gen_dv.gen_ral(top_block, str(out_path))
+    gen_dv.gen_ral(top_block, dv_base_prefix, str(out_path))
 
 
 def main():
@@ -896,6 +896,10 @@ def main():
         default=False,
         action='store_true',
         help="If set, the tool generates top level RAL model for DV")
+    parser.add_argument('--dv-base-prefix',
+                        default='dv_base',
+                        help='Prefix for the DV register classes from which '
+                        'the register models are derived.')
     # Generator options for compile time random netlist constants
     parser.add_argument(
         '--rnd_cnst_seed',
@@ -1062,7 +1066,7 @@ def main():
     completecfg = merge_top(topcfg, ip_objs, xbar_objs)
 
     if args.top_ral:
-        generate_top_ral(completecfg, ip_objs, out_path)
+        generate_top_ral(completecfg, ip_objs, args.dv_base_prefix, out_path)
         sys.exit()
 
     # Generate PLIC


### PR DESCRIPTION
This came out of a discussion with Nuvoton to add support for generating
UVM reg models that are extended not from `dv_base_reg*` classes
but from custom classes that add Nuvoton-specific functionality on top of
`dv_base_reg*` classes. With this PR, this can be achieved by setting
the switch `--dv-base-class-prefix foo`. This approach assumes that the
following exist, given the arg value of `foo`:

- A fusesoc core with the name `lowrisc:dv:foo_reg` that sources the
following files at minimum:
  - `foo_reg_pkg.sv`: includes the `foo` reg classes below.
  - `foo_reg.sv`: register class
  - `foo_reg_field.sv`: field class abstraction
  - `foo_reg_block.sv`: register block class abstraction
  - `foo_mem.sv`: memory abstraction
- These are required to derive from their corresponding `dv_base_reg*`
classes.
- If any of these specialized abstractions is not needed, they need to
be typedef'ed to the `dv_baes_reg*` one in the pkg.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>