### PR TITLE
[ci] Revert recent changes in lint flow

### DIFF
--- a/hw/lint/tools/ascentlint/parse-lint-report.py
+++ b/hw/lint/tools/ascentlint/parse-lint-report.py
@@ -111,14 +111,13 @@ def main():
                    for_json=True,
                    use_decimal=True)
 
-    # Pass/fail status is determined in the LintCfg class.
-    log.info(("Found %d flow warnings, %d flow errors, %d lint infos,\n"
-             "%d lint warnings and %d lint errors."),
-             len(results["warnings"]),
-             len(results["errors"]),
-             len(results["lint_infos"]),
-             len(results["lint_warnings"]),
-             len(results["lint_errors"]))
+    # return nonzero status if any warnings or errors are present
+    # lint infos do not count as failures
+    n_errors = len(results["errors"]) + len(results["lint_errors"])
+    n_warnings = len(results["warnings"]) + len(results["lint_warnings"])
+    if n_errors > 0 or n_warnings > 0:
+        log.info("Found %d lint errors and %d lint warnings", n_errors, n_warnings)
+        sys.exit(1)
 
     log.info("Lint logfile parsed succesfully")
     sys.exit(0)

--- a/hw/lint/tools/ascentlint/parse-lint-report.py
+++ b/hw/lint/tools/ascentlint/parse-lint-report.py
@@ -113,7 +113,7 @@ def main():
 
     # Pass/fail status is determined in the LintCfg class.
     log.info(("Found %d flow warnings, %d flow errors, %d lint infos,\n"
-              "%d lint warnings and %d lint errors."),
+             "%d lint warnings and %d lint errors."),
              len(results["warnings"]),
              len(results["errors"]),
              len(results["lint_infos"]),

--- a/hw/lint/tools/veriblelint/parse-lint-report.py
+++ b/hw/lint/tools/veriblelint/parse-lint-report.py
@@ -57,7 +57,11 @@ def get_results(resdir):
                 # this is a workaround until we actually have native Edalize
                 # support for JasperGold and "formal" targets
                 ("warnings",
-                 r"^(?!WARNING: Unknown item formal in section Target)WARNING: .*"),
+                 r"^(?!WARNING: Unknown item formal in section Target)WARNING: .*"
+                 # TODO(https://github.com/lowRISC/ibex/issues/1033):
+                 # remove once this has been fixed in Edalize or in the corefile.
+                 r"^(?!WARNING: Unknown item symbiyosis in section Target)WARNING: .*"
+                 ),
                 ("warnings", r"^Warning: .* "),
                 ("warnings", r"^W .*"),
                 ("lint_warnings", r"^.*\[Style:.*")

--- a/hw/lint/tools/veriblelint/parse-lint-report.py
+++ b/hw/lint/tools/veriblelint/parse-lint-report.py
@@ -113,14 +113,13 @@ def main():
                    for_json=True,
                    use_decimal=True)
 
-    # Pass/fail status is determined in the LintCfg class.
-    log.info(("Found %d flow warnings, %d flow errors, %d lint infos,\n"
-             "%d lint warnings and %d lint errors."),
-             len(results["warnings"]),
-             len(results["errors"]),
-             len(results["lint_infos"]),
-             len(results["lint_warnings"]),
-             len(results["lint_errors"]))
+    # return nonzero status if any warnings or errors are present
+    # lint infos do not count as failures
+    n_errors = len(results["errors"]) + len(results["lint_errors"])
+    n_warnings = len(results["warnings"]) + len(results["lint_warnings"])
+    if n_errors > 0 or n_warnings > 0:
+        log.info("Found %d lint errors and %d lint warnings", n_errors, n_warnings)
+        sys.exit(1)
 
     log.info("Lint logfile parsed succesfully")
     sys.exit(0)

--- a/hw/lint/tools/veriblelint/parse-lint-report.py
+++ b/hw/lint/tools/veriblelint/parse-lint-report.py
@@ -53,10 +53,6 @@ def get_results(resdir):
                 ("errors", r"^Error: .*"),
                 ("errors", r"^E .*"),
                 ("errors", r"^F .*"),
-                # TODO(https://github.com/google/verible/issues/652): uncomment
-                # this regex once the endproperty and first_match keywords are supported
-                # in the Verible style linter.
-                #("errors", r".*: syntax error, rejected.*"),
                 # TODO(https://github.com/olofk/edalize/issues/90):
                 # this is a workaround until we actually have native Edalize
                 # support for JasperGold and "formal" targets
@@ -119,7 +115,7 @@ def main():
 
     # Pass/fail status is determined in the LintCfg class.
     log.info(("Found %d flow warnings, %d flow errors, %d lint infos,\n"
-              "%d lint warnings and %d lint errors."),
+             "%d lint warnings and %d lint errors."),
              len(results["warnings"]),
              len(results["errors"]),
              len(results["lint_infos"]),

