### PR TITLE
[prim_util_pkg] Fix DC warning in _clog2()

### DIFF
--- a/hw/ip/prim/rtl/prim_util_pkg.sv
+++ b/hw/ip/prim/rtl/prim_util_pkg.sv
@@ -27,9 +27,12 @@ package prim_util_pkg;
    */
   function automatic integer _clog2(integer value);
     integer result;
-    value = value - 1;
-    for (result = 0; value > 0; result = result + 1) begin
-      value = value >> 1;
+    // Use an intermediate value to avoid assigning to an input port, which produces a warning in
+    // Synopsys DC.
+    integer v = value;
+    v = v - 1;
+    for (result = 0; v > 0; result++) begin
+      v = v >> 1;
     end
     return result;
   endfunction
@@ -77,7 +80,7 @@ package prim_util_pkg;
     // to an implementation without a system function. Remove this workaround
     // if we require a newer Xcelium version.
     // See #2579 and #2597.
-    return (value == 1) ? 1 : prim_util_pkg::_clog2(value);
+    return (value == 1) ? 1 : _clog2(value);
 `else
     return (value == 1) ? 1 : $clog2(value);
 `endif


### PR DESCRIPTION
DC warns about assigning to an input port (`value`). Use an intermediate
variable instead.

```
Warning:  ../src/lowrisc_prim_util_0.1/rtl/prim_util_pkg.sv:30: Port value of type input is being assigned.  (VER-1005)
Warning:  ../src/lowrisc_prim_util_0.1/rtl/prim_util_pkg.sv:32: Port value of type input is being assigned.  (VER-1005)
```