### PR TITLE
[ci] Fix syntax error

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -334,7 +334,7 @@ jobs:
     - lint
     # The bootrom is built into the FPGA image at synthesis time.
     - sw_build_nexysvideo
-  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0')
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
   pool: ci-public
   timeoutInMinutes: 120 # 2 hours
   steps:
@@ -386,7 +386,7 @@ jobs:
     # By generating the CW305 bootrom binary we would break execute_fpga_tests executed on the
     # NexysVideo.
     - sw_build
-  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0')
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
   pool: ci-public
   timeoutInMinutes: 120 # 2 hours
   steps:

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
@@ -236,7 +236,7 @@ package otp_ctrl_part_pkg;
     }),
     1920'({
       64'hABFF25A58087D34A,
-      1600'h0, // unallocated space 
+      1600'h0, // unallocated space
       256'h37E5AE39A58FACEE41389646B3968A3B128F4AF0AFFC1AAC77ADEFF42376E09D
     }),
     6144'({

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv.tpl
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv.tpl
@@ -166,7 +166,7 @@ package otp_ctrl_part_pkg;
     ${int(part["size"])*8}'({
     % for item in part["items"][::-1]:
       % if offset != item['offset'] + item['size']:
-      ${"{}'h{:0X}".format((offset - item['size'] - item['offset']) * 8, 0)}, // unallocated space <% offset = item['offset'] + item['size'] %>
+      ${"{}'h{:0X}".format((offset - item['size'] - item['offset']) * 8, 0)}, // unallocated space<% offset = item['offset'] + item['size'] %>
       % endif
       ${"{}'h{:0X}".format(item["size"] * 8, item["inv_default"])}${("\n    })," if k < len(otp_mmap.config["partitions"])-1 else "\n    })});") if loop.last else ","}<% offset -= item['size'] %>
     % endfor


### PR DESCRIPTION
a10943bd9dd3bf00158b5e1a067937b0794cdc30 introduced a syntax error in
our CI configuration which wasn't caught before merging into master. Fix
that.