### PR TITLE
[dv/lc_ctrl] lc_ctrl alert naming change

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
@@ -77,7 +77,7 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
                       .DeviceDataWidth(OTP_PROG_DDATA_WIDTH)) item_rcv;
       otp_prog_fifo.get(item_rcv);
       if (cfg.lc_ctrl_vif.prog_err == 1) begin
-        void'(set_exp_alert(.alert_name("lc_programming_failure"), .max_delay(0), .always_on(1)));
+        void'(set_exp_alert(.alert_name("fatal_prog_error"), .max_delay(0), .always_on(1)));
       end
     end
   endtask


### PR DESCRIPTION
This PR reflects the change of lc_ctrl alert naming. This PR updates the
change in lc_ctrl_scoreboard.

Signed-off-by: Cindy Chen <chencindy@google.com>