### PR TITLE
[topgen] Silence warning on missing power domain

### DIFF
--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -495,13 +495,12 @@ def check_power_domains(top):
     # If there is one defined, check that it is a valid definition
     for end_point in top['module'] + top['memory'] + top['xbar']:
         if 'domain' not in end_point:
-            log.warning("{} does not have a power domain defined, \
-            assigning default".format(end_point['name']))
-
             end_point['domain'] = top['power']['default']
-        elif end_point['domain'] not in top['power']['domains']:
-            log.error("{} defined invalid domain {}".format(
-                end_point['name'], end_point['domain']))
+
+        if end_point['domain'] not in top['power']['domains']:
+            log.error("{} defined invalid domain {}"
+                      .format(end_point['name'],
+                              end_point['domain']))
             error += 1
             return error
 


### PR DESCRIPTION
Most of our blocks don't currently define a power domain, and thus get
assigned to "default". That seems like a perfectly reasonable
behaviour and doesn't need a warning, I don't think.
