### PR TITLE
[lint] Spot errors in the lint flow that we weren't expecting

### DIFF
--- a/hw/formal/tools/csr_assert_gen/csr_assert_gen.core
+++ b/hw/formal/tools/csr_assert_gen/csr_assert_gen.core
@@ -5,7 +5,20 @@ CAPI=2:
 
 name: "lowrisc:fpv:csr_assert_gen"
 description: "Generator for CSR assertion check module used in FPV and DV testbenches."
-generators:
-  csr_assert_gen:
-    interpreter: python3
-    command: csr_assert_gen.py
+filesets:
+  files_dv:
+    depend:
+      # TODO(#5027, https://github.com/google/verible/issues/652):
+      # This is a hack to prevent the generated FPV assertion files
+      # being passed into the Verible style linter. The tool currently
+      # does not support certain SVA language constructs, causing it
+      # to throw syntax errors. Fold the contents of
+      # csr_assert_gen_script.core back into this file once the issue
+      # has been addressed upstream.
+      - "! tool_veriblelint ? (lowrisc:fpv:csr_assert_gen_script)"
+      - "tool_veriblelint ? (lowrisc:fpv:csr_assert_gen_dummy)"
+
+targets:
+  default: &default_target
+    filesets:
+      - files_dv

--- a/hw/formal/tools/csr_assert_gen/csr_assert_gen_dummy.core
+++ b/hw/formal/tools/csr_assert_gen/csr_assert_gen_dummy.core
@@ -1,0 +1,17 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# TODO(#5027, https://github.com/google/verible/issues/652):
+# This is a hack to prevent the generated FPV assertion files being
+# passed into the Verible style linter. The tool currently does not
+# support certain SVA language constructs, causing it to throw syntax
+# errors. Remove this file once the issue has been addressed upstream.
+
+name: "lowrisc:fpv:csr_assert_gen_dummy"
+description: "Dummy generator that does nothing."
+generators:
+  csr_assert_gen:
+    interpreter: echo
+    command: none

--- a/hw/formal/tools/csr_assert_gen/csr_assert_gen_script.core
+++ b/hw/formal/tools/csr_assert_gen/csr_assert_gen_script.core
@@ -1,0 +1,18 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# TODO(#5027, https://github.com/google/verible/issues/652):
+# This is a hack to prevent the generated FPV assertion files being
+# passed into the Verible style linter. The tool currently does not
+# support certain SVA language constructs, causing it to throw syntax
+# errors. Remove this file (and point csr_assert_gen.core straight at
+# csr_assert_gen.py) once the issue has been addressed upstream.
+
+name: "lowrisc:fpv:csr_assert_gen_script"
+description: "Generator for CSR assertion check module used in FPV and DV testbenches."
+generators:
+  csr_assert_gen:
+    interpreter: python3
+    command: csr_assert_gen.py

--- a/hw/lint/tools/dvsim/ascentlint.hjson
+++ b/hw/lint/tools/dvsim/ascentlint.hjson
@@ -6,6 +6,6 @@
 
   // Ascentlint-specific results parsing script that is called after running lint
   report_cmd: "{lint_root}/tools/{tool}/parse-lint-report.py "
-  report_opts: ["--repdir={build_dir}/lint-{tool}",
+  report_opts: ["--repdir={build_dir}",
                 "--outdir={build_dir}"]
 }

--- a/hw/lint/tools/veriblelint/parse-lint-report.py
+++ b/hw/lint/tools/veriblelint/parse-lint-report.py
@@ -57,11 +57,7 @@ def get_results(resdir):
                 # this is a workaround until we actually have native Edalize
                 # support for JasperGold and "formal" targets
                 ("warnings",
-                 r"^(?!WARNING: Unknown item formal in section Target)WARNING: .*"
-                 # TODO(https://github.com/lowRISC/ibex/issues/1033):
-                 # remove once this has been fixed in Edalize or in the corefile.
-                 r"^(?!WARNING: Unknown item symbiyosis in section Target)WARNING: .*"
-                 ),
+                 r"^(?!WARNING: Unknown item formal in section Target)WARNING: .*"),
                 ("warnings", r"^Warning: .* "),
                 ("warnings", r"^W .*"),
                 ("lint_warnings", r"^.*\[Style:.*")

--- a/hw/lint/tools/veriblelint/parse-lint-report.py
+++ b/hw/lint/tools/veriblelint/parse-lint-report.py
@@ -62,15 +62,16 @@ def get_results(resdir):
          r"^ERROR: Failed to run .*: Lint failed.*"),
         ("errors",
          r"^(?!ERROR: Failed to run .* Lint failed)ERROR: .*"),
-        ("errors", r"^Error: .*"),
+        ("errors", r"^.*Error: .*"),
         ("errors", r"^E .*"),
         ("errors", r"^F .*"),
+        ("errors", r".*: syntax error, rejected.*"),
         # TODO(https://github.com/olofk/edalize/issues/90):
         # this is a workaround until we actually have native Edalize
         # support for JasperGold and "formal" targets
         ("warnings",
          r"^(?!WARNING: Unknown item formal in section Target)WARNING: .*"),
-        ("warnings", r"^Warning: .* "),
+        ("warnings", r"^.*Warning: .* "),
         ("warnings", r"^W .*"),
         ("lint_warnings", r"^.*\[Style:.*")
     ]

--- a/hw/lint/tools/verilator/parse-lint-report.py
+++ b/hw/lint/tools/verilator/parse-lint-report.py
@@ -39,17 +39,14 @@ def parse_lint_log(str_buffer):
         ("errors",
          r"^(?!ERROR: Failed to build .* 'make' exited with an error code)ERROR: .*"),
         ("errors",
-        # This is a redundant Verilator error that we ignore for the same reason as above.
+         # This is a redundant Verilator error that we ignore for the same
+         # reason as above.
          r"^(?!%Error: Exiting due to .* warning.*)%Error: .*"),
         # TODO(https://github.com/olofk/edalize/issues/90):
         # this is a workaround until we actually have native Edalize
         # support for JasperGold and "formal" targets
         ("warnings",
-         r"^(?!WARNING: Unknown item formal in section Target)WARNING: .*"
-         # TODO(https://github.com/lowRISC/ibex/issues/1033):
-         # remove once this has been fixed in Edalize or in the corefile.
-         r"^(?!WARNING: Unknown item symbiyosis in section Target)WARNING: .*"
-         ),
+         r"^(?!WARNING: Unknown item formal in section Target)WARNING: .*"),
         ("warnings", r"^%Warning: .* "),
         ("lint_errors", r"^%Error-.*"),
         ("lint_warnings", r"^%Warning-.*"),


### PR DESCRIPTION
If something goes wrong and the lint tool returns a nonzero exit
status (causing edalize/fusesoc to complain), we normally want to
squash that error message because it's something we have other
warnings about anyway.

However, we *do* want to see the message if something more dramatic
has happened. For example, we weren't seeing syntax error messages
from a very confused Verible, meaning that we reported no lint errors
when in fact the tool had died completely.

This PR will obviously fail CI at the moment (that's sort of the point!). We'll either have to waive otp_ctrl or get it working properly before merging it.