### PR TITLE
[prim-flash] Add missing deps

### DIFF
--- a/hw/ip/prim/prim_flash.core
+++ b/hw/ip/prim/prim_flash.core
@@ -13,6 +13,8 @@ filesets:
       # TODO olofk/fusesoc#404: The below dependency is already added to prim_generic_flash.core.
       # However, the generator for the prim:ram1p does not kick in, causing compile errors.
       - lowrisc:prim:ram_1p
+      - lowrisc:prim:clock_inv
+      - lowrisc:prim:clock_gating
 
 
   files_verilator_waiver:


### PR DESCRIPTION
- These are actually added to the TSMC version of prim_flash. Due to a
bug in FuseSoC, those dependencies (which are also generators) do not
get invoked.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>