### PR TITLE
[otbn] Teach RIG to generate BEQ and BNE instructions

### DIFF
--- a/hw/ip/otbn/util/otbn-rig
+++ b/hw/ip/otbn/util/otbn-rig
@@ -19,7 +19,7 @@ from shared.insn_yaml import InsnsFile, load_insns_yaml
 sys.path.append(os.path.dirname(__file__))
 
 from rig.init_data import InitData  # noqa: E402
-from rig.rig import gen_program, snippets_to_program  # noqa: E402
+from rig.rig import gen_program  # noqa: E402
 from rig.snippet import Snippet  # noqa: E402
 
 
@@ -41,12 +41,12 @@ def gen_main(args: argparse.Namespace) -> int:
         return 1
 
     # Run the generator
-    init_data, snippets = gen_program(args.start_addr, args.size, insns_file)
+    init_data, snippet = gen_program(args.start_addr, args.size, insns_file)
 
     # Write out the data and snippets to a JSON file
     ser_data = init_data.as_json()
-    ser_snippets = [snippet.to_json() for snippet in snippets]
-    ser = [ser_data, ser_snippets]
+    ser_snippet = snippet.to_json()
+    ser = [ser_data, ser_snippet]
     try:
         if args.output == '-':
             json.dump(ser, sys.stdout)
@@ -86,17 +86,16 @@ def asm_main(args: argparse.Namespace) -> int:
         if not (isinstance(json_data, list) and len(json_data) == 2):
             raise ValueError('Top-level structure should be a length 2 list.')
 
-        json_init_data, json_snippets = json_data
+        json_init_data, json_snippet = json_data
         init_data = InitData.read(json_init_data)
-        snippets = [Snippet.from_json(insns_file, idx, x)
-                    for idx, x in enumerate(json_snippets)]
+        snippet = Snippet.from_json(insns_file, [], json_snippet)
     except ValueError as err:
         print('Failed to parse snippets from {!r}: {}'
               .format(args.snippets.name, err),
               file=sys.stderr)
         return 1
 
-    program = snippets_to_program(snippets)
+    program = snippet.to_program()
     dsegs = init_data.as_segs()
 
     # Dump the assembly output, and the linker script too if we're writing to

