### PR TITLE
[otp_ctrl/lc_ctrl] Make invalid defaults for lc state random constants

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
@@ -259,10 +259,12 @@
             items: [
                 {
                     name: "LC_STATE",
+                    inv_default: "<random>",
                     size: "24"
                 }
                 {
                     name: "LC_TRANSITION_CNT",
+                    inv_default: "<random>",
                     size: "32"
                 }
             ],

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -1005,11 +1005,10 @@ module otp_ctrl
       assign part_tlul_rerror[k] = '0;
       assign part_tlul_rvalid[k] = 1'b0;
       assign part_tlul_rdata[k]  = '0;
-end else if (PartInfo[k].variant == LifeCycle) begin : gen_lifecycle
+    end else if (PartInfo[k].variant == LifeCycle) begin : gen_lifecycle
       otp_ctrl_part_buf #(
         .Info(PartInfo[k]),
-        // TODO: set to a random netlist constant
-        .DataDefault('0)
+        .DataDefault(PartInvDefault[PartInfo[k].offset*8 +: PartInfo[k].size*8])
       ) u_part_buf (
         .clk_i,
         .rst_ni,

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
@@ -215,8 +215,8 @@ package otp_ctrl_part_pkg;
   // OTP invalid partition default for buffered partitions.
   parameter logic [16383:0] PartInvDefault = 16384'({
     448'({
-      256'h0,
-      192'h0
+      256'h1D00E175E3739EC1DAAF8720F255C5C84D1D9C10648A878DB1D5ABE9610E8395,
+      192'h490EC23C0A1EDCCE280E8ECA88CEA2E99470329E17324EDB
     }),
     960'({
       64'h1E2960279AB8F882,


### PR DESCRIPTION
This changes the invalid default state of the life cycle partition in OTP to a random netlist constant.

Signed-off-by: Michael Schaffner <msf@google.com>