### PR TITLE
[dv] Gracefully kill simulation

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_test.sv
+++ b/hw/dv/sv/dv_lib/dv_base_test.sv
@@ -14,6 +14,8 @@ class dv_base_test #(type CFG_T = dv_base_env_cfg,
   uint   max_quit_count  = 1;
   uint64 test_timeout_ns = 200_000_000; // 200ms
   uint   drain_time_ns   = 2_000;  // 2us
+  bit    poll_for_stop   = 1'b1;
+  uint   poll_for_stop_interval_ns = 1000;
 
   `uvm_component_new
 
@@ -55,6 +57,9 @@ class dv_base_test #(type CFG_T = dv_base_env_cfg,
   virtual task run_phase(uvm_phase phase);
     void'($value$plusargs("drain_time_ns=%0d", drain_time_ns));
     phase.phase_done.set_drain_time(this, (drain_time_ns * 1ns));
+    void'($value$plusargs("poll_for_stop=%0b", poll_for_stop));
+    void'($value$plusargs("poll_for_stop_interval_ns=%0d", poll_for_stop_interval_ns));
+    if (poll_for_stop) dv_utils_pkg::poll_for_stop(.interval_ns(poll_for_stop_interval_ns));
     void'($value$plusargs("UVM_TEST_SEQ=%0s", test_seq_s));
     if (run_test_seq) begin
       run_seq(test_seq_s, phase);

--- a/hw/dv/sv/dv_utils/dv_utils_pkg.sv
+++ b/hw/dv/sv/dv_utils/dv_utils_pkg.sv
@@ -180,6 +180,20 @@ package dv_utils_pkg;
     return (hier.substr(0, idx - 1));
   endfunction
 
+  // Periodically check for the existence of a magic file (dv.stop). Exit if it exists. This
+  // provides a mechanism to gracefully kill a simulation without direct access to the process.
+  task automatic poll_for_stop(uint interval_ns = 1000, string filename = "dv.stop");
+    fork
+      while (1) begin
+        #(interval_ns * 1ns);
+        if (!$system($sformatf("test -f %0s", filename))) begin
+          $system($sformatf("rm %0s", filename));
+          `dv_fatal($sformatf("Found %0s file. Exiting!", filename), "poll_for_stop")
+        end
+      end
+    join_none
+  endtask : poll_for_stop
+
   // sources
 `ifdef UVM
   `include "dv_report_server.sv"

--- a/hw/ip/prim/dv/prim_lfsr/tb/prim_lfsr_tb.sv
+++ b/hw/ip/prim/dv/prim_lfsr/tb/prim_lfsr_tb.sv
@@ -214,4 +214,13 @@ module prim_lfsr_tb;
     $finish();
   end
 
+  // TODO: perhaps wrap this in a macro?
+  initial begin
+    bit poll_for_stop = 1'b1;
+    int unsigned poll_for_stop_interval_ns = 1000;
+    void'($value$plusargs("poll_for_stop=%0b", poll_for_stop));
+    void'($value$plusargs("poll_for_stop_interval_ns=%0d", poll_for_stop_interval_ns));
+    if (poll_for_stop) dv_utils_pkg::poll_for_stop(.interval_ns(poll_for_stop_interval_ns));
+  end
+
 endmodule : prim_lfsr_tb

--- a/hw/ip/prim/dv/prim_present/prim_present_sim.core
+++ b/hw/ip/prim/dv/prim_present/prim_present_sim.core
@@ -12,6 +12,7 @@ filesets:
 
   files_dv:
     depend:
+      - lowrisc:dv:dv_utils
       - lowrisc:dv:dv_macros
       - lowrisc:dv:dv_test_status
       - lowrisc:dv:crypto_dpi_present:0.1

--- a/hw/ip/prim/dv/prim_present/tb/prim_present_tb.sv
+++ b/hw/ip/prim/dv/prim_present/tb/prim_present_tb.sv
@@ -251,4 +251,13 @@ module prim_present_tb;
     $finish();
   end
 
+  // TODO: perhaps wrap this in a macro?
+  initial begin
+    bit poll_for_stop = 1'b1;
+    int unsigned poll_for_stop_interval_ns = 1000;
+    void'($value$plusargs("poll_for_stop=%0b", poll_for_stop));
+    void'($value$plusargs("poll_for_stop_interval_ns=%0d", poll_for_stop_interval_ns));
+    if (poll_for_stop) dv_utils_pkg::poll_for_stop(.interval_ns(poll_for_stop_interval_ns));
+  end
+
 endmodule : prim_present_tb

--- a/hw/ip/prim/dv/prim_prince/tb/prim_prince_tb.sv
+++ b/hw/ip/prim/dv/prim_prince/tb/prim_prince_tb.sv
@@ -294,4 +294,13 @@ module prim_prince_tb;
     $finish();
   end
 
+  // TODO: perhaps wrap this in a macro?
+  initial begin
+    bit poll_for_stop = 1'b1;
+    int unsigned poll_for_stop_interval_ns = 1000;
+    void'($value$plusargs("poll_for_stop=%0b", poll_for_stop));
+    void'($value$plusargs("poll_for_stop_interval_ns=%0d", poll_for_stop_interval_ns));
+    if (poll_for_stop) dv_utils_pkg::poll_for_stop(.interval_ns(poll_for_stop_interval_ns));
+  end
+
 endmodule : prim_prince_tb


### PR DESCRIPTION
When running sims remotely (LSF, etc), if we need to kill a simulation
that might be hung, then issuing a TERM signal to the process running
the simulation (or `bkill`ing the LSF job) sometimes causes the simulation to
terminate unexpectedly and uncleanly. If wavedump is enabled, it causes
the dump to get corrupted, preventing us from debugging the cause of the
hang in the first place.

Also, there may be a need to kill a test that is known to fail while letting the 
rest of the simulations continue to run. It is hard to figure out the process 
/ job id to send the kill signal to it specifically. This patch provides an easy 
way to do it.  

In this patch, there is logic added to the simulation that checks for
the presence of a `dv.stop` file in the run directory periodically every
1ms. Whether to enable this logic AND the polling interval can be
changed via plusargs. This file can be easily added to the run directory
by running `touch <rundir>/dv.stop`. DVsim can use this method rather
then killing the process (more updates on that coming soon).

Signed-off-by: Srikrishna Iyer <sriyer@google.com>