### PR TITLE
[prim] Properly fix widths in tlul_adapter_sram

### DIFF
--- a/hw/ip/tlul/lint/tlul_adapter_sram.waiver
+++ b/hw/ip/tlul/lint/tlul_adapter_sram.waiver
@@ -25,5 +25,3 @@ waive -rules NOT_READ -msg {Signal 'rspfifo_wready' is not read from in module '
 waive -rules VAR_INDEX_RANGE -regexp {.*woffset' of length 1 is larger than the 0 bits required to address.*} \
       -comment "The woffset signal is tied to constant 0 in this case. Fixing this warning in RTL would complicate \
       the design since multiple generate blocks would be needed with almost identical content."
-waive -rules ZERO_REP -location {tlul_adapter_sram.sv} -regexp {Replication count is zero in '\{SramDw - top_pkg::TL_DW\{1'b0\}\}'} \
-      -comment "The zero-expansion is done for cases when SramDw != top_pkg::TL_DW."

--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -65,8 +65,8 @@ module tlul_adapter_sram #(
   } req_t ;
 
   typedef struct packed {
-    logic [SramDw-1:0] data ;
-    logic              error ;
+    logic [top_pkg::TL_DW-1:0] data ;
+    logic                      error ;
   } rsp_t ;
 
   localparam int SramReqFifoWidth = $bits(sram_req_t) ;
@@ -142,7 +142,7 @@ module tlul_adapter_sram #(
       d_source : (d_valid) ? reqfifo_rdata.source : '0,
       d_sink   : 1'b0,
       d_data   : (d_valid && rspfifo_rvalid && reqfifo_rdata.op == OpRead)
-                 ? rspfifo_rdata.data[top_pkg::TL_DW-1:0] : '0,
+                 ? rspfifo_rdata.data : '0,
       d_user   : '0,
       d_error  : d_valid && d_error,
 
@@ -256,7 +256,7 @@ module tlul_adapter_sram #(
   assign rdata_tlword = rdata[sramreqfifo_rdata.woffset];
 
   assign rspfifo_wdata  = '{
-    data : {{SramDw - top_pkg::TL_DW{1'b0}}, rdata_tlword},
+    data : rdata_tlword,
     error: rerror_i[1] // Only care for Uncorrectable error
   };
   assign rspfifo_rready = (reqfifo_rdata.op == OpRead & ~reqfifo_rdata.error)


### PR DESCRIPTION
In commit 51ea6b8, I tried to sort out widths properly when `SramDw !=
TL_DW` but didn't quite get it right. In this module, we have two FIFOs
(`u_reqfifo` and `u_rspfifo`) for bus accesses. These should be sized for
the bus width, rather than the SRAM width.

Doing so gets rid of some nasty casts, which is nice, and should fix a
remaining AscentLint width mismatch error.
