### PR TITLE
[i2c, dv] Update interrupt interface for i2c target mode

### DIFF
--- a/hw/ip/i2c/dv/env/i2c_env_pkg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_pkg.sv
@@ -35,7 +35,8 @@ package i2c_env_pkg;
     TxOverflow     = 12,
     AcqOverflow    = 13,
     AckStop        = 14,
-    NumI2cIntr     = 15
+    HostTimeout    = 15,
+    NumI2cIntr     = 16
   } i2c_intr_e;
 
   typedef enum int {

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_error_intr_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_error_intr_vseq.sv
@@ -29,7 +29,7 @@ class i2c_error_intr_vseq extends i2c_rx_tx_vseq;
   virtual task body();
     `uvm_info(`gfn, "\n--> start of i2c_error_intr_vseq", UVM_DEBUG)
     initialization();
-    do_dut_init = 1'b1;
+    do_apply_reset = 1'b1;
     for (int i = 1; i <= num_runs; i++) begin
       `uvm_info(`gfn, $sformatf("\n  run simulation %0d/%0d", i, num_runs), UVM_DEBUG)
       fork

--- a/hw/ip/i2c/dv/tb/tb.sv
+++ b/hw/ip/i2c/dv/tb/tb.sv
@@ -30,6 +30,7 @@ module tb;
   wire intr_tx_overflow;
   wire intr_acq_overflow;
   wire intr_ack_stop;
+  wire intr_host_timeout;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
 
   wire cio_scl_i;
@@ -76,7 +77,8 @@ module tb;
     .intr_tx_nonempty_o      (intr_tx_nonempty      ),
     .intr_tx_overflow_o      (intr_tx_overflow      ),
     .intr_acq_overflow_o     (intr_acq_overflow     ),
-    .intr_ack_stop_o         (intr_ack_stop         )
+    .intr_ack_stop_o         (intr_ack_stop         ),
+    .intr_host_timeout_o     (intr_host_timeout     )
   );
 
   // virtual open drain
@@ -105,6 +107,7 @@ module tb;
   assign interrupts[TxOverflow]     = intr_tx_overflow;
   assign interrupts[AcqOverflow]    = intr_acq_overflow;
   assign interrupts[AckStop]        = intr_ack_stop;
+  assign interrupts[HostTimeout]    = intr_host_timeout;
 
   initial begin
     // drive clk and rst_n from clk_if


### PR DESCRIPTION
Add missing intr_host_timeout into dv

Signed-off-by: Tung Hoang <hoang.tung@wdc.com>