### PR TITLE
[otbn] Allow multiple errors in a single instruction

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/alert.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/alert.py
@@ -17,11 +17,11 @@ ERR_CODE_FATAL_DMEM = 1 << 6
 ERR_CODE_FATAL_REG = 1 << 7
 
 
-class Alert(Exception):
-    '''An exception raised to signal that the program did something wrong
+class Alert:
+    '''An object describing something the program did wrong
 
     This maps onto alerts in the implementation. The err_code value is the
-    value that should be written to the ERR_CODE external register.
+    value that should be OR'd into the ERR_BITS external register.
 
     '''
     # Subclasses should override this class field or the error_code method
@@ -33,7 +33,7 @@ class Alert(Exception):
 
 
 class BadAddrError(Alert):
-    '''Raised when loading or storing or setting PC with a bad address'''
+    '''Generated when loading or storing or setting PC with a bad address'''
 
     def __init__(self, operation: str, addr: int, what: str):
         assert operation in ['pc',
@@ -54,7 +54,7 @@ class BadAddrError(Alert):
 
 
 class LoopError(Alert):
-    '''Raised when doing something wrong with a LOOP/LOOPI'''
+    '''Generated when doing something wrong with a LOOP/LOOPI'''
 
     err_code = ERR_CODE_LOOP
 
@@ -63,3 +63,15 @@ class LoopError(Alert):
 
     def __str__(self) -> str:
         return 'Loop error: {}'.format(self.what)
+
+
+class IllegalInsnError(Alert):
+    '''Generated on a bad instruction'''
+    err_code = ERR_CODE_ILLEGAL_INSN
+
+    def __init__(self, word: int, msg: str):
+        self.word = word
+        self.msg = msg
+
+    def __str__(self) -> str:
+        return ('Illegal instruction {:#010x}: {}'.format(self.word, self.msg))

--- a/hw/ip/otbn/dv/otbnsim/sim/alert.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/alert.py
@@ -4,32 +4,32 @@
 
 from typing import Optional
 
-# A copy of the list of error codes. This also appears in the documentation and
-# otbn_pkg.sv: we should probably be generating them from the hjson every time.
-ERR_CODE_NO_ERROR = 0
-ERR_CODE_BAD_DATA_ADDR = 1 << 0
-ERR_CODE_BAD_INSN_ADDR = 1 << 1
-ERR_CODE_CALL_STACK = 1 << 2
-ERR_CODE_ILLEGAL_INSN = 1 << 3
-ERR_CODE_LOOP = 1 << 4
-ERR_CODE_FATAL_IMEM = 1 << 5
-ERR_CODE_FATAL_DMEM = 1 << 6
-ERR_CODE_FATAL_REG = 1 << 7
+# A copy of the list of bits in the ERR_BITS register. This also appears in the
+# documentation and otbn_pkg.sv: we should probably be generating them from the
+# hjson every time.
+BAD_DATA_ADDR = 1 << 0
+BAD_INSN_ADDR = 1 << 1
+CALL_STACK = 1 << 2
+ILLEGAL_INSN = 1 << 3
+LOOP = 1 << 4
+FATAL_IMEM = 1 << 5
+FATAL_DMEM = 1 << 6
+FATAL_REG = 1 << 7
 
 
 class Alert:
     '''An object describing something the program did wrong
 
