### PR TITLE
[hw] Remove redundant AscentLint options

### DIFF
--- a/hw/ip/alert_handler/alert_handler.core
+++ b/hw/ip/alert_handler/alert_handler.core
@@ -29,10 +29,6 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
-      ascentlint:
-        ascentlint_options:
-          - "-wait_license"
-          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -99,10 +99,6 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
-      ascentlint:
-        ascentlint_options:
-          - "-wait_license"
-          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/padctrl/padctrl.core
+++ b/hw/ip/padctrl/padctrl.core
@@ -29,10 +29,6 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
-      ascentlint:
-        ascentlint_options:
-          - "-wait_license"
-          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/pinmux/pinmux.core
+++ b/hw/ip/pinmux/pinmux.core
@@ -29,9 +29,6 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
-      ascentlint:
-        ascentlint_options:
-          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/rv_plic/rv_plic.core
+++ b/hw/ip/rv_plic/rv_plic.core
@@ -34,10 +34,6 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
-      ascentlint:
-        ascentlint_options:
-          - "-wait_license"
-          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/trial1/dv/trial1_sim.core
+++ b/hw/ip/trial1/dv/trial1_sim.core
@@ -34,10 +34,6 @@ targets:
     <<: *sim_target
     default_tool: verilator
     tools:
-      ascentlint:
-        ascentlint_options:
-          - "-wait_license"
-          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:


### PR DESCRIPTION
Complete the work started in 09550b1355539513a73168ef8052856387404d6a
and remove all AscentLint tool options from individual IP files. These
options are picked up from the common lint core.