--- a/hw/ip/otbn/util/rig/gens/branch.py
+++ b/hw/ip/otbn/util/rig/gens/branch.py
@@ -1,0 +1,238 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import random
+from typing import Optional, Sequence, Tuple
+
+from shared.insn_yaml import InsnsFile
+from shared.operand import ImmOperandType, RegOperandType
+
+from .jump import Jump
+from ..program import ProgInsn, Program
+from ..model import Model
+from ..snippet import BranchSnippet, ProgSnippet, SeqSnippet
+from ..snippet_gen import GenCont, GenRet, SnippetGen
+
+
+class Branch(SnippetGen):
+    '''A generator that makes a snippet with a BEQ or BNE branch'''
+    def __init__(self, insns_file: InsnsFile) -> None:
+        self.jump_gen = Jump(insns_file)
+        self.beq = self._get_named_insn(insns_file, 'beq')
+        self.bne = self._get_named_insn(insns_file, 'bne')
+
+        # beq and bne expect operands: grs1, grs2, offset
+        for insn in [self.beq, self.bne]:
+            if not (len(insn.operands) == 3 and
+                    isinstance(insn.operands[0].op_type, RegOperandType) and
+                    insn.operands[0].op_type.reg_type == 'gpr' and
+                    not insn.operands[0].op_type.is_dest() and
+                    isinstance(insn.operands[1].op_type, RegOperandType) and
+                    insn.operands[1].op_type.reg_type == 'gpr' and
+                    not insn.operands[1].op_type.is_dest() and
+                    isinstance(insn.operands[2].op_type, ImmOperandType) and
+                    insn.operands[2].op_type.signed):
+                raise RuntimeError('{} instruction from instructions file is not '
+                                   'the shape expected by the Branch generator.'
+                                   .format(insn.mnemonic))
+
+    _FloatRng = Tuple[float, float]
+    _WeightedFloatRng = Tuple[float, _FloatRng]
+
+    @staticmethod
+    def pick_from_weighted_ranges(r: Sequence[_WeightedFloatRng]) -> float:
+        ff0, ff1 = random.choices([rng for _, rng in r],
+                                  weights=[w for w, _ in r])[0]
+        return random.uniform(ff0, ff1)
+
+    def _pick_tgt_addr(self,
+                       pc: int,
+                       off_min: int,
+                       off_max: int,
+                       program: Program) -> Optional[int]:
+        '''Pick the target address for a branch'''
+        # Make sure we can cover the case where we branch conditionally to
+        # PC+4, which is probably quite unlikely otherwise, by giving at 1%
+        # chance.
+        #
+        # We'll need at least 4 instructions' space for a proper branch: the
+        # branch instruction, the fall-through instruction, the branch target
+        # (which will jump back if necessary), and an eventual ECALL)
+        if program.get_insn_space_left() < 4:
+            fall_thru = True
+        else:
+            fall_thru = random.random() < 0.01
+
+        return (pc + 4 if fall_thru else
+                program.pick_branch_target(pc, 1, off_min, off_max))
+
+    def gen(self,
+            cont: GenCont,
+            model: Model,
+            program: Program) -> Optional[GenRet]:
+
+        if model.fuel <= 1:
+            # The shortest possible branch sequence (branch to PC + 4) takes an
+            # instruction and needs at least one instruction afterwards for the
+            # ECALL, so don't generate anything if fuel is less than 2.
+            return None
+
+        # Return None if this is the last instruction in the current gap
+        # because we need to either jump or do an ECALL to avoid getting stuck
+        # (just like the StraightLineInsn generator)
+        if program.get_insn_space_at(model.pc) <= 1:
+            return None
+
+        # Decide whether to generate BEQ or BNE. In the future, we'll load
+        # this weighting from somewhere else.
+        beq_weight = 1.0
+        bne_weight = 1.0
+        sum_weights = beq_weight + bne_weight
+        is_beq = random.random() < beq_weight / sum_weights
+
+        insn = self.beq if is_beq else self.bne
+        grs1_op, grs2_op, off_op = insn.operands
+
+        assert isinstance(off_op.op_type, ImmOperandType)
+
+        # Calculate the range of target addresses we can encode (this includes
+        # any PC-relative adjustment)
+        off_rng = off_op.op_type.get_op_val_range(model.pc)
+        assert off_rng is not None
+        off_min, off_max = off_rng
+
+        # Pick the source GPRs that we're comparing.
+        assert isinstance(grs1_op.op_type, RegOperandType)
+        assert isinstance(grs2_op.op_type, RegOperandType)
+        grs1 = model.pick_reg_operand_value(grs1_op.op_type)
+        grs2 = model.pick_reg_operand_value(grs2_op.op_type)
+        if grs1 is None or grs2 is None:
+            return None
+
+        tgt_addr = self._pick_tgt_addr(model.pc, off_min, off_max, program)
+        if tgt_addr is None:
+            return None
+
+        assert off_min <= tgt_addr <= off_max
+
+        off_enc = off_op.op_type.op_val_to_enc_val(tgt_addr, model.pc)
+        assert off_enc is not None
+
+        branch_insn = ProgInsn(insn, [grs1, grs2, off_enc], None)
+
+        if tgt_addr == model.pc + 4:
+            # If tgt_addr equals model.pc + 4, this actually behaves like a
+            # straight-line instruction! Add the branch instruction, update the
+            # model, and return.
+            psnip = ProgSnippet(model.pc, [branch_insn])
+            psnip.insert_into_program(program)
+            model.update_for_insn(branch_insn)
+            model.pc += 4
+            return (psnip, model)
+
+        # Decide how much of our remaining fuel to give the code below the
+        # branch. Each side gets the same amount because only one side appears
+        # in the instruction stream.
+        fuel_frac_ranges = [(1, (0, 0.1)),
+                            (10, (0.1, 0.5)),
+                            (1, (0.5, 1.0))]
+        fuel_frac = self.pick_from_weighted_ranges(fuel_frac_ranges)
+        assert 0 <= fuel_frac <= 1
+        branch_fuel = max(1, int(0.5 + fuel_frac * model.fuel))
+
+        # Similarly, decide how much of our remaining space to give the code
+        # below the branch. Unlike with the fuel, we halve the result for each
+        # side (since each side of the branch consumes instruction space)
+        space_frac_ranges = fuel_frac_ranges
+        space_frac = self.pick_from_weighted_ranges(space_frac_ranges)
+        assert 0 <= space_frac <= 1
+        # Subtract 2: one for the branch instruction and one for an eventual
+        # ECALL. We checked earlier we had at least 4 instructions' space left,
+        # so there should always be at least 2 instructions' space left
+        # afterwards.
+        max_space_for_branches = program.get_insn_space_left() - 2
+        assert max_space_for_branches >= 2
+        branch_space = max(1, int(space_frac * (max_space_for_branches / 2)))
+        assert 2 * branch_space <= max_space_for_branches
+
+        # Make an updated copy of program that includes the branch instruction.
+        # Similarly, take a copy of the model and update it as if we've fallen
+        # through the branch instruction. Note that we can't just modify
+        # program or model here because generation might fail.
+        #
+        # Insert a bogus instruction at tgt_addr into prog0. This represents
+        # the first instruction on the other side of the branch: we need to do
+        # this to avoid both sides of the branch trying to put an instruction
+        # there.
+        prog0 = program.copy()
+        prog0.add_insns(model.pc, [branch_insn])
+        model0 = model.copy()
+        model0.update_for_insn(branch_insn)
+
+        model0.pc += 4
+        prog0.add_insns(tgt_addr, [branch_insn])
+
+        model0.fuel = branch_fuel
+        prog0.constrain_space(branch_space)
+
+        ret0 = cont(model0, prog0)
+        if ret0 is None:
+            return None
+
+        snippet0, model0 = ret0
+
+        # We successfully generated the fall-through branch. Now we want to
+        # generate the other side. Make another copy of program and insert the
+        # instructions from snippet0 into it. Add the bogus instruction at
+        # model.pc, as above. Also add a bogus instruction at model0.pc: this
+        # represents "the next thing" that happens at the end of the first
+        # branch, and we mustn't allow snippet1 to use that space.
+        prog1 = program.copy()
+        snippet0.insert_into_program(prog1)
+        prog1.add_insns(model.pc, [branch_insn])
+        prog1.add_insns(model0.pc, [branch_insn])
+
+        model1 = model.copy()
+        model1.update_for_insn(branch_insn)
+        model1.pc = tgt_addr
+
+        prog1.constrain_space(branch_space)
+        model1.fuel = branch_fuel
+
+        ret1 = cont(model1, prog1)
+        if ret1 is None:
+            return None
+
+        snippet1, model1 = ret1
+
+        # We've managed to generate both sides of the branch. All that's left
+        # to do is fix up the execution paths to converge again. To do this, we
+        # need to add a jump to one side or the other. (Alternatively, we could
+        # jump from both to another address, but this shouldn't provide any
+        # extra coverage, so there's not much point)
+        if random.random() < 0.5:
+            # Add the jump to go from branch 0 to branch 1
+            jump_ret = self.jump_gen.gen_tgt(model0, prog0, model1.pc)
+            if jump_ret is None:
+                return None
+
+            jmp_snippet, model0 = jump_ret
+            if not snippet0.merge(jmp_snippet):
+                snippet0 = SeqSnippet([snippet0, jmp_snippet])
+        else:
+            # Add the jump to go from branch 1 to branch 0
+            jump_ret = self.jump_gen.gen_tgt(model1, prog1, model0.pc)
+            if jump_ret is None:
+                return None
+
+            jmp_snippet, model1 = jump_ret
+            if not snippet1.merge(jmp_snippet):
+                snippet1 = SeqSnippet([snippet1, jmp_snippet])
+
+        assert model0.pc == model1.pc
+        model0.merge(model1)
+
+        snippet = BranchSnippet(model.pc, branch_insn, snippet0, snippet1)
+        snippet.insert_into_program(program)
+        return (snippet, model0)

