### PR TITLE
[otbn] Remove dummy register fields

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -72,16 +72,6 @@
             "excl:CsrAllTests:CsrExclWrite"
           ]
         }
-        { bits: "1",
-          name: "dummy",
-          desc: '''
-            Reggen doesn't generate sub-fields with only a single field
-            specified; instead, the whole register is taken as a field, leading
-            to signals like `hw2reg.status.d` instead of
-            `hw2reg.status.start.d`. Since we expect to add more commands later,
-            we force the generation of fields with this dummy field for now.
-          '''
-        }
       ],
     }
     { name: "STATUS",
@@ -93,12 +83,6 @@
         { bits: "0",
           name: "busy",
           desc: "OTBN is performing an operation."
-        }
-        { bits: "1",
-          name: "dummy",
-          desc: '''
-            See !!CMD.dummy for details.
-          '''
         }
       ]
     } // register : status

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -359,11 +359,12 @@ module otbn
   );
 
   // CMD register
-  assign start = reg2hw.cmd.start.qe & reg2hw.cmd.start.q;
+  // CMD.start ("start" is omitted by reggen since it is the only field)
+  assign start = reg2hw.cmd.qe & reg2hw.cmd.q;
 
   // STATUS register
-  assign hw2reg.status.busy.d = busy_q;
-  assign hw2reg.status.dummy.d = 1'b0;
+  // STATUS.busy ("busy" is omitted by reggen since since it is the only field)
+  assign hw2reg.status.d = busy_q;
 
   // ERR_BITS register
   // The error bits for an OTBN operation get stored on the cycle that done is

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -40,14 +40,8 @@ package otbn_reg_pkg;
   } otbn_reg2hw_alert_test_reg_t;
 
   typedef struct packed {
-    struct packed {
-      logic        q;
-      logic        qe;
-    } start;
-    struct packed {
-      logic        q;
-      logic        qe;
-    } dummy;
+    logic        q;
+    logic        qe;
   } otbn_reg2hw_cmd_reg_t;
 
   typedef struct packed {
@@ -61,12 +55,7 @@ package otbn_reg_pkg;
   } otbn_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
-    struct packed {
-      logic        d;
-    } busy;
-    struct packed {
-      logic        d;
-    } dummy;
+    logic        d;
   } otbn_hw2reg_status_reg_t;
 
   typedef struct packed {
@@ -124,11 +113,11 @@ package otbn_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    otbn_reg2hw_intr_state_reg_t intr_state; // [43:43]
-    otbn_reg2hw_intr_enable_reg_t intr_enable; // [42:42]
-    otbn_reg2hw_intr_test_reg_t intr_test; // [41:40]
-    otbn_reg2hw_alert_test_reg_t alert_test; // [39:36]
-    otbn_reg2hw_cmd_reg_t cmd; // [35:32]
+    otbn_reg2hw_intr_state_reg_t intr_state; // [41:41]
+    otbn_reg2hw_intr_enable_reg_t intr_enable; // [40:40]
+    otbn_reg2hw_intr_test_reg_t intr_test; // [39:38]
+    otbn_reg2hw_alert_test_reg_t alert_test; // [37:34]
+    otbn_reg2hw_cmd_reg_t cmd; // [33:32]
     otbn_reg2hw_start_addr_reg_t start_addr; // [31:0]
   } otbn_reg2hw_t;
 
@@ -136,8 +125,8 @@ package otbn_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    otbn_hw2reg_intr_state_reg_t intr_state; // [25:24]
-    otbn_hw2reg_status_reg_t status; // [23:22]
+    otbn_hw2reg_intr_state_reg_t intr_state; // [24:23]
+    otbn_hw2reg_status_reg_t status; // [22:22]
     otbn_hw2reg_err_bits_reg_t err_bits; // [21:6]
     otbn_hw2reg_fatal_alert_cause_reg_t fatal_alert_cause; // [5:0]
   } otbn_hw2reg_t;

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -133,14 +133,10 @@ module otbn_reg_top (
   logic alert_test_fatal_we;
   logic alert_test_recov_wd;
   logic alert_test_recov_we;
-  logic cmd_start_wd;
-  logic cmd_start_we;
-  logic cmd_dummy_wd;
-  logic cmd_dummy_we;
-  logic status_busy_qs;
-  logic status_busy_re;
-  logic status_dummy_qs;
-  logic status_dummy_re;
+  logic cmd_wd;
+  logic cmd_we;
+  logic status_qs;
+  logic status_re;
   logic err_bits_bad_data_addr_qs;
   logic err_bits_bad_insn_addr_qs;
   logic err_bits_call_stack_qs;
@@ -260,65 +256,33 @@ module otbn_reg_top (
 
   // R[cmd]: V(True)
 
-  //   F[start]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_cmd_start (
+  ) u_cmd (
     .re     (1'b0),
-    .we     (cmd_start_we),
-    .wd     (cmd_start_wd),
+    .we     (cmd_we),
+    .wd     (cmd_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.cmd.start.qe),
-    .q      (reg2hw.cmd.start.q ),
-    .qs     ()
-  );
-
-
-  //   F[dummy]: 1:1
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_cmd_dummy (
-    .re     (1'b0),
-    .we     (cmd_dummy_we),
-    .wd     (cmd_dummy_wd),
-    .d      ('0),
-    .qre    (),
-    .qe     (reg2hw.cmd.dummy.qe),
-    .q      (reg2hw.cmd.dummy.q ),
+    .qe     (reg2hw.cmd.qe),
+    .q      (reg2hw.cmd.q ),
     .qs     ()
   );
 
 
   // R[status]: V(True)
 
-  //   F[busy]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_status_busy (
-    .re     (status_busy_re),
+  ) u_status (
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.status.busy.d),
+    .d      (hw2reg.status.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (status_busy_qs)
-  );
-
-
-  //   F[dummy]: 1:1
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_status_dummy (
-    .re     (status_dummy_re),
-    .we     (1'b0),
-    .wd     ('0),
-    .d      (hw2reg.status.dummy.d),
-    .qre    (),
-    .qe     (),
-    .q      (),
-    .qs     (status_dummy_qs)
+    .qs     (status_qs)
   );
 
 
@@ -674,15 +638,10 @@ module otbn_reg_top (
   assign alert_test_recov_we = addr_hit[3] & reg_we & ~wr_err;
   assign alert_test_recov_wd = reg_wdata[1];
 
-  assign cmd_start_we = addr_hit[4] & reg_we & ~wr_err;
-  assign cmd_start_wd = reg_wdata[0];
+  assign cmd_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cmd_wd = reg_wdata[0];
 
-  assign cmd_dummy_we = addr_hit[4] & reg_we & ~wr_err;
-  assign cmd_dummy_wd = reg_wdata[1];
-
-  assign status_busy_re = addr_hit[5] && reg_re;
-
-  assign status_dummy_re = addr_hit[5] && reg_re;
+  assign status_re = addr_hit[5] && reg_re;
 
 
 
@@ -721,12 +680,10 @@ module otbn_reg_top (
 
       addr_hit[4]: begin
         reg_rdata_next[0] = '0;
-        reg_rdata_next[1] = '0;
       end
 
       addr_hit[5]: begin
-        reg_rdata_next[0] = status_busy_qs;
-        reg_rdata_next[1] = status_dummy_qs;
+        reg_rdata_next[0] = status_qs;
       end
 
       addr_hit[6]: begin


### PR DESCRIPTION
The `dummy` fields in the `CMD` and `STATUS` registers were inserted to
work around a reggen bug, which has been fixed since (in #3418). Remove
the workaround.