### PR TITLE
[dv/otp_ctrl] regwen sequence

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.sv
@@ -62,6 +62,11 @@ class dv_base_reg extends uvm_reg;
     locked_regs.push_back(locked_reg);
   endfunction
 
+  function bit is_inside_locked_regs(dv_base_reg csr);
+    if (csr inside {locked_regs}) return 1;
+    else                          return 0;
+  endfunction
+
   function bit is_enable_reg();
     return (locked_regs.size() > 0);
   endfunction

--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -39,6 +39,7 @@
             - Read out keys from key_manager, flash, SRAM, OTBN
             - Write random values to random addresses within each OTP partition
             - Read out the random selected write addresses, check if the readout values are expected
+            - During read and write operations, check if direct_access_regwen is correctly set by HW
             - Perform a system-level reset and check corresponding CSRs are set correctly
             - Lock all partitions except life_cycle by triggering digest calculations
             - Read back and verify the digest
@@ -69,6 +70,20 @@
             '''
       milestone: V2
       tests: []
+    }
+    {
+      name: regwen_during_otp_init
+      desc: '''
+            DIRECT_ACCESS_REGWEN is RO reg and it gates bunch of write access of other registers,
+            which isn't tested in common CSR tests. HW will set this register to 0 when OTP_CTRL's
+            DAI interface is busy.
+
+            Stimulus and checks:
+            - Random read DIRECT_ACCESS_REGWEN and ensure the value is set to 0 during OTP init.
+            - Test accessing registers gated by DIRECT_ACCESS_REGWEN is ignored during OTP init.
+            '''
+      milestone: V2
+      tests: ["otp_ctrl_regwen"]
     }
     {
       name: partition_lock

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -27,6 +27,7 @@ filesets:
       - seq_lib/otp_ctrl_lc_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_dai_lock_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_dai_errs_vseq.sv: {is_include_file: true}
+      - seq_lib/otp_ctrl_regwen_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_rand_key_rsp_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -8,6 +8,7 @@ package otp_ctrl_env_pkg;
   import top_pkg::*;
   import dv_utils_pkg::*;
   import dv_lib_pkg::*;
+  import dv_base_reg_pkg::*;
   import tl_agent_pkg::*;
   import cip_base_pkg::*;
   import csr_utils_pkg::*;

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_regwen_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_regwen_vseq.sv
@@ -1,0 +1,69 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// During DAI operation HW will set direct_access_regwen=0 to prevent write to registers that
+// affect DAI interface
+// Test those registers can't be written during OTP power up operation
+// Also check regwen value is updated by design correctly
+class otp_ctrl_regwen_vseq extends otp_ctrl_smoke_vseq;
+  `uvm_object_utils(otp_ctrl_regwen_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    bit regular_vseq_done;
+    fork
+      write_regwen_gate_regs_during_otp_busy(regular_vseq_done);
+      begin
+        super.body();
+        // let the unblocking thread finish before ending this seq
+        regular_vseq_done = 1;
+      end
+    join
+  endtask : body
+
+  virtual task write_regwen_gate_regs_during_otp_busy(ref bit regular_vseq_done);
+    while (!regular_vseq_done) begin
+      bit [TL_DW-1:0] regwen_val, status_val;
+      uint delay;
+      wait (cfg.otp_ctrl_vif.pwr_otp_done_o === 0 && !cfg.under_reset || regular_vseq_done);
+      if (regular_vseq_done) return;
+
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(delay,
+                                         delay dist {[0:10]    :/ 1,
+                                                     [11:100]  :/ 1,
+                                                     [101:500] :/ 1};)
+      cfg.clk_rst_vif.wait_clks(delay);
+
+      if ($urandom_range(0, 1)) begin
+        if (!cfg.under_reset) csr_rd(ral.direct_access_regwen, regwen_val);
+      end
+
+      // writing during DAI operation is timing sensitive
+      // 1. make sure other thread is not accessing registers
+      // 2. use backdoor check otp init is not done and is not under reset
+      wait_no_outstanding_access();
+      if (cfg.otp_ctrl_vif.pwr_otp_done_o === 0 && !cfg.under_reset) begin
+        write_and_check_regwen_locked_reg();
+      end
+      wait (cfg.otp_ctrl_vif.pwr_otp_done_o === 1 || cfg.under_reset || regular_vseq_done);
+    end
+  endtask
+
+  virtual task write_and_check_regwen_locked_reg();
+    bit [TL_DW-1:0] val = $urandom;
+    // since it's timing sensitive, only write one of these reg
+    dv_base_reg     locked_reg;
+    dv_base_reg     locked_regs[$];
+
+    ral.direct_access_regwen.get_locked_regs(locked_regs);
+    locked_regs.shuffle();
+    locked_reg = locked_regs[0];
+
+    `uvm_info(`gfn, $sformatf("Write regwen locked reg %0s, and this write should be ignored",
+                              locked_reg.get_name()), UVM_HIGH)
+    csr_wr(locked_reg, val);
+    csr_rd(locked_reg, val); // checking is done with scb
+  endtask : write_and_check_regwen_locked_reg
+
+endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -102,6 +102,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
           tl_access(.addr(tlul_addr), .write(0), .data(tlul_val), .blocking(1));
         end
 
+        if ($urandom_range(0, 1)) csr_rd(.ptr(ral.direct_access_regwen), .value(tlul_val));
         if ($urandom_range(0, 1)) csr_rd(.ptr(ral.status), .value(tlul_val));
       end
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
@@ -10,3 +10,4 @@
 `include "otp_ctrl_rand_key_rsp_vseq.sv"
 `include "otp_ctrl_dai_lock_vseq.sv"
 `include "otp_ctrl_dai_errs_vseq.sv"
+`include "otp_ctrl_regwen_vseq.sv"

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -80,6 +80,14 @@
       uvm_test_seq: otp_ctrl_rand_key_rsp_vseq
     }
 
+    {
+      name: otp_ctrl_regwen
+      uvm_test_seq: otp_ctrl_regwen_vseq
+      // This test is to check reg programming is gated when direct_access_regwen=0
+      // Thus this test is timing sensitive
+      run_opts: ["+zero_delays=1"]
+    }
+
   ]
 
   // List of regressions.


### PR DESCRIPTION
This PR adds a regwen sequence in OTP_CTRL. The timing to check
direct_access_regwen is very sensitive because it is written by HW and
write to 0 only when DAI operation is in-progress.
This PR follows keymgr's cfgen sequence example and read
direct_access_regwen register during DAI busy, and write one of the
enabled registers when access is locked.

Signed-off-by: Cindy Chen <chencindy@google.com>