### PR TITLE
[reggen] Add check for alert naming scheme

### DIFF
--- a/util/reggen/validate.py
+++ b/util/reggen/validate.py
@@ -921,7 +921,7 @@ def validate_fields(fields, rname, default_sw, default_hw, full_resval,
                     resval &= max_in_field
 
                 if (full_resval is not None and
-                    (resval != ((full_resval >> field_lsb) & max_in_field))):
+                   (resval != ((full_resval >> field_lsb) & max_in_field))):
                     error += 1
                     log.error(fname + ": Field resval " + field['resval'] +
                               " differs from value in main register resval " +
@@ -1720,6 +1720,18 @@ def validate(regs, **kwargs):
                     "{}: Consider naming each alert individually instead of "
                     "declaring an alert signal with width > 1.".format(
                         alert['name']))
+
+            # check alert naming scheme
+            if alert['name'] == "":
+                log.error("{}: Alert name cannot be empty".format(alert['name']))
+                error += 1
+            prefix = alert['name'].split('_')
+            if prefix[0] not in ['recov', 'fatal']:
+                # TODO: to be elevated to error severity
+                log.warning(
+                    "{}: Alerts must be prefixed with either 'recov_' or "
+                    "'fatal_'.".format(alert['name']))
+                # error += 1
 
         if num_alerts != 0:
             param = ''


### PR DESCRIPTION
As discussed on #3767, this adds an alert naming convention check to the reggen tool.
Currently this just issues a warning, but once we have renamed all alerts, we can bump this to an error.

Signed-off-by: Michael Schaffner <msf@opentitan.org>