### PR TITLE
[doc] Add package install command for CentOS 7

### DIFF
--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -111,11 +111,21 @@ The repository will be checked out into `<working-area>/opentitan` (this is the 
 
 ### Install required software
 
-A number of software packages from the distribution's package manager is required.
-All installation instructions below are for Ubuntu 18.04.
-Adjust as necessary for other Linux distributions.
+A number of software packages from the distribution's package manager are required.
+On Ubuntu 18.04, the required packages can be installed with the following command.
 
-{{< apt_cmd >}}
+{{< pkgmgr_cmd "apt" >}}
+
+Our recommended reference platform is Ubuntu 18.04, but the command can be adjusted as necessary for other Linux distributions.
+
+For example, for Red Hat Enterprise Linux (RHEL) 7 and derivatives (such as CentOS 7) the following packages are required.
+Note that we don't have the possibilities to actively verify that our instructions continue work on RHEL/CentOS and hence also can't test anything on these distributions.
+The following instructions are effectively community contributed and we encourage users to raise pull requests if they find the package requirements to be outdated.
+First of all, the [EPEL repository](https://fedoraproject.org/wiki/EPEL) has to be enabled.
+A sufficiently recent version of GCC or LLVM (clang) can be obtained through [Red Hat Software Collections](https://www.softwarecollections.org/en/).
+Then run the following command to install the required package dependencies on RHEL/CentOS 7.
+
+{{< pkgmgr_cmd "yum" >}}
 
 Some tools in this repository are written in Python 3 and require Python dependencies to be installed through `pip`.
 

--- a/site/docs/layouts/shortcodes/apt_cmd.html
+++ b/site/docs/layouts/shortcodes/apt_cmd.html
@@ -1,6 +1,0 @@
-{{ $path := path.Join .Site.Params.generatedRoot "apt_cmd.txt" }}
-{{ if not (fileExists $path) }}
-  {{ errorf "apt_cmd.txt has not been generated" }}
-{{ end }}
-
-<pre><code class="language-console" data-lang="console">{{ readFile $path | safeHTML }}</code></pre>

--- a/site/docs/layouts/shortcodes/pkgmgr_cmd.html
+++ b/site/docs/layouts/shortcodes/pkgmgr_cmd.html
@@ -1,0 +1,8 @@
+{{- $pkgmgr := .Get 0 -}}
+{{- $file := (print $pkgmgr "_cmd.txt") -}}
+{{- $path := path.Join .Site.Params.generatedRoot $file -}}
+{{- if not (fileExists $path) -}}
+  {{- errorf (print $file " has not been generated") -}}
+{{- end -}}
+
+<pre><code class="language-console" data-lang="console">{{ readFile $path | safeHTML }}</code></pre>

--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -201,34 +201,38 @@ def generate_selfdocs():
                 fout.write(tlgen.selfdoc(heading=3, cmd='tlgen.py --doc'))
 
 
-def generate_apt_reqs():
-    """Generate an apt-get command line invocation from apt-requirements.txt
+def generate_pkg_reqs():
+    """Generate an apt/yum command line invocation from
+    apt/yum-requirements.txt
 
-    This will be saved in outdir-generated/apt_cmd.txt
+    This will be saved in outdir-generated/apt_cmd.txt and
+    outdir-generated/yum_cmd.txt, respectively.
     """
-    # Read the apt-requirements.txt
-    apt_requirements = []
-    requirements_file = open(str(SRCTREE_TOP.joinpath("apt-requirements.txt")))
-    for package_line in requirements_file.readlines():
-        # Ignore everything after `#` on each line, and strip whitespace
-        package = package_line.split('#', 1)[0].strip()
-        if package:
-            # only add non-empty lines to packages
-            apt_requirements.append(package)
 
-    apt_cmd = "$ sudo apt-get install " + " ".join(apt_requirements)
-    apt_cmd_lines = textwrap.wrap(apt_cmd,
+    for pkgmgr in ["apt", "yum"]:
+        # Read the apt/yum-requirements.txt
+        requirements = []
+        requirements_file = open(str(SRCTREE_TOP.joinpath(pkgmgr + "-requirements.txt")))
+        for package_line in requirements_file.readlines():
+            # Ignore everything after `#` on each line, and strip whitespace
+            package = package_line.split('#', 1)[0].strip()
+            if package:
+                # only add non-empty lines to packages
+                requirements.append(package)
+
+        cmd = "$ sudo " + pkgmgr + " install " + " ".join(requirements)
+        cmd_lines = textwrap.wrap(cmd,
                                   width=78,
                                   replace_whitespace=True,
                                   subsequent_indent='    ')
-    # Newlines need to be escaped
-    apt_cmd = " \\\n".join(apt_cmd_lines)
+        # Newlines need to be escaped
+        cmd = " \\\n".join(cmd_lines)
 
-    # And then to write the generated string directly to the file.
-    apt_cmd_path = config["outdir-generated"].joinpath('apt_cmd.txt')
-    apt_cmd_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(str(apt_cmd_path), mode='w') as fout:
-        fout.write(apt_cmd)
+        # And then to write the generated string directly to the file.
+        cmd_path = config["outdir-generated"].joinpath(pkgmgr + '_cmd.txt')
+        cmd_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(str(cmd_path), mode='w') as fout:
+            fout.write(cmd)
 
 
 def generate_tool_versions():
@@ -446,7 +450,7 @@ def main():
     generate_dashboards()
     generate_testplans()
     generate_selfdocs()
-    generate_apt_reqs()
+    generate_pkg_reqs()
     generate_tool_versions()
     generate_dif_docs()
     generate_otbn_isa()

--- a/yum-requirements.txt
+++ b/yum-requirements.txt
@@ -2,11 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# List of packages installed with apt on our reference Ubuntu platform.
-#
-# When updating this list, please keep the yum package requirements for
-# RHEL/CentOS 7 in sync. These were derived from the Ubuntu requirements
-# and are maintained in yum-requirements.txt.
+# List of packages installed with yum on RHEL/CentOS 7 platforms.
 #
 # This list of packages is also included in the documentation at
 # doc/ug/install_instructions/index.md. When updating this file also check if
@@ -26,13 +22,15 @@ libelf1
 libelf-dev
 libftdi1-2
 libftdi1-dev
-# A requirement of the prebuilt clang toolchain.
-libncurses5
 libssl-dev
 libusb-1.0-0
 lsb-release
 make
+# A requirement of the prebuilt clang toolchain.
+ncurses
 ninja-build
+openssl11-libs
+openssl11-devel
 pkgconf
 python3
 python3-pip


### PR DESCRIPTION
This PR adds instructions for installing package dependencies for CentOS 7, which is among the most used Linux distributions in the hardware world. At the moment there are only a few subtle differences between the dependencies for Ubuntu 18.04 and CentOS 7, but this might change in the future.

This is related to lowRISC/OpenTitan#3299.