### PR TITLE
[dv] Enforce SW test status transition

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -270,7 +270,7 @@
 
 // print static/dynamic 1d array or queue
 `ifndef DV_PRINT_ARR_CONTENTS
-`define DV_PRINT_ARR_CONTENTS(ARR_, V_=UVM_MEDIUM, ID_=`gfn) \
+`define DV_PRINT_ARR_CONTENTS(ARR_, V_=uvm_pkg::UVM_MEDIUM, ID_=`gfn) \
   begin \
     foreach (ARR_[i]) begin \
       `dv_info($sformatf("%s[%0d] = 0x%0d[0x%0h]", `"ARR_`", i, ARR_[i], ARR_[i]), V_, ID_) \
@@ -364,7 +364,7 @@
         begin \
           EXIT_ \
           if (MSG_ != "") begin \
-            `dv_info(MSG_, UVM_HIGH, ID_) \
+            `dv_info(MSG_, uvm_pkg::UVM_HIGH, ID_) \
           end \
         end \
       join_any \
@@ -438,7 +438,7 @@
 `ifdef UVM
 `ifndef dv_info
   // verilog_lint: waive macro-name-style
-  `define dv_info(MSG_,  VERBOSITY_ = UVM_LOW, ID_ = $sformatf("%m")) \
+  `define dv_info(MSG_,  VERBOSITY_ = uvm_pkg::UVM_LOW, ID_ = $sformatf("%m")) \
     if (uvm_pkg::uvm_report_enabled(VERBOSITY_, uvm_pkg::UVM_INFO, ID_)) begin \
         uvm_pkg::uvm_report_info(ID_, MSG_, VERBOSITY_, `uvm_file, `uvm_line, "", 1); \
     end
@@ -552,7 +552,7 @@
     /* The #1 delay below allows any part of the tb to control the conditions first at t = 0. */ \
     #1; \
     if ((en_``__CG_NAME) || (__COND)) begin \
-      `dv_info({"Creating covergroup ", `"__CG_NAME`"}, UVM_MEDIUM) \
+      `dv_info({"Creating covergroup ", `"__CG_NAME`"}, uvm_pkg::UVM_MEDIUM) \
       __CG_NAME``_inst = new``__CG_ARGS; \
     end \
   end

--- a/hw/dv/sv/sw_test_status/sw_test_status_if.sv
+++ b/hw/dv/sv/sw_test_status/sw_test_status_if.sv
@@ -11,23 +11,22 @@ interface sw_test_status_if #(
   input logic [15:0] data           // Incoming data.
 );
 
-`ifdef UVM
-  import uvm_pkg::*;
-`endif
   import sw_test_status_pkg::*;
-
-  // macro includes
   `include "dv_macros.svh"
 
   // Address to which the test status is written to. This is set by the testbench.
   logic [AddrWidth-1:0] sw_test_status_addr;
+
+  // Enforce that the SW test pass indication is made only from the SwTestStatusInTest state.
+  bit can_pass_only_in_test = 1'b1;
 
   // Validate the incoming write address.
   logic data_valid;
   assign data_valid = wr_valid && (addr == sw_test_status_addr);
 
   // SW test status indication.
-  sw_test_status_e sw_test_status = SwTestStatusUnderReset;
+  sw_test_status_e sw_test_status;
+  sw_test_status_e sw_test_status_prev;
 
   // If the sw_test_status reaches the terminal states, assert that we are done.
   bit sw_test_done;
@@ -35,15 +34,32 @@ interface sw_test_status_if #(
 
   always @(posedge clk_i) begin
     if (data_valid) begin
+      sw_test_status_prev = sw_test_status;
       sw_test_status = sw_test_status_e'(data);
-      sw_test_done = sw_test_done | sw_test_status inside {SwTestStatusPassed, SwTestStatusFailed};
-      sw_test_passed = sw_test_status == SwTestStatusPassed;
-      if (sw_test_status == SwTestStatusPassed) begin
-        `dv_info("==== SW TEST PASSED ====")
-      end else if (sw_test_status == SwTestStatusFailed) begin
-        `dv_error("==== SW TEST FAILED ====")
-      end else begin
-        `dv_info($sformatf("SW test status changed: %0s", sw_test_status.name()))
+
+      // Do further processing only on status transitions.
+      if (sw_test_status_prev != sw_test_status) begin
+        `dv_info($sformatf("SW test transitioned to %s.", sw_test_status.name()))
+
+        // SW MUST not transition to any other state, if it is already done.
+        if (sw_test_done) begin
+          `dv_error("SW test status must not change after reaching the pass or fail state.")
+          `dv_error("==== SW TEST FAILED ====")
+        end
+        sw_test_done |= sw_test_status inside {SwTestStatusPassed, SwTestStatusFailed};
+
+        if (sw_test_status == SwTestStatusPassed) begin
+          if (can_pass_only_in_test && sw_test_status_prev != SwTestStatusInTest) begin
+            `dv_error($sformatf("SW test transitioned to %s from an illegal state: %s.",
+                                sw_test_status.name(), sw_test_status_prev.name()))
+            `dv_error("==== SW TEST FAILED ====")
+          end else begin
+            sw_test_passed = 1'b1;
+            `dv_info("==== SW TEST PASSED ====")
+          end
+        end else if (sw_test_status == SwTestStatusFailed) begin
+          `dv_error("==== SW TEST FAILED ====")
+        end
       end
     end
   end

--- a/test/systemtest/earlgrey/test_sim_verilator.py
+++ b/test/systemtest/earlgrey/test_sim_verilator.py
@@ -213,7 +213,7 @@ def app_selfchecking(request, bin_dir):
 
 def assert_selfchecking_test_passes(sim):
     assert sim.find_in_output(
-        re.compile(r"SW test status changed: SwTestStatusInTest$"),
+        re.compile(r"SW test transitioned to SwTestStatusInTest.$"),
         timeout=120,
         filter_func=utils.filter_remove_sw_test_status_log_prefix
     ) is not None, "Start of test indication not found."


### PR DESCRIPTION
Enforce that SW test can transition to the passed state ONLY if it was
in `SwTestStatusInTest`.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>