### PR TITLE
[aes] Use sparse encodings for MUX selector signals

### DIFF
--- a/hw/ip/aes/aes.core
+++ b/hw/ip/aes/aes.core
@@ -18,6 +18,7 @@ filesets:
       - rtl/aes_ctr.sv
       - rtl/aes_control.sv
       - rtl/aes_reg_status.sv
+      - rtl/aes_sel_buf_chk.sv
       - rtl/aes_cipher_core.sv
       - rtl/aes_cipher_control.sv
       - rtl/aes_sub_bytes.sv

--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -150,7 +150,7 @@
     }
     { name: "fatal",
       desc: '''
-        The fatal alert is triggered i) upon detecting a storage error in the Control Register, or ii) if any internal FSM enters an invalid state.
+        The fatal alert is triggered i) upon detecting a storage error in the Control Register, ii) if any internal FSM enters an invalid state, or iii) if a mux selector signal takes on an invalid value.
         The AES unit cannot recover from such an error and needs to be reset.
       '''
     }
@@ -526,7 +526,7 @@
         desc:  '''
           No fatal alert condition has occurred (0).
           A fatal alert condition has occurred and the AES unit needs to be reset (1).
-          Examples for fatal alert conditions include i) storage errors in the Control Register, and ii) if any internal FSM enters an invalid state.
+          Examples for fatal alert conditions include i) storage errors in the Control Register, ii) if any internal FSM enters an invalid state, and iii) if a mux selector signal takes on an invalid value.
         '''
       }
     ]

--- a/hw/ip/aes/rtl/aes_cipher_control.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control.sv
@@ -35,6 +35,7 @@ module aes_cipher_control
   output logic                    key_clear_o,
   input  logic                    data_out_clear_i,
   output logic                    data_out_clear_o,
+  input  logic                    mux_sel_err_i,
   output logic                    alert_o,
 
   // Control signals for masking PRNG
@@ -375,6 +376,13 @@ module aes_cipher_control
         aes_cipher_ctrl_ns = ERROR;
       end
     endcase
+
+    // Unconditionally jump into the terminal error state in case a mux selector signal becomes
+    // invalid.
+    if (mux_sel_err_i) begin
+      alert_o            = 1'b1;
+      aes_cipher_ctrl_ns = ERROR;
+    end
   end
 
   // This primitive is used to place a size-only constraint on the

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -27,6 +27,7 @@ module aes_control
   input  logic                    key_iv_data_in_clear_i,
   input  logic                    data_out_clear_i,
   input  logic                    prng_reseed_i,
+  input  logic                    mux_sel_err_i,
   input  logic                    alert_fatal_i,
   output logic                    alert_o,
 
@@ -533,6 +534,13 @@ module aes_control
         aes_ctrl_ns = ERROR;
       end
     endcase
+
+    // Unconditionally jump into the terminal error state in case a mux selector signal becomes
+    // invalid.
+    if (mux_sel_err_i) begin
+      alert_o     = 1'b1;
+      aes_ctrl_ns = ERROR;
+    end
   end
 
   // This primitive is used to place a size-only constraint on the

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -65,12 +65,18 @@ module aes_core
   logic                        ctrl_err_storage_d;
   logic                        ctrl_err_storage_q;
   logic                        ctrl_alert;
-
+  logic                        mux_sel_err;
 
   logic        [3:0][3:0][7:0] state_in;
+  logic       [SISelWidth-1:0] state_in_sel_raw;
+  si_sel_e                     state_in_sel_ctrl;
   si_sel_e                     state_in_sel;
+  logic                        state_in_sel_err;
   logic        [3:0][3:0][7:0] add_state_in;
+  logic    [AddSISelWidth-1:0] add_state_in_sel_raw;
+  add_si_sel_e                 add_state_in_sel_ctrl;
   add_si_sel_e                 add_state_in_sel;
+  logic                        add_state_in_sel_err;
 
   logic        [3:0][3:0][7:0] state_mask;
   logic        [3:0][3:0][7:0] state_init [NumShares];
@@ -83,14 +89,20 @@ module aes_core
   logic            [7:0][31:0] key_init_q [2];
   logic            [7:0][31:0] key_init_cipher [NumShares];
   logic            [7:0]       key_init_we [2];
