### PR TITLE
[prim, tlul] Wire up new full_o output from prim_fifo_sync

### DIFF
--- a/hw/ip/prim/rtl/prim_sram_arbiter.sv
+++ b/hw/ip/prim/rtl/prim_sram_arbiter.sv
@@ -112,10 +112,11 @@ module prim_sram_arbiter #(
     .wvalid_i (sram_req_o & ~sram_write_o),  // Push only for read
     .wready_o (),     // TODO: Generate Error
     .wdata_i  (gnt_o),
-    .depth_o  (),     // Not used
     .rvalid_o (),     // TODO; Generate error if sram_rvalid_i but rvalid==0
     .rready_i (sram_ack),
-    .rdata_o  (steer)
+    .rdata_o  (steer),
+    .full_o   (),
+    .depth_o  ()     // Not used
   );
 
   assign rsp_rvalid_o = steer & {N{sram_rvalid_i}};

--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -294,10 +294,11 @@ module tlul_adapter_sram #(
     .wvalid_i(reqfifo_wvalid),
     .wready_o(reqfifo_wready),
     .wdata_i (reqfifo_wdata),
-    .depth_o (),
     .rvalid_o(reqfifo_rvalid),
     .rready_i(reqfifo_rready),
-    .rdata_o (reqfifo_rdata)
+    .rdata_o (reqfifo_rdata),
+    .full_o  (),
+    .depth_o ()
   );
 
   // sramreqfifo:
@@ -315,10 +316,11 @@ module tlul_adapter_sram #(
     .wvalid_i(sramreqfifo_wvalid),
     .wready_o(sramreqfifo_wready),
     .wdata_i (sramreqfifo_wdata),
-    .depth_o (),
     .rvalid_o(),
     .rready_i(sramreqfifo_rready),
-    .rdata_o (sramreqfifo_rdata)
+    .rdata_o (sramreqfifo_rdata),
+    .full_o  (),
+    .depth_o ()
   );
 
   // Rationale having #Outstanding depth in response FIFO.
@@ -338,10 +340,11 @@ module tlul_adapter_sram #(
     .wvalid_i(rspfifo_wvalid),
     .wready_o(rspfifo_wready),
     .wdata_i (rspfifo_wdata),
-    .depth_o (),
     .rvalid_o(rspfifo_rvalid),
     .rready_i(rspfifo_rready),
-    .rdata_o (rspfifo_rdata)
+    .rdata_o (rspfifo_rdata),
+    .full_o  (),
+    .depth_o ()
   );
 
   // below assertion fails when SRAM rvalid is asserted even though ReqFifo is empty

--- a/hw/ip/tlul/rtl/tlul_fifo_sync.sv
+++ b/hw/ip/tlul/rtl/tlul_fifo_sync.sv
@@ -44,7 +44,6 @@ module tlul_fifo_sync #(
                      tl_h_i.a_data   ,
                      tl_h_i.a_user   ,
                      spare_req_i}),
-    .depth_o       (),
     .rvalid_o      (tl_d_o.a_valid),
     .rready_i      (tl_d_i.a_ready),
     .rdata_o       ({tl_d_o.a_opcode ,
@@ -55,7 +54,9 @@ module tlul_fifo_sync #(
                      tl_d_o.a_mask   ,
                      tl_d_o.a_data   ,
                      tl_d_o.a_user   ,
-                     spare_req_o}));
+                     spare_req_o}),
+    .full_o        (),
+    .depth_o       ());
 
   // Put everything on the response side into the other FIFO
 
@@ -77,7 +78,6 @@ module tlul_fifo_sync #(
                      tl_d_i.d_user  ,
                      tl_d_i.d_error ,
                      spare_rsp_i}),
-    .depth_o       (),
     .rvalid_o      (tl_h_o.d_valid),
     .rready_i      (tl_h_i.d_ready),
     .rdata_o       ({tl_h_o.d_opcode,
@@ -88,6 +88,8 @@ module tlul_fifo_sync #(
                      tl_h_o.d_data  ,
                      tl_h_o.d_user  ,
                      tl_h_o.d_error ,
-                     spare_rsp_o}));
+                     spare_rsp_o}),
+    .full_o        (),
+    .depth_o       ());
 
 endmodule


### PR DESCRIPTION
`prim_fifo_sync` has just gained a new output port. These modules don't need the signal (they can just use `wready_o`), so we don't need to connect it to anything. But we *do* need to explicitly mention it to avoid lint errors.

Fixes #5019.