### PR TITLE
[flash_ctrl] Align flash ports

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -16,7 +16,18 @@
     { name: "rd_full",    desc: "Read FIFO full" },
     { name: "rd_lvl",     desc: "Read FIFO filled to level" },
     { name: "op_done",    desc: "Operation complete" },
-    { name: "op_error",   desc: "Operation failed with error" },
+  ],
+
+  alert_list: [
+    { name: "recov_err",
+      desc: "flash alerts directly from prim_flash",
+    },
+    { name: "recov_mp_err",
+      desc: "recoverable flash alert for permission error"
+    },
+    { name: "recov_ecc_err",
+      desc: "recoverable flash alert for ecc error"
+    },
   ],
 
   // Define flash_ctrl <-> flash_phy struct package
@@ -1257,9 +1268,10 @@
         { bits: "0", name: "done",
           desc: "Flash operation done. Set by HW, cleared by SW" },
         { bits: "1", name: "err",
-          desc: "Flash operation error. Set by HW, cleared by SW"},
+          desc: "Flash operation error. Set by HW, cleared by SW. See !!ERR_CODE for more details."},
       ]
     },
+
     { name: "STATUS",
       desc: "Flash Controller Status",
       swaccess: "ro",
@@ -1270,8 +1282,97 @@
         { bits: "2",    name: "prog_full",  desc: "Flash program FIFO full"},
         { bits: "3",    name: "prog_empty", desc: "Flash program FIFO empty, software must provide data", resval: "1"},
         { bits: "4",    name: "init_wip",   desc: "Flash controller undergoing init, inclusive of phy init"},
-        { bits: "16:8", name: "error_addr", desc: "Flash controller error address."},
       ]
+    },
+
+    { name: "ERR_CODE",
+      desc: '''
+        Flash error code register.
+        This register tabulates detailed error status of the flash.
+        This is separate from !!OP_STATUS, which is used to indicate the current state of the software initiated
+        flash operation.
+      '''
+      swaccess: "rw",
+      hwaccess: "hwo",
+      fields: [
+        { bits: "0",
+          name: "flash_err",
+          desc: '''
+            The flash memory itself has an error, please check the vendor specs for details of the error.
+          '''
+        },
+        { bits: "1",
+          name: "flash_alert",
+          desc: '''
+            The flash memory itself has triggered an alert, please check the vendor specs for details of the error.
+          '''
+        },
+        { bits: "2",
+          name: "mp_err",
+          desc: '''
+            Flash access has encountered an access permission error.
+            Please see !!ERR_ADDR for exact address.
+          '''
+        },
+        { bits: "3",
+          name: "ecc_single_err",
+          desc: '''
+            Flash access has encountered a single bit ECC error.
+            Please see !!ECC_ERR_ADDR for exact address.
+          '''
+        },
+        { bits: "4",
+          name: "ecc_multi_err",
+          desc: '''
+            Flash access has encountered a multi bit ECC error.
+            Please see !!ECC_ERR_ADDR for exact address.
+          '''
+        },
+      ]
+    },
+
+    { name: "ERR_ADDR",
+      desc: "Access permission error address",
+      swaccess: "ro",
+      hwaccess: "hwo",
+      fields: [
+        { bits: "8:0",
+          resval: 0,
+        },
+      ]
+    },
+
+    { multireg: {
+        cname: "ECC_ERR"
+        name: "ECC_ERR_ADDR",
+        desc: "ecc error address",
+        count: "RegNumBanks",
+        swaccess: "ro",
+        hwaccess: "hwo",
+        fields: [
+          { bits: "19:0",
+            resval: 0,
+          },
+        ]
+      }
+    },
+
+    { name: "PHY_ALERT_CFG",
+      desc: "Phy alert configuration",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "0",
+          name: "alert_ack",
+          desc: "Acknowledge flash phy alert"
+        },
+        { bits: "1",
+          name: "alert_trig",
+          desc: "Trigger flash phy alert"
+        }
+      ]
+      tags: [ // alert triggers should be tested by directed tests
+             "excl:CsrAllTests:CsrExclWrite"]
     },
 
     { name: "PHY_STATUS",

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -26,8 +26,8 @@
   ],
 
   alert_list: [
-    { name: "fatal_err",
-      desc: "fatal flash alerts directly from prim_flash",
+    { name: "recov_err",
+      desc: "flash alerts directly from prim_flash",
     },
     { name: "recov_mp_err",
       desc: "recoverable flash alert for permission error"
@@ -833,14 +833,14 @@
         { bits: "3",
           name: "ecc_single_err",
           desc: '''
-            Flash access has encountered a recoverable ECC error.
+            Flash access has encountered a single bit ECC error.
             Please see !!ECC_ERR_ADDR for exact address.
           '''
         },
         { bits: "4",
           name: "ecc_multi_err",
           desc: '''
-            Flash access has encountered a non-recoverable ECC error.
+            Flash access has encountered a multi bit ECC error.
             Please see !!ECC_ERR_ADDR for exact address.
           '''
         },
@@ -887,6 +887,8 @@
           desc: "Trigger flash phy alert"
         }
       ]
+      tags: [ // alert triggers should be tested by directed tests
+             "excl:CsrAllTests:CsrExclWrite"]
     },
 
     { name: "PHY_STATUS",

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -790,8 +790,8 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
   logic [NumAlerts-1:0] alert_srcs;
   logic [NumAlerts-1:0] alert_tests;
 
-  logic fatal_err;
-  assign fatal_err = flash_i.flash_alert_p | ~flash_i.flash_alert_n;
+  logic recov_err;
+  assign recov_err = flash_i.flash_alert_p | ~flash_i.flash_alert_n;
 
   logic recov_mp_err;
   assign recov_mp_err = flash_mp_error;
@@ -801,12 +801,12 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
 
   assign alert_srcs = { recov_ecc_err,
                         recov_mp_err,
-                        fatal_err
+                        recov_err
                       };
 
   assign alert_tests = { reg2hw.alert_test.recov_ecc_err.q & reg2hw.alert_test.recov_ecc_err.qe,
                          reg2hw.alert_test.recov_mp_err.q  & reg2hw.alert_test.recov_mp_err.qe,
-                         reg2hw.alert_test.fatal_err.q     & reg2hw.alert_test.fatal_err.qe
+                         reg2hw.alert_test.recov_err.q     & reg2hw.alert_test.recov_err.qe
                        };
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -815,8 +815,10 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
     ) u_alert_sender (
       .clk_i,
       .rst_ni,
-      .alert_req_i(alert_srcs[i] | alert_tests[i]),
+      .alert_req_i(alert_srcs[i]),
+      .alert_test_i(alert_tests[i]),
       .alert_ack_o(),
+      .alert_state_o(),
       .alert_rx_i(alert_rx_i[i]),
       .alert_tx_o(alert_tx_o[i])
     );

--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -299,6 +299,8 @@ package flash_ctrl_pkg;
     logic [KeyWidth-1:0]  data_key;
     logic                 rd_buf_en;
     tlul_pkg::tl_h2d_t    tl_flash_c2p;
+    logic                 alert_trig;
+    logic                 alert_ack;
   } flash_req_t;
 
   // default value of flash_req_t (for dangling ports)
@@ -322,7 +324,9 @@ package flash_ctrl_pkg;
     addr_key:      RndCnstAddrKeyDefault,
     data_key:      RndCnstDataKeyDefault,
     rd_buf_en:     1'b0,
-    tl_flash_c2p:  '0
+    tl_flash_c2p:  '0,
+    alert_trig:    1'b0,
+    alert_ack:     1'b0
   };
 
   // memory to flash controller
@@ -335,6 +339,12 @@ package flash_ctrl_pkg;
     logic [BusWidth-1:0] rd_data;
     logic                init_busy;
     tlul_pkg::tl_d2h_t   tl_flash_p2c;
+    logic                flash_err;
+    logic                flash_alert_p;
+    logic                flash_alert_n;
+    logic [NumBanks-1:0] ecc_single_err;
+    logic [NumBanks-1:0] ecc_multi_err;
+    logic [NumBanks-1:0][BusAddrW-1:0] ecc_addr;
   } flash_rsp_t;
 
   // default value of flash_rsp_t (for dangling ports)
@@ -346,7 +356,13 @@ package flash_ctrl_pkg;
     rd_err:             '0,
     rd_data:            '0,
     init_busy:          1'b0,
-    tl_flash_p2c:       '0
+    tl_flash_p2c:       '0,
+    flash_err:          1'b0,
+    flash_alert_p:      1'b0,
+    flash_alert_n:      1'b1,
+    ecc_single_err:     '0,
+    ecc_multi_err:      '0,
+    ecc_addr:           '0
   };
 
   // RMA entries

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -25,6 +25,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(flash_ctrl_reg_block)
   `uvm_object_new
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
+    list_of_alerts = flash_ctrl_env_pkg::LIST_OF_ALERTS;
     super.initialize(csr_base_addr);
     // create tl agent config obj
     m_eflash_tl_agent_cfg = tl_agent_cfg::type_id::create("m_eflash_tl_agent_cfg");

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -20,7 +20,8 @@ package flash_ctrl_env_pkg;
   `include "dv_macros.svh"
 
   // parameters
-
+  parameter string LIST_OF_ALERTS[] = {"fatal_err", "recov_mp_err", "recov_ecc_err"};
+  parameter uint NUM_ALERTS = 3;
   parameter uint FlashNumPages            = flash_ctrl_pkg::NumBanks * flash_ctrl_pkg::PagesPerBank;
   parameter uint FlashSizeBytes           = FlashNumPages * flash_ctrl_pkg::WordsPerPage *
                                             flash_ctrl_pkg::DataWidth / 8;

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -20,7 +20,7 @@ package flash_ctrl_env_pkg;
   `include "dv_macros.svh"
 
   // parameters
-  parameter string LIST_OF_ALERTS[] = {"fatal_err", "recov_mp_err", "recov_ecc_err"};
+  parameter string LIST_OF_ALERTS[] = {"recov_err", "recov_mp_err", "recov_ecc_err"};
   parameter uint NUM_ALERTS = 3;
   parameter uint FlashNumPages            = flash_ctrl_pkg::NumBanks * flash_ctrl_pkg::PagesPerBank;
   parameter uint FlashSizeBytes           = FlashNumPages * flash_ctrl_pkg::WordsPerPage *

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -50,8 +50,7 @@ package flash_ctrl_env_pkg;
     FlashCtrlIntrRdFull     = 2,
     FlashCtrlIntrRdLvl      = 3,
     FlashCtrlIntrOpDone     = 4,
-    FlashCtrlIntrOpError    = 5,
-    NumFlashCtrlIntr        = 6
+    NumFlashCtrlIntr        = 5
   } flash_ctrl_intr_e;
 
   typedef enum {

--- a/hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv
+++ b/hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv
@@ -43,7 +43,10 @@ module flash_ctrl_wrapper (
   output logic intr_prog_lvl_o,   // Program fifo is empty
   output logic intr_rd_full_o,    // Read fifo is full
   output logic intr_rd_lvl_o,     // Read fifo is full
-  output logic intr_op_done_o     // Requested flash operation (wr/erase) done
+  output logic intr_op_done_o,    // Requested flash operation (wr/erase) done
+
+  input  prim_alert_pkg::alert_rx_t [flash_ctrl_reg_pkg::NumAlerts-1:0] alert_rx_i,
+  output prim_alert_pkg::alert_tx_t [flash_ctrl_reg_pkg::NumAlerts-1:0] alert_tx_o
 );
 
   // define inter-module signals
@@ -60,6 +63,10 @@ module flash_ctrl_wrapper (
     .intr_rd_full_o   (intr_rd_full_o),
     .intr_rd_lvl_o    (intr_rd_lvl_o),
     .intr_op_done_o   (intr_op_done_o),
+
+    // Alerts
+    .alert_rx_i,
+    .alert_tx_o,
 
     // Inter-module signals
     .flash_o           (flash_ctrl_flash_req),

--- a/hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv
+++ b/hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv
@@ -21,7 +21,7 @@ module flash_ctrl_wrapper (
   input        flash_power_down_h_i,
 
   // DFT Interface
-  input        flash_bist_enable_i,
+  input        lc_ctrl_pkg::lc_tx_t flash_bist_enable_i,
 
   // OTP interface
   input        otp_ctrl_pkg::flash_otp_key_req_t otp_i,
@@ -43,8 +43,7 @@ module flash_ctrl_wrapper (
   output logic intr_prog_lvl_o,   // Program fifo is empty
   output logic intr_rd_full_o,    // Read fifo is full
   output logic intr_rd_lvl_o,     // Read fifo is full
-  output logic intr_op_done_o,    // Requested flash operation (wr/erase) done
-  output logic intr_op_error_o    // Requested flash operation (wr/erase) done
+  output logic intr_op_done_o     // Requested flash operation (wr/erase) done
 );
 
   // define inter-module signals
@@ -61,7 +60,6 @@ module flash_ctrl_wrapper (
     .intr_rd_full_o   (intr_rd_full_o),
     .intr_rd_lvl_o    (intr_rd_lvl_o),
     .intr_op_done_o   (intr_op_done_o),
-    .intr_op_error_o  (intr_op_error_o),
 
     // Inter-module signals
     .flash_o           (flash_ctrl_flash_req),

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -31,6 +31,8 @@ module tb;
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   tl_if eflash_tl_if(.clk(clk), .rst_n(rst_n));
 
+  `DV_ALERT_IF_CONNECT
+
   // dut
   flash_ctrl_wrapper dut (
     .clk_i              (clk      ),
@@ -67,7 +69,9 @@ module tb;
     .intr_prog_lvl_o    (intr_prog_lvl  ),
     .intr_rd_full_o     (intr_rd_full   ),
     .intr_rd_lvl_o      (intr_rd_lvl    ),
-    .intr_op_done_o     (intr_op_done   )
+    .intr_op_done_o     (intr_op_done   ),
+    .alert_rx_i         (alert_rx       ),
+    .alert_tx_o         (alert_tx       )
   );
 
   // bind mem_bkdr_if

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -22,7 +22,6 @@ module tb;
   wire intr_rd_full;
   wire intr_rd_lvl;
   wire intr_op_done;
-  wire intr_op_error;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
 
   // interfaces
@@ -44,6 +43,7 @@ module tb;
 
     .flash_power_ready_h_i (1'b1  ),
     .flash_power_down_h_i  (1'b0  ),
+    .flash_bist_enable_i   (lc_ctrl_pkg::Off),
 
     .eflash_tl_i        (eflash_tl_if.h2d),
     .eflash_tl_o        (eflash_tl_if.d2h),
@@ -67,8 +67,7 @@ module tb;
     .intr_prog_lvl_o    (intr_prog_lvl  ),
     .intr_rd_full_o     (intr_rd_full   ),
     .intr_rd_lvl_o      (intr_rd_lvl    ),
-    .intr_op_done_o     (intr_op_done   ),
-    .intr_op_error_o    (intr_op_error  )
+    .intr_op_done_o     (intr_op_done   )
   );
 
   // bind mem_bkdr_if
@@ -102,7 +101,6 @@ module tb;
   assign interrupts[FlashCtrlIntrRdFull]    = intr_rd_full;
   assign interrupts[FlashCtrlIntrRdLvl]     = intr_rd_lvl;
   assign interrupts[FlashCtrlIntrOpDone]    = intr_op_done;
-  assign interrupts[FlashCtrlIntrOpError]   = intr_op_error;
 
   initial begin
     // drive clk and rst_n from clk_if

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -9,6 +9,7 @@
 `include "prim_assert.sv"
 
 module flash_ctrl import flash_ctrl_pkg::*; #(
+  parameter logic AlertAsyncOn          = 1'b1,
   parameter flash_key_t RndCnstAddrKey  = RndCnstAddrKeyDefault,
   parameter flash_key_t RndCnstDataKey  = RndCnstDataKeyDefault,
   parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault,
@@ -51,7 +52,12 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
   output logic intr_rd_full_o,    // Read fifo is full
   output logic intr_rd_lvl_o,     // Read fifo is full
   output logic intr_op_done_o,    // Requested flash operation (wr/erase) done
-  output logic intr_op_error_o    // Requested flash operation (wr/erase) done
+
+  // Alerts
+  input  prim_alert_pkg::alert_rx_t [flash_ctrl_reg_pkg::NumAlerts-1:0] alert_rx_i,
+  output prim_alert_pkg::alert_tx_t [flash_ctrl_reg_pkg::NumAlerts-1:0] alert_tx_o
+
+
 );
 
   import flash_ctrl_reg_pkg::*;
@@ -731,8 +737,6 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
   assign hw2reg.status.prog_empty.de = sw_sel;
   assign hw2reg.status.init_wip.d    = flash_phy_busy | ctrl_init_busy;
   assign hw2reg.status.init_wip.de   = 1'b1;
-  assign hw2reg.status.error_addr.d  = err_addr;
-  assign hw2reg.status.error_addr.de = sw_sel;
   assign hw2reg.control.start.d      = 1'b0;
   assign hw2reg.control.start.de     = sw_ctrl_done;
   // if software operation selected, based on transaction start
@@ -758,6 +762,8 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
   assign flash_o.addr_key = addr_key;
   assign flash_o.data_key = data_key;
   assign flash_o.tl_flash_c2p = tl_win_h2d[2];
+  assign flash_o.alert_trig = reg2hw.phy_alert_cfg.alert_trig.q;
+  assign flash_o.alert_ack = reg2hw.phy_alert_cfg.alert_ack.q;
   assign flash_rd_err = flash_i.rd_err;
   assign flash_rd_data = flash_i.rd_data;
   assign flash_phy_busy = flash_i.init_busy;
@@ -778,8 +784,71 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
     .q_o(pwrmgr_o.flash_idle)
   );
 
+  //////////////////////////////////////
+  // Alert senders
+  //////////////////////////////////////
 
-  // Interrupts
+  logic [NumAlerts-1:0] alert_srcs;
+  logic [NumAlerts-1:0] alert_tests;
+
+  logic recov_err;
+  assign recov_err = flash_i.flash_alert_p | ~flash_i.flash_alert_n;
+
+  logic recov_mp_err;
+  assign recov_mp_err = flash_mp_error;
+
+  logic recov_ecc_err;
+  assign recov_ecc_err = |flash_i.ecc_single_err | |flash_i.ecc_multi_err;
+
+  assign alert_srcs = { recov_ecc_err,
+                        recov_mp_err,
+                        recov_err
+                      };
+
+  assign alert_tests = { reg2hw.alert_test.recov_ecc_err.q & reg2hw.alert_test.recov_ecc_err.qe,
+                         reg2hw.alert_test.recov_mp_err.q  & reg2hw.alert_test.recov_mp_err.qe,
+                         reg2hw.alert_test.recov_err.q     & reg2hw.alert_test.recov_err.qe
+                       };
+
+  for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
+    prim_alert_sender #(
+      .AsyncOn(AlertAsyncOn)
+    ) u_alert_sender (
+      .clk_i,
+      .rst_ni,
+      .alert_req_i(alert_srcs[i]),
+      .alert_test_i(alert_tests[i]),
+      .alert_ack_o(),
+      .alert_state_o(),
+      .alert_rx_i(alert_rx_i[i]),
+      .alert_tx_o(alert_tx_o[i])
+    );
+  end
+
+
+  //////////////////////////////////////
+  // Errors and Interrupts
+  //////////////////////////////////////
+
+  assign hw2reg.err_code.mp_err.d = 1'b1;
+  assign hw2reg.err_code.ecc_single_err.d = 1'b1;
+  assign hw2reg.err_code.ecc_multi_err.d = 1'b1;
+  assign hw2reg.err_code.flash_err.d = 1'b1;
+  assign hw2reg.err_code.flash_alert.d = 1'b1;
+  assign hw2reg.err_code.mp_err.de = flash_mp_error;
+  assign hw2reg.err_code.ecc_single_err.de = |flash_i.ecc_single_err;
+  assign hw2reg.err_code.ecc_multi_err.de = |flash_i.ecc_multi_err;
+  assign hw2reg.err_code.flash_err.de = flash_i.flash_err;
+  assign hw2reg.err_code.flash_alert.de = flash_i.flash_alert_p | ~flash_i.flash_alert_n;
+  assign hw2reg.err_addr.d = err_addr;
+  assign hw2reg.err_addr.de = flash_mp_error;
+
+  for (genvar bank = 0; bank < NumBanks; bank++) begin : gen_err_cons
+    assign hw2reg.ecc_err_addr[bank].d  = {flash_i.ecc_addr[bank], {BusByteWidth{1'b0}}};
+    assign hw2reg.ecc_err_addr[bank].de = flash_i.ecc_single_err[bank] |
+                                          flash_i.ecc_multi_err[bank];
+  end
+
   // Generate edge triggered signals for sources that are level
   logic [3:0] intr_src;
   logic [3:0] intr_src_q;
@@ -807,7 +876,6 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
   assign intr_rd_full_o = reg2hw.intr_enable.rd_full.q & reg2hw.intr_state.rd_full.q;
   assign intr_rd_lvl_o = reg2hw.intr_enable.rd_lvl.q & reg2hw.intr_state.rd_lvl.q;
   assign intr_op_done_o = reg2hw.intr_enable.op_done.q & reg2hw.intr_state.op_done.q;
-  assign intr_op_error_o = reg2hw.intr_enable.op_error.q & reg2hw.intr_state.op_error.q;
 
   assign hw2reg.intr_state.prog_empty.d  = 1'b1;
   assign hw2reg.intr_state.prog_empty.de = intr_assert[3]  |
@@ -835,12 +903,6 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
                                         (reg2hw.intr_test.op_done.qe  &
                                         reg2hw.intr_test.op_done.q);
 
-  assign hw2reg.intr_state.op_error.d  = 1'b1;
-  assign hw2reg.intr_state.op_error.de = sw_ctrl_err  |
-                                        (reg2hw.intr_test.op_error.qe  &
-                                        reg2hw.intr_test.op_error.q);
-
-
 
   // Unused bits
   logic [BusByteWidth-1:0] unused_byte_sel;
@@ -866,6 +928,5 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
   `ASSERT_KNOWN(IntrProgRdFullKnownO_A, intr_rd_full_o   )
   `ASSERT_KNOWN(IntrRdLvlKnownO_A,      intr_rd_lvl_o    )
   `ASSERT_KNOWN(IntrOpDoneKnownO_A,     intr_op_done_o   )
-  `ASSERT_KNOWN(IntrOpErrorKnownO_A,    intr_op_error_o  )
 
 endmodule

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -299,6 +299,8 @@ package flash_ctrl_pkg;
     logic [KeyWidth-1:0]  data_key;
     logic                 rd_buf_en;
     tlul_pkg::tl_h2d_t    tl_flash_c2p;
+    logic                 alert_trig;
+    logic                 alert_ack;
   } flash_req_t;
 
   // default value of flash_req_t (for dangling ports)
@@ -322,7 +324,9 @@ package flash_ctrl_pkg;
     addr_key:      RndCnstAddrKeyDefault,
     data_key:      RndCnstDataKeyDefault,
     rd_buf_en:     1'b0,
-    tl_flash_c2p:  '0
+    tl_flash_c2p:  '0,
+    alert_trig:    1'b0,
+    alert_ack:     1'b0
   };
 
   // memory to flash controller
@@ -335,6 +339,12 @@ package flash_ctrl_pkg;
     logic [BusWidth-1:0] rd_data;
     logic                init_busy;
     tlul_pkg::tl_d2h_t   tl_flash_p2c;
+    logic                flash_err;
+    logic                flash_alert_p;
+    logic                flash_alert_n;
+    logic [NumBanks-1:0] ecc_single_err;
+    logic [NumBanks-1:0] ecc_multi_err;
+    logic [NumBanks-1:0][BusAddrW-1:0] ecc_addr;
   } flash_rsp_t;
 
   // default value of flash_rsp_t (for dangling ports)
@@ -346,7 +356,13 @@ package flash_ctrl_pkg;
     rd_err:             '0,
     rd_data:            '0,
     init_busy:          1'b0,
-    tl_flash_p2c:       '0
+    tl_flash_p2c:       '0,
+    flash_err:          1'b0,
+    flash_alert_p:      1'b0,
+    flash_alert_n:      1'b1,
+    ecc_single_err:     '0,
+    ecc_multi_err:      '0,
+    ecc_addr:           '0
   };
 
   // RMA entries

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -20,6 +20,7 @@ package flash_ctrl_reg_pkg;
   parameter int BytesPerWord = 8;
   parameter int BytesPerPage = 2048;
   parameter int BytesPerBank = 524288;
+  parameter int NumAlerts = 3;
 
   // Address width within the block
   parameter int BlockAw = 9;
@@ -43,9 +44,6 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } op_done;
-    struct packed {
-      logic        q;
-    } op_error;
   } flash_ctrl_reg2hw_intr_state_reg_t;
 
   typedef struct packed {
@@ -64,9 +62,6 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } op_done;
-    struct packed {
-      logic        q;
-    } op_error;
   } flash_ctrl_reg2hw_intr_enable_reg_t;
 
   typedef struct packed {
@@ -90,11 +85,22 @@ package flash_ctrl_reg_pkg;
       logic        q;
       logic        qe;
     } op_done;
+  } flash_ctrl_reg2hw_intr_test_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        q;
       logic        qe;
-    } op_error;
-  } flash_ctrl_reg2hw_intr_test_reg_t;
+    } recov_err;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } recov_mp_err;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } recov_ecc_err;
+  } flash_ctrl_reg2hw_alert_test_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -337,6 +343,15 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_reg2hw_mp_bank_cfg_mreg_t;
 
   typedef struct packed {
+    struct packed {
+      logic        q;
+    } alert_ack;
+    struct packed {
+      logic        q;
+    } alert_trig;
+  } flash_ctrl_reg2hw_phy_alert_cfg_reg_t;
+
+  typedef struct packed {
     logic [31:0] q;
   } flash_ctrl_reg2hw_scratch_reg_t;
 
@@ -375,10 +390,6 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } op_done;
-    struct packed {
-      logic        d;
-      logic        de;
-    } op_error;
   } flash_ctrl_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
@@ -429,11 +440,40 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } init_wip;
-    struct packed {
-      logic [8:0]  d;
-      logic        de;
-    } error_addr;
   } flash_ctrl_hw2reg_status_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        d;
+      logic        de;
+    } flash_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } flash_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } mp_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } ecc_single_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } ecc_multi_err;
+  } flash_ctrl_hw2reg_err_code_reg_t;
+
+  typedef struct packed {
+    logic [8:0]  d;
+    logic        de;
+  } flash_ctrl_hw2reg_err_addr_reg_t;
+
+  typedef struct packed {
+    logic [19:0] d;
+    logic        de;
+  } flash_ctrl_hw2reg_ecc_err_addr_mreg_t;
 
   typedef struct packed {
     struct packed {
@@ -455,22 +495,24 @@ package flash_ctrl_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [519:514]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [513:508]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [507:496]
-    flash_ctrl_reg2hw_control_reg_t control; // [495:476]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [475:444]
-    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [443:442]
-    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [441:441]
-    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [440:233]
-    flash_ctrl_reg2hw_default_region_reg_t default_region; // [232:227]
-    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [9:0] bank0_info0_page_cfg; // [226:157]
-    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [0:0] bank0_info1_page_cfg; // [156:150]
-    flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t [1:0] bank0_info2_page_cfg; // [149:136]
-    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [9:0] bank1_info0_page_cfg; // [135:66]
-    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [0:0] bank1_info1_page_cfg; // [65:59]
-    flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t [1:0] bank1_info2_page_cfg; // [58:45]
-    flash_ctrl_reg2hw_mp_bank_cfg_mreg_t [1:0] mp_bank_cfg; // [44:43]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [523:519]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [518:514]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [513:504]
+    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [503:498]
+    flash_ctrl_reg2hw_control_reg_t control; // [497:478]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [477:446]
+    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [445:444]
+    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [443:443]
+    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [442:235]
+    flash_ctrl_reg2hw_default_region_reg_t default_region; // [234:229]
+    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [9:0] bank0_info0_page_cfg; // [228:159]
+    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [0:0] bank0_info1_page_cfg; // [158:152]
+    flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t [1:0] bank0_info2_page_cfg; // [151:138]
+    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [9:0] bank1_info0_page_cfg; // [137:68]
+    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [0:0] bank1_info1_page_cfg; // [67:61]
+    flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t [1:0] bank1_info2_page_cfg; // [60:47]
+    flash_ctrl_reg2hw_mp_bank_cfg_mreg_t [1:0] mp_bank_cfg; // [46:45]
+    flash_ctrl_reg2hw_phy_alert_cfg_reg_t phy_alert_cfg; // [44:43]
     flash_ctrl_reg2hw_scratch_reg_t scratch; // [42:11]
     flash_ctrl_reg2hw_fifo_lvl_reg_t fifo_lvl; // [10:1]
     flash_ctrl_reg2hw_fifo_rst_reg_t fifo_rst; // [0:0]
@@ -480,12 +522,15 @@ package flash_ctrl_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [46:35]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [34:34]
-    flash_ctrl_hw2reg_control_reg_t control; // [33:32]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [31:30]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [29:26]
-    flash_ctrl_hw2reg_status_reg_t status; // [25:6]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [96:87]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [86:86]
+    flash_ctrl_hw2reg_control_reg_t control; // [85:84]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [83:82]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [81:78]
+    flash_ctrl_hw2reg_status_reg_t status; // [77:68]
+    flash_ctrl_hw2reg_err_code_reg_t err_code; // [67:58]
+    flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [57:48]
+    flash_ctrl_hw2reg_ecc_err_addr_mreg_t [1:0] ecc_err_addr; // [47:6]
     flash_ctrl_hw2reg_phy_status_reg_t phy_status; // [5:0]
   } flash_ctrl_hw2reg_t;
 
@@ -493,93 +538,99 @@ package flash_ctrl_reg_pkg;
   parameter logic [BlockAw-1:0] FLASH_CTRL_INTR_STATE_OFFSET = 9'h 0;
   parameter logic [BlockAw-1:0] FLASH_CTRL_INTR_ENABLE_OFFSET = 9'h 4;
   parameter logic [BlockAw-1:0] FLASH_CTRL_INTR_TEST_OFFSET = 9'h 8;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_CTRL_REGWEN_OFFSET = 9'h c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_CONTROL_OFFSET = 9'h 10;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_ADDR_OFFSET = 9'h 14;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_PROG_TYPE_EN_OFFSET = 9'h 18;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_ERASE_SUSPEND_OFFSET = 9'h 1c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_0_OFFSET = 9'h 20;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_1_OFFSET = 9'h 24;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_2_OFFSET = 9'h 28;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_3_OFFSET = 9'h 2c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_4_OFFSET = 9'h 30;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_5_OFFSET = 9'h 34;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_6_OFFSET = 9'h 38;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_7_OFFSET = 9'h 3c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_0_OFFSET = 9'h 40;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_1_OFFSET = 9'h 44;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_2_OFFSET = 9'h 48;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_3_OFFSET = 9'h 4c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_4_OFFSET = 9'h 50;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_5_OFFSET = 9'h 54;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_6_OFFSET = 9'h 58;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_7_OFFSET = 9'h 5c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_DEFAULT_REGION_OFFSET = 9'h 60;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_0_OFFSET = 9'h 64;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_1_OFFSET = 9'h 68;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_2_OFFSET = 9'h 6c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_3_OFFSET = 9'h 70;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_4_OFFSET = 9'h 74;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_5_OFFSET = 9'h 78;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_6_OFFSET = 9'h 7c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_7_OFFSET = 9'h 80;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_8_OFFSET = 9'h 84;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_9_OFFSET = 9'h 88;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_OFFSET = 9'h 8c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1_OFFSET = 9'h 90;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2_OFFSET = 9'h 94;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3_OFFSET = 9'h 98;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4_OFFSET = 9'h 9c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5_OFFSET = 9'h a0;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6_OFFSET = 9'h a4;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7_OFFSET = 9'h a8;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8_OFFSET = 9'h ac;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9_OFFSET = 9'h b0;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO1_REGWEN_OFFSET = 9'h b4;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_OFFSET = 9'h b8;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO2_REGWEN_0_OFFSET = 9'h bc;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO2_REGWEN_1_OFFSET = 9'h c0;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0_OFFSET = 9'h c4;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1_OFFSET = 9'h c8;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_0_OFFSET = 9'h cc;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_1_OFFSET = 9'h d0;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_2_OFFSET = 9'h d4;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_3_OFFSET = 9'h d8;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_4_OFFSET = 9'h dc;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_5_OFFSET = 9'h e0;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_6_OFFSET = 9'h e4;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_7_OFFSET = 9'h e8;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_8_OFFSET = 9'h ec;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_9_OFFSET = 9'h f0;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_OFFSET = 9'h f4;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1_OFFSET = 9'h f8;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2_OFFSET = 9'h fc;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3_OFFSET = 9'h 100;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4_OFFSET = 9'h 104;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5_OFFSET = 9'h 108;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6_OFFSET = 9'h 10c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7_OFFSET = 9'h 110;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8_OFFSET = 9'h 114;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9_OFFSET = 9'h 118;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO1_REGWEN_OFFSET = 9'h 11c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_OFFSET = 9'h 120;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO2_REGWEN_0_OFFSET = 9'h 124;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO2_REGWEN_1_OFFSET = 9'h 128;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0_OFFSET = 9'h 12c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1_OFFSET = 9'h 130;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK_CFG_REGWEN_OFFSET = 9'h 134;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_BANK_CFG_OFFSET = 9'h 138;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_OP_STATUS_OFFSET = 9'h 13c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_STATUS_OFFSET = 9'h 140;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_PHY_STATUS_OFFSET = 9'h 144;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_SCRATCH_OFFSET = 9'h 148;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_FIFO_LVL_OFFSET = 9'h 14c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_FIFO_RST_OFFSET = 9'h 150;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_ALERT_TEST_OFFSET = 9'h c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_CTRL_REGWEN_OFFSET = 9'h 10;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_CONTROL_OFFSET = 9'h 14;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_ADDR_OFFSET = 9'h 18;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_PROG_TYPE_EN_OFFSET = 9'h 1c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_ERASE_SUSPEND_OFFSET = 9'h 20;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_0_OFFSET = 9'h 24;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_1_OFFSET = 9'h 28;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_2_OFFSET = 9'h 2c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_3_OFFSET = 9'h 30;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_4_OFFSET = 9'h 34;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_5_OFFSET = 9'h 38;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_6_OFFSET = 9'h 3c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_7_OFFSET = 9'h 40;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_0_OFFSET = 9'h 44;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_1_OFFSET = 9'h 48;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_2_OFFSET = 9'h 4c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_3_OFFSET = 9'h 50;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_4_OFFSET = 9'h 54;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_5_OFFSET = 9'h 58;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_6_OFFSET = 9'h 5c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_7_OFFSET = 9'h 60;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_DEFAULT_REGION_OFFSET = 9'h 64;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_0_OFFSET = 9'h 68;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_1_OFFSET = 9'h 6c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_2_OFFSET = 9'h 70;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_3_OFFSET = 9'h 74;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_4_OFFSET = 9'h 78;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_5_OFFSET = 9'h 7c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_6_OFFSET = 9'h 80;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_7_OFFSET = 9'h 84;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_8_OFFSET = 9'h 88;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_9_OFFSET = 9'h 8c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_OFFSET = 9'h 90;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1_OFFSET = 9'h 94;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2_OFFSET = 9'h 98;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3_OFFSET = 9'h 9c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4_OFFSET = 9'h a0;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5_OFFSET = 9'h a4;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6_OFFSET = 9'h a8;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7_OFFSET = 9'h ac;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8_OFFSET = 9'h b0;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9_OFFSET = 9'h b4;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO1_REGWEN_OFFSET = 9'h b8;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_OFFSET = 9'h bc;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO2_REGWEN_0_OFFSET = 9'h c0;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO2_REGWEN_1_OFFSET = 9'h c4;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0_OFFSET = 9'h c8;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1_OFFSET = 9'h cc;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_0_OFFSET = 9'h d0;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_1_OFFSET = 9'h d4;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_2_OFFSET = 9'h d8;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_3_OFFSET = 9'h dc;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_4_OFFSET = 9'h e0;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_5_OFFSET = 9'h e4;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_6_OFFSET = 9'h e8;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_7_OFFSET = 9'h ec;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_8_OFFSET = 9'h f0;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_9_OFFSET = 9'h f4;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_OFFSET = 9'h f8;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1_OFFSET = 9'h fc;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2_OFFSET = 9'h 100;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3_OFFSET = 9'h 104;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4_OFFSET = 9'h 108;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5_OFFSET = 9'h 10c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6_OFFSET = 9'h 110;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7_OFFSET = 9'h 114;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8_OFFSET = 9'h 118;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9_OFFSET = 9'h 11c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO1_REGWEN_OFFSET = 9'h 120;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_OFFSET = 9'h 124;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO2_REGWEN_0_OFFSET = 9'h 128;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO2_REGWEN_1_OFFSET = 9'h 12c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0_OFFSET = 9'h 130;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1_OFFSET = 9'h 134;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK_CFG_REGWEN_OFFSET = 9'h 138;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_BANK_CFG_OFFSET = 9'h 13c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_OP_STATUS_OFFSET = 9'h 140;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_STATUS_OFFSET = 9'h 144;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_ERR_CODE_OFFSET = 9'h 148;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_ERR_ADDR_OFFSET = 9'h 14c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_ECC_ERR_ADDR_0_OFFSET = 9'h 150;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_ECC_ERR_ADDR_1_OFFSET = 9'h 154;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_PHY_ALERT_CFG_OFFSET = 9'h 158;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_PHY_STATUS_OFFSET = 9'h 15c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_SCRATCH_OFFSET = 9'h 160;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_FIFO_LVL_OFFSET = 9'h 164;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_FIFO_RST_OFFSET = 9'h 168;
 
   // Window parameter
-  parameter logic [BlockAw-1:0] FLASH_CTRL_PROG_FIFO_OFFSET = 9'h 154;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_PROG_FIFO_OFFSET = 9'h 16c;
   parameter logic [BlockAw-1:0] FLASH_CTRL_PROG_FIFO_SIZE   = 9'h 4;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_RD_FIFO_OFFSET = 9'h 158;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_RD_FIFO_OFFSET = 9'h 170;
   parameter logic [BlockAw-1:0] FLASH_CTRL_RD_FIFO_SIZE   = 9'h 4;
   parameter logic [BlockAw-1:0] FLASH_CTRL_PRIM_FLASH_CFG_OFFSET = 9'h 180;
   parameter logic [BlockAw-1:0] FLASH_CTRL_PRIM_FLASH_CFG_SIZE   = 9'h 54;
@@ -589,6 +640,7 @@ package flash_ctrl_reg_pkg;
     FLASH_CTRL_INTR_STATE,
     FLASH_CTRL_INTR_ENABLE,
     FLASH_CTRL_INTR_TEST,
+    FLASH_CTRL_ALERT_TEST,
     FLASH_CTRL_CTRL_REGWEN,
     FLASH_CTRL_CONTROL,
     FLASH_CTRL_ADDR,
@@ -667,6 +719,11 @@ package flash_ctrl_reg_pkg;
     FLASH_CTRL_MP_BANK_CFG,
     FLASH_CTRL_OP_STATUS,
     FLASH_CTRL_STATUS,
+    FLASH_CTRL_ERR_CODE,
+    FLASH_CTRL_ERR_ADDR,
+    FLASH_CTRL_ECC_ERR_ADDR_0,
+    FLASH_CTRL_ECC_ERR_ADDR_1,
+    FLASH_CTRL_PHY_ALERT_CFG,
     FLASH_CTRL_PHY_STATUS,
     FLASH_CTRL_SCRATCH,
     FLASH_CTRL_FIFO_LVL,
@@ -674,92 +731,98 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] FLASH_CTRL_PERMIT [85] = '{
+  parameter logic [3:0] FLASH_CTRL_PERMIT [91] = '{
     4'b 0001, // index[ 0] FLASH_CTRL_INTR_STATE
     4'b 0001, // index[ 1] FLASH_CTRL_INTR_ENABLE
     4'b 0001, // index[ 2] FLASH_CTRL_INTR_TEST
-    4'b 0001, // index[ 3] FLASH_CTRL_CTRL_REGWEN
-    4'b 1111, // index[ 4] FLASH_CTRL_CONTROL
-    4'b 1111, // index[ 5] FLASH_CTRL_ADDR
-    4'b 0001, // index[ 6] FLASH_CTRL_PROG_TYPE_EN
-    4'b 0001, // index[ 7] FLASH_CTRL_ERASE_SUSPEND
-    4'b 0001, // index[ 8] FLASH_CTRL_REGION_CFG_REGWEN_0
-    4'b 0001, // index[ 9] FLASH_CTRL_REGION_CFG_REGWEN_1
-    4'b 0001, // index[10] FLASH_CTRL_REGION_CFG_REGWEN_2
-    4'b 0001, // index[11] FLASH_CTRL_REGION_CFG_REGWEN_3
-    4'b 0001, // index[12] FLASH_CTRL_REGION_CFG_REGWEN_4
-    4'b 0001, // index[13] FLASH_CTRL_REGION_CFG_REGWEN_5
-    4'b 0001, // index[14] FLASH_CTRL_REGION_CFG_REGWEN_6
-    4'b 0001, // index[15] FLASH_CTRL_REGION_CFG_REGWEN_7
-    4'b 1111, // index[16] FLASH_CTRL_MP_REGION_CFG_0
-    4'b 1111, // index[17] FLASH_CTRL_MP_REGION_CFG_1
-    4'b 1111, // index[18] FLASH_CTRL_MP_REGION_CFG_2
-    4'b 1111, // index[19] FLASH_CTRL_MP_REGION_CFG_3
-    4'b 1111, // index[20] FLASH_CTRL_MP_REGION_CFG_4
-    4'b 1111, // index[21] FLASH_CTRL_MP_REGION_CFG_5
-    4'b 1111, // index[22] FLASH_CTRL_MP_REGION_CFG_6
-    4'b 1111, // index[23] FLASH_CTRL_MP_REGION_CFG_7
-    4'b 0001, // index[24] FLASH_CTRL_DEFAULT_REGION
-    4'b 0001, // index[25] FLASH_CTRL_BANK0_INFO0_REGWEN_0
-    4'b 0001, // index[26] FLASH_CTRL_BANK0_INFO0_REGWEN_1
-    4'b 0001, // index[27] FLASH_CTRL_BANK0_INFO0_REGWEN_2
-    4'b 0001, // index[28] FLASH_CTRL_BANK0_INFO0_REGWEN_3
-    4'b 0001, // index[29] FLASH_CTRL_BANK0_INFO0_REGWEN_4
-    4'b 0001, // index[30] FLASH_CTRL_BANK0_INFO0_REGWEN_5
-    4'b 0001, // index[31] FLASH_CTRL_BANK0_INFO0_REGWEN_6
-    4'b 0001, // index[32] FLASH_CTRL_BANK0_INFO0_REGWEN_7
-    4'b 0001, // index[33] FLASH_CTRL_BANK0_INFO0_REGWEN_8
-    4'b 0001, // index[34] FLASH_CTRL_BANK0_INFO0_REGWEN_9
-    4'b 0001, // index[35] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0
-    4'b 0001, // index[36] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1
-    4'b 0001, // index[37] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2
-    4'b 0001, // index[38] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3
-    4'b 0001, // index[39] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4
-    4'b 0001, // index[40] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5
-    4'b 0001, // index[41] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6
-    4'b 0001, // index[42] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7
-    4'b 0001, // index[43] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8
-    4'b 0001, // index[44] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9
-    4'b 0001, // index[45] FLASH_CTRL_BANK0_INFO1_REGWEN
-    4'b 0001, // index[46] FLASH_CTRL_BANK0_INFO1_PAGE_CFG
-    4'b 0001, // index[47] FLASH_CTRL_BANK0_INFO2_REGWEN_0
-    4'b 0001, // index[48] FLASH_CTRL_BANK0_INFO2_REGWEN_1
-    4'b 0001, // index[49] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0
-    4'b 0001, // index[50] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1
-    4'b 0001, // index[51] FLASH_CTRL_BANK1_INFO0_REGWEN_0
-    4'b 0001, // index[52] FLASH_CTRL_BANK1_INFO0_REGWEN_1
-    4'b 0001, // index[53] FLASH_CTRL_BANK1_INFO0_REGWEN_2
-    4'b 0001, // index[54] FLASH_CTRL_BANK1_INFO0_REGWEN_3
-    4'b 0001, // index[55] FLASH_CTRL_BANK1_INFO0_REGWEN_4
-    4'b 0001, // index[56] FLASH_CTRL_BANK1_INFO0_REGWEN_5
-    4'b 0001, // index[57] FLASH_CTRL_BANK1_INFO0_REGWEN_6
-    4'b 0001, // index[58] FLASH_CTRL_BANK1_INFO0_REGWEN_7
-    4'b 0001, // index[59] FLASH_CTRL_BANK1_INFO0_REGWEN_8
-    4'b 0001, // index[60] FLASH_CTRL_BANK1_INFO0_REGWEN_9
-    4'b 0001, // index[61] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0
-    4'b 0001, // index[62] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1
-    4'b 0001, // index[63] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2
-    4'b 0001, // index[64] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3
-    4'b 0001, // index[65] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4
-    4'b 0001, // index[66] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5
-    4'b 0001, // index[67] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6
-    4'b 0001, // index[68] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7
-    4'b 0001, // index[69] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8
-    4'b 0001, // index[70] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9
-    4'b 0001, // index[71] FLASH_CTRL_BANK1_INFO1_REGWEN
-    4'b 0001, // index[72] FLASH_CTRL_BANK1_INFO1_PAGE_CFG
-    4'b 0001, // index[73] FLASH_CTRL_BANK1_INFO2_REGWEN_0
-    4'b 0001, // index[74] FLASH_CTRL_BANK1_INFO2_REGWEN_1
-    4'b 0001, // index[75] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0
-    4'b 0001, // index[76] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1
-    4'b 0001, // index[77] FLASH_CTRL_BANK_CFG_REGWEN
-    4'b 0001, // index[78] FLASH_CTRL_MP_BANK_CFG
-    4'b 0001, // index[79] FLASH_CTRL_OP_STATUS
-    4'b 0111, // index[80] FLASH_CTRL_STATUS
-    4'b 0001, // index[81] FLASH_CTRL_PHY_STATUS
-    4'b 1111, // index[82] FLASH_CTRL_SCRATCH
-    4'b 0011, // index[83] FLASH_CTRL_FIFO_LVL
-    4'b 0001  // index[84] FLASH_CTRL_FIFO_RST
+    4'b 0001, // index[ 3] FLASH_CTRL_ALERT_TEST
+    4'b 0001, // index[ 4] FLASH_CTRL_CTRL_REGWEN
+    4'b 1111, // index[ 5] FLASH_CTRL_CONTROL
+    4'b 1111, // index[ 6] FLASH_CTRL_ADDR
+    4'b 0001, // index[ 7] FLASH_CTRL_PROG_TYPE_EN
+    4'b 0001, // index[ 8] FLASH_CTRL_ERASE_SUSPEND
+    4'b 0001, // index[ 9] FLASH_CTRL_REGION_CFG_REGWEN_0
+    4'b 0001, // index[10] FLASH_CTRL_REGION_CFG_REGWEN_1
+    4'b 0001, // index[11] FLASH_CTRL_REGION_CFG_REGWEN_2
+    4'b 0001, // index[12] FLASH_CTRL_REGION_CFG_REGWEN_3
+    4'b 0001, // index[13] FLASH_CTRL_REGION_CFG_REGWEN_4
+    4'b 0001, // index[14] FLASH_CTRL_REGION_CFG_REGWEN_5
+    4'b 0001, // index[15] FLASH_CTRL_REGION_CFG_REGWEN_6
+    4'b 0001, // index[16] FLASH_CTRL_REGION_CFG_REGWEN_7
+    4'b 1111, // index[17] FLASH_CTRL_MP_REGION_CFG_0
+    4'b 1111, // index[18] FLASH_CTRL_MP_REGION_CFG_1
+    4'b 1111, // index[19] FLASH_CTRL_MP_REGION_CFG_2
+    4'b 1111, // index[20] FLASH_CTRL_MP_REGION_CFG_3
+    4'b 1111, // index[21] FLASH_CTRL_MP_REGION_CFG_4
+    4'b 1111, // index[22] FLASH_CTRL_MP_REGION_CFG_5
+    4'b 1111, // index[23] FLASH_CTRL_MP_REGION_CFG_6
+    4'b 1111, // index[24] FLASH_CTRL_MP_REGION_CFG_7
+    4'b 0001, // index[25] FLASH_CTRL_DEFAULT_REGION
+    4'b 0001, // index[26] FLASH_CTRL_BANK0_INFO0_REGWEN_0
+    4'b 0001, // index[27] FLASH_CTRL_BANK0_INFO0_REGWEN_1
+    4'b 0001, // index[28] FLASH_CTRL_BANK0_INFO0_REGWEN_2
+    4'b 0001, // index[29] FLASH_CTRL_BANK0_INFO0_REGWEN_3
+    4'b 0001, // index[30] FLASH_CTRL_BANK0_INFO0_REGWEN_4
+    4'b 0001, // index[31] FLASH_CTRL_BANK0_INFO0_REGWEN_5
+    4'b 0001, // index[32] FLASH_CTRL_BANK0_INFO0_REGWEN_6
+    4'b 0001, // index[33] FLASH_CTRL_BANK0_INFO0_REGWEN_7
+    4'b 0001, // index[34] FLASH_CTRL_BANK0_INFO0_REGWEN_8
+    4'b 0001, // index[35] FLASH_CTRL_BANK0_INFO0_REGWEN_9
+    4'b 0001, // index[36] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0
+    4'b 0001, // index[37] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1
+    4'b 0001, // index[38] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2
+    4'b 0001, // index[39] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3
+    4'b 0001, // index[40] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4
+    4'b 0001, // index[41] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5
+    4'b 0001, // index[42] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6
+    4'b 0001, // index[43] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7
+    4'b 0001, // index[44] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8
+    4'b 0001, // index[45] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9
+    4'b 0001, // index[46] FLASH_CTRL_BANK0_INFO1_REGWEN
+    4'b 0001, // index[47] FLASH_CTRL_BANK0_INFO1_PAGE_CFG
+    4'b 0001, // index[48] FLASH_CTRL_BANK0_INFO2_REGWEN_0
+    4'b 0001, // index[49] FLASH_CTRL_BANK0_INFO2_REGWEN_1
+    4'b 0001, // index[50] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0
+    4'b 0001, // index[51] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1
+    4'b 0001, // index[52] FLASH_CTRL_BANK1_INFO0_REGWEN_0
+    4'b 0001, // index[53] FLASH_CTRL_BANK1_INFO0_REGWEN_1
+    4'b 0001, // index[54] FLASH_CTRL_BANK1_INFO0_REGWEN_2
+    4'b 0001, // index[55] FLASH_CTRL_BANK1_INFO0_REGWEN_3
+    4'b 0001, // index[56] FLASH_CTRL_BANK1_INFO0_REGWEN_4
+    4'b 0001, // index[57] FLASH_CTRL_BANK1_INFO0_REGWEN_5
+    4'b 0001, // index[58] FLASH_CTRL_BANK1_INFO0_REGWEN_6
+    4'b 0001, // index[59] FLASH_CTRL_BANK1_INFO0_REGWEN_7
+    4'b 0001, // index[60] FLASH_CTRL_BANK1_INFO0_REGWEN_8
+    4'b 0001, // index[61] FLASH_CTRL_BANK1_INFO0_REGWEN_9
+    4'b 0001, // index[62] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0
+    4'b 0001, // index[63] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1
+    4'b 0001, // index[64] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2
+    4'b 0001, // index[65] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3
+    4'b 0001, // index[66] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4
+    4'b 0001, // index[67] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5
+    4'b 0001, // index[68] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6
+    4'b 0001, // index[69] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7
+    4'b 0001, // index[70] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8
+    4'b 0001, // index[71] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9
+    4'b 0001, // index[72] FLASH_CTRL_BANK1_INFO1_REGWEN
+    4'b 0001, // index[73] FLASH_CTRL_BANK1_INFO1_PAGE_CFG
+    4'b 0001, // index[74] FLASH_CTRL_BANK1_INFO2_REGWEN_0
+    4'b 0001, // index[75] FLASH_CTRL_BANK1_INFO2_REGWEN_1
+    4'b 0001, // index[76] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0
+    4'b 0001, // index[77] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1
+    4'b 0001, // index[78] FLASH_CTRL_BANK_CFG_REGWEN
+    4'b 0001, // index[79] FLASH_CTRL_MP_BANK_CFG
+    4'b 0001, // index[80] FLASH_CTRL_OP_STATUS
+    4'b 0001, // index[81] FLASH_CTRL_STATUS
+    4'b 0001, // index[82] FLASH_CTRL_ERR_CODE
+    4'b 0011, // index[83] FLASH_CTRL_ERR_ADDR
+    4'b 0111, // index[84] FLASH_CTRL_ECC_ERR_ADDR_0
+    4'b 0111, // index[85] FLASH_CTRL_ECC_ERR_ADDR_1
+    4'b 0001, // index[86] FLASH_CTRL_PHY_ALERT_CFG
+    4'b 0001, // index[87] FLASH_CTRL_PHY_STATUS
+    4'b 1111, // index[88] FLASH_CTRL_SCRATCH
+    4'b 0011, // index[89] FLASH_CTRL_FIFO_LVL
+    4'b 0001  // index[90] FLASH_CTRL_FIFO_RST
   };
 endpackage
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
@@ -90,10 +90,10 @@ module flash_ctrl_reg_top (
     reg_steer = 3;       // Default set to register
 
     // TODO: Can below codes be unique case () inside ?
-    if (tl_i.a_address[AW-1:0] >= 340 && tl_i.a_address[AW-1:0] < 344) begin
+    if (tl_i.a_address[AW-1:0] >= 364 && tl_i.a_address[AW-1:0] < 368) begin
       reg_steer = 0;
     end
-    if (tl_i.a_address[AW-1:0] >= 344 && tl_i.a_address[AW-1:0] < 348) begin
+    if (tl_i.a_address[AW-1:0] >= 368 && tl_i.a_address[AW-1:0] < 372) begin
       reg_steer = 1;
     end
     if (tl_i.a_address[AW-1:0] >= 384 && tl_i.a_address[AW-1:0] < 468) begin
@@ -141,9 +141,6 @@ module flash_ctrl_reg_top (
   logic intr_state_op_done_qs;
   logic intr_state_op_done_wd;
   logic intr_state_op_done_we;
-  logic intr_state_op_error_qs;
-  logic intr_state_op_error_wd;
-  logic intr_state_op_error_we;
   logic intr_enable_prog_empty_qs;
   logic intr_enable_prog_empty_wd;
   logic intr_enable_prog_empty_we;
@@ -159,9 +156,6 @@ module flash_ctrl_reg_top (
   logic intr_enable_op_done_qs;
   logic intr_enable_op_done_wd;
   logic intr_enable_op_done_we;
-  logic intr_enable_op_error_qs;
-  logic intr_enable_op_error_wd;
-  logic intr_enable_op_error_we;
   logic intr_test_prog_empty_wd;
   logic intr_test_prog_empty_we;
   logic intr_test_prog_lvl_wd;
@@ -172,8 +166,12 @@ module flash_ctrl_reg_top (
   logic intr_test_rd_lvl_we;
   logic intr_test_op_done_wd;
   logic intr_test_op_done_we;
-  logic intr_test_op_error_wd;
-  logic intr_test_op_error_we;
+  logic alert_test_recov_err_wd;
+  logic alert_test_recov_err_we;
+  logic alert_test_recov_mp_err_wd;
+  logic alert_test_recov_mp_err_we;
+  logic alert_test_recov_ecc_err_wd;
+  logic alert_test_recov_ecc_err_we;
   logic ctrl_regwen_qs;
   logic ctrl_regwen_re;
   logic control_start_qs;
@@ -1111,7 +1109,30 @@ module flash_ctrl_reg_top (
   logic status_prog_full_qs;
   logic status_prog_empty_qs;
   logic status_init_wip_qs;
-  logic [8:0] status_error_addr_qs;
+  logic err_code_flash_err_qs;
+  logic err_code_flash_err_wd;
+  logic err_code_flash_err_we;
+  logic err_code_flash_alert_qs;
+  logic err_code_flash_alert_wd;
+  logic err_code_flash_alert_we;
+  logic err_code_mp_err_qs;
+  logic err_code_mp_err_wd;
+  logic err_code_mp_err_we;
+  logic err_code_ecc_single_err_qs;
+  logic err_code_ecc_single_err_wd;
+  logic err_code_ecc_single_err_we;
+  logic err_code_ecc_multi_err_qs;
+  logic err_code_ecc_multi_err_wd;
+  logic err_code_ecc_multi_err_we;
+  logic [8:0] err_addr_qs;
+  logic [19:0] ecc_err_addr_0_qs;
+  logic [19:0] ecc_err_addr_1_qs;
+  logic phy_alert_cfg_alert_ack_qs;
+  logic phy_alert_cfg_alert_ack_wd;
+  logic phy_alert_cfg_alert_ack_we;
+  logic phy_alert_cfg_alert_trig_qs;
+  logic phy_alert_cfg_alert_trig_wd;
+  logic phy_alert_cfg_alert_trig_we;
   logic phy_status_init_wip_qs;
   logic phy_status_prog_normal_avail_qs;
   logic phy_status_prog_repair_avail_qs;
@@ -1261,32 +1282,6 @@ module flash_ctrl_reg_top (
   );
 
 
-  //   F[op_error]: 5:5
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W1C"),
-    .RESVAL  (1'h0)
-  ) u_intr_state_op_error (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (intr_state_op_error_we),
-    .wd     (intr_state_op_error_wd),
-
-    // from internal hardware
-    .de     (hw2reg.intr_state.op_error.de),
-    .d      (hw2reg.intr_state.op_error.d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.intr_state.op_error.q ),
-
-    // to register interface (read)
-    .qs     (intr_state_op_error_qs)
-  );
-
-
   // R[intr_enable]: V(False)
 
   //   F[prog_empty]: 0:0
@@ -1419,32 +1414,6 @@ module flash_ctrl_reg_top (
   );
 
 
-  //   F[op_error]: 5:5
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_intr_enable_op_error (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (intr_enable_op_error_we),
-    .wd     (intr_enable_op_error_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.intr_enable.op_error.q ),
-
-    // to register interface (read)
-    .qs     (intr_enable_op_error_qs)
-  );
-
-
   // R[intr_test]: V(True)
 
   //   F[prog_empty]: 0:0
@@ -1522,17 +1491,49 @@ module flash_ctrl_reg_top (
   );
 
 
-  //   F[op_error]: 5:5
+  // R[alert_test]: V(True)
+
+  //   F[recov_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_intr_test_op_error (
+  ) u_alert_test_recov_err (
     .re     (1'b0),
-    .we     (intr_test_op_error_we),
-    .wd     (intr_test_op_error_wd),
+    .we     (alert_test_recov_err_we),
+    .wd     (alert_test_recov_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.op_error.qe),
-    .q      (reg2hw.intr_test.op_error.q ),
+    .qe     (reg2hw.alert_test.recov_err.qe),
+    .q      (reg2hw.alert_test.recov_err.q ),
+    .qs     ()
+  );
+
+
+  //   F[recov_mp_err]: 1:1
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_alert_test_recov_mp_err (
+    .re     (1'b0),
+    .we     (alert_test_recov_mp_err_we),
+    .wd     (alert_test_recov_mp_err_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.alert_test.recov_mp_err.qe),
+    .q      (reg2hw.alert_test.recov_mp_err.q ),
+    .qs     ()
+  );
+
+
+  //   F[recov_ecc_err]: 2:2
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_alert_test_recov_ecc_err (
+    .re     (1'b0),
+    .we     (alert_test_recov_ecc_err_we),
+    .wd     (alert_test_recov_ecc_err_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.alert_test.recov_ecc_err.qe),
+    .q      (reg2hw.alert_test.recov_ecc_err.q ),
     .qs     ()
   );
 
@@ -9920,12 +9921,145 @@ module flash_ctrl_reg_top (
   );
 
 
-  //   F[error_addr]: 16:8
+  // R[err_code]: V(False)
+
+  //   F[flash_err]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_err_code_flash_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (err_code_flash_err_we),
+    .wd     (err_code_flash_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.err_code.flash_err.de),
+    .d      (hw2reg.err_code.flash_err.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_code_flash_err_qs)
+  );
+
+
+  //   F[flash_alert]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_err_code_flash_alert (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (err_code_flash_alert_we),
+    .wd     (err_code_flash_alert_wd),
+
+    // from internal hardware
+    .de     (hw2reg.err_code.flash_alert.de),
+    .d      (hw2reg.err_code.flash_alert.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_code_flash_alert_qs)
+  );
+
+
+  //   F[mp_err]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_err_code_mp_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (err_code_mp_err_we),
+    .wd     (err_code_mp_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.err_code.mp_err.de),
+    .d      (hw2reg.err_code.mp_err.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_code_mp_err_qs)
+  );
+
+
+  //   F[ecc_single_err]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_err_code_ecc_single_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (err_code_ecc_single_err_we),
+    .wd     (err_code_ecc_single_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.err_code.ecc_single_err.de),
+    .d      (hw2reg.err_code.ecc_single_err.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_code_ecc_single_err_qs)
+  );
+
+
+  //   F[ecc_multi_err]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_err_code_ecc_multi_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (err_code_ecc_multi_err_we),
+    .wd     (err_code_ecc_multi_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.err_code.ecc_multi_err.de),
+    .d      (hw2reg.err_code.ecc_multi_err.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_code_ecc_multi_err_qs)
+  );
+
+
+  // R[err_addr]: V(False)
+
   prim_subreg #(
     .DW      (9),
     .SWACCESS("RO"),
     .RESVAL  (9'h0)
-  ) u_status_error_addr (
+  ) u_err_addr (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
@@ -9933,15 +10067,123 @@ module flash_ctrl_reg_top (
     .wd     ('0  ),
 
     // from internal hardware
-    .de     (hw2reg.status.error_addr.de),
-    .d      (hw2reg.status.error_addr.d ),
+    .de     (hw2reg.err_addr.de),
+    .d      (hw2reg.err_addr.d ),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (status_error_addr_qs)
+    .qs     (err_addr_qs)
+  );
+
+
+
+  // Subregister 0 of Multireg ecc_err_addr
+  // R[ecc_err_addr_0]: V(False)
+
+  prim_subreg #(
+    .DW      (20),
+    .SWACCESS("RO"),
+    .RESVAL  (20'h0)
+  ) u_ecc_err_addr_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.ecc_err_addr[0].de),
+    .d      (hw2reg.ecc_err_addr[0].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (ecc_err_addr_0_qs)
+  );
+
+  // Subregister 1 of Multireg ecc_err_addr
+  // R[ecc_err_addr_1]: V(False)
+
+  prim_subreg #(
+    .DW      (20),
+    .SWACCESS("RO"),
+    .RESVAL  (20'h0)
+  ) u_ecc_err_addr_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.ecc_err_addr[1].de),
+    .d      (hw2reg.ecc_err_addr[1].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (ecc_err_addr_1_qs)
+  );
+
+
+  // R[phy_alert_cfg]: V(False)
+
+  //   F[alert_ack]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_phy_alert_cfg_alert_ack (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (phy_alert_cfg_alert_ack_we),
+    .wd     (phy_alert_cfg_alert_ack_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.phy_alert_cfg.alert_ack.q ),
+
+    // to register interface (read)
+    .qs     (phy_alert_cfg_alert_ack_qs)
+  );
+
+
+  //   F[alert_trig]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_phy_alert_cfg_alert_trig (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (phy_alert_cfg_alert_trig_we),
+    .wd     (phy_alert_cfg_alert_trig_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.phy_alert_cfg.alert_trig.q ),
+
+    // to register interface (read)
+    .qs     (phy_alert_cfg_alert_trig_qs)
   );
 
 
@@ -10132,94 +10374,100 @@ module flash_ctrl_reg_top (
 
 
 
-  logic [84:0] addr_hit;
+  logic [90:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == FLASH_CTRL_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == FLASH_CTRL_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == FLASH_CTRL_INTR_TEST_OFFSET);
-    addr_hit[ 3] = (reg_addr == FLASH_CTRL_CTRL_REGWEN_OFFSET);
-    addr_hit[ 4] = (reg_addr == FLASH_CTRL_CONTROL_OFFSET);
-    addr_hit[ 5] = (reg_addr == FLASH_CTRL_ADDR_OFFSET);
-    addr_hit[ 6] = (reg_addr == FLASH_CTRL_PROG_TYPE_EN_OFFSET);
-    addr_hit[ 7] = (reg_addr == FLASH_CTRL_ERASE_SUSPEND_OFFSET);
-    addr_hit[ 8] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_0_OFFSET);
-    addr_hit[ 9] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_1_OFFSET);
-    addr_hit[10] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_2_OFFSET);
-    addr_hit[11] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_3_OFFSET);
-    addr_hit[12] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_4_OFFSET);
-    addr_hit[13] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_5_OFFSET);
-    addr_hit[14] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_6_OFFSET);
-    addr_hit[15] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_7_OFFSET);
-    addr_hit[16] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_0_OFFSET);
-    addr_hit[17] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_1_OFFSET);
-    addr_hit[18] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_2_OFFSET);
-    addr_hit[19] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_3_OFFSET);
-    addr_hit[20] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_4_OFFSET);
-    addr_hit[21] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_5_OFFSET);
-    addr_hit[22] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_6_OFFSET);
-    addr_hit[23] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_7_OFFSET);
-    addr_hit[24] = (reg_addr == FLASH_CTRL_DEFAULT_REGION_OFFSET);
-    addr_hit[25] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_0_OFFSET);
-    addr_hit[26] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_1_OFFSET);
-    addr_hit[27] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_2_OFFSET);
-    addr_hit[28] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_3_OFFSET);
-    addr_hit[29] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_4_OFFSET);
-    addr_hit[30] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_5_OFFSET);
-    addr_hit[31] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_6_OFFSET);
-    addr_hit[32] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_7_OFFSET);
-    addr_hit[33] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_8_OFFSET);
-    addr_hit[34] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_9_OFFSET);
-    addr_hit[35] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_OFFSET);
-    addr_hit[36] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1_OFFSET);
-    addr_hit[37] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2_OFFSET);
-    addr_hit[38] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3_OFFSET);
-    addr_hit[39] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4_OFFSET);
-    addr_hit[40] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5_OFFSET);
-    addr_hit[41] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6_OFFSET);
-    addr_hit[42] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7_OFFSET);
-    addr_hit[43] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8_OFFSET);
-    addr_hit[44] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9_OFFSET);
-    addr_hit[45] = (reg_addr == FLASH_CTRL_BANK0_INFO1_REGWEN_OFFSET);
-    addr_hit[46] = (reg_addr == FLASH_CTRL_BANK0_INFO1_PAGE_CFG_OFFSET);
-    addr_hit[47] = (reg_addr == FLASH_CTRL_BANK0_INFO2_REGWEN_0_OFFSET);
-    addr_hit[48] = (reg_addr == FLASH_CTRL_BANK0_INFO2_REGWEN_1_OFFSET);
-    addr_hit[49] = (reg_addr == FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0_OFFSET);
-    addr_hit[50] = (reg_addr == FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1_OFFSET);
-    addr_hit[51] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_0_OFFSET);
-    addr_hit[52] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_1_OFFSET);
-    addr_hit[53] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_2_OFFSET);
-    addr_hit[54] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_3_OFFSET);
-    addr_hit[55] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_4_OFFSET);
-    addr_hit[56] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_5_OFFSET);
-    addr_hit[57] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_6_OFFSET);
-    addr_hit[58] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_7_OFFSET);
-    addr_hit[59] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_8_OFFSET);
-    addr_hit[60] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_9_OFFSET);
-    addr_hit[61] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_OFFSET);
-    addr_hit[62] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1_OFFSET);
-    addr_hit[63] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2_OFFSET);
-    addr_hit[64] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3_OFFSET);
-    addr_hit[65] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4_OFFSET);
-    addr_hit[66] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5_OFFSET);
-    addr_hit[67] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6_OFFSET);
-    addr_hit[68] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7_OFFSET);
-    addr_hit[69] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8_OFFSET);
-    addr_hit[70] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9_OFFSET);
-    addr_hit[71] = (reg_addr == FLASH_CTRL_BANK1_INFO1_REGWEN_OFFSET);
-    addr_hit[72] = (reg_addr == FLASH_CTRL_BANK1_INFO1_PAGE_CFG_OFFSET);
-    addr_hit[73] = (reg_addr == FLASH_CTRL_BANK1_INFO2_REGWEN_0_OFFSET);
-    addr_hit[74] = (reg_addr == FLASH_CTRL_BANK1_INFO2_REGWEN_1_OFFSET);
-    addr_hit[75] = (reg_addr == FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0_OFFSET);
-    addr_hit[76] = (reg_addr == FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1_OFFSET);
-    addr_hit[77] = (reg_addr == FLASH_CTRL_BANK_CFG_REGWEN_OFFSET);
-    addr_hit[78] = (reg_addr == FLASH_CTRL_MP_BANK_CFG_OFFSET);
-    addr_hit[79] = (reg_addr == FLASH_CTRL_OP_STATUS_OFFSET);
-    addr_hit[80] = (reg_addr == FLASH_CTRL_STATUS_OFFSET);
-    addr_hit[81] = (reg_addr == FLASH_CTRL_PHY_STATUS_OFFSET);
-    addr_hit[82] = (reg_addr == FLASH_CTRL_SCRATCH_OFFSET);
-    addr_hit[83] = (reg_addr == FLASH_CTRL_FIFO_LVL_OFFSET);
-    addr_hit[84] = (reg_addr == FLASH_CTRL_FIFO_RST_OFFSET);
+    addr_hit[ 3] = (reg_addr == FLASH_CTRL_ALERT_TEST_OFFSET);
+    addr_hit[ 4] = (reg_addr == FLASH_CTRL_CTRL_REGWEN_OFFSET);
+    addr_hit[ 5] = (reg_addr == FLASH_CTRL_CONTROL_OFFSET);
+    addr_hit[ 6] = (reg_addr == FLASH_CTRL_ADDR_OFFSET);
+    addr_hit[ 7] = (reg_addr == FLASH_CTRL_PROG_TYPE_EN_OFFSET);
+    addr_hit[ 8] = (reg_addr == FLASH_CTRL_ERASE_SUSPEND_OFFSET);
+    addr_hit[ 9] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_0_OFFSET);
+    addr_hit[10] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_1_OFFSET);
+    addr_hit[11] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_2_OFFSET);
+    addr_hit[12] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_3_OFFSET);
+    addr_hit[13] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_4_OFFSET);
+    addr_hit[14] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_5_OFFSET);
+    addr_hit[15] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_6_OFFSET);
+    addr_hit[16] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_7_OFFSET);
+    addr_hit[17] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_0_OFFSET);
+    addr_hit[18] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_1_OFFSET);
+    addr_hit[19] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_2_OFFSET);
+    addr_hit[20] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_3_OFFSET);
+    addr_hit[21] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_4_OFFSET);
+    addr_hit[22] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_5_OFFSET);
+    addr_hit[23] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_6_OFFSET);
+    addr_hit[24] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_7_OFFSET);
+    addr_hit[25] = (reg_addr == FLASH_CTRL_DEFAULT_REGION_OFFSET);
+    addr_hit[26] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_0_OFFSET);
+    addr_hit[27] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_1_OFFSET);
+    addr_hit[28] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_2_OFFSET);
+    addr_hit[29] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_3_OFFSET);
+    addr_hit[30] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_4_OFFSET);
+    addr_hit[31] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_5_OFFSET);
+    addr_hit[32] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_6_OFFSET);
+    addr_hit[33] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_7_OFFSET);
+    addr_hit[34] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_8_OFFSET);
+    addr_hit[35] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_9_OFFSET);
+    addr_hit[36] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_OFFSET);
+    addr_hit[37] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1_OFFSET);
+    addr_hit[38] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2_OFFSET);
+    addr_hit[39] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3_OFFSET);
+    addr_hit[40] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4_OFFSET);
+    addr_hit[41] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5_OFFSET);
+    addr_hit[42] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6_OFFSET);
+    addr_hit[43] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7_OFFSET);
+    addr_hit[44] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8_OFFSET);
+    addr_hit[45] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9_OFFSET);
+    addr_hit[46] = (reg_addr == FLASH_CTRL_BANK0_INFO1_REGWEN_OFFSET);
+    addr_hit[47] = (reg_addr == FLASH_CTRL_BANK0_INFO1_PAGE_CFG_OFFSET);
+    addr_hit[48] = (reg_addr == FLASH_CTRL_BANK0_INFO2_REGWEN_0_OFFSET);
+    addr_hit[49] = (reg_addr == FLASH_CTRL_BANK0_INFO2_REGWEN_1_OFFSET);
+    addr_hit[50] = (reg_addr == FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0_OFFSET);
+    addr_hit[51] = (reg_addr == FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1_OFFSET);
+    addr_hit[52] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_0_OFFSET);
+    addr_hit[53] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_1_OFFSET);
+    addr_hit[54] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_2_OFFSET);
+    addr_hit[55] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_3_OFFSET);
+    addr_hit[56] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_4_OFFSET);
+    addr_hit[57] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_5_OFFSET);
+    addr_hit[58] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_6_OFFSET);
+    addr_hit[59] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_7_OFFSET);
+    addr_hit[60] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_8_OFFSET);
+    addr_hit[61] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_9_OFFSET);
+    addr_hit[62] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_OFFSET);
+    addr_hit[63] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1_OFFSET);
+    addr_hit[64] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2_OFFSET);
+    addr_hit[65] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3_OFFSET);
+    addr_hit[66] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4_OFFSET);
+    addr_hit[67] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5_OFFSET);
+    addr_hit[68] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6_OFFSET);
+    addr_hit[69] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7_OFFSET);
+    addr_hit[70] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8_OFFSET);
+    addr_hit[71] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9_OFFSET);
+    addr_hit[72] = (reg_addr == FLASH_CTRL_BANK1_INFO1_REGWEN_OFFSET);
+    addr_hit[73] = (reg_addr == FLASH_CTRL_BANK1_INFO1_PAGE_CFG_OFFSET);
+    addr_hit[74] = (reg_addr == FLASH_CTRL_BANK1_INFO2_REGWEN_0_OFFSET);
+    addr_hit[75] = (reg_addr == FLASH_CTRL_BANK1_INFO2_REGWEN_1_OFFSET);
+    addr_hit[76] = (reg_addr == FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0_OFFSET);
+    addr_hit[77] = (reg_addr == FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1_OFFSET);
+    addr_hit[78] = (reg_addr == FLASH_CTRL_BANK_CFG_REGWEN_OFFSET);
+    addr_hit[79] = (reg_addr == FLASH_CTRL_MP_BANK_CFG_OFFSET);
+    addr_hit[80] = (reg_addr == FLASH_CTRL_OP_STATUS_OFFSET);
+    addr_hit[81] = (reg_addr == FLASH_CTRL_STATUS_OFFSET);
+    addr_hit[82] = (reg_addr == FLASH_CTRL_ERR_CODE_OFFSET);
+    addr_hit[83] = (reg_addr == FLASH_CTRL_ERR_ADDR_OFFSET);
+    addr_hit[84] = (reg_addr == FLASH_CTRL_ECC_ERR_ADDR_0_OFFSET);
+    addr_hit[85] = (reg_addr == FLASH_CTRL_ECC_ERR_ADDR_1_OFFSET);
+    addr_hit[86] = (reg_addr == FLASH_CTRL_PHY_ALERT_CFG_OFFSET);
+    addr_hit[87] = (reg_addr == FLASH_CTRL_PHY_STATUS_OFFSET);
+    addr_hit[88] = (reg_addr == FLASH_CTRL_SCRATCH_OFFSET);
+    addr_hit[89] = (reg_addr == FLASH_CTRL_FIFO_LVL_OFFSET);
+    addr_hit[90] = (reg_addr == FLASH_CTRL_FIFO_RST_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -10312,6 +10560,12 @@ module flash_ctrl_reg_top (
     if (addr_hit[82] && reg_we && (FLASH_CTRL_PERMIT[82] != (FLASH_CTRL_PERMIT[82] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[83] && reg_we && (FLASH_CTRL_PERMIT[83] != (FLASH_CTRL_PERMIT[83] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[84] && reg_we && (FLASH_CTRL_PERMIT[84] != (FLASH_CTRL_PERMIT[84] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[85] && reg_we && (FLASH_CTRL_PERMIT[85] != (FLASH_CTRL_PERMIT[85] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[86] && reg_we && (FLASH_CTRL_PERMIT[86] != (FLASH_CTRL_PERMIT[86] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[87] && reg_we && (FLASH_CTRL_PERMIT[87] != (FLASH_CTRL_PERMIT[87] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[88] && reg_we && (FLASH_CTRL_PERMIT[88] != (FLASH_CTRL_PERMIT[88] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[89] && reg_we && (FLASH_CTRL_PERMIT[89] != (FLASH_CTRL_PERMIT[89] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[90] && reg_we && (FLASH_CTRL_PERMIT[90] != (FLASH_CTRL_PERMIT[90] & reg_be))) wr_err = 1'b1 ;
   end
 
   assign intr_state_prog_empty_we = addr_hit[0] & reg_we & ~wr_err;
@@ -10329,9 +10583,6 @@ module flash_ctrl_reg_top (
   assign intr_state_op_done_we = addr_hit[0] & reg_we & ~wr_err;
   assign intr_state_op_done_wd = reg_wdata[4];
 
-  assign intr_state_op_error_we = addr_hit[0] & reg_we & ~wr_err;
-  assign intr_state_op_error_wd = reg_wdata[5];
-
   assign intr_enable_prog_empty_we = addr_hit[1] & reg_we & ~wr_err;
   assign intr_enable_prog_empty_wd = reg_wdata[0];
 
@@ -10346,9 +10597,6 @@ module flash_ctrl_reg_top (
 
   assign intr_enable_op_done_we = addr_hit[1] & reg_we & ~wr_err;
   assign intr_enable_op_done_wd = reg_wdata[4];
-
-  assign intr_enable_op_error_we = addr_hit[1] & reg_we & ~wr_err;
-  assign intr_enable_op_error_wd = reg_wdata[5];
 
   assign intr_test_prog_empty_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_prog_empty_wd = reg_wdata[0];
@@ -10365,939 +10613,945 @@ module flash_ctrl_reg_top (
   assign intr_test_op_done_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_op_done_wd = reg_wdata[4];
 
-  assign intr_test_op_error_we = addr_hit[2] & reg_we & ~wr_err;
-  assign intr_test_op_error_wd = reg_wdata[5];
+  assign alert_test_recov_err_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_recov_err_wd = reg_wdata[0];
 
-  assign ctrl_regwen_re = addr_hit[3] && reg_re;
+  assign alert_test_recov_mp_err_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_recov_mp_err_wd = reg_wdata[1];
 
-  assign control_start_we = addr_hit[4] & reg_we & ~wr_err;
+  assign alert_test_recov_ecc_err_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_recov_ecc_err_wd = reg_wdata[2];
+
+  assign ctrl_regwen_re = addr_hit[4] && reg_re;
+
+  assign control_start_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_start_wd = reg_wdata[0];
 
-  assign control_op_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_op_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_op_wd = reg_wdata[5:4];
 
-  assign control_prog_sel_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_prog_sel_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_prog_sel_wd = reg_wdata[6];
 
-  assign control_erase_sel_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_erase_sel_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_erase_sel_wd = reg_wdata[7];
 
-  assign control_partition_sel_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_partition_sel_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_partition_sel_wd = reg_wdata[8];
 
-  assign control_info_sel_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_info_sel_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_info_sel_wd = reg_wdata[10:9];
 
-  assign control_num_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_num_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_num_wd = reg_wdata[27:16];
 
-  assign addr_we = addr_hit[5] & reg_we & ~wr_err;
+  assign addr_we = addr_hit[6] & reg_we & ~wr_err;
   assign addr_wd = reg_wdata[31:0];
 
-  assign prog_type_en_normal_we = addr_hit[6] & reg_we & ~wr_err;
+  assign prog_type_en_normal_we = addr_hit[7] & reg_we & ~wr_err;
   assign prog_type_en_normal_wd = reg_wdata[0];
 
-  assign prog_type_en_repair_we = addr_hit[6] & reg_we & ~wr_err;
+  assign prog_type_en_repair_we = addr_hit[7] & reg_we & ~wr_err;
   assign prog_type_en_repair_wd = reg_wdata[1];
 
-  assign erase_suspend_we = addr_hit[7] & reg_we & ~wr_err;
+  assign erase_suspend_we = addr_hit[8] & reg_we & ~wr_err;
   assign erase_suspend_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_0_we = addr_hit[8] & reg_we & ~wr_err;
+  assign region_cfg_regwen_0_we = addr_hit[9] & reg_we & ~wr_err;
   assign region_cfg_regwen_0_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_1_we = addr_hit[9] & reg_we & ~wr_err;
+  assign region_cfg_regwen_1_we = addr_hit[10] & reg_we & ~wr_err;
   assign region_cfg_regwen_1_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_2_we = addr_hit[10] & reg_we & ~wr_err;
+  assign region_cfg_regwen_2_we = addr_hit[11] & reg_we & ~wr_err;
   assign region_cfg_regwen_2_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_3_we = addr_hit[11] & reg_we & ~wr_err;
+  assign region_cfg_regwen_3_we = addr_hit[12] & reg_we & ~wr_err;
   assign region_cfg_regwen_3_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_4_we = addr_hit[12] & reg_we & ~wr_err;
+  assign region_cfg_regwen_4_we = addr_hit[13] & reg_we & ~wr_err;
   assign region_cfg_regwen_4_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_5_we = addr_hit[13] & reg_we & ~wr_err;
+  assign region_cfg_regwen_5_we = addr_hit[14] & reg_we & ~wr_err;
   assign region_cfg_regwen_5_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_6_we = addr_hit[14] & reg_we & ~wr_err;
+  assign region_cfg_regwen_6_we = addr_hit[15] & reg_we & ~wr_err;
   assign region_cfg_regwen_6_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_7_we = addr_hit[15] & reg_we & ~wr_err;
+  assign region_cfg_regwen_7_we = addr_hit[16] & reg_we & ~wr_err;
   assign region_cfg_regwen_7_wd = reg_wdata[0];
 
-  assign mp_region_cfg_0_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_en_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign mp_region_cfg_0_rd_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_rd_en_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign mp_region_cfg_0_prog_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_prog_en_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign mp_region_cfg_0_erase_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_erase_en_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign mp_region_cfg_0_scramble_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_scramble_en_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign mp_region_cfg_0_ecc_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_ecc_en_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign mp_region_cfg_0_he_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_he_en_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign mp_region_cfg_0_base_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_base_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_0_base_0_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_0_size_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_size_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_0_size_0_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_1_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_en_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign mp_region_cfg_1_rd_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_rd_en_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign mp_region_cfg_1_prog_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_prog_en_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign mp_region_cfg_1_erase_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_erase_en_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign mp_region_cfg_1_scramble_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_scramble_en_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign mp_region_cfg_1_ecc_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_ecc_en_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign mp_region_cfg_1_he_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_he_en_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign mp_region_cfg_1_base_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_base_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_1_base_1_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_1_size_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_size_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_1_size_1_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_2_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_en_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign mp_region_cfg_2_rd_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_rd_en_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign mp_region_cfg_2_prog_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_prog_en_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign mp_region_cfg_2_erase_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_erase_en_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign mp_region_cfg_2_scramble_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_scramble_en_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign mp_region_cfg_2_ecc_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_ecc_en_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign mp_region_cfg_2_he_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_he_en_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_2_he_en_2_wd = reg_wdata[6];
 
-  assign mp_region_cfg_2_base_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_base_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_2_base_2_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_2_size_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_size_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_2_size_2_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_3_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_en_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign mp_region_cfg_3_rd_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_rd_en_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign mp_region_cfg_3_prog_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_prog_en_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign mp_region_cfg_3_erase_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_erase_en_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign mp_region_cfg_3_scramble_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_scramble_en_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign mp_region_cfg_3_ecc_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_ecc_en_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign mp_region_cfg_3_he_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_he_en_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_3_he_en_3_wd = reg_wdata[6];
 
-  assign mp_region_cfg_3_base_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_base_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_3_base_3_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_3_size_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_size_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_3_size_3_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_4_en_4_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_en_4_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign mp_region_cfg_4_rd_en_4_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_rd_en_4_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign mp_region_cfg_4_prog_en_4_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_prog_en_4_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign mp_region_cfg_4_erase_en_4_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_erase_en_4_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign mp_region_cfg_4_scramble_en_4_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_scramble_en_4_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign mp_region_cfg_4_ecc_en_4_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_ecc_en_4_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign mp_region_cfg_4_he_en_4_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_he_en_4_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_4_he_en_4_wd = reg_wdata[6];
 
-  assign mp_region_cfg_4_base_4_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_base_4_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_4_base_4_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_4_size_4_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_size_4_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_4_size_4_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_5_en_5_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_en_5_we = addr_hit[22] & reg_we & ~wr_err;
   assign mp_region_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign mp_region_cfg_5_rd_en_5_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_rd_en_5_we = addr_hit[22] & reg_we & ~wr_err;
   assign mp_region_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign mp_region_cfg_5_prog_en_5_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_prog_en_5_we = addr_hit[22] & reg_we & ~wr_err;
   assign mp_region_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign mp_region_cfg_5_erase_en_5_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_erase_en_5_we = addr_hit[22] & reg_we & ~wr_err;
   assign mp_region_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign mp_region_cfg_5_scramble_en_5_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_scramble_en_5_we = addr_hit[22] & reg_we & ~wr_err;
   assign mp_region_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign mp_region_cfg_5_ecc_en_5_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_ecc_en_5_we = addr_hit[22] & reg_we & ~wr_err;
   assign mp_region_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign mp_region_cfg_5_he_en_5_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_he_en_5_we = addr_hit[22] & reg_we & ~wr_err;
   assign mp_region_cfg_5_he_en_5_wd = reg_wdata[6];
 
-  assign mp_region_cfg_5_base_5_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_base_5_we = addr_hit[22] & reg_we & ~wr_err;
   assign mp_region_cfg_5_base_5_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_5_size_5_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_size_5_we = addr_hit[22] & reg_we & ~wr_err;
   assign mp_region_cfg_5_size_5_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_6_en_6_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_en_6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mp_region_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign mp_region_cfg_6_rd_en_6_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_rd_en_6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mp_region_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign mp_region_cfg_6_prog_en_6_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_prog_en_6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mp_region_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign mp_region_cfg_6_erase_en_6_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_erase_en_6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mp_region_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign mp_region_cfg_6_scramble_en_6_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_scramble_en_6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mp_region_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign mp_region_cfg_6_ecc_en_6_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_ecc_en_6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mp_region_cfg_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign mp_region_cfg_6_he_en_6_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_he_en_6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mp_region_cfg_6_he_en_6_wd = reg_wdata[6];
 
-  assign mp_region_cfg_6_base_6_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_base_6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mp_region_cfg_6_base_6_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_6_size_6_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_size_6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mp_region_cfg_6_size_6_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_7_en_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_en_7_we = addr_hit[24] & reg_we & ~wr_err;
   assign mp_region_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign mp_region_cfg_7_rd_en_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_rd_en_7_we = addr_hit[24] & reg_we & ~wr_err;
   assign mp_region_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign mp_region_cfg_7_prog_en_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_prog_en_7_we = addr_hit[24] & reg_we & ~wr_err;
   assign mp_region_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign mp_region_cfg_7_erase_en_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_erase_en_7_we = addr_hit[24] & reg_we & ~wr_err;
   assign mp_region_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign mp_region_cfg_7_scramble_en_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_scramble_en_7_we = addr_hit[24] & reg_we & ~wr_err;
   assign mp_region_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign mp_region_cfg_7_ecc_en_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_ecc_en_7_we = addr_hit[24] & reg_we & ~wr_err;
   assign mp_region_cfg_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign mp_region_cfg_7_he_en_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_he_en_7_we = addr_hit[24] & reg_we & ~wr_err;
   assign mp_region_cfg_7_he_en_7_wd = reg_wdata[6];
 
-  assign mp_region_cfg_7_base_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_base_7_we = addr_hit[24] & reg_we & ~wr_err;
   assign mp_region_cfg_7_base_7_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_7_size_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_size_7_we = addr_hit[24] & reg_we & ~wr_err;
   assign mp_region_cfg_7_size_7_wd = reg_wdata[26:17];
 
-  assign default_region_rd_en_we = addr_hit[24] & reg_we & ~wr_err;
+  assign default_region_rd_en_we = addr_hit[25] & reg_we & ~wr_err;
   assign default_region_rd_en_wd = reg_wdata[0];
 
-  assign default_region_prog_en_we = addr_hit[24] & reg_we & ~wr_err;
+  assign default_region_prog_en_we = addr_hit[25] & reg_we & ~wr_err;
   assign default_region_prog_en_wd = reg_wdata[1];
 
-  assign default_region_erase_en_we = addr_hit[24] & reg_we & ~wr_err;
+  assign default_region_erase_en_we = addr_hit[25] & reg_we & ~wr_err;
   assign default_region_erase_en_wd = reg_wdata[2];
 
-  assign default_region_scramble_en_we = addr_hit[24] & reg_we & ~wr_err;
+  assign default_region_scramble_en_we = addr_hit[25] & reg_we & ~wr_err;
   assign default_region_scramble_en_wd = reg_wdata[3];
 
-  assign default_region_ecc_en_we = addr_hit[24] & reg_we & ~wr_err;
+  assign default_region_ecc_en_we = addr_hit[25] & reg_we & ~wr_err;
   assign default_region_ecc_en_wd = reg_wdata[4];
 
-  assign default_region_he_en_we = addr_hit[24] & reg_we & ~wr_err;
+  assign default_region_he_en_we = addr_hit[25] & reg_we & ~wr_err;
   assign default_region_he_en_wd = reg_wdata[5];
 
-  assign bank0_info0_regwen_0_we = addr_hit[25] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_0_we = addr_hit[26] & reg_we & ~wr_err;
   assign bank0_info0_regwen_0_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_1_we = addr_hit[26] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_1_we = addr_hit[27] & reg_we & ~wr_err;
   assign bank0_info0_regwen_1_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_2_we = addr_hit[27] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_2_we = addr_hit[28] & reg_we & ~wr_err;
   assign bank0_info0_regwen_2_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_3_we = addr_hit[28] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_3_we = addr_hit[29] & reg_we & ~wr_err;
   assign bank0_info0_regwen_3_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_4_we = addr_hit[29] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_4_we = addr_hit[30] & reg_we & ~wr_err;
   assign bank0_info0_regwen_4_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_5_we = addr_hit[30] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_5_we = addr_hit[31] & reg_we & ~wr_err;
   assign bank0_info0_regwen_5_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_6_we = addr_hit[31] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_6_we = addr_hit[32] & reg_we & ~wr_err;
   assign bank0_info0_regwen_6_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_7_we = addr_hit[32] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_7_we = addr_hit[33] & reg_we & ~wr_err;
   assign bank0_info0_regwen_7_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_8_we = addr_hit[33] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_8_we = addr_hit[34] & reg_we & ~wr_err;
   assign bank0_info0_regwen_8_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_9_we = addr_hit[34] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_9_we = addr_hit[35] & reg_we & ~wr_err;
   assign bank0_info0_regwen_9_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_0_en_0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_en_0_we = addr_hit[36] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_0_rd_en_0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_rd_en_0_we = addr_hit[36] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_0_prog_en_0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_prog_en_0_we = addr_hit[36] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_0_erase_en_0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_erase_en_0_we = addr_hit[36] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_0_scramble_en_0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_scramble_en_0_we = addr_hit[36] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_0_ecc_en_0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_ecc_en_0_we = addr_hit[36] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_0_he_en_0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_he_en_0_we = addr_hit[36] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_1_en_1_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_en_1_we = addr_hit[37] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_1_rd_en_1_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_rd_en_1_we = addr_hit[37] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_1_prog_en_1_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_prog_en_1_we = addr_hit[37] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_1_erase_en_1_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_erase_en_1_we = addr_hit[37] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_1_scramble_en_1_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_scramble_en_1_we = addr_hit[37] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_1_ecc_en_1_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_ecc_en_1_we = addr_hit[37] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_1_he_en_1_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_he_en_1_we = addr_hit[37] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_2_en_2_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_en_2_we = addr_hit[38] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_2_rd_en_2_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_rd_en_2_we = addr_hit[38] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_2_prog_en_2_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_prog_en_2_we = addr_hit[38] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_2_erase_en_2_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_erase_en_2_we = addr_hit[38] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_2_scramble_en_2_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_scramble_en_2_we = addr_hit[38] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_2_ecc_en_2_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_ecc_en_2_we = addr_hit[38] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_2_he_en_2_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_he_en_2_we = addr_hit[38] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_he_en_2_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_3_en_3_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_en_3_we = addr_hit[39] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_3_rd_en_3_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_rd_en_3_we = addr_hit[39] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_3_prog_en_3_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_prog_en_3_we = addr_hit[39] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_3_erase_en_3_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_erase_en_3_we = addr_hit[39] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_3_scramble_en_3_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_scramble_en_3_we = addr_hit[39] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_3_ecc_en_3_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_ecc_en_3_we = addr_hit[39] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_3_he_en_3_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_he_en_3_we = addr_hit[39] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_he_en_3_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_4_en_4_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_en_4_we = addr_hit[40] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_4_rd_en_4_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_rd_en_4_we = addr_hit[40] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_4_prog_en_4_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_prog_en_4_we = addr_hit[40] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_4_erase_en_4_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_erase_en_4_we = addr_hit[40] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_4_scramble_en_4_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_scramble_en_4_we = addr_hit[40] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_4_ecc_en_4_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_ecc_en_4_we = addr_hit[40] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_4_he_en_4_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_he_en_4_we = addr_hit[40] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_4_he_en_4_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_5_en_5_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_en_5_we = addr_hit[41] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_5_rd_en_5_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_rd_en_5_we = addr_hit[41] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_5_prog_en_5_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_prog_en_5_we = addr_hit[41] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_5_erase_en_5_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_erase_en_5_we = addr_hit[41] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_5_scramble_en_5_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_scramble_en_5_we = addr_hit[41] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_5_ecc_en_5_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_ecc_en_5_we = addr_hit[41] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_5_he_en_5_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_he_en_5_we = addr_hit[41] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_5_he_en_5_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_6_en_6_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_en_6_we = addr_hit[42] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_6_rd_en_6_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_rd_en_6_we = addr_hit[42] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_6_prog_en_6_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_prog_en_6_we = addr_hit[42] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_6_erase_en_6_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_erase_en_6_we = addr_hit[42] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_6_scramble_en_6_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_scramble_en_6_we = addr_hit[42] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_6_ecc_en_6_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_ecc_en_6_we = addr_hit[42] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_6_he_en_6_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_he_en_6_we = addr_hit[42] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_6_he_en_6_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_7_en_7_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_en_7_we = addr_hit[43] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_7_rd_en_7_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_rd_en_7_we = addr_hit[43] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_7_prog_en_7_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_prog_en_7_we = addr_hit[43] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_7_erase_en_7_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_erase_en_7_we = addr_hit[43] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_7_scramble_en_7_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_scramble_en_7_we = addr_hit[43] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_7_ecc_en_7_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_ecc_en_7_we = addr_hit[43] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_7_he_en_7_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_he_en_7_we = addr_hit[43] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_7_he_en_7_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_8_en_8_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_en_8_we = addr_hit[44] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_8_en_8_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_8_rd_en_8_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_rd_en_8_we = addr_hit[44] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_8_rd_en_8_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_8_prog_en_8_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_prog_en_8_we = addr_hit[44] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_8_prog_en_8_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_8_erase_en_8_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_erase_en_8_we = addr_hit[44] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_8_erase_en_8_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_8_scramble_en_8_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_scramble_en_8_we = addr_hit[44] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_8_scramble_en_8_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_8_ecc_en_8_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_ecc_en_8_we = addr_hit[44] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_8_ecc_en_8_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_8_he_en_8_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_he_en_8_we = addr_hit[44] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_8_he_en_8_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_9_en_9_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_en_9_we = addr_hit[45] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_9_en_9_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_9_rd_en_9_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_rd_en_9_we = addr_hit[45] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_9_rd_en_9_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_9_prog_en_9_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_prog_en_9_we = addr_hit[45] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_9_prog_en_9_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_9_erase_en_9_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_erase_en_9_we = addr_hit[45] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_9_erase_en_9_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_9_scramble_en_9_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_scramble_en_9_we = addr_hit[45] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_9_scramble_en_9_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_9_ecc_en_9_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_ecc_en_9_we = addr_hit[45] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_9_ecc_en_9_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_9_he_en_9_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_he_en_9_we = addr_hit[45] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_9_he_en_9_wd = reg_wdata[6];
 
-  assign bank0_info1_regwen_we = addr_hit[45] & reg_we & ~wr_err;
+  assign bank0_info1_regwen_we = addr_hit[46] & reg_we & ~wr_err;
   assign bank0_info1_regwen_wd = reg_wdata[0];
 
-  assign bank0_info1_page_cfg_en_0_we = addr_hit[46] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_en_0_we = addr_hit[47] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_en_0_wd = reg_wdata[0];
 
-  assign bank0_info1_page_cfg_rd_en_0_we = addr_hit[46] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_rd_en_0_we = addr_hit[47] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info1_page_cfg_prog_en_0_we = addr_hit[46] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_prog_en_0_we = addr_hit[47] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info1_page_cfg_erase_en_0_we = addr_hit[46] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_erase_en_0_we = addr_hit[47] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info1_page_cfg_scramble_en_0_we = addr_hit[46] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_scramble_en_0_we = addr_hit[47] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info1_page_cfg_ecc_en_0_we = addr_hit[46] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_ecc_en_0_we = addr_hit[47] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info1_page_cfg_he_en_0_we = addr_hit[46] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_he_en_0_we = addr_hit[47] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_he_en_0_wd = reg_wdata[6];
 
-  assign bank0_info2_regwen_0_we = addr_hit[47] & reg_we & ~wr_err;
+  assign bank0_info2_regwen_0_we = addr_hit[48] & reg_we & ~wr_err;
   assign bank0_info2_regwen_0_wd = reg_wdata[0];
 
-  assign bank0_info2_regwen_1_we = addr_hit[48] & reg_we & ~wr_err;
+  assign bank0_info2_regwen_1_we = addr_hit[49] & reg_we & ~wr_err;
   assign bank0_info2_regwen_1_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_0_en_0_we = addr_hit[49] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_en_0_we = addr_hit[50] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_0_rd_en_0_we = addr_hit[49] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_rd_en_0_we = addr_hit[50] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info2_page_cfg_0_prog_en_0_we = addr_hit[49] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_prog_en_0_we = addr_hit[50] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info2_page_cfg_0_erase_en_0_we = addr_hit[49] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_erase_en_0_we = addr_hit[50] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info2_page_cfg_0_scramble_en_0_we = addr_hit[49] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_scramble_en_0_we = addr_hit[50] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info2_page_cfg_0_ecc_en_0_we = addr_hit[49] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_ecc_en_0_we = addr_hit[50] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info2_page_cfg_0_he_en_0_we = addr_hit[49] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_he_en_0_we = addr_hit[50] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign bank0_info2_page_cfg_1_en_1_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_en_1_we = addr_hit[51] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_1_rd_en_1_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_rd_en_1_we = addr_hit[51] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank0_info2_page_cfg_1_prog_en_1_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_prog_en_1_we = addr_hit[51] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank0_info2_page_cfg_1_erase_en_1_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_erase_en_1_we = addr_hit[51] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank0_info2_page_cfg_1_scramble_en_1_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_scramble_en_1_we = addr_hit[51] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank0_info2_page_cfg_1_ecc_en_1_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_ecc_en_1_we = addr_hit[51] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank0_info2_page_cfg_1_he_en_1_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_he_en_1_we = addr_hit[51] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign bank1_info0_regwen_0_we = addr_hit[51] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_0_we = addr_hit[52] & reg_we & ~wr_err;
   assign bank1_info0_regwen_0_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_1_we = addr_hit[52] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_1_we = addr_hit[53] & reg_we & ~wr_err;
   assign bank1_info0_regwen_1_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_2_we = addr_hit[53] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_2_we = addr_hit[54] & reg_we & ~wr_err;
   assign bank1_info0_regwen_2_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_3_we = addr_hit[54] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_3_we = addr_hit[55] & reg_we & ~wr_err;
   assign bank1_info0_regwen_3_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_4_we = addr_hit[55] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_4_we = addr_hit[56] & reg_we & ~wr_err;
   assign bank1_info0_regwen_4_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_5_we = addr_hit[56] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_5_we = addr_hit[57] & reg_we & ~wr_err;
   assign bank1_info0_regwen_5_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_6_we = addr_hit[57] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_6_we = addr_hit[58] & reg_we & ~wr_err;
   assign bank1_info0_regwen_6_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_7_we = addr_hit[58] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_7_we = addr_hit[59] & reg_we & ~wr_err;
   assign bank1_info0_regwen_7_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_8_we = addr_hit[59] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_8_we = addr_hit[60] & reg_we & ~wr_err;
   assign bank1_info0_regwen_8_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_9_we = addr_hit[60] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_9_we = addr_hit[61] & reg_we & ~wr_err;
   assign bank1_info0_regwen_9_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_0_en_0_we = addr_hit[61] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_en_0_we = addr_hit[62] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_0_rd_en_0_we = addr_hit[61] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_rd_en_0_we = addr_hit[62] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_0_prog_en_0_we = addr_hit[61] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_prog_en_0_we = addr_hit[62] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_0_erase_en_0_we = addr_hit[61] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_erase_en_0_we = addr_hit[62] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_0_scramble_en_0_we = addr_hit[61] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_scramble_en_0_we = addr_hit[62] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_0_ecc_en_0_we = addr_hit[61] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_ecc_en_0_we = addr_hit[62] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_0_he_en_0_we = addr_hit[61] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_he_en_0_we = addr_hit[62] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_1_en_1_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_en_1_we = addr_hit[63] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_1_rd_en_1_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_rd_en_1_we = addr_hit[63] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_1_prog_en_1_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_prog_en_1_we = addr_hit[63] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_1_erase_en_1_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_erase_en_1_we = addr_hit[63] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_1_scramble_en_1_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_scramble_en_1_we = addr_hit[63] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_1_ecc_en_1_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_ecc_en_1_we = addr_hit[63] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_1_he_en_1_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_he_en_1_we = addr_hit[63] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_2_en_2_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_en_2_we = addr_hit[64] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_2_rd_en_2_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_rd_en_2_we = addr_hit[64] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_2_prog_en_2_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_prog_en_2_we = addr_hit[64] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_2_erase_en_2_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_erase_en_2_we = addr_hit[64] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_2_scramble_en_2_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_scramble_en_2_we = addr_hit[64] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_2_ecc_en_2_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_ecc_en_2_we = addr_hit[64] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_2_he_en_2_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_he_en_2_we = addr_hit[64] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_he_en_2_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_3_en_3_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_en_3_we = addr_hit[65] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_3_rd_en_3_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_rd_en_3_we = addr_hit[65] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_3_prog_en_3_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_prog_en_3_we = addr_hit[65] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_3_erase_en_3_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_erase_en_3_we = addr_hit[65] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_3_scramble_en_3_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_scramble_en_3_we = addr_hit[65] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_3_ecc_en_3_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_ecc_en_3_we = addr_hit[65] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_3_he_en_3_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_he_en_3_we = addr_hit[65] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_he_en_3_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_4_en_4_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_en_4_we = addr_hit[66] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_4_rd_en_4_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_rd_en_4_we = addr_hit[66] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_4_prog_en_4_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_prog_en_4_we = addr_hit[66] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_4_erase_en_4_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_erase_en_4_we = addr_hit[66] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_4_scramble_en_4_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_scramble_en_4_we = addr_hit[66] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_4_ecc_en_4_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_ecc_en_4_we = addr_hit[66] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_4_he_en_4_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_he_en_4_we = addr_hit[66] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_4_he_en_4_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_5_en_5_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_en_5_we = addr_hit[67] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_5_rd_en_5_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_rd_en_5_we = addr_hit[67] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_5_prog_en_5_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_prog_en_5_we = addr_hit[67] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_5_erase_en_5_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_erase_en_5_we = addr_hit[67] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_5_scramble_en_5_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_scramble_en_5_we = addr_hit[67] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_5_ecc_en_5_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_ecc_en_5_we = addr_hit[67] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_5_he_en_5_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_he_en_5_we = addr_hit[67] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_5_he_en_5_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_6_en_6_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_en_6_we = addr_hit[68] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_6_rd_en_6_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_rd_en_6_we = addr_hit[68] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_6_prog_en_6_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_prog_en_6_we = addr_hit[68] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_6_erase_en_6_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_erase_en_6_we = addr_hit[68] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_6_scramble_en_6_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_scramble_en_6_we = addr_hit[68] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_6_ecc_en_6_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_ecc_en_6_we = addr_hit[68] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_6_he_en_6_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_he_en_6_we = addr_hit[68] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_6_he_en_6_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_7_en_7_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_en_7_we = addr_hit[69] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_7_rd_en_7_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_rd_en_7_we = addr_hit[69] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_7_prog_en_7_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_prog_en_7_we = addr_hit[69] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_7_erase_en_7_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_erase_en_7_we = addr_hit[69] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_7_scramble_en_7_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_scramble_en_7_we = addr_hit[69] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_7_ecc_en_7_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_ecc_en_7_we = addr_hit[69] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_7_he_en_7_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_he_en_7_we = addr_hit[69] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_7_he_en_7_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_8_en_8_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_en_8_we = addr_hit[70] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_8_en_8_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_8_rd_en_8_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_rd_en_8_we = addr_hit[70] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_8_rd_en_8_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_8_prog_en_8_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_prog_en_8_we = addr_hit[70] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_8_prog_en_8_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_8_erase_en_8_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_erase_en_8_we = addr_hit[70] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_8_erase_en_8_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_8_scramble_en_8_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_scramble_en_8_we = addr_hit[70] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_8_scramble_en_8_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_8_ecc_en_8_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_ecc_en_8_we = addr_hit[70] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_8_ecc_en_8_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_8_he_en_8_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_he_en_8_we = addr_hit[70] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_8_he_en_8_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_9_en_9_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_en_9_we = addr_hit[71] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_9_en_9_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_9_rd_en_9_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_rd_en_9_we = addr_hit[71] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_9_rd_en_9_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_9_prog_en_9_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_prog_en_9_we = addr_hit[71] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_9_prog_en_9_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_9_erase_en_9_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_erase_en_9_we = addr_hit[71] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_9_erase_en_9_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_9_scramble_en_9_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_scramble_en_9_we = addr_hit[71] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_9_scramble_en_9_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_9_ecc_en_9_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_ecc_en_9_we = addr_hit[71] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_9_ecc_en_9_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_9_he_en_9_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_he_en_9_we = addr_hit[71] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_9_he_en_9_wd = reg_wdata[6];
 
-  assign bank1_info1_regwen_we = addr_hit[71] & reg_we & ~wr_err;
+  assign bank1_info1_regwen_we = addr_hit[72] & reg_we & ~wr_err;
   assign bank1_info1_regwen_wd = reg_wdata[0];
 
-  assign bank1_info1_page_cfg_en_0_we = addr_hit[72] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_en_0_we = addr_hit[73] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_en_0_wd = reg_wdata[0];
 
-  assign bank1_info1_page_cfg_rd_en_0_we = addr_hit[72] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_rd_en_0_we = addr_hit[73] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info1_page_cfg_prog_en_0_we = addr_hit[72] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_prog_en_0_we = addr_hit[73] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info1_page_cfg_erase_en_0_we = addr_hit[72] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_erase_en_0_we = addr_hit[73] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info1_page_cfg_scramble_en_0_we = addr_hit[72] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_scramble_en_0_we = addr_hit[73] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info1_page_cfg_ecc_en_0_we = addr_hit[72] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_ecc_en_0_we = addr_hit[73] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info1_page_cfg_he_en_0_we = addr_hit[72] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_he_en_0_we = addr_hit[73] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_he_en_0_wd = reg_wdata[6];
 
-  assign bank1_info2_regwen_0_we = addr_hit[73] & reg_we & ~wr_err;
+  assign bank1_info2_regwen_0_we = addr_hit[74] & reg_we & ~wr_err;
   assign bank1_info2_regwen_0_wd = reg_wdata[0];
 
-  assign bank1_info2_regwen_1_we = addr_hit[74] & reg_we & ~wr_err;
+  assign bank1_info2_regwen_1_we = addr_hit[75] & reg_we & ~wr_err;
   assign bank1_info2_regwen_1_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_0_en_0_we = addr_hit[75] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_en_0_we = addr_hit[76] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_0_rd_en_0_we = addr_hit[75] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_rd_en_0_we = addr_hit[76] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info2_page_cfg_0_prog_en_0_we = addr_hit[75] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_prog_en_0_we = addr_hit[76] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info2_page_cfg_0_erase_en_0_we = addr_hit[75] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_erase_en_0_we = addr_hit[76] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info2_page_cfg_0_scramble_en_0_we = addr_hit[75] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_scramble_en_0_we = addr_hit[76] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info2_page_cfg_0_ecc_en_0_we = addr_hit[75] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_ecc_en_0_we = addr_hit[76] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info2_page_cfg_0_he_en_0_we = addr_hit[75] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_he_en_0_we = addr_hit[76] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign bank1_info2_page_cfg_1_en_1_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_en_1_we = addr_hit[77] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_1_rd_en_1_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_rd_en_1_we = addr_hit[77] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank1_info2_page_cfg_1_prog_en_1_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_prog_en_1_we = addr_hit[77] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank1_info2_page_cfg_1_erase_en_1_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_erase_en_1_we = addr_hit[77] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank1_info2_page_cfg_1_scramble_en_1_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_scramble_en_1_we = addr_hit[77] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank1_info2_page_cfg_1_ecc_en_1_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_ecc_en_1_we = addr_hit[77] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank1_info2_page_cfg_1_he_en_1_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_he_en_1_we = addr_hit[77] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign bank_cfg_regwen_we = addr_hit[77] & reg_we & ~wr_err;
+  assign bank_cfg_regwen_we = addr_hit[78] & reg_we & ~wr_err;
   assign bank_cfg_regwen_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en_0_we = addr_hit[78] & reg_we & ~wr_err;
+  assign mp_bank_cfg_erase_en_0_we = addr_hit[79] & reg_we & ~wr_err;
   assign mp_bank_cfg_erase_en_0_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en_1_we = addr_hit[78] & reg_we & ~wr_err;
+  assign mp_bank_cfg_erase_en_1_we = addr_hit[79] & reg_we & ~wr_err;
   assign mp_bank_cfg_erase_en_1_wd = reg_wdata[1];
 
-  assign op_status_done_we = addr_hit[79] & reg_we & ~wr_err;
+  assign op_status_done_we = addr_hit[80] & reg_we & ~wr_err;
   assign op_status_done_wd = reg_wdata[0];
 
-  assign op_status_err_we = addr_hit[79] & reg_we & ~wr_err;
+  assign op_status_err_we = addr_hit[80] & reg_we & ~wr_err;
   assign op_status_err_wd = reg_wdata[1];
 
 
@@ -11305,20 +11559,43 @@ module flash_ctrl_reg_top (
 
 
 
+  assign err_code_flash_err_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_flash_err_wd = reg_wdata[0];
+
+  assign err_code_flash_alert_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_flash_alert_wd = reg_wdata[1];
+
+  assign err_code_mp_err_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_mp_err_wd = reg_wdata[2];
+
+  assign err_code_ecc_single_err_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_ecc_single_err_wd = reg_wdata[3];
+
+  assign err_code_ecc_multi_err_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_ecc_multi_err_wd = reg_wdata[4];
 
 
 
 
-  assign scratch_we = addr_hit[82] & reg_we & ~wr_err;
+  assign phy_alert_cfg_alert_ack_we = addr_hit[86] & reg_we & ~wr_err;
+  assign phy_alert_cfg_alert_ack_wd = reg_wdata[0];
+
+  assign phy_alert_cfg_alert_trig_we = addr_hit[86] & reg_we & ~wr_err;
+  assign phy_alert_cfg_alert_trig_wd = reg_wdata[1];
+
+
+
+
+  assign scratch_we = addr_hit[88] & reg_we & ~wr_err;
   assign scratch_wd = reg_wdata[31:0];
 
-  assign fifo_lvl_prog_we = addr_hit[83] & reg_we & ~wr_err;
+  assign fifo_lvl_prog_we = addr_hit[89] & reg_we & ~wr_err;
   assign fifo_lvl_prog_wd = reg_wdata[4:0];
 
-  assign fifo_lvl_rd_we = addr_hit[83] & reg_we & ~wr_err;
+  assign fifo_lvl_rd_we = addr_hit[89] & reg_we & ~wr_err;
   assign fifo_lvl_rd_wd = reg_wdata[12:8];
 
-  assign fifo_rst_we = addr_hit[84] & reg_we & ~wr_err;
+  assign fifo_rst_we = addr_hit[90] & reg_we & ~wr_err;
   assign fifo_rst_wd = reg_wdata[0];
 
   // Read data return
@@ -11331,7 +11608,6 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = intr_state_rd_full_qs;
         reg_rdata_next[3] = intr_state_rd_lvl_qs;
         reg_rdata_next[4] = intr_state_op_done_qs;
-        reg_rdata_next[5] = intr_state_op_error_qs;
       end
 
       addr_hit[1]: begin
@@ -11340,7 +11616,6 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = intr_enable_rd_full_qs;
         reg_rdata_next[3] = intr_enable_rd_lvl_qs;
         reg_rdata_next[4] = intr_enable_op_done_qs;
-        reg_rdata_next[5] = intr_enable_op_error_qs;
       end
 
       addr_hit[2]: begin
@@ -11349,14 +11624,19 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = '0;
         reg_rdata_next[3] = '0;
         reg_rdata_next[4] = '0;
-        reg_rdata_next[5] = '0;
       end
 
       addr_hit[3]: begin
-        reg_rdata_next[0] = ctrl_regwen_qs;
+        reg_rdata_next[0] = '0;
+        reg_rdata_next[1] = '0;
+        reg_rdata_next[2] = '0;
       end
 
       addr_hit[4]: begin
+        reg_rdata_next[0] = ctrl_regwen_qs;
+      end
+
+      addr_hit[5]: begin
         reg_rdata_next[0] = control_start_qs;
         reg_rdata_next[5:4] = control_op_qs;
         reg_rdata_next[6] = control_prog_sel_qs;
@@ -11366,52 +11646,52 @@ module flash_ctrl_reg_top (
         reg_rdata_next[27:16] = control_num_qs;
       end
 
-      addr_hit[5]: begin
+      addr_hit[6]: begin
         reg_rdata_next[31:0] = addr_qs;
       end
 
-      addr_hit[6]: begin
+      addr_hit[7]: begin
         reg_rdata_next[0] = prog_type_en_normal_qs;
         reg_rdata_next[1] = prog_type_en_repair_qs;
       end
 
-      addr_hit[7]: begin
+      addr_hit[8]: begin
         reg_rdata_next[0] = erase_suspend_qs;
       end
 
-      addr_hit[8]: begin
+      addr_hit[9]: begin
         reg_rdata_next[0] = region_cfg_regwen_0_qs;
       end
 
-      addr_hit[9]: begin
+      addr_hit[10]: begin
         reg_rdata_next[0] = region_cfg_regwen_1_qs;
       end
 
-      addr_hit[10]: begin
+      addr_hit[11]: begin
         reg_rdata_next[0] = region_cfg_regwen_2_qs;
       end
 
-      addr_hit[11]: begin
+      addr_hit[12]: begin
         reg_rdata_next[0] = region_cfg_regwen_3_qs;
       end
 
-      addr_hit[12]: begin
+      addr_hit[13]: begin
         reg_rdata_next[0] = region_cfg_regwen_4_qs;
       end
 
-      addr_hit[13]: begin
+      addr_hit[14]: begin
         reg_rdata_next[0] = region_cfg_regwen_5_qs;
       end
 
-      addr_hit[14]: begin
+      addr_hit[15]: begin
         reg_rdata_next[0] = region_cfg_regwen_6_qs;
       end
 
-      addr_hit[15]: begin
+      addr_hit[16]: begin
         reg_rdata_next[0] = region_cfg_regwen_7_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[17]: begin
         reg_rdata_next[0] = mp_region_cfg_0_en_0_qs;
         reg_rdata_next[1] = mp_region_cfg_0_rd_en_0_qs;
         reg_rdata_next[2] = mp_region_cfg_0_prog_en_0_qs;
@@ -11423,7 +11703,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[26:17] = mp_region_cfg_0_size_0_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[18]: begin
         reg_rdata_next[0] = mp_region_cfg_1_en_1_qs;
         reg_rdata_next[1] = mp_region_cfg_1_rd_en_1_qs;
         reg_rdata_next[2] = mp_region_cfg_1_prog_en_1_qs;
@@ -11435,7 +11715,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[26:17] = mp_region_cfg_1_size_1_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[19]: begin
         reg_rdata_next[0] = mp_region_cfg_2_en_2_qs;
         reg_rdata_next[1] = mp_region_cfg_2_rd_en_2_qs;
         reg_rdata_next[2] = mp_region_cfg_2_prog_en_2_qs;
@@ -11447,7 +11727,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[26:17] = mp_region_cfg_2_size_2_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[20]: begin
         reg_rdata_next[0] = mp_region_cfg_3_en_3_qs;
         reg_rdata_next[1] = mp_region_cfg_3_rd_en_3_qs;
         reg_rdata_next[2] = mp_region_cfg_3_prog_en_3_qs;
@@ -11459,7 +11739,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[26:17] = mp_region_cfg_3_size_3_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[21]: begin
         reg_rdata_next[0] = mp_region_cfg_4_en_4_qs;
         reg_rdata_next[1] = mp_region_cfg_4_rd_en_4_qs;
         reg_rdata_next[2] = mp_region_cfg_4_prog_en_4_qs;
@@ -11471,7 +11751,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[26:17] = mp_region_cfg_4_size_4_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[22]: begin
         reg_rdata_next[0] = mp_region_cfg_5_en_5_qs;
         reg_rdata_next[1] = mp_region_cfg_5_rd_en_5_qs;
         reg_rdata_next[2] = mp_region_cfg_5_prog_en_5_qs;
@@ -11483,7 +11763,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[26:17] = mp_region_cfg_5_size_5_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[23]: begin
         reg_rdata_next[0] = mp_region_cfg_6_en_6_qs;
         reg_rdata_next[1] = mp_region_cfg_6_rd_en_6_qs;
         reg_rdata_next[2] = mp_region_cfg_6_prog_en_6_qs;
@@ -11495,7 +11775,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[26:17] = mp_region_cfg_6_size_6_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[24]: begin
         reg_rdata_next[0] = mp_region_cfg_7_en_7_qs;
         reg_rdata_next[1] = mp_region_cfg_7_rd_en_7_qs;
         reg_rdata_next[2] = mp_region_cfg_7_prog_en_7_qs;
@@ -11507,7 +11787,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[26:17] = mp_region_cfg_7_size_7_qs;
       end
 
-      addr_hit[24]: begin
+      addr_hit[25]: begin
         reg_rdata_next[0] = default_region_rd_en_qs;
         reg_rdata_next[1] = default_region_prog_en_qs;
         reg_rdata_next[2] = default_region_erase_en_qs;
@@ -11516,47 +11796,47 @@ module flash_ctrl_reg_top (
         reg_rdata_next[5] = default_region_he_en_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[26]: begin
         reg_rdata_next[0] = bank0_info0_regwen_0_qs;
       end
 
-      addr_hit[26]: begin
+      addr_hit[27]: begin
         reg_rdata_next[0] = bank0_info0_regwen_1_qs;
       end
 
-      addr_hit[27]: begin
+      addr_hit[28]: begin
         reg_rdata_next[0] = bank0_info0_regwen_2_qs;
       end
 
-      addr_hit[28]: begin
+      addr_hit[29]: begin
         reg_rdata_next[0] = bank0_info0_regwen_3_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[30]: begin
         reg_rdata_next[0] = bank0_info0_regwen_4_qs;
       end
 
-      addr_hit[30]: begin
+      addr_hit[31]: begin
         reg_rdata_next[0] = bank0_info0_regwen_5_qs;
       end
 
-      addr_hit[31]: begin
+      addr_hit[32]: begin
         reg_rdata_next[0] = bank0_info0_regwen_6_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[33]: begin
         reg_rdata_next[0] = bank0_info0_regwen_7_qs;
       end
 
-      addr_hit[33]: begin
+      addr_hit[34]: begin
         reg_rdata_next[0] = bank0_info0_regwen_8_qs;
       end
 
-      addr_hit[34]: begin
+      addr_hit[35]: begin
         reg_rdata_next[0] = bank0_info0_regwen_9_qs;
       end
 
-      addr_hit[35]: begin
+      addr_hit[36]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_0_en_0_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_0_rd_en_0_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_0_prog_en_0_qs;
@@ -11566,7 +11846,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_0_he_en_0_qs;
       end
 
-      addr_hit[36]: begin
+      addr_hit[37]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_1_en_1_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_1_rd_en_1_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_1_prog_en_1_qs;
@@ -11576,7 +11856,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_1_he_en_1_qs;
       end
 
-      addr_hit[37]: begin
+      addr_hit[38]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_2_en_2_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_2_rd_en_2_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_2_prog_en_2_qs;
@@ -11586,7 +11866,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_2_he_en_2_qs;
       end
 
-      addr_hit[38]: begin
+      addr_hit[39]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_3_en_3_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_3_rd_en_3_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_3_prog_en_3_qs;
@@ -11596,7 +11876,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_3_he_en_3_qs;
       end
 
-      addr_hit[39]: begin
+      addr_hit[40]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_4_en_4_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_4_rd_en_4_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_4_prog_en_4_qs;
@@ -11606,7 +11886,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_4_he_en_4_qs;
       end
 
-      addr_hit[40]: begin
+      addr_hit[41]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_5_en_5_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_5_rd_en_5_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_5_prog_en_5_qs;
@@ -11616,7 +11896,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_5_he_en_5_qs;
       end
 
-      addr_hit[41]: begin
+      addr_hit[42]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_6_en_6_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_6_rd_en_6_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_6_prog_en_6_qs;
@@ -11626,7 +11906,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_6_he_en_6_qs;
       end
 
-      addr_hit[42]: begin
+      addr_hit[43]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_7_en_7_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_7_rd_en_7_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_7_prog_en_7_qs;
@@ -11636,7 +11916,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_7_he_en_7_qs;
       end
 
-      addr_hit[43]: begin
+      addr_hit[44]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_8_en_8_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_8_rd_en_8_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_8_prog_en_8_qs;
@@ -11646,7 +11926,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_8_he_en_8_qs;
       end
 
-      addr_hit[44]: begin
+      addr_hit[45]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_9_en_9_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_9_rd_en_9_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_9_prog_en_9_qs;
@@ -11656,11 +11936,11 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_9_he_en_9_qs;
       end
 
-      addr_hit[45]: begin
+      addr_hit[46]: begin
         reg_rdata_next[0] = bank0_info1_regwen_qs;
       end
 
-      addr_hit[46]: begin
+      addr_hit[47]: begin
         reg_rdata_next[0] = bank0_info1_page_cfg_en_0_qs;
         reg_rdata_next[1] = bank0_info1_page_cfg_rd_en_0_qs;
         reg_rdata_next[2] = bank0_info1_page_cfg_prog_en_0_qs;
@@ -11670,15 +11950,15 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info1_page_cfg_he_en_0_qs;
       end
 
-      addr_hit[47]: begin
+      addr_hit[48]: begin
         reg_rdata_next[0] = bank0_info2_regwen_0_qs;
       end
 
-      addr_hit[48]: begin
+      addr_hit[49]: begin
         reg_rdata_next[0] = bank0_info2_regwen_1_qs;
       end
 
-      addr_hit[49]: begin
+      addr_hit[50]: begin
         reg_rdata_next[0] = bank0_info2_page_cfg_0_en_0_qs;
         reg_rdata_next[1] = bank0_info2_page_cfg_0_rd_en_0_qs;
         reg_rdata_next[2] = bank0_info2_page_cfg_0_prog_en_0_qs;
@@ -11688,7 +11968,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info2_page_cfg_0_he_en_0_qs;
       end
 
-      addr_hit[50]: begin
+      addr_hit[51]: begin
         reg_rdata_next[0] = bank0_info2_page_cfg_1_en_1_qs;
         reg_rdata_next[1] = bank0_info2_page_cfg_1_rd_en_1_qs;
         reg_rdata_next[2] = bank0_info2_page_cfg_1_prog_en_1_qs;
@@ -11698,47 +11978,47 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info2_page_cfg_1_he_en_1_qs;
       end
 
-      addr_hit[51]: begin
+      addr_hit[52]: begin
         reg_rdata_next[0] = bank1_info0_regwen_0_qs;
       end
 
-      addr_hit[52]: begin
+      addr_hit[53]: begin
         reg_rdata_next[0] = bank1_info0_regwen_1_qs;
       end
 
-      addr_hit[53]: begin
+      addr_hit[54]: begin
         reg_rdata_next[0] = bank1_info0_regwen_2_qs;
       end
 
-      addr_hit[54]: begin
+      addr_hit[55]: begin
         reg_rdata_next[0] = bank1_info0_regwen_3_qs;
       end
 
-      addr_hit[55]: begin
+      addr_hit[56]: begin
         reg_rdata_next[0] = bank1_info0_regwen_4_qs;
       end
 
-      addr_hit[56]: begin
+      addr_hit[57]: begin
         reg_rdata_next[0] = bank1_info0_regwen_5_qs;
       end
 
-      addr_hit[57]: begin
+      addr_hit[58]: begin
         reg_rdata_next[0] = bank1_info0_regwen_6_qs;
       end
 
-      addr_hit[58]: begin
+      addr_hit[59]: begin
         reg_rdata_next[0] = bank1_info0_regwen_7_qs;
       end
 
-      addr_hit[59]: begin
+      addr_hit[60]: begin
         reg_rdata_next[0] = bank1_info0_regwen_8_qs;
       end
 
-      addr_hit[60]: begin
+      addr_hit[61]: begin
         reg_rdata_next[0] = bank1_info0_regwen_9_qs;
       end
 
-      addr_hit[61]: begin
+      addr_hit[62]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_0_en_0_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_0_rd_en_0_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_0_prog_en_0_qs;
@@ -11748,7 +12028,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_0_he_en_0_qs;
       end
 
-      addr_hit[62]: begin
+      addr_hit[63]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_1_en_1_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_1_rd_en_1_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_1_prog_en_1_qs;
@@ -11758,7 +12038,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_1_he_en_1_qs;
       end
 
-      addr_hit[63]: begin
+      addr_hit[64]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_2_en_2_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_2_rd_en_2_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_2_prog_en_2_qs;
@@ -11768,7 +12048,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_2_he_en_2_qs;
       end
 
-      addr_hit[64]: begin
+      addr_hit[65]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_3_en_3_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_3_rd_en_3_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_3_prog_en_3_qs;
@@ -11778,7 +12058,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_3_he_en_3_qs;
       end
 
-      addr_hit[65]: begin
+      addr_hit[66]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_4_en_4_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_4_rd_en_4_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_4_prog_en_4_qs;
@@ -11788,7 +12068,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_4_he_en_4_qs;
       end
 
-      addr_hit[66]: begin
+      addr_hit[67]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_5_en_5_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_5_rd_en_5_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_5_prog_en_5_qs;
@@ -11798,7 +12078,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_5_he_en_5_qs;
       end
 
-      addr_hit[67]: begin
+      addr_hit[68]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_6_en_6_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_6_rd_en_6_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_6_prog_en_6_qs;
@@ -11808,7 +12088,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_6_he_en_6_qs;
       end
 
-      addr_hit[68]: begin
+      addr_hit[69]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_7_en_7_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_7_rd_en_7_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_7_prog_en_7_qs;
@@ -11818,7 +12098,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_7_he_en_7_qs;
       end
 
-      addr_hit[69]: begin
+      addr_hit[70]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_8_en_8_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_8_rd_en_8_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_8_prog_en_8_qs;
@@ -11828,7 +12108,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_8_he_en_8_qs;
       end
 
-      addr_hit[70]: begin
+      addr_hit[71]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_9_en_9_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_9_rd_en_9_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_9_prog_en_9_qs;
@@ -11838,11 +12118,11 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_9_he_en_9_qs;
       end
 
-      addr_hit[71]: begin
+      addr_hit[72]: begin
         reg_rdata_next[0] = bank1_info1_regwen_qs;
       end
 
-      addr_hit[72]: begin
+      addr_hit[73]: begin
         reg_rdata_next[0] = bank1_info1_page_cfg_en_0_qs;
         reg_rdata_next[1] = bank1_info1_page_cfg_rd_en_0_qs;
         reg_rdata_next[2] = bank1_info1_page_cfg_prog_en_0_qs;
@@ -11852,15 +12132,15 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info1_page_cfg_he_en_0_qs;
       end
 
-      addr_hit[73]: begin
+      addr_hit[74]: begin
         reg_rdata_next[0] = bank1_info2_regwen_0_qs;
       end
 
-      addr_hit[74]: begin
+      addr_hit[75]: begin
         reg_rdata_next[0] = bank1_info2_regwen_1_qs;
       end
 
-      addr_hit[75]: begin
+      addr_hit[76]: begin
         reg_rdata_next[0] = bank1_info2_page_cfg_0_en_0_qs;
         reg_rdata_next[1] = bank1_info2_page_cfg_0_rd_en_0_qs;
         reg_rdata_next[2] = bank1_info2_page_cfg_0_prog_en_0_qs;
@@ -11870,7 +12150,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info2_page_cfg_0_he_en_0_qs;
       end
 
-      addr_hit[76]: begin
+      addr_hit[77]: begin
         reg_rdata_next[0] = bank1_info2_page_cfg_1_en_1_qs;
         reg_rdata_next[1] = bank1_info2_page_cfg_1_rd_en_1_qs;
         reg_rdata_next[2] = bank1_info2_page_cfg_1_prog_en_1_qs;
@@ -11880,45 +12160,69 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info2_page_cfg_1_he_en_1_qs;
       end
 
-      addr_hit[77]: begin
+      addr_hit[78]: begin
         reg_rdata_next[0] = bank_cfg_regwen_qs;
       end
 
-      addr_hit[78]: begin
+      addr_hit[79]: begin
         reg_rdata_next[0] = mp_bank_cfg_erase_en_0_qs;
         reg_rdata_next[1] = mp_bank_cfg_erase_en_1_qs;
       end
 
-      addr_hit[79]: begin
+      addr_hit[80]: begin
         reg_rdata_next[0] = op_status_done_qs;
         reg_rdata_next[1] = op_status_err_qs;
       end
 
-      addr_hit[80]: begin
+      addr_hit[81]: begin
         reg_rdata_next[0] = status_rd_full_qs;
         reg_rdata_next[1] = status_rd_empty_qs;
         reg_rdata_next[2] = status_prog_full_qs;
         reg_rdata_next[3] = status_prog_empty_qs;
         reg_rdata_next[4] = status_init_wip_qs;
-        reg_rdata_next[16:8] = status_error_addr_qs;
       end
 
-      addr_hit[81]: begin
+      addr_hit[82]: begin
+        reg_rdata_next[0] = err_code_flash_err_qs;
+        reg_rdata_next[1] = err_code_flash_alert_qs;
+        reg_rdata_next[2] = err_code_mp_err_qs;
+        reg_rdata_next[3] = err_code_ecc_single_err_qs;
+        reg_rdata_next[4] = err_code_ecc_multi_err_qs;
+      end
+
+      addr_hit[83]: begin
+        reg_rdata_next[8:0] = err_addr_qs;
+      end
+
+      addr_hit[84]: begin
+        reg_rdata_next[19:0] = ecc_err_addr_0_qs;
+      end
+
+      addr_hit[85]: begin
+        reg_rdata_next[19:0] = ecc_err_addr_1_qs;
+      end
+
+      addr_hit[86]: begin
+        reg_rdata_next[0] = phy_alert_cfg_alert_ack_qs;
+        reg_rdata_next[1] = phy_alert_cfg_alert_trig_qs;
+      end
+
+      addr_hit[87]: begin
         reg_rdata_next[0] = phy_status_init_wip_qs;
         reg_rdata_next[1] = phy_status_prog_normal_avail_qs;
         reg_rdata_next[2] = phy_status_prog_repair_avail_qs;
       end
 
-      addr_hit[82]: begin
+      addr_hit[88]: begin
         reg_rdata_next[31:0] = scratch_qs;
       end
 
-      addr_hit[83]: begin
+      addr_hit[89]: begin
         reg_rdata_next[4:0] = fifo_lvl_prog_qs;
         reg_rdata_next[12:8] = fifo_lvl_rd_qs;
       end
 
-      addr_hit[84]: begin
+      addr_hit[90]: begin
         reg_rdata_next[0] = fifo_rst_qs;
       end
 

--- a/hw/ip/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy.sv
@@ -27,7 +27,7 @@ module flash_phy import flash_ctrl_pkg::*; (
   input flash_power_down_h_i,
   input [1:0] flash_test_mode_a_i,
   input flash_test_voltage_h_i,
-  input flash_bist_enable_i,
+  input lc_ctrl_pkg::lc_tx_t flash_bist_enable_i,
   input lc_ctrl_pkg::lc_tx_t lc_nvm_debug_en_i,
   input jtag_pkg::jtag_req_t jtag_req_i,
   output jtag_pkg::jtag_rsp_t jtag_rsp_o
@@ -145,6 +145,13 @@ module flash_phy import flash_ctrl_pkg::*; (
   // Prim flash to flash_phy_core connections
   flash_phy_pkg::flash_phy_prim_flash_req_t [NumBanks-1:0] prim_flash_req;
   flash_phy_pkg::flash_phy_prim_flash_rsp_t [NumBanks-1:0] prim_flash_rsp;
+  logic [NumBanks-1:0] ecc_single_err;
+  logic [NumBanks-1:0] ecc_multi_err;
+  logic [NumBanks-1:0][BusAddrW-1:0] ecc_addr;
+
+  assign flash_ctrl_o.ecc_single_err = ecc_single_err;
+  assign flash_ctrl_o.ecc_multi_err = ecc_multi_err;
+  assign flash_ctrl_o.ecc_addr = ecc_addr;
 
   for (genvar bank = 0; bank < NumBanks; bank++) begin : gen_flash_cores
 
@@ -172,6 +179,7 @@ module flash_phy import flash_ctrl_pkg::*; (
     logic ctrl_req;
     assign host_req = host_req_i & (host_bank_sel == bank) & host_rsp_avail[bank];
     assign ctrl_req = flash_ctrl_i.req & (ctrl_bank_sel == bank);
+    assign ecc_addr[bank][BusBankAddrW +: BankW] = bank;
 
     flash_phy_core u_core (
       .clk_i,
@@ -208,7 +216,10 @@ module flash_phy import flash_ctrl_pkg::*; (
       .rd_data_o(rd_data[bank]),
       .rd_err_o(rd_err[bank]),
       .prim_flash_req_o(prim_flash_req[bank]),
-      .prim_flash_rsp_i(prim_flash_rsp[bank])
+      .prim_flash_rsp_i(prim_flash_rsp[bank]),
+      .ecc_single_err_o(ecc_single_err[bank]),
+      .ecc_multi_err_o(ecc_multi_err[bank]),
+      .ecc_addr_o(ecc_addr[bank][BusBankAddrW-1:0])
     );
   end // block: gen_flash_banks
 
@@ -249,13 +260,18 @@ module flash_phy import flash_ctrl_pkg::*; (
     .tdi_i(jtag_req_i.tdi & (lc_nvm_debug_en[FlashLcTdiSel] == lc_ctrl_pkg::On)),
     .tms_i(jtag_req_i.tms & (lc_nvm_debug_en[FlashLcTmsSel] == lc_ctrl_pkg::On)),
     .tdo_o(tdo),
-    .bist_enable_i(flash_bist_enable_i & (lc_nvm_debug_en[FlashBistSel] == lc_ctrl_pkg::On)),
+    .bist_enable_i(flash_bist_enable_i & lc_nvm_debug_en[FlashBistSel]),
     .scanmode_i,
     .scan_rst_ni,
     .flash_power_ready_h_i,
     .flash_power_down_h_i,
     .flash_test_mode_a_i,
-    .flash_test_voltage_h_i
+    .flash_test_voltage_h_i,
+    .flash_err_o(flash_ctrl_o.flash_err),
+    .flash_alert_po(flash_ctrl_o.flash_alert_p),
+    .flash_alert_no(flash_ctrl_o.flash_alert_n),
+    .flash_alert_ack_i(flash_ctrl_i.alert_ack),
+    .flash_alert_trig_i(flash_ctrl_i.alert_trig)
   );
 
   logic unused_trst_n;

--- a/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
@@ -44,7 +44,10 @@ module flash_phy_core import flash_phy_pkg::*; #(
   output logic                       prog_done_o,
   output logic                       erase_done_o,
   output logic [BusWidth-1:0]        rd_data_o,
-  output logic                       rd_err_o
+  output logic                       rd_err_o,
+  output logic                       ecc_single_err_o,
+  output logic                       ecc_multi_err_o,
+  output logic [BusBankAddrW-1:0]    ecc_addr_o
 );
 
 
@@ -273,7 +276,10 @@ module flash_phy_core import flash_phy_pkg::*; #(
     .calc_ack_i(calc_ack),
     .descramble_ack_i(op_ack),
     .mask_i(scramble_mask),
-    .descrambled_data_i(rd_descrambled_data)
+    .descrambled_data_i(rd_descrambled_data),
+    .ecc_single_err_o,
+    .ecc_multi_err_o,
+    .ecc_addr_o
     );
 
   ////////////////////////

--- a/hw/ip/prim/doc/prim_flash.md
+++ b/hw/ip/prim/doc/prim_flash.md
@@ -29,7 +29,7 @@ TestModeWidth  | int    | The number of test modes for a bank of flash
 Name                    | In/Out | Description
 ------------------------|--------|---------------------------------
 clk_i                   | input  | Clock input
-rst_n_i                 | input  | Reset input
+rst_ni                  | input  | Reset input
 flash_req_i             | input  | Inputs from flash protocol and physical controllers
 flash_rsp_o             | output | Outputs to flash protocol and physical controllers
 prog_type_avail_o       | output | Available program types in this flash wrapper: Currently there are only two types, program normal and program repair
@@ -41,14 +41,14 @@ tdo_o                   | output | jtag tdo
 bist_enable_i           | input  | lc_ctrl_pkg :: On for bist_enable input
 scanmode_i              | input  | dft scanmode input
 scan_en_i               | input  | dft scan shift input
-scan_rst_n_i            | input  | dft scanmode reset
+scan_rst_ni             | input  | dft scanmode reset
 flash_power_ready_h_i   | input  | flash power is ready (high voltage connection)
 flash_power_down_h_i    | input  | flash wrapper is powering down (high voltage connection)
 flash_test_mode_a_i     | input  | flash test mode values (analog connection)
 flash_test_voltage_h_i  | input  | flash test mode voltage (high voltage connection)
 flash_err_o             | output | flash level error interrupt indication, cleared on write 1 to status register
-flash_alert_po          | output | flash positive detector alert 
-flash_alert_no          | output | flash negative detector alert 
+flash_alert_po          | output | flash positive detector alert
+flash_alert_no          | output | flash negative detector alert
 flash_alert_ack         | input  | single pulse ack
 flash_alert_trig        | input  | alert force trig by SW
 tl_i                    | input  | TL_UL  interface for rd/wr registers access
@@ -148,7 +148,7 @@ A program type not supported by the wrapper, indicated through `prog_type_avail`
 
 ## Erase Suspend
 Since erase operations can take a significant amount of time, sometimes it is necessary for software or other components to suspend the operation.
-The suspend operation input request starts with `erase_suspend_req` assertion. Flash wrapper circuit acks when wrapper starts suspend. 
+The suspend operation input request starts with `erase_suspend_req` assertion. Flash wrapper circuit acks when wrapper starts suspend.
 When the erase suspend completes, the flash wrapper circuitry also asserts `done` for the ongoing erase transaction to ensure all hardware gracefully completes.
 
 The following is an example diagram

--- a/hw/ip/prim_generic/rtl/prim_generic_flash.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash.sv
@@ -26,13 +26,19 @@ module prim_generic_flash #(
   input tdi_i,
   input tms_i,
   output logic tdo_o,
-  input bist_enable_i,
+  input lc_ctrl_pkg::lc_tx_t bist_enable_i,
   input scanmode_i,
+  input scan_en_i,
   input scan_rst_ni,
   input flash_power_ready_h_i,
   input flash_power_down_h_i,
   input [TestModeWidth-1:0] flash_test_mode_a_i,
   input flash_test_voltage_h_i,
+  output logic flash_err_o,
+  output logic flash_alert_po,
+  output logic flash_alert_no,
+  input flash_alert_ack_i,
+  input flash_alert_trig_i,
   input tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o
 );
@@ -90,6 +96,7 @@ module prim_generic_flash #(
   end
 
   logic unused_scanmode;
+  logic unused_scan_en;
   logic unused_scan_rst_n;
   logic [TestModeWidth-1:0] unused_flash_test_mode;
   logic unused_flash_test_voltage;
@@ -98,6 +105,7 @@ module prim_generic_flash #(
   logic unused_tms;
 
   assign unused_scanmode = scanmode_i;
+  assign unused_scan_en = scan_en_i;
   assign unused_scan_rst_n = scan_rst_ni;
   assign unused_flash_test_mode = flash_test_mode_a_i;
   assign unused_flash_test_voltage = flash_test_voltage_h_i;
@@ -156,7 +164,28 @@ module prim_generic_flash #(
     .rdata_o(cfg_rdata)
   );
 
-  logic unused_bist_enable;
+  lc_ctrl_pkg::lc_tx_t unused_bist_enable;
   assign unused_bist_enable = bist_enable_i;
+
+  // open source model has no error respons at the moment
+  assign flash_err_o = 1'b0;
+
+  logic alerts_active;
+  assign alerts_active = flash_alert_po | ~flash_alert_no;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      flash_alert_po <= 1'b0;
+      flash_alert_no <= 1'b1;
+    end else if (flash_alert_trig_i) begin
+      flash_alert_po <= 1'b1;
+      flash_alert_no <= 1'b0;
+    end else if (alerts_active && flash_alert_ack_i) begin
+      flash_alert_po <= 1'b0;
+      flash_alert_no <= 1'b1;
+    end
+  end
+
+
 
 endmodule // prim_generic_flash

--- a/hw/ip/prim_generic/rtl/prim_generic_flash.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash.sv
@@ -167,7 +167,7 @@ module prim_generic_flash #(
   lc_ctrl_pkg::lc_tx_t unused_bist_enable;
   assign unused_bist_enable = bist_enable_i;
 
-  // open source model has no error respons at the moment
+  // open source model has no error response at the moment
   assign flash_err_o = 1'b0;
 
   logic alerts_active;

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3868,20 +3868,49 @@
           ]
           type: interrupt
         }
+      ]
+      alert_list:
+      [
         {
-          name: op_error
+          name: recov_err
           width: 1
-          bits: "5"
+          bits: "0"
           bitinfo:
           [
-            32
             1
-            5
+            1
+            0
           ]
-          type: interrupt
+          type: alert
+          async: 1
+        }
+        {
+          name: recov_mp_err
+          width: 1
+          bits: "1"
+          bitinfo:
+          [
+            2
+            1
+            1
+          ]
+          type: alert
+          async: 1
+        }
+        {
+          name: recov_ecc_err
+          width: 1
+          bits: "2"
+          bitinfo:
+          [
+            4
+            1
+            2
+          ]
+          type: alert
+          async: 1
         }
       ]
-      alert_list: []
       wakeup_list: []
       reset_request_list: []
       scan: "false"
@@ -5886,8 +5915,8 @@
           index: -1
         }
         {
-          struct: logic
-          package: ""
+          struct: lc_tx
+          package: lc_ctrl_pkg
           type: uni
           act: rcv
           name: flash_bist_enable
@@ -8308,19 +8337,6 @@
       module_name: flash_ctrl
     }
     {
-      name: flash_ctrl_op_error
-      width: 1
-      bits: "5"
-      bitinfo:
-      [
-        32
-        1
-        5
-      ]
-      type: interrupt
-      module_name: flash_ctrl
-    }
-    {
       name: hmac_hmac_done
       width: 1
       bits: "0"
@@ -8930,6 +8946,7 @@
     entropy_src
     sram_ctrl_main
     sram_ctrl_ret
+    flash_ctrl
   ]
   alert:
   [
@@ -9212,6 +9229,48 @@
       type: alert
       async: 0
       module_name: sram_ctrl_ret
+    }
+    {
+      name: flash_ctrl_recov_err
+      width: 1
+      bits: "0"
+      bitinfo:
+      [
+        1
+        1
+        0
+      ]
+      type: alert
+      async: 1
+      module_name: flash_ctrl
+    }
+    {
+      name: flash_ctrl_recov_mp_err
+      width: 1
+      bits: "1"
+      bitinfo:
+      [
+        2
+        1
+        1
+      ]
+      type: alert
+      async: 1
+      module_name: flash_ctrl
+    }
+    {
+      name: flash_ctrl_recov_ecc_err
+      width: 1
+      bits: "2"
+      bitinfo:
+      [
+        4
+        1
+        2
+      ]
+      type: alert
+      async: 1
+      module_name: flash_ctrl
     }
   ]
   pinmux:
@@ -11709,8 +11768,8 @@
         index: -1
       }
       {
-        struct: logic
-        package: ""
+        struct: lc_tx
+        package: lc_ctrl_pkg
         type: uni
         act: rcv
         name: flash_bist_enable
@@ -12463,8 +12522,8 @@
         direction: in
       }
       {
-        package: ""
-        struct: logic
+        package: lc_ctrl_pkg
+        struct: lc_tx
         signame: flash_bist_enable_i
         width: 1
         type: uni

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -583,8 +583,8 @@
           act: "rcv"
           name: "lc_nvm_debug_en"
         },
-        { struct: "logic"
-          package: ""
+        { struct: "lc_tx"
+          package: "lc_ctrl_pkg"
           type: "uni"
           act: "rcv"
           name: "flash_bist_enable"
@@ -781,7 +781,7 @@
   // list all modules that expose alerts
   // first item goes to LSB of the alert source
   alert_module: [ "aes", "otbn", "sensor_ctrl", "keymgr", "otp_ctrl", "lc_ctrl",
-                  "entropy_src", "sram_ctrl_main", "sram_ctrl_ret"]
+                  "entropy_src", "sram_ctrl_main", "sram_ctrl_ret", "flash_ctrl"]
 
   // generated list of alerts:
   alert: [

--- a/hw/top_earlgrey/dv/autogen/tb__alert_handler_connect.sv
+++ b/hw/top_earlgrey/dv/autogen/tb__alert_handler_connect.sv
@@ -24,3 +24,6 @@ assign alert_if[16].alert_tx = `CHIP_HIER.u_lc_ctrl.alert_tx_o[1];
 assign alert_if[17].alert_tx = `CHIP_HIER.u_entropy_src.alert_tx_o[0];
 assign alert_if[18].alert_tx = `CHIP_HIER.u_sram_ctrl_main.alert_tx_o[0];
 assign alert_if[19].alert_tx = `CHIP_HIER.u_sram_ctrl_ret.alert_tx_o[0];
+assign alert_if[20].alert_tx = `CHIP_HIER.u_flash_ctrl.alert_tx_o[0];
+assign alert_if[21].alert_tx = `CHIP_HIER.u_flash_ctrl.alert_tx_o[1];
+assign alert_if[22].alert_tx = `CHIP_HIER.u_flash_ctrl.alert_tx_o[2];

--- a/hw/top_earlgrey/dv/env/autogen/alert_handler_env_pkg__params.sv
+++ b/hw/top_earlgrey/dv/env/autogen/alert_handler_env_pkg__params.sv
@@ -24,7 +24,10 @@ parameter string LIST_OF_ALERTS[] = {
   "lc_ctrl_fatal_state_error",
   "entropy_src_recov_alert_count_met",
   "sram_ctrl_main_fatal_parity_error",
-  "sram_ctrl_ret_fatal_parity_error"
+  "sram_ctrl_ret_fatal_parity_error",
+  "flash_ctrl_recov_err",
+  "flash_ctrl_recov_mp_err",
+  "flash_ctrl_recov_ecc_err"
 };
 
-parameter uint NUM_ALERTS = 20;
+parameter uint NUM_ALERTS = 23;

--- a/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
@@ -43,7 +43,7 @@
     { name: "NAlerts",
       desc: "Number of peripheral inputs",
       type: "int",
-      default: "20",
+      default: "23",
       local: "true"
     },
     { name: "EscCntDw",
@@ -61,7 +61,7 @@
     { name: "AsyncOn",
       desc: "Number of peripheral outputs",
       type: "logic [NAlerts-1:0]",
-      default: "20'b01100001100000001111",
+      default: "23'b11101100001100000001111",
       local: "true"
     },
     { name: "N_CLASSES",

--- a/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_env_pkg__params.sv
+++ b/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_env_pkg__params.sv
@@ -10,5 +10,5 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-parameter uint NUM_ALERTS = 20;
-parameter bit [NUM_ALERTS-1:0] ASYNC_ON = 20'b01100001100000001111;
+parameter uint NUM_ALERTS = 23;
+parameter bit [NUM_ALERTS-1:0] ASYNC_ON = 23'b11101100001100000001111;

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
@@ -7,10 +7,10 @@
 package alert_handler_reg_pkg;
 
   // Param list
-  parameter int NAlerts = 20;
+  parameter int NAlerts = 23;
   parameter int EscCntDw = 32;
   parameter int AccuCntDw = 16;
-  parameter logic [NAlerts-1:0] AsyncOn = 20'b01100001100000001111;
+  parameter logic [NAlerts-1:0] AsyncOn = 23'b11101100001100000001111;
   parameter int N_CLASSES = 4;
   parameter int N_ESC_SEV = 4;
   parameter int N_PHASES = 4;
@@ -457,14 +457,14 @@ package alert_handler_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    alert_handler_reg2hw_intr_state_reg_t intr_state; // [904:901]
-    alert_handler_reg2hw_intr_enable_reg_t intr_enable; // [900:897]
-    alert_handler_reg2hw_intr_test_reg_t intr_test; // [896:889]
-    alert_handler_reg2hw_regen_reg_t regen; // [888:888]
-    alert_handler_reg2hw_ping_timeout_cyc_reg_t ping_timeout_cyc; // [887:864]
-    alert_handler_reg2hw_alert_en_mreg_t [19:0] alert_en; // [863:844]
-    alert_handler_reg2hw_alert_class_mreg_t [19:0] alert_class; // [843:804]
-    alert_handler_reg2hw_alert_cause_mreg_t [19:0] alert_cause; // [803:784]
+    alert_handler_reg2hw_intr_state_reg_t intr_state; // [916:913]
+    alert_handler_reg2hw_intr_enable_reg_t intr_enable; // [912:909]
+    alert_handler_reg2hw_intr_test_reg_t intr_test; // [908:901]
+    alert_handler_reg2hw_regen_reg_t regen; // [900:900]
+    alert_handler_reg2hw_ping_timeout_cyc_reg_t ping_timeout_cyc; // [899:876]
+    alert_handler_reg2hw_alert_en_mreg_t [22:0] alert_en; // [875:853]
+    alert_handler_reg2hw_alert_class_mreg_t [22:0] alert_class; // [852:807]
+    alert_handler_reg2hw_alert_cause_mreg_t [22:0] alert_cause; // [806:784]
     alert_handler_reg2hw_loc_alert_en_mreg_t [3:0] loc_alert_en; // [783:780]
     alert_handler_reg2hw_loc_alert_class_mreg_t [3:0] loc_alert_class; // [779:772]
     alert_handler_reg2hw_loc_alert_cause_mreg_t [3:0] loc_alert_cause; // [771:768]
@@ -506,8 +506,8 @@ package alert_handler_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    alert_handler_hw2reg_intr_state_reg_t intr_state; // [267:260]
-    alert_handler_hw2reg_alert_cause_mreg_t [19:0] alert_cause; // [259:220]
+    alert_handler_hw2reg_intr_state_reg_t intr_state; // [273:266]
+    alert_handler_hw2reg_alert_cause_mreg_t [22:0] alert_cause; // [265:220]
     alert_handler_hw2reg_loc_alert_cause_mreg_t [3:0] loc_alert_cause; // [219:212]
     alert_handler_hw2reg_classa_clren_reg_t classa_clren; // [211:210]
     alert_handler_hw2reg_classa_accum_cnt_reg_t classa_accum_cnt; // [209:194]
@@ -663,7 +663,7 @@ package alert_handler_reg_pkg;
     4'b 0111, // index[ 4] ALERT_HANDLER_PING_TIMEOUT_CYC
     4'b 0111, // index[ 5] ALERT_HANDLER_ALERT_EN
     4'b 1111, // index[ 6] ALERT_HANDLER_ALERT_CLASS_0
-    4'b 0001, // index[ 7] ALERT_HANDLER_ALERT_CLASS_1
+    4'b 0011, // index[ 7] ALERT_HANDLER_ALERT_CLASS_1
     4'b 0111, // index[ 8] ALERT_HANDLER_ALERT_CAUSE
     4'b 0001, // index[ 9] ALERT_HANDLER_LOC_ALERT_EN
     4'b 0001, // index[10] ALERT_HANDLER_LOC_ALERT_CLASS

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
@@ -169,6 +169,15 @@ module alert_handler_reg_top (
   logic alert_en_en_a_19_qs;
   logic alert_en_en_a_19_wd;
   logic alert_en_en_a_19_we;
+  logic alert_en_en_a_20_qs;
+  logic alert_en_en_a_20_wd;
+  logic alert_en_en_a_20_we;
+  logic alert_en_en_a_21_qs;
+  logic alert_en_en_a_21_wd;
+  logic alert_en_en_a_21_we;
+  logic alert_en_en_a_22_qs;
+  logic alert_en_en_a_22_wd;
+  logic alert_en_en_a_22_we;
   logic [1:0] alert_class_0_class_a_0_qs;
   logic [1:0] alert_class_0_class_a_0_wd;
   logic alert_class_0_class_a_0_we;
@@ -229,6 +238,15 @@ module alert_handler_reg_top (
   logic [1:0] alert_class_1_class_a_19_qs;
   logic [1:0] alert_class_1_class_a_19_wd;
   logic alert_class_1_class_a_19_we;
+  logic [1:0] alert_class_1_class_a_20_qs;
+  logic [1:0] alert_class_1_class_a_20_wd;
+  logic alert_class_1_class_a_20_we;
+  logic [1:0] alert_class_1_class_a_21_qs;
+  logic [1:0] alert_class_1_class_a_21_wd;
+  logic alert_class_1_class_a_21_we;
+  logic [1:0] alert_class_1_class_a_22_qs;
+  logic [1:0] alert_class_1_class_a_22_wd;
+  logic alert_class_1_class_a_22_we;
   logic alert_cause_a_0_qs;
   logic alert_cause_a_0_wd;
   logic alert_cause_a_0_we;
@@ -289,6 +307,15 @@ module alert_handler_reg_top (
   logic alert_cause_a_19_qs;
   logic alert_cause_a_19_wd;
   logic alert_cause_a_19_we;
+  logic alert_cause_a_20_qs;
+  logic alert_cause_a_20_wd;
+  logic alert_cause_a_20_we;
+  logic alert_cause_a_21_qs;
+  logic alert_cause_a_21_wd;
+  logic alert_cause_a_21_we;
+  logic alert_cause_a_22_qs;
+  logic alert_cause_a_22_wd;
+  logic alert_cause_a_22_we;
   logic loc_alert_en_en_la_0_qs;
   logic loc_alert_en_en_la_0_wd;
   logic loc_alert_en_en_la_0_we;
@@ -1415,6 +1442,84 @@ module alert_handler_reg_top (
   );
 
 
+  // F[en_a_20]: 20:20
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_alert_en_en_a_20 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (alert_en_en_a_20_we & regen_qs),
+    .wd     (alert_en_en_a_20_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_en[20].q ),
+
+    // to register interface (read)
+    .qs     (alert_en_en_a_20_qs)
+  );
+
+
+  // F[en_a_21]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_alert_en_en_a_21 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (alert_en_en_a_21_we & regen_qs),
+    .wd     (alert_en_en_a_21_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_en[21].q ),
+
+    // to register interface (read)
+    .qs     (alert_en_en_a_21_qs)
+  );
+
+
+  // F[en_a_22]: 22:22
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_alert_en_en_a_22 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (alert_en_en_a_22_we & regen_qs),
+    .wd     (alert_en_en_a_22_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_en[22].q ),
+
+    // to register interface (read)
+    .qs     (alert_en_en_a_22_qs)
+  );
+
+
 
 
   // Subregister 0 of Multireg alert_class
@@ -1943,6 +2048,84 @@ module alert_handler_reg_top (
   );
 
 
+  // F[class_a_20]: 9:8
+  prim_subreg #(
+    .DW      (2),
+    .SWACCESS("RW"),
+    .RESVAL  (2'h0)
+  ) u_alert_class_1_class_a_20 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (alert_class_1_class_a_20_we & regen_qs),
+    .wd     (alert_class_1_class_a_20_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_class[20].q ),
+
+    // to register interface (read)
+    .qs     (alert_class_1_class_a_20_qs)
+  );
+
+
+  // F[class_a_21]: 11:10
+  prim_subreg #(
+    .DW      (2),
+    .SWACCESS("RW"),
+    .RESVAL  (2'h0)
+  ) u_alert_class_1_class_a_21 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (alert_class_1_class_a_21_we & regen_qs),
+    .wd     (alert_class_1_class_a_21_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_class[21].q ),
+
+    // to register interface (read)
+    .qs     (alert_class_1_class_a_21_qs)
+  );
+
+
+  // F[class_a_22]: 13:12
+  prim_subreg #(
+    .DW      (2),
+    .SWACCESS("RW"),
+    .RESVAL  (2'h0)
+  ) u_alert_class_1_class_a_22 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (alert_class_1_class_a_22_we & regen_qs),
+    .wd     (alert_class_1_class_a_22_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_class[22].q ),
+
+    // to register interface (read)
+    .qs     (alert_class_1_class_a_22_qs)
+  );
+
+
 
 
   // Subregister 0 of Multireg alert_cause
@@ -2465,6 +2648,84 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_cause_a_19_qs)
+  );
+
+
+  // F[a_20]: 20:20
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_alert_cause_a_20 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (alert_cause_a_20_we),
+    .wd     (alert_cause_a_20_wd),
+
+    // from internal hardware
+    .de     (hw2reg.alert_cause[20].de),
+    .d      (hw2reg.alert_cause[20].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_cause[20].q ),
+
+    // to register interface (read)
+    .qs     (alert_cause_a_20_qs)
+  );
+
+
+  // F[a_21]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_alert_cause_a_21 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (alert_cause_a_21_we),
+    .wd     (alert_cause_a_21_wd),
+
+    // from internal hardware
+    .de     (hw2reg.alert_cause[21].de),
+    .d      (hw2reg.alert_cause[21].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_cause[21].q ),
+
+    // to register interface (read)
+    .qs     (alert_cause_a_21_qs)
+  );
+
+
+  // F[a_22]: 22:22
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_alert_cause_a_22 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (alert_cause_a_22_we),
+    .wd     (alert_cause_a_22_wd),
+
+    // from internal hardware
+    .de     (hw2reg.alert_cause[22].de),
+    .d      (hw2reg.alert_cause[22].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_cause[22].q ),
+
+    // to register interface (read)
+    .qs     (alert_cause_a_22_qs)
   );
 
 
@@ -5132,6 +5393,15 @@ module alert_handler_reg_top (
   assign alert_en_en_a_19_we = addr_hit[5] & reg_we & ~wr_err;
   assign alert_en_en_a_19_wd = reg_wdata[19];
 
+  assign alert_en_en_a_20_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_20_wd = reg_wdata[20];
+
+  assign alert_en_en_a_21_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_21_wd = reg_wdata[21];
+
+  assign alert_en_en_a_22_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_22_wd = reg_wdata[22];
+
   assign alert_class_0_class_a_0_we = addr_hit[6] & reg_we & ~wr_err;
   assign alert_class_0_class_a_0_wd = reg_wdata[1:0];
 
@@ -5192,6 +5462,15 @@ module alert_handler_reg_top (
   assign alert_class_1_class_a_19_we = addr_hit[7] & reg_we & ~wr_err;
   assign alert_class_1_class_a_19_wd = reg_wdata[7:6];
 
+  assign alert_class_1_class_a_20_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_class_1_class_a_20_wd = reg_wdata[9:8];
+
+  assign alert_class_1_class_a_21_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_class_1_class_a_21_wd = reg_wdata[11:10];
+
+  assign alert_class_1_class_a_22_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_class_1_class_a_22_wd = reg_wdata[13:12];
+
   assign alert_cause_a_0_we = addr_hit[8] & reg_we & ~wr_err;
   assign alert_cause_a_0_wd = reg_wdata[0];
 
@@ -5251,6 +5530,15 @@ module alert_handler_reg_top (
 
   assign alert_cause_a_19_we = addr_hit[8] & reg_we & ~wr_err;
   assign alert_cause_a_19_wd = reg_wdata[19];
+
+  assign alert_cause_a_20_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_20_wd = reg_wdata[20];
+
+  assign alert_cause_a_21_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_21_wd = reg_wdata[21];
+
+  assign alert_cause_a_22_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_22_wd = reg_wdata[22];
 
   assign loc_alert_en_en_la_0_we = addr_hit[9] & reg_we & ~wr_err;
   assign loc_alert_en_en_la_0_wd = reg_wdata[0];
@@ -5582,6 +5870,9 @@ module alert_handler_reg_top (
         reg_rdata_next[17] = alert_en_en_a_17_qs;
         reg_rdata_next[18] = alert_en_en_a_18_qs;
         reg_rdata_next[19] = alert_en_en_a_19_qs;
+        reg_rdata_next[20] = alert_en_en_a_20_qs;
+        reg_rdata_next[21] = alert_en_en_a_21_qs;
+        reg_rdata_next[22] = alert_en_en_a_22_qs;
       end
 
       addr_hit[6]: begin
@@ -5608,6 +5899,9 @@ module alert_handler_reg_top (
         reg_rdata_next[3:2] = alert_class_1_class_a_17_qs;
         reg_rdata_next[5:4] = alert_class_1_class_a_18_qs;
         reg_rdata_next[7:6] = alert_class_1_class_a_19_qs;
+        reg_rdata_next[9:8] = alert_class_1_class_a_20_qs;
+        reg_rdata_next[11:10] = alert_class_1_class_a_21_qs;
+        reg_rdata_next[13:12] = alert_class_1_class_a_22_qs;
       end
 
       addr_hit[8]: begin
@@ -5631,6 +5925,9 @@ module alert_handler_reg_top (
         reg_rdata_next[17] = alert_cause_a_17_qs;
         reg_rdata_next[18] = alert_cause_a_18_qs;
         reg_rdata_next[19] = alert_cause_a_19_qs;
+        reg_rdata_next[20] = alert_cause_a_20_qs;
+        reg_rdata_next[21] = alert_cause_a_21_qs;
+        reg_rdata_next[22] = alert_cause_a_22_qs;
       end
 
       addr_hit[9]: begin

--- a/hw/top_earlgrey/ip/ast/ast_wrapper_pkg.core
+++ b/hw/top_earlgrey/ip/ast/ast_wrapper_pkg.core
@@ -9,6 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:constants:top_pkg
+      - lowrisc:ip:lc_ctrl_pkg
     files:
       - rtl/ast_wrapper_pkg.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip/ast/rtl/ast_wrapper.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_wrapper.sv
@@ -231,6 +231,6 @@ module ast_wrapper import ast_wrapper_pkg::*;
   );
 
   // TODO hook-up to ast
-  assign ast_eflash_o.flash_bist_enable = 1'b0;
+  assign ast_eflash_o.flash_bist_enable = lc_ctrl_pkg::Off;
 
 endmodule // ast_wrapper

--- a/hw/top_earlgrey/ip/ast/rtl/ast_wrapper_pkg.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_wrapper_pkg.sv
@@ -64,7 +64,7 @@ package ast_wrapper_pkg;
   };
 
   typedef struct packed {
-    logic flash_bist_enable;
+    lc_ctrl_pkg::lc_tx_t flash_bist_enable;
     logic flash_power_down_h;
     logic flash_power_ready_h;
   } ast_eflash_t;

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -22,7 +22,18 @@
     { name: "rd_full",    desc: "Read FIFO full" },
     { name: "rd_lvl",     desc: "Read FIFO filled to level" },
     { name: "op_done",    desc: "Operation complete" },
-    { name: "op_error",   desc: "Operation failed with error" },
+  ],
+
+  alert_list: [
+    { name: "recov_err",
+      desc: "flash alerts directly from prim_flash",
+    },
+    { name: "recov_mp_err",
+      desc: "recoverable flash alert for permission error"
+    },
+    { name: "recov_ecc_err",
+      desc: "recoverable flash alert for ecc error"
+    },
   ],
 
   // Define flash_ctrl <-> flash_phy struct package
@@ -1263,9 +1274,10 @@
         { bits: "0", name: "done",
           desc: "Flash operation done. Set by HW, cleared by SW" },
         { bits: "1", name: "err",
-          desc: "Flash operation error. Set by HW, cleared by SW"},
+          desc: "Flash operation error. Set by HW, cleared by SW. See !!ERR_CODE for more details."},
       ]
     },
+
     { name: "STATUS",
       desc: "Flash Controller Status",
       swaccess: "ro",
@@ -1276,8 +1288,97 @@
         { bits: "2",    name: "prog_full",  desc: "Flash program FIFO full"},
         { bits: "3",    name: "prog_empty", desc: "Flash program FIFO empty, software must provide data", resval: "1"},
         { bits: "4",    name: "init_wip",   desc: "Flash controller undergoing init, inclusive of phy init"},
-        { bits: "16:8", name: "error_addr", desc: "Flash controller error address."},
       ]
+    },
+
+    { name: "ERR_CODE",
+      desc: '''
+        Flash error code register.
+        This register tabulates detailed error status of the flash.
+        This is separate from !!OP_STATUS, which is used to indicate the current state of the software initiated
+        flash operation.
+      '''
+      swaccess: "rw",
+      hwaccess: "hwo",
+      fields: [
+        { bits: "0",
+          name: "flash_err",
+          desc: '''
+            The flash memory itself has an error, please check the vendor specs for details of the error.
+          '''
+        },
+        { bits: "1",
+          name: "flash_alert",
+          desc: '''
+            The flash memory itself has triggered an alert, please check the vendor specs for details of the error.
+          '''
+        },
+        { bits: "2",
+          name: "mp_err",
+          desc: '''
+            Flash access has encountered an access permission error.
+            Please see !!ERR_ADDR for exact address.
+          '''
+        },
+        { bits: "3",
+          name: "ecc_single_err",
+          desc: '''
+            Flash access has encountered a single bit ECC error.
+            Please see !!ECC_ERR_ADDR for exact address.
+          '''
+        },
+        { bits: "4",
+          name: "ecc_multi_err",
+          desc: '''
+            Flash access has encountered a multi bit ECC error.
+            Please see !!ECC_ERR_ADDR for exact address.
+          '''
+        },
+      ]
+    },
+
+    { name: "ERR_ADDR",
+      desc: "Access permission error address",
+      swaccess: "ro",
+      hwaccess: "hwo",
+      fields: [
+        { bits: "8:0",
+          resval: 0,
+        },
+      ]
+    },
+
+    { multireg: {
+        cname: "ECC_ERR"
+        name: "ECC_ERR_ADDR",
+        desc: "ecc error address",
+        count: "RegNumBanks",
+        swaccess: "ro",
+        hwaccess: "hwo",
+        fields: [
+          { bits: "19:0",
+            resval: 0,
+          },
+        ]
+      }
+    },
+
+    { name: "PHY_ALERT_CFG",
+      desc: "Phy alert configuration",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "0",
+          name: "alert_ack",
+          desc: "Acknowledge flash phy alert"
+        },
+        { bits: "1",
+          name: "alert_trig",
+          desc: "Trigger flash phy alert"
+        }
+      ]
+      tags: [ // alert triggers should be tested by directed tests
+             "excl:CsrAllTests:CsrExclWrite"]
     },
 
     { name: "PHY_STATUS",

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -15,6 +15,7 @@
 `include "prim_assert.sv"
 
 module flash_ctrl import flash_ctrl_pkg::*; #(
+  parameter logic AlertAsyncOn          = 1'b1,
   parameter flash_key_t RndCnstAddrKey  = RndCnstAddrKeyDefault,
   parameter flash_key_t RndCnstDataKey  = RndCnstDataKeyDefault,
   parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault,
@@ -57,7 +58,12 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
   output logic intr_rd_full_o,    // Read fifo is full
   output logic intr_rd_lvl_o,     // Read fifo is full
   output logic intr_op_done_o,    // Requested flash operation (wr/erase) done
-  output logic intr_op_error_o    // Requested flash operation (wr/erase) done
+
+  // Alerts
+  input  prim_alert_pkg::alert_rx_t [flash_ctrl_reg_pkg::NumAlerts-1:0] alert_rx_i,
+  output prim_alert_pkg::alert_tx_t [flash_ctrl_reg_pkg::NumAlerts-1:0] alert_tx_o
+
+
 );
 
   import flash_ctrl_reg_pkg::*;
@@ -737,8 +743,6 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
   assign hw2reg.status.prog_empty.de = sw_sel;
   assign hw2reg.status.init_wip.d    = flash_phy_busy | ctrl_init_busy;
   assign hw2reg.status.init_wip.de   = 1'b1;
-  assign hw2reg.status.error_addr.d  = err_addr;
-  assign hw2reg.status.error_addr.de = sw_sel;
   assign hw2reg.control.start.d      = 1'b0;
   assign hw2reg.control.start.de     = sw_ctrl_done;
   // if software operation selected, based on transaction start
@@ -764,6 +768,8 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
   assign flash_o.addr_key = addr_key;
   assign flash_o.data_key = data_key;
   assign flash_o.tl_flash_c2p = tl_win_h2d[2];
+  assign flash_o.alert_trig = reg2hw.phy_alert_cfg.alert_trig.q;
+  assign flash_o.alert_ack = reg2hw.phy_alert_cfg.alert_ack.q;
   assign flash_rd_err = flash_i.rd_err;
   assign flash_rd_data = flash_i.rd_data;
   assign flash_phy_busy = flash_i.init_busy;
@@ -784,8 +790,71 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
     .q_o(pwrmgr_o.flash_idle)
   );
 
+  //////////////////////////////////////
+  // Alert senders
+  //////////////////////////////////////
 
-  // Interrupts
+  logic [NumAlerts-1:0] alert_srcs;
+  logic [NumAlerts-1:0] alert_tests;
+
+  logic recov_err;
+  assign recov_err = flash_i.flash_alert_p | ~flash_i.flash_alert_n;
+
+  logic recov_mp_err;
+  assign recov_mp_err = flash_mp_error;
+
+  logic recov_ecc_err;
+  assign recov_ecc_err = |flash_i.ecc_single_err | |flash_i.ecc_multi_err;
+
+  assign alert_srcs = { recov_ecc_err,
+                        recov_mp_err,
+                        recov_err
+                      };
+
+  assign alert_tests = { reg2hw.alert_test.recov_ecc_err.q & reg2hw.alert_test.recov_ecc_err.qe,
+                         reg2hw.alert_test.recov_mp_err.q  & reg2hw.alert_test.recov_mp_err.qe,
+                         reg2hw.alert_test.recov_err.q     & reg2hw.alert_test.recov_err.qe
+                       };
+
+  for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
+    prim_alert_sender #(
+      .AsyncOn(AlertAsyncOn)
+    ) u_alert_sender (
+      .clk_i,
+      .rst_ni,
+      .alert_req_i(alert_srcs[i]),
+      .alert_test_i(alert_tests[i]),
+      .alert_ack_o(),
+      .alert_state_o(),
+      .alert_rx_i(alert_rx_i[i]),
+      .alert_tx_o(alert_tx_o[i])
+    );
+  end
+
+
+  //////////////////////////////////////
+  // Errors and Interrupts
+  //////////////////////////////////////
+
+  assign hw2reg.err_code.mp_err.d = 1'b1;
+  assign hw2reg.err_code.ecc_single_err.d = 1'b1;
+  assign hw2reg.err_code.ecc_multi_err.d = 1'b1;
+  assign hw2reg.err_code.flash_err.d = 1'b1;
+  assign hw2reg.err_code.flash_alert.d = 1'b1;
+  assign hw2reg.err_code.mp_err.de = flash_mp_error;
+  assign hw2reg.err_code.ecc_single_err.de = |flash_i.ecc_single_err;
+  assign hw2reg.err_code.ecc_multi_err.de = |flash_i.ecc_multi_err;
+  assign hw2reg.err_code.flash_err.de = flash_i.flash_err;
+  assign hw2reg.err_code.flash_alert.de = flash_i.flash_alert_p | ~flash_i.flash_alert_n;
+  assign hw2reg.err_addr.d = err_addr;
+  assign hw2reg.err_addr.de = flash_mp_error;
+
+  for (genvar bank = 0; bank < NumBanks; bank++) begin : gen_err_cons
+    assign hw2reg.ecc_err_addr[bank].d  = {flash_i.ecc_addr[bank], {BusByteWidth{1'b0}}};
+    assign hw2reg.ecc_err_addr[bank].de = flash_i.ecc_single_err[bank] |
+                                          flash_i.ecc_multi_err[bank];
+  end
+
   // Generate edge triggered signals for sources that are level
   logic [3:0] intr_src;
   logic [3:0] intr_src_q;
@@ -813,7 +882,6 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
   assign intr_rd_full_o = reg2hw.intr_enable.rd_full.q & reg2hw.intr_state.rd_full.q;
   assign intr_rd_lvl_o = reg2hw.intr_enable.rd_lvl.q & reg2hw.intr_state.rd_lvl.q;
   assign intr_op_done_o = reg2hw.intr_enable.op_done.q & reg2hw.intr_state.op_done.q;
-  assign intr_op_error_o = reg2hw.intr_enable.op_error.q & reg2hw.intr_state.op_error.q;
 
   assign hw2reg.intr_state.prog_empty.d  = 1'b1;
   assign hw2reg.intr_state.prog_empty.de = intr_assert[3]  |
@@ -841,12 +909,6 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
                                         (reg2hw.intr_test.op_done.qe  &
                                         reg2hw.intr_test.op_done.q);
 
-  assign hw2reg.intr_state.op_error.d  = 1'b1;
-  assign hw2reg.intr_state.op_error.de = sw_ctrl_err  |
-                                        (reg2hw.intr_test.op_error.qe  &
-                                        reg2hw.intr_test.op_error.q);
-
-
 
   // Unused bits
   logic [BusByteWidth-1:0] unused_byte_sel;
@@ -872,6 +934,5 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
   `ASSERT_KNOWN(IntrProgRdFullKnownO_A, intr_rd_full_o   )
   `ASSERT_KNOWN(IntrRdLvlKnownO_A,      intr_rd_lvl_o    )
   `ASSERT_KNOWN(IntrOpDoneKnownO_A,     intr_op_done_o   )
-  `ASSERT_KNOWN(IntrOpErrorKnownO_A,    intr_op_error_o  )
 
 endmodule

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
@@ -305,6 +305,8 @@ package flash_ctrl_pkg;
     logic [KeyWidth-1:0]  data_key;
     logic                 rd_buf_en;
     tlul_pkg::tl_h2d_t    tl_flash_c2p;
+    logic                 alert_trig;
+    logic                 alert_ack;
   } flash_req_t;
 
   // default value of flash_req_t (for dangling ports)
@@ -328,7 +330,9 @@ package flash_ctrl_pkg;
     addr_key:      RndCnstAddrKeyDefault,
     data_key:      RndCnstDataKeyDefault,
     rd_buf_en:     1'b0,
-    tl_flash_c2p:  '0
+    tl_flash_c2p:  '0,
+    alert_trig:    1'b0,
+    alert_ack:     1'b0
   };
 
   // memory to flash controller
@@ -341,6 +345,12 @@ package flash_ctrl_pkg;
     logic [BusWidth-1:0] rd_data;
     logic                init_busy;
     tlul_pkg::tl_d2h_t   tl_flash_p2c;
+    logic                flash_err;
+    logic                flash_alert_p;
+    logic                flash_alert_n;
+    logic [NumBanks-1:0] ecc_single_err;
+    logic [NumBanks-1:0] ecc_multi_err;
+    logic [NumBanks-1:0][BusAddrW-1:0] ecc_addr;
   } flash_rsp_t;
 
   // default value of flash_rsp_t (for dangling ports)
@@ -352,7 +362,13 @@ package flash_ctrl_pkg;
     rd_err:             '0,
     rd_data:            '0,
     init_busy:          1'b0,
-    tl_flash_p2c:       '0
+    tl_flash_p2c:       '0,
+    flash_err:          1'b0,
+    flash_alert_p:      1'b0,
+    flash_alert_n:      1'b1,
+    ecc_single_err:     '0,
+    ecc_multi_err:      '0,
+    ecc_addr:           '0
   };
 
   // RMA entries

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
@@ -20,6 +20,7 @@ package flash_ctrl_reg_pkg;
   parameter int BytesPerWord = 8;
   parameter int BytesPerPage = 2048;
   parameter int BytesPerBank = 524288;
+  parameter int NumAlerts = 3;
 
   // Address width within the block
   parameter int BlockAw = 9;
@@ -43,9 +44,6 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } op_done;
-    struct packed {
-      logic        q;
-    } op_error;
   } flash_ctrl_reg2hw_intr_state_reg_t;
 
   typedef struct packed {
@@ -64,9 +62,6 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } op_done;
-    struct packed {
-      logic        q;
-    } op_error;
   } flash_ctrl_reg2hw_intr_enable_reg_t;
 
   typedef struct packed {
@@ -90,11 +85,22 @@ package flash_ctrl_reg_pkg;
       logic        q;
       logic        qe;
     } op_done;
+  } flash_ctrl_reg2hw_intr_test_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        q;
       logic        qe;
-    } op_error;
-  } flash_ctrl_reg2hw_intr_test_reg_t;
+    } recov_err;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } recov_mp_err;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } recov_ecc_err;
+  } flash_ctrl_reg2hw_alert_test_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -337,6 +343,15 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_reg2hw_mp_bank_cfg_mreg_t;
 
   typedef struct packed {
+    struct packed {
+      logic        q;
+    } alert_ack;
+    struct packed {
+      logic        q;
+    } alert_trig;
+  } flash_ctrl_reg2hw_phy_alert_cfg_reg_t;
+
+  typedef struct packed {
     logic [31:0] q;
   } flash_ctrl_reg2hw_scratch_reg_t;
 
@@ -375,10 +390,6 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } op_done;
-    struct packed {
-      logic        d;
-      logic        de;
-    } op_error;
   } flash_ctrl_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
@@ -429,11 +440,40 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } init_wip;
-    struct packed {
-      logic [8:0]  d;
-      logic        de;
-    } error_addr;
   } flash_ctrl_hw2reg_status_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        d;
+      logic        de;
+    } flash_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } flash_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } mp_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } ecc_single_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } ecc_multi_err;
+  } flash_ctrl_hw2reg_err_code_reg_t;
+
+  typedef struct packed {
+    logic [8:0]  d;
+    logic        de;
+  } flash_ctrl_hw2reg_err_addr_reg_t;
+
+  typedef struct packed {
+    logic [19:0] d;
+    logic        de;
+  } flash_ctrl_hw2reg_ecc_err_addr_mreg_t;
 
   typedef struct packed {
     struct packed {
@@ -455,22 +495,24 @@ package flash_ctrl_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [519:514]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [513:508]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [507:496]
-    flash_ctrl_reg2hw_control_reg_t control; // [495:476]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [475:444]
-    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [443:442]
-    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [441:441]
-    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [440:233]
-    flash_ctrl_reg2hw_default_region_reg_t default_region; // [232:227]
-    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [9:0] bank0_info0_page_cfg; // [226:157]
-    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [0:0] bank0_info1_page_cfg; // [156:150]
-    flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t [1:0] bank0_info2_page_cfg; // [149:136]
-    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [9:0] bank1_info0_page_cfg; // [135:66]
-    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [0:0] bank1_info1_page_cfg; // [65:59]
-    flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t [1:0] bank1_info2_page_cfg; // [58:45]
-    flash_ctrl_reg2hw_mp_bank_cfg_mreg_t [1:0] mp_bank_cfg; // [44:43]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [523:519]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [518:514]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [513:504]
+    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [503:498]
+    flash_ctrl_reg2hw_control_reg_t control; // [497:478]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [477:446]
+    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [445:444]
+    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [443:443]
+    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [442:235]
+    flash_ctrl_reg2hw_default_region_reg_t default_region; // [234:229]
+    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [9:0] bank0_info0_page_cfg; // [228:159]
+    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [0:0] bank0_info1_page_cfg; // [158:152]
+    flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t [1:0] bank0_info2_page_cfg; // [151:138]
+    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [9:0] bank1_info0_page_cfg; // [137:68]
+    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [0:0] bank1_info1_page_cfg; // [67:61]
+    flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t [1:0] bank1_info2_page_cfg; // [60:47]
+    flash_ctrl_reg2hw_mp_bank_cfg_mreg_t [1:0] mp_bank_cfg; // [46:45]
+    flash_ctrl_reg2hw_phy_alert_cfg_reg_t phy_alert_cfg; // [44:43]
     flash_ctrl_reg2hw_scratch_reg_t scratch; // [42:11]
     flash_ctrl_reg2hw_fifo_lvl_reg_t fifo_lvl; // [10:1]
     flash_ctrl_reg2hw_fifo_rst_reg_t fifo_rst; // [0:0]
@@ -480,12 +522,15 @@ package flash_ctrl_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [46:35]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [34:34]
-    flash_ctrl_hw2reg_control_reg_t control; // [33:32]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [31:30]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [29:26]
-    flash_ctrl_hw2reg_status_reg_t status; // [25:6]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [96:87]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [86:86]
+    flash_ctrl_hw2reg_control_reg_t control; // [85:84]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [83:82]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [81:78]
+    flash_ctrl_hw2reg_status_reg_t status; // [77:68]
+    flash_ctrl_hw2reg_err_code_reg_t err_code; // [67:58]
+    flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [57:48]
+    flash_ctrl_hw2reg_ecc_err_addr_mreg_t [1:0] ecc_err_addr; // [47:6]
     flash_ctrl_hw2reg_phy_status_reg_t phy_status; // [5:0]
   } flash_ctrl_hw2reg_t;
 
@@ -493,93 +538,99 @@ package flash_ctrl_reg_pkg;
   parameter logic [BlockAw-1:0] FLASH_CTRL_INTR_STATE_OFFSET = 9'h 0;
   parameter logic [BlockAw-1:0] FLASH_CTRL_INTR_ENABLE_OFFSET = 9'h 4;
   parameter logic [BlockAw-1:0] FLASH_CTRL_INTR_TEST_OFFSET = 9'h 8;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_CTRL_REGWEN_OFFSET = 9'h c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_CONTROL_OFFSET = 9'h 10;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_ADDR_OFFSET = 9'h 14;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_PROG_TYPE_EN_OFFSET = 9'h 18;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_ERASE_SUSPEND_OFFSET = 9'h 1c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_0_OFFSET = 9'h 20;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_1_OFFSET = 9'h 24;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_2_OFFSET = 9'h 28;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_3_OFFSET = 9'h 2c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_4_OFFSET = 9'h 30;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_5_OFFSET = 9'h 34;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_6_OFFSET = 9'h 38;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_7_OFFSET = 9'h 3c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_0_OFFSET = 9'h 40;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_1_OFFSET = 9'h 44;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_2_OFFSET = 9'h 48;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_3_OFFSET = 9'h 4c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_4_OFFSET = 9'h 50;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_5_OFFSET = 9'h 54;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_6_OFFSET = 9'h 58;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_7_OFFSET = 9'h 5c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_DEFAULT_REGION_OFFSET = 9'h 60;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_0_OFFSET = 9'h 64;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_1_OFFSET = 9'h 68;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_2_OFFSET = 9'h 6c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_3_OFFSET = 9'h 70;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_4_OFFSET = 9'h 74;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_5_OFFSET = 9'h 78;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_6_OFFSET = 9'h 7c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_7_OFFSET = 9'h 80;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_8_OFFSET = 9'h 84;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_9_OFFSET = 9'h 88;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_OFFSET = 9'h 8c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1_OFFSET = 9'h 90;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2_OFFSET = 9'h 94;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3_OFFSET = 9'h 98;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4_OFFSET = 9'h 9c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5_OFFSET = 9'h a0;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6_OFFSET = 9'h a4;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7_OFFSET = 9'h a8;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8_OFFSET = 9'h ac;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9_OFFSET = 9'h b0;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO1_REGWEN_OFFSET = 9'h b4;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_OFFSET = 9'h b8;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO2_REGWEN_0_OFFSET = 9'h bc;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO2_REGWEN_1_OFFSET = 9'h c0;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0_OFFSET = 9'h c4;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1_OFFSET = 9'h c8;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_0_OFFSET = 9'h cc;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_1_OFFSET = 9'h d0;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_2_OFFSET = 9'h d4;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_3_OFFSET = 9'h d8;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_4_OFFSET = 9'h dc;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_5_OFFSET = 9'h e0;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_6_OFFSET = 9'h e4;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_7_OFFSET = 9'h e8;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_8_OFFSET = 9'h ec;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_9_OFFSET = 9'h f0;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_OFFSET = 9'h f4;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1_OFFSET = 9'h f8;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2_OFFSET = 9'h fc;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3_OFFSET = 9'h 100;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4_OFFSET = 9'h 104;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5_OFFSET = 9'h 108;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6_OFFSET = 9'h 10c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7_OFFSET = 9'h 110;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8_OFFSET = 9'h 114;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9_OFFSET = 9'h 118;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO1_REGWEN_OFFSET = 9'h 11c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_OFFSET = 9'h 120;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO2_REGWEN_0_OFFSET = 9'h 124;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO2_REGWEN_1_OFFSET = 9'h 128;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0_OFFSET = 9'h 12c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1_OFFSET = 9'h 130;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK_CFG_REGWEN_OFFSET = 9'h 134;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_BANK_CFG_OFFSET = 9'h 138;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_OP_STATUS_OFFSET = 9'h 13c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_STATUS_OFFSET = 9'h 140;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_PHY_STATUS_OFFSET = 9'h 144;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_SCRATCH_OFFSET = 9'h 148;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_FIFO_LVL_OFFSET = 9'h 14c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_FIFO_RST_OFFSET = 9'h 150;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_ALERT_TEST_OFFSET = 9'h c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_CTRL_REGWEN_OFFSET = 9'h 10;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_CONTROL_OFFSET = 9'h 14;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_ADDR_OFFSET = 9'h 18;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_PROG_TYPE_EN_OFFSET = 9'h 1c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_ERASE_SUSPEND_OFFSET = 9'h 20;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_0_OFFSET = 9'h 24;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_1_OFFSET = 9'h 28;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_2_OFFSET = 9'h 2c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_3_OFFSET = 9'h 30;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_4_OFFSET = 9'h 34;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_5_OFFSET = 9'h 38;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_6_OFFSET = 9'h 3c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_7_OFFSET = 9'h 40;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_0_OFFSET = 9'h 44;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_1_OFFSET = 9'h 48;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_2_OFFSET = 9'h 4c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_3_OFFSET = 9'h 50;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_4_OFFSET = 9'h 54;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_5_OFFSET = 9'h 58;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_6_OFFSET = 9'h 5c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_REGION_CFG_7_OFFSET = 9'h 60;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_DEFAULT_REGION_OFFSET = 9'h 64;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_0_OFFSET = 9'h 68;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_1_OFFSET = 9'h 6c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_2_OFFSET = 9'h 70;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_3_OFFSET = 9'h 74;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_4_OFFSET = 9'h 78;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_5_OFFSET = 9'h 7c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_6_OFFSET = 9'h 80;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_7_OFFSET = 9'h 84;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_8_OFFSET = 9'h 88;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_9_OFFSET = 9'h 8c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_OFFSET = 9'h 90;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1_OFFSET = 9'h 94;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2_OFFSET = 9'h 98;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3_OFFSET = 9'h 9c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4_OFFSET = 9'h a0;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5_OFFSET = 9'h a4;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6_OFFSET = 9'h a8;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7_OFFSET = 9'h ac;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8_OFFSET = 9'h b0;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9_OFFSET = 9'h b4;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO1_REGWEN_OFFSET = 9'h b8;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_OFFSET = 9'h bc;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO2_REGWEN_0_OFFSET = 9'h c0;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO2_REGWEN_1_OFFSET = 9'h c4;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0_OFFSET = 9'h c8;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1_OFFSET = 9'h cc;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_0_OFFSET = 9'h d0;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_1_OFFSET = 9'h d4;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_2_OFFSET = 9'h d8;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_3_OFFSET = 9'h dc;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_4_OFFSET = 9'h e0;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_5_OFFSET = 9'h e4;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_6_OFFSET = 9'h e8;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_7_OFFSET = 9'h ec;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_8_OFFSET = 9'h f0;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_9_OFFSET = 9'h f4;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_OFFSET = 9'h f8;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1_OFFSET = 9'h fc;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2_OFFSET = 9'h 100;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3_OFFSET = 9'h 104;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4_OFFSET = 9'h 108;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5_OFFSET = 9'h 10c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6_OFFSET = 9'h 110;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7_OFFSET = 9'h 114;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8_OFFSET = 9'h 118;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9_OFFSET = 9'h 11c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO1_REGWEN_OFFSET = 9'h 120;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_OFFSET = 9'h 124;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO2_REGWEN_0_OFFSET = 9'h 128;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO2_REGWEN_1_OFFSET = 9'h 12c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0_OFFSET = 9'h 130;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1_OFFSET = 9'h 134;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_BANK_CFG_REGWEN_OFFSET = 9'h 138;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_MP_BANK_CFG_OFFSET = 9'h 13c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_OP_STATUS_OFFSET = 9'h 140;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_STATUS_OFFSET = 9'h 144;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_ERR_CODE_OFFSET = 9'h 148;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_ERR_ADDR_OFFSET = 9'h 14c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_ECC_ERR_ADDR_0_OFFSET = 9'h 150;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_ECC_ERR_ADDR_1_OFFSET = 9'h 154;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_PHY_ALERT_CFG_OFFSET = 9'h 158;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_PHY_STATUS_OFFSET = 9'h 15c;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_SCRATCH_OFFSET = 9'h 160;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_FIFO_LVL_OFFSET = 9'h 164;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_FIFO_RST_OFFSET = 9'h 168;
 
   // Window parameter
-  parameter logic [BlockAw-1:0] FLASH_CTRL_PROG_FIFO_OFFSET = 9'h 154;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_PROG_FIFO_OFFSET = 9'h 16c;
   parameter logic [BlockAw-1:0] FLASH_CTRL_PROG_FIFO_SIZE   = 9'h 4;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_RD_FIFO_OFFSET = 9'h 158;
+  parameter logic [BlockAw-1:0] FLASH_CTRL_RD_FIFO_OFFSET = 9'h 170;
   parameter logic [BlockAw-1:0] FLASH_CTRL_RD_FIFO_SIZE   = 9'h 4;
   parameter logic [BlockAw-1:0] FLASH_CTRL_PRIM_FLASH_CFG_OFFSET = 9'h 180;
   parameter logic [BlockAw-1:0] FLASH_CTRL_PRIM_FLASH_CFG_SIZE   = 9'h 54;
@@ -589,6 +640,7 @@ package flash_ctrl_reg_pkg;
     FLASH_CTRL_INTR_STATE,
     FLASH_CTRL_INTR_ENABLE,
     FLASH_CTRL_INTR_TEST,
+    FLASH_CTRL_ALERT_TEST,
     FLASH_CTRL_CTRL_REGWEN,
     FLASH_CTRL_CONTROL,
     FLASH_CTRL_ADDR,
@@ -667,6 +719,11 @@ package flash_ctrl_reg_pkg;
     FLASH_CTRL_MP_BANK_CFG,
     FLASH_CTRL_OP_STATUS,
     FLASH_CTRL_STATUS,
+    FLASH_CTRL_ERR_CODE,
+    FLASH_CTRL_ERR_ADDR,
+    FLASH_CTRL_ECC_ERR_ADDR_0,
+    FLASH_CTRL_ECC_ERR_ADDR_1,
+    FLASH_CTRL_PHY_ALERT_CFG,
     FLASH_CTRL_PHY_STATUS,
     FLASH_CTRL_SCRATCH,
     FLASH_CTRL_FIFO_LVL,
@@ -674,92 +731,98 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] FLASH_CTRL_PERMIT [85] = '{
+  parameter logic [3:0] FLASH_CTRL_PERMIT [91] = '{
     4'b 0001, // index[ 0] FLASH_CTRL_INTR_STATE
     4'b 0001, // index[ 1] FLASH_CTRL_INTR_ENABLE
     4'b 0001, // index[ 2] FLASH_CTRL_INTR_TEST
-    4'b 0001, // index[ 3] FLASH_CTRL_CTRL_REGWEN
-    4'b 1111, // index[ 4] FLASH_CTRL_CONTROL
-    4'b 1111, // index[ 5] FLASH_CTRL_ADDR
-    4'b 0001, // index[ 6] FLASH_CTRL_PROG_TYPE_EN
-    4'b 0001, // index[ 7] FLASH_CTRL_ERASE_SUSPEND
-    4'b 0001, // index[ 8] FLASH_CTRL_REGION_CFG_REGWEN_0
-    4'b 0001, // index[ 9] FLASH_CTRL_REGION_CFG_REGWEN_1
-    4'b 0001, // index[10] FLASH_CTRL_REGION_CFG_REGWEN_2
-    4'b 0001, // index[11] FLASH_CTRL_REGION_CFG_REGWEN_3
-    4'b 0001, // index[12] FLASH_CTRL_REGION_CFG_REGWEN_4
-    4'b 0001, // index[13] FLASH_CTRL_REGION_CFG_REGWEN_5
-    4'b 0001, // index[14] FLASH_CTRL_REGION_CFG_REGWEN_6
-    4'b 0001, // index[15] FLASH_CTRL_REGION_CFG_REGWEN_7
-    4'b 1111, // index[16] FLASH_CTRL_MP_REGION_CFG_0
-    4'b 1111, // index[17] FLASH_CTRL_MP_REGION_CFG_1
-    4'b 1111, // index[18] FLASH_CTRL_MP_REGION_CFG_2
-    4'b 1111, // index[19] FLASH_CTRL_MP_REGION_CFG_3
-    4'b 1111, // index[20] FLASH_CTRL_MP_REGION_CFG_4
-    4'b 1111, // index[21] FLASH_CTRL_MP_REGION_CFG_5
-    4'b 1111, // index[22] FLASH_CTRL_MP_REGION_CFG_6
-    4'b 1111, // index[23] FLASH_CTRL_MP_REGION_CFG_7
-    4'b 0001, // index[24] FLASH_CTRL_DEFAULT_REGION
-    4'b 0001, // index[25] FLASH_CTRL_BANK0_INFO0_REGWEN_0
-    4'b 0001, // index[26] FLASH_CTRL_BANK0_INFO0_REGWEN_1
-    4'b 0001, // index[27] FLASH_CTRL_BANK0_INFO0_REGWEN_2
-    4'b 0001, // index[28] FLASH_CTRL_BANK0_INFO0_REGWEN_3
-    4'b 0001, // index[29] FLASH_CTRL_BANK0_INFO0_REGWEN_4
-    4'b 0001, // index[30] FLASH_CTRL_BANK0_INFO0_REGWEN_5
-    4'b 0001, // index[31] FLASH_CTRL_BANK0_INFO0_REGWEN_6
-    4'b 0001, // index[32] FLASH_CTRL_BANK0_INFO0_REGWEN_7
-    4'b 0001, // index[33] FLASH_CTRL_BANK0_INFO0_REGWEN_8
-    4'b 0001, // index[34] FLASH_CTRL_BANK0_INFO0_REGWEN_9
-    4'b 0001, // index[35] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0
-    4'b 0001, // index[36] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1
-    4'b 0001, // index[37] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2
-    4'b 0001, // index[38] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3
-    4'b 0001, // index[39] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4
-    4'b 0001, // index[40] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5
-    4'b 0001, // index[41] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6
-    4'b 0001, // index[42] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7
-    4'b 0001, // index[43] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8
-    4'b 0001, // index[44] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9
-    4'b 0001, // index[45] FLASH_CTRL_BANK0_INFO1_REGWEN
-    4'b 0001, // index[46] FLASH_CTRL_BANK0_INFO1_PAGE_CFG
-    4'b 0001, // index[47] FLASH_CTRL_BANK0_INFO2_REGWEN_0
-    4'b 0001, // index[48] FLASH_CTRL_BANK0_INFO2_REGWEN_1
-    4'b 0001, // index[49] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0
-    4'b 0001, // index[50] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1
-    4'b 0001, // index[51] FLASH_CTRL_BANK1_INFO0_REGWEN_0
-    4'b 0001, // index[52] FLASH_CTRL_BANK1_INFO0_REGWEN_1
-    4'b 0001, // index[53] FLASH_CTRL_BANK1_INFO0_REGWEN_2
-    4'b 0001, // index[54] FLASH_CTRL_BANK1_INFO0_REGWEN_3
-    4'b 0001, // index[55] FLASH_CTRL_BANK1_INFO0_REGWEN_4
-    4'b 0001, // index[56] FLASH_CTRL_BANK1_INFO0_REGWEN_5
-    4'b 0001, // index[57] FLASH_CTRL_BANK1_INFO0_REGWEN_6
-    4'b 0001, // index[58] FLASH_CTRL_BANK1_INFO0_REGWEN_7
-    4'b 0001, // index[59] FLASH_CTRL_BANK1_INFO0_REGWEN_8
-    4'b 0001, // index[60] FLASH_CTRL_BANK1_INFO0_REGWEN_9
-    4'b 0001, // index[61] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0
-    4'b 0001, // index[62] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1
-    4'b 0001, // index[63] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2
-    4'b 0001, // index[64] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3
-    4'b 0001, // index[65] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4
-    4'b 0001, // index[66] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5
-    4'b 0001, // index[67] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6
-    4'b 0001, // index[68] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7
-    4'b 0001, // index[69] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8
-    4'b 0001, // index[70] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9
-    4'b 0001, // index[71] FLASH_CTRL_BANK1_INFO1_REGWEN
-    4'b 0001, // index[72] FLASH_CTRL_BANK1_INFO1_PAGE_CFG
-    4'b 0001, // index[73] FLASH_CTRL_BANK1_INFO2_REGWEN_0
-    4'b 0001, // index[74] FLASH_CTRL_BANK1_INFO2_REGWEN_1
-    4'b 0001, // index[75] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0
-    4'b 0001, // index[76] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1
-    4'b 0001, // index[77] FLASH_CTRL_BANK_CFG_REGWEN
-    4'b 0001, // index[78] FLASH_CTRL_MP_BANK_CFG
-    4'b 0001, // index[79] FLASH_CTRL_OP_STATUS
-    4'b 0111, // index[80] FLASH_CTRL_STATUS
-    4'b 0001, // index[81] FLASH_CTRL_PHY_STATUS
-    4'b 1111, // index[82] FLASH_CTRL_SCRATCH
-    4'b 0011, // index[83] FLASH_CTRL_FIFO_LVL
-    4'b 0001  // index[84] FLASH_CTRL_FIFO_RST
+    4'b 0001, // index[ 3] FLASH_CTRL_ALERT_TEST
+    4'b 0001, // index[ 4] FLASH_CTRL_CTRL_REGWEN
+    4'b 1111, // index[ 5] FLASH_CTRL_CONTROL
+    4'b 1111, // index[ 6] FLASH_CTRL_ADDR
+    4'b 0001, // index[ 7] FLASH_CTRL_PROG_TYPE_EN
+    4'b 0001, // index[ 8] FLASH_CTRL_ERASE_SUSPEND
+    4'b 0001, // index[ 9] FLASH_CTRL_REGION_CFG_REGWEN_0
+    4'b 0001, // index[10] FLASH_CTRL_REGION_CFG_REGWEN_1
+    4'b 0001, // index[11] FLASH_CTRL_REGION_CFG_REGWEN_2
+    4'b 0001, // index[12] FLASH_CTRL_REGION_CFG_REGWEN_3
+    4'b 0001, // index[13] FLASH_CTRL_REGION_CFG_REGWEN_4
+    4'b 0001, // index[14] FLASH_CTRL_REGION_CFG_REGWEN_5
+    4'b 0001, // index[15] FLASH_CTRL_REGION_CFG_REGWEN_6
+    4'b 0001, // index[16] FLASH_CTRL_REGION_CFG_REGWEN_7
+    4'b 1111, // index[17] FLASH_CTRL_MP_REGION_CFG_0
+    4'b 1111, // index[18] FLASH_CTRL_MP_REGION_CFG_1
+    4'b 1111, // index[19] FLASH_CTRL_MP_REGION_CFG_2
+    4'b 1111, // index[20] FLASH_CTRL_MP_REGION_CFG_3
+    4'b 1111, // index[21] FLASH_CTRL_MP_REGION_CFG_4
+    4'b 1111, // index[22] FLASH_CTRL_MP_REGION_CFG_5
+    4'b 1111, // index[23] FLASH_CTRL_MP_REGION_CFG_6
+    4'b 1111, // index[24] FLASH_CTRL_MP_REGION_CFG_7
+    4'b 0001, // index[25] FLASH_CTRL_DEFAULT_REGION
+    4'b 0001, // index[26] FLASH_CTRL_BANK0_INFO0_REGWEN_0
+    4'b 0001, // index[27] FLASH_CTRL_BANK0_INFO0_REGWEN_1
+    4'b 0001, // index[28] FLASH_CTRL_BANK0_INFO0_REGWEN_2
+    4'b 0001, // index[29] FLASH_CTRL_BANK0_INFO0_REGWEN_3
+    4'b 0001, // index[30] FLASH_CTRL_BANK0_INFO0_REGWEN_4
+    4'b 0001, // index[31] FLASH_CTRL_BANK0_INFO0_REGWEN_5
+    4'b 0001, // index[32] FLASH_CTRL_BANK0_INFO0_REGWEN_6
+    4'b 0001, // index[33] FLASH_CTRL_BANK0_INFO0_REGWEN_7
+    4'b 0001, // index[34] FLASH_CTRL_BANK0_INFO0_REGWEN_8
+    4'b 0001, // index[35] FLASH_CTRL_BANK0_INFO0_REGWEN_9
+    4'b 0001, // index[36] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0
+    4'b 0001, // index[37] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1
+    4'b 0001, // index[38] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2
+    4'b 0001, // index[39] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3
+    4'b 0001, // index[40] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4
+    4'b 0001, // index[41] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5
+    4'b 0001, // index[42] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6
+    4'b 0001, // index[43] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7
+    4'b 0001, // index[44] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8
+    4'b 0001, // index[45] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9
+    4'b 0001, // index[46] FLASH_CTRL_BANK0_INFO1_REGWEN
+    4'b 0001, // index[47] FLASH_CTRL_BANK0_INFO1_PAGE_CFG
+    4'b 0001, // index[48] FLASH_CTRL_BANK0_INFO2_REGWEN_0
+    4'b 0001, // index[49] FLASH_CTRL_BANK0_INFO2_REGWEN_1
+    4'b 0001, // index[50] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0
+    4'b 0001, // index[51] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1
+    4'b 0001, // index[52] FLASH_CTRL_BANK1_INFO0_REGWEN_0
+    4'b 0001, // index[53] FLASH_CTRL_BANK1_INFO0_REGWEN_1
+    4'b 0001, // index[54] FLASH_CTRL_BANK1_INFO0_REGWEN_2
+    4'b 0001, // index[55] FLASH_CTRL_BANK1_INFO0_REGWEN_3
+    4'b 0001, // index[56] FLASH_CTRL_BANK1_INFO0_REGWEN_4
+    4'b 0001, // index[57] FLASH_CTRL_BANK1_INFO0_REGWEN_5
+    4'b 0001, // index[58] FLASH_CTRL_BANK1_INFO0_REGWEN_6
+    4'b 0001, // index[59] FLASH_CTRL_BANK1_INFO0_REGWEN_7
+    4'b 0001, // index[60] FLASH_CTRL_BANK1_INFO0_REGWEN_8
+    4'b 0001, // index[61] FLASH_CTRL_BANK1_INFO0_REGWEN_9
+    4'b 0001, // index[62] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0
+    4'b 0001, // index[63] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1
+    4'b 0001, // index[64] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2
+    4'b 0001, // index[65] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3
+    4'b 0001, // index[66] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4
+    4'b 0001, // index[67] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5
+    4'b 0001, // index[68] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6
+    4'b 0001, // index[69] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7
+    4'b 0001, // index[70] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8
+    4'b 0001, // index[71] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9
+    4'b 0001, // index[72] FLASH_CTRL_BANK1_INFO1_REGWEN
+    4'b 0001, // index[73] FLASH_CTRL_BANK1_INFO1_PAGE_CFG
+    4'b 0001, // index[74] FLASH_CTRL_BANK1_INFO2_REGWEN_0
+    4'b 0001, // index[75] FLASH_CTRL_BANK1_INFO2_REGWEN_1
+    4'b 0001, // index[76] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0
+    4'b 0001, // index[77] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1
+    4'b 0001, // index[78] FLASH_CTRL_BANK_CFG_REGWEN
+    4'b 0001, // index[79] FLASH_CTRL_MP_BANK_CFG
+    4'b 0001, // index[80] FLASH_CTRL_OP_STATUS
+    4'b 0001, // index[81] FLASH_CTRL_STATUS
+    4'b 0001, // index[82] FLASH_CTRL_ERR_CODE
+    4'b 0011, // index[83] FLASH_CTRL_ERR_ADDR
+    4'b 0111, // index[84] FLASH_CTRL_ECC_ERR_ADDR_0
+    4'b 0111, // index[85] FLASH_CTRL_ECC_ERR_ADDR_1
+    4'b 0001, // index[86] FLASH_CTRL_PHY_ALERT_CFG
+    4'b 0001, // index[87] FLASH_CTRL_PHY_STATUS
+    4'b 1111, // index[88] FLASH_CTRL_SCRATCH
+    4'b 0011, // index[89] FLASH_CTRL_FIFO_LVL
+    4'b 0001  // index[90] FLASH_CTRL_FIFO_RST
   };
 endpackage
 

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_top.sv
@@ -90,10 +90,10 @@ module flash_ctrl_reg_top (
     reg_steer = 3;       // Default set to register
 
     // TODO: Can below codes be unique case () inside ?
-    if (tl_i.a_address[AW-1:0] >= 340 && tl_i.a_address[AW-1:0] < 344) begin
+    if (tl_i.a_address[AW-1:0] >= 364 && tl_i.a_address[AW-1:0] < 368) begin
       reg_steer = 0;
     end
-    if (tl_i.a_address[AW-1:0] >= 344 && tl_i.a_address[AW-1:0] < 348) begin
+    if (tl_i.a_address[AW-1:0] >= 368 && tl_i.a_address[AW-1:0] < 372) begin
       reg_steer = 1;
     end
     if (tl_i.a_address[AW-1:0] >= 384 && tl_i.a_address[AW-1:0] < 468) begin
@@ -141,9 +141,6 @@ module flash_ctrl_reg_top (
   logic intr_state_op_done_qs;
   logic intr_state_op_done_wd;
   logic intr_state_op_done_we;
-  logic intr_state_op_error_qs;
-  logic intr_state_op_error_wd;
-  logic intr_state_op_error_we;
   logic intr_enable_prog_empty_qs;
   logic intr_enable_prog_empty_wd;
   logic intr_enable_prog_empty_we;
@@ -159,9 +156,6 @@ module flash_ctrl_reg_top (
   logic intr_enable_op_done_qs;
   logic intr_enable_op_done_wd;
   logic intr_enable_op_done_we;
-  logic intr_enable_op_error_qs;
-  logic intr_enable_op_error_wd;
-  logic intr_enable_op_error_we;
   logic intr_test_prog_empty_wd;
   logic intr_test_prog_empty_we;
   logic intr_test_prog_lvl_wd;
@@ -172,8 +166,12 @@ module flash_ctrl_reg_top (
   logic intr_test_rd_lvl_we;
   logic intr_test_op_done_wd;
   logic intr_test_op_done_we;
-  logic intr_test_op_error_wd;
-  logic intr_test_op_error_we;
+  logic alert_test_recov_err_wd;
+  logic alert_test_recov_err_we;
+  logic alert_test_recov_mp_err_wd;
+  logic alert_test_recov_mp_err_we;
+  logic alert_test_recov_ecc_err_wd;
+  logic alert_test_recov_ecc_err_we;
   logic ctrl_regwen_qs;
   logic ctrl_regwen_re;
   logic control_start_qs;
@@ -1111,7 +1109,30 @@ module flash_ctrl_reg_top (
   logic status_prog_full_qs;
   logic status_prog_empty_qs;
   logic status_init_wip_qs;
-  logic [8:0] status_error_addr_qs;
+  logic err_code_flash_err_qs;
+  logic err_code_flash_err_wd;
+  logic err_code_flash_err_we;
+  logic err_code_flash_alert_qs;
+  logic err_code_flash_alert_wd;
+  logic err_code_flash_alert_we;
+  logic err_code_mp_err_qs;
+  logic err_code_mp_err_wd;
+  logic err_code_mp_err_we;
+  logic err_code_ecc_single_err_qs;
+  logic err_code_ecc_single_err_wd;
+  logic err_code_ecc_single_err_we;
+  logic err_code_ecc_multi_err_qs;
+  logic err_code_ecc_multi_err_wd;
+  logic err_code_ecc_multi_err_we;
+  logic [8:0] err_addr_qs;
+  logic [19:0] ecc_err_addr_0_qs;
+  logic [19:0] ecc_err_addr_1_qs;
+  logic phy_alert_cfg_alert_ack_qs;
+  logic phy_alert_cfg_alert_ack_wd;
+  logic phy_alert_cfg_alert_ack_we;
+  logic phy_alert_cfg_alert_trig_qs;
+  logic phy_alert_cfg_alert_trig_wd;
+  logic phy_alert_cfg_alert_trig_we;
   logic phy_status_init_wip_qs;
   logic phy_status_prog_normal_avail_qs;
   logic phy_status_prog_repair_avail_qs;
@@ -1261,32 +1282,6 @@ module flash_ctrl_reg_top (
   );
 
 
-  //   F[op_error]: 5:5
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W1C"),
-    .RESVAL  (1'h0)
-  ) u_intr_state_op_error (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (intr_state_op_error_we),
-    .wd     (intr_state_op_error_wd),
-
-    // from internal hardware
-    .de     (hw2reg.intr_state.op_error.de),
-    .d      (hw2reg.intr_state.op_error.d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.intr_state.op_error.q ),
-
-    // to register interface (read)
-    .qs     (intr_state_op_error_qs)
-  );
-
-
   // R[intr_enable]: V(False)
 
   //   F[prog_empty]: 0:0
@@ -1419,32 +1414,6 @@ module flash_ctrl_reg_top (
   );
 
 
-  //   F[op_error]: 5:5
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_intr_enable_op_error (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (intr_enable_op_error_we),
-    .wd     (intr_enable_op_error_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.intr_enable.op_error.q ),
-
-    // to register interface (read)
-    .qs     (intr_enable_op_error_qs)
-  );
-
-
   // R[intr_test]: V(True)
 
   //   F[prog_empty]: 0:0
@@ -1522,17 +1491,49 @@ module flash_ctrl_reg_top (
   );
 
 
-  //   F[op_error]: 5:5
+  // R[alert_test]: V(True)
+
+  //   F[recov_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_intr_test_op_error (
+  ) u_alert_test_recov_err (
     .re     (1'b0),
-    .we     (intr_test_op_error_we),
-    .wd     (intr_test_op_error_wd),
+    .we     (alert_test_recov_err_we),
+    .wd     (alert_test_recov_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.op_error.qe),
-    .q      (reg2hw.intr_test.op_error.q ),
+    .qe     (reg2hw.alert_test.recov_err.qe),
+    .q      (reg2hw.alert_test.recov_err.q ),
+    .qs     ()
+  );
+
+
+  //   F[recov_mp_err]: 1:1
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_alert_test_recov_mp_err (
+    .re     (1'b0),
+    .we     (alert_test_recov_mp_err_we),
+    .wd     (alert_test_recov_mp_err_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.alert_test.recov_mp_err.qe),
+    .q      (reg2hw.alert_test.recov_mp_err.q ),
+    .qs     ()
+  );
+
+
+  //   F[recov_ecc_err]: 2:2
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_alert_test_recov_ecc_err (
+    .re     (1'b0),
+    .we     (alert_test_recov_ecc_err_we),
+    .wd     (alert_test_recov_ecc_err_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.alert_test.recov_ecc_err.qe),
+    .q      (reg2hw.alert_test.recov_ecc_err.q ),
     .qs     ()
   );
 
@@ -9920,12 +9921,145 @@ module flash_ctrl_reg_top (
   );
 
 
-  //   F[error_addr]: 16:8
+  // R[err_code]: V(False)
+
+  //   F[flash_err]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_err_code_flash_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (err_code_flash_err_we),
+    .wd     (err_code_flash_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.err_code.flash_err.de),
+    .d      (hw2reg.err_code.flash_err.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_code_flash_err_qs)
+  );
+
+
+  //   F[flash_alert]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_err_code_flash_alert (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (err_code_flash_alert_we),
+    .wd     (err_code_flash_alert_wd),
+
+    // from internal hardware
+    .de     (hw2reg.err_code.flash_alert.de),
+    .d      (hw2reg.err_code.flash_alert.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_code_flash_alert_qs)
+  );
+
+
+  //   F[mp_err]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_err_code_mp_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (err_code_mp_err_we),
+    .wd     (err_code_mp_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.err_code.mp_err.de),
+    .d      (hw2reg.err_code.mp_err.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_code_mp_err_qs)
+  );
+
+
+  //   F[ecc_single_err]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_err_code_ecc_single_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (err_code_ecc_single_err_we),
+    .wd     (err_code_ecc_single_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.err_code.ecc_single_err.de),
+    .d      (hw2reg.err_code.ecc_single_err.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_code_ecc_single_err_qs)
+  );
+
+
+  //   F[ecc_multi_err]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_err_code_ecc_multi_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (err_code_ecc_multi_err_we),
+    .wd     (err_code_ecc_multi_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.err_code.ecc_multi_err.de),
+    .d      (hw2reg.err_code.ecc_multi_err.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_code_ecc_multi_err_qs)
+  );
+
+
+  // R[err_addr]: V(False)
+
   prim_subreg #(
     .DW      (9),
     .SWACCESS("RO"),
     .RESVAL  (9'h0)
-  ) u_status_error_addr (
+  ) u_err_addr (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
@@ -9933,15 +10067,123 @@ module flash_ctrl_reg_top (
     .wd     ('0  ),
 
     // from internal hardware
-    .de     (hw2reg.status.error_addr.de),
-    .d      (hw2reg.status.error_addr.d ),
+    .de     (hw2reg.err_addr.de),
+    .d      (hw2reg.err_addr.d ),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (status_error_addr_qs)
+    .qs     (err_addr_qs)
+  );
+
+
+
+  // Subregister 0 of Multireg ecc_err_addr
+  // R[ecc_err_addr_0]: V(False)
+
+  prim_subreg #(
+    .DW      (20),
+    .SWACCESS("RO"),
+    .RESVAL  (20'h0)
+  ) u_ecc_err_addr_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.ecc_err_addr[0].de),
+    .d      (hw2reg.ecc_err_addr[0].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (ecc_err_addr_0_qs)
+  );
+
+  // Subregister 1 of Multireg ecc_err_addr
+  // R[ecc_err_addr_1]: V(False)
+
+  prim_subreg #(
+    .DW      (20),
+    .SWACCESS("RO"),
+    .RESVAL  (20'h0)
+  ) u_ecc_err_addr_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.ecc_err_addr[1].de),
+    .d      (hw2reg.ecc_err_addr[1].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (ecc_err_addr_1_qs)
+  );
+
+
+  // R[phy_alert_cfg]: V(False)
+
+  //   F[alert_ack]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_phy_alert_cfg_alert_ack (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (phy_alert_cfg_alert_ack_we),
+    .wd     (phy_alert_cfg_alert_ack_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.phy_alert_cfg.alert_ack.q ),
+
+    // to register interface (read)
+    .qs     (phy_alert_cfg_alert_ack_qs)
+  );
+
+
+  //   F[alert_trig]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_phy_alert_cfg_alert_trig (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (phy_alert_cfg_alert_trig_we),
+    .wd     (phy_alert_cfg_alert_trig_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.phy_alert_cfg.alert_trig.q ),
+
+    // to register interface (read)
+    .qs     (phy_alert_cfg_alert_trig_qs)
   );
 
 
@@ -10132,94 +10374,100 @@ module flash_ctrl_reg_top (
 
 
 
-  logic [84:0] addr_hit;
+  logic [90:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == FLASH_CTRL_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == FLASH_CTRL_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == FLASH_CTRL_INTR_TEST_OFFSET);
-    addr_hit[ 3] = (reg_addr == FLASH_CTRL_CTRL_REGWEN_OFFSET);
-    addr_hit[ 4] = (reg_addr == FLASH_CTRL_CONTROL_OFFSET);
-    addr_hit[ 5] = (reg_addr == FLASH_CTRL_ADDR_OFFSET);
-    addr_hit[ 6] = (reg_addr == FLASH_CTRL_PROG_TYPE_EN_OFFSET);
-    addr_hit[ 7] = (reg_addr == FLASH_CTRL_ERASE_SUSPEND_OFFSET);
-    addr_hit[ 8] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_0_OFFSET);
-    addr_hit[ 9] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_1_OFFSET);
-    addr_hit[10] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_2_OFFSET);
-    addr_hit[11] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_3_OFFSET);
-    addr_hit[12] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_4_OFFSET);
-    addr_hit[13] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_5_OFFSET);
-    addr_hit[14] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_6_OFFSET);
-    addr_hit[15] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_7_OFFSET);
-    addr_hit[16] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_0_OFFSET);
-    addr_hit[17] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_1_OFFSET);
-    addr_hit[18] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_2_OFFSET);
-    addr_hit[19] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_3_OFFSET);
-    addr_hit[20] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_4_OFFSET);
-    addr_hit[21] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_5_OFFSET);
-    addr_hit[22] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_6_OFFSET);
-    addr_hit[23] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_7_OFFSET);
-    addr_hit[24] = (reg_addr == FLASH_CTRL_DEFAULT_REGION_OFFSET);
-    addr_hit[25] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_0_OFFSET);
-    addr_hit[26] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_1_OFFSET);
-    addr_hit[27] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_2_OFFSET);
-    addr_hit[28] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_3_OFFSET);
-    addr_hit[29] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_4_OFFSET);
-    addr_hit[30] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_5_OFFSET);
-    addr_hit[31] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_6_OFFSET);
-    addr_hit[32] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_7_OFFSET);
-    addr_hit[33] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_8_OFFSET);
-    addr_hit[34] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_9_OFFSET);
-    addr_hit[35] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_OFFSET);
-    addr_hit[36] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1_OFFSET);
-    addr_hit[37] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2_OFFSET);
-    addr_hit[38] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3_OFFSET);
-    addr_hit[39] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4_OFFSET);
-    addr_hit[40] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5_OFFSET);
-    addr_hit[41] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6_OFFSET);
-    addr_hit[42] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7_OFFSET);
-    addr_hit[43] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8_OFFSET);
-    addr_hit[44] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9_OFFSET);
-    addr_hit[45] = (reg_addr == FLASH_CTRL_BANK0_INFO1_REGWEN_OFFSET);
-    addr_hit[46] = (reg_addr == FLASH_CTRL_BANK0_INFO1_PAGE_CFG_OFFSET);
-    addr_hit[47] = (reg_addr == FLASH_CTRL_BANK0_INFO2_REGWEN_0_OFFSET);
-    addr_hit[48] = (reg_addr == FLASH_CTRL_BANK0_INFO2_REGWEN_1_OFFSET);
-    addr_hit[49] = (reg_addr == FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0_OFFSET);
-    addr_hit[50] = (reg_addr == FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1_OFFSET);
-    addr_hit[51] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_0_OFFSET);
-    addr_hit[52] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_1_OFFSET);
-    addr_hit[53] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_2_OFFSET);
-    addr_hit[54] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_3_OFFSET);
-    addr_hit[55] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_4_OFFSET);
-    addr_hit[56] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_5_OFFSET);
-    addr_hit[57] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_6_OFFSET);
-    addr_hit[58] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_7_OFFSET);
-    addr_hit[59] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_8_OFFSET);
-    addr_hit[60] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_9_OFFSET);
-    addr_hit[61] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_OFFSET);
-    addr_hit[62] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1_OFFSET);
-    addr_hit[63] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2_OFFSET);
-    addr_hit[64] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3_OFFSET);
-    addr_hit[65] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4_OFFSET);
-    addr_hit[66] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5_OFFSET);
-    addr_hit[67] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6_OFFSET);
-    addr_hit[68] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7_OFFSET);
-    addr_hit[69] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8_OFFSET);
-    addr_hit[70] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9_OFFSET);
-    addr_hit[71] = (reg_addr == FLASH_CTRL_BANK1_INFO1_REGWEN_OFFSET);
-    addr_hit[72] = (reg_addr == FLASH_CTRL_BANK1_INFO1_PAGE_CFG_OFFSET);
-    addr_hit[73] = (reg_addr == FLASH_CTRL_BANK1_INFO2_REGWEN_0_OFFSET);
-    addr_hit[74] = (reg_addr == FLASH_CTRL_BANK1_INFO2_REGWEN_1_OFFSET);
-    addr_hit[75] = (reg_addr == FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0_OFFSET);
-    addr_hit[76] = (reg_addr == FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1_OFFSET);
-    addr_hit[77] = (reg_addr == FLASH_CTRL_BANK_CFG_REGWEN_OFFSET);
-    addr_hit[78] = (reg_addr == FLASH_CTRL_MP_BANK_CFG_OFFSET);
-    addr_hit[79] = (reg_addr == FLASH_CTRL_OP_STATUS_OFFSET);
-    addr_hit[80] = (reg_addr == FLASH_CTRL_STATUS_OFFSET);
-    addr_hit[81] = (reg_addr == FLASH_CTRL_PHY_STATUS_OFFSET);
-    addr_hit[82] = (reg_addr == FLASH_CTRL_SCRATCH_OFFSET);
-    addr_hit[83] = (reg_addr == FLASH_CTRL_FIFO_LVL_OFFSET);
-    addr_hit[84] = (reg_addr == FLASH_CTRL_FIFO_RST_OFFSET);
+    addr_hit[ 3] = (reg_addr == FLASH_CTRL_ALERT_TEST_OFFSET);
+    addr_hit[ 4] = (reg_addr == FLASH_CTRL_CTRL_REGWEN_OFFSET);
+    addr_hit[ 5] = (reg_addr == FLASH_CTRL_CONTROL_OFFSET);
+    addr_hit[ 6] = (reg_addr == FLASH_CTRL_ADDR_OFFSET);
+    addr_hit[ 7] = (reg_addr == FLASH_CTRL_PROG_TYPE_EN_OFFSET);
+    addr_hit[ 8] = (reg_addr == FLASH_CTRL_ERASE_SUSPEND_OFFSET);
+    addr_hit[ 9] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_0_OFFSET);
+    addr_hit[10] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_1_OFFSET);
+    addr_hit[11] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_2_OFFSET);
+    addr_hit[12] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_3_OFFSET);
+    addr_hit[13] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_4_OFFSET);
+    addr_hit[14] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_5_OFFSET);
+    addr_hit[15] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_6_OFFSET);
+    addr_hit[16] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_7_OFFSET);
+    addr_hit[17] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_0_OFFSET);
+    addr_hit[18] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_1_OFFSET);
+    addr_hit[19] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_2_OFFSET);
+    addr_hit[20] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_3_OFFSET);
+    addr_hit[21] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_4_OFFSET);
+    addr_hit[22] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_5_OFFSET);
+    addr_hit[23] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_6_OFFSET);
+    addr_hit[24] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_7_OFFSET);
+    addr_hit[25] = (reg_addr == FLASH_CTRL_DEFAULT_REGION_OFFSET);
+    addr_hit[26] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_0_OFFSET);
+    addr_hit[27] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_1_OFFSET);
+    addr_hit[28] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_2_OFFSET);
+    addr_hit[29] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_3_OFFSET);
+    addr_hit[30] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_4_OFFSET);
+    addr_hit[31] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_5_OFFSET);
+    addr_hit[32] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_6_OFFSET);
+    addr_hit[33] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_7_OFFSET);
+    addr_hit[34] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_8_OFFSET);
+    addr_hit[35] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_9_OFFSET);
+    addr_hit[36] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_OFFSET);
+    addr_hit[37] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1_OFFSET);
+    addr_hit[38] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2_OFFSET);
+    addr_hit[39] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3_OFFSET);
+    addr_hit[40] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4_OFFSET);
+    addr_hit[41] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5_OFFSET);
+    addr_hit[42] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6_OFFSET);
+    addr_hit[43] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7_OFFSET);
+    addr_hit[44] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8_OFFSET);
+    addr_hit[45] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9_OFFSET);
+    addr_hit[46] = (reg_addr == FLASH_CTRL_BANK0_INFO1_REGWEN_OFFSET);
+    addr_hit[47] = (reg_addr == FLASH_CTRL_BANK0_INFO1_PAGE_CFG_OFFSET);
+    addr_hit[48] = (reg_addr == FLASH_CTRL_BANK0_INFO2_REGWEN_0_OFFSET);
+    addr_hit[49] = (reg_addr == FLASH_CTRL_BANK0_INFO2_REGWEN_1_OFFSET);
+    addr_hit[50] = (reg_addr == FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0_OFFSET);
+    addr_hit[51] = (reg_addr == FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1_OFFSET);
+    addr_hit[52] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_0_OFFSET);
+    addr_hit[53] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_1_OFFSET);
+    addr_hit[54] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_2_OFFSET);
+    addr_hit[55] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_3_OFFSET);
+    addr_hit[56] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_4_OFFSET);
+    addr_hit[57] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_5_OFFSET);
+    addr_hit[58] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_6_OFFSET);
+    addr_hit[59] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_7_OFFSET);
+    addr_hit[60] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_8_OFFSET);
+    addr_hit[61] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_9_OFFSET);
+    addr_hit[62] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_OFFSET);
+    addr_hit[63] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1_OFFSET);
+    addr_hit[64] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2_OFFSET);
+    addr_hit[65] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3_OFFSET);
+    addr_hit[66] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4_OFFSET);
+    addr_hit[67] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5_OFFSET);
+    addr_hit[68] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6_OFFSET);
+    addr_hit[69] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7_OFFSET);
+    addr_hit[70] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8_OFFSET);
+    addr_hit[71] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9_OFFSET);
+    addr_hit[72] = (reg_addr == FLASH_CTRL_BANK1_INFO1_REGWEN_OFFSET);
+    addr_hit[73] = (reg_addr == FLASH_CTRL_BANK1_INFO1_PAGE_CFG_OFFSET);
+    addr_hit[74] = (reg_addr == FLASH_CTRL_BANK1_INFO2_REGWEN_0_OFFSET);
+    addr_hit[75] = (reg_addr == FLASH_CTRL_BANK1_INFO2_REGWEN_1_OFFSET);
+    addr_hit[76] = (reg_addr == FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0_OFFSET);
+    addr_hit[77] = (reg_addr == FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1_OFFSET);
+    addr_hit[78] = (reg_addr == FLASH_CTRL_BANK_CFG_REGWEN_OFFSET);
+    addr_hit[79] = (reg_addr == FLASH_CTRL_MP_BANK_CFG_OFFSET);
+    addr_hit[80] = (reg_addr == FLASH_CTRL_OP_STATUS_OFFSET);
+    addr_hit[81] = (reg_addr == FLASH_CTRL_STATUS_OFFSET);
+    addr_hit[82] = (reg_addr == FLASH_CTRL_ERR_CODE_OFFSET);
+    addr_hit[83] = (reg_addr == FLASH_CTRL_ERR_ADDR_OFFSET);
+    addr_hit[84] = (reg_addr == FLASH_CTRL_ECC_ERR_ADDR_0_OFFSET);
+    addr_hit[85] = (reg_addr == FLASH_CTRL_ECC_ERR_ADDR_1_OFFSET);
+    addr_hit[86] = (reg_addr == FLASH_CTRL_PHY_ALERT_CFG_OFFSET);
+    addr_hit[87] = (reg_addr == FLASH_CTRL_PHY_STATUS_OFFSET);
+    addr_hit[88] = (reg_addr == FLASH_CTRL_SCRATCH_OFFSET);
+    addr_hit[89] = (reg_addr == FLASH_CTRL_FIFO_LVL_OFFSET);
+    addr_hit[90] = (reg_addr == FLASH_CTRL_FIFO_RST_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -10312,6 +10560,12 @@ module flash_ctrl_reg_top (
     if (addr_hit[82] && reg_we && (FLASH_CTRL_PERMIT[82] != (FLASH_CTRL_PERMIT[82] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[83] && reg_we && (FLASH_CTRL_PERMIT[83] != (FLASH_CTRL_PERMIT[83] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[84] && reg_we && (FLASH_CTRL_PERMIT[84] != (FLASH_CTRL_PERMIT[84] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[85] && reg_we && (FLASH_CTRL_PERMIT[85] != (FLASH_CTRL_PERMIT[85] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[86] && reg_we && (FLASH_CTRL_PERMIT[86] != (FLASH_CTRL_PERMIT[86] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[87] && reg_we && (FLASH_CTRL_PERMIT[87] != (FLASH_CTRL_PERMIT[87] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[88] && reg_we && (FLASH_CTRL_PERMIT[88] != (FLASH_CTRL_PERMIT[88] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[89] && reg_we && (FLASH_CTRL_PERMIT[89] != (FLASH_CTRL_PERMIT[89] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[90] && reg_we && (FLASH_CTRL_PERMIT[90] != (FLASH_CTRL_PERMIT[90] & reg_be))) wr_err = 1'b1 ;
   end
 
   assign intr_state_prog_empty_we = addr_hit[0] & reg_we & ~wr_err;
@@ -10329,9 +10583,6 @@ module flash_ctrl_reg_top (
   assign intr_state_op_done_we = addr_hit[0] & reg_we & ~wr_err;
   assign intr_state_op_done_wd = reg_wdata[4];
 
-  assign intr_state_op_error_we = addr_hit[0] & reg_we & ~wr_err;
-  assign intr_state_op_error_wd = reg_wdata[5];
-
   assign intr_enable_prog_empty_we = addr_hit[1] & reg_we & ~wr_err;
   assign intr_enable_prog_empty_wd = reg_wdata[0];
 
@@ -10346,9 +10597,6 @@ module flash_ctrl_reg_top (
 
   assign intr_enable_op_done_we = addr_hit[1] & reg_we & ~wr_err;
   assign intr_enable_op_done_wd = reg_wdata[4];
-
-  assign intr_enable_op_error_we = addr_hit[1] & reg_we & ~wr_err;
-  assign intr_enable_op_error_wd = reg_wdata[5];
 
   assign intr_test_prog_empty_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_prog_empty_wd = reg_wdata[0];
@@ -10365,939 +10613,945 @@ module flash_ctrl_reg_top (
   assign intr_test_op_done_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_op_done_wd = reg_wdata[4];
 
-  assign intr_test_op_error_we = addr_hit[2] & reg_we & ~wr_err;
-  assign intr_test_op_error_wd = reg_wdata[5];
+  assign alert_test_recov_err_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_recov_err_wd = reg_wdata[0];
 
-  assign ctrl_regwen_re = addr_hit[3] && reg_re;
+  assign alert_test_recov_mp_err_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_recov_mp_err_wd = reg_wdata[1];
 
-  assign control_start_we = addr_hit[4] & reg_we & ~wr_err;
+  assign alert_test_recov_ecc_err_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_recov_ecc_err_wd = reg_wdata[2];
+
+  assign ctrl_regwen_re = addr_hit[4] && reg_re;
+
+  assign control_start_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_start_wd = reg_wdata[0];
 
-  assign control_op_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_op_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_op_wd = reg_wdata[5:4];
 
-  assign control_prog_sel_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_prog_sel_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_prog_sel_wd = reg_wdata[6];
 
-  assign control_erase_sel_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_erase_sel_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_erase_sel_wd = reg_wdata[7];
 
-  assign control_partition_sel_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_partition_sel_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_partition_sel_wd = reg_wdata[8];
 
-  assign control_info_sel_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_info_sel_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_info_sel_wd = reg_wdata[10:9];
 
-  assign control_num_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_num_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_num_wd = reg_wdata[27:16];
 
-  assign addr_we = addr_hit[5] & reg_we & ~wr_err;
+  assign addr_we = addr_hit[6] & reg_we & ~wr_err;
   assign addr_wd = reg_wdata[31:0];
 
-  assign prog_type_en_normal_we = addr_hit[6] & reg_we & ~wr_err;
+  assign prog_type_en_normal_we = addr_hit[7] & reg_we & ~wr_err;
   assign prog_type_en_normal_wd = reg_wdata[0];
 
-  assign prog_type_en_repair_we = addr_hit[6] & reg_we & ~wr_err;
+  assign prog_type_en_repair_we = addr_hit[7] & reg_we & ~wr_err;
   assign prog_type_en_repair_wd = reg_wdata[1];
 
-  assign erase_suspend_we = addr_hit[7] & reg_we & ~wr_err;
+  assign erase_suspend_we = addr_hit[8] & reg_we & ~wr_err;
   assign erase_suspend_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_0_we = addr_hit[8] & reg_we & ~wr_err;
+  assign region_cfg_regwen_0_we = addr_hit[9] & reg_we & ~wr_err;
   assign region_cfg_regwen_0_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_1_we = addr_hit[9] & reg_we & ~wr_err;
+  assign region_cfg_regwen_1_we = addr_hit[10] & reg_we & ~wr_err;
   assign region_cfg_regwen_1_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_2_we = addr_hit[10] & reg_we & ~wr_err;
+  assign region_cfg_regwen_2_we = addr_hit[11] & reg_we & ~wr_err;
   assign region_cfg_regwen_2_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_3_we = addr_hit[11] & reg_we & ~wr_err;
+  assign region_cfg_regwen_3_we = addr_hit[12] & reg_we & ~wr_err;
   assign region_cfg_regwen_3_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_4_we = addr_hit[12] & reg_we & ~wr_err;
+  assign region_cfg_regwen_4_we = addr_hit[13] & reg_we & ~wr_err;
   assign region_cfg_regwen_4_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_5_we = addr_hit[13] & reg_we & ~wr_err;
+  assign region_cfg_regwen_5_we = addr_hit[14] & reg_we & ~wr_err;
   assign region_cfg_regwen_5_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_6_we = addr_hit[14] & reg_we & ~wr_err;
+  assign region_cfg_regwen_6_we = addr_hit[15] & reg_we & ~wr_err;
   assign region_cfg_regwen_6_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_7_we = addr_hit[15] & reg_we & ~wr_err;
+  assign region_cfg_regwen_7_we = addr_hit[16] & reg_we & ~wr_err;
   assign region_cfg_regwen_7_wd = reg_wdata[0];
 
-  assign mp_region_cfg_0_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_en_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign mp_region_cfg_0_rd_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_rd_en_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign mp_region_cfg_0_prog_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_prog_en_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign mp_region_cfg_0_erase_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_erase_en_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign mp_region_cfg_0_scramble_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_scramble_en_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign mp_region_cfg_0_ecc_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_ecc_en_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign mp_region_cfg_0_he_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_he_en_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign mp_region_cfg_0_base_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_base_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_0_base_0_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_0_size_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_size_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_0_size_0_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_1_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_en_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign mp_region_cfg_1_rd_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_rd_en_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign mp_region_cfg_1_prog_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_prog_en_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign mp_region_cfg_1_erase_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_erase_en_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign mp_region_cfg_1_scramble_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_scramble_en_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign mp_region_cfg_1_ecc_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_ecc_en_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign mp_region_cfg_1_he_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_he_en_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign mp_region_cfg_1_base_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_base_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_1_base_1_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_1_size_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_size_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_1_size_1_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_2_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_en_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign mp_region_cfg_2_rd_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_rd_en_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign mp_region_cfg_2_prog_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_prog_en_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign mp_region_cfg_2_erase_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_erase_en_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign mp_region_cfg_2_scramble_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_scramble_en_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign mp_region_cfg_2_ecc_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_ecc_en_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign mp_region_cfg_2_he_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_he_en_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_2_he_en_2_wd = reg_wdata[6];
 
-  assign mp_region_cfg_2_base_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_base_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_2_base_2_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_2_size_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_size_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_2_size_2_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_3_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_en_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign mp_region_cfg_3_rd_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_rd_en_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign mp_region_cfg_3_prog_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_prog_en_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign mp_region_cfg_3_erase_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_erase_en_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign mp_region_cfg_3_scramble_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_scramble_en_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign mp_region_cfg_3_ecc_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_ecc_en_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign mp_region_cfg_3_he_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_he_en_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_3_he_en_3_wd = reg_wdata[6];
 
-  assign mp_region_cfg_3_base_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_base_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_3_base_3_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_3_size_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_size_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_3_size_3_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_4_en_4_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_en_4_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign mp_region_cfg_4_rd_en_4_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_rd_en_4_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign mp_region_cfg_4_prog_en_4_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_prog_en_4_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign mp_region_cfg_4_erase_en_4_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_erase_en_4_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign mp_region_cfg_4_scramble_en_4_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_scramble_en_4_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign mp_region_cfg_4_ecc_en_4_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_ecc_en_4_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign mp_region_cfg_4_he_en_4_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_he_en_4_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_4_he_en_4_wd = reg_wdata[6];
 
-  assign mp_region_cfg_4_base_4_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_base_4_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_4_base_4_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_4_size_4_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_size_4_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_4_size_4_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_5_en_5_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_en_5_we = addr_hit[22] & reg_we & ~wr_err;
   assign mp_region_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign mp_region_cfg_5_rd_en_5_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_rd_en_5_we = addr_hit[22] & reg_we & ~wr_err;
   assign mp_region_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign mp_region_cfg_5_prog_en_5_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_prog_en_5_we = addr_hit[22] & reg_we & ~wr_err;
   assign mp_region_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign mp_region_cfg_5_erase_en_5_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_erase_en_5_we = addr_hit[22] & reg_we & ~wr_err;
   assign mp_region_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign mp_region_cfg_5_scramble_en_5_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_scramble_en_5_we = addr_hit[22] & reg_we & ~wr_err;
   assign mp_region_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign mp_region_cfg_5_ecc_en_5_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_ecc_en_5_we = addr_hit[22] & reg_we & ~wr_err;
   assign mp_region_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign mp_region_cfg_5_he_en_5_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_he_en_5_we = addr_hit[22] & reg_we & ~wr_err;
   assign mp_region_cfg_5_he_en_5_wd = reg_wdata[6];
 
-  assign mp_region_cfg_5_base_5_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_base_5_we = addr_hit[22] & reg_we & ~wr_err;
   assign mp_region_cfg_5_base_5_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_5_size_5_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_size_5_we = addr_hit[22] & reg_we & ~wr_err;
   assign mp_region_cfg_5_size_5_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_6_en_6_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_en_6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mp_region_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign mp_region_cfg_6_rd_en_6_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_rd_en_6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mp_region_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign mp_region_cfg_6_prog_en_6_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_prog_en_6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mp_region_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign mp_region_cfg_6_erase_en_6_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_erase_en_6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mp_region_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign mp_region_cfg_6_scramble_en_6_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_scramble_en_6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mp_region_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign mp_region_cfg_6_ecc_en_6_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_ecc_en_6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mp_region_cfg_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign mp_region_cfg_6_he_en_6_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_he_en_6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mp_region_cfg_6_he_en_6_wd = reg_wdata[6];
 
-  assign mp_region_cfg_6_base_6_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_base_6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mp_region_cfg_6_base_6_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_6_size_6_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_size_6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mp_region_cfg_6_size_6_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_7_en_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_en_7_we = addr_hit[24] & reg_we & ~wr_err;
   assign mp_region_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign mp_region_cfg_7_rd_en_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_rd_en_7_we = addr_hit[24] & reg_we & ~wr_err;
   assign mp_region_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign mp_region_cfg_7_prog_en_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_prog_en_7_we = addr_hit[24] & reg_we & ~wr_err;
   assign mp_region_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign mp_region_cfg_7_erase_en_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_erase_en_7_we = addr_hit[24] & reg_we & ~wr_err;
   assign mp_region_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign mp_region_cfg_7_scramble_en_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_scramble_en_7_we = addr_hit[24] & reg_we & ~wr_err;
   assign mp_region_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign mp_region_cfg_7_ecc_en_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_ecc_en_7_we = addr_hit[24] & reg_we & ~wr_err;
   assign mp_region_cfg_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign mp_region_cfg_7_he_en_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_he_en_7_we = addr_hit[24] & reg_we & ~wr_err;
   assign mp_region_cfg_7_he_en_7_wd = reg_wdata[6];
 
-  assign mp_region_cfg_7_base_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_base_7_we = addr_hit[24] & reg_we & ~wr_err;
   assign mp_region_cfg_7_base_7_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_7_size_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_size_7_we = addr_hit[24] & reg_we & ~wr_err;
   assign mp_region_cfg_7_size_7_wd = reg_wdata[26:17];
 
-  assign default_region_rd_en_we = addr_hit[24] & reg_we & ~wr_err;
+  assign default_region_rd_en_we = addr_hit[25] & reg_we & ~wr_err;
   assign default_region_rd_en_wd = reg_wdata[0];
 
-  assign default_region_prog_en_we = addr_hit[24] & reg_we & ~wr_err;
+  assign default_region_prog_en_we = addr_hit[25] & reg_we & ~wr_err;
   assign default_region_prog_en_wd = reg_wdata[1];
 
-  assign default_region_erase_en_we = addr_hit[24] & reg_we & ~wr_err;
+  assign default_region_erase_en_we = addr_hit[25] & reg_we & ~wr_err;
   assign default_region_erase_en_wd = reg_wdata[2];
 
-  assign default_region_scramble_en_we = addr_hit[24] & reg_we & ~wr_err;
+  assign default_region_scramble_en_we = addr_hit[25] & reg_we & ~wr_err;
   assign default_region_scramble_en_wd = reg_wdata[3];
 
-  assign default_region_ecc_en_we = addr_hit[24] & reg_we & ~wr_err;
+  assign default_region_ecc_en_we = addr_hit[25] & reg_we & ~wr_err;
   assign default_region_ecc_en_wd = reg_wdata[4];
 
-  assign default_region_he_en_we = addr_hit[24] & reg_we & ~wr_err;
+  assign default_region_he_en_we = addr_hit[25] & reg_we & ~wr_err;
   assign default_region_he_en_wd = reg_wdata[5];
 
-  assign bank0_info0_regwen_0_we = addr_hit[25] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_0_we = addr_hit[26] & reg_we & ~wr_err;
   assign bank0_info0_regwen_0_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_1_we = addr_hit[26] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_1_we = addr_hit[27] & reg_we & ~wr_err;
   assign bank0_info0_regwen_1_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_2_we = addr_hit[27] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_2_we = addr_hit[28] & reg_we & ~wr_err;
   assign bank0_info0_regwen_2_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_3_we = addr_hit[28] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_3_we = addr_hit[29] & reg_we & ~wr_err;
   assign bank0_info0_regwen_3_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_4_we = addr_hit[29] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_4_we = addr_hit[30] & reg_we & ~wr_err;
   assign bank0_info0_regwen_4_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_5_we = addr_hit[30] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_5_we = addr_hit[31] & reg_we & ~wr_err;
   assign bank0_info0_regwen_5_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_6_we = addr_hit[31] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_6_we = addr_hit[32] & reg_we & ~wr_err;
   assign bank0_info0_regwen_6_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_7_we = addr_hit[32] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_7_we = addr_hit[33] & reg_we & ~wr_err;
   assign bank0_info0_regwen_7_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_8_we = addr_hit[33] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_8_we = addr_hit[34] & reg_we & ~wr_err;
   assign bank0_info0_regwen_8_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_9_we = addr_hit[34] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_9_we = addr_hit[35] & reg_we & ~wr_err;
   assign bank0_info0_regwen_9_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_0_en_0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_en_0_we = addr_hit[36] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_0_rd_en_0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_rd_en_0_we = addr_hit[36] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_0_prog_en_0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_prog_en_0_we = addr_hit[36] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_0_erase_en_0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_erase_en_0_we = addr_hit[36] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_0_scramble_en_0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_scramble_en_0_we = addr_hit[36] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_0_ecc_en_0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_ecc_en_0_we = addr_hit[36] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_0_he_en_0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_he_en_0_we = addr_hit[36] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_1_en_1_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_en_1_we = addr_hit[37] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_1_rd_en_1_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_rd_en_1_we = addr_hit[37] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_1_prog_en_1_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_prog_en_1_we = addr_hit[37] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_1_erase_en_1_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_erase_en_1_we = addr_hit[37] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_1_scramble_en_1_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_scramble_en_1_we = addr_hit[37] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_1_ecc_en_1_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_ecc_en_1_we = addr_hit[37] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_1_he_en_1_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_he_en_1_we = addr_hit[37] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_2_en_2_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_en_2_we = addr_hit[38] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_2_rd_en_2_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_rd_en_2_we = addr_hit[38] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_2_prog_en_2_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_prog_en_2_we = addr_hit[38] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_2_erase_en_2_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_erase_en_2_we = addr_hit[38] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_2_scramble_en_2_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_scramble_en_2_we = addr_hit[38] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_2_ecc_en_2_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_ecc_en_2_we = addr_hit[38] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_2_he_en_2_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_he_en_2_we = addr_hit[38] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_he_en_2_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_3_en_3_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_en_3_we = addr_hit[39] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_3_rd_en_3_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_rd_en_3_we = addr_hit[39] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_3_prog_en_3_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_prog_en_3_we = addr_hit[39] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_3_erase_en_3_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_erase_en_3_we = addr_hit[39] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_3_scramble_en_3_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_scramble_en_3_we = addr_hit[39] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_3_ecc_en_3_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_ecc_en_3_we = addr_hit[39] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_3_he_en_3_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_he_en_3_we = addr_hit[39] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_he_en_3_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_4_en_4_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_en_4_we = addr_hit[40] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_4_rd_en_4_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_rd_en_4_we = addr_hit[40] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_4_prog_en_4_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_prog_en_4_we = addr_hit[40] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_4_erase_en_4_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_erase_en_4_we = addr_hit[40] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_4_scramble_en_4_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_scramble_en_4_we = addr_hit[40] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_4_ecc_en_4_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_ecc_en_4_we = addr_hit[40] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_4_he_en_4_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_he_en_4_we = addr_hit[40] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_4_he_en_4_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_5_en_5_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_en_5_we = addr_hit[41] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_5_rd_en_5_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_rd_en_5_we = addr_hit[41] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_5_prog_en_5_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_prog_en_5_we = addr_hit[41] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_5_erase_en_5_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_erase_en_5_we = addr_hit[41] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_5_scramble_en_5_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_scramble_en_5_we = addr_hit[41] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_5_ecc_en_5_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_ecc_en_5_we = addr_hit[41] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_5_he_en_5_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_he_en_5_we = addr_hit[41] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_5_he_en_5_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_6_en_6_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_en_6_we = addr_hit[42] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_6_rd_en_6_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_rd_en_6_we = addr_hit[42] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_6_prog_en_6_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_prog_en_6_we = addr_hit[42] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_6_erase_en_6_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_erase_en_6_we = addr_hit[42] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_6_scramble_en_6_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_scramble_en_6_we = addr_hit[42] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_6_ecc_en_6_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_ecc_en_6_we = addr_hit[42] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_6_he_en_6_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_he_en_6_we = addr_hit[42] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_6_he_en_6_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_7_en_7_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_en_7_we = addr_hit[43] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_7_rd_en_7_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_rd_en_7_we = addr_hit[43] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_7_prog_en_7_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_prog_en_7_we = addr_hit[43] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_7_erase_en_7_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_erase_en_7_we = addr_hit[43] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_7_scramble_en_7_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_scramble_en_7_we = addr_hit[43] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_7_ecc_en_7_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_ecc_en_7_we = addr_hit[43] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_7_he_en_7_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_he_en_7_we = addr_hit[43] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_7_he_en_7_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_8_en_8_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_en_8_we = addr_hit[44] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_8_en_8_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_8_rd_en_8_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_rd_en_8_we = addr_hit[44] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_8_rd_en_8_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_8_prog_en_8_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_prog_en_8_we = addr_hit[44] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_8_prog_en_8_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_8_erase_en_8_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_erase_en_8_we = addr_hit[44] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_8_erase_en_8_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_8_scramble_en_8_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_scramble_en_8_we = addr_hit[44] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_8_scramble_en_8_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_8_ecc_en_8_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_ecc_en_8_we = addr_hit[44] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_8_ecc_en_8_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_8_he_en_8_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_he_en_8_we = addr_hit[44] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_8_he_en_8_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_9_en_9_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_en_9_we = addr_hit[45] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_9_en_9_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_9_rd_en_9_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_rd_en_9_we = addr_hit[45] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_9_rd_en_9_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_9_prog_en_9_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_prog_en_9_we = addr_hit[45] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_9_prog_en_9_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_9_erase_en_9_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_erase_en_9_we = addr_hit[45] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_9_erase_en_9_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_9_scramble_en_9_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_scramble_en_9_we = addr_hit[45] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_9_scramble_en_9_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_9_ecc_en_9_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_ecc_en_9_we = addr_hit[45] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_9_ecc_en_9_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_9_he_en_9_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_he_en_9_we = addr_hit[45] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_9_he_en_9_wd = reg_wdata[6];
 
-  assign bank0_info1_regwen_we = addr_hit[45] & reg_we & ~wr_err;
+  assign bank0_info1_regwen_we = addr_hit[46] & reg_we & ~wr_err;
   assign bank0_info1_regwen_wd = reg_wdata[0];
 
-  assign bank0_info1_page_cfg_en_0_we = addr_hit[46] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_en_0_we = addr_hit[47] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_en_0_wd = reg_wdata[0];
 
-  assign bank0_info1_page_cfg_rd_en_0_we = addr_hit[46] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_rd_en_0_we = addr_hit[47] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info1_page_cfg_prog_en_0_we = addr_hit[46] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_prog_en_0_we = addr_hit[47] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info1_page_cfg_erase_en_0_we = addr_hit[46] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_erase_en_0_we = addr_hit[47] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info1_page_cfg_scramble_en_0_we = addr_hit[46] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_scramble_en_0_we = addr_hit[47] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info1_page_cfg_ecc_en_0_we = addr_hit[46] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_ecc_en_0_we = addr_hit[47] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info1_page_cfg_he_en_0_we = addr_hit[46] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_he_en_0_we = addr_hit[47] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_he_en_0_wd = reg_wdata[6];
 
-  assign bank0_info2_regwen_0_we = addr_hit[47] & reg_we & ~wr_err;
+  assign bank0_info2_regwen_0_we = addr_hit[48] & reg_we & ~wr_err;
   assign bank0_info2_regwen_0_wd = reg_wdata[0];
 
-  assign bank0_info2_regwen_1_we = addr_hit[48] & reg_we & ~wr_err;
+  assign bank0_info2_regwen_1_we = addr_hit[49] & reg_we & ~wr_err;
   assign bank0_info2_regwen_1_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_0_en_0_we = addr_hit[49] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_en_0_we = addr_hit[50] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_0_rd_en_0_we = addr_hit[49] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_rd_en_0_we = addr_hit[50] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info2_page_cfg_0_prog_en_0_we = addr_hit[49] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_prog_en_0_we = addr_hit[50] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info2_page_cfg_0_erase_en_0_we = addr_hit[49] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_erase_en_0_we = addr_hit[50] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info2_page_cfg_0_scramble_en_0_we = addr_hit[49] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_scramble_en_0_we = addr_hit[50] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info2_page_cfg_0_ecc_en_0_we = addr_hit[49] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_ecc_en_0_we = addr_hit[50] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info2_page_cfg_0_he_en_0_we = addr_hit[49] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_he_en_0_we = addr_hit[50] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign bank0_info2_page_cfg_1_en_1_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_en_1_we = addr_hit[51] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_1_rd_en_1_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_rd_en_1_we = addr_hit[51] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank0_info2_page_cfg_1_prog_en_1_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_prog_en_1_we = addr_hit[51] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank0_info2_page_cfg_1_erase_en_1_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_erase_en_1_we = addr_hit[51] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank0_info2_page_cfg_1_scramble_en_1_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_scramble_en_1_we = addr_hit[51] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank0_info2_page_cfg_1_ecc_en_1_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_ecc_en_1_we = addr_hit[51] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank0_info2_page_cfg_1_he_en_1_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_he_en_1_we = addr_hit[51] & reg_we & ~wr_err;
   assign bank0_info2_page_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign bank1_info0_regwen_0_we = addr_hit[51] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_0_we = addr_hit[52] & reg_we & ~wr_err;
   assign bank1_info0_regwen_0_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_1_we = addr_hit[52] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_1_we = addr_hit[53] & reg_we & ~wr_err;
   assign bank1_info0_regwen_1_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_2_we = addr_hit[53] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_2_we = addr_hit[54] & reg_we & ~wr_err;
   assign bank1_info0_regwen_2_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_3_we = addr_hit[54] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_3_we = addr_hit[55] & reg_we & ~wr_err;
   assign bank1_info0_regwen_3_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_4_we = addr_hit[55] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_4_we = addr_hit[56] & reg_we & ~wr_err;
   assign bank1_info0_regwen_4_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_5_we = addr_hit[56] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_5_we = addr_hit[57] & reg_we & ~wr_err;
   assign bank1_info0_regwen_5_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_6_we = addr_hit[57] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_6_we = addr_hit[58] & reg_we & ~wr_err;
   assign bank1_info0_regwen_6_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_7_we = addr_hit[58] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_7_we = addr_hit[59] & reg_we & ~wr_err;
   assign bank1_info0_regwen_7_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_8_we = addr_hit[59] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_8_we = addr_hit[60] & reg_we & ~wr_err;
   assign bank1_info0_regwen_8_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_9_we = addr_hit[60] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_9_we = addr_hit[61] & reg_we & ~wr_err;
   assign bank1_info0_regwen_9_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_0_en_0_we = addr_hit[61] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_en_0_we = addr_hit[62] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_0_rd_en_0_we = addr_hit[61] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_rd_en_0_we = addr_hit[62] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_0_prog_en_0_we = addr_hit[61] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_prog_en_0_we = addr_hit[62] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_0_erase_en_0_we = addr_hit[61] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_erase_en_0_we = addr_hit[62] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_0_scramble_en_0_we = addr_hit[61] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_scramble_en_0_we = addr_hit[62] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_0_ecc_en_0_we = addr_hit[61] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_ecc_en_0_we = addr_hit[62] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_0_he_en_0_we = addr_hit[61] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_he_en_0_we = addr_hit[62] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_1_en_1_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_en_1_we = addr_hit[63] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_1_rd_en_1_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_rd_en_1_we = addr_hit[63] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_1_prog_en_1_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_prog_en_1_we = addr_hit[63] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_1_erase_en_1_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_erase_en_1_we = addr_hit[63] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_1_scramble_en_1_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_scramble_en_1_we = addr_hit[63] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_1_ecc_en_1_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_ecc_en_1_we = addr_hit[63] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_1_he_en_1_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_he_en_1_we = addr_hit[63] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_2_en_2_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_en_2_we = addr_hit[64] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_2_rd_en_2_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_rd_en_2_we = addr_hit[64] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_2_prog_en_2_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_prog_en_2_we = addr_hit[64] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_2_erase_en_2_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_erase_en_2_we = addr_hit[64] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_2_scramble_en_2_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_scramble_en_2_we = addr_hit[64] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_2_ecc_en_2_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_ecc_en_2_we = addr_hit[64] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_2_he_en_2_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_he_en_2_we = addr_hit[64] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_he_en_2_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_3_en_3_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_en_3_we = addr_hit[65] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_3_rd_en_3_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_rd_en_3_we = addr_hit[65] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_3_prog_en_3_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_prog_en_3_we = addr_hit[65] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_3_erase_en_3_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_erase_en_3_we = addr_hit[65] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_3_scramble_en_3_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_scramble_en_3_we = addr_hit[65] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_3_ecc_en_3_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_ecc_en_3_we = addr_hit[65] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_3_he_en_3_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_he_en_3_we = addr_hit[65] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_he_en_3_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_4_en_4_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_en_4_we = addr_hit[66] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_4_rd_en_4_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_rd_en_4_we = addr_hit[66] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_4_prog_en_4_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_prog_en_4_we = addr_hit[66] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_4_erase_en_4_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_erase_en_4_we = addr_hit[66] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_4_scramble_en_4_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_scramble_en_4_we = addr_hit[66] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_4_ecc_en_4_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_ecc_en_4_we = addr_hit[66] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_4_he_en_4_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_he_en_4_we = addr_hit[66] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_4_he_en_4_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_5_en_5_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_en_5_we = addr_hit[67] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_5_rd_en_5_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_rd_en_5_we = addr_hit[67] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_5_prog_en_5_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_prog_en_5_we = addr_hit[67] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_5_erase_en_5_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_erase_en_5_we = addr_hit[67] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_5_scramble_en_5_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_scramble_en_5_we = addr_hit[67] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_5_ecc_en_5_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_ecc_en_5_we = addr_hit[67] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_5_he_en_5_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_he_en_5_we = addr_hit[67] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_5_he_en_5_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_6_en_6_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_en_6_we = addr_hit[68] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_6_rd_en_6_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_rd_en_6_we = addr_hit[68] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_6_prog_en_6_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_prog_en_6_we = addr_hit[68] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_6_erase_en_6_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_erase_en_6_we = addr_hit[68] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_6_scramble_en_6_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_scramble_en_6_we = addr_hit[68] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_6_ecc_en_6_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_ecc_en_6_we = addr_hit[68] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_6_he_en_6_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_he_en_6_we = addr_hit[68] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_6_he_en_6_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_7_en_7_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_en_7_we = addr_hit[69] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_7_rd_en_7_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_rd_en_7_we = addr_hit[69] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_7_prog_en_7_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_prog_en_7_we = addr_hit[69] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_7_erase_en_7_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_erase_en_7_we = addr_hit[69] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_7_scramble_en_7_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_scramble_en_7_we = addr_hit[69] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_7_ecc_en_7_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_ecc_en_7_we = addr_hit[69] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_7_he_en_7_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_he_en_7_we = addr_hit[69] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_7_he_en_7_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_8_en_8_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_en_8_we = addr_hit[70] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_8_en_8_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_8_rd_en_8_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_rd_en_8_we = addr_hit[70] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_8_rd_en_8_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_8_prog_en_8_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_prog_en_8_we = addr_hit[70] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_8_prog_en_8_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_8_erase_en_8_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_erase_en_8_we = addr_hit[70] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_8_erase_en_8_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_8_scramble_en_8_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_scramble_en_8_we = addr_hit[70] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_8_scramble_en_8_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_8_ecc_en_8_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_ecc_en_8_we = addr_hit[70] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_8_ecc_en_8_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_8_he_en_8_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_he_en_8_we = addr_hit[70] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_8_he_en_8_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_9_en_9_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_en_9_we = addr_hit[71] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_9_en_9_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_9_rd_en_9_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_rd_en_9_we = addr_hit[71] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_9_rd_en_9_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_9_prog_en_9_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_prog_en_9_we = addr_hit[71] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_9_prog_en_9_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_9_erase_en_9_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_erase_en_9_we = addr_hit[71] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_9_erase_en_9_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_9_scramble_en_9_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_scramble_en_9_we = addr_hit[71] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_9_scramble_en_9_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_9_ecc_en_9_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_ecc_en_9_we = addr_hit[71] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_9_ecc_en_9_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_9_he_en_9_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_he_en_9_we = addr_hit[71] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_9_he_en_9_wd = reg_wdata[6];
 
-  assign bank1_info1_regwen_we = addr_hit[71] & reg_we & ~wr_err;
+  assign bank1_info1_regwen_we = addr_hit[72] & reg_we & ~wr_err;
   assign bank1_info1_regwen_wd = reg_wdata[0];
 
-  assign bank1_info1_page_cfg_en_0_we = addr_hit[72] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_en_0_we = addr_hit[73] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_en_0_wd = reg_wdata[0];
 
-  assign bank1_info1_page_cfg_rd_en_0_we = addr_hit[72] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_rd_en_0_we = addr_hit[73] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info1_page_cfg_prog_en_0_we = addr_hit[72] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_prog_en_0_we = addr_hit[73] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info1_page_cfg_erase_en_0_we = addr_hit[72] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_erase_en_0_we = addr_hit[73] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info1_page_cfg_scramble_en_0_we = addr_hit[72] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_scramble_en_0_we = addr_hit[73] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info1_page_cfg_ecc_en_0_we = addr_hit[72] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_ecc_en_0_we = addr_hit[73] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info1_page_cfg_he_en_0_we = addr_hit[72] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_he_en_0_we = addr_hit[73] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_he_en_0_wd = reg_wdata[6];
 
-  assign bank1_info2_regwen_0_we = addr_hit[73] & reg_we & ~wr_err;
+  assign bank1_info2_regwen_0_we = addr_hit[74] & reg_we & ~wr_err;
   assign bank1_info2_regwen_0_wd = reg_wdata[0];
 
-  assign bank1_info2_regwen_1_we = addr_hit[74] & reg_we & ~wr_err;
+  assign bank1_info2_regwen_1_we = addr_hit[75] & reg_we & ~wr_err;
   assign bank1_info2_regwen_1_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_0_en_0_we = addr_hit[75] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_en_0_we = addr_hit[76] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_0_rd_en_0_we = addr_hit[75] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_rd_en_0_we = addr_hit[76] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info2_page_cfg_0_prog_en_0_we = addr_hit[75] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_prog_en_0_we = addr_hit[76] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info2_page_cfg_0_erase_en_0_we = addr_hit[75] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_erase_en_0_we = addr_hit[76] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info2_page_cfg_0_scramble_en_0_we = addr_hit[75] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_scramble_en_0_we = addr_hit[76] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info2_page_cfg_0_ecc_en_0_we = addr_hit[75] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_ecc_en_0_we = addr_hit[76] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info2_page_cfg_0_he_en_0_we = addr_hit[75] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_he_en_0_we = addr_hit[76] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign bank1_info2_page_cfg_1_en_1_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_en_1_we = addr_hit[77] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_1_rd_en_1_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_rd_en_1_we = addr_hit[77] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank1_info2_page_cfg_1_prog_en_1_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_prog_en_1_we = addr_hit[77] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank1_info2_page_cfg_1_erase_en_1_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_erase_en_1_we = addr_hit[77] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank1_info2_page_cfg_1_scramble_en_1_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_scramble_en_1_we = addr_hit[77] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank1_info2_page_cfg_1_ecc_en_1_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_ecc_en_1_we = addr_hit[77] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank1_info2_page_cfg_1_he_en_1_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_he_en_1_we = addr_hit[77] & reg_we & ~wr_err;
   assign bank1_info2_page_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign bank_cfg_regwen_we = addr_hit[77] & reg_we & ~wr_err;
+  assign bank_cfg_regwen_we = addr_hit[78] & reg_we & ~wr_err;
   assign bank_cfg_regwen_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en_0_we = addr_hit[78] & reg_we & ~wr_err;
+  assign mp_bank_cfg_erase_en_0_we = addr_hit[79] & reg_we & ~wr_err;
   assign mp_bank_cfg_erase_en_0_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en_1_we = addr_hit[78] & reg_we & ~wr_err;
+  assign mp_bank_cfg_erase_en_1_we = addr_hit[79] & reg_we & ~wr_err;
   assign mp_bank_cfg_erase_en_1_wd = reg_wdata[1];
 
-  assign op_status_done_we = addr_hit[79] & reg_we & ~wr_err;
+  assign op_status_done_we = addr_hit[80] & reg_we & ~wr_err;
   assign op_status_done_wd = reg_wdata[0];
 
-  assign op_status_err_we = addr_hit[79] & reg_we & ~wr_err;
+  assign op_status_err_we = addr_hit[80] & reg_we & ~wr_err;
   assign op_status_err_wd = reg_wdata[1];
 
 
@@ -11305,20 +11559,43 @@ module flash_ctrl_reg_top (
 
 
 
+  assign err_code_flash_err_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_flash_err_wd = reg_wdata[0];
+
+  assign err_code_flash_alert_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_flash_alert_wd = reg_wdata[1];
+
+  assign err_code_mp_err_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_mp_err_wd = reg_wdata[2];
+
+  assign err_code_ecc_single_err_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_ecc_single_err_wd = reg_wdata[3];
+
+  assign err_code_ecc_multi_err_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_ecc_multi_err_wd = reg_wdata[4];
 
 
 
 
-  assign scratch_we = addr_hit[82] & reg_we & ~wr_err;
+  assign phy_alert_cfg_alert_ack_we = addr_hit[86] & reg_we & ~wr_err;
+  assign phy_alert_cfg_alert_ack_wd = reg_wdata[0];
+
+  assign phy_alert_cfg_alert_trig_we = addr_hit[86] & reg_we & ~wr_err;
+  assign phy_alert_cfg_alert_trig_wd = reg_wdata[1];
+
+
+
+
+  assign scratch_we = addr_hit[88] & reg_we & ~wr_err;
   assign scratch_wd = reg_wdata[31:0];
 
-  assign fifo_lvl_prog_we = addr_hit[83] & reg_we & ~wr_err;
+  assign fifo_lvl_prog_we = addr_hit[89] & reg_we & ~wr_err;
   assign fifo_lvl_prog_wd = reg_wdata[4:0];
 
-  assign fifo_lvl_rd_we = addr_hit[83] & reg_we & ~wr_err;
+  assign fifo_lvl_rd_we = addr_hit[89] & reg_we & ~wr_err;
   assign fifo_lvl_rd_wd = reg_wdata[12:8];
 
-  assign fifo_rst_we = addr_hit[84] & reg_we & ~wr_err;
+  assign fifo_rst_we = addr_hit[90] & reg_we & ~wr_err;
   assign fifo_rst_wd = reg_wdata[0];
 
   // Read data return
@@ -11331,7 +11608,6 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = intr_state_rd_full_qs;
         reg_rdata_next[3] = intr_state_rd_lvl_qs;
         reg_rdata_next[4] = intr_state_op_done_qs;
-        reg_rdata_next[5] = intr_state_op_error_qs;
       end
 
       addr_hit[1]: begin
@@ -11340,7 +11616,6 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = intr_enable_rd_full_qs;
         reg_rdata_next[3] = intr_enable_rd_lvl_qs;
         reg_rdata_next[4] = intr_enable_op_done_qs;
-        reg_rdata_next[5] = intr_enable_op_error_qs;
       end
 
       addr_hit[2]: begin
@@ -11349,14 +11624,19 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = '0;
         reg_rdata_next[3] = '0;
         reg_rdata_next[4] = '0;
-        reg_rdata_next[5] = '0;
       end
 
       addr_hit[3]: begin
-        reg_rdata_next[0] = ctrl_regwen_qs;
+        reg_rdata_next[0] = '0;
+        reg_rdata_next[1] = '0;
+        reg_rdata_next[2] = '0;
       end
 
       addr_hit[4]: begin
+        reg_rdata_next[0] = ctrl_regwen_qs;
+      end
+
+      addr_hit[5]: begin
         reg_rdata_next[0] = control_start_qs;
         reg_rdata_next[5:4] = control_op_qs;
         reg_rdata_next[6] = control_prog_sel_qs;
@@ -11366,52 +11646,52 @@ module flash_ctrl_reg_top (
         reg_rdata_next[27:16] = control_num_qs;
       end
 
-      addr_hit[5]: begin
+      addr_hit[6]: begin
         reg_rdata_next[31:0] = addr_qs;
       end
 
-      addr_hit[6]: begin
+      addr_hit[7]: begin
         reg_rdata_next[0] = prog_type_en_normal_qs;
         reg_rdata_next[1] = prog_type_en_repair_qs;
       end
 
-      addr_hit[7]: begin
+      addr_hit[8]: begin
         reg_rdata_next[0] = erase_suspend_qs;
       end
 
-      addr_hit[8]: begin
+      addr_hit[9]: begin
         reg_rdata_next[0] = region_cfg_regwen_0_qs;
       end
 
-      addr_hit[9]: begin
+      addr_hit[10]: begin
         reg_rdata_next[0] = region_cfg_regwen_1_qs;
       end
 
-      addr_hit[10]: begin
+      addr_hit[11]: begin
         reg_rdata_next[0] = region_cfg_regwen_2_qs;
       end
 
-      addr_hit[11]: begin
+      addr_hit[12]: begin
         reg_rdata_next[0] = region_cfg_regwen_3_qs;
       end
 
-      addr_hit[12]: begin
+      addr_hit[13]: begin
         reg_rdata_next[0] = region_cfg_regwen_4_qs;
       end
 
-      addr_hit[13]: begin
+      addr_hit[14]: begin
         reg_rdata_next[0] = region_cfg_regwen_5_qs;
       end
 
-      addr_hit[14]: begin
+      addr_hit[15]: begin
         reg_rdata_next[0] = region_cfg_regwen_6_qs;
       end
 
-      addr_hit[15]: begin
+      addr_hit[16]: begin
         reg_rdata_next[0] = region_cfg_regwen_7_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[17]: begin
         reg_rdata_next[0] = mp_region_cfg_0_en_0_qs;
         reg_rdata_next[1] = mp_region_cfg_0_rd_en_0_qs;
         reg_rdata_next[2] = mp_region_cfg_0_prog_en_0_qs;
@@ -11423,7 +11703,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[26:17] = mp_region_cfg_0_size_0_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[18]: begin
         reg_rdata_next[0] = mp_region_cfg_1_en_1_qs;
         reg_rdata_next[1] = mp_region_cfg_1_rd_en_1_qs;
         reg_rdata_next[2] = mp_region_cfg_1_prog_en_1_qs;
@@ -11435,7 +11715,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[26:17] = mp_region_cfg_1_size_1_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[19]: begin
         reg_rdata_next[0] = mp_region_cfg_2_en_2_qs;
         reg_rdata_next[1] = mp_region_cfg_2_rd_en_2_qs;
         reg_rdata_next[2] = mp_region_cfg_2_prog_en_2_qs;
@@ -11447,7 +11727,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[26:17] = mp_region_cfg_2_size_2_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[20]: begin
         reg_rdata_next[0] = mp_region_cfg_3_en_3_qs;
         reg_rdata_next[1] = mp_region_cfg_3_rd_en_3_qs;
         reg_rdata_next[2] = mp_region_cfg_3_prog_en_3_qs;
@@ -11459,7 +11739,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[26:17] = mp_region_cfg_3_size_3_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[21]: begin
         reg_rdata_next[0] = mp_region_cfg_4_en_4_qs;
         reg_rdata_next[1] = mp_region_cfg_4_rd_en_4_qs;
         reg_rdata_next[2] = mp_region_cfg_4_prog_en_4_qs;
@@ -11471,7 +11751,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[26:17] = mp_region_cfg_4_size_4_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[22]: begin
         reg_rdata_next[0] = mp_region_cfg_5_en_5_qs;
         reg_rdata_next[1] = mp_region_cfg_5_rd_en_5_qs;
         reg_rdata_next[2] = mp_region_cfg_5_prog_en_5_qs;
@@ -11483,7 +11763,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[26:17] = mp_region_cfg_5_size_5_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[23]: begin
         reg_rdata_next[0] = mp_region_cfg_6_en_6_qs;
         reg_rdata_next[1] = mp_region_cfg_6_rd_en_6_qs;
         reg_rdata_next[2] = mp_region_cfg_6_prog_en_6_qs;
@@ -11495,7 +11775,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[26:17] = mp_region_cfg_6_size_6_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[24]: begin
         reg_rdata_next[0] = mp_region_cfg_7_en_7_qs;
         reg_rdata_next[1] = mp_region_cfg_7_rd_en_7_qs;
         reg_rdata_next[2] = mp_region_cfg_7_prog_en_7_qs;
@@ -11507,7 +11787,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[26:17] = mp_region_cfg_7_size_7_qs;
       end
 
-      addr_hit[24]: begin
+      addr_hit[25]: begin
         reg_rdata_next[0] = default_region_rd_en_qs;
         reg_rdata_next[1] = default_region_prog_en_qs;
         reg_rdata_next[2] = default_region_erase_en_qs;
@@ -11516,47 +11796,47 @@ module flash_ctrl_reg_top (
         reg_rdata_next[5] = default_region_he_en_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[26]: begin
         reg_rdata_next[0] = bank0_info0_regwen_0_qs;
       end
 
-      addr_hit[26]: begin
+      addr_hit[27]: begin
         reg_rdata_next[0] = bank0_info0_regwen_1_qs;
       end
 
-      addr_hit[27]: begin
+      addr_hit[28]: begin
         reg_rdata_next[0] = bank0_info0_regwen_2_qs;
       end
 
-      addr_hit[28]: begin
+      addr_hit[29]: begin
         reg_rdata_next[0] = bank0_info0_regwen_3_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[30]: begin
         reg_rdata_next[0] = bank0_info0_regwen_4_qs;
       end
 
-      addr_hit[30]: begin
+      addr_hit[31]: begin
         reg_rdata_next[0] = bank0_info0_regwen_5_qs;
       end
 
-      addr_hit[31]: begin
+      addr_hit[32]: begin
         reg_rdata_next[0] = bank0_info0_regwen_6_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[33]: begin
         reg_rdata_next[0] = bank0_info0_regwen_7_qs;
       end
 
-      addr_hit[33]: begin
+      addr_hit[34]: begin
         reg_rdata_next[0] = bank0_info0_regwen_8_qs;
       end
 
-      addr_hit[34]: begin
+      addr_hit[35]: begin
         reg_rdata_next[0] = bank0_info0_regwen_9_qs;
       end
 
-      addr_hit[35]: begin
+      addr_hit[36]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_0_en_0_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_0_rd_en_0_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_0_prog_en_0_qs;
@@ -11566,7 +11846,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_0_he_en_0_qs;
       end
 
-      addr_hit[36]: begin
+      addr_hit[37]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_1_en_1_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_1_rd_en_1_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_1_prog_en_1_qs;
@@ -11576,7 +11856,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_1_he_en_1_qs;
       end
 
-      addr_hit[37]: begin
+      addr_hit[38]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_2_en_2_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_2_rd_en_2_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_2_prog_en_2_qs;
@@ -11586,7 +11866,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_2_he_en_2_qs;
       end
 
-      addr_hit[38]: begin
+      addr_hit[39]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_3_en_3_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_3_rd_en_3_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_3_prog_en_3_qs;
@@ -11596,7 +11876,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_3_he_en_3_qs;
       end
 
-      addr_hit[39]: begin
+      addr_hit[40]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_4_en_4_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_4_rd_en_4_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_4_prog_en_4_qs;
@@ -11606,7 +11886,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_4_he_en_4_qs;
       end
 
-      addr_hit[40]: begin
+      addr_hit[41]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_5_en_5_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_5_rd_en_5_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_5_prog_en_5_qs;
@@ -11616,7 +11896,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_5_he_en_5_qs;
       end
 
-      addr_hit[41]: begin
+      addr_hit[42]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_6_en_6_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_6_rd_en_6_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_6_prog_en_6_qs;
@@ -11626,7 +11906,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_6_he_en_6_qs;
       end
 
-      addr_hit[42]: begin
+      addr_hit[43]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_7_en_7_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_7_rd_en_7_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_7_prog_en_7_qs;
@@ -11636,7 +11916,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_7_he_en_7_qs;
       end
 
-      addr_hit[43]: begin
+      addr_hit[44]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_8_en_8_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_8_rd_en_8_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_8_prog_en_8_qs;
@@ -11646,7 +11926,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_8_he_en_8_qs;
       end
 
-      addr_hit[44]: begin
+      addr_hit[45]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_9_en_9_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_9_rd_en_9_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_9_prog_en_9_qs;
@@ -11656,11 +11936,11 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info0_page_cfg_9_he_en_9_qs;
       end
 
-      addr_hit[45]: begin
+      addr_hit[46]: begin
         reg_rdata_next[0] = bank0_info1_regwen_qs;
       end
 
-      addr_hit[46]: begin
+      addr_hit[47]: begin
         reg_rdata_next[0] = bank0_info1_page_cfg_en_0_qs;
         reg_rdata_next[1] = bank0_info1_page_cfg_rd_en_0_qs;
         reg_rdata_next[2] = bank0_info1_page_cfg_prog_en_0_qs;
@@ -11670,15 +11950,15 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info1_page_cfg_he_en_0_qs;
       end
 
-      addr_hit[47]: begin
+      addr_hit[48]: begin
         reg_rdata_next[0] = bank0_info2_regwen_0_qs;
       end
 
-      addr_hit[48]: begin
+      addr_hit[49]: begin
         reg_rdata_next[0] = bank0_info2_regwen_1_qs;
       end
 
-      addr_hit[49]: begin
+      addr_hit[50]: begin
         reg_rdata_next[0] = bank0_info2_page_cfg_0_en_0_qs;
         reg_rdata_next[1] = bank0_info2_page_cfg_0_rd_en_0_qs;
         reg_rdata_next[2] = bank0_info2_page_cfg_0_prog_en_0_qs;
@@ -11688,7 +11968,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info2_page_cfg_0_he_en_0_qs;
       end
 
-      addr_hit[50]: begin
+      addr_hit[51]: begin
         reg_rdata_next[0] = bank0_info2_page_cfg_1_en_1_qs;
         reg_rdata_next[1] = bank0_info2_page_cfg_1_rd_en_1_qs;
         reg_rdata_next[2] = bank0_info2_page_cfg_1_prog_en_1_qs;
@@ -11698,47 +11978,47 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank0_info2_page_cfg_1_he_en_1_qs;
       end
 
-      addr_hit[51]: begin
+      addr_hit[52]: begin
         reg_rdata_next[0] = bank1_info0_regwen_0_qs;
       end
 
-      addr_hit[52]: begin
+      addr_hit[53]: begin
         reg_rdata_next[0] = bank1_info0_regwen_1_qs;
       end
 
-      addr_hit[53]: begin
+      addr_hit[54]: begin
         reg_rdata_next[0] = bank1_info0_regwen_2_qs;
       end
 
-      addr_hit[54]: begin
+      addr_hit[55]: begin
         reg_rdata_next[0] = bank1_info0_regwen_3_qs;
       end
 
-      addr_hit[55]: begin
+      addr_hit[56]: begin
         reg_rdata_next[0] = bank1_info0_regwen_4_qs;
       end
 
-      addr_hit[56]: begin
+      addr_hit[57]: begin
         reg_rdata_next[0] = bank1_info0_regwen_5_qs;
       end
 
-      addr_hit[57]: begin
+      addr_hit[58]: begin
         reg_rdata_next[0] = bank1_info0_regwen_6_qs;
       end
 
-      addr_hit[58]: begin
+      addr_hit[59]: begin
         reg_rdata_next[0] = bank1_info0_regwen_7_qs;
       end
 
-      addr_hit[59]: begin
+      addr_hit[60]: begin
         reg_rdata_next[0] = bank1_info0_regwen_8_qs;
       end
 
-      addr_hit[60]: begin
+      addr_hit[61]: begin
         reg_rdata_next[0] = bank1_info0_regwen_9_qs;
       end
 
-      addr_hit[61]: begin
+      addr_hit[62]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_0_en_0_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_0_rd_en_0_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_0_prog_en_0_qs;
@@ -11748,7 +12028,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_0_he_en_0_qs;
       end
 
-      addr_hit[62]: begin
+      addr_hit[63]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_1_en_1_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_1_rd_en_1_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_1_prog_en_1_qs;
@@ -11758,7 +12038,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_1_he_en_1_qs;
       end
 
-      addr_hit[63]: begin
+      addr_hit[64]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_2_en_2_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_2_rd_en_2_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_2_prog_en_2_qs;
@@ -11768,7 +12048,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_2_he_en_2_qs;
       end
 
-      addr_hit[64]: begin
+      addr_hit[65]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_3_en_3_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_3_rd_en_3_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_3_prog_en_3_qs;
@@ -11778,7 +12058,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_3_he_en_3_qs;
       end
 
-      addr_hit[65]: begin
+      addr_hit[66]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_4_en_4_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_4_rd_en_4_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_4_prog_en_4_qs;
@@ -11788,7 +12068,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_4_he_en_4_qs;
       end
 
-      addr_hit[66]: begin
+      addr_hit[67]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_5_en_5_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_5_rd_en_5_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_5_prog_en_5_qs;
@@ -11798,7 +12078,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_5_he_en_5_qs;
       end
 
-      addr_hit[67]: begin
+      addr_hit[68]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_6_en_6_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_6_rd_en_6_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_6_prog_en_6_qs;
@@ -11808,7 +12088,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_6_he_en_6_qs;
       end
 
-      addr_hit[68]: begin
+      addr_hit[69]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_7_en_7_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_7_rd_en_7_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_7_prog_en_7_qs;
@@ -11818,7 +12098,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_7_he_en_7_qs;
       end
 
-      addr_hit[69]: begin
+      addr_hit[70]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_8_en_8_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_8_rd_en_8_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_8_prog_en_8_qs;
@@ -11828,7 +12108,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_8_he_en_8_qs;
       end
 
-      addr_hit[70]: begin
+      addr_hit[71]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_9_en_9_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_9_rd_en_9_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_9_prog_en_9_qs;
@@ -11838,11 +12118,11 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info0_page_cfg_9_he_en_9_qs;
       end
 
-      addr_hit[71]: begin
+      addr_hit[72]: begin
         reg_rdata_next[0] = bank1_info1_regwen_qs;
       end
 
-      addr_hit[72]: begin
+      addr_hit[73]: begin
         reg_rdata_next[0] = bank1_info1_page_cfg_en_0_qs;
         reg_rdata_next[1] = bank1_info1_page_cfg_rd_en_0_qs;
         reg_rdata_next[2] = bank1_info1_page_cfg_prog_en_0_qs;
@@ -11852,15 +12132,15 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info1_page_cfg_he_en_0_qs;
       end
 
-      addr_hit[73]: begin
+      addr_hit[74]: begin
         reg_rdata_next[0] = bank1_info2_regwen_0_qs;
       end
 
-      addr_hit[74]: begin
+      addr_hit[75]: begin
         reg_rdata_next[0] = bank1_info2_regwen_1_qs;
       end
 
-      addr_hit[75]: begin
+      addr_hit[76]: begin
         reg_rdata_next[0] = bank1_info2_page_cfg_0_en_0_qs;
         reg_rdata_next[1] = bank1_info2_page_cfg_0_rd_en_0_qs;
         reg_rdata_next[2] = bank1_info2_page_cfg_0_prog_en_0_qs;
@@ -11870,7 +12150,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info2_page_cfg_0_he_en_0_qs;
       end
 
-      addr_hit[76]: begin
+      addr_hit[77]: begin
         reg_rdata_next[0] = bank1_info2_page_cfg_1_en_1_qs;
         reg_rdata_next[1] = bank1_info2_page_cfg_1_rd_en_1_qs;
         reg_rdata_next[2] = bank1_info2_page_cfg_1_prog_en_1_qs;
@@ -11880,45 +12160,69 @@ module flash_ctrl_reg_top (
         reg_rdata_next[6] = bank1_info2_page_cfg_1_he_en_1_qs;
       end
 
-      addr_hit[77]: begin
+      addr_hit[78]: begin
         reg_rdata_next[0] = bank_cfg_regwen_qs;
       end
 
-      addr_hit[78]: begin
+      addr_hit[79]: begin
         reg_rdata_next[0] = mp_bank_cfg_erase_en_0_qs;
         reg_rdata_next[1] = mp_bank_cfg_erase_en_1_qs;
       end
 
-      addr_hit[79]: begin
+      addr_hit[80]: begin
         reg_rdata_next[0] = op_status_done_qs;
         reg_rdata_next[1] = op_status_err_qs;
       end
 
-      addr_hit[80]: begin
+      addr_hit[81]: begin
         reg_rdata_next[0] = status_rd_full_qs;
         reg_rdata_next[1] = status_rd_empty_qs;
         reg_rdata_next[2] = status_prog_full_qs;
         reg_rdata_next[3] = status_prog_empty_qs;
         reg_rdata_next[4] = status_init_wip_qs;
-        reg_rdata_next[16:8] = status_error_addr_qs;
       end
 
-      addr_hit[81]: begin
+      addr_hit[82]: begin
+        reg_rdata_next[0] = err_code_flash_err_qs;
+        reg_rdata_next[1] = err_code_flash_alert_qs;
+        reg_rdata_next[2] = err_code_mp_err_qs;
+        reg_rdata_next[3] = err_code_ecc_single_err_qs;
+        reg_rdata_next[4] = err_code_ecc_multi_err_qs;
+      end
+
+      addr_hit[83]: begin
+        reg_rdata_next[8:0] = err_addr_qs;
+      end
+
+      addr_hit[84]: begin
+        reg_rdata_next[19:0] = ecc_err_addr_0_qs;
+      end
+
+      addr_hit[85]: begin
+        reg_rdata_next[19:0] = ecc_err_addr_1_qs;
+      end
+
+      addr_hit[86]: begin
+        reg_rdata_next[0] = phy_alert_cfg_alert_ack_qs;
+        reg_rdata_next[1] = phy_alert_cfg_alert_trig_qs;
+      end
+
+      addr_hit[87]: begin
         reg_rdata_next[0] = phy_status_init_wip_qs;
         reg_rdata_next[1] = phy_status_prog_normal_avail_qs;
         reg_rdata_next[2] = phy_status_prog_repair_avail_qs;
       end
 
-      addr_hit[82]: begin
+      addr_hit[88]: begin
         reg_rdata_next[31:0] = scratch_qs;
       end
 
-      addr_hit[83]: begin
+      addr_hit[89]: begin
         reg_rdata_next[4:0] = fifo_lvl_prog_qs;
         reg_rdata_next[12:8] = fifo_lvl_rd_qs;
       end
 
-      addr_hit[84]: begin
+      addr_hit[90]: begin
         reg_rdata_next[0] = fifo_rst_qs;
       end
 

--- a/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
+++ b/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
@@ -25,7 +25,7 @@
     { name: "NumSrc",
       desc: "Number of interrupt sources",
       type: "int",
-      default: "123",
+      default: "122",
       local: "true"
     },
     { name: "NumTarget",
@@ -1039,14 +1039,6 @@
     }
     { name: "PRIO121",
       desc: "Interrupt Source 121 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO122",
-      desc: "Interrupt Source 122 Priority",
       swaccess: "rw",
       hwaccess: "hro",
       fields: [

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
@@ -216,12 +216,11 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   assign prio[119] = reg2hw.prio119.q;
   assign prio[120] = reg2hw.prio120.q;
   assign prio[121] = reg2hw.prio121.q;
-  assign prio[122] = reg2hw.prio122.q;
 
   //////////////////////
   // Interrupt Enable //
   //////////////////////
-  for (genvar s = 0; s < 123; s++) begin : gen_ie0
+  for (genvar s = 0; s < 122; s++) begin : gen_ie0
     assign ie[0][s] = reg2hw.ie0[s].q;
   end
 
@@ -247,7 +246,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ////////
   // IP //
   ////////
-  for (genvar s = 0; s < 123; s++) begin : gen_ip
+  for (genvar s = 0; s < 122; s++) begin : gen_ip
     assign hw2reg.ip[s].de = 1'b1; // Always write
     assign hw2reg.ip[s].d  = ip[s];
   end
@@ -255,7 +254,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ///////////////////////////////////
   // Detection:: 0: Level, 1: Edge //
   ///////////////////////////////////
-  for (genvar s = 0; s < 123; s++) begin : gen_le
+  for (genvar s = 0; s < 122; s++) begin : gen_le
     assign le[s] = reg2hw.le[s].q;
   end
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
@@ -7,7 +7,7 @@
 package rv_plic_reg_pkg;
 
   // Param list
-  parameter int NumSrc = 123;
+  parameter int NumSrc = 122;
   parameter int NumTarget = 1;
   parameter int PrioWidth = 2;
 
@@ -510,10 +510,6 @@ package rv_plic_reg_pkg;
   } rv_plic_reg2hw_prio121_reg_t;
 
   typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio122_reg_t;
-
-  typedef struct packed {
     logic        q;
   } rv_plic_reg2hw_ie0_mreg_t;
 
@@ -546,131 +542,130 @@ package rv_plic_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_plic_reg2hw_le_mreg_t [122:0] le; // [503:381]
-    rv_plic_reg2hw_prio0_reg_t prio0; // [380:379]
-    rv_plic_reg2hw_prio1_reg_t prio1; // [378:377]
-    rv_plic_reg2hw_prio2_reg_t prio2; // [376:375]
-    rv_plic_reg2hw_prio3_reg_t prio3; // [374:373]
-    rv_plic_reg2hw_prio4_reg_t prio4; // [372:371]
-    rv_plic_reg2hw_prio5_reg_t prio5; // [370:369]
-    rv_plic_reg2hw_prio6_reg_t prio6; // [368:367]
-    rv_plic_reg2hw_prio7_reg_t prio7; // [366:365]
-    rv_plic_reg2hw_prio8_reg_t prio8; // [364:363]
-    rv_plic_reg2hw_prio9_reg_t prio9; // [362:361]
-    rv_plic_reg2hw_prio10_reg_t prio10; // [360:359]
-    rv_plic_reg2hw_prio11_reg_t prio11; // [358:357]
-    rv_plic_reg2hw_prio12_reg_t prio12; // [356:355]
-    rv_plic_reg2hw_prio13_reg_t prio13; // [354:353]
-    rv_plic_reg2hw_prio14_reg_t prio14; // [352:351]
-    rv_plic_reg2hw_prio15_reg_t prio15; // [350:349]
-    rv_plic_reg2hw_prio16_reg_t prio16; // [348:347]
-    rv_plic_reg2hw_prio17_reg_t prio17; // [346:345]
-    rv_plic_reg2hw_prio18_reg_t prio18; // [344:343]
-    rv_plic_reg2hw_prio19_reg_t prio19; // [342:341]
-    rv_plic_reg2hw_prio20_reg_t prio20; // [340:339]
-    rv_plic_reg2hw_prio21_reg_t prio21; // [338:337]
-    rv_plic_reg2hw_prio22_reg_t prio22; // [336:335]
-    rv_plic_reg2hw_prio23_reg_t prio23; // [334:333]
-    rv_plic_reg2hw_prio24_reg_t prio24; // [332:331]
-    rv_plic_reg2hw_prio25_reg_t prio25; // [330:329]
-    rv_plic_reg2hw_prio26_reg_t prio26; // [328:327]
-    rv_plic_reg2hw_prio27_reg_t prio27; // [326:325]
-    rv_plic_reg2hw_prio28_reg_t prio28; // [324:323]
-    rv_plic_reg2hw_prio29_reg_t prio29; // [322:321]
-    rv_plic_reg2hw_prio30_reg_t prio30; // [320:319]
-    rv_plic_reg2hw_prio31_reg_t prio31; // [318:317]
-    rv_plic_reg2hw_prio32_reg_t prio32; // [316:315]
-    rv_plic_reg2hw_prio33_reg_t prio33; // [314:313]
-    rv_plic_reg2hw_prio34_reg_t prio34; // [312:311]
-    rv_plic_reg2hw_prio35_reg_t prio35; // [310:309]
-    rv_plic_reg2hw_prio36_reg_t prio36; // [308:307]
-    rv_plic_reg2hw_prio37_reg_t prio37; // [306:305]
-    rv_plic_reg2hw_prio38_reg_t prio38; // [304:303]
-    rv_plic_reg2hw_prio39_reg_t prio39; // [302:301]
-    rv_plic_reg2hw_prio40_reg_t prio40; // [300:299]
-    rv_plic_reg2hw_prio41_reg_t prio41; // [298:297]
-    rv_plic_reg2hw_prio42_reg_t prio42; // [296:295]
-    rv_plic_reg2hw_prio43_reg_t prio43; // [294:293]
-    rv_plic_reg2hw_prio44_reg_t prio44; // [292:291]
-    rv_plic_reg2hw_prio45_reg_t prio45; // [290:289]
-    rv_plic_reg2hw_prio46_reg_t prio46; // [288:287]
-    rv_plic_reg2hw_prio47_reg_t prio47; // [286:285]
-    rv_plic_reg2hw_prio48_reg_t prio48; // [284:283]
-    rv_plic_reg2hw_prio49_reg_t prio49; // [282:281]
-    rv_plic_reg2hw_prio50_reg_t prio50; // [280:279]
-    rv_plic_reg2hw_prio51_reg_t prio51; // [278:277]
-    rv_plic_reg2hw_prio52_reg_t prio52; // [276:275]
-    rv_plic_reg2hw_prio53_reg_t prio53; // [274:273]
-    rv_plic_reg2hw_prio54_reg_t prio54; // [272:271]
-    rv_plic_reg2hw_prio55_reg_t prio55; // [270:269]
-    rv_plic_reg2hw_prio56_reg_t prio56; // [268:267]
-    rv_plic_reg2hw_prio57_reg_t prio57; // [266:265]
-    rv_plic_reg2hw_prio58_reg_t prio58; // [264:263]
-    rv_plic_reg2hw_prio59_reg_t prio59; // [262:261]
-    rv_plic_reg2hw_prio60_reg_t prio60; // [260:259]
-    rv_plic_reg2hw_prio61_reg_t prio61; // [258:257]
-    rv_plic_reg2hw_prio62_reg_t prio62; // [256:255]
-    rv_plic_reg2hw_prio63_reg_t prio63; // [254:253]
-    rv_plic_reg2hw_prio64_reg_t prio64; // [252:251]
-    rv_plic_reg2hw_prio65_reg_t prio65; // [250:249]
-    rv_plic_reg2hw_prio66_reg_t prio66; // [248:247]
-    rv_plic_reg2hw_prio67_reg_t prio67; // [246:245]
-    rv_plic_reg2hw_prio68_reg_t prio68; // [244:243]
-    rv_plic_reg2hw_prio69_reg_t prio69; // [242:241]
-    rv_plic_reg2hw_prio70_reg_t prio70; // [240:239]
-    rv_plic_reg2hw_prio71_reg_t prio71; // [238:237]
-    rv_plic_reg2hw_prio72_reg_t prio72; // [236:235]
-    rv_plic_reg2hw_prio73_reg_t prio73; // [234:233]
-    rv_plic_reg2hw_prio74_reg_t prio74; // [232:231]
-    rv_plic_reg2hw_prio75_reg_t prio75; // [230:229]
-    rv_plic_reg2hw_prio76_reg_t prio76; // [228:227]
-    rv_plic_reg2hw_prio77_reg_t prio77; // [226:225]
-    rv_plic_reg2hw_prio78_reg_t prio78; // [224:223]
-    rv_plic_reg2hw_prio79_reg_t prio79; // [222:221]
-    rv_plic_reg2hw_prio80_reg_t prio80; // [220:219]
-    rv_plic_reg2hw_prio81_reg_t prio81; // [218:217]
-    rv_plic_reg2hw_prio82_reg_t prio82; // [216:215]
-    rv_plic_reg2hw_prio83_reg_t prio83; // [214:213]
-    rv_plic_reg2hw_prio84_reg_t prio84; // [212:211]
-    rv_plic_reg2hw_prio85_reg_t prio85; // [210:209]
-    rv_plic_reg2hw_prio86_reg_t prio86; // [208:207]
-    rv_plic_reg2hw_prio87_reg_t prio87; // [206:205]
-    rv_plic_reg2hw_prio88_reg_t prio88; // [204:203]
-    rv_plic_reg2hw_prio89_reg_t prio89; // [202:201]
-    rv_plic_reg2hw_prio90_reg_t prio90; // [200:199]
-    rv_plic_reg2hw_prio91_reg_t prio91; // [198:197]
-    rv_plic_reg2hw_prio92_reg_t prio92; // [196:195]
-    rv_plic_reg2hw_prio93_reg_t prio93; // [194:193]
-    rv_plic_reg2hw_prio94_reg_t prio94; // [192:191]
-    rv_plic_reg2hw_prio95_reg_t prio95; // [190:189]
-    rv_plic_reg2hw_prio96_reg_t prio96; // [188:187]
-    rv_plic_reg2hw_prio97_reg_t prio97; // [186:185]
-    rv_plic_reg2hw_prio98_reg_t prio98; // [184:183]
-    rv_plic_reg2hw_prio99_reg_t prio99; // [182:181]
-    rv_plic_reg2hw_prio100_reg_t prio100; // [180:179]
-    rv_plic_reg2hw_prio101_reg_t prio101; // [178:177]
-    rv_plic_reg2hw_prio102_reg_t prio102; // [176:175]
-    rv_plic_reg2hw_prio103_reg_t prio103; // [174:173]
-    rv_plic_reg2hw_prio104_reg_t prio104; // [172:171]
-    rv_plic_reg2hw_prio105_reg_t prio105; // [170:169]
-    rv_plic_reg2hw_prio106_reg_t prio106; // [168:167]
-    rv_plic_reg2hw_prio107_reg_t prio107; // [166:165]
-    rv_plic_reg2hw_prio108_reg_t prio108; // [164:163]
-    rv_plic_reg2hw_prio109_reg_t prio109; // [162:161]
-    rv_plic_reg2hw_prio110_reg_t prio110; // [160:159]
-    rv_plic_reg2hw_prio111_reg_t prio111; // [158:157]
-    rv_plic_reg2hw_prio112_reg_t prio112; // [156:155]
-    rv_plic_reg2hw_prio113_reg_t prio113; // [154:153]
-    rv_plic_reg2hw_prio114_reg_t prio114; // [152:151]
-    rv_plic_reg2hw_prio115_reg_t prio115; // [150:149]
-    rv_plic_reg2hw_prio116_reg_t prio116; // [148:147]
-    rv_plic_reg2hw_prio117_reg_t prio117; // [146:145]
-    rv_plic_reg2hw_prio118_reg_t prio118; // [144:143]
-    rv_plic_reg2hw_prio119_reg_t prio119; // [142:141]
-    rv_plic_reg2hw_prio120_reg_t prio120; // [140:139]
-    rv_plic_reg2hw_prio121_reg_t prio121; // [138:137]
-    rv_plic_reg2hw_prio122_reg_t prio122; // [136:135]
-    rv_plic_reg2hw_ie0_mreg_t [122:0] ie0; // [134:12]
+    rv_plic_reg2hw_le_mreg_t [121:0] le; // [499:378]
+    rv_plic_reg2hw_prio0_reg_t prio0; // [377:376]
+    rv_plic_reg2hw_prio1_reg_t prio1; // [375:374]
+    rv_plic_reg2hw_prio2_reg_t prio2; // [373:372]
+    rv_plic_reg2hw_prio3_reg_t prio3; // [371:370]
+    rv_plic_reg2hw_prio4_reg_t prio4; // [369:368]
+    rv_plic_reg2hw_prio5_reg_t prio5; // [367:366]
+    rv_plic_reg2hw_prio6_reg_t prio6; // [365:364]
+    rv_plic_reg2hw_prio7_reg_t prio7; // [363:362]
+    rv_plic_reg2hw_prio8_reg_t prio8; // [361:360]
+    rv_plic_reg2hw_prio9_reg_t prio9; // [359:358]
+    rv_plic_reg2hw_prio10_reg_t prio10; // [357:356]
+    rv_plic_reg2hw_prio11_reg_t prio11; // [355:354]
+    rv_plic_reg2hw_prio12_reg_t prio12; // [353:352]
+    rv_plic_reg2hw_prio13_reg_t prio13; // [351:350]
+    rv_plic_reg2hw_prio14_reg_t prio14; // [349:348]
+    rv_plic_reg2hw_prio15_reg_t prio15; // [347:346]
+    rv_plic_reg2hw_prio16_reg_t prio16; // [345:344]
+    rv_plic_reg2hw_prio17_reg_t prio17; // [343:342]
+    rv_plic_reg2hw_prio18_reg_t prio18; // [341:340]
+    rv_plic_reg2hw_prio19_reg_t prio19; // [339:338]
+    rv_plic_reg2hw_prio20_reg_t prio20; // [337:336]
+    rv_plic_reg2hw_prio21_reg_t prio21; // [335:334]
+    rv_plic_reg2hw_prio22_reg_t prio22; // [333:332]
+    rv_plic_reg2hw_prio23_reg_t prio23; // [331:330]
+    rv_plic_reg2hw_prio24_reg_t prio24; // [329:328]
+    rv_plic_reg2hw_prio25_reg_t prio25; // [327:326]
+    rv_plic_reg2hw_prio26_reg_t prio26; // [325:324]
+    rv_plic_reg2hw_prio27_reg_t prio27; // [323:322]
+    rv_plic_reg2hw_prio28_reg_t prio28; // [321:320]
+    rv_plic_reg2hw_prio29_reg_t prio29; // [319:318]
+    rv_plic_reg2hw_prio30_reg_t prio30; // [317:316]
+    rv_plic_reg2hw_prio31_reg_t prio31; // [315:314]
+    rv_plic_reg2hw_prio32_reg_t prio32; // [313:312]
+    rv_plic_reg2hw_prio33_reg_t prio33; // [311:310]
+    rv_plic_reg2hw_prio34_reg_t prio34; // [309:308]
+    rv_plic_reg2hw_prio35_reg_t prio35; // [307:306]
+    rv_plic_reg2hw_prio36_reg_t prio36; // [305:304]
+    rv_plic_reg2hw_prio37_reg_t prio37; // [303:302]
+    rv_plic_reg2hw_prio38_reg_t prio38; // [301:300]
+    rv_plic_reg2hw_prio39_reg_t prio39; // [299:298]
+    rv_plic_reg2hw_prio40_reg_t prio40; // [297:296]
+    rv_plic_reg2hw_prio41_reg_t prio41; // [295:294]
+    rv_plic_reg2hw_prio42_reg_t prio42; // [293:292]
+    rv_plic_reg2hw_prio43_reg_t prio43; // [291:290]
+    rv_plic_reg2hw_prio44_reg_t prio44; // [289:288]
+    rv_plic_reg2hw_prio45_reg_t prio45; // [287:286]
+    rv_plic_reg2hw_prio46_reg_t prio46; // [285:284]
+    rv_plic_reg2hw_prio47_reg_t prio47; // [283:282]
+    rv_plic_reg2hw_prio48_reg_t prio48; // [281:280]
+    rv_plic_reg2hw_prio49_reg_t prio49; // [279:278]
+    rv_plic_reg2hw_prio50_reg_t prio50; // [277:276]
+    rv_plic_reg2hw_prio51_reg_t prio51; // [275:274]
+    rv_plic_reg2hw_prio52_reg_t prio52; // [273:272]
+    rv_plic_reg2hw_prio53_reg_t prio53; // [271:270]
+    rv_plic_reg2hw_prio54_reg_t prio54; // [269:268]
+    rv_plic_reg2hw_prio55_reg_t prio55; // [267:266]
+    rv_plic_reg2hw_prio56_reg_t prio56; // [265:264]
+    rv_plic_reg2hw_prio57_reg_t prio57; // [263:262]
+    rv_plic_reg2hw_prio58_reg_t prio58; // [261:260]
+    rv_plic_reg2hw_prio59_reg_t prio59; // [259:258]
+    rv_plic_reg2hw_prio60_reg_t prio60; // [257:256]
+    rv_plic_reg2hw_prio61_reg_t prio61; // [255:254]
+    rv_plic_reg2hw_prio62_reg_t prio62; // [253:252]
+    rv_plic_reg2hw_prio63_reg_t prio63; // [251:250]
+    rv_plic_reg2hw_prio64_reg_t prio64; // [249:248]
+    rv_plic_reg2hw_prio65_reg_t prio65; // [247:246]
+    rv_plic_reg2hw_prio66_reg_t prio66; // [245:244]
+    rv_plic_reg2hw_prio67_reg_t prio67; // [243:242]
+    rv_plic_reg2hw_prio68_reg_t prio68; // [241:240]
+    rv_plic_reg2hw_prio69_reg_t prio69; // [239:238]
+    rv_plic_reg2hw_prio70_reg_t prio70; // [237:236]
+    rv_plic_reg2hw_prio71_reg_t prio71; // [235:234]
+    rv_plic_reg2hw_prio72_reg_t prio72; // [233:232]
+    rv_plic_reg2hw_prio73_reg_t prio73; // [231:230]
+    rv_plic_reg2hw_prio74_reg_t prio74; // [229:228]
+    rv_plic_reg2hw_prio75_reg_t prio75; // [227:226]
+    rv_plic_reg2hw_prio76_reg_t prio76; // [225:224]
+    rv_plic_reg2hw_prio77_reg_t prio77; // [223:222]
+    rv_plic_reg2hw_prio78_reg_t prio78; // [221:220]
+    rv_plic_reg2hw_prio79_reg_t prio79; // [219:218]
+    rv_plic_reg2hw_prio80_reg_t prio80; // [217:216]
+    rv_plic_reg2hw_prio81_reg_t prio81; // [215:214]
+    rv_plic_reg2hw_prio82_reg_t prio82; // [213:212]
+    rv_plic_reg2hw_prio83_reg_t prio83; // [211:210]
+    rv_plic_reg2hw_prio84_reg_t prio84; // [209:208]
+    rv_plic_reg2hw_prio85_reg_t prio85; // [207:206]
+    rv_plic_reg2hw_prio86_reg_t prio86; // [205:204]
+    rv_plic_reg2hw_prio87_reg_t prio87; // [203:202]
+    rv_plic_reg2hw_prio88_reg_t prio88; // [201:200]
+    rv_plic_reg2hw_prio89_reg_t prio89; // [199:198]
+    rv_plic_reg2hw_prio90_reg_t prio90; // [197:196]
+    rv_plic_reg2hw_prio91_reg_t prio91; // [195:194]
+    rv_plic_reg2hw_prio92_reg_t prio92; // [193:192]
+    rv_plic_reg2hw_prio93_reg_t prio93; // [191:190]
+    rv_plic_reg2hw_prio94_reg_t prio94; // [189:188]
+    rv_plic_reg2hw_prio95_reg_t prio95; // [187:186]
+    rv_plic_reg2hw_prio96_reg_t prio96; // [185:184]
+    rv_plic_reg2hw_prio97_reg_t prio97; // [183:182]
+    rv_plic_reg2hw_prio98_reg_t prio98; // [181:180]
+    rv_plic_reg2hw_prio99_reg_t prio99; // [179:178]
+    rv_plic_reg2hw_prio100_reg_t prio100; // [177:176]
+    rv_plic_reg2hw_prio101_reg_t prio101; // [175:174]
+    rv_plic_reg2hw_prio102_reg_t prio102; // [173:172]
+    rv_plic_reg2hw_prio103_reg_t prio103; // [171:170]
+    rv_plic_reg2hw_prio104_reg_t prio104; // [169:168]
+    rv_plic_reg2hw_prio105_reg_t prio105; // [167:166]
+    rv_plic_reg2hw_prio106_reg_t prio106; // [165:164]
+    rv_plic_reg2hw_prio107_reg_t prio107; // [163:162]
+    rv_plic_reg2hw_prio108_reg_t prio108; // [161:160]
+    rv_plic_reg2hw_prio109_reg_t prio109; // [159:158]
+    rv_plic_reg2hw_prio110_reg_t prio110; // [157:156]
+    rv_plic_reg2hw_prio111_reg_t prio111; // [155:154]
+    rv_plic_reg2hw_prio112_reg_t prio112; // [153:152]
+    rv_plic_reg2hw_prio113_reg_t prio113; // [151:150]
+    rv_plic_reg2hw_prio114_reg_t prio114; // [149:148]
+    rv_plic_reg2hw_prio115_reg_t prio115; // [147:146]
+    rv_plic_reg2hw_prio116_reg_t prio116; // [145:144]
+    rv_plic_reg2hw_prio117_reg_t prio117; // [143:142]
+    rv_plic_reg2hw_prio118_reg_t prio118; // [141:140]
+    rv_plic_reg2hw_prio119_reg_t prio119; // [139:138]
+    rv_plic_reg2hw_prio120_reg_t prio120; // [137:136]
+    rv_plic_reg2hw_prio121_reg_t prio121; // [135:134]
+    rv_plic_reg2hw_ie0_mreg_t [121:0] ie0; // [133:12]
     rv_plic_reg2hw_threshold0_reg_t threshold0; // [11:10]
     rv_plic_reg2hw_cc0_reg_t cc0; // [9:1]
     rv_plic_reg2hw_msip0_reg_t msip0; // [0:0]
@@ -680,7 +675,7 @@ package rv_plic_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_plic_hw2reg_ip_mreg_t [122:0] ip; // [252:7]
+    rv_plic_hw2reg_ip_mreg_t [121:0] ip; // [250:7]
     rv_plic_hw2reg_cc0_reg_t cc0; // [6:0]
   } rv_plic_hw2reg_t;
 
@@ -815,7 +810,6 @@ package rv_plic_reg_pkg;
   parameter logic [BlockAw-1:0] RV_PLIC_PRIO119_OFFSET = 10'h 1fc;
   parameter logic [BlockAw-1:0] RV_PLIC_PRIO120_OFFSET = 10'h 200;
   parameter logic [BlockAw-1:0] RV_PLIC_PRIO121_OFFSET = 10'h 204;
-  parameter logic [BlockAw-1:0] RV_PLIC_PRIO122_OFFSET = 10'h 208;
   parameter logic [BlockAw-1:0] RV_PLIC_IE0_0_OFFSET = 10'h 300;
   parameter logic [BlockAw-1:0] RV_PLIC_IE0_1_OFFSET = 10'h 304;
   parameter logic [BlockAw-1:0] RV_PLIC_IE0_2_OFFSET = 10'h 308;
@@ -957,7 +951,6 @@ package rv_plic_reg_pkg;
     RV_PLIC_PRIO119,
     RV_PLIC_PRIO120,
     RV_PLIC_PRIO121,
-    RV_PLIC_PRIO122,
     RV_PLIC_IE0_0,
     RV_PLIC_IE0_1,
     RV_PLIC_IE0_2,
@@ -968,7 +961,7 @@ package rv_plic_reg_pkg;
   } rv_plic_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] RV_PLIC_PERMIT [138] = '{
+  parameter logic [3:0] RV_PLIC_PERMIT [137] = '{
     4'b 1111, // index[  0] RV_PLIC_IP_0
     4'b 1111, // index[  1] RV_PLIC_IP_1
     4'b 1111, // index[  2] RV_PLIC_IP_2
@@ -1099,14 +1092,13 @@ package rv_plic_reg_pkg;
     4'b 0001, // index[127] RV_PLIC_PRIO119
     4'b 0001, // index[128] RV_PLIC_PRIO120
     4'b 0001, // index[129] RV_PLIC_PRIO121
-    4'b 0001, // index[130] RV_PLIC_PRIO122
-    4'b 1111, // index[131] RV_PLIC_IE0_0
-    4'b 1111, // index[132] RV_PLIC_IE0_1
-    4'b 1111, // index[133] RV_PLIC_IE0_2
-    4'b 1111, // index[134] RV_PLIC_IE0_3
-    4'b 0001, // index[135] RV_PLIC_THRESHOLD0
-    4'b 0001, // index[136] RV_PLIC_CC0
-    4'b 0001  // index[137] RV_PLIC_MSIP0
+    4'b 1111, // index[130] RV_PLIC_IE0_0
+    4'b 1111, // index[131] RV_PLIC_IE0_1
+    4'b 1111, // index[132] RV_PLIC_IE0_2
+    4'b 1111, // index[133] RV_PLIC_IE0_3
+    4'b 0001, // index[134] RV_PLIC_THRESHOLD0
+    4'b 0001, // index[135] RV_PLIC_CC0
+    4'b 0001  // index[136] RV_PLIC_MSIP0
   };
 endpackage
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
@@ -193,7 +193,6 @@ module rv_plic_reg_top (
   logic ip_3_p_119_qs;
   logic ip_3_p_120_qs;
   logic ip_3_p_121_qs;
-  logic ip_3_p_122_qs;
   logic le_0_le_0_qs;
   logic le_0_le_0_wd;
   logic le_0_le_0_we;
@@ -560,9 +559,6 @@ module rv_plic_reg_top (
   logic le_3_le_121_qs;
   logic le_3_le_121_wd;
   logic le_3_le_121_we;
-  logic le_3_le_122_qs;
-  logic le_3_le_122_wd;
-  logic le_3_le_122_we;
   logic [1:0] prio0_qs;
   logic [1:0] prio0_wd;
   logic prio0_we;
@@ -929,9 +925,6 @@ module rv_plic_reg_top (
   logic [1:0] prio121_qs;
   logic [1:0] prio121_wd;
   logic prio121_we;
-  logic [1:0] prio122_qs;
-  logic [1:0] prio122_wd;
-  logic prio122_we;
   logic ie0_0_e_0_qs;
   logic ie0_0_e_0_wd;
   logic ie0_0_e_0_we;
@@ -1298,9 +1291,6 @@ module rv_plic_reg_top (
   logic ie0_3_e_121_qs;
   logic ie0_3_e_121_wd;
   logic ie0_3_e_121_we;
-  logic ie0_3_e_122_qs;
-  logic ie0_3_e_122_wd;
-  logic ie0_3_e_122_we;
   logic [1:0] threshold0_qs;
   logic [1:0] threshold0_wd;
   logic threshold0_we;
@@ -4373,31 +4363,6 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (ip_3_p_121_qs)
-  );
-
-
-  // F[p_122]: 26:26
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_3_p_122 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[122].de),
-    .d      (hw2reg.ip[122].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_3_p_122_qs)
   );
 
 
@@ -7584,32 +7549,6 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (le_3_le_121_qs)
-  );
-
-
-  // F[le_122]: 26:26
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_3_le_122 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_3_le_122_we),
-    .wd     (le_3_le_122_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[122].q ),
-
-    // to register interface (read)
-    .qs     (le_3_le_122_qs)
   );
 
 
@@ -10908,33 +10847,6 @@ module rv_plic_reg_top (
   );
 
 
-  // R[prio122]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio122 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio122_we),
-    .wd     (prio122_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio122.q ),
-
-    // to register interface (read)
-    .qs     (prio122_qs)
-  );
-
-
 
   // Subregister 0 of Multireg ie0
   // R[ie0_0]: V(False)
@@ -14120,32 +14032,6 @@ module rv_plic_reg_top (
   );
 
 
-  // F[e_122]: 26:26
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_3_e_122 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_3_e_122_we),
-    .wd     (ie0_3_e_122_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[122].q ),
-
-    // to register interface (read)
-    .qs     (ie0_3_e_122_qs)
-  );
-
-
 
   // R[threshold0]: V(False)
 
@@ -14219,7 +14105,7 @@ module rv_plic_reg_top (
 
 
 
-  logic [137:0] addr_hit;
+  logic [136:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[  0] = (reg_addr == RV_PLIC_IP_0_OFFSET);
@@ -14352,14 +14238,13 @@ module rv_plic_reg_top (
     addr_hit[127] = (reg_addr == RV_PLIC_PRIO119_OFFSET);
     addr_hit[128] = (reg_addr == RV_PLIC_PRIO120_OFFSET);
     addr_hit[129] = (reg_addr == RV_PLIC_PRIO121_OFFSET);
-    addr_hit[130] = (reg_addr == RV_PLIC_PRIO122_OFFSET);
-    addr_hit[131] = (reg_addr == RV_PLIC_IE0_0_OFFSET);
-    addr_hit[132] = (reg_addr == RV_PLIC_IE0_1_OFFSET);
-    addr_hit[133] = (reg_addr == RV_PLIC_IE0_2_OFFSET);
-    addr_hit[134] = (reg_addr == RV_PLIC_IE0_3_OFFSET);
-    addr_hit[135] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
-    addr_hit[136] = (reg_addr == RV_PLIC_CC0_OFFSET);
-    addr_hit[137] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
+    addr_hit[130] = (reg_addr == RV_PLIC_IE0_0_OFFSET);
+    addr_hit[131] = (reg_addr == RV_PLIC_IE0_1_OFFSET);
+    addr_hit[132] = (reg_addr == RV_PLIC_IE0_2_OFFSET);
+    addr_hit[133] = (reg_addr == RV_PLIC_IE0_3_OFFSET);
+    addr_hit[134] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
+    addr_hit[135] = (reg_addr == RV_PLIC_CC0_OFFSET);
+    addr_hit[136] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -14504,9 +14389,7 @@ module rv_plic_reg_top (
     if (addr_hit[134] && reg_we && (RV_PLIC_PERMIT[134] != (RV_PLIC_PERMIT[134] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[135] && reg_we && (RV_PLIC_PERMIT[135] != (RV_PLIC_PERMIT[135] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[136] && reg_we && (RV_PLIC_PERMIT[136] != (RV_PLIC_PERMIT[136] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[137] && reg_we && (RV_PLIC_PERMIT[137] != (RV_PLIC_PERMIT[137] & reg_be))) wr_err = 1'b1 ;
   end
-
 
 
 
@@ -14996,9 +14879,6 @@ module rv_plic_reg_top (
   assign le_3_le_121_we = addr_hit[7] & reg_we & ~wr_err;
   assign le_3_le_121_wd = reg_wdata[25];
 
-  assign le_3_le_122_we = addr_hit[7] & reg_we & ~wr_err;
-  assign le_3_le_122_wd = reg_wdata[26];
-
   assign prio0_we = addr_hit[8] & reg_we & ~wr_err;
   assign prio0_wd = reg_wdata[1:0];
 
@@ -15365,386 +15245,380 @@ module rv_plic_reg_top (
   assign prio121_we = addr_hit[129] & reg_we & ~wr_err;
   assign prio121_wd = reg_wdata[1:0];
 
-  assign prio122_we = addr_hit[130] & reg_we & ~wr_err;
-  assign prio122_wd = reg_wdata[1:0];
-
-  assign ie0_0_e_0_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_0_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_0_wd = reg_wdata[0];
 
-  assign ie0_0_e_1_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_1_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_1_wd = reg_wdata[1];
 
-  assign ie0_0_e_2_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_2_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_2_wd = reg_wdata[2];
 
-  assign ie0_0_e_3_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_3_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_3_wd = reg_wdata[3];
 
-  assign ie0_0_e_4_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_4_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_4_wd = reg_wdata[4];
 
-  assign ie0_0_e_5_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_5_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_5_wd = reg_wdata[5];
 
-  assign ie0_0_e_6_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_6_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_6_wd = reg_wdata[6];
 
-  assign ie0_0_e_7_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_7_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_7_wd = reg_wdata[7];
 
-  assign ie0_0_e_8_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_8_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_8_wd = reg_wdata[8];
 
-  assign ie0_0_e_9_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_9_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_9_wd = reg_wdata[9];
 
-  assign ie0_0_e_10_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_10_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_10_wd = reg_wdata[10];
 
-  assign ie0_0_e_11_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_11_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_11_wd = reg_wdata[11];
 
-  assign ie0_0_e_12_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_12_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_12_wd = reg_wdata[12];
 
-  assign ie0_0_e_13_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_13_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_13_wd = reg_wdata[13];
 
-  assign ie0_0_e_14_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_14_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_14_wd = reg_wdata[14];
 
-  assign ie0_0_e_15_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_15_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_15_wd = reg_wdata[15];
 
-  assign ie0_0_e_16_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_16_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_16_wd = reg_wdata[16];
 
-  assign ie0_0_e_17_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_17_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_17_wd = reg_wdata[17];
 
-  assign ie0_0_e_18_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_18_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_18_wd = reg_wdata[18];
 
-  assign ie0_0_e_19_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_19_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_19_wd = reg_wdata[19];
 
-  assign ie0_0_e_20_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_20_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_20_wd = reg_wdata[20];
 
-  assign ie0_0_e_21_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_21_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_21_wd = reg_wdata[21];
 
-  assign ie0_0_e_22_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_22_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_22_wd = reg_wdata[22];
 
-  assign ie0_0_e_23_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_23_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_23_wd = reg_wdata[23];
 
-  assign ie0_0_e_24_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_24_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_24_wd = reg_wdata[24];
 
-  assign ie0_0_e_25_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_25_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_25_wd = reg_wdata[25];
 
-  assign ie0_0_e_26_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_26_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_26_wd = reg_wdata[26];
 
-  assign ie0_0_e_27_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_27_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_27_wd = reg_wdata[27];
 
-  assign ie0_0_e_28_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_28_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_28_wd = reg_wdata[28];
 
-  assign ie0_0_e_29_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_29_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_29_wd = reg_wdata[29];
 
-  assign ie0_0_e_30_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_30_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_30_wd = reg_wdata[30];
 
-  assign ie0_0_e_31_we = addr_hit[131] & reg_we & ~wr_err;
+  assign ie0_0_e_31_we = addr_hit[130] & reg_we & ~wr_err;
   assign ie0_0_e_31_wd = reg_wdata[31];
 
-  assign ie0_1_e_32_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_32_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_32_wd = reg_wdata[0];
 
-  assign ie0_1_e_33_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_33_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_33_wd = reg_wdata[1];
 
-  assign ie0_1_e_34_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_34_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_34_wd = reg_wdata[2];
 
-  assign ie0_1_e_35_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_35_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_35_wd = reg_wdata[3];
 
-  assign ie0_1_e_36_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_36_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_36_wd = reg_wdata[4];
 
-  assign ie0_1_e_37_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_37_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_37_wd = reg_wdata[5];
 
-  assign ie0_1_e_38_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_38_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_38_wd = reg_wdata[6];
 
-  assign ie0_1_e_39_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_39_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_39_wd = reg_wdata[7];
 
-  assign ie0_1_e_40_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_40_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_40_wd = reg_wdata[8];
 
-  assign ie0_1_e_41_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_41_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_41_wd = reg_wdata[9];
 
-  assign ie0_1_e_42_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_42_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_42_wd = reg_wdata[10];
 
-  assign ie0_1_e_43_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_43_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_43_wd = reg_wdata[11];
 
-  assign ie0_1_e_44_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_44_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_44_wd = reg_wdata[12];
 
-  assign ie0_1_e_45_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_45_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_45_wd = reg_wdata[13];
 
-  assign ie0_1_e_46_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_46_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_46_wd = reg_wdata[14];
 
-  assign ie0_1_e_47_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_47_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_47_wd = reg_wdata[15];
 
-  assign ie0_1_e_48_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_48_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_48_wd = reg_wdata[16];
 
-  assign ie0_1_e_49_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_49_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_49_wd = reg_wdata[17];
 
-  assign ie0_1_e_50_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_50_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_50_wd = reg_wdata[18];
 
-  assign ie0_1_e_51_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_51_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_51_wd = reg_wdata[19];
 
-  assign ie0_1_e_52_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_52_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_52_wd = reg_wdata[20];
 
-  assign ie0_1_e_53_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_53_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_53_wd = reg_wdata[21];
 
-  assign ie0_1_e_54_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_54_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_54_wd = reg_wdata[22];
 
-  assign ie0_1_e_55_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_55_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_55_wd = reg_wdata[23];
 
-  assign ie0_1_e_56_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_56_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_56_wd = reg_wdata[24];
 
-  assign ie0_1_e_57_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_57_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_57_wd = reg_wdata[25];
 
-  assign ie0_1_e_58_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_58_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_58_wd = reg_wdata[26];
 
-  assign ie0_1_e_59_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_59_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_59_wd = reg_wdata[27];
 
-  assign ie0_1_e_60_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_60_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_60_wd = reg_wdata[28];
 
-  assign ie0_1_e_61_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_61_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_61_wd = reg_wdata[29];
 
-  assign ie0_1_e_62_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_62_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_62_wd = reg_wdata[30];
 
-  assign ie0_1_e_63_we = addr_hit[132] & reg_we & ~wr_err;
+  assign ie0_1_e_63_we = addr_hit[131] & reg_we & ~wr_err;
   assign ie0_1_e_63_wd = reg_wdata[31];
 
-  assign ie0_2_e_64_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_64_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_64_wd = reg_wdata[0];
 
-  assign ie0_2_e_65_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_65_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_65_wd = reg_wdata[1];
 
-  assign ie0_2_e_66_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_66_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_66_wd = reg_wdata[2];
 
-  assign ie0_2_e_67_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_67_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_67_wd = reg_wdata[3];
 
-  assign ie0_2_e_68_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_68_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_68_wd = reg_wdata[4];
 
-  assign ie0_2_e_69_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_69_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_69_wd = reg_wdata[5];
 
-  assign ie0_2_e_70_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_70_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_70_wd = reg_wdata[6];
 
-  assign ie0_2_e_71_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_71_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_71_wd = reg_wdata[7];
 
-  assign ie0_2_e_72_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_72_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_72_wd = reg_wdata[8];
 
-  assign ie0_2_e_73_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_73_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_73_wd = reg_wdata[9];
 
-  assign ie0_2_e_74_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_74_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_74_wd = reg_wdata[10];
 
-  assign ie0_2_e_75_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_75_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_75_wd = reg_wdata[11];
 
-  assign ie0_2_e_76_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_76_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_76_wd = reg_wdata[12];
 
-  assign ie0_2_e_77_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_77_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_77_wd = reg_wdata[13];
 
-  assign ie0_2_e_78_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_78_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_78_wd = reg_wdata[14];
 
-  assign ie0_2_e_79_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_79_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_79_wd = reg_wdata[15];
 
-  assign ie0_2_e_80_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_80_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_80_wd = reg_wdata[16];
 
-  assign ie0_2_e_81_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_81_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_81_wd = reg_wdata[17];
 
-  assign ie0_2_e_82_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_82_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_82_wd = reg_wdata[18];
 
-  assign ie0_2_e_83_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_83_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_83_wd = reg_wdata[19];
 
-  assign ie0_2_e_84_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_84_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_84_wd = reg_wdata[20];
 
-  assign ie0_2_e_85_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_85_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_85_wd = reg_wdata[21];
 
-  assign ie0_2_e_86_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_86_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_86_wd = reg_wdata[22];
 
-  assign ie0_2_e_87_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_87_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_87_wd = reg_wdata[23];
 
-  assign ie0_2_e_88_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_88_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_88_wd = reg_wdata[24];
 
-  assign ie0_2_e_89_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_89_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_89_wd = reg_wdata[25];
 
-  assign ie0_2_e_90_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_90_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_90_wd = reg_wdata[26];
 
-  assign ie0_2_e_91_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_91_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_91_wd = reg_wdata[27];
 
-  assign ie0_2_e_92_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_92_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_92_wd = reg_wdata[28];
 
-  assign ie0_2_e_93_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_93_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_93_wd = reg_wdata[29];
 
-  assign ie0_2_e_94_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_94_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_94_wd = reg_wdata[30];
 
-  assign ie0_2_e_95_we = addr_hit[133] & reg_we & ~wr_err;
+  assign ie0_2_e_95_we = addr_hit[132] & reg_we & ~wr_err;
   assign ie0_2_e_95_wd = reg_wdata[31];
 
-  assign ie0_3_e_96_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_96_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_96_wd = reg_wdata[0];
 
-  assign ie0_3_e_97_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_97_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_97_wd = reg_wdata[1];
 
-  assign ie0_3_e_98_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_98_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_98_wd = reg_wdata[2];
 
-  assign ie0_3_e_99_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_99_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_99_wd = reg_wdata[3];
 
-  assign ie0_3_e_100_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_100_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_100_wd = reg_wdata[4];
 
-  assign ie0_3_e_101_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_101_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_101_wd = reg_wdata[5];
 
-  assign ie0_3_e_102_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_102_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_102_wd = reg_wdata[6];
 
-  assign ie0_3_e_103_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_103_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_103_wd = reg_wdata[7];
 
-  assign ie0_3_e_104_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_104_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_104_wd = reg_wdata[8];
 
-  assign ie0_3_e_105_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_105_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_105_wd = reg_wdata[9];
 
-  assign ie0_3_e_106_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_106_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_106_wd = reg_wdata[10];
 
-  assign ie0_3_e_107_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_107_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_107_wd = reg_wdata[11];
 
-  assign ie0_3_e_108_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_108_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_108_wd = reg_wdata[12];
 
-  assign ie0_3_e_109_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_109_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_109_wd = reg_wdata[13];
 
-  assign ie0_3_e_110_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_110_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_110_wd = reg_wdata[14];
 
-  assign ie0_3_e_111_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_111_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_111_wd = reg_wdata[15];
 
-  assign ie0_3_e_112_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_112_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_112_wd = reg_wdata[16];
 
-  assign ie0_3_e_113_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_113_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_113_wd = reg_wdata[17];
 
-  assign ie0_3_e_114_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_114_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_114_wd = reg_wdata[18];
 
-  assign ie0_3_e_115_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_115_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_115_wd = reg_wdata[19];
 
-  assign ie0_3_e_116_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_116_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_116_wd = reg_wdata[20];
 
-  assign ie0_3_e_117_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_117_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_117_wd = reg_wdata[21];
 
-  assign ie0_3_e_118_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_118_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_118_wd = reg_wdata[22];
 
-  assign ie0_3_e_119_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_119_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_119_wd = reg_wdata[23];
 
-  assign ie0_3_e_120_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_120_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_120_wd = reg_wdata[24];
 
-  assign ie0_3_e_121_we = addr_hit[134] & reg_we & ~wr_err;
+  assign ie0_3_e_121_we = addr_hit[133] & reg_we & ~wr_err;
   assign ie0_3_e_121_wd = reg_wdata[25];
 
-  assign ie0_3_e_122_we = addr_hit[134] & reg_we & ~wr_err;
-  assign ie0_3_e_122_wd = reg_wdata[26];
-
-  assign threshold0_we = addr_hit[135] & reg_we & ~wr_err;
+  assign threshold0_we = addr_hit[134] & reg_we & ~wr_err;
   assign threshold0_wd = reg_wdata[1:0];
 
-  assign cc0_we = addr_hit[136] & reg_we & ~wr_err;
+  assign cc0_we = addr_hit[135] & reg_we & ~wr_err;
   assign cc0_wd = reg_wdata[6:0];
-  assign cc0_re = addr_hit[136] && reg_re;
+  assign cc0_re = addr_hit[135] && reg_re;
 
-  assign msip0_we = addr_hit[137] & reg_we & ~wr_err;
+  assign msip0_we = addr_hit[136] & reg_we & ~wr_err;
   assign msip0_wd = reg_wdata[0];
 
   // Read data return
@@ -15883,7 +15757,6 @@ module rv_plic_reg_top (
         reg_rdata_next[23] = ip_3_p_119_qs;
         reg_rdata_next[24] = ip_3_p_120_qs;
         reg_rdata_next[25] = ip_3_p_121_qs;
-        reg_rdata_next[26] = ip_3_p_122_qs;
       end
 
       addr_hit[4]: begin
@@ -16018,7 +15891,6 @@ module rv_plic_reg_top (
         reg_rdata_next[23] = le_3_le_119_qs;
         reg_rdata_next[24] = le_3_le_120_qs;
         reg_rdata_next[25] = le_3_le_121_qs;
-        reg_rdata_next[26] = le_3_le_122_qs;
       end
 
       addr_hit[8]: begin
@@ -16510,10 +16382,6 @@ module rv_plic_reg_top (
       end
 
       addr_hit[130]: begin
-        reg_rdata_next[1:0] = prio122_qs;
-      end
-
-      addr_hit[131]: begin
         reg_rdata_next[0] = ie0_0_e_0_qs;
         reg_rdata_next[1] = ie0_0_e_1_qs;
         reg_rdata_next[2] = ie0_0_e_2_qs;
@@ -16548,7 +16416,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_0_e_31_qs;
       end
 
-      addr_hit[132]: begin
+      addr_hit[131]: begin
         reg_rdata_next[0] = ie0_1_e_32_qs;
         reg_rdata_next[1] = ie0_1_e_33_qs;
         reg_rdata_next[2] = ie0_1_e_34_qs;
@@ -16583,7 +16451,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_1_e_63_qs;
       end
 
-      addr_hit[133]: begin
+      addr_hit[132]: begin
         reg_rdata_next[0] = ie0_2_e_64_qs;
         reg_rdata_next[1] = ie0_2_e_65_qs;
         reg_rdata_next[2] = ie0_2_e_66_qs;
@@ -16618,7 +16486,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_2_e_95_qs;
       end
 
-      addr_hit[134]: begin
+      addr_hit[133]: begin
         reg_rdata_next[0] = ie0_3_e_96_qs;
         reg_rdata_next[1] = ie0_3_e_97_qs;
         reg_rdata_next[2] = ie0_3_e_98_qs;
@@ -16645,18 +16513,17 @@ module rv_plic_reg_top (
         reg_rdata_next[23] = ie0_3_e_119_qs;
         reg_rdata_next[24] = ie0_3_e_120_qs;
         reg_rdata_next[25] = ie0_3_e_121_qs;
-        reg_rdata_next[26] = ie0_3_e_122_qs;
       end
 
-      addr_hit[135]: begin
+      addr_hit[134]: begin
         reg_rdata_next[1:0] = threshold0_qs;
       end
 
-      addr_hit[136]: begin
+      addr_hit[135]: begin
         reg_rdata_next[6:0] = cc0_qs;
       end
 
-      addr_hit[137]: begin
+      addr_hit[136]: begin
         reg_rdata_next[0] = msip0_qs;
       end
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -70,7 +70,7 @@ module top_earlgrey #(
   input  tlul_pkg::tl_d2h_t       ast_tl_rsp_i,
   output otp_ctrl_pkg::otp_ast_req_t       otp_ctrl_otp_ast_pwr_seq_o,
   input  otp_ctrl_pkg::otp_ast_rsp_t       otp_ctrl_otp_ast_pwr_seq_h_i,
-  input  logic       flash_bist_enable_i,
+  input  lc_ctrl_pkg::lc_tx_t       flash_bist_enable_i,
   input  logic       flash_power_down_h_i,
   input  logic       flash_power_ready_h_i,
   input  logic [1:0] flash_test_mode_a_i,
@@ -179,7 +179,7 @@ module top_earlgrey #(
   // otbn
 
 
-  logic [122:0]  intr_vector;
+  logic [121:0]  intr_vector;
   // Interrupt source list
   logic intr_uart0_tx_watermark;
   logic intr_uart0_rx_watermark;
@@ -253,7 +253,6 @@ module top_earlgrey #(
   logic intr_flash_ctrl_rd_full;
   logic intr_flash_ctrl_rd_lvl;
   logic intr_flash_ctrl_op_done;
-  logic intr_flash_ctrl_op_error;
   logic intr_hmac_hmac_done;
   logic intr_hmac_fifo_empty;
   logic intr_hmac_hmac_err;
@@ -1323,7 +1322,12 @@ module top_earlgrey #(
       .intr_rd_full_o    (intr_flash_ctrl_rd_full),
       .intr_rd_lvl_o     (intr_flash_ctrl_rd_lvl),
       .intr_op_done_o    (intr_flash_ctrl_op_done),
-      .intr_op_error_o   (intr_flash_ctrl_op_error),
+
+      // [12]: recov_err
+      // [13]: recov_mp_err
+      // [14]: recov_ecc_err
+      .alert_tx_o  ( alert_tx[14:12] ),
+      .alert_rx_i  ( alert_rx[14:12] ),
 
       // Inter-module signals
       .flash_o(flash_ctrl_flash_req),
@@ -1376,10 +1380,10 @@ module top_earlgrey #(
     .RndCnstMskgChunkLfsrPerm(aes_pkg::RndCnstMskgChunkLfsrPermDefault)
   ) u_aes (
 
-      // [12]: recov_ctrl_update_err
-      // [13]: fatal_fault
-      .alert_tx_o  ( alert_tx[13:12] ),
-      .alert_rx_i  ( alert_rx[13:12] ),
+      // [15]: recov_ctrl_update_err
+      // [16]: fatal_fault
+      .alert_tx_o  ( alert_tx[16:15] ),
+      .alert_rx_i  ( alert_rx[16:15] ),
 
       // Inter-module signals
       .idle_o(clkmgr_idle[0]),
@@ -1448,10 +1452,10 @@ module top_earlgrey #(
       // Interrupt
       .intr_op_done_o (intr_keymgr_op_done),
 
-      // [14]: fault_err
-      // [15]: operation_err
-      .alert_tx_o  ( alert_tx[15:14] ),
-      .alert_rx_i  ( alert_rx[15:14] ),
+      // [17]: fault_err
+      // [18]: operation_err
+      .alert_tx_o  ( alert_tx[18:17] ),
+      .alert_rx_i  ( alert_rx[18:17] ),
 
       // Inter-module signals
       .edn_o(),
@@ -1504,9 +1508,9 @@ module top_earlgrey #(
       .intr_es_health_test_failed_o (intr_entropy_src_es_health_test_failed),
       .intr_es_fifo_err_o           (intr_entropy_src_es_fifo_err),
 
-      // [16]: recov_alert_count_met
-      .alert_tx_o  ( alert_tx[16:16] ),
-      .alert_rx_i  ( alert_rx[16:16] ),
+      // [19]: recov_alert_count_met
+      .alert_tx_o  ( alert_tx[19:19] ),
+      .alert_rx_i  ( alert_rx[19:19] ),
 
       // Inter-module signals
       .entropy_src_hw_if_i(csrng_entropy_src_hw_if_req),
@@ -1561,9 +1565,9 @@ module top_earlgrey #(
     .RndCnstSramNonce(RndCnstSramCtrlMainSramNonce)
   ) u_sram_ctrl_main (
 
-      // [17]: fatal_parity_error
-      .alert_tx_o  ( alert_tx[17:17] ),
-      .alert_rx_i  ( alert_rx[17:17] ),
+      // [20]: fatal_parity_error
+      .alert_tx_o  ( alert_tx[20:20] ),
+      .alert_rx_i  ( alert_rx[20:20] ),
 
       // Inter-module signals
       .sram_otp_key_o(otp_ctrl_sram_otp_key_req[0]),
@@ -1586,10 +1590,10 @@ module top_earlgrey #(
       // Interrupt
       .intr_done_o (intr_otbn_done),
 
-      // [18]: fatal
-      // [19]: recov
-      .alert_tx_o  ( alert_tx[19:18] ),
-      .alert_rx_i  ( alert_rx[19:18] ),
+      // [21]: fatal
+      // [22]: recov
+      .alert_tx_o  ( alert_tx[22:21] ),
+      .alert_rx_i  ( alert_rx[22:21] ),
 
       // Inter-module signals
       .idle_o(clkmgr_idle[3]),
@@ -1647,7 +1651,6 @@ module top_earlgrey #(
       intr_hmac_hmac_err,
       intr_hmac_fifo_empty,
       intr_hmac_hmac_done,
-      intr_flash_ctrl_op_error,
       intr_flash_ctrl_op_done,
       intr_flash_ctrl_rd_lvl,
       intr_flash_ctrl_rd_full,

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.c
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.c
@@ -11,7 +11,7 @@
  * `top_earlgrey_plic_peripheral_t`.
  */
 const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[123] = {
+    top_earlgrey_plic_interrupt_for_peripheral[122] = {
   [kTopEarlgreyPlicIrqIdNone] = kTopEarlgreyPlicPeripheralUnknown,
   [kTopEarlgreyPlicIrqIdUart0TxWatermark] = kTopEarlgreyPlicPeripheralUart0,
   [kTopEarlgreyPlicIrqIdUart0RxWatermark] = kTopEarlgreyPlicPeripheralUart0,
@@ -88,7 +88,6 @@ const top_earlgrey_plic_peripheral_t
   [kTopEarlgreyPlicIrqIdFlashCtrlRdFull] = kTopEarlgreyPlicPeripheralFlashCtrl,
   [kTopEarlgreyPlicIrqIdFlashCtrlRdLvl] = kTopEarlgreyPlicPeripheralFlashCtrl,
   [kTopEarlgreyPlicIrqIdFlashCtrlOpDone] = kTopEarlgreyPlicPeripheralFlashCtrl,
-  [kTopEarlgreyPlicIrqIdFlashCtrlOpError] = kTopEarlgreyPlicPeripheralFlashCtrl,
   [kTopEarlgreyPlicIrqIdHmacHmacDone] = kTopEarlgreyPlicPeripheralHmac,
   [kTopEarlgreyPlicIrqIdHmacFifoEmpty] = kTopEarlgreyPlicPeripheralHmac,
   [kTopEarlgreyPlicIrqIdHmacHmacErr] = kTopEarlgreyPlicPeripheralHmac,
@@ -145,7 +144,7 @@ const top_earlgrey_plic_peripheral_t
  * `top_earlgrey_alert_peripheral_t`.
  */
 const top_earlgrey_alert_peripheral_t
-    top_earlgrey_alert_for_peripheral[20] = {
+    top_earlgrey_alert_for_peripheral[23] = {
   [kTopEarlgreyAlertIdAesRecovCtrlUpdateErr] = kTopEarlgreyAlertPeripheralAes,
   [kTopEarlgreyAlertIdAesFatalFault] = kTopEarlgreyAlertPeripheralAes,
   [kTopEarlgreyAlertIdOtbnFatal] = kTopEarlgreyAlertPeripheralOtbn,
@@ -166,5 +165,8 @@ const top_earlgrey_alert_peripheral_t
   [kTopEarlgreyAlertIdEntropySrcRecovAlertCountMet] = kTopEarlgreyAlertPeripheralEntropySrc,
   [kTopEarlgreyAlertIdSramCtrlMainFatalParityError] = kTopEarlgreyAlertPeripheralSramCtrlMain,
   [kTopEarlgreyAlertIdSramCtrlRetFatalParityError] = kTopEarlgreyAlertPeripheralSramCtrlRet,
+  [kTopEarlgreyAlertIdFlashCtrlRecovErr] = kTopEarlgreyAlertPeripheralFlashCtrl,
+  [kTopEarlgreyAlertIdFlashCtrlRecovMpErr] = kTopEarlgreyAlertPeripheralFlashCtrl,
+  [kTopEarlgreyAlertIdFlashCtrlRecovEccErr] = kTopEarlgreyAlertPeripheralFlashCtrl,
 };
 

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -739,54 +739,53 @@ typedef enum top_earlgrey_plic_irq_id {
   kTopEarlgreyPlicIrqIdFlashCtrlRdFull = 73, /**< flash_ctrl_rd_full */
   kTopEarlgreyPlicIrqIdFlashCtrlRdLvl = 74, /**< flash_ctrl_rd_lvl */
   kTopEarlgreyPlicIrqIdFlashCtrlOpDone = 75, /**< flash_ctrl_op_done */
-  kTopEarlgreyPlicIrqIdFlashCtrlOpError = 76, /**< flash_ctrl_op_error */
-  kTopEarlgreyPlicIrqIdHmacHmacDone = 77, /**< hmac_hmac_done */
-  kTopEarlgreyPlicIrqIdHmacFifoEmpty = 78, /**< hmac_fifo_empty */
-  kTopEarlgreyPlicIrqIdHmacHmacErr = 79, /**< hmac_hmac_err */
-  kTopEarlgreyPlicIrqIdAlertHandlerClassa = 80, /**< alert_handler_classa */
-  kTopEarlgreyPlicIrqIdAlertHandlerClassb = 81, /**< alert_handler_classb */
-  kTopEarlgreyPlicIrqIdAlertHandlerClassc = 82, /**< alert_handler_classc */
-  kTopEarlgreyPlicIrqIdAlertHandlerClassd = 83, /**< alert_handler_classd */
-  kTopEarlgreyPlicIrqIdNmiGenEsc0 = 84, /**< nmi_gen_esc0 */
-  kTopEarlgreyPlicIrqIdNmiGenEsc1 = 85, /**< nmi_gen_esc1 */
-  kTopEarlgreyPlicIrqIdNmiGenEsc2 = 86, /**< nmi_gen_esc2 */
-  kTopEarlgreyPlicIrqIdUsbdevPktReceived = 87, /**< usbdev_pkt_received */
-  kTopEarlgreyPlicIrqIdUsbdevPktSent = 88, /**< usbdev_pkt_sent */
-  kTopEarlgreyPlicIrqIdUsbdevDisconnected = 89, /**< usbdev_disconnected */
-  kTopEarlgreyPlicIrqIdUsbdevHostLost = 90, /**< usbdev_host_lost */
-  kTopEarlgreyPlicIrqIdUsbdevLinkReset = 91, /**< usbdev_link_reset */
-  kTopEarlgreyPlicIrqIdUsbdevLinkSuspend = 92, /**< usbdev_link_suspend */
-  kTopEarlgreyPlicIrqIdUsbdevLinkResume = 93, /**< usbdev_link_resume */
-  kTopEarlgreyPlicIrqIdUsbdevAvEmpty = 94, /**< usbdev_av_empty */
-  kTopEarlgreyPlicIrqIdUsbdevRxFull = 95, /**< usbdev_rx_full */
-  kTopEarlgreyPlicIrqIdUsbdevAvOverflow = 96, /**< usbdev_av_overflow */
-  kTopEarlgreyPlicIrqIdUsbdevLinkInErr = 97, /**< usbdev_link_in_err */
-  kTopEarlgreyPlicIrqIdUsbdevRxCrcErr = 98, /**< usbdev_rx_crc_err */
-  kTopEarlgreyPlicIrqIdUsbdevRxPidErr = 99, /**< usbdev_rx_pid_err */
-  kTopEarlgreyPlicIrqIdUsbdevRxBitstuffErr = 100, /**< usbdev_rx_bitstuff_err */
-  kTopEarlgreyPlicIrqIdUsbdevFrame = 101, /**< usbdev_frame */
-  kTopEarlgreyPlicIrqIdUsbdevConnected = 102, /**< usbdev_connected */
-  kTopEarlgreyPlicIrqIdUsbdevLinkOutErr = 103, /**< usbdev_link_out_err */
-  kTopEarlgreyPlicIrqIdPwrmgrWakeup = 104, /**< pwrmgr_wakeup */
-  kTopEarlgreyPlicIrqIdOtbnDone = 105, /**< otbn_done */
-  kTopEarlgreyPlicIrqIdKeymgrOpDone = 106, /**< keymgr_op_done */
-  kTopEarlgreyPlicIrqIdKmacKmacDone = 107, /**< kmac_kmac_done */
-  kTopEarlgreyPlicIrqIdKmacFifoEmpty = 108, /**< kmac_fifo_empty */
-  kTopEarlgreyPlicIrqIdKmacKmacErr = 109, /**< kmac_kmac_err */
-  kTopEarlgreyPlicIrqIdOtpCtrlOtpOperationDone = 110, /**< otp_ctrl_otp_operation_done */
-  kTopEarlgreyPlicIrqIdOtpCtrlOtpError = 111, /**< otp_ctrl_otp_error */
-  kTopEarlgreyPlicIrqIdCsrngCsCmdReqDone = 112, /**< csrng_cs_cmd_req_done */
-  kTopEarlgreyPlicIrqIdCsrngCsEntropyReq = 113, /**< csrng_cs_entropy_req */
-  kTopEarlgreyPlicIrqIdCsrngCsHwInstExc = 114, /**< csrng_cs_hw_inst_exc */
-  kTopEarlgreyPlicIrqIdCsrngCsFifoErr = 115, /**< csrng_cs_fifo_err */
-  kTopEarlgreyPlicIrqIdEdn0EdnCmdReqDone = 116, /**< edn0_edn_cmd_req_done */
-  kTopEarlgreyPlicIrqIdEdn0EdnFifoErr = 117, /**< edn0_edn_fifo_err */
-  kTopEarlgreyPlicIrqIdEdn1EdnCmdReqDone = 118, /**< edn1_edn_cmd_req_done */
-  kTopEarlgreyPlicIrqIdEdn1EdnFifoErr = 119, /**< edn1_edn_fifo_err */
-  kTopEarlgreyPlicIrqIdEntropySrcEsEntropyValid = 120, /**< entropy_src_es_entropy_valid */
-  kTopEarlgreyPlicIrqIdEntropySrcEsHealthTestFailed = 121, /**< entropy_src_es_health_test_failed */
-  kTopEarlgreyPlicIrqIdEntropySrcEsFifoErr = 122, /**< entropy_src_es_fifo_err */
-  kTopEarlgreyPlicIrqIdLast = 122, /**< \internal The Last Valid Interrupt ID. */
+  kTopEarlgreyPlicIrqIdHmacHmacDone = 76, /**< hmac_hmac_done */
+  kTopEarlgreyPlicIrqIdHmacFifoEmpty = 77, /**< hmac_fifo_empty */
+  kTopEarlgreyPlicIrqIdHmacHmacErr = 78, /**< hmac_hmac_err */
+  kTopEarlgreyPlicIrqIdAlertHandlerClassa = 79, /**< alert_handler_classa */
+  kTopEarlgreyPlicIrqIdAlertHandlerClassb = 80, /**< alert_handler_classb */
+  kTopEarlgreyPlicIrqIdAlertHandlerClassc = 81, /**< alert_handler_classc */
+  kTopEarlgreyPlicIrqIdAlertHandlerClassd = 82, /**< alert_handler_classd */
+  kTopEarlgreyPlicIrqIdNmiGenEsc0 = 83, /**< nmi_gen_esc0 */
+  kTopEarlgreyPlicIrqIdNmiGenEsc1 = 84, /**< nmi_gen_esc1 */
+  kTopEarlgreyPlicIrqIdNmiGenEsc2 = 85, /**< nmi_gen_esc2 */
+  kTopEarlgreyPlicIrqIdUsbdevPktReceived = 86, /**< usbdev_pkt_received */
+  kTopEarlgreyPlicIrqIdUsbdevPktSent = 87, /**< usbdev_pkt_sent */
+  kTopEarlgreyPlicIrqIdUsbdevDisconnected = 88, /**< usbdev_disconnected */
+  kTopEarlgreyPlicIrqIdUsbdevHostLost = 89, /**< usbdev_host_lost */
+  kTopEarlgreyPlicIrqIdUsbdevLinkReset = 90, /**< usbdev_link_reset */
+  kTopEarlgreyPlicIrqIdUsbdevLinkSuspend = 91, /**< usbdev_link_suspend */
+  kTopEarlgreyPlicIrqIdUsbdevLinkResume = 92, /**< usbdev_link_resume */
+  kTopEarlgreyPlicIrqIdUsbdevAvEmpty = 93, /**< usbdev_av_empty */
+  kTopEarlgreyPlicIrqIdUsbdevRxFull = 94, /**< usbdev_rx_full */
+  kTopEarlgreyPlicIrqIdUsbdevAvOverflow = 95, /**< usbdev_av_overflow */
+  kTopEarlgreyPlicIrqIdUsbdevLinkInErr = 96, /**< usbdev_link_in_err */
+  kTopEarlgreyPlicIrqIdUsbdevRxCrcErr = 97, /**< usbdev_rx_crc_err */
+  kTopEarlgreyPlicIrqIdUsbdevRxPidErr = 98, /**< usbdev_rx_pid_err */
+  kTopEarlgreyPlicIrqIdUsbdevRxBitstuffErr = 99, /**< usbdev_rx_bitstuff_err */
+  kTopEarlgreyPlicIrqIdUsbdevFrame = 100, /**< usbdev_frame */
+  kTopEarlgreyPlicIrqIdUsbdevConnected = 101, /**< usbdev_connected */
+  kTopEarlgreyPlicIrqIdUsbdevLinkOutErr = 102, /**< usbdev_link_out_err */
+  kTopEarlgreyPlicIrqIdPwrmgrWakeup = 103, /**< pwrmgr_wakeup */
+  kTopEarlgreyPlicIrqIdOtbnDone = 104, /**< otbn_done */
+  kTopEarlgreyPlicIrqIdKeymgrOpDone = 105, /**< keymgr_op_done */
+  kTopEarlgreyPlicIrqIdKmacKmacDone = 106, /**< kmac_kmac_done */
+  kTopEarlgreyPlicIrqIdKmacFifoEmpty = 107, /**< kmac_fifo_empty */
+  kTopEarlgreyPlicIrqIdKmacKmacErr = 108, /**< kmac_kmac_err */
+  kTopEarlgreyPlicIrqIdOtpCtrlOtpOperationDone = 109, /**< otp_ctrl_otp_operation_done */
+  kTopEarlgreyPlicIrqIdOtpCtrlOtpError = 110, /**< otp_ctrl_otp_error */
+  kTopEarlgreyPlicIrqIdCsrngCsCmdReqDone = 111, /**< csrng_cs_cmd_req_done */
+  kTopEarlgreyPlicIrqIdCsrngCsEntropyReq = 112, /**< csrng_cs_entropy_req */
+  kTopEarlgreyPlicIrqIdCsrngCsHwInstExc = 113, /**< csrng_cs_hw_inst_exc */
+  kTopEarlgreyPlicIrqIdCsrngCsFifoErr = 114, /**< csrng_cs_fifo_err */
+  kTopEarlgreyPlicIrqIdEdn0EdnCmdReqDone = 115, /**< edn0_edn_cmd_req_done */
+  kTopEarlgreyPlicIrqIdEdn0EdnFifoErr = 116, /**< edn0_edn_fifo_err */
+  kTopEarlgreyPlicIrqIdEdn1EdnCmdReqDone = 117, /**< edn1_edn_cmd_req_done */
+  kTopEarlgreyPlicIrqIdEdn1EdnFifoErr = 118, /**< edn1_edn_fifo_err */
+  kTopEarlgreyPlicIrqIdEntropySrcEsEntropyValid = 119, /**< entropy_src_es_entropy_valid */
+  kTopEarlgreyPlicIrqIdEntropySrcEsHealthTestFailed = 120, /**< entropy_src_es_health_test_failed */
+  kTopEarlgreyPlicIrqIdEntropySrcEsFifoErr = 121, /**< entropy_src_es_fifo_err */
+  kTopEarlgreyPlicIrqIdLast = 121, /**< \internal The Last Valid Interrupt ID. */
 } top_earlgrey_plic_irq_id_t;
 
 /**
@@ -796,7 +795,7 @@ typedef enum top_earlgrey_plic_irq_id {
  * `top_earlgrey_plic_peripheral_t`.
  */
 extern const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[123];
+    top_earlgrey_plic_interrupt_for_peripheral[122];
 
 /**
  * PLIC Interrupt Target.
@@ -825,7 +824,8 @@ typedef enum top_earlgrey_alert_peripheral {
   kTopEarlgreyAlertPeripheralEntropySrc = 6, /**< entropy_src */
   kTopEarlgreyAlertPeripheralSramCtrlMain = 7, /**< sram_ctrl_main */
   kTopEarlgreyAlertPeripheralSramCtrlRet = 8, /**< sram_ctrl_ret */
-  kTopEarlgreyAlertPeripheralLast = 8, /**< \internal Final Alert peripheral */
+  kTopEarlgreyAlertPeripheralFlashCtrl = 9, /**< flash_ctrl */
+  kTopEarlgreyAlertPeripheralLast = 9, /**< \internal Final Alert peripheral */
 } top_earlgrey_alert_peripheral_t;
 
 /**
@@ -855,7 +855,10 @@ typedef enum top_earlgrey_alert_id {
   kTopEarlgreyAlertIdEntropySrcRecovAlertCountMet = 17, /**< entropy_src_recov_alert_count_met */
   kTopEarlgreyAlertIdSramCtrlMainFatalParityError = 18, /**< sram_ctrl_main_fatal_parity_error */
   kTopEarlgreyAlertIdSramCtrlRetFatalParityError = 19, /**< sram_ctrl_ret_fatal_parity_error */
-  kTopEarlgreyAlertIdLast = 19, /**< \internal The Last Valid Alert ID. */
+  kTopEarlgreyAlertIdFlashCtrlRecovErr = 20, /**< flash_ctrl_recov_err */
+  kTopEarlgreyAlertIdFlashCtrlRecovMpErr = 21, /**< flash_ctrl_recov_mp_err */
+  kTopEarlgreyAlertIdFlashCtrlRecovEccErr = 22, /**< flash_ctrl_recov_ecc_err */
+  kTopEarlgreyAlertIdLast = 22, /**< \internal The Last Valid Alert ID. */
 } top_earlgrey_alert_id_t;
 
 /**
@@ -865,7 +868,7 @@ typedef enum top_earlgrey_alert_id {
  * `top_earlgrey_alert_peripheral_t`.
  */
 extern const top_earlgrey_alert_peripheral_t
-    top_earlgrey_alert_for_peripheral[20];
+    top_earlgrey_alert_for_peripheral[23];
 
 #define PINMUX_PERIPH_INSEL_IDX_OFFSET 2
 

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -643,7 +643,7 @@
   // list all modules that expose alerts
   // first item goes to LSB of the alert source
   alert_module: [ "aes", "sensor_ctrl", "lc_ctrl",
-                  "sram_ctrl_main", "sram_ctrl_ret"]
+                  "sram_ctrl_main", "sram_ctrl_ret", "flash_ctrl"]
 
   // generated list of alerts:
   alert: [

--- a/sw/device/lib/flash_ctrl.c
+++ b/sw/device/lib/flash_ctrl.c
@@ -42,9 +42,8 @@ void flash_init_block(void) {
 /* Return status error and clear internal status register */
 static int get_clr_err(void) {
   uint32_t err_status =
-      REG32(FLASH_CTRL0_BASE_ADDR + FLASH_CTRL_INTR_STATE_REG_OFFSET) &
-      (0x1 << FLASH_CTRL_INTR_STATE_OP_ERROR_BIT);
-  REG32(FLASH_CTRL0_BASE_ADDR + FLASH_CTRL_INTR_STATE_REG_OFFSET) = err_status;
+      REG32(FLASH_CTRL0_BASE_ADDR + FLASH_CTRL_ERR_CODE_REG_OFFSET);
+  REG32(FLASH_CTRL0_BASE_ADDR + FLASH_CTRL_ERR_CODE_REG_OFFSET) = 0;
   return err_status;
 }
 

--- a/sw/device/tests/dif/dif_plic_unittest.cc
+++ b/sw/device/tests/dif/dif_plic_unittest.cc
@@ -20,7 +20,7 @@ using testing::Test;
 
 // If either of these static assertions fail, then the unit-tests for related
 // API should be revisited.
-static_assert(RV_PLIC_PARAM_NUMSRC == 123,
+static_assert(RV_PLIC_PARAM_NUMSRC == 122,
               "PLIC instantiation parameters have changed.");
 static_assert(RV_PLIC_PARAM_NUMTARGET == 1,
               "PLIC instantiation parameters have changed.");
@@ -106,21 +106,21 @@ class IrqTest : public PlicTest {
           {RV_PLIC_IE0_0_REG_OFFSET, RV_PLIC_IE0_0_E_31_BIT},
           {RV_PLIC_IE0_1_REG_OFFSET, RV_PLIC_IE0_1_E_63_BIT},
           {RV_PLIC_IE0_2_REG_OFFSET, RV_PLIC_IE0_2_E_95_BIT},
-          {RV_PLIC_IE0_3_REG_OFFSET, RV_PLIC_IE0_3_E_122_BIT},
+          {RV_PLIC_IE0_3_REG_OFFSET, RV_PLIC_IE0_3_E_121_BIT},
       }};
   static constexpr std::array<Register, RV_PLIC_LE_MULTIREG_COUNT>
       kTriggerRegisters{{
           {RV_PLIC_LE_0_REG_OFFSET, RV_PLIC_LE_0_LE_31_BIT},
           {RV_PLIC_LE_1_REG_OFFSET, RV_PLIC_LE_1_LE_63_BIT},
           {RV_PLIC_LE_2_REG_OFFSET, RV_PLIC_LE_2_LE_95_BIT},
-          {RV_PLIC_LE_3_REG_OFFSET, RV_PLIC_LE_3_LE_122_BIT},
+          {RV_PLIC_LE_3_REG_OFFSET, RV_PLIC_LE_3_LE_121_BIT},
       }};
   static constexpr std::array<Register, RV_PLIC_IP_MULTIREG_COUNT>
       kPendingRegisters{{
           {RV_PLIC_IP_0_REG_OFFSET, RV_PLIC_IP_0_P_31_BIT},
           {RV_PLIC_IP_1_REG_OFFSET, RV_PLIC_IP_1_P_63_BIT},
           {RV_PLIC_IP_2_REG_OFFSET, RV_PLIC_IP_2_P_95_BIT},
-          {RV_PLIC_IP_3_REG_OFFSET, RV_PLIC_IP_3_P_122_BIT},
+          {RV_PLIC_IP_3_REG_OFFSET, RV_PLIC_IP_3_P_121_BIT},
       }};
 
   // Set enable/disable multireg expectations, one bit per call.

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -881,7 +881,7 @@ def _process_top(topcfg, args, cfg_path, out_path, pass_idx):
 
     for ip in generated_list:
         # For modules that are generated prior to gathering, we need to take it from
-        # the ouptput path.  For modules not generated before, it may exist in a
+        # the output path.  For modules not generated before, it may exist in a
         # pre-defined area already.
         log.info("Appending {}".format(ip))
         if ip == 'clkmgr' or (pass_idx > 0):

--- a/util/topgen/__init__.py
+++ b/util/topgen/__init__.py
@@ -5,4 +5,4 @@
 from .lib import get_hjsonobj_xbars, search_ips  # noqa: F401
 # noqa: F401 These functions are used in topgen.py
 from .merge import amend_clocks, merge_top  # noqa: F401
-from .validate import validate_top  # noqa: F401
+from .validate import validate_top, check_flash  # noqa: F401


### PR DESCRIPTION
- Add ERR_CODE register and separate various error sources
- Update prim_generic_flash interface to align with latest spec
- Add fatal and recoverable alerts
- Various scripting / sw changes were required to enable this change.