+  logic  [KeyInitSelWidth-1:0] key_init_sel_raw;
+  key_init_sel_e               key_init_sel_ctrl;
   key_init_sel_e               key_init_sel;
+  logic                        key_init_sel_err;
 
   logic            [3:0][31:0] iv;
   logic            [3:0]       iv_qe;
   logic            [7:0][15:0] iv_d;
   logic            [7:0][15:0] iv_q;
   logic            [7:0]       iv_we;
+  logic       [IVSelWidth-1:0] iv_sel_raw;
+  iv_sel_e                     iv_sel_ctrl;
   iv_sel_e                     iv_sel;
+  logic                        iv_sel_err;
 
   logic            [7:0][15:0] ctr;
   logic            [7:0]       ctr_we;
@@ -101,14 +113,20 @@ module aes_core
   logic            [3:0][31:0] data_in_prev_d;
   logic            [3:0][31:0] data_in_prev_q;
   logic                        data_in_prev_we;
+  logic      [DIPSelWidth-1:0] data_in_prev_sel_raw;
+  dip_sel_e                    data_in_prev_sel_ctrl;
   dip_sel_e                    data_in_prev_sel;
+  logic                        data_in_prev_sel_err;
 
   logic            [3:0][31:0] data_in;
   logic            [3:0]       data_in_qe;
   logic                        data_in_we;
 
   logic        [3:0][3:0][7:0] add_state_out;
+  logic    [AddSOSelWidth-1:0] add_state_out_sel_raw;
+  add_so_sel_e                 add_state_out_sel_ctrl;
   add_so_sel_e                 add_state_out_sel;
+  logic                        add_state_out_sel_err;
 
   logic            [3:0][31:0] data_out_d;
   logic            [3:0][31:0] data_out_q;
@@ -500,6 +518,7 @@ module aes_core
     .key_iv_data_in_clear_i    ( reg2hw.trigger.key_iv_data_in_clear.q  ),
     .data_out_clear_i          ( reg2hw.trigger.data_out_clear.q        ),
     .prng_reseed_i             ( reg2hw.trigger.prng_reseed.q           ),
+    .mux_sel_err_i             ( mux_sel_err                            ),
     .alert_fatal_i             ( alert_fatal_o                          ),
     .alert_o                   ( ctrl_alert                             ),
 
@@ -510,12 +529,12 @@ module aes_core
     .data_in_we_o              ( data_in_we                             ),
     .data_out_we_o             ( data_out_we                            ),
 
-    .data_in_prev_sel_o        ( data_in_prev_sel                       ),
+    .data_in_prev_sel_o        ( data_in_prev_sel_ctrl                  ),
     .data_in_prev_we_o         ( data_in_prev_we                        ),
 
-    .state_in_sel_o            ( state_in_sel                           ),
-    .add_state_in_sel_o        ( add_state_in_sel                       ),
-    .add_state_out_sel_o       ( add_state_out_sel                      ),
+    .state_in_sel_o            ( state_in_sel_ctrl                      ),
+    .add_state_in_sel_o        ( add_state_in_sel_ctrl                  ),
+    .add_state_out_sel_o       ( add_state_out_sel_ctrl                 ),
 
     .ctr_incr_o                ( ctr_incr                               ),
     .ctr_ready_i               ( ctr_ready                              ),
@@ -534,9 +553,9 @@ module aes_core
     .cipher_data_out_clear_o   ( cipher_data_out_clear                  ),
     .cipher_data_out_clear_i   ( cipher_data_out_clear_busy             ),
 
-    .key_init_sel_o            ( key_init_sel                           ),
+    .key_init_sel_o            ( key_init_sel_ctrl                      ),
     .key_init_we_o             ( key_init_we                            ),
-    .iv_sel_o                  ( iv_sel                                 ),
+    .iv_sel_o                  ( iv_sel_ctrl                            ),
     .iv_we_o                   ( iv_we                                  ),
 
     .prng_data_req_o           ( prd_clearing_upd_req                   ),
@@ -570,6 +589,93 @@ module aes_core
       hw2reg.data_in[i].de = data_in_we;
     end
   end
