### PR TITLE
[clkgen] Replace IBUFG with IBUF

### DIFF
--- a/hw/top_earlgrey/rtl/clkgen_xil7series.sv
+++ b/hw/top_earlgrey/rtl/clkgen_xil7series.sv
@@ -24,7 +24,7 @@ module clkgen_xil7series # (
   logic clk_48_unbuf;
 
   // input clock buffer
-  IBUFG io_clk_ibufg (
+  IBUF io_clk_ibuf (
     .I (IO_CLK),
     .O (io_clk_buf)
   );


### PR DESCRIPTION
The IBUFG primitive doesn't exist in 7 series+ devices and is replaced
by a normal IBUF during syntheis, as Vivado notes:

```
[Netlist 29-432] The IBUFG primitive 'clkgen/io_clk_ibufg' has been
retargeted to an IBUF primitive only. No BUFG will be added. If a
global buffer is intended, please instantiate an available global
clock primitive from the current architecture.
```

In our case we don't need a global buffer as the output of the IBUF(G)
primitive will be fed into a PLL block before being used for logic,
and we add appropriate global clock buffers there.