### PR TITLE
[dv/enable_regs] Support enable registers have more than one field

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/cip_base_vseq.sv
@@ -630,8 +630,8 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
         end
         csr_utils_pkg::wait_no_outstanding_access();
 
-        // reset after writing to enable_reg to avoid it locking associated regs
-        if (test_csrs[i].is_enable_reg()) dut_init("HARD");
+        // reset after writing to wen_reg to avoid it locking associated regs
+        if (test_csrs[i].is_wen_reg()) dut_init("HARD");
       end
     end
   endtask

--- a/hw/dv/sv/dv_base_reg/dv_base_reg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.sv
@@ -71,6 +71,8 @@ class dv_base_reg extends uvm_reg;
     return wen_fld.locks_reg_or_fld(obj);
   endfunction
 
+  // Even though user can add lockable register or field via `add_lockable_reg_or_fld` method, the
+  // get_lockable_flds function will always return a queue of lockable fields.
   function void get_lockable_flds(ref dv_base_reg_field lockable_flds_q[$]);
     dv_base_reg_field wen_fld;
     `DV_CHECK_FATAL(m_fields.size(), 1, "This register has more than one field.\
@@ -79,6 +81,7 @@ class dv_base_reg extends uvm_reg;
     wen_fld.get_lockable_flds(lockable_flds_q);
   endfunction
 
+  // The register is a write enable register (wen_reg) if its fields are wen_flds.
   function bit is_wen_reg();
     foreach (m_fields[i]) begin
       dv_base_reg_field fld;

--- a/hw/dv/sv/dv_base_reg/dv_base_reg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.sv
@@ -36,25 +36,19 @@ class dv_base_reg extends uvm_reg;
   endfunction : new
 
   function void get_dv_base_reg_fields(ref dv_base_reg_field dv_fields[$]);
-    uvm_reg_field ral_fields[$];
-    get_fields(ral_fields);
-    foreach (ral_fields[i]) `downcast(dv_fields[i], ral_fields[i])
+    foreach (m_fields[i]) `downcast(dv_fields[i], m_fields[i])
   endfunction
 
   // get_n_bits will return number of all the bits in the csr
   // while this function will return actual number of bits used in reg field
   function uint get_n_used_bits();
-    uvm_reg_field fields[$];
-    get_fields(fields);
-    foreach (fields[i]) get_n_used_bits += fields[i].get_n_bits();
+    foreach (m_fields[i]) get_n_used_bits += m_fields[i].get_n_bits();
   endfunction
 
   // loop all the fields to find the msb position of this reg
   function uint get_msb_pos();
-    uvm_reg_field fields[$];
-    get_fields(fields);
-    foreach (fields[i]) begin
-      uint field_msb_pos = fields[i].get_lsb_pos() + fields[i].get_n_bits() - 1;
+    foreach (m_fields[i]) begin
+      uint field_msb_pos = m_fields[i].get_lsb_pos() + m_fields[i].get_n_bits() - 1;
       if (field_msb_pos > get_msb_pos) get_msb_pos = field_msb_pos;
     end
   endfunction

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -48,30 +48,12 @@ class dv_base_reg_block extends uvm_reg_block;
     end
   endfunction
 
-  function void get_enable_regs(ref dv_base_reg enable_regs[$]);
-    dv_base_reg all_regs[$];
-    this.get_dv_base_regs(all_regs);
-    foreach (all_regs[i]) begin
-      if (all_regs[i].is_enable_reg()) enable_regs.push_back(all_regs[i]);
-    end
-  endfunction
-
   function void get_shadowed_regs(ref dv_base_reg shadowed_regs[$]);
     dv_base_reg all_regs[$];
     this.get_dv_base_regs(all_regs);
     foreach (all_regs[i]) begin
       if (all_regs[i].get_is_shadowed()) shadowed_regs.push_back(all_regs[i]);
     end
-  endfunction
-
-  // override RAL's reset function to support enable registers
-  // when reset issued - the locked registers' access will be reset to original access
-  virtual function void reset(string kind = "HARD");
-    dv_base_reg enable_regs[$];
-    `uvm_info(`gfn, "Resetting RAL reg block", UVM_MEDIUM)
-    super.reset(kind);
-    get_enable_regs(enable_regs);
-    foreach (enable_regs[i]) enable_regs[i].set_locked_regs_access();
   endfunction
 
   // Internal function, used to compute the address mask for this register block.

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_pkg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_pkg.sv
@@ -48,7 +48,13 @@ package dv_base_reg_pkg;
 
 
   typedef class dv_base_reg;
-  typedef class dv_base_reg_field;
+
+  `include "csr_excl_item.sv"
+  `include "dv_base_reg_field.sv"
+  `include "dv_base_reg.sv"
+  `include "dv_base_mem.sv"
+  `include "dv_base_reg_block.sv"
+  `include "dv_base_reg_map.sv"
 
   function automatic void get_flds_from_uvm_object(input uvm_object obj,
                                                    input string msg = "dv_base_reg_pkg",
@@ -56,6 +62,7 @@ package dv_base_reg_pkg;
     dv_base_reg       csr;
     dv_base_reg_field fld;
 
+    flds.delete();
     if ($cast(csr, obj)) begin
       csr.get_dv_base_reg_fields(flds);
     end else if ($cast(fld, obj)) begin
@@ -65,12 +72,5 @@ package dv_base_reg_pkg;
                       obj.get_full_name()))
     end
   endfunction
-
-  `include "csr_excl_item.sv"
-  `include "dv_base_reg_field.sv"
-  `include "dv_base_reg.sv"
-  `include "dv_base_mem.sv"
-  `include "dv_base_reg_block.sv"
-  `include "dv_base_reg_map.sv"
 
 endpackage

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_pkg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_pkg.sv
@@ -46,8 +46,26 @@ package dv_base_reg_pkg;
     BkdrRegPathGlsShdow      // backdoor path for shadow reg's shadow val in GLS
   } bkdr_reg_path_e;
 
-  // package sources
-  // base ral
+
+  typedef class dv_base_reg;
+  typedef class dv_base_reg_field;
+
+  function automatic void get_flds_from_uvm_object(input uvm_object obj,
+                                                   input string msg = "dv_base_reg_pkg",
+                                                   ref dv_base_reg_field flds[$]);
+    dv_base_reg       csr;
+    dv_base_reg_field fld;
+
+    if ($cast(csr, obj)) begin
+      csr.get_dv_base_reg_fields(flds);
+    end else if ($cast(fld, obj)) begin
+      flds.push_back(fld);
+    end else begin
+      `uvm_fatal(msg, $sformatf("obj %0s is not of type uvm_reg or uvm_reg_field",
+                      obj.get_full_name()))
+    end
+  endfunction
+
   `include "csr_excl_item.sv"
   `include "dv_base_reg_field.sv"
   `include "dv_base_reg.sv"

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -247,7 +247,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
               update_state(get_next_state(current_state));
               // set sw_binding_regwen after advance OP
               void'(ral.sw_binding_regwen.predict(.value(1)));
-              ral.sw_binding_regwen.set_locked_regs_access("original_access");
+              ral.sw_binding_regwen.en.set_locked_regs_access("original_access");
             end
           end
           keymgr_pkg::OpDisable: begin
@@ -336,7 +336,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
       // in StReset, can't change sw_binding_regwen value
       // set related locked reg back to original_access as this is updated automatic in post_write
       #0; // push below update to be done after post_write
-      ral.sw_binding_regwen.set_locked_regs_access("original_access");
+      ral.sw_binding_regwen.en.set_locked_regs_access("original_access");
     end
 
     // process the csr req

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -247,7 +247,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
               update_state(get_next_state(current_state));
               // set sw_binding_regwen after advance OP
               void'(ral.sw_binding_regwen.predict(.value(1)));
-              ral.sw_binding_regwen.en.set_locked_regs_access("original_access");
+              ral.sw_binding_regwen.en.set_lockable_flds_access(.lock(0));
             end
           end
           keymgr_pkg::OpDisable: begin
@@ -314,7 +314,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
     if (addr_phase_write) begin
       // if OP WIP or keymgr_en=0, will clear cfg_regwen and below csr can't be written
       if ((current_op_status == keymgr_pkg::OpWip || !cfg.keymgr_vif.get_keymgr_en()) &&
-          ral.cfg_regwen.is_inside_locked_regs(dv_reg)) begin
+          ral.cfg_regwen.locks_reg_or_fld(dv_reg)) begin
         `uvm_info(`gfn, $sformatf("Reg write to %0s is ignored due to cfg_regwen=0", csr.get_name()),
                   UVM_MEDIUM)
         return;
@@ -336,7 +336,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
       // in StReset, can't change sw_binding_regwen value
       // set related locked reg back to original_access as this is updated automatic in post_write
       #0; // push below update to be done after post_write
-      ral.sw_binding_regwen.en.set_locked_regs_access("original_access");
+      ral.sw_binding_regwen.en.set_lockable_flds_access(.lock(0));
     end
 
     // process the csr req

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -200,7 +200,7 @@ class kmac_scoreboard extends cip_base_scoreboard #(
         // - entropy_seed_upper
         // - key_len
         // if writes to these csrs are seen, must check that they are not locked first.
-        if (ral.cfg_regwen.is_inside_locked_regs(check_locked_reg) &&
+        if (ral.cfg_regwen.locks_reg_or_fld(check_locked_reg) &&
             `gmv(ral.cfg_regwen) == 0) return;
 
         void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -388,7 +388,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
 
     if (addr_phase_write) begin
       // Skip predict if the register is locked by `direct_access_regwen`.
-      if (ral.direct_access_regwen.is_inside_locked_regs(dv_reg) &&
+      if (ral.direct_access_regwen.locks_reg_or_fld(dv_reg) &&
           `gmv(ral.direct_access_regwen) == 0) return;
 
       // Skip predict if the register is accessing DAI interface while macro alert is triggered.

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_regwen_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_regwen_vseq.sv
@@ -44,26 +44,26 @@ class otp_ctrl_regwen_vseq extends otp_ctrl_smoke_vseq;
       // 2. use backdoor check otp init is not done and is not under reset
       wait_no_outstanding_access();
       if (cfg.otp_ctrl_vif.pwr_otp_done_o === 0 && !cfg.under_reset) begin
-        write_and_check_regwen_locked_reg();
+        write_and_check_regwen_lockable_reg();
       end
       wait (cfg.otp_ctrl_vif.pwr_otp_done_o === 1 || cfg.under_reset || regular_vseq_done);
     end
   endtask
 
-  virtual task write_and_check_regwen_locked_reg();
+  virtual task write_and_check_regwen_lockable_reg();
     bit [TL_DW-1:0] val = $urandom;
     // since it's timing sensitive, only write one of these reg
-    dv_base_reg     locked_reg;
-    dv_base_reg     locked_regs[$];
+    dv_base_reg     lockable_reg;
+    dv_base_reg_field     lockable_flds[$];
 
-    ral.direct_access_regwen.get_locked_regs(locked_regs);
-    locked_regs.shuffle();
-    locked_reg = locked_regs[0];
+    ral.direct_access_regwen.get_lockable_flds(lockable_flds);
+    lockable_flds.shuffle();
+    lockable_reg = lockable_flds[0].get_dv_base_reg_parent();
 
-    `uvm_info(`gfn, $sformatf("Write regwen locked reg %0s, and this write should be ignored",
-                              locked_reg.get_name()), UVM_HIGH)
-    csr_wr(locked_reg, val);
-    csr_rd(locked_reg, val); // checking is done with scb
-  endtask : write_and_check_regwen_locked_reg
+    `uvm_info(`gfn, $sformatf("Write regwen lockable reg %0s, and this write should be ignored",
+                              lockable_reg.get_name()), UVM_HIGH)
+    csr_wr(lockable_reg, val);
+    csr_rd(lockable_reg, val); // checking is done with scb
+  endtask : write_and_check_regwen_lockable_reg
 
 endclass

--- a/util/reggen/uvm_reg.sv.tpl
+++ b/util/reggen/uvm_reg.sv.tpl
@@ -275,7 +275,19 @@ package ${block.name}_ral_pkg;
       // assign locked reg to its regwen reg
 % for r in regs_flat:
   % if r.regwen:
-      ${r.regwen.lower()}.add_locked_reg(${r.name.lower()});
+    % for reg in regs_flat:
+      % if r.regwen.lower() == reg.name.lower():
+      ${r.regwen.lower()}.add_lockable_reg_or_fld(${r.name.lower()});
+<% break %>\
+      % elif reg.name.lower() in r.regwen.lower():
+        % for field in reg.get_field_list():
+          % if r.regwen.lower() == (reg.name.lower() + "_" + field.name.lower()):
+      ${r.regwen.lower()}.${field.name.lower()}.add_lockable_reg_or_fld(${r.name.lower()});
+<% break %>\
+          % endif
+        % endfor
+      % endif
+    % endfor
   % endif
 % endfor
 


### PR DESCRIPTION
This PR implements the DV support for PR #5128, which allows an enable
register to be a multi-reg. This enable register will have many fields,
each field locks a certain set of registers.

This PR support it by moving the `locked_reg_q` to dv_base_reg_field,
and copied enable register related methods to dv_base_reg_field. If the
enable register has only one field, normal methods still work (which
means we do not need to change current testbench). If the enable
register has more than one field, CSR automation test will work, but if
user want to access the `locked_reg_q`, they have to call from
dv_base_reg_field rather than dv_base_reg.

This PR also updates the `uvm_reg.sv_tpl` script. 
Current `regwen` output from hjson is `RegName_FieldName`, but DV needs
`RegName.FieldName` to get the correct reg field.


Signed-off-by: Cindy Chen <chencindy@google.com>