### PR TITLE
[dv/tl_agent] Update tl_host_single_seq

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/cip_base_vseq.sv
@@ -150,7 +150,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
                              tl_sequencer            tl_sequencer_h = p_sequencer.tl_sequencer_h);
     `DV_SPINWAIT(
         // thread to read/write tlul
-        tl_host_single_seq  tl_seq;
+        tl_host_directed_seq  tl_seq;
         `uvm_create_on(tl_seq, tl_sequencer_h)
         if (cfg.zero_delays) begin
           tl_seq.min_req_delay = 0;

--- a/hw/dv/sv/tl_agent/seq_lib/tl_host_custom_seq.sv
+++ b/hw/dv/sv/tl_agent/seq_lib/tl_host_custom_seq.sv
@@ -4,7 +4,7 @@
 
 // Disable TL protocol related constraint on a_chan to create a fully customized tl_item for error
 // cases
-class tl_host_custom_seq extends tl_host_single_seq;
+class tl_host_custom_seq extends tl_host_directed_seq;
 
   `uvm_object_utils(tl_host_custom_seq)
   `uvm_object_new

--- a/hw/dv/sv/tl_agent/seq_lib/tl_host_directed_seq.sv
+++ b/hw/dv/sv/tl_agent/seq_lib/tl_host_directed_seq.sv
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Extend host seq to send single specific item constructed by the caller
-class tl_host_single_seq extends tl_host_seq;
+// Extends the tl_host_seq to send fully customizable sequence items constructed by the caller
+class tl_host_directed_seq extends tl_host_seq;
     rand bit                    write;
     rand bit [AddrWidth-1:0]    addr;
     rand bit [OpcodeWidth-1:0]  opcode;
@@ -19,10 +19,11 @@ class tl_host_single_seq extends tl_host_seq;
     bit control_rand_source    = 0;
     bit control_rand_opcode    = 0;
 
-  `uvm_object_utils(tl_host_single_seq)
+  `uvm_object_utils(tl_host_directed_seq)
   `uvm_object_new
 
-  constraint req_cnt_eq_1_c { req_cnt == 1; }
+  // Default to a single customizable transaction, but can be overridden by caller.
+  constraint req_cnt_eq_1_c { soft req_cnt == 1; }
 
   virtual function void randomize_req(tl_seq_item req, int idx);
     if (!(req.randomize() with {

--- a/hw/dv/sv/tl_agent/seq_lib/tl_host_protocol_err_seq.sv
+++ b/hw/dv/sv/tl_agent/seq_lib/tl_host_protocol_err_seq.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // This seq will send an item that triggers d_error due to protocol violation
-class tl_host_protocol_err_seq extends tl_host_single_seq;
+class tl_host_protocol_err_seq extends tl_host_directed_seq;
 
   `uvm_object_utils(tl_host_protocol_err_seq)
   `uvm_object_new

--- a/hw/dv/sv/tl_agent/seq_lib/tl_seq_list.sv
+++ b/hw/dv/sv/tl_agent/seq_lib/tl_seq_list.sv
@@ -4,7 +4,7 @@
 
 `include "tl_host_base_seq.sv"
 `include "tl_host_seq.sv"
-`include "tl_host_single_seq.sv"
+`include "tl_host_directed_seq.sv"
 `include "tl_host_custom_seq.sv"
 `include "tl_host_protocol_err_seq.sv"
 `include "tl_device_seq.sv"

--- a/hw/dv/sv/tl_agent/tl_agent.core
+++ b/hw/dv/sv/tl_agent/tl_agent.core
@@ -27,7 +27,7 @@ filesets:
       - seq_lib/tl_seq_list.sv: {is_include_file: true}
       - seq_lib/tl_host_base_seq.sv: {is_include_file: true}
       - seq_lib/tl_host_seq.sv: {is_include_file: true}
-      - seq_lib/tl_host_single_seq.sv: {is_include_file: true}
+      - seq_lib/tl_host_directed_seq.sv: {is_include_file: true}
       - seq_lib/tl_host_custom_seq.sv: {is_include_file: true}
       - seq_lib/tl_host_protocol_err_seq.sv: {is_include_file: true}
       - seq_lib/tl_device_seq.sv: {is_include_file: true}


### PR DESCRIPTION
This PR updates the `tl_host_single_seq` to allow the caller to also
randomize the `req_cnt`, and changes the sequence name to
`tl_host_directed_seq`.

The default `req_cnt` will stay at 1, so existing functionality will
remain unchanged throughout the various DV environments.

One potential usecase: in SRAM tb it would be useful to sequence
multiple back-to-back transactions to the same memory address to stress the
encryption pipline.

Any other suggestions/ideas are welcome!

Signed-off-by: Udi Jonnalagadda <udij@google.com>