### PR TITLE
[pattgen, dv] Update base_vseq for stress_all test

### DIFF
--- a/hw/ip/pattgen/data/pattgen_testplan.hjson
+++ b/hw/ip/pattgen/data/pattgen_testplan.hjson
@@ -5,7 +5,6 @@
   name: "pattgen"
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"],
   entries: [
     {

--- a/hw/ip/pattgen/dv/env/seq_lib/pattgen_base_vseq.sv
+++ b/hw/ip/pattgen/dv/env/seq_lib/pattgen_base_vseq.sv
@@ -92,32 +92,15 @@ class pattgen_base_vseq extends cip_base_vseq #(
            channel_start) begin             // at least one channel is running
       wait(cfg.clk_rst_vif.rst_n); // wait until reset is de-asserted
       fork
-        begin : isolation_thread
-          fork
-            process_reset();
-            fork
-              // all channels are completely independent (programm, start w/ or wo/ sync, and stop)
-              setup_pattgen_channel_0();
-              setup_pattgen_channel_1();
-              start_pattgen_channels();
-              stop_pattgen_channels();
-            join
-          join_any
-          disable fork;
-        end : isolation_thread
+        // all channels are completely independent (programm, start w/ or wo/ sync, and stop)
+        setup_pattgen_channel_0();
+        setup_pattgen_channel_1();
+        start_pattgen_channels();
+        stop_pattgen_channels();
       join
     end
     `uvm_info(`gfn, "\n--> end of sequence", UVM_DEBUG)
   endtask : body
-
-  virtual task process_reset();
-    // when reset is asserted, all threads for channels are stopped
-    @(negedge cfg.clk_rst_vif.rst_n);
-    channel_setup = 'h0;
-    channel_start = 'h0;
-    channel_grant = 'h1;
-    `uvm_info(`gfn, "\n  process_reset is called", UVM_DEBUG)
-  endtask : process_reset
 
   virtual task setup_pattgen_channel_0();
     if (num_pattern_req < num_trans &&

--- a/hw/ip/pattgen/dv/env/seq_lib/pattgen_perf_vseq.sv
+++ b/hw/ip/pattgen/dv/env/seq_lib/pattgen_perf_vseq.sv
@@ -8,7 +8,7 @@ class pattgen_perf_vseq extends pattgen_base_vseq;
   `uvm_object_new
 
   // reduce num_trans due to long running simulations
-  constraint num_trans_c        { num_trans inside {[5:10]}; }
+  constraint num_trans_c        { num_trans inside {[3:6]}; }
   // fast clear interrupt
   constraint clear_intr_dly_c   { clear_intr_dly == 0; }
   // fast stop/start channel

--- a/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson
+++ b/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson
@@ -60,6 +60,12 @@
       name: pattgen_error
       uvm_test_seq: pattgen_error_vseq
     }
+
+    // TODO: this test description is removed when stress_tests.hjson is included
+    {
+      name: pattgen_stress_all
+      uvm_test_seq: pattgen_stress_all_vseq
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
[pattgen, dv] Update base_vseq for stress_all test

  - Update body task to remove reset handler
  - Enable do_read_check in scoreboard

Signed-off-by: Tung Hoang <hoang.tung@wdc.com>