### PR TITLE
[dv/alert]  Fix cip_base_scoreboard alert checking

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
@@ -70,7 +70,7 @@ class alert_esc_agent extends dv_base_agent#(
         int min_freq_mhz = (cfg.clk_freq_mhz / 10) ? (cfg.clk_freq_mhz / 10) : 1;
         cfg.vif.clk_rst_async_if.set_freq_mhz($urandom_range(min_freq_mhz, cfg.clk_freq_mhz * 10));
       end else begin
-        cfg.vif.clk_rst_async_if.set_freq_mhz($urandom_range(1, 200));
+        cfg.vif.clk_rst_async_if.set_freq_mhz($urandom_range(10, 240));
       end
     end
   endfunction

--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
@@ -33,7 +33,9 @@ class alert_esc_agent_cfg extends dv_base_agent_cfg;
   int unsigned ping_delay_min = 0;
   int unsigned ping_delay_max = 10;
 
-  int unsigned handshake_timeout_cycle = 200;
+  // this timeout is to ensure handshake protocol did not hang, this timeout is not implemented in
+  // design. In design, if protocol hangs, the period ping check will catch the issue
+  int unsigned handshake_timeout_cycle = 100_000;
   int unsigned ping_timeout_cycle = 32;
 
   `uvm_object_utils_begin(alert_esc_agent_cfg)

--- a/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
@@ -26,14 +26,14 @@ interface alert_esc_if(input clk, input rst_n);
   prim_esc_pkg::esc_tx_t     esc_tx_int;   // internal esc_tx
   prim_esc_pkg::esc_rx_t     esc_rx_int;   // internal esc_rx
 
-  wire                    sender_clk;
+  wire                    async_clk;
   bit                     is_async, is_alert;
   dv_utils_pkg::if_mode_e if_mode;
-  clk_rst_if              clk_rst_async_if(.clk(sender_clk), .rst_n(rst_n));
+  clk_rst_if              clk_rst_async_if(.clk(async_clk), .rst_n(rst_n));
 
   // if alert sender is async mode, the clock will be drived in alert_esc_agent,
   // if it is sync mode, will assign to dut clk here
-  assign sender_clk = (is_async) ? 'z : clk ;
+  assign async_clk = (is_async) ? 'z : clk ;
 
   // async interface for alert_tx has two_clock cycles delay
   // TODO: this is not needed once the CDC module is implemented
@@ -55,7 +55,7 @@ interface alert_esc_if(input clk, input rst_n);
   assign alert_rx_final = (is_async && (if_mode == dv_utils_pkg::Device)) ?
                           alert_rx_sync_dly2 : alert_rx;
 
-  clocking sender_cb @(posedge sender_clk);
+  clocking sender_cb @(posedge async_clk);
     input  rst_n;
     output alert_tx_int;
     input  alert_rx;
@@ -63,7 +63,7 @@ interface alert_esc_if(input clk, input rst_n);
     input  esc_rx;
   endclocking
 
-  clocking receiver_cb @(posedge clk);
+  clocking receiver_cb @(posedge async_clk);
     input  rst_n;
     input  alert_tx;
     output alert_rx_int;

--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -118,6 +118,7 @@ class alert_monitor extends alert_esc_base_monitor;
                 req.alert_handshake_sta = AlertComplete;
                 wait_ack_complete();
                 req.alert_handshake_sta = AlertAckComplete;
+                @(cfg.vif.monitor_cb);
               end
               begin
                 wait(under_reset);

--- a/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
@@ -90,9 +90,8 @@ class alert_receiver_driver extends alert_esc_base_driver;
   endtask : rsp_alert
 
   virtual task drive_alert_ping(alert_esc_seq_item req);
-    int unsigned       ping_delay;
-    ping_delay = (cfg.use_seq_item_ping_delay) ?
-                 req.ping_delay : $urandom_range(cfg.ping_delay_max, cfg.ping_delay_min);
+    int unsigned ping_delay = (cfg.use_seq_item_ping_delay) ? req.ping_delay :
+                               $urandom_range(cfg.ping_delay_max, cfg.ping_delay_min);
     if (!req.int_err) begin
       @(cfg.vif.receiver_cb);
       repeat (ping_delay) @(cfg.vif.receiver_cb);
@@ -118,11 +117,10 @@ class alert_receiver_driver extends alert_esc_base_driver;
   endtask
 
   virtual task set_ack_pins(alert_esc_seq_item req);
-    int unsigned ack_delay, ack_stable;
-    ack_delay = (cfg.use_seq_item_ack_delay) ? req.ack_delay :
-        $urandom_range(cfg.ack_delay_max, cfg.ack_delay_min);
-    ack_stable = (cfg.use_seq_item_ack_stable) ? req.ack_stable :
-        $urandom_range(cfg.ack_stable_max, cfg.ack_stable_min);
+    int unsigned ack_delay = (cfg.use_seq_item_ack_delay) ? req.ack_delay :
+                              $urandom_range(cfg.ack_delay_max, cfg.ack_delay_min);
+    int unsigned ack_stable = (cfg.use_seq_item_ack_stable) ? req.ack_stable :
+                               $urandom_range(cfg.ack_stable_max, cfg.ack_stable_min);
     if (!req.int_err) begin
       @(cfg.vif.receiver_cb);
       repeat (ack_delay) @(cfg.vif.receiver_cb);

--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -45,6 +45,7 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
       uvm_config_db#(alert_esc_agent_cfg)::set(this, agent_name, "cfg",
           cfg.m_alert_agent_cfg[alert_name]);
       cfg.m_alert_agent_cfg[alert_name].en_cov = cfg.en_cov;
+      cfg.m_alert_agent_cfg[alert_name].clk_freq_mhz = int'(cfg.clk_freq_mhz);
     end
 
     // Create and configure the EDN agent if available.

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -24,8 +24,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   bit do_alert_check = 1;
   local bit under_alert_handshake[string];
   local bit exp_alert[string];
-  local bit is_always_on_alert[string];
-  local int alert_max_delay[string];
+  local bit is_fatal_alert[string];
 
   `uvm_component_new
 
