### PR TITLE
[kmac] Do not shadow ErrNone constant

### DIFF
--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -5,11 +5,8 @@
 // kmac_pkg
 
 package kmac_pkg;
-
-  // import necessary functions from sha3_pkg
-  import sha3_pkg::*;
-  export sha3_pkg::MsgWidth;
-  export sha3_pkg::MsgStrbW;
+  parameter int MsgWidth = sha3_pkg::MsgWidth;
+  parameter int MsgStrbW = sha3_pkg::MsgStrbW;
 
   // Message FIFO depth
   //


### PR DESCRIPTION
A constant named ErrNone is present in the sha3_pkg as well as in
kmac_pkg. The latter did a wildcard-import of all of sha3_pkg, resulting
in a redeclaration of the ErrNone symbol. To prevent that from happening
in the future, remove the wildcard import and fully qualify the used
constants (which matches our style guide anyways).

Reported by DC:

```
Error:  ../src/lowrisc_ip_kmac_0.1/rtl/kmac_pkg.sv:102: redeclaration of symbol ErrNone as constant. (VER-513)

Error:  ../src/lowrisc_ip_kmac_0.1/rtl/kmac_pkg.sv:102: invalid symbol ErrNone found in expression. (VER-255)
```