### PR TITLE
[aes] Fix lint errors

### DIFF
--- a/hw/ip/aes/lint/aes.waiver
+++ b/hw/ip/aes/lint/aes.waiver
@@ -16,7 +16,7 @@ waive -rules {RESET_USE} -location {aes_cipher_core.sv} -regexp {'rst_ni' is con
       -comment "when using fully combinational S-Box implementations, no reset is used inside aes_sub_bytes"
 
 waive -rules {RESET_USE} -location {aes_key_expand.sv} -regexp {'rst_ni' is connected to 'aes_sbox' port} \
-       -comment "when using fully combinational S-Box implementations, no reset is used inside aes_sbox"
+      -comment "when using fully combinational S-Box implementations, no reset is used inside aes_sbox"
 
 waive -rules {CLOCK_USE} -location {aes_core.sv} -regexp {clk_i' is connected to 'aes_sel_buf_chk' port} \
       -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
@@ -29,3 +29,6 @@ waive -rules {RESET_USE} -location {aes_core.sv} -regexp {'rst_ni' is connected 
 
 waive -rules {RESET_USE} -location {aes_cipher_core.sv} -regexp {'rst_ni' is connected to 'aes_sel_buf_chk' port} \
       -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
+
+waive -rules {ONE_BRANCH} -location {aes_sel_buf_chk.sv} -regexp {unique case statement has only one branch} \
+      -comment "check for legal combinations only, assert error signal otherwise"

--- a/hw/ip/aes/rtl/aes_cipher_control.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control.sv
@@ -101,6 +101,7 @@ module aes_cipher_control
   // Signals
   logic [3:0] rnd_ctr_d, rnd_ctr_q;
   logic [3:0] rnd_ctr_rem_d, rnd_ctr_rem_q;
+  logic [3:0] rnd_ctr_sum;
   logic [3:0] num_rounds_d, num_rounds_q;
   logic [3:0] num_rounds_regular;
   logic       rnd_ctr_parity, rnd_ctr_parity_d, rnd_ctr_parity_q;
@@ -451,7 +452,7 @@ module aes_cipher_control
   // In addition, we use one parity bit for the rnd_ctr_d/q counter.
   //
   // An alert is signaled and the FSM goes into the terminal error state if
-  // i) the sum of the counters doesn't add up, i.e. if rnd_ctr_q + rnd_ctr_rem_q != num_rounds_q, or
+  // i) the sum of the counters doesn't add up, i.e. rnd_ctr_q + rnd_ctr_rem_q != num_rounds_q, or
   // ii) the parity information is incorrect.
 
   // The following primitives are used to place size-only constraints on the
@@ -486,12 +487,13 @@ module aes_cipher_control
     .q_o ( rnd_ctr_parity_q )
   );
 
-  // Generate parity bits.
+  // Generate parity bits and sum.
   assign rnd_ctr_parity_d = ^rnd_ctr_d;
   assign rnd_ctr_parity   = ^rnd_ctr_q;
+  assign rnd_ctr_sum      = rnd_ctr_q + rnd_ctr_rem_q;
 
   // Detect faults.
-  assign rnd_ctr_err_sum    = (rnd_ctr_q + rnd_ctr_rem_q != num_rounds_q) ? 1'b1 : 1'b0;
+  assign rnd_ctr_err_sum    = (rnd_ctr_sum != num_rounds_q)        ? 1'b1 : 1'b0;
   assign rnd_ctr_err_parity = (rnd_ctr_parity != rnd_ctr_parity_q) ? 1'b1 : 1'b0;
 
   assign rnd_ctr_err = rnd_ctr_err_sum | rnd_ctr_err_parity;

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -233,12 +233,14 @@ module aes_core
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : key_init_reg
-    for (int s=0; s<2; s++) begin
-      for (int i=0; i<8; i++) begin
-        if (!rst_ni) begin
-          key_init_q[s][i] <= '0;
-        end else if (key_init_we[s][i]) begin
-          key_init_q[s][i] <= key_init_d[s][i];
+    if (!rst_ni) begin
+      key_init_q <= '{default: '0};
+    end else begin
+      for (int s=0; s<2; s++) begin
+        for (int i=0; i<8; i++) begin
+          if (key_init_we[s][i]) begin
+            key_init_q[s][i] <= key_init_d[s][i];
+          end
         end
       end
     end
@@ -258,11 +260,13 @@ module aes_core
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : iv_reg
-    for (int i=0; i<8; i++) begin
-      if (!rst_ni) begin
-        iv_q[i] <= '0;
-      end else if (iv_we[i]) begin
-        iv_q[i] <= iv_d[i];
+    if (!rst_ni) begin
+      iv_q <= '0;
+    end else begin
+      for (int i=0; i<8; i++) begin
+        if (iv_we[i]) begin
+          iv_q[i] <= iv_d[i];
+        end
       end
     end
   end


### PR DESCRIPTION
This PR fixes lint errors in AES.

Most of the new waivers are required because AscentLint seems to get severly confused by `for` loops nested inside `always_ff` statements with async reset:
```systemverilog
  always_ff @(posedge clk_i or negedge rst_ni) begin : iv_reg
    for (int i=0; i<8; i++) begin
      if (!rst_ni) begin
        iv_q[i] <= '0;
      end else if (iv_we[i]) begin
        iv_q[i] <= iv_d[i];
      end
    end
  end
```
Without the async reset (was added in #4761) everything is fine. Alternatively I could maybe rewrite those processes as:
```systemverilog
  always_ff @(posedge clk_i or negedge rst_ni) begin : iv_reg
    if (!rst_ni) begin
      iv_q <= '0;
    end else begin
      for (int i=0; i<8; i++) begin
        if (iv_we[i]) begin
          iv_q[i] <= iv_d[i];
        end
      end
    end
  end
```
I don't know if that will work and if it's actually better/more readable. Other lint tools don't have problems with the current style.