### PR TITLE
[dv] stress_all_with_rand_reset update

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/cip_base_vseq.sv
@@ -534,7 +534,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
                   end else begin
                     `downcast(dv_vseq, seq.clone())
                   end
-                  dv_vseq.do_dut_init = 0;
+                  dv_vseq.do_apply_reset = 0;
                   dv_vseq.set_sequencer(p_sequencer);
                   `DV_CHECK_RANDOMIZE_FATAL(dv_vseq)
                   dv_vseq.start(p_sequencer);

--- a/hw/dv/sv/dv_lib/dv_base_scoreboard.sv
+++ b/hw/dv/sv/dv_lib/dv_base_scoreboard.sv
@@ -33,9 +33,12 @@ class dv_base_scoreboard #(type RAL_T = dv_base_reg_block,
       if (!cfg.clk_rst_vif.rst_n) begin
         `uvm_info(`gfn, "reset occurred", UVM_HIGH)
         cfg.reset_asserted();
+        csr_utils_pkg::reset_asserted();
         @(posedge cfg.clk_rst_vif.rst_n);
         reset();
         cfg.reset_deasserted();
+        csr_utils_pkg::clear_outstanding_access();
+        csr_utils_pkg::reset_deasserted();
         `uvm_info(`gfn, "out of reset", UVM_HIGH)
       end
       else begin

--- a/hw/dv/sv/dv_lib/dv_base_vseq.sv
+++ b/hw/dv/sv/dv_lib/dv_base_vseq.sv
@@ -25,7 +25,7 @@ class dv_base_vseq #(type RAL_T               = dv_base_reg_block,
   // knobs to enable pre_start routines
   bit do_dut_init       = 1'b1;
   bit do_apply_reset    = 1'b1;
-  bit do_wait_for_reset = 1'b1;
+  bit do_wait_for_reset = 1'b0;
 
   // knobs to enable post_start routines
   bit do_dut_shutdown   = 1'b1;
@@ -86,10 +86,7 @@ class dv_base_vseq #(type RAL_T               = dv_base_reg_block,
 
   virtual task apply_reset(string kind = "HARD");
     if (kind == "HARD") begin
-      csr_utils_pkg::reset_asserted();
       cfg.clk_rst_vif.apply_reset();
-      csr_utils_pkg::clear_outstanding_access();
-      csr_utils_pkg::reset_deasserted();
     end
     if (cfg.has_ral) begin
       foreach (cfg.ral_models[i]) cfg.ral_models[i].reset(kind);

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_stress_all_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_stress_all_vseq.sv
@@ -28,14 +28,14 @@ class alert_handler_stress_all_vseq extends alert_handler_base_vseq;
       seq = create_seq_by_name(seq_names[seq_idx]);
       `downcast(alert_vseq, seq)
 
-      // if upper seq disables do_dut_init for this seq, then can't issue reset
+      // if upper seq disables do_apply_reset for this seq, then can't issue reset
       // as upper seq may drive reset
-      if (do_dut_init) begin
-        alert_vseq.do_dut_init = $urandom_range(0, 1);
+      if (do_apply_reset) begin
+        alert_vseq.do_apply_reset = $urandom_range(0, 1);
         // config_locked will be set unless reset is issued
-        alert_vseq.config_locked = alert_vseq.do_dut_init ? 0 : config_locked;
+        alert_vseq.config_locked = alert_vseq.do_apply_reset ? 0 : config_locked;
       end else begin
-        alert_vseq.do_dut_init = 0;
+        alert_vseq.do_apply_reset = 0;
         alert_vseq.config_locked = config_locked;
       end
 

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_stress_all_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_stress_all_vseq.sv
@@ -28,7 +28,7 @@ class gpio_stress_all_vseq extends gpio_base_vseq;
       `downcast(gpio_vseq, seq)
 
       // hard_reset in dut_init can be skipped
