### PR TITLE
[pattgen, dv] Support pattgen_error test

### DIFF
--- a/hw/dv/sv/pattgen_agent/pattgen_agent_cfg.sv
+++ b/hw/dv/sv/pattgen_agent/pattgen_agent_cfg.sv
@@ -8,12 +8,13 @@ class pattgen_agent_cfg extends dv_base_agent_cfg;
   // interface handle used by driver, monitor & the sequencer, via cfg handle
   virtual pattgen_if vif;
 
-  bit reset_asserted;
+  bit [NUM_PATTGEN_CHANNELS-1:0] error_injected;
 
   bit  polarity[NUM_PATTGEN_CHANNELS-1:0];
   uint length[NUM_PATTGEN_CHANNELS-1:0];
 
   `uvm_object_utils_begin(pattgen_agent_cfg)
+    `uvm_field_int(error_injected,  UVM_DEFAULT)
     `uvm_field_sarray_int(polarity, UVM_DEFAULT)
     `uvm_field_sarray_int(length,   UVM_DEFAULT)
   `uvm_object_utils_end

--- a/hw/dv/sv/pattgen_agent/pattgen_monitor.sv
+++ b/hw/dv/sv/pattgen_agent/pattgen_monitor.sv
@@ -10,6 +10,8 @@ class pattgen_monitor extends dv_base_monitor #(
   `uvm_component_utils(pattgen_monitor)
   `uvm_component_new
 
+  bit reset_asserted = 1'b0;
+
   // analysis ports connected to scb
   uvm_analysis_port #(pattgen_item) item_port[NUM_PATTGEN_CHANNELS];
 
@@ -25,7 +27,7 @@ class pattgen_monitor extends dv_base_monitor #(
     collect_trans(phase);
   endtask : run_phase
 
-  virtual protected task collect_trans(uvm_phase phase);
+  virtual task collect_trans(uvm_phase phase);
     for (uint i = 0; i < NUM_PATTGEN_CHANNELS; i++) begin
       fork
         automatic uint channel = i;
@@ -35,7 +37,7 @@ class pattgen_monitor extends dv_base_monitor #(
     end
   endtask : collect_trans
 
-  virtual protected task collect_channel_trans(uint channel);
+  virtual task collect_channel_trans(uint channel);
     bit  bit_data;
     uint bit_cnt;
 
@@ -43,26 +45,31 @@ class pattgen_monitor extends dv_base_monitor #(
     forever begin
       dut_item = pattgen_item::type_id::create("dut_item");
       bit_cnt = 0;
-      fork 
+      fork
         begin : isolation_thread
           fork
+            // capture pattern bits
             begin
               do begin
                 wait(cfg.en_monitor);
                 get_pattgen_bit(channel, bit_data);
-                `uvm_info(`gfn, $sformatf("\n--> monitor: channel %0d, polarity %0d, data[%0d] %b",
+                `uvm_info(`gfn, $sformatf("\n--> monitor: channel %0d, polar %b, data[%0d] %b",
                     channel, cfg.polarity[channel], bit_cnt, bit_data), UVM_DEBUG)
                 dut_item.data_q.push_back(bit_data);
                 bit_cnt++;
               end while (bit_cnt < cfg.length[channel]);
               // avoid race condition (counter is achieved and reset is issued at the same time)
-              if (!cfg.reset_asserted) begin
+              if (!reset_asserted && !cfg.error_injected[channel]) begin
                 item_port[channel].write(dut_item);
-                `uvm_info(`gfn, $sformatf("\n--> monitor: send dut_item on channel %0d to scb\n%s",
+                `uvm_info(`gfn, $sformatf("\n--> monitor: send dut_item for channel %0d\n%s",
                     channel, dut_item.sprint()), UVM_DEBUG)
+                bit_cnt = 0;
               end
             end
-            @(posedge cfg.reset_asserted);
+            // handle reset
+            @(posedge reset_asserted);
+            // handle errored channels
+            error_channel_process(channel, bit_cnt, dut_item);
           join_any
           disable fork;
         end : isolation_thread
@@ -73,12 +80,20 @@ class pattgen_monitor extends dv_base_monitor #(
   virtual task reset_thread();
     forever begin
       @(negedge cfg.vif.rst_ni);
-      cfg.reset_asserted = 1'b1;
+      reset_asserted = 1'b1;
       // implement other clean-up actions under reset here
       @(posedge cfg.vif.rst_ni);
-      cfg.reset_asserted = 1'b0;
+      reset_asserted = 1'b0;
     end
   endtask : reset_thread
+
+  virtual task error_channel_process(uint channel, ref uint bit_cnt, ref pattgen_item item);
+    @(posedge cfg.error_injected[channel]);
+    bit_cnt = 0;
+    `uvm_info(`gfn, $sformatf("\n--> monitor: drop dut_item for channel %0d\n%s",
+        channel, item.sprint()), UVM_DEBUG)
+    @(negedge cfg.error_injected[channel]);
+  endtask: error_channel_process
 
   // update of_to_end to prevent sim finished when there is any activity on the bus
   // ok_to_end = 0 (bus busy) / 1 (bus idle)

--- a/hw/ip/pattgen/data/pattgen_testplan.hjson
+++ b/hw/ip/pattgen/data/pattgen_testplan.hjson
@@ -56,7 +56,7 @@
 
             Stimulus:
               - Programm the configuration registers of the output channels
-              - Randomly reset the output channel in progress
+              - Randomly reset the in progress output channels
               - Re-program the configuration registers of the output channels
 
             Checking:

--- a/hw/ip/pattgen/dv/env/pattgen_channel_cfg.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_channel_cfg.sv
@@ -7,8 +7,9 @@ class pattgen_channel_cfg extends uvm_object;
   `uvm_object_new
 
   bit                start;
-  bit                done;
+  bit                stop;
   bit                enable;
+
   rand bit           polarity;
   rand bit [31:0]    prediv;
   rand bit [63:0]    data;
@@ -18,24 +19,25 @@ class pattgen_channel_cfg extends uvm_object;
   // functions
   virtual function void reset_channel_config();
     start    = 1'b0;
-    done     = 1'b0;
+    stop     = 1'b0;
+    enable   = 1'b0;
   endfunction : reset_channel_config
 
   // this function print channel configuration for debug
-  virtual function void print_config(string msg, bit do_print = 1'b0);
-    string str;
+  virtual function string convert2string();
+      string str;
 
-    if (do_print) begin
-      str = {msg, "\n"};
-      str = {str, $sformatf("    polarity    %b\n",  polarity)};
-      str = {str, $sformatf("    prediv      %0d\n", prediv)};
-      str = {str, $sformatf("    len         %0d\n", len)};
-      str = {str, $sformatf("    reps        %0d\n", reps)};
-      str = {str, $sformatf("    data[0]     %0d\n", data[31:0])};
-      str = {str, $sformatf("    data[1]     %0d\n", data[63:32])};
-      str = {str, $sformatf("    patt_len    %0d",   len * reps)};
-      `uvm_info(`gfn, $sformatf("%s", str), UVM_LOW)
-    end
-  endfunction : print_config
+      str = {str, $sformatf("  start     %b\n",  start)};
+      str = {str, $sformatf("  stop      %b\n",  stop)};
+      str = {str, $sformatf("  enable    %b\n",  enable)};
+      str = {str, $sformatf("  polarity  %b\n",  polarity)};
+      str = {str, $sformatf("  prediv    %0d\n", prediv)};
+      str = {str, $sformatf("  len       %0d\n", len)};
+      str = {str, $sformatf("  reps      %0d\n", reps)};
+      str = {str, $sformatf("  data[0]   %0d\n", data[31:0])};
+      str = {str, $sformatf("  data[1]   %0d\n", data[63:32])};
+      str = {str, $sformatf("  patt_len  %0d",   (len + 1) * (reps + 1))};
+      return str;
+  endfunction : convert2string
 
 endclass : pattgen_channel_cfg

--- a/hw/ip/pattgen/dv/env/pattgen_env.core
+++ b/hw/ip/pattgen/dv/env/pattgen_env.core
@@ -25,6 +25,7 @@ filesets:
       - seq_lib/pattgen_common_vseq.sv: {is_include_file: true}
       - seq_lib/pattgen_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/pattgen_perf_vseq.sv: {is_include_file: true}
+      - seq_lib/pattgen_error_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/pattgen/dv/env/pattgen_env_pkg.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_env_pkg.sv
@@ -27,9 +27,10 @@ package pattgen_env_pkg;
   } pattgen_intr_e;
 
   typedef enum bit[1:0] {
-    Channel0    = 2'b01,
-    Channel1    = 2'b10,
-    AllChannels = 2'b11
+    NoChannels   = 2'b00,
+    Channel0     = 2'b01,
+    Channel1     = 2'b10,
+    AllChannels  = 2'b11
   } channel_select_e;
 
   typedef enum bit {

--- a/hw/ip/pattgen/dv/env/pattgen_seq_cfg.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_seq_cfg.sv
@@ -23,14 +23,17 @@ class pattgen_seq_cfg extends uvm_object;
   // see the specification document, the effective values of prediv, len, and reps
   // are incremented from the coresponding register values
   uint pattgen_min_prediv            = 0;
-  uint pattgen_max_prediv            = 5;
+  uint pattgen_max_prediv            = 20;
   uint pattgen_min_len               = 0;
   uint pattgen_max_len               = 10;
   uint pattgen_min_reps              = 0;
   uint pattgen_max_reps              = 10;
 
-  uint pattgen_polarity_pct          = 50;  // in percentage
-
+  uint pattgen_low_polarity_pct      = 50;  // in percentage
   uint pattgen_sync_channels_pct     = 30;  // in percentage
+
+  // for error_vseq
+  bit  error_injected_enb            = 1'b0;
+  uint error_injected_pct            = 50;  // in percentage
 
 endclass : pattgen_seq_cfg

--- a/hw/ip/pattgen/dv/env/seq_lib/pattgen_base_vseq.sv
+++ b/hw/ip/pattgen/dv/env/seq_lib/pattgen_base_vseq.sv
@@ -12,24 +12,26 @@ class pattgen_base_vseq extends cip_base_vseq #(
   `uvm_object_new
 
   // variables
-  uint                     num_pattern_req = 0;
-  uint                     num_pattern_gen = 0;
+  uint                                num_pattern_req = 0;
+  uint                                num_pattern_gen = 0;
   // channel config
-  rand pattgen_channel_cfg channel_cfg[NUM_PATTGEN_CHANNELS-1:0];
+  rand pattgen_channel_cfg            channel_cfg[NUM_PATTGEN_CHANNELS-1:0];
 
   // indicate channels are setup before enabled
-  bit [NUM_PATTGEN_CHANNELS-1:0] ch_under_setup = 'h0;
-  bit [NUM_PATTGEN_CHANNELS-1:0] ch_under_start = 'h0;
+  bit [NUM_PATTGEN_CHANNELS-1:0]      channel_setup = 'h0;
+  bit [NUM_PATTGEN_CHANNELS-1:0]      channel_start = 'h0;
   // this one-hot vector is used for round-robin arbitrating the accesses to the shared registers
   // this vector is initialized to 1 (the channel 0 is granted by default)
-  bit [NUM_PATTGEN_CHANNELS-1:0] ch_grant_setup = 'h1;
+  bit [NUM_PATTGEN_CHANNELS-1:0]      channel_grant = 'h1;
 
   // random variables
-  rand uint                num_runs;    // TODO: this variable is reserved for V2 tests
-  rand uint                stop_channel_dly;
-  rand uint                clear_intr_dly;
-  // if sync_all_channels bit is set: both channels can start simmultaneously
-  rand bit                 sync_all_channels;
+  rand uint                           num_runs;
+  rand uint                           b2b_pattern_dly;
+  rand uint                           clear_intr_dly;
+  // if start_all_channels bit is set: both channels can start simmultaneously
+  rand bit                            start_all_channels;
+  rand bit                            do_error_injected;
+  rand bit [NUM_PATTGEN_CHANNELS-1:0] reset_channels;
 
   // constraints
   constraint num_trans_c {
@@ -38,34 +40,44 @@ class pattgen_base_vseq extends cip_base_vseq #(
   constraint num_runs_c {
     num_runs inside {[cfg.seq_cfg.pattgen_min_num_runs : cfg.seq_cfg.pattgen_max_num_runs]};
   }
-  constraint sync_all_channels_c {
-    sync_all_channels dist {
+  constraint start_all_channels_c {
+    start_all_channels dist {
       1'b1 :/ cfg.seq_cfg.pattgen_sync_channels_pct,
       1'b0 :/ (100 - cfg.seq_cfg.pattgen_sync_channels_pct)
     };
   }
-  constraint stop_channel_dly_c {
-    stop_channel_dly inside {[cfg.seq_cfg.pattgen_min_dly : cfg.seq_cfg.pattgen_max_dly]};
+  constraint do_error_injected_c {
+    do_error_injected dist {
+      1'b1:/ cfg.seq_cfg.error_injected_pct,
+      1'b0:/ (100 - cfg.seq_cfg.error_injected_pct)
+    };
+  }
+  constraint b2b_pattern_dly_c {
+    b2b_pattern_dly inside {[cfg.seq_cfg.pattgen_min_dly : cfg.seq_cfg.pattgen_max_dly]};
   }
   constraint clear_intr_dly_c {
     clear_intr_dly inside {[cfg.seq_cfg.pattgen_min_dly : cfg.seq_cfg.pattgen_max_dly]};
   }
 
   virtual task pre_start();
-    num_runs.rand_mode(0);
     cfg.m_pattgen_agent_cfg.en_monitor = cfg.en_scb;
-    // set time to stop test
-    cfg.m_pattgen_agent_cfg.ok_to_end_delay_ns = cfg.ok_to_end_delay_ns;
     `uvm_info(`gfn, $sformatf("\n--> %s monitor and scoreboard",
         cfg.en_scb ? "enable" : "disable"), UVM_DEBUG)
     super.pre_start();
   endtask : pre_start
 
+  virtual task post_start();
+    // env_cfg must be reset after vseq completion
+    cfg.seq_cfg.error_injected_enb = 1'b0;
+    cfg.seq_cfg.pattgen_min_prediv = 0;
+    cfg.seq_cfg.pattgen_min_len    = 0;
+    cfg.seq_cfg.pattgen_min_reps   = 0;
+    super.post_start();
+  endtask : post_start
+
   // setup basic pattgen features
   virtual task initialize_dut();
-    csr_wr(.csr(ral.ctrl),        .value({TL_DW{1'b0}}));
     csr_wr(.csr(ral.intr_enable), .value({TL_DW{1'b1}}));
-    csr_wr(.csr(ral.intr_state),  .value({TL_DW{1'b0}}));
     `uvm_info(`gfn, "\n  call pattgen_init", UVM_DEBUG)
   endtask : initialize_dut
 
@@ -78,7 +90,7 @@ class pattgen_base_vseq extends cip_base_vseq #(
     initialize_dut();
     while (num_pattern_req < num_trans ||   // not send all pattern configs
            num_pattern_gen < num_trans ||   // not get  all pattern done interrupts
-           ch_under_start) begin            // at least one channel is running
+           channel_start) begin             // at least one channel is running
       fork
         // all channels are completely independent (programm, start w/ or wo/ sync, and stop)
         setup_pattgen_channel_0();
@@ -87,8 +99,8 @@ class pattgen_base_vseq extends cip_base_vseq #(
         stop_pattgen_channels();
       join
     end
-    `uvm_info(`gfn, $sformatf("\n--> ch_under_setup %b", ch_under_setup), UVM_DEBUG)
-    `uvm_info(`gfn, $sformatf("\n--> ch_under_start %b", ch_under_start), UVM_DEBUG)
+    `uvm_info(`gfn, $sformatf("\n--> channel_setup %b", channel_setup), UVM_DEBUG)
+    `uvm_info(`gfn, $sformatf("\n--> channel_start %b", channel_start), UVM_DEBUG)
     `uvm_info(`gfn, "\n--> end of sequence", UVM_DEBUG)
   endtask : body
 
@@ -96,11 +108,11 @@ class pattgen_base_vseq extends cip_base_vseq #(
   // e.g. index the regster groups of channels before entering while-loop in body task
   virtual task setup_pattgen_channel_0();
     if (num_pattern_req < num_trans &&
-         ch_grant_setup[0] &&       // ch0 setup is granted
-        !ch_under_setup[0] &&       // ch0 has not been programmed
-        !ch_under_start[1]) begin   // ch1 is not under start (avoid re-programming regs)
+         channel_grant[0] &&       // ch0 setup is granted
+        !channel_setup[0] &&       // ch0 has not been programmed
+        !channel_start[1]) begin   // ch1 is not under start (avoid re-programming regs)
+      wait_for_channel_ready(Channel0);
       channel_cfg[0] = get_random_channel_config(.channel(0));
-      update_pattgen_agent_cfg(.channel(0));
       ral.size.len_ch0.set(channel_cfg[0].len);
       ral.size.reps_ch0.set(channel_cfg[0].reps);
       csr_update(ral.size);
@@ -108,20 +120,21 @@ class pattgen_base_vseq extends cip_base_vseq #(
       csr_wr(.csr(ral.data_ch0_0), .value(channel_cfg[0].data[31:0]));
       csr_wr(.csr(ral.data_ch0_1), .value(channel_cfg[0].data[63:32]));
       ral.ctrl.polarity_ch0.set(channel_cfg[0].polarity);
+      update_pattgen_agent_cfg(.channel(0));
       csr_update(ral.ctrl);
-      ch_under_setup[0] = 1'b1;
-      void'(right_rotation(ch_grant_setup));
-      `uvm_info(`gfn, "\n  channel 0 is programmed", UVM_DEBUG)
+      channel_setup[0] = 1'b1;
+      void'(right_rotation(channel_grant));
+      `uvm_info(`gfn, "\n  channel 0: programmed", UVM_DEBUG)
     end
   endtask : setup_pattgen_channel_0
 
   virtual task setup_pattgen_channel_1();
     if (num_pattern_req < num_trans &&
-        ch_grant_setup[1]  &&       // ch1 setup is granted
-        !ch_under_setup[1] &&       // ch1 has not been programmed
-        !ch_under_start[0]) begin   // ch0 is not under start (avoid re-programming regs)
+        channel_grant[1]  &&       // ch1 setup is granted
+        !channel_setup[1] &&       // ch1 has not been programmed
+        !channel_start[0]) begin   // ch0 is not under start (avoid re-programming regs)
+      wait_for_channel_ready(Channel1);
       channel_cfg[1] = get_random_channel_config(.channel(1));
-      update_pattgen_agent_cfg(.channel(1));
       ral.size.len_ch1.set(channel_cfg[1].len);
       ral.size.reps_ch1.set(channel_cfg[1].reps);
       csr_update(ral.size);
@@ -129,35 +142,40 @@ class pattgen_base_vseq extends cip_base_vseq #(
       csr_wr(.csr(ral.data_ch1_0), .value(channel_cfg[1].data[31:0]));
       csr_wr(.csr(ral.data_ch1_1), .value(channel_cfg[1].data[63:32]));
       ral.ctrl.polarity_ch1.set(channel_cfg[1].polarity);
+      update_pattgen_agent_cfg(.channel(1));
       csr_update(ral.ctrl);
-      ch_under_setup[1] = 1'b1;
-      void'(right_rotation(ch_grant_setup));
-      `uvm_info(`gfn, "\n  channel 1 is programmed", UVM_DEBUG)
+      channel_setup[1] = 1'b1;
+      void'(right_rotation(channel_grant));
+      `uvm_info(`gfn, "\n  channel 1: programmed", UVM_DEBUG)
     end
   endtask : setup_pattgen_channel_1
 
   virtual task start_pattgen_channels();
     if (num_pattern_req < num_trans) begin
-      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(sync_all_channels)
-      // if sync_all_channels is set, then activate both channels if they are setup and not busy
-      if (sync_all_channels) begin
-        // once sync_all_channels is set, temporaly disable its randomization to sync all channels
-        sync_all_channels.rand_mode(0);
-        if (ch_under_setup[0] && !ch_under_start[0] && ch_under_setup[1] && !ch_under_start[1]) begin
-          {ch_under_start[0], ch_under_start[1]} = {1'b1, 1'b1};
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(start_all_channels)
+      // if start_all_channels is set, then activate both channels if they are setup and not busy
+      if (start_all_channels) begin
+        // once start_all_channels is set, temporaly disable its randomization to sync all channels
+        start_all_channels.rand_mode(0);
+        if (channel_setup[0] && !channel_start[0] && channel_setup[1] && !channel_start[1]) begin
+          `DV_CHECK_MEMBER_RANDOMIZE_FATAL(b2b_pattern_dly)
+          cfg.clk_rst_vif.wait_clks(b2b_pattern_dly);
           control_channels(AllChannels, Enable);
+          {channel_start[0], channel_start[1]} = {1'b1, 1'b1};
           `uvm_info(`gfn, "\n  all channels: activated", UVM_DEBUG)
-          // re-enable sync_all_channels's randomization after all channels have been started
-          sync_all_channels.rand_mode(1);
+          // re-enable start_all_channels's randomization after all channels have been started
+          start_all_channels.rand_mode(1);
         end
       end else begin
       // otherwise, activate channels independently
         for (uint i = 0; i < NUM_PATTGEN_CHANNELS; i++) begin
-          if (ch_under_setup[i] && !ch_under_start[i]) begin
+          if (channel_setup[i] && !channel_start[i]) begin
             channel_select_e ch_select;
             `downcast(ch_select, i+1)
-            ch_under_start[i]= 1'b1;
+            `DV_CHECK_MEMBER_RANDOMIZE_FATAL(b2b_pattern_dly)
+            cfg.clk_rst_vif.wait_clks(b2b_pattern_dly);
             control_channels(ch_select, Enable);
+            channel_start[i]= 1'b1;
             `uvm_info(`gfn, $sformatf("\n  channel %0d: activated", i), UVM_DEBUG)
           end
         end
@@ -167,41 +185,88 @@ class pattgen_base_vseq extends cip_base_vseq #(
 
   // this task allows channels to be stopped independently/simultaneously
   virtual task stop_pattgen_channels();
-    bit [TL_DW-1:0] intr_state;
+    bit error_injected;
+    bit [NUM_PATTGEN_CHANNELS-1:0] intr_status;
+    bit [NUM_PATTGEN_CHANNELS-1:0] channel_stop;
 
-    if (ch_under_start) begin
-      csr_rd(.ptr(ral.intr_state), .value(intr_state));
-      case ({intr_state[DoneCh1], intr_state[DoneCh0]})
+    if (channel_start) begin
+      error_injected = 1'b0;
+      get_interrupt_states(intr_status);
+      //--------------------------------------------------------------------------------
+      // inject error
+      //--------------------------------------------------------------------------------
+      // ch_start  intr_status   ch_stop   description
+      //--------------------------------------------------------------------------------
+      // 01 (CH0)  01            01        CH0 finished          CH1 not started
+      // 01 (CH0)  00            01        CH0 error injected*   CH1 not started
+      // 10 (CH1)  10            10        CH0 not started       CH1 finished
+      // 10 (CH1)  00            10        CH0 not started       CH1 error injected*
+      // 11 (CH1)  01            01        CH0 finished          CH1 error injected*
+      // 11 (CH1)  10            10        CH0 error injected*   CH1 finished
+      // 11 (CH1)  11            11        CH0 finished          CH1 finished
+      // 11 (CH1)  00            11        CH0 error injected    CH1 error injected*
+      channel_stop = intr_status; // default setting
+      if (cfg.seq_cfg.error_injected_enb) begin
+        `DV_CHECK_MEMBER_RANDOMIZE_FATAL(do_error_injected)
+        if (do_error_injected) begin
+          if (intr_status != channel_start) begin
+            channel_stop = channel_start;
+            error_injected = 1'b1;
+            cfg.m_pattgen_agent_cfg.error_injected = channel_stop;
+            `uvm_info(`gfn, $sformatf("\n  error inject: intr_status %b ch_stop %b ch_start %b",
+                intr_status, channel_stop, channel_start), UVM_DEBUG)
+          end
+        end
+      end
+
+      case (channel_stop)
         Channel0: begin
+          clear_interrupts(Channel0, error_injected);
           control_channels(Channel0, Disable);
-          clear_interrupts(Channel0);
+          if (error_injected) cfg.m_pattgen_agent_cfg.error_injected[0] = 1'b0;
           num_pattern_gen++;
-          `uvm_info(`gfn, $sformatf("\n  channel 0: completed %0d/%0d",
-              num_pattern_gen, num_trans), UVM_DEBUG)
-          {ch_under_setup[0], ch_under_start[0]} = {1'b0, 1'b0};
+          {channel_setup[0], channel_start[0]} = {1'b0, 1'b0};
+          `uvm_info(`gfn, $sformatf("\n  channel 0: %s %0d/%0d",
+              error_injected ? "error" : "completed", num_pattern_gen, num_trans), UVM_DEBUG)
         end
         Channel1: begin
+          clear_interrupts(Channel1, error_injected);
           control_channels(Channel1, Disable);
-          clear_interrupts(Channel1);
+          if (error_injected) cfg.m_pattgen_agent_cfg.error_injected[1] = 1'b0;
           num_pattern_gen++;
-          {ch_under_setup[1], ch_under_start[1]} = {1'b0, 1'b0};
-          `uvm_info(`gfn, $sformatf("\n  channel 1: completed %0d/%0d",
-              num_pattern_gen, num_trans), UVM_DEBUG)
+          {channel_setup[1], channel_start[1]} = {1'b0, 1'b0};
+          `uvm_info(`gfn, $sformatf("\n  channel 1: %s %0d/%0d",
+              error_injected ? "error" : "completed", num_pattern_gen, num_trans), UVM_DEBUG)
         end
         AllChannels: begin
+          clear_interrupts(AllChannels, error_injected);
           control_channels(AllChannels, Disable);
-          clear_interrupts(AllChannels);
+          if (error_injected) begin
+            cfg.m_pattgen_agent_cfg.error_injected = NoChannels;
+            `uvm_info(`gfn, $sformatf("\n  update m_pattgen_agent_cfg.error_injected"), UVM_DEBUG)
+          end
           num_pattern_gen += 2;
-          ch_under_setup = {NUM_PATTGEN_CHANNELS{1'b0}};
-          ch_under_start = {NUM_PATTGEN_CHANNELS{1'b0}};
-          `uvm_info(`gfn, $sformatf("\n  all channel: completed %0d/%0d",
-              num_pattern_gen, num_trans), UVM_DEBUG)
+          channel_setup = {NUM_PATTGEN_CHANNELS{1'b0}};
+          channel_start = {NUM_PATTGEN_CHANNELS{1'b0}};
+          `uvm_info(`gfn, $sformatf("\n  all channels: %s %0d/%0d",
+              error_injected ? "error" : "completed", num_pattern_gen, num_trans), UVM_DEBUG)
         end
       endcase
     end
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(stop_channel_dly)
-    cfg.clk_rst_vif.wait_clks(stop_channel_dly);
-  endtask: stop_pattgen_channels
+  endtask : stop_pattgen_channels
+
+  virtual task wait_for_channel_ready(channel_select_e ch_select);
+    case (ch_select)
+      Channel0: begin
+        csr_spinwait(.ptr(ral.ctrl.enable_ch0), .exp_data(1'b0));
+        `uvm_info(`gfn, $sformatf("\n  channel 0 is ready for programmed"), UVM_DEBUG)
+      end
+      Channel1: begin
+        csr_spinwait(.ptr(ral.ctrl.enable_ch1), .exp_data(1'b0));
+        `uvm_info(`gfn, $sformatf("\n  channel 1 is ready for programmed"), UVM_DEBUG)
+      end
+    endcase
+  endtask : wait_for_channel_ready
 
   // this task allows channels to be activated or stopped independently/simultaneously
   virtual task control_channels(channel_select_e ch_select, channel_status_e status);
@@ -213,16 +278,16 @@ class pattgen_base_vseq extends cip_base_vseq #(
         ral.ctrl.enable_ch0.set(status);
         if (status == Enable) begin
           num_pattern_req++;
-          channel_cfg[0].print_config($sformatf("\n  channel 0: request %0d/%0d",
-              num_pattern_req, num_trans));
+          `uvm_info(`gfn, $sformatf("\n  channel 0: request %0d/%0d\n%s",
+              num_pattern_req, num_trans, channel_cfg[0].convert2string()), UVM_DEBUG)
         end
       end
       Channel1: begin
         ral.ctrl.enable_ch1.set(status);
         if (status == Enable) begin
           num_pattern_req++;
-          channel_cfg[1].print_config($sformatf("\n  channel 1: request %0d/%0d",
-              num_pattern_req, num_trans));
+          `uvm_info(`gfn, $sformatf("\n  channel 1: request %0d/%0d\n%s",
+              num_pattern_req, num_trans, channel_cfg[1].convert2string()), UVM_DEBUG)
         end
       end
       AllChannels: begin
@@ -230,10 +295,10 @@ class pattgen_base_vseq extends cip_base_vseq #(
         ral.ctrl.enable_ch1.set(status);
         if (status == Enable) begin
           num_pattern_req += 2;
-          channel_cfg[0].print_config($sformatf("\n  sync channel 0: request %0d/%0d",
-              num_pattern_req - 1, num_trans));
-          channel_cfg[1].print_config($sformatf("\n  sync channel 1: request %0d/%0d",
-              num_pattern_req, num_trans));
+          `uvm_info(`gfn, $sformatf("\n  sync channel 0: request %0d/%0d\n%s",
+              num_pattern_req - 1, num_trans, channel_cfg[0].convert2string()), UVM_DEBUG);
+          `uvm_info(`gfn, $sformatf("\n  sync channel 1: request %0d/%0d\n%s",
+              num_pattern_req, num_trans, channel_cfg[1].convert2string()), UVM_DEBUG);
         end
       end
     endcase
@@ -247,19 +312,30 @@ class pattgen_base_vseq extends cip_base_vseq #(
     csr_update(ral.ctrl);
   endtask : control_channels
 
+  virtual task get_interrupt_states(output bit[NUM_PATTGEN_CHANNELS-1:0] intr_bits);
+    bit [TL_DW-1:0] intr_state;
+    csr_rd(.ptr(ral.intr_state), .value(intr_state));
+    intr_bits = NUM_PATTGEN_CHANNELS'(intr_state);
+    `uvm_info(`gfn, $sformatf("\n  intr_state %b", intr_bits), UVM_DEBUG)
+  endtask : get_interrupt_states
+
   // this task allows the interrupts of channels to be cleared independently/simultaneously
-  virtual task clear_interrupts(channel_select_e ch_select);
-    bit [TL_DW-1:0] intr_clear;
-    
-    case (ch_select)
-      Channel0:    intr_clear = 1 << DoneCh0;
-      Channel1:    intr_clear = 1 << DoneCh1;
-      AllChannels: intr_clear = (1 << DoneCh1) | (1 << DoneCh0);
-      default:     `uvm_fatal(`gfn, "  invalid argument")
-    endcase
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(clear_intr_dly)
-    cfg.clk_rst_vif.wait_clks(clear_intr_dly);
-    csr_wr(.csr(ral.intr_state), .value(intr_clear));
+  virtual task clear_interrupts(channel_select_e ch_select, bit error = 1'b0);
+    bit [TL_DW-1:0] intr_clear ='h0;
+
+    if (!error) begin
+      case (ch_select)
+        Channel0:    intr_clear = 1 << DoneCh0;
+        Channel1:    intr_clear = 1 << DoneCh1;
+        AllChannels: intr_clear = (1 << DoneCh1) | (1 << DoneCh0);
+        default:     `uvm_fatal(`gfn, "  invalid argument")
+      endcase
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(clear_intr_dly)
+      cfg.clk_rst_vif.wait_clks(clear_intr_dly);
+      csr_wr(.csr(ral.intr_state), .value(intr_clear));
+    end else begin
+      `uvm_info(`gfn, $sformatf("\n  channel error, no clear interrupts %b", intr_clear), UVM_DEBUG)
+    end
   endtask : clear_interrupts
 
   // this function randomizes the channel config
@@ -268,8 +344,8 @@ class pattgen_base_vseq extends cip_base_vseq #(
     ch_cfg = pattgen_channel_cfg::type_id::create($sformatf("channel_cfg_%0d", channel));
     `DV_CHECK_RANDOMIZE_WITH_FATAL(ch_cfg,
       ch_cfg.polarity dist {
-        1'b0 :/ cfg.seq_cfg.pattgen_polarity_pct,
-        1'b1 :/ (100 - cfg.seq_cfg.pattgen_polarity_pct)
+        1'b0 :/ cfg.seq_cfg.pattgen_low_polarity_pct,
+        1'b1 :/ (100 - cfg.seq_cfg.pattgen_low_polarity_pct)
       };
       ch_cfg.prediv inside {[cfg.seq_cfg.pattgen_min_prediv : cfg.seq_cfg.pattgen_max_prediv]};
       ch_cfg.len    inside {[cfg.seq_cfg.pattgen_min_len    : cfg.seq_cfg.pattgen_max_len]};
@@ -296,5 +372,13 @@ class pattgen_base_vseq extends cip_base_vseq #(
   virtual function right_rotation(ref bit [NUM_PATTGEN_CHANNELS-1:0] x);
     x = {x[NUM_PATTGEN_CHANNELS-2:0], x[NUM_PATTGEN_CHANNELS-1]};
   endfunction : right_rotation
+
+  // TODO: this task is reserved for the next PR
+  task wait_host_for_idle();
+    csr_spinwait(.ptr(ral.ctrl.enable_ch0),     .exp_data(1'b0));
+    csr_spinwait(.ptr(ral.ctrl.enable_ch1),     .exp_data(1'b0));
+    csr_spinwait(.ptr(ral.intr_state.done_ch0), .exp_data(1'b0));
+    csr_spinwait(.ptr(ral.intr_state.done_ch1), .exp_data(1'b0));
+  endtask : wait_host_for_idle
 
 endclass : pattgen_base_vseq

--- a/hw/ip/pattgen/dv/env/seq_lib/pattgen_error_vseq.sv
+++ b/hw/ip/pattgen/dv/env/seq_lib/pattgen_error_vseq.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// basic error test vseq
+// During the channels are operating (patterns are not fully generated),
+// this vseq can randomly disable channels that causes error patterns which
+// must be detected and dropped in scoreboard and agent_monitor
+class pattgen_error_vseq extends pattgen_base_vseq;
+  `uvm_object_utils(pattgen_error_vseq)
+  `uvm_object_new
+
+  virtual task pre_start();
+    super.pre_start();
+    cfg.seq_cfg.error_injected_enb = 1'b1;
+    // in order to inject error, the generated patterns should be long enough because
+    // completed interrupts can be triggerred before enable bit is unset in the last bit
+    // which indicates a correct correct patterns
+    cfg.seq_cfg.pattgen_min_prediv = 10;
+    cfg.seq_cfg.pattgen_max_prediv = 20;
+    cfg.seq_cfg.pattgen_min_len    = 5;
+    cfg.seq_cfg.pattgen_min_reps   = 5;
+  endtask : pre_start
+
+endclass : pattgen_error_vseq

--- a/hw/ip/pattgen/dv/env/seq_lib/pattgen_perf_vseq.sv
+++ b/hw/ip/pattgen/dv/env/seq_lib/pattgen_perf_vseq.sv
@@ -8,11 +8,11 @@ class pattgen_perf_vseq extends pattgen_base_vseq;
   `uvm_object_new
 
   // reduce num_trans due to long running simulations
-  constraint num_trans_c { num_trans inside {[5:10]}; }
+  constraint num_trans_c        { num_trans inside {[5:10]}; }
   // fast clear interrupt
-  constraint clear_intr_dly_c { clear_intr_dly == 0; }
+  constraint clear_intr_dly_c   { clear_intr_dly == 0; }
   // fast stop/start channel
-  constraint stop_channel_dly_c { stop_channel_dly == 0; }
+  constraint b2b_pattern_dly_c { b2b_pattern_dly == 0; }
 
   // override this function for pattgen_perf test
   function pattgen_channel_cfg get_random_channel_config(uint channel);
@@ -20,8 +20,8 @@ class pattgen_perf_vseq extends pattgen_base_vseq;
     ch_cfg = pattgen_channel_cfg::type_id::create($sformatf("channel_cfg_%0d", channel));
     `DV_CHECK_RANDOMIZE_WITH_FATAL(ch_cfg,
       ch_cfg.polarity dist {
-        1'b0 :/ cfg.seq_cfg.pattgen_polarity_pct,
-        1'b1 :/ (100 - cfg.seq_cfg.pattgen_polarity_pct)
+        1'b0 :/ cfg.seq_cfg.pattgen_low_polarity_pct,
+        1'b1 :/ (100 - cfg.seq_cfg.pattgen_low_polarity_pct)
       };
       ch_cfg.prediv dist {0 :/ 1, 1024 :/ 2};
       ch_cfg.len    dist {0 :/ 1, 1023 :/ 1};

--- a/hw/ip/pattgen/dv/env/seq_lib/pattgen_vseq_list.sv
+++ b/hw/ip/pattgen/dv/env/seq_lib/pattgen_vseq_list.sv
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 `include "pattgen_base_vseq.sv"
+`include "pattgen_common_vseq.sv"
 `include "pattgen_smoke_vseq.sv"
 `include "pattgen_perf_vseq.sv"
-`include "pattgen_common_vseq.sv"
+`include "pattgen_error_vseq.sv"

--- a/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson
+++ b/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson
@@ -12,7 +12,7 @@
   tb: tb
 
   // Simulator used to sign off this block
-  tool: vcs
+  tool: xcelium
 
   // Fusesoc core file used for building the file list.
   fusesoc_core: lowrisc:dv:pattgen_sim:0.1
@@ -54,6 +54,11 @@
     {
       name: pattgen_perf
       uvm_test_seq: pattgen_perf_vseq
+    }
+
+    {
+      name: pattgen_error
+      uvm_test_seq: pattgen_error_vseq
     }
   ]
 


### PR DESCRIPTION
[pattgen, dv] Support pattgen_error test (V2)

- In-progress channels are randomly disabled to cause error patterns that are dropped in both scoreboard and monitor.

Signed-off-by: Tung Hoang <hoang.tung@wdc.com>