### PR TITLE
[dv/otp_ctrl] key_request optimization

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -28,8 +28,9 @@ filesets:
       - seq_lib/otp_ctrl_lc_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_dai_lock_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_dai_errs_vseq.sv: {is_include_file: true}
+      - seq_lib/otp_ctrl_parallel_base_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_regwen_vseq.sv: {is_include_file: true}
-      - seq_lib/otp_ctrl_rand_key_rsp_vseq.sv: {is_include_file: true}
+      - seq_lib/otp_ctrl_parallel_key_req_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_base_vseq.sv
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is a base sequence that serves as a template for the scenarios below:
+// Two sequences run in parallel:
+// 1. One sequence is otp_ctrl's DAI interface access sequence with errors
+// 2. Another sequence is an empty task that needs to be override, this could be: key_request
+//    sequences or lc_request sequences.
+
+class otp_ctrl_parallel_base_vseq extends otp_ctrl_dai_errs_vseq;
+  `uvm_object_utils(otp_ctrl_parallel_base_vseq)
+
+  `uvm_object_new
+
+  constraint num_iterations_c {
+    num_trans  inside {[1:5]};
+    num_dai_op inside {[1:500]};
+  }
+
+  virtual task body();
+    bit base_vseq_done;
+
+    fork
+      begin
+        run_parallel_seq(base_vseq_done);
+      end
+      begin
+        super.body();
+        base_vseq_done = 1;
+      end
+    join
+  endtask
+
+  virtual task run_parallel_seq(ref bit base_vseq_done);
+    // Override with real parallel sequence
+    `uvm_fatal(`gfn, "please override this method!")
+  endtask
+
+  virtual task wait_clk_or_reset(int wait_clks);
+    repeat(wait_clks) begin
+      @(posedge cfg.clk_rst_vif.clk);
+      if (cfg.under_reset) break;
+    end
+  endtask
+
+endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_key_req_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_key_req_vseq.sv
@@ -6,31 +6,16 @@
 // is locked.
 // This sequence will check if nonce, seed_valid, and output keys are correct via scb.
 
-class otp_ctrl_rand_key_rsp_vseq extends otp_ctrl_dai_errs_vseq;
-  `uvm_object_utils(otp_ctrl_rand_key_rsp_vseq)
+class otp_ctrl_parallel_key_req_vseq extends otp_ctrl_parallel_base_vseq;
+  `uvm_object_utils(otp_ctrl_parallel_key_req_vseq)
 
   `uvm_object_new
 
-  constraint num_iterations_c {
-    num_trans  inside {[1:5]};
-    num_dai_op inside {[1:500]};
+  constraint key_reqs_c {
+    do_req_keys == 0;
   }
 
-  virtual task body();
-    bit base_vseq_done;
-
-    fork
-      begin
-        key_requests(base_vseq_done);
-      end
-      begin
-        super.body();
-        base_vseq_done = 1;
-      end
-    join
-  endtask
-
-  virtual task key_requests(ref bit base_vseq_done);
+  virtual task run_parallel_seq(ref bit base_vseq_done);
     forever
       begin
         if (base_vseq_done) return;
@@ -66,13 +51,6 @@ class otp_ctrl_rand_key_rsp_vseq extends otp_ctrl_dai_errs_vseq;
           end
         join
       end
-  endtask
-
-  virtual task wait_clk_or_reset(int wait_clks);
-    repeat(wait_clks) begin
-      @(posedge cfg.clk_rst_vif.clk);
-      if (cfg.under_reset) break;
-    end
   endtask
 
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -14,6 +14,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
   bit do_lc_trans;
   bit collect_used_addr = 1;
 
+  rand bit                           do_req_keys;
   rand bit                           access_locked_parts;
   rand bit [TL_AW-1:0]               dai_addr;
   rand bit [TL_DW-1:0]               wdata0, wdata1;
@@ -91,6 +92,13 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
       csr_wr(ral.check_trigger_regwen, check_trigger_regwen_val);
       csr_wr(ral.check_timeout, check_timeout_val);
       trigger_checks(.val(check_trigger_val), .wait_done(1));
+
+      if (do_req_keys) begin
+        req_otbn_key();
+        req_flash_addr_key();
+        req_flash_data_key();
+        req_all_sram_keys();
+      end
 
       for (int i = 0; i < num_dai_op; i++) begin
         bit [TL_DW-1:0] rdata0, rdata1;

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
@@ -10,5 +10,6 @@
 `include "otp_ctrl_lc_vseq.sv"
 `include "otp_ctrl_dai_lock_vseq.sv"
 `include "otp_ctrl_dai_errs_vseq.sv"
-`include "otp_ctrl_rand_key_rsp_vseq.sv"
+`include "otp_ctrl_parallel_base_vseq.sv"
+`include "otp_ctrl_parallel_key_req_vseq.sv"
 `include "otp_ctrl_regwen_vseq.sv"

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -81,8 +81,8 @@
     }
 
     {
-      name: otp_ctrl_rand_key_rsp
-      uvm_test_seq: otp_ctrl_rand_key_rsp_vseq
+      name: otp_ctrl_parallel_key_req
+      uvm_test_seq: otp_ctrl_parallel_key_req_vseq
     }
 
     {


### PR DESCRIPTION
This PR optimize the key_req vseq by:
1. add rand check for key request in all seqs
2. rename the rand_key_rsp to parallel_key_req
3. add a parallel_base_vseq so we can use that in parallel_lc_req
sequences.

Signed-off-by: Cindy Chen <chencindy@google.com>