### PR TITLE
[keymgr/dv] Add kmac respond error seq

### DIFF
--- a/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_agent_cfg.sv
+++ b/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_agent_cfg.sv
@@ -17,6 +17,9 @@ class keymgr_kmac_agent_cfg extends dv_base_agent_cfg;
   // Enable starting the device auto-response sequence by default if configured in Device mode.
   bit start_default_device_seq = 1;
 
+  // Knob to enable percentage of error response in auto-response sequence
+  int unsigned error_rsp_pct = 0;
+
   // Bias randomization in favor of enabling zero delays less often.
   constraint zero_delays_c {
     zero_delays dist { 0 := 8,

--- a/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_item.sv
+++ b/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_item.sv
@@ -4,16 +4,21 @@
 
 class keymgr_kmac_item extends uvm_sequence_item;
 
+  // below 3 cases will trigger KMAC invalid output error
+  `define CALC_KMAC_DATA_INVALID \
+      (rsp_digest_share0 inside {0, '1} || rsp_digest_share1 inside {0, '1})
+
   // random variables
   rand byte               byte_data_q[$];
   rand bit [KeyWidth-1:0] rsp_digest_share0;
   rand bit [KeyWidth-1:0] rsp_digest_share1;
   rand bit                rsp_error;
 
+  rand bit                is_kmac_rsp_err;
   rand int unsigned       rsp_delay;
 
-  constraint rsp_error_c {
-    soft rsp_error == 0;
+  constraint is_kmac_rsp_err_c {
+    (`CALC_KMAC_DATA_INVALID || rsp_error) == is_kmac_rsp_err;
   }
 
   `uvm_object_utils_begin(keymgr_kmac_item)
@@ -21,9 +26,15 @@ class keymgr_kmac_item extends uvm_sequence_item;
     `uvm_field_int(rsp_digest_share0, UVM_DEFAULT)
     `uvm_field_int(rsp_digest_share1, UVM_DEFAULT)
     `uvm_field_int(rsp_error,         UVM_DEFAULT)
+    `uvm_field_int(is_kmac_rsp_err,   UVM_DEFAULT)
     `uvm_field_int(rsp_delay,         UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new
 
+  virtual function bit get_is_kmac_rsp_data_invalid();
+    return `CALC_KMAC_DATA_INVALID;
+  endfunction
+
+  `undef CALC_KMAC_DATA_INVALID
 endclass

--- a/hw/dv/sv/keymgr_kmac_agent/seq_lib/keymgr_kmac_device_seq.sv
+++ b/hw/dv/sv/keymgr_kmac_agent/seq_lib/keymgr_kmac_device_seq.sv
@@ -17,6 +17,7 @@ class keymgr_kmac_device_seq extends keymgr_kmac_base_seq;
       `uvm_info(`gfn, $sformatf("Sent response: %0s", rsp.sprint()), UVM_HIGH)
     end
   endtask
+
   virtual function void randomize_item(REQ item);
     `DV_CHECK_RANDOMIZE_WITH_FATAL(item,
       if (cfg.zero_delays) {
@@ -24,6 +25,8 @@ class keymgr_kmac_device_seq extends keymgr_kmac_base_seq;
       } else {
         rsp_delay inside {[cfg.rsp_delay_min : cfg.rsp_delay_max]};
       }
+      is_kmac_rsp_err dist {1 :/ cfg.error_rsp_pct,
+                            0 :/ 100 - cfg.error_rsp_pct};
     )
   endfunction
 endclass

--- a/hw/ip/keymgr/dv/env/keymgr_env.core
+++ b/hw/ip/keymgr/dv/env/keymgr_env.core
@@ -29,6 +29,7 @@ filesets:
       - seq_lib/keymgr_lc_disable_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_sw_invalid_input_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_hwsw_invalid_input_vseq.sv: {is_include_file: true}
+      - seq_lib/keymgr_kmac_rsp_err_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -161,14 +161,11 @@ class keymgr_base_vseq extends cip_base_vseq #(
     // in seq
     if (get_check_en()) begin
       `DV_CHECK_EQ(`gmv(ral.op_status.status), exp_status)
-    end else begin
-      return;
+      // check and clear interrupt
+      check_interrupts(.interrupts(1 << IntrOpDone), .check_set(1));
     end
 
     read_current_state();
-
-    // check and clear interrupt
-    check_interrupts(.interrupts(1 << IntrOpDone), .check_set(1));
 
     // check for chech in scb and clear err_code
     csr_rd(.ptr(ral.err_code), .value(rd_val));

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_hwsw_invalid_input_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_hwsw_invalid_input_vseq.sv
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test Invalid_kmac_input error by setting key_version > current_max_key_ver
+// Test below HW invalid input, also combine with SW invalid input
+// 1. During Initialized state, creator seed, device ID and health state data is checked for all 0’s
+// and all 1’s.
+// 2. During CreatorRootKey state, the owner seed is checked for all 0’s and all 1’s.
 class keymgr_hwsw_invalid_input_vseq extends keymgr_sw_invalid_input_vseq;
   `uvm_object_utils(keymgr_hwsw_invalid_input_vseq)
   `uvm_object_new

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_kmac_rsp_err_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_kmac_rsp_err_vseq.sv
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test these 2 types error cases, also combine with hw/sw invalid input
+// 1. invalid kmac operation - The KMAC module itself reported an error.
+// 2. invalid output - The data return from KMAC is all 0’s or all 1’s.
+class keymgr_kmac_rsp_err_vseq extends keymgr_hwsw_invalid_input_vseq;
+  `uvm_object_utils(keymgr_kmac_rsp_err_vseq)
+  `uvm_object_new
+
+  // enable key_version error with 1/5 chance
+  constraint is_key_version_err_c {
+    is_key_version_err dist {0 :/ 9, 1 :/ 1};
+  }
+
+  // enable HW invalid input
+  constraint num_invalid_hw_input_c {
+    num_invalid_hw_input dist {0     :/ 18,
+                               1     :/ 1,
+                               [2:6] :/ 1};
+  }
+
+  task pre_start();
+    cfg.m_keymgr_kmac_agent_cfg.error_rsp_pct = 20;
+    super.pre_start();
+  endtask
+
+endclass : keymgr_kmac_rsp_err_vseq

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_vseq_list.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_vseq_list.sv
@@ -12,4 +12,5 @@
 `include "keymgr_lc_disable_vseq.sv"
 `include "keymgr_sw_invalid_input_vseq.sv"
 `include "keymgr_hwsw_invalid_input_vseq.sv"
+`include "keymgr_kmac_rsp_err_vseq.sv"
 `include "keymgr_stress_all_vseq.sv"

--- a/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
+++ b/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
@@ -91,6 +91,11 @@
     }
 
     {
+      name: keymgr_kmac_rsp_err
+      uvm_test_seq: keymgr_kmac_rsp_err_vseq
+    }
+
+    {
       name: keymgr_stress_all
       uvm_test_seq: keymgr_stress_all_vseq
     }


### PR DESCRIPTION
1. support kmac to respond error or invalid data in eymgr_kmac_agent
2. add keymgr_kmac_rsp_err_vseq and update scb to check it

Signed-off-by: Weicai Yang <weicai@google.com>