### PR TITLE
[uart] FIFO reset signals to be self-cleared

### DIFF
--- a/hw/ip/uart/data/uart.hjson
+++ b/hw/ip/uart/data/uart.hjson
@@ -175,17 +175,16 @@
       desc: "UART FIFO control register",
       swaccess: "rw",
       hwaccess: "hrw",
-      hwqe:     "true",
       fields: [
         { bits: "0",
           swaccess: "wo",
-          hwaccess: "hro",
+          hwaccess: "hrw",
           name: "RXRST",
           desc: "RX fifo reset. Write 1 to the register resets RX_FIFO. Read returns 0"
         }
         { bits: "1",
           swaccess: "wo",
-          hwaccess: "hro",
+          hwaccess: "hrw",
           name: "TXRST",
           desc: "TX fifo reset. Write 1 to the register resets TX_FIFO. Read returns 0"
         }

--- a/hw/ip/uart/rtl/uart_core.sv
+++ b/hw/ip/uart/rtl/uart_core.sv
@@ -67,10 +67,16 @@ module uart_core (
   assign sys_loopback     = reg2hw.ctrl.slpbk.q;
   assign line_loopback    = reg2hw.ctrl.llpbk.q;
 
-  assign uart_fifo_rxrst  = reg2hw.fifo_ctrl.rxrst.q & reg2hw.fifo_ctrl.rxrst.qe;
-  assign uart_fifo_txrst  = reg2hw.fifo_ctrl.txrst.q & reg2hw.fifo_ctrl.txrst.qe;
+  assign uart_fifo_rxrst  = reg2hw.fifo_ctrl.rxrst.q;
+  assign uart_fifo_txrst  = reg2hw.fifo_ctrl.txrst.q;
   assign uart_fifo_rxilvl = reg2hw.fifo_ctrl.rxilvl.q;
   assign uart_fifo_txilvl = reg2hw.fifo_ctrl.txilvl.q;
+
+  // clear FIFO Reset signal
+  assign hw2reg.fifo_ctrl.rxrst.de = reg2hw.fifo_ctrl.rxrst.q;
+  assign hw2reg.fifo_ctrl.rxrst.d  = 1'b 0;
+  assign hw2reg.fifo_ctrl.txrst.de = reg2hw.fifo_ctrl.txrst.q;
+  assign hw2reg.fifo_ctrl.txrst.d  = 1'b 0;
 
   assign ovrd_tx_en       = reg2hw.ovrd.txen.q;
   assign ovrd_tx_val      = reg2hw.ovrd.txval.q;

--- a/hw/ip/uart/rtl/uart_reg_pkg.sv
+++ b/hw/ip/uart/rtl/uart_reg_pkg.sv
@@ -168,19 +168,15 @@ package uart_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
-      logic        qe;
     } rxrst;
     struct packed {
       logic        q;
-      logic        qe;
     } txrst;
     struct packed {
       logic [2:0]  q;
-      logic        qe;
     } rxilvl;
     struct packed {
       logic [1:0]  q;
-      logic        qe;
     } txilvl;
   } uart_reg2hw_fifo_ctrl_reg_t;
 
@@ -265,6 +261,14 @@ package uart_reg_pkg;
 
   typedef struct packed {
     struct packed {
+      logic        d;
+      logic        de;
+    } rxrst;
+    struct packed {
+      logic        d;
+      logic        de;
+    } txrst;
+    struct packed {
       logic [2:0]  d;
       logic        de;
     } rxilvl;
@@ -292,14 +296,14 @@ package uart_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    uart_reg2hw_intr_state_reg_t intr_state; // [124:117]
-    uart_reg2hw_intr_enable_reg_t intr_enable; // [116:109]
-    uart_reg2hw_intr_test_reg_t intr_test; // [108:93]
-    uart_reg2hw_ctrl_reg_t ctrl; // [92:68]
-    uart_reg2hw_status_reg_t status; // [67:56]
-    uart_reg2hw_rdata_reg_t rdata; // [55:47]
-    uart_reg2hw_wdata_reg_t wdata; // [46:38]
-    uart_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [37:27]
+    uart_reg2hw_intr_state_reg_t intr_state; // [120:113]
+    uart_reg2hw_intr_enable_reg_t intr_enable; // [112:105]
+    uart_reg2hw_intr_test_reg_t intr_test; // [104:89]
+    uart_reg2hw_ctrl_reg_t ctrl; // [88:64]
+    uart_reg2hw_status_reg_t status; // [63:52]
+    uart_reg2hw_rdata_reg_t rdata; // [51:43]
+    uart_reg2hw_wdata_reg_t wdata; // [42:34]
+    uart_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [33:27]
     uart_reg2hw_ovrd_reg_t ovrd; // [26:25]
     uart_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [24:0]
   } uart_reg2hw_t;
@@ -308,10 +312,10 @@ package uart_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    uart_hw2reg_intr_state_reg_t intr_state; // [64:49]
-    uart_hw2reg_status_reg_t status; // [48:43]
-    uart_hw2reg_rdata_reg_t rdata; // [42:35]
-    uart_hw2reg_fifo_ctrl_reg_t fifo_ctrl; // [34:28]
+    uart_hw2reg_intr_state_reg_t intr_state; // [68:53]
+    uart_hw2reg_status_reg_t status; // [52:47]
+    uart_hw2reg_rdata_reg_t rdata; // [46:39]
+    uart_hw2reg_fifo_ctrl_reg_t fifo_ctrl; // [38:28]
     uart_hw2reg_fifo_status_reg_t fifo_status; // [27:16]
     uart_hw2reg_val_reg_t val; // [15:0]
   } uart_hw2reg_t;

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -1136,11 +1136,11 @@ module uart_reg_top (
     .wd     (fifo_ctrl_rxrst_wd),
 
     // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
+    .de     (hw2reg.fifo_ctrl.rxrst.de),
+    .d      (hw2reg.fifo_ctrl.rxrst.d ),
 
     // to internal hardware
-    .qe     (reg2hw.fifo_ctrl.rxrst.qe),
+    .qe     (),
     .q      (reg2hw.fifo_ctrl.rxrst.q ),
 
     .qs     ()
@@ -1161,11 +1161,11 @@ module uart_reg_top (
     .wd     (fifo_ctrl_txrst_wd),
 
     // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
+    .de     (hw2reg.fifo_ctrl.txrst.de),
+    .d      (hw2reg.fifo_ctrl.txrst.d ),
 
     // to internal hardware
-    .qe     (reg2hw.fifo_ctrl.txrst.qe),
+    .qe     (),
     .q      (reg2hw.fifo_ctrl.txrst.q ),
 
     .qs     ()
@@ -1190,7 +1190,7 @@ module uart_reg_top (
     .d      (hw2reg.fifo_ctrl.rxilvl.d ),
 
     // to internal hardware
-    .qe     (reg2hw.fifo_ctrl.rxilvl.qe),
+    .qe     (),
     .q      (reg2hw.fifo_ctrl.rxilvl.q ),
 
     // to register interface (read)
@@ -1216,7 +1216,7 @@ module uart_reg_top (
     .d      (hw2reg.fifo_ctrl.txilvl.d ),
 
     // to internal hardware
-    .qe     (reg2hw.fifo_ctrl.txilvl.qe),
+    .qe     (),
     .q      (reg2hw.fifo_ctrl.txilvl.q ),
 
     // to register interface (read)


### PR DESCRIPTION
This PR addresses the issue discussed in #4728 

I revised the UART design to self-clear the fifo reset signals in FIFO_CTRL register. Changed the HW access type to RW and uart_core module writes 0 back to fifo_ctrl.rxrst , fifo_ctrl.txrst when the values become 1.

Didn't make the fields external to avoid glitches on the line.