--- a/hw/lint/tools/verilator/parse-lint-report.py
+++ b/hw/lint/tools/verilator/parse-lint-report.py
@@ -115,14 +115,13 @@ def main():
                    for_json=True,
                    use_decimal=True)
 
-    # Pass/fail status is determined in the LintCfg class.
-    log.info(("Found %d flow warnings, %d flow errors, %d lint infos,\n"
-             "%d lint warnings and %d lint errors."),
-             len(results["warnings"]),
-             len(results["errors"]),
-             len(results["lint_infos"]),
-             len(results["lint_warnings"]),
-             len(results["lint_errors"]))
+    # return nonzero status if any warnings or errors are present
+    # lint infos do not count as failures
+    n_errors = len(results["errors"]) + len(results["lint_errors"])
+    n_warnings = len(results["warnings"]) + len(results["lint_warnings"])
+    if n_errors > 0 or n_warnings > 0:
+        log.info("Found %d lint errors and %d lint warnings", n_errors, n_warnings)
+        sys.exit(1)
 
     log.info("Lint logfile parsed succesfully")
     sys.exit(0)

--- a/hw/lint/tools/verilator/parse-lint-report.py
+++ b/hw/lint/tools/verilator/parse-lint-report.py
@@ -117,7 +117,7 @@ def main():
 
     # Pass/fail status is determined in the LintCfg class.
     log.info(("Found %d flow warnings, %d flow errors, %d lint infos,\n"
-              "%d lint warnings and %d lint errors."),
+             "%d lint warnings and %d lint errors."),
              len(results["warnings"]),
              len(results["errors"]),
              len(results["lint_infos"]),

--- a/hw/lint/tools/verilator/parse-lint-report.py
+++ b/hw/lint/tools/verilator/parse-lint-report.py
@@ -45,7 +45,11 @@ def parse_lint_log(str_buffer):
         # this is a workaround until we actually have native Edalize
         # support for JasperGold and "formal" targets
         ("warnings",
-         r"^(?!WARNING: Unknown item formal in section Target)WARNING: .*"),
+         r"^(?!WARNING: Unknown item formal in section Target)WARNING: .*"
+         # TODO(https://github.com/lowRISC/ibex/issues/1033):
+         # remove once this has been fixed in Edalize or in the corefile.
+         r"^(?!WARNING: Unknown item symbiyosis in section Target)WARNING: .*"
+         ),
         ("warnings", r"^%Warning: .* "),
         ("lint_errors", r"^%Error-.*"),
         ("lint_warnings", r"^%Warning-.*"),

--- a/util/dvsim/LintCfg.py
+++ b/util/dvsim/LintCfg.py
@@ -54,7 +54,7 @@ class LintCfg(OneShotCfg):
         results_str += "\n"
 
         header = [
-            "Name", "Flow Warnings", "Flow Errors", "Lint Warnings",
+            "Name", "Tool Warnings", "Tool Errors", "Lint Warnings",
             "Lint Errors"
         ]
         colalign = ("center", ) * len(header)
@@ -180,25 +180,22 @@ class LintCfg(OneShotCfg):
             self.result_summary["lint_errors"] += self.result["lint_errors"]
 
             # Append detailed messages if they exist
-            # Indicate whether message leads to failure or not.
-            hdr_key_pairs = [("Flow Warnings", "warnings", False),
-                             ("Flow Errors", "errors", True),
-                             ("Lint Warnings", "lint_warnings", True),
-                             ("Lint Errors", "lint_errors", True)]
+            hdr_key_pairs = [("Tool Warnings", "warnings"),
+                             ("Tool Errors", "errors"),
+                             ("Lint Warnings", "lint_warnings"),
+                             ("Lint Errors", "lint_errors")]
 
             # Lint fails if any warning or error message has occurred
             self.errors_seen = False
-            errors_to_report = False
-            for _, key, fail in hdr_key_pairs:
+            for _, key in hdr_key_pairs:
                 if key in self.result:
                     if self.result.get(key):
-                        self.errors_seen = fail
-                        errors_to_report = True
+                        self.errors_seen = True
                         break
 
-            if errors_to_report:
+            if self.errors_seen:
                 fail_msgs += "\n### Errors and Warnings for Build Mode `'" + mode.name + "'`\n"
-                for hdr, key, _ in hdr_key_pairs:
+                for hdr, key in hdr_key_pairs:
                     msgs = self.result.get(key)
                     fail_msgs += print_msg_list("#### " + hdr, msgs, self.max_msg_count)
 


### PR DESCRIPTION
This reverts a recent change in the Verible style lint parser that makes the CI check flaky.

The change removed some fusesoc related message waivers which should not be needed anymore (see https://github.com/lowRISC/ibex/issues/1033).
However, it looks like the waiver we've removed masked other Fusesoc messages that are not properly handled by the parser script, and this now makes CI flaky.
I need some more time to investigate this, and since this affects CI, I am reverting all related commits for now.