@@ -132,15 +131,15 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   endfunction
 
   // this task is implemented to check if expected alert is triggered within certain clock cycles
-  // if alert is always_on, it will expect alert handshakes until reset
-  // if alert is not always_on, it will set exp_alert back to 0 once finish alert_checking
+  // if alert is fatal alert, it will expect alert handshakes until reset
+  // if alert is not fatal alert, it will set exp_alert back to 0 once finish alert_checking
   virtual task check_alerts();
     foreach (cfg.list_of_alerts[i]) begin
       automatic string alert_name = cfg.list_of_alerts[i];
       fork
         forever begin
           wait(exp_alert[alert_name] == 1 && cfg.under_reset == 0);
-          if (is_always_on_alert[alert_name]) begin
+          if (is_fatal_alert[alert_name]) begin
             while (cfg.under_reset == 0) begin
               check_alert_triggered(alert_name);
               wait(under_alert_handshake[alert_name] == 0 || cfg.under_reset == 1);
@@ -155,44 +154,42 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   endtask
 
   virtual task check_alert_triggered(string alert_name);
-    repeat(alert_max_delay[alert_name]) begin
-      cfg.clk_rst_vif.wait_clks(1);
-      if (under_alert_handshake[alert_name] || cfg.under_reset) break;
+    // 2 clock cycles between two alert handshakes, 1 clock cycle to go back to `Idle` state,
+    // 1 clock cycle for monitor to detect alert, 1 negedge edge to make sure no race condition.
+    repeat(5) begin
+      cfg.clk_rst_vif.wait_n_clks(1);
+      if (under_alert_handshake[alert_name] || cfg.under_reset) return;
     end
-    if (!under_alert_handshake[alert_name] && !cfg.under_reset) begin
-      `uvm_error(`gfn, $sformatf("alert %0s did not trigger within %0d cycles",
-                 alert_name, alert_max_delay[alert_name]))
-    end
+    `uvm_error(`gfn, $sformatf("alert %0s did not trigger", alert_name))
   endtask
 
   // this function is used for individual IPs to set when they expect certain alert to trigger
   // - input alert_name is the full name of the alert listed in LIST_OF_ALERTS
