### PR TITLE
[systemtest] Do not use UART for test status in Verilator

### DIFF
--- a/sw/device/lib/arch/device_sim_verilator.c
+++ b/sw/device/lib/arch/device_sim_verilator.c
@@ -12,7 +12,8 @@
 const device_type_t kDeviceType = kDeviceSimVerilator;
 
 // Changes to the clock frequency or UART baud rate must also be reflected at
-// `hw/top_earlgrey/rtl/top_earlgrey_verilator.sv`.
+// `hw/top_earlgrey/rtl/top_earlgrey_verilator.sv` and
+// `test/systemtest/earlgrey/test_sim_verilator.py`.
 const uint64_t kClockFreqCpuHz = 500 * 1000;  // 500kHz
 
 const uint64_t kClockFreqPeripheralHz = 125 * 1000;  // 125kHz

--- a/test/systemtest/earlgrey/test_sim_verilator.py
+++ b/test/systemtest/earlgrey/test_sim_verilator.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 
 class VerilatorSimEarlgrey:
-    UART0_SPEED = 9600  # see device/lib/arch/device_sim_verilator.c
+    UART0_SPEED = 7200  # see device/lib/arch/device_sim_verilator.c
 
     def __init__(self, sim_path: Path, rom_elf_path: Path, work_dir: Path):
         """ A verilator simulation of the Earl Grey toplevel """

--- a/test/systemtest/earlgrey/test_sim_verilator.py
+++ b/test/systemtest/earlgrey/test_sim_verilator.py
@@ -22,6 +22,8 @@ class VerilatorSimEarlgrey:
         assert sim_path.is_file()
         self._sim_path = sim_path
 
+        self.p_sim = None
+
         assert rom_elf_path.is_file()
         self._rom_elf_path = rom_elf_path
 
@@ -134,6 +136,19 @@ class VerilatorSimEarlgrey:
             # process is already dead
             pass
 
+    def find_in_output(self,
+                       pattern,
+                       timeout,
+                       filter_func=None,
+                       from_start=False):
+        """ Find a pattern in STDOUT or STDERR of the Verilator simulation """
+        assert self.p_sim
+
+        return self.p_sim.find_in_output(pattern,
+                                         timeout,
+                                         from_start=from_start,
+                                         filter_func=filter_func)
+
     def find_in_uart0(self,
                       pattern,
                       timeout,
@@ -196,6 +211,24 @@ def app_selfchecking(request, bin_dir):
 # Therefore, if we do not read quickly enough, we miss the PASS/FAIL indication
 # and the test never finishes.
 
+def assert_selfchecking_test_passes(sim):
+    assert sim.find_in_output(
+        re.compile(r"SW test status changed: SwTestStatusInTest$"),
+        timeout=120,
+        filter_func=utils.filter_remove_sw_test_status_log_prefix
+    ) is not None, "Start of test indication not found."
+
+    log.debug("Waiting for pass string from device test")
+
+    result_match = sim.find_in_output(
+        re.compile(r'^==== SW TEST (PASSED|FAILED) ====$'),
+        timeout=600,
+        filter_func=utils.filter_remove_sw_test_status_log_prefix)
+    assert result_match is not None, "PASSED/FAILED indication not found in test output."
+
+    result_msg = result_match.group(1)
+    log.info("Test ended with {}".format(result_msg))
+    assert result_msg == 'PASSED'
 
 def test_apps_selfchecking(tmp_path, bin_dir, app_selfchecking):
     """
@@ -214,20 +247,7 @@ def test_apps_selfchecking(tmp_path, bin_dir, app_selfchecking):
 
     sim.run(app_selfchecking[0], extra_sim_args=app_selfchecking[1])
 
-    bootmsg_exp = b'Boot ROM initialisation has completed, jump into flash!'
-    assert sim.find_in_uart0(
-        bootmsg_exp,
-        timeout=120) is not None, "End-of-bootrom string not found."
-
-    log.debug("Waiting for pass string from device test")
-
-    result_match = sim.find_in_uart0(re.compile(rb'^(PASS|FAIL)!$'),
-                                     timeout=600)
-    assert result_match is not None, "PASS/FAIL indication not found in test output."
-
-    result_msg = result_match.group(1)
-    log.info("Test ended with {}".format(result_msg))
-    assert result_msg == b'PASS'
+    assert_selfchecking_test_passes(sim)
 
     sim.terminate()
 
@@ -253,19 +273,6 @@ def test_spiflash(tmp_path, bin_dir):
     utils.load_sw_over_spi(tmp_path, spiflash, app_bin,
                            ['--verilator', sim.spi0_device_path])
 
-    bootmsg_exp = b'Boot ROM initialisation has completed, jump into flash!'
-    assert sim.find_in_uart0(
-        bootmsg_exp,
-        timeout=600) is not None, "End-of-bootrom string not found."
-
-    log.debug("Waiting for pass string from device test")
-
-    result_match = sim.find_in_uart0(re.compile(rb'^(PASS|FAIL)!$'),
-                                     timeout=240)
-    assert result_match is not None, "PASS/FAIL indication not found in test output."
-
-    result_msg = result_match.group(1)
-    log.info("Test ended with {}".format(result_msg))
-    assert result_msg == b'PASS'
+    assert_selfchecking_test_passes(sim)
 
     sim.terminate()

--- a/test/systemtest/utils.py
+++ b/test/systemtest/utils.py
@@ -425,6 +425,7 @@ def find_in_files(file_objects,
         for file_object in file_objects:
             file_object.seek(0)
 
+    end_loop = False
     while True:
         for file_object in file_objects:
             for line in file_object:
@@ -432,12 +433,17 @@ def find_in_files(file_objects,
                 if m is not None:
                     return m
 
+        if end_loop:
+            break
+
         if timeout is not None and time.time() >= t_end:
             raise subprocess.TimeoutExpired(None, timeout)
 
+        # The wait function returns True to indicate that no more data will be
+        # produced (e.g. because the producing process terminated). But we still
+        # need to check one last time if the already produced data is matching
+        # the `pattern`.
         end_loop = wait_func()
-        if end_loop:
-            break
 
     return None
 

--- a/test/systemtest/utils.py
+++ b/test/systemtest/utils.py
@@ -497,3 +497,17 @@ def filter_remove_device_sw_log_prefix(line):
         return re.sub(bytes(pattern, encoding='utf-8'), b'', line)
     else:
         return re.sub(pattern, '', line)
+
+
+def filter_remove_sw_test_status_log_prefix(line):
+    """
+    Remove the logging prefix produced by the sw_test_status DV component.
+    """
+
+    # Example of a full prefix to be matched:
+    # 1629002: (../src/lowrisc_dv_sw_test_status_0/sw_test_status_if.sv:42) [TOP.top_earlgrey_verilator.u_sw_test_status_if]
+    pattern = r'\d+: \(.+/sw_test_status_if\.sv:\d+\) \[TOP\..+\] '
+    if isinstance(line, bytes):
+        return re.sub(bytes(pattern, encoding='utf-8'), b'', line)
+    else:
+        return re.sub(pattern, '', line)


### PR DESCRIPTION
Self-checking software tests produce test status over UART, but also through the `sw_test_status_if` machinery, which ends up on stdout in Verilator. Use this output to determine if a test passed or failed.
    
The UART logging output can now used for human debugging, or disabled  entirely to speed up test runs.

This PR doesn't change how tests are run or how their results are evaluated; it's just a preparation to be able to run without UART logging in the future.

Also included are two fixes to the framework that are a pre-requisite to the main work.