### PR TITLE
[dv/otp_ctrl] Add rand_key_rsp sequence

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -83,11 +83,12 @@
     {
       name: interface_key_check
       desc: '''
-            OTP_CTRL can output keys to key_manager, flash, sram, and OTBN. This test will modify
-            inputs and OTP storage, the check if generated keys are correct.
+            OTP_CTRL will generate keys to flash, sram, and OTBN upon their requests.
+            This test will randomly issue key requests from the above modules either before or
+            after partitions are locked, and check if generated keys are correct.
             '''
       milestone: V2
-      tests: []
+      tests: ["otp_ctrl_rand_key_rsp"]
     }
     {
       name: lc_interactions

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -27,6 +27,7 @@ filesets:
       - seq_lib/otp_ctrl_lc_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_dai_lock_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_dai_errs_vseq.sv: {is_include_file: true}
+      - seq_lib/otp_ctrl_rand_key_rsp_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_rand_key_rsp_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_rand_key_rsp_vseq.sv
@@ -1,0 +1,83 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence will randomly issue key otbn, sram, flash key requests during or after partition
+// is locked.
+// This sequence will check if nonce, seed_valid, and output keys are correct via scb.
+
+class otp_ctrl_rand_key_rsp_vseq extends otp_ctrl_smoke_vseq;
+  `uvm_object_utils(otp_ctrl_rand_key_rsp_vseq)
+
+  `uvm_object_new
+
+  constraint num_iterations_c {
+    num_trans  inside {[1:5]};
+    num_dai_op inside {[1:500]};
+  }
+
+  function void pre_randomize();
+    this.dai_wr_blank_addr_c.constraint_mode(0);
+    collect_used_addr = 0;
+  endfunction
+
+  virtual task body();
+    bit base_vseq_done;
+
+    fork
+      begin
+        key_requests(base_vseq_done);
+      end
+      begin
+        super.body();
+        base_vseq_done = 1;
+      end
+    join
+  endtask
+
+  virtual task key_requests(ref bit base_vseq_done);
+    forever
+      begin
+        if (base_vseq_done) return;
+
+        fork
+          begin
+            // get otbn keys
+            if ($urandom_range(0, 1)) begin
+              wait_clk_or_reset($urandom_range(0, 500));
+              if (!base_vseq_done && !cfg.under_reset) req_otbn_key();
+            end
+          end
+          begin
+            // get flash addr key
+            if ($urandom_range(0, 1)) begin
+              wait_clk_or_reset($urandom_range(0, 500));
+              if (!base_vseq_done && !cfg.under_reset) req_flash_addr_key();
+            end
+          end
+          begin
+            // get flash datta key
+            if ($urandom_range(0, 1)) begin
+              wait_clk_or_reset($urandom_range(0, 500));
+              if (!base_vseq_done && !cfg.under_reset) req_flash_data_key();
+            end
+          end
+          begin
+            // get sram keys
+            if ($urandom_range(0, 1)) begin
+              wait_clk_or_reset($urandom_range(0, 500));
+              if (!base_vseq_done && !cfg.under_reset) req_all_sram_keys();
+            end
+          end
+        join
+      end
+  endtask
+
+  virtual task wait_clk_or_reset(int wait_clks);
+    repeat(wait_clks) begin
+      @(posedge cfg.clk_rst_vif.clk);
+      if (cfg.under_reset) break;
+    end
+  endtask
+
+endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -74,16 +74,6 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
       end
       do_otp_ctrl_init = 0;
 
-      // get otbn keys
-      req_otbn_key();
-
-      // get flash addr and data
-      req_flash_addr_key();
-      req_flash_data_key();
-
-      // get sram keys
-      req_all_sram_keys();
-
       for (int i = 0; i < num_dai_op; i++) begin
         bit [TL_DW-1:0] rdata0, rdata1;
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
@@ -7,5 +7,6 @@
 `include "otp_ctrl_smoke_vseq.sv"
 `include "otp_ctrl_common_vseq.sv"
 `include "otp_ctrl_lc_vseq.sv"
+`include "otp_ctrl_rand_key_rsp_vseq.sv"
 `include "otp_ctrl_dai_lock_vseq.sv"
 `include "otp_ctrl_dai_errs_vseq.sv"

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -75,6 +75,11 @@
       uvm_test_seq: otp_ctrl_dai_errs_vseq
     }
 
+    {
+      name: otp_ctrl_rand_key_rsp
+      uvm_test_seq: otp_ctrl_rand_key_rsp_vseq
+    }
+
   ]
 
   // List of regressions.


### PR DESCRIPTION
This PR adds a rand_key response sequence in OTP Testbench.
This test will randomly issue any key request, and check if responses
are correct.

Signed-off-by: Cindy Chen <chencindy@google.com>