### PR TITLE
[dv/otp_ctrl] DAI and TLUL interface parition_walk sequence

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -50,13 +50,13 @@
       tests: ["otp_ctrl_smoke"]
     }
     {
-      name: all_partitions
+      name: dai_access_partition_walk
       desc: '''
-            Based on the smoke test, this test ensures every address in each partition can be accessed
-            successfully within its access policy.
+            Similar to UVM's memory walk test, this test ensures every address in each partition
+            can be accessed successfully via DAI and TLUL interfacs according to its access policy.
             '''
       milestone: V2
-      tests: []
+      tests: ["otp_ctrl_partition_walk"]
     }
     {
       name: partition_check_failure

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -24,6 +24,7 @@ filesets:
       - seq_lib/otp_ctrl_common_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_wake_up_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_smoke_vseq.sv: {is_include_file: true}
+      - seq_lib/otp_ctrl_partition_walk_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_lc_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_dai_lock_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_dai_errs_vseq.sv: {is_include_file: true}

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -158,6 +158,12 @@ package otp_ctrl_env_pkg;
     end
   endfunction
 
+  function automatic bit is_sw_part(bit [TL_DW-1:0] addr);
+    int part_idx = get_part_index(addr);
+    if (part_idx inside {CreatorSwCfgDigestOffset, OwnerSwCfgDigestOffset}) return 1;
+    else return 0;
+  endfunction
+
   // Resolve an offset within the software window as an offset within the whole otp_ctrl block.
   function automatic bit [TL_AW-1:0] get_sw_window_offset(bit [TL_AW-1:0] dai_addr);
     return dai_addr + SW_WINDOW_BASE_ADDR;

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -377,9 +377,13 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
                   void'(ral.status.predict(OtpDaiIdle));
                   // write digest
                   if (is_sw_digest(dai_addr)) begin
-                    if (otp_a[otp_addr] == 0 && otp_a[otp_addr+1] == 0) begin
-                      digests[part_idx] = {`gmv(ral.direct_access_wdata_1),
-                                           `gmv(ral.direct_access_wdata_0)};
+                    bit [TL_DW*2-1:0] curr_digest, prev_digest;
+                    curr_digest = {`gmv(ral.direct_access_wdata_1),
+                                   `gmv(ral.direct_access_wdata_0)};
+                    prev_digest = {otp_a[otp_addr+1], otp_a[otp_addr]};
+                    // allow bit write
+                    if ((prev_digest & curr_digest) == prev_digest) begin
+                      digests[part_idx] = curr_digest;
                       // sw digest directly write to OTP, so reading out digest val do not need to
                       // wait a reset
                       update_sw_digests_to_otp(part_idx);

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -90,9 +90,20 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     csr_spinwait(ral.intr_state.otp_operation_done, 1);
 
     csr_rd(ral.direct_access_rdata_0, rdata0);
-    if (is_secret(addr)) csr_rd(ral.direct_access_rdata_1, rdata1);
+    if (is_secret(addr) || is_digest(addr)) csr_rd(ral.direct_access_rdata_1, rdata1);
     csr_wr(ral.intr_state, 1'b1 << OtpOperationDone);
   endtask : dai_rd
+
+  virtual task dai_rd_check(bit [TL_DW-1:0] addr,
+                            bit [TL_DW-1:0] exp_data0,
+                            bit [TL_DW-1:0] exp_data1 = 0);
+    bit [TL_DW-1:0] rdata0, rdata1;
+    dai_rd(addr, rdata0, rdata1);
+    `DV_CHECK_EQ(rdata0, exp_data0, $sformatf("dai addr %0h rdata0 readout mismatch", addr))
+    if (is_secret(addr) || is_digest(addr)) begin
+      `DV_CHECK_EQ(rdata1, exp_data1, $sformatf("dai addr %0h rdata1 readout mismatch", addr))
+    end
+  endtask: dai_rd_check
 
   // this task exercises an OTP digest calculation via the DAI interface
   virtual task cal_digest(int part_idx);

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_partition_walk_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_partition_walk_vseq.sv
@@ -1,0 +1,40 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence walk through all partitions via DAI access and TLUL interface
+class otp_ctrl_partition_walk_vseq extends otp_ctrl_base_vseq;
+  `uvm_object_utils(otp_ctrl_partition_walk_vseq)
+
+  `uvm_object_new
+
+  virtual task body();
+    for (int addr = CreatorSwCfgOffset / 4; addr < LifeCycleOffset / 4; addr++) begin
+      int dai_addr = addr * 4;
+      `uvm_info(`gfn, $sformatf("writing dai addr %0h", dai_addr), UVM_HIGH)
+
+      // granularity of 64 bits
+      if (is_secret(dai_addr) || is_digest(dai_addr)) begin
+        if (dai_addr % 2 || !is_sw_digest(dai_addr)) continue;
+        dai_wr(dai_addr, dai_addr, dai_addr + 1);
+        dai_rd_check(dai_addr, dai_addr, dai_addr + 1);
+
+      // granularity of 32 bits
+      end else begin
+        dai_wr(dai_addr, dai_addr);
+        dai_rd_check(dai_addr, dai_addr);
+
+        // check reading from tlul interface if it is sw partition
+        if (is_sw_part(dai_addr)) begin
+          bit [TL_DW-1:0] tlul_val;
+          uvm_reg_addr_t tlul_addr = cfg.ral.get_addr_from_offset(get_sw_window_offset(dai_addr));
+          tl_access(.addr(tlul_addr), .write(0), .data(tlul_val), .blocking(1));
+          `DV_CHECK_EQ(tlul_val, dai_addr,
+                       $sformatf("sw parts read out mismatch at tlul_addr %0h, dai_addr %0h",
+                                  tlul_addr, dai_addr))
+        end
+      end
+    end
+  endtask
+
+endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -94,7 +94,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
         end
 
         // if write sw partitions, check tlul window
-        if (part_idx inside {CreatorSwCfgIdx, OwnerSwCfgIdx} && ($urandom_range(0, 1))) begin
+        if (is_sw_part(dai_addr) && ($urandom_range(0, 1))) begin
           uvm_reg_addr_t tlul_addr = cfg.ral.get_addr_from_offset(get_sw_window_offset(dai_addr));
 
           // random issue reset, OTP content should not be cleared

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
@@ -6,6 +6,7 @@
 `include "otp_ctrl_wake_up_vseq.sv"
 `include "otp_ctrl_smoke_vseq.sv"
 `include "otp_ctrl_common_vseq.sv"
+`include "otp_ctrl_partition_walk_vseq.sv"
 `include "otp_ctrl_lc_vseq.sv"
 `include "otp_ctrl_rand_key_rsp_vseq.sv"
 `include "otp_ctrl_dai_lock_vseq.sv"

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -24,7 +24,6 @@
   ral_spec: "{proj_root}/hw/ip/otp_ctrl/data/otp_ctrl.hjson"
 
   // Import additional common sim cfg files.
-  // TODO: remove imported cfgs that do not apply.
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
@@ -58,6 +57,12 @@
     {
       name: otp_ctrl_smoke
       uvm_test_seq: otp_ctrl_smoke_vseq
+    }
+
+    {
+      name: otp_ctrl_partition_walk
+      uvm_test_seq: otp_ctrl_partition_walk_vseq
+      reseed: 1
     }
 
     {


### PR DESCRIPTION
This PR implements a partition memory walk tests similar to UVM
memory_walk sequence. But in this mem_walk test, we will use DAI
interface and TLUL interfaces to access OTP memories.

Signed-off-by: Cindy Chen <chencindy@google.com>