### PR TITLE
[aes] Use sparse signals between FSMs and inside cipher core

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -151,7 +151,7 @@
     { name: "fatal_fault",
       desc: '''
         This fatal alert is triggered upon detecting a fatal fault inside the AES unit.
-        Examples for such faults include i) storage errors in the shadowed Control Register, ii) any internal FSM entering an invalid state, iii) a mux selector or handshake signal taking on an invalid value, and iv) errors in the internal round counter.
+        Examples for such faults include i) storage errors in the shadowed Control Register, ii) any internal FSM entering an invalid state, iii) any sparsely encoded signal taking on an invalid value, and iv) errors in the internal round counter.
         The AES unit cannot recover from such an error and needs to be reset.
       '''
     }
@@ -540,7 +540,7 @@
         desc:  '''
           No fatal fault has occurred inside the AES unit (0).
           A fatal fault has occurred and the AES unit needs to be reset (1).
-          Examples for fatal faults include i) storage errors in the Control Register, ii) if any internal FSM enters an invalid state, iii) if a mux selector or handshake signal takes on an invalid value, and iv) errors in the internal round counter.
+          Examples for fatal faults include i) storage errors in the Control Register, ii) if any internal FSM enters an invalid state, iii) if any sparsely encoded signal takes on an invalid value, and iv) errors in the internal round counter.
         '''
       }
     ]

--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -151,7 +151,7 @@
     { name: "fatal_fault",
       desc: '''
         This fatal alert is triggered upon detecting a fatal fault inside the AES unit.
-        Examples for such faults include i) storage errors in the shadowed Control Register, ii) any internal FSM entering an invalid state, iii) a mux selector signal taking on an invalid value, and iv) errors in the internal round counter.
+        Examples for such faults include i) storage errors in the shadowed Control Register, ii) any internal FSM entering an invalid state, iii) a mux selector or handshake signal taking on an invalid value, and iv) errors in the internal round counter.
         The AES unit cannot recover from such an error and needs to be reset.
       '''
     }
@@ -540,7 +540,7 @@
         desc:  '''
           No fatal fault has occurred inside the AES unit (0).
           A fatal fault has occurred and the AES unit needs to be reset (1).
-          Examples for fatal faults include i) storage errors in the Control Register, ii) if any internal FSM enters an invalid state, iii) if a mux selector signal takes on an invalid value, and iv) errors in the internal round counter.
+          Examples for fatal faults include i) storage errors in the Control Register, ii) if any internal FSM enters an invalid state, iii) if a mux selector or handshake signal takes on an invalid value, and iv) errors in the internal round counter.
         '''
       }
     ]

--- a/hw/ip/aes/lint/aes.vlt
+++ b/hw/ip/aes/lint/aes.vlt
@@ -13,3 +13,14 @@ lint_off -rule ALWCOMBORDER -file "*/rtl/aes_key_expand.sv" -match "*'regular'"
 // Masked SBox implementations may require multiple modules to prevent aggressive synthesis optimizations.
 lint_off -rule DECLFILENAME -file "*/rtl/aes_sbox_*_masked*.sv" -match "Filename 'aes_sbox_*_masked*' does not match MODULE name: *"
 lint_off -rule DECLFILENAME -file "*/rtl/aes_sbox_dom*.sv" -match "Filename 'aes_sbox_dom*' does not match MODULE name: *"
+
+// The tool erroneously thinks there would be circular logic through the aes_mux_sel_buf_chk units inside aes_cipher_control.sv.
+// If these units are not generated inside a for loop, everything is fine.
+lint_off -rule UNOPTFLAT -file "*/rtl/aes_core.sv" -match "Signal unoptimizable: Feedback to clock or circular logic: '*cipher_out_valid'"
+lint_off -rule UNOPTFLAT -file "*/rtl/aes_control.sv" -match "Signal unoptimizable: Feedback to clock or circular logic: '*sp2v_sig'"
+lint_off -rule UNOPTFLAT -file "*/rtl/aes_cipher_control.sv" -match "Signal unoptimizable: Feedback to clock or circular logic: '*sp2v_sig_chk_raw'"
+
+// The tool erroneously thinks there would be circular logic through the aes_mux_sel_buf_chk units inside aes_control.sv.
+// If unit for cipher_out_done is not generated inside a for loop, everything is fine.
+lint_off -rule UNOPTFLAT -file "*/rtl/aes_control.sv" -match "Signal unoptimizable: Feedback to clock or circular logic: '*cipher_out_done'"
+lint_off -rule UNOPTFLAT -file "*/rtl/aes_control.sv" -match "Signal unoptimizable: Feedback to clock or circular logic: '*sp2v_sig_chk_raw'"

--- a/hw/ip/aes/lint/aes.waiver
+++ b/hw/ip/aes/lint/aes.waiver
@@ -21,13 +21,25 @@ waive -rules {RESET_USE} -location {aes_key_expand.sv} -regexp {'rst_ni' is conn
 waive -rules {CLOCK_USE} -location {aes_core.sv} -regexp {clk_i' is connected to 'aes_sel_buf_chk' port} \
       -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
 
+waive -rules {CLOCK_USE} -location {aes_control.sv} -regexp {clk_i' is connected to 'aes_sel_buf_chk' port} \
+      -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
+
 waive -rules {CLOCK_USE} -location {aes_cipher_core.sv} -regexp {clk_i' is connected to 'aes_sel_buf_chk' port} \
+      -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
+
+waive -rules {CLOCK_USE} -location {aes_cipher_control.sv} -regexp {clk_i' is connected to 'aes_sel_buf_chk' port} \
       -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
 
 waive -rules {RESET_USE} -location {aes_core.sv} -regexp {'rst_ni' is connected to 'aes_sel_buf_chk' port} \
       -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
 
+waive -rules {RESET_USE} -location {aes_control.sv} -regexp {'rst_ni' is connected to 'aes_sel_buf_chk' port} \
+      -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
+
 waive -rules {RESET_USE} -location {aes_cipher_core.sv} -regexp {'rst_ni' is connected to 'aes_sel_buf_chk' port} \
+      -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
+
+waive -rules {RESET_USE} -location {aes_cipher_control.sv} -regexp {'rst_ni' is connected to 'aes_sel_buf_chk' port} \
       -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
 
 waive -rules {ONE_BRANCH} -location {aes_sel_buf_chk.sv} -regexp {unique case statement has only one branch} \

--- a/hw/ip/aes/lint/aes.waiver
+++ b/hw/ip/aes/lint/aes.waiver
@@ -6,14 +6,14 @@
 waive -rules COMBO_READ_WRITE -location {aes_key_expand.sv} -regexp {'regular\[[0-9]+\]\[2:1|4:2|6:5\]' is read from within the same combinational process block} \
       -comment "regular[*] is assigned in a for loop, regular[*][1|2|5] depends on regular[*][0|1|4]"
 
-waive -rules {CLOCK_USE} -location {aes_cipher_core.sv} -regexp {clk_i' is connected to 'aes_sub_bytes' port} \
-      -comment "when using fully combinational S-Box implementations, no clock is used inside aes_sub_bytes"
+waive -rules {CLOCK_USE} -location {aes_sub_bytes.sv} -regexp {clk_i' is connected to 'aes_sbox' port} \
+      -comment "when using fully combinational S-Box implementations, no clock is used inside aes_sbox"
 
 waive -rules {CLOCK_USE} -location {aes_key_expand.sv} -regexp {clk_i' is connected to 'aes_sbox' port} \
       -comment "when using fully combinational S-Box implementations, no clock is used inside aes_sbox"
 
-waive -rules {RESET_USE} -location {aes_cipher_core.sv} -regexp {'rst_ni' is connected to 'aes_sub_bytes' port} \
-      -comment "when using fully combinational S-Box implementations, no reset is used inside aes_sub_bytes"
+waive -rules {RESET_USE} -location {aes_sub_bytes.sv} -regexp {'rst_ni' is connected to 'aes_sbox' port} \
+      -comment "when using fully combinational S-Box implementations, no reset is used inside aes_sbox"
 
 waive -rules {RESET_USE} -location {aes_key_expand.sv} -regexp {'rst_ni' is connected to 'aes_sbox' port} \
       -comment "when using fully combinational S-Box implementations, no reset is used inside aes_sbox"
@@ -30,6 +30,15 @@ waive -rules {CLOCK_USE} -location {aes_cipher_core.sv} -regexp {clk_i' is conne
 waive -rules {CLOCK_USE} -location {aes_cipher_control.sv} -regexp {clk_i' is connected to 'aes_sel_buf_chk' port} \
       -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
 
+waive -rules {CLOCK_USE} -location {aes_sub_bytes.sv} -regexp {clk_i' is connected to 'aes_sel_buf_chk' port} \
+      -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
+
+waive -rules {CLOCK_USE} -location {aes_key_expand.sv} -regexp {clk_i' is connected to 'aes_sel_buf_chk' port} \
+      -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
+
+waive -rules {CLOCK_USE} -location {aes_ctr.sv} -regexp {clk_i' is connected to 'aes_sel_buf_chk' port} \
+      -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
+
 waive -rules {RESET_USE} -location {aes_core.sv} -regexp {'rst_ni' is connected to 'aes_sel_buf_chk' port} \
       -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
 
@@ -40,6 +49,15 @@ waive -rules {RESET_USE} -location {aes_cipher_core.sv} -regexp {'rst_ni' is con
       -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
 
 waive -rules {RESET_USE} -location {aes_cipher_control.sv} -regexp {'rst_ni' is connected to 'aes_sel_buf_chk' port} \
+      -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
+
+waive -rules {RESET_USE} -location {aes_sub_bytes.sv} -regexp {'rst_ni' is connected to 'aes_sel_buf_chk' port} \
+      -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
+
+waive -rules {RESET_USE} -location {aes_key_expand.sv} -regexp {'rst_ni' is connected to 'aes_sel_buf_chk' port} \
+      -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
+
+waive -rules {RESET_USE} -location {aes_ctr.sv} -regexp {'rst_ni' is connected to 'aes_sel_buf_chk' port} \
       -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"
 
 waive -rules {ONE_BRANCH} -location {aes_sel_buf_chk.sv} -regexp {unique case statement has only one branch} \

--- a/hw/ip/aes/rtl/aes_cipher_control.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control.sv
@@ -28,15 +28,16 @@ module aes_cipher_control import aes_pkg::*;
   input  logic                    cfg_valid_i,
   input  ciph_op_e                op_i,
   input  key_len_e                key_len_i,
-  input  logic                    crypt_i,
-  output logic                    crypt_o,
-  input  logic                    dec_key_gen_i,
-  output logic                    dec_key_gen_o,
+  input  sp2v_e                   crypt_i,
+  output sp2v_e                   crypt_o,
+  input  sp2v_e                   dec_key_gen_i,
+  output sp2v_e                   dec_key_gen_o,
   input  logic                    key_clear_i,
   output logic                    key_clear_o,
   input  logic                    data_out_clear_i,
   output logic                    data_out_clear_o,
   input  logic                    mux_sel_err_i,
+  input  logic                    sp_enc_err_i,
   output logic                    alert_o,
 
   // Control signals for masking PRNG
@@ -46,21 +47,21 @@ module aes_cipher_control import aes_pkg::*;
 
   // Control and sync signals for cipher data path
   output state_sel_e              state_sel_o,
-  output logic                    state_we_o,
-  output logic                    sub_bytes_en_o,
-  input  logic                    sub_bytes_out_req_i,
-  output logic                    sub_bytes_out_ack_o,
+  output sp2v_e                   state_we_o,
+  output sp2v_e                   sub_bytes_en_o,
+  input  sp2v_e                   sub_bytes_out_req_i,
+  output sp2v_e                   sub_bytes_out_ack_o,
   output add_rk_sel_e             add_rk_sel_o,
 
   // Control and sync signals for key expand data path
   output ciph_op_e                key_expand_op_o,
   output key_full_sel_e           key_full_sel_o,
-  output logic                    key_full_we_o,
+  output sp2v_e                   key_full_we_o,
   output key_dec_sel_e            key_dec_sel_o,
-  output logic                    key_dec_we_o,
-  output logic                    key_expand_en_o,
-  input  logic                    key_expand_out_req_i,
-  output logic                    key_expand_out_ack_o,
+  output sp2v_e                   key_dec_we_o,
+  output sp2v_e                   key_expand_en_o,
+  input  sp2v_e                   key_expand_out_req_i,
+  output sp2v_e                   key_expand_out_ack_o,
   output logic                    key_expand_clear_o,
   output logic [3:0]              key_expand_round_o,
   output key_words_sel_e          key_words_sel_o,
@@ -105,17 +106,19 @@ module aes_cipher_control import aes_pkg::*;
   logic [3:0] num_rounds_regular;
   logic       rnd_ctr_parity, rnd_ctr_parity_d, rnd_ctr_parity_q;
   logic       rnd_ctr_err, rnd_ctr_err_sum, rnd_ctr_err_parity;
-  logic       crypt_d, crypt_q;
-  logic       dec_key_gen_d, dec_key_gen_q;
+  sp2v_e      crypt_d, crypt_q;
+  sp2v_e      dec_key_gen_d, dec_key_gen_q;
   logic       key_clear_d, key_clear_q;
   logic       data_out_clear_d, data_out_clear_q;
   logic       prng_reseed_done_d, prng_reseed_done_q;
-  logic       advance;
+  sp2v_e      sub_bytes_out_req;
+  sp2v_e      key_expand_out_req;
+  sp2v_e      advance, advance_chk;
   sp2v_e      in_valid;
-  logic       in_valid_err;
   sp2v_e      out_ready;
-  logic       out_ready_err;
-  logic       hs_err;
+  sp2v_e      crypt;
+  sp2v_e      dec_key_gen;
+  logic       sp_enc_err;
 
   // cfg_valid_i is used for gating assertions only.
   logic       unused_cfg_valid;
@@ -134,18 +137,18 @@ module aes_cipher_control import aes_pkg::*;
 
     // Cipher data path
     state_sel_o          = STATE_ROUND;
-    state_we_o           = 1'b0;
+    state_we_o           = SP2V_LOW;
     add_rk_sel_o         = ADD_RK_ROUND;
-    sub_bytes_en_o       = 1'b0;
-    sub_bytes_out_ack_o  = 1'b0;
+    sub_bytes_en_o       = SP2V_LOW;
+    sub_bytes_out_ack_o  = SP2V_LOW;
 
     // Key expand data path
     key_full_sel_o       = KEY_FULL_ROUND;
-    key_full_we_o        = 1'b0;
+    key_full_we_o        = SP2V_LOW;
     key_dec_sel_o        = KEY_DEC_EXPAND;
-    key_dec_we_o         = 1'b0;
-    key_expand_en_o      = 1'b0;
-    key_expand_out_ack_o = 1'b0;
+    key_dec_we_o         = SP2V_LOW;
+    key_expand_en_o      = SP2V_LOW;
+    key_expand_out_ack_o = SP2V_LOW;
     key_expand_clear_o   = 1'b0;
     key_words_sel_o      = KEY_WORDS_ZERO;
     round_key_sel_o      = ROUND_KEY_DIRECT;
@@ -160,7 +163,7 @@ module aes_cipher_control import aes_pkg::*;
     key_clear_d          = key_clear_q;
     data_out_clear_d     = data_out_clear_q;
     prng_reseed_done_d   = prng_reseed_done_q | prng_reseed_ack_i;
-    advance              = 1'b0;
+    advance              = SP2V_LOW;
 
     // Alert
     alert_o              = 1'b0;
@@ -168,7 +171,7 @@ module aes_cipher_control import aes_pkg::*;
     unique case (aes_cipher_ctrl_cs)
 
       IDLE: begin
-        dec_key_gen_d = 1'b0;
+        dec_key_gen_d = SP2V_LOW;
 
         // Signal that we are ready, wait for handshake.
         in_ready_o = SP2V_HIGH;
@@ -182,27 +185,27 @@ module aes_cipher_control import aes_pkg::*;
             // To clear the data output registers, we must first clear the state.
             aes_cipher_ctrl_ns = data_out_clear_i ? CLEAR_S : CLEAR_KD;
 
-          end else if (dec_key_gen_i || crypt_i) begin
+          end else if (dec_key_gen == SP2V_HIGH || crypt == SP2V_HIGH) begin
             // Start encryption/decryption or generation of start key for decryption.
-            crypt_d       = ~dec_key_gen_i;
+            crypt_d       = (dec_key_gen_i == SP2V_LOW) ? crypt : SP2V_LOW;
             dec_key_gen_d =  dec_key_gen_i;
 
             // Load input data to state
-            state_sel_o = dec_key_gen_i ? STATE_CLEAR : STATE_INIT;
-            state_we_o  = 1'b1;
+            state_sel_o = (dec_key_gen_i == SP2V_HIGH) ? STATE_CLEAR : STATE_INIT;
+            state_we_o  = SP2V_HIGH;
 
             // Make the masking PRNG advance. The current pseudo-random data is used to mask the
             // input data.
-            prng_update_o = dec_key_gen_i ? 1'b0 : Masking;
+            prng_update_o = (dec_key_gen_i == SP2V_HIGH) ? 1'b0 : Masking;
 
             // Init key expand
             key_expand_clear_o = 1'b1;
 
             // Load full key
-            key_full_sel_o = dec_key_gen_i ? KEY_FULL_ENC_INIT :
-                        (op_i == CIPH_FWD) ? KEY_FULL_ENC_INIT :
-                                             KEY_FULL_DEC_INIT;
-            key_full_we_o  = 1'b1;
+            key_full_sel_o = (dec_key_gen_i == SP2V_HIGH) ? KEY_FULL_ENC_INIT :
+                                       (op_i == CIPH_FWD) ? KEY_FULL_ENC_INIT :
+                                                            KEY_FULL_DEC_INIT;
+            key_full_we_o  = SP2V_HIGH;
 
             // Load num_rounds, initialize round counters.
             num_rounds_d = (key_len_i == AES_128) ? 4'd10 :
@@ -211,6 +214,11 @@ module aes_cipher_control import aes_pkg::*;
             rnd_ctr_rem_d      = num_rounds_d;
             rnd_ctr_d          = '0;
             aes_cipher_ctrl_ns = INIT;
+
+          end else begin
+            // Handshake without a valid command. We should never get here. If we do (e.g. via a
+            // malicious glitch), error out immediately.
+            aes_cipher_ctrl_ns = ERROR;
           end
         end
       end
@@ -220,7 +228,7 @@ module aes_cipher_control import aes_pkg::*;
         add_rk_sel_o = ADD_RK_INIT;
 
         // Select key words for initial add_round_key
-        key_words_sel_o = dec_key_gen_q                ? KEY_WORDS_ZERO :
+        key_words_sel_o = (dec_key_gen_q == SP2V_HIGH) ? KEY_WORDS_ZERO :
             (key_len_i == AES_128)                     ? KEY_WORDS_0123 :
             (key_len_i == AES_192 && op_i == CIPH_FWD) ? KEY_WORDS_0123 :
             (key_len_i == AES_192 && op_i == CIPH_INV) ? KEY_WORDS_2345 :
@@ -236,19 +244,19 @@ module aes_cipher_control import aes_pkg::*;
           // Advance in sync with KeyExpand. Based on the S-Box implementation, it can take
           // multiple cycles to finish. Wait for handshake. The DOM S-Boxes take fresh PRD
           // in every cycle except the last.
-          advance         = key_expand_out_req_i;
-          prng_update_o   = (SBoxImpl == SBoxImplDom) ? ~advance : Masking;
-          key_expand_en_o = 1'b1;
-          if (advance) begin
-            key_expand_out_ack_o = 1'b1;
-            state_we_o           = ~dec_key_gen_q;
-            key_full_we_o        = 1'b1;
+          advance         = key_expand_out_req;
+          prng_update_o   = (SBoxImpl == SBoxImplDom) ? (advance_chk == SP2V_LOW) : Masking;
+          key_expand_en_o = SP2V_HIGH;
+          if (advance_chk == SP2V_HIGH) begin
+            key_expand_out_ack_o = SP2V_HIGH;
+            state_we_o           = (dec_key_gen_q == SP2V_LOW) ? SP2V_HIGH : SP2V_LOW;
+            key_full_we_o        = SP2V_HIGH;
             rnd_ctr_d            = rnd_ctr_q     + 4'b0001;
             rnd_ctr_rem_d        = rnd_ctr_rem_q - 4'b0001;
             aes_cipher_ctrl_ns   = ROUND;
           end
         end else begin
-          state_we_o         = ~dec_key_gen_q;
+          state_we_o         = (dec_key_gen_q == SP2V_LOW) ? SP2V_HIGH : SP2V_LOW;
           rnd_ctr_d          = rnd_ctr_q     + 4'b0001;
           rnd_ctr_rem_d      = rnd_ctr_rem_q - 4'b0001;
           aes_cipher_ctrl_ns = ROUND;
@@ -259,7 +267,7 @@ module aes_cipher_control import aes_pkg::*;
         // Normal rounds
 
         // Select key words for add_round_key
-        key_words_sel_o = dec_key_gen_q                ? KEY_WORDS_ZERO :
+        key_words_sel_o = (dec_key_gen_q == SP2V_HIGH) ? KEY_WORDS_ZERO :
             (key_len_i == AES_128)                     ? KEY_WORDS_0123 :
             (key_len_i == AES_192 && op_i == CIPH_FWD) ? KEY_WORDS_2345 :
             (key_len_i == AES_192 && op_i == CIPH_INV) ? KEY_WORDS_0123 :
@@ -275,16 +283,17 @@ module aes_cipher_control import aes_pkg::*;
         // Advance in sync with SubBytes and KeyExpand. Based on the S-Box implementation, both can
         // take multiple cycles to finish. Wait for handshake. Make the masking PRNG advance every
         // cycle. The DOM S-Boxes take fresh PRD in every cycle except the last.
-        advance         = (dec_key_gen_q | sub_bytes_out_req_i) & key_expand_out_req_i;
-        prng_update_o   = (SBoxImpl == SBoxImplDom) ? ~advance : Masking;
-        sub_bytes_en_o  = ~dec_key_gen_q;
-        key_expand_en_o = 1'b1;
-        if (advance) begin
-          sub_bytes_out_ack_o  = ~dec_key_gen_q;
-          key_expand_out_ack_o = 1'b1;
+        advance         = ((dec_key_gen_q == SP2V_HIGH || sub_bytes_out_req == SP2V_HIGH) &&
+            key_expand_out_req == SP2V_HIGH) ? SP2V_HIGH : SP2V_LOW;
+        prng_update_o   = (SBoxImpl == SBoxImplDom) ? (advance_chk == SP2V_LOW) : Masking;
+        sub_bytes_en_o  = (dec_key_gen_q == SP2V_LOW) ? SP2V_HIGH : SP2V_LOW;
+        key_expand_en_o = SP2V_HIGH;
+        if (advance_chk == SP2V_HIGH) begin
+          sub_bytes_out_ack_o  = (dec_key_gen_q == SP2V_LOW) ? SP2V_HIGH : SP2V_LOW;
+          key_expand_out_ack_o = SP2V_HIGH;
 
-          state_we_o    = ~dec_key_gen_q;
-          key_full_we_o = 1'b1;
+          state_we_o    = (dec_key_gen_q == SP2V_LOW) ? SP2V_HIGH : SP2V_LOW;
+          key_full_we_o = SP2V_HIGH;
 
           // Update round
           rnd_ctr_d     = rnd_ctr_q     + 4'b0001;
@@ -294,9 +303,9 @@ module aes_cipher_control import aes_pkg::*;
           if (rnd_ctr_q == num_rounds_regular) begin
             aes_cipher_ctrl_ns = FINISH;
 
-            if (dec_key_gen_q) begin
+            if (dec_key_gen_q == SP2V_HIGH) begin
               // Write decryption key.
-              key_dec_we_o = 1'b1;
+              key_dec_we_o = SP2V_HIGH;
 
               // Indicate that we are done, try to perform the handshake. But we don't wait here.
               // If we don't get the handshake now, we will wait in the finish state. When using
@@ -304,7 +313,7 @@ module aes_cipher_control import aes_pkg::*;
               out_valid_o = Masking ? (prng_reseed_done_q ? SP2V_HIGH : SP2V_LOW) : SP2V_HIGH;
               if (out_valid_o == SP2V_HIGH && out_ready == SP2V_HIGH) begin
                 // Go to idle state directly.
-                dec_key_gen_d      = 1'b0;
+                dec_key_gen_d      = SP2V_LOW;
                 aes_cipher_ctrl_ns = IDLE;
               end
             end
@@ -316,7 +325,7 @@ module aes_cipher_control import aes_pkg::*;
         // Final round
 
         // Select key words for add_round_key
-        key_words_sel_o = dec_key_gen_q                ? KEY_WORDS_ZERO :
+        key_words_sel_o = (dec_key_gen_q == SP2V_HIGH) ? KEY_WORDS_ZERO :
             (key_len_i == AES_128)                     ? KEY_WORDS_0123 :
             (key_len_i == AES_192 && op_i == CIPH_FWD) ? KEY_WORDS_2345 :
             (key_len_i == AES_192 && op_i == CIPH_INV) ? KEY_WORDS_0123 :
@@ -334,34 +343,36 @@ module aes_cipher_control import aes_pkg::*;
         // cycles to finish. Only indicate that we are done if:
         // - we have valid output (SubBytes finished),
         // - the masking PRNG has been reseeded (if masking is used),
-        // - all mux selector signals are valid (don't release data in that case of errors), and
-        // - all handshake signals are valid (don't release data in that case of errors).
+        // - all mux selector signals are valid (don't release data in case of errors), and
+        // - all sparsely encoded signals are valid (don't release data in case of errors).
         // Perform both handshakes simultaneously.
-        advance        = dec_key_gen_q | sub_bytes_out_req_i;
-        sub_bytes_en_o = ~dec_key_gen_q;
-        out_valid_o    = (advance & (Masking == prng_reseed_done_q) &
-            ~mux_sel_err_i & ~hs_err) ? SP2V_HIGH : SP2V_LOW;
+        advance = (sub_bytes_out_req == SP2V_HIGH ||
+                          dec_key_gen_q == SP2V_HIGH) ? SP2V_HIGH : SP2V_LOW;
+        sub_bytes_en_o = (dec_key_gen_q == SP2V_LOW)  ? SP2V_HIGH : SP2V_LOW;
+        out_valid_o = (advance_chk == SP2V_HIGH &&
+            Masking == prng_reseed_done_q &&
+                       !mux_sel_err_i && !sp_enc_err) ? SP2V_HIGH : SP2V_LOW;
         // When using DOM S-Boxes, make the masking PRNG advance every cycle until the output is
         // ready. For other S-Boxes, make it advance once only. Updating it while being stalled
         // would cause non-DOM S-Boxes to be re-evaluated, thereby creating additional SCA leakage.
-        prng_update_o  = (SBoxImpl == SBoxImplDom) ? ~advance              :
-            Masking ? (out_valid_o == SP2V_HIGH && out_ready == SP2V_HIGH) : 1'b0;
+        prng_update_o = (SBoxImpl == SBoxImplDom) ? (advance_chk == SP2V_LOW) :
+            Masking ? (out_valid_o == SP2V_HIGH && out_ready == SP2V_HIGH)    : 1'b0;
         if (out_valid_o == SP2V_HIGH && out_ready == SP2V_HIGH) begin
-          sub_bytes_out_ack_o = ~dec_key_gen_q;
+          sub_bytes_out_ack_o = (dec_key_gen_q == SP2V_LOW) ? SP2V_HIGH : SP2V_LOW;
 
           // Clear the state.
-          state_we_o          = 1'b1;
-          crypt_d             = 1'b0;
+          state_we_o          = SP2V_HIGH;
+          crypt_d             = SP2V_LOW;
           // If we were generating the decryption key and didn't get the handshake in the last
           // regular round, we should clear dec_key_gen now.
-          dec_key_gen_d       = 1'b0;
+          dec_key_gen_d       = SP2V_LOW;
           aes_cipher_ctrl_ns  = IDLE;
         end
       end
 
       CLEAR_S: begin
         // Clear the state with pseudo-random data.
-        state_we_o         = 1'b1;
+        state_we_o         = SP2V_HIGH;
         state_sel_o        = STATE_CLEAR;
         aes_cipher_ctrl_ns = CLEAR_KD;
       end
@@ -370,9 +381,9 @@ module aes_cipher_control import aes_pkg::*;
         // Clear internal key registers and/or external data output registers.
         if (key_clear_q) begin
           key_full_sel_o = KEY_FULL_CLEAR;
-          key_full_we_o  = 1'b1;
+          key_full_we_o  = SP2V_HIGH;
           key_dec_sel_o  = KEY_DEC_CLEAR;
-          key_dec_we_o   = 1'b1;
+          key_dec_we_o   = SP2V_HIGH;
         end
         if (data_out_clear_q) begin
           // Forward the state (previously cleared with psuedo-random data).
@@ -400,9 +411,9 @@ module aes_cipher_control import aes_pkg::*;
       end
     endcase
 
-    // Unconditionally jump into the terminal error state in case a mux selector or a handshake
-    // signal becomes invalid, or in case we have detected a fault in the round counter.
-    if (mux_sel_err_i || hs_err || rnd_ctr_err) begin
+    // Unconditionally jump into the terminal error state in case a mux selector or a sparsely
+    // encoded signal becomes invalid, or in case we have detected a fault in the round counter.
+    if (mux_sel_err_i || sp_enc_err || rnd_ctr_err) begin
       aes_cipher_ctrl_ns = ERROR;
     end
   end
@@ -424,15 +435,11 @@ module aes_cipher_control import aes_pkg::*;
   always_ff @(posedge clk_i or negedge rst_ni) begin : reg_fsm
     if (!rst_ni) begin
       num_rounds_q       <= '0;
-      crypt_q            <= 1'b0;
-      dec_key_gen_q      <= 1'b0;
       key_clear_q        <= 1'b0;
       data_out_clear_q   <= 1'b0;
       prng_reseed_done_q <= 1'b0;
     end else begin
       num_rounds_q       <= num_rounds_d;
-      crypt_q            <= crypt_d;
-      dec_key_gen_q      <= dec_key_gen_d;
       key_clear_q        <= key_clear_d;
       data_out_clear_q   <= data_out_clear_d;
       prng_reseed_done_q <= prng_reseed_done_d;
@@ -443,7 +450,8 @@ module aes_cipher_control import aes_pkg::*;
   assign num_rounds_regular = num_rounds_q - 4'd1;
 
   // Use separate signal for key expand operation, forward round.
-  assign key_expand_op_o    = (dec_key_gen_d || dec_key_gen_q) ? CIPH_FWD : op_i;
+  assign key_expand_op_o    = (dec_key_gen_d == SP2V_HIGH ||
+                               dec_key_gen_q == SP2V_HIGH) ? CIPH_FWD : op_i;
   assign key_expand_round_o = rnd_ctr_q;
 
   // Let the main controller know whate we are doing.
@@ -508,48 +516,91 @@ module aes_cipher_control import aes_pkg::*;
 
   assign rnd_ctr_err = rnd_ctr_err_sum | rnd_ctr_err_parity;
 
-  ///////////////////////
-  // Handshake Signals //
-  ///////////////////////
+  //////////////////////////////
+  // Sparsely Encoded Signals //
+  //////////////////////////////
 
-  // We use sparse encodings for handshake signals and must ensure that:
+  // We use sparse encodings for various critical signals and must ensure that:
   // 1. The synthesis tool doesn't optimize away the sparse encoding.
-  // 2. The handshake signal is always valid. More precisely, an alert or SVA is triggered if a
-  //    handshake signal takes on an invalid value.
-  // 3. The alert signal remains asserted until reset even if the handshake signal becomes valid
-  //    again. This is achieved by driving the control FSM into the terminal error state whenever
-  //    any handshake signal becomes invalid.
+  // 2. The sparsely encoded signal is always valid. More precisely, an alert or SVA is triggered
+  //    if a sparse signal takes on an invalid value.
+  // 3. The alert signal remains asserted until reset even if the sparse signal becomes valid again
+  //    This is achieved by driving the control FSM into the terminal error state whenever any
+  //    sparsely encoded signal becomes invalid.
   //
-  // If any handshake signal becomes invalid, the cipher core further immediately de-asserts
+  // If any sparsely encoded signal becomes invalid, the cipher core further immediately de-asserts
   // the out_valid_o signal to prevent any data from being released.
 
-  logic [Sp2VWidth-1:0] in_valid_raw;
-  aes_sel_buf_chk #(
-    .Num   ( Sp2VNum   ),
-    .Width ( Sp2VWidth )
-  ) u_aes_in_valid_sel_buf_chk (
-    .clk_i  ( clk_i        ),
-    .rst_ni ( rst_ni       ),
-    .sel_i  ( in_valid_i   ),
-    .sel_o  ( in_valid_raw ),
-    .err_o  ( in_valid_err )
+  // The following primitives are used to place a size-only constraint on the
+  // flops in order to prevent optimizations on these status signals.
+  logic [Sp2VWidth-1:0] crypt_q_raw;
+  prim_flop #(
+    .Width      ( Sp2VWidth            ),
+    .ResetValue ( Sp2VWidth'(SP2V_LOW) )
+  ) u_crypt_regs (
+    .clk_i  ( clk_i       ),
+    .rst_ni ( rst_ni      ),
+    .d_i    ( crypt_d     ),
+    .q_o    ( crypt_q_raw )
   );
-  assign in_valid = sp2v_e'(in_valid_raw);
 
-  logic [Sp2VWidth-1:0] out_ready_raw;
-  aes_sel_buf_chk #(
-    .Num   ( Sp2VNum   ),
-    .Width ( Sp2VWidth )
-  ) u_aes_out_ready_sel_buf_chk (
-    .clk_i  ( clk_i         ),
-    .rst_ni ( rst_ni        ),
-    .sel_i  ( out_ready_i   ),
-    .sel_o  ( out_ready_raw ),
-    .err_o  ( out_ready_err )
+  logic [Sp2VWidth-1:0] dec_key_gen_q_raw;
+  prim_flop #(
+    .Width      ( Sp2VWidth            ),
+    .ResetValue ( Sp2VWidth'(SP2V_LOW) )
+  ) u_dec_key_gen_regs (
+    .clk_i  ( clk_i             ),
+    .rst_ni ( rst_ni            ),
+    .d_i    ( dec_key_gen_d     ),
+    .q_o    ( dec_key_gen_q_raw )
   );
-  assign out_ready = sp2v_e'(out_ready_raw);
 
-  assign hs_err = in_valid_err | out_ready_err;
+  // We use vectors of sparsely encoded signals to reduce code duplication.
+  localparam int unsigned NumSp2VSig = 9;
+  sp2v_e [NumSp2VSig-1:0]                sp2v_sig;
+  sp2v_e [NumSp2VSig-1:0]                sp2v_sig_chk;
+  logic  [NumSp2VSig-1:0][Sp2VWidth-1:0] sp2v_sig_chk_raw;
+  logic  [NumSp2VSig-1:0]                sp2v_sig_err;
+
+  assign sp2v_sig[0] = in_valid_i;
+  assign sp2v_sig[1] = out_ready_i;
+  assign sp2v_sig[2] = crypt_i;
+  assign sp2v_sig[3] = dec_key_gen_i;
+  assign sp2v_sig[4] = sp2v_e'(crypt_q_raw);
+  assign sp2v_sig[5] = sp2v_e'(dec_key_gen_q_raw);
+  assign sp2v_sig[6] = advance;
+  assign sp2v_sig[7] = sub_bytes_out_req_i;
+  assign sp2v_sig[8] = key_expand_out_req_i;
+
+  // Individually check sparsely encoded signals.
+  for (genvar i = 0; i < NumSp2VSig; i++) begin : gen_sel_buf_chk
+    aes_sel_buf_chk #(
+      .Num   ( Sp2VNum   ),
+      .Width ( Sp2VWidth )
+    ) u_aes_sp2v_sig_buf_chk_i (
+      .clk_i  ( clk_i               ),
+      .rst_ni ( rst_ni              ),
+      .sel_i  ( sp2v_sig[i]         ),
+      .sel_o  ( sp2v_sig_chk_raw[i] ),
+      .err_o  ( sp2v_sig_err[i]     )
+    );
+    assign sp2v_sig_chk[i] = sp2v_e'(sp2v_sig_chk_raw[i]);
+  end
+
+  assign in_valid           = sp2v_sig_chk[0];
+  assign out_ready          = sp2v_sig_chk[1];
+  assign crypt              = sp2v_sig_chk[2];
+  assign dec_key_gen        = sp2v_sig_chk[3];
+  assign crypt_q            = sp2v_sig_chk[4];
+  assign dec_key_gen_q      = sp2v_sig_chk[5];
+  assign advance_chk        = sp2v_sig_chk[6];
+  assign sub_bytes_out_req  = sp2v_sig_chk[7];
+  assign key_expand_out_req = sp2v_sig_chk[8];
+
+  // Collect encoding errors.
+  // We instantiate the checker modules as close as possible to where the sparsely encoded signals
+  // are used. Here, we collect also encoding errors detected in other places of the cipher core.
+  assign sp_enc_err = |sp2v_sig_err | sp_enc_err_i;
 
   ////////////////
   // Assertions //

--- a/hw/ip/aes/rtl/aes_cipher_core.sv
+++ b/hw/ip/aes/rtl/aes_cipher_core.sv
@@ -724,7 +724,7 @@ module aes_cipher_core import aes_pkg::*;
       logic [(4*WidthPRDSBox)-1:0] in
     );
       logic [3:0][(WidthPRDSBox-8)-1:0] prd_msbs;
-      for (int i=0; i<4; i++) begin
+      for (int i = 0; i < 4; i++) begin
         prd_msbs[i] = in[(i*WidthPRDSBox) + 8 +: (WidthPRDSBox-8)];
       end
       return prd_msbs;
@@ -738,7 +738,7 @@ module aes_cipher_core import aes_pkg::*;
       logic [3:0][(WidthPRDSBox-8)-1:0] prd_msbs
     );
       logic [(4*WidthPRDSBox)-1:0] prd;
-      for (int i=0; i<4; i++) begin
+      for (int i = 0; i < 4; i++) begin
         prd[(i*WidthPRDSBox) +: WidthPRDSBox] = {prd_msbs[i], prd_lsbs[i]};
       end
       return prd;

--- a/hw/ip/aes/rtl/aes_cipher_core.sv
+++ b/hw/ip/aes/rtl/aes_cipher_core.sv
@@ -108,12 +108,12 @@ module aes_cipher_core import aes_pkg::*;
   input  logic                        rst_ni,
 
   // Input handshake signals
-  input  logic                        in_valid_i,
-  output logic                        in_ready_o,
+  input  sp2v_e                       in_valid_i,
+  output sp2v_e                       in_ready_o,
 
   // Output handshake signals
-  output logic                        out_valid_o,
-  input  logic                        out_ready_i,
+  output sp2v_e                       out_valid_o,
+  input  sp2v_e                       out_ready_i,
 
   // Control and sync signals
   input  logic                        cfg_valid_i, // Used for gating assertions only.

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -343,12 +343,12 @@ module aes_control import aes_pkg::*;
 
         if (idle_o) begin
           // Initial key and IV updates are ignored if we are not idle.
-          for (int s=0; s<2; s++) begin
-            for (int i=0; i<8; i++) begin
+          for (int s = 0; s < 2; s++) begin
+            for (int i = 0; i < 8; i++) begin
               key_init_we_o[s][i] = key_init_qe_i[s][i] ? SP2V_HIGH : SP2V_LOW;
             end
           end
-          for (int i=0; i<8; i++) begin
+          for (int i = 0; i < 8; i++) begin
             iv_we_o[i] = iv_qe[i] ? SP2V_HIGH : SP2V_LOW;
           end
 

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -28,6 +28,7 @@ module aes_control import aes_pkg::*;
   input  logic                    data_out_clear_i,
   input  logic                    prng_reseed_i,
   input  logic                    mux_sel_err_i,
+  input  logic                    sp_enc_err_i,
   input  logic                    alert_fatal_i,
   output logic                    alert_o,
 
@@ -37,11 +38,11 @@ module aes_control import aes_pkg::*;
   input  logic [3:0]              data_in_qe_i,
   input  logic [3:0]              data_out_re_i,
   output logic                    data_in_we_o,
-  output logic                    data_out_we_o,
+  output sp2v_e                   data_out_we_o,
 
   // Previous input data register
   output dip_sel_e                data_in_prev_sel_o,
-  output logic                    data_in_prev_we_o,
+  output sp2v_e                   data_in_prev_we_o,
 
   // Cipher I/O muxes
   output si_sel_e                 state_in_sel_o,
@@ -49,19 +50,19 @@ module aes_control import aes_pkg::*;
   output add_so_sel_e             add_state_out_sel_o,
 
   // Counter
-  output logic                    ctr_incr_o,
-  input  logic                    ctr_ready_i,
-  input  logic [7:0]              ctr_we_i,
+  output sp2v_e                   ctr_incr_o,
+  input  sp2v_e                   ctr_ready_i,
+  input  sp2v_e [7:0]             ctr_we_i,
 
   // Cipher core control and sync
   output sp2v_e                   cipher_in_valid_o,
   input  sp2v_e                   cipher_in_ready_i,
   input  sp2v_e                   cipher_out_valid_i,
   output sp2v_e                   cipher_out_ready_o,
-  output logic                    cipher_crypt_o,
-  input  logic                    cipher_crypt_i,
-  output logic                    cipher_dec_key_gen_o,
-  input  logic                    cipher_dec_key_gen_i,
+  output sp2v_e                   cipher_crypt_o,
+  input  sp2v_e                   cipher_crypt_i,
+  output sp2v_e                   cipher_dec_key_gen_o,
+  input  sp2v_e                   cipher_dec_key_gen_i,
   output logic                    cipher_key_clear_o,
   input  logic                    cipher_key_clear_i,
   output logic                    cipher_data_out_clear_o,
@@ -69,11 +70,11 @@ module aes_control import aes_pkg::*;
 
   // Initial key registers
   output key_init_sel_e           key_init_sel_o,
-  output logic [7:0]              key_init_we_o [2],
+  output sp2v_e [7:0]             key_init_we_o [2],
 
   // IV registers
   output iv_sel_e                 iv_sel_o,
-  output logic [7:0]              iv_we_o,
+  output sp2v_e [7:0]             iv_we_o,
 
   // Pseudo-random number generator interface
   output logic                    prng_data_req_o,
@@ -137,43 +138,49 @@ module aes_control import aes_pkg::*;
   aes_ctrl_e aes_ctrl_ns, aes_ctrl_cs;
 
   // Signals
-  logic       key_init_clear;
-  logic       key_init_new;
-  logic       key_init_load;
-  logic       key_init_arm;
-  logic       key_init_ready;
+  aes_mode_e   mode;
+  logic        key_init_clear;
+  sp2v_e       key_init_new, key_init_new_chk;
+  logic        key_init_load;
+  logic        key_init_arm;
+  sp2v_e       key_init_ready, key_init_ready_chk;
 
-  logic [7:0] iv_qe;
-  logic       iv_clear;
-  logic       iv_load;
-  logic       iv_arm;
-  logic       iv_ready;
+  logic  [7:0] iv_qe;
+  logic        iv_clear;
+  logic        iv_load;
+  logic        iv_arm;
+  sp2v_e       iv_ready, iv_ready_chk;
 
-  logic [3:0] data_in_new_d, data_in_new_q;
-  logic       data_in_new;
-  logic       data_in_load;
+  logic  [3:0] data_in_new_d, data_in_new_q;
+  sp2v_e       data_in_new, data_in_new_chk;
+  logic        data_in_load;
 
-  logic [3:0] data_out_read_d, data_out_read_q;
-  logic       data_out_read;
-  logic       output_valid_q;
+  logic  [3:0] data_out_read_d, data_out_read_q;
+  sp2v_e       data_out_read, data_out_read_chk;
+  sp2v_e       output_valid_d, output_valid_q;
 
-  logic       start_trigger;
-  logic       cfg_valid;
-  logic       no_alert;
-  logic       start, finish;
-  logic       cipher_crypt;
-  logic       cipher_out_done;
-  logic       doing_cbc_enc, doing_cbc_dec;
-  logic       doing_cfb_enc, doing_cfb_dec;
-  logic       doing_ofb;
-  logic       doing_ctr;
-  logic       ctrl_we_q;
-  logic       clear_in_out_status;
-  sp2v_e      cipher_in_ready;
-  logic       cipher_in_ready_err;
-  sp2v_e      cipher_out_valid;
-  logic       cipher_out_valid_err;
-  logic       hs_err;
+  logic        start_trigger;
+  logic        cfg_valid;
+  logic        no_alert;
+  sp2v_e       start_common, start_ecb, start_cbc, start_cfb, start_ofb, start_ctr;
+  sp2v_e       start, start_chk;
+  sp2v_e       finish, finish_chk;
+  sp2v_e       crypt, crypt_chk;
+  sp2v_e       cipher_out_done, cipher_out_done_chk;
+  logic        cipher_out_done_err_d, cipher_out_done_err_q;
+  sp2v_e       doing_cbc_enc, doing_cbc_enc_chk, doing_cbc_dec, doing_cbc_dec_chk;
+  sp2v_e       doing_cfb_enc, doing_cfb_enc_chk, doing_cfb_dec, doing_cfb_dec_chk;
+  sp2v_e       doing_ofb, doing_ofb_chk;
+  sp2v_e       doing_ctr, doing_ctr_chk;
+  logic        ctrl_we_q;
+  sp2v_e       ctr_ready;
+  sp2v_e [7:0] ctr_we;
+  logic        clear_in_out_status;
+  sp2v_e       cipher_in_ready;
+  sp2v_e       cipher_out_valid;
+  sp2v_e       cipher_crypt;
+  sp2v_e       cipher_dec_key_gen;
+  logic        sp_enc_err;
 
   if (SecStartTriggerDelay > 0) begin : gen_start_delay
     // Delay the manual start trigger input for SCA measurements.
@@ -204,41 +211,65 @@ module aes_control import aes_pkg::*;
 
   // The cipher core is only ever allowed to start or finish if the control register holds a valid
   // configuration and if no fatal alert condition occured.
-  assign cfg_valid = ~((mode_i == AES_NONE) | ctrl_err_storage_i);
+  assign cfg_valid = ~((mode == AES_NONE) | ctrl_err_storage_i);
   assign no_alert  = ~alert_fatal_i;
 
-  // If set to start manually, we just wait for the trigger. Otherwise, we start once we have valid
-  // data available. If the IV (and counter) is needed, we only start if also the IV (and counter)
-  // is ready.
-  assign start = cfg_valid & no_alert &
-      ( manual_operation_i ? start_trigger                                           :
-       (mode_i == AES_ECB) ? (key_init_ready & data_in_new)                          :
-       (mode_i == AES_CBC) ? (key_init_ready & data_in_new & iv_ready)               :
-       (mode_i == AES_CFB) ? (key_init_ready & data_in_new & iv_ready)               :
-       (mode_i == AES_OFB) ? (key_init_ready & data_in_new & iv_ready)               :
-       (mode_i == AES_CTR) ? (key_init_ready & data_in_new & iv_ready & ctr_ready_i) : 1'b0);
+  // Check common start conditions. These are needed for any mode, unless we are running in
+  // manual mode.
+  assign start_common = (key_init_ready_chk == SP2V_HIGH) ? data_in_new_chk : SP2V_LOW;
+
+  // Check mode-specific start conditions. If the IV (and counter) is needed, we only start if
+  // also the IV (and counter) is ready.
+  assign start_ecb = (mode == AES_ECB)                                ? SP2V_HIGH : SP2V_LOW;
+  assign start_cbc = (mode == AES_CBC && iv_ready_chk == SP2V_HIGH)   ? SP2V_HIGH : SP2V_LOW;
+  assign start_cfb = (mode == AES_CFB && iv_ready_chk == SP2V_HIGH)   ? SP2V_HIGH : SP2V_LOW;
+  assign start_ofb = (mode == AES_OFB && iv_ready_chk == SP2V_HIGH)   ? SP2V_HIGH : SP2V_LOW;
+  assign start_ctr = (mode == AES_CTR && iv_ready_chk == SP2V_HIGH &&
+                                              ctr_ready == SP2V_HIGH) ? SP2V_HIGH : SP2V_LOW;
+
+  // If set to start manually, we just wait for the trigger. Otherwise, check common as well as
+  // mode-specific start conditions.
+  assign start =
+      (cfg_valid && no_alert && (SP2V_HIGH ==
+          // Manual operation has priority.
+          (manual_operation_i      ? (start_trigger ? SP2V_HIGH : SP2V_LOW) :
+          // Check start conditions for automatic operation.
+          (start_ecb == SP2V_HIGH ||
+           start_cbc == SP2V_HIGH ||
+           start_cfb == SP2V_HIGH ||
+           start_ofb == SP2V_HIGH ||
+           start_ctr == SP2V_HIGH) ? start_common                           : SP2V_LOW))
+      ) ? SP2V_HIGH : SP2V_LOW;
 
   // If not set to overwrite data, we wait for any previous output data to be read. data_out_read
   // synchronously clears output_valid_q, unless new output data is written in the exact same
   // clock cycle.
-  assign finish = cfg_valid & no_alert &
-      (manual_operation_i ? 1'b1 : (~output_valid_q | data_out_read));
+  assign finish =
+      (cfg_valid && no_alert && (SP2V_HIGH ==
+          // Manual operation has priority.
+          (manual_operation_i              ? SP2V_HIGH :
+          // Make sure previous output data has been read.
+          (output_valid_q    == SP2V_LOW ||
+           data_out_read_chk == SP2V_HIGH) ? SP2V_HIGH : SP2V_LOW))
+      ) ? SP2V_HIGH : SP2V_LOW;
 
   // Helper signals for FSM
-  assign cipher_crypt  = cipher_crypt_o | cipher_crypt_i;
-  assign doing_cbc_enc = cipher_crypt & (mode_i == AES_CBC) & (op_i == AES_ENC);
-  assign doing_cbc_dec = cipher_crypt & (mode_i == AES_CBC) & (op_i == AES_DEC);
-  assign doing_cfb_enc = cipher_crypt & (mode_i == AES_CFB) & (op_i == AES_ENC);
-  assign doing_cfb_dec = cipher_crypt & (mode_i == AES_CFB) & (op_i == AES_DEC);
-  assign doing_ofb     = cipher_crypt & (mode_i == AES_OFB);
-  assign doing_ctr     = cipher_crypt & (mode_i == AES_CTR);
+  assign crypt = (cipher_crypt_o == SP2V_HIGH ||
+                  cipher_crypt_i == SP2V_HIGH) ? SP2V_HIGH : SP2V_LOW;
+
+  assign doing_cbc_enc = (mode == AES_CBC && op_i == AES_ENC) ? crypt_chk : SP2V_LOW;
+  assign doing_cbc_dec = (mode == AES_CBC && op_i == AES_DEC) ? crypt_chk : SP2V_LOW;
+  assign doing_cfb_enc = (mode == AES_CFB && op_i == AES_ENC) ? crypt_chk : SP2V_LOW;
+  assign doing_cfb_dec = (mode == AES_CFB && op_i == AES_DEC) ? crypt_chk : SP2V_LOW;
+  assign doing_ofb     = (mode == AES_OFB)                    ? crypt_chk : SP2V_LOW;
+  assign doing_ctr     = (mode == AES_CTR)                    ? crypt_chk : SP2V_LOW;
 
   // FSM
   always_comb begin : aes_ctrl_fsm
 
     // Previous input data register control
     data_in_prev_sel_o = DIP_CLEAR;
-    data_in_prev_we_o  = 1'b0;
+    data_in_prev_we_o  = SP2V_LOW;
 
     // Cipher I/O mux control
     state_in_sel_o      = SI_DATA;
@@ -246,24 +277,24 @@ module aes_control import aes_pkg::*;
     add_state_out_sel_o = ADD_SO_ZERO;
 
     // Counter control
-    ctr_incr_o = 1'b0;
+    ctr_incr_o = SP2V_LOW;
 
     // Cipher core control
     cipher_in_valid_o       = SP2V_LOW;
     cipher_out_ready_o      = SP2V_LOW;
-    cipher_out_done         = 1'b0;
-    cipher_crypt_o          = 1'b0;
-    cipher_dec_key_gen_o    = 1'b0;
+    cipher_out_done         = SP2V_LOW;
+    cipher_crypt_o          = SP2V_LOW;
+    cipher_dec_key_gen_o    = SP2V_LOW;
     cipher_key_clear_o      = 1'b0;
     cipher_data_out_clear_o = 1'b0;
 
     // Initial key registers
     key_init_sel_o = KEY_INIT_INPUT;
-    key_init_we_o  = '{8'h00, 8'h00};
+    key_init_we_o  = '{{8{SP2V_LOW}}, {8{SP2V_LOW}}};
 
     // IV registers
     iv_sel_o = IV_INPUT;
-    iv_we_o  = 8'h00;
+    iv_we_o  = {8{SP2V_LOW}};
 
     // Control register
     ctrl_we_o = 1'b0;
@@ -290,7 +321,7 @@ module aes_control import aes_pkg::*;
     // Key, data I/O register control
     data_in_load  = 1'b0;
     data_in_we_o  = 1'b0;
-    data_out_we_o = 1'b0;
+    data_out_we_o = SP2V_LOW;
 
     // Register status tracker control
     key_init_clear = 1'b0;
@@ -306,14 +337,20 @@ module aes_control import aes_pkg::*;
     unique case (aes_ctrl_cs)
 
       IDLE: begin
-        idle_o    = (start || key_iv_data_in_clear_i || data_out_clear_i ||
+        idle_o    = (start_chk == SP2V_HIGH || key_iv_data_in_clear_i || data_out_clear_i ||
                     prng_reseed_i) ? 1'b0 : 1'b1;
         idle_we_o = 1'b1;
 
         if (idle_o) begin
           // Initial key and IV updates are ignored if we are not idle.
-          key_init_we_o  = key_init_qe_i;
-          iv_we_o        = iv_qe;
+          for (int s=0; s<2; s++) begin
+            for (int i=0; i<8; i++) begin
+              key_init_we_o[s][i] = key_init_qe_i[s][i] ? SP2V_HIGH : SP2V_LOW;
+            end
+          end
+          for (int i=0; i<8; i++) begin
+            iv_we_o[i] = iv_qe[i] ? SP2V_HIGH : SP2V_LOW;
+          end
 
           // Updates to the control register are only allowed if we are idle and we don't have a
           // storage error. A storage error is unrecoverable and requires a reset.
@@ -336,45 +373,45 @@ module aes_control import aes_pkg::*;
           // To clear registers, we must first request fresh pseudo-random data.
           aes_ctrl_ns = UPDATE_PRNG;
 
-        end else if (start) begin
+        end else if (start_chk == SP2V_HIGH) begin
           // Signal that we want to start encryption/decryption.
-          cipher_crypt_o = 1'b1;
+          cipher_crypt_o = SP2V_HIGH;
 
           // We got a new initial key, but want to do decryption. The cipher core must first
           // generate the start key for decryption.
-          cipher_dec_key_gen_o = key_init_new & (cipher_op_i == CIPH_INV);
+          cipher_dec_key_gen_o = (cipher_op_i == CIPH_INV) ? key_init_new_chk : SP2V_LOW;
 
           // Previous input data register control
-          data_in_prev_sel_o = doing_cbc_dec ? DIP_DATA_IN :
-                               doing_cfb_enc ? DIP_DATA_IN :
-                               doing_cfb_dec ? DIP_DATA_IN :
-                               doing_ofb     ? DIP_DATA_IN :
-                               doing_ctr     ? DIP_DATA_IN : DIP_CLEAR;
-          data_in_prev_we_o  = doing_cbc_dec ? 1'b1 :
-                               doing_cfb_enc ? 1'b1 :
-                               doing_cfb_dec ? 1'b1 :
-                               doing_ofb     ? 1'b1 :
-                               doing_ctr     ? 1'b1 : 1'b0;
+          data_in_prev_sel_o = (doing_cbc_dec_chk == SP2V_HIGH) ? DIP_DATA_IN :
+                               (doing_cfb_enc_chk == SP2V_HIGH) ? DIP_DATA_IN :
+                               (doing_cfb_dec_chk == SP2V_HIGH) ? DIP_DATA_IN :
+                               (doing_ofb         == SP2V_HIGH) ? DIP_DATA_IN :
+                               (doing_ctr         == SP2V_HIGH) ? DIP_DATA_IN : DIP_CLEAR;
+          data_in_prev_we_o  = (doing_cbc_dec_chk == SP2V_HIGH) ? SP2V_HIGH :
+                               (doing_cfb_enc_chk == SP2V_HIGH) ? SP2V_HIGH :
+                               (doing_cfb_dec_chk == SP2V_HIGH) ? SP2V_HIGH :
+                               (doing_ofb_chk     == SP2V_HIGH) ? SP2V_HIGH :
+                               (doing_ctr_chk     == SP2V_HIGH) ? SP2V_HIGH : SP2V_LOW;
 
           // State input mux control
-          state_in_sel_o     = doing_cfb_enc ? SI_ZERO :
-                               doing_cfb_dec ? SI_ZERO :
-                               doing_ofb     ? SI_ZERO :
-                               doing_ctr     ? SI_ZERO : SI_DATA;
+          state_in_sel_o     = (doing_cfb_enc_chk == SP2V_HIGH) ? SI_ZERO :
+                               (doing_cfb_dec_chk == SP2V_HIGH) ? SI_ZERO :
+                               (doing_ofb_chk     == SP2V_HIGH) ? SI_ZERO :
+                               (doing_ctr_chk     == SP2V_HIGH) ? SI_ZERO : SI_DATA;
 
           // State input additon mux control
-          add_state_in_sel_o = doing_cbc_enc ? ADD_SI_IV :
-                               doing_cfb_enc ? ADD_SI_IV :
-                               doing_cfb_dec ? ADD_SI_IV :
-                               doing_ofb     ? ADD_SI_IV :
-                               doing_ctr     ? ADD_SI_IV : ADD_SI_ZERO;
+          add_state_in_sel_o = (doing_cbc_enc_chk == SP2V_HIGH) ? ADD_SI_IV :
+                               (doing_cfb_enc_chk == SP2V_HIGH) ? ADD_SI_IV :
+                               (doing_cfb_dec_chk == SP2V_HIGH) ? ADD_SI_IV :
+                               (doing_ofb_chk     == SP2V_HIGH) ? ADD_SI_IV :
+                               (doing_ctr_chk     == SP2V_HIGH) ? ADD_SI_IV : ADD_SI_ZERO;
 
           // We have work for the cipher core, perform handshake.
           cipher_in_valid_o = SP2V_HIGH;
           if (cipher_in_ready == SP2V_HIGH) begin
             // Do not yet clear a possible start trigger if we are just starting the generation of
             // the start key for decryption.
-            start_we_o  = ~cipher_dec_key_gen_o;
+            start_we_o  = (cipher_dec_key_gen_o == SP2V_LOW);
             aes_ctrl_ns = LOAD;
           end
         end
@@ -382,18 +419,21 @@ module aes_control import aes_pkg::*;
 
       LOAD: begin
         // Signal that we have used the current key, IV, data input to register status tracking.
-        key_init_load =  cipher_dec_key_gen_i; // This key is no longer "new", but still clean.
-        key_init_arm  = ~cipher_dec_key_gen_i; // The key is still "new", prevent partial updates.
-        iv_load       = ~cipher_dec_key_gen_i & (doing_cbc_enc | doing_cbc_dec |
-                                                 doing_cfb_enc | doing_cfb_dec |
-                                                 doing_ofb | doing_ctr);
-        data_in_load  = ~cipher_dec_key_gen_i;
+        key_init_load = (cipher_dec_key_gen == SP2V_HIGH); // This key is no longer "new", but
+                                                           // still clean.
+        key_init_arm  = (cipher_dec_key_gen == SP2V_LOW);  // The key is still "new", prevent
+                                                           // partial updates.
+        iv_load       = (cipher_dec_key_gen == SP2V_HIGH) &
+                            (doing_cbc_enc_chk == SP2V_HIGH | doing_cbc_dec_chk == SP2V_HIGH |
+                             doing_cfb_enc_chk == SP2V_HIGH | doing_cfb_dec_chk == SP2V_HIGH |
+                             doing_ofb_chk     == SP2V_HIGH | doing_ctr_chk     == SP2V_HIGH);
+        data_in_load  = (cipher_dec_key_gen == SP2V_LOW);
 
         // Trigger counter increment.
-        ctr_incr_o   = doing_ctr ? 1'b1 : 1'b0;
+        ctr_incr_o   = doing_ctr_chk;
 
         // Unless we are just generating the start key for decryption, we must update the PRNG.
-        aes_ctrl_ns  = ~cipher_dec_key_gen_i ? UPDATE_PRNG : FINISH;
+        aes_ctrl_ns  = (cipher_dec_key_gen == SP2V_LOW) ? UPDATE_PRNG : FINISH;
       end
 
       UPDATE_PRNG: begin
@@ -403,8 +443,8 @@ module aes_control import aes_pkg::*;
 
         // IV control in case of ongoing encryption/decryption
         // - CTR: IV registers are updated by counter during cipher operation
-        iv_sel_o = doing_ctr ? IV_CTR   : IV_INPUT;
-        iv_we_o  = doing_ctr ? ctr_we_i : 8'h00;
+        iv_sel_o = (doing_ctr_chk == SP2V_HIGH) ? IV_CTR : IV_INPUT;
+        iv_we_o  = (doing_ctr_chk == SP2V_HIGH) ? ctr_we : {8{SP2V_LOW}};
 
         // Request fresh pseudo-random data, perform handshake.
         prng_data_req_o = 1'b1;
@@ -412,7 +452,7 @@ module aes_control import aes_pkg::*;
 
           // Ongoing encryption/decryption operations have the highest priority. The clear triggers
           // might have become asserted after the handshake with the cipher core.
-          if (cipher_crypt_i) begin
+          if (cipher_crypt == SP2V_HIGH) begin
             aes_ctrl_ns = FINISH;
 
           end else begin // (key_iv_data_in_clear_i || data_out_clear_i)
@@ -427,64 +467,66 @@ module aes_control import aes_pkg::*;
             if (cipher_in_ready == SP2V_HIGH) begin
               aes_ctrl_ns = CLEAR;
             end
-          end // cipher_crypt_i
+          end // cipher_crypt
         end // prng_data_ack_i
       end
 
       FINISH: begin
         // Wait for cipher core to finish.
 
-        if (cipher_dec_key_gen_i) begin
+        if (cipher_dec_key_gen == SP2V_HIGH) begin
           // We are ready.
           cipher_out_ready_o = SP2V_HIGH;
           if (cipher_out_valid == SP2V_HIGH) begin
             aes_ctrl_ns = IDLE;
           end
         end else begin
-          // Handshake signals: We are ready once the output data registers can be written.
-          cipher_out_ready_o = finish ? SP2V_HIGH : SP2V_LOW;
-          cipher_out_done    = finish & (cipher_out_valid == SP2V_HIGH);
+          // Handshake signals: We are ready once the output data registers can be written. Don't
+          // let data propagate in case of mux selector or sparsely encoded signals taking on
+          // invalid values.
+          cipher_out_ready_o = finish_chk;
+          cipher_out_done    = (finish_chk == SP2V_HIGH && cipher_out_valid == SP2V_HIGH &&
+              !mux_sel_err_i && !sp_enc_err) ? SP2V_HIGH : SP2V_LOW;
 
           // Signal if the cipher core is stalled (because previous output has not yet been read).
-          stall_o    = ~finish & (cipher_out_valid == SP2V_HIGH);
+          stall_o    = (finish_chk == SP2V_LOW) & (cipher_out_valid == SP2V_HIGH);
           stall_we_o = 1'b1;
 
           // State out addition mux control
-          add_state_out_sel_o = doing_cbc_dec ? ADD_SO_IV  :
-                                doing_cfb_enc ? ADD_SO_DIP :
-                                doing_cfb_dec ? ADD_SO_DIP :
-                                doing_ofb     ? ADD_SO_DIP :
-                                doing_ctr     ? ADD_SO_DIP : ADD_SO_ZERO;
+          add_state_out_sel_o = (doing_cbc_dec_chk == SP2V_HIGH) ? ADD_SO_IV  :
+                                (doing_cfb_enc_chk == SP2V_HIGH) ? ADD_SO_DIP :
+                                (doing_cfb_dec_chk == SP2V_HIGH) ? ADD_SO_DIP :
+                                (doing_ofb_chk     == SP2V_HIGH) ? ADD_SO_DIP :
+                                (doing_ctr_chk     == SP2V_HIGH) ? ADD_SO_DIP : ADD_SO_ZERO;
 
           // IV control
           // - CBC/CFB/OFB: IV registers are only updated when cipher finishes.
           // - CTR: IV registers are updated by counter during cipher operation.
-          iv_sel_o = doing_cbc_enc  ? IV_DATA_OUT     :
-                     doing_cbc_dec  ? IV_DATA_IN_PREV :
-                     doing_cfb_enc  ? IV_DATA_OUT     :
-                     doing_cfb_dec  ? IV_DATA_IN_PREV :
-                     doing_ofb      ? IV_DATA_OUT_RAW :
-                     doing_ctr      ? IV_CTR          : IV_INPUT;
-          iv_we_o  = doing_cbc_enc ||
-                     doing_cbc_dec ||
-                     doing_cfb_enc ||
-                     doing_cfb_dec ||
-                     doing_ofb     ? {8{cipher_out_done}} :
-                     doing_ctr     ? ctr_we_i             : 8'h00;
+          iv_sel_o = (doing_cbc_enc_chk == SP2V_HIGH)  ? IV_DATA_OUT     :
+                     (doing_cbc_dec_chk == SP2V_HIGH)  ? IV_DATA_IN_PREV :
+                     (doing_cfb_enc_chk == SP2V_HIGH)  ? IV_DATA_OUT     :
+                     (doing_cfb_dec_chk == SP2V_HIGH)  ? IV_DATA_IN_PREV :
+                     (doing_ofb_chk     == SP2V_HIGH)  ? IV_DATA_OUT_RAW :
+                     (doing_ctr_chk     == SP2V_HIGH)  ? IV_CTR          : IV_INPUT;
+          iv_we_o  = (doing_cbc_enc_chk == SP2V_HIGH) ||
+                     (doing_cbc_dec_chk == SP2V_HIGH) ||
+                     (doing_cfb_enc_chk == SP2V_HIGH) ||
+                     (doing_cfb_dec_chk == SP2V_HIGH) ||
+                     (doing_ofb_chk     == SP2V_HIGH) ? {8{cipher_out_done_chk}} :
+                     (doing_ctr_chk     == SP2V_HIGH) ? ctr_we                   : {8{SP2V_LOW}};
 
           // Arm the IV status tracker: After finishing, the IV registers can be written again
           // by software. We need to make sure software does not partially update the IV.
-          iv_arm = doing_cbc_enc ||
-                   doing_cbc_dec ||
-                   doing_cfb_enc ||
-                   doing_cfb_dec ||
-                   doing_ofb     ||
-                   doing_ctr     ? cipher_out_done : 1'b0;
+          iv_arm = (doing_cbc_enc_chk == SP2V_HIGH) ||
+                   (doing_cbc_dec_chk == SP2V_HIGH) ||
+                   (doing_cfb_enc_chk == SP2V_HIGH) ||
+                   (doing_cfb_dec_chk == SP2V_HIGH) ||
+                   (doing_ofb_chk     == SP2V_HIGH) ||
+                   (doing_ctr_chk     == SP2V_HIGH) ? (cipher_out_done_chk == SP2V_HIGH) : 1'b0;
 
           // Proceed upon successful handshake.
-          if (finish && (cipher_out_valid == SP2V_HIGH)) begin
-            // Don't release data from cipher core in case of invalid mux selector signals.
-            data_out_we_o = ~mux_sel_err_i;
+          if (cipher_out_done_chk == SP2V_HIGH) begin
+            data_out_we_o = SP2V_HIGH;
             aes_ctrl_ns   = IDLE;
           end
         end
@@ -495,18 +537,18 @@ module aes_control import aes_pkg::*;
         if (key_iv_data_in_clear_i) begin
           // Initial Key
           key_init_sel_o = KEY_INIT_CLEAR;
-          key_init_we_o  = '{8'hFF, 8'hFF};
+          key_init_we_o  = '{{8{SP2V_HIGH}}, {8{SP2V_HIGH}}};
           key_init_clear = 1'b1;
 
           // IV
           iv_sel_o = IV_CLEAR;
-          iv_we_o  = 8'hFF;
+          iv_we_o  = {8{SP2V_HIGH}};
           iv_clear = 1'b1;
 
           // Input data
           data_in_we_o       = 1'b1;
           data_in_prev_sel_o = DIP_CLEAR;
-          data_in_prev_we_o  = 1'b1;
+          data_in_prev_we_o  = SP2V_HIGH;
         end
 
         // Perform handshake with cipher core.
@@ -524,8 +566,8 @@ module aes_control import aes_pkg::*;
           // data_out_clear_i is acknowledged by the cipher core with cipher_data_out_clear_i.
           if (cipher_data_out_clear_i) begin
             // Clear output data and the trigger bit. Don't release data from cipher core in case
-            // of invalid mux selector or handshake signals.
-            data_out_we_o       = ~mux_sel_err_i & ~hs_err;
+            // of mux selector or sparsely encoded signals taking on invalid values.
+            data_out_we_o       = (!mux_sel_err_i && !sp_enc_err) ? SP2V_HIGH : SP2V_LOW;
             data_out_clear_we_o = 1'b1;
           end
 
@@ -544,9 +586,9 @@ module aes_control import aes_pkg::*;
       end
     endcase
 
-    // Unconditionally jump into the terminal error state in case a mux selector or handshake
-    // signal becomes invalid.
-    if (mux_sel_err_i || hs_err) begin
+    // Unconditionally jump into the terminal error state in case a mux selector or a sparsely
+    // encoded signal becomes invalid
+    if (mux_sel_err_i || sp_enc_err) begin
       aes_ctrl_ns = ERROR;
     end
   end
@@ -572,29 +614,39 @@ module aes_control import aes_pkg::*;
   // We only use clean initial keys. Either software/counter has updated
   // - all initial key registers, or
   // - none of the initial key registers but the registers were updated in the past.
+  logic [7:0] key_init_we [2];
+  for (genvar s = 0; s < 2; s++) begin : gen_status_key_init_we_shares
+    for (genvar i = 0; i < 8; i++) begin : gen_status_key_init_we
+      assign key_init_we[s][i] = (key_init_we_o[s][i] == SP2V_HIGH);
+    end
+  end
   aes_reg_status #(
-    .Width ( $bits(key_init_we_o) )
+    .Width ( $bits(key_init_we) )
   ) u_reg_status_key_init (
-    .clk_i   ( clk_i                                ),
-    .rst_ni  ( rst_ni                               ),
-    .we_i    ( {key_init_we_o[1], key_init_we_o[0]} ),
-    .use_i   ( key_init_load                        ),
-    .clear_i ( key_init_clear                       ),
-    .arm_i   ( key_init_arm                         ),
-    .new_o   ( key_init_new                         ),
-    .clean_o ( key_init_ready                       )
+    .clk_i   ( clk_i                            ),
+    .rst_ni  ( rst_ni                           ),
+    .we_i    ( {key_init_we[1], key_init_we[0]} ),
+    .use_i   ( key_init_load                    ),
+    .clear_i ( key_init_clear                   ),
+    .arm_i   ( key_init_arm                     ),
+    .new_o   ( key_init_new                     ),
+    .clean_o ( key_init_ready                   )
   );
 
   // We only use clean and unused IVs. Either software/counter has updated
   // - all IV registers, or
   // - none of the IV registers but the registers were updated in the past
   // and this particular IV has not yet been used.
+  logic [7:0] iv_we;
+  for (genvar i = 0; i < 8; i++) begin : gen_status_iv_we
+    assign iv_we[i] = (iv_we_o[i] == SP2V_HIGH);
+  end
   aes_reg_status #(
-    .Width ( $bits(iv_we_o) )
+    .Width ( $bits(iv_we) )
   ) u_reg_status_iv (
     .clk_i   ( clk_i    ),
     .rst_ni  ( rst_ni   ),
-    .we_i    ( iv_we_o  ),
+    .we_i    ( iv_we    ),
     .use_i   ( iv_load  ),
     .clear_i ( iv_clear ),
     .arm_i   ( iv_arm   ),
@@ -624,7 +676,7 @@ module aes_control import aes_pkg::*;
   // - clearing the status tracking.
   assign data_in_new_d = data_in_load || data_in_we_o || clear_in_out_status ? '0 :
       data_in_new_q | data_in_qe_i;
-  assign data_in_new   = &data_in_new_d;
+  assign data_in_new   = &data_in_new_d ? SP2V_HIGH : SP2V_LOW;
 
   // Collect reads of data output registers. data_out_read is high for one clock cycle only and
   // clears output_valid_q unless new output is written in the exact same cycle. Cleared if:
@@ -632,7 +684,7 @@ module aes_control import aes_pkg::*;
   // - clearing the status tracking.
   assign data_out_read_d = &data_out_read_q || clear_in_out_status ? '0 :
       data_out_read_q | data_out_re_i;
-  assign data_out_read   = &data_out_read_d;
+  assign data_out_read   = &data_out_read_d ? SP2V_HIGH : SP2V_LOW;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : reg_edge_detection
     if (!rst_ni) begin
@@ -649,31 +701,41 @@ module aes_control import aes_pkg::*;
   // - data is loaded into cipher core,
   // - clearing data input registers with random data,
   // - clearing the status tracking.
-  assign input_ready_o    = ~data_in_new;
-  assign input_ready_we_o =  data_in_new | data_in_load | data_in_we_o | clear_in_out_status;
+  assign input_ready_o    = (data_in_new == SP2V_LOW);
+  assign input_ready_we_o = (data_in_new == SP2V_HIGH) | data_in_load | data_in_we_o |
+      clear_in_out_status;
 
   // Cleared if:
   // - all data output registers have been read (unless new output is written in the same cycle),
   // - clearing data ouput registers with random data,
   // - clearing the status tracking.
-  assign output_valid_o    = data_out_we_o & ~data_out_clear_we_o;
-  assign output_valid_we_o = data_out_we_o | data_out_read | data_out_clear_we_o |
-      clear_in_out_status;
+  assign output_valid_o    = (data_out_we_o == SP2V_HIGH) & ~data_out_clear_we_o;
+  assign output_valid_we_o = (data_out_we_o == SP2V_HIGH) | (data_out_read_chk == SP2V_HIGH) |
+      data_out_clear_we_o | clear_in_out_status;
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_output_valid
-    if (!rst_ni) begin
-      output_valid_q <= '0;
-    end else if (output_valid_we_o) begin
-      output_valid_q <= output_valid_o;
-    end
-  end
+  assign output_valid_d    = !output_valid_we_o ? output_valid_q :
+                                 output_valid_o ? SP2V_HIGH      : SP2V_LOW;
+
+  // This primitive is used to place a size-only constraint on the
+  // flops in order to prevent optimizations on this status signal.
+  logic [Sp2VWidth-1:0] output_valid_q_raw;
+  prim_flop #(
+    .Width      ( Sp2VWidth            ),
+    .ResetValue ( Sp2VWidth'(SP2V_LOW) )
+  ) u_crypt_regs (
+    .clk_i  ( clk_i              ),
+    .rst_ni ( rst_ni             ),
+    .d_i    ( output_valid_d     ),
+    .q_o    ( output_valid_q_raw )
+  );
 
   // Output lost status register bit
   // Cleared when updating the Control Register. Set when overwriting previous output data that has
   // not yet been read.
   assign output_lost_o    = ctrl_we_o     ? 1'b0 :
-                            output_lost_i ? 1'b1 : output_valid_q & ~data_out_read;
-  assign output_lost_we_o = ctrl_we_o | data_out_we_o;
+                            output_lost_i ? 1'b1 :
+                                (output_valid_q == SP2V_HIGH) & (data_out_read_chk == SP2V_LOW);
+  assign output_lost_we_o = ctrl_we_o | (data_out_we_o == SP2V_HIGH);
 
   // Trigger register, the control only ever clears these
   assign start_o                = 1'b0;
@@ -681,55 +743,125 @@ module aes_control import aes_pkg::*;
   assign data_out_clear_o       = 1'b0;
   assign prng_reseed_o          = 1'b0;
 
-  ///////////////////////
-  // Handshake Signals //
-  ///////////////////////
+  //////////////////////////////
+  // Sparsely Encoded Signals //
+  //////////////////////////////
 
-  // We use sparse encodings for handshake signals and must ensure that:
+  // We use sparse encodings for various critical signals and must ensure that:
   // 1. The synthesis tool doesn't optimize away the sparse encoding.
-  // 2. The handshake signal is always valid. More precisely, an alert or SVA is triggered if a
-  //    handshake signal takes on an invalid value.
-  // 3. The alert signal remains asserted until reset even if the handshake signal becomes valid
-  //    again. This is achieved by driving the control FSM into the terminal error state whenever
-  //    any handshake signal becomes invalid.
+  // 2. The sparsely encoded signal is always valid. More precisely, an alert or SVA is triggered
+  //    if a sparse signal takes on an invalid value.
+  // 3. The alert signal remains asserted until reset even if the sparse signal becomes valid again
+  //    This is achieved by driving the control FSM into the terminal error state whenever any
+  //    sparsely encoded signal becomes invalid.
   //
-  // If any handshake signal becomes invalid, the cipher core further immediately de-asserts
-  // the out_valid_o signal to prevent any data from being released.
+  // If any sparsely encoded signal becomes invalid, the controller further immediately de-asserts
+  // data_out_we_o and other write-enable signals to prevent any data from being released.
 
-  logic [Sp2VWidth-1:0] cipher_in_ready_raw;
-  aes_sel_buf_chk #(
-    .Num   ( Sp2VNum   ),
-    .Width ( Sp2VWidth )
-  ) u_aes_cipher_in_ready_buf_chk (
-    .clk_i  ( clk_i               ),
-    .rst_ni ( rst_ni              ),
-    .sel_i  ( cipher_in_ready_i   ),
-    .sel_o  ( cipher_in_ready_raw ),
-    .err_o  ( cipher_in_ready_err )
-  );
-  assign cipher_in_ready = sp2v_e'(cipher_in_ready_raw);
+  // We use vectors of sparsely encoded signals to reduce code duplication.
+  localparam int unsigned NumSp2VSig = 29;
+  sp2v_e [NumSp2VSig-1:0]                sp2v_sig;
+  sp2v_e [NumSp2VSig-1:0]                sp2v_sig_chk;
+  logic  [NumSp2VSig-1:0][Sp2VWidth-1:0] sp2v_sig_chk_raw;
+  logic  [NumSp2VSig-1:0]                sp2v_sig_err;
 
-  logic [Sp2VWidth-1:0] cipher_out_valid_raw;
-  aes_sel_buf_chk #(
-    .Num   ( Sp2VNum   ),
-    .Width ( Sp2VWidth )
-  ) u_aes_cipher_out_valid_buf_chk (
-    .clk_i  ( clk_i                ),
-    .rst_ni ( rst_ni               ),
-    .sel_i  ( cipher_out_valid_i   ),
-    .sel_o  ( cipher_out_valid_raw ),
-    .err_o  ( cipher_out_valid_err )
-  );
-  assign cipher_out_valid = sp2v_e'(cipher_out_valid_raw);
+  assign sp2v_sig[0]  = cipher_in_ready_i;
+  assign sp2v_sig[1]  = cipher_out_valid_i;
+  assign sp2v_sig[2]  = cipher_crypt_i;
+  assign sp2v_sig[3]  = cipher_dec_key_gen_i;
+  assign sp2v_sig[4]  = crypt;
+  assign sp2v_sig[5]  = doing_cbc_enc;
+  assign sp2v_sig[6]  = doing_cbc_dec;
+  assign sp2v_sig[7]  = doing_cfb_enc;
+  assign sp2v_sig[8]  = doing_cfb_dec;
+  assign sp2v_sig[9]  = doing_ofb;
+  assign sp2v_sig[10] = doing_ctr;
+  assign sp2v_sig[11] = key_init_new;
+  assign sp2v_sig[12] = key_init_ready;
+  assign sp2v_sig[13] = iv_ready;
+  assign sp2v_sig[14] = data_in_new;
+  assign sp2v_sig[15] = data_out_read;
+  assign sp2v_sig[16] = sp2v_e'(output_valid_q_raw);
+  assign sp2v_sig[17] = ctr_ready_i;
+  assign sp2v_sig[18] = start;
+  assign sp2v_sig[19] = finish;
+  for (genvar i = 0; i < 8; i++) begin : gen_use_ctr_we_i
+    assign sp2v_sig[20+i] = ctr_we_i[i];
+  end
+  assign sp2v_sig[28] = cipher_out_done;
 
-  assign hs_err = cipher_in_ready_err | cipher_out_valid_err;
+  // Individually check sparsely encoded signals.
+  for (genvar i = 0; i < NumSp2VSig; i++) begin : gen_sel_buf_chk
+    aes_sel_buf_chk #(
+      .Num   ( Sp2VNum   ),
+      .Width ( Sp2VWidth )
+    ) u_aes_sp2v_sig_buf_chk_i (
+      .clk_i  ( clk_i               ),
+      .rst_ni ( rst_ni              ),
+      .sel_i  ( sp2v_sig[i]         ),
+      .sel_o  ( sp2v_sig_chk_raw[i] ),
+      .err_o  ( sp2v_sig_err[i]     )
+    );
+    assign sp2v_sig_chk[i] = sp2v_e'(sp2v_sig_chk_raw[i]);
+  end
+
+  assign cipher_in_ready       = sp2v_sig_chk[0];
+  assign cipher_out_valid      = sp2v_sig_chk[1];
+  assign cipher_crypt          = sp2v_sig_chk[2];
+  assign cipher_dec_key_gen    = sp2v_sig_chk[3];
+  assign crypt_chk             = sp2v_sig_chk[4];
+  assign doing_cbc_enc_chk     = sp2v_sig_chk[5];
+  assign doing_cbc_dec_chk     = sp2v_sig_chk[6];
+  assign doing_cfb_enc_chk     = sp2v_sig_chk[7];
+  assign doing_cfb_dec_chk     = sp2v_sig_chk[8];
+  assign doing_ofb_chk         = sp2v_sig_chk[9];
+  assign doing_ctr_chk         = sp2v_sig_chk[10];
+  assign key_init_new_chk      = sp2v_sig_chk[11];
+  assign key_init_ready_chk    = sp2v_sig_chk[12];
+  assign iv_ready_chk          = sp2v_sig_chk[13];
+  assign data_in_new_chk       = sp2v_sig_chk[14];
+  assign data_out_read_chk     = sp2v_sig_chk[15];
+  assign output_valid_q        = sp2v_sig_chk[16];
+  assign ctr_ready             = sp2v_sig_chk[17];
+  assign start_chk             = sp2v_sig_chk[18];
+  assign finish_chk            = sp2v_sig_chk[19];
+  for (genvar i = 0; i < 8; i++) begin : gen_ctr_we
+    assign ctr_we[i]           = sp2v_sig_chk[20+i];
+  end
+  assign cipher_out_done_chk   = sp2v_sig_chk[28];
+  assign cipher_out_done_err_d = sp2v_sig_err[28];
+
+  // We need to register the error signal for cipher_out_done to avoid circular loops in the FSM.
+  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_sp_enc_err
+    if (!rst_ni) begin
+      cipher_out_done_err_q <= 1'b0;
+    end else if (cipher_out_done_err_d) begin
+      cipher_out_done_err_q <= 1'b1;
+    end
+  end
+
+  // Collect encoding errors.
+  // We instantiate the checker modules as close as possible to where the sparsely encoded signals
+  // are used. Here, we collect also encoding errors detected in other places of the core.
+  assign sp_enc_err = |sp2v_sig_err[NumSp2VSig-2:0] | cipher_out_done_err_q | sp_enc_err_i;
+
+  // Prevent synthesis optimizations on the mode signal.
+  logic [$bits(aes_mode_e)-1:0] mode_in_raw, mode_buf_raw;
+  assign mode_in_raw = {mode_i};
+  for (genvar i = 0; i < $bits(mode_i); i++) begin : gen_mode_buf
+    prim_buf u_prim_buf_sel_i (
+      .in_i  ( mode_in_raw[i]  ),
+      .out_o ( mode_buf_raw[i] )
+    );
+  end
+  assign mode = aes_mode_e'(mode_buf_raw);
 
   ////////////////
   // Assertions //
   ////////////////
 
   // Selectors must be known/valid
-  `ASSERT(AesModeValid, !ctrl_err_storage_i |-> mode_i inside {
+  `ASSERT(AesModeValid, !ctrl_err_storage_i |-> mode inside {
       AES_ECB,
       AES_CBC,
       AES_CFB,

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -194,7 +194,7 @@ module aes_core
   ////////////
 
   always_comb begin : key_init_get
-    for (int i=0; i<8; i++) begin
+    for (int i = 0; i < 8; i++) begin
       key_init[0][i]    = reg2hw.key_share0[i].q;
       key_init_qe[0][i] = reg2hw.key_share0[i].qe;
       key_init[1][i]    = reg2hw.key_share1[i].q;
@@ -203,21 +203,21 @@ module aes_core
   end
 
   always_comb begin : iv_get
-    for (int i=0; i<4; i++) begin
+    for (int i = 0; i < 4; i++) begin
       iv[i]    = reg2hw.iv[i].q;
       iv_qe[i] = reg2hw.iv[i].qe;
     end
   end
 
   always_comb begin : data_in_get
-    for (int i=0; i<4; i++) begin
+    for (int i = 0; i < 4; i++) begin
       data_in[i]    = reg2hw.data_in[i].q;
       data_in_qe[i] = reg2hw.data_in[i].qe;
     end
   end
 
   always_comb begin : data_out_get
-    for (int i=0; i<4; i++) begin
+    for (int i = 0; i < 4; i++) begin
       // data_out is actually hwo, but we need hrw for hwre
       unused_data_out_q[i] = reg2hw.data_out[i].q;
       data_out_re[i]       = reg2hw.data_out[i].re;
@@ -241,8 +241,8 @@ module aes_core
     if (!rst_ni) begin
       key_init_q <= '{default: '0};
     end else begin
-      for (int s=0; s<2; s++) begin
-        for (int i=0; i<8; i++) begin
+      for (int s = 0; s < 2; s++) begin
+        for (int i = 0; i < 8; i++) begin
           if (key_init_we[s][i] == SP2V_HIGH) begin
             key_init_q[s][i] <= key_init_d[s][i];
           end
@@ -268,7 +268,7 @@ module aes_core
     if (!rst_ni) begin
       iv_q <= '0;
     end else begin
-      for (int i=0; i<8; i++) begin
+      for (int i = 0; i < 8; i++) begin
         if (iv_we[i] == SP2V_HIGH) begin
           iv_q[i] <= iv_d[i];
         end
@@ -593,7 +593,7 @@ module aes_core
 
   // Input data register clear
   always_comb begin : data_in_reg_clear
-    for (int i=0; i<4; i++) begin
+    for (int i = 0; i < 4; i++) begin
       hw2reg.data_in[i].d  = prd_clearing_128[i*32 +: 32];
       hw2reg.data_in[i].de = data_in_we;
     end
@@ -778,20 +778,20 @@ module aes_core
   end
 
   always_comb begin : key_reg_put
-    for (int i=0; i<8; i++) begin
+    for (int i = 0; i < 8; i++) begin
       hw2reg.key_share0[i].d = key_init_q[0][i];
       hw2reg.key_share1[i].d = key_init_q[1][i];
     end
   end
 
   always_comb begin : iv_reg_put
-    for (int i=0; i<4; i++) begin
+    for (int i = 0; i < 4; i++) begin
       hw2reg.iv[i].d  = {iv_q[2*i+1], iv_q[2*i]};
     end
   end
 
   always_comb begin : data_out_put
-    for (int i=0; i<4; i++) begin
+    for (int i = 0; i < 4; i++) begin
       hw2reg.data_out[i].d = data_out_q[i];
     end
   end

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -129,10 +129,10 @@ module aes_core
   logic                        data_out_we;
   logic                  [3:0] data_out_re;
 
-  logic                        cipher_in_valid;
-  logic                        cipher_in_ready;
-  logic                        cipher_out_valid;
-  logic                        cipher_out_ready;
+  sp2v_e                       cipher_in_valid;
+  sp2v_e                       cipher_in_ready;
+  sp2v_e                       cipher_out_valid;
+  sp2v_e                       cipher_out_ready;
   logic                        cipher_crypt;
   logic                        cipher_crypt_busy;
   logic                        cipher_dec_key_gen;

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -62,6 +62,7 @@ module aes_core
   logic                        ctrl_err_storage_q;
   logic                        ctrl_alert;
   logic                        mux_sel_err;
+  logic                        sp_enc_err_d, sp_enc_err_q;
 
   logic        [3:0][3:0][7:0] state_in;
   logic       [SISelWidth-1:0] state_in_sel_raw;
@@ -84,7 +85,8 @@ module aes_core
   logic            [7:0][31:0] key_init_d [2];
   logic            [7:0][31:0] key_init_q [2];
   logic            [7:0][31:0] key_init_cipher [NumShares];
-  logic            [7:0]       key_init_we [2];
+  sp2v_e           [7:0]       key_init_we_ctrl [2];
+  sp2v_e           [7:0]       key_init_we [2];
   logic  [KeyInitSelWidth-1:0] key_init_sel_raw;
   key_init_sel_e               key_init_sel_ctrl;
   key_init_sel_e               key_init_sel;
@@ -94,21 +96,23 @@ module aes_core
   logic            [3:0]       iv_qe;
   logic            [7:0][15:0] iv_d;
   logic            [7:0][15:0] iv_q;
-  logic            [7:0]       iv_we;
+  sp2v_e           [7:0]       iv_we_ctrl;
+  sp2v_e           [7:0]       iv_we;
   logic       [IVSelWidth-1:0] iv_sel_raw;
   iv_sel_e                     iv_sel_ctrl;
   iv_sel_e                     iv_sel;
   logic                        iv_sel_err;
 
   logic            [7:0][15:0] ctr;
-  logic            [7:0]       ctr_we;
-  logic                        ctr_incr;
-  logic                        ctr_ready;
+  sp2v_e           [7:0]       ctr_we;
+  sp2v_e                       ctr_incr;
+  sp2v_e                       ctr_ready;
   logic                        ctr_alert;
 
   logic            [3:0][31:0] data_in_prev_d;
   logic            [3:0][31:0] data_in_prev_q;
-  logic                        data_in_prev_we;
+  sp2v_e                       data_in_prev_we_ctrl;
+  sp2v_e                       data_in_prev_we;
   logic      [DIPSelWidth-1:0] data_in_prev_sel_raw;
   dip_sel_e                    data_in_prev_sel_ctrl;
   dip_sel_e                    data_in_prev_sel;
@@ -126,17 +130,18 @@ module aes_core
 
   logic            [3:0][31:0] data_out_d;
   logic            [3:0][31:0] data_out_q;
-  logic                        data_out_we;
+  sp2v_e                       data_out_we_ctrl;
+  sp2v_e                       data_out_we;
   logic                  [3:0] data_out_re;
 
   sp2v_e                       cipher_in_valid;
   sp2v_e                       cipher_in_ready;
   sp2v_e                       cipher_out_valid;
   sp2v_e                       cipher_out_ready;
-  logic                        cipher_crypt;
-  logic                        cipher_crypt_busy;
-  logic                        cipher_dec_key_gen;
-  logic                        cipher_dec_key_gen_busy;
+  sp2v_e                       cipher_crypt;
+  sp2v_e                       cipher_crypt_busy;
+  sp2v_e                       cipher_dec_key_gen;
+  sp2v_e                       cipher_dec_key_gen_busy;
   logic                        cipher_key_clear;
   logic                        cipher_key_clear_busy;
   logic                        cipher_data_out_clear;
@@ -238,7 +243,7 @@ module aes_core
     end else begin
       for (int s=0; s<2; s++) begin
         for (int i=0; i<8; i++) begin
-          if (key_init_we[s][i]) begin
+          if (key_init_we[s][i] == SP2V_HIGH) begin
             key_init_q[s][i] <= key_init_d[s][i];
           end
         end
@@ -264,7 +269,7 @@ module aes_core
       iv_q <= '0;
     end else begin
       for (int i=0; i<8; i++) begin
-        if (iv_we[i]) begin
+        if (iv_we[i] == SP2V_HIGH) begin
           iv_q[i] <= iv_d[i];
         end
       end
@@ -283,7 +288,7 @@ module aes_core
   always_ff @(posedge clk_i or negedge rst_ni) begin : data_in_prev_reg
     if (!rst_ni) begin
       data_in_prev_q <= '0;
-    end else if (data_in_prev_we) begin
+    end else if (data_in_prev_we == SP2V_HIGH) begin
       data_in_prev_q <= data_in_prev_d;
     end
   end
@@ -519,6 +524,7 @@ module aes_core
     .data_out_clear_i          ( reg2hw.trigger.data_out_clear.q        ),
     .prng_reseed_i             ( reg2hw.trigger.prng_reseed.q           ),
     .mux_sel_err_i             ( mux_sel_err                            ),
+    .sp_enc_err_i              ( sp_enc_err_q                           ),
     .alert_fatal_i             ( alert_fatal_o                          ),
     .alert_o                   ( ctrl_alert                             ),
 
@@ -527,10 +533,10 @@ module aes_core
     .data_in_qe_i              ( data_in_qe                             ),
     .data_out_re_i             ( data_out_re                            ),
     .data_in_we_o              ( data_in_we                             ),
-    .data_out_we_o             ( data_out_we                            ),
+    .data_out_we_o             ( data_out_we_ctrl                       ),
 
     .data_in_prev_sel_o        ( data_in_prev_sel_ctrl                  ),
-    .data_in_prev_we_o         ( data_in_prev_we                        ),
+    .data_in_prev_we_o         ( data_in_prev_we_ctrl                   ),
 
     .state_in_sel_o            ( state_in_sel_ctrl                      ),
     .add_state_in_sel_o        ( add_state_in_sel_ctrl                  ),
@@ -554,9 +560,9 @@ module aes_core
     .cipher_data_out_clear_i   ( cipher_data_out_clear_busy             ),
 
     .key_init_sel_o            ( key_init_sel_ctrl                      ),
-    .key_init_we_o             ( key_init_we                            ),
+    .key_init_we_o             ( key_init_we_ctrl                       ),
     .iv_sel_o                  ( iv_sel_ctrl                            ),
-    .iv_we_o                   ( iv_we                                  ),
+    .iv_we_o                   ( iv_we_ctrl                             ),
 
     .prng_data_req_o           ( prd_clearing_upd_req                   ),
     .prng_data_ack_i           ( prd_clearing_upd_ack                   ),
@@ -685,6 +691,80 @@ module aes_core
   assign mux_sel_err = data_in_prev_sel_err | state_in_sel_err | add_state_in_sel_err |
       add_state_out_sel_err | key_init_sel_err | iv_sel_err;
 
+  //////////////////////////////
+  // Sparsely Encoded Signals //
+  //////////////////////////////
+
+  // We use sparse encodings for various critical signals and must ensure that:
+  // 1. The synthesis tool doesn't optimize away the sparse encoding.
+  // 2. The sparsely encoded signal is always valid. More precisely, an alert or SVA is triggered
+  //    if a sparse signal takes on an invalid value.
+  // 3. The alert signal remains asserted until reset even if the sparse signal becomes valid again
+  //    This is achieved by driving the control FSM into the terminal error state whenever any
+  //    sparsely encoded signal becomes invalid.
+  //
+  // If any sparsely encoded signal becomes invalid, the core controller further immediately
+  // de-asserts the data_out_we_o signal to prevent any data from being released.
+
+  // We use vectors of sparsely encoded signals to reduce code duplication.
+  localparam int unsigned NumSp2VSig = 26;
+  sp2v_e [NumSp2VSig-1:0]                sp2v_sig;
+  sp2v_e [NumSp2VSig-1:0]                sp2v_sig_chk;
+  logic  [NumSp2VSig-1:0][Sp2VWidth-1:0] sp2v_sig_chk_raw;
+  logic  [NumSp2VSig-1:0]                sp2v_sig_err;
+
+  for (genvar s = 0; s < 2; s++) begin : gen_use_key_init_we_ctrl_shares
+    for (genvar i = 0; i < 8; i++) begin : gen_use_key_init_we_ctrl
+      assign sp2v_sig[s*8+i] = key_init_we_ctrl[s][i];
+    end
+  end
+  for (genvar i = 0; i < 8; i++) begin : gen_use_iv_we_ctrl
+    assign sp2v_sig[16+i] = iv_we_ctrl[i];
+  end
+  assign sp2v_sig[24] = data_in_prev_we_ctrl;
+  assign sp2v_sig[25] = data_out_we_ctrl;
+
+  // Individually check sparsely encoded signals.
+  for (genvar i = 0; i < NumSp2VSig; i++) begin : gen_sel_buf_chk
+    aes_sel_buf_chk #(
+      .Num   ( Sp2VNum   ),
+      .Width ( Sp2VWidth )
+    ) u_aes_sp2v_sig_buf_chk_i (
+      .clk_i  ( clk_i               ),
+      .rst_ni ( rst_ni              ),
+      .sel_i  ( sp2v_sig[i]         ),
+      .sel_o  ( sp2v_sig_chk_raw[i] ),
+      .err_o  ( sp2v_sig_err[i]     )
+    );
+    assign sp2v_sig_chk[i] = sp2v_e'(sp2v_sig_chk_raw[i]);
+  end
+
+  for (genvar s = 0; s < 2; s++) begin : gen_key_init_we_shares
+    for (genvar i = 0; i < 8; i++) begin : gen_key_init_we
+      assign key_init_we[s][i] = sp2v_sig_chk[s*8+i];
+    end
+  end
+  for (genvar i = 0; i < 8; i++) begin : gen_iv_we
+    assign iv_we[i]      = sp2v_sig_chk[16+i];
+  end
+  assign data_in_prev_we = sp2v_sig_chk[24];
+  assign data_out_we     = sp2v_sig_chk[25];
+
+  // Collect encoding errors.
+  // We instantiate the checker modules as close as possible to where the sparsely encoded signals
+  // are used. Here, we collect also encoding errors detected in other places of the core.
+  assign sp_enc_err_d = |sp2v_sig_err;
+
+  // We need to register the collected error signal to avoid circular loops in the core controller
+  // related to iv_we and data_out_we.
+  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_sp_enc_err
+    if (!rst_ni) begin
+      sp_enc_err_q <= 1'b0;
+    end else if (sp_enc_err_d) begin
+      sp_enc_err_q <= 1'b1;
+    end
+  end
+
   /////////////
   // Outputs //
   /////////////
@@ -692,7 +772,7 @@ module aes_core
   always_ff @(posedge clk_i or negedge rst_ni) begin : data_out_reg
     if (!rst_ni) begin
       data_out_q <= '0;
-    end else if (data_out_we) begin
+    end else if (data_out_we == SP2V_HIGH) begin
       data_out_q <= data_out_d;
     end
   end

--- a/hw/ip/aes/rtl/aes_ctr.sv
+++ b/hw/ip/aes/rtl/aes_ctr.sv
@@ -25,7 +25,7 @@ module aes_ctr import aes_pkg::*;
   // Reverse byte order
   function automatic logic [15:0][7:0] aes_rev_order_byte(logic [15:0][7:0] in);
     logic [15:0][7:0] out;
-    for (int i=0; i<16; i++) begin
+    for (int i = 0; i < 16; i++) begin
       out[i] = in[15-i];
     end
     return out;
@@ -34,7 +34,7 @@ module aes_ctr import aes_pkg::*;
   // Reverse sp2v order
   function automatic sp2v_e [7:0] aes_rev_order_sp2v(sp2v_e [7:0] in);
     sp2v_e [7:0] out;
-    for (int i=0; i<8; i++) begin
+    for (int i = 0; i < 8; i++) begin
       out[i] = in[7-i];
     end
     return out;

--- a/hw/ip/aes/rtl/aes_key_expand.sv
+++ b/hw/ip/aes/rtl/aes_key_expand.sv
@@ -260,13 +260,13 @@ module aes_key_expand import aes_pkg::*;
           regular[s][0] = irregular[s] ^ key_i[s][0];
           unique case (op_i)
             CIPH_FWD: begin
-              for (int i=1; i<4; i++) begin
+              for (int i = 1; i < 4; i++) begin
                 regular[s][i] = regular[s][i-1] ^ key_i[s][i];
               end
             end
 
             CIPH_INV: begin
-              for (int i=1; i<4; i++) begin
+              for (int i = 1; i < 4; i++) begin
                 regular[s][i] = key_i[s][i-1] ^ key_i[s][i];
               end
             end
@@ -295,7 +295,7 @@ module aes_key_expand import aes_pkg::*;
                   // Shift down two upper most words
                   regular[s][1:0] = key_i[s][5:4];
                   // Generate new upper four words
-                  for (int i=0; i<4; i++) begin
+                  for (int i = 0; i < 4; i++) begin
                     if ((i == 0 && rnd_type[2]) ||
                         (i == 2 && rnd_type[3])) begin
                       regular[s][i+2] = irregular[s]    ^ key_i[s][i];
@@ -311,14 +311,14 @@ module aes_key_expand import aes_pkg::*;
                   // Shift up four lowest words
                   regular[s][5:2] = key_i[s][3:0];
                   // Generate Word 44 and 45
-                  for (int i=0; i<2; i++) begin
+                  for (int i = 0; i < 2; i++) begin
                     regular[s][i] = key_i[s][3+i] ^ key_i[s][3+i+1];
                   end
                 end else begin
                   // Shift up two lowest words
                   regular[s][5:4] = key_i[s][1:0];
                   // Generate new lower four words
-                  for (int i=0; i<4; i++) begin
+                  for (int i = 0; i < 4; i++) begin
                     if ((i == 2 && rnd_type[1]) ||
                         (i == 0 && rnd_type[2])) begin
                       regular[s][i] = irregular[s]  ^ key_i[s][i+2];
@@ -352,7 +352,7 @@ module aes_key_expand import aes_pkg::*;
                 regular[s][3:0] = key_i[s][7:4];
                 // Generate new upper half
                 regular[s][4]   = irregular[s] ^ key_i[s][0];
-                for (int i=1; i<4; i++) begin
+                for (int i = 1; i < 4; i++) begin
                   regular[s][i+4] = regular[s][i+4-1] ^ key_i[s][i];
                 end
               end // rnd == 0
@@ -368,7 +368,7 @@ module aes_key_expand import aes_pkg::*;
                 regular[s][7:4] = key_i[s][3:0];
                 // Generate new lower half
                 regular[s][0]   = irregular[s] ^ key_i[s][4];
-                for (int i=0; i<3; i++) begin
+                for (int i = 0; i < 3; i++) begin
                   regular[s][i+1] = key_i[s][4+i] ^ key_i[s][4+i+1];
                 end
               end // rnd == 0

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -85,7 +85,7 @@ typedef enum logic [2:0] {
 // Generic, sparse mux selector encodings
 
 // Encoding generated with:
-// $ ./sparse-fsm-encode.py -d 3 -m 2 -n 4 \
+// $ ./util/design/sparse-fsm-encode.py -d 3 -m 2 -n 3 \
 //      -s 31468618 --language=sv
 //
 // Hamming distance histogram:
@@ -94,15 +94,16 @@ typedef enum logic [2:0] {
 //  1: --
 //  2: --
 //  3: |||||||||||||||||||| (100.00%)
-//  4: --
 //
 // Minimum Hamming distance: 3
 // Maximum Hamming distance: 3
+// Minimum Hamming weight: 1
+// Maximum Hamming weight: 2
 //
-parameter int Mux2SelWidth = 4;
+parameter int Mux2SelWidth = 3;
 typedef enum logic [Mux2SelWidth-1:0] {
-  MUX2_SEL_0 = 4'b0111,
-  MUX2_SEL_1 = 4'b1100
+  MUX2_SEL_0 = 3'b011,
+  MUX2_SEL_1 = 3'b100
 } mux2_sel_e;
 
 // Encoding generated with:

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -353,8 +353,8 @@ endfunction
 function automatic logic [3:0][3:0][7:0] aes_transpose(logic [3:0][3:0][7:0] in);
   logic [3:0][3:0][7:0] transpose;
   transpose = '0;
-  for (int j=0; j<4; j++) begin
-    for (int i=0; i<4; i++) begin
+  for (int j = 0; j < 4; j++) begin
+    for (int i = 0; i < 4; i++) begin
       transpose[i][j] = in[j][i];
     end
   end
@@ -364,7 +364,7 @@ endfunction
 // Extract single column from state matrix
 function automatic logic [3:0][7:0] aes_col_get(logic [3:0][3:0][7:0] in, logic [1:0] idx);
   logic [3:0][7:0] out;
-  for (int i=0; i<4; i++) begin
+  for (int i = 0; i < 4; i++) begin
     out[i] = in[i][idx];
   end
   return out;
@@ -377,8 +377,8 @@ function automatic logic [7:0] aes_mvm(
 );
   logic [7:0] vec_c;
   vec_c = '0;
-  for (int i=0; i<8; i++) begin
-    for (int j=0; j<8; j++) begin
+  for (int i = 0; i < 8; i++) begin
+    for (int j = 0; j < 8; j++) begin
       vec_c[i] = vec_c[i] ^ (mat_a[j][i] & vec_b[7-j]);
     end
   end
@@ -416,7 +416,7 @@ function automatic logic [3:0][7:0] aes_prd_get_lsbs(
   logic [(4*WidthPRDSBox)-1:0] in
 );
   logic [3:0][7:0] prd_lsbs;
-  for (int i=0; i<4; i++) begin
+  for (int i = 0; i < 4; i++) begin
     prd_lsbs[i] = in[i*WidthPRDSBox +: 8];
   end
   return prd_lsbs;

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -275,6 +275,15 @@ typedef enum logic [AddSOSelWidth-1:0] {
   ADD_SO_DIP  = MUX3_SEL_2
 } add_so_sel_e;
 
+// Sparse two-value signal type sp2v_e
+parameter int Sp2VNum = 2;
+parameter int Sp2VWidth = Mux2SelWidth;
+typedef enum logic [Sp2VWidth-1:0] {
+  SP2V_HIGH = MUX2_SEL_0,
+  SP2V_LOW  = MUX2_SEL_1
+} sp2v_e;
+
+// Control register type
 typedef struct packed {
   logic      force_zero_masks;
   logic      manual_operation;

--- a/hw/ip/aes/rtl/aes_reg_status.sv
+++ b/hw/ip/aes/rtl/aes_reg_status.sv
@@ -6,7 +6,8 @@
 //
 // This module tracks the collective status of multiple registers.
 
-module aes_reg_status #(
+module aes_reg_status import aes_pkg::*;
+#(
   parameter int Width = 1
 ) (
   input  logic             clk_i,
@@ -16,16 +17,16 @@ module aes_reg_status #(
   input  logic             use_i,
   input  logic             clear_i,
   input  logic             arm_i,
-  output logic             new_o,
-  output logic             clean_o
+  output sp2v_e            new_o,
+  output sp2v_e            clean_o
 );
 
   logic [Width-1:0] we_d, we_q;
   logic             armed_d, armed_q;
-  logic             all_written;
-  logic             none_written;
-  logic             new_d, new_q;
-  logic             clean_d, clean_q;
+  sp2v_e            all_written;
+  sp2v_e            none_written;
+  sp2v_e            new_d, new_q;
+  sp2v_e            clean_d, clean_q;
 
   // Collect write operations. Upon clear or use, we start over. If armed, the next write will
   // restart the tracking.
@@ -45,11 +46,11 @@ module aes_reg_status #(
   end
 
   // Status tracking
-  assign all_written  =  &we_d;
-  assign none_written = ~|we_d;
+  assign all_written  =  &we_d ? SP2V_HIGH : SP2V_LOW;
+  assign none_written = ~|we_d ? SP2V_HIGH : SP2V_LOW;
 
   // We have a complete new value if all registers have been written at least once.
-  assign new_d   = (clear_i || use_i) ? 1'b0 : all_written;
+  assign new_d   = (clear_i || use_i) ? SP2V_LOW : all_written;
 
   // We have a clean value, if either:
   // - all registers have been written at least once, or
@@ -57,19 +58,35 @@ module aes_reg_status #(
   // A value is NOT clean, if either:
   // - we get a clear or reset, or
   // - some but not all registers have been written.
-  assign clean_d = clear_i      ? 1'b0    :
-                   all_written  ? 1'b1    :
-                   none_written ? clean_q : 1'b0;
+  assign clean_d =  clear_i                    ? SP2V_LOW  :
+                   (all_written  == SP2V_HIGH) ? SP2V_HIGH :
+                   (none_written == SP2V_HIGH) ? clean_q   : SP2V_LOW;
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_status
-    if (!rst_ni) begin
-      new_q   <= 1'b0;
-      clean_q <= 1'b0;
-    end else begin
-      new_q   <= new_d;
-      clean_q <= clean_d;
-    end
-  end
+  // The following primitives are used to place a size-only constraint on the
+  // flops in order to prevent optimizations on these status signals.
+  logic [Sp2VWidth-1:0] new_q_raw;
+  prim_flop #(
+    .Width      ( Sp2VWidth            ),
+    .ResetValue ( Sp2VWidth'(SP2V_LOW) )
+  ) u_new_status_regs (
+    .clk_i  ( clk_i     ),
+    .rst_ni ( rst_ni    ),
+    .d_i    ( new_d     ),
+    .q_o    ( new_q_raw )
+  );
+  assign new_q = sp2v_e'(new_q_raw);
+
+  logic [Sp2VWidth-1:0] clean_q_raw;
+  prim_flop #(
+    .Width      ( Sp2VWidth            ),
+    .ResetValue ( Sp2VWidth'(SP2V_LOW) )
+  ) u_clean_status_regs (
+    .clk_i  ( clk_i       ),
+    .rst_ni ( rst_ni      ),
+    .d_i    ( clean_d     ),
+    .q_o    ( clean_q_raw )
+  );
+  assign clean_q = sp2v_e'(clean_q_raw);
 
   assign new_o   = new_q;
   assign clean_o = clean_q;

--- a/hw/ip/aes/rtl/aes_sub_bytes.sv
+++ b/hw/ip/aes/rtl/aes_sub_bytes.sv
@@ -10,21 +10,50 @@ module aes_sub_bytes import aes_pkg::*;
 ) (
   input  logic                              clk_i,
   input  logic                              rst_ni,
-  input  logic                              en_i,
-  output logic                              out_req_o,
-  input  logic                              out_ack_i,
+  input  sp2v_e                             en_i,
+  output sp2v_e                             out_req_o,
+  input  sp2v_e                             out_ack_i,
   input  ciph_op_e                          op_i,
   input  logic              [3:0][3:0][7:0] data_i,
   input  logic              [3:0][3:0][7:0] mask_i,
   input  logic [3:0][3:0][WidthPRDSBox-1:0] prd_i,
   output logic              [3:0][3:0][7:0] data_o,
-  output logic              [3:0][3:0][7:0] mask_o
+  output logic              [3:0][3:0][7:0] mask_o,
+  output logic                              err_o
 );
 
+  sp2v_e           en;
+  logic            en_err;
   logic [3:0][3:0] out_req;
+  sp2v_e           out_ack;
+  logic            out_ack_err;
 
-  // Collect REQ signals.
-  assign out_req_o = &out_req;
+  // Check sparsely encoded signals.
+  logic [Sp2VWidth-1:0] en_raw;
+  aes_sel_buf_chk #(
+    .Num   ( Sp2VNum   ),
+    .Width ( Sp2VWidth )
+  ) u_aes_sb_en_buf_chk (
+    .clk_i  ( clk_i  ),
+    .rst_ni ( rst_ni ),
+    .sel_i  ( en_i   ),
+    .sel_o  ( en_raw ),
+    .err_o  ( en_err )
+  );
+  assign en = sp2v_e'(en_raw);
+
+  logic [Sp2VWidth-1:0] out_ack_raw;
+  aes_sel_buf_chk #(
+    .Num   ( Sp2VNum   ),
+    .Width ( Sp2VWidth )
+  ) u_aes_sb_out_ack_buf_chk (
+    .clk_i  ( clk_i       ),
+    .rst_ni ( rst_ni      ),
+    .sel_i  ( out_ack_i   ),
+    .sel_o  ( out_ack_raw ),
+    .err_o  ( out_ack_err )
+  );
+  assign out_ack = sp2v_e'(out_ack_raw);
 
   // Individually substitute bytes.
   for (genvar j = 0; j < 4; j++) begin : gen_sbox_j
@@ -32,19 +61,25 @@ module aes_sub_bytes import aes_pkg::*;
       aes_sbox #(
         .SBoxImpl ( SBoxImpl )
       ) u_aes_sbox_ij (
-        .clk_i     ( clk_i         ),
-        .rst_ni    ( rst_ni        ),
-        .en_i      ( en_i          ),
-        .out_req_o ( out_req[i][j] ),
-        .out_ack_i ( out_ack_i     ),
-        .op_i      ( op_i          ),
-        .data_i    ( data_i[i][j]  ),
-        .mask_i    ( mask_i[i][j]  ),
-        .prd_i     ( prd_i [i][j]  ),
-        .data_o    ( data_o[i][j]  ),
-        .mask_o    ( mask_o[i][j]  )
+        .clk_i     ( clk_i                ),
+        .rst_ni    ( rst_ni               ),
+        .en_i      ( en == SP2V_HIGH      ),
+        .out_req_o ( out_req[i][j]        ),
+        .out_ack_i ( out_ack == SP2V_HIGH ),
+        .op_i      ( op_i                 ),
+        .data_i    ( data_i[i][j]         ),
+        .mask_i    ( mask_i[i][j]         ),
+        .prd_i     ( prd_i [i][j]         ),
+        .data_o    ( data_o[i][j]         ),
+        .mask_o    ( mask_o[i][j]         )
       );
     end
   end
+
+  // Collect REQ signals.
+  assign out_req_o = &out_req ? SP2V_HIGH : SP2V_LOW;
+
+  // Collect encoding errors.
+  assign err_o = en_err | out_ack_err;
 
 endmodule

--- a/hw/ip/csrng/rtl/csrng_block_encrypt.sv
+++ b/hw/ip/csrng/rtl/csrng_block_encrypt.sv
@@ -99,10 +99,10 @@ module csrng_block_encrypt #(
     .out_ready_i        ( cipher_out_ready           ),
     .op_i               ( aes_pkg::CIPH_FWD          ),
     .key_len_i          ( aes_pkg::AES_256           ),
-    .crypt_i            ( aes_cipher_core_enable     ),
+    .crypt_i            ( aes_pkg::SP2V_HIGH         ), // Enable
     .crypt_o            (                            ),
     .alert_o            ( block_encrypt_aes_cipher_sm_err_o),
-    .dec_key_gen_i      ( 1'b0                       ), // Disable
+    .dec_key_gen_i      ( aes_pkg::SP2V_LOW          ), // Disable
     .dec_key_gen_o      (                            ),
     .key_clear_i        ( 1'b0                       ), // Disable
     .key_clear_o        (                            ),


### PR DESCRIPTION
This PR adds more protection against FI attacks on the control path of AES. It contains two main commits:
1. The first commit replaces the 1-bit handshake signals between the main control FSM and the cipher core controller with sparsely encoded signals to protect these against fault injection. To represent these signals, a new enum type `sp2v_e` (sparse 2-value signal) is introduced and to reuse existing checking logic and infrastructure to stop aggressive synthesis optimization (`aes_sel_buf_chk.sv`) this type uses the `mux2_sel_e` enum type under the hood. The checking logic is always introduced where the signals are used.
2. Since even with the first commit, there remain a couple of single points of failure in the design that would allow an adversary to early terminate cipher operation (to be absolutely avoided), the second commit extends this protection mechanism to other critical signals, some of which inside the cipher core (multicycle S-Boxes inside SubBytes and KeyExpand) and some in the main controller FSM (status signals).

All the additional checkers and error signals don't look beautiful and ultimately, we will need to protect even more signals. E.g. inside the main controller FSM and between that FSM and the CTR module. But before going further down that road, I would be glad to get your opinions. Do you guys think this approach is good? Or do you have ideas for more elegant/better solutions?

Note that this PR contains many whitespace changes, it is recommended to hide these during review.