### PR TITLE
[util/simplespi] Fix the spitest tool due to the PyFtdi API update

### DIFF
--- a/util/simplespi/spitest.py
+++ b/util/simplespi/spitest.py
@@ -137,7 +137,7 @@ def main():
 
     while len(s):
         write_buf = bytes(s[:4], encoding='utf8')
-        read_buf = device.exchange(write_buf, duplex=True).tobytes()
+        read_buf = device.exchange(write_buf, duplex=True)
         print("Got " + str(read_buf))
         s = s[4:]
 


### PR DESCRIPTION
As mentioned in #4907, the calls to PyFtdi need to be updated. 
Please verify if any other changes are needed. Thank you.