### PR TITLE
[aes] Add status bit indicating lost output data in manual mode

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -489,18 +489,30 @@
           The AES unit is not stalled (0) or stalled (1) because there is previous
           output data that must be read by the processor before the AES unit can
           overwrite this data.
-          This flag not meaningful if MANUAL_OPERATION=1 (see Control Register).
+          This flag is not meaningful if MANUAL_OPERATION=1 (see Control Register).
         '''
         tags: ["excl:CsrNonInitTests:CsrExclCheck"]
       }
       { bits: "2",
+        name: "OUTPUT_LOST",
+        hwaccess: "hrw",
+        desc:  '''
+          All previous output data has been fully read by the processor (0) or at least one previous output data block has been lost (1).
+          It has been overwritten by the AES unit before the processor could fully read it.
+          Once set to `1`, this flag remains set until AES operation is restarted by successfully updating the Control Register.
+          The primary use of this flag is for design verification.
+          This flag is not meaningful if MANUAL_OPERATION=0 (see Control Register).
+        '''
+        tags: ["excl:CsrNonInitTests:CsrExclCheck"]
+      }
+      { bits: "3",
         name: "OUTPUT_VALID",
         desc:  '''
           The AES unit has no valid output (0) or has valid output data (1).
         '''
         tags: ["excl:CsrNonInitTests:CsrExclCheck"]
       }
-      { bits: "3",
+      { bits: "4",
         name: "INPUT_READY",
         resval: "1",
         desc:  '''
@@ -510,7 +522,7 @@
         '''
         tags: ["excl:CsrNonInitTests:CsrExclCheck"]
       }
-      { bits: "4",
+      { bits: "5",
         name: "ALERT_RECOVERABLE",
         resval: "0",
         desc:  '''
@@ -520,7 +532,7 @@
         '''
         tags: ["excl:CsrNonInitTests:CsrExclCheck"]
       }
-      { bits: "5",
+      { bits: "6",
         name: "ALERT_FATAL",
         resval: "0",
         desc:  '''

--- a/hw/ip/aes/dv/env/aes_env_pkg.sv
+++ b/hw/ip/aes/dv/env/aes_env_pkg.sv
@@ -46,11 +46,12 @@ package aes_env_pkg;
   } cfg_error_type_t;
 
   typedef struct packed {
-    logic [31:6] unused;
+    logic [31:7] unused;
     logic        alert_fatal;
     logic        alert_recoverable;
     logic        input_ready;
     logic        output_valid;
+    logic        output_lost;
     logic        stall;
     logic        idle;
   } status_t;

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -356,7 +356,8 @@ class aes_scoreboard extends cip_base_scoreboard #(
           // and no output is ready
           // there won't be a response for this item
           // reset/clear was triggered
-          if (item.d_data[3:0] == 4'b1001) begin
+          if (get_field_val(ral.status.idle, item.d_data) &&
+              get_field_val(ral.status.output_lost, item.d_data)) begin
             if (rcv_item_q.size() != 0) begin
               void'(rcv_item_q.pop_back());
               `uvm_info(`gfn, $sformatf("\n\t ----| removing item from input queue"), UVM_MEDIUM)
@@ -580,10 +581,11 @@ class aes_scoreboard extends cip_base_scoreboard #(
 
     super.report_phase(phase);
     txt = $sformatf("\n\t ----|        TEST FINISHED        |----");
