### PR TITLE
[sram/dv] Fix RAL hdl path

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
@@ -22,6 +22,10 @@ class sram_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(sram_ctrl_reg_block));
     list_of_alerts = sram_ctrl_env_pkg::LIST_OF_ALERTS;
     super.initialize(csr_base_addr);
 
+    ral.set_hdl_path_root("tb.dut.u_sram_ctrl", "BkdrRegPathRtl");
+    ral.set_hdl_path_root("tb.dut.u_sram_ctrl", "BkdrRegPathRtlCommitted");
+    ral.set_hdl_path_root("tb.dut.u_sram_ctrl", "BkdrRegPathRtlShadow");
+
     // Build KDI cfg object
     m_kdi_cfg = push_pull_agent_cfg#(.DeviceDataWidth(KDI_DATA_SIZE))::type_id::create("m_kdi_cfg");
 


### PR DESCRIPTION
sram dut path is `tb.dut.u_sram_ctrl` which isn't same as the others
override it in sram_ctrl_env_cfg with the correct path

@udinator I think this PR should fix the hdl path issue, but I saw other errors when rerunning with this. LMK if this doesn't work.

Signed-off-by: Weicai Yang <weicai@google.com>