--- a/hw/ip/otbn/util/rig/gens/straight_line_insn.py
+++ b/hw/ip/otbn/util/rig/gens/straight_line_insn.py
@@ -11,8 +11,8 @@ from shared.operand import ImmOperandType, OptionOperandType, RegOperandType
 
 from ..program import ProgInsn, Program
 from ..model import Model
-from ..snippet import Snippet
-from ..snippet_gen import SnippetGen
+from ..snippet import ProgSnippet
+from ..snippet_gen import GenCont, GenRet, SnippetGen
 
 
 class StraightLineInsn(SnippetGen):
@@ -32,9 +32,9 @@ class StraightLineInsn(SnippetGen):
             self.insns.append(insn)
 
     def gen(self,
-            size: int,
+            cont: GenCont,
             model: Model,
-            program: Program) -> Optional[Tuple[Snippet, bool, int]]:
+            program: Program) -> Optional[GenRet]:
 
         # Return None if this is the last instruction in the current gap
         # because we need to either jump or do an ECALL to avoid getting stuck.
@@ -68,14 +68,14 @@ class StraightLineInsn(SnippetGen):
 
         # Success! We have generated an instruction. Put it in a snippet and
         # add that to the program
-        snippet = Snippet([(model.pc, [prog_insn])])
+        snippet = ProgSnippet(model.pc, [prog_insn])
         snippet.insert_into_program(program)
 
         # Then update the model with the instruction and update the model PC
         model.update_for_insn(prog_insn)
         model.pc += 4
 