+
+  ///////////////
+  // Selectors //
+  ///////////////
+
+  // We use sparse encodings for these mux selector signals and must ensure that:
+  // 1. The synthesis tool doesn't optimize away the sparse encoding.
+  // 2. The selector signal is always valid. More precisely, an alert or SVA is triggered if a
+  //    selector signal takes on an invalid value.
+  // 3. The error/alert signal remains asserted until reset even if the selector signal becomes
+  //    valid again.
+
+  aes_sel_buf_chk #(
+    .Num   ( DIPSelNum   ),
+    .Width ( DIPSelWidth )
+  ) u_aes_data_in_prev_sel_buf_chk (
+    .clk_i  ( clk_i                 ),
+    .rst_ni ( rst_ni                ),
+    .sel_i  ( data_in_prev_sel_ctrl ),
+    .sel_o  ( data_in_prev_sel_raw  ),
+    .err_o  ( data_in_prev_sel_err  )
+  );
+  assign data_in_prev_sel = dip_sel_e'(data_in_prev_sel_raw);
+
+  aes_sel_buf_chk #(
+    .Num   ( SISelNum   ),
+    .Width ( SISelWidth )
+  ) u_aes_state_in_sel_buf_chk (
+    .clk_i  ( clk_i             ),
+    .rst_ni ( rst_ni            ),
+    .sel_i  ( state_in_sel_ctrl ),
+    .sel_o  ( state_in_sel_raw  ),
+    .err_o  ( state_in_sel_err  )
+  );
+  assign state_in_sel = si_sel_e'(state_in_sel_raw);
+
+  aes_sel_buf_chk #(
+    .Num   ( AddSISelNum   ),
+    .Width ( AddSISelWidth )
+  ) u_aes_add_state_in_sel_buf_chk (
+    .clk_i  ( clk_i                 ),
+    .rst_ni ( rst_ni                ),
+    .sel_i  ( add_state_in_sel_ctrl ),
+    .sel_o  ( add_state_in_sel_raw  ),
+    .err_o  ( add_state_in_sel_err  )
+  );
+  assign add_state_in_sel = add_si_sel_e'(add_state_in_sel_raw);
+
+  aes_sel_buf_chk #(
+    .Num   ( AddSOSelNum   ),
+    .Width ( AddSOSelWidth )
+  ) u_aes_add_state_out_sel_buf_chk (
+    .clk_i  ( clk_i                  ),
+    .rst_ni ( rst_ni                 ),
+    .sel_i  ( add_state_out_sel_ctrl ),
+    .sel_o  ( add_state_out_sel_raw  ),
+    .err_o  ( add_state_out_sel_err  )
+  );
+  assign add_state_out_sel = add_so_sel_e'(add_state_out_sel_raw);
+
+  aes_sel_buf_chk #(
+    .Num   ( KeyInitSelNum   ),
+    .Width ( KeyInitSelWidth )
+  ) u_aes_key_init_sel_buf_chk (
+    .clk_i  ( clk_i             ),
+    .rst_ni ( rst_ni            ),
+    .sel_i  ( key_init_sel_ctrl ),
+    .sel_o  ( key_init_sel_raw  ),
+    .err_o  ( key_init_sel_err  )
+  );
+  assign key_init_sel = key_init_sel_e'(key_init_sel_raw);
+
+  aes_sel_buf_chk #(
+    .Num   ( IVSelNum   ),
+    .Width ( IVSelWidth )
+  ) u_aes_iv_sel_buf_chk (
+    .clk_i  ( clk_i       ),
+    .rst_ni ( rst_ni      ),
+    .sel_i  ( iv_sel_ctrl ),
+    .sel_o  ( iv_sel_raw  ),
+    .err_o  ( iv_sel_err  )
+  );
+  assign iv_sel = iv_sel_e'(iv_sel_raw);
+
+  // Signal invalid mux selector signals to control FSM which will lock up and trigger an alert.
+  assign mux_sel_err = data_in_prev_sel_err | state_in_sel_err | add_state_in_sel_err |
+      add_state_out_sel_err | key_init_sel_err | iv_sel_err;
 
   /////////////
   // Outputs //
@@ -657,16 +763,6 @@ module aes_core
   ////////////////
 
   // Selectors must be known/valid
