### PR TITLE
[keymgr/dv] Fix falures in keymgr_lc_disable

### DIFF
--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -99,7 +99,7 @@ class keymgr_base_vseq extends cip_base_vseq #(
     max_key_ver_val = (current_state == keymgr_pkg::StCreatorRootKey)
         ? max_creator_key_ver_val : (current_state == keymgr_pkg::StOwnerIntKey)
         ? max_owner_int_key_ver_val : (current_state == keymgr_pkg::StOwnerKey)
-        ? max_owner_key_ver_val : '1;
+        ? max_owner_key_ver_val : 0;
 
     // if current key_version already match to what we need, return without updating it
     if (is_key_version_err && key_version_val > max_key_ver_val ||
@@ -149,12 +149,10 @@ class keymgr_base_vseq extends cip_base_vseq #(
     `uvm_info(`gfn, $sformatf("Wait for operation done in state %0s, operation %0s, good_op %0d",
                               current_state.name, operation.name, is_good_op), UVM_MEDIUM)
 
-    // if keymgr_en is off, all OP is ignored, don't need to check status
-    if (cfg.keymgr_vif.keymgr_en != lc_ctrl_pkg::On) return;
-
     // wait for status to get out of OpWip and check
     csr_spinwait(.ptr(ral.op_status.status), .exp_data(keymgr_pkg::OpWip),
                  .compare_op(CompareOpNe), .spinwait_delay_ns($urandom_range(0, 100)));
+
     exp_status = is_good_op ? keymgr_pkg::OpDoneSuccess : keymgr_pkg::OpDoneFail;
 
     // if keymgr_en is set to off during OP, status is checked in scb. hard to predict the result

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
@@ -30,6 +30,8 @@ class keymgr_common_vseq extends keymgr_base_vseq;
   endtask : body
 
   virtual task read_and_check_all_csrs_after_reset();
+    // need to set keymgr_en to be On, before it can be read back with correct init values
+    cfg.keymgr_vif.init();
     delay_after_reset_before_access_csr();
 
     super.read_and_check_all_csrs_after_reset();

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_lc_disable_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_lc_disable_vseq.sv
@@ -35,9 +35,11 @@ class keymgr_lc_disable_vseq extends keymgr_random_vseq;
       // wait until enter a random state and add some delay
       1: begin
         keymgr_pkg::keymgr_working_state_e state;
-        `DV_CHECK_STD_RANDOMIZE_FATAL(state)
+        `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(state, state != keymgr_pkg::StInvalid;)
         csr_spinwait(.ptr(ral.working_state), .exp_data(state),
-                     .spinwait_delay_ns($urandom_range(0, 1000)));
+                     // can't use too large delay, as it may jump over to next state and this
+                     // csr_spinwait doesn't see it
+                     .spinwait_delay_ns($urandom_range(10, 20)));
 
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(delay_cycles,
                                            delay_cycles dist {[0:10]     :/ 1,


### PR DESCRIPTION
1. add 2 sync cycle for keymgr_en, which makes it more accurary to
predict csr value
2. fix randomize to Invalid state which can't be there normally
3. fix prediction of csr working_state, which can be read anytime and
need to be more precise in term of cycle

Signed-off-by: Weicai Yang <weicai@google.com>