### PR TITLE
[keymgr/dv] update stress_all with reset

### DIFF
--- a/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_device_driver.sv
+++ b/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_device_driver.sv
@@ -32,16 +32,16 @@ class keymgr_kmac_device_driver extends keymgr_kmac_driver;
       rsp.set_id_info(req);
       `uvm_info(`gfn, $sformatf("rcvd item:\n%0s", req.sprint()), UVM_HIGH)
 
-      repeat (rsp.rsp_delay) begin
-        if (cfg.vif.rst_n) @(cfg.vif.device_cb);
-      end
+      `DV_SPINWAIT_EXIT(repeat (rsp.rsp_delay) @(cfg.vif.device_cb);,
+                        wait(!cfg.vif.rst_n))
 
       cfg.vif.device_cb.rsp_done          <= 1;
       cfg.vif.device_cb.rsp_digest_share0 <= rsp.rsp_digest_share0;
       cfg.vif.device_cb.rsp_digest_share1 <= rsp.rsp_digest_share1;
       cfg.vif.device_cb.rsp_error         <= rsp.rsp_error;
 
-      if (cfg.vif.rst_n) @(cfg.vif.device_cb);
+      `DV_SPINWAIT_EXIT(@(cfg.vif.device_cb);,
+                        wait(!cfg.vif.rst_n))
       invalidate_signals();
 
       `uvm_info(`gfn, "item sent", UVM_HIGH)

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_stress_all_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_stress_all_vseq.sv
@@ -16,9 +16,11 @@ class keymgr_stress_all_vseq extends keymgr_base_vseq;
                           "keymgr_sideload_vseq",
                           "keymgr_random_vseq",
                           "keymgr_direct_to_disabled_vseq",
+                          "keymgr_sw_invalid_input_vseq"
                           // TODO, add this later
+                          // "keymgr_hwsw_invalid_input_vseq",
                           //"keymgr_lc_disable_vseq",
-                          "keymgr_invalid_kmac_input_vseq"};
+                          };
     for (int i = 1; i <= num_trans; i++) begin
       uvm_sequence     seq;
       keymgr_base_vseq keymgr_vseq;


### PR DESCRIPTION
2 commits in this PR
1. increase num_trans for stress_all with reset
`num_trans` is often set to very low number for CSR, but stress_all with
reset is also using the same common_vseq.
Also fix the `delay_to_reset` to make it random for each iteration

2. update keymgr stress_all with reset
Enhance keymgr_kmac_agent to handle reset
Fix issues on checking sw_bind_en and err_code

Signed-off-by: Weicai Yang <weicai@google.com>
