### PR TITLE
[i2c, rtl] Fixes to Lint Errors and Warnings

### DIFF
--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -84,6 +84,7 @@ module  i2c_core (
   logic        fmt_fifo_rvalid;
   logic        fmt_fifo_rready;
   logic [12:0] fmt_fifo_rdata;
+  logic        fmt_fifo_full;
   logic [7:0]  fmt_byte;
   logic        fmt_flag_start_before;
   logic        fmt_flag_stop_after;
@@ -103,6 +104,7 @@ module  i2c_core (
   logic        rx_fifo_rvalid;
   logic        rx_fifo_rready;
   logic [7:0]  rx_fifo_rdata;
+  logic        rx_fifo_full;
 
   logic        fmt_watermark_d;
   logic        fmt_watermark_q;
@@ -116,6 +118,7 @@ module  i2c_core (
   logic        tx_fifo_rvalid;
   logic        tx_fifo_rready;
   logic [7:0]  tx_fifo_rdata;
+  logic        tx_fifo_full;
 
   logic        acq_fifo_wvalid;
   logic        acq_fifo_wready;
@@ -124,6 +127,7 @@ module  i2c_core (
   logic        acq_fifo_rvalid;
   logic        acq_fifo_rready;
   logic [9:0]  acq_fifo_rdata;
+  logic        acq_fifo_full;
 
   logic        i2c_fifo_txrst;
   logic        i2c_fifo_acqrst;
@@ -298,7 +302,8 @@ module  i2c_core (
     .depth_o (fmt_fifo_depth),
     .rvalid_o(fmt_fifo_rvalid),
     .rready_i(fmt_fifo_rready),
-    .rdata_o (fmt_fifo_rdata)
+    .rdata_o (fmt_fifo_rdata),
+    .full_o  (fmt_fifo_full)
   );
 
   assign rx_fifo_rready = reg2hw.rdata.re;
@@ -317,7 +322,8 @@ module  i2c_core (
     .depth_o (rx_fifo_depth),
     .rvalid_o(rx_fifo_rvalid),
     .rready_i(rx_fifo_rready),
-    .rdata_o (rx_fifo_rdata)
+    .rdata_o (rx_fifo_rdata),
+    .full_o  (rx_fifo_full)
   );
 
   // Target TX and ACQ FIFOs
@@ -341,7 +347,8 @@ module  i2c_core (
     .depth_o (tx_fifo_depth),
     .rvalid_o(tx_fifo_rvalid),
     .rready_i(tx_fifo_rready),
-    .rdata_o (tx_fifo_rdata)
+    .rdata_o (tx_fifo_rdata),
+    .full_o  (tx_fifo_full)
   );
 
   assign acq_fifo_rready = reg2hw.acqdata.abyte.re & reg2hw.acqdata.signal.re;
@@ -360,7 +367,8 @@ module  i2c_core (
     .depth_o (acq_fifo_depth),
     .rvalid_o(acq_fifo_rvalid),
     .rready_i(acq_fifo_rready),
-    .rdata_o (acq_fifo_rdata)
+    .rdata_o (acq_fifo_rdata),
+    .full_o  (acq_fifo_full)
   );
 
   i2c_fsm u_i2c_fsm (

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -166,7 +166,7 @@ module i2c_fsm (
   always_ff @ (posedge clk_i or negedge rst_ni) begin : clk_stretch
     if (!rst_ni) begin
       stretch <= '0;
-    end else if (scl_temp == 1'b1 && scl_i == '0) begin
+    end else if (scl_temp && !scl_i) begin
       stretch <= stretch + 1'b1;
     end else begin
       stretch <= '0;
@@ -245,8 +245,8 @@ module i2c_fsm (
   always_ff @ (posedge clk_i or negedge rst_ni) begin : s_detect
     if (!rst_ni) begin
       start_det <= 1'b0;
-    end else if (scl_i_q == 1'b1 && scl_i == 1'b1) begin
-      if (sda_i_q == 1'b1 && sda_i == '0) start_det <= 1'b1;
+    end else if (scl_i_q && scl_i) begin
+      if (sda_i_q && !sda_i) start_det <= 1'b1;
       else start_det <= 1'b0;
     end else begin
       start_det <= 1'b0;
@@ -257,8 +257,8 @@ module i2c_fsm (
   always_ff @ (posedge clk_i or negedge rst_ni) begin : p_detect
     if (!rst_ni) begin
       stop_det <= 1'b0;
-    end else if (scl_i_q == 1'b1 && scl_i == 1'b1) begin
-      if (sda_i_q == '0 && sda_i == 1'b1) stop_det <= 1'b1;
+    end else if (scl_i_q && scl_i) begin
+      if (!sda_i_q && sda_i) stop_det <= 1'b1;
       else stop_det <= 1'b0;
     end else begin
       stop_det <= 1'b0;
@@ -274,7 +274,7 @@ module i2c_fsm (
       bit_idx <= 4'd0;
     end else if (start_det || bit_ack) begin
       bit_idx <= 4'd0;
-    end else if (scl_i_q == 1'b1 && scl_i == '0) begin
+    end else if (scl_i_q && !scl_i) begin
       bit_idx <= bit_idx + 1'b1;
     end else begin
       bit_idx <= bit_idx;
@@ -304,7 +304,7 @@ module i2c_fsm (
       input_byte <= 8'h00;
     end else if (input_byte_clr) begin
       input_byte <= 8'h00;
-    end else if (scl_i_q == '0 && scl_i == 1'b1) begin
+    end else if (!scl_i_q && scl_i) begin
       if (!bit_ack) input_byte[7:0] <= {input_byte[6:0], sda_i};  // MSB goes in first
     end
   end
@@ -313,7 +313,7 @@ module i2c_fsm (
   always_ff @ (posedge clk_i or negedge rst_ni) begin : host_ack_register
     if (!rst_ni) begin
       host_ack <= 1'b0;
-    end else if (scl_i_q == '0 && scl_i == 1'b1) begin
+    end else if (!scl_i_q && scl_i) begin
       if (bit_ack) host_ack <= ~sda_i;
     end
   end
@@ -362,18 +362,15 @@ module i2c_fsm (
         host_idle_o = 1'b1;
         sda_temp = 1'b1;
         scl_temp = 1'b1;
-        if (host_enable_i && sda_i == '0) event_sda_interference_o = 1'b1;
-        if (!target_address0_i && !target_mask0_i && !target_address1_i && !target_mask1_i) begin
-          acq_fifo_wvalid_o = 1'b0;
-        end
+        if (host_enable_i && !sda_i) event_sda_interference_o = 1'b1;
       end
       // SetupStart: SDA and SCL are released
       SetupStart : begin
         host_idle_o = 1'b0;
         sda_temp = 1'b1;
         scl_temp = 1'b1;
-        if (sda_i == '0) event_sda_interference_o = 1'b1;
-        if (restart == 1'b1) event_trans_complete_o = 1'b1;
+        if (!sda_i) event_sda_interference_o = 1'b1;
+        if (restart) event_trans_complete_o = 1'b1;
       end
       // HoldStart: SDA is pulled low, SCL is released
       HoldStart : begin
@@ -398,7 +395,7 @@ module i2c_fsm (
         host_idle_o = 1'b0;
         sda_temp = fmt_byte_i[bit_index];
         scl_temp = 1'b0;
-        if (sda_temp == 1'b1 && sda_i == '0) event_sda_interference_o = 1'b1;
+        if (sda_temp && !sda_i) event_sda_interference_o = 1'b1;
       end
       // ClockPulse: SCL is released, SDA keeps the indexed bit value
       ClockPulse : begin
@@ -408,16 +405,16 @@ module i2c_fsm (
         if ((stretch > stretch_timeout_i) && timeout_enable_i) begin
           event_stretch_timeout_o = 1'b1;
         end
-        if (scl_i_q == 1'b1 && scl_i == '0)  event_scl_interference_o = 1'b1;
-        if (sda_temp == 1'b1 && sda_i == '0) event_sda_interference_o = 1'b1;
-        if (sda_i_q != sda_i)            event_sda_unstable_o = 1'b1;
+        if (scl_i_q && !scl_i)  event_scl_interference_o = 1'b1;
+        if (sda_temp && !sda_i) event_sda_interference_o = 1'b1;
+        if (sda_i_q != sda_i)   event_sda_unstable_o = 1'b1;
       end
       // HoldBit: SCL is pulled low
       HoldBit : begin
         host_idle_o = 1'b0;
         sda_temp = fmt_byte_i[bit_index];
         scl_temp = 1'b0;
-        if (sda_temp == 1'b1 && sda_i == '0) event_sda_interference_o = 1'b1;
+        if (sda_temp && !sda_i) event_sda_interference_o = 1'b1;
       end
       // ClockLowAck: SCL and SDA are pulled low
       ClockLowAck : begin
@@ -436,12 +433,12 @@ module i2c_fsm (
         host_idle_o = 1'b0;
         sda_temp = 1'b1;
         scl_temp = 1'b1;
-        if (sda_i == '0 && !fmt_flag_nak_ok_i) event_nak_o = 1'b1;
+        if (!sda_i && !fmt_flag_nak_ok_i) event_nak_o = 1'b1;
         if ((stretch > stretch_timeout_i) && timeout_enable_i) begin
           event_stretch_timeout_o = 1'b1;
         end
-        if (scl_i_q == 1'b1 && scl_i == '0)  event_scl_interference_o = 1'b1;
-        if (sda_i_q != sda_i)            event_sda_unstable_o = 1'b1;
+        if (scl_i_q && !scl_i)  event_scl_interference_o = 1'b1;
+        if (sda_i_q != sda_i)   event_sda_unstable_o = 1'b1;
       end
       // HoldDevAck: SCL is pulled low
       HoldDevAck : begin
@@ -467,8 +464,8 @@ module i2c_fsm (
         if ((stretch > stretch_timeout_i) && timeout_enable_i) begin
           event_stretch_timeout_o = 1'b1;
         end
-        if (scl_i_q == 1'b1 && scl_i == '0)  event_scl_interference_o = 1'b1;
-        if (sda_i_q != sda_i)            event_sda_unstable_o = 1'b1;
+        if (scl_i_q && !scl_i)  event_scl_interference_o = 1'b1;
+        if (sda_i_q != sda_i)   event_sda_unstable_o = 1'b1;
       end
       // ReadHoldBit: SCL is pulled low
       ReadHoldBit : begin
@@ -492,7 +489,7 @@ module i2c_fsm (
         else if (byte_index == 9'd1) sda_temp = 1'b1;
         else sda_temp = 1'b0;
         scl_temp = 1'b0;
-        if (sda_temp == 1'b1 && sda_i == '0) event_sda_interference_o = 1'b1;
+        if (sda_temp && !sda_i) event_sda_interference_o = 1'b1;
       end
       // HostClockPulseAck: SCL is released
       HostClockPulseAck : begin
@@ -504,9 +501,9 @@ module i2c_fsm (
         if ((stretch > stretch_timeout_i) && timeout_enable_i) begin
           event_stretch_timeout_o = 1'b1;
         end
-        if (scl_i_q == 1'b1 && scl_i == '0)  event_scl_interference_o = 1'b1;
-        if (sda_temp == 1'b1 && sda_i == '0) event_sda_interference_o = 1'b1;
-        if (sda_i_q != sda_i)            event_sda_unstable_o = 1'b1;
+        if (scl_i_q && !scl_i)  event_scl_interference_o = 1'b1;
+        if (sda_temp && !sda_i) event_sda_interference_o = 1'b1;
+        if (sda_i_q != sda_i)   event_sda_unstable_o = 1'b1;
       end
       // HostHoldBitAck: SCL is pulled low
       HostHoldBitAck : begin
@@ -515,7 +512,7 @@ module i2c_fsm (
         else if (byte_index == 9'd1) sda_temp = 1'b1;
         else sda_temp = 1'b0;
         scl_temp = 1'b0;
-        if (sda_temp == 1'b1 && sda_i == '0) event_sda_interference_o = 1'b1;
+        if (sda_temp && !sda_i) event_sda_interference_o = 1'b1;
       end
       // ClockStop: SCL is pulled low, SDA stays low
       ClockStop : begin
@@ -534,7 +531,7 @@ module i2c_fsm (
         host_idle_o = 1'b0;
         sda_temp = 1'b1;
         scl_temp = 1'b1;
-        if (sda_i == '0) event_sda_interference_o = 1'b1;
+        if (!sda_i) event_sda_interference_o = 1'b1;
         event_trans_complete_o = 1'b1;
       end
       // Active: continue while keeping SCL low


### PR DESCRIPTION
1. Added full_o pins to prim_fifo_sync instances (see PR #5020)
2. Fixed warnings and made minor logic simplifications

Signed-off-by: Igor Kouznetsov <igor.kouznetsov@wdc.com>