### PR TITLE
[alert/doc] add instructions to add alert device in modules

### DIFF
--- a/hw/dv/sv/alert_esc_agent/README.md
+++ b/hw/dv/sv/alert_esc_agent/README.md
@@ -1,1 +1,23 @@
-# ALERT Agent
+# ALERT_ESC Agent
+
+ALERT_ESC UVM Agent is extended from DV library agent classes.
+
+## Description
+
+This agent implements both alert(alert_rx, alert_tx) and escalation (esc_rx,
+esc_tx) interface protocols, and can be configured to behave in both host and
+device modes. For design documentation, please refer to [alert_handler
+spec]({{< relref "hw/ip/alert_handler/doc/_index.md" >}}).
+
+### Alert Agent
+
+Alert agent supports both synchronous and asynchronous modes.
+
+#### Alert Device Agent
+
+For IPs that send out alerts, it is recommended to attach alert device agents to
+the block level testbench.
+Please refer to [cip_lib documentation]({{< relref "hw/dv/sv/cip_lib/doc/index.md" >}})
+regarding instructions to configure alert device agent in DV testbenches.
+
+### Escalation Agent

--- a/hw/dv/sv/cip_lib/cip_base_env_cov.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cov.sv
@@ -44,19 +44,12 @@ covergroup intr_pins_cg (uint num_interrupts) with function sample(uint intr_pin
   cp_intr_pins_all_values: cross cp_intr_pin, cp_intr_pin_value;
 endgroup
 
-covergroup alert_cg (uint num_alerts) with function sample(uint alert);
-  cp_alert: coverpoint alert {
-    bins all_values[] = {[0:num_alerts-1]};
-  }
-endgroup
-
 class cip_base_env_cov #(type CFG_T = cip_base_env_cfg) extends dv_base_env_cov #(CFG_T);
   `uvm_component_param_utils(cip_base_env_cov #(CFG_T))
 
   intr_cg        intr_cg;
   intr_test_cg   intr_test_cg;
   intr_pins_cg   intr_pins_cg;
-  alert_cg       alert_cg;
   // Coverage for sticky interrupt functionality described in CIP specification
   // As some interrupts are non-sticky, this covergroup should be populated on "as and when needed"
   // basis in extended <ip>_env_cov class for interrupt types that are sticky
@@ -71,7 +64,6 @@ class cip_base_env_cov #(type CFG_T = cip_base_env_cfg) extends dv_base_env_cov 
       intr_test_cg = new(cfg.num_interrupts);
       intr_pins_cg = new(cfg.num_interrupts);
     end
-    if (cfg.list_of_alerts.size() != 0) alert_cg = new(cfg.list_of_alerts.size());
   endfunction
 
 endclass


### PR DESCRIPTION
Recently more modules added functions to send alerts. This PR adds some
documentations on how to add alert device agent in block level
testbench.

Signed-off-by: Cindy Chen <chencindy@google.com>