### PR TITLE
[tlul] Explicitly cast between SRAM width and TL width

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -142,7 +142,7 @@ module tlul_adapter_sram #(
       d_source : (d_valid) ? reqfifo_rdata.source : '0,
       d_sink   : 1'b0,
       d_data   : (d_valid && rspfifo_rvalid && reqfifo_rdata.op == OpRead)
-                 ? rspfifo_rdata.data : '0,
+                 ? rspfifo_rdata.data[top_pkg::TL_DW-1:0] : '0,
       d_user   : '0,
       d_error  : d_valid && d_error,
 
@@ -256,7 +256,7 @@ module tlul_adapter_sram #(
   assign rdata_tlword = rdata[sramreqfifo_rdata.woffset];
 
   assign rspfifo_wdata  = '{
-    data : rdata_tlword,
+    data : {{SramDw - top_pkg::TL_DW{1'b0}}, rdata_tlword},
     error: rerror_i[1] // Only care for Uncorrectable error
   };
   assign rspfifo_rready = (reqfifo_rdata.op == OpRead & ~reqfifo_rdata.error)


### PR DESCRIPTION
OTBN uses `tlul_adapter_sram` with a width of 256 bits: more than the TL
bus width of 32 bits. This triggers a couple of Verilator warnings
caused by width mismatches. This patch makes the "extract bottom bits"
and "zero extend" steps explicit. There should be no change in
behaviour.
