### PR TITLE
[dv] Make CSR fields randomizable by default.

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg_field.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_field.sv
@@ -9,6 +9,29 @@ class dv_base_reg_field extends uvm_reg_field;
   `uvm_object_utils(dv_base_reg_field)
   `uvm_object_new
 
+  // Issue #5105: UVM forces the value member to be non-randomizable for certain access policies.
+  // We restore it in this extended class.
+  virtual function void configure(uvm_reg        parent,
+                                  int unsigned   size,
+                                  int unsigned   lsb_pos,
+                                  string         access,
+                                  bit            volatile,
+                                  uvm_reg_data_t reset,
+                                  bit            has_reset,
+                                  bit            is_rand,
+                                  bit            individually_accessible);
+      super.configure(.parent   (parent),
+                      .size     (size),
+                      .lsb_pos  (lsb_pos),
+                      .access   (access),
+                      .volatile (volatile),
+                      .reset    (reset),
+                      .has_reset(has_reset),
+                      .is_rand  (is_rand),
+                      .individually_accessible(individually_accessible));
+      value.rand_mode(is_rand);
+    endfunction
+
   // when use UVM_PREDICT_WRITE and the CSR access is WO, this function will return the default
   // val of the register, rather than the written value
   virtual function uvm_reg_data_t XpredictX(uvm_reg_data_t cur_val,


### PR DESCRIPTION
- Partially fixes #5105. As a safeguard, the fixes suggested by
@weicaiyang must also be employed.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>