### PR TITLE
[otp_ctrl] otp dai interface errors

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -104,20 +104,32 @@
       milestone: V2
       tests: ["otp_ctrl_lc"]
     }
+    { name: otp_dai_errors
+      desc: '''
+            This test will randomly run the following OTP errors:
+            - DAI interface write non-blank OTP address
+            - DAI interface access LC partition
+            - DAI interface write HW digests
+
+            The test will check:
+            - The value of err_code and status registers
+            '''
+      milestone: V2
+      tests: ["otp_ctrl_dai_errs"]
+    }
     { name: otp_macro_errors
       desc: '''
             This test will randomly run the following OTP errors:
             - MacroError
             - MacroEccCorrError
             - MacroEccUncorrError
-            - MacroWriteBlankError
 
             The test will check:
             - The value of err_code and status registers
             - If error is unrecoverable, ensure that OTP entered terminal state
             '''
       milestone: V2
-      tests: ["otp_ctrl_macro_errs"]
+      tests: []
     }
     {
       name: otp_ctrl_errors

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -26,7 +26,7 @@ filesets:
       - seq_lib/otp_ctrl_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_lc_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_dai_lock_vseq.sv: {is_include_file: true}
-      - seq_lib/otp_ctrl_macro_errs_vseq.sv: {is_include_file: true}
+      - seq_lib/otp_ctrl_dai_errs_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -142,6 +142,7 @@ package otp_ctrl_env_pkg;
         break;
       end
     end
+    if (index == NumPart) index--;
     return index;
   endfunction
 
@@ -149,6 +150,24 @@ package otp_ctrl_env_pkg;
     int part_index = get_part_index(addr);
     if (part_index inside {[Secret0Idx:Secret2Idx]}) return 1;
     else return 0;
+  endfunction
+
+  function automatic bit is_sw_digest(bit [TL_DW-1:0] addr);
+    if ({addr[TL_DW-1:3], 3'b0} inside {CreatorSwCfgDigestOffset, OwnerSwCfgDigestOffset}) begin
+      return 1;
+    end else begin
+      return 0;
+    end
+  endfunction
+
+  function automatic bit is_digest(bit [TL_DW-1:0] addr);
+    if (is_sw_digest(addr)) return 1;
+    if ({addr[TL_DW-1:3], 3'b0} inside {HwCfgDigestOffset, Secret0DigestOffset,
+                                        Secret1DigestOffset, Secret2DigestOffset}) begin
+      return 1;
+    end else begin
+      return 0;
+    end
   endfunction
 
   // Resolve an offset within the software window as an offset within the whole otp_ctrl block.

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -68,9 +68,8 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     addr = randomize_dai_addr(addr);
     csr_wr(ral.direct_access_address, addr);
     csr_wr(ral.direct_access_wdata_0, wdata0);
-    if (is_secret(addr) || addr inside {CreatorSwCfgDigestOffset, OwnerSwCfgDigestOffset}) begin
-      csr_wr(ral.direct_access_wdata_1, wdata1);
-    end
+    if (is_secret(addr) || is_sw_digest(addr)) csr_wr(ral.direct_access_wdata_1, wdata1);
+
     csr_wr(ral.direct_access_cmd, int'(otp_ctrl_pkg::DaiWrite));
     `uvm_info(`gfn, $sformatf("DAI write, address %0h, data0 %0h data1 %0h, is_secret = %0b",
               addr, wdata0, wdata1, is_secret(addr)), UVM_DEBUG)
@@ -134,6 +133,8 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     bit [TL_DW-1:0] val;
     csr_rd(.ptr(ral.creator_sw_cfg_digest_0), .value(val));
     csr_rd(.ptr(ral.creator_sw_cfg_digest_1), .value(val));
+    csr_rd(.ptr(ral.owner_sw_cfg_digest_0),   .value(val));
+    csr_rd(.ptr(ral.owner_sw_cfg_digest_1),   .value(val));
     csr_rd(.ptr(ral.hw_cfg_digest_0),         .value(val));
     csr_rd(.ptr(ral.hw_cfg_digest_1),         .value(val));
     csr_rd(.ptr(ral.secret0_digest_0),        .value(val));

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// otp_ctrl_marco_errs_vseq is developed to randomly read/write to any address within OTP:
+// otp_ctrl_dai_errs_vseq is developed to randomly read/write to any address within OTP:
 // - A writeblank error will be triggered if write to a non-empty address
 // - An access error will be triggered if write to lc partition via DAI interface, or if DAI write
 //   to digest addrs for non-sw partitions
-class otp_ctrl_macro_errs_vseq extends otp_ctrl_smoke_vseq;
-  `uvm_object_utils(otp_ctrl_macro_errs_vseq)
+class otp_ctrl_dai_errs_vseq extends otp_ctrl_smoke_vseq;
+  `uvm_object_utils(otp_ctrl_dai_errs_vseq)
 
   `uvm_object_new
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_errs_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_errs_vseq.sv
@@ -16,11 +16,14 @@ class otp_ctrl_macro_errs_vseq extends otp_ctrl_smoke_vseq;
     num_dai_op inside {[100:500]};
   }
 
+  constraint dai_wr_legal_addr_c {
+    {dai_addr[TL_AW-1:2], 2'b0} inside {[CreatorSwCfgOffset : (LifeCycleOffset + LifeCycleSize)]};
+  }
+
   function void pre_randomize();
-    // TODO: enable this once support
-    // this.partition_index_c.constraint_mode(0);
-    // this.dai_wr_legal_addr_c.constraint_mode(0);
+    this.partition_index_c.constraint_mode(0);
     this.dai_wr_blank_addr_c.constraint_mode(0);
+    this.no_access_err_c.constraint_mode(0);
     collect_used_addr = 0;
   endfunction
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -84,11 +84,14 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
       // get sram keys
       req_all_sram_keys();
 
-
       for (int i = 0; i < num_dai_op; i++) begin
         bit [TL_DW-1:0] rdata0, rdata1;
-        `uvm_info(`gfn, $sformatf("starting dai access seq %0d/%0d", i, num_dai_op), UVM_DEBUG)
+
         `DV_CHECK_RANDOMIZE_FATAL(this)
+        // recalculate part_idx in case some test turn off constraint dai_wr_legal_addr_c
+        part_idx = get_part_index(dai_addr);
+        `uvm_info(`gfn, $sformatf("starting dai access seq %0d/%0d with addr %0h in partition %0d",
+                  i, num_dai_op, dai_addr, part_idx), UVM_DEBUG)
 
         // OTP write via DAI
         if ($urandom_range(0, 1)) begin
@@ -113,13 +116,15 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
         if ($urandom_range(0, 1)) csr_rd(.ptr(ral.status), .value(tlul_val));
       end
 
-      // lock HW digests
+      // lock digests
       `uvm_info(`gfn, "Trigger HW digest calculation", UVM_HIGH)
       cal_hw_digests();
       if ($urandom_range(0, 1)) csr_rd(.ptr(ral.status), .value(tlul_val));
       write_sw_digests();
       if ($urandom_range(0, 1)) csr_rd(.ptr(ral.status), .value(tlul_val));
       write_sw_rd_locks();
+
+      if ($urandom_range(0, 1)) rd_digests();
       dut_init();
 
       // read and check digest in scb

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
@@ -8,4 +8,4 @@
 `include "otp_ctrl_common_vseq.sv"
 `include "otp_ctrl_lc_vseq.sv"
 `include "otp_ctrl_dai_lock_vseq.sv"
-`include "otp_ctrl_macro_errs_vseq.sv"
+`include "otp_ctrl_dai_errs_vseq.sv"

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -71,8 +71,8 @@
     }
 
     {
-      name: otp_ctrl_macro_errs
-      uvm_test_seq: otp_ctrl_macro_errs_vseq
+      name: otp_ctrl_dai_errs
+      uvm_test_seq: otp_ctrl_dai_errs_vseq
     }
 
   ]

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -679,9 +679,8 @@ module otp_ctrl_dai
     end else if (PartInfo[part_idx].hw_digest && (base_sel_q == PartOffset)) begin
         otp_size_o = OtpSizeWidth'(unsigned'(ScrmblBlockWidth / OtpWidth - 1));
         addr_base = PartInfo[part_idx].offset;
-    // 64bit transaction if this partition does not have a HW digest, and the DAI address points to
-    // the digest offset.
-    end else if (!PartInfo[part_idx].hw_digest && (base_sel_q == DaiOffset) &&
+    // 64bit transaction if the DAI address points to the partition's digest offset.
+    end else if ((base_sel_q == DaiOffset) &&
         ({dai_addr_i[OtpByteAddrWidth-1:3], 2'b0} == digest_addr_lut[part_idx])) begin
       otp_size_o = OtpSizeWidth'(unsigned'(ScrmblBlockWidth / OtpWidth - 1));
       addr_base = {dai_addr_i[OtpByteAddrWidth-1:3], 3'h0};


### PR DESCRIPTION
This PR has three commits:
1. Add following error cases to the err_sequence:
   1). DAI interface access LC partition
   2). DAI interface write HW and secret digests
   3). DAI interface access partitions that are locked

2. Rename the otp_macro_errs_vseq to otp_dai_errs_vseq:
   otp_macro errors are related to OTP cells like ECC error, but the error cases above
   should be categorized as dai_errors.

3. Fix a small design logic issue:
  In previous statement, `addr_base` will normalize the last 3 bits if the DAI address request
  a SW partition's digest address. But this could happen in HW partitions' digests as well. 
  For the HW partitions, we can still use DAI interface to read digests. 
  So I delete the constraints `PartInfo[part_idx].hw_digest`