### PR TITLE
[usbdev / pinmux / top] usb wake detection and connection

### DIFF
--- a/hw/ip/pinmux/data/pinmux.hjson
+++ b/hw/ip/pinmux/data/pinmux.hjson
@@ -13,7 +13,7 @@
 #  - n_dio_pads:          Number of dedicated IO pads
 #  - n_wkup_detect:       Number of wakeup condition detectors
 #  - wkup_cnt_width:      Width of wakeup counters
-# 
+#
 {
   name: "PINMUX",
   clock_primary: "clk_i",
@@ -463,4 +463,3 @@
     },
   ],
 }
-

--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -74,6 +74,47 @@
       package: "",
       default: "1'b0"
     },
+    { struct:  "logic",
+      type:    "uni",
+      name:    "usb_wkup_req",
+      act:     "req",
+      package: "",
+      default: "1'b0"
+    },
+    { name:    "usb_out_of_rst",
+      type:    "uni",
+      act:     "rcv",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    },
+    { name:    "usb_aon_wake_en",
+      type:    "uni",
+      act:     "rcv",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    },
+    { name:    "usb_aon_wake_ack",
+      type:    "uni",
+      act:     "rcv",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    },
+    { name:    "usb_suspend",
+      type:    "uni",
+      act:     "rcv",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    },
+    { name:    "usb_state_debug",
+      type:    "uni",
+      act:     "req",
+      package: "usbdev_pkg",
+      struct:  "awk_state",
+    },
   ]
 
   param_list: [
@@ -113,6 +154,43 @@
       default: "${wkup_cnt_width}",
       local: "true"
     },
+    { name: "NUsbDevPads",
+      desc: "Number of usbdev pins",
+      type: "int",
+      default: "${n_usb_pins}",
+      local: "true"
+    },
+    { name: "NDioPadUsbDevStart",
+      desc: "Start position for usbdev pins",
+      type: "int",
+      default: "${usb_start_pos}",
+      local: "true"
+    },
+    { name: "UsbDpSel",
+      desc: "index of usbdev_dp",
+      type: "int",
+      default: "${usb_dp_sel}",
+      local: "true"
+    },
+    { name: "UsbDnSel",
+      desc: "index of usbdev_dn",
+      type: "int",
+      default: "${usb_dn_sel}",
+      local: "true"
+    },
+    { name: "UsbDpPullUpSel",
+      desc: "index of usbdev_dp_pullup",
+      type: "int",
+      default: "${usb_dp_pull_sel}",
+      local: "true"
+    },
+    { name: "UsbDnPullUpSel",
+      desc: "index of usbdev_dn_pullup",
+      type: "int",
+      default: "${usb_dn_pull_sel}",
+      local: "true"
+    },
+
     // TODO: Enable these once supported by topgen and the C header generation script.
     // These parameters are currently located in pinmux_pkg.sv
     // // If a bit is set to 1 in this vector, this MIO activates low power

