### PR TITLE
[otbn] BN.MOV shouldn't enable base RF read

### DIFF
--- a/hw/ip/otbn/rtl/otbn_decoder.sv
+++ b/hw/ip/otbn/rtl/otbn_decoder.sv
@@ -589,11 +589,11 @@ module otbn_decoder
             insn_subset     = InsnSubsetBignum;
             rf_we_bignum    = 1'b1;
             rf_ren_a_bignum = 1'b1;
-            rf_ren_a_base   = 1'b1;
 
-            if (insn[31]) begin
+            if (insn[31]) begin // BN.MOVR
               rf_a_indirect_bignum = 1'b1;
               rf_d_indirect_bignum = 1'b1;
+              rf_ren_a_base        = 1'b1;
               rf_ren_b_base        = 1'b1;
 
               if (insn[9]) begin


### PR DESCRIPTION
Fixes #4721

Signed-off-by: Greg Chadwick <gac@lowrisc.org>