### PR TITLE
[sw] Add global pointer initialization to CRT library

### DIFF
--- a/sw/device/boot_rom/rom_crt.S
+++ b/sw/device/boot_rom/rom_crt.S
@@ -18,6 +18,13 @@
 
   .extern crt_section_clear
   .extern crt_section_copy
+  .extern crt_global_pointer_init
+
+  // Linker Relaxation is disabled until `gp` is setup, below, because
+  // otherwise some sequences may be turned into gp-relative sequences,
+  // which is incorrect when `gp` is not initialized.
+  .option push
+  .option norelax
 
 /**
  * Entry point after reset. This symbol is jumped to from the handler
@@ -63,11 +70,10 @@ _reset_start:
   // Set up the stack.
   la  sp, _stack_end
 
-  // Set up the global pointer. This requires that we disable linker relaxations
-  // (or it will be relaxed to `mv gp, gp`).
-  .option push
-  .option norelax
-  la  gp, __global_pointer$
+  // Set up the global pointer (`gp`).
+  call crt_global_pointer_init
+
+  // Re-enable linker relaxations now that `gp` is setup.
   .option pop
 
   // Explicit fall-through to `_start`.

--- a/sw/device/lib/crt/crt.S
+++ b/sw/device/lib/crt/crt.S
@@ -132,3 +132,32 @@ L_copy_error:
 
   // Set function size to allow disassembly.
   .size crt_section_copy, .-crt_section_copy
+
+/**
+ * Set the global pointer register (`gp`) to the value of `__global_pointer$`.
+ *
+ * This function follows the standard ILP32 calling convention for arguments
+ * but does not require a valid stack pointer, thread pointer or global
+ * pointer.
+ *
+ * Clobbers gp.
+ *
+ * No parameters.
+ */
+crt_global_pointer_init:
+  .globl crt_global_pointer_init
+  .type crt_global_pointer_init, @function
+
+  // Disable linker relaxation so that `_global_pointer$` does not get
+  // 'optimized' into `gp`.
+  .option push
+  .option norelax
+
+  la gp, __global_pointer$
+  ret
+
+  // Re-enable linker relaxation.
+  .option pop
+
+  // Set size so this function can be disassembled.
+  .size crt_global_pointer_init, .-crt_global_pointer_init

--- a/sw/device/silicon_creator/mask_rom/mask_rom_start.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_start.S
@@ -114,8 +114,8 @@ _mask_rom_interrupt_vector:
   // is allocated executable space in ROM by the linker.
   .section .crt, "ax"
 
-  // Linker Relaxation is disabled until `__global_pointer$` is setup, below,
-  // because otherwise some sequences may be turned into gp-relative sequences,
+  // Linker Relaxation is disabled until `gp` is setup, below, because
+  // otherwise some sequences may be turned into gp-relative sequences,
   // which is incorrect when `gp` is not initialized.
   .option push
   .option norelax
@@ -205,6 +205,7 @@ _mask_rom_start_boot:
 
   .extern crt_section_clear
   .extern crt_section_copy
+  .extern crt_global_pointer_init
 
   // TODO: Setup SRAM Scrambling
   // Temporarily: Zero out ram_main
@@ -230,6 +231,12 @@ _mask_rom_start_boot:
   la   a1, _bss_end
   call crt_section_clear
 
+  // Setup global pointer (`gp`).
+  call crt_global_pointer_init
+
+  // Re-enable linker relaxations now that `gp` is initialized.
+  .option pop
+
   // Re-clobber all of the temporary registers (may have been used in calls).
   li t0, 0x0
   li t1, 0x0
@@ -249,12 +256,6 @@ _mask_rom_start_boot:
   li a6, 0x0
   li a7, 0x0
 
-  // Setup global pointer.
-  //
-  // This requires that we disable linker relaxations, or it will be relaxed to
-  // `mv gp, gp`, so we disabled relaxations for all of `_mask_rom_start_boot`.
-  la gp, __global_pointer$
-
   /**
    * Jump to C Code
    */
@@ -263,6 +264,3 @@ _mask_rom_start_boot:
 
   // Set size so this function can be disassembled.
   .size _mask_rom_start_boot, .-_mask_rom_start_boot
-
-  // Re-enable linker relaxation.
-  .option pop

--- a/sw/device/silicon_creator/rom_exts/rom_ext_start.S
+++ b/sw/device/silicon_creator/rom_exts/rom_ext_start.S
@@ -120,8 +120,8 @@ _rom_ext_interrupt_vector:
   .section .crt, "ax"
 
   /**
-   * Linker Relaxation is disabled until `__global_pointer$` is setup, below,
-   * because otherwise some sequences may be turned into gp-relative sequences,
+   * Linker Relaxation is disabled until `gp` is setup, below, because
+   * otherwise some sequences may be turned into gp-relative sequences,
    * which is incorrect when `gp` is not initialized.
    */
   .option push
@@ -202,6 +202,17 @@ _rom_ext_start_boot:
   .extern crt_section_clear
   call crt_section_clear
 
+  /**
+   * Setup global pointer (`gp`).
+   */
+  .extern crt_global_pointer_init
+  call crt_global_pointer_init
+
+  /**
+   * Re-enable linker relaxations now that `gp` is initialized.
+   */
+  .option pop
+
   // Re-clobber all of the temporary registers.
   li t0, 0x0
   li t1, 0x0
@@ -220,17 +231,6 @@ _rom_ext_start_boot:
   li a5, 0x0
   li a6, 0x0
   li a7, 0x0
-
-  /**
-   * Setup global pointer.
-   *
-   * This requires that we disable linker relaxations, or it will be relaxed to
-   * `mv gp, gp`, so we disabled relaxations for all of `_mask_rom_start_boot`.
-   */
-  la gp, __global_pointer$
-
-  // Re-enable linker relaxation.
-  .option pop
 
   /**
    * Jump to C Code


### PR DESCRIPTION
Add a new crt_global_pointer_init function to initialize the global
pointer. This is nice because it means we don't need to disable
linker relaxations in as many places.