### PR TITLE
[dv] Fix tl host for reset

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/cip_base_vseq.sv
@@ -562,7 +562,6 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
               do_read_and_check_all_csrs = 1'b1;
             end
           join_any
-          p_sequencer.tl_sequencer_h.stop_sequences();
           disable fork;
           `uvm_info(`gfn, $sformatf("\nStress w/ reset is done for run %0d/%0d", i, num_times),
                     UVM_LOW)


### PR DESCRIPTION
In #4282, we updated it to avoid printing too much log and reduce loops
However, when a req comes in the the middle of reset, we won't process
it as driver is waiting for reset to be released, which causes
uncompleted items in RAL

Changed to still polling every 1ns but don't enter `DV_SPINWAIT_EXIT if
it's in the reset

Signed-off-by: Weicai Yang <weicai@google.com>