### PR TITLE
[dv/top-earlgrey] exclude alert_en from csr write

### DIFF
--- a/hw/ip/alert_handler/data/alert_handler.hjson
+++ b/hw/ip/alert_handler/data/alert_handler.hjson
@@ -201,6 +201,9 @@
                   hwaccess: "hro",
                   regwen:   "REGEN",
                   cname:    "alert",
+                  tags:     [// Enable `alert_en` might cause top-level escalators to trigger
+                             // unexpected reset
+                             "excl:CsrAllTests:CsrExclWrite"]
                   fields: [
                     { bits: "0",
                       name: "EN_A",

--- a/hw/ip/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip/alert_handler/data/alert_handler.hjson.tpl
@@ -195,7 +195,10 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
                   hwaccess: "hro",
                   regwen:   "REGEN",
                   cname:    "alert",
-                  fields: [
+                  tags:     [// Enable `alert_en` might cause top-level escalators to trigger
+                             // unexpected reset
+                             "excl:CsrAllTests:CsrExclWrite"]
+                 fields: [
                     { bits: "0",
                       name: "EN_A",
                       desc: "Alert enable "

--- a/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
@@ -209,7 +209,10 @@
                   hwaccess: "hro",
                   regwen:   "REGEN",
                   cname:    "alert",
-                  fields: [
+                  tags:     [// Enable `alert_en` might cause top-level escalators to trigger
+                             // unexpected reset
+                             "excl:CsrAllTests:CsrExclWrite"]
+                 fields: [
                     { bits: "0",
                       name: "EN_A",
                       desc: "Alert enable "

--- a/util/reggen/validate.py
+++ b/util/reggen/validate.py
@@ -1344,7 +1344,7 @@ def make_intr_alert_reg(regs, name, offset, swaccess, hwaccess, desc):
     genreg['hwqe'] = 'true' if name in testreg_names else 'false'
     genreg['hwre'] = 'false'
     # Add tags.
-    if name in testreg_names:
+    if name == 'INTR_TEST':
         # intr_test csr is WO which - it reads back 0s
         genreg['tags'] = ["excl:CsrNonInitTests:CsrExclWrite"]
     elif name == 'INTR_STATE':


### PR DESCRIPTION
This PR excludes `alert_en` registers from CSR_write.
Because randomly triggered alert might cause the escalators to trigger
unexpected reset. For csr automation test, we do not support this kind
of reset.
So this PR:
1. Disable `alert_en` registers by excluding them from CSR write.
2. Enable write to `alert_test` registers, because now randomly trigger
alert does not affect our CSR testing.

Signed-off-by: Cindy Chen <chencindy@google.com>