### PR TITLE
[dv/alert] update shadow_reg alert naming in DV

### DIFF
--- a/doc/rm/register_tool/index.md
+++ b/doc/rm/register_tool/index.md
@@ -677,6 +677,13 @@ The following aspects need to be considered when integrating shadow registers in
     - Alert escalation and sensor configuration registers, and
     - Countermeasure tuning and functional/bandgap calibration registers.
 
+### DV shadow register alert test automation
+
+In DV, the `shadow_reg_errors` automated test will check if shadow registers' update and storage errors trigger the correct alerts.
+This alert automation test requires the user to add the following items in `.hjson` file under each shadow register:
+- Update_err_alert: Alert triggered by a shadow register's update error
+- Storage_err_alert: Alert triggered by a shadow register's storage error
+
 ### Future enhancements
 
 The following features are currently not implemented but might be added in the future.

--- a/hw/dv/sv/cip_lib/cip_base_pkg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_pkg.sv
@@ -30,6 +30,16 @@ package cip_base_pkg;
   } shadow_reg_alert_e;
 
   // functions
+  function automatic void split_all_csrs_by_shadowed(input  dv_base_reg_block ral,
+                                                     output dv_base_reg shadowed_csrs[$],
+                                                     output dv_base_reg non_shadowed_csrs[$]);
+    dv_base_reg all_csrs[$];
+    ral.get_dv_base_regs(all_csrs);
+    foreach (all_csrs[i]) begin
+      if (all_csrs[i].get_is_shadowed()) shadowed_csrs.push_back(all_csrs[i]);
+      else non_shadowed_csrs.push_back(all_csrs[i]);
+    end
+  endfunction
 
   // package sources
   // base env

--- a/hw/dv/sv/dv_base_reg/dv_base_reg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.sv
@@ -14,6 +14,8 @@ class dv_base_reg extends uvm_reg;
   local bit            shadow_wr_staged; // stage the first shadow reg write
   local bit            shadow_update_err;
   local bit            en_shadow_wr = 1;
+  local string         update_err_alert_name;
+  local string         storage_err_alert_name;
 
   // atomic_shadow_wr: semaphore to guarantee atomicity of the two writes for shadowed registers.
   // In case a parallel thread writing a different value to the same reg causing an update_err
@@ -257,4 +259,33 @@ class dv_base_reg extends uvm_reg;
       atomic_en_shadow_wr.put(1);
     end
   endfunction
+
+  function void add_update_err_alert(string name);
+    if (update_err_alert_name == "") update_err_alert_name = name;
+  endfunction
+
+  function void add_storage_err_alert(string name);
+    if (storage_err_alert_name == "") storage_err_alert_name = name;
+  endfunction
+
+  function string get_update_err_alert_name();
+    string parent_name = this.get_parent().get_name();
+
+    // block level alert name is input alert name from hjson
+    if (parent_name == "ral") return update_err_alert_name;
+
+    // top-level alert name is ${block_name} + alert name from hjson
+    return ($sformatf("%0s_%0s", parent_name, update_err_alert_name));
+  endfunction
+
+  function string get_storage_err_alert_name();
+    string parent_name = this.get_parent().get_name();
+
+    // block level alert name is input alert name from hjson
+    if (parent_name == "ral") return storage_err_alert_name;
+
+    // top-level alert name is ${block_name} + alert name from hjson
+    return ($sformatf("%0s_%0s", parent_name, storage_err_alert_name));
+  endfunction
+
 endclass

--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -297,6 +297,8 @@
     hwext:    "true",
     hwqe:     "true",
     shadowed: "true",
