### PR TITLE
Update COMMITTERS

### DIFF
--- a/COMMITTERS
+++ b/COMMITTERS
@@ -10,7 +10,6 @@ Committer list:
 * Greg Chadwick (gregac)
 * Cindy Chen (cindychip)
 * Timothy Chen (tjaychen)
-* Sam Elliott (lenary)
 * Jon Flatley (jon-flatley)
 * Srikrishna Iyer (sriyerg)
 * Scott Johnson (sjgitty)


### PR DESCRIPTION
Sam is no longer working on OpenTitan. This commit updates the
COMMITTERS file to reflect the changes that were already made to the
GitHub ACL.

Thank you Sam for all your contributions!