### PR TITLE
[sw, plic] Refactor DIF PLIC to be top level agnostic

### DIFF
--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -13,16 +13,8 @@
 
 #include "rv_plic_regs.h"  // Generated.
 
-// If either of these static assertions fail, then the assumptions in this DIF
-// implementation should be revisited. In particular, `kPlicTargets`
-// may need updating,
-_Static_assert(RV_PLIC_PARAM_NUMSRC == 99,
-               "PLIC instantiation parameters have changed.");
-_Static_assert(RV_PLIC_PARAM_NUMTARGET == 1,
-               "PLIC instantiation parameters have changed.");
-
 const uint32_t kDifPlicMinPriority = 0;
-const uint32_t kDifPlicMaxPriority = 0x3u;
+const uint32_t kDifPlicMaxPriority = RV_PLIC_PRIO0_PRIO0_MASK;
 
 /**
  * PLIC register info.
@@ -34,56 +26,6 @@ typedef struct plic_reg_info {
   ptrdiff_t offset;
   bitfield_bit32_index_t bit_index;
 } plic_reg_info_t;
-
-/**
- * PLIC target specific register offsets.
- *
- * PLIC is designed to support multiple targets, and every target has a set
- * of its own registers. This data type is used to store PLIC target specific
- * register offsets.
- */
-typedef struct plic_target_reg_offset {
-  /**
-   * IRQ enable register offset for this target.
-   */
-  ptrdiff_t irq_enable;
-  /**
-   * Claim/complete register offset for this target.
-   */
-  ptrdiff_t claim_complete;
-  /**
-   * Threshold register offset for this target.
-   */
-  ptrdiff_t threshold;
-  /**
-   * Software interrupt register offset.
-   */
-  ptrdiff_t msip;
-} plic_target_reg_offset_t;
-
-// This array gives a way of getting the target-specific register offsets from
-// a `dif_plic_target_t`.
-//
-// There should be an instance of `plic_target_reg_offset_t` for each possible
-// target, so there should be `RV_PLIC_PARAM_NUMTARGET` entries in this array.
-// The `i`th entry should contain the offsets of the `i`th target specific
-// registers:
-// - `RV_PLIC_IE<i>_0_REG_OFFSET` (the first IE reg for target `i`).
-// - `RV_PLIC_CC<i>_REG_OFFSET`
-// - `RV_PLIC_THRESHOLD<i>_REG_OFFSET`
-// - `RV_PLIC_MSIP<i>_REG_OFFSET`
-static const plic_target_reg_offset_t kPlicTargets[] = {
-    [0] =
-        {
-            .irq_enable = RV_PLIC_IE0_0_REG_OFFSET,
-            .claim_complete = RV_PLIC_CC0_REG_OFFSET,
-            .threshold = RV_PLIC_THRESHOLD0_REG_OFFSET,
-            .msip = RV_PLIC_MSIP0_REG_OFFSET,
-        },
-};
-_Static_assert(sizeof(kPlicTargets) / sizeof(*kPlicTargets) ==
-                   RV_PLIC_PARAM_NUMTARGET,
-               "There should be an entry in kPlicTargets for every target");
 
 /**
  * Get an IE, IP or LE register offset (IE0_0, IE01, ...) from an IRQ source ID.
@@ -110,13 +52,42 @@ static uint8_t plic_irq_bit_index(dif_plic_irq_id_t irq) {
 }
 
 /**
+ * Get the address of the first target N interrupt enable register (IEN0).
+ */
+static ptrdiff_t plic_irq_enable_base_for_target(dif_plic_target_t target) {
+  ptrdiff_t range = RV_PLIC_IE0_MULTIREG_COUNT * sizeof(uint32_t);
+  return RV_PLIC_IE0_0_REG_OFFSET + (range * target);
+}
+
+/**
+ * Get the address of the first target N software interrupt register (MSIPN).
+ */
+static ptrdiff_t plic_software_irq_base_for_target(dif_plic_target_t target) {
+  return RV_PLIC_MSIP0_REG_OFFSET + (target * sizeof(uint32_t));
+}
+
+/**
+ * Get the address of the first target N threshold register (THRESHOLDN).
+ */
+static ptrdiff_t plic_threshold_base_for_target(dif_plic_target_t target) {
+  return RV_PLIC_THRESHOLD0_REG_OFFSET + (target * sizeof(uint32_t));
+}
+
+/**
+ * Get the address of the first target N claim complete register (CCN).
+ */
+static ptrdiff_t plic_claim_complete_base_for_target(dif_plic_target_t target) {
+  return RV_PLIC_CC0_REG_OFFSET + (target * sizeof(uint32_t));
+}
+
+/**
  * Get a target and an IRQ source specific Interrupt Enable register info.
  */
 static plic_reg_info_t plic_irq_enable_reg_info(dif_plic_irq_id_t irq,
                                                 dif_plic_target_t target) {
   ptrdiff_t offset = plic_offset_from_reg0(irq);
   return (plic_reg_info_t){
-      .offset = kPlicTargets[target].irq_enable + offset,
+      .offset = plic_irq_enable_base_for_target(target) + offset,
       .bit_index = plic_irq_bit_index(irq),
   };
 }
