### PR TITLE
[dv/cip_scb] alert checking fix

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -187,9 +187,9 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
                     exp_alert[alert_name]), UVM_MEDIUM)
         end else begin
           `uvm_info(`gfn, $sformatf("alert %0s is expected to trigger", alert_name), UVM_MEDIUM)
+          is_fatal_alert[alert_name] = is_fatal;
+          exp_alert[alert_name] = 1;
         end
-        is_fatal_alert[alert_name] = is_fatal;
-        exp_alert[alert_name] = 1;
       end
     join_none
   endfunction


### PR DESCRIPTION
This PR fixes a logic in cip_scb when alert checking is ignored due to
alert in progress, it still assign the exp alert. This is fixed in this
PR.
Thanks @weicaiyang for the issue and waveform.

Signed-off-by: Cindy Chen <chencindy@google.com>