### PR TITLE
[ci] Fix BIN_DIR merging and artifact passing between jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -127,10 +127,23 @@ jobs:
       . util/build_consts.sh
       ninja -C "$OBJ_DIR" test
     displayName: Run unit tests
+  - bash: |
+      . util/build_consts.sh
+      # Remove all Nexys Video-related build artifacts, which will be produced
+      # by the sw_build_nexysvideo job below (see comment there).
+      find "$BIN_DIR/sw/device" -name '*fpga_nexysvideo*' -type f -delete
+    displayName: Delete all Nexys Video build artifacts
   - template: ci/upload-artifacts-template.yml
     parameters:
       artifact: sw_build
 
+# Software targeting the Nexys Video board is produced by patching the source
+# tree before building. This produces a full sw build tree, however only the
+# artifacts with "nexysvideo" in the name are actually the ones we're looking
+# for. Everything else will be discarded.
+# TODO: This is a rather ugly hack, which will go away once we properly support
+# building more than one top-level design with different parametrizations.
+# Work towards this goal is tracked in issue #4669.
 - job: sw_build_nexysvideo
   displayName: Build Software for Earl Grey toplevel design targeting the Nexys Video board
   dependsOn: lint
@@ -151,6 +164,9 @@ jobs:
       ./hw/top_earlgrey/util/top_earlgrey_reduce.py
       ./meson_init.sh -A
       ninja -C "$OBJ_DIR" all
+
+      # Delete all build artifacts which are *not* for the Nexys Video board.
+      find "$BIN_DIR/sw/device" -not -name '*fpga_nexysvideo*' -type f -delete
     displayName: Build embedded targets
   - bash: |
       . util/build_consts.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -188,9 +188,6 @@ jobs:
       . util/build_consts.sh
       ninja -C "$OBJ_DIR" test
     displayName: Run unit tests
-  - template: ci/upload-artifacts-template.yml
-    parameters:
-      artifact: sw_build_gcc
 
 - job: top_earlgrey_verilator
   displayName: Build Verilator simulation of the Earl Grey toplevel design

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -269,6 +269,10 @@ jobs:
   steps:
   - template: ci/install-package-dependencies.yml
   - template: ci/download-artifacts-template.yml
+    parameters:
+      downloadPartialBuildBinFrom:
+        - top_earlgrey_verilator
+        - sw_build
   - bash: |
       # Install an additional pytest dependency for result upload.
       pip3 install pytest-azurepipelines
@@ -337,6 +341,9 @@ jobs:
   steps:
   - template: ci/install-package-dependencies.yml
   - template: ci/download-artifacts-template.yml
+    parameters:
+      downloadPartialBuildBinFrom:
+        - sw_build_nexysvideo
   - bash: |
       set -e
       . util/build_consts.sh
@@ -389,6 +396,9 @@ jobs:
   steps:
   - template: ci/install-package-dependencies.yml
   - template: ci/download-artifacts-template.yml
+    parameters:
+      downloadPartialBuildBinFrom:
+        - sw_build_nexysvideo
   - bash: |
       set -e
       . util/build_consts.sh
@@ -421,9 +431,15 @@ jobs:
   dependsOn:
     - top_earlgrey_nexysvideo
     - sw_build_nexysvideo
+    - sw_build
   steps:
   - template: ci/install-package-dependencies.yml
   - template: ci/download-artifacts-template.yml
+    parameters:
+      downloadPartialBuildBinFrom:
+        - top_earlgrey_nexysvideo
+        - sw_build_nexysvideo
+        - sw_build
   - bash: |
       set -e
 
@@ -456,6 +472,13 @@ jobs:
   steps:
   - template: ci/install-package-dependencies.yml
   - template: ci/download-artifacts-template.yml