-  // - input delay_window sets the max clock cycle delay until the actual alert triggers. This
-  //   number will be added an additional default delay in this function. In async mode, we will
-  //   add additional 6 clock cycles(the min window between two handshakes); in sync mode, 2 clock
-  //   cycles are added
-  // - input always_on indicates once the alert is triggered, it always sends alert request to
-  //   alert_sender until reset is asserted
-  // - output is one bit. It returns true if set_exp_alert is successful, it returns false if user
-  //   is trying to set alerts during alert_handshake or exp_alert is already set
-  virtual function bit set_exp_alert(string alert_name, int max_delay = 0, bit always_on = 0);
+  // - input is_fatal, if set, expects to continuously trigger alert request until reset is
+  //   asserted
+  // Note that this function requires user to know exact time that alert should be triggered,
+  // which means the time when `alert_req_i` is set. Because we need to accurately predict if two
+  // alerts are merged or not
+  // TODO: needs to handle a corner case where user could not predict the exact time when
+  // `alert_req_i` is set
+  virtual function void set_exp_alert(string alert_name, bit is_fatal = 0);
     if (!(alert_name inside {cfg.list_of_alerts})) begin
       `uvm_fatal(`gfn, $sformatf("alert_name %0s is not in cfg.list_of_alerts!", alert_name))
     end
-
-    if (under_alert_handshake[alert_name] || exp_alert[alert_name]) begin
-      `uvm_info(`gfn, $sformatf("Current %0s alert status under_alert_handshake=%0b,\
-                exp_alert=%0b, request ignored", under_alert_handshake[alert_name],
-                exp_alert[alert_name], alert_name), UVM_MEDIUM)
-      return 0;
-    end
-
-    is_always_on_alert[alert_name] = always_on;
-    // in async mode, 6 clock cycles are the min window between two alert handshakes
-    // in sync mode, 2 clock cycles are the min window
-    alert_max_delay[alert_name] = max_delay + cfg.m_alert_agent_cfg[alert_name].is_async ? 6 : 2;
-    exp_alert[alert_name] = 1;
-    return 1;
+    fork
+      begin
+        // delay a negedge clk to avoid race condition between this function and
+        // `under_alert_handshake` variable
+        cfg.clk_rst_vif.wait_n_clks(1);
+        if (under_alert_handshake[alert_name] || exp_alert[alert_name]) begin
+          `uvm_info(`gfn, $sformatf("Current %0s alert status under_alert_handshake=%0b,\
+                    exp_alert=%0b, request ignored", under_alert_handshake[alert_name],
+                    exp_alert[alert_name], alert_name), UVM_MEDIUM)
+        end
+        is_fatal_alert[alert_name] = is_fatal;
+        exp_alert[alert_name] = 1;
+      end
+    join_none
   endfunction
 
   // task to process tl access
@@ -319,8 +316,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
       alert_fifos[cfg.list_of_alerts[i]].flush();
       exp_alert[cfg.list_of_alerts[i]]             = 0;
       under_alert_handshake[cfg.list_of_alerts[i]] = 0;
-      is_always_on_alert[cfg.list_of_alerts[i]]    = 0;
-      alert_max_delay[cfg.list_of_alerts[i]]       = 0;
+      is_fatal_alert[cfg.list_of_alerts[i]]    = 0;
     end
   endfunction
 

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
@@ -77,7 +77,7 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
                       .DeviceDataWidth(OTP_PROG_DDATA_WIDTH)) item_rcv;
       otp_prog_fifo.get(item_rcv);
       if (cfg.lc_ctrl_vif.prog_err == 1) begin
-        void'(set_exp_alert(.alert_name("fatal_prog_error"), .max_delay(0), .always_on(1)));
+        set_exp_alert(.alert_name("fatal_prog_error"), .is_fatal(1));
       end
     end
   endtask


### PR DESCRIPTION
This PR has two commit:
1. Add support for async alert responser.
2. Fix logic error in cip_base_scoreboard:
  This commit fixes logic in cip_base_scoreboard that checks alert.
  Main issue is the delay, we remove the flexibility for user to set their
  own delay in alert check. We need to know the accurate predict for when
  alert happens in order to know if the alert request is ignored due to
  alert handshake in progress