-  `ASSERT_KNOWN(AesKeyInitSelKnown, key_init_sel)
-  `ASSERT(AesIvSelValid, iv_sel inside {
-      IV_INPUT,
-      IV_DATA_OUT,
-      IV_DATA_OUT_RAW,
-      IV_DATA_IN_PREV,
-      IV_CTR,
-      IV_CLEAR
-      })
-  `ASSERT_KNOWN(AesDataInPrevSelKnown, data_in_prev_sel)
   `ASSERT(AesModeValid, !ctrl_err_storage |-> aes_mode_q inside {
       AES_ECB,
       AES_CBC,
@@ -676,12 +772,5 @@ module aes_core
       AES_NONE
       })
   `ASSERT_KNOWN(AesOpKnown, aes_op_q)
-  `ASSERT_KNOWN(AesStateInSelKnown, state_in_sel)
-  `ASSERT_KNOWN(AesAddStateInSelKnown, add_state_in_sel)
-  `ASSERT(AesAddStateOutSelValid, add_state_out_sel inside {
-      ADD_SO_ZERO,
-      ADD_SO_IV,
-      ADD_SO_DIP
-      })
 
 endmodule

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -81,75 +81,197 @@ typedef enum logic [2:0] {
   AES_256 = 3'b100
 } key_len_e;
 
