### PR TITLE
[dv/dvsim] collect coverage in scheduler

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -65,6 +65,11 @@ class Deploy():
         # A list of jobs on which this job depends
         self.dependencies = []
 
+        # Indicates whether running this job requires all dependencies to pass.
+        # If this flag is set to False, any passing dependency will trigger
+        # this current job to run
+        self.needs_all_dependencies_passing = True
+
         # Process
         self.process = None
         self.log_fd = None
@@ -739,6 +744,7 @@ class CovMerge(Deploy):
         super().__init__(sim_cfg)
 
         self.dependencies += run_items
+        self.needs_all_dependencies_passing = False
 
         self.target = "cov_merge"
         self.pass_patterns = []


### PR DESCRIPTION
Current Scheduler.py will kill the `next_item` if any dependencies
failed or killed.
So for nightly regression: https://reports.opentitan.org/hw/top_earlgrey/dv/summary.html,
only modules with 100% pass rate collects coverage.
 
But for nightly regression coverage runs, I think the
goal is to collect coverage as long as there is any passing test. 
As @sriyerg suggested, we added a parameter `needs_all_dependencies_passing`
as a flag to see if current job requires all dependencies to pass.

Signed-off-by: Cindy Chen <chencindy@google.com>