-    This maps onto alerts in the implementation. The err_code value is the
+    This maps onto alerts in the implementation. The err_bit value is the
     value that should be OR'd into the ERR_BITS external register.
 
     '''
-    # Subclasses should override this class field or the error_code method
-    err_code = None  # type: Optional[int]
+    # Subclasses should override this class field or the error_bit method
+    err_bit = None  # type: Optional[int]
 
-    def error_code(self) -> int:
-        assert self.err_code is not None
-        return self.err_code
+    def error_bit(self) -> int:
+        assert self.err_bit is not None
+        return self.err_bit
 
 
 class BadAddrError(Alert):
@@ -43,10 +43,8 @@ class BadAddrError(Alert):
         self.addr = addr
         self.what = what
 
-    def error_code(self) -> int:
-        return (ERR_CODE_BAD_INSN_ADDR
-                if self.operation == 'fetch'
-                else ERR_CODE_BAD_DATA_ADDR)
+    def error_bit(self) -> int:
+        return BAD_INSN_ADDR if self.operation == 'fetch' else BAD_DATA_ADDR
 
     def __str__(self) -> str:
         return ('Bad {} address of {:#08x}: {}.'
@@ -56,7 +54,7 @@ class BadAddrError(Alert):
 class LoopError(Alert):
     '''Generated when doing something wrong with a LOOP/LOOPI'''
 
-    err_code = ERR_CODE_LOOP
+    err_bit = LOOP
 
     def __init__(self, what: str):
         self.what = what
@@ -67,7 +65,7 @@ class LoopError(Alert):
 
 class IllegalInsnError(Alert):
     '''Generated on a bad instruction'''
-    err_code = ERR_CODE_ILLEGAL_INSN
+    err_bit = ILLEGAL_INSN
 
     def __init__(self, word: int, msg: str):
         self.word = word
@@ -75,3 +73,16 @@ class IllegalInsnError(Alert):
 
     def __str__(self) -> str:
         return ('Illegal instruction {:#010x}: {}'.format(self.word, self.msg))
+
+
+class CallStackError(Alert):
+    '''Raised when under- or over-flowing the call stack'''
+
+    err_bit = CALL_STACK
+
+    def __init__(self, is_overflow: bool):
+        self.is_overflow = is_overflow
+
+    def __str__(self) -> str:
+        xflow = 'overflow' if self.is_overflow else 'underflow'
+        return 'Instruction caused {} of x1 call stack.'.format(xflow)

--- a/hw/ip/otbn/dv/otbnsim/sim/decode.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/decode.py
@@ -7,7 +7,7 @@
 import struct
 from typing import List, Optional, Tuple, Type
 
-from .alert import Alert, ERR_CODE_ILLEGAL_INSN
+from .alert import IllegalInsnError
 from .isa import DecodeError, OTBNInsn
 from .insn import INSN_CLASSES
 from .state import OTBNState
@@ -16,18 +16,6 @@ from .state import OTBNState
 # word has all the bits in m0 clear and all the bits in m1 set, then you should
 # decode it with the given class".
 _MaskTuple = Tuple[int, int, Type[OTBNInsn]]
-
-
-class IllegalInsnError(Alert):
-    '''Raised on a bad instruction'''
-    err_code = ERR_CODE_ILLEGAL_INSN
-
-    def __init__(self, word: int, msg: str):
-        self.word = word
-        self.msg = msg
-
-    def __str__(self) -> str:
-        return ('Illegal instruction {:#010x}: {}'.format(self.word, self.msg))
 
 
 class IllegalInsn(OTBNInsn):
@@ -51,7 +39,7 @@ class IllegalInsn(OTBNInsn):
         self._disasm = (pc, '?? 0x{:08x}'.format(raw))
 
     def execute(self, state: OTBNState) -> None:
-        raise IllegalInsnError(self.raw, self.msg)
+        state.on_error(IllegalInsnError(self.raw, self.msg))
 
 
 MASK_TUPLES = None  # type: Optional[List[_MaskTuple]]

--- a/hw/ip/otbn/dv/otbnsim/sim/gpr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/gpr.py
@@ -48,9 +48,6 @@ class CallStackReg(Reg):
         self.saw_read = True
         return self.stack[-1]
 
-    def write_unsigned(self, uval: int, backdoor: bool = False) -> None:
-        super().write_unsigned(uval, backdoor)
-
     def commit(self) -> None:
         if self.saw_read:
             assert self.stack

--- a/hw/ip/otbn/dv/otbnsim/sim/gpr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/gpr.py
@@ -4,21 +4,8 @@
 
 from typing import List
 
-from .alert import Alert, ERR_CODE_CALL_STACK
+from .alert import CallStackError
 from .reg import Reg, RegFile
-
-
-class CallStackError(Alert):
-    '''Raised when under- or over-flowing the call stack'''
-
-    err_code = ERR_CODE_CALL_STACK
-
-    def __init__(self, is_overflow: bool):
-        self.is_overflow = is_overflow
-
-    def __str__(self) -> str:
-        xflow = 'overflow' if self.is_overflow else 'underflow'
-        return 'Instruction caused {} of x1 call stack.'.format(xflow)
 
 
 class CallStackReg(Reg):

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -4,7 +4,7 @@
 
 from typing import Dict
 
-from .alert import ERR_CODE_NO_ERROR, LoopError
+from .alert import LoopError
 from .flags import FlagReg
 from .isa import (DecodeError, OTBNInsn, RV32RegReg, RV32RegImm, RV32ImmShift,
                   insn_for_mnemonic, logical_byte_shift)
@@ -315,7 +315,7 @@ class ECALL(OTBNInsn):
 
     def execute(self, state: OTBNState) -> None:
         # Set INTR_STATE.done and STATUS, reflecting the fact we've stopped.
-        state._stop(ERR_CODE_NO_ERROR)
+        state._stop(0)
 
 
 class LOOP(OTBNInsn):

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -4,7 +4,7 @@
 
 from typing import Dict
 
-from .alert import LoopError
+from .alert import ERR_CODE_NO_ERROR, LoopError
 from .flags import FlagReg
 from .isa import (DecodeError, OTBNInsn, RV32RegReg, RV32RegImm, RV32ImmShift,
                   insn_for_mnemonic, logical_byte_shift)
@@ -315,7 +315,7 @@ class ECALL(OTBNInsn):
 
     def execute(self, state: OTBNState) -> None:
         # Set INTR_STATE.done and STATUS, reflecting the fact we've stopped.
-        state.stop(None)
+        state._stop(ERR_CODE_NO_ERROR)
 
 
 class LOOP(OTBNInsn):
@@ -330,8 +330,9 @@ class LOOP(OTBNInsn):
     def execute(self, state: OTBNState) -> None:
         num_iters = state.gprs.get_reg(self.grs).read_unsigned()
         if num_iters == 0:
-            raise LoopError('loop count in x{} was zero'
-                            .format(self.grs))
+            state.on_error(LoopError('loop count in x{} was zero'
+                                     .format(self.grs)))
+            return
 
         state.loop_start(num_iters, self.bodysize)
 

--- a/hw/ip/otbn/dv/otbnsim/sim/loop.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/loop.py
@@ -1,0 +1,126 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List, Optional
+
+from .alert import LoopError
+from .trace import Trace
+
+
+class TraceLoopStart(Trace):
+    def __init__(self, iterations: int, bodysize: int):
+        self.iterations = iterations
+        self.bodysize = bodysize
+
+    def trace(self) -> str:
+        return "Start LOOP, {} iterations, bodysize: {}".format(
+            self.iterations, self.bodysize)
+
+
+class TraceLoopIteration(Trace):
+    def __init__(self, iteration: int, total: int):
+        self.iteration = iteration
+        self.total = total
+
+    def trace(self) -> str:
+        return "LOOP iteration {}/{}".format(self.iteration, self.total)
+
+
+class LoopLevel:
+    '''An object representing a level in the current loop stack
+
+    start_addr is the first instruction inside the loop (the instruction
+    following the loop instruction). insn_count is the number of instructions
+    in the loop (and must be positive). restarts is one less than the number of
+    iterations, and must be non-negative.
+
+    '''
+    def __init__(self, start_addr: int, insn_count: int, restarts: int):
+        assert 0 <= start_addr
+        assert 0 < insn_count
+        assert 0 <= restarts
+
+        self.loop_count = 1 + restarts
+        self.restarts_left = restarts
+        self.start_addr = start_addr
+        self.match_addr = start_addr + 4 * insn_count
+
+
+class LoopStack:
+    '''An object representing the loop stack
+
+    The loop stack holds up to 8 LoopLevel objects, corresponding to nested
+    loops.
+
+    '''
+    stack_depth = 8
+
+    def __init__(self) -> None:
+        self.stack = []  # type: List[LoopLevel]
+        self.trace = []  # type: List[Trace]
+
+    def start_loop(self,
+                   next_addr: int,
+                   loop_count: int,
+                   insn_count: int) -> None:
+        '''Start a loop.
+
+        next_addr is the address of the first instruction in the loop body.
+        loop_count must be positive and is the number of times to execute the
+        loop. insn_count must be positive and is the number of instructions in
+        the loop body.
+
+        '''
+        assert 0 <= next_addr
+        assert 0 < insn_count
+        assert 0 < loop_count
+
+        if len(self.stack) == LoopStack.stack_depth:
+            raise LoopError('loop stack overflow')
+
+        self.trace.append(TraceLoopStart(loop_count, insn_count))
+        self.stack.append(LoopLevel(next_addr, insn_count, loop_count - 1))
+
+    def check_insn(self, pc: int, insn_affects_control: bool) -> None:
+        '''Check for branch instructions at the end of a loop body'''
+        if self.stack:
+            top = self.stack[-1]
+            if pc + 4 == top.match_addr:
+                # We're about to execute the last instruction in the loop body.
+                # Make sure that it isn't a jump, branch or another loop
+                # instruction.
+                if insn_affects_control:
+                    raise LoopError('control instruction at end of loop')
+
+    def step(self, next_pc: int) -> Optional[int]:
+        '''Update loop stack. If we should loop, return new PC'''
+        if self.stack:
+            top = self.stack[-1]
+
+            if next_pc == top.match_addr:
+                assert top.restarts_left >= 0
+
+                # 1-based iteration number
+                loop_idx = top.loop_count - top.restarts_left
+
+                if not top.restarts_left:
+                    self.stack.pop()
+                    ret_val = None
+                else:
+                    top.restarts_left -= 1
+                    ret_val = top.start_addr
+
+                self.trace.append(TraceLoopIteration(loop_idx, top.loop_count))
+                return ret_val
+
+        return None
+
+    def changes(self) -> List[Trace]:
+        return self.trace
+
+    def commit(self) -> None:
+        self.trace = []
+
+    def abort(self) -> None:
+        self.trace = []

--- a/hw/ip/otbn/dv/otbnsim/sim/reg.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/reg.py
@@ -41,10 +41,10 @@ class Reg:
     def read_unsigned(self, backdoor: bool = False) -> int:
         return self._uval
 
-    def write_unsigned(self, uval: int, backdoor: bool = False) -> None:
+    def write_unsigned(self, uval: int) -> None:
         assert 0 <= uval < (1 << self._width)
         self._next_uval = uval
-        if not backdoor and self._parent is not None:
+        if self._parent is not None:
             self._parent.mark_written(self._idx)
 
     def read_next(self) -> Optional[int]:

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -164,7 +164,7 @@ class OTBNState:
     def die(self, alerts: List[Alert]) -> None:
         err_bits = 0
         for alert in alerts:
-            err_bits |= alert.error_code()
+            err_bits |= alert.error_bit()
 
         self._abort()
         self._stop(err_bits)

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -6,133 +6,16 @@ from typing import List, Optional, Tuple
 
 from shared.mem_layout import get_memory_layout
 
-from .alert import BadAddrError, LoopError
+from .alert import BadAddrError
 from .csr import CSRFile
 from .dmem import Dmem
 from .ext_regs import OTBNExtRegs
 from .flags import FlagReg
 from .gpr import GPRs
+from .loop import LoopStack
 from .reg import RegFile
 from .trace import Trace, TracePC
 from .wsr import WSRFile
-
-
-class TraceLoopStart(Trace):
-    def __init__(self, iterations: int, bodysize: int):
-        self.iterations = iterations
-        self.bodysize = bodysize
-
-    def trace(self) -> str:
-        return "Start LOOP, {} iterations, bodysize: {}".format(
-            self.iterations, self.bodysize)
-
-
-class TraceLoopIteration(Trace):
-    def __init__(self, iteration: int, total: int):
-        self.iteration = iteration
-        self.total = total
-
-    def trace(self) -> str:
-        return "LOOP iteration {}/{}".format(self.iteration, self.total)
-
-
-class LoopLevel:
-    '''An object representing a level in the current loop stack
-
-    start_addr is the first instruction inside the loop (the instruction
-    following the loop instruction). insn_count is the number of instructions
-    in the loop (and must be positive). restarts is one less than the number of
-    iterations, and must be non-negative.
-
-    '''
-    def __init__(self, start_addr: int, insn_count: int, restarts: int):
-        assert 0 <= start_addr
-        assert 0 < insn_count
-        assert 0 <= restarts
-
-        self.loop_count = 1 + restarts
-        self.restarts_left = restarts
-        self.start_addr = start_addr
-        self.match_addr = start_addr + 4 * insn_count
-
-
-class LoopStack:
-    '''An object representing the loop stack
-
-    The loop stack holds up to 8 LoopLevel objects, corresponding to nested
-    loops.
-
-    '''
-    stack_depth = 8
-
-    def __init__(self) -> None:
-        self.stack = []  # type: List[LoopLevel]
-        self.trace = []  # type: List[Trace]
-
-    def start_loop(self,
-                   next_addr: int,
-                   loop_count: int,
-                   insn_count: int) -> None:
-        '''Start a loop.
-
-        next_addr is the address of the first instruction in the loop body.
-        loop_count must be positive and is the number of times to execute the
-        loop. insn_count must be positive and is the number of instructions in
-        the loop body.
-
-        '''
-        assert 0 <= next_addr
-        assert 0 < insn_count
-        assert 0 < loop_count
-
-        if len(self.stack) == LoopStack.stack_depth:
-            raise LoopError('loop stack overflow')
-
-        self.trace.append(TraceLoopStart(loop_count, insn_count))
-        self.stack.append(LoopLevel(next_addr, insn_count, loop_count - 1))
-
-    def check_insn(self, pc: int, insn_affects_control: bool) -> None:
-        '''Check for branch instructions at the end of a loop body'''
-        if self.stack:
-            top = self.stack[-1]
-            if pc + 4 == top.match_addr:
-                # We're about to execute the last instruction in the loop body.
-                # Make sure that it isn't a jump, branch or another loop
-                # instruction.
-                if insn_affects_control:
-                    raise LoopError('control instruction at end of loop')
-
-    def step(self, next_pc: int) -> Optional[int]:
-        '''Update loop stack. If we should loop, return new PC'''
-        if self.stack:
-            top = self.stack[-1]
-
-            if next_pc == top.match_addr:
-                assert top.restarts_left >= 0
-
-                # 1-based iteration number
-                loop_idx = top.loop_count - top.restarts_left
-
-                if not top.restarts_left:
-                    self.stack.pop()
-                    ret_val = None
-                else:
-                    top.restarts_left -= 1
-                    ret_val = top.start_addr
-
-                self.trace.append(TraceLoopIteration(loop_idx, top.loop_count))
-                return ret_val
-
-        return None
-
-    def changes(self) -> List[Trace]:
-        return self.trace
-
-    def commit(self) -> None:
-        self.trace = []
-
-    def abort(self) -> None:
-        self.trace = []
 
 
 class OTBNState:


### PR DESCRIPTION
The first two commits are minor clean-ups. The interesting commit is the third, with the following commit message:

**[otbn] Allow multiple errors in a single cycle in ISS**

This means we can't just raise an exception any more, which makes
things a little more fiddly. Instead, any component of the state that
might raise an error has an "`errs`" list, to which it appends an error
if it sees one. These lists get concatenated in a tree, in much the
same way as we gather up changes.

After executing an instruction, the code checks whether there were any
errors. If not, it commits pending changes. If there is an error, it
figures out the correct value of `ERR_BITS` and stops.

Fixes #4958.