### PR TITLE
[lint/regtool/topgen/ralgen] Introduce --nowarn verbosity level

### DIFF
--- a/hw/dv/tools/ralgen/ralgen.py
+++ b/hw/dv/tools/ralgen/ralgen.py
@@ -60,11 +60,11 @@ def main():
     if ip_hjson:
         ral_spec = get_full_path(root_dir, ip_hjson)
         cmd = os.path.join(util_path, "regtool.py")
-        args = [cmd, "-s", "-t", ".", ral_spec]
+        args = [cmd, "--nowarn", "-s", "-t", ".", ral_spec]
     else:
         ral_spec = get_full_path(root_dir, top_hjson)
         cmd = os.path.join(util_path, "topgen.py")
-        args = [cmd, "-r", "-o", ".", "-t", ral_spec]
+        args = [cmd, "--nowarn", "-r", "-o", ".", "-t", ral_spec]
 
     depends = ["lowrisc:dv:dv_base_reg"]
     if dv_base_prefix and dv_base_prefix != "dv_base":

--- a/hw/formal/tools/csr_assert_gen/csr_assert_gen.py
+++ b/hw/formal/tools/csr_assert_gen/csr_assert_gen.py
@@ -54,7 +54,7 @@ def main():
         sys.exit(1)
 
     cmd = os.path.join(util_path, "regtool.py")
-    args = [cmd, "-f", "-t", ".", spec]
+    args = [cmd, "--nowarn", "-f", "-t", ".", spec]
 
     try:
         subprocess.run(args, check=True)

--- a/util/regtool.py
+++ b/util/regtool.py
@@ -84,6 +84,10 @@ def main():
                         '-v',
                         action='store_true',
                         help='Verbose and run validate twice')
+    parser.add_argument('--nowarn',
+                        '-n',
+                        action='store_true',
+                        help='Suppress all warnings')
     parser.add_argument('--param',
                         '-p',
                         type=str,
@@ -108,8 +112,12 @@ def main():
         version.show_and_exit(__file__, ["Hjson", "Mako"])
 
     verbose = args.verbose
-    if (verbose):
+    if verbose:
         log.basicConfig(format="%(levelname)s: %(message)s", level=log.DEBUG)
+        if args.nowarn:
+            log.warning('Both --verbose and --nowarn are specified. --verbose takes precedence.')
+    elif args.nowarn:
+        log.basicConfig(format="%(levelname)s: %(message)s",  level=log.ERROR)
     else:
         log.basicConfig(format="%(levelname)s: %(message)s")
 

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -1008,7 +1008,10 @@ def main():
              Module is created under rtl/. (default: dir(topcfg)/..)
              ''')  # yapf: disable
     parser.add_argument('--verbose', '-v', action='store_true', help="Verbose")
-
+    parser.add_argument('--nowarn',
+                        '-n',
+                        action='store_true',
+                        help='Suppress all warnings')
     # Generator options: 'no' series. cannot combined with 'only' series
     parser.add_argument(
         '--no-top',
@@ -1080,6 +1083,10 @@ def main():
 
     if args.verbose:
         log.basicConfig(format="%(levelname)s: %(message)s", level=log.DEBUG)
+        if args.nowarn:
+            log.warning('Both --verbose and --nowarn are specified. --verbose takes precedence.')
+    elif args.nowarn:
+        log.basicConfig(format="%(levelname)s: %(message)s",  level=log.ERROR)
     else:
         log.basicConfig(format="%(levelname)s: %(message)s")
 


### PR DESCRIPTION
The regtool and topgen tools output several warnings that can
potentially clutter up the logs when called through other scripts like
ralgen and csr_assert_gen.

In particular, this causes issues when these scripts are called as part
of the fusesoc lint flows, since these warnings make it into the fusesoc
build log. It is not possible for the lint log parser script to tell
where these warnings came from, and causes the lint runs to block on
these warnings during CI.

The workaround in this commit introduces a '--nowarn' verbosity level
in both topgen and the regtool. This switch is set when called from
within other scripts such as csr_assert_gen or ralgen.

Signed-off-by: Michael Schaffner <msf@opentitan.org>