-    txt = {   txt, $sformatf("\n\t Saw %d Good messages ", good_cnt)};
-    txt = {   txt, $sformatf("\n\t Skipped %d messages " , skipped_cnt)};
-    txt = {   txt, $sformatf("\n\t Split %d messages "   , cfg.split_cnt)};
-    txt = {   txt, $sformatf("\n\t Expected %d messages ", cfg.num_messages)};
+    txt = { txt, $sformatf("\n\t Saw %d Good messages  ", good_cnt)};
+    txt = { txt, $sformatf("\n\t Skipped %d messages  " , skipped_cnt)};
+    txt = { txt, $sformatf("\n\t Split %d messages  "   , cfg.split_cnt)};
+    txt = { txt, $sformatf("\n\t Expected %d messages  ", cfg.num_messages)};
+    txt = { txt, $sformatf("\n\t Expected %d corrupted ", cfg.num_corrupt_messages)};
     rpt_srvr = uvm_report_server::get_server();
     if (rpt_srvr.get_severity_count(UVM_FATAL)+rpt_srvr.get_severity_count(UVM_ERROR)>0) begin
       `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -98,7 +98,10 @@ module aes_control
   output logic                    idle_o,
   output logic                    idle_we_o,
   output logic                    stall_o,
-  output logic                    stall_we_o
+  output logic                    stall_we_o,
+  input  logic                    output_lost_i,
+  output logic                    output_lost_o,
+  output logic                    output_lost_we_o
 );
 
   import aes_pkg::*;
@@ -647,6 +650,13 @@ module aes_control
       output_valid_q <= output_valid_o;
     end
   end
+
+  // Output lost status register bit
+  // Cleared when updating the Control Register. Set when overwriting previous output data that has
+  // not yet been read.
+  assign output_lost_o    = ctrl_we_o     ? 1'b0 :
+                            output_lost_i ? 1'b1 : output_valid_q & ~data_out_read;
+  assign output_lost_we_o = ctrl_we_o | data_out_we_o;
 
   // Trigger register, the control only ever clears these
   assign start_o                = 1'b0;

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -560,7 +560,10 @@ module aes_core
     .idle_o                    ( hw2reg.status.idle.d                   ),
     .idle_we_o                 ( hw2reg.status.idle.de                  ),
     .stall_o                   ( hw2reg.status.stall.d                  ),
-    .stall_we_o                ( hw2reg.status.stall.de                 )
+    .stall_we_o                ( hw2reg.status.stall.de                 ),
+    .output_lost_i             ( reg2hw.status.output_lost.q            ),
+    .output_lost_o             ( hw2reg.status.output_lost.d            ),
+    .output_lost_we_o          ( hw2reg.status.output_lost.de           )
   );
 
   // Input data register clear

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -94,6 +94,12 @@ package aes_reg_pkg;
     } prng_reseed;
   } aes_reg2hw_trigger_reg_t;
 
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } output_lost;
+  } aes_reg2hw_status_reg_t;
+
 
   typedef struct packed {
     logic [31:0] d;
@@ -165,6 +171,10 @@ package aes_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
+    } output_lost;
+    struct packed {
+      logic        d;
+      logic        de;
     } output_valid;
     struct packed {
       logic        d;
@@ -185,28 +195,29 @@ package aes_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    aes_reg2hw_alert_test_reg_t alert_test; // [948:945]
-    aes_reg2hw_key_share0_mreg_t [7:0] key_share0; // [944:681]
-    aes_reg2hw_key_share1_mreg_t [7:0] key_share1; // [680:417]
-    aes_reg2hw_iv_mreg_t [3:0] iv; // [416:285]
-    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [284:153]
-    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [152:21]
-    aes_reg2hw_ctrl_shadowed_reg_t ctrl_shadowed; // [20:4]
-    aes_reg2hw_trigger_reg_t trigger; // [3:0]
+    aes_reg2hw_alert_test_reg_t alert_test; // [949:946]
+    aes_reg2hw_key_share0_mreg_t [7:0] key_share0; // [945:682]
+    aes_reg2hw_key_share1_mreg_t [7:0] key_share1; // [681:418]
+    aes_reg2hw_iv_mreg_t [3:0] iv; // [417:286]
+    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [285:154]
+    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [153:22]
+    aes_reg2hw_ctrl_shadowed_reg_t ctrl_shadowed; // [21:5]
+    aes_reg2hw_trigger_reg_t trigger; // [4:1]
+    aes_reg2hw_status_reg_t status; // [0:0]
   } aes_reg2hw_t;
 
   ///////////////////////////////////////
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    aes_hw2reg_key_share0_mreg_t [7:0] key_share0; // [931:676]
-    aes_hw2reg_key_share1_mreg_t [7:0] key_share1; // [675:420]
-    aes_hw2reg_iv_mreg_t [3:0] iv; // [419:292]
-    aes_hw2reg_data_in_mreg_t [3:0] data_in; // [291:160]
-    aes_hw2reg_data_out_mreg_t [3:0] data_out; // [159:32]
-    aes_hw2reg_ctrl_shadowed_reg_t ctrl_shadowed; // [31:20]
-    aes_hw2reg_trigger_reg_t trigger; // [19:12]
-    aes_hw2reg_status_reg_t status; // [11:0]
+    aes_hw2reg_key_share0_mreg_t [7:0] key_share0; // [933:678]
+    aes_hw2reg_key_share1_mreg_t [7:0] key_share1; // [677:422]
+    aes_hw2reg_iv_mreg_t [3:0] iv; // [421:294]
+    aes_hw2reg_data_in_mreg_t [3:0] data_in; // [293:162]
+    aes_hw2reg_data_out_mreg_t [3:0] data_out; // [161:34]
+    aes_hw2reg_ctrl_shadowed_reg_t ctrl_shadowed; // [33:22]
+    aes_hw2reg_trigger_reg_t trigger; // [21:14]
+    aes_hw2reg_status_reg_t status; // [13:0]
   } aes_hw2reg_t;
 
   // Register Address

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -161,6 +161,7 @@ module aes_reg_top (
   logic trigger_prng_reseed_we;
   logic status_idle_qs;
   logic status_stall_qs;
+  logic status_output_lost_qs;
   logic status_output_valid_qs;
   logic status_input_ready_qs;
   logic status_alert_recoverable_qs;
@@ -928,7 +929,32 @@ module aes_reg_top (
   );
 
 
-  //   F[output_valid]: 2:2
+  //   F[output_lost]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_status_output_lost (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.status.output_lost.de),
+    .d      (hw2reg.status.output_lost.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.status.output_lost.q ),
+
+    // to register interface (read)
+    .qs     (status_output_lost_qs)
+  );
+
+
+  //   F[output_valid]: 3:3
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RO"),
@@ -953,7 +979,7 @@ module aes_reg_top (
   );
 
 
-  //   F[input_ready]: 3:3
+  //   F[input_ready]: 4:4
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RO"),
@@ -978,7 +1004,7 @@ module aes_reg_top (
   );
 
 
-  //   F[alert_recoverable]: 4:4
+  //   F[alert_recoverable]: 5:5
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RO"),
@@ -1003,7 +1029,7 @@ module aes_reg_top (
   );
 
 
-  //   F[alert_fatal]: 5:5
+  //   F[alert_fatal]: 6:6
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RO"),
@@ -1230,6 +1256,7 @@ module aes_reg_top (
 
 
 
+
   // Read data return
   always_comb begin
     reg_rdata_next = '0;
@@ -1369,10 +1396,11 @@ module aes_reg_top (
       addr_hit[31]: begin
         reg_rdata_next[0] = status_idle_qs;
         reg_rdata_next[1] = status_stall_qs;
-        reg_rdata_next[2] = status_output_valid_qs;
-        reg_rdata_next[3] = status_input_ready_qs;
-        reg_rdata_next[4] = status_alert_recoverable_qs;
-        reg_rdata_next[5] = status_alert_fatal_qs;
+        reg_rdata_next[2] = status_output_lost_qs;
+        reg_rdata_next[3] = status_output_valid_qs;
+        reg_rdata_next[4] = status_input_ready_qs;
+        reg_rdata_next[5] = status_alert_recoverable_qs;
+        reg_rdata_next[6] = status_alert_fatal_qs;
       end
 
       default: begin


### PR DESCRIPTION
This PR adds a new status bit `OUTPUT_LOST` indicating if previous output data has been overwritten by the AES unit before it could be read by the processor. Once set, the flag remains high until AES operation is restarted by updating the Control Register. The primary use of this flag is design verification of manual mode operation.