### PR TITLE
[dv] improve runtime for sha_vector test in smoke regression and optimize rv_timer_cfg.hjson file

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -13,6 +13,12 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   bit under_reset       = 0;
   bit is_initialized;        // Indicates that the initialize() method has been called.
 
+  // The scope and runtime of a existing test can be reduced by setting this variable. This is
+  // useful to keep the runtime down especially in time-sensitive runs such as CI, which is meant
+  // to check the code health and not find design bugs. It is set via plusarg and retrieved in
+  // `dv_base_test`.
+  bit smoke_test        = 0;
+
   // bit to configure all uvcs with zero delays to create high bw test
   rand bit zero_delays;
 

--- a/hw/dv/sv/dv_lib/dv_base_test.sv
+++ b/hw/dv/sv/dv_lib/dv_base_test.sv
@@ -39,6 +39,9 @@ class dv_base_test #(type CFG_T = dv_base_env_cfg,
 
     // Enable coverage collection.
     void'($value$plusargs("en_cov=%0b", cfg.en_cov));
+
+    // Enable reduced runtime test.
+    void'($value$plusargs("smoke_test=%0b", cfg.smoke_test));
   endfunction : build_phase
 
   virtual function void end_of_elaboration_phase(uvm_phase phase);

--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -111,6 +111,8 @@
       name: smoke
       tests: []
       reseed: 1
