### PR TITLE
[keymgr/dv] Add sideload key check

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_env.core
+++ b/hw/ip/keymgr/dv/env/keymgr_env.core
@@ -11,8 +11,8 @@ filesets:
       - lowrisc:dv:cip_lib
       - lowrisc:dv:keymgr_kmac_agent
     files:
-      - keymgr_if.sv
       - keymgr_env_pkg.sv
+      - keymgr_if.sv
       - keymgr_env_cfg.sv: {is_include_file: true}
       - keymgr_env_cov.sv: {is_include_file: true}
       - keymgr_virtual_sequencer.sv: {is_include_file: true}

--- a/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
@@ -24,6 +24,7 @@ package keymgr_env_pkg;
   parameter uint DIGEST_SHARE_WORD_NUM = keymgr_pkg::KeyWidth / TL_DW;
 
   typedef virtual keymgr_if keymgr_vif;
+  typedef bit [keymgr_pkg::Shares-1:0][keymgr_pkg::KeyWidth-1:0] key_shares_t;
   typedef enum {
     IntrOpDone,
     NumKeyMgrIntr

--- a/hw/ip/keymgr/dv/env/keymgr_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_if.sv
@@ -17,12 +17,25 @@ interface keymgr_if(input clk, input rst_n);
   keymgr_pkg::hw_key_req_t hmac_key;
   keymgr_pkg::hw_key_req_t aes_key;
 
-  keymgr_pkg::hw_key_req_t kmac_key_exp;
-  keymgr_pkg::hw_key_req_t hmac_key_exp;
-  keymgr_pkg::hw_key_req_t aes_key_exp;
+  keymgr_pkg::hw_key_req_t kmac_key_exp = '0;
+  keymgr_pkg::hw_key_req_t hmac_key_exp = '0;
+  keymgr_pkg::hw_key_req_t aes_key_exp = '0;
 
-  // indicate keymgr entered disabled directly. kmac_key are wiped, don't check output it
-  bit direct_to_disabled;
+  // connect KDF interface for assertion check
+  wire keymgr_pkg::kmac_data_req_t kmac_data_req;
+  wire keymgr_pkg::kmac_data_rsp_t kmac_data_rsp;
+
+  // indicate if check the key is same as expected or shouldn't match to any meaningful key
+  bit is_kmac_key_good = 0;
+  bit is_hmac_key_good = 0;
+  bit is_aes_key_good = 0;
+
+  // when kmac sideload key is generated, kmac may be used to do other OP, but once the OP is done,
+  // it should automatically switch back to sideload key
+  bit is_kmac_sideload_avail = 0;
+  keymgr_env_pkg::key_shares_t kmac_sideload_key_shares;
+
+  keymgr_env_pkg::key_shares_t keys_a_array[string][string];
 
   string msg_id = "keymgr_if";
 
@@ -31,7 +44,7 @@ interface keymgr_if(input clk, input rst_n);
     // the key manager comes out of reset.
     // The power/reset manager ensures that
     // this sequencing is correct.
-    keymgr_en = lc_ctrl_pkg::Off;
+    keymgr_en = lc_ctrl_pkg::lc_tx_t'($urandom);
 
     // async delay as these signals are from different clock domain
     #($urandom_range(1000, 0) * 1ns);
@@ -40,7 +53,6 @@ interface keymgr_if(input clk, input rst_n);
     otp_hw_cfg.data.device_id = 'hF0F0;
     otp_key = otp_ctrl_pkg::OTP_KEYMGR_KEY_DEFAULT;
     flash   = flash_ctrl_pkg::KEYMGR_FLASH_DEFAULT;
-    direct_to_disabled = 0;
   endtask
 
   // randomize otp, lc, flash input data
@@ -74,35 +86,105 @@ interface keymgr_if(input clk, input rst_n);
     flash   = local_flash;
   endtask
 
-  task automatic update_exp_key(bit [keymgr_pkg::Shares-1:0][keymgr_pkg::KeyWidth-1:0] key_shares,
-                                keymgr_pkg::keymgr_key_dest_e dest = keymgr_pkg::Kmac);
+  // update kmac key for comparison during KDF
+  function automatic void update_kdf_key(keymgr_env_pkg::key_shares_t key_shares,
+                                         keymgr_pkg::keymgr_working_state_e state,
+                                         bit good_key = 1);
+
+    kmac_key_exp <= '{1'b1, key_shares[0], key_shares[1]};
+    is_kmac_key_good = good_key;
+  endfunction
+
+  // store internal key once it's available and use to compare if future OP is invalid
+  function automatic void store_internal_key(keymgr_env_pkg::key_shares_t key_shares,
+                                             keymgr_pkg::keymgr_working_state_e state);
+
+    keys_a_array[state.name]["Internal"] = key_shares;
+  endfunction
+
+  // update sideload key for comparison
+  // if it's good key, store it to compare for future invalid OP
+  function automatic void update_sideload_key(keymgr_env_pkg::key_shares_t key_shares,
+                                              keymgr_pkg::keymgr_working_state_e state,
+                                              keymgr_pkg::keymgr_key_dest_e dest = keymgr_pkg::Kmac,
+                                              bit good_key = 1);
     case (dest)
       keymgr_pkg::Kmac: begin
