### PR TITLE
[dv/kmac] kmac_long_msg_and_output_test

### DIFF
--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -36,7 +36,7 @@
       tests: ["{name}_smoke"]
     }
     {
-      name: long_message_and_output
+      name: long_msg_and_output
       desc: '''
             Same as the smoke test, except with a message of up to 100KB.
             Max firmware input size for KMAX is around 392KB, but this is too large for a DV
@@ -51,7 +51,7 @@
             applicable).
             '''
       milestone: V2
-      tests: ["{name}_long_message_and_output"]
+      tests: ["{name}_long_msg_and_output"]
     }
     {
       name: burst_wr

--- a/hw/ip/kmac/dv/env/kmac_env.core
+++ b/hw/ip/kmac/dv/env/kmac_env.core
@@ -26,6 +26,7 @@ filesets:
       - seq_lib/kmac_base_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_common_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_smoke_vseq.sv: {is_include_file: true}
+      - seq_lib/kmac_long_msg_and_output_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_long_msg_and_output_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_long_msg_and_output_vseq.sv
@@ -1,0 +1,38 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// long msg and output test
+class kmac_long_msg_and_output_vseq extends kmac_smoke_vseq;
+
+  `uvm_object_utils(kmac_long_msg_and_output_vseq)
+  `uvm_object_new
+
+  // up to 1KB (1024B) output
+  constraint output_len_c {
+    output_len dist {
+      [1                     : keccak_block_size] :/ 1, // will not require manual squeezing
+      [keccak_block_size + 1 : 512]               :/ 2,
+      [513                   : 768]               :/ 5,
+      [769                   : 1024]              :/ 2
+    };
+  }
+
+  // up to 100KB (102,400B) input message
+  constraint msg_c {
+    msg.size() dist {
+      0                   :/ 1,
+      [1       : 10_000]  :/ 4,
+      [10_001  : 75_000]  :/ 12,
+      [75_001  : 100_000] :/ 2,
+      [100_001 : 102_400] :/ 1
+    };
+  }
+
+  // allow full randomization of customization string
+  virtual task pre_start();
+    custom_str_len_c.constraint_mode(0);
+    super.pre_start();
+  endtask
+
+endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
@@ -5,3 +5,4 @@
 `include "kmac_base_vseq.sv"
 `include "kmac_smoke_vseq.sv"
 `include "kmac_common_vseq.sv"
+`include "kmac_long_msg_and_output_vseq.sv"

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -50,12 +50,12 @@
     {
       name: enable_mask_mode
       build_opts: ["+define+EN_MASKING=1", "+define+REUSE_SHARE=0"]
-      run_opts: ["+enable_masking=1", "+test_timeout_ns=2000000000"]
+      run_opts: ["+enable_masking=1"]
     }
     {
       name: disable_mask_mode
       build_opts: ["+define+EN_MASKING=0", "+define+REUSE_SHARE=0"]
-      run_opts: ["+enable_masking=0", "+test_timeout_ns=2000000000"]
+      run_opts: ["+enable_masking=0"]
     }
   ]
 
@@ -68,9 +68,13 @@
     {
       name: "{variant}_smoke"
       uvm_test_seq: kmac_smoke_vseq
+      run_opts: ["+test_timeout_ns=4000000000"]
     }
-
-    // TODO: add more tests here
+    {
+      name: "{variant}_long_msg_and_output"
+      uvm_test_seq: kmac_long_msg_and_output_vseq
+      run_opts: ["+test_timeout_ns=10000000000"]
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
This PR adds the `kmac_long_msg_and_output_test` as specified
in the testplan.

Signed-off-by: Udi Jonnalagadda <udij@google.com>