### PR TITLE
[dv/otp_ctrl] Fix regwen error in regression

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -345,7 +345,6 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
           // here only normalize to 2 lsb, if is secret, will be reduced further
           bit [TL_AW-1:0] dai_addr = `gmv(ral.direct_access_address) >> 2 << 2;
           int part_idx = get_part_index(dai_addr);
-          void'(ral.direct_access_regwen.predict(0));
           // LC partition cannot be access via DAI
           if (part_idx == LifeCycleIdx) begin
             predict_status_err(.dai_err(1));
@@ -416,6 +415,8 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
                 `uvm_fatal(`gfn, $sformatf("invalid cmd: %0d", item.a_data))
               end
             endcase
+            // regwen is set to 0 only if the dai operation is successfully
+            if (`gmv(ral.intr_state.otp_error) == 0) void'(ral.direct_access_regwen.predict(0));
           end
         end
       end

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -16,6 +16,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
 
   rand bit [NumOtpCtrlIntr-1:0] en_intr;
   bit [TL_AW-1:0] used_dai_addr_q[$];
+  bit is_valid_dai_op = 1;
 
   `uvm_object_new
 
@@ -69,7 +70,12 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     `uvm_info(`gfn, $sformatf("DAI write, address %0h, data0 %0h data1 %0h, is_secret = %0b",
               addr, wdata0, wdata1, is_secret(addr)), UVM_DEBUG)
 
-    if ($urandom_range(0, 1) && cfg.zero_delays) begin
+    // direct_access_regwen is set only when following conditions are met:
+    // - the dai operation is valid, otherwise it is hard to predict which cycle the error is
+    //   detected and regwen is set back to 1
+    // - zero delays in TLUL interface, otherwise dai operation might be finished before reading
+    //   this regwen CSR
+    if ($urandom_range(0, 1) && cfg.zero_delays && is_valid_dai_op) begin
       csr_rd(.ptr(ral.direct_access_regwen), .value(val));
     end
     csr_spinwait(ral.intr_state.otp_operation_done, 1);
@@ -84,7 +90,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     addr = randomize_dai_addr(addr);
     csr_wr(ral.direct_access_address, addr);
     csr_wr(ral.direct_access_cmd, int'(otp_ctrl_pkg::DaiRead));
-    if ($urandom_range(0, 1) && cfg.zero_delays) begin
+    if ($urandom_range(0, 1) && cfg.zero_delays && is_valid_dai_op) begin
       csr_rd(.ptr(ral.direct_access_regwen), .value(val));
     end
     csr_spinwait(ral.intr_state.otp_operation_done, 1);
@@ -100,7 +106,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     csr_wr(ral.direct_access_address, PART_BASE_ADDRS[part_idx]);
     csr_wr(ral.direct_access_cmd, otp_ctrl_pkg::DaiDigest);
 
-    if ($urandom_range(0, 1) && cfg.zero_delays) begin
+    if ($urandom_range(0, 1) && cfg.zero_delays && is_valid_dai_op) begin
       csr_rd(.ptr(ral.direct_access_regwen), .value(val));
     end
     csr_spinwait(ral.intr_state.otp_operation_done, 1);

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
@@ -6,7 +6,7 @@
 // - A writeblank error will be triggered if write to a non-empty address
 // - An access error will be triggered if write to lc partition via DAI interface, or if DAI write
 //   to digest addrs for non-sw partitions
-class otp_ctrl_dai_errs_vseq extends otp_ctrl_smoke_vseq;
+class otp_ctrl_dai_errs_vseq extends otp_ctrl_dai_lock_vseq;
   `uvm_object_utils(otp_ctrl_dai_errs_vseq)
 
   `uvm_object_new
@@ -24,6 +24,7 @@ class otp_ctrl_dai_errs_vseq extends otp_ctrl_smoke_vseq;
     this.partition_index_c.constraint_mode(0);
     this.dai_wr_blank_addr_c.constraint_mode(0);
     this.no_access_err_c.constraint_mode(0);
+    this.num_iterations_up_to_num_valid_addr_c.constraint_mode(0);
     collect_used_addr = 0;
   endfunction
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
@@ -16,4 +16,9 @@ class otp_ctrl_dai_lock_vseq extends otp_ctrl_smoke_vseq;
   constraint num_iterations_up_to_num_valid_addr_c {
     num_trans * num_dai_op <= DAI_ADDR_SIZE;
   }
+
+  virtual task pre_start();
+    super.pre_start();
+    is_valid_dai_op = 0;
+  endtask
 endclass


### PR DESCRIPTION
This PR removes the check for regwen in dai error sequence because it is
hard to predict which clock cycle the error is found and then set regwen
back to 1.

Signed-off-by: Cindy Chen <chencindy@google.com>