@@ -163,12 +134,6 @@ static ptrdiff_t plic_priority_reg_offset(dif_plic_irq_id_t irq) {
  * resource has cleared/completed the CC access.
  */
 static void plic_reset(const dif_plic_t *plic) {
-  // Clear all of the Interrupt Enable registers.
-  for (int i = 0; i < RV_PLIC_IE0_MULTIREG_COUNT; ++i) {
-    ptrdiff_t offset = RV_PLIC_IE0_0_REG_OFFSET + (i * sizeof(uint32_t));
-    mmio_region_write32(plic->params.base_addr, offset, 0);
-  }
-
   // Clear all of the Level/Edge registers.
   for (int i = 0; i < RV_PLIC_LE_MULTIREG_COUNT; ++i) {
     ptrdiff_t offset = RV_PLIC_LE_0_REG_OFFSET + (i * sizeof(uint32_t));
@@ -181,15 +146,24 @@ static void plic_reset(const dif_plic_t *plic) {
     mmio_region_write32(plic->params.base_addr, offset, 0);
   }
 
-  // Clear all of the target threshold registers.
+  // Clear all of the target related registers.
   for (dif_plic_target_t target = 0; target < RV_PLIC_PARAM_NUMTARGET;
        ++target) {
-    ptrdiff_t offset = kPlicTargets[target].threshold;
+    // Clear interrupt enable registers.
+    ptrdiff_t offset = plic_irq_enable_base_for_target(target);
+    for (int i = 0; i < RV_PLIC_IE0_MULTIREG_COUNT; ++i) {
+      ptrdiff_t multireg_offset = offset + (i * sizeof(uint32_t));
+      mmio_region_write32(plic->params.base_addr, multireg_offset, 0);
+    }
+
+    // Clear threshold registers.
+    offset = plic_threshold_base_for_target(target);
+    mmio_region_write32(plic->params.base_addr, offset, 0);
+
+    // Clear software interrupt registers.
+    offset = plic_software_irq_base_for_target(target);
     mmio_region_write32(plic->params.base_addr, offset, 0);
   }
-
-  // Clear software interrupt pending register.
-  mmio_region_write32(plic->params.base_addr, RV_PLIC_MSIP0_REG_OFFSET, 0);
 }
 
 dif_plic_result_t dif_plic_init(dif_plic_params_t params, dif_plic_t *plic) {
@@ -303,7 +277,7 @@ dif_plic_result_t dif_plic_target_set_threshold(const dif_plic_t *plic,
     return kDifPlicBadArg;
   }
 
-  ptrdiff_t threshold_offset = kPlicTargets[target].threshold;
+  ptrdiff_t threshold_offset = plic_threshold_base_for_target(target);
   mmio_region_write32(plic->params.base_addr, threshold_offset, threshold);
 
   return kDifPlicOk;
@@ -330,7 +304,7 @@ dif_plic_result_t dif_plic_irq_claim(const dif_plic_t *plic,
     return kDifPlicBadArg;
   }
 
-  ptrdiff_t claim_complete_reg = kPlicTargets[target].claim_complete;
+  ptrdiff_t claim_complete_reg = plic_claim_complete_base_for_target(target);
   *claim_data = mmio_region_read32(plic->params.base_addr, claim_complete_reg);
 
   return kDifPlicOk;
@@ -346,7 +320,7 @@ dif_plic_result_t dif_plic_irq_complete(
 
   // Write back the claimed IRQ ID to the target specific CC register,
   // to notify the PLIC of the IRQ completion.
-  ptrdiff_t claim_complete_reg = kPlicTargets[target].claim_complete;
+  ptrdiff_t claim_complete_reg = plic_claim_complete_base_for_target(target);
   mmio_region_write32(plic->params.base_addr, claim_complete_reg,
                       *complete_data);
 
@@ -359,7 +333,7 @@ dif_plic_result_t dif_plic_software_irq_force(const dif_plic_t *plic,
     return kDifPlicBadArg;
   }
 
-  ptrdiff_t msip_offset = kPlicTargets[target].msip;
+  ptrdiff_t msip_offset = plic_software_irq_base_for_target(target);
   mmio_region_write32(plic->params.base_addr, msip_offset, 1);
 
   return kDifPlicOk;
@@ -371,7 +345,7 @@ dif_plic_result_t dif_plic_software_irq_acknowledge(const dif_plic_t *plic,
     return kDifPlicBadArg;
   }
 
-  ptrdiff_t msip_offset = kPlicTargets[target].msip;
+  ptrdiff_t msip_offset = plic_software_irq_base_for_target(target);
   mmio_region_write32(plic->params.base_addr, msip_offset, 0);
 
   return kDifPlicOk;
@@ -384,7 +358,7 @@ dif_plic_result_t dif_plic_software_irq_is_pending(const dif_plic_t *plic,
     return kDifPlicBadArg;
   }
 
-  ptrdiff_t msip_offset = kPlicTargets[target].msip;
+  ptrdiff_t msip_offset = plic_software_irq_base_for_target(target);
   uint32_t register_value =
       mmio_region_read32(plic->params.base_addr, msip_offset);
 

--- a/sw/device/tests/dif/dif_plic_unittest.cc
+++ b/sw/device/tests/dif/dif_plic_unittest.cc
@@ -18,6 +18,13 @@ using mock_mmio::MmioTest;
 using mock_mmio::MockDevice;
 using testing::Test;
 
+// If either of these static assertions fail, then the unit-tests for related
+// API should be revisited.
+static_assert(RV_PLIC_PARAM_NUMSRC == 99,
+              "PLIC instantiation parameters have changed.");
+static_assert(RV_PLIC_PARAM_NUMTARGET == 1,
+              "PLIC instantiation parameters have changed.");
+
 constexpr uint32_t kTarget0 = 0;
 constexpr uint32_t kFirstIrq = 1;
 
@@ -31,12 +38,6 @@ class PlicTest : public Test, public MmioTest {
 class InitTest : public PlicTest {
  protected:
   void ExpectInitReset() {
-    // Interrupt enable multireg.
-    EXPECT_WRITE32(RV_PLIC_IE0_0_REG_OFFSET, 0);
-    EXPECT_WRITE32(RV_PLIC_IE0_1_REG_OFFSET, 0);
-    EXPECT_WRITE32(RV_PLIC_IE0_2_REG_OFFSET, 0);
-    EXPECT_WRITE32(RV_PLIC_IE0_3_REG_OFFSET, 0);
-
     // Level/edge multireg.
     EXPECT_WRITE32(RV_PLIC_LE_0_REG_OFFSET, 0);
     EXPECT_WRITE32(RV_PLIC_LE_1_REG_OFFSET, 0);
@@ -48,6 +49,12 @@ class InitTest : public PlicTest {
       ptrdiff_t offset = RV_PLIC_PRIO0_REG_OFFSET + (sizeof(uint32_t) * i);
       EXPECT_WRITE32(offset, 0);
     }
+
+    // Interrupt enable multireg.
+    EXPECT_WRITE32(RV_PLIC_IE0_0_REG_OFFSET, 0);
+    EXPECT_WRITE32(RV_PLIC_IE0_1_REG_OFFSET, 0);
+    EXPECT_WRITE32(RV_PLIC_IE0_2_REG_OFFSET, 0);
+    EXPECT_WRITE32(RV_PLIC_IE0_3_REG_OFFSET, 0);
 
     // Target threshold registers.
     EXPECT_WRITE32(RV_PLIC_THRESHOLD0_REG_OFFSET, 0);


### PR DESCRIPTION
Recent OT changes have introduced "secondary" top levels, which can have different number of IP blocks (more or less than "MAIN" top_earlgrey). This has an impact on peripherals like PLIC that have number of interrupt sources and targets directly dependent on presence of IP blocks on the chip. As the result:

We cannot:
  - Use any top_earlgrey related defines or hard coded values
  - Assume top_earlgrey number of targets
  - Assume top_earlgrey number of interrupt sources

In this change we assume that related registers and multireg registers are consecutive in the address space (IE00..IENN).

All the addresses are calculated at runtime, and depend on the input parameters into public API, such as interrupt source id and target id.

Internal check and other calculation values come from the peripheral auto-generated definitions, which are generated per instantiation, and will always have correct parameters (NUM_SOURCES, etc...).

The static asserts have been moved into the unittest, as that is expected to be top_earlgrey exclusive (at least for now).