### PR TITLE
[dv/kmac] update kmac_smoke_test

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_sideload_if.sv
+++ b/hw/ip/kmac/dv/env/kmac_sideload_if.sv
@@ -9,4 +9,19 @@ interface kmac_sideload_if;
   // - key_share1
   keymgr_pkg::hw_key_req_t sideload_key;
 
+  string path = "kmac_sideload_if";
+
+  // share0 and share1 are only driven when `valid` is 1.
+  task automatic drive_sideload_key(logic key_valid,
+                                    logic [keymgr_pkg::KeyWidth-1:0] share0,
+                                    logic [keymgr_pkg::KeyWidth-1:0] share1);
+    keymgr_pkg::hw_key_req_t key;
+
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(key, key.valid == key_valid;, , path)
+    key.key_share0 = (key_valid) ? share0 : 'hx;
+    key.key_share1 = (key_valid) ? share1 : 'hx;
+
+    sideload_key = key;
+  endtask
+
 endinterface

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
@@ -501,13 +501,12 @@ class kmac_base_vseq extends cip_base_vseq #(
       tl_access(.addr(ral.get_addr_from_offset(fifo_addr)),
                 .write(1),
                 .data(data_word),
-                .mask(data_mask));
+                .mask(data_mask),
+                .blocking($urandom_range(0, 1)));
     end
 
     // wait for all msgfifo accesses to complete
-    //
-    // TODO: uncomment once nonblocking TL accesses are enabled.
-    // wait_no_outstanding_access();
+    wait_no_outstanding_access();
 
     // TODO: final csr checks might be needed
   endtask
@@ -558,7 +557,6 @@ class kmac_base_vseq extends cip_base_vseq #(
     bit [7:0] digest_byte;
 
     while (output_len > 0) begin
-      // TODO: randomize non/blocking?
       tl_access(.addr(ral.get_addr_from_offset(state_addr)),
                 .write(1'b0),
                 .data(digest_word));


### PR DESCRIPTION
This PR makes some small enhancements to the kmac_smoke_test:
- randomizes blocking/nonblocking TLUL transactions when writing to
  msgfifo
- randomly provides a sideload key to verify that it is ignored

Signed-off-by: Udi Jonnalagadda <udij@google.com>