### PR TITLE
[otbn] Exclude non-synthesizable files from being compiled

### DIFF
--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`ifndef SYNTHESIS
+
 /**
  * Interface designed to be bound into otbn_core and extract out signals useful for the tracer.
  *
@@ -219,3 +221,5 @@ interface otbn_trace_if
     assign flags_read_data[i_fg] = u_otbn_alu_bignum.flags_q[i_fg];
   end
 endinterface
+
+`endif // SYNTHESIS

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`ifndef SYNTHESIS
+
 /**
  * Tracer module for OTBN. This produces a multi-line string as trace output at most once every
  * cycle and provides it to the simulation environment via a DPI call. It uses `otbn_trace_if` to
@@ -216,3 +218,5 @@ module otbn_tracer
     end
   end
 endmodule
+
+`endif // SYNTHESIS


### PR DESCRIPTION
Synthesis with DC currently fails as DC is unable to parse the code in
otbn_tracer. We include those files in the default set of files to
build, but never use them; still, the tool must be able to parse them,
which isn't the case here.

Extend the approach in 5101724e7febb15d16acb6f0024be09d7fdc104c to the
remaining model-only files. See also
https://github.com/lowRISC/opentitan/issues/4144#issuecomment-726937662
for a more detailed discussion of the problem.