### PR TITLE
[lc_ctrl/dv] Fix num of input token CSRs

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
@@ -97,13 +97,14 @@ class lc_ctrl_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task sw_transition_req(bit [TL_DW-1:0] next_lc_state,
-                                 bit [TL_DW*3-1:0] token_val,
+                                 bit [TL_DW*4-1:0] token_val,
                                  bit trans_success = 1);
     csr_wr(ral.claim_transition_if, CLAIM_TRANS_VAL);
     csr_wr(ral.transition_target, next_lc_state);
     csr_wr(ral.transition_token_0, token_val[TL_DW-1:0]);
-    csr_wr(ral.transition_token_1, token_val[TL_DW*2-1:TL_DW]);
-    csr_wr(ral.transition_token_2, token_val[TL_DW*3-1:TL_DW*2]);
+    csr_wr(ral.transition_token_1, token_val[TL_DW*2-1-:TL_DW]);
+    csr_wr(ral.transition_token_2, token_val[TL_DW*3-1-:TL_DW]);
+    csr_wr(ral.transition_token_3, token_val[TL_DW*4-1-:TL_DW]);
     csr_wr(ral.transition_cmd, 'h01);
     if (trans_success) begin
       csr_spinwait(ral.status.transition_successful, 1);

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
@@ -38,7 +38,7 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
 
       // SW transition request
       if (valid_state_for_trans(lc_state) && lc_cnt != LcCnt16) begin
-        bit [TL_DW*3-1:0] token_val = {$urandom(), $urandom(), $urandom()};
+        bit [TL_DW*4-1:0] token_val = {$urandom(), $urandom(), $urandom(), $urandom()};
         randomize_next_lc_state(dec_lc_state(lc_state));
         `uvm_info(`gfn, $sformatf("next_LC_state is %0s, input token is %0h", next_lc_state.name,
                                   token_val), UVM_DEBUG)


### PR DESCRIPTION
This PR fix an tb issue pointed out by @msfschaffner. The input token has four
CSRs with a total width of 128 bits, but in TB I only write three CSRs
with a width of 96 bits. This PR fixed this error.
Thanks Michael!

Signed-off-by: Cindy Chen <chencindy@google.com>