### PR TITLE
[prim_ram_1p_scr] Make parity and diffusion layer settings more flexible

### DIFF
--- a/hw/ip/sram_ctrl/doc/_index.md
+++ b/hw/ip/sram_ctrl/doc/_index.md
@@ -208,9 +208,12 @@ Parameter                   | Default (Max)         | Top Earlgrey | Description
 ----------------------------|-----------------------|--------------|---------------
 `Depth`                     | 512                   | multiple     | SRAM depth, needs to be a power of 2 if `NumAddrScrRounds` > 0.
 `Width`                     | 32                    | 32           | Effective SRAM width without redundancy.
+`DataBitsPerMask`           | 8                     | 8            | Number of data bits per write mask.
+`EnableParity`              | 1                     | 1            | This parameter enables byte parity.
 `CfgWidth`                  | 8                     | 8            | Width of SRAM attributes field.
 `NumPrinceRoundsHalf`       | 2 (5)                 | 2            | Number of PRINCE half-rounds.
-`NumByteScrRounds`          | 2                     | 2            | Number of intra-byte diffusion rounds, set to 0 to disable.
+`NumDiffRounds`             | 2                     | 2            | Number of additional diffusion rounds, set to 0 to disable.
+`DiffWidth`                 | 8                     | 8            | Width of additional diffusion rounds, set to 8 for intra-byte diffusion.
 `NumAddrScrRounds`          | 2                     | 2            | Number of address scrambling rounds, set to 0 to disable.
 `ReplicateKeyStream`        | 0 (1)                 | 0            | If set to 1, the same 64bit key stream is replicated if the data port is wider than 64bit. Otherwise, multiple PRINCE primitives are employed to generate a unique keystream for the full data width.
 

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -350,6 +350,7 @@ module top_${top["name"]} #(
   prim_ram_1p_scr #(
     .Width(${data_width}),
     .Depth(${sram_depth}),
+    .EnableParity(1),
     .CfgWidth(8)
   ) u_ram1p_${m["name"]} (
     % for key in clocks:

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -736,6 +736,7 @@ module top_earlgrey #(
   prim_ram_1p_scr #(
     .Width(32),
     .Depth(32768),
+    .EnableParity(1),
     .CfgWidth(8)
   ) u_ram1p_ram_main (
     .clk_i   (clkmgr_aon_clocks.clk_main_infra),
@@ -795,6 +796,7 @@ module top_earlgrey #(
   prim_ram_1p_scr #(
     .Width(32),
     .Depth(1024),
+    .EnableParity(1),
     .CfgWidth(8)
   ) u_ram1p_ram_ret_aon (
     .clk_i   (clkmgr_aon_clocks.clk_io_div4_infra),


### PR DESCRIPTION
This adds two some more configurability to the SRAM scrambling primitive. In particular, byte parity (calculated after scrambling the data) can now be optionally disabled, and the additional diffusion layer can now be applied to larger chunks than just bytes.

This enables the use of this scrambling primitive on oddly shaped words (e.g. 39bit wide).

Note that this additional functionality has not been tested yet.

Signed-off-by: Michael Schaffner <msf@opentitan.org>