### PR TITLE
[prim/fifo_async] Disallow non-power-of-two depths

### DIFF
--- a/hw/top_earlgrey/ip/xbar_main/rtl/autogen/xbar_main.sv
+++ b/hw/top_earlgrey/ip/xbar_main/rtl/autogen/xbar_main.sv
@@ -746,8 +746,8 @@ end
     .dev_select_i (dev_sel_s1n_27)
   );
   tlul_fifo_async #(
-    .ReqDepth        (3),// At least 3 to make async work
-    .RspDepth        (3) // At least 3 to make async work
+    .ReqDepth        (4),// At least 4 to make async work
+    .RspDepth        (4) // At least 4 to make async work
   ) u_asf_28 (
     .clk_h_i      (clk_main_i),
     .rst_h_ni     (rst_main_ni),

--- a/util/tlgen/xbar.rtl.sv.tpl
+++ b/util/tlgen/xbar.rtl.sv.tpl
@@ -198,8 +198,8 @@ ${"end" if loop.last else ""}
 % for block in xbar.nodes:
   % if block.node_type.name   == "ASYNC_FIFO":
   tlul_fifo_async #(
-    .ReqDepth        (3),// At least 3 to make async work
-    .RspDepth        (3) // At least 3 to make async work
+    .ReqDepth        (4),// At least 4 to make async work
+    .RspDepth        (4) // At least 4 to make async work
   ) u_${block.name} (
     .clk_h_i      (${block.clocks[0]}),
     .rst_h_ni     (${block.resets[0]}),


### PR DESCRIPTION
The pointers will not be gray coded when they wrap if they are not a power of two, which violates the guarantees we rely on for synchronizing across the clock domains.

Let me know if I have missed something else which makes this work even for non-powers-of-two.

As an aside, I'm hoping to add a lightweight version of the async fifo soon which will work with fewer entries (down to 1) and doesn't have the depth status outputs (to use in the aon timer).