-typedef enum logic {
-  DIP_DATA_IN,
-  DIP_CLEAR
+// Generic, sparse mux selector encodings
+
+// Encoding generated with:
+// $ ./sparse-fsm-encode.py -d 3 -m 2 -n 4 \
+//      -s 31468618 --language=sv
+//
+// Hamming distance histogram:
+//
+//  0: --
+//  1: --
+//  2: --
+//  3: |||||||||||||||||||| (100.00%)
+//  4: --
+//
+// Minimum Hamming distance: 3
+// Maximum Hamming distance: 3
+//
+parameter int Mux2SelWidth = 4;
+typedef enum logic [Mux2SelWidth-1:0] {
+  MUX2_SEL_0 = 4'b0111,
+  MUX2_SEL_1 = 4'b1100
+} mux2_sel_e;
+
+// Encoding generated with:
+// $ ./sparse-fsm-encode.py -d 3 -m 3 -n 5 \
+//      -s 31468618 --language=sv
+//
+// Hamming distance histogram:
+//
+//  0: --
+//  1: --
+//  2: --
+//  3: |||||||||||||||||||| (66.67%)
+//  4: |||||||||| (33.33%)
+//  5: --
+//
+// Minimum Hamming distance: 3
+// Maximum Hamming distance: 4
+//
+parameter int Mux3SelWidth = 5;
+typedef enum logic [Mux3SelWidth-1:0] {
+  MUX3_SEL_0 = 5'b01110,
+  MUX3_SEL_1 = 5'b11000,
+  MUX3_SEL_2 = 5'b00001
+} mux3_sel_e;
+
+// Encoding generated with:
+// $ ./sparse-fsm-encode.py -d 3 -m 4 -n 5 \
+//      -s 31468618 --language=sv
+//
+// Hamming distance histogram:
+//
+//  0: --
+//  1: --
+//  2: --
+//  3: |||||||||||||||||||| (66.67%)
+//  4: |||||||||| (33.33%)
+//  5: --
+//
+// Minimum Hamming distance: 3
+// Maximum Hamming distance: 4
+//
+parameter int Mux4SelWidth = 5;
+typedef enum logic [Mux4SelWidth-1:0] {
+  MUX4_SEL_0 = 5'b01110,
+  MUX4_SEL_1 = 5'b11000,
+  MUX4_SEL_2 = 5'b00001,
+  MUX4_SEL_3 = 5'b10111
+} mux4_sel_e;
+
+// $ ./sparse-fsm-encode.py -d 3 -m 6 -n 6 \
+//      -s 31468618 --language=sv
+//
+// Hamming distance histogram:
+//
+//  0: --
+//  1: --
+//  2: --
+//  3: |||||||||||||||||||| (53.33%)
+//  4: ||||||||||||||| (40.00%)
+//  5: || (6.67%)
+//  6: --
+//
+// Minimum Hamming distance: 3
+// Maximum Hamming distance: 5
+//
+localparam int Mux6SelWidth = 6;
+typedef enum logic [Mux6SelWidth-1:0] {
+  MUX6_SEL_0 = 6'b011101,
+  MUX6_SEL_1 = 6'b110000,
+  MUX6_SEL_2 = 6'b001000,
+  MUX6_SEL_3 = 6'b000011,
+  MUX6_SEL_4 = 6'b111110,
+  MUX6_SEL_5 = 6'b100101
+} mux6_sel_e;
+
+// Mux selector signal types. These use the generic types defined above.
+
+parameter int DIPSelNum = 2;
+parameter int DIPSelWidth = Mux2SelWidth;
+typedef enum logic [DIPSelWidth-1:0] {
+  DIP_DATA_IN = MUX2_SEL_0,
+  DIP_CLEAR   = MUX2_SEL_1
 } dip_sel_e;
 
-typedef enum logic {
-  SI_ZERO,
-  SI_DATA
+parameter int SISelNum = 2;
+parameter int SISelWidth = Mux2SelWidth;
+typedef enum logic [SISelWidth-1:0] {
+  SI_ZERO = MUX2_SEL_0,
+  SI_DATA = MUX2_SEL_1
 } si_sel_e;
 
-typedef enum logic {
-  ADD_SI_ZERO,
-  ADD_SI_IV
+parameter int AddSISelNum = 2;
+parameter int AddSISelWidth = Mux2SelWidth;
+typedef enum logic [AddSISelWidth-1:0] {
+  ADD_SI_ZERO = MUX2_SEL_0,
+  ADD_SI_IV   = MUX2_SEL_1
 } add_si_sel_e;
 
-typedef enum logic [1:0] {
-  STATE_INIT,
-  STATE_ROUND,
-  STATE_CLEAR
+parameter int StateSelNum = 3;
+parameter int StateSelWidth = Mux3SelWidth;
+typedef enum logic [StateSelWidth-1:0] {
+  STATE_INIT  = MUX3_SEL_0,
+  STATE_ROUND = MUX3_SEL_1,
+  STATE_CLEAR = MUX3_SEL_2
 } state_sel_e;
 
-typedef enum logic [1:0] {
-  ADD_RK_INIT,
-  ADD_RK_ROUND,
-  ADD_RK_FINAL
+parameter int AddRKSelNum = 3;
+parameter int AddRKSelWidth = Mux3SelWidth;
+typedef enum logic [AddRKSelWidth-1:0] {
+  ADD_RK_INIT  = MUX3_SEL_0,
+  ADD_RK_ROUND = MUX3_SEL_1,
+  ADD_RK_FINAL = MUX3_SEL_2
 } add_rk_sel_e;
 
-typedef enum logic {
-  KEY_INIT_INPUT,
-  KEY_INIT_CLEAR
+parameter int KeyInitSelNum = 2;
+parameter int KeyInitSelWidth = Mux2SelWidth;
+typedef enum logic [KeyInitSelWidth-1:0] {
+  KEY_INIT_INPUT = MUX2_SEL_0,
+  KEY_INIT_CLEAR = MUX2_SEL_1
 } key_init_sel_e;
 
-typedef enum logic [2:0] {
-  IV_INPUT,
-  IV_DATA_OUT,
-  IV_DATA_OUT_RAW,
-  IV_DATA_IN_PREV,
-  IV_CTR,
-  IV_CLEAR
+parameter int IVSelNum = 6;
+parameter int IVSelWidth = Mux6SelWidth;
+typedef enum logic [IVSelWidth-1:0] {
+  IV_INPUT        = MUX6_SEL_0,
+  IV_DATA_OUT     = MUX6_SEL_1,
+  IV_DATA_OUT_RAW = MUX6_SEL_2,
+  IV_DATA_IN_PREV = MUX6_SEL_3,
+  IV_CTR          = MUX6_SEL_4,
+  IV_CLEAR        = MUX6_SEL_5
 } iv_sel_e;
 
-typedef enum logic [1:0] {
-  KEY_FULL_ENC_INIT,
-  KEY_FULL_DEC_INIT,
-  KEY_FULL_ROUND,
-  KEY_FULL_CLEAR
+parameter int KeyFullSelNum = 4;
+parameter int KeyFullSelWidth = Mux4SelWidth;
+typedef enum logic [KeyFullSelWidth-1:0] {
+  KEY_FULL_ENC_INIT = MUX4_SEL_0,
+  KEY_FULL_DEC_INIT = MUX4_SEL_1,
+  KEY_FULL_ROUND    = MUX4_SEL_2,
+  KEY_FULL_CLEAR    = MUX4_SEL_3
 } key_full_sel_e;
 
-typedef enum logic {
-  KEY_DEC_EXPAND,
-  KEY_DEC_CLEAR
+parameter int KeyDecSelNum = 2;
+parameter int KeyDecSelWidth = Mux2SelWidth;
+typedef enum logic [KeyDecSelWidth-1:0] {
+  KEY_DEC_EXPAND = MUX2_SEL_0,
+  KEY_DEC_CLEAR  = MUX2_SEL_1
 } key_dec_sel_e;
 
-typedef enum logic [1:0] {
-  KEY_WORDS_0123,
-  KEY_WORDS_2345,
-  KEY_WORDS_4567,
-  KEY_WORDS_ZERO
+parameter int KeyWordsSelNum = 4;
+parameter int KeyWordsSelWidth = Mux4SelWidth;
+typedef enum logic [KeyWordsSelWidth-1:0] {
+  KEY_WORDS_0123 = MUX4_SEL_0,
+  KEY_WORDS_2345 = MUX4_SEL_1,
+  KEY_WORDS_4567 = MUX4_SEL_2,
+  KEY_WORDS_ZERO = MUX4_SEL_3
 } key_words_sel_e;
 
-typedef enum logic {
-  ROUND_KEY_DIRECT,
-  ROUND_KEY_MIXED
+parameter int RoundKeySelNum = 2;
+parameter int RoundKeySelWidth = Mux2SelWidth;
+typedef enum logic [RoundKeySelWidth-1:0] {
+  ROUND_KEY_DIRECT = MUX2_SEL_0,
+  ROUND_KEY_MIXED  = MUX2_SEL_1
 } round_key_sel_e;
 
-typedef enum logic [2:0] {
-  ADD_SO_ZERO,
-  ADD_SO_IV,
-  ADD_SO_DIP
+parameter int AddSOSelNum = 3;
+parameter int AddSOSelWidth = Mux3SelWidth;
+typedef enum logic [AddSOSelWidth-1:0] {
+  ADD_SO_ZERO = MUX3_SEL_0,
+  ADD_SO_IV   = MUX3_SEL_1,
+  ADD_SO_DIP  = MUX3_SEL_2
 } add_so_sel_e;
 
 typedef struct packed {

--- a/hw/ip/aes/rtl/aes_sel_buf_chk.sv
+++ b/hw/ip/aes/rtl/aes_sel_buf_chk.sv
@@ -1,0 +1,162 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// AES mux selector buffer and checker
+//
+// When using sparse encodings for mux selector signals, this module can be used to:
+// 1. Prevent aggressive synthesis optimizations on the selector signal, to
+// 2. check that the selector signal is valid, i.e., doesn't take on invalid values, and to
+// 3. keep outputting an error until reset even if the selector signal becomes valid again.
+
+`include "prim_assert.sv"
+
+module aes_sel_buf_chk #(
+  parameter int Num   = 2,
+  parameter int Width = 1
+) (
+  input  logic             clk_i,  // Used for assertions only.
+  input  logic             rst_ni, // Used for assertions only.
+  input  logic [Width-1:0] sel_i,
+  output logic [Width-1:0] sel_o,
+  output logic             err_o
+);
+
+  import aes_pkg::*;
+
+  // Signals
+  logic err, err_d, err_q;
+
+  ////////////
+  // Buffer //
+  ////////////
+
+  for (genvar i = 0; i < Width; i++) begin : gen_sel_buf
+    prim_buf u_prim_buf_sel_i (
+      .in_i  ( sel_i[i] ),
+      .out_o ( sel_o[i] )
+    );
+  end
+
+  /////////////
+  // Checker //
+  /////////////
+
+  if (Num == 2) begin : gen_mux2_sel_chk
+    // Cast to generic type.
+    mux2_sel_e sel_chk;
+    assign sel_chk = mux2_sel_e'(sel_o);
+
+    // Actual checker
+    always_comb begin : mux2_sel_chk
+      unique case (sel_chk)
+        MUX2_SEL_0,
+        MUX2_SEL_1: err = 1'b0;
+        default:    err = 1'b1;
+      endcase
+    end
+
+    // Assertion
+    `ASSERT(AesMux2SelValid, !err |-> sel_chk inside {
+        MUX2_SEL_0,
+        MUX2_SEL_1
+        })
+
+  end else if (Num == 3) begin : gen_mux3_sel_chk
+    // Cast to generic type.
+    mux3_sel_e sel_chk;
+    assign sel_chk = mux3_sel_e'(sel_o);
+
+    // Actual checker
+    always_comb begin : mux3_sel_chk
+      unique case (sel_chk)
+        MUX3_SEL_0,
+        MUX3_SEL_1,
+        MUX3_SEL_2: err = 1'b0;
+        default:    err = 1'b1;
+      endcase
+    end
+
+    // Assertion
+    `ASSERT(AesMux3SelValid, !err |-> sel_chk inside {
+        MUX3_SEL_0,
+        MUX3_SEL_1,
+        MUX3_SEL_2
+        })
+
+  end else if (Num == 4) begin : gen_mux4_sel_chk
+    // Cast to generic type.
+    mux4_sel_e sel_chk;
+    assign sel_chk = mux4_sel_e'(sel_o);
+
+    // Actual checker
+    always_comb begin : mux4_sel_chk
+      unique case (sel_chk)
+        MUX4_SEL_0,
+        MUX4_SEL_1,
+        MUX4_SEL_2,
+        MUX4_SEL_3: err = 1'b0;
+        default:    err = 1'b1;
+      endcase
+    end
+
+    // Assertion
+    `ASSERT(AesMux4SelValid, !err |-> sel_chk inside {
+        MUX4_SEL_0,
+        MUX4_SEL_1,
+        MUX4_SEL_2,
+        MUX4_SEL_3
+        })
+
+  end else if (Num == 6) begin : gen_mux6_sel_chk
+    // Cast to generic type.
+    mux6_sel_e sel_chk;
+    assign sel_chk = mux6_sel_e'(sel_o);
+
+    // Actual checker
+    always_comb begin : mux6_sel_chk
+      unique case (sel_chk)
+        MUX6_SEL_0,
+        MUX6_SEL_1,
+        MUX6_SEL_2,
+        MUX6_SEL_3,
+        MUX6_SEL_4,
+        MUX6_SEL_5: err = 1'b0;
+        default:    err = 1'b1;
+      endcase
+    end
+
+    // Assertion
+    `ASSERT(AesMux6SelValid, !err |-> sel_chk inside {
+        MUX6_SEL_0,
+        MUX6_SEL_1,
+        MUX6_SEL_2,
+        MUX6_SEL_3,
+        MUX6_SEL_4,
+        MUX6_SEL_5
+        })
+
+  end else begin : gen_width_unsupported
+    // Selected width not supported, signal error.
+    assign err = 1'b1;
+  end
+
+  // Make sure the error remains asserted until reset.
+  assign err_d = err | err_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_err
+    if (!rst_ni) begin
+      err_q <= '0;
+    end else if (err_d) begin
+      err_q <= err_d;
+    end
+  end
+  assign err_o = err_q;
+
+  ////////////////
+  // Assertions //
+  ////////////////
+
+  // We only have generic sparse encodings defined for certain mux input numbers (see aes_pkg.sv).
+  `ASSERT_INIT(AesSelBufChkNum, Num inside {2, 3, 4, 6})
+
+endmodule


### PR DESCRIPTION
This PR changes all main mux selector signals to use sparse encodings. To prevent synthesis optimizations, check that selector signals always take on valid values only and trigger an alert otherwise, a somewhat generic selector buffer and checker unit `aes_sel_buf_chk` is introduced. To make this possible, all selector signals of equal width and number of mux inputs share the same generic encoding.