-        return (snippet, False, size - 1)
+        return (snippet, model)
 
     def fill_insn(self, insn: Insn, model: Model) -> Optional[ProgInsn]:
         '''Try to fill out an instruction

--- a/hw/ip/otbn/util/rig/snippet.py
+++ b/hw/ip/otbn/util/rig/snippet.py
@@ -2,30 +2,16 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Tuple
+from typing import List, Optional
 
 from shared.insn_yaml import InsnsFile
+from shared.mem_layout import get_memory_layout
 
 from .program import ProgInsn, Program
 
 
 class Snippet:
-    '''A collection of instructions, generated as part of a random program.
-
-    parts is a list of pairs (addr, insns), where insns is a nonempty list of
-    instructions and addr is the address of its first element. The entry point
-    for the snippet is the address of the first part.
-
-    '''
-    def __init__(self,
-                 parts: List[Tuple[int, List[ProgInsn]]]):
-        assert parts
-        for idx, (addr, insns) in enumerate(parts):
-            assert addr >= 0
-            assert addr & 3 == 0
-
-        self.parts = parts
-
+    '''A collection of instructions, generated as part of a random program.'''
     def insert_into_program(self, program: Program) -> None:
         '''Insert this snippet into the given program
 
@@ -33,66 +19,213 @@ class Snippet:
         instructions in the program.
 
         '''
-        for addr, insns in self.parts:
-            program.add_insns(addr, insns)
+        raise NotImplementedError()
 
     def to_json(self) -> object:
         '''Serialize to an object that can be written as JSON'''
-        lst = []
-        for addr, insns in self.parts:
-            lst.append((addr, [i.to_json() for i in insns]))
-        return lst
+        raise NotImplementedError()
+
+    @staticmethod
+    def _addr_from_json(where: str, json: object) -> int:
+        '''Read an instruction address from a parsed json object'''
+
+        # The address should be an aligned non-negative integer and insns
+        # should itself be a list (of serialized Insn objects).
+        if not isinstance(json, int):
+            raise ValueError('First coordinate of {} is not an integer.'
+                             .format(where))
+        if json < 0:
+            raise ValueError('Address of {} is {}, but should be non-negative.'
+                             .format(where, json))
+        if json & 3:
+            raise ValueError('Address of {} is {}, '
+                             'but should be 4-byte aligned.'
+                             .format(where, json))
+        return json
+
+    @staticmethod
+    def _from_json_lst(insns_file: InsnsFile,
+                       idx: List[int],
+                       json: List[object]) -> 'Snippet':
+        raise NotImplementedError()
 
     @staticmethod
     def from_json(insns_file: InsnsFile,
-                  idx: int,
+                  idx: List[int],
                   json: object) -> 'Snippet':
-        '''The inverse of to_json.
+        '''The inverse of to_json'''
+        if not (isinstance(json, list) and json):
+            raise ValueError('Snippet {} is not a nonempty list.'.format(idx))
 