-        kmac_key_exp = '{1'b1, key_shares[0], key_shares[1]};
+        kmac_key_exp             <= '{1'b1, key_shares[0], key_shares[1]};
+        is_kmac_key_good         <= good_key;
+        is_kmac_sideload_avail   <= 1;
+        kmac_sideload_key_shares <= key_shares;
       end
       keymgr_pkg::Hmac: begin
-        hmac_key_exp = '{1'b1, key_shares[0], key_shares[1]};
+        hmac_key_exp     <= '{1'b1, key_shares[0], key_shares[1]};
+        is_hmac_key_good <= good_key;
       end
       keymgr_pkg::Aes: begin
-        aes_key_exp = '{1'b1, key_shares[0], key_shares[1]};
+        aes_key_exp     <= '{1'b1, key_shares[0], key_shares[1]};
+        is_aes_key_good <= good_key;
       end
       default: `uvm_fatal("keymgr_if", $sformatf("Unexpect dest type %0s", dest.name))
     endcase
-  endtask
 
-  task automatic enter_disabled_directly();
-    direct_to_disabled = 1;
-  endtask
-  // TODO kmac_key only last until done signal is set. Fix this later
-  //`ASSERT(KmacKeyStable, $stable(kmac_key_exp) && $stable(direct_to_disabled) |=> $stable(kmac_key),
-  //    clk, !rst_n)
-  //`ASSERT(KmacKeyUpdate, !$stable(kmac_key_exp) |=> kmac_key == kmac_key_exp,
-  //    clk, !rst_n && !direct_to_disabled)
+    if (good_key) keys_a_array[state.name][dest.name]  = key_shares;
+  endfunction
 
-  `ASSERT(HmacKeyStable, $stable(hmac_key_exp) |=> $stable(hmac_key), clk, !rst_n)
-  `ASSERT(HmacKeyUpdate, !$stable(hmac_key_exp) |=> hmac_key == hmac_key_exp, clk, !rst_n)
+  // if kmac sideload key is available, switch to it after an operation is completed
+  // if not available, de-assert valid after done is asserted
+  initial begin
+    forever begin
+      @(posedge clk);
+      if (kmac_data_rsp.done) begin
+        if (is_kmac_sideload_avail) begin
+          kmac_key_exp <= '{1'b1, kmac_sideload_key_shares[0], kmac_sideload_key_shares[1]};
+          is_kmac_key_good <= 1;
+        end else begin
+          kmac_key_exp.valid <= 0;
+        end
+      end // kmac_data_rsp.done
+    end // forever
+  end
 
-  `ASSERT(AesKeyStable, $stable(aes_key_exp) |=> $stable(aes_key), clk, !rst_n)
-  `ASSERT(AesKeyUpdate, !$stable(aes_key_exp) |=> aes_key == aes_key_exp, clk, !rst_n)
+  // check if key is invalid, it should not match to any of the meaningful keys
+  initial begin
+    fork
+      forever begin
+        @(posedge clk);
+        if (!is_kmac_key_good) check_invalid_key(kmac_key, "KMAC");
+      end
+      forever begin
+        @(posedge clk);
+        if (!is_hmac_key_good) check_invalid_key(hmac_key, "HMAC");
+      end
+      forever begin
+        @(posedge clk);
+        if (!is_aes_key_good) check_invalid_key(aes_key, "AES");
+      end
+    join
+  end
 