+    parameters:
+      downloadPartialBuildBinFrom:
+        - sw_build
+        - sw_build_nexysvideo
+        - top_earlgrey_verilator
+        - top_earlgrey_nexysvideo
+        - top_englishbreakfast_verilator
   - bash: |
       . util/build_consts.sh
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,7 +135,8 @@ jobs:
     displayName: Delete all Nexys Video build artifacts
   - template: ci/upload-artifacts-template.yml
     parameters:
-      artifact: sw_build
+      includePatterns:
+        - "/sw/***"
 
 # Software targeting the Nexys Video board is produced by patching the source
 # tree before building. This produces a full sw build tree, however only the
@@ -174,7 +175,8 @@ jobs:
     displayName: Run unit tests
   - template: ci/upload-artifacts-template.yml
     parameters:
-      artifact: sw_build_nexysvideo
+      includePatterns:
+        - "/sw/device/**/*nexysvideo*"
 
 # We continue building with GCC, despite defaulting to Clang. This is a copy of
 # `sw_build` with `meson_init.sh` configured with the GCC toolchain, instead of
@@ -238,7 +240,8 @@ jobs:
     displayName: Build simulation with Verilator
   - template: ci/upload-artifacts-template.yml
     parameters:
-      artifact: top_earlgrey_verilator
+      includePatterns:
+        - "/hw/top_earlgrey/Vtop_earlgrey_verilator"
 
 - job: top_englishbreakfast_verilator
   displayName: Build Verilator simulation of the English Breakfast toplevel design
@@ -273,7 +276,8 @@ jobs:
     displayName: Build simulation with Verilator
   - template: ci/upload-artifacts-template.yml
     parameters:
-      artifact: top_englishbreakfast_verilator
+      includePatterns:
+        - "/hw/top_englishbreakfast/Vtop_englishbreakfast_verilator"
 
 - job: execute_verilated_tests
   displayName: Execute tests on the Verilated system
@@ -394,7 +398,8 @@ jobs:
     displayName: Display synthesis and implementation logs
   - template: ci/upload-artifacts-template.yml
     parameters:
-      artifact: top_earlgrey_nexysvideo
+      includePatterns:
+        - "/hw/top_earlgrey/lowrisc_systems_top_earlgrey_nexysvideo_0.1.bit"
 
 - job: top_englishbreakfast_cw305
   displayName: Build CW305 variant of the English Breakfast toplevel design using Vivado
@@ -438,7 +443,8 @@ jobs:
     displayName: Build bitstream with Vivado
   - template: ci/upload-artifacts-template.yml
     parameters:
-      artifact: top_englishbreakfast_cw305
+      includePatterns:
+        - "/hw/top_englishbreakfast/lowrisc_systems_top_englishbreakfast_cw305_0.1.bit"
 
 - job: execute_fpga_tests
   displayName: Execute tests on FPGA

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -476,9 +476,6 @@ jobs:
         --log-cli-level=DEBUG \
         --test-run-title="Run system tests on Nexys Video FPGA board" \
         --napoleon-docstrings
-    # Temporary workaround, see
-    # https://github.com/lowRISC/opentitan/issues/5029 for details.
-    continueOnError: true
     displayName: Execute tests
 
 - job: deploy_release_artifacts

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -382,7 +382,7 @@ jobs:
     # using the NexysVideo bootrom here and the resulting CW305 bitstream is not functional.
     # By generating the CW305 bootrom binary we would break execute_fpga_tests executed on the
     # NexysVideo.
-    - sw_build
+    - sw_build_nexysvideo
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
   pool: ci-public
   timeoutInMinutes: 120 # 2 hours

--- a/ci/download-artifacts-template.yml
+++ b/ci/download-artifacts-template.yml
@@ -4,27 +4,40 @@
 
 # Azure template for downloading pipeline step outputs and unpacking them.
 #
-# This template will download all artifacts from upstream jobs (which are
-# expected to use upload_artifacts_template.yml) and unpack them.
+# This template will download all artifacts from the upstream jobs listed in
+# `downloadPartialBuildBinFrom` (which are expected to use
+# upload-artifacts-template.yml) and unpack them.
 #
 # This template expects that a variable $BUILD_ROOT is set to a writeable
 # directory; the results will be available in $BIN_DIR. See
 # util/build_consts.sh for more information.
 
