### PR TITLE
[dvsim] Fix Syn class

### DIFF
--- a/util/dvsim/SynCfg.py
+++ b/util/dvsim/SynCfg.py
@@ -48,7 +48,7 @@ class SynCfg(OneShotCfg):
         # Return only the tables
         return self.results_summary_md
 
-    def _gen_results(self):
+    def _gen_results(self, results):
         # '''
         # The function is called after the regression has completed. It looks
         # for a regr_results.hjson file with aggregated results from the


### PR DESCRIPTION
The number of _gen_results arguments has recently changed and that caused the syn class to fail. 
This commit aligns this.

Signed-off-by: Michael Schaffner <msf@google.com>