### PR TITLE
[prim_fifo_sync] Add full_o output to all instantiations

### DIFF
--- a/hw/ip/csrng/rtl/csrng_block_encrypt.sv
+++ b/hw/ip/csrng/rtl/csrng_block_encrypt.sv
@@ -137,7 +137,8 @@ module csrng_block_encrypt #(
     .rvalid_o (sfifo_blkenc_not_empty),
     .rready_i (sfifo_blkenc_pop),
     .rdata_o  (sfifo_blkenc_rdata),
-    .depth_o  ()
+    .depth_o  (),
+    .full_o   ()
   );
 
   assign sfifo_blkenc_push = block_encrypt_req_i && sfifo_blkenc_not_full;

--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -124,7 +124,8 @@ module csrng_cmd_stage import csrng_pkg::*; #(
     .rvalid_o       (sfifo_cmd_not_empty),
     .rready_i       (sfifo_cmd_pop),
     .rdata_o        (sfifo_cmd_rdata),
-    .depth_o        (sfifo_cmd_depth)
+    .depth_o        (sfifo_cmd_depth),
+    .full_o         ()
   );
 
   assign sfifo_cmd_wdata = cmd_stage_bus_i;
@@ -318,7 +319,8 @@ module csrng_cmd_stage import csrng_pkg::*; #(
     .rvalid_o       (sfifo_genbits_not_empty),
     .rready_i       (sfifo_genbits_pop),
     .rdata_o        (sfifo_genbits_rdata),
-    .depth_o        () // sfifo_genbits_depth)
+    .depth_o        (),
+    .full_o         ()
   );
 
   assign sfifo_genbits_wdata = {genbits_fips_i,genbits_bus_i};

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_cmd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_cmd.sv
@@ -134,7 +134,8 @@ module csrng_ctr_drbg_cmd import csrng_pkg::*; #(
     .rvalid_o       (sfifo_cmdreq_not_empty),
     .rready_i       (sfifo_cmdreq_pop),
     .rdata_o        (sfifo_cmdreq_rdata),
-    .depth_o        ()
+    .depth_o        (),
+    .full_o         ()
   );
 
   assign fips_modified = (ctr_drbg_cmd_ccmd_i == INS) ? ctr_drbg_cmd_entropy_fips_i :
@@ -221,7 +222,8 @@ module csrng_ctr_drbg_cmd import csrng_pkg::*; #(
     .rvalid_o       (sfifo_rcstage_not_empty),
     .rready_i       (sfifo_rcstage_pop),
     .rdata_o        (sfifo_rcstage_rdata),
-    .depth_o        ()
+    .depth_o        (),
+    .full_o         ()
   );
 
   assign sfifo_rcstage_push = sfifo_cmdreq_pop;
@@ -255,7 +257,8 @@ module csrng_ctr_drbg_cmd import csrng_pkg::*; #(
     .rvalid_o       (sfifo_keyvrc_not_empty),
     .rready_i       (sfifo_keyvrc_pop),
     .rdata_o        (sfifo_keyvrc_rdata),
-    .depth_o        ()
+    .depth_o        (),
+    .full_o         ()
   );
 
   assign sfifo_keyvrc_push = sfifo_rcstage_pop;

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
@@ -231,7 +231,8 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
     .rvalid_o       (sfifo_genreq_not_empty),
     .rready_i       (sfifo_genreq_pop),
     .rdata_o        (sfifo_genreq_rdata),
-    .depth_o        ()
+    .depth_o        (),
+    .full_o         ()
   );
 
   assign genreq_ccmd_modified = (ctr_drbg_gen_ccmd_i == GEN) ? GENB : INV;
@@ -341,7 +342,8 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
     .rvalid_o       (sfifo_adstage_not_empty),
     .rready_i       (sfifo_adstage_pop),
     .rdata_o        (sfifo_adstage_rdata),