+    update_err_alert: "recov_ctrl_update_err",
+    storage_err_alert: "fatal_fault",
     fields: [
       { bits: "0",
         name: "OPERATION",

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_shadow_reg_errors_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_shadow_reg_errors_vseq.sv
@@ -17,7 +17,7 @@ class chip_shadow_reg_errors_vseq extends chip_common_vseq;
     dv_base_reg shadowed_csrs[$], non_shadowed_csrs[$];
 
     // Get all shadowed_regs from each IP
-    split_all_csrs_by_shadowed(shadowed_csrs, non_shadowed_csrs);
+    split_all_csrs_by_shadowed(ral, shadowed_csrs, non_shadowed_csrs);
     shadowed_csrs.shuffle();
 
     foreach (shadowed_csrs[i]) begin
@@ -30,7 +30,7 @@ class chip_shadow_reg_errors_vseq extends chip_common_vseq;
       wr_shadowed_reg_update_err(shadowed_csrs[i], alert_triggered);
 
       // Check update error alerts
-      alert_name = get_alert_agent_name(err_update, shadowed_csrs[i]);
+      alert_name = shadowed_csrs[i].get_update_err_alert_name();
       `DV_SPINWAIT(while (!alert_triggered && !cfg.m_alert_agent_cfg[alert_name].vif.get_alert())
                    cfg.clk_rst_vif.wait_clks(1);,
                    $sformatf("%0s update_err alert not detected", shadowed_csrs[i].get_name()));
@@ -45,7 +45,7 @@ class chip_shadow_reg_errors_vseq extends chip_common_vseq;
       csr_poke(.csr(shadowed_csrs[i]), .value(poke_val), .kind(kind), .predict(1));
 
       // Check storage error alerts
-      alert_name = get_alert_agent_name(err_storage, shadowed_csrs[i]);
+      alert_name = shadowed_csrs[i].get_storage_err_alert_name();
       `DV_SPINWAIT(while (!cfg.m_alert_agent_cfg[alert_name].vif.get_alert())
                    cfg.clk_rst_vif.wait_clks(1);,
                    $sformatf("%0s storage_err alert not detected", shadowed_csrs[i].get_name()));
@@ -53,7 +53,6 @@ class chip_shadow_reg_errors_vseq extends chip_common_vseq;
       `DV_SPINWAIT(cfg.m_alert_agent_cfg[alert_name].vif.wait_ack_complete();,
                    $sformatf("timeout for alert:%0s", alert_name))
     end
-
   endtask : body
 
   // Generally we should get update error if first write of the register is 'h5555_5555,

--- a/util/reggen/data.py
+++ b/util/reggen/data.py
@@ -77,6 +77,8 @@ class Reg():
         self.ishomog = 0
         self.tags = []
         self.shadowed = False
+        self.update_err_alert = ""  # Used by shadow reg DV
+        self.storage_err_alert = ""  # Used by shadow reg DV
 
     def is_multi_reg(self):
         """Returns true if this is a multireg"""

--- a/util/reggen/gen_rtl.py
+++ b/util/reggen/gen_rtl.py
@@ -91,6 +91,9 @@ def parse_reg(obj):
         reg.ishomog = len(obj['fields']) == 1
         reg.tags = (obj['tags'])
         reg.shadowed = (obj["shadowed"] == "true")
+        # For DV only: TODO: any good way we can move it to gen_dv?
+        reg.update_err_alert = (obj["update_err_alert"] if "update_err_alert" in obj else "")
+        reg.storage_err_alert = (obj["storage_err_alert"] if "storage_err_alert" in obj else "")
 
         # Parsing Fields
         for f in obj["fields"]:

--- a/util/reggen/uvm_reg.sv.tpl
+++ b/util/reggen/uvm_reg.sv.tpl
@@ -123,6 +123,8 @@ package ${block.name}_ral_pkg;
   % endif
 % endfor
 % if reg_shadowed and r.hwext:
+    add_update_err_alert("${r.update_err_alert}");
+    add_storage_err_alert("${r.storage_err_alert}");
 <% shadowed_reg_path = "" %>\
   % for r_tag in r.tags:
 <% tag = r_tag.split(":") %>\

--- a/util/reggen/validate.py
+++ b/util/reggen/validate.py
@@ -489,7 +489,13 @@ reg_optional = {
         's',
         "tags for the register, followed by the format 'tag_name:item1:item2...'"
     ],
-    'shadowed': ['s', "'true' if the register is shadowed"]
+    'shadowed': ['s', "'true' if the register is shadowed"],
+    'update_err_alert': ['s', "alert that will be triggered if " +
+                         "this shadowed register has update error"
+    ],
+    'storage_err_alert': ['s', "alert that will be triggered if " +
+                          "this shadowed register has storage error"
+    ]
 }
 reg_added = {
     'genresval': ['pi', "reset value generated from resval and fields"],


### PR DESCRIPTION
This PR finishes the first step report in Issue #4895.
Previously shadow_reg has a naming convention but current change does
not adpot that convention anymore. So in order to automatically check
shadow_register's update and storage error, it requires to user to
manaully link the related alerts in hjson file.

Signed-off-by: Cindy Chen <chencindy@google.com>