### PR TITLE
[doc] Small fixes to documentation rendering

### DIFF
--- a/doc/ug/getting_started_verilator.md
+++ b/doc/ug/getting_started_verilator.md
@@ -75,9 +75,7 @@ Note that `screen` will only show output that has been generated after `screen` 
 
 You can exit `screen` (in the default configuration) by pressing `CTRL-a k` and confirm with `y`.
 
-If everything is working correctly you should expect to see text like
-the following from the virtual UART (replacing `/dev/pts/11` with the reported
-device):
+If everything is working correctly you should expect to see text like the following from the virtual UART (replacing `/dev/pts/11` with the reported device):
 
 ```console
 $ cat /dev/pts/11

--- a/site/docs/assets/scss/_base.scss
+++ b/site/docs/assets/scss/_base.scss
@@ -2,7 +2,12 @@
 // HTML & Body
 
 html {
-  font-size: 1rem;
+  /*
+  Explicitly set the font size to the typical browser default to work around a
+  bug in Chrome where <code> elements don't get the right font size when using
+  @font-size=1rem (https://bugs.chromium.org/p/chromium/issues/detail?id=833697)
+  */
+  font-size: 16px;
   scroll-behavior: smooth;
 }
 

--- a/site/docs/assets/scss/_chroma.scss
+++ b/site/docs/assets/scss/_chroma.scss
@@ -1,5 +1,6 @@
 /* Colorful style (`hugo gen chromastyles --style=colorful`) */
 /* Changes: default background color */
+:not([data-user-color-scheme]),
 [data-user-color-scheme='light'] {
 /* Background */ .chroma { background-color: adjust-color($white, $lightness: -3%) }
 /* Other */ .chroma .x {  }

--- a/site/docs/layouts/partials/footer.html
+++ b/site/docs/layouts/partials/footer.html
@@ -44,8 +44,7 @@
     Policy</a>.</p>
 </footer>
 
-<script type="text/javascript"
-  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/wavedrom/2.1.2/skins/default.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/wavedrom/2.1.2/wavedrom.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/markdown-it/10.0.0/markdown-it.min.js"></script>


### PR DESCRIPTION
Fix some small issues in docs rendering:

* Ensure code blocks are rendered properly in Chrome
* Always highlight code blocks
* Work around delayed math rendering
* Small editorial fix