--- a/hw/ip/pinmux/pinmux_component.core
+++ b/hw/ip/pinmux/pinmux_component.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:all
+      - lowrisc:ip:usbdev
       # pinmux_wkup.sv depends on pinmux_reg_pkg.sv
       - "fileset_topgen ? (lowrisc:systems:topgen-reg-only)"
     files:

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 { name: "usbdev",
   clock_primary: "clk_i",
-  other_clock_list: [ "clk_usb_48mhz_i" ]
+  other_clock_list: [ "clk_aon_i", "clk_usb_48mhz_i" ]
   reset_primary: "rst_ni",
-  other_reset_list: [ "rst_usb_48mhz_ni" ]
+  other_reset_list: [ "rst_aon_ni", "rst_usb_48mhz_ni" ]
   bus_device: "tlul",
   bus_host: "none",
   available_inout_list: [
@@ -37,7 +37,41 @@
       package: "",
       struct:  "logic",
       width:   "1"
-    }
+    },
+    { name:    "usb_out_of_rst",
+      type:    "uni",
+      act:     "req",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    },
+    { name:    "usb_aon_wake_en",
+      type:    "uni",
+      act:     "req",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    },
+    { name:    "usb_aon_wake_ack",
+      type:    "uni",
+      act:     "req",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    },
+    { name:    "usb_suspend",
+      type:    "uni",
+      act:     "req",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    },
+    { name:    "usb_state_debug",
+      type:    "uni",
+      act:     "rcv",
+      package: "usbdev_pkg",
+      struct:  "awk_state",
+    },
   ]
   param_list: [
     { name:    "NEndpoints",
@@ -705,6 +739,51 @@
                 Note that while in oscillator test mode, the device no longer receives SOFs and consequently does not generate the reference signal for clock synchronization.
                 The clock might drift off.
 
+                '''
+        }
+      ]
+    }
+
+    { name: "wake_config",
+      desc: "USB wake configuration for suspend / resume",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        {
+          bits: "0",
+          resval: "0",
+          name: "wake_en",
+          desc: '''
+                Enable the usb resume wake function.  When this is set, a resume indication from
+                a usb host can be used to drive a wake from sleep event.
+                '''
+        }
+        {
+          bits: "1",
+          resval: "0",
+          name: "wake_ack",
+          desc: '''
+                Wake acknowledgement. Once the usb device resumes from suspend, this acknowledgement is used
+                to transition the module back to normal operation.
+
+                Note wake acknowledgement is only necessary if wake_en was '1' when the usb device was suspended.
+                However, setting/clearing this bit during other conditions has no side effects.
+                '''
+        },
+      ]
+    }
+
+    { name: "wake_debug",
+      desc: "USB wake module debug",
+      swaccess: "ro",
+      hwaccess: "hwo",
+      fields: [
+        {
+          bits: "2:0",
+          resval: "0",
+          name: "state",
+          desc: '''
+                  USB aon wake module state read back
                 '''
         }
       ]

--- a/hw/ip/usbdev/dv/tb/tb.sv
+++ b/hw/ip/usbdev/dv/tb/tb.sv
@@ -47,12 +47,16 @@ module tb;
   usbdev dut (
     .clk_i                (clk        ),
     .rst_ni               (rst_n      ),
-
+    .clk_aon_i            (clk        ),
+    .rst_aon_ni           (rst_n      ),
     .clk_usb_48mhz_i      (usb_clk    ),
     .rst_usb_48mhz_ni     (usb_rst_n  ),
 
     .tl_i                 (tl_if.h2d  ),
     .tl_o                 (tl_if.d2h  ),
+
+    // pinmux wakeup interface
+    .usb_state_debug_i    ('0),
 
     // USB Interface
     // TOOD: need to hook up an interface

--- a/hw/ip/usbdev/rtl/usb_aon_wake.sv
+++ b/hw/ip/usbdev/rtl/usb_aon_wake.sv
@@ -1,0 +1,214 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Always On USB wake detect
+//
+
+module usb_aon_wake (
+  input  logic clk_aon_i,
+  input  logic rst_aon_ni,
+
+  // signals tagged _upwr_ are only valid when this is set
+  input  logic usb_out_of_rst_alw_i,
+
+  // These come from the chip pin
+  input  logic usb_dp_async_alw_i,
+  input  logic usb_dn_async_alw_i,
+
+  // These I/O enables come from the IP and need to be held when IP is off
+  input  logic usb_dppullup_en_upwr_i,
+  input  logic usb_dnpullup_en_upwr_i,
+  input  logic usb_dp_en_upwr_i,
+  input  logic usb_dn_en_upwr_i,
+  input  logic usb_d_en_upwr_i,
+
+  // Register signals from IP
+  input  logic usb_aon_wake_en_upwr_i,
+  input  logic usb_aon_woken_upwr_i,
+
+  // Status from IP, must be valid for long enough for aon clock to catch (>15us)
+  input  logic usb_suspended_upwr_i,
+
+  // Pass through enables to the pins
+  output logic usb_dppullup_en_alw_o,
+  output logic usb_dnpullup_en_alw_o,
+  output logic usb_dp_en_alw_o,
+  output logic usb_dn_en_alw_o,
+  output logic usb_d_en_alw_o,
+
+  // wake/powerup request
+  output logic wake_req_alw_o
+);
+
+  // Code the state values so that the transitions software could poll are single bit
+  // Woken->Idle and WokenUon->Idle (after sw ack) should therefore be single bit changes
+  typedef enum logic [2:0] {
+    AwkIdle =     3'b000,
+    AwkTrigUon =  3'b011,   // 2 bit change from Idle but sw not monitoring
+    AwkTrigUoff = 3'b010,   // ok with two bit change out because chip power is off
+    AwkWokenUon = 3'b001,   // one bit change in/out to TrigUon and Idle, chip off to Woken
+    AwkWoken =    3'b100    // one bit change out to Idle, in has chip power off
+  } awk_state_e;
+
+  awk_state_e astate_d, astate_q;
+
+  logic trigger_async, trigger;
+  logic wake_ack_async, wake_ack;
+
+  // note the _upwr signals are only valid when usb_out_of_rst_alw_i is set
+  assign trigger_async = usb_aon_wake_en_upwr_i & usb_suspended_upwr_i & usb_out_of_rst_alw_i;
+  assign wake_ack_async = usb_aon_woken_upwr_i & usb_out_of_rst_alw_i;
+
+  prim_flop_2sync #(
+    .Width (2)
+  ) cdc_trigger (
+    .clk_i  (clk_aon_i),
+    .rst_ni (rst_aon_ni),
+    .d_i    ({trigger_async, wake_ack_async})
+    .q_o    ({trigger, wake_ack})
+  );
+
+
+  // In suspend it is the device pullup that sets the line state
+  // so if the input value differs then the host is doing something
+  // This covers both host generated wake (J->K) and host generated reset (J->SE0)
+  // Use of the pullups takes care of pinflipping
+  assign notidle_async = (usb_dp_alw_i != usb_dppullup_en_alw_o) |
+                         (usb_dn_alw_i != usb_dnpullup_en_alw_o);
+
+  // aon clock is ~200kHz so 4 cycle filter is about 20us
+  // as well as noise debounce this gives the main IP time to detect resume if it didn't turn off
+  prim_filter #(.Cycles(4)) filter_activity (
+    .clk_i    (clk_aon_i),
+    .rst_ni   (rst_aon_ni),
+    .enable_i (1'b1),
+    .filter_i (notidle_async),
+    .filter_o (notidle_filtered)
+  );
+
+  always_comb begin : proc_awk_fsm
+    astate_d  = astate_q;
+
+    unique case (astate_q)
+      // No aon suspend entry has been requested or detected
+      AwkIdle: begin
+        if (trigger) begin
+          astate_d = AwkTrigUon;
+        end
+      end
+
+      // Suspend has been triggered but the USB IP power is still on
+      AwkTrigUon: begin
+        if (notidle_filtered) begin
+          // USP IP may manage the wake
+          astate_d = AwkWokenUon;
+        end else if (!usb_out_of_rst_alw_i) begin
+          astate_d = AwkTrigUoff;
+        end
+      end
+
+      // Suspend has been triggered and the USB IP is powered off
+      AwkTrigUoff: begin
+        if (notidle_filtered) begin
+          astate_d = AwkWoken;
+        end
+      end
+
+      // The link went not-idle before the USB IP powered off
+      // It could be about to power down, it could manage the wake, or this was a glitch
+      AwkWokenUon: begin
+        if (wake_ack) begin
+          astate_d = AwkIdle;
+        end else if (trigger) begin
+          astate_d = AwkTrigUon;
+        end else if (!usb_out_of_rst_alw_i) begin
+          astate_d = AwkWoken;
+        end
+      end
+
+      // The USB IP was powered down and the link went not-idle, time to wake up
+      AwkWoken: begin
+        if (wake_ack) begin
+          astate_d = AwkIdle;
+        end
+      end
+
+      default : astate_d = AwkIdle;
+    endcase
+  end
+
+  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin : proc_reg_awk
+    if (!rst_aon_ni) begin
+      astate_q <= AwkIdle;
+    end else begin
+      astate_q <= astate_d;
+    end
+  end
+
+  assign wake_req_alw_o = (astate_q == AwkWoken);
+
+  // Since pullup signals are static could make capture_ios = ~hold_ios
+  // This ensures capture flop will be holding value before mux swings
+  // astate_q           I I I I T T T
+  // astate_d           I I I T T T T
+  // capture_ios        Y Y Y n n n n
+  // hold_ios           n n n n Y Y Y
+  // d?pullup_en        1 2 3 4 5 6 7 actually static
+  // held_d?pullup_en     1 2 3 3 3 3
+  // d?pullup_en_alw_o  1 2 3 4 3 3 3
+  // hold_ios
+  logic capture_ios, hold_ios;
+  logic dppullup_en, dnpullup_en;
+  logic held_dppullup_en, held_dnpullup_en;
+
+  assign capture_ios = (astate_q == AwkIdle) && (astate_d == AwkIdle);
+  assign hold_ios = (astate_q != AwkIdle);
+
+  // The pullup signals are static while the USB interface is in use
+  // so no need to worry about cdc delays here
+  prim_flop_2sync #(
+    .Width (2)
+  ) cdc_to_aon (
+    .clk_i  (clk_aon_i),
+    .rst_ni (rst_aon_ni),
+    .d_i    ({usb_dppullup_en_upwr_i, usb_dnpullup_en_upwr_i})
+    .q_o    ({dppullup_en, dnpullup_en})
+  );
+
+  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
+    if (!rst_aon_ni) begin
+      held_dppullup_en <= 0;
+      held_dnpullup_en <= 0;
+    end else begin
+      held_dppullup_en <= capture_ios ? dppullup_en : held_dppullup_en;
+      held_dnpullup_en <= capture_ios ? dnpullup_en : held_dnpullup_en;
+    end
+  end
+
+  prim_generic_clock_mux2 #(
+    .NoFpgaBufG(1)
+  ) i_mux_dppullup_en (
+    .clk0_i (usb_dppullup_en_upwr_i),
+    .clk1_i (held_dppullup_en),
+    .sel_i  (hold_ios),
+    .clk_o  (usb_dppullup_en_alw_o)
+  );
+
+  prim_generic_clock_mux2 #(
+    .NoFpgaBufG(1)
+  ) i_mux_dnpullup_en (
+    .clk0_i (usb_dnpullup_en_upwr_i),
+    .clk1_i (held_dnpullup_en),
+    .sel_i  (hold_ios),
+    .clk_o  (usb_dnpullup_en_alw_o)
+  );
+
+  // outputs never enabled when in suspend with USB IP powered off
+  // the _en_upwr signals will always be 0 when suspend is detected so no glitch
+  // (would this be cleaner as _en_alw_o = _en_upwr_i & !hold_ios)
+  assign usb_dp_en_alw_o = hold_ios ? 0 : usb_dp_en_upwr_i;
+  assign usb_dn_en_alw_o = hold_ios ? 0 : usb_dn_en_upwr_i;
+  assign usb_d_en_alw_o  = hold_ios ? 0 : usb_d_en_upwr_i;
+
+endmodule

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -7,9 +7,11 @@
 //
 
 
-module usbdev (
+module usbdev import usbdev_pkg::*; (
   input  logic       clk_i,
   input  logic       rst_ni,
+  input  logic       clk_aon_i,
+  input  logic       rst_aon_ni,
   input  logic       clk_usb_48mhz_i, // use usb_ prefix for signals in this clk
   input  logic       rst_usb_48mhz_ni, // async reset, with relase sync to clk_usb_48_mhz_i
 
@@ -42,6 +44,15 @@ module usbdev (
   output logic       cio_suspend_en_o,
   output logic       cio_tx_mode_se_o,
   output logic       cio_tx_mode_se_en_o,
+
+  // Direct pinmux aon detect connections
+  output logic       usb_out_of_rst_o,
+  output logic       usb_aon_wake_en_o,
+  output logic       usb_aon_wake_ack_o,
+  output logic       usb_suspend_o,
+
+  // Debug info from wakeup module
+  input awk_state_t  usb_state_debug_i,
 
   // SOF reference for clock calibration
   output logic       usb_ref_val_o,
@@ -1044,5 +1055,58 @@ module usbdev (
   end
 
   assign usb_ref_val_o = usb_ref_val_q;
+
+  /////////////////////////////////////////
+  // USB aon detector signaling          //
+  /////////////////////////////////////////
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      usb_out_of_rst_o <= 1'b0;
+    end else begin
+      usb_out_of_rst_o <= 1'b1;
+    end
+  end
+
+  assign usb_aon_wake_en_o = reg2hw.wake_config.wake_en.q;
+  assign usb_aon_wake_ack_o = reg2hw.wake_config.wake_ack.q;
+  assign usb_suspend_o = usb_event_link_suspend;
+
+  /////////////////////////////////////////
+  // capture async debug info            //
+  /////////////////////////////////////////
+
+  logic aon_tgl;
+  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
+    if (!rst_aon_ni) begin
+      aon_tgl <= 1'b0;
+    end else begin
+      aon_tgl <= aon_tgl ^ 1'b1;
+    end
+  end
+
+  logic tgl_sync, tgl_sync_d1;
+  prim_flop_2sync #(
+    .Width(1)
+  ) u_tgl_sync (
+    .clk_i,
+    .rst_ni,
+    .d_i(aon_tgl),
+    .q_o(tgl_sync)
+    );
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      tgl_sync_d1 <= 1'b0;
+    end else begin
+      tgl_sync_d1 <= tgl_sync;
+    end
+  end
+
+  logic tgl_en;
+  assign tgl_en = tgl_sync ^ tgl_sync_d1;
+
+  assign hw2reg.wake_debug.de = tgl_en;
+  assign hw2reg.wake_debug.d = usb_state_debug_i;
 
 endmodule

--- a/hw/ip/usbdev/rtl/usbdev_aon_wake.sv
+++ b/hw/ip/usbdev/rtl/usbdev_aon_wake.sv
@@ -5,7 +5,7 @@
 // Always On USB wake detect
 //
 
-module usb_aon_wake (
+module usbdev_aon_wake import usbdev_pkg::*;(
   input  logic clk_aon_i,
   input  logic rst_aon_ni,
 
@@ -16,12 +16,9 @@ module usb_aon_wake (
   input  logic usb_dp_async_alw_i,
   input  logic usb_dn_async_alw_i,
 
-  // These I/O enables come from the IP and need to be held when IP is off
-  input  logic usb_dppullup_en_upwr_i,
-  input  logic usb_dnpullup_en_upwr_i,
-  input  logic usb_dp_en_upwr_i,
-  input  logic usb_dn_en_upwr_i,
-  input  logic usb_d_en_upwr_i,
+  // These come from post pinmux sleep handling logic
+  input  logic usb_dppullup_en_alw_i,
+  input  logic usb_dnpullup_en_alw_i,
 
   // Register signals from IP
   input  logic usb_aon_wake_en_upwr_i,
@@ -30,26 +27,12 @@ module usb_aon_wake (
   // Status from IP, must be valid for long enough for aon clock to catch (>15us)
   input  logic usb_suspended_upwr_i,
 
-  // Pass through enables to the pins
-  output logic usb_dppullup_en_alw_o,
-  output logic usb_dnpullup_en_alw_o,
-  output logic usb_dp_en_alw_o,
-  output logic usb_dn_en_alw_o,
-  output logic usb_d_en_alw_o,
-
   // wake/powerup request
-  output logic wake_req_alw_o
-);
+  output logic wake_req_alw_o,
 
-  // Code the state values so that the transitions software could poll are single bit
-  // Woken->Idle and WokenUon->Idle (after sw ack) should therefore be single bit changes
-  typedef enum logic [2:0] {
-    AwkIdle =     3'b000,
-    AwkTrigUon =  3'b011,   // 2 bit change from Idle but sw not monitoring
-    AwkTrigUoff = 3'b010,   // ok with two bit change out because chip power is off
-    AwkWokenUon = 3'b001,   // one bit change in/out to TrigUon and Idle, chip off to Woken
-    AwkWoken =    3'b100    // one bit change out to Idle, in has chip power off
-  } awk_state_e;
+  // state debug information
+  output awk_state_e state_debug_o
+);
 
   awk_state_e astate_d, astate_q;
 
@@ -65,17 +48,19 @@ module usb_aon_wake (
   ) cdc_trigger (
     .clk_i  (clk_aon_i),
     .rst_ni (rst_aon_ni),
-    .d_i    ({trigger_async, wake_ack_async})
+    .d_i    ({trigger_async, wake_ack_async}),
     .q_o    ({trigger, wake_ack})
   );
 
 
+  logic notidle_async;
+  logic notidle_filtered;
   // In suspend it is the device pullup that sets the line state
   // so if the input value differs then the host is doing something
   // This covers both host generated wake (J->K) and host generated reset (J->SE0)
   // Use of the pullups takes care of pinflipping
-  assign notidle_async = (usb_dp_alw_i != usb_dppullup_en_alw_o) |
-                         (usb_dn_alw_i != usb_dnpullup_en_alw_o);
+  assign notidle_async = (usb_dp_async_alw_i != usb_dppullup_en_alw_i) |
+                         (usb_dn_async_alw_i != usb_dnpullup_en_alw_i);
 
   // aon clock is ~200kHz so 4 cycle filter is about 20us
   // as well as noise debounce this gives the main IP time to detect resume if it didn't turn off
@@ -148,67 +133,6 @@ module usb_aon_wake (
 
   assign wake_req_alw_o = (astate_q == AwkWoken);
 
-  // Since pullup signals are static could make capture_ios = ~hold_ios
-  // This ensures capture flop will be holding value before mux swings
-  // astate_q           I I I I T T T
-  // astate_d           I I I T T T T
-  // capture_ios        Y Y Y n n n n
-  // hold_ios           n n n n Y Y Y
-  // d?pullup_en        1 2 3 4 5 6 7 actually static
-  // held_d?pullup_en     1 2 3 3 3 3
-  // d?pullup_en_alw_o  1 2 3 4 3 3 3
-  // hold_ios
-  logic capture_ios, hold_ios;
-  logic dppullup_en, dnpullup_en;
-  logic held_dppullup_en, held_dnpullup_en;
-
-  assign capture_ios = (astate_q == AwkIdle) && (astate_d == AwkIdle);
-  assign hold_ios = (astate_q != AwkIdle);
-
-  // The pullup signals are static while the USB interface is in use
-  // so no need to worry about cdc delays here
-  prim_flop_2sync #(
-    .Width (2)
-  ) cdc_to_aon (
-    .clk_i  (clk_aon_i),
-    .rst_ni (rst_aon_ni),
-    .d_i    ({usb_dppullup_en_upwr_i, usb_dnpullup_en_upwr_i})
-    .q_o    ({dppullup_en, dnpullup_en})
-  );
-
-  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
-    if (!rst_aon_ni) begin
-      held_dppullup_en <= 0;
-      held_dnpullup_en <= 0;
-    end else begin
-      held_dppullup_en <= capture_ios ? dppullup_en : held_dppullup_en;
-      held_dnpullup_en <= capture_ios ? dnpullup_en : held_dnpullup_en;
-    end
-  end
-
-  prim_generic_clock_mux2 #(
-    .NoFpgaBufG(1)
-  ) i_mux_dppullup_en (
-    .clk0_i (usb_dppullup_en_upwr_i),
-    .clk1_i (held_dppullup_en),
-    .sel_i  (hold_ios),
-    .clk_o  (usb_dppullup_en_alw_o)
-  );
-
-  prim_generic_clock_mux2 #(
-    .NoFpgaBufG(1)
-  ) i_mux_dnpullup_en (
-    .clk0_i (usb_dnpullup_en_upwr_i),
-    .clk1_i (held_dnpullup_en),
-    .sel_i  (hold_ios),
-    .clk_o  (usb_dnpullup_en_alw_o)
-  );
-
-  // outputs never enabled when in suspend with USB IP powered off
-  // the _en_upwr signals will always be 0 when suspend is detected so no glitch
-  // (would this be cleaner as _en_alw_o = _en_upwr_i & !hold_ios)
-  assign usb_dp_en_alw_o = hold_ios ? 0 : usb_dp_en_upwr_i;
-  assign usb_dn_en_alw_o = hold_ios ? 0 : usb_dn_en_upwr_i;
-  assign usb_d_en_alw_o  = hold_ios ? 0 : usb_d_en_upwr_i;
+  assign state_debug_o = astate_q;
 
 endmodule

--- a/hw/ip/usbdev/rtl/usbdev_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_pkg.sv
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package usbdev_pkg;
+
+  // Code the state values so that the transitions software could poll are single bit
+  // Woken->Idle and WokenUon->Idle (after sw ack) should therefore be single bit changes
+  typedef enum logic [2:0] {
+    AwkIdle =     3'b000,
+    AwkTrigUon =  3'b011,   // 2 bit change from Idle but sw not monitoring
+    AwkTrigUoff = 3'b010,   // ok with two bit change out because chip power is off
+    AwkWokenUon = 3'b001,   // one bit change in/out to TrigUon and Idle, chip off to Woken
+    AwkWoken =    3'b100    // one bit change out to Idle, in has chip power off
+  } awk_state_e;
+
+  typedef awk_state_e awk_state_t;
+
+endpackage : usbdev_pkg

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -323,6 +323,15 @@ package usbdev_reg_pkg;
     } tx_osc_test_mode;
   } usbdev_reg2hw_phy_config_reg_t;
 
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } wake_en;
+    struct packed {
+      logic        q;
+    } wake_ack;
+  } usbdev_reg2hw_wake_config_reg_t;
+
 
   typedef struct packed {
     struct packed {
@@ -498,39 +507,46 @@ package usbdev_reg_pkg;
     } pwr_sense;
   } usbdev_hw2reg_phy_pins_sense_reg_t;
 
+  typedef struct packed {
+    logic [2:0]  d;
+    logic        de;
+  } usbdev_hw2reg_wake_debug_reg_t;
+
 
   ///////////////////////////////////////
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    usbdev_reg2hw_intr_state_reg_t intr_state; // [360:344]
-    usbdev_reg2hw_intr_enable_reg_t intr_enable; // [343:327]
-    usbdev_reg2hw_intr_test_reg_t intr_test; // [326:293]
-    usbdev_reg2hw_usbctrl_reg_t usbctrl; // [292:285]
-    usbdev_reg2hw_avbuffer_reg_t avbuffer; // [284:279]
-    usbdev_reg2hw_rxfifo_reg_t rxfifo; // [278:258]
-    usbdev_reg2hw_rxenable_setup_mreg_t [11:0] rxenable_setup; // [257:246]
-    usbdev_reg2hw_rxenable_out_mreg_t [11:0] rxenable_out; // [245:234]
-    usbdev_reg2hw_stall_mreg_t [11:0] stall; // [233:222]
-    usbdev_reg2hw_configin_mreg_t [11:0] configin; // [221:54]
-    usbdev_reg2hw_iso_mreg_t [11:0] iso; // [53:42]
-    usbdev_reg2hw_data_toggle_clear_mreg_t [11:0] data_toggle_clear; // [41:18]
-    usbdev_reg2hw_phy_pins_drive_reg_t phy_pins_drive; // [17:8]
-    usbdev_reg2hw_phy_config_reg_t phy_config; // [7:0]
+    usbdev_reg2hw_intr_state_reg_t intr_state; // [362:346]
+    usbdev_reg2hw_intr_enable_reg_t intr_enable; // [345:329]
+    usbdev_reg2hw_intr_test_reg_t intr_test; // [328:295]
+    usbdev_reg2hw_usbctrl_reg_t usbctrl; // [294:287]
+    usbdev_reg2hw_avbuffer_reg_t avbuffer; // [286:281]
+    usbdev_reg2hw_rxfifo_reg_t rxfifo; // [280:260]
+    usbdev_reg2hw_rxenable_setup_mreg_t [11:0] rxenable_setup; // [259:248]
+    usbdev_reg2hw_rxenable_out_mreg_t [11:0] rxenable_out; // [247:236]
+    usbdev_reg2hw_stall_mreg_t [11:0] stall; // [235:224]
+    usbdev_reg2hw_configin_mreg_t [11:0] configin; // [223:56]
+    usbdev_reg2hw_iso_mreg_t [11:0] iso; // [55:44]
+    usbdev_reg2hw_data_toggle_clear_mreg_t [11:0] data_toggle_clear; // [43:20]
+    usbdev_reg2hw_phy_pins_drive_reg_t phy_pins_drive; // [19:10]
+    usbdev_reg2hw_phy_config_reg_t phy_config; // [9:2]
+    usbdev_reg2hw_wake_config_reg_t wake_config; // [1:0]
   } usbdev_reg2hw_t;
 
   ///////////////////////////////////////
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    usbdev_hw2reg_intr_state_reg_t intr_state; // [188:155]
-    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [154:147]
-    usbdev_hw2reg_usbstat_reg_t usbstat; // [146:123]
-    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [122:106]
-    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [105:82]
-    usbdev_hw2reg_stall_mreg_t [11:0] stall; // [81:58]
-    usbdev_hw2reg_configin_mreg_t [11:0] configin; // [57:10]
-    usbdev_hw2reg_phy_pins_sense_reg_t phy_pins_sense; // [9:0]
+    usbdev_hw2reg_intr_state_reg_t intr_state; // [192:159]
+    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [158:151]
+    usbdev_hw2reg_usbstat_reg_t usbstat; // [150:127]
+    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [126:110]
+    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [109:86]
+    usbdev_hw2reg_stall_mreg_t [11:0] stall; // [85:62]
+    usbdev_hw2reg_configin_mreg_t [11:0] configin; // [61:14]
+    usbdev_hw2reg_phy_pins_sense_reg_t phy_pins_sense; // [13:4]
+    usbdev_hw2reg_wake_debug_reg_t wake_debug; // [3:0]
   } usbdev_hw2reg_t;
 
   // Register Address
@@ -562,6 +578,8 @@ package usbdev_reg_pkg;
   parameter logic [BlockAw-1:0] USBDEV_PHY_PINS_SENSE_OFFSET = 12'h 64;
   parameter logic [BlockAw-1:0] USBDEV_PHY_PINS_DRIVE_OFFSET = 12'h 68;
   parameter logic [BlockAw-1:0] USBDEV_PHY_CONFIG_OFFSET = 12'h 6c;
+  parameter logic [BlockAw-1:0] USBDEV_WAKE_CONFIG_OFFSET = 12'h 70;
+  parameter logic [BlockAw-1:0] USBDEV_WAKE_DEBUG_OFFSET = 12'h 74;
 
   // Window parameter
   parameter logic [BlockAw-1:0] USBDEV_BUFFER_OFFSET = 12'h 800;
@@ -596,11 +614,13 @@ package usbdev_reg_pkg;
     USBDEV_DATA_TOGGLE_CLEAR,
     USBDEV_PHY_PINS_SENSE,
     USBDEV_PHY_PINS_DRIVE,
-    USBDEV_PHY_CONFIG
+    USBDEV_PHY_CONFIG,
+    USBDEV_WAKE_CONFIG,
+    USBDEV_WAKE_DEBUG
   } usbdev_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] USBDEV_PERMIT [28] = '{
+  parameter logic [3:0] USBDEV_PERMIT [30] = '{
     4'b 0111, // index[ 0] USBDEV_INTR_STATE
     4'b 0111, // index[ 1] USBDEV_INTR_ENABLE
     4'b 0111, // index[ 2] USBDEV_INTR_TEST
@@ -628,7 +648,9 @@ package usbdev_reg_pkg;
     4'b 0011, // index[24] USBDEV_DATA_TOGGLE_CLEAR
     4'b 0111, // index[25] USBDEV_PHY_PINS_SENSE
     4'b 0111, // index[26] USBDEV_PHY_PINS_DRIVE
-    4'b 0001  // index[27] USBDEV_PHY_CONFIG
+    4'b 0001, // index[27] USBDEV_PHY_CONFIG
+    4'b 0001, // index[28] USBDEV_WAKE_CONFIG
+    4'b 0001  // index[29] USBDEV_WAKE_DEBUG
   };
 endpackage
 

--- a/hw/ip/usbdev/usbdev.core
+++ b/hw/ip/usbdev/usbdev.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:ip:tlul
       - lowrisc:prim:ram_2p_async_adv
       - lowrisc:ip:usb_fs_nb_pe
+      - lowrisc:ip:usbdev_pkg
     files:
       - rtl/usbdev_reg_pkg.sv
       - rtl/usbdev_reg_top.sv
@@ -18,6 +19,7 @@ filesets:
       - rtl/usbdev_flop_2syncpulse.sv
       - rtl/usbdev_linkstate.sv
       - rtl/usbdev_iomux.sv
+      - rtl/usbdev_aon_wake.sv
       - rtl/usbdev.sv
     file_type: systemVerilogSource
 
@@ -82,5 +84,3 @@ targets:
         mode: lint-only
         verilator_options:
           - "-Wall"
-
-

--- a/hw/ip/usbdev/usbdev_pkg.core
+++ b/hw/ip/usbdev/usbdev_pkg.core
@@ -1,0 +1,18 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:ip:usbdev_pkg:0.1"
+description: "Usb device package"
+filesets:
+  files_rtl:
+    depend:
+    files:
+      - rtl/usbdev_pkg.sv
+    file_type: systemVerilogSource
+
+
+targets:
+  default: &default_target
+    filesets:
+      - files_rtl

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -139,6 +139,7 @@
         clocks:
         {
           clk_io_div4_peri: io_div4
+          clk_aon_peri: aon
           clk_usb_peri: usb
         }
       }
@@ -319,6 +320,7 @@
         domains:
         [
           Aon
+          "0"
         ]
         parent: sys_src
         clk: aon
@@ -341,7 +343,7 @@
         type: top
         domains:
         [
-          Aon
+          "0"
         ]
         parent: sys_src
         clk: usb
@@ -3198,6 +3200,77 @@
           index: -1
         }
         {
+          struct: logic
+          type: uni
+          name: usb_wkup_req
+          act: req
+          package: ""
+          default: 1'b0
+          inst_name: pinmux
+          index: -1
+        }
+        {
+          name: usb_out_of_rst
+          type: uni
+          act: rcv
+          package: ""
+          struct: logic
+          width: 1
+          inst_name: pinmux
+          default: ""
+          top_signame: usbdev_usb_out_of_rst
+          index: -1
+        }
+        {
+          name: usb_aon_wake_en
+          type: uni
+          act: rcv
+          package: ""
+          struct: logic
+          width: 1
+          inst_name: pinmux
+          default: ""
+          top_signame: usbdev_usb_aon_wake_en
+          index: -1
+        }
+        {
+          name: usb_aon_wake_ack
+          type: uni
+          act: rcv
+          package: ""
+          struct: logic
+          width: 1
+          inst_name: pinmux
+          default: ""
+          top_signame: usbdev_usb_aon_wake_ack
+          index: -1
+        }
+        {
+          name: usb_suspend
+          type: uni
+          act: rcv
+          package: ""
+          struct: logic
+          width: 1
+          inst_name: pinmux
+          default: ""
+          top_signame: usbdev_usb_suspend
+          index: -1
+        }
+        {
+          name: usb_state_debug
+          type: uni
+          act: req
+          package: usbdev_pkg
+          struct: awk_state
+          inst_name: pinmux
+          width: 1
+          default: ""
+          top_type: broadcast
+          top_signame: pinmux_usb_state_debug
+          index: -1
+        }
+        {
           struct: tl
           package: tlul_pkg
           type: req_rsp
@@ -3267,6 +3340,7 @@
       clock_srcs:
       {
         clk_i: io_div4
+        clk_aon_i: aon
         clk_usb_48mhz_i: usb
       }
       clock_group: peri
@@ -3276,16 +3350,18 @@
       ]
       reset_connections:
       {
-        rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]
-        rst_usb_48mhz_ni: rstmgr_resets.rst_usb_n[rstmgr_pkg::DomainAonSel]
+        rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
+        rst_aon_ni: rstmgr_resets.rst_sys_aon_n[rstmgr_pkg::Domain0Sel]
+        rst_usb_48mhz_ni: rstmgr_resets.rst_usb_n[rstmgr_pkg::Domain0Sel]
       }
-      domain: Aon
       base_addr: 0x40500000
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_io_div4_peri
+        clk_aon_i: clkmgr_clocks.clk_aon_peri
         clk_usb_48mhz_i: clkmgr_clocks.clk_usb_peri
       }
+      domain: "0"
       size: 0x1000
       bus_device: tlul
       bus_host: none
@@ -3582,6 +3658,70 @@
           default: ""
           external: true
           top_signame: usbdev_usb_ref_pulse
+          index: -1
+        }
+        {
+          name: usb_out_of_rst
+          type: uni
+          act: req
+          package: ""
+          struct: logic
+          width: 1
+          inst_name: usbdev
+          default: ""
+          top_type: broadcast
+          top_signame: usbdev_usb_out_of_rst
+          index: -1
+        }
+        {
+          name: usb_aon_wake_en
+          type: uni
+          act: req
+          package: ""
+          struct: logic
+          width: 1
+          inst_name: usbdev
+          default: ""
+          top_type: broadcast
+          top_signame: usbdev_usb_aon_wake_en
+          index: -1
+        }
+        {
+          name: usb_aon_wake_ack
+          type: uni
+          act: req
+          package: ""
+          struct: logic
+          width: 1
+          inst_name: usbdev
+          default: ""
+          top_type: broadcast
+          top_signame: usbdev_usb_aon_wake_ack
+          index: -1
+        }
+        {
+          name: usb_suspend
+          type: uni
+          act: req
+          package: ""
+          struct: logic
+          width: 1
+          inst_name: usbdev
+          default: ""
+          top_type: broadcast
+          top_signame: usbdev_usb_suspend
+          index: -1
+        }
+        {
+          name: usb_state_debug
+          type: uni
+          act: rcv
+          package: usbdev_pkg
+          struct: awk_state
+          inst_name: usbdev
+          width: 1
+          default: ""
+          top_signame: pinmux_usb_state_debug
           index: -1
         }
         {
@@ -6062,6 +6202,26 @@
       rv_core_ibex.crashdump:
       [
         rstmgr.cpu_dump
+      ]
+      usbdev.usb_out_of_rst:
+      [
+        pinmux.usb_out_of_rst
+      ]
+      usbdev.usb_aon_wake_en:
+      [
+        pinmux.usb_aon_wake_en
+      ]
+      usbdev.usb_aon_wake_ack:
+      [
+        pinmux.usb_aon_wake_ack
+      ]
+      usbdev.usb_suspend:
+      [
+        pinmux.usb_suspend
+      ]
+      pinmux.usb_state_debug:
+      [
+        usbdev.usb_state_debug
       ]
       otp_ctrl.otp_keymgr_key:
       [
@@ -9551,6 +9711,7 @@
       usbdev:
       [
         io_div4_peri
+        aon_peri
         usb_peri
       ]
     }
@@ -9581,6 +9742,7 @@
       usbdev:
       [
         sys_io_div4
+        sys_aon
         usb
       ]
     }
@@ -10837,6 +10999,77 @@
         index: -1
       }
       {
+        struct: logic
+        type: uni
+        name: usb_wkup_req
+        act: req
+        package: ""
+        default: 1'b0
+        inst_name: pinmux
+        index: -1
+      }
+      {
+        name: usb_out_of_rst
+        type: uni
+        act: rcv
+        package: ""
+        struct: logic
+        width: 1
+        inst_name: pinmux
+        default: ""
+        top_signame: usbdev_usb_out_of_rst
+        index: -1
+      }
+      {
+        name: usb_aon_wake_en
+        type: uni
+        act: rcv
+        package: ""
+        struct: logic
+        width: 1
+        inst_name: pinmux
+        default: ""
+        top_signame: usbdev_usb_aon_wake_en
+        index: -1
+      }
+      {
+        name: usb_aon_wake_ack
+        type: uni
+        act: rcv
+        package: ""
+        struct: logic
+        width: 1
+        inst_name: pinmux
+        default: ""
+        top_signame: usbdev_usb_aon_wake_ack
+        index: -1
+      }
+      {
+        name: usb_suspend
+        type: uni
+        act: rcv
+        package: ""
+        struct: logic
+        width: 1
+        inst_name: pinmux
+        default: ""
+        top_signame: usbdev_usb_suspend
+        index: -1
+      }
+      {
+        name: usb_state_debug
+        type: uni
+        act: req
+        package: usbdev_pkg
+        struct: awk_state
+        inst_name: pinmux
+        width: 1
+        default: ""
+        top_type: broadcast
+        top_signame: pinmux_usb_state_debug
+        index: -1
+      }
+      {
         struct: tl
         package: tlul_pkg
         type: req_rsp
@@ -10884,6 +11117,70 @@
         default: ""
         external: true
         top_signame: usbdev_usb_ref_pulse
+        index: -1
+      }
+      {
+        name: usb_out_of_rst
+        type: uni
+        act: req
+        package: ""
+        struct: logic
+        width: 1
+        inst_name: usbdev
+        default: ""
+        top_type: broadcast
+        top_signame: usbdev_usb_out_of_rst
+        index: -1
+      }
+      {
+        name: usb_aon_wake_en
+        type: uni
+        act: req
+        package: ""
+        struct: logic
+        width: 1
+        inst_name: usbdev
+        default: ""
+        top_type: broadcast
+        top_signame: usbdev_usb_aon_wake_en
+        index: -1
+      }
+      {
+        name: usb_aon_wake_ack
+        type: uni
+        act: req
+        package: ""
+        struct: logic
+        width: 1
+        inst_name: usbdev
+        default: ""
+        top_type: broadcast
+        top_signame: usbdev_usb_aon_wake_ack
+        index: -1
+      }
+      {
+        name: usb_suspend
+        type: uni
+        act: req
+        package: ""
+        struct: logic
+        width: 1
+        inst_name: usbdev
+        default: ""
+        top_type: broadcast
+        top_signame: usbdev_usb_suspend
+        index: -1
+      }
+      {
+        name: usb_state_debug
+        type: uni
+        act: rcv
+        package: usbdev_pkg
+        struct: awk_state
+        inst_name: usbdev
+        width: 1
+        default: ""
+        top_signame: pinmux_usb_state_debug
         index: -1
       }
       {
@@ -12780,6 +13077,46 @@
         package: rv_core_ibex_pkg
         struct: crashdump
         signame: rv_core_ibex_crashdump
+        width: 1
+        type: uni
+        default: ""
+      }
+      {
+        package: ""
+        struct: logic
+        signame: usbdev_usb_out_of_rst
+        width: 1
+        type: uni
+        default: ""
+      }
+      {
+        package: ""
+        struct: logic
+        signame: usbdev_usb_aon_wake_en
+        width: 1
+        type: uni
+        default: ""
+      }
+      {
+        package: ""
+        struct: logic
+        signame: usbdev_usb_aon_wake_ack
+        width: 1
+        type: uni
+        default: ""
+      }
+      {
+        package: ""
+        struct: logic
+        signame: usbdev_usb_suspend
+        width: 1
+        type: uni
+        default: ""
+      }
+      {
+        package: usbdev_pkg
+        struct: awk_state
+        signame: pinmux_usb_state_debug
         width: 1
         type: uni
         default: ""

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -153,9 +153,9 @@
       { name: "lc_io_div4",  gen: true,  type: "top", domains: [       "0"], parent: "lc_src",  clk: "io_div4" }
       { name: "sys",         gen: true,  type: "top", domains: ["Aon", "0"], parent: "sys_src", clk: "main"    }
       { name: "sys_io_div4", gen: true,  type: "top", domains: ["Aon", "0"], parent: "sys_src", clk: "io_div4" }
-      { name: "sys_aon",     gen: true,  type: "top", domains: ["Aon",    ], parent: "sys_src", clk: "aon"     }
+      { name: "sys_aon",     gen: true,  type: "top", domains: ["Aon", "0"], parent: "sys_src", clk: "aon"     }
       { name: "spi_device",  gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "io_div2", sw: 1 }
-      { name: "usb",         gen: true,  type: "top", domains: ["Aon",    ], parent: "sys_src", clk: "usb",     sw: 1 }
+      { name: "usb",         gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "usb",     sw: 1 }
     ]
   }
 
@@ -383,11 +383,10 @@
     },
     { name: "usbdev",
       type: "usbdev",
-      clock_srcs: {clk_i: "io_div4", clk_usb_48mhz_i: "usb"},
+      clock_srcs: {clk_i: "io_div4", clk_aon_i: "aon", clk_usb_48mhz_i: "usb"},
       clock_group: "peri",
       clock_reset_export: ["ast"],
-      reset_connections: {rst_ni: "sys_io_div4", rst_usb_48mhz_ni: "usb"},
-      domain: "Aon",
+      reset_connections: {rst_ni: "sys_io_div4", rst_aon_ni: "sys_aon", rst_usb_48mhz_ni: "usb"},
       base_addr: "0x40500000",
     },
     { name: "sram_ctrl_ret",
@@ -656,6 +655,14 @@
       'alert_handler.crashdump' : ['rstmgr.alert_dump'],
       'rv_core_ibex.crashdump'  : ['rstmgr.cpu_dump'],
       'csrng.entropy_src_hw_if' : ['entropy_src.entropy_src_hw_if'],
+
+      // usbdev connection to pinmux
+      'usbdev.usb_out_of_rst'   : ['pinmux.usb_out_of_rst'],
+      'usbdev.usb_aon_wake_en'  : ['pinmux.usb_aon_wake_en'],
+      'usbdev.usb_aon_wake_ack' : ['pinmux.usb_aon_wake_ack'],
+      'usbdev.usb_suspend'      : ['pinmux.usb_suspend'],
+      'pinmux.usb_state_debug'  : ['usbdev.usb_state_debug'],
+
       // TODO see #4447
       //'edn0.edn'              : ['keymgr.edn', 'otp_ctrl.edn'],
 

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -155,6 +155,10 @@ module clkmgr import clkmgr_pkg::*; (
     .clk_i(clk_aon_i),
     .clk_o(clocks_o.clk_aon_secure)
   );
+  prim_clock_buf u_clk_aon_peri_buf (
+    .clk_i(clk_aon_i),
+    .clk_o(clocks_o.clk_aon_peri)
+  );
 
   ////////////////////////////////////////////////////
   // Root gating
@@ -444,6 +448,7 @@ module clkmgr import clkmgr_pkg::*; (
 
   assign clocks_ast_o.clk_ast_sensor_ctrl_io_div4_secure = clocks_o.clk_io_div4_secure;
   assign clocks_ast_o.clk_ast_usbdev_io_div4_peri = clocks_o.clk_io_div4_peri;
+  assign clocks_ast_o.clk_ast_usbdev_aon_peri = clocks_o.clk_aon_peri;
   assign clocks_ast_o.clk_ast_usbdev_usb_peri = clocks_o.clk_usb_peri;
 
   ////////////////////////////////////////////////////

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -27,6 +27,7 @@ package clkmgr_pkg;
   logic clk_usb_powerup;
   logic clk_io_div2_powerup;
   logic clk_aon_secure;
+  logic clk_aon_peri;
   logic clk_main_aes;
   logic clk_main_hmac;
   logic clk_main_kmac;
@@ -46,6 +47,7 @@ package clkmgr_pkg;
   typedef struct packed {
     logic clk_ast_sensor_ctrl_io_div4_secure;
     logic clk_ast_usbdev_io_div4_peri;
+    logic clk_ast_usbdev_aon_peri;
     logic clk_ast_usbdev_usb_peri;
   } clkmgr_ast_out_t;
 

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -82,6 +82,47 @@
       package: "",
       default: "1'b0"
     },
+    { struct:  "logic",
+      type:    "uni",
+      name:    "usb_wkup_req",
+      act:     "req",
+      package: "",
+      default: "1'b0"
+    },
+    { name:    "usb_out_of_rst",
+      type:    "uni",
+      act:     "rcv",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    },
+    { name:    "usb_aon_wake_en",
+      type:    "uni",
+      act:     "rcv",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    },
+    { name:    "usb_aon_wake_ack",
+      type:    "uni",
+      act:     "rcv",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    },
+    { name:    "usb_suspend",
+      type:    "uni",
+      act:     "rcv",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    },
+    { name:    "usb_state_debug",
+      type:    "uni",
+      act:     "req",
+      package: "usbdev_pkg",
+      struct:  "awk_state",
+    },
   ]
 
   param_list: [
@@ -121,6 +162,43 @@
       default: "8",
       local: "true"
     },
+    { name: "NUsbDevPads",
+      desc: "Number of usbdev pins",
+      type: "int",
+      default: "9",
+      local: "true"
+    },
+    { name: "NDioPadUsbDevStart",
+      desc: "Start position for usbdev pins",
+      type: "int",
+      default: "0",
+      local: "true"
+    },
+    { name: "UsbDpSel",
+      desc: "index of usbdev_dp",
+      type: "int",
+      default: "1",
+      local: "true"
+    },
+    { name: "UsbDnSel",
+      desc: "index of usbdev_dn",
+      type: "int",
+      default: "0",
+      local: "true"
+    },
+    { name: "UsbDpPullUpSel",
+      desc: "index of usbdev_dp_pullup",
+      type: "int",
+      default: "6",
+      local: "true"
+    },
+    { name: "UsbDnPullUpSel",
+      desc: "index of usbdev_dn_pullup",
+      type: "int",
+      default: "5",
+      local: "true"
+    },
+
     // TODO: Enable these once supported by topgen and the C header generation script.
     // These parameters are currently located in pinmux_pkg.sv
     // // If a bit is set to 1 in this vector, this MIO activates low power

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
@@ -13,6 +13,12 @@ package pinmux_reg_pkg;
   parameter int NDioPads = 15;
   parameter int NWkupDetect = 8;
   parameter int WkupCntWidth = 8;
+  parameter int NUsbDevPads = 9;
+  parameter int NDioPadUsbDevStart = 0;
+  parameter int UsbDpSel = 1;
+  parameter int UsbDnSel = 0;
+  parameter int UsbDpPullUpSel = 6;
+  parameter int UsbDnPullUpSel = 5;
 
   // Address width within the block
   parameter int BlockAw = 7;

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -462,9 +462,24 @@ module rstmgr import rstmgr_pkg::*; (
     .clk_o(resets_o.rst_sys_aon_n[DomainAonSel])
   );
 
-  assign rst_sys_aon_n[Domain0Sel] = 1'b0;
-  assign resets_o.rst_sys_aon_n[Domain0Sel] = rst_sys_aon_n[Domain0Sel];
+  prim_flop_2sync #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_0_sys_aon (
+    .clk_i(clk_aon_i),
+    .rst_ni(rst_sys_src_n[Domain0Sel]),
+    .d_i(1'b1),
+    .q_o(rst_sys_aon_n[Domain0Sel])
+  );
 
+  prim_clock_mux2 #(
+    .NoFpgaBufG(1'b1)
+  ) u_0_sys_aon_mux (
+    .clk0_i(rst_sys_aon_n[Domain0Sel]),
+    .clk1_i(scan_rst_ni),
+    .sel_i(scanmode_i),
+    .clk_o(resets_o.rst_sys_aon_n[Domain0Sel])
+  );
 
   logic [PowerDomains-1:0] rst_spi_device_n;
   assign rst_spi_device_n[DomainAonSel] = 1'b0;
@@ -491,28 +506,28 @@ module rstmgr import rstmgr_pkg::*; (
   );
 
   logic [PowerDomains-1:0] rst_usb_n;
+  assign rst_usb_n[DomainAonSel] = 1'b0;
+  assign resets_o.rst_usb_n[DomainAonSel] = rst_usb_n[DomainAonSel];
+
+
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
-  ) u_aon_usb (
+  ) u_0_usb (
     .clk_i(clk_usb_i),
-    .rst_ni(rst_sys_src_n[DomainAonSel]),
+    .rst_ni(rst_sys_src_n[Domain0Sel]),
     .d_i(sw_rst_ctrl_n[USB]),
-    .q_o(rst_usb_n[DomainAonSel])
+    .q_o(rst_usb_n[Domain0Sel])
   );
 
   prim_clock_mux2 #(
     .NoFpgaBufG(1'b1)
-  ) u_aon_usb_mux (
-    .clk0_i(rst_usb_n[DomainAonSel]),
+  ) u_0_usb_mux (
+    .clk0_i(rst_usb_n[Domain0Sel]),
     .clk1_i(scan_rst_ni),
     .sel_i(scanmode_i),
-    .clk_o(resets_o.rst_usb_n[DomainAonSel])
+    .clk_o(resets_o.rst_usb_n[Domain0Sel])
   );
-
-  assign rst_usb_n[Domain0Sel] = 1'b0;
-  assign resets_o.rst_usb_n[Domain0Sel] = rst_usb_n[Domain0Sel];
-
 
 
   ////////////////////////////////////////////////////
@@ -606,6 +621,7 @@ module rstmgr import rstmgr_pkg::*; (
   ////////////////////////////////////////////////////
   assign resets_ast_o.rst_ast_sensor_ctrl_sys_io_div4_n = resets_o.rst_sys_io_div4_n;
   assign resets_ast_o.rst_ast_usbdev_sys_io_div4_n = resets_o.rst_sys_io_div4_n;
+  assign resets_ast_o.rst_ast_usbdev_sys_aon_n = resets_o.rst_sys_aon_n;
   assign resets_ast_o.rst_ast_usbdev_usb_n = resets_o.rst_usb_n;
 
 

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_pkg.sv
@@ -64,6 +64,7 @@ package rstmgr_pkg;
   typedef struct packed {
     logic [PowerDomains-1:0] rst_ast_sensor_ctrl_sys_io_div4_n;
     logic [PowerDomains-1:0] rst_ast_usbdev_sys_io_div4_n;
+    logic [PowerDomains-1:0] rst_ast_usbdev_sys_aon_n;
     logic [PowerDomains-1:0] rst_ast_usbdev_usb_n;
   } rstmgr_ast_out_t;
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -322,6 +322,11 @@ module top_earlgrey #(
   pwrmgr_pkg::pwr_lc_req_t       pwrmgr_pwr_lc_req;
   pwrmgr_pkg::pwr_lc_rsp_t       pwrmgr_pwr_lc_rsp;
   rv_core_ibex_pkg::crashdump_t       rv_core_ibex_crashdump;
+  logic       usbdev_usb_out_of_rst;
+  logic       usbdev_usb_aon_wake_en;
+  logic       usbdev_usb_aon_wake_ack;
+  logic       usbdev_usb_suspend;
+  usbdev_pkg::awk_state_t       pinmux_usb_state_debug;
   otp_ctrl_pkg::otp_keymgr_key_t       otp_ctrl_otp_keymgr_key;
   keymgr_pkg::hw_key_req_t       keymgr_kmac_key;
   keymgr_pkg::kmac_data_req_t       keymgr_kmac_data_req;
@@ -444,9 +449,8 @@ module top_earlgrey #(
   logic unused_d0_rst_por_usb;
   logic unused_daon_rst_lc;
   logic unused_daon_rst_lc_io_div4;
-  logic unused_d0_rst_sys_aon;
   logic unused_daon_rst_spi_device;
-  logic unused_d0_rst_usb;
+  logic unused_daon_rst_usb;
   assign unused_d0_rst_por_aon = rstmgr_resets.rst_por_aon_n[rstmgr_pkg::Domain0Sel];
   assign unused_d0_rst_por = rstmgr_resets.rst_por_n[rstmgr_pkg::Domain0Sel];
   assign unused_d0_rst_por_io = rstmgr_resets.rst_por_io_n[rstmgr_pkg::Domain0Sel];
@@ -455,9 +459,8 @@ module top_earlgrey #(
   assign unused_d0_rst_por_usb = rstmgr_resets.rst_por_usb_n[rstmgr_pkg::Domain0Sel];
   assign unused_daon_rst_lc = rstmgr_resets.rst_lc_n[rstmgr_pkg::DomainAonSel];
   assign unused_daon_rst_lc_io_div4 = rstmgr_resets.rst_lc_io_div4_n[rstmgr_pkg::DomainAonSel];
-  assign unused_d0_rst_sys_aon = rstmgr_resets.rst_sys_aon_n[rstmgr_pkg::Domain0Sel];
   assign unused_daon_rst_spi_device = rstmgr_resets.rst_spi_device_n[rstmgr_pkg::DomainAonSel];
-  assign unused_d0_rst_usb = rstmgr_resets.rst_usb_n[rstmgr_pkg::Domain0Sel];
+  assign unused_daon_rst_usb = rstmgr_resets.rst_usb_n[rstmgr_pkg::DomainAonSel];
 
   // Non-debug module reset == reset for everything except for the debug module
   logic ndmreset_req;
@@ -1195,6 +1198,12 @@ module top_earlgrey #(
       .io_pok_i({pinmux_pkg::NIOPokSignals{1'b1}}),
       .sleep_en_i(1'b0),
       .aon_wkup_req_o(pwrmgr_wakeups),
+      .usb_wkup_req_o(),
+      .usb_out_of_rst_i(usbdev_usb_out_of_rst),
+      .usb_aon_wake_en_i(usbdev_usb_aon_wake_en),
+      .usb_aon_wake_ack_i(usbdev_usb_aon_wake_ack),
+      .usb_suspend_i(usbdev_usb_suspend),
+      .usb_state_debug_o(pinmux_usb_state_debug),
       .tl_i(pinmux_tl_req),
       .tl_o(pinmux_tl_rsp),
 
@@ -1279,12 +1288,19 @@ module top_earlgrey #(
       // Inter-module signals
       .usb_ref_val_o(usbdev_usb_ref_val_o),
       .usb_ref_pulse_o(usbdev_usb_ref_pulse_o),
+      .usb_out_of_rst_o(usbdev_usb_out_of_rst),
+      .usb_aon_wake_en_o(usbdev_usb_aon_wake_en),
+      .usb_aon_wake_ack_o(usbdev_usb_aon_wake_ack),
+      .usb_suspend_o(usbdev_usb_suspend),
+      .usb_state_debug_i(pinmux_usb_state_debug),
       .tl_i(usbdev_tl_req),
       .tl_o(usbdev_tl_rsp),
       .clk_i (clkmgr_clocks.clk_io_div4_peri),
+      .clk_aon_i (clkmgr_clocks.clk_aon_peri),
       .clk_usb_48mhz_i (clkmgr_clocks.clk_usb_peri),
-      .rst_ni (rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]),
-      .rst_usb_48mhz_ni (rstmgr_resets.rst_usb_n[rstmgr_pkg::DomainAonSel])
+      .rst_ni (rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]),
+      .rst_aon_ni (rstmgr_resets.rst_sys_aon_n[rstmgr_pkg::Domain0Sel]),
+      .rst_usb_48mhz_ni (rstmgr_resets.rst_usb_n[rstmgr_pkg::Domain0Sel])
   );
 
   sram_ctrl #(

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -331,10 +331,10 @@
     },
     { name: "usbdev",
       type: "usbdev",
-      clock_srcs: {clk_i: "io_div4", clk_usb_48mhz_i: "usb"},
+      clock_srcs: {clk_i: "io_div4", clk_aon_i: "aon", clk_usb_48mhz_i: "usb"},
       clock_group: "peri",
       clock_reset_export: ["ast"],
-      reset_connections: {rst_ni: "sys_io_div4", rst_usb_48mhz_ni: "usb"},
+      reset_connections: {rst_ni: "sys_io_div4", rst_aon_ni: "sys_aon", rst_usb_48mhz_ni: "usb"},
       domain: "Aon",
       base_addr: "0x40500000",
     },
@@ -545,6 +545,14 @@
       'pwrmgr.pwr_clk'          : ['clkmgr.pwr'],
       'pwrmgr.pwr_lc'           : ['lc_ctrl.pwr_lc'],
       'rv_core_ibex.crashdump'  : ['rstmgr.cpu_dump'],
+
+      // usbdev connection to pinmux
+      'usbdev.usb_out_of_rst'   : ['pinmux.usb_out_of_rst'],
+      'usbdev.usb_aon_wake_en'  : ['pinmux.usb_aon_wake_en'],
+      'usbdev.usb_aon_wake_ack' : ['pinmux.usb_aon_wake_ack'],
+      'usbdev.usb_suspend'      : ['pinmux.usb_suspend'],
+      'pinmux.usb_state_debug'  : ['usbdev.usb_state_debug'],
+
       // TODO see #4447
       //'edn0.edn' : ['keymgr.edn'],
 

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -288,6 +288,48 @@ def generate_plic(top, out_path):
         fout.write(genhdr + gencmd + out)
 
 
+# returns the dedicated pin positions of a particular module
+# For example, if a module is connected to 6:1 of the dio connections,
+# [6, 1] will be returned.
+def _calc_dio_pin_pos(top, mname):
+    dios = top["pinmux"]["dio"]
+
+    last_index = dios.index(dios[-1])
+    bit_pos = []
+    first_index = False
+
+    for dio in dios:
+        if dio['module_name'] == mname and not first_index:
+            bit_pos.append(last_index - dios.index(dio))
+            first_index = True
+        elif first_index and dio['module_name'] != mname:
+            bit_pos.append(last_index - dios.index(dio) - 1)
+
+    # The last one, need to insert last element if only the msb
+    # position is found
+    if len(bit_pos) == 1:
+        bit_pos.append(0)
+
+    log.debug("bit pos {}".format(bit_pos))
+    return bit_pos
+
+
+def _find_dio_pin_pos(top, sname):
+    dios = top["pinmux"]["dio"]
+
+    last_index = dios.index(dios[-1])
+    bit_pos = -1
+
+    for dio in dios:
+        if dio['name'] == sname:
+            bit_pos = last_index - dios.index(dio)
+
+    if bit_pos < 0:
+        log.error("Could not find bit position of {} in dios".format(sname))
+
+    return bit_pos
+
+
 def generate_pinmux_and_padctrl(top, out_path):
     topname = top["name"]
     # MIO Pads
@@ -354,6 +396,15 @@ def generate_pinmux_and_padctrl(top, out_path):
                   "without DIOs.")
         return
 
+    # find the start and end pin positions for usbdev
+    usb_pin_pos = _calc_dio_pin_pos(top, "usbdev")
+    usb_start_pos = usb_pin_pos[-1]
+    n_usb_pins = usb_pin_pos[0] - usb_pin_pos[-1] + 1
+    usb_dp_sel = _find_dio_pin_pos(top, "usbdev_dp")
+    usb_dn_sel = _find_dio_pin_pos(top, "usbdev_dn")
+    usb_dp_pull_sel = _find_dio_pin_pos(top, "usbdev_dp_pullup")
+    usb_dn_pull_sel = _find_dio_pin_pos(top, "usbdev_dn_pullup")
+
     log.info("Generating pinmux with following info from hjson:")
     log.info("num_mio_inputs:  %d" % num_mio_inputs)
     log.info("num_mio_outputs: %d" % num_mio_outputs)
@@ -369,6 +420,8 @@ def generate_pinmux_and_padctrl(top, out_path):
     log.info("n_dio_periph_in:  %d" % n_dio_periph_in)
     log.info("n_dio_periph_out: %d" % n_dio_periph_out)
     log.info("n_dio_pads:       %d" % n_dio_pads)
+    log.info("usb_start_pos:    %d" % usb_start_pos)
+    log.info("n_usb_pins:       %d" % n_usb_pins)
 
     # Target path
     #   rtl: pinmux_reg_pkg.sv & pinmux_reg_top.sv
@@ -408,7 +461,14 @@ def generate_pinmux_and_padctrl(top, out_path):
                 n_dio_periph_out=n_dio_pads,
                 n_dio_pads=n_dio_pads,
                 n_wkup_detect=num_wkup_detect,
-                wkup_cnt_width=wkup_cnt_width)
+                wkup_cnt_width=wkup_cnt_width,
+                usb_start_pos=usb_start_pos,
+                n_usb_pins=n_usb_pins,
+                usb_dp_sel=usb_dp_sel,
+                usb_dn_sel=usb_dn_sel,
+                usb_dp_pull_sel=usb_dp_pull_sel,
+                usb_dn_pull_sel=usb_dn_pull_sel
+            )
         except:  # noqa: E722
             log.error(exceptions.text_error_template().render())
         log.info("PINMUX HJSON: %s" % out)


### PR DESCRIPTION
Continuation of #4697 
Rebased on #4944 

I took @mdhayter `usbdev_aon_wake` module and am trying to massage into the design.

There are a few things:
- `usbdev_aon_wake` is instantiated as basically a custom wake-up detector inside `pinmux`.  I think this location makes sense, as it also allows us to re-use some other pinmux functionality (see below). 
- I've currently removed all the io-holding capability of `usbdev_aon_wake` module, because this functionality exists in the `pinmux`.  After thinking about it some, I think we can re-use this function inside after some minor changes.  @mdhayter what do you think? I'll add some suggestions to the programmers model to explain my thinking.
- To fully support this, `pinmux` would need to be updated such that the entrance and exit of sleep behavior must be software controllable per pin.  In the case of `usbdev`, these pin values would need to hold for quite awhile after software initialization before they can be released.  The same may not be true for other pins.  In general would be better to place these under separate controls
 