### PR TITLE
[dv/otp_ctrl] improve rand_key_request vseq

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_rand_key_rsp_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_rand_key_rsp_vseq.sv
@@ -6,7 +6,7 @@
 // is locked.
 // This sequence will check if nonce, seed_valid, and output keys are correct via scb.
 
-class otp_ctrl_rand_key_rsp_vseq extends otp_ctrl_smoke_vseq;
+class otp_ctrl_rand_key_rsp_vseq extends otp_ctrl_dai_errs_vseq;
   `uvm_object_utils(otp_ctrl_rand_key_rsp_vseq)
 
   `uvm_object_new
@@ -15,11 +15,6 @@ class otp_ctrl_rand_key_rsp_vseq extends otp_ctrl_smoke_vseq;
     num_trans  inside {[1:5]};
     num_dai_op inside {[1:500]};
   }
-
-  function void pre_randomize();
-    this.dai_wr_blank_addr_c.constraint_mode(0);
-    collect_used_addr = 0;
-  endfunction
 
   virtual task body();
     bit base_vseq_done;

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
@@ -8,7 +8,7 @@
 `include "otp_ctrl_common_vseq.sv"
 `include "otp_ctrl_partition_walk_vseq.sv"
 `include "otp_ctrl_lc_vseq.sv"
-`include "otp_ctrl_rand_key_rsp_vseq.sv"
 `include "otp_ctrl_dai_lock_vseq.sv"
 `include "otp_ctrl_dai_errs_vseq.sv"
+`include "otp_ctrl_rand_key_rsp_vseq.sv"
 `include "otp_ctrl_regwen_vseq.sv"


### PR DESCRIPTION
This PR adjusts rand_key_request_vseq to extends from dai_errs_vseq in order to cross with more dai interface access scenarios.

Signed-off-by: Cindy Chen <chencindy@google.com>