### PR TITLE
[dv/otp] add checkings for otp_ctrl_if output

### DIFF
--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -47,7 +47,7 @@ module tb;
 
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
 
-  otp_ctrl_if otp_ctrl_if();
+  otp_ctrl_if otp_ctrl_if(.clk_i(clk), .rst_ni(rst_n));
 
   `DV_ALERT_IF_CONNECT
 


### PR DESCRIPTION
This PR mainly checks some otp signals via otp_ctrl_if.sv
according to the spec.

Signed-off-by: Cindy Chen <chencindy@google.com>