### PR TITLE
[otp_ctrl] Update behavior of LCI idle signals

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -301,7 +301,7 @@ module otp_ctrl
   // DAI-related CSRs //
   //////////////////////
 
-  logic                         dai_idle, dai_prog_idle;
+  logic                         dai_idle;
   logic                         dai_req;
   dai_cmd_e                     dai_cmd;
   logic [OtpByteAddrWidth-1:0]  dai_addr;
@@ -327,8 +327,8 @@ module otp_ctrl
   // are pending. Hence, we signal the LCI/DAI idle state to the
   // power manager. This signal is flopped here as it has to
   // cross a clock boundary to the power manager.
-  logic lci_idle, otp_idle_d, otp_idle_q;
-  assign otp_idle_d = lci_idle & dai_prog_idle;
+  logic dai_prog_idle, lci_prog_idle, otp_idle_d, otp_idle_q;
+  assign otp_idle_d = lci_prog_idle & dai_prog_idle;
   assign pwr_otp_o.otp_idle = otp_idle_q;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_idle_reg
@@ -824,7 +824,7 @@ module otp_ctrl
     .lci_en_i         ( pwr_otp_o.otp_done                ),
     .escalate_en_i    ( lc_escalate_en[LciIdx]            ),
     .error_o          ( part_error[LciIdx]                ),
-    .lci_idle_o       ( lci_idle                          ),
+    .lci_prog_idle_o  ( lci_prog_idle                     ),
     .lc_req_i         ( lc_otp_program_i.req              ),
     .lc_state_i       ( lc_otp_program_i.state            ),
     .lc_count_i       ( lc_otp_program_i.count            ),

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -201,6 +201,7 @@ module otp_ctrl_dai
       // to the InitOtpSt waiting state.
       ResetSt: begin
         init_done_o = 1'b0;
+        dai_prog_idle_o = 1'b0;
         data_clr = 1'b1;
         if (init_req_i) begin
           otp_req_o = 1'b1;
@@ -215,6 +216,7 @@ module otp_ctrl_dai
       // error and move into a terminal error  state.
       InitOtpSt: begin
         init_done_o = 1'b0;
+        dai_prog_idle_o = 1'b0;
         if (otp_rvalid_i) begin
           if ((!(otp_err_e'(otp_err_i) inside {NoError, MacroEccCorrError}))) begin
             state_d = ErrorSt;
@@ -230,6 +232,7 @@ module otp_ctrl_dai
       // all have initialized.
       InitPartSt: begin
         init_done_o = 1'b0;
+        dai_prog_idle_o = 1'b0;
         part_init_req_o = 1'b1;
         if (part_init_done_i == {NumPart{1'b1}}) begin
           state_d = IdleSt;


### PR DESCRIPTION
The idle signal is now only deasserted during programming operations to
be consistent with the idle signal behavior of the DAI.

Fixes #5132

Signed-off-by: Michael Schaffner <msf@opentitan.org>