-      if (do_dut_init) gpio_vseq.do_init_reset = $urandom_range(0, 1);
+      if (do_apply_reset) gpio_vseq.do_init_reset = $urandom_range(0, 1);
       else gpio_vseq.do_init_reset = 0;
 
       gpio_vseq.set_sequencer(p_sequencer);

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_stress_all_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_stress_all_vseq.sv
@@ -28,8 +28,8 @@ class hmac_stress_all_vseq extends hmac_base_vseq;
       `downcast(hmac_vseq, seq)
 
       // dut_init (reset) can be skipped
-      if (do_dut_init) hmac_vseq.do_dut_init = $urandom_range(0, 1);
-      else hmac_vseq.do_dut_init = 0;
+      if (do_apply_reset) hmac_vseq.do_apply_reset = $urandom_range(0, 1);
+      else hmac_vseq.do_apply_reset = 0;
 
       hmac_vseq.set_sequencer(p_sequencer);
       `DV_CHECK_RANDOMIZE_FATAL(hmac_vseq)

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_stress_all_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_stress_all_vseq.sv
@@ -43,16 +43,16 @@ class i2c_stress_all_vseq extends i2c_rx_tx_vseq;
       seq = create_seq_by_name(seq_name);
       `downcast(i2c_vseq, seq)
 
-      // if upper seq disables do_dut_init for this seq, then can't issue reset
+      // if upper seq disables do_apply_reset for this seq, then can't issue reset
       // as upper seq may drive reset
-      `uvm_info(`gfn, $sformatf("\n  *do_dut_init %0b", do_dut_init), UVM_DEBUG)
-      if (do_dut_init) begin
-        i2c_vseq.do_dut_init = $urandom_range(0, 1);
-        if (i2c_vseq.do_dut_init) begin
+      `uvm_info(`gfn, $sformatf("\n  *do_apply_reset %0b", do_apply_reset), UVM_DEBUG)
+      if (do_apply_reset) begin
+        i2c_vseq.do_apply_reset = $urandom_range(0, 1);
+        if (i2c_vseq.do_apply_reset) begin
           `uvm_info(`gfn, "\n  *reset is randomly issued with stress_test", UVM_DEBUG)
         end
       end else begin
-        i2c_vseq.do_dut_init = 0;
+        i2c_vseq.do_apply_reset = 0;
         `uvm_info(`gfn, "\n  *upper_seq may drive reset thus not issue reset", UVM_DEBUG)
       end
 

--- a/hw/ip/keymgr/dv/env/keymgr_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_if.sv
@@ -46,15 +46,6 @@ interface keymgr_if(input clk, input rst_n);
     // this sequencing is correct.
     keymgr_en = lc_ctrl_pkg::lc_tx_t'($urandom);
 
-    // reset exp variables
-    kmac_key_exp = '0;
-    hmac_key_exp = '0;
-    aes_key_exp  = '0;
-    is_kmac_key_good = 0;
-    is_hmac_key_good = 0;
-    is_aes_key_good  = 0;
-    is_kmac_sideload_avail = 0;
-
     // async delay as these signals are from different clock domain
     #($urandom_range(1000, 0) * 1ns);
     keymgr_en = lc_ctrl_pkg::On;
@@ -62,6 +53,17 @@ interface keymgr_if(input clk, input rst_n);
     otp_hw_cfg.data.device_id = 'hF0F0;
     otp_key = otp_ctrl_pkg::OTP_KEYMGR_KEY_DEFAULT;
     flash   = flash_ctrl_pkg::KEYMGR_FLASH_DEFAULT;
+  endtask
+
+  // reset local exp variables when reset is issued
+  task automatic reset();
+    kmac_key_exp = '0;
+    hmac_key_exp = '0;
+    aes_key_exp  = '0;
+    is_kmac_key_good = 0;
+    is_hmac_key_good = 0;
+    is_aes_key_good  = 0;
+    is_kmac_sideload_avail = 0;
   endtask
 
   // randomize otp, lc, flash input data

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -709,6 +709,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
     id_data_a_array.delete();
     sw_data_a_array.delete();
     hw_data_a_array.delete();
+    cfg.keymgr_vif.reset();
   endfunction
 
   function void check_phase(uvm_phase phase);

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -181,8 +181,10 @@ class keymgr_base_vseq extends cip_base_vseq #(
     bit [TL_DW-1:0] rdata;
 
     csr_rd(.ptr(ral.working_state), .value(rdata));
-    `downcast(current_state, rdata)
-    `uvm_info(`gfn, $sformatf("Current state %0s", current_state.name), UVM_MEDIUM)
+    if (!cfg.under_reset) begin
+      `downcast(current_state, rdata)
+      `uvm_info(`gfn, $sformatf("Current state %0s", current_state.name), UVM_MEDIUM)
+    end
   endtask : read_current_state
 
   virtual task keymgr_advance(bit wait_done = 1);

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_direct_to_disabled_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_direct_to_disabled_vseq.sv
@@ -26,7 +26,7 @@ class keymgr_direct_to_disabled_vseq extends keymgr_random_vseq;
     csr_update(.csr(ral.control));
 
     wait_op_done();
-    `DV_CHECK_EQ(current_state, keymgr_pkg::StDisabled)
+    if (get_check_en()) `DV_CHECK_EQ(current_state, keymgr_pkg::StDisabled)
 
     // issue some random operations in StDisabled
     keymgr_operations();

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_stress_all_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_stress_all_vseq.sv
@@ -28,10 +28,10 @@ class keymgr_stress_all_vseq extends keymgr_base_vseq;
       `downcast(keymgr_vseq, seq)
 
       // at the end of each vseq, design has enterred StDisabled, need to reset to recover
-      // if upper seq disables do_dut_init for this seq, then can't issue reset
+      // if upper seq disables do_apply_reset for this seq, then can't issue reset
       // as upper seq may drive reset
-      if (do_dut_init && i > 1) keymgr_vseq.do_dut_init = 1;
-      else                      keymgr_vseq.do_dut_init = 0;
+      if (do_apply_reset && i > 1) keymgr_vseq.do_apply_reset = 1;
+      else                         keymgr_vseq.do_apply_reset = 0;
 
       keymgr_vseq.set_sequencer(p_sequencer);
       `DV_CHECK_RANDOMIZE_FATAL(keymgr_vseq)
@@ -47,7 +47,7 @@ class keymgr_stress_all_vseq extends keymgr_base_vseq;
       // we need to reset for each vseq, but in keymgr_stress_all_with_rand_reset, reset should be
       // issued in upper seq. So, wait forever until reset is issued and this vseq is killed by
       // upper seq
-      if (!do_dut_init) wait(0);
+      if (!do_apply_reset) wait(0);
     end
   endtask : body
 

--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_stress_all_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_stress_all_vseq.sv
@@ -23,8 +23,8 @@ class rv_timer_stress_all_vseq extends rv_timer_base_vseq;
       `downcast(rv_timer_vseq, seq)
 
       // dut_init (reset) can be skipped
-      if (do_dut_init) rv_timer_vseq.do_dut_init = $urandom_range(0, 1);
-      else rv_timer_vseq.do_dut_init = 0;
+      if (do_apply_reset) rv_timer_vseq.do_apply_reset = $urandom_range(0, 1);
+      else rv_timer_vseq.do_apply_reset = 0;
 
       rv_timer_vseq.set_sequencer(p_sequencer);
       `DV_CHECK_RANDOMIZE_FATAL(rv_timer_vseq)

--- a/hw/ip/tlul/generic_dv/env/seq_lib/xbar_stress_all_vseq.sv
+++ b/hw/ip/tlul/generic_dv/env/seq_lib/xbar_stress_all_vseq.sv
@@ -55,7 +55,7 @@ class xbar_stress_all_vseq extends xbar_base_vseq;
         // if this seq is called as a sub-seq, and run with another seq that contains reset,
         // when reset is issued in both seq at the same time, can't know where is the end of reset
         // hence, if we want to kill unfinished seq after reset, we may not kill it at a right time
-        if (do_dut_init && $urandom_range(0, 1)) dut_init();
+        if (do_apply_reset && $urandom_range(0, 1)) dut_init();
         `uvm_info(`gfn, $sformatf("finished run %0d/%0d", i, num_trans), UVM_LOW)
       end // isolation thread
     join

--- a/hw/ip/tlul/generic_dv/env/seq_lib/xbar_stress_all_with_rand_reset_vseq.sv
+++ b/hw/ip/tlul/generic_dv/env/seq_lib/xbar_stress_all_with_rand_reset_vseq.sv
@@ -28,7 +28,7 @@ class xbar_stress_all_with_rand_reset_vseq extends xbar_base_vseq;
         begin : seq_wo_reset
           xbar_vseq = xbar_stress_all_vseq::type_id::create("xbar_stress_all_vseq");
 
-          xbar_vseq.do_dut_init = 0;
+          xbar_vseq.do_apply_reset = 0;
           xbar_vseq.set_sequencer(p_sequencer);
           `DV_CHECK_RANDOMIZE_FATAL(xbar_vseq)
           xbar_vseq.start(p_sequencer);

--- a/hw/ip/uart/dv/env/seq_lib/uart_stress_all_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_stress_all_vseq.sv
@@ -33,10 +33,10 @@ class uart_stress_all_vseq extends uart_base_vseq;
       seq = create_seq_by_name(seq_names[seq_idx]);
       `downcast(uart_vseq, seq)
 
-      // if upper seq disables do_dut_init for this seq, then can't issue reset
+      // if upper seq disables do_apply_reset for this seq, then can't issue reset
       // as upper seq may drive reset
-      if (do_dut_init) uart_vseq.do_dut_init = $urandom_range(0, 1);
-      else             uart_vseq.do_dut_init = 0;
+      if (do_apply_reset) uart_vseq.do_apply_reset = $urandom_range(0, 1);
+      else                uart_vseq.do_apply_reset = 0;
 
       uart_vseq.set_sequencer(p_sequencer);
       `DV_CHECK_RANDOMIZE_FATAL(uart_vseq)


### PR DESCRIPTION
This PR contains 3 commits.
1. Align csr_utils_pkg::reset_asserted to actual reset pin
previous implementation may assert reset for CSR pkg before reset
actually occurs. Move those calls to dv_base_scoreboard, where we
monitors the reset
2. use do_apply_reset knob to avoid calling reset in sub seq
This is related to stress_all with reset
In previous implementation, we used do_dut_init knob to avoid calling
reset in sub seq, but this knob disables the entire dut_init
IP TB may have register setting in this task.
Change to only skip reset (task apply_reset) and keep other logic in
dut_init being executed
Have ran more than 50 seeds for all the IP *_stress_all_with_rand_reset test
and all tests are passing

3. Fix failure in keymgr stress_all with reset
Disable check in vseq when reset occurs
Use do_apply_reset to avoid doing reset in sub seq