### PR TITLE
[ci] Don't fail CI on broken FPGA tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -601,6 +601,9 @@ jobs:
         --log-cli-level=DEBUG \
         --test-run-title="Run system tests on Nexys Video FPGA board" \
         --napoleon-docstrings
+    # Temporary workaround, see
+    # https://github.com/lowRISC/opentitan/issues/5029 for details.
+    continueOnError: true
     displayName: Execute tests
 
 - job: deploy_release_artifacts

--- a/test/systemtest/earlgrey/test_fpga_nexysvideo.py
+++ b/test/systemtest/earlgrey/test_fpga_nexysvideo.py
@@ -124,7 +124,10 @@ def test_apps_selfchecking(tmp_path, localconf_nexysvideo, nexysvideo_earlgrey,
     """ Load a simple application, and check its output. """
 
     spiflash = bin_dir / 'sw/host/spiflash/spiflash'
-    utils.load_sw_over_spi(tmp_path, spiflash, app_selfchecking_bin)
+    utils.load_sw_over_spi(tmp_path,
+                           spiflash,
+                           app_selfchecking_bin,
+                           timeout=30)
 
     # We need to wait for this message to ensure we are asserting on the output
     # of the newly flashed software, not the software which might be already on

--- a/test/systemtest/utils.py
+++ b/test/systemtest/utils.py
@@ -364,7 +364,11 @@ def dump_temp_files(tmp_path):
             "^^^^^^^^^^^^^^^^^^^^ {} ^^^^^^^^^^^^^^^^^^^^\n".format(f))
 
 
-def load_sw_over_spi(tmp_path, spiflash_path, sw_test_bin, spiflash_args=[]):
+def load_sw_over_spi(tmp_path,
+                     spiflash_path,
+                     sw_test_bin,
+                     spiflash_args=[],
+                     timeout=600):
     """ Use the spiflash utility to load software onto a device. """
 
     log.info("Flashing device software from {} over SPI".format(
@@ -373,7 +377,7 @@ def load_sw_over_spi(tmp_path, spiflash_path, sw_test_bin, spiflash_args=[]):
     cmd_flash = [spiflash_path, '--input', sw_test_bin] + spiflash_args
     p_flash = Process(cmd_flash, logdir=tmp_path, cwd=tmp_path)
     p_flash.run()
-    p_flash.proc.wait(timeout=600)
+    p_flash.proc.wait(timeout=timeout)
     assert p_flash.proc.returncode == 0
 
     log.info("Device software flashed.")


### PR DESCRIPTION
Due to a yet undiagnosed issue, FPGA tests fail currently. This commit
allows them to fail without failing the whole CI. This is clearly a
temporary measure until we have diagnosed the underlying problem.

This commit also reduces the FPGA test timeout to 10 minutes. A normal
test should take between 2 and 3 minutes, a failing one takes ~30
minutes with nothing interesting happening during that time. To be able
to keep the test running (even though it may fail), but keep the test
capacity at 6 runs/hour we timeout earlier than before.

See also https://github.com/lowRISC/opentitan/issues/5029