### PR TITLE
[aes] Protect round counter against fault injection

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -151,7 +151,7 @@
     { name: "fatal_fault",
       desc: '''
         This fatal alert is triggered upon detecting a fatal fault inside the AES unit.
-        Examples for such faults include i) storage errors in the shadowed Control Register, ii) any internal FSM entering an invalid state, or iii) a mux selector signal taking on an invalid value.
+        Examples for such faults include i) storage errors in the shadowed Control Register, ii) any internal FSM entering an invalid state, iii) a mux selector signal taking on an invalid value, and iv) errors in the internal round counter.
         The AES unit cannot recover from such an error and needs to be reset.
       '''
     }
@@ -538,7 +538,7 @@
         desc:  '''
           No fatal fault has occurred inside the AES unit (0).
           A fatal fault has occurred and the AES unit needs to be reset (1).
-          Examples for fatal faults include i) storage errors in the Control Register, ii) if any internal FSM enters an invalid state, and iii) if a mux selector signal takes on an invalid value.
+          Examples for fatal faults include i) storage errors in the Control Register, ii) if any internal FSM enters an invalid state, iii) if a mux selector signal takes on an invalid value, and iv) errors in the internal round counter.
         '''
       }
     ]

--- a/hw/ip/aes/lint/aes.waiver
+++ b/hw/ip/aes/lint/aes.waiver
@@ -17,3 +17,15 @@ waive -rules {RESET_USE} -location {aes_cipher_core.sv} -regexp {'rst_ni' is con
 
 waive -rules {RESET_USE} -location {aes_key_expand.sv} -regexp {'rst_ni' is connected to 'aes_sbox' port} \
        -comment "when using fully combinational S-Box implementations, no reset is used inside aes_sbox"
+
+waive -rules {CLOCK_USE} -location {aes_core.sv} -regexp {clk_i' is connected to 'aes_sel_buf_chk' port} \
+      -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
+
+waive -rules {CLOCK_USE} -location {aes_cipher_core.sv} -regexp {clk_i' is connected to 'aes_sel_buf_chk' port} \
+      -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
+
+waive -rules {RESET_USE} -location {aes_core.sv} -regexp {'rst_ni' is connected to 'aes_sel_buf_chk' port} \
+      -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
+
+waive -rules {RESET_USE} -location {aes_cipher_core.sv} -regexp {'rst_ni' is connected to 'aes_sel_buf_chk' port} \
+      -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"

--- a/hw/ip/aes/rtl/aes_cipher_core.sv
+++ b/hw/ip/aes/rtl/aes_cipher_core.sv
@@ -513,8 +513,12 @@ module aes_cipher_core import aes_pkg::*;
   // 1. The synthesis tool doesn't optimize away the sparse encoding.
   // 2. The selector signal is always valid. More precisely, an alert or SVA is triggered if a
   //    selector signal takes on an invalid value.
-  // 3. The error/alert signal remains asserted until reset even if the selector signal becomes
-  //    valid again.
+  // 3. The alert signal remains asserted until reset even if the selector signal becomes valid
+  //    again. This is achieved by driving the control FSM into the terminal error state whenever
+  //    any mux selector signal becomes invalid.
+  //
+  // If any mux selector signal becomes invalid, the cipher core further immediately de-asserts
+  // the out_valid_o signal to prevent any data from being released.
 
   aes_sel_buf_chk #(
     .Num   ( StateSelNum   ),

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -478,7 +478,8 @@ module aes_control
 
           // Proceed upon successful handshake.
           if (cipher_out_done) begin
-            data_out_we_o = 1'b1;
+            // Don't release data from cipher core in case of invalid mux selector signals.
+            data_out_we_o = ~mux_sel_err_i;
             aes_ctrl_ns   = IDLE;
           end
         end
@@ -517,8 +518,9 @@ module aes_control
           // To clear the output data registers, we re-use the muxing resources of the cipher core.
           // data_out_clear_i is acknowledged by the cipher core with cipher_data_out_clear_i.
           if (cipher_data_out_clear_i) begin
-            // Clear output data and the trigger bit.
-            data_out_we_o       = 1'b1;
+            // Clear output data and the trigger bit. Don't release data from cipher core in case
+            // of invalid mux selector signals.
+            data_out_we_o       = ~mux_sel_err_i;
             data_out_clear_we_o = 1'b1;
           end
 
@@ -533,7 +535,6 @@ module aes_control
 
       // We should never get here. If we do (e.g. via a malicious glitch), error out immediately.
       default: begin
-        alert_o     = 1'b1;
         aes_ctrl_ns = ERROR;
       end
     endcase
@@ -541,7 +542,6 @@ module aes_control
     // Unconditionally jump into the terminal error state in case a mux selector signal becomes
     // invalid.
     if (mux_sel_err_i) begin
-      alert_o     = 1'b1;
       aes_ctrl_ns = ERROR;
     end
   end
@@ -559,6 +559,10 @@ module aes_control
     .d_i ( aes_ctrl_ns     ),
     .q_o ( aes_ctrl_cs_raw )
   );
+
+  /////////////////////
+  // Status Tracking //
+  /////////////////////
 
   // We only use clean initial keys. Either software/counter has updated
   // - all initial key registers, or
@@ -671,6 +675,10 @@ module aes_control
   assign key_iv_data_in_clear_o = 1'b0;
   assign data_out_clear_o       = 1'b0;
   assign prng_reseed_o          = 1'b0;
+
+  ////////////////
+  // Assertions //
+  ////////////////
 
   // Selectors must be known/valid
   `ASSERT(AesModeValid, !ctrl_err_storage_i |-> mode_i inside {

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -597,8 +597,13 @@ module aes_core
   // 1. The synthesis tool doesn't optimize away the sparse encoding.
   // 2. The selector signal is always valid. More precisely, an alert or SVA is triggered if a
   //    selector signal takes on an invalid value.
-  // 3. The error/alert signal remains asserted until reset even if the selector signal becomes
-  //    valid again.
+  // 3. The alert signal remains asserted until reset even if the selector signal becomes valid
+  //    again. This is achieved by driving the control FSM into the terminal error state whenever
+  //    any mux selector signal becomes invalid.
+  //
+  // If any mux selector signal becomes invalid, the control FSM further prevents any data from
+  // being released from the cipher core by de-asserting the write enable of the output data
+  // registers.
 
   aes_sel_buf_chk #(
     .Num   ( DIPSelNum   ),

--- a/hw/ip/aes/rtl/aes_ctr.sv
+++ b/hw/ip/aes/rtl/aes_ctr.sv
@@ -139,7 +139,6 @@ module aes_ctr(
       // We should never get here. If we do (e.g. via a malicious
       // glitch), error out immediately.
       default: begin
-        alert_o    = 1'b1;
         aes_ctr_ns = ERROR;
       end
     endcase


### PR DESCRIPTION
This PR adds protection against fault injection attacks for the round counter inside the cipher core. This is achieved by introducing a second counter as well as parity information. If a fault is detected, the FSM goes into the terminal error state and a fatal alert is triggered.