### PR TITLE
[keymgr] Fix a combo loop between keymgr and kmac

### DIFF
--- a/hw/ip/keymgr/rtl/keymgr_sideload_key_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_sideload_key_ctrl.sv
@@ -74,7 +74,6 @@ module keymgr_sideload_key_ctrl import keymgr_pkg::*;(
       StSideloadIdle: begin
         keys_en = 1'b1;
         if (wipe_key_i || clr_key_i) begin
-          keys_en = 1'b0;
           state_d = wipe_key_i ? StSideloadWipe : StSideloadClear;
         end
       end


### PR DESCRIPTION
The path was roughly...
keymgr.key_valid -> kmac.error -> keymgr.wipe_key -> keymgr.key_valid

This fix breaks the last arrow.

Signed-off-by: Timothy Chen <timothytim@google.com>