### PR TITLE
[keymgr/dv] Fix cfgen seq

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -401,6 +401,8 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
                 cfg.keymgr_vif.update_kdf_key(current_internal_key, current_state, good_key);
               end
             endcase
+            // start will be clear after OP is done
+            void'(ral.control.start.predict(.value(0), .kind(UVM_PREDICT_WRITE)));
           end // start
         end // addr_phase_write
       end


### PR DESCRIPTION
One condition was wrong, the write to locked reg never occured.
Avoid checking start field, when it's not clear during the OP.

Signed-off-by: Weicai Yang <weicai@google.com>