+parameters:
+  # Names of jobs to download a partial $BIN_DIR from.
+  # List all "upstream" jobs here which produce files in $BIN_DIR which are
+  # needed in the current job. In other words, list all jobs which need to be
+  # executed and produce some build outputs before this job can start. The
+  # current job will find all outputs from those upstream jobs in $BIN_DIR and
+  # can use them.
+  - name: downloadPartialBuildBinFrom
+    type: object
+    default: []
+
 steps:
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      buildType: current
-      targetPath: '$(BUILD_ROOT)/downloads'
-      # The first "path" segment is the name of the artifact.
-      pattern: "*-build-bin/**"
-    displayName: 'Download upstream outputs'
+  - ${{ each job in parameters.downloadPartialBuildBinFrom }}:
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        buildType: current
+        path: '$(BUILD_ROOT)/downloads/${{ job }}'
+        artifact: "partial-build-bin-${{ job }}"
+      displayName: Downloading partial build-bin directory from job ${{ job }}
   - bash: |
       set -e
       test -n "$BUILD_ROOT"
       . util/build_consts.sh
       mkdir -p "$BIN_DIR"
 
+      echo 'Extracting partial BIN_DIRs:'
       find "$BUILD_ROOT/downloads" \
         -name 'build-bin.tar' \
         -exec \
@@ -32,4 +45,4 @@ steps:
           --strip-components=1 \
           --overwrite \
           -xvf {} \;
-    displayName: 'Unpack upstream outputs'
+    displayName: Unpack upstream outputs

--- a/ci/download-artifacts-template.yml
+++ b/ci/download-artifacts-template.yml
@@ -35,6 +35,12 @@ steps:
       set -e
       test -n "$BUILD_ROOT"
       . util/build_consts.sh
+
+      test -f "$BUILD_ROOT/upstream_bin_dir_contents.txt" && {
+        echo The download-artifacts-template.yml template can be called only once per job.
+        exit 1
+      }
+
       mkdir -p "$BIN_DIR"
 
       echo 'Extracting partial BIN_DIRs:'
@@ -43,6 +49,14 @@ steps:
         -exec \
           tar -C "$BIN_DIR" \
           --strip-components=1 \
-          --overwrite \
           -xvf {} \;
+
+      # Remember all files which were present in the upstream $BIN_DIRs.
+      find "$BIN_DIR" -type f -fprintf "$BUILD_ROOT/upstream_bin_dir_contents.txt" '%P\n'
+
+      echo
+      echo Upstream BIN_DIR contents:
+      echo vvvvvvvvvvvvvvvvvv
+      cat "$BUILD_ROOT/upstream_bin_dir_contents.txt"
+      echo ^^^^^^^^^^^^^^^^^^
     displayName: Unpack upstream outputs

--- a/ci/install-package-dependencies.yml
+++ b/ci/install-package-dependencies.yml
@@ -43,6 +43,7 @@ steps:
 
       cp apt-requirements.txt apt-requirements-ci.txt
       echo "verilator-$(VERILATOR_VERSION)" >> apt-requirements-ci.txt
+      echo rsync >> apt-requirements-ci.txt
       cat apt-requirements-ci.txt
 
       # Ensure apt package index is up-to-date.

--- a/ci/upload-artifacts-template.yml
+++ b/ci/upload-artifacts-template.yml
@@ -5,10 +5,17 @@
 # Azure template for archiving pipeline step outputs and uploading them.
 #
 # This template will archive all of $BIN_DIR, and upload it for use by
-# downstream jobs using download_artifacts_template.yml.
+# downstream jobs using download-artifacts-template.yml.
 #
 # This template expects that a variable $BUILD_ROOT is set. See
 # util/build_consts.sh for more information.
