### PR TITLE
[dv/prim] minor updates

### DIFF
--- a/hw/ip/prim/dv/prim_present/tb/prim_present_tb.sv
+++ b/hw/ip/prim/dv/prim_present/tb/prim_present_tb.sv
@@ -99,10 +99,8 @@ module prim_present_tb;
 
     crypto_dpi_present_pkg::sv_dpi_present_get_key_schedule(key, KeySize80, key_schedule);
 
-    $display("Starting encryption pass with data[0x%0x] and key[0x%0x]!", plaintext, key);
     check_encryption(plaintext, key, key_schedule, encrypted_text);
 
-    $display("Starting decryption pass!");
     check_decryption(encrypted_text, key, key_out[Encrypt]);
 
   endtask
@@ -238,7 +236,7 @@ module prim_present_tb;
 
     // Test random vectors
     void'($value$plusargs("smoke_test=%0b", smoke_test));
-    num_trans = smoke_test ? 1 : $urandom_range(2500, 5000);
+    num_trans = smoke_test ? 1 : $urandom_range(5000, 25000);
     for (int i = 0; i < num_trans; i++) begin
       `DV_CHECK_STD_RANDOMIZE_FATAL(plaintext, "", msg_id)
       `DV_CHECK_STD_RANDOMIZE_FATAL(key, "", msg_id)

--- a/hw/ip/prim/dv/prim_prince/tb/prim_prince_tb.sv
+++ b/hw/ip/prim/dv/prim_prince/tb/prim_prince_tb.sv
@@ -106,9 +106,9 @@ module prim_prince_tb;
                              bit [KeyWidth-1:0]  key);
 
     bit [1:0][1:0][NumRoundsHalf-1:0][DataWidth-1:0] encrypted_text;
-    $display("Starting encryption with data[0x%0x] and key[0x%0x]!", plaintext, key);
+
     check_encryption(plaintext, key, encrypted_text);
-    $display("Starting decryption pass!");
+
     check_decryption(encrypted_text, key);
 
   endtask
@@ -280,7 +280,7 @@ module prim_prince_tb;
 
     // Test random vectors
     void'($value$plusargs("smoke_test=%0b", smoke_test));
-    num_trans = smoke_test ? 1 : $urandom_range(10000, 30000);
+    num_trans = smoke_test ? 1 : $urandom_range(5000, 25000);
     for (int i = 0; i < num_trans; i++) begin
       `DV_CHECK_STD_RANDOMIZE_FATAL(plaintext, "", msg_id)
       `DV_CHECK_STD_RANDOMIZE_FATAL(k0, "", msg_id)


### PR DESCRIPTION
This PR updates the number of rounds run in the PRESENT testbench, and
removes some unnecessary `$display` statements from both PRINCE/PRESENT
testbenches.

Signed-off-by: Udi Jonnalagadda <udij@google.com>