### PR TITLE
Document the need to have libncurses5 installed

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -22,6 +22,8 @@ libelf1
 libelf-dev
 libftdi1-2
 libftdi1-dev
+# A requirement of the prebuilt clang toolchain.
+libncurses5
 libssl-dev
 libusb-1.0-0
 lsb-release


### PR DESCRIPTION
The prebuilt version of clang requires `libtinfo.so.5` to be present,
which is provided by ncurses5.