### PR TITLE
[util/design] Align log message format in some of the design scripts

### DIFF
--- a/util/design/gen-lc-state-enc.py
+++ b/util/design/gen-lc-state-enc.py
@@ -24,8 +24,7 @@ TEMPLATES = ["hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv.tpl"]
 
 def main():
     log.basicConfig(level=log.INFO,
-                    format="%(asctime)s - %(message)s",
-                    datefmt="%Y-%m-%d %H:%M")
+                    format="%(levelname)s: %(message)s")
 
     parser = argparse.ArgumentParser(
         prog="gen-lc-state-enc",

--- a/util/design/gen-lfsr-seed.py
+++ b/util/design/gen-lfsr-seed.py
@@ -23,8 +23,7 @@ SV_INSTRUCTIONS = """
 
 def main():
     log.basicConfig(level=log.INFO,
-                    format="%(asctime)s - %(message)s",
-                    datefmt="%Y-%m-%d %H:%M")
+                    format="%(levelname)s: %(message)s")
 
     parser = argparse.ArgumentParser(
         prog="gen-lfsre-perm",

--- a/util/design/gen-otp-mmap.py
+++ b/util/design/gen-otp-mmap.py
@@ -37,8 +37,7 @@ TEMPLATES = [
 
 def main():
     log.basicConfig(level=log.INFO,
-                    format="%(asctime)s - %(message)s",
-                    datefmt="%Y-%m-%d %H:%M")
+                    format="%(levelname)s: %(message)s")
 
     parser = argparse.ArgumentParser(
         prog="gen-otp-mmap",

--- a/util/design/sparse-fsm-encode.py
+++ b/util/design/sparse-fsm-encode.py
@@ -56,9 +56,8 @@ RUST_INSTRUCTIONS = """
 
 
 def main():
-    logging.basicConfig(level=logging.INFO,
-                        format="%(asctime)s - %(message)s",
-                        datefmt="%Y-%m-%d %H:%M")
+    log.basicConfig(level=log.INFO,
+                    format="%(levelname)s: %(message)s")
 
     parser = argparse.ArgumentParser(
         prog="sparse-fsm-encode",


### PR DESCRIPTION
This shortens the log message prefix in some of the design scripts that use a common format.

Signed-off-by: Michael Schaffner <msf@opentitan.org>