+      // Knob used to configure an existing test / vseq to have a shorter runtime.
+      run_opts: ["+smoke_test=1"]
     }
 
     {

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_test_vectors_sha_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_test_vectors_sha_vseq.sv
@@ -28,16 +28,21 @@ class hmac_test_vectors_sha_vseq extends hmac_base_vseq;
     foreach (vector_list[i]) begin
       // import function from the test_vectors_pkg to parse the sha vector file
       test_vectors_pkg::get_hash_test_vectors(vector_list[i], parsed_vectors);
+      parsed_vectors.shuffle();
+
+      // if in smoke_regression mode, to reduce the run time, we will randomly pick 2 vectors to
+      // run this sequence
+      if (cfg.smoke_test) parsed_vectors = parsed_vectors[0:1];
 
       foreach (parsed_vectors[j]) begin
         bit [TL_DW-1:0] intr_state_val;
-        `uvm_info(`gfn, $sformatf("vector[%0d]: %0p", j, parsed_vectors[j]), UVM_LOW)
+        `uvm_info(`gfn, $sformatf("vector[%0d]: %0p", j, parsed_vectors[j]), UVM_HIGH)
         // wr init: SHA256 only. HMAC, endian swap, digest swap all disabled
         hmac_init(.hmac_en(hmac_en), .endian_swap(1'b0), .digest_swap(1'b0));
 
         `uvm_info(`gtn, $sformatf("%s, starting seq %0d, msg size = %0d",
                                   test_vectors_pkg::sha_file_list[i], j,
-                                  parsed_vectors[j].msg_length_byte), UVM_LOW)
+                                  parsed_vectors[j].msg_length_byte), UVM_MEDIUM)
 
         if ($urandom_range(0, 1) && !hmac_en) begin
           `DV_CHECK_RANDOMIZE_FATAL(this) // only key is randomized

--- a/hw/ip/rv_timer/data/rv_timer_testplan.hjson
+++ b/hw/ip/rv_timer/data/rv_timer_testplan.hjson
@@ -17,7 +17,7 @@
             - Wait for number of cycles to have mTime>= mTimeCmp
             - Check Interrupt state register and Interrupt signal (scoreboard logic)'''
       milestone: V1
-      tests: ["rv_timer_smoke", "rv_timer_random"]
+      tests: ["rv_timer_random"]
     }
     {
       name: random_reset

--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_random_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_random_vseq.sv
@@ -18,11 +18,6 @@ class rv_timer_random_vseq extends rv_timer_base_vseq;
   rand uint ticks[NUM_HARTS];
   rand bit  assert_reset;
 
-  // The scope and runtime of this test can be reduced by setting this variable. This is useful to
-  // keep the runtime down especially in time-sensitive runs such as CI, which is meant to check
-  // the code health and not find design bugs. It is set via plusarg.
-  bit smoke_test;
-
   uint64 max_clks_until_expiry = 5_000_000;
 
   constraint assert_reset_c {
@@ -30,8 +25,8 @@ class rv_timer_random_vseq extends rv_timer_base_vseq;
   }
 
   constraint num_trans_c {
-    if (smoke_test) num_trans == 1;
-    else            num_trans inside {[1:6]};
+    if (cfg.smoke_test) num_trans == 1;
+    else                num_trans inside {[1:6]};
   }
 
   // Enable at least 1 timer.
@@ -49,8 +44,8 @@ class rv_timer_random_vseq extends rv_timer_base_vseq;
     solve en_harts before prescale;
     foreach (prescale[i]) {
       if (en_harts[i]) {
-        if (smoke_test) prescale[i] == 1;
-        else            prescale[i] inside {[0:max_prescale]};
+        if (cfg.smoke_test) prescale[i] == 1;
+        else                prescale[i] inside {[0:max_prescale]};
       } else {
         prescale[i] == 0;
       }
@@ -62,8 +57,8 @@ class rv_timer_random_vseq extends rv_timer_base_vseq;
     solve en_harts before step;
     foreach (step[i]) {
       if (en_harts[i]) {
-        if (smoke_test) step[i] == 1;
-        else            step[i] inside {[1:max_step]};
+        if (cfg.smoke_test) step[i] == 1;
+        else                step[i] inside {[1:max_step]};
       } else {
         step[i] == 0;
       }
@@ -76,8 +71,8 @@ class rv_timer_random_vseq extends rv_timer_base_vseq;
     foreach (ticks[i]) {
       if (en_harts[i]) {
         // For smoke test, timeout between 50 and 200 ticks.
-        if (smoke_test) ticks[i] inside {[50:200]};
-        else            (ticks[i] * (prescale[i] + 1)) <= max_clks_until_expiry;
+        if (cfg.smoke_test) ticks[i] inside {[50:200]};
+        else                (ticks[i] * (prescale[i] + 1)) <= max_clks_until_expiry;
       }
     }
   }
@@ -97,12 +92,6 @@ class rv_timer_random_vseq extends rv_timer_base_vseq;
       }
     }
   }
-
-  function void pre_randomize();
-    super.pre_randomize();
-    // Retrieve this before randomization, so that it can be used inside constraints.
-    void'($value$plusargs("smoke_test=%0b", smoke_test));
-  endfunction
 
   task pre_start();
     super.pre_start();

--- a/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
+++ b/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
@@ -45,13 +45,6 @@
   // List of test specifications.
   tests: [
     {
-      name: rv_timer_smoke
-      uvm_test_seq: rv_timer_random_vseq
-      run_opts: ["+smoke_test=1"]
-      reseed: 20
-    }
-
-    {
       name: rv_timer_random
       uvm_test_seq: rv_timer_random_vseq
       reseed: 200
@@ -80,7 +73,7 @@
   regressions: [
     {
       name: smoke
-      tests: ["rv_timer_smoke"]
+      tests: ["rv_timer_random"]
     }
   ]
 }


### PR DESCRIPTION
This PR has two commits:
1. First commits includes two related changes:
  1. The sha_vector test reads a input txt file into sequences input and check if
  the output is expected from the txt file. This process took 408s CPU
  time. Due to the current private CI timeout issue, we will only randomly
  run 2 sequences. This reduce the runtime to 20s.

  2. Moves the control knob `smoke_test` from rv_timer_random_vseq to `dv_base_env_cfg.sv`.
  In this way, all other IPs that intended to reduce the run time can share the same variable.

2. Remove the `rv_timer_smoke` entry in rv_timer_cfg. This is used to reduce the runtime for `rv_timer_random_vseq`
  in order to do a smoke check for CI. Now we can use `smoke_test` knob under `smoke_regression` directly.

Signed-off-by: Cindy Chen <chencindy@google.com>