+  function automatic void check_invalid_key(keymgr_pkg::hw_key_req_t act_key, string key_name);
+    if (rst_n && act_key.valid) begin
+      foreach (keys_a_array[i, j]) begin
+        `DV_CHECK_NE({act_key.key_share1, act_key.key_share0}, keys_a_array[i][j],
+            $sformatf("%s key at state %s from %s", key_name, i, j), , msg_id)
+      end
+    end
+  endfunction
+
+  `define KM_ASSERT(NAME, SEQ) \
+    `ASSERT(NAME, SEQ, clk, !rst_n || keymgr_en != lc_ctrl_pkg::On)
+
+  `KM_ASSERT(CheckKmacKey, is_kmac_key_good && kmac_key_exp.valid -> kmac_key == kmac_key_exp)
+
+  `KM_ASSERT(CheckKmacKeyValid, kmac_key_exp.valid == kmac_key.valid)
+
+  // TODO update hmac and aes checker later
+  //`KM_ASSERT(HmacKeyStable, $stable(hmac_key_exp) |=> $stable(hmac_key))
+  //`KM_ASSERT(HmacKeyUpdate, !$stable(hmac_key_exp) |=> hmac_key == hmac_key_exp)
+
+  //`KM_ASSERT(AesKeyStable, $stable(aes_key_exp) |=> $stable(aes_key))
+  //`KM_ASSERT(AesKeyUpdate, !$stable(aes_key_exp) |=> aes_key == aes_key_exp)
+
+  `undef KM_ASSERT
 endinterface

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_cfgen_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_cfgen_vseq.sv
@@ -26,7 +26,7 @@ class keymgr_cfgen_vseq extends keymgr_random_vseq;
     // randomly add 0-100 cycle delay, backdoor check op_status again
     // When status is still OpWip, call write_cfgen_gated_reg and the write will be ignored
     while (!regular_vseq_done) begin
-      bit [TL_DW-1] op_status_val, cfgen_val;
+      bit [TL_DW-1:0] op_status_val, cfgen_val;
       uint delay;
 
       forever begin
@@ -57,7 +57,7 @@ class keymgr_cfgen_vseq extends keymgr_random_vseq;
   endtask
 
   virtual task write_cfgen_gated_reg();
-    bit [TL_DW-1] val = $urandom;
+    bit [TL_DW-1:0] val = $urandom;
 
     `uvm_info(`gfn, "Write cfgen gated reg, and this write should be ignored", UVM_HIGH)
     // since it's timing sensitive, only write one of these reg

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_lc_disable_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_lc_disable_vseq.sv
@@ -54,7 +54,7 @@ class keymgr_lc_disable_vseq extends keymgr_random_vseq;
         cfg.clk_rst_vif.wait_clks(delay_cycles);
 
         forever begin
-          bit [TL_DW-1] op_status_val;
+          bit [TL_DW-1:0] op_status_val;
           csr_rd(ral.op_status, op_status_val);
 
           if (op_status_val == keymgr_pkg::OpWip) break;

--- a/hw/ip/keymgr/dv/tb.sv
+++ b/hw/ip/keymgr/dv/tb.sv
@@ -26,6 +26,10 @@ module tb;
   keymgr_kmac_intf keymgr_kmac_intf(.clk(clk), .rst_n(rst_n));
   push_pull_if #(.DeviceDataWidth(cip_base_pkg::EDN_DATA_WIDTH)) edn_if(.clk(clk), .rst_n(rst_n));
 
+  // connect KDF interface for assertion check
+  assign keymgr_if.kmac_data_req = keymgr_kmac_intf.kmac_data_req;
+  assign keymgr_if.kmac_data_rsp = keymgr_kmac_intf.kmac_data_rsp;
+
   `DV_ALERT_IF_CONNECT
 
   // dut


### PR DESCRIPTION
1. Add sideload key check in interface in order to check the duration as
well
2. create a `get_err_code` function and simpilfy some logic in scb
3. store generated meaningful key in interface to compare with invalid
keys generated by error cases
4. fix some typos in cfgen_vseq and lc_disable_vseq

Signed-off-by: Weicai Yang <weicai@google.com>