### PR TITLE
[keymgr] remove one cycle drop at op_accept after keymgr_en is off

### DIFF
--- a/hw/ip/keymgr/rtl/keymgr_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_ctrl.sv
@@ -424,6 +424,7 @@ module keymgr_ctrl import keymgr_pkg::*;(
       default: begin
         if (!en_i && in_disabled) begin
           state_d = StCtrlWipe;
+          op_accept = 1'b1;
         end else begin
           update_sel = KeyUpdateInvalid;
           op_accept = 1'b1;


### PR DESCRIPTION
op_accept is low for one cycle when LC turns off KM
When it's low, kmac key is switched to sideload key. And this cycle may
expose the good sideload key. It's probably not a security issue but scb
checks any good key shouldn't be exposed at this point.
It may be easy to update design so that we don't need to hack scb to
skip checking this cycle.

![Screen Shot 2021-02-02 at 6 13 48 PM](https://user-images.githubusercontent.com/49293026/106826137-254f7500-663b-11eb-8ead-234df9dd9be7.png)
/edascratch/weicai-opentitan/ot/km_kmac_err/keymgr-sim-vcs/18.keymgr_lc_disable/out
verdi -ssr Verdi.ses &

I made this change on design to solve this issue. WDYT? @tjaychen 

Signed-off-by: Weicai Yang <weicai@google.com>