### PR TITLE
[aes] Add missing CSR exclusion for ALERT_RECOVERABLE status bit

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -485,7 +485,7 @@
     # Tag info (CSR test exclusions):
     #  Updated by the HW.
     #  Updates based on writes to other regs.
-    #  -> Exclude all fields (except CTRL_STORAGE_ERROR) from init and write-read checks.
+    #  -> Exclude all fields (except ALERT_FATAL) from init and write-read checks.
     #  Upon reset, internal operations are triggered that temporarily change the IDLE field.
     #  -> Exclude IDLE field from init and write-read checks (also in reset test).
     fields: [
@@ -534,6 +534,7 @@
           A recoverable alert condition has occurred and AES operation needs to be restarted by successfully updating the Control Register (1).
           Examples for recoverable alert conditions include update errors in the Control Register.
         '''
+        tags: ["excl:CsrNonInitTests:CsrExclCheck"]
       }
       { bits: "5",
         name: "ALERT_FATAL",

--- a/hw/ip/aes/dv/env/aes_env_pkg.sv
+++ b/hw/ip/aes/dv/env/aes_env_pkg.sv
@@ -46,8 +46,9 @@ package aes_env_pkg;
   } cfg_error_type_t;
 
   typedef struct packed {
-    logic [31:5] unused;
-    logic        ctrl_error_storage;
+    logic [31:6] unused;
+    logic        alert_fatal;
+    logic        alert_recoverable;
     logic        input_ready;
     logic        output_valid;
     logic        stall;

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -473,7 +473,7 @@ class aes_base_vseq extends cip_base_vseq #(
       //read the status register to see that we have triggered the operation
       csr_rd(.ptr(ral.status), .value(status), .blocking(is_blocking));
       // check status and act accordingly //
-      if (status.ctrl_error_storage) begin
+      if (status.alert_fatal) begin
         // stuck pull reset //
       end else begin
         // state 0
@@ -546,7 +546,7 @@ class aes_base_vseq extends cip_base_vseq #(
           `uvm_fatal(`gfn, $sformatf("\n\t %s",txt))
         end
         `uvm_info(`gfn, $sformatf("\n\t %s",txt), UVM_MEDIUM)
-      end // else: !if(status.ctrl_error_storage)
+      end // else: !if(status.alert_fatal)
     end // while (!done)
 
   endtask // transmit_fsm


### PR DESCRIPTION
This bit can be asserted if during CSR tests the Control Register is not properly used. It should thus be excluded. This should fix some regression failures we are currently seeing.