### PR TITLE
[fpv] fix otp_ctrl, lc_ctrl, and flash_ctrl syntax error

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -187,11 +187,11 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
   logic lfsr_seed_en;
 
   // life cycle connections
-  lc_ctrl_pkg::lc_tx_t lc_creator_seed_sw_rw_en;
-  lc_ctrl_pkg::lc_tx_t lc_owner_seed_sw_rw_en;
-  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_rd_en;
-  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_wr_en;
-  lc_ctrl_pkg::lc_tx_t lc_seed_hw_rd_en;
+  lc_ctrl_pkg::lc_tx_t [0:0] lc_creator_seed_sw_rw_en;
+  lc_ctrl_pkg::lc_tx_t [0:0] lc_owner_seed_sw_rw_en;
+  lc_ctrl_pkg::lc_tx_t [0:0] lc_iso_part_sw_rd_en;
+  lc_ctrl_pkg::lc_tx_t [0:0] lc_iso_part_sw_wr_en;
+  lc_ctrl_pkg::lc_tx_t [0:0] lc_seed_hw_rd_en;
 
   // synchronize enables into local domain
   prim_lc_sync #(
@@ -343,10 +343,10 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
   assign sw_sel        = if_sel == SwSel;
 
   // software privilege to creator seed
-  assign creator_seed_priv = lc_creator_seed_sw_rw_en == lc_ctrl_pkg::On;
+  assign creator_seed_priv = lc_creator_seed_sw_rw_en[0] == lc_ctrl_pkg::On;
 
   // software privilege to owner seed
-  assign owner_seed_priv = lc_owner_seed_sw_rw_en == lc_ctrl_pkg::On;
+  assign owner_seed_priv = lc_owner_seed_sw_rw_en[0] == lc_ctrl_pkg::On;
 
   // hardware interface
   flash_ctrl_lcmgr #(
@@ -360,7 +360,7 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
 
     .init_i(pwrmgr_i.flash_init),
     .init_done_o(pwrmgr_o.flash_done),
-    .provision_en_i(lc_seed_hw_rd_en == lc_ctrl_pkg::On),
+    .provision_en_i(lc_seed_hw_rd_en[0] == lc_ctrl_pkg::On),
 
     // interface to ctrl arb control ports
     .ctrl_o(hw_ctrl),
@@ -642,8 +642,8 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
         .cfgs_i(reg2hw_info_page_cfgs[i][j]),
         .creator_seed_priv_i(creator_seed_priv),
         .owner_seed_priv_i(owner_seed_priv),
-        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en == lc_ctrl_pkg::On),
-        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en == lc_ctrl_pkg::On),
+        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en[0] == lc_ctrl_pkg::On),
+        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en[0] == lc_ctrl_pkg::On),
         .cfgs_o(info_page_cfgs[i][j])
       );
     end

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -187,11 +187,11 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
   logic lfsr_seed_en;
 
   // life cycle connections
-  lc_ctrl_pkg::lc_tx_t lc_creator_seed_sw_rw_en;
-  lc_ctrl_pkg::lc_tx_t lc_owner_seed_sw_rw_en;
-  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_rd_en;
-  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_wr_en;
-  lc_ctrl_pkg::lc_tx_t lc_seed_hw_rd_en;
+  lc_ctrl_pkg::lc_tx_t [0:0] lc_creator_seed_sw_rw_en;
+  lc_ctrl_pkg::lc_tx_t [0:0] lc_owner_seed_sw_rw_en;
+  lc_ctrl_pkg::lc_tx_t [0:0] lc_iso_part_sw_rd_en;
+  lc_ctrl_pkg::lc_tx_t [0:0] lc_iso_part_sw_wr_en;
+  lc_ctrl_pkg::lc_tx_t [0:0] lc_seed_hw_rd_en;
 
   // synchronize enables into local domain
   prim_lc_sync #(
@@ -343,10 +343,10 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
   assign sw_sel        = if_sel == SwSel;
 
   // software privilege to creator seed