+
+
+parameters:
+  # Rsync-style file patterns to include in the partial BIN_DIR output.
+  - name: includePatterns
+    type: object
+    default: []
 
 steps:
   - bash: |
@@ -16,11 +23,50 @@ steps:
       test -n "$BUILD_ROOT"
       . util/build_consts.sh
 
+      # Write all include patterns to a file used by rsync.
+      echo "${{ join('\n', parameters.includePatterns) }}" > "$BUILD_ROOT/include_patterns.txt"
+
+      echo
+      echo Files matching these patterns will be included in the binary build artifact for this job:
+      echo vvvvvvvvvvvvvvvvvv
+      cat "$BUILD_ROOT/include_patterns.txt"
+      echo ^^^^^^^^^^^^^^^^^^
+
+      # The file upstream_bin_dir_contents.txt lists all files which were part
+      # of an "upstream" BIN_DIR which got downloaded at the beginning of this
+      # job. Ensure that this file exists, even if no upstream BIN_DIR was
+      # downloaded.
+      touch "$BUILD_ROOT/upstream_bin_dir_contents.txt"
+
+      BIN_DIR_FULL="${BIN_DIR}.full"
+      mv "$BIN_DIR" "$BIN_DIR_FULL"
+      mkdir -p "$BIN_DIR"
+
+      echo
+      echo Copying files into the output archive:
+      rsync \
+        --archive \
+        --verbose \
+        --remove-source-files \
+        --prune-empty-dirs \
+        --exclude-from="$BUILD_ROOT/upstream_bin_dir_contents.txt" \
+        --include="*/" \
+        --include-from="$BUILD_ROOT/include_patterns.txt" \
+        --exclude="*" \
+        "${BIN_DIR_FULL}/" "${BIN_DIR}/"
+
+      echo
+      echo 'Files in $BIN_DIR not considered outputs of this job:'
+      echo vvvvvvvvvvvvvvvvvv
+      find "$BIN_DIR_FULL"
+      echo ^^^^^^^^^^^^^^^^^^
+
       tar -C "$BUILD_ROOT" \
         -cvf "$BUILD_ROOT/build-bin.tar" \
         "${BIN_DIR#"$BUILD_ROOT/"}"
-    displayName: 'Archive step outputs'
+    displayName: Archive step outputs
   - publish: "$(Build.ArtifactStagingDirectory)/build-bin.tar"
-    artifact: ${{ parameters.artifact }}-build-bin
-    displayName: 'Upload step outputs'
-
+    # The PhaseName is the string after the "job" key in the build description,
+    # e.g. "job: my_phase_name".
+    artifact: partial-build-bin-$(System.PhaseName)
+    displayName: Upload step outputs


### PR DESCRIPTION
The CI build pipelines is split into different jobs. Build artifacts between jobs are passed in the `BIN_DIR` directory. Due to a variety of misunderstandings and bugs, this passing wasn't working as expected:

* Multiple jobs produced identical artifacts in BIN_DIR, i.e. we didn't have an unambiguous build rule for each output in BIN_DIR any more.
* Partial BIN_DIR artifacts were downloaded from unrelated jobs in a non-determinisic manner.
* The overall system of selecting intended build artifacts and merging partial BIN_DIR outputs into a final result wasn't very robust.

This series of commits fixes the underlying problems and makes the whole build pipeline a bit more robust and explicit; see the individual commit messages for details.

In the medium term, much of the logic contained in the pipeline definitions today should be part of a higher-level build system, which, for example, takes care of having unambiguous ways to produce output artifacts, and ensures that the right input artifact dependencies are present or built if needed. That work has started and will hopefully come to fruition soon. In the meantime, I went for a fix which improves on the status quo without going overboard.

Thanks a lot to @vogelpi for ultimately finding the reason why builds were failing when I got lost in the weeds of synthesis logs.

Fixes #5029
Fixes #5044