### PR TITLE
[dv/shadow_reg] move get_shadow_regs function to dv_base_ral_block

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -119,10 +119,10 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   // - If the update error and storage error alerts are assigned to each shadowed register
   // - If input alert names are within the cfg.list_of_alerts
   virtual function void check_shadow_reg_alerts();
-    dv_base_reg shadowed_csrs[$], non_shadowed_csrs[$];
+    dv_base_reg shadowed_csrs[$];
     string update_err_alert_name, storage_err_alert_name;
 
-    split_all_csrs_by_shadowed(ral, shadowed_csrs, non_shadowed_csrs);
+    ral.get_shadowed_regs(shadowed_csrs);
     foreach (shadowed_csrs[i]) begin
       update_err_alert_name = shadowed_csrs[i].get_update_err_alert_name();
       storage_err_alert_name = shadowed_csrs[i].get_storage_err_alert_name();

--- a/hw/dv/sv/cip_lib/cip_base_pkg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_pkg.sv
@@ -30,17 +30,6 @@ package cip_base_pkg;
   } shadow_reg_alert_e;
 
   // functions
-  function automatic void split_all_csrs_by_shadowed(input  dv_base_reg_block ral,
-                                                     output dv_base_reg shadowed_csrs[$],
-                                                     output dv_base_reg non_shadowed_csrs[$]);
-    dv_base_reg all_csrs[$];
-    ral.get_dv_base_regs(all_csrs);
-    foreach (all_csrs[i]) begin
-      if (all_csrs[i].get_is_shadowed()) shadowed_csrs.push_back(all_csrs[i]);
-      else non_shadowed_csrs.push_back(all_csrs[i]);
-    end
-  endfunction
-
   // package sources
   // base env
   `include "cip_base_env_cfg.sv"

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -34,6 +34,7 @@ class dv_base_reg_block extends uvm_reg_block;
 
   function void get_dv_base_regs(ref dv_base_reg dv_regs[$]);
     uvm_reg ral_regs[$];
+    // if the ral has hier, this function will recursively includes the registers in the sub-blocks
     this.get_registers(ral_regs);
     foreach (ral_regs[i]) `downcast(dv_regs[i], ral_regs[i])
   endfunction
@@ -48,17 +49,18 @@ class dv_base_reg_block extends uvm_reg_block;
   endfunction
 
   function void get_enable_regs(ref dv_base_reg enable_regs[$]);
-    dv_base_reg_block blks[$];
-    get_dv_base_reg_blocks(blks);
-    if (blks.size() == 0) begin
-      dv_base_reg all_regs[$];
-      this.get_dv_base_regs(all_regs);
-      foreach (all_regs[i]) begin
-        if (all_regs[i].is_enable_reg()) enable_regs.push_back(all_regs[i]);
-      end
-      return;
-    end else begin
-      foreach (blks[i]) blks[i].get_enable_regs(enable_regs);
+    dv_base_reg all_regs[$];
+    this.get_dv_base_regs(all_regs);
+    foreach (all_regs[i]) begin
+      if (all_regs[i].is_enable_reg()) enable_regs.push_back(all_regs[i]);
+    end
+  endfunction
+
+  function void get_shadowed_regs(ref dv_base_reg shadowed_regs[$]);
+    dv_base_reg all_regs[$];
+    this.get_dv_base_regs(all_regs);
+    foreach (all_regs[i]) begin
+      if (all_regs[i].get_is_shadowed()) shadowed_regs.push_back(all_regs[i]);
     end
   endfunction
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_shadow_reg_errors_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_shadow_reg_errors_vseq.sv
@@ -14,10 +14,10 @@ class chip_shadow_reg_errors_vseq extends chip_common_vseq;
 
   // Most of the shadow_reg related tasks are from `dv/sv/cip_lib/cip_base_vseq.sv`
   virtual task body();
-    dv_base_reg shadowed_csrs[$], non_shadowed_csrs[$];
+    dv_base_reg shadowed_csrs[$];
 
     // Get all shadowed_regs from each IP
-    split_all_csrs_by_shadowed(ral, shadowed_csrs, non_shadowed_csrs);
+    ral.get_shadowed_regs(shadowed_csrs);
     shadowed_csrs.shuffle();
 
     foreach (shadowed_csrs[i]) begin


### PR DESCRIPTION
This PR is created to response the suggestions from PR  #4967 
The main purpose of this PR is to move the get_shadow_regs function to
dv_base_reg_block.
This PR also fixed a small logic in get_enabled_regs. The
`get_registers` function already return all registers recursively, so
there is no need to recursively all every block again.

Signed-off-by: Cindy Chen <chencindy@google.com>