-    .depth_o        ()
+    .depth_o        (),
+    .full_o         ()
   );
 
 //  assign sfifo_adstage_push = sfifo_genreq_pop;
@@ -374,7 +376,8 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
     .rvalid_o (sfifo_bencack_not_empty),
     .rready_i (sfifo_bencack_pop),
     .rdata_o  (sfifo_bencack_rdata),
-    .depth_o  ()
+    .depth_o  (),
+    .full_o   ()
   );
 
   assign bencack_ccmd_modified = (block_encrypt_ccmd_i == GENB) ? GENU : INV;
@@ -425,7 +428,8 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
     .rvalid_o       (sfifo_rcstage_not_empty),
     .rready_i       (sfifo_rcstage_pop),
     .rdata_o        (sfifo_rcstage_rdata),
-    .depth_o        ()
+    .depth_o        (),
+    .full_o         ()
   );
 
   assign sfifo_rcstage_push = sfifo_adstage_pop;
@@ -460,7 +464,8 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
     .rvalid_o       (sfifo_genbits_not_empty),
     .rready_i       (sfifo_genbits_pop),
     .rdata_o        (sfifo_genbits_rdata),
-    .depth_o        ()
+    .depth_o        (),
+    .full_o         ()
   );
 
   assign sfifo_genbits_push = sfifo_rcstage_pop;

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
@@ -260,7 +260,8 @@ module csrng_ctr_drbg_upd #(
     .rvalid_o (sfifo_updreq_not_empty),
     .rready_i (sfifo_updreq_pop),
     .rdata_o  (sfifo_updreq_rdata),
-    .depth_o  ()
+    .depth_o  (),
+    .full_o   ()
   );
 
   assign sfifo_updreq_push = sfifo_updreq_not_full && ctr_drbg_upd_req_i;
@@ -355,7 +356,8 @@ module csrng_ctr_drbg_upd #(
     .rvalid_o (sfifo_bencreq_not_empty),
     .rready_i (sfifo_bencreq_pop),
     .rdata_o  (sfifo_bencreq_rdata),
-    .depth_o  ()
+    .depth_o  (),
+    .full_o   ()
   );
 
   assign sfifo_bencreq_pop = block_encrypt_req_o && block_encrypt_rdy_i;
@@ -395,7 +397,8 @@ module csrng_ctr_drbg_upd #(
     .rvalid_o (sfifo_bencack_not_empty),
     .rready_i (sfifo_bencack_pop),
     .rdata_o  (sfifo_bencack_rdata),
-    .depth_o  ()
+    .depth_o  (),
+    .full_o   ()
   );
 
   assign sfifo_bencack_push = sfifo_bencack_not_full && block_encrypt_ack_i;
@@ -427,7 +430,8 @@ module csrng_ctr_drbg_upd #(
     .rvalid_o (sfifo_pdata_not_empty),
     .rready_i (sfifo_pdata_pop),
     .rdata_o  (sfifo_pdata_rdata),
-    .depth_o  ()
+    .depth_o  (),
+    .full_o   ()
   );
 
   assign sfifo_pdata_wdata = sfifo_updreq_pdata;
@@ -519,7 +523,8 @@ module csrng_ctr_drbg_upd #(
     .rvalid_o (sfifo_final_not_empty),
     .rready_i (sfifo_final_pop),
     .rdata_o  (sfifo_final_rdata),
-    .depth_o  ()
+    .depth_o  (),
+    .full_o   ()
   );
 
   assign sfifo_final_wdata = {updated_key_and_v,concat_inst_id_q,concat_ccmd_q};

--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -298,7 +298,8 @@ module edn_core import edn_pkg::*; #(
     .rvalid_o (sfifo_rescmd_not_empty),
     .rready_i (sfifo_rescmd_pop),
     .rdata_o  (sfifo_rescmd_rdata),
-    .depth_o  (sfifo_rescmd_depth)
+    .depth_o  (sfifo_rescmd_depth),
+    .full_o   ()
   );
 
   // feedback cmd back into rescmd fifo
@@ -333,7 +334,8 @@ module edn_core import edn_pkg::*; #(
     .rvalid_o (sfifo_gencmd_not_empty),
     .rready_i (sfifo_gencmd_pop),
     .rdata_o  (sfifo_gencmd_rdata),
-    .depth_o  (sfifo_gencmd_depth)
+    .depth_o  (sfifo_gencmd_depth),
+    .full_o   ()
   );
 
   // feedback cmd back into gencmd fifo

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -473,7 +473,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .rvalid_o   (sfifo_esrng_not_empty),
     .rdata_o    (sfifo_esrng_rdata),
     .rready_i   (sfifo_esrng_pop),
-    .depth_o    ()
+    .depth_o    (),
+    .full_o     ()
   );
 
   // fifo controls
@@ -1262,7 +1263,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .rvalid_o   (sfifo_precon_not_empty),
     .rdata_o    (sfifo_precon_rdata),
     .rready_i   (sfifo_precon_pop),
-    .depth_o    (sfifo_precon_depth)
+    .depth_o    (sfifo_precon_depth),
+    .full_o     ()
   );
 
 
@@ -1426,7 +1428,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .rvalid_o       (sfifo_esfinal_not_empty),
     .rready_i       (sfifo_esfinal_pop),
     .rdata_o        (sfifo_esfinal_rdata),
-    .depth_o        (sfifo_esfinal_depth)
+    .depth_o        (sfifo_esfinal_depth),
+    .full_o         ()
   );
 
   assign fips_compliance = !es_bypass_mode && es_enable_rng && !es_enable_lfsr && !rng_bit_en;

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -453,6 +453,7 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
     .wready_o(prog_fifo_wready),
     .wdata_i (prog_fifo_wdata),
     .depth_o (prog_fifo_depth),
+    .full_o  (),
     .rvalid_o(prog_fifo_rvalid),
     .rready_i(prog_fifo_ren),
     .rdata_o (prog_fifo_rdata)

--- a/hw/ip/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy.sv
@@ -108,6 +108,7 @@ module flash_phy import flash_ctrl_pkg::*; (
     .wready_o(seq_fifo_rdy),
     .wdata_i (host_bank_sel),
     .depth_o (),
+    .full_o (),
     .rvalid_o(seq_fifo_pending),
     .rready_i(host_req_done_o),
     .rdata_o (rsp_bank_sel)
@@ -170,6 +171,7 @@ module flash_phy import flash_ctrl_pkg::*; (
       .wready_o(host_rsp_avail[bank]),
       .wdata_i ({rd_err[bank], rd_data[bank]}),
       .depth_o (),
+      .full_o (),
       .rvalid_o(host_rsp_vld[bank]),
       .rready_i(host_rsp_ack[bank]),
       .rdata_o ({host_rsp_err[bank], host_rsp_data[bank]})

--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
@@ -285,6 +285,7 @@ module flash_phy_rd import flash_phy_pkg::*; (
     .wready_o(rsp_fifo_rdy),
     .wdata_i (rsp_fifo_wdata),
     .depth_o (),
+    .full_o (),
     .rvalid_o(rsp_fifo_vld),
     .rready_i(data_valid_o), // pop when a match has been found
     .rdata_o (rsp_fifo_rdata)
@@ -434,6 +435,7 @@ module flash_phy_rd import flash_phy_pkg::*; (
     .wready_o(data_fifo_rdy),
     .wdata_i ({alloc_q, descram, forward, data_err, data_int}),
     .depth_o (),
+    .full_o (),
     .rvalid_o(fifo_data_valid),
     .rready_i(fifo_data_ready | fifo_forward_pop),
     .rdata_o ({alloc_q2, hint_descram, hint_forward, data_err_q, fifo_data})
@@ -453,6 +455,7 @@ module flash_phy_rd import flash_phy_pkg::*; (
     .wready_o(mask_fifo_rdy),
     .wdata_i (mask_i),
     .depth_o (),
+    .full_o (),
     .rvalid_o(mask_valid),
     .rready_i(fifo_data_ready | fifo_forward_pop),
     .rdata_o (mask)

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -274,6 +274,7 @@ module hmac
     .wdata_i (fifo_wdata),
 
     .depth_o (fifo_depth),
+    .full_o  (),
 
     .rvalid_o(fifo_rvalid),
     .rready_i(fifo_rready),

--- a/hw/ip/kmac/rtl/kmac_msgfifo.sv
+++ b/hw/ip/kmac/rtl/kmac_msgfifo.sv
@@ -144,6 +144,7 @@ module kmac_msgfifo
     .wdata_i (fifo_wdata),
 
     .depth_o (fifo_depth_o),
+    .full_o  (fifo_full_o),
 
     .rvalid_o (fifo_rvalid),
     .rready_i (fifo_rready),
@@ -159,7 +160,6 @@ module kmac_msgfifo
   assign msg_strb_o  = fifo_rdata.strb;
 
   assign fifo_empty_o = fifo_depth_o == '0;
-  assign fifo_full_o  = fifo_depth_o == MsgDepth;
 
   // Flush (process from outside) handling
   flush_st_e flush_st, flush_st_d;
@@ -237,4 +237,3 @@ module kmac_msgfifo
   `ASSUME(MessageValid_a, fifo_valid_i |-> flush_st == FlushIdle)
 
 endmodule
-

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -646,7 +646,8 @@ module otp_ctrl
     .rvalid_o ( otp_fifo_valid ),
     .rready_i ( otp_rvalid     ),
     .rdata_o  ( otp_part_idx   ),
-    .depth_o  (                )
+    .depth_o  (                ),
+    .full_o   (                )
   );
 
   // Steer response back to the partition where this request originated.

--- a/hw/ip/prim_generic/rtl/prim_generic_flash_bank.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash_bank.sv
@@ -139,6 +139,7 @@ module prim_generic_flash_bank #(
     .wready_o(ack),
     .wdata_i (cmd_d),
     .depth_o (),
+    .full_o (),
     .rvalid_o(cmd_valid),
     .rready_i(pop_cmd),
     .rdata_o (cmd_q)

--- a/hw/ip/uart/rtl/uart_core.sv
+++ b/hw/ip/uart/rtl/uart_core.sv
@@ -181,6 +181,7 @@ module uart_core (
     .wready_o(tx_fifo_wready),
     .wdata_i (reg2hw.wdata.q),
     .depth_o (tx_fifo_depth),
+    .full_o (),
     .rvalid_o(tx_fifo_rvalid),
     .rready_i(tx_fifo_rready),
     .rdata_o (tx_fifo_data)
@@ -280,6 +281,7 @@ module uart_core (
     .wready_o(rx_fifo_wready),
     .wdata_i (rx_fifo_data),
     .depth_o (rx_fifo_depth),
+    .full_o (),
     .rvalid_o(rx_fifo_rvalid),
     .rready_i(reg2hw.rdata.re),
     .rdata_o (uart_rdata)

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -459,6 +459,7 @@ module flash_ctrl import flash_ctrl_pkg::*; #(
     .wready_o(prog_fifo_wready),
     .wdata_i (prog_fifo_wdata),
     .depth_o (prog_fifo_depth),
+    .full_o  (),
     .rvalid_o(prog_fifo_rvalid),
     .rready_i(prog_fifo_ren),
     .rdata_o (prog_fifo_rdata)

--- a/hw/vendor/patches/pulp_riscv_dbg/0001-Style-lint-cleanup-to-make-Verible-lint-happy.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0001-Style-lint-cleanup-to-make-Verible-lint-happy.patch
@@ -4,13 +4,6 @@ Date: Mon, 13 Jul 2020 19:25:04 -0700
 Subject: [PATCH 1/2] Style lint cleanup to make Verible lint happy
 
 Signed-off-by: Michael Schaffner <msf@google.com>
----
- src/dm_csrs.sv    |  6 +++---
- src/dm_mem.sv     |  7 +++++--
- src/dm_obi_top.sv | 50 ++++++++++++++++++++++++++---------------------
- src/dm_pkg.sv     |  2 +-
- src/dm_sba.sv     |  6 +++---
- 5 files changed, 40 insertions(+), 31 deletions(-)
 
 diff --git a/src/dm_csrs.sv b/src/dm_csrs.sv
 index 78fd32a..f131392 100644
@@ -211,6 +204,3 @@ index f605088..c97f956 100644
          end
        end
  
--- 
-2.28.0.rc0.105.gf9edc3c819-goog
-

--- a/hw/vendor/patches/pulp_riscv_dbg/0002-Use-lowrisc-instead-of-PULP-primitives.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0002-Use-lowrisc-instead-of-PULP-primitives.patch
@@ -1,17 +1,12 @@
-From 256422ad7df932c6f9934e65361cd963b8ac3bf0 Mon Sep 17 00:00:00 2001
+From c9bb351a0d0f915b0f66cf0bee38afedbea3c02c Mon Sep 17 00:00:00 2001
 From: Philipp Wagner <phw@lowrisc.org>
 Date: Fri, 22 Feb 2019 14:48:46 +0000
 Subject: [PATCH 2/2] Use lowrisc instead of PULP primitives
 
 Signed-off-by: Michael Schaffner <msf@google.com>
----
- src/dm_csrs.sv      | 42 +++++++++++++++-------------------
- src/dmi_cdc.sv      | 56 +++++++++++++++++++++++++++------------------
- src/dmi_jtag_tap.sv | 20 +++++++---------
- 3 files changed, 60 insertions(+), 58 deletions(-)
 
 diff --git a/src/dm_csrs.sv b/src/dm_csrs.sv
-index f131392..0d88e79 100644
+index f131392..e4698eb 100644
 --- a/src/dm_csrs.sv
 +++ b/src/dm_csrs.sv
 @@ -78,6 +78,7 @@ module dm_csrs #(
@@ -43,7 +38,7 @@ index f131392..0d88e79 100644
    // SBA
    assign sbautoincrement_o = sbcs_q.sbautoincrement;
    assign sbreadonaddr_o    = sbcs_q.sbreadonaddr;
-@@ -550,27 +544,27 @@ module dm_csrs #(
+@@ -550,27 +544,28 @@ module dm_csrs #(
    assign progbuf_o   = progbuf_q;
    assign data_o      = data_q;
  
@@ -84,7 +79,8 @@ index f131392..0d88e79 100644
 +    .rdata_o ( dmi_resp_o.data      ),
 +    .rvalid_o( dmi_resp_valid_o     ),
 +    .rready_i( dmi_resp_ready_i     ),
-+    .depth_o (                      )  // Doesn't use
++    .full_o  (                      ), // Unused
++    .depth_o (                      )  // Unused
    );
  
    always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
@@ -190,6 +186,3 @@ index 3d11145..94b51d6 100644
    );
  
    // TDO changes state at negative edge of TCK
--- 
-2.28.0.rc0.105.gf9edc3c819-goog
-

--- a/hw/vendor/pulp_riscv_dbg/src/dm_csrs.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dm_csrs.sv
@@ -564,7 +564,8 @@ module dm_csrs #(
     .rdata_o ( dmi_resp_o.data      ),
     .rvalid_o( dmi_resp_valid_o     ),
     .rready_i( dmi_resp_ready_i     ),
-    .depth_o (                      )  // Doesn't use
+    .full_o  (                      ), // Unused
+    .depth_o (                      )  // Unused
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs


### PR DESCRIPTION
Fix all users of `prim_fifo_sync` to include the newly added `full_o` output.

Should fix #5019 completely.