### PR TITLE
[dv/otp] fix edn request regression error

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -83,6 +83,9 @@ package otp_ctrl_env_pkg;
   parameter uint SCRAMBLE_KEY_SIZE  = 128;
   parameter uint NUM_ROUND          = 31;
 
+  parameter uint NUM_SRAM_EDN_REQ = 10;
+  parameter uint NUM_OTBN_EDN_REQ = 16;
+
   // lc does not have digest
   parameter int PART_BASE_ADDRS [NumPart-1] = {
     CreatorSwCfgOffset,


### PR DESCRIPTION
This PR fixes a regression mismatch during OTBN key request, TB expects
EDN request size is 16 while design is 18. The extra two edn request
coming from the background LFSR timer for checks.
To avoid this mismatch, if edn request is two more than expected, scb
will assume it is a LFSR timer request and ignore the output check.

Signed-off-by: Cindy Chen <chencindy@google.com>