### PR TITLE
[otbn] Switch to using bitfield for errors

### DIFF
--- a/hw/ip/otbn/data/base-insns.yml
+++ b/hw/ip/otbn/data/base-insns.yml
@@ -256,7 +256,7 @@
   doc: |
     Loads a 32b word from address `offset + grs1` in data memory, writing the result to `grd`.
     Unaligned loads are not supported.
-    Any address that is unaligned or is above the top of memory will result in an error (with error code `ErrCodeBadDataAddr`).
+    Any address that is unaligned or is above the top of memory will result in an error (setting bit `bad_data_addr` in `ERR_BITS`).
   cycles: 2
   lsu:
     type: mem-load
@@ -283,7 +283,7 @@
   doc: |
     Stores a 32b word in `grs2` to address `offset + grs1` in data memory.
     Unaligned stores are not supported.
-    Any address that is unaligned or is above the top of memory will result in an error (with error code `ErrCodeBadDataAddr`).
+    Any address that is unaligned or is above the top of memory will result in an error (setting bit `bad_data_addr` in `ERR_BITS`).
   lsu:
     type: mem-store
     target: [offset, grs1]
@@ -450,12 +450,12 @@
     The number of instructions in the loop is given in the `bodysize` immediate.
 
     The `LOOP` instruction doesn't support a zero iteration count.