-  assign creator_seed_priv = lc_creator_seed_sw_rw_en == lc_ctrl_pkg::On;
+  assign creator_seed_priv = lc_creator_seed_sw_rw_en[0] == lc_ctrl_pkg::On;
 
   // software privilege to owner seed
-  assign owner_seed_priv = lc_owner_seed_sw_rw_en == lc_ctrl_pkg::On;
+  assign owner_seed_priv = lc_owner_seed_sw_rw_en[0] == lc_ctrl_pkg::On;
 
   // hardware interface
   flash_ctrl_lcmgr #(
@@ -360,7 +360,7 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
 
     .init_i(pwrmgr_i.flash_init),
     .init_done_o(pwrmgr_o.flash_done),
-    .provision_en_i(lc_seed_hw_rd_en == lc_ctrl_pkg::On),
+    .provision_en_i(lc_seed_hw_rd_en[0] == lc_ctrl_pkg::On),
 
     // interface to ctrl arb control ports
     .ctrl_o(hw_ctrl),
@@ -643,8 +643,8 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
         .cfgs_i(reg2hw_info_page_cfgs[i][j]),
         .creator_seed_priv_i(creator_seed_priv),
         .owner_seed_priv_i(owner_seed_priv),
-        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en == lc_ctrl_pkg::On),
-        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en == lc_ctrl_pkg::On),
+        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en[0] == lc_ctrl_pkg::On),
+        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en[0] == lc_ctrl_pkg::On),
         .cfgs_o(info_page_cfgs[i][j])
       );
     end

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
@@ -194,7 +194,7 @@ module flash_ctrl_lcmgr import flash_ctrl_pkg::*; #(
 
   // synchronize inputs
   logic init_q;
-  lc_ctrl_pkg::lc_tx_t rma_req;
+  lc_ctrl_pkg::lc_tx_t [0:0] rma_req;
 
   prim_flop_2sync #(
     .Width(1),
@@ -377,7 +377,7 @@ module flash_ctrl_lcmgr import flash_ctrl_pkg::*; #(
       // Waiting for an rma entry command
       StWait: begin
         rd_buf_en_o = 1'b1;
-        if (rma_req == lc_ctrl_pkg::On) begin
+        if (rma_req[0] == lc_ctrl_pkg::On) begin
           state_d = StEntropyReseed;
         end
       end

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -446,7 +446,7 @@ module lc_ctrl
   assign pwr_lc_o.lc_idle = lc_idle_q;
 
   // Life cycle ACK signals.
-  lc_tx_t lc_clk_byp_ack;
+  lc_tx_t [0:0] lc_clk_byp_ack;
   prim_lc_sync u_prim_lc_sync_clk_byp_ack (
     .clk_i,
     .rst_ni,
@@ -454,7 +454,7 @@ module lc_ctrl
     .lc_en_o(lc_clk_byp_ack)
   );
 
-  lc_tx_t lc_flash_rma_ack;
+  lc_tx_t [0:0] lc_flash_rma_ack;
   prim_lc_sync u_prim_lc_sync_flash_rma_ack (
     .clk_i,
     .rst_ni,
@@ -521,9 +521,9 @@ module lc_ctrl
     .lc_escalate_en_o,
     .lc_check_byp_en_o,
     .lc_clk_byp_req_o,
-    .lc_clk_byp_ack_i      ( lc_clk_byp_ack                  ),
+    .lc_clk_byp_ack_i      ( lc_clk_byp_ack[0]               ),
     .lc_flash_rma_req_o,
-    .lc_flash_rma_ack_i    ( lc_flash_rma_ack                ),
+    .lc_flash_rma_ack_i    ( lc_flash_rma_ack[0]             ),
     .lc_keymgr_div_o
   );
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -113,7 +113,7 @@ module otp_ctrl
   // Life Cycle Signal Synchronization //
   ///////////////////////////////////////
 
