### PR TITLE
[topgen, reggen] Fix "extra key" warnings in topgen and reggen

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -413,7 +413,6 @@
         rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40000000
-      clock_reset_export: []
       clock_group: secure
       clock_connections:
       {
@@ -573,7 +572,6 @@
         rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40010000
-      clock_reset_export: []
       clock_group: secure
       clock_connections:
       {
@@ -733,7 +731,6 @@
         rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40020000
-      clock_reset_export: []
       clock_group: secure
       clock_connections:
       {
@@ -893,7 +890,6 @@
         rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40030000
-      clock_reset_export: []
       clock_group: secure
       clock_connections:
       {
@@ -1054,7 +1050,6 @@
         rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40040000
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_io_div4_peri
@@ -1123,7 +1118,6 @@
         rst_ni: rstmgr_resets.rst_spi_device_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40050000
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_io_div4_peri
@@ -1269,7 +1263,6 @@
         rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40100000
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_io_div4_timers
@@ -1497,7 +1490,6 @@
         rst_edn_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40130000
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_io_div4_timers
@@ -1830,7 +1822,6 @@
         rst_ni: rstmgr_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40140000
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_io_div4_timers
@@ -2296,7 +2287,6 @@
         AccuCntDw: 16
         LfsrSeed: 0x7FFFFFFF
       }
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_io_div4_timers
@@ -2468,7 +2458,6 @@
         rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40160000
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_io_div4_timers
@@ -2594,7 +2583,6 @@
       domain: Aon
       base_addr: 0x40400000
       generated: "true"
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_io_div4_powerup
@@ -2799,7 +2787,6 @@
       domain: Aon
       base_addr: 0x40410000
       generated: "true"
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_io_div4_powerup
@@ -2945,7 +2932,6 @@
       domain: Aon
       base_addr: 0x40420000
       generated: "true"
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_io_div4_powerup
@@ -3120,7 +3106,6 @@
       domain: Aon
       base_addr: 0x40460000
       generated: "true"
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_secure
@@ -3300,7 +3285,6 @@
       domain: Aon
       base_addr: 0x40470000
       generated: "true"
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_secure
@@ -3754,7 +3738,6 @@
       }
       domain: Aon
       base_addr: 0x40510000
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_io_div4_peri
@@ -3882,7 +3865,6 @@
       }
       base_addr: 0x41000000
       generated: "true"
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_infra
@@ -4233,7 +4215,6 @@
       }
       base_addr: 0x41010000
       generated: "true"
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_secure
@@ -4281,7 +4262,6 @@
         rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x41100000
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_aes
@@ -4494,7 +4474,6 @@
         rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x41110000
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_hmac
@@ -4594,7 +4573,6 @@
         rst_edn_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x41120000
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_kmac
@@ -4766,7 +4744,6 @@
         rst_edn_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x41130000
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_secure
@@ -5125,7 +5102,6 @@
         rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x41150000
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_secure
@@ -5280,7 +5256,6 @@
         rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x41160000
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_secure
@@ -5421,7 +5396,6 @@
         rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x41170000
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_secure
@@ -5526,7 +5500,6 @@
         rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x41180000
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_secure
@@ -5633,7 +5606,6 @@
         rst_otp_ni: rstmgr_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x411C0000
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_secure
@@ -5759,7 +5731,6 @@
         rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x411D0000
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_otbn
@@ -5894,7 +5865,6 @@
           index: -1
         }
       ]
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_infra
@@ -5943,7 +5913,6 @@
           index: -1
         }
       ]
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_infra
@@ -5993,7 +5962,6 @@
           index: -1
         }
       ]
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_io_div4_infra
@@ -6120,7 +6088,6 @@
           index: -1
         }
       ]
-      clock_reset_export: []
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_infra
@@ -6543,7 +6510,6 @@
         rst_main_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
         rst_fixed_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
-      clock_reset_export: []
       clock_connections:
       {
         clk_main_i: clkmgr_clocks.clk_main_infra
@@ -7265,7 +7231,6 @@
       {
         rst_peri_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
-      clock_reset_export: []
       clock_connections:
       {
         clk_peri_i: clkmgr_clocks.clk_io_div4_infra

--- a/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
@@ -20,7 +20,6 @@
     rst_main_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
     rst_fixed_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
   }
-  clock_reset_export: []
   clock_connections:
   {
     clk_main_i: clkmgr_clocks.clk_main_infra

--- a/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
@@ -18,7 +18,6 @@
   {
     rst_peri_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
   }
-  clock_reset_export: []
   clock_connections:
   {
     clk_peri_i: clkmgr_clocks.clk_io_div4_infra

--- a/util/reggen/validate.py
+++ b/util/reggen/validate.py
@@ -363,31 +363,34 @@ top_required = {
      "offset control groups"]
 }
 top_optional = {
-    'reset_primary': ['s', "primary reset used by the module"],
-    'other_reset_list': ['l', "list of other resets"],
-    'bus_host': ['s', "name of the bus interface as host"],
-    'other_clock_list': ['l', "list of other chip clocks needed"],
+    'alert_list': ['lnw', "list of peripheral alerts"],
+    'available_inout_list': ['lnw', "list of available peripheral inouts"],
     'available_input_list': ['lnw', "list of available peripheral inputs"],
     'available_output_list': ['lnw', "list of available peripheral outputs"],
-    'available_inout_list': ['lnw', "list of available peripheral inouts"],
+    'bus_host': ['s', "name of the bus interface as host"],
+    'hier_path': [
+        None,
+        'additional hierarchy path before the reg block instance'
+    ],
     'interrupt_list': ['lnw', "list of peripheral interrupts"],
     'inter_signal_list': ['l', "list of inter-module signals"],
-    'no_auto_intr_regs': [
-        's', "Set to true to suppress automatic "
-        "generation of interrupt registers. "
-        "Defaults to true if no interrupt_list is present. "
-        "Otherwise this defaults to false. "
-    ],
-    'alert_list': ['lnw', "list of peripheral alerts"],
     'no_auto_alert_regs': [
         's', "Set to true to suppress automatic "
         "generation of alert test registers. "
         "Defaults to true if no alert_list is present. "
         "Otherwise this defaults to false. "
     ],
-    'wakeup_list': ['lnw', "list of peripheral wakeups"],
-    'regwidth': ['d', "width of registers in bits (default 32)"],
+    'no_auto_intr_regs': [
+        's', "Set to true to suppress automatic "
+        "generation of interrupt registers. "
+        "Defaults to true if no interrupt_list is present. "
+        "Otherwise this defaults to false. "
+    ],
+    'other_clock_list': ['l', "list of other chip clocks needed"],
+    'other_reset_list': ['l', "list of other resets"],
     'param_list': ['lp', "list of parameters of the IP"],
+    'regwidth': ['d', "width of registers in bits (default 32)"],
+    'reset_primary': ['s', "primary reset used by the module"],
     'scan': ['pb', 'Indicates the module have `scanmode_i`'],
     'scan_reset': ['pb', 'Indicates the module have `test_rst_ni`'],
     'SPDX-License-Identifier': [
@@ -396,8 +399,7 @@ top_optional = {
         "information in a comment at the top of the "
         "file."
     ],
-    'hier_path':
-    [None, 'additional hierarchy path before the reg block instance']
+    'wakeup_list': ['lnw', "list of peripheral wakeups"]
 }
 top_added = {
     'genrnames': ['pl', "list of register names"],

--- a/util/reggen/validate.py
+++ b/util/reggen/validate.py
@@ -391,6 +391,7 @@ top_optional = {
     'param_list': ['lp', "list of parameters of the IP"],
     'regwidth': ['d', "width of registers in bits (default 32)"],
     'reset_primary': ['s', "primary reset used by the module"],
+    'reset_request_list': ['l', 'list of signals requesting reset'],
     'scan': ['pb', 'Indicates the module have `scanmode_i`'],
     'scan_reset': ['pb', 'Indicates the module have `test_rst_ni`'],
     'SPDX-License-Identifier': [

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -546,15 +546,6 @@ def xbar_cross_node(node_name, device_xbar, xbars, visited=[]):
     return result
 
 
-# Check if the export field already exists
-# If yes, return it
-# If no, set a default and return that
-def check_clk_rst_export(module):
-    if 'clock_reset_export' not in module:
-        module['clock_reset_export'] = []
-    return module['clock_reset_export']
-
-
 def amend_clocks(top: OrderedDict):
     """Add a list of clocks to each clock group
        Amend the clock connections of each entry to reflect the actual gated clock
@@ -587,7 +578,7 @@ def amend_clocks(top: OrderedDict):
         clock_connections = OrderedDict()
 
         # Ensure each module has a default case
-        export_if = check_clk_rst_export(ep)
+        export_if = ep.get('clock_reset_export', [])
 
         # if no clock group assigned, default is unique
         ep['clock_group'] = 'secure' if 'clock_group' not in ep else ep[
@@ -682,7 +673,7 @@ def amend_resets(top):
 
         # This code is here to ensure if amend_clocks/resets switched order
         # everything would still work
-        export_if = check_clk_rst_export(module)
+        export_if = module.get('clock_reset_export', [])
 
         # There may be multiple export interfaces
         for intf in export_if:

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -126,16 +126,15 @@ clock_groups_added = {}
 
 eflash_required = {
     'banks': ['d', 'number of flash banks'],
-    'pages_per_bank': ['d', 'number of data pages per flash bank'],
-    'program_resolution':
-    ['d', 'maximum number of flash words allowed to program'],
-    'clock_srcs': ['g', 'clock connections'],
-    'clock_group': ['s', 'associated clock attribute group'],
-    'reset_connections': ['g', 'reset connections'],
-    'type': ['s', 'type of memory'],
     'base_addr': ['s', 'strarting hex address of memory'],
+    'clock_group': ['s', 'associated clock attribute group'],
+    'clock_srcs': ['g', 'clock connections'],
+    'inter_signal_list': ['lg', 'intersignal list'],
+    'pages_per_bank': ['d', 'number of data pages per flash bank'],
+    'program_resolution': ['d', 'maximum number of flash words allowed to program'],
+    'reset_connections': ['g', 'reset connections'],
     'swaccess': ['s', 'software accessibility'],
-    'inter_signal_list': ['lg', 'intersignal list']
+    'type': ['s', 'type of memory']
 }
 
 eflash_optional = {}

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -51,18 +51,22 @@ module'],
 }
 
 top_optional = {
-    'interrupt_module': ['l', 'list of the modules that connects to rv_plic'],
-    'interrupt': ['lnw', 'interrupts (generated)'],
-    'alert_module':
-    ['l', 'list of the modules that connects to alert_handler'],
-    'alert': ['lnw', 'alerts (generated)'],
     'alert_async': ['l', 'async alerts (generated)'],
-    'pinmux': ['g', 'pinmux definition if doesn\'t exist, tool uses defaults'],
-    'padctrl':
-    ['g', 'PADS instantiation, if doesn\'t exist, tool creates direct output'],
-    'inter_module': ['g', 'define the signal connections between the modules'],
-    'num_cores': ['pn', "number of computing units"],
+    'alert': ['lnw', 'alerts (generated)'],
+    'alert_module': [
+        'l',
+        'list of the modules that connects to alert_handler'
+    ],
     'datawidth': ['pn', "default data width"],
+    'inter_module': ['g', 'define the signal connections between the modules'],
+    'interrupt': ['lnw', 'interrupts (generated)'],
+    'interrupt_module': ['l', 'list of the modules that connects to rv_plic'],
+    'num_cores': ['pn', "number of computing units"],
+    'padctrl': [
+        'g',
+        'PADS instantiation, if doesn\'t exist, tool creates direct output'
+    ],
+    'pinmux': ['g', 'pinmux definition if doesn\'t exist, tool uses defaults'],
 }
 
 top_added = {}

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -58,6 +58,8 @@ top_optional = {
         'list of the modules that connects to alert_handler'
     ],
     'datawidth': ['pn', "default data width"],
+    'exported_clks': ['g', 'clock signal routing rules'],
+    'host': ['g', 'list of host-only components in the system'],
     'inter_module': ['g', 'define the signal connections between the modules'],
     'interrupt': ['lnw', 'interrupts (generated)'],
     'interrupt_module': ['l', 'list of the modules that connects to rv_plic'],
@@ -67,6 +69,7 @@ top_optional = {
         'PADS instantiation, if doesn\'t exist, tool creates direct output'
     ],
     'pinmux': ['g', 'pinmux definition if doesn\'t exist, tool uses defaults'],
+    'power': ['g', 'power domains supported by the design'],
 }
 
 top_added = {}

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -130,9 +130,11 @@ clock_groups_added = {}
 eflash_required = {
     'banks': ['d', 'number of flash banks'],
     'base_addr': ['s', 'strarting hex address of memory'],
+    'clock_connections': ['g', 'generated, elaborated version of clock_srcs'],
     'clock_group': ['s', 'associated clock attribute group'],
     'clock_srcs': ['g', 'clock connections'],
     'inter_signal_list': ['lg', 'intersignal list'],
+    'name': ['s', 'name of flash memory'],
     'pages_per_bank': ['d', 'number of data pages per flash bank'],
     'program_resolution': ['d', 'maximum number of flash words allowed to program'],
     'reset_connections': ['g', 'reset connections'],


### PR DESCRIPTION
This series of commits silences warnings for various fields that have been added to our topgen hjson files over the last year or so. It's a step towards being able to run `make -C hw top` without warnings.