### PR TITLE
[kmac] Fix typo in wiring between KMAC and main crossbar

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -6770,7 +6770,7 @@
           name: kmac
           type: device
           clock: clk_main_i
-          rset: rst_main_ni
+          reset: rst_main_ni
           pipeline_byp: "false"
           inst_type: kmac
           addr_range:

--- a/hw/top_earlgrey/data/xbar_main.hjson
+++ b/hw/top_earlgrey/data/xbar_main.hjson
@@ -75,7 +75,7 @@
     { name:         "kmac"
       type:         "device"
       clock:        "clk_main_i"
-      rset:         "rst_main_ni"
+      reset:        "rst_main_ni"
       pipeline_byp: "false"
     }
     { name:      "aes",

--- a/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
@@ -247,7 +247,7 @@
       name: kmac
       type: device
       clock: clk_main_i
-      rset: rst_main_ni
+      reset: rst_main_ni
       pipeline_byp: "false"
       inst_type: kmac
       addr_range:


### PR DESCRIPTION
This was spotted as part of the effort to get a warning-free topgen
run. A bug, at last!

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>