-    If the value in `grs` is zero, OTBN stops with the `ErrCodeLoop` error.
+    If the value in `grs` is zero, OTBN stops, setting bit `loop` in `ERR_BITS`.
     Starting a loop pushes an entry on to the [loop stack](../#loop-stack).
-    If the stack is already full, OTBN stops with the `ErrCodeLoop` error.
+    If the stack is already full, OTBN stops, setting bit `loop` in `ERR_BITS`.
 
     `LOOP`, `LOOPI`, jump and branch instructions are all permitted inside a loop but may not appear as the last instruction in a loop.
-    OTBN will stop on that instruction with the `ErrCodeLoop` error.
+    OTBN will stop on that instruction with the, setting bit `loop` in `ERR_BITS`.
 
     For more information on how to correctly use `LOOP` see [loop nesting](../#loop-nesting).
   encoding:
@@ -480,10 +480,10 @@
     The `LOOPI` instruction doesn't support a zero iteration count.
     If the value of `iterations` is zero, OTBN stops with the `ErrCodeLoop` error.
     Starting a loop pushes an entry on to the [loop stack](../#loop-stack).
-    If the stack is already full, OTBN stops with the `ErrCodeLoop` error.
+    If the stack is already full, OTBN stops, setting bit `loop` in `ERR_BITS`.
 
     `LOOP`, `LOOPI`, jump and branch instructions are all permitted inside a loop but may not appear as the last instruction in a loop.
-    OTBN will stop on that instruction with the `ErrCodeLoop` error.
+    OTBN will stop on that instruction, setting bit `loop` in `ERR_BITS`.
 
     For more information on how to correctly use `LOOPI` see [loop nesting](../#loop-nesting).
   encoding:

--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -738,7 +738,7 @@
     - If `grs1_inc` is set, the value in `grs1` is incremented by value WLEN/8 (one word).
 
     The memory address must be aligned to WLEN bits.
-    Any address that is unaligned or is above the top of memory results in an error (with error code `ErrCodeBadDataAddr`).
+    Any address that is unaligned or is above the top of memory results in an error (setting bit `bad_data_addr` in `ERR_BITS`).
   cycles: 2
   operation: |
     mem_addr = GPR[grs1] + offset
@@ -814,7 +814,7 @@
     - If `grs2_inc` is set, the value in `grs2` is updated to be `(*grs2 + 1) & 0x1f`.
 
     The memory address must be aligned to WLEN bits.
-    Any address that is unaligned or is above the top of memory results in an error (with error code `ErrCodeBadDataAddr`).
+    Any address that is unaligned or is above the top of memory results in an error (setting bit `bad_data_addr` in `ERR_BITS`).
   operation: |
     mem_addr = GPR[grs1] + offset
     wdr_src = GPR[grs2]

--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -102,30 +102,79 @@
         }
       ]
     } // register : status
-    { name: "ERR_CODE",
-      desc: "Error Code",
+    { name: "ERR_BITS",
+      desc: '''
+        Error bitfield. Reads as non-zero if an error was seen during OTBN
+        operation
+      ''',
       swaccess: "ro",
       hwaccess: "hwo",
       fields: [
-        { bits: "31:0",
-          name: "err_code",
+        { bits: "0",
+          name: "bad_data_addr"
           desc: '''
-            The error cause if an error occurred.
-
-            This is set to zero (ErrCodeNoError) when OTBN successfully
-            completes an operation or a positive value when OTBN stops on an
-            error.
-
-            While OTBN is running (!!CMD.busy set), this has no meaning. When
-            OTBN stops this will be set to indicate the outcome. It is
-            guaranteed not to change until OTBN is run again (with !!CMD.start).
-
-            See <a href='#error-conditions'>Error Conditions</a> for
-            details on the possible values.
+            A DMEM read or write occurred with an out of bounds or unaligned
+            address.
           '''
         }
+        { bits: "1",
+          name: "bad_insn_addr"
+          desc: '''
+            An IMEM read or write occurred with an out of bounds or unaligned
+            address.
+          '''
+        }
+        { bits: "2",
+          name: "call_stack"
+          desc: '''
+            A instruction tried to pop from an empty call stack or push to a
+            full call stack.
+          '''
+        }
+        { bits: "3",
+          name: "illegal_insn"
+          desc: '''
+            One of the following happened:
+            <ul>
+              <li>An instruction being excuted had an invalid encoding.</li>
+              <li>An access occurred for an invalid CSR or WSR.</li>
+              <li>
+                A CSR or WSR access occurred that is not permitted (e.g. writing
+                to a read-only CSR or WSR).
+              </li>
+            </ul>
+          '''
+        }
+        { bits: "4",
+          name: "loop"
+          desc: '''
+            One of the following happened:
+            <ul>
+              <li>A loop was started with an iteration count of zero.</li>
+              <li>
+                The final instruction of a loop was a branch or another loop.
+              </li>
+              <li>
+                A new loop tried to push to a full loop stack (loop nesting
+                level too deep).
+              </li>
+            </ul>
+          '''
+        }
+        { bits: "5",
+          name: "fatal_imem"
+          desc: "A fatal failure was seen on an instruction fetch."
+        }
+        { bits: "6",
+          name: "fatal_dmem"
+          desc: "A fatal failure was seen on a DMEM read."
+        }
+        { bits: "7",
+          name: "fatal_reg"
+          desc: "A fatal failure was seen on a GPR or WDR read."
+        }
       ]
-    } // register : err_code
+    } // register : err_bits
     { name: "START_ADDR",
       desc: "Start byte address in the instruction memory",
       swaccess: "wo",

--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -332,7 +332,7 @@ std::pair<bool, uint32_t> ISSWrapper::step(bool gen_trace) {
   // The busy flag is bit 0 of the STATUS register, so is cleared on this cycle
   // if we see a write that sets the value to an even number.
   bool done = (read_ext_reg("STATUS", lines, 1) & 1) == 0;
-  uint32_t err_code = done ? read_ext_reg("ERR_CODE", lines, 0) : 0;
+  uint32_t err_code = done ? read_ext_reg("ERR_BITS", lines, 0) : 0;
   return std::make_pair(done, err_code);
 }
 

--- a/hw/ip/otbn/dv/otbnsim/sim/alert.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/alert.py
@@ -6,15 +6,15 @@ from typing import Optional
 
 # A copy of the list of error codes. This also appears in the documentation and
 # otbn_pkg.sv: we should probably be generating them from the hjson every time.
-ERR_CODE_NO_ERROR = 0x0
-ERR_CODE_BAD_DATA_ADDR = 0x1
-ERR_CODE_BAD_INSN_ADDR = 0x2
-ERR_CODE_CALL_STACK = 0x3
-ERR_CODE_ILLEGAL_INSN = 0x4
-ERR_CODE_LOOP = 0x5
-ERR_CODE_FATAL_IMEM = 0x80
-ERR_CODE_FATAL_DMEM = 0x81
-ERR_CODE_FATAL_REG = 0x82
+ERR_CODE_NO_ERROR = 0
+ERR_CODE_BAD_DATA_ADDR = 1 << 0
+ERR_CODE_BAD_INSN_ADDR = 1 << 1
+ERR_CODE_CALL_STACK = 1 << 2
+ERR_CODE_ILLEGAL_INSN = 1 << 3
+ERR_CODE_LOOP = 1 << 4
+ERR_CODE_FATAL_IMEM = 1 << 5
+ERR_CODE_FATAL_DMEM = 1 << 6
+ERR_CODE_FATAL_REG = 1 << 7
 
 
 class Alert(Exception):

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -378,7 +378,7 @@ class OTBNState:
     def stop(self, err_code: Optional[int]) -> None:
         '''Set flags to stop the processor.
 
-        If err_code is not None, it is the value to write to the ERR_CODE
+        If err_code is not None, it is the value to write to the ERR_BITS
         register.
 
         '''
@@ -389,6 +389,6 @@ class OTBNState:
         self.ext_regs.clear_bits('STATUS', 1 << 0)
 
         if err_code is not None:
-            self.ext_regs.write('ERR_CODE', err_code, True)
+            self.ext_regs.write('ERR_BITS', err_code, True)
 
         self.running = False

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -52,7 +52,7 @@ module otbn
   logic busy_d, busy_q;
   logic done;
 
-  logic [31:0] err_code;
+  err_bits_t err_bits;
 
   logic [ImemAddrWidth-1:0] start_addr;
 
@@ -92,7 +92,6 @@ module otbn
     .hw2reg_intr_state_d_o  (hw2reg.intr_state.d),
     .intr_o                 (intr_done_o)
   );
-
 
   // Instruction Memory (IMEM) =================================================
 
@@ -366,11 +365,32 @@ module otbn
   assign hw2reg.status.busy.d = busy_q;
   assign hw2reg.status.dummy.d = 1'b0;
 
-  // ERR_CODE register
-  // The error code (stored as ERR_CODE) for an OTBN operation gets stored on the cycle that done is
-  // asserted. Software is expected to read out this value before starting the next operation.
-  assign hw2reg.err_code.de = done;
-  assign hw2reg.err_code.d  = err_code;
+  // ERR_BITS register
+  // The error bits for an OTBN operation get stored on the cycle that done is
+  // asserted. Software is expected to read them out before starting the next operation.
+  assign hw2reg.err_bits.bad_data_addr.de = done;
+  assign hw2reg.err_bits.bad_data_addr.d = err_bits.bad_data_addr;
+
+  assign hw2reg.err_bits.bad_insn_addr.de = done;
+  assign hw2reg.err_bits.bad_insn_addr.d = err_bits.bad_insn_addr;
+
+  assign hw2reg.err_bits.call_stack.de = done;
+  assign hw2reg.err_bits.call_stack.d = err_bits.call_stack;
+
+  assign hw2reg.err_bits.illegal_insn.de = done;
+  assign hw2reg.err_bits.illegal_insn.d = err_bits.illegal_insn;
+
+  assign hw2reg.err_bits.loop.de = done;
+  assign hw2reg.err_bits.loop.d = err_bits.loop;
+
+  assign hw2reg.err_bits.fatal_imem.de = done;
+  assign hw2reg.err_bits.fatal_imem.d = err_bits.fatal_imem;
+
+  assign hw2reg.err_bits.fatal_dmem.de = done;
+  assign hw2reg.err_bits.fatal_dmem.d = err_bits.fatal_dmem;
+
+  assign hw2reg.err_bits.fatal_reg.de = done;
+  assign hw2reg.err_bits.fatal_reg.d = err_bits.fatal_reg;
 
   // START_ADDR register
   assign start_addr = reg2hw.start_addr.q[ImemAddrWidth-1:0];
@@ -438,10 +458,10 @@ module otbn
     // Mux between model and RTL implementation at runtime.
     logic      done_model, done_rtl;
     logic      start_model, start_rtl;
-    err_code_e err_code_model, err_code_rtl;
+    err_bits_t err_bits_model, err_bits_rtl;
 
     assign done = otbn_use_model ? done_model : done_rtl;
-    assign err_code = otbn_use_model ? err_code_model : err_code_rtl;
+    assign err_bits = otbn_use_model ? err_bits_model : err_bits_rtl;
     assign start_model = start & otbn_use_model;
     assign start_rtl = start & ~otbn_use_model;
 
@@ -464,7 +484,7 @@ module otbn
       .start_i (start_model),
       .done_o (done_model),
 
-      .err_code_o (err_code_model),
+      .err_bits_o (err_bits_model),
 
       .start_addr_i (start_addr),
 
@@ -483,7 +503,7 @@ module otbn
       .start_i (start_rtl),
       .done_o  (done_rtl),
 
-      .err_code_o (err_code_rtl),
+      .err_bits_o (err_bits_rtl),
 
       .start_addr_i  (start_addr),
 
@@ -515,7 +535,7 @@ module otbn
       .start_i (start),
       .done_o  (done),
 
-      .err_code_o (err_code),
+      .err_bits_o (err_bits),
 
       .start_addr_i  (start_addr),
 

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -24,7 +24,7 @@ module otbn_controller
   input  logic  start_i, // start the processing at start_addr_i
   output logic  done_o,  // processing done, signaled by ECALL or error occurring
 
-  output err_code_e err_code_o, // valid when done_o is asserted
+  output err_bits_t err_bits_o, // valid when done_o is asserted
 
   input  logic [ImemAddrWidth-1:0] start_addr_i,
 
@@ -266,31 +266,30 @@ module otbn_controller
   // Err signal and code generation and prioritisation
   always_comb begin
     err        = 1'b1;
-    err_code_o = ErrCodeNoError;
+    err_bits_o = '0;
 
     if (insn_fetch_err_i) begin
-      err_code_o = ErrCodeFatalImem;
+      err_bits_o.fatal_imem = 1'b1;
     end else if (lsu_rdata_err_i) begin
-      err_code_o = ErrCodeFatalDmem;
+      err_bits_o.fatal_dmem = 1'b1;
     end else if (insn_illegal_i) begin
-      err_code_o = ErrCodeIllegalInsn;
+      err_bits_o.illegal_insn = 1'b1;
     end else if (ispr_err) begin
-      err_code_o = ErrCodeIllegalInsn;
+      err_bits_o.illegal_insn = 1'b1;
     end else if (dmem_addr_err) begin
-      err_code_o = ErrCodeBadDataAddr;
+      err_bits_o.bad_data_addr = 1'b1;
     end else if (loop_err) begin
-      err_code_o = ErrCodeLoop;
+      err_bits_o.loop = 1'b1;
     end else if (rf_base_call_stack_err_i) begin
-      err_code_o = ErrCodeCallStack;
+      err_bits_o.call_stack = 1'b1;
     end else if (imem_addr_err) begin
-      err_code_o = ErrCodeBadInsnAddr;
+      err_bits_o.bad_insn_addr = 1'b1;
     end else begin
       err        = 1'b0;
-      err_code_o = ErrCodeNoError;
     end
   end
 
-  `ASSERT(ErrCodeOnErr, err |-> err_code_o != ErrCodeNoError)
+  `ASSERT(ErrBitSetOnErr, err |-> |err_bits_o)
 
   `ASSERT(ControllerStateValid, state_q inside {OtbnStateHalt, OtbnStateRun, OtbnStateStall})
   // Branch only takes effect in OtbnStateRun so must not go into stall state for branch

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -29,7 +29,7 @@ module otbn_core
   input  logic  start_i, // start the operation
   output logic  done_o,  // operation done
 
-  output err_code_e err_code_o, // valid when done_o is asserted
+  output err_bits_t err_bits_o, // valid when done_o is asserted
 
   input  logic [ImemAddrWidth-1:0] start_addr_i, // start byte address in IMEM
 
@@ -199,7 +199,7 @@ module otbn_core
     .start_i,
     .done_o,
 
-    .err_code_o,
+    .err_bits_o,
 
     .start_addr_i,
 

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -41,21 +41,20 @@ package otbn_pkg;
     RegFileFPGA  = 1  // FPGA implmentation, does infer RAM primitives.
   } regfile_e;
 
-  // Error codes
+  // Error bits
   //
-  // Note: This list is duplicated in the documentation (../doc/_index.md), the ISS
-  // (../dv/otbnsim/sim/alert.py), and the DIF. If updating it here, update those too.
-  typedef enum logic [31:0] {
-    ErrCodeNoError     = 32'h00,
-    ErrCodeBadDataAddr = 32'h01,
-    ErrCodeBadInsnAddr = 32'h02,
-    ErrCodeCallStack   = 32'h03,
-    ErrCodeIllegalInsn = 32'h04,
-    ErrCodeLoop        = 32'h05,
-    ErrCodeFatalImem   = 32'h80,
-    ErrCodeFatalDmem   = 32'h81,
-    ErrCodeFatalReg    = 32'h82
-  } err_code_e;
+  // Note: These errors are duplicated in the register HJSON (../data/otbn.hjson), the ISS
+  // (../dv/otbnsim/sim/alert.py), and the DIF. If updating them here, update those too.
+  typedef struct packed {
+    logic fatal_reg;
+    logic fatal_dmem;
+    logic fatal_imem;
+    logic loop;
+    logic illegal_insn;
+    logic call_stack;
+    logic bad_insn_addr;
+    logic bad_data_addr;
+  } err_bits_t;
 
   // Constants =====================================================================================
 

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -70,9 +70,39 @@ package otbn_reg_pkg;
   } otbn_hw2reg_status_reg_t;
 
   typedef struct packed {
-    logic [31:0] d;
-    logic        de;
-  } otbn_hw2reg_err_code_reg_t;
+    struct packed {
+      logic        d;
+      logic        de;
+    } bad_data_addr;
+    struct packed {
+      logic        d;
+      logic        de;
+    } bad_insn_addr;
+    struct packed {
+      logic        d;
+      logic        de;
+    } call_stack;
+    struct packed {
+      logic        d;
+      logic        de;
+    } illegal_insn;
+    struct packed {
+      logic        d;
+      logic        de;
+    } loop;
+    struct packed {
+      logic        d;
+      logic        de;
+    } fatal_imem;
+    struct packed {
+      logic        d;
+      logic        de;
+    } fatal_dmem;
+    struct packed {
+      logic        d;
+      logic        de;
+    } fatal_reg;
+  } otbn_hw2reg_err_bits_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -106,9 +136,9 @@ package otbn_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    otbn_hw2reg_intr_state_reg_t intr_state; // [42:41]
-    otbn_hw2reg_status_reg_t status; // [40:39]
-    otbn_hw2reg_err_code_reg_t err_code; // [38:6]
+    otbn_hw2reg_intr_state_reg_t intr_state; // [25:24]
+    otbn_hw2reg_status_reg_t status; // [23:22]
+    otbn_hw2reg_err_bits_reg_t err_bits; // [21:6]
     otbn_hw2reg_fatal_alert_cause_reg_t fatal_alert_cause; // [5:0]
   } otbn_hw2reg_t;
 
@@ -119,7 +149,7 @@ package otbn_reg_pkg;
   parameter logic [BlockAw-1:0] OTBN_ALERT_TEST_OFFSET = 16'h c;
   parameter logic [BlockAw-1:0] OTBN_CMD_OFFSET = 16'h 10;
   parameter logic [BlockAw-1:0] OTBN_STATUS_OFFSET = 16'h 14;
-  parameter logic [BlockAw-1:0] OTBN_ERR_CODE_OFFSET = 16'h 18;
+  parameter logic [BlockAw-1:0] OTBN_ERR_BITS_OFFSET = 16'h 18;
   parameter logic [BlockAw-1:0] OTBN_START_ADDR_OFFSET = 16'h 1c;
   parameter logic [BlockAw-1:0] OTBN_FATAL_ALERT_CAUSE_OFFSET = 16'h 20;
 
@@ -137,7 +167,7 @@ package otbn_reg_pkg;
     OTBN_ALERT_TEST,
     OTBN_CMD,
     OTBN_STATUS,
-    OTBN_ERR_CODE,
+    OTBN_ERR_BITS,
     OTBN_START_ADDR,
     OTBN_FATAL_ALERT_CAUSE
   } otbn_id_e;
@@ -150,7 +180,7 @@ package otbn_reg_pkg;
     4'b 0001, // index[3] OTBN_ALERT_TEST
     4'b 0001, // index[4] OTBN_CMD
     4'b 0001, // index[5] OTBN_STATUS
-    4'b 1111, // index[6] OTBN_ERR_CODE
+    4'b 0001, // index[6] OTBN_ERR_BITS
     4'b 1111, // index[7] OTBN_START_ADDR
     4'b 0001  // index[8] OTBN_FATAL_ALERT_CAUSE
   };

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -141,7 +141,14 @@ module otbn_reg_top (
   logic status_busy_re;
   logic status_dummy_qs;
   logic status_dummy_re;
-  logic [31:0] err_code_qs;
+  logic err_bits_bad_data_addr_qs;
+  logic err_bits_bad_insn_addr_qs;
+  logic err_bits_call_stack_qs;
+  logic err_bits_illegal_insn_qs;
+  logic err_bits_loop_qs;
+  logic err_bits_fatal_imem_qs;
+  logic err_bits_fatal_dmem_qs;
+  logic err_bits_fatal_reg_qs;
   logic [31:0] start_addr_wd;
   logic start_addr_we;
   logic fatal_alert_cause_imem_error_qs;
@@ -315,13 +322,14 @@ module otbn_reg_top (
   );
 
 
-  // R[err_code]: V(False)
+  // R[err_bits]: V(False)
 
+  //   F[bad_data_addr]: 0:0
   prim_subreg #(
-    .DW      (32),
+    .DW      (1),
     .SWACCESS("RO"),
-    .RESVAL  (32'h0)
-  ) u_err_code (
+    .RESVAL  (1'h0)
+  ) u_err_bits_bad_data_addr (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
@@ -329,15 +337,190 @@ module otbn_reg_top (
     .wd     ('0  ),
 
     // from internal hardware
-    .de     (hw2reg.err_code.de),
-    .d      (hw2reg.err_code.d ),
+    .de     (hw2reg.err_bits.bad_data_addr.de),
+    .d      (hw2reg.err_bits.bad_data_addr.d ),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (err_code_qs)
+    .qs     (err_bits_bad_data_addr_qs)
+  );
+
+
+  //   F[bad_insn_addr]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_err_bits_bad_insn_addr (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.err_bits.bad_insn_addr.de),
+    .d      (hw2reg.err_bits.bad_insn_addr.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_bits_bad_insn_addr_qs)
+  );
+
+
+  //   F[call_stack]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_err_bits_call_stack (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.err_bits.call_stack.de),
+    .d      (hw2reg.err_bits.call_stack.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_bits_call_stack_qs)
+  );
+
+
+  //   F[illegal_insn]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_err_bits_illegal_insn (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.err_bits.illegal_insn.de),
+    .d      (hw2reg.err_bits.illegal_insn.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_bits_illegal_insn_qs)
+  );
+
+
+  //   F[loop]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_err_bits_loop (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.err_bits.loop.de),
+    .d      (hw2reg.err_bits.loop.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_bits_loop_qs)
+  );
+
+
+  //   F[fatal_imem]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_err_bits_fatal_imem (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.err_bits.fatal_imem.de),
+    .d      (hw2reg.err_bits.fatal_imem.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_bits_fatal_imem_qs)
+  );
+
+
+  //   F[fatal_dmem]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_err_bits_fatal_dmem (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.err_bits.fatal_dmem.de),
+    .d      (hw2reg.err_bits.fatal_dmem.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_bits_fatal_dmem_qs)
+  );
+
+
+  //   F[fatal_reg]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_err_bits_fatal_reg (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.err_bits.fatal_reg.de),
+    .d      (hw2reg.err_bits.fatal_reg.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_bits_fatal_reg_qs)
   );
 
 
@@ -455,7 +638,7 @@ module otbn_reg_top (
     addr_hit[3] = (reg_addr == OTBN_ALERT_TEST_OFFSET);
     addr_hit[4] = (reg_addr == OTBN_CMD_OFFSET);
     addr_hit[5] = (reg_addr == OTBN_STATUS_OFFSET);
-    addr_hit[6] = (reg_addr == OTBN_ERR_CODE_OFFSET);
+    addr_hit[6] = (reg_addr == OTBN_ERR_BITS_OFFSET);
     addr_hit[7] = (reg_addr == OTBN_START_ADDR_OFFSET);
     addr_hit[8] = (reg_addr == OTBN_FATAL_ALERT_CAUSE_OFFSET);
   end
@@ -502,6 +685,13 @@ module otbn_reg_top (
   assign status_dummy_re = addr_hit[5] && reg_re;
 
 
+
+
+
+
+
+
+
   assign start_addr_we = addr_hit[7] & reg_we & ~wr_err;
   assign start_addr_wd = reg_wdata[31:0];
 
@@ -540,7 +730,14 @@ module otbn_reg_top (
       end
 
       addr_hit[6]: begin
-        reg_rdata_next[31:0] = err_code_qs;
+        reg_rdata_next[0] = err_bits_bad_data_addr_qs;
+        reg_rdata_next[1] = err_bits_bad_insn_addr_qs;
+        reg_rdata_next[2] = err_bits_call_stack_qs;
+        reg_rdata_next[3] = err_bits_illegal_insn_qs;
+        reg_rdata_next[4] = err_bits_loop_qs;
+        reg_rdata_next[5] = err_bits_fatal_imem_qs;
+        reg_rdata_next[6] = err_bits_fatal_dmem_qs;
+        reg_rdata_next[7] = err_bits_fatal_reg_qs;
       end
 
       addr_hit[7]: begin

--- a/sw/device/lib/dif/dif_otbn.c
+++ b/sw/device/lib/dif/dif_otbn.c
@@ -8,6 +8,26 @@
 
 #include "otbn_regs.h"  // Generated.
 
+_Static_assert(kDifOtbnErrBitsBadDataAddr ==
+                   (1 << OTBN_ERR_BITS_BAD_DATA_ADDR_BIT),
+               "Layout of error bits changed.");
+_Static_assert(kDifOtbnErrBitsBadInsnAddr ==
+                   (1 << OTBN_ERR_BITS_BAD_INSN_ADDR_BIT),
+               "Layout of error bits changed.");
+_Static_assert(kDifOtbnErrBitsCallStack == (1 << OTBN_ERR_BITS_CALL_STACK_BIT),
+               "Layout of error bits changed.");
+_Static_assert(kDifOtbnErrBitsIllegalInsn ==
+                   (1 << OTBN_ERR_BITS_ILLEGAL_INSN_BIT),
+               "Layout of error bits changed.");
+_Static_assert(kDifOtbnErrBitsLoop == (1 << OTBN_ERR_BITS_LOOP_BIT),
+               "Layout of error bits changed.");
+_Static_assert(kDifOtbnErrBitsFatalImem == (1 << OTBN_ERR_BITS_FATAL_IMEM_BIT),
+               "Layout of error bits changed.");
+_Static_assert(kDifOtbnErrBitsFatalDmem == (1 << OTBN_ERR_BITS_FATAL_DMEM_BIT),
+               "Layout of error bits changed.");
+_Static_assert(kDifOtbnErrBitsFatalReg == (1 << OTBN_ERR_BITS_FATAL_REG_BIT),
+               "Layout of error bits changed.");
+
 /**
  * Data width of big number subset, in bytes.
  */
@@ -213,33 +233,17 @@ dif_otbn_result_t dif_otbn_is_busy(const dif_otbn_t *otbn, bool *busy) {
   return kDifOtbnOk;
 }
 
-dif_otbn_result_t dif_otbn_get_err_code(const dif_otbn_t *otbn,
-                                        dif_otbn_err_code_t *err_code) {
-  if (otbn == NULL || err_code == NULL) {
+dif_otbn_result_t dif_otbn_get_err_bits(const dif_otbn_t *otbn,
+                                        dif_otbn_err_bits_t *err_bits) {
+  if (otbn == NULL || err_bits == NULL) {
     return kDifOtbnBadArg;
   }
 
-  uint32_t err_code_raw =
-      mmio_region_read32(otbn->base_addr, OTBN_ERR_CODE_REG_OFFSET);
+  uint32_t err_bits_raw =
+      mmio_region_read32(otbn->base_addr, OTBN_ERR_BITS_REG_OFFSET);
 
-  // Ensure that all values returned from hardware match explicitly defined
-  // values in the DIF.
-  switch (err_code_raw) {
-    case kDifOtbnErrCodeNoError:
-    case kDifOtbnErrCodeBadDataAddr:
-    case kDifOtbnErrCodeBadInsnAddr:
-    case kDifOtbnErrCodeCallStack:
-    case kDifOtbnErrCodeIllegalInsn:
-    case kDifOtbnErrCodeLoop:
-    case kDifOtbnErrCodeFatalImem:
-    case kDifOtbnErrCodeFatalDmem:
-    case kDifOtbnErrCodeFatalReg:
-      *err_code = (dif_otbn_err_code_t)err_code_raw;
-      return kDifOtbnOk;
-
-    default:
-      return kDifOtbnUnexpectedData;
-  }
+  *err_bits = err_bits_raw;
+  return kDifOtbnOk;
 }
 
 dif_otbn_result_t dif_otbn_imem_write(const dif_otbn_t *otbn,

--- a/sw/device/lib/dif/dif_otbn.h
+++ b/sw/device/lib/dif/dif_otbn.h
@@ -61,41 +61,35 @@ typedef enum dif_otbn_result {
    * This error is recoverable and the operation can be retried after correcting
    * the problem with the argument(s).
    */
-  kDifOtbnBadArg,
-
-  /**
-   * The hardware returned unexpected data.
-   *
-   * This error either indicates malfunctioning hardware, or a mismatch between
-   * software and hardware.
-   */
-  kDifOtbnUnexpectedData,
+  kDifOtbnBadArg
 } dif_otbn_result_t;
 
 /**
- * Error codes received from the hardware.
+ * OTBN Errors
+ *
+ * OTBN uses a bitfield to indicate which errors have been seen. Multiple errors
+ * can be seen at the same time. This enum gives the individual bits that may be
+ * set for different errors.
  */
-typedef enum dif_otbn_err_code {
-  // Keep error codes in sync with the hardware!
-  /** No error occurred. */
-  kDifOtbnErrCodeNoError = 0x0,
+typedef enum dif_otbn_err_bits {
+  kDifOtbnErrBitsNoError = 0,
   /** Load or store to invalid address. */
-  kDifOtbnErrCodeBadDataAddr = 0x1,
+  kDifOtbnErrBitsBadDataAddr = (1 << 0),
   /** Instruction fetch from invalid address. */
-  kDifOtbnErrCodeBadInsnAddr = 0x2,
+  kDifOtbnErrBitsBadInsnAddr = (1 << 1),
   /** Call stack underflow or overflow. */
-  kDifOtbnErrCodeCallStack = 0x3,
+  kDifOtbnErrBitsCallStack = (1 << 2),
   /** Illegal instruction execution attempted */
-  kDifOtbnErrCodeIllegalInsn = 0x4,
+  kDifOtbnErrBitsIllegalInsn = (1 << 3),
   /** LOOP[I] related error */
-  kDifOtbnErrCodeLoop = 0x5,
+  kDifOtbnErrBitsLoop = (1 << 4),
   /** Error seen in Imem read */
-  kDifOtbnErrCodeFatalImem = 0x80,
+  kDifOtbnErrBitsFatalImem = (1 << 5),
   /** Error seen in Dmem read */
-  kDifOtbnErrCodeFatalDmem = 0x81,
-  /** Error seen in RF */
-  kDifOtbnErrCodeFatalReg = 0x82
-} dif_otbn_err_code_t;
+  kDifOtbnErrBitsFatalDmem = (1 << 6),
+  /** Error seen in RF read */
+  kDifOtbnErrBitsFatalReg = (1 << 7)
+} dif_otbn_err_bits_t;
 
 /**
  * OTBN interrupt configuration.
@@ -251,16 +245,15 @@ dif_otbn_result_t dif_otbn_start(const dif_otbn_t *otbn,
 dif_otbn_result_t dif_otbn_is_busy(const dif_otbn_t *otbn, bool *busy);
 
 /**
- * Get the error code set by the device if the operation failed.
+ * Get the error bits set by the device if the operation failed.
  *
  * @param otbn OTBN instance
- * @param[out] err_code The error code returned by the hardware.
+ * @param[out] err_bits The error bits returned by the hardware.
  * @return `kDifOtbnBadArg` if `otbn` or `err_code` is `NULL`,
- *         `kDifOtbnUnexpectedData` if an unexpected/unknown error code is read,
  *         `kDifOtbnOk` otherwise.
  */
-dif_otbn_result_t dif_otbn_get_err_code(const dif_otbn_t *otbn,
-                                        dif_otbn_err_code_t *err_code);
+dif_otbn_result_t dif_otbn_get_err_bits(const dif_otbn_t *otbn,
+                                        dif_otbn_err_bits_t *err_bits);
 
 /**
  * Write an OTBN application into its instruction memory (IMEM)

--- a/sw/device/lib/runtime/otbn.c
+++ b/sw/device/lib/runtime/otbn.c
@@ -63,11 +63,11 @@ otbn_result_t otbn_busy_wait_for_done(otbn_t *ctx) {
     }
   }
 
-  dif_otbn_err_code_t err_code;
-  if (dif_otbn_get_err_code(&ctx->dif, &err_code) != kDifOtbnOk) {
+  dif_otbn_err_bits_t err_bits;
+  if (dif_otbn_get_err_bits(&ctx->dif, &err_bits) != kDifOtbnOk) {
     return kOtbnError;
   }
-  if (err_code != kDifOtbnErrCodeNoError) {
+  if (err_bits != kDifOtbnErrBitsNoError) {
     return kOtbnExecutionFailed;
   }
   return kOtbnOk;

--- a/sw/device/tests/dif/dif_otbn_smoketest.c
+++ b/sw/device/tests/dif/dif_otbn_smoketest.c
@@ -194,16 +194,16 @@ static void zero_dmem(void) {
 }
 
 /**
- * Get OTBN error code, check this succeeds and code matches `expected_err_code`
+ * Get OTBN error bits, check this succeeds and code matches `expected_err_bits`
  */
-static void check_otbn_err_code(dif_otbn_err_code_t expected_err_code) {
-  LOG_INFO("Checking error code");
-  dif_otbn_err_code_t otbn_err_code;
-  dif_otbn_result_t rv = dif_otbn_get_err_code(&otbn, &otbn_err_code);
-  CHECK(rv == kDifOtbnOk, "dif_otbn_get_err_code() failed: %d", rv);
-  CHECK(otbn_err_code == expected_err_code,
-        "dif_otbn_get_err_code() produced unexpected error code: %d",
-        otbn_err_code);
+static void check_otbn_err_bits(dif_otbn_err_bits_t expected_err_bits) {
+  LOG_INFO("Checking error bits");
+  dif_otbn_err_bits_t otbn_err_bits;
+  dif_otbn_result_t rv = dif_otbn_get_err_bits(&otbn, &otbn_err_bits);
+  CHECK(rv == kDifOtbnOk, "dif_otbn_get_err_bits() failed: %d", rv);
+  CHECK(otbn_err_bits == expected_err_bits,
+        "dif_otbn_get_err_bits() produced unexpected error bits: %x",
+        otbn_err_bits);
 }
 
 /**
@@ -276,7 +276,7 @@ static void test_barrett384(void) {
   LOG_INFO("Function execution on OTBN took %d cycles (end-to-end).",
            t_end - t_start);
 
-  check_otbn_err_code(kDifOtbnErrCodeNoError);
+  check_otbn_err_bits(kDifOtbnErrBitsNoError);
 
   LOG_INFO("Reading back result (c)");
   dif_otbn_dmem_read(&otbn, 512, &c, sizeof(c));
@@ -291,8 +291,8 @@ static void test_barrett384(void) {
 /**
  * Run err_test on OTBN and check it produces the expected error
  *
- * This test tries to load from an invalid address which should result in a
- * kDifOtbnErrCodeBadDataAddr error code
+ * This test tries to load from an invalid address which should result in the
+ * kDifOtbnErrBitsBadDataAddr error bit being set
  *
  * The code executed on OTBN can be found in sw/otbn/code-snippets/err_test.s.
  * The entry point wrap_err_test() is called, no arguments are passed or results
@@ -312,7 +312,7 @@ static void test_err_test(void) {
   LOG_INFO("Function execution on OTBN took %d cycles (end-to-end).",
            t_end - t_start);
 
-  check_otbn_err_code(kDifOtbnErrCodeBadDataAddr);
+  check_otbn_err_bits(kDifOtbnErrBitsBadDataAddr);
 }
 
 bool test_main() {

--- a/sw/device/tests/dif/dif_otbn_unittest.cc
+++ b/sw/device/tests/dif/dif_otbn_unittest.cc
@@ -293,44 +293,32 @@ TEST_F(IsBusyTest, Success) {
   EXPECT_EQ(busy, true);
 }
 
-class GetErrCodeTest : public OtbnTest {};
+class GetErrBitsTest : public OtbnTest {};
 
-TEST_F(GetErrCodeTest, NullArgs) {
+TEST_F(GetErrBitsTest, NullArgs) {
   dif_otbn_result_t result;
-  dif_otbn_err_code_t err_code;
+  dif_otbn_err_bits_t err_bits;
 
-  result = dif_otbn_get_err_code(nullptr, nullptr);
+  result = dif_otbn_get_err_bits(nullptr, nullptr);
   EXPECT_EQ(result, kDifOtbnBadArg);
 
-  result = dif_otbn_get_err_code(&dif_otbn_, nullptr);
+  result = dif_otbn_get_err_bits(&dif_otbn_, nullptr);
   EXPECT_EQ(result, kDifOtbnBadArg);
 
-  err_code = kDifOtbnErrCodeBadDataAddr;
-  result = dif_otbn_get_err_code(nullptr, &err_code);
+  err_bits = kDifOtbnErrBitsBadDataAddr;
+  result = dif_otbn_get_err_bits(nullptr, &err_bits);
   EXPECT_EQ(result, kDifOtbnBadArg);
-  EXPECT_EQ(err_code, kDifOtbnErrCodeBadDataAddr);
+  EXPECT_EQ(err_bits, kDifOtbnErrBitsBadDataAddr);
 }
 
-TEST_F(GetErrCodeTest, Success) {
-  EXPECT_READ32(OTBN_ERR_CODE_REG_OFFSET, kDifOtbnErrCodeBadDataAddr);
+TEST_F(GetErrBitsTest, Success) {
+  EXPECT_READ32(OTBN_ERR_BITS_REG_OFFSET,
+                kDifOtbnErrBitsIllegalInsn | kDifOtbnErrBitsFatalReg);
 
-  dif_otbn_err_code_t err_code;
-  dif_otbn_result_t result = dif_otbn_get_err_code(&dif_otbn_, &err_code);
+  dif_otbn_err_bits_t err_bits;
+  dif_otbn_result_t result = dif_otbn_get_err_bits(&dif_otbn_, &err_bits);
   EXPECT_EQ(result, kDifOtbnOk);
-  EXPECT_EQ(err_code, kDifOtbnErrCodeBadDataAddr);
-}
-
-TEST_F(GetErrCodeTest, HardwareReturnsUnknownErrorCode) {
-  // Fragile test ahead! False positives possible if "1234" becomes a valid
-  // error code.
-  EXPECT_READ32(OTBN_ERR_CODE_REG_OFFSET, 1234);
-
-  dif_otbn_err_code_t err_code = kDifOtbnErrCodeBadDataAddr;
-  dif_otbn_result_t result = dif_otbn_get_err_code(&dif_otbn_, &err_code);
-  EXPECT_EQ(result, kDifOtbnUnexpectedData);
-
-  // Should stay unchanged.
-  EXPECT_EQ(err_code, kDifOtbnErrCodeBadDataAddr);
+  EXPECT_EQ(err_bits, kDifOtbnErrBitsIllegalInsn | kDifOtbnErrBitsFatalReg);
 }
 
 class ImemWriteTest : public OtbnTest {};


### PR DESCRIPTION
This replaces the `ERR_CODE` register with an `ERR_BITS` register. This
is a bitfield where a particular bit signals a particular error. The
commit includes all RTL, documentation and software updates needed.

For the ISS this commit alters the error codes it uses to match the
`ERR_BITS` encoding but further work is required so the ISS can produce
several errors at once.

For now the RTL continues to prioritise errors and will only signal a
single error. This is to ease the transition to the use of `ERR_BITS`
whilst the ISS changes are still needed. The RTL will drop the
prioritising and will be capable of signalling several errors at once
when the ISS is ready to deal with this.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>