### PR TITLE
[site] Remove double break

### DIFF
--- a/site/docs/assets/scss/_markdown.scss
+++ b/site/docs/assets/scss/_markdown.scss
@@ -105,10 +105,6 @@
       margin-top: 0.5em;
     }
   }
-
-  br + br {
-    display: none;
-  }
 }
 
 .overflow-table {

--- a/util/reggen/gen_html.py
+++ b/util/reggen/gen_html.py
@@ -211,7 +211,7 @@ def gen_html_register(outfile, reg, comp, width, rnames, toc, toclvl):
         genout(outfile, "</td></tr>\n")
         nextbit = fieldlsb + field.bits.width()
 
-    genout(outfile, "</table>\n<br><br>\n")
+    genout(outfile, "</table>\n<br>\n")
 
     return
 
@@ -261,7 +261,7 @@ def gen_html_window(outfile, win, comp, regwidth, rnames, toc, toclvl):
     genout(outfile, '</td></tr></table>')
     genout(outfile,
            '<tr>{}</tr>'.format(render_td(win['desc'], rnames, 'regde')))
-    genout(outfile, "</table>\n<br><br>\n")
+    genout(outfile, "</table>\n<br>\n")
     if toc is not None:
         toc.append((toclvl, comp + "." + wname, "Reg_" + wname.lower()))
 


### PR DESCRIPTION
Only create one line break after a register table.
Remove the double line break formatting.

This allows multiple line breaks to be formatted correctly.

Fixes #4762

Signed-off-by: Tobias Wölfel <tobias.woelfel@mailbox.org>