-  lc_ctrl_pkg::lc_tx_t lc_creator_seed_sw_rw_en, lc_seed_hw_rd_en, lc_check_byp_en;
+  lc_ctrl_pkg::lc_tx_t [0:0] lc_creator_seed_sw_rw_en, lc_seed_hw_rd_en, lc_check_byp_en;
   lc_ctrl_pkg::lc_tx_t [1:0] lc_dft_en;
   // NumAgents + lfsr timer and scrambling datapath.
   lc_ctrl_pkg::lc_tx_t [NumAgentsIdx+1:0] lc_escalate_en;
@@ -1023,7 +1023,7 @@ end else if (PartInfo[k].variant == LifeCycle) begin : gen_lifecycle
         // This is only supported by the life cycle partition. We need to prevent this partition
         // from escalating once the life cycle state in memory is being updated (and hence not
         // consistent with the values in the buffer regs anymore).
-        .check_byp_en_i ( lc_check_byp_en              ),
+        .check_byp_en_i    ( lc_check_byp_en[0]              ),
         .error_o           ( part_error[k]                   ),
         .access_i          ( part_access_csrs[k]             ),
         .access_o          ( part_access_dai[k]              ),

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -193,11 +193,11 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
   logic lfsr_seed_en;
 
   // life cycle connections
-  lc_ctrl_pkg::lc_tx_t lc_creator_seed_sw_rw_en;
-  lc_ctrl_pkg::lc_tx_t lc_owner_seed_sw_rw_en;
-  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_rd_en;
-  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_wr_en;
-  lc_ctrl_pkg::lc_tx_t lc_seed_hw_rd_en;
+  lc_ctrl_pkg::lc_tx_t [0:0] lc_creator_seed_sw_rw_en;
+  lc_ctrl_pkg::lc_tx_t [0:0] lc_owner_seed_sw_rw_en;
+  lc_ctrl_pkg::lc_tx_t [0:0] lc_iso_part_sw_rd_en;
+  lc_ctrl_pkg::lc_tx_t [0:0] lc_iso_part_sw_wr_en;
+  lc_ctrl_pkg::lc_tx_t [0:0] lc_seed_hw_rd_en;
 
   // synchronize enables into local domain
   prim_lc_sync #(
@@ -349,10 +349,10 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
   assign sw_sel        = if_sel == SwSel;
 
   // software privilege to creator seed
-  assign creator_seed_priv = lc_creator_seed_sw_rw_en == lc_ctrl_pkg::On;
+  assign creator_seed_priv = lc_creator_seed_sw_rw_en[0] == lc_ctrl_pkg::On;
 
   // software privilege to owner seed
-  assign owner_seed_priv = lc_owner_seed_sw_rw_en == lc_ctrl_pkg::On;
+  assign owner_seed_priv = lc_owner_seed_sw_rw_en[0] == lc_ctrl_pkg::On;
 
   // hardware interface
   flash_ctrl_lcmgr #(
@@ -366,7 +366,7 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
 
     .init_i(pwrmgr_i.flash_init),
     .init_done_o(pwrmgr_o.flash_done),
-    .provision_en_i(lc_seed_hw_rd_en == lc_ctrl_pkg::On),
+    .provision_en_i(lc_seed_hw_rd_en[0] == lc_ctrl_pkg::On),
 
     // interface to ctrl arb control ports
     .ctrl_o(hw_ctrl),
@@ -649,8 +649,8 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
         .cfgs_i(reg2hw_info_page_cfgs[i][j]),
         .creator_seed_priv_i(creator_seed_priv),
         .owner_seed_priv_i(owner_seed_priv),
-        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en == lc_ctrl_pkg::On),
-        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en == lc_ctrl_pkg::On),
+        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en[0] == lc_ctrl_pkg::On),
+        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en[0] == lc_ctrl_pkg::On),
         .cfgs_o(info_page_cfgs[i][j])
       );
     end


### PR DESCRIPTION
This PR fixes syntax error reported in issue #5035 according to
michael's suggestion.

Signed-off-by: Cindy Chen <chencindy@google.com>