### PR TITLE
[reggen] Improvements to generated documentation

### DIFF
--- a/util/reggen/gen_cfg_html.py
+++ b/util/reggen/gen_cfg_html.py
@@ -5,6 +5,8 @@
 Generate HTML documentation from validated configuration Hjson tree
 """
 
+from .html_helpers import render_td
+
 
 def genout(outfile, msg):
     outfile.write(msg)
@@ -20,6 +22,8 @@ def name_width(x):
 
 
 def gen_cfg_html(cfgs, outfile):
+    rnames = cfgs['genrnames']
+
     genout(outfile, "<p>Referring to the \n")
     genout(
         outfile,
@@ -48,29 +52,23 @@ def gen_cfg_html(cfgs, outfile):
             cfgs['bus_host'] + "</code></b></p>\n")
     else:
         genout(outfile, "<p><i>Bus Host Interface: none</i></p>\n")
+
     # IO
-    if ('available_input_list' in cfgs or 'available_output_list' in cfgs or
-            'available_inout_list' in cfgs):
+    ios = ([('input', x) for x in cfgs.get('available_input_list', [])] +
+           [('output', x) for x in cfgs.get('available_output_list', [])] +
+           [('inout', x) for x in cfgs.get('available_inout_list', [])])
+    if ios:
         genout(outfile, "<p><i>Peripheral Pins for Chip IO:</i></p>\n")
         genout(
             outfile, "<table class=\"cfgtable\"><tr>" +
             "<th>Pin name</th><th>direction</th>" +
             "<th>Description</th></tr>\n")
-        if 'available_input_list' in cfgs:
-            for x in cfgs['available_input_list']:
-                genout(
-                    outfile, "<tr><td>" + name_width(x) +
-                    "</td><td>input</td><td>" + x['desc'] + "</td></tr>\n")
-        if 'available_output_list' in cfgs:
-            for x in cfgs['available_output_list']:
-                genout(
-                    outfile, "<tr><td>" + name_width(x) +
-                    "</td><td>output</td><td>" + x['desc'] + "</td></tr>\n")
-        if 'available_inout_list' in cfgs:
-            for x in cfgs['available_inout_list']:
-                genout(
-                    outfile, "<tr><td>" + name_width(x) +
-                    "</td><td>inout</td><td>" + x['desc'] + "</td></tr>\n")
+        for direction, x in ios:
+            genout(outfile,
+                   '<tr><td>{}</td><td>{}</td>{}</tr>'
+                   .format(name_width(x),
+                           direction,
+                           render_td(x['desc'], rnames, None)))
         genout(outfile, "</table>\n")
     else:
         genout(outfile, "<p><i>Peripheral Pins for Chip IO: none</i></p>\n")
@@ -81,9 +79,10 @@ def gen_cfg_html(cfgs, outfile):
             outfile, "<table class=\"cfgtable\"><tr><th>Interrupt Name</th>" +
             "<th>Description</th></tr>\n")
         for x in cfgs['interrupt_list']:
-            genout(
-                outfile, "<tr><td>" + name_width(x) + "</td><td>" + x['desc'] +
-                "</td></tr>\n")
+            genout(outfile,
+                   '<tr><td>{}</td>{}</tr>'
+                   .format(name_width(x),
+                           render_td(x['desc'], rnames, None)))
         genout(outfile, "</table>\n")
     else:
         genout(outfile, "<p><i>Interrupts: none</i></p>\n")
@@ -93,9 +92,10 @@ def gen_cfg_html(cfgs, outfile):
             outfile, "<table class=\"cfgtable\"><tr><th>Alert Name</th>" +
             "<th>Description</th></tr>\n")
         for x in cfgs['alert_list']:
-            genout(
-                outfile, "<tr><td>" + x['name'] + "</td><td>" + x['desc'] +
-                "</td></tr>\n")
+            genout(outfile,
+                   '<tr><td>{}</td>{}</tr>'
+                   .format(x['name'],
+                           render_td(x['desc'], rnames, None)))
         genout(outfile, "</table>\n")
     else:
         genout(outfile, "<p><i>Security Alerts: none</i></p>\n")

--- a/util/reggen/gen_cfg_html.py
+++ b/util/reggen/gen_cfg_html.py
@@ -72,32 +72,33 @@ def gen_cfg_html(cfgs, outfile):
         genout(outfile, "</table>\n")
     else:
         genout(outfile, "<p><i>Peripheral Pins for Chip IO: none</i></p>\n")
-    # interrupts
-    if 'interrupt_list' in cfgs:
+
+    interrupts = cfgs.get('interrupt_list', [])
+    if not interrupts:
+        genout(outfile, "<p><i>Interrupts: none</i></p>\n")
+    else:
         genout(outfile, "<p><i>Interrupts:</i></p>\n")
         genout(
             outfile, "<table class=\"cfgtable\"><tr><th>Interrupt Name</th>" +
             "<th>Description</th></tr>\n")
-        for x in cfgs['interrupt_list']:
+        for x in interrupts:
             genout(outfile,
                    '<tr><td>{}</td>{}</tr>'
                    .format(name_width(x),
                            render_td(x['desc'], rnames, None)))
         genout(outfile, "</table>\n")
+
+    alerts = cfgs.get('alert_list', [])
+    if not alerts:
+        genout(outfile, "<p><i>Security Alerts: none</i></p>\n")
     else:
-        genout(outfile, "<p><i>Interrupts: none</i></p>\n")
-    if 'alert_list' in cfgs:
         genout(outfile, "<p><i>Security Alerts:</i></p>\n")
         genout(
             outfile, "<table class=\"cfgtable\"><tr><th>Alert Name</th>" +
             "<th>Description</th></tr>\n")
-        for x in cfgs['alert_list']:
+        for x in alerts:
             genout(outfile,
                    '<tr><td>{}</td>{}</tr>'
                    .format(x['name'],
                            render_td(x['desc'], rnames, None)))
         genout(outfile, "</table>\n")
-    else:
-        genout(outfile, "<p><i>Security Alerts: none</i></p>\n")
-    # interrupts
-    return

--- a/util/reggen/gen_html.py
+++ b/util/reggen/gen_html.py
@@ -159,16 +159,30 @@ def gen_html_register(outfile, reg, comp, width, rnames, toc, toclvl):
     # in a multireg with multiple regs give anchor with base register name
     if 'genbasebits' in reg and rname[-1] == '0':
         genout(outfile, "<div id=\"Reg_" + rname[:-1].lower() + "\"></div>\n")
-    regwen_string = ''
+
+    regwen_div = ''
     if 'regwen' in reg and (reg['regwen'] != ''):
-        regwen_string = '<br>Register enable = ' + reg['regwen']
-    genout(
-        outfile, "<table class=\"regdef\" id=\"Reg_" + rname.lower() + "\">\n"
-        "<tr><th class=\"regdef\" colspan=5><div>" + comp + "." + rname +
-        " @ + " + hex(offset) + "</div><div>" +
-        desc_expand(reg['desc'], rnames) + "</div>" + "<div>Reset default = " +
-        hex(reg['genresval']) + ", mask " + hex(reg['genresmask']) +
-        regwen_string + "</div></th></tr>\n")
+        regwen_div = ('    <div>Register enable = {}</div>\n'
+                      .format(reg['regwen']))
+
+    genout(outfile,
+           '<table class="regdef" id="Reg_{lrname}">\n'
+           ' <tr>\n'
+           '  <th class="regdef" colspan=5>\n'
+           '   <div>{comp}.{rname} @ {off:#x}</div>\n'
+           '   <div>{desc}</div>\n'
+           '   <div>Reset default = {resval:#x}, mask {mask:#x}</div>\n'
+           '{wen}'
+           '  </th>\n'
+           ' </tr>\n'
+           .format(lrname=rname.lower(),
+                   comp=comp,
+                   rname=rname,
+                   off=offset,
+                   desc=desc_expand(reg['desc'], rnames),
+                   resval=reg['genresval'],
+                   mask=reg['genresmask'],
+                   wen=regwen_div))
     if toc is not None:
         toc.append((toclvl, comp + "." + rname, "Reg_" + rname.lower()))
     genout(outfile, "<tr><td colspan=5>")

--- a/util/reggen/html_helpers.py
+++ b/util/reggen/html_helpers.py
@@ -1,0 +1,67 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging as log
+import re
+
+
+def expand_paras(s, rnames):
+    '''Expand a description field to HTML.
+
+    This supports a sort of simple pseudo-markdown. Supported Markdown
+    features:
+
+    - Separate paragraphs on a blank line
+    - **bold** and *italicised* text
+
+    We also generate links to registers when a name is prefixed with a double
+    exclamation mark. For example, if there is a register FOO then !!FOO or
+    !!FOO.field will generate a link to that register.
+
+    Returns a list of rendered paragraphs
+
+    '''
+    # Start by splitting into paragraphs. The regex matches a newline followed
+    # by one or more lines that just contain whitespace. Then render each
+    # paragraph with the _expand_paragraph worker function.
+    paras = [_expand_paragraph(paragraph.strip(), rnames)
+             for paragraph in re.split(r'\n(?:\s*\n)+', s)]
+
+    # There will always be at least one paragraph (splitting an empty string
+    # gives [''])
+    assert paras
+    return paras
+
+
+def _expand_paragraph(s, rnames):
+    '''Expand a single paragraph, as described in _get_desc_paras'''
+    def fieldsub(match):
+        base = match.group(1).partition('.')[0].lower()
+        if base in rnames:
+            if match.group(1)[-1] == ".":
+                return ('<a href="#Reg_' + base + '"><code class=\"reg\">' +
+                        match.group(1)[:-1] + '</code></a>.')
+            else:
+                return ('<a href="#Reg_' + base + '"><code class=\"reg\">' +
+                        match.group(1) + '</code></a>')
+        log.warn('!!' + match.group(1).partition('.')[0] +
+                 ' not found in register list.')
+        return match.group(0)
+
+    s = re.sub(r"!!([A-Za-z0-9_.]+)", fieldsub, s)
+    s = re.sub(r"(?s)\*\*(.+?)\*\*", r'<B>\1</B>', s)
+    s = re.sub(r"\*([^*]+?)\*", r'<I>\1</I>', s)
+    return s
+
+
+def render_td(s, rnames, td_class):
+    '''Expand a description field and put it in a <td>.
+
+    Returns a string. See _get_desc_paras for the format that gets expanded.
+
+    '''
+    desc_paras = expand_paras(s, rnames)
+    class_attr = '' if td_class is None else ' class="{}"'.format(td_class)
+    return ('<td{}><p>{}</p></td>'
+            .format(class_attr, '</p><p>'.join(desc_paras)))


### PR DESCRIPTION
This sequence of patches adds support for multiple paragraphs in register and field descriptions. It also adds formatting support to the stuff generated by `gen_cfg_html.py` (it's the same data and ends up in the same document, so we should probably render it the same). Finally, we add support for back-ticks in our not-quite-markdown syntax.