### PR TITLE
[keymgr/dv] Fix intr_test failure in stress_all

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -214,6 +214,8 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
     update_result_e update_result;
     keymgr_pkg::keymgr_ops_e op = get_operation();
 
+    // op_status is updated one cycle after done. If SW reads at this edge, still return old value
+    // use non-blocking assignment to push the update available in next cycle
     if (get_err_code() != 0) current_op_status <= keymgr_pkg::OpDoneFail;
     else                     current_op_status <= keymgr_pkg::OpDoneSuccess;
 

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_stress_all_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_stress_all_vseq.sv
@@ -10,6 +10,14 @@ class keymgr_stress_all_vseq extends keymgr_base_vseq;
 
   `uvm_object_new
 
+  // keymgr_init is done in each sub-vseq
+  // some vseq like keymgr_common_vseq should not invoke keymgr_init.
+  // Let sub-vseq do keymgr_init and don't do it in stress_all
+  virtual task pre_start();
+    do_keymgr_init = 1'b0;
+    super.pre_start();
+  endtask
+
   task body();
     string seq_names[] = {"keymgr_smoke_vseq",
                           "keymgr_common_vseq", // for intr_test


### PR DESCRIPTION
1. stress_all shouldn't call keymgr_init which does some reg programming
and screws up intr_test
2. Add comment to address #5159

Signed-off-by: Weicai Yang <weicai@google.com>