### PR TITLE
[dv/keymgr] Enable testing for sw_binding_*

### DIFF
--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_cfgen_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_cfgen_vseq.sv
@@ -50,9 +50,12 @@ class keymgr_cfgen_vseq extends keymgr_random_vseq;
       // writing during cfgen is timing sensitive
       // 1. make sure no other thread is accessing register
       // 2. use backdoor check op_status again in case it's not OpWip after front-door read
+      // 3. make sure done isn't high, because if done is high, next cycle status won't be WIP
       wait_no_outstanding_access();
       csr_rd(ral.op_status, op_status_val, .backdoor(1));
-      if (op_status_val == keymgr_pkg::OpWip) write_cfgen_gated_reg();
+      if (op_status_val == keymgr_pkg::OpWip && cfg.keymgr_vif.kmac_data_rsp.done) begin
+        write_cfgen_gated_reg();
+      end
     end
   endtask
 
@@ -64,11 +67,10 @@ class keymgr_cfgen_vseq extends keymgr_random_vseq;
     randcase
       1: csr_wr(ral.control,            val);
       1: csr_wr(ral.key_version,        val);
-      // TODO enable these after #4564 is solved
-      //1: csr_wr(ral.sw_binding_0,       val);
-      //1: csr_wr(ral.sw_binding_1,       val);
-      //1: csr_wr(ral.sw_binding_2,       val);
-      //1: csr_wr(ral.sw_binding_3,       val);
+      1: csr_wr(ral.sw_binding_0,       val);
+      1: csr_wr(ral.sw_binding_1,       val);
+      1: csr_wr(ral.sw_binding_2,       val);
+      1: csr_wr(ral.sw_binding_3,       val);
       1: csr_wr(ral.salt_0,             val);
       1: csr_wr(ral.salt_1,             val);
       1: csr_wr(ral.salt_2,             val);

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_random_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_random_vseq.sv
@@ -10,6 +10,7 @@ class keymgr_random_vseq extends keymgr_sideload_vseq;
   task write_random_sw_content();
     uvm_reg         csr_update_q[$];
 
+    csr_random_n_add_to_q(ral.sw_binding_en, csr_update_q);
     csr_random_n_add_to_q(ral.sw_binding_0, csr_update_q);
     csr_random_n_add_to_q(ral.sw_binding_1, csr_update_q);
     csr_random_n_add_to_q(ral.sw_binding_2, csr_update_q);


### PR DESCRIPTION
this feature was disabled due to #4564.

Also fix a corner case in cfgen_vseq: when done is asserted, skipping
writing cfgen gated csr

Signed-off-by: Weicai Yang <weicai@google.com>