### PR TITLE
[dv/otp_ctrl] clean up macro errors sequence

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -113,14 +113,14 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   // SW digest data are calculated in sw and won't be checked in OTP.
   // Here to simplify testbench, write random data to sw digest
   virtual task write_sw_digests(bit [1:0] wr_digest = $urandom());
-    bit [TL_DW*2-1:0] rdata;
+    bit [TL_DW*2-1:0] wdata;
     if (wr_digest[0]) begin
-      `DV_CHECK_STD_RANDOMIZE_FATAL(rdata);
-      dai_wr(CreatorSwCfgDigestOffset, rdata[TL_DW-1:0], rdata[TL_DW*2-1:TL_DW]);
+      `DV_CHECK_STD_RANDOMIZE_FATAL(wdata);
+      dai_wr(CreatorSwCfgDigestOffset, wdata[TL_DW-1:0], wdata[TL_DW*2-1:TL_DW]);
     end
     if (wr_digest[1]) begin
-      `DV_CHECK_STD_RANDOMIZE_FATAL(rdata);
-      dai_wr(OwnerSwCfgDigestOffset, rdata[TL_DW-1:0], rdata[TL_DW*2-1:TL_DW]);
+      `DV_CHECK_STD_RANDOMIZE_FATAL(wdata);
+      dai_wr(OwnerSwCfgDigestOffset, wdata[TL_DW-1:0], wdata[TL_DW*2-1:TL_DW]);
     end
   endtask
 
@@ -130,7 +130,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   endtask
 
   // The digest CSR values are verified in otp_ctrl_scoreboard
-  virtual task check_digests();
+  virtual task rd_digests();
     bit [TL_DW-1:0] val;
     csr_rd(.ptr(ral.creator_sw_cfg_digest_0), .value(val));
     csr_rd(.ptr(ral.creator_sw_cfg_digest_1), .value(val));

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_errs_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_errs_vseq.sv
@@ -16,13 +16,12 @@ class otp_ctrl_macro_errs_vseq extends otp_ctrl_smoke_vseq;
     num_dai_op inside {[100:500]};
   }
 
-  virtual task pre_start();
-    super.pre_start();
+  function void pre_randomize();
     // TODO: enable this once support
     // this.partition_index_c.constraint_mode(0);
     // this.dai_wr_legal_addr_c.constraint_mode(0);
     this.dai_wr_blank_addr_c.constraint_mode(0);
     collect_used_addr = 0;
-  endtask
+  endfunction
 
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -122,8 +122,8 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
       write_sw_rd_locks();
       dut_init();
 
-      // check digest
-      check_digests();
+      // read and check digest in scb
+      rd_digests();
 
       if (do_lc_trans) begin
         req_lc_transition();


### PR DESCRIPTION
A few updates related to macro_errors sequences:
1. Change from pre_start task to pre_randomize.
2. Updates a few namings in scb and sequences.

Signed-off-by: Cindy Chen <chencindy@google.com>