### PR TITLE
[dv/push-pull-agent] Fix async clock and reset issue

### DIFF
--- a/hw/dv/sv/push_pull_agent/push_pull_monitor.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_monitor.sv
@@ -99,8 +99,9 @@ class push_pull_monitor #(parameter int HostDataWidth = 32,
         req_port.write(item);
         // After picking up a request, wait until a response is sent before
         // detecting another request, as this is not a pipelined protocol.
-        while (!cfg.vif.mon_cb.ack && !in_reset) @(cfg.vif.mon_cb);
-      end
+        `DV_SPINWAIT_EXIT(while (!cfg.vif.mon_cb.ack) @(cfg.vif.mon_cb);,
+                          wait(in_reset))
+       end
     end
   endtask
 


### PR DESCRIPTION
This PR fixes a corner case caused by reset and async clk.
If the async clk frequency is low and reset is toggled within a clock
cycle, the monitor might miss the reset condition. This PR fixed it by
adding two thread to check reset and clock.

This screenshot shows the corner case:
![image](https://user-images.githubusercontent.com/11466553/105897611-3eb64880-5fcd-11eb-92c0-1d6e3a375aad.png)

Signed-off-by: Cindy Chen <chencindy@google.com>