### PR TITLE
[otp_ctrl] Fix a DAI/KDI concurrency issue

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
@@ -371,6 +371,7 @@ module otp_ctrl_kdi
       ///////////////////////////////////////////////////////////////////
       // Fetch random data to ingest for key derivation.
       FetchEntropySt: begin
+        scrmbl_mtx_req_o = 1'b1;
         edn_req_o = 1'b1;
         if (edn_ack_i) begin
           nonce_reg_en = 1'b1;


### PR DESCRIPTION
Fix #4852

The scrambling datapath mutex was accidentally released in the KDI when
requesting data from EDN.

Signed-off-by: Michael Schaffner <msf@opentitan.org>