### PR TITLE
[otbn] Rename "recoverable" alert to just "recov" & set fatal flag

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -23,7 +23,7 @@
     { name: "fatal"
       desc: "A fatal error. Fatal alerts are non-recoverable and will be asserted until a hard reset."
     }
-    { name: "recoverable"
+    { name: "recov"
       desc: "A recoverable error. Just sent once (as the processor stops)."
     }
   ]

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
@@ -29,7 +29,7 @@ package otbn_env_pkg;
   import "DPI-C" function string OtbnTestHelperGetFilePath(chandle helper, int index);
 
   // parameters
-  parameter string LIST_OF_ALERTS[] = {"fatal", "recoverable"};
+  parameter string LIST_OF_ALERTS[] = {"fatal", "recov"};
   parameter uint NUM_ALERTS = otbn_reg_pkg::NumAlerts;
 
   // typedefs

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -390,28 +390,17 @@ module otbn
   logic [NumAlerts-1:0] alert_test;
   assign alert_test[AlertFatal] = reg2hw.alert_test.fatal.q &
                                   reg2hw.alert_test.fatal.qe;
-  assign alert_test[AlertRecoverable] = reg2hw.alert_test.recoverable.q &
-                                        reg2hw.alert_test.recoverable.qe;
-
-  // Latch any error that we consider fatal.
-  logic fatal_err_q, fatal_err_d;
-  assign fatal_err_d = fatal_err_q | imem_rerror | dmem_rerror;
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      fatal_err_q <= 1'b0;
-    end else begin
-      fatal_err_q <= fatal_err_d;
-    end
-  end
+  assign alert_test[AlertRecov] = reg2hw.alert_test.recov.q &
+                                  reg2hw.alert_test.recov.qe;
 
   logic [NumAlerts-1:0] alerts;
-  assign alerts[AlertFatal]       = fatal_err_d;
-  assign alerts[AlertRecoverable] = 1'b0; // TODO: Implement
+  assign alerts[AlertFatal] = imem_rerror | dmem_rerror;
+  assign alerts[AlertRecov] = 1'b0; // TODO: Implement
 
   for (genvar i = 0; i < NumAlerts; i++) begin: gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
-      .IsFatal(0)
+      .IsFatal(i == AlertFatal)
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -33,7 +33,7 @@ package otbn_pkg;
   // Toplevel constants ============================================================================
 
   parameter int AlertFatal = 0;
-  parameter int AlertRecoverable = 1;
+  parameter int AlertRecov = 1;
 
   // Register file implementation selection enum.
   typedef enum integer {

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -36,7 +36,7 @@ package otbn_reg_pkg;
     struct packed {
       logic        q;
       logic        qe;
-    } recoverable;
+    } recov;
   } otbn_reg2hw_alert_test_reg_t;
 
   typedef struct packed {

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -131,8 +131,8 @@ module otbn_reg_top (
   logic intr_test_we;
   logic alert_test_fatal_wd;
   logic alert_test_fatal_we;
-  logic alert_test_recoverable_wd;
-  logic alert_test_recoverable_we;
+  logic alert_test_recov_wd;
+  logic alert_test_recov_we;
   logic cmd_start_wd;
   logic cmd_start_we;
   logic cmd_dummy_wd;
@@ -236,17 +236,17 @@ module otbn_reg_top (
   );
 
 
-  //   F[recoverable]: 1:1
+  //   F[recov]: 1:1
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test_recoverable (
+  ) u_alert_test_recov (
     .re     (1'b0),
-    .we     (alert_test_recoverable_we),
-    .wd     (alert_test_recoverable_wd),
+    .we     (alert_test_recov_we),
+    .wd     (alert_test_recov_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.recoverable.qe),
-    .q      (reg2hw.alert_test.recoverable.q ),
+    .qe     (reg2hw.alert_test.recov.qe),
+    .q      (reg2hw.alert_test.recov.q ),
     .qs     ()
   );
 
@@ -488,8 +488,8 @@ module otbn_reg_top (
   assign alert_test_fatal_we = addr_hit[3] & reg_we & ~wr_err;
   assign alert_test_fatal_wd = reg_wdata[0];
 
-  assign alert_test_recoverable_we = addr_hit[3] & reg_we & ~wr_err;
-  assign alert_test_recoverable_wd = reg_wdata[1];
+  assign alert_test_recov_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_recov_wd = reg_wdata[1];
 
   assign cmd_start_we = addr_hit[4] & reg_we & ~wr_err;
   assign cmd_start_wd = reg_wdata[0];

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -5167,7 +5167,7 @@
           async: 1
         }
         {
-          name: recoverable
+          name: recov
           width: 1
           bits: "1"
           bitinfo:
@@ -8080,7 +8080,7 @@
       module_name: otbn
     }
     {
-      name: otbn_recoverable
+      name: otbn_recov
       width: 1
       bits: "1"
       bitinfo:

--- a/hw/top_earlgrey/dv/env/autogen/alert_handler_env_pkg__params.sv
+++ b/hw/top_earlgrey/dv/env/autogen/alert_handler_env_pkg__params.sv
@@ -8,7 +8,7 @@ parameter string LIST_OF_ALERTS[] = {
   "aes_recoverable",
   "aes_fatal",
   "otbn_fatal",
-  "otbn_recoverable",
+  "otbn_recov",
   "sensor_ctrl_as",
   "sensor_ctrl_cg",
   "sensor_ctrl_gd",

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1467,7 +1467,7 @@ module top_earlgrey #(
       .intr_done_o (intr_otbn_done),
 
       // [18]: fatal
-      // [19]: recoverable
+      // [19]: recov
       .alert_tx_o  ( alert_tx[19:18] ),
       .alert_rx_i  ( alert_rx[19:18] ),
 

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.c
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.c
@@ -125,7 +125,7 @@ const top_earlgrey_alert_peripheral_t
   [kTopEarlgreyAlertIdAesRecoverable] = kTopEarlgreyAlertPeripheralAes,
   [kTopEarlgreyAlertIdAesFatal] = kTopEarlgreyAlertPeripheralAes,
   [kTopEarlgreyAlertIdOtbnFatal] = kTopEarlgreyAlertPeripheralOtbn,
-  [kTopEarlgreyAlertIdOtbnRecoverable] = kTopEarlgreyAlertPeripheralOtbn,
+  [kTopEarlgreyAlertIdOtbnRecov] = kTopEarlgreyAlertPeripheralOtbn,
   [kTopEarlgreyAlertIdSensorCtrlAs] = kTopEarlgreyAlertPeripheralSensorCtrl,
   [kTopEarlgreyAlertIdSensorCtrlCg] = kTopEarlgreyAlertPeripheralSensorCtrl,
   [kTopEarlgreyAlertIdSensorCtrlGd] = kTopEarlgreyAlertPeripheralSensorCtrl,

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -757,7 +757,7 @@ typedef enum top_earlgrey_alert_id {
   kTopEarlgreyAlertIdAesRecoverable = 0, /**< aes_recoverable */
   kTopEarlgreyAlertIdAesFatal = 1, /**< aes_fatal */
   kTopEarlgreyAlertIdOtbnFatal = 2, /**< otbn_fatal */
-  kTopEarlgreyAlertIdOtbnRecoverable = 3, /**< otbn_recoverable */
+  kTopEarlgreyAlertIdOtbnRecov = 3, /**< otbn_recov */
   kTopEarlgreyAlertIdSensorCtrlAs = 4, /**< sensor_ctrl_as */
   kTopEarlgreyAlertIdSensorCtrlCg = 5, /**< sensor_ctrl_cg */
   kTopEarlgreyAlertIdSensorCtrlGd = 6, /**< sensor_ctrl_gd */


### PR DESCRIPTION
This fixes a warning from reggen (which expects recoverable alerts to
be called `recov_FOO` or just `recov`). Also, set the `IsFatal` flag
correctly when instantiating `prim_alert_sender`.
