### PR TITLE
[otp/pwrmgr/top] VCS-related fixes for simulation with closed-source simulation models

### DIFF
--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -62,7 +62,8 @@
                "+define+UVM_REGEX_NO_DPI",
                "+define+UVM_REG_ADDR_WIDTH={tl_aw}",
                "+define+UVM_REG_DATA_WIDTH={tl_dw}",
-               "+define+UVM_REG_BYTENABLE_WIDTH={tl_dbw}"]
+               "+define+UVM_REG_BYTENABLE_WIDTH={tl_dbw}",
+               "+define+SIMULATION"]
 
   run_opts: ["+UVM_NO_RELNOTES",
              "+UVM_VERBOSITY={expand_uvm_verbosity_{verbosity}}"]

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -156,14 +156,14 @@ package otp_ctrl_pkg;
   parameter otp_lc_data_t OTP_LC_DATA_DEFAULT = '{
     valid: 1'b1,
     error: 1'b0,
-    state: '0,
-    count: '0,
+    state: lc_ctrl_pkg::LcStRaw,
+    count: lc_ctrl_pkg::LcCntRaw,
     all_zero_token: '0,
     raw_unlock_token: '0,
     test_unlock_token: '0,
     test_exit_token: '0,
     rma_token: '0,
-    id_state: '0
+    id_state: lc_ctrl_pkg::LcIdBlank
   };
 
   typedef struct packed {

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -84,10 +84,6 @@
   uvm_test_seq: chip_sw_base_vseq
   sw_build_device: sim_dv
 
-  // Add default build_opts.
-  build_opts: [// Use generic implementations of prim modules.
-               "+define+PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric"]
-
   // Add build modes.
   build_modes: [
     {

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -81,13 +81,6 @@ parameters:
   SYNTHESIS:
     datatype: bool
     paramtype: vlogdefine
-  # For value definition, please see ip/prim/rtl/prim_pkg.sv
-  PRIM_DEFAULT_IMPL:
-    datatype: str
-    paramtype: vlogdefine
-    description: Primitives implementation to use, e.g. "prim_pkg::ImplGeneric".
-    default: prim_pkg::ImplGeneric
-
 
 targets:
   default: &default_target
@@ -96,16 +89,12 @@ targets:
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
       - files_rtl_generic
-    parameters:
-      - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
     toplevel: top_earlgrey
 
   sim:
     default_tool: icarus
     filesets:
       - files_rtl_generic
-    parameters:
-      - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
     toplevel: top_earlgrey
 
   lint:

--- a/hw/top_earlgrey/top_earlgrey_asic.core
+++ b/hw/top_earlgrey/top_earlgrey_asic.core
@@ -47,8 +47,6 @@ targets:
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
       - files_rtl
-    parameters:
-      - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
     toplevel: top_earlgrey_asic
 
   lint:


### PR DESCRIPTION
This PR contains a couple of VCS related fixes to get compilation going with closed-source sim models. 
In particular:
- This fixes a couple of  VCS / lint warnings and errors that I encountered when setting up a chip-level VCS target with closed source simulation models.
- `PRIM_DEFAULT_IMPL` assignments that set this define to `ImplGeneric` in dvsim config and core files are removed since they are not strictly required and interfere with the target specific overrides in dvsim.
- Also, it this PR adds the `SIMULATION` define to `common_sim_cfg.hjson` such that closed source simulation models are included.