### PR TITLE
[sw, dif_clkmgr] Mark clock manager DIF as S1

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.prj.hjson
+++ b/hw/ip/clkmgr/data/clkmgr.prj.hjson
@@ -14,7 +14,7 @@
         life_stage:         "L1",
         design_stage:       "D1",
         verification_stage: "V0", // this module is not verified at the block level
-        dif_stage:          "S0",
+        dif_stage:          "S1",
       }
     ]
 }

--- a/sw/device/lib/dif/dif_clkmgr.md
+++ b/sw/device/lib/dif/dif_clkmgr.md
@@ -10,7 +10,7 @@ All checklist items refer to the content in the [Checklist]({{< relref "/doc/pro
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
 Implementation | [DIF_EXISTS][]       | Done        |
-Implementation | [DIF_USED_IN_TREE][] | Not Started |
+Implementation | [DIF_USED_IN_TREE][] | Done        |
 Tests          | [DIF_TEST_UNIT][]    | Done        |
 Tests          | [DIF_TEST_SMOKE][]   | Done        |
 


### PR DESCRIPTION
No (non-DIF) uses of the clock manager have been found in the tree.
The requirements for S1 are now fulfilled.