-        idx is the 0-based number of the snippet in the file, just used for
-        error messages.
+        key = json[0]
+        if not isinstance(key, str):
+            raise ValueError('Key for snippet {} is not a string.'.format(idx))
+
+        if key == 'PS':
+            return ProgSnippet._from_json_lst(insns_file, idx, json[1:])
+        elif key == 'BS':
+            return BranchSnippet._from_json_lst(insns_file, idx, json[1:])
+        elif key == 'SS':
+            return SeqSnippet._from_json_lst(insns_file, idx, json[1:])
+        else:
+            raise ValueError('Snippet {} has unknown key {!r}.'
+                             .format(idx, key))
+
+    def merge(self, snippet: 'Snippet') -> bool:
+        '''Merge snippet after this one and return True if possible.
+
+        If not possible, leaves self unchanged and returns False.
 
         '''
-        if not isinstance(json, list):
-            raise ValueError('Object for snippet {} is not a list.'
-                             .format(idx))
+        return False
 
-        parts = []
-        for idx1, part in enumerate(json):
-            # Each element should be a pair: (addr, insns). This will have come
-            # out as a list (since tuples serialize as lists).
-            if not (isinstance(part, list) and len(part) == 2):
-                raise ValueError('Part {} for snippet {} is not a pair.'
-                                 .format(idx1, idx))
+    def to_program(self) -> Program:
+        '''Write a series of disjoint snippets to make a program'''
+        # Find the size of the memory that we can access. Both memories start
+        # at address 0: a strict Harvard architecture. (mems[x][0] is the LMA
+        # for memory x, not the VMA)
+        mems = get_memory_layout()
+        imem_lma, imem_size = mems['IMEM']
+        dmem_lma, dmem_size = mems['DMEM']
+        program = Program(imem_lma, imem_size, dmem_lma, dmem_size)
+        self.insert_into_program(program)
+        return program
 
-            addr, insns_json = part
 
-            # The address should be an aligned non-negative integer and insns
-            # should itself be a list (of serialized Insn objects).
-            if not isinstance(addr, int):
-                raise ValueError('First coordinate of part {} for snippet {} '
-                                 'is not an integer.'
-                                 .format(idx1, idx))
-            if addr < 0:
-                raise ValueError('Address of part {} for snippet {} is {}, '
-                                 'but should be non-negative.'
-                                 .format(idx1, idx, addr))
-            if addr & 3:
-                raise ValueError('Address of part {} for snippet {} is {}, '
-                                 'but should be 4-byte aligned.'
-                                 .format(idx1, idx, addr))
+class ProgSnippet(Snippet):
+    '''A sequence of instructions that are executed in order'''
+    def __init__(self, addr: int, insns: List[ProgInsn]):
+        assert addr >= 0
+        assert addr & 3 == 0
 
-            if not isinstance(insns_json, list):
-                raise ValueError('Second coordinate of part {} for snippet {} '
-                                 'is not a list.'
-                                 .format(idx1, idx))
+        self.addr = addr
+        self.insns = insns
 
-            insns = []
-            for insn_idx, insn_json in enumerate(insns_json):
-                where = ('In snippet {}, part {}, instruction {}'
-                         .format(idx, idx1, insn_idx))
-                insns.append(ProgInsn.from_json(insns_file, where, insn_json))
+    def insert_into_program(self, program: Program) -> None:
+        program.add_insns(self.addr, self.insns)
 
-            parts.append((addr, insns))
+    def to_json(self) -> object:
+        '''Serialize to an object that can be written as JSON'''
+        return ['PS', self.addr, [i.to_json() for i in self.insns]]
 
-        return Snippet(parts)
+    @staticmethod
+    def _from_json_lst(insns_file: InsnsFile,
+                       idx: List[int],
+                       json: List[object]) -> Snippet:
+        '''The inverse of to_json.'''
+        # Each element should be a pair: (addr, insns).
+        if len(json) != 2:
+            raise ValueError('Snippet {} has {} arguments; '
+                             'expected 2 for a ProgSnippet.'
+                             .format(idx, len(json)))
+        j_addr, j_insns = json
+
+        where = 'snippet {}'.format(idx)
+        addr = Snippet._addr_from_json(where, j_addr)
+
+        if not isinstance(j_insns, list):
+            raise ValueError('Second coordinate of {} is not a list.'
+                             .format(where))
+
+        insns = []
+        for insn_idx, insn_json in enumerate(j_insns):
+            pi_where = ('In snippet {}, instruction {}'
+                        .format(idx, insn_idx))
+            pi = ProgInsn.from_json(insns_file, pi_where, insn_json)
+            insns.append(pi)
+
+        return ProgSnippet(addr, insns)
+
+    def merge(self, snippet: Snippet) -> bool:
+        if not isinstance(snippet, ProgSnippet):
+            return False
+
+        next_addr = self.addr + 4 * len(self.insns)
+        if snippet.addr != next_addr:
+            return False
+
+        self.insns += snippet.insns
+        return True
+
+
+class SeqSnippet(Snippet):
+    '''A nonempty sequence of snippets that run one after another'''
+    def __init__(self, children: List[Snippet]):
+        assert children
+        self.children = children
+
+    def insert_into_program(self, program: Program) -> None:
+        for child in self.children:
+            child.insert_into_program(program)
+
+    def to_json(self) -> object:
+        ret = ['SS']  # type: List[object]
+        ret += [c.to_json() for c in self.children]
+        return ret
+
+    @staticmethod
+    def _from_json_lst(insns_file: InsnsFile,
+                       idx: List[int],
+                       json: List[object]) -> Snippet:
+        if len(json) == 0:
+            raise ValueError('List at {} for SeqSnippet is empty.'.format(idx))
+
+        children = []
+        for i, item in enumerate(json):
+            children.append(Snippet.from_json(insns_file, idx + [i], item))
+        return SeqSnippet(children)
+
+
+class BranchSnippet(Snippet):
+    '''A snippet representing a branch
+
+    branch_insn is the first instruction that runs, at address addr, then
+    either snippet0 or snippet1 will run. The program will complete in either
+    case.
+
+    '''
+    def __init__(self,
+                 addr: int,
+                 branch_insn: ProgInsn,
+                 snippet0: Snippet,
+                 snippet1: Snippet):
+        self.addr = addr
+        self.branch_insn = branch_insn
+        self.snippet0 = snippet0
+        self.snippet1 = snippet1
+
+    def insert_into_program(self, program: Program) -> None:
+        program.add_insns(self.addr, [self.branch_insn])
+        self.snippet0.insert_into_program(program)
+        if self.snippet1 is not None:
+            self.snippet1.insert_into_program(program)
+
+    def to_json(self) -> object:
+        js1 = None if self.snippet1 is None else self.snippet1.to_json()
+        return ['BS',
+                self.addr,
+                self.branch_insn.to_json(),
+                self.snippet0.to_json(),
+                js1]
+
+    @staticmethod
+    def _from_json_lst(insns_file: InsnsFile,
+                       idx: List[int],
+                       json: List[object]) -> Snippet:
+        if len(json) != 4:
+            raise ValueError('List for snippet {} is of the wrong '
+                             'length for a BranchSnippet ({}, not 4)'
+                             .format(idx, len(json)))
+
+        j_addr, j_branch_insn, j_snippet0, j_snippet1 = json
+
+        addr_where = 'address for snippet {}'.format(idx)
+        addr = Snippet._addr_from_json(addr_where, j_addr)
+
+        bi_where = 'branch instruction for snippet {}'.format(idx)
+        branch_insn = ProgInsn.from_json(insns_file, bi_where, j_branch_insn)
+
+        snippet0 = Snippet.from_json(insns_file, idx + [0], j_snippet0)
+        snippet1 = Snippet.from_json(insns_file, idx + [1], j_snippet1)
+
+        return BranchSnippet(addr, branch_insn, snippet0, snippet1)


### PR DESCRIPTION
The branching program flow means that we have to teach the RIG some
new tricks. Firstly, we need to add "recursive" generation (so that
the generator for a branch can generate stuff in each side below it).
We do this by passing a continuation of type `GenCont` to the generator.

Secondly, we need to tighten up the snippet type a bit. Branches are
represented as branches in the expression tree (as you'd expect), and
we also needed to add a sequencing type, `SeqSnippet` (so that you can
have a list of instructions followed by a branch, for example).

We always generate branches that converge (so there will only ever be
one `ECALL` in the generated program). To glue the branches back
together, we generate a jump from the end of one to the end of the
other. This needs slight changes in the `Jump` generator so that we can
specify the target address that we want in this case.

The final big change is that we need to add support for "φ nodes" to
the model, to cope with when execution joins back together. This is
the "merge" method added to `Model`, `CallStack` and `KnownMem`.
