### PR TITLE
[rtl/sram] fix otp<->sram connection parameters

### DIFF
--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -172,7 +172,8 @@ module sram_ctrl
   end
 
   prim_sync_reqack_data #(
-    .Width($bits(otp_ctrl_pkg::sram_otp_key_rsp_t)-1)
+    .Width($bits(otp_ctrl_pkg::sram_otp_key_rsp_t)-1),
+    .DataSrc2Dst(1'b0)
   ) u_prim_sync_reqack_data (
     .clk_src_i  ( clk_i              ),
     .rst_src_ni ( rst_ni             ),


### PR DESCRIPTION
Currently the `prim_sync_reqack_data` module instantiated to connect the
OTP and SRAM is parameterized such that it expects data to be
transferred from the SRC side (SRAM) to the DST side (OTP).

However this needs to be reversed, as the OTP is sending scrambling seed
data over to the SRAM.

This PR adds the relevant parameters.

Signed-off-by: Udi Jonnalagadda <udij@google.com>