### PR TITLE
[dv/kmac] update kmac_sideload_test description

### DIFF
--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -75,7 +75,7 @@
     {
       name: sideload
       desc: '''
-            Same as long_message_and_output test, except we set cfg.sideload and provide a
+            Same as the smoke test, except we set cfg.sideload and provide a
             valid sideloaded key as well as a valid SW-provided key.
             KMAC should operate on the sideloaded key.
             '''


### PR DESCRIPTION
This PR updates the `kmac_sideload_test` to be based on the smoke test
rather than the `long_message` test to cut down simulation time.

Signed-off-by: Udi Jonnalagadda <udij@google.com>