### PR TITLE
[top, fpga] Fix reference and documentation of reduce script, fix boot ROM splicing script for NexysVideo

### DIFF
--- a/doc/ug/getting_started_fpga.md
+++ b/doc/ug/getting_started_fpga.md
@@ -38,12 +38,13 @@ $ ninja -C build-out sw/device/boot_rom/boot_rom_export_fpga_nexysvideo
 
 Since not all FPGAs are able to fit the full design, there is a separate script that can be invoked to reduce the size of the design.
 
-To reduce the design:
+To reduce the design such that it fits the Nexys Video FPGA board:
 ```console
 $ cd $REPO_TOP
-$ ./hw/top_earlgrey/util/top_earlgrey_reduce.py
+$ ./hw/top_earlgrey/util/top_earlgrey_reduce.py --build
 ```
-By default, the reduce script targets 'nexysvideo', cw305 is also supported.
+The `--build` argument is optional and ensures that the boot ROM is rebuilt for the reduced design.
+Alternatively, the boot ROM can be manually regenerated using the previous command.
 
 
 In the following example we synthesize the Earl Grey design for the Nexys Video board using Xilinx Vivado 2020.1.
@@ -56,7 +57,7 @@ $ ./hw/top_earlgrey/util/top_earlgrey_reduce.py
 $ ninja -C build-out sw/device/boot_rom/boot_rom_export_fpga_nexysvideo
 $ fusesoc --cores-root . run --flag=fileset_top --target=synth lowrisc:systems:top_earlgrey_nexysvideo
 ```
-The fsel_top flag used above is specific to the OpenTitan project to select the correct fileset.
+The `fileset_top` flag used above is specific to the OpenTitan project to select the correct fileset.
 
 The resulting bitstream is located at `build/lowrisc_systems_top_earlgrey_nexysvideo_0.1/synth-vivado/lowrisc_systems_top_earlgrey_nexysvideo_0.1.bit`.
 See the [reference manual]({{< relref "ref_manual_fpga.md" >}}) for more information.

--- a/hw/top_earlgrey/util/top_earlgrey_size_check.py
+++ b/hw/top_earlgrey/util/top_earlgrey_size_check.py
@@ -36,18 +36,18 @@ def _nexysvideo_check():
 
     return files, match
 
+
 def main():
 
     parser = argparse.ArgumentParser(
         prog="flash_size_check",
         formatter_class=argparse.RawDescriptionHelpFormatter)
 
-    parser.add_argument(
-        '--target',
-        '-g',
-        default='nexysvideo',
-        choices=['nexysvideo'],
-        help='fpga reduction target')
+    parser.add_argument('--target',
+                        '-g',
+                        default='nexysvideo',
+                        choices=['nexysvideo'],
+                        help='fpga reduction target')
 
     args = parser.parse_args()
 
@@ -71,11 +71,10 @@ def main():
 
     if not all_good:
         log.error(
-            "It seems that the size of the embedded flash has not been adjusted for the targeted " +
-            "FPGA device. The design might not fit. \n" +
-            "Please run hw/top_earlgrey/util/opentitan_earlgrey_flash_size_reduce.py before " +
-            "running this fusesoc core."
-        )
+            "It seems that the size of the embedded flash has not been adjusted for the " +
+            "targeted FPGA device. The design might not fit. \n" +
+            "Please run hw/top_earlgrey/util/top_earlgrey_reduce.py --build before " +
+            "running this fusesoc core.")
         return 1
 
     return 0

--- a/util/fpga/bram_load.mmi
+++ b/util/fpga/bram_load.mmi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MemInfo Version="1" Minor="0">
   <Processor Endianness="Little" InstPath="dummy">
-  <AddressSpace Name="brom" Begin="0" End="4095">
+  <AddressSpace Name="brom" Begin="0" End="16383">
       <BusBlock>
         <BitLane MemType="RAMB32" Placement="X4Y18">
           <DataWidth MSB="7" LSB="0"/>

--- a/util/fpga/splice_nexysvideo.sh
+++ b/util/fpga/splice_nexysvideo.sh
@@ -9,30 +9,41 @@
 #   cd $REPO_TOP
 #   ./util/fpga/splice_nexysvideo.sh
 
-# Updated bitfile located : at the same place as raw vivado bitfile @
+# Updated bitfile located at the same place as raw vivado bitfile at
 # $REPO_TOP/build/lowrisc_systems_top_earlgrey_nexysvideo_0.1/synth-vivado/
-#  lowrisc_systems_top_earlgrey_nexysvideo_0.1.splice.bit
+#  lowrisc_systems_top_earlgrey_nexysvideo_0.1.bit
+# A copy of the original bitfile is created at
+# $REPO_TOP/build/lowrisc_systems_top_earlgrey_nexysvideo_0.1/synth-vivado/
+#  lowrisc_systems_top_earlgrey_nexysvideo_0.1.bit.orig
 set -e
 
 . util/build_consts.sh
 
-TARGET_PREFIX="sw/device/boot_rom/boot_rom_fpga_nexysvideo"
-TARGET="${BIN_DIR}/${TARGET_PREFIX}"
+TARGET_PREFIX="sw/device/boot_rom/"
+TARGET_EXPORT="${TARGET_PREFIX}/boot_rom_export_fpga_nexysvideo"
+TARGET="${BIN_DIR}/${TARGET_PREFIX}/boot_rom_fpga_nexysvideo"
+
 FPGA_BUILD_DIR=build/lowrisc_systems_top_earlgrey_nexysvideo_0.1/synth-vivado/
 FPGA_BIT_NAME=lowrisc_systems_top_earlgrey_nexysvideo_0.1
 
 ./meson_init.sh
-ninja -C "$BIN_DIR" "${TARGET_PREFIX}.bin"
+ninja -C "${OBJ_DIR}" "${TARGET_EXPORT}"
 
 srec_cat "${TARGET}.bin" -binary -offset 0x0 -o "${TARGET}.brammem" \
   -vmem -Output_Block_Size 4;
 
 util/fpga/addr4x.py -i "${TARGET}.brammem" -o "${TARGET}.mem"
 
+# The --debug flag is undocumented and causes updatemem to print out the INIT_XX
+# values of the four BRAM cells. These values are also oberservable when opening
+# the implemented design in Vivado and then inspecting the cell properties of
+# the corresponding BRAM cells. This information is very useful when debugging
+# the splicing flow.
 updatemem -force --meminfo util/fpga/bram_load.mmi \
   --data "${TARGET}.mem" \
   --bit "${FPGA_BUILD_DIR}/${FPGA_BIT_NAME}.bit"  --proc dummy \
-  --out "${FPGA_BUILD_DIR}/${FPGA_BIT_NAME}.splice.bit"
+  --out "${FPGA_BUILD_DIR}/${FPGA_BIT_NAME}.splice.bit" \
+  --debug
 
 mv ${FPGA_BUILD_DIR}/${FPGA_BIT_NAME}.bit ${FPGA_BUILD_DIR}/${FPGA_BIT_NAME}.bit.orig
 mv ${FPGA_BUILD_DIR}/${FPGA_BIT_NAME}.splice.bit ${FPGA_BUILD_DIR}/${FPGA_BIT_NAME}.bit


### PR DESCRIPTION
This PR contains two commits:
1. Fix reference and documentation of top_earlgrey_reduce.py script. In particular, the `--build` option wasn't mentioned in the doc but this is required for the script to actually rebuild the boot ROM. Otherwise, just the sources are patched.
2. Repair the FPGA splicing script to patch the boot ROM after bitstream generation. When doubling the size of the boot ROM we accidentally reduced the ROM range the script touches. Also, some re-alignment is to the latest SW build flow was required.

This is related to #5029.