### PR TITLE
[reggen] Remove sameaddr support

### DIFF
--- a/doc/rm/register_tool/index.md
+++ b/doc/rm/register_tool/index.md
@@ -63,24 +63,6 @@ For example to place ITCR at offset 0x100:
 
 ```
 
-Historically, peripherals have put multiple registers at the same offset either different based on read or write, or with some other bit controlling the overlay.
-This is not permitted for Comportable peripherals but may be required for compatibility.
-These registers are grouped in a list.
-For example to have REGA and REGB (and more) at the same offest:
-
-```hjson
-    { sameaddr: [
-      { name: "REGA",
-        ...register definition...
-      }
-      { name: "REGB",
-        ...register definition...
-      }
-      ...register definitions...
-      ]
-    }
-```
-
 The tool can reserve an area of the memory space for something that is not a simple register, for example access to a buffer memory.
 This is done with a `window` declaration.
 The window size is specified as `items:` where each item is a `regwidth` wide word.

--- a/util/reggen/gen_cheader.py
+++ b/util/reggen/gen_cheader.py
@@ -340,13 +340,6 @@ def gen_cdefines(regs, outfile, src_lic, src_copy):
             continue
 
         assert isinstance(x, dict)
-        if 'sameaddr' in x:
-            for sareg in x['sameaddr']:
-                assert isinstance(sareg, Register)
-                gen_cdefine_register(outstr, sareg, component, regwidth,
-                                     rnames, existing_defines)
-            continue
-
         if 'window' in x:
             gen_cdefine_window(outstr, x['window'], component, regwidth,
                                rnames, existing_defines)

--- a/util/reggen/gen_ctheader.py
+++ b/util/reggen/gen_ctheader.py
@@ -6,9 +6,6 @@ Generate C header (Titan style) from validated register JSON tree
 """
 
 import io
-import logging as log
-import re
-import sys
 
 
 def genout(outfile, msg):
@@ -107,12 +104,6 @@ def gen_cdefines(regs, outfile, src_lic, src_copy):
             continue
 
         if 'skipto' in x:
-            continue
-
-        if 'sameaddr' in x:
-            for sareg in x['sameaddr']:
-                gen_cdefine_register(outstr, sareg, component, regwidth,
-                                     rnames)
             continue
 
         if 'window' in x:

--- a/util/reggen/gen_html.py
+++ b/util/reggen/gen_html.py
@@ -291,13 +291,6 @@ def gen_html(regs, outfile, toclist=None, toclevel=3):
             continue
 
         assert isinstance(x, dict)
-        if 'sameaddr' in x:
-            for reg in x['sameaddr']:
-                assert isinstance(reg, Register)
-                gen_html_register(outfile, reg, component, regwidth, rnames,
-                                  toclist, toclevel)
-            continue
-
         if 'window' in x:
             gen_html_window(outfile, x['window'], component, regwidth, rnames,
                             toclist, toclevel)

--- a/util/reggen/gen_rtl.py
+++ b/util/reggen/gen_rtl.py
@@ -163,15 +163,12 @@ def json_to_reg(obj):
         if isinstance(r, MultiRegister):
             block.regs.append(parse_multireg(r))
             continue
-        if isinstance(r, dict):
-            if 'sameaddr' in r:
-                log.error("Current tool doesn't support 'sameaddr' type")
-                continue
-            if 'window' in r:
-                win = parse_win(r['window'], block.width)
-                if win is not None:
-                    block.wins.append(win)
-                continue
+        assert isinstance(r, dict)
+        if 'window' in r:
+            win = parse_win(r['window'], block.width)
+            if win is not None:
+                block.wins.append(win)
+            continue
 
     # Last offset and calculate space
     #  Later on, it could use block.regs[-1].genoffset

--- a/util/reggen/validate.py
+++ b/util/reggen/validate.py
@@ -367,9 +367,6 @@ lp_optional = {
 list_optone = {
     'reserved': ['d', "number of registers to reserve space for"],
     'skipto': ['d', "set next register offset to value"],
-    'sameaddr':
-    ['l', "list of register definition groups "
-     "that share the same offset"],
     'window': [
         'g', "group defining an address range "
         "for something other than standard registers"
@@ -715,8 +712,6 @@ def check_wen_regs(regs):
             x_regs = [x]
         elif isinstance(x, MultiRegister):
             x_regs = x.regs
-        elif isinstance(x, dict):
-            x_regs = x.get('sameaddr', [])
         else:
             x_regs = []
 
@@ -958,29 +953,6 @@ def validate(regs, **kwargs):
                 offset = skipto
 
             vld_regs.append(x)
-            continue
-
-        if 'sameaddr' in x:
-            saregs = []
-            for sareg_idx, sareg in enumerate(x['sameaddr']):
-                try:
-                    reg = Register.from_raw(fullwidth, offset,
-                                            regs.get('param_list', []),
-                                            sareg)
-                    saregs.append(reg)
-                    error += _upd_gennames(regs, offset, reg)
-                except ValueError as err:
-                    log.error('Error in reg {} of sameaddr at offset {:#x}: {}'
-                              .format(sareg_idx + 1,
-                                      offset,
-                                      err))
-                    error += 1
-
-            xx = x.copy()
-            xx['sameaddr'] = saregs
-            vld_regs.append(xx)
-
-            offset += addrsep
             continue
 
         if 'window' in x:


### PR DESCRIPTION
This is unused, presumably untested, and is unsupported by gen_rtl.py.
