### PR TITLE
[reggen] Add naming check for REGWEN and standardize on RW0C accesses

### DIFF
--- a/hw/ip/alert_handler/data/alert_handler.hjson
+++ b/hw/ip/alert_handler/data/alert_handler.hjson
@@ -110,12 +110,12 @@
       act:     "req",
       package: "alert_pkg"
     },
-    // TODO: connect this to EDN
-    { struct:  "logic",
-      type:    "uni",
-      name:    "entropy",
-      default: " 1'b0",
-      act:     "rcv",
+    { struct:  "edn"
+      type:    "req_rsp"
+      name:    "edn"
+      act:     "req"
+      width:   "1"
+      package: "edn_pkg"
     },
     { struct:  "esc_rx"
       type:    "uni"
@@ -158,11 +158,11 @@
 
   registers: [
 # register locks for alerts and class configs
-    { name: "REGEN",
+    { name: "REGWEN",
       desc: '''
             Register write enable for all control registers.
             ''',
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hro",
       fields: [
         {
@@ -182,7 +182,7 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         {
           # TODO: add PING_CNT_DW parameter here
@@ -202,12 +202,12 @@
                   count:    "NAlerts",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "alert",
                   tags:     [// Enable `alert_en` might cause top-level escalators to trigger
                              // unexpected reset
                              "excl:CsrAllTests:CsrExclWrite"]
-                  fields: [
+                 fields: [
                     { bits: "0",
                       name: "EN_A",
                       desc: "Alert enable "
@@ -222,7 +222,7 @@
                   count:    "NAlerts",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "alert",
                   fields: [
                     {
@@ -265,7 +265,7 @@
                   count:    "N_LOC_ALERT",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "local alert",
                   fields: [
                     { bits: "0",
@@ -282,7 +282,7 @@
                   count:    "N_LOC_ALERT",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "local alert",
                   fields: [
                     {
@@ -322,10 +322,10 @@
 # classes
 
     { name:     "CLASSA_CTRL",
-      desc:     "Escalation control register for alert Class A. Can not be modified if !!REGEN is false."
+      desc:     "Escalation control register for alert Class A. Can not be modified if !!REGWEN is false."
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "0",
           name: "EN",
@@ -387,11 +387,11 @@
         }
       ]
     },
-    { name:     "CLASSA_CLREN",
+    { name:     "CLASSA_REGWEN",
       desc:     '''
                 Clear enable for escalation protocol of Class A alerts.
                 '''
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hwo",
       fields: [
       {   bits:   "0",
@@ -414,11 +414,11 @@
       swaccess: "wo",
       hwaccess: "hro",
       hwqe:     "true",
-      regwen:   "CLASSA_CLREN",
+      regwen:   "CLASSA_REGWEN",
       fields: [
         { bits: "0",
           desc: '''Writing to this register clears the accumulator and aborts escalation
-          (if it has been triggered). This clear is disabled if !!CLASSA_CLREN is false.
+          (if it has been triggered). This clear is disabled if !!CLASSA_REGWEN is false.
           '''
         }
       ]
@@ -426,7 +426,7 @@
     { name:     "CLASSA_ACCUM_CNT",
       desc:     '''
                 Current accumulation value for alert Class A. Software can clear this register
-                with a write to !!CLASSA_CLR register unless !!CLASSA_CLREN is false.
+                with a write to !!CLASSA_CLR register unless !!CLASSA_REGWEN is false.
                 '''
       swaccess: "ro",
       hwaccess: "hwo",
@@ -444,12 +444,12 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "15:0",
           desc: '''Once the accumulation value register is equal to the threshold escalation will
           be triggered on the next alert occurrence within this class A begins. Note that this
-          register can not be modified if !!REGEN is false.
+          register can not be modified if !!REGWEN is false.
           '''
         }
       ]
@@ -460,14 +460,14 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0",
           desc: '''If the interrupt corresponding to this class is not
           handled within the specified amount of cycles, escalation will be triggered.
           Set to a positive value to enable the interrupt timeout for Class A. The timeout is set to zero
           by default, which disables this feature. Note that this register can not be modified if
-          !!REGEN is false.
+          !!REGWEN is false.
           '''
         }
       ]
@@ -478,11 +478,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -492,11 +492,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -506,11 +506,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -520,11 +520,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -544,7 +544,7 @@
           corresponding interrupt bit.
 
           If this class is in any of the escalation phases (e.g. Phase0), escalation protocol can be
-          aborted by writing to !!CLASSA_CLR. Note however that has no effect if !!CLASSA_CLREN
+          aborted by writing to !!CLASSA_CLR. Note however that has no effect if !!CLASSA_REGWEN
           is set to false (either by SW or by HW via the !!CLASSA_CTRL.LOCK feature).
           '''
         }
@@ -579,10 +579,10 @@
     },
 
     { name:     "CLASSB_CTRL",
-      desc:     "Escalation control register for alert Class B. Can not be modified if !!REGEN is false."
+      desc:     "Escalation control register for alert Class B. Can not be modified if !!REGWEN is false."
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "0",
           name: "EN",
@@ -644,11 +644,11 @@
         }
       ]
     },
-    { name:     "CLASSB_CLREN",
+    { name:     "CLASSB_REGWEN",
       desc:     '''
                 Clear enable for escalation protocol of Class B alerts.
                 '''
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hwo",
       fields: [
       {   bits:   "0",
@@ -671,11 +671,11 @@
       swaccess: "wo",
       hwaccess: "hro",
       hwqe:     "true",
-      regwen:   "CLASSB_CLREN",
+      regwen:   "CLASSB_REGWEN",
       fields: [
         { bits: "0",
           desc: '''Writing to this register clears the accumulator and aborts escalation
-          (if it has been triggered). This clear is disabled if !!CLASSB_CLREN is false.
+          (if it has been triggered). This clear is disabled if !!CLASSB_REGWEN is false.
           '''
         }
       ]
@@ -683,7 +683,7 @@
     { name:     "CLASSB_ACCUM_CNT",
       desc:     '''
                 Current accumulation value for alert Class B. Software can clear this register
-                with a write to !!CLASSB_CLR register unless !!CLASSB_CLREN is false.
+                with a write to !!CLASSB_CLR register unless !!CLASSB_REGWEN is false.
                 '''
       swaccess: "ro",
       hwaccess: "hwo",
@@ -701,12 +701,12 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "15:0",
           desc: '''Once the accumulation value register is equal to the threshold escalation will
           be triggered on the next alert occurrence within this class B begins. Note that this
-          register can not be modified if !!REGEN is false.
+          register can not be modified if !!REGWEN is false.
           '''
         }
       ]
@@ -717,14 +717,14 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0",
           desc: '''If the interrupt corresponding to this class is not
           handled within the specified amount of cycles, escalation will be triggered.
           Set to a positive value to enable the interrupt timeout for Class B. The timeout is set to zero
           by default, which disables this feature. Note that this register can not be modified if
-          !!REGEN is false.
+          !!REGWEN is false.
           '''
         }
       ]
@@ -735,11 +735,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -749,11 +749,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -763,11 +763,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -777,11 +777,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -801,7 +801,7 @@
           corresponding interrupt bit.
 
           If this class is in any of the escalation phases (e.g. Phase0), escalation protocol can be
-          aborted by writing to !!CLASSB_CLR. Note however that has no effect if !!CLASSB_CLREN
+          aborted by writing to !!CLASSB_CLR. Note however that has no effect if !!CLASSB_REGWEN
           is set to false (either by SW or by HW via the !!CLASSB_CTRL.LOCK feature).
           '''
         }
@@ -836,10 +836,10 @@
     },
 
     { name:     "CLASSC_CTRL",
-      desc:     "Escalation control register for alert Class C. Can not be modified if !!REGEN is false."
+      desc:     "Escalation control register for alert Class C. Can not be modified if !!REGWEN is false."
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "0",
           name: "EN",
@@ -901,11 +901,11 @@
         }
       ]
     },
-    { name:     "CLASSC_CLREN",
+    { name:     "CLASSC_REGWEN",
       desc:     '''
                 Clear enable for escalation protocol of Class C alerts.
                 '''
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hwo",
       fields: [
       {   bits:   "0",
@@ -928,11 +928,11 @@
       swaccess: "wo",
       hwaccess: "hro",
       hwqe:     "true",
-      regwen:   "CLASSC_CLREN",
+      regwen:   "CLASSC_REGWEN",
       fields: [
         { bits: "0",
           desc: '''Writing to this register clears the accumulator and aborts escalation
-          (if it has been triggered). This clear is disabled if !!CLASSC_CLREN is false.
+          (if it has been triggered). This clear is disabled if !!CLASSC_REGWEN is false.
           '''
         }
       ]
@@ -940,7 +940,7 @@
     { name:     "CLASSC_ACCUM_CNT",
       desc:     '''
                 Current accumulation value for alert Class C. Software can clear this register
-                with a write to !!CLASSC_CLR register unless !!CLASSC_CLREN is false.
+                with a write to !!CLASSC_CLR register unless !!CLASSC_REGWEN is false.
                 '''
       swaccess: "ro",
       hwaccess: "hwo",
@@ -958,12 +958,12 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "15:0",
           desc: '''Once the accumulation value register is equal to the threshold escalation will
           be triggered on the next alert occurrence within this class C begins. Note that this
-          register can not be modified if !!REGEN is false.
+          register can not be modified if !!REGWEN is false.
           '''
         }
       ]
@@ -974,14 +974,14 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0",
           desc: '''If the interrupt corresponding to this class is not
           handled within the specified amount of cycles, escalation will be triggered.
           Set to a positive value to enable the interrupt timeout for Class C. The timeout is set to zero
           by default, which disables this feature. Note that this register can not be modified if
-          !!REGEN is false.
+          !!REGWEN is false.
           '''
         }
       ]
@@ -992,11 +992,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -1006,11 +1006,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -1020,11 +1020,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -1034,11 +1034,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -1058,7 +1058,7 @@
           corresponding interrupt bit.
 
           If this class is in any of the escalation phases (e.g. Phase0), escalation protocol can be
-          aborted by writing to !!CLASSC_CLR. Note however that has no effect if !!CLASSC_CLREN
+          aborted by writing to !!CLASSC_CLR. Note however that has no effect if !!CLASSC_REGWEN
           is set to false (either by SW or by HW via the !!CLASSC_CTRL.LOCK feature).
           '''
         }
@@ -1093,10 +1093,10 @@
     },
 
     { name:     "CLASSD_CTRL",
-      desc:     "Escalation control register for alert Class D. Can not be modified if !!REGEN is false."
+      desc:     "Escalation control register for alert Class D. Can not be modified if !!REGWEN is false."
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "0",
           name: "EN",
@@ -1158,11 +1158,11 @@
         }
       ]
     },
-    { name:     "CLASSD_CLREN",
+    { name:     "CLASSD_REGWEN",
       desc:     '''
                 Clear enable for escalation protocol of Class D alerts.
                 '''
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hwo",
       fields: [
       {   bits:   "0",
@@ -1185,11 +1185,11 @@
       swaccess: "wo",
       hwaccess: "hro",
       hwqe:     "true",
-      regwen:   "CLASSD_CLREN",
+      regwen:   "CLASSD_REGWEN",
       fields: [
         { bits: "0",
           desc: '''Writing to this register clears the accumulator and aborts escalation
-          (if it has been triggered). This clear is disabled if !!CLASSD_CLREN is false.
+          (if it has been triggered). This clear is disabled if !!CLASSD_REGWEN is false.
           '''
         }
       ]
@@ -1197,7 +1197,7 @@
     { name:     "CLASSD_ACCUM_CNT",
       desc:     '''
                 Current accumulation value for alert Class D. Software can clear this register
-                with a write to !!CLASSD_CLR register unless !!CLASSD_CLREN is false.
+                with a write to !!CLASSD_CLR register unless !!CLASSD_REGWEN is false.
                 '''
       swaccess: "ro",
       hwaccess: "hwo",
@@ -1215,12 +1215,12 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "15:0",
           desc: '''Once the accumulation value register is equal to the threshold escalation will
           be triggered on the next alert occurrence within this class D begins. Note that this
-          register can not be modified if !!REGEN is false.
+          register can not be modified if !!REGWEN is false.
           '''
         }
       ]
@@ -1231,14 +1231,14 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0",
           desc: '''If the interrupt corresponding to this class is not
           handled within the specified amount of cycles, escalation will be triggered.
           Set to a positive value to enable the interrupt timeout for Class D. The timeout is set to zero
           by default, which disables this feature. Note that this register can not be modified if
-          !!REGEN is false.
+          !!REGWEN is false.
           '''
         }
       ]
@@ -1249,11 +1249,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -1263,11 +1263,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -1277,11 +1277,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -1291,11 +1291,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -1315,7 +1315,7 @@
           corresponding interrupt bit.
 
           If this class is in any of the escalation phases (e.g. Phase0), escalation protocol can be
-          aborted by writing to !!CLASSD_CLR. Note however that has no effect if !!CLASSD_CLREN
+          aborted by writing to !!CLASSD_CLR. Note however that has no effect if !!CLASSD_REGWEN
           is set to false (either by SW or by HW via the !!CLASSD_CTRL.LOCK feature).
           '''
         }
@@ -1350,3 +1350,4 @@
     },
   ],
 }
+

--- a/hw/ip/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip/alert_handler/data/alert_handler.hjson.tpl
@@ -151,11 +151,11 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
   registers: [
 ##############################################################################
 # register locks for alerts and class configs
-    { name: "REGEN",
+    { name: "REGWEN",
       desc: '''
             Register write enable for all control registers.
             ''',
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hro",
       fields: [
         {
@@ -175,7 +175,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         {
           # TODO: add PING_CNT_DW parameter here
@@ -196,7 +196,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
                   count:    "NAlerts",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "alert",
                   tags:     [// Enable `alert_en` might cause top-level escalators to trigger
                              // unexpected reset
@@ -216,7 +216,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
                   count:    "NAlerts",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "alert",
                   fields: [
                     {
@@ -259,7 +259,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
                   count:    "N_LOC_ALERT",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "local alert",
                   fields: [
                     { bits: "0",
@@ -276,7 +276,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
                   count:    "N_LOC_ALERT",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "local alert",
                   fields: [
                     {
@@ -317,10 +317,10 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
 % for i in range(n_classes):
 <% c = chars[i] %>
     { name:     "CLASS${chars[i]}_CTRL",
-      desc:     "Escalation control register for alert Class ${chars[i]}. Can not be modified if !!REGEN is false."
+      desc:     "Escalation control register for alert Class ${chars[i]}. Can not be modified if !!REGWEN is false."
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "0",
           name: "EN",
@@ -382,11 +382,11 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
         }
       ]
     },
-    { name:     "CLASS${chars[i]}_CLREN",
+    { name:     "CLASS${chars[i]}_REGWEN",
       desc:     '''
                 Clear enable for escalation protocol of Class ${chars[i]} alerts.
                 '''
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hwo",
       fields: [
       {   bits:   "0",
@@ -409,11 +409,11 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       swaccess: "wo",
       hwaccess: "hro",
       hwqe:     "true",
-      regwen:   "CLASS${chars[i]}_CLREN",
+      regwen:   "CLASS${chars[i]}_REGWEN",
       fields: [
         { bits: "0",
           desc: '''Writing to this register clears the accumulator and aborts escalation
-          (if it has been triggered). This clear is disabled if !!CLASS${chars[i]}_CLREN is false.
+          (if it has been triggered). This clear is disabled if !!CLASS${chars[i]}_REGWEN is false.
           '''
         }
       ]
@@ -421,7 +421,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     { name:     "CLASS${chars[i]}_ACCUM_CNT",
       desc:     '''
                 Current accumulation value for alert Class ${chars[i]}. Software can clear this register
-                with a write to !!CLASS${chars[i]}_CLR register unless !!CLASS${chars[i]}_CLREN is false.
+                with a write to !!CLASS${chars[i]}_CLR register unless !!CLASS${chars[i]}_REGWEN is false.
                 '''
       swaccess: "ro",
       hwaccess: "hwo",
@@ -439,12 +439,12 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "${accu_cnt_dw - 1}:0",
           desc: '''Once the accumulation value register is equal to the threshold escalation will
           be triggered on the next alert occurrence within this class ${chars[i]} begins. Note that this
-          register can not be modified if !!REGEN is false.
+          register can not be modified if !!REGWEN is false.
           '''
         }
       ]
@@ -455,14 +455,14 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "${esc_cnt_dw - 1}:0",
           desc: '''If the interrupt corresponding to this class is not
           handled within the specified amount of cycles, escalation will be triggered.
           Set to a positive value to enable the interrupt timeout for Class ${chars[i]}. The timeout is set to zero
           by default, which disables this feature. Note that this register can not be modified if
-          !!REGEN is false.
+          !!REGWEN is false.
           '''
         }
       ]
@@ -474,11 +474,11 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "${esc_cnt_dw - 1}:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -499,7 +499,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
           corresponding interrupt bit.
 
           If this class is in any of the escalation phases (e.g. Phase0), escalation protocol can be
-          aborted by writing to !!CLASS${chars[i]}_CLR. Note however that has no effect if !!CLASS${chars[i]}_CLREN
+          aborted by writing to !!CLASS${chars[i]}_CLR. Note however that has no effect if !!CLASS${chars[i]}_REGWEN
           is set to false (either by SW or by HW via the !!CLASS${chars[i]}_CTRL.LOCK feature).
           '''
         }

--- a/hw/ip/alert_handler/doc/_index.md
+++ b/hw/ip/alert_handler/doc/_index.md
@@ -865,7 +865,7 @@ the security settings process) should do the following:
           changed from the default mapping (0->0, 1->1, 2->2, 3->3).
 
 4. After initial configuration at startup, lock the alert enable and escalation
-config registers by writing 1 to {{< regref "REGEN" >}}. This protects the registers from being
+config registers by writing 1 to {{< regref "REGWEN" >}}. This protects the registers from being
 altered later on, and activates the ping mechanism for the enabled alerts and
 escalation signals.
 
@@ -902,8 +902,8 @@ the interrupt as follows:
     - Resetting the accumulation register for the class by writing {{< regref "CLASSA_CLR" >}}.
       This also aborts escalation protocol if it has been triggered. If for some
       reason it is desired to never allow the accumulator or escalation to be
-      cleared, software can initialize the {{< regref "CLASSA_CLREN" >}} register to zero.
-      If {{< regref "CLASSA_CLREN" >}} is already false when an alert interrupt is detected
+      cleared, software can initialize the {{< regref "CLASSA_REGWEN" >}} register to zero.
+      If {{< regref "CLASSA_REGWEN" >}} is already false when an alert interrupt is detected
       (either due to software control or hardware trigger via
       {{< regref "CLASSA_CTRL.LOCK" >}}), then the accumulation counter can not be cleared and
       this step has no effect.

--- a/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -221,7 +221,7 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
     bit [TL_DW-1:0] class_ctrl = get_class_ctrl(class_i);
     if (class_ctrl[AlertClassCtrlLock]) begin
       uvm_reg clren_rg;
-      clren_rg = ral.get_reg_by_name($sformatf("class%s_clren", class_name[class_i]));
+      clren_rg = ral.get_reg_by_name($sformatf("class%s_regwen", class_name[class_i]));
       `DV_CHECK_NE_FATAL(clren_rg, null)
       void'(clren_rg.predict(0));
     end
@@ -233,7 +233,7 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
     // if ping periodic check enabled, will not check cycle count, because cycle count might be
     // connected with ping request, which makes the length unpredictable
     // it is beyond this scb to check ping timer (FPV checks it).
-    if (ral.regen.get_mirrored_value()) begin
+    if (ral.regwen.get_mirrored_value()) begin
       `DV_CHECK_EQ(cycle_cnt, esc_cnter_per_signal[esc_sig_i],
                    $sformatf("check signal_%0d", esc_sig_i))
       if (cfg.en_cov) cov.esc_sig_length_cg.sample(esc_sig_i, cycle_cnt);
@@ -303,10 +303,10 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
               if (item.a_data[i] == 0) under_intr_classes[i] = 0;
             end
           end
-          "classa_clr": if (ral.classa_clren.get_mirrored_value()) clr_reset_esc_class(0);
-          "classb_clr": if (ral.classb_clren.get_mirrored_value()) clr_reset_esc_class(1);
-          "classc_clr": if (ral.classc_clren.get_mirrored_value()) clr_reset_esc_class(2);
-          "classd_clr": if (ral.classd_clren.get_mirrored_value()) clr_reset_esc_class(3);
+          "classa_clr": if (ral.classa_regwen.get_mirrored_value()) clr_reset_esc_class(0);
+          "classb_clr": if (ral.classb_regwen.get_mirrored_value()) clr_reset_esc_class(1);
+          "classc_clr": if (ral.classc_regwen.get_mirrored_value()) clr_reset_esc_class(2);
+          "classd_clr": if (ral.classd_regwen.get_mirrored_value()) clr_reset_esc_class(3);
           default: begin
            //`uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
           end

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -73,17 +73,17 @@ class alert_handler_base_vseq extends cip_base_vseq #(
     if (class_en[3]) `RAND_WRITE_CLASS_CTRL(d, lock_bit[3])
   endtask
 
-  virtual task alert_handler_wr_clren_regs(bit [NUM_ALERT_HANDLER_CLASSES-1:0] clr_en);
-    if (!clr_en[0]) csr_wr(.csr(ral.classa_clren), .value($urandom_range(0, 1)));
-    if (!clr_en[1]) csr_wr(.csr(ral.classb_clren), .value($urandom_range(0, 1)));
-    if (!clr_en[2]) csr_wr(.csr(ral.classc_clren), .value($urandom_range(0, 1)));
-    if (!clr_en[3]) csr_wr(.csr(ral.classd_clren), .value($urandom_range(0, 1)));
+  virtual task alert_handler_wr_regwen_regs(bit [NUM_ALERT_HANDLER_CLASSES-1:0] regwen);
+    if (!regwen[0]) csr_wr(.csr(ral.classa_regwen), .value($urandom_range(0, 1)));
+    if (!regwen[1]) csr_wr(.csr(ral.classb_regwen), .value($urandom_range(0, 1)));
+    if (!regwen[2]) csr_wr(.csr(ral.classc_regwen), .value($urandom_range(0, 1)));
+    if (!regwen[3]) csr_wr(.csr(ral.classd_regwen), .value($urandom_range(0, 1)));
   endtask
 
   // write regen register if do_lock_config is set. If not set, 50% of chance to write value 0
   // to regen register.
   virtual task lock_config(bit do_lock_config);
-    if (do_lock_config || $urandom_range(0,1)) csr_wr(.csr(ral.regen), .value(do_lock_config));
+    if (do_lock_config || $urandom_range(0,1)) csr_wr(.csr(ral.regwen), .value(do_lock_config));
   endtask
 
   virtual task drive_alert(bit[NUM_ALERTS-1:0] alert_trigger, bit[NUM_ALERTS-1:0] alert_int_err);

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
@@ -123,7 +123,7 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
 
       // write class_ctrl and clren_reg
       alert_handler_rand_wr_class_ctrl(lock_bit_en);
-      alert_handler_wr_clren_regs(clr_en);
+      alert_handler_wr_regwen_regs(clr_en);
 
       // randomly write phase cycle registers
       // always set phase_cycle for the first iteration, in order to pass stress_all test

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_pkg.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_pkg.sv
@@ -76,7 +76,7 @@ package alert_handler_reg_pkg;
 
   typedef struct packed {
     logic        q;
-  } alert_handler_reg2hw_regen_reg_t;
+  } alert_handler_reg2hw_regwen_reg_t;
 
   typedef struct packed {
     logic [23:0] q;
@@ -387,7 +387,7 @@ package alert_handler_reg_pkg;
   typedef struct packed {
     logic        d;
     logic        de;
-  } alert_handler_hw2reg_classa_clren_reg_t;
+  } alert_handler_hw2reg_classa_regwen_reg_t;
 
   typedef struct packed {
     logic [15:0] d;
@@ -404,7 +404,7 @@ package alert_handler_reg_pkg;
   typedef struct packed {
     logic        d;
     logic        de;
-  } alert_handler_hw2reg_classb_clren_reg_t;
+  } alert_handler_hw2reg_classb_regwen_reg_t;
 
   typedef struct packed {
     logic [15:0] d;
@@ -421,7 +421,7 @@ package alert_handler_reg_pkg;
   typedef struct packed {
     logic        d;
     logic        de;
-  } alert_handler_hw2reg_classc_clren_reg_t;
+  } alert_handler_hw2reg_classc_regwen_reg_t;
 
   typedef struct packed {
     logic [15:0] d;
@@ -438,7 +438,7 @@ package alert_handler_reg_pkg;
   typedef struct packed {
     logic        d;
     logic        de;
-  } alert_handler_hw2reg_classd_clren_reg_t;
+  } alert_handler_hw2reg_classd_regwen_reg_t;
 
   typedef struct packed {
     logic [15:0] d;
@@ -460,7 +460,7 @@ package alert_handler_reg_pkg;
     alert_handler_reg2hw_intr_state_reg_t intr_state; // [840:837]
     alert_handler_reg2hw_intr_enable_reg_t intr_enable; // [836:833]
     alert_handler_reg2hw_intr_test_reg_t intr_test; // [832:825]
-    alert_handler_reg2hw_regen_reg_t regen; // [824:824]
+    alert_handler_reg2hw_regwen_reg_t regwen; // [824:824]
     alert_handler_reg2hw_ping_timeout_cyc_reg_t ping_timeout_cyc; // [823:800]
     alert_handler_reg2hw_alert_en_mreg_t [3:0] alert_en; // [799:796]
     alert_handler_reg2hw_alert_class_mreg_t [3:0] alert_class; // [795:788]
@@ -509,19 +509,19 @@ package alert_handler_reg_pkg;
     alert_handler_hw2reg_intr_state_reg_t intr_state; // [235:228]
     alert_handler_hw2reg_alert_cause_mreg_t [3:0] alert_cause; // [227:220]
     alert_handler_hw2reg_loc_alert_cause_mreg_t [3:0] loc_alert_cause; // [219:212]
-    alert_handler_hw2reg_classa_clren_reg_t classa_clren; // [211:210]
+    alert_handler_hw2reg_classa_regwen_reg_t classa_regwen; // [211:210]
     alert_handler_hw2reg_classa_accum_cnt_reg_t classa_accum_cnt; // [209:194]
     alert_handler_hw2reg_classa_esc_cnt_reg_t classa_esc_cnt; // [193:162]
     alert_handler_hw2reg_classa_state_reg_t classa_state; // [161:159]
-    alert_handler_hw2reg_classb_clren_reg_t classb_clren; // [158:157]
+    alert_handler_hw2reg_classb_regwen_reg_t classb_regwen; // [158:157]
     alert_handler_hw2reg_classb_accum_cnt_reg_t classb_accum_cnt; // [156:141]
     alert_handler_hw2reg_classb_esc_cnt_reg_t classb_esc_cnt; // [140:109]
     alert_handler_hw2reg_classb_state_reg_t classb_state; // [108:106]
-    alert_handler_hw2reg_classc_clren_reg_t classc_clren; // [105:104]
+    alert_handler_hw2reg_classc_regwen_reg_t classc_regwen; // [105:104]
     alert_handler_hw2reg_classc_accum_cnt_reg_t classc_accum_cnt; // [103:88]
     alert_handler_hw2reg_classc_esc_cnt_reg_t classc_esc_cnt; // [87:56]
     alert_handler_hw2reg_classc_state_reg_t classc_state; // [55:53]
-    alert_handler_hw2reg_classd_clren_reg_t classd_clren; // [52:51]
+    alert_handler_hw2reg_classd_regwen_reg_t classd_regwen; // [52:51]
     alert_handler_hw2reg_classd_accum_cnt_reg_t classd_accum_cnt; // [50:35]
     alert_handler_hw2reg_classd_esc_cnt_reg_t classd_esc_cnt; // [34:3]
     alert_handler_hw2reg_classd_state_reg_t classd_state; // [2:0]
@@ -531,7 +531,7 @@ package alert_handler_reg_pkg;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_INTR_STATE_OFFSET = 10'h 0;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_INTR_ENABLE_OFFSET = 10'h 4;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_INTR_TEST_OFFSET = 10'h 8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_REGEN_OFFSET = 10'h c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_REGWEN_OFFSET = 10'h c;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_PING_TIMEOUT_CYC_OFFSET = 10'h 10;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_OFFSET = 10'h 20;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_OFFSET = 10'h 120;
@@ -540,7 +540,7 @@ package alert_handler_reg_pkg;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_OFFSET = 10'h 324;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_OFFSET = 10'h 328;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_CTRL_OFFSET = 10'h 32c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_CLREN_OFFSET = 10'h 330;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_REGWEN_OFFSET = 10'h 330;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_CLR_OFFSET = 10'h 334;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_ACCUM_CNT_OFFSET = 10'h 338;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_ACCUM_THRESH_OFFSET = 10'h 33c;
@@ -552,7 +552,7 @@ package alert_handler_reg_pkg;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_ESC_CNT_OFFSET = 10'h 354;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_STATE_OFFSET = 10'h 358;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_CTRL_OFFSET = 10'h 35c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_CLREN_OFFSET = 10'h 360;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_REGWEN_OFFSET = 10'h 360;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_CLR_OFFSET = 10'h 364;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_ACCUM_CNT_OFFSET = 10'h 368;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_ACCUM_THRESH_OFFSET = 10'h 36c;
@@ -564,7 +564,7 @@ package alert_handler_reg_pkg;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_ESC_CNT_OFFSET = 10'h 384;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_STATE_OFFSET = 10'h 388;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_CTRL_OFFSET = 10'h 38c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_CLREN_OFFSET = 10'h 390;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_REGWEN_OFFSET = 10'h 390;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_CLR_OFFSET = 10'h 394;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_ACCUM_CNT_OFFSET = 10'h 398;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_ACCUM_THRESH_OFFSET = 10'h 39c;
@@ -576,7 +576,7 @@ package alert_handler_reg_pkg;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_ESC_CNT_OFFSET = 10'h 3b4;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_STATE_OFFSET = 10'h 3b8;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_CTRL_OFFSET = 10'h 3bc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_CLREN_OFFSET = 10'h 3c0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_REGWEN_OFFSET = 10'h 3c0;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_CLR_OFFSET = 10'h 3c4;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_ACCUM_CNT_OFFSET = 10'h 3c8;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_ACCUM_THRESH_OFFSET = 10'h 3cc;
@@ -594,7 +594,7 @@ package alert_handler_reg_pkg;
     ALERT_HANDLER_INTR_STATE,
     ALERT_HANDLER_INTR_ENABLE,
     ALERT_HANDLER_INTR_TEST,
-    ALERT_HANDLER_REGEN,
+    ALERT_HANDLER_REGWEN,
     ALERT_HANDLER_PING_TIMEOUT_CYC,
     ALERT_HANDLER_ALERT_EN,
     ALERT_HANDLER_ALERT_CLASS,
@@ -603,7 +603,7 @@ package alert_handler_reg_pkg;
     ALERT_HANDLER_LOC_ALERT_CLASS,
     ALERT_HANDLER_LOC_ALERT_CAUSE,
     ALERT_HANDLER_CLASSA_CTRL,
-    ALERT_HANDLER_CLASSA_CLREN,
+    ALERT_HANDLER_CLASSA_REGWEN,
     ALERT_HANDLER_CLASSA_CLR,
     ALERT_HANDLER_CLASSA_ACCUM_CNT,
     ALERT_HANDLER_CLASSA_ACCUM_THRESH,
@@ -615,7 +615,7 @@ package alert_handler_reg_pkg;
     ALERT_HANDLER_CLASSA_ESC_CNT,
     ALERT_HANDLER_CLASSA_STATE,
     ALERT_HANDLER_CLASSB_CTRL,
-    ALERT_HANDLER_CLASSB_CLREN,
+    ALERT_HANDLER_CLASSB_REGWEN,
     ALERT_HANDLER_CLASSB_CLR,
     ALERT_HANDLER_CLASSB_ACCUM_CNT,
     ALERT_HANDLER_CLASSB_ACCUM_THRESH,
@@ -627,7 +627,7 @@ package alert_handler_reg_pkg;
     ALERT_HANDLER_CLASSB_ESC_CNT,
     ALERT_HANDLER_CLASSB_STATE,
     ALERT_HANDLER_CLASSC_CTRL,
-    ALERT_HANDLER_CLASSC_CLREN,
+    ALERT_HANDLER_CLASSC_REGWEN,
     ALERT_HANDLER_CLASSC_CLR,
     ALERT_HANDLER_CLASSC_ACCUM_CNT,
     ALERT_HANDLER_CLASSC_ACCUM_THRESH,
@@ -639,7 +639,7 @@ package alert_handler_reg_pkg;
     ALERT_HANDLER_CLASSC_ESC_CNT,
     ALERT_HANDLER_CLASSC_STATE,
     ALERT_HANDLER_CLASSD_CTRL,
-    ALERT_HANDLER_CLASSD_CLREN,
+    ALERT_HANDLER_CLASSD_REGWEN,
     ALERT_HANDLER_CLASSD_CLR,
     ALERT_HANDLER_CLASSD_ACCUM_CNT,
     ALERT_HANDLER_CLASSD_ACCUM_THRESH,
@@ -657,7 +657,7 @@ package alert_handler_reg_pkg;
     4'b 0001, // index[ 0] ALERT_HANDLER_INTR_STATE
     4'b 0001, // index[ 1] ALERT_HANDLER_INTR_ENABLE
     4'b 0001, // index[ 2] ALERT_HANDLER_INTR_TEST
-    4'b 0001, // index[ 3] ALERT_HANDLER_REGEN
+    4'b 0001, // index[ 3] ALERT_HANDLER_REGWEN
     4'b 0111, // index[ 4] ALERT_HANDLER_PING_TIMEOUT_CYC
     4'b 0001, // index[ 5] ALERT_HANDLER_ALERT_EN
     4'b 0001, // index[ 6] ALERT_HANDLER_ALERT_CLASS
@@ -666,7 +666,7 @@ package alert_handler_reg_pkg;
     4'b 0001, // index[ 9] ALERT_HANDLER_LOC_ALERT_CLASS
     4'b 0001, // index[10] ALERT_HANDLER_LOC_ALERT_CAUSE
     4'b 0011, // index[11] ALERT_HANDLER_CLASSA_CTRL
-    4'b 0001, // index[12] ALERT_HANDLER_CLASSA_CLREN
+    4'b 0001, // index[12] ALERT_HANDLER_CLASSA_REGWEN
     4'b 0001, // index[13] ALERT_HANDLER_CLASSA_CLR
     4'b 0011, // index[14] ALERT_HANDLER_CLASSA_ACCUM_CNT
     4'b 0011, // index[15] ALERT_HANDLER_CLASSA_ACCUM_THRESH
@@ -678,7 +678,7 @@ package alert_handler_reg_pkg;
     4'b 1111, // index[21] ALERT_HANDLER_CLASSA_ESC_CNT
     4'b 0001, // index[22] ALERT_HANDLER_CLASSA_STATE
     4'b 0011, // index[23] ALERT_HANDLER_CLASSB_CTRL
-    4'b 0001, // index[24] ALERT_HANDLER_CLASSB_CLREN
+    4'b 0001, // index[24] ALERT_HANDLER_CLASSB_REGWEN
     4'b 0001, // index[25] ALERT_HANDLER_CLASSB_CLR
     4'b 0011, // index[26] ALERT_HANDLER_CLASSB_ACCUM_CNT
     4'b 0011, // index[27] ALERT_HANDLER_CLASSB_ACCUM_THRESH
@@ -690,7 +690,7 @@ package alert_handler_reg_pkg;
     4'b 1111, // index[33] ALERT_HANDLER_CLASSB_ESC_CNT
     4'b 0001, // index[34] ALERT_HANDLER_CLASSB_STATE
     4'b 0011, // index[35] ALERT_HANDLER_CLASSC_CTRL
-    4'b 0001, // index[36] ALERT_HANDLER_CLASSC_CLREN
+    4'b 0001, // index[36] ALERT_HANDLER_CLASSC_REGWEN
     4'b 0001, // index[37] ALERT_HANDLER_CLASSC_CLR
     4'b 0011, // index[38] ALERT_HANDLER_CLASSC_ACCUM_CNT
     4'b 0011, // index[39] ALERT_HANDLER_CLASSC_ACCUM_THRESH
@@ -702,7 +702,7 @@ package alert_handler_reg_pkg;
     4'b 1111, // index[45] ALERT_HANDLER_CLASSC_ESC_CNT
     4'b 0001, // index[46] ALERT_HANDLER_CLASSC_STATE
     4'b 0011, // index[47] ALERT_HANDLER_CLASSD_CTRL
-    4'b 0001, // index[48] ALERT_HANDLER_CLASSD_CLREN
+    4'b 0001, // index[48] ALERT_HANDLER_CLASSD_REGWEN
     4'b 0001, // index[49] ALERT_HANDLER_CLASSD_CLR
     4'b 0011, // index[50] ALERT_HANDLER_CLASSD_ACCUM_CNT
     4'b 0011, // index[51] ALERT_HANDLER_CLASSD_ACCUM_THRESH

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_top.sv
@@ -103,9 +103,9 @@ module alert_handler_reg_top (
   logic intr_test_classc_we;
   logic intr_test_classd_wd;
   logic intr_test_classd_we;
-  logic regen_qs;
-  logic regen_wd;
-  logic regen_we;
+  logic regwen_qs;
+  logic regwen_wd;
+  logic regwen_we;
   logic [23:0] ping_timeout_cyc_qs;
   logic [23:0] ping_timeout_cyc_wd;
   logic ping_timeout_cyc_we;
@@ -211,9 +211,9 @@ module alert_handler_reg_top (
   logic [1:0] classa_ctrl_map_e3_qs;
   logic [1:0] classa_ctrl_map_e3_wd;
   logic classa_ctrl_map_e3_we;
-  logic classa_clren_qs;
-  logic classa_clren_wd;
-  logic classa_clren_we;
+  logic classa_regwen_qs;
+  logic classa_regwen_wd;
+  logic classa_regwen_we;
   logic classa_clr_wd;
   logic classa_clr_we;
   logic [15:0] classa_accum_cnt_qs;
@@ -270,9 +270,9 @@ module alert_handler_reg_top (
   logic [1:0] classb_ctrl_map_e3_qs;
   logic [1:0] classb_ctrl_map_e3_wd;
   logic classb_ctrl_map_e3_we;
-  logic classb_clren_qs;
-  logic classb_clren_wd;
-  logic classb_clren_we;
+  logic classb_regwen_qs;
+  logic classb_regwen_wd;
+  logic classb_regwen_we;
   logic classb_clr_wd;
   logic classb_clr_we;
   logic [15:0] classb_accum_cnt_qs;
@@ -329,9 +329,9 @@ module alert_handler_reg_top (
   logic [1:0] classc_ctrl_map_e3_qs;
   logic [1:0] classc_ctrl_map_e3_wd;
   logic classc_ctrl_map_e3_we;
-  logic classc_clren_qs;
-  logic classc_clren_wd;
-  logic classc_clren_we;
+  logic classc_regwen_qs;
+  logic classc_regwen_wd;
+  logic classc_regwen_we;
   logic classc_clr_wd;
   logic classc_clr_we;
   logic [15:0] classc_accum_cnt_qs;
@@ -388,9 +388,9 @@ module alert_handler_reg_top (
   logic [1:0] classd_ctrl_map_e3_qs;
   logic [1:0] classd_ctrl_map_e3_wd;
   logic classd_ctrl_map_e3_we;
-  logic classd_clren_qs;
-  logic classd_clren_wd;
-  logic classd_clren_we;
+  logic classd_regwen_qs;
+  logic classd_regwen_wd;
+  logic classd_regwen_we;
   logic classd_clr_wd;
   logic classd_clr_we;
   logic [15:0] classd_accum_cnt_qs;
@@ -693,19 +693,19 @@ module alert_handler_reg_top (
   );
 
 
-  // R[regen]: V(False)
+  // R[regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_regen (
+  ) u_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (regen_we),
-    .wd     (regen_wd),
+    .we     (regwen_we),
+    .wd     (regwen_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -713,10 +713,10 @@ module alert_handler_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.regen.q ),
+    .q      (reg2hw.regwen.q ),
 
     // to register interface (read)
-    .qs     (regen_qs)
+    .qs     (regwen_qs)
   );
 
 
@@ -731,7 +731,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (ping_timeout_cyc_we & regen_qs),
+    .we     (ping_timeout_cyc_we & regwen_qs),
     .wd     (ping_timeout_cyc_wd),
 
     // from internal hardware
@@ -761,7 +761,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_0_we & regen_qs),
+    .we     (alert_en_en_a_0_we & regwen_qs),
     .wd     (alert_en_en_a_0_wd),
 
     // from internal hardware
@@ -787,7 +787,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_1_we & regen_qs),
+    .we     (alert_en_en_a_1_we & regwen_qs),
     .wd     (alert_en_en_a_1_wd),
 
     // from internal hardware
@@ -813,7 +813,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_2_we & regen_qs),
+    .we     (alert_en_en_a_2_we & regwen_qs),
     .wd     (alert_en_en_a_2_wd),
 
     // from internal hardware
@@ -839,7 +839,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_3_we & regen_qs),
+    .we     (alert_en_en_a_3_we & regwen_qs),
     .wd     (alert_en_en_a_3_wd),
 
     // from internal hardware
@@ -870,7 +870,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_class_a_0_we & regen_qs),
+    .we     (alert_class_class_a_0_we & regwen_qs),
     .wd     (alert_class_class_a_0_wd),
 
     // from internal hardware
@@ -896,7 +896,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_class_a_1_we & regen_qs),
+    .we     (alert_class_class_a_1_we & regwen_qs),
     .wd     (alert_class_class_a_1_wd),
 
     // from internal hardware
@@ -922,7 +922,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_class_a_2_we & regen_qs),
+    .we     (alert_class_class_a_2_we & regwen_qs),
     .wd     (alert_class_class_a_2_wd),
 
     // from internal hardware
@@ -948,7 +948,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_class_a_3_we & regen_qs),
+    .we     (alert_class_class_a_3_we & regwen_qs),
     .wd     (alert_class_class_a_3_wd),
 
     // from internal hardware
@@ -1088,7 +1088,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (loc_alert_en_en_la_0_we & regen_qs),
+    .we     (loc_alert_en_en_la_0_we & regwen_qs),
     .wd     (loc_alert_en_en_la_0_wd),
 
     // from internal hardware
@@ -1114,7 +1114,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (loc_alert_en_en_la_1_we & regen_qs),
+    .we     (loc_alert_en_en_la_1_we & regwen_qs),
     .wd     (loc_alert_en_en_la_1_wd),
 
     // from internal hardware
@@ -1140,7 +1140,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (loc_alert_en_en_la_2_we & regen_qs),
+    .we     (loc_alert_en_en_la_2_we & regwen_qs),
     .wd     (loc_alert_en_en_la_2_wd),
 
     // from internal hardware
@@ -1166,7 +1166,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (loc_alert_en_en_la_3_we & regen_qs),
+    .we     (loc_alert_en_en_la_3_we & regwen_qs),
     .wd     (loc_alert_en_en_la_3_wd),
 
     // from internal hardware
@@ -1197,7 +1197,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (loc_alert_class_class_la_0_we & regen_qs),
+    .we     (loc_alert_class_class_la_0_we & regwen_qs),
     .wd     (loc_alert_class_class_la_0_wd),
 
     // from internal hardware
@@ -1223,7 +1223,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (loc_alert_class_class_la_1_we & regen_qs),
+    .we     (loc_alert_class_class_la_1_we & regwen_qs),
     .wd     (loc_alert_class_class_la_1_wd),
 
     // from internal hardware
@@ -1249,7 +1249,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (loc_alert_class_class_la_2_we & regen_qs),
+    .we     (loc_alert_class_class_la_2_we & regwen_qs),
     .wd     (loc_alert_class_class_la_2_wd),
 
     // from internal hardware
@@ -1275,7 +1275,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (loc_alert_class_class_la_3_we & regen_qs),
+    .we     (loc_alert_class_class_la_3_we & regwen_qs),
     .wd     (loc_alert_class_class_la_3_wd),
 
     // from internal hardware
@@ -1413,7 +1413,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_en_we & regen_qs),
+    .we     (classa_ctrl_en_we & regwen_qs),
     .wd     (classa_ctrl_en_wd),
 
     // from internal hardware
@@ -1439,7 +1439,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_lock_we & regen_qs),
+    .we     (classa_ctrl_lock_we & regwen_qs),
     .wd     (classa_ctrl_lock_wd),
 
     // from internal hardware
@@ -1465,7 +1465,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_en_e0_we & regen_qs),
+    .we     (classa_ctrl_en_e0_we & regwen_qs),
     .wd     (classa_ctrl_en_e0_wd),
 
     // from internal hardware
@@ -1491,7 +1491,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_en_e1_we & regen_qs),
+    .we     (classa_ctrl_en_e1_we & regwen_qs),
     .wd     (classa_ctrl_en_e1_wd),
 
     // from internal hardware
@@ -1517,7 +1517,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_en_e2_we & regen_qs),
+    .we     (classa_ctrl_en_e2_we & regwen_qs),
     .wd     (classa_ctrl_en_e2_wd),
 
     // from internal hardware
@@ -1543,7 +1543,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_en_e3_we & regen_qs),
+    .we     (classa_ctrl_en_e3_we & regwen_qs),
     .wd     (classa_ctrl_en_e3_wd),
 
     // from internal hardware
@@ -1569,7 +1569,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_map_e0_we & regen_qs),
+    .we     (classa_ctrl_map_e0_we & regwen_qs),
     .wd     (classa_ctrl_map_e0_wd),
 
     // from internal hardware
@@ -1595,7 +1595,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_map_e1_we & regen_qs),
+    .we     (classa_ctrl_map_e1_we & regwen_qs),
     .wd     (classa_ctrl_map_e1_wd),
 
     // from internal hardware
@@ -1621,7 +1621,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_map_e2_we & regen_qs),
+    .we     (classa_ctrl_map_e2_we & regwen_qs),
     .wd     (classa_ctrl_map_e2_wd),
 
     // from internal hardware
@@ -1647,7 +1647,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_map_e3_we & regen_qs),
+    .we     (classa_ctrl_map_e3_we & regwen_qs),
     .wd     (classa_ctrl_map_e3_wd),
 
     // from internal hardware
@@ -1663,30 +1663,30 @@ module alert_handler_reg_top (
   );
 
 
-  // R[classa_clren]: V(False)
+  // R[classa_regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_classa_clren (
+  ) u_classa_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (classa_clren_we),
-    .wd     (classa_clren_wd),
+    .we     (classa_regwen_we),
+    .wd     (classa_regwen_wd),
 
     // from internal hardware
-    .de     (hw2reg.classa_clren.de),
-    .d      (hw2reg.classa_clren.d ),
+    .de     (hw2reg.classa_regwen.de),
+    .d      (hw2reg.classa_regwen.d ),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (classa_clren_qs)
+    .qs     (classa_regwen_qs)
   );
 
 
@@ -1701,7 +1701,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_clr_we & classa_clren_qs),
+    .we     (classa_clr_we & classa_regwen_qs),
     .wd     (classa_clr_wd),
 
     // from internal hardware
@@ -1743,7 +1743,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_accum_thresh_we & regen_qs),
+    .we     (classa_accum_thresh_we & regwen_qs),
     .wd     (classa_accum_thresh_wd),
 
     // from internal hardware
@@ -1770,7 +1770,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_timeout_cyc_we & regen_qs),
+    .we     (classa_timeout_cyc_we & regwen_qs),
     .wd     (classa_timeout_cyc_wd),
 
     // from internal hardware
@@ -1797,7 +1797,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_phase0_cyc_we & regen_qs),
+    .we     (classa_phase0_cyc_we & regwen_qs),
     .wd     (classa_phase0_cyc_wd),
 
     // from internal hardware
@@ -1824,7 +1824,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_phase1_cyc_we & regen_qs),
+    .we     (classa_phase1_cyc_we & regwen_qs),
     .wd     (classa_phase1_cyc_wd),
 
     // from internal hardware
@@ -1851,7 +1851,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_phase2_cyc_we & regen_qs),
+    .we     (classa_phase2_cyc_we & regwen_qs),
     .wd     (classa_phase2_cyc_wd),
 
     // from internal hardware
@@ -1878,7 +1878,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_phase3_cyc_we & regen_qs),
+    .we     (classa_phase3_cyc_we & regwen_qs),
     .wd     (classa_phase3_cyc_wd),
 
     // from internal hardware
@@ -1938,7 +1938,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_en_we & regen_qs),
+    .we     (classb_ctrl_en_we & regwen_qs),
     .wd     (classb_ctrl_en_wd),
 
     // from internal hardware
@@ -1964,7 +1964,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_lock_we & regen_qs),
+    .we     (classb_ctrl_lock_we & regwen_qs),
     .wd     (classb_ctrl_lock_wd),
 
     // from internal hardware
@@ -1990,7 +1990,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_en_e0_we & regen_qs),
+    .we     (classb_ctrl_en_e0_we & regwen_qs),
     .wd     (classb_ctrl_en_e0_wd),
 
     // from internal hardware
@@ -2016,7 +2016,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_en_e1_we & regen_qs),
+    .we     (classb_ctrl_en_e1_we & regwen_qs),
     .wd     (classb_ctrl_en_e1_wd),
 
     // from internal hardware
@@ -2042,7 +2042,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_en_e2_we & regen_qs),
+    .we     (classb_ctrl_en_e2_we & regwen_qs),
     .wd     (classb_ctrl_en_e2_wd),
 
     // from internal hardware
@@ -2068,7 +2068,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_en_e3_we & regen_qs),
+    .we     (classb_ctrl_en_e3_we & regwen_qs),
     .wd     (classb_ctrl_en_e3_wd),
 
     // from internal hardware
@@ -2094,7 +2094,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_map_e0_we & regen_qs),
+    .we     (classb_ctrl_map_e0_we & regwen_qs),
     .wd     (classb_ctrl_map_e0_wd),
 
     // from internal hardware
@@ -2120,7 +2120,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_map_e1_we & regen_qs),
+    .we     (classb_ctrl_map_e1_we & regwen_qs),
     .wd     (classb_ctrl_map_e1_wd),
 
     // from internal hardware
@@ -2146,7 +2146,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_map_e2_we & regen_qs),
+    .we     (classb_ctrl_map_e2_we & regwen_qs),
     .wd     (classb_ctrl_map_e2_wd),
 
     // from internal hardware
@@ -2172,7 +2172,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_map_e3_we & regen_qs),
+    .we     (classb_ctrl_map_e3_we & regwen_qs),
     .wd     (classb_ctrl_map_e3_wd),
 
     // from internal hardware
@@ -2188,30 +2188,30 @@ module alert_handler_reg_top (
   );
 
 
-  // R[classb_clren]: V(False)
+  // R[classb_regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_classb_clren (
+  ) u_classb_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (classb_clren_we),
-    .wd     (classb_clren_wd),
+    .we     (classb_regwen_we),
+    .wd     (classb_regwen_wd),
 
     // from internal hardware
-    .de     (hw2reg.classb_clren.de),
-    .d      (hw2reg.classb_clren.d ),
+    .de     (hw2reg.classb_regwen.de),
+    .d      (hw2reg.classb_regwen.d ),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (classb_clren_qs)
+    .qs     (classb_regwen_qs)
   );
 
 
@@ -2226,7 +2226,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_clr_we & classb_clren_qs),
+    .we     (classb_clr_we & classb_regwen_qs),
     .wd     (classb_clr_wd),
 
     // from internal hardware
@@ -2268,7 +2268,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_accum_thresh_we & regen_qs),
+    .we     (classb_accum_thresh_we & regwen_qs),
     .wd     (classb_accum_thresh_wd),
 
     // from internal hardware
@@ -2295,7 +2295,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_timeout_cyc_we & regen_qs),
+    .we     (classb_timeout_cyc_we & regwen_qs),
     .wd     (classb_timeout_cyc_wd),
 
     // from internal hardware
@@ -2322,7 +2322,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_phase0_cyc_we & regen_qs),
+    .we     (classb_phase0_cyc_we & regwen_qs),
     .wd     (classb_phase0_cyc_wd),
 
     // from internal hardware
@@ -2349,7 +2349,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_phase1_cyc_we & regen_qs),
+    .we     (classb_phase1_cyc_we & regwen_qs),
     .wd     (classb_phase1_cyc_wd),
 
     // from internal hardware
@@ -2376,7 +2376,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_phase2_cyc_we & regen_qs),
+    .we     (classb_phase2_cyc_we & regwen_qs),
     .wd     (classb_phase2_cyc_wd),
 
     // from internal hardware
@@ -2403,7 +2403,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_phase3_cyc_we & regen_qs),
+    .we     (classb_phase3_cyc_we & regwen_qs),
     .wd     (classb_phase3_cyc_wd),
 
     // from internal hardware
@@ -2463,7 +2463,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_en_we & regen_qs),
+    .we     (classc_ctrl_en_we & regwen_qs),
     .wd     (classc_ctrl_en_wd),
 
     // from internal hardware
@@ -2489,7 +2489,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_lock_we & regen_qs),
+    .we     (classc_ctrl_lock_we & regwen_qs),
     .wd     (classc_ctrl_lock_wd),
 
     // from internal hardware
@@ -2515,7 +2515,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_en_e0_we & regen_qs),
+    .we     (classc_ctrl_en_e0_we & regwen_qs),
     .wd     (classc_ctrl_en_e0_wd),
 
     // from internal hardware
@@ -2541,7 +2541,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_en_e1_we & regen_qs),
+    .we     (classc_ctrl_en_e1_we & regwen_qs),
     .wd     (classc_ctrl_en_e1_wd),
 
     // from internal hardware
@@ -2567,7 +2567,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_en_e2_we & regen_qs),
+    .we     (classc_ctrl_en_e2_we & regwen_qs),
     .wd     (classc_ctrl_en_e2_wd),
 
     // from internal hardware
@@ -2593,7 +2593,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_en_e3_we & regen_qs),
+    .we     (classc_ctrl_en_e3_we & regwen_qs),
     .wd     (classc_ctrl_en_e3_wd),
 
     // from internal hardware
@@ -2619,7 +2619,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_map_e0_we & regen_qs),
+    .we     (classc_ctrl_map_e0_we & regwen_qs),
     .wd     (classc_ctrl_map_e0_wd),
 
     // from internal hardware
@@ -2645,7 +2645,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_map_e1_we & regen_qs),
+    .we     (classc_ctrl_map_e1_we & regwen_qs),
     .wd     (classc_ctrl_map_e1_wd),
 
     // from internal hardware
@@ -2671,7 +2671,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_map_e2_we & regen_qs),
+    .we     (classc_ctrl_map_e2_we & regwen_qs),
     .wd     (classc_ctrl_map_e2_wd),
 
     // from internal hardware
@@ -2697,7 +2697,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_map_e3_we & regen_qs),
+    .we     (classc_ctrl_map_e3_we & regwen_qs),
     .wd     (classc_ctrl_map_e3_wd),
 
     // from internal hardware
@@ -2713,30 +2713,30 @@ module alert_handler_reg_top (
   );
 
 
-  // R[classc_clren]: V(False)
+  // R[classc_regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_classc_clren (
+  ) u_classc_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (classc_clren_we),
-    .wd     (classc_clren_wd),
+    .we     (classc_regwen_we),
+    .wd     (classc_regwen_wd),
 
     // from internal hardware
-    .de     (hw2reg.classc_clren.de),
-    .d      (hw2reg.classc_clren.d ),
+    .de     (hw2reg.classc_regwen.de),
+    .d      (hw2reg.classc_regwen.d ),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (classc_clren_qs)
+    .qs     (classc_regwen_qs)
   );
 
 
@@ -2751,7 +2751,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_clr_we & classc_clren_qs),
+    .we     (classc_clr_we & classc_regwen_qs),
     .wd     (classc_clr_wd),
 
     // from internal hardware
@@ -2793,7 +2793,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_accum_thresh_we & regen_qs),
+    .we     (classc_accum_thresh_we & regwen_qs),
     .wd     (classc_accum_thresh_wd),
 
     // from internal hardware
@@ -2820,7 +2820,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_timeout_cyc_we & regen_qs),
+    .we     (classc_timeout_cyc_we & regwen_qs),
     .wd     (classc_timeout_cyc_wd),
 
     // from internal hardware
@@ -2847,7 +2847,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_phase0_cyc_we & regen_qs),
+    .we     (classc_phase0_cyc_we & regwen_qs),
     .wd     (classc_phase0_cyc_wd),
 
     // from internal hardware
@@ -2874,7 +2874,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_phase1_cyc_we & regen_qs),
+    .we     (classc_phase1_cyc_we & regwen_qs),
     .wd     (classc_phase1_cyc_wd),
 
     // from internal hardware
@@ -2901,7 +2901,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_phase2_cyc_we & regen_qs),
+    .we     (classc_phase2_cyc_we & regwen_qs),
     .wd     (classc_phase2_cyc_wd),
 
     // from internal hardware
@@ -2928,7 +2928,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_phase3_cyc_we & regen_qs),
+    .we     (classc_phase3_cyc_we & regwen_qs),
     .wd     (classc_phase3_cyc_wd),
 
     // from internal hardware
@@ -2988,7 +2988,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_en_we & regen_qs),
+    .we     (classd_ctrl_en_we & regwen_qs),
     .wd     (classd_ctrl_en_wd),
 
     // from internal hardware
@@ -3014,7 +3014,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_lock_we & regen_qs),
+    .we     (classd_ctrl_lock_we & regwen_qs),
     .wd     (classd_ctrl_lock_wd),
 
     // from internal hardware
@@ -3040,7 +3040,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_en_e0_we & regen_qs),
+    .we     (classd_ctrl_en_e0_we & regwen_qs),
     .wd     (classd_ctrl_en_e0_wd),
 
     // from internal hardware
@@ -3066,7 +3066,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_en_e1_we & regen_qs),
+    .we     (classd_ctrl_en_e1_we & regwen_qs),
     .wd     (classd_ctrl_en_e1_wd),
 
     // from internal hardware
@@ -3092,7 +3092,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_en_e2_we & regen_qs),
+    .we     (classd_ctrl_en_e2_we & regwen_qs),
     .wd     (classd_ctrl_en_e2_wd),
 
     // from internal hardware
@@ -3118,7 +3118,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_en_e3_we & regen_qs),
+    .we     (classd_ctrl_en_e3_we & regwen_qs),
     .wd     (classd_ctrl_en_e3_wd),
 
     // from internal hardware
@@ -3144,7 +3144,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_map_e0_we & regen_qs),
+    .we     (classd_ctrl_map_e0_we & regwen_qs),
     .wd     (classd_ctrl_map_e0_wd),
 
     // from internal hardware
@@ -3170,7 +3170,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_map_e1_we & regen_qs),
+    .we     (classd_ctrl_map_e1_we & regwen_qs),
     .wd     (classd_ctrl_map_e1_wd),
 
     // from internal hardware
@@ -3196,7 +3196,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_map_e2_we & regen_qs),
+    .we     (classd_ctrl_map_e2_we & regwen_qs),
     .wd     (classd_ctrl_map_e2_wd),
 
     // from internal hardware
@@ -3222,7 +3222,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_map_e3_we & regen_qs),
+    .we     (classd_ctrl_map_e3_we & regwen_qs),
     .wd     (classd_ctrl_map_e3_wd),
 
     // from internal hardware
@@ -3238,30 +3238,30 @@ module alert_handler_reg_top (
   );
 
 
-  // R[classd_clren]: V(False)
+  // R[classd_regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_classd_clren (
+  ) u_classd_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (classd_clren_we),
-    .wd     (classd_clren_wd),
+    .we     (classd_regwen_we),
+    .wd     (classd_regwen_wd),
 
     // from internal hardware
-    .de     (hw2reg.classd_clren.de),
-    .d      (hw2reg.classd_clren.d ),
+    .de     (hw2reg.classd_regwen.de),
+    .d      (hw2reg.classd_regwen.d ),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (classd_clren_qs)
+    .qs     (classd_regwen_qs)
   );
 
 
@@ -3276,7 +3276,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_clr_we & classd_clren_qs),
+    .we     (classd_clr_we & classd_regwen_qs),
     .wd     (classd_clr_wd),
 
     // from internal hardware
@@ -3318,7 +3318,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_accum_thresh_we & regen_qs),
+    .we     (classd_accum_thresh_we & regwen_qs),
     .wd     (classd_accum_thresh_wd),
 
     // from internal hardware
@@ -3345,7 +3345,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_timeout_cyc_we & regen_qs),
+    .we     (classd_timeout_cyc_we & regwen_qs),
     .wd     (classd_timeout_cyc_wd),
 
     // from internal hardware
@@ -3372,7 +3372,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_phase0_cyc_we & regen_qs),
+    .we     (classd_phase0_cyc_we & regwen_qs),
     .wd     (classd_phase0_cyc_wd),
 
     // from internal hardware
@@ -3399,7 +3399,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_phase1_cyc_we & regen_qs),
+    .we     (classd_phase1_cyc_we & regwen_qs),
     .wd     (classd_phase1_cyc_wd),
 
     // from internal hardware
@@ -3426,7 +3426,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_phase2_cyc_we & regen_qs),
+    .we     (classd_phase2_cyc_we & regwen_qs),
     .wd     (classd_phase2_cyc_wd),
 
     // from internal hardware
@@ -3453,7 +3453,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_phase3_cyc_we & regen_qs),
+    .we     (classd_phase3_cyc_we & regwen_qs),
     .wd     (classd_phase3_cyc_wd),
 
     // from internal hardware
@@ -3509,7 +3509,7 @@ module alert_handler_reg_top (
     addr_hit[ 0] = (reg_addr == ALERT_HANDLER_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == ALERT_HANDLER_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == ALERT_HANDLER_INTR_TEST_OFFSET);
-    addr_hit[ 3] = (reg_addr == ALERT_HANDLER_REGEN_OFFSET);
+    addr_hit[ 3] = (reg_addr == ALERT_HANDLER_REGWEN_OFFSET);
     addr_hit[ 4] = (reg_addr == ALERT_HANDLER_PING_TIMEOUT_CYC_OFFSET);
     addr_hit[ 5] = (reg_addr == ALERT_HANDLER_ALERT_EN_OFFSET);
     addr_hit[ 6] = (reg_addr == ALERT_HANDLER_ALERT_CLASS_OFFSET);
@@ -3518,7 +3518,7 @@ module alert_handler_reg_top (
     addr_hit[ 9] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_OFFSET);
     addr_hit[10] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_OFFSET);
     addr_hit[11] = (reg_addr == ALERT_HANDLER_CLASSA_CTRL_OFFSET);
-    addr_hit[12] = (reg_addr == ALERT_HANDLER_CLASSA_CLREN_OFFSET);
+    addr_hit[12] = (reg_addr == ALERT_HANDLER_CLASSA_REGWEN_OFFSET);
     addr_hit[13] = (reg_addr == ALERT_HANDLER_CLASSA_CLR_OFFSET);
     addr_hit[14] = (reg_addr == ALERT_HANDLER_CLASSA_ACCUM_CNT_OFFSET);
     addr_hit[15] = (reg_addr == ALERT_HANDLER_CLASSA_ACCUM_THRESH_OFFSET);
@@ -3530,7 +3530,7 @@ module alert_handler_reg_top (
     addr_hit[21] = (reg_addr == ALERT_HANDLER_CLASSA_ESC_CNT_OFFSET);
     addr_hit[22] = (reg_addr == ALERT_HANDLER_CLASSA_STATE_OFFSET);
     addr_hit[23] = (reg_addr == ALERT_HANDLER_CLASSB_CTRL_OFFSET);
-    addr_hit[24] = (reg_addr == ALERT_HANDLER_CLASSB_CLREN_OFFSET);
+    addr_hit[24] = (reg_addr == ALERT_HANDLER_CLASSB_REGWEN_OFFSET);
     addr_hit[25] = (reg_addr == ALERT_HANDLER_CLASSB_CLR_OFFSET);
     addr_hit[26] = (reg_addr == ALERT_HANDLER_CLASSB_ACCUM_CNT_OFFSET);
     addr_hit[27] = (reg_addr == ALERT_HANDLER_CLASSB_ACCUM_THRESH_OFFSET);
@@ -3542,7 +3542,7 @@ module alert_handler_reg_top (
     addr_hit[33] = (reg_addr == ALERT_HANDLER_CLASSB_ESC_CNT_OFFSET);
     addr_hit[34] = (reg_addr == ALERT_HANDLER_CLASSB_STATE_OFFSET);
     addr_hit[35] = (reg_addr == ALERT_HANDLER_CLASSC_CTRL_OFFSET);
-    addr_hit[36] = (reg_addr == ALERT_HANDLER_CLASSC_CLREN_OFFSET);
+    addr_hit[36] = (reg_addr == ALERT_HANDLER_CLASSC_REGWEN_OFFSET);
     addr_hit[37] = (reg_addr == ALERT_HANDLER_CLASSC_CLR_OFFSET);
     addr_hit[38] = (reg_addr == ALERT_HANDLER_CLASSC_ACCUM_CNT_OFFSET);
     addr_hit[39] = (reg_addr == ALERT_HANDLER_CLASSC_ACCUM_THRESH_OFFSET);
@@ -3554,7 +3554,7 @@ module alert_handler_reg_top (
     addr_hit[45] = (reg_addr == ALERT_HANDLER_CLASSC_ESC_CNT_OFFSET);
     addr_hit[46] = (reg_addr == ALERT_HANDLER_CLASSC_STATE_OFFSET);
     addr_hit[47] = (reg_addr == ALERT_HANDLER_CLASSD_CTRL_OFFSET);
-    addr_hit[48] = (reg_addr == ALERT_HANDLER_CLASSD_CLREN_OFFSET);
+    addr_hit[48] = (reg_addr == ALERT_HANDLER_CLASSD_REGWEN_OFFSET);
     addr_hit[49] = (reg_addr == ALERT_HANDLER_CLASSD_CLR_OFFSET);
     addr_hit[50] = (reg_addr == ALERT_HANDLER_CLASSD_ACCUM_CNT_OFFSET);
     addr_hit[51] = (reg_addr == ALERT_HANDLER_CLASSD_ACCUM_THRESH_OFFSET);
@@ -3669,8 +3669,8 @@ module alert_handler_reg_top (
   assign intr_test_classd_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_classd_wd = reg_wdata[3];
 
-  assign regen_we = addr_hit[3] & reg_we & ~wr_err;
-  assign regen_wd = reg_wdata[0];
+  assign regwen_we = addr_hit[3] & reg_we & ~wr_err;
+  assign regwen_wd = reg_wdata[0];
 
   assign ping_timeout_cyc_we = addr_hit[4] & reg_we & ~wr_err;
   assign ping_timeout_cyc_wd = reg_wdata[23:0];
@@ -3777,8 +3777,8 @@ module alert_handler_reg_top (
   assign classa_ctrl_map_e3_we = addr_hit[11] & reg_we & ~wr_err;
   assign classa_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classa_clren_we = addr_hit[12] & reg_we & ~wr_err;
-  assign classa_clren_wd = reg_wdata[0];
+  assign classa_regwen_we = addr_hit[12] & reg_we & ~wr_err;
+  assign classa_regwen_wd = reg_wdata[0];
 
   assign classa_clr_we = addr_hit[13] & reg_we & ~wr_err;
   assign classa_clr_wd = reg_wdata[0];
@@ -3837,8 +3837,8 @@ module alert_handler_reg_top (
   assign classb_ctrl_map_e3_we = addr_hit[23] & reg_we & ~wr_err;
   assign classb_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classb_clren_we = addr_hit[24] & reg_we & ~wr_err;
-  assign classb_clren_wd = reg_wdata[0];
+  assign classb_regwen_we = addr_hit[24] & reg_we & ~wr_err;
+  assign classb_regwen_wd = reg_wdata[0];
 
   assign classb_clr_we = addr_hit[25] & reg_we & ~wr_err;
   assign classb_clr_wd = reg_wdata[0];
@@ -3897,8 +3897,8 @@ module alert_handler_reg_top (
   assign classc_ctrl_map_e3_we = addr_hit[35] & reg_we & ~wr_err;
   assign classc_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classc_clren_we = addr_hit[36] & reg_we & ~wr_err;
-  assign classc_clren_wd = reg_wdata[0];
+  assign classc_regwen_we = addr_hit[36] & reg_we & ~wr_err;
+  assign classc_regwen_wd = reg_wdata[0];
 
   assign classc_clr_we = addr_hit[37] & reg_we & ~wr_err;
   assign classc_clr_wd = reg_wdata[0];
@@ -3957,8 +3957,8 @@ module alert_handler_reg_top (
   assign classd_ctrl_map_e3_we = addr_hit[47] & reg_we & ~wr_err;
   assign classd_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classd_clren_we = addr_hit[48] & reg_we & ~wr_err;
-  assign classd_clren_wd = reg_wdata[0];
+  assign classd_regwen_we = addr_hit[48] & reg_we & ~wr_err;
+  assign classd_regwen_wd = reg_wdata[0];
 
   assign classd_clr_we = addr_hit[49] & reg_we & ~wr_err;
   assign classd_clr_wd = reg_wdata[0];
@@ -4013,7 +4013,7 @@ module alert_handler_reg_top (
       end
 
       addr_hit[3]: begin
-        reg_rdata_next[0] = regen_qs;
+        reg_rdata_next[0] = regwen_qs;
       end
 
       addr_hit[4]: begin
@@ -4076,7 +4076,7 @@ module alert_handler_reg_top (
       end
 
       addr_hit[12]: begin
-        reg_rdata_next[0] = classa_clren_qs;
+        reg_rdata_next[0] = classa_regwen_qs;
       end
 
       addr_hit[13]: begin
@@ -4133,7 +4133,7 @@ module alert_handler_reg_top (
       end
 
       addr_hit[24]: begin
-        reg_rdata_next[0] = classb_clren_qs;
+        reg_rdata_next[0] = classb_regwen_qs;
       end
 
       addr_hit[25]: begin
@@ -4190,7 +4190,7 @@ module alert_handler_reg_top (
       end
 
       addr_hit[36]: begin
-        reg_rdata_next[0] = classc_clren_qs;
+        reg_rdata_next[0] = classc_regwen_qs;
       end
 
       addr_hit[37]: begin
@@ -4247,7 +4247,7 @@ module alert_handler_reg_top (
       end
 
       addr_hit[48]: begin
-        reg_rdata_next[0] = classd_clren_qs;
+        reg_rdata_next[0] = classd_regwen_qs;
       end
 
       addr_hit[49]: begin

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_wrap.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_wrap.sv
@@ -126,17 +126,17 @@ module alert_handler_reg_wrap import alert_pkg::*; (
   // ping timeout in cycles
   // autolock can clear these regs automatically upon entering escalation
   // note: the class must be activated for this to occur
-  assign { hw2reg.classd_clren.d,
-           hw2reg.classc_clren.d,
-           hw2reg.classb_clren.d,
-           hw2reg.classa_clren.d } = '0;
+  assign { hw2reg.classd_regwen.d,
+           hw2reg.classc_regwen.d,
+           hw2reg.classb_regwen.d,
+           hw2reg.classa_regwen.d } = '0;
 
-  assign { hw2reg.classd_clren.de,
-           hw2reg.classc_clren.de,
-           hw2reg.classb_clren.de,
-           hw2reg.classa_clren.de } = hw2reg_wrap.class_esc_trig    &
-                                      class_autolock_en             &
-                                      reg2hw_wrap.class_en;
+  assign { hw2reg.classd_regwen.de,
+           hw2reg.classc_regwen.de,
+           hw2reg.classb_regwen.de,
+           hw2reg.classa_regwen.de } = hw2reg_wrap.class_esc_trig &
+                                       class_autolock_en          &
+                                       reg2hw_wrap.class_en;
 
   // current accumulator counts
   assign { hw2reg.classd_accum_cnt.d,
@@ -161,7 +161,7 @@ module alert_handler_reg_wrap import alert_pkg::*; (
   /////////////////////
 
   // config register lock
-  assign reg2hw_wrap.config_locked = ~reg2hw.regen.q;
+  assign reg2hw_wrap.config_locked = ~reg2hw.regwen.q;
 
   // alert enable and class assignments
   for (genvar k = 0; k < NAlerts; k++) begin : gen_alert_en_class

--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -61,9 +61,9 @@
   ],
   regwidth: "32",
   registers: [
-    { name: "REGEN",
+    { name: "REGWEN",
       desc: "Register write enable for all control registers",
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hro",
       fields: [
         {
@@ -81,7 +81,7 @@
       desc: "Control register",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen: "REGEN",
+      regwen: "REGWEN",
       fields: [
         {
             bits: "0",
@@ -133,7 +133,7 @@
       swaccess: "wo",
       hwaccess: "hro",
       hwqe: "true",
-      regwen: "REGEN",
+      regwen: "REGWEN",
       fields: [
         { bits: "31:0",
           name: "CMD_REQ",
@@ -212,7 +212,7 @@
       swaccess: "rw",
       hwaccess: "hro",
       hwqe: "true",
-      regwen: "REGEN",
+      regwen: "REGWEN",
       fields: [
         {
             bits: "3:0",

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -85,7 +85,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
       "intr_test": begin
         // FIXME
       end
-      "regen": begin
+      "regwen": begin
       end
       "ctrl": begin
       end

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -1164,7 +1164,7 @@ module csrng_core import csrng_pkg::*; #(
 
   assign hw2reg.sum_sts.diag.de = !cs_enable;
   assign hw2reg.sum_sts.diag.d  =
-         (reg2hw.regen.q)        && // not used
+         (reg2hw.regwen.q)       && // not used
          (|reg2hw.genbits.q)     && // not used
          (|reg2hw.int_state_val.q); // not used
 

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -66,7 +66,7 @@ package csrng_reg_pkg;
 
   typedef struct packed {
     logic        q;
-  } csrng_reg2hw_regen_reg_t;
+  } csrng_reg2hw_regwen_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -251,7 +251,7 @@ package csrng_reg_pkg;
     csrng_reg2hw_intr_state_reg_t intr_state; // [126:123]
     csrng_reg2hw_intr_enable_reg_t intr_enable; // [122:119]
     csrng_reg2hw_intr_test_reg_t intr_test; // [118:111]
-    csrng_reg2hw_regen_reg_t regen; // [110:110]
+    csrng_reg2hw_regwen_reg_t regwen; // [110:110]
     csrng_reg2hw_ctrl_reg_t ctrl; // [109:104]
     csrng_reg2hw_cmd_req_reg_t cmd_req; // [103:71]
     csrng_reg2hw_genbits_reg_t genbits; // [70:38]
@@ -277,7 +277,7 @@ package csrng_reg_pkg;
   parameter logic [BlockAw-1:0] CSRNG_INTR_STATE_OFFSET = 6'h 0;
   parameter logic [BlockAw-1:0] CSRNG_INTR_ENABLE_OFFSET = 6'h 4;
   parameter logic [BlockAw-1:0] CSRNG_INTR_TEST_OFFSET = 6'h 8;
-  parameter logic [BlockAw-1:0] CSRNG_REGEN_OFFSET = 6'h c;
+  parameter logic [BlockAw-1:0] CSRNG_REGWEN_OFFSET = 6'h c;
   parameter logic [BlockAw-1:0] CSRNG_CTRL_OFFSET = 6'h 10;
   parameter logic [BlockAw-1:0] CSRNG_SUM_STS_OFFSET = 6'h 14;
   parameter logic [BlockAw-1:0] CSRNG_CMD_REQ_OFFSET = 6'h 18;
@@ -295,7 +295,7 @@ package csrng_reg_pkg;
     CSRNG_INTR_STATE,
     CSRNG_INTR_ENABLE,
     CSRNG_INTR_TEST,
-    CSRNG_REGEN,
+    CSRNG_REGWEN,
     CSRNG_CTRL,
     CSRNG_SUM_STS,
     CSRNG_CMD_REQ,
@@ -313,7 +313,7 @@ package csrng_reg_pkg;
     4'b 0001, // index[ 0] CSRNG_INTR_STATE
     4'b 0001, // index[ 1] CSRNG_INTR_ENABLE
     4'b 0001, // index[ 2] CSRNG_INTR_TEST
-    4'b 0001, // index[ 3] CSRNG_REGEN
+    4'b 0001, // index[ 3] CSRNG_REGWEN
     4'b 0111, // index[ 4] CSRNG_CTRL
     4'b 1111, // index[ 5] CSRNG_SUM_STS
     4'b 1111, // index[ 6] CSRNG_CMD_REQ

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -103,9 +103,9 @@ module csrng_reg_top (
   logic intr_test_cs_hw_inst_exc_we;
   logic intr_test_cs_fifo_err_wd;
   logic intr_test_cs_fifo_err_we;
-  logic regen_qs;
-  logic regen_wd;
-  logic regen_we;
+  logic regwen_qs;
+  logic regwen_wd;
+  logic regwen_we;
   logic ctrl_enable_qs;
   logic ctrl_enable_wd;
   logic ctrl_enable_we;
@@ -468,19 +468,19 @@ module csrng_reg_top (
   );
 
 
-  // R[regen]: V(False)
+  // R[regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_regen (
+  ) u_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (regen_we),
-    .wd     (regen_wd),
+    .we     (regwen_we),
+    .wd     (regwen_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -488,10 +488,10 @@ module csrng_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.regen.q ),
+    .q      (reg2hw.regwen.q ),
 
     // to register interface (read)
-    .qs     (regen_qs)
+    .qs     (regwen_qs)
   );
 
 
@@ -507,7 +507,7 @@ module csrng_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (ctrl_enable_we & regen_qs),
+    .we     (ctrl_enable_we & regwen_qs),
     .wd     (ctrl_enable_wd),
 
     // from internal hardware
@@ -533,7 +533,7 @@ module csrng_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (ctrl_aes_cipher_disable_we & regen_qs),
+    .we     (ctrl_aes_cipher_disable_we & regwen_qs),
     .wd     (ctrl_aes_cipher_disable_wd),
 
     // from internal hardware
@@ -559,7 +559,7 @@ module csrng_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (ctrl_fifo_depth_sts_sel_we & regen_qs),
+    .we     (ctrl_fifo_depth_sts_sel_we & regwen_qs),
     .wd     (ctrl_fifo_depth_sts_sel_wd),
 
     // from internal hardware
@@ -638,7 +638,7 @@ module csrng_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (cmd_req_we & regen_qs),
+    .we     (cmd_req_we & regwen_qs),
     .wd     (cmd_req_wd),
 
     // from internal hardware
@@ -764,7 +764,7 @@ module csrng_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (int_state_num_we & regen_qs),
+    .we     (int_state_num_we & regwen_qs),
     .wd     (int_state_num_wd),
 
     // from internal hardware
@@ -1327,7 +1327,7 @@ module csrng_reg_top (
     addr_hit[ 0] = (reg_addr == CSRNG_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == CSRNG_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == CSRNG_INTR_TEST_OFFSET);
-    addr_hit[ 3] = (reg_addr == CSRNG_REGEN_OFFSET);
+    addr_hit[ 3] = (reg_addr == CSRNG_REGWEN_OFFSET);
     addr_hit[ 4] = (reg_addr == CSRNG_CTRL_OFFSET);
     addr_hit[ 5] = (reg_addr == CSRNG_SUM_STS_OFFSET);
     addr_hit[ 6] = (reg_addr == CSRNG_CMD_REQ_OFFSET);
@@ -1397,8 +1397,8 @@ module csrng_reg_top (
   assign intr_test_cs_fifo_err_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_cs_fifo_err_wd = reg_wdata[3];
 
-  assign regen_we = addr_hit[3] & reg_we & ~wr_err;
-  assign regen_wd = reg_wdata[0];
+  assign regwen_we = addr_hit[3] & reg_we & ~wr_err;
+  assign regwen_wd = reg_wdata[0];
 
   assign ctrl_enable_we = addr_hit[4] & reg_we & ~wr_err;
   assign ctrl_enable_wd = reg_wdata[0];
@@ -1513,7 +1513,7 @@ module csrng_reg_top (
       end
 
       addr_hit[3]: begin
-        reg_rdata_next[0] = regen_qs;
+        reg_rdata_next[0] = regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -61,9 +61,9 @@
 
   regwidth: "32",
   registers: [
-    { name: "REGEN",
+    { name: "REGWEN",
       desc: "Register write enable for all control registers",
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hro",
       fields: [
         { bits: "0",
@@ -160,7 +160,7 @@
       hwaccess: "hro",
       hwext: "true",
       hwqe: "true",
-      regwen: "REGEN",
+      regwen: "REGWEN",
       fields: [
         { bits: "31:0",
           name: "SW_CMD_REQ",
@@ -204,7 +204,7 @@
       hwaccess: "hro",
       hwext: "true",
       hwqe: "true",
-      regwen: "REGEN",
+      regwen: "REGWEN",
       fields: [
         { bits: "31:0",
           name: "RESEED_CMD",
@@ -225,7 +225,7 @@
       hwaccess: "hro",
       hwext: "true",
       hwqe: "true",
-      regwen: "REGEN",
+      regwen: "REGWEN",
       fields: [
         { bits: "31:0",
           name: "GENERATE_CMD",

--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -533,7 +533,7 @@ module edn_core import edn_pkg::*; #(
   //--------------------------------------------
 
   assign     hw2reg.sum_sts.internal_use.de = !edn_enable;
-  assign     hw2reg.sum_sts.internal_use.d  = reg2hw.regen.q;
+  assign     hw2reg.sum_sts.internal_use.d  = reg2hw.regwen.q;
 
 
 endmodule

--- a/hw/ip/edn/rtl/edn_reg_pkg.sv
+++ b/hw/ip/edn/rtl/edn_reg_pkg.sv
@@ -48,7 +48,7 @@ package edn_reg_pkg;
 
   typedef struct packed {
     logic        q;
-  } edn_reg2hw_regen_reg_t;
+  } edn_reg2hw_regwen_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -154,7 +154,7 @@ package edn_reg_pkg;
     edn_reg2hw_intr_state_reg_t intr_state; // [144:143]
     edn_reg2hw_intr_enable_reg_t intr_enable; // [142:141]
     edn_reg2hw_intr_test_reg_t intr_test; // [140:137]
-    edn_reg2hw_regen_reg_t regen; // [136:136]
+    edn_reg2hw_regwen_reg_t regwen; // [136:136]
     edn_reg2hw_ctrl_reg_t ctrl; // [135:132]
     edn_reg2hw_sw_cmd_req_reg_t sw_cmd_req; // [131:99]
     edn_reg2hw_reseed_cmd_reg_t reseed_cmd; // [98:66]
@@ -176,7 +176,7 @@ package edn_reg_pkg;
   parameter logic [BlockAw-1:0] EDN_INTR_STATE_OFFSET = 6'h 0;
   parameter logic [BlockAw-1:0] EDN_INTR_ENABLE_OFFSET = 6'h 4;
   parameter logic [BlockAw-1:0] EDN_INTR_TEST_OFFSET = 6'h 8;
-  parameter logic [BlockAw-1:0] EDN_REGEN_OFFSET = 6'h c;
+  parameter logic [BlockAw-1:0] EDN_REGWEN_OFFSET = 6'h c;
   parameter logic [BlockAw-1:0] EDN_CTRL_OFFSET = 6'h 10;
   parameter logic [BlockAw-1:0] EDN_SUM_STS_OFFSET = 6'h 14;
   parameter logic [BlockAw-1:0] EDN_SW_CMD_REQ_OFFSET = 6'h 18;
@@ -192,7 +192,7 @@ package edn_reg_pkg;
     EDN_INTR_STATE,
     EDN_INTR_ENABLE,
     EDN_INTR_TEST,
-    EDN_REGEN,
+    EDN_REGWEN,
     EDN_CTRL,
     EDN_SUM_STS,
     EDN_SW_CMD_REQ,
@@ -208,7 +208,7 @@ package edn_reg_pkg;
     4'b 0001, // index[ 0] EDN_INTR_STATE
     4'b 0001, // index[ 1] EDN_INTR_ENABLE
     4'b 0001, // index[ 2] EDN_INTR_TEST
-    4'b 0001, // index[ 3] EDN_REGEN
+    4'b 0001, // index[ 3] EDN_REGWEN
     4'b 0001, // index[ 4] EDN_CTRL
     4'b 1111, // index[ 5] EDN_SUM_STS
     4'b 1111, // index[ 6] EDN_SW_CMD_REQ

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -87,9 +87,9 @@ module edn_reg_top (
   logic intr_test_edn_cmd_req_done_we;
   logic intr_test_edn_fifo_err_wd;
   logic intr_test_edn_fifo_err_we;
-  logic regen_qs;
-  logic regen_wd;
-  logic regen_we;
+  logic regwen_qs;
+  logic regwen_wd;
+  logic regwen_we;
   logic ctrl_edn_enable_qs;
   logic ctrl_edn_enable_wd;
   logic ctrl_edn_enable_we;
@@ -279,19 +279,19 @@ module edn_reg_top (
   );
 
 
-  // R[regen]: V(False)
+  // R[regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_regen (
+  ) u_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (regen_we),
-    .wd     (regen_wd),
+    .we     (regwen_we),
+    .wd     (regwen_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -299,10 +299,10 @@ module edn_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.regen.q ),
+    .q      (reg2hw.regwen.q ),
 
     // to register interface (read)
-    .qs     (regen_qs)
+    .qs     (regwen_qs)
   );
 
 
@@ -499,7 +499,7 @@ module edn_reg_top (
   ) u_sw_cmd_req (
     .re     (1'b0),
     // qualified with register enable
-    .we     (sw_cmd_req_we & regen_qs),
+    .we     (sw_cmd_req_we & regwen_qs),
     .wd     (sw_cmd_req_wd),
     .d      ('0),
     .qre    (),
@@ -568,7 +568,7 @@ module edn_reg_top (
   ) u_reseed_cmd (
     .re     (1'b0),
     // qualified with register enable
-    .we     (reseed_cmd_we & regen_qs),
+    .we     (reseed_cmd_we & regwen_qs),
     .wd     (reseed_cmd_wd),
     .d      ('0),
     .qre    (),
@@ -585,7 +585,7 @@ module edn_reg_top (
   ) u_generate_cmd (
     .re     (1'b0),
     // qualified with register enable
-    .we     (generate_cmd_we & regen_qs),
+    .we     (generate_cmd_we & regwen_qs),
     .wd     (generate_cmd_wd),
     .d      ('0),
     .qre    (),
@@ -762,7 +762,7 @@ module edn_reg_top (
     addr_hit[ 0] = (reg_addr == EDN_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == EDN_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == EDN_INTR_TEST_OFFSET);
-    addr_hit[ 3] = (reg_addr == EDN_REGEN_OFFSET);
+    addr_hit[ 3] = (reg_addr == EDN_REGWEN_OFFSET);
     addr_hit[ 4] = (reg_addr == EDN_CTRL_OFFSET);
     addr_hit[ 5] = (reg_addr == EDN_SUM_STS_OFFSET);
     addr_hit[ 6] = (reg_addr == EDN_SW_CMD_REQ_OFFSET);
@@ -810,8 +810,8 @@ module edn_reg_top (
   assign intr_test_edn_fifo_err_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_edn_fifo_err_wd = reg_wdata[1];
 
-  assign regen_we = addr_hit[3] & reg_we & ~wr_err;
-  assign regen_wd = reg_wdata[0];
+  assign regwen_we = addr_hit[3] & reg_we & ~wr_err;
+  assign regwen_wd = reg_wdata[0];
 
   assign ctrl_edn_enable_we = addr_hit[4] & reg_we & ~wr_err;
   assign ctrl_edn_enable_wd = reg_wdata[0];
@@ -883,7 +883,7 @@ module edn_reg_top (
       end
 
       addr_hit[3]: begin
-        reg_rdata_next[0] = regen_qs;
+        reg_rdata_next[0] = regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -5,7 +5,7 @@
   clock_primary: "clk_i",
   bus_device: "tlul",
   bus_host: "none",
-  param_list: [
+param_list: [
     { name: "EsFifoDepth",
       desc: "Depth of the entropy FIFO",
       type: "int",
@@ -57,9 +57,9 @@
 
   regwidth: "32",
   registers: [
-    { name: "REGEN",
+    { name: "REGWEN",
       desc: "Register write enable for all control registers",
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hro",
       fields: [
         {
@@ -98,7 +98,7 @@
       desc: "Configuration register",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "1:0",
           name: "ENABLE",
@@ -178,7 +178,7 @@
       desc: "Entropy control register",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "0",
           name: "ES_ROUTE",
@@ -213,7 +213,7 @@
       desc: "Health test windows register",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "15:0",
           name: "FIPS_WINDOW",
@@ -238,7 +238,7 @@
       desc: "Repetition count test thresholds register",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "15:0",
           name: "FIPS_REPCNT_THRESH",
@@ -264,7 +264,7 @@
       desc: "Adaptive proportion test high thresholds register",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "15:0",
           name: "FIPS_ADAPTP_HI_THRESH",
@@ -290,7 +290,7 @@
       desc: "Adaptive proportion test low thresholds register",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "15:0",
           name: "FIPS_ADAPTP_LO_THRESH",
@@ -316,7 +316,7 @@
       desc: "Bucket test thresholds register",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "15:0",
           name: "FIPS_BUCKET_THRESH",
@@ -342,7 +342,7 @@
       desc: "Markov test high thresholds register",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "15:0",
           name: "FIPS_MARKOV_HI_THRESH",
@@ -368,7 +368,7 @@
       desc: "Markov test low thresholds register",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "15:0",
           name: "FIPS_MARKOV_LO_THRESH",
@@ -394,7 +394,7 @@
       desc: "External health test high thresholds register",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "15:0",
           name: "FIPS_EXTHT_HI_THRESH",
@@ -420,7 +420,7 @@
       desc: "External health test low thresholds register",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "15:0",
           name: "FIPS_EXTHT_LO_THRESH",
@@ -686,7 +686,7 @@
       desc: "Alert threshold register",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "3:0",
           name: "ALERT_THRESHOLD",
@@ -794,7 +794,7 @@
       desc: "Firmware override control register",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "0",
           name: "FW_OV_MODE",
@@ -868,7 +868,7 @@
       desc: "Pre-conditioner FIFO depth control register",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "6:0",
           desc: '''This field to set the logical depth of the
@@ -901,11 +901,11 @@
     { name: "SEED",
       desc: "ENTROPY_SRC seed register",
       swaccess: "rw",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "3:0",
           name: "LFSR_SEED",
-          desc: "Seed used to load into the LFSR for the initial state. This field will not update if the REGEN bit 0 is cleared.",
+          desc: "Seed used to load into the LFSR for the initial state. This field will not update if the REGWEN bit 0 is cleared.",
           resval: "0xb"
        }
       ]

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -70,7 +70,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard #(
       end
       "intr_test": begin
       end
-      "regen": begin
+      "regwen": begin
       end
       "conf": begin
       end

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -1499,7 +1499,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   //--------------------------------------------
 
   assign hw2reg.debug_status.diag.d  =
-         reg2hw.regen.q &&
+         reg2hw.regwen.q &&
          (&reg2hw.entropy_data.q) &&
          (&reg2hw.fw_ov_rd_data.q);
 

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -62,7 +62,7 @@ package entropy_src_reg_pkg;
 
   typedef struct packed {
     logic        q;
-  } entropy_src_reg2hw_regen_reg_t;
+  } entropy_src_reg2hw_regwen_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -440,7 +440,7 @@ package entropy_src_reg_pkg;
     entropy_src_reg2hw_intr_enable_reg_t intr_enable; // [446:444]
     entropy_src_reg2hw_intr_test_reg_t intr_test; // [443:438]
     entropy_src_reg2hw_alert_test_reg_t alert_test; // [437:436]
-    entropy_src_reg2hw_regen_reg_t regen; // [435:435]
+    entropy_src_reg2hw_regwen_reg_t regwen; // [435:435]
     entropy_src_reg2hw_conf_reg_t conf; // [434:423]
     entropy_src_reg2hw_rate_reg_t rate; // [422:407]
     entropy_src_reg2hw_entropy_control_reg_t entropy_control; // [406:405]
@@ -497,7 +497,7 @@ package entropy_src_reg_pkg;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_INTR_ENABLE_OFFSET = 8'h 4;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_INTR_TEST_OFFSET = 8'h 8;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_TEST_OFFSET = 8'h c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REGEN_OFFSET = 8'h 10;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REGWEN_OFFSET = 8'h 10;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_REV_OFFSET = 8'h 14;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_CONF_OFFSET = 8'h 18;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_RATE_OFFSET = 8'h 1c;
@@ -547,7 +547,7 @@ package entropy_src_reg_pkg;
     ENTROPY_SRC_INTR_ENABLE,
     ENTROPY_SRC_INTR_TEST,
     ENTROPY_SRC_ALERT_TEST,
-    ENTROPY_SRC_REGEN,
+    ENTROPY_SRC_REGWEN,
     ENTROPY_SRC_REV,
     ENTROPY_SRC_CONF,
     ENTROPY_SRC_RATE,
@@ -597,7 +597,7 @@ package entropy_src_reg_pkg;
     4'b 0001, // index[ 1] ENTROPY_SRC_INTR_ENABLE
     4'b 0001, // index[ 2] ENTROPY_SRC_INTR_TEST
     4'b 0001, // index[ 3] ENTROPY_SRC_ALERT_TEST
-    4'b 0001, // index[ 4] ENTROPY_SRC_REGEN
+    4'b 0001, // index[ 4] ENTROPY_SRC_REGWEN
     4'b 0111, // index[ 5] ENTROPY_SRC_REV
     4'b 0011, // index[ 6] ENTROPY_SRC_CONF
     4'b 0011, // index[ 7] ENTROPY_SRC_RATE

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -97,9 +97,9 @@ module entropy_src_reg_top (
   logic intr_test_es_fifo_err_we;
   logic alert_test_wd;
   logic alert_test_we;
-  logic regen_qs;
-  logic regen_wd;
-  logic regen_we;
+  logic regwen_qs;
+  logic regwen_wd;
+  logic regwen_we;
   logic [7:0] rev_abi_revision_qs;
   logic [7:0] rev_hw_revision_qs;
   logic [7:0] rev_chip_type_qs;
@@ -535,19 +535,19 @@ module entropy_src_reg_top (
   );
 
 
-  // R[regen]: V(False)
+  // R[regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_regen (
+  ) u_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (regen_we),
-    .wd     (regen_wd),
+    .we     (regwen_we),
+    .wd     (regwen_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -555,10 +555,10 @@ module entropy_src_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.regen.q ),
+    .q      (reg2hw.regwen.q ),
 
     // to register interface (read)
-    .qs     (regen_qs)
+    .qs     (regwen_qs)
   );
 
 
@@ -591,7 +591,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (conf_enable_we & regen_qs),
+    .we     (conf_enable_we & regwen_qs),
     .wd     (conf_enable_wd),
 
     // from internal hardware
@@ -617,7 +617,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (conf_boot_bypass_disable_we & regen_qs),
+    .we     (conf_boot_bypass_disable_we & regwen_qs),
     .wd     (conf_boot_bypass_disable_wd),
 
     // from internal hardware
@@ -643,7 +643,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (conf_repcnt_disable_we & regen_qs),
+    .we     (conf_repcnt_disable_we & regwen_qs),
     .wd     (conf_repcnt_disable_wd),
 
     // from internal hardware
@@ -669,7 +669,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (conf_adaptp_disable_we & regen_qs),
+    .we     (conf_adaptp_disable_we & regwen_qs),
     .wd     (conf_adaptp_disable_wd),
 
     // from internal hardware
@@ -695,7 +695,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (conf_bucket_disable_we & regen_qs),
+    .we     (conf_bucket_disable_we & regwen_qs),
     .wd     (conf_bucket_disable_wd),
 
     // from internal hardware
@@ -721,7 +721,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (conf_markov_disable_we & regen_qs),
+    .we     (conf_markov_disable_we & regwen_qs),
     .wd     (conf_markov_disable_wd),
 
     // from internal hardware
@@ -747,7 +747,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (conf_health_test_clr_we & regen_qs),
+    .we     (conf_health_test_clr_we & regwen_qs),
     .wd     (conf_health_test_clr_wd),
 
     // from internal hardware
@@ -773,7 +773,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (conf_rng_bit_en_we & regen_qs),
+    .we     (conf_rng_bit_en_we & regwen_qs),
     .wd     (conf_rng_bit_en_wd),
 
     // from internal hardware
@@ -799,7 +799,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (conf_rng_bit_sel_we & regen_qs),
+    .we     (conf_rng_bit_sel_we & regwen_qs),
     .wd     (conf_rng_bit_sel_wd),
 
     // from internal hardware
@@ -825,7 +825,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (conf_extht_enable_we & regen_qs),
+    .we     (conf_extht_enable_we & regwen_qs),
     .wd     (conf_extht_enable_wd),
 
     // from internal hardware
@@ -880,7 +880,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (entropy_control_es_route_we & regen_qs),
+    .we     (entropy_control_es_route_we & regwen_qs),
     .wd     (entropy_control_es_route_wd),
 
     // from internal hardware
@@ -906,7 +906,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (entropy_control_es_type_we & regen_qs),
+    .we     (entropy_control_es_type_we & regwen_qs),
     .wd     (entropy_control_es_type_wd),
 
     // from internal hardware
@@ -950,7 +950,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (health_test_windows_fips_window_we & regen_qs),
+    .we     (health_test_windows_fips_window_we & regwen_qs),
     .wd     (health_test_windows_fips_window_wd),
 
     // from internal hardware
@@ -976,7 +976,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (health_test_windows_bypass_window_we & regen_qs),
+    .we     (health_test_windows_bypass_window_we & regwen_qs),
     .wd     (health_test_windows_bypass_window_wd),
 
     // from internal hardware
@@ -1004,7 +1004,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (repcnt_thresholds_fips_repcnt_thresh_we & regen_qs),
+    .we     (repcnt_thresholds_fips_repcnt_thresh_we & regwen_qs),
     .wd     (repcnt_thresholds_fips_repcnt_thresh_wd),
 
     // from internal hardware
@@ -1030,7 +1030,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (repcnt_thresholds_bypass_repcnt_thresh_we & regen_qs),
+    .we     (repcnt_thresholds_bypass_repcnt_thresh_we & regwen_qs),
     .wd     (repcnt_thresholds_bypass_repcnt_thresh_wd),
 
     // from internal hardware
@@ -1058,7 +1058,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (adaptp_hi_thresholds_fips_adaptp_hi_thresh_we & regen_qs),
+    .we     (adaptp_hi_thresholds_fips_adaptp_hi_thresh_we & regwen_qs),
     .wd     (adaptp_hi_thresholds_fips_adaptp_hi_thresh_wd),
 
     // from internal hardware
@@ -1084,7 +1084,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (adaptp_hi_thresholds_bypass_adaptp_hi_thresh_we & regen_qs),
+    .we     (adaptp_hi_thresholds_bypass_adaptp_hi_thresh_we & regwen_qs),
     .wd     (adaptp_hi_thresholds_bypass_adaptp_hi_thresh_wd),
 
     // from internal hardware
@@ -1112,7 +1112,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (adaptp_lo_thresholds_fips_adaptp_lo_thresh_we & regen_qs),
+    .we     (adaptp_lo_thresholds_fips_adaptp_lo_thresh_we & regwen_qs),
     .wd     (adaptp_lo_thresholds_fips_adaptp_lo_thresh_wd),
 
     // from internal hardware
@@ -1138,7 +1138,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (adaptp_lo_thresholds_bypass_adaptp_lo_thresh_we & regen_qs),
+    .we     (adaptp_lo_thresholds_bypass_adaptp_lo_thresh_we & regwen_qs),
     .wd     (adaptp_lo_thresholds_bypass_adaptp_lo_thresh_wd),
 
     // from internal hardware
@@ -1166,7 +1166,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (bucket_thresholds_fips_bucket_thresh_we & regen_qs),
+    .we     (bucket_thresholds_fips_bucket_thresh_we & regwen_qs),
     .wd     (bucket_thresholds_fips_bucket_thresh_wd),
 
     // from internal hardware
@@ -1192,7 +1192,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (bucket_thresholds_bypass_bucket_thresh_we & regen_qs),
+    .we     (bucket_thresholds_bypass_bucket_thresh_we & regwen_qs),
     .wd     (bucket_thresholds_bypass_bucket_thresh_wd),
 
     // from internal hardware
@@ -1220,7 +1220,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (markov_hi_thresholds_fips_markov_hi_thresh_we & regen_qs),
+    .we     (markov_hi_thresholds_fips_markov_hi_thresh_we & regwen_qs),
     .wd     (markov_hi_thresholds_fips_markov_hi_thresh_wd),
 
     // from internal hardware
@@ -1246,7 +1246,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (markov_hi_thresholds_bypass_markov_hi_thresh_we & regen_qs),
+    .we     (markov_hi_thresholds_bypass_markov_hi_thresh_we & regwen_qs),
     .wd     (markov_hi_thresholds_bypass_markov_hi_thresh_wd),
 
     // from internal hardware
@@ -1274,7 +1274,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (markov_lo_thresholds_fips_markov_lo_thresh_we & regen_qs),
+    .we     (markov_lo_thresholds_fips_markov_lo_thresh_we & regwen_qs),
     .wd     (markov_lo_thresholds_fips_markov_lo_thresh_wd),
 
     // from internal hardware
@@ -1300,7 +1300,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (markov_lo_thresholds_bypass_markov_lo_thresh_we & regen_qs),
+    .we     (markov_lo_thresholds_bypass_markov_lo_thresh_we & regwen_qs),
     .wd     (markov_lo_thresholds_bypass_markov_lo_thresh_wd),
 
     // from internal hardware
@@ -1328,7 +1328,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (extht_hi_thresholds_fips_extht_hi_thresh_we & regen_qs),
+    .we     (extht_hi_thresholds_fips_extht_hi_thresh_we & regwen_qs),
     .wd     (extht_hi_thresholds_fips_extht_hi_thresh_wd),
 
     // from internal hardware
@@ -1354,7 +1354,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (extht_hi_thresholds_bypass_extht_hi_thresh_we & regen_qs),
+    .we     (extht_hi_thresholds_bypass_extht_hi_thresh_we & regwen_qs),
     .wd     (extht_hi_thresholds_bypass_extht_hi_thresh_wd),
 
     // from internal hardware
@@ -1382,7 +1382,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (extht_lo_thresholds_fips_extht_lo_thresh_we & regen_qs),
+    .we     (extht_lo_thresholds_fips_extht_lo_thresh_we & regwen_qs),
     .wd     (extht_lo_thresholds_fips_extht_lo_thresh_wd),
 
     // from internal hardware
@@ -1408,7 +1408,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (extht_lo_thresholds_bypass_extht_lo_thresh_we & regen_qs),
+    .we     (extht_lo_thresholds_bypass_extht_lo_thresh_we & regwen_qs),
     .wd     (extht_lo_thresholds_bypass_extht_lo_thresh_wd),
 
     // from internal hardware
@@ -1819,7 +1819,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_threshold_we & regen_qs),
+    .we     (alert_threshold_we & regwen_qs),
     .wd     (alert_threshold_wd),
 
     // from internal hardware
@@ -1986,7 +1986,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (fw_ov_control_fw_ov_mode_we & regen_qs),
+    .we     (fw_ov_control_fw_ov_mode_we & regwen_qs),
     .wd     (fw_ov_control_fw_ov_mode_wd),
 
     // from internal hardware
@@ -2012,7 +2012,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (fw_ov_control_fw_ov_fifo_reg_rd_we & regen_qs),
+    .we     (fw_ov_control_fw_ov_fifo_reg_rd_we & regwen_qs),
     .wd     (fw_ov_control_fw_ov_fifo_reg_rd_wd),
 
     // from internal hardware
@@ -2038,7 +2038,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (fw_ov_control_fw_ov_fifo_reg_wr_we & regen_qs),
+    .we     (fw_ov_control_fw_ov_fifo_reg_wr_we & regwen_qs),
     .wd     (fw_ov_control_fw_ov_fifo_reg_wr_wd),
 
     // from internal hardware
@@ -2113,7 +2113,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (pre_cond_fifo_depth_we & regen_qs),
+    .we     (pre_cond_fifo_depth_we & regwen_qs),
     .wd     (pre_cond_fifo_depth_wd),
 
     // from internal hardware
@@ -2172,7 +2172,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (seed_we & regen_qs),
+    .we     (seed_we & regwen_qs),
     .wd     (seed_wd),
 
     // from internal hardware
@@ -2355,7 +2355,7 @@ module entropy_src_reg_top (
     addr_hit[ 1] = (reg_addr == ENTROPY_SRC_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == ENTROPY_SRC_INTR_TEST_OFFSET);
     addr_hit[ 3] = (reg_addr == ENTROPY_SRC_ALERT_TEST_OFFSET);
-    addr_hit[ 4] = (reg_addr == ENTROPY_SRC_REGEN_OFFSET);
+    addr_hit[ 4] = (reg_addr == ENTROPY_SRC_REGWEN_OFFSET);
     addr_hit[ 5] = (reg_addr == ENTROPY_SRC_REV_OFFSET);
     addr_hit[ 6] = (reg_addr == ENTROPY_SRC_CONF_OFFSET);
     addr_hit[ 7] = (reg_addr == ENTROPY_SRC_RATE_OFFSET);
@@ -2482,8 +2482,8 @@ module entropy_src_reg_top (
   assign alert_test_we = addr_hit[3] & reg_we & ~wr_err;
   assign alert_test_wd = reg_wdata[0];
 
-  assign regen_we = addr_hit[4] & reg_we & ~wr_err;
-  assign regen_wd = reg_wdata[0];
+  assign regwen_we = addr_hit[4] & reg_we & ~wr_err;
+  assign regwen_wd = reg_wdata[0];
 
 
 
@@ -2723,7 +2723,7 @@ module entropy_src_reg_top (
       end
 
       addr_hit[4]: begin
-        reg_rdata_next[0] = regen_qs;
+        reg_rdata_next[0] = regwen_qs;
       end
 
       addr_hit[5]: begin

--- a/hw/ip/keymgr/data/keymgr.hjson
+++ b/hw/ip/keymgr/data/keymgr.hjson
@@ -198,7 +198,7 @@
 
   regwidth: "32",
   registers: [
-    { name: "CFGEN",
+    { name: "CFG_REGWEN",
       desc: "Key manager configuration enable",
       swaccess: "ro",  // this particular lock is meant to be fully HW managed
       hwaccess: "hwo",
@@ -221,7 +221,7 @@
 
     { name: "CONTROL",
       desc: "Key manager operation controls",
-      regwen: "CFGEN",
+      regwen: "CFG_REGWEN",
       swaccess: "rw",
       hwaccess: "hro",
       fields: [
@@ -361,7 +361,7 @@
     //                     32b * NumOutReg * 2 (if key shares desired) for outputs
     //                     32b * NumOutReg * NumCryptos * 2 (if key shares desired) for hidden key bus
     // This totals to over 2kb of storage
-    { name: "SW_BINDING_EN",
+    { name: "SW_BINDING_REGWEN",
       desc: "Register write enable for SOFTWARE_BINDING",
       swaccess: "rw0c",
       hwaccess: "hrw",
@@ -386,7 +386,7 @@
     { multireg: {
         cname: "KEYMGR",
         name: "SW_BINDING",
-        regwen: "SW_BINDING_EN",
+        regwen: "SW_BINDING_REGWEN",
         desc: '''
           Software binding input to key manager.
           This register is lockable and shared between key manager stages.
@@ -412,7 +412,7 @@
     { multireg: {
         cname: "KEYMGR",
         name: "Salt",
-        regwen: "CFGEN",
+        regwen: "CFG_REGWEN",
         desc: '''
           Salt value used as part of output generation
         ''',
@@ -434,7 +434,7 @@
     { multireg: {
         cname: "KEYMGR",
         name: "KEY_VERSION",
-        regwen: "CFGEN",
+        regwen: "CFG_REGWEN",
         desc: '''
           Version used as part of output generation
         ''',
@@ -462,7 +462,7 @@
     // The following storage is also huge, should consider switching to RAMs after examining
     // the security implications
 
-    { name: "MAX_CREATOR_KEY_VER_EN",
+    { name: "MAX_CREATOR_KEY_VER_REGWEN",
       desc: "Register write enable for MAX_CREATOR_KEY_VERSION",
       swaccess: "rw0c",
       hwaccess: "none",
@@ -482,7 +482,7 @@
       desc: "Max creator key version",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen: "MAX_CREATOR_KEY_VER_EN",
+      regwen: "MAX_CREATOR_KEY_VER_REGWEN",
       fields: [
         { bits: "31:0",
           name: "VAL",
@@ -496,7 +496,7 @@
       ]
     },
 
-    { name: "MAX_OWNER_INT_KEY_VER_EN",
+    { name: "MAX_OWNER_INT_KEY_VER_REGWEN",
       desc: "Register write enable for MAX_OWNER_INT_KEY_VERSION",
       swaccess: "rw0c",
       hwaccess: "none",
@@ -516,7 +516,7 @@
       desc: "Max owner intermediate key version",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen: "MAX_OWNER_INT_KEY_VER_EN",
+      regwen: "MAX_OWNER_INT_KEY_VER_REGWEN",
       fields: [
         { bits: "31:0",
           name: "VAL",
@@ -530,7 +530,7 @@
       ]
     },
 
-    { name: "MAX_OWNER_KEY_VER_EN",
+    { name: "MAX_OWNER_KEY_VER_REGWEN",
       desc: "Register write enable for MAX_OWNER_KEY_VERSION",
       swaccess: "rw0c",
       hwaccess: "none",
@@ -550,7 +550,7 @@
       desc: "Max owner key version",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen: "MAX_OWNER_KEY_VER_EN",
+      regwen: "MAX_OWNER_KEY_VER_REGWEN",
       fields: [
         { bits: "31:0",
           name: "VAL",

--- a/hw/ip/keymgr/dv/env/keymgr_env.core
+++ b/hw/ip/keymgr/dv/env/keymgr_env.core
@@ -24,7 +24,7 @@ filesets:
       - seq_lib/keymgr_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_sideload_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_random_vseq.sv: {is_include_file: true}
-      - seq_lib/keymgr_cfgen_vseq.sv: {is_include_file: true}
+      - seq_lib/keymgr_cfg_regwen_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_direct_to_disabled_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_lc_disable_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_sw_invalid_input_vseq.sv: {is_include_file: true}

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_random_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_random_vseq.sv
@@ -17,7 +17,7 @@ class keymgr_random_vseq extends keymgr_sideload_vseq;
   task write_random_sw_content();
     uvm_reg         csr_update_q[$];
 
-    csr_random_n_add_to_q(ral.sw_binding_en, csr_update_q);
+    csr_random_n_add_to_q(ral.sw_binding_regwen, csr_update_q);
     csr_random_n_add_to_q(ral.sw_binding_0, csr_update_q);
     csr_random_n_add_to_q(ral.sw_binding_1, csr_update_q);
     csr_random_n_add_to_q(ral.sw_binding_2, csr_update_q);
@@ -31,9 +31,9 @@ class keymgr_random_vseq extends keymgr_sideload_vseq;
     csr_random_n_add_to_q(ral.max_owner_int_key_ver, csr_update_q);
     csr_random_n_add_to_q(ral.max_owner_key_ver, csr_update_q);
 
-    csr_random_n_add_to_q(ral.max_creator_key_ver_en, csr_update_q);
-    csr_random_n_add_to_q(ral.max_owner_int_key_ver_en, csr_update_q);
-    csr_random_n_add_to_q(ral.max_owner_key_ver_en, csr_update_q);
+    csr_random_n_add_to_q(ral.max_creator_key_ver_regwen, csr_update_q);
+    csr_random_n_add_to_q(ral.max_owner_int_key_ver_regwen, csr_update_q);
+    csr_random_n_add_to_q(ral.max_owner_key_ver_regwen, csr_update_q);
     csr_random_n_add_to_q(ral.key_version, csr_update_q);
 
     csr_update_q.shuffle();

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_stress_all_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_stress_all_vseq.sv
@@ -4,7 +4,7 @@
 
 // combine all keymgr seqs (except below seqs) in one seq to run sequentially
 // 1. csr seq, which requires scb to be disabled
-// 2. keymgr_cfgen_vseq as it's very timing sensitive
+// 2. keymgr_cfg_regwen_vseq as it's very timing sensitive
 class keymgr_stress_all_vseq extends keymgr_base_vseq;
   `uvm_object_utils(keymgr_stress_all_vseq)
 

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_vseq_list.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_vseq_list.sv
@@ -7,7 +7,7 @@
 `include "keymgr_common_vseq.sv"
 `include "keymgr_sideload_vseq.sv"
 `include "keymgr_random_vseq.sv"
-`include "keymgr_cfgen_vseq.sv"
+`include "keymgr_cfg_regwen_vseq.sv"
 `include "keymgr_direct_to_disabled_vseq.sv"
 `include "keymgr_lc_disable_vseq.sv"
 `include "keymgr_sw_invalid_input_vseq.sv"

--- a/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
+++ b/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
@@ -64,9 +64,9 @@
     }
 
     {
-      name: keymgr_cfgen
-      uvm_test_seq: keymgr_cfgen_vseq
-      // This test is to check reg programming is gated when cfgen=0, it's timing sensitive
+      name: keymgr_cfg_regwen
+      uvm_test_seq: keymgr_cfg_regwen_vseq
+      // This test is to check reg programming is gated when cfg_regwen=0, it's timing sensitive
       run_opts: ["+zero_delays=1"]
     }
 

--- a/hw/ip/keymgr/rtl/keymgr.sv
+++ b/hw/ip/keymgr/rtl/keymgr.sv
@@ -238,36 +238,36 @@ module keymgr import keymgr_pkg::*; #(
     .en_i(lc_keymgr_en[KeyMgrEnCfgEn] == lc_ctrl_pkg::On),
     .set_i(reg2hw.control.start.q & op_done),
     .clr_i(reg2hw.control.start.q),
-    .out_o(hw2reg.cfgen.d)
+    .out_o(hw2reg.cfg_regwen.d)
   );
 
 
   logic sw_binding_set;
   logic sw_binding_clr;
-  logic sw_binding_en;
+  logic sw_binding_regwen;
 
   // set on a successful advance
   assign sw_binding_set = reg2hw.control.operation.q == OpAdvance &
                           sw_binding_unlock;
 
   // this is w0c
-  assign sw_binding_clr = reg2hw.sw_binding_en.qe & ~reg2hw.sw_binding_en.q;
+  assign sw_binding_clr = reg2hw.sw_binding_regwen.qe & ~reg2hw.sw_binding_regwen.q;
 
   // software clears the enable
   // hardware restores it upon successful advance
   keymgr_cfg_en #(
     .NonInitClr(1'b0)  // clear has no effect until init
-  ) u_sw_binding_en (
+  ) u_sw_binding_regwen (
     .clk_i,
     .rst_ni,
     .init_i(init),
     .en_i(lc_keymgr_en[KeyMgrEnSwBindingEn] == lc_ctrl_pkg::On),
     .set_i(sw_binding_set),
     .clr_i(sw_binding_clr),
-    .out_o(sw_binding_en)
+    .out_o(sw_binding_regwen)
   );
 
-  assign hw2reg.sw_binding_en.d = sw_binding_en & hw2reg.cfgen.d;
+  assign hw2reg.sw_binding_regwen.d = sw_binding_regwen & hw2reg.cfg_regwen.d;
 
   /////////////////////////////////////
   //  Key Manager Input Construction

--- a/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
@@ -65,7 +65,7 @@ package keymgr_reg_pkg;
   typedef struct packed {
     logic        q;
     logic        qe;
-  } keymgr_reg2hw_sw_binding_en_reg_t;
+  } keymgr_reg2hw_sw_binding_regwen_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
@@ -114,7 +114,7 @@ package keymgr_reg_pkg;
 
   typedef struct packed {
     logic        d;
-  } keymgr_hw2reg_cfgen_reg_t;
+  } keymgr_hw2reg_cfg_regwen_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -125,7 +125,7 @@ package keymgr_reg_pkg;
 
   typedef struct packed {
     logic        d;
-  } keymgr_hw2reg_sw_binding_en_reg_t;
+  } keymgr_hw2reg_sw_binding_regwen_reg_t;
 
   typedef struct packed {
     logic [31:0] d;
@@ -178,7 +178,7 @@ package keymgr_reg_pkg;
     keymgr_reg2hw_control_reg_t control; // [412:407]
     keymgr_reg2hw_sideload_clear_reg_t sideload_clear; // [406:406]
     keymgr_reg2hw_reseed_interval_reg_t reseed_interval; // [405:390]
-    keymgr_reg2hw_sw_binding_en_reg_t sw_binding_en; // [389:388]
+    keymgr_reg2hw_sw_binding_regwen_reg_t sw_binding_regwen; // [389:388]
     keymgr_reg2hw_sw_binding_mreg_t [3:0] sw_binding; // [387:260]
     keymgr_reg2hw_salt_mreg_t [3:0] salt; // [259:132]
     keymgr_reg2hw_key_version_mreg_t [0:0] key_version; // [131:100]
@@ -193,9 +193,9 @@ package keymgr_reg_pkg;
   ///////////////////////////////////////
   typedef struct packed {
     keymgr_hw2reg_intr_state_reg_t intr_state; // [548:547]
-    keymgr_hw2reg_cfgen_reg_t cfgen; // [546:546]
+    keymgr_hw2reg_cfg_regwen_reg_t cfg_regwen; // [546:546]
     keymgr_hw2reg_control_reg_t control; // [545:544]
-    keymgr_hw2reg_sw_binding_en_reg_t sw_binding_en; // [543:543]
+    keymgr_hw2reg_sw_binding_regwen_reg_t sw_binding_regwen; // [543:543]
     keymgr_hw2reg_sw_share0_output_mreg_t [7:0] sw_share0_output; // [542:279]
     keymgr_hw2reg_sw_share1_output_mreg_t [7:0] sw_share1_output; // [278:15]
     keymgr_hw2reg_working_state_reg_t working_state; // [14:11]
@@ -208,11 +208,11 @@ package keymgr_reg_pkg;
   parameter logic [BlockAw-1:0] KEYMGR_INTR_ENABLE_OFFSET = 8'h 4;
   parameter logic [BlockAw-1:0] KEYMGR_INTR_TEST_OFFSET = 8'h 8;
   parameter logic [BlockAw-1:0] KEYMGR_ALERT_TEST_OFFSET = 8'h c;
-  parameter logic [BlockAw-1:0] KEYMGR_CFGEN_OFFSET = 8'h 10;
+  parameter logic [BlockAw-1:0] KEYMGR_CFG_REGWEN_OFFSET = 8'h 10;
   parameter logic [BlockAw-1:0] KEYMGR_CONTROL_OFFSET = 8'h 14;
   parameter logic [BlockAw-1:0] KEYMGR_SIDELOAD_CLEAR_OFFSET = 8'h 18;
   parameter logic [BlockAw-1:0] KEYMGR_RESEED_INTERVAL_OFFSET = 8'h 1c;
-  parameter logic [BlockAw-1:0] KEYMGR_SW_BINDING_EN_OFFSET = 8'h 20;
+  parameter logic [BlockAw-1:0] KEYMGR_SW_BINDING_REGWEN_OFFSET = 8'h 20;
   parameter logic [BlockAw-1:0] KEYMGR_SW_BINDING_0_OFFSET = 8'h 24;
   parameter logic [BlockAw-1:0] KEYMGR_SW_BINDING_1_OFFSET = 8'h 28;
   parameter logic [BlockAw-1:0] KEYMGR_SW_BINDING_2_OFFSET = 8'h 2c;
@@ -222,11 +222,11 @@ package keymgr_reg_pkg;
   parameter logic [BlockAw-1:0] KEYMGR_SALT_2_OFFSET = 8'h 3c;
   parameter logic [BlockAw-1:0] KEYMGR_SALT_3_OFFSET = 8'h 40;
   parameter logic [BlockAw-1:0] KEYMGR_KEY_VERSION_OFFSET = 8'h 44;
-  parameter logic [BlockAw-1:0] KEYMGR_MAX_CREATOR_KEY_VER_EN_OFFSET = 8'h 48;
+  parameter logic [BlockAw-1:0] KEYMGR_MAX_CREATOR_KEY_VER_REGWEN_OFFSET = 8'h 48;
   parameter logic [BlockAw-1:0] KEYMGR_MAX_CREATOR_KEY_VER_OFFSET = 8'h 4c;
-  parameter logic [BlockAw-1:0] KEYMGR_MAX_OWNER_INT_KEY_VER_EN_OFFSET = 8'h 50;
+  parameter logic [BlockAw-1:0] KEYMGR_MAX_OWNER_INT_KEY_VER_REGWEN_OFFSET = 8'h 50;
   parameter logic [BlockAw-1:0] KEYMGR_MAX_OWNER_INT_KEY_VER_OFFSET = 8'h 54;
-  parameter logic [BlockAw-1:0] KEYMGR_MAX_OWNER_KEY_VER_EN_OFFSET = 8'h 58;
+  parameter logic [BlockAw-1:0] KEYMGR_MAX_OWNER_KEY_VER_REGWEN_OFFSET = 8'h 58;
   parameter logic [BlockAw-1:0] KEYMGR_MAX_OWNER_KEY_VER_OFFSET = 8'h 5c;
   parameter logic [BlockAw-1:0] KEYMGR_SW_SHARE0_OUTPUT_0_OFFSET = 8'h 60;
   parameter logic [BlockAw-1:0] KEYMGR_SW_SHARE0_OUTPUT_1_OFFSET = 8'h 64;
@@ -255,11 +255,11 @@ package keymgr_reg_pkg;
     KEYMGR_INTR_ENABLE,
     KEYMGR_INTR_TEST,
     KEYMGR_ALERT_TEST,
-    KEYMGR_CFGEN,
+    KEYMGR_CFG_REGWEN,
     KEYMGR_CONTROL,
     KEYMGR_SIDELOAD_CLEAR,
     KEYMGR_RESEED_INTERVAL,
-    KEYMGR_SW_BINDING_EN,
+    KEYMGR_SW_BINDING_REGWEN,
     KEYMGR_SW_BINDING_0,
     KEYMGR_SW_BINDING_1,
     KEYMGR_SW_BINDING_2,
@@ -269,11 +269,11 @@ package keymgr_reg_pkg;
     KEYMGR_SALT_2,
     KEYMGR_SALT_3,
     KEYMGR_KEY_VERSION,
-    KEYMGR_MAX_CREATOR_KEY_VER_EN,
+    KEYMGR_MAX_CREATOR_KEY_VER_REGWEN,
     KEYMGR_MAX_CREATOR_KEY_VER,
-    KEYMGR_MAX_OWNER_INT_KEY_VER_EN,
+    KEYMGR_MAX_OWNER_INT_KEY_VER_REGWEN,
     KEYMGR_MAX_OWNER_INT_KEY_VER,
-    KEYMGR_MAX_OWNER_KEY_VER_EN,
+    KEYMGR_MAX_OWNER_KEY_VER_REGWEN,
     KEYMGR_MAX_OWNER_KEY_VER,
     KEYMGR_SW_SHARE0_OUTPUT_0,
     KEYMGR_SW_SHARE0_OUTPUT_1,
@@ -302,11 +302,11 @@ package keymgr_reg_pkg;
     4'b 0001, // index[ 1] KEYMGR_INTR_ENABLE
     4'b 0001, // index[ 2] KEYMGR_INTR_TEST
     4'b 0001, // index[ 3] KEYMGR_ALERT_TEST
-    4'b 0001, // index[ 4] KEYMGR_CFGEN
+    4'b 0001, // index[ 4] KEYMGR_CFG_REGWEN
     4'b 0011, // index[ 5] KEYMGR_CONTROL
     4'b 0001, // index[ 6] KEYMGR_SIDELOAD_CLEAR
     4'b 0011, // index[ 7] KEYMGR_RESEED_INTERVAL
-    4'b 0001, // index[ 8] KEYMGR_SW_BINDING_EN
+    4'b 0001, // index[ 8] KEYMGR_SW_BINDING_REGWEN
     4'b 1111, // index[ 9] KEYMGR_SW_BINDING_0
     4'b 1111, // index[10] KEYMGR_SW_BINDING_1
     4'b 1111, // index[11] KEYMGR_SW_BINDING_2
@@ -316,11 +316,11 @@ package keymgr_reg_pkg;
     4'b 1111, // index[15] KEYMGR_SALT_2
     4'b 1111, // index[16] KEYMGR_SALT_3
     4'b 1111, // index[17] KEYMGR_KEY_VERSION
-    4'b 0001, // index[18] KEYMGR_MAX_CREATOR_KEY_VER_EN
+    4'b 0001, // index[18] KEYMGR_MAX_CREATOR_KEY_VER_REGWEN
     4'b 1111, // index[19] KEYMGR_MAX_CREATOR_KEY_VER
-    4'b 0001, // index[20] KEYMGR_MAX_OWNER_INT_KEY_VER_EN
+    4'b 0001, // index[20] KEYMGR_MAX_OWNER_INT_KEY_VER_REGWEN
     4'b 1111, // index[21] KEYMGR_MAX_OWNER_INT_KEY_VER
-    4'b 0001, // index[22] KEYMGR_MAX_OWNER_KEY_VER_EN
+    4'b 0001, // index[22] KEYMGR_MAX_OWNER_KEY_VER_REGWEN
     4'b 1111, // index[23] KEYMGR_MAX_OWNER_KEY_VER
     4'b 1111, // index[24] KEYMGR_SW_SHARE0_OUTPUT_0
     4'b 1111, // index[25] KEYMGR_SW_SHARE0_OUTPUT_1

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -83,8 +83,8 @@ module keymgr_reg_top (
   logic alert_test_fatal_fault_err_we;
   logic alert_test_recov_operation_err_wd;
   logic alert_test_recov_operation_err_we;
-  logic cfgen_qs;
-  logic cfgen_re;
+  logic cfg_regwen_qs;
+  logic cfg_regwen_re;
   logic control_start_qs;
   logic control_start_wd;
   logic control_start_we;
@@ -100,10 +100,10 @@ module keymgr_reg_top (
   logic [15:0] reseed_interval_qs;
   logic [15:0] reseed_interval_wd;
   logic reseed_interval_we;
-  logic sw_binding_en_qs;
-  logic sw_binding_en_wd;
-  logic sw_binding_en_we;
-  logic sw_binding_en_re;
+  logic sw_binding_regwen_qs;
+  logic sw_binding_regwen_wd;
+  logic sw_binding_regwen_we;
+  logic sw_binding_regwen_re;
   logic [31:0] sw_binding_0_qs;
   logic [31:0] sw_binding_0_wd;
   logic sw_binding_0_we;
@@ -131,21 +131,21 @@ module keymgr_reg_top (
   logic [31:0] key_version_qs;
   logic [31:0] key_version_wd;
   logic key_version_we;
-  logic max_creator_key_ver_en_qs;
-  logic max_creator_key_ver_en_wd;
-  logic max_creator_key_ver_en_we;
+  logic max_creator_key_ver_regwen_qs;
+  logic max_creator_key_ver_regwen_wd;
+  logic max_creator_key_ver_regwen_we;
   logic [31:0] max_creator_key_ver_qs;
   logic [31:0] max_creator_key_ver_wd;
   logic max_creator_key_ver_we;
-  logic max_owner_int_key_ver_en_qs;
-  logic max_owner_int_key_ver_en_wd;
-  logic max_owner_int_key_ver_en_we;
+  logic max_owner_int_key_ver_regwen_qs;
+  logic max_owner_int_key_ver_regwen_wd;
+  logic max_owner_int_key_ver_regwen_we;
   logic [31:0] max_owner_int_key_ver_qs;
   logic [31:0] max_owner_int_key_ver_wd;
   logic max_owner_int_key_ver_we;
-  logic max_owner_key_ver_en_qs;
-  logic max_owner_key_ver_en_wd;
-  logic max_owner_key_ver_en_we;
+  logic max_owner_key_ver_regwen_qs;
+  logic max_owner_key_ver_regwen_wd;
+  logic max_owner_key_ver_regwen_we;
   logic [31:0] max_owner_key_ver_qs;
   logic [31:0] max_owner_key_ver_wd;
   logic max_owner_key_ver_we;
@@ -317,19 +317,19 @@ module keymgr_reg_top (
   );
 
 
-  // R[cfgen]: V(True)
+  // R[cfg_regwen]: V(True)
 
   prim_subreg_ext #(
     .DW    (1)
-  ) u_cfgen (
-    .re     (cfgen_re),
+  ) u_cfg_regwen (
+    .re     (cfg_regwen_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.cfgen.d),
+    .d      (hw2reg.cfg_regwen.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (cfgen_qs)
+    .qs     (cfg_regwen_qs)
   );
 
 
@@ -345,7 +345,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (control_start_we & cfgen_qs),
+    .we     (control_start_we & cfg_regwen_qs),
     .wd     (control_start_wd),
 
     // from internal hardware
@@ -371,7 +371,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (control_operation_we & cfgen_qs),
+    .we     (control_operation_we & cfg_regwen_qs),
     .wd     (control_operation_wd),
 
     // from internal hardware
@@ -397,7 +397,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (control_dest_sel_we & cfgen_qs),
+    .we     (control_dest_sel_we & cfg_regwen_qs),
     .wd     (control_dest_sel_wd),
 
     // from internal hardware
@@ -467,19 +467,19 @@ module keymgr_reg_top (
   );
 
 
-  // R[sw_binding_en]: V(True)
+  // R[sw_binding_regwen]: V(True)
 
   prim_subreg_ext #(
     .DW    (1)
-  ) u_sw_binding_en (
-    .re     (sw_binding_en_re),
-    .we     (sw_binding_en_we),
-    .wd     (sw_binding_en_wd),
-    .d      (hw2reg.sw_binding_en.d),
+  ) u_sw_binding_regwen (
+    .re     (sw_binding_regwen_re),
+    .we     (sw_binding_regwen_we),
+    .wd     (sw_binding_regwen_wd),
+    .d      (hw2reg.sw_binding_regwen.d),
     .qre    (),
-    .qe     (reg2hw.sw_binding_en.qe),
-    .q      (reg2hw.sw_binding_en.q ),
-    .qs     (sw_binding_en_qs)
+    .qe     (reg2hw.sw_binding_regwen.qe),
+    .q      (reg2hw.sw_binding_regwen.q ),
+    .qs     (sw_binding_regwen_qs)
   );
 
 
@@ -496,7 +496,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (sw_binding_0_we & sw_binding_en_qs),
+    .we     (sw_binding_0_we & sw_binding_regwen_qs),
     .wd     (sw_binding_0_wd),
 
     // from internal hardware
@@ -523,7 +523,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (sw_binding_1_we & sw_binding_en_qs),
+    .we     (sw_binding_1_we & sw_binding_regwen_qs),
     .wd     (sw_binding_1_wd),
 
     // from internal hardware
@@ -550,7 +550,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (sw_binding_2_we & sw_binding_en_qs),
+    .we     (sw_binding_2_we & sw_binding_regwen_qs),
     .wd     (sw_binding_2_wd),
 
     // from internal hardware
@@ -577,7 +577,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (sw_binding_3_we & sw_binding_en_qs),
+    .we     (sw_binding_3_we & sw_binding_regwen_qs),
     .wd     (sw_binding_3_wd),
 
     // from internal hardware
@@ -606,7 +606,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (salt_0_we & cfgen_qs),
+    .we     (salt_0_we & cfg_regwen_qs),
     .wd     (salt_0_wd),
 
     // from internal hardware
@@ -633,7 +633,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (salt_1_we & cfgen_qs),
+    .we     (salt_1_we & cfg_regwen_qs),
     .wd     (salt_1_wd),
 
     // from internal hardware
@@ -660,7 +660,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (salt_2_we & cfgen_qs),
+    .we     (salt_2_we & cfg_regwen_qs),
     .wd     (salt_2_wd),
 
     // from internal hardware
@@ -687,7 +687,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (salt_3_we & cfgen_qs),
+    .we     (salt_3_we & cfg_regwen_qs),
     .wd     (salt_3_wd),
 
     // from internal hardware
@@ -716,7 +716,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (key_version_we & cfgen_qs),
+    .we     (key_version_we & cfg_regwen_qs),
     .wd     (key_version_wd),
 
     // from internal hardware
@@ -732,19 +732,19 @@ module keymgr_reg_top (
   );
 
 
-  // R[max_creator_key_ver_en]: V(False)
+  // R[max_creator_key_ver_regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_max_creator_key_ver_en (
+  ) u_max_creator_key_ver_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (max_creator_key_ver_en_we),
-    .wd     (max_creator_key_ver_en_wd),
+    .we     (max_creator_key_ver_regwen_we),
+    .wd     (max_creator_key_ver_regwen_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -755,7 +755,7 @@ module keymgr_reg_top (
     .q      (),
 
     // to register interface (read)
-    .qs     (max_creator_key_ver_en_qs)
+    .qs     (max_creator_key_ver_regwen_qs)
   );
 
 
@@ -770,7 +770,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (max_creator_key_ver_we & max_creator_key_ver_en_qs),
+    .we     (max_creator_key_ver_we & max_creator_key_ver_regwen_qs),
     .wd     (max_creator_key_ver_wd),
 
     // from internal hardware
@@ -786,19 +786,19 @@ module keymgr_reg_top (
   );
 
 
-  // R[max_owner_int_key_ver_en]: V(False)
+  // R[max_owner_int_key_ver_regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_max_owner_int_key_ver_en (
+  ) u_max_owner_int_key_ver_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (max_owner_int_key_ver_en_we),
-    .wd     (max_owner_int_key_ver_en_wd),
+    .we     (max_owner_int_key_ver_regwen_we),
+    .wd     (max_owner_int_key_ver_regwen_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -809,7 +809,7 @@ module keymgr_reg_top (
     .q      (),
 
     // to register interface (read)
-    .qs     (max_owner_int_key_ver_en_qs)
+    .qs     (max_owner_int_key_ver_regwen_qs)
   );
 
 
@@ -824,7 +824,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (max_owner_int_key_ver_we & max_owner_int_key_ver_en_qs),
+    .we     (max_owner_int_key_ver_we & max_owner_int_key_ver_regwen_qs),
     .wd     (max_owner_int_key_ver_wd),
 
     // from internal hardware
@@ -840,19 +840,19 @@ module keymgr_reg_top (
   );
 
 
-  // R[max_owner_key_ver_en]: V(False)
+  // R[max_owner_key_ver_regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_max_owner_key_ver_en (
+  ) u_max_owner_key_ver_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (max_owner_key_ver_en_we),
-    .wd     (max_owner_key_ver_en_wd),
+    .we     (max_owner_key_ver_regwen_we),
+    .wd     (max_owner_key_ver_regwen_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -863,7 +863,7 @@ module keymgr_reg_top (
     .q      (),
 
     // to register interface (read)
-    .qs     (max_owner_key_ver_en_qs)
+    .qs     (max_owner_key_ver_regwen_qs)
   );
 
 
@@ -878,7 +878,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (max_owner_key_ver_we & max_owner_key_ver_en_qs),
+    .we     (max_owner_key_ver_we & max_owner_key_ver_regwen_qs),
     .wd     (max_owner_key_ver_wd),
 
     // from internal hardware
@@ -1498,11 +1498,11 @@ module keymgr_reg_top (
     addr_hit[ 1] = (reg_addr == KEYMGR_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == KEYMGR_INTR_TEST_OFFSET);
     addr_hit[ 3] = (reg_addr == KEYMGR_ALERT_TEST_OFFSET);
-    addr_hit[ 4] = (reg_addr == KEYMGR_CFGEN_OFFSET);
+    addr_hit[ 4] = (reg_addr == KEYMGR_CFG_REGWEN_OFFSET);
     addr_hit[ 5] = (reg_addr == KEYMGR_CONTROL_OFFSET);
     addr_hit[ 6] = (reg_addr == KEYMGR_SIDELOAD_CLEAR_OFFSET);
     addr_hit[ 7] = (reg_addr == KEYMGR_RESEED_INTERVAL_OFFSET);
-    addr_hit[ 8] = (reg_addr == KEYMGR_SW_BINDING_EN_OFFSET);
+    addr_hit[ 8] = (reg_addr == KEYMGR_SW_BINDING_REGWEN_OFFSET);
     addr_hit[ 9] = (reg_addr == KEYMGR_SW_BINDING_0_OFFSET);
     addr_hit[10] = (reg_addr == KEYMGR_SW_BINDING_1_OFFSET);
     addr_hit[11] = (reg_addr == KEYMGR_SW_BINDING_2_OFFSET);
@@ -1512,11 +1512,11 @@ module keymgr_reg_top (
     addr_hit[15] = (reg_addr == KEYMGR_SALT_2_OFFSET);
     addr_hit[16] = (reg_addr == KEYMGR_SALT_3_OFFSET);
     addr_hit[17] = (reg_addr == KEYMGR_KEY_VERSION_OFFSET);
-    addr_hit[18] = (reg_addr == KEYMGR_MAX_CREATOR_KEY_VER_EN_OFFSET);
+    addr_hit[18] = (reg_addr == KEYMGR_MAX_CREATOR_KEY_VER_REGWEN_OFFSET);
     addr_hit[19] = (reg_addr == KEYMGR_MAX_CREATOR_KEY_VER_OFFSET);
-    addr_hit[20] = (reg_addr == KEYMGR_MAX_OWNER_INT_KEY_VER_EN_OFFSET);
+    addr_hit[20] = (reg_addr == KEYMGR_MAX_OWNER_INT_KEY_VER_REGWEN_OFFSET);
     addr_hit[21] = (reg_addr == KEYMGR_MAX_OWNER_INT_KEY_VER_OFFSET);
-    addr_hit[22] = (reg_addr == KEYMGR_MAX_OWNER_KEY_VER_EN_OFFSET);
+    addr_hit[22] = (reg_addr == KEYMGR_MAX_OWNER_KEY_VER_REGWEN_OFFSET);
     addr_hit[23] = (reg_addr == KEYMGR_MAX_OWNER_KEY_VER_OFFSET);
     addr_hit[24] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_0_OFFSET);
     addr_hit[25] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_1_OFFSET);
@@ -1604,7 +1604,7 @@ module keymgr_reg_top (
   assign alert_test_recov_operation_err_we = addr_hit[3] & reg_we & ~wr_err;
   assign alert_test_recov_operation_err_wd = reg_wdata[1];
 
-  assign cfgen_re = addr_hit[4] && reg_re;
+  assign cfg_regwen_re = addr_hit[4] && reg_re;
 
   assign control_start_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_start_wd = reg_wdata[0];
@@ -1621,9 +1621,9 @@ module keymgr_reg_top (
   assign reseed_interval_we = addr_hit[7] & reg_we & ~wr_err;
   assign reseed_interval_wd = reg_wdata[15:0];
 
-  assign sw_binding_en_we = addr_hit[8] & reg_we & ~wr_err;
-  assign sw_binding_en_wd = reg_wdata[0];
-  assign sw_binding_en_re = addr_hit[8] && reg_re;
+  assign sw_binding_regwen_we = addr_hit[8] & reg_we & ~wr_err;
+  assign sw_binding_regwen_wd = reg_wdata[0];
+  assign sw_binding_regwen_re = addr_hit[8] && reg_re;
 
   assign sw_binding_0_we = addr_hit[9] & reg_we & ~wr_err;
   assign sw_binding_0_wd = reg_wdata[31:0];
@@ -1652,20 +1652,20 @@ module keymgr_reg_top (
   assign key_version_we = addr_hit[17] & reg_we & ~wr_err;
   assign key_version_wd = reg_wdata[31:0];
 
-  assign max_creator_key_ver_en_we = addr_hit[18] & reg_we & ~wr_err;
-  assign max_creator_key_ver_en_wd = reg_wdata[0];
+  assign max_creator_key_ver_regwen_we = addr_hit[18] & reg_we & ~wr_err;
+  assign max_creator_key_ver_regwen_wd = reg_wdata[0];
 
   assign max_creator_key_ver_we = addr_hit[19] & reg_we & ~wr_err;
   assign max_creator_key_ver_wd = reg_wdata[31:0];
 
-  assign max_owner_int_key_ver_en_we = addr_hit[20] & reg_we & ~wr_err;
-  assign max_owner_int_key_ver_en_wd = reg_wdata[0];
+  assign max_owner_int_key_ver_regwen_we = addr_hit[20] & reg_we & ~wr_err;
+  assign max_owner_int_key_ver_regwen_wd = reg_wdata[0];
 
   assign max_owner_int_key_ver_we = addr_hit[21] & reg_we & ~wr_err;
   assign max_owner_int_key_ver_wd = reg_wdata[31:0];
 
-  assign max_owner_key_ver_en_we = addr_hit[22] & reg_we & ~wr_err;
-  assign max_owner_key_ver_en_wd = reg_wdata[0];
+  assign max_owner_key_ver_regwen_we = addr_hit[22] & reg_we & ~wr_err;
+  assign max_owner_key_ver_regwen_wd = reg_wdata[0];
 
   assign max_owner_key_ver_we = addr_hit[23] & reg_we & ~wr_err;
   assign max_owner_key_ver_wd = reg_wdata[31:0];
@@ -1756,7 +1756,7 @@ module keymgr_reg_top (
       end
 
       addr_hit[4]: begin
-        reg_rdata_next[0] = cfgen_qs;
+        reg_rdata_next[0] = cfg_regwen_qs;
       end
 
       addr_hit[5]: begin
@@ -1774,7 +1774,7 @@ module keymgr_reg_top (
       end
 
       addr_hit[8]: begin
-        reg_rdata_next[0] = sw_binding_en_qs;
+        reg_rdata_next[0] = sw_binding_regwen_qs;
       end
 
       addr_hit[9]: begin
@@ -1814,7 +1814,7 @@ module keymgr_reg_top (
       end
 
       addr_hit[18]: begin
-        reg_rdata_next[0] = max_creator_key_ver_en_qs;
+        reg_rdata_next[0] = max_creator_key_ver_regwen_qs;
       end
 
       addr_hit[19]: begin
@@ -1822,7 +1822,7 @@ module keymgr_reg_top (
       end
 
       addr_hit[20]: begin
-        reg_rdata_next[0] = max_owner_int_key_ver_en_qs;
+        reg_rdata_next[0] = max_owner_int_key_ver_regwen_qs;
       end
 
       addr_hit[21]: begin
@@ -1830,7 +1830,7 @@ module keymgr_reg_top (
       end
 
       addr_hit[22]: begin
-        reg_rdata_next[0] = max_owner_key_ver_en_qs;
+        reg_rdata_next[0] = max_owner_key_ver_regwen_qs;
       end
 
       addr_hit[23]: begin

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -897,7 +897,7 @@
       desc: '''
             Register write enable for !!CHECK_TRIGGER.
             ''',
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "none",
       fields: [
         { bits:   "0",
@@ -939,7 +939,7 @@
       desc: '''
             Register write enable for !!INTEGRITY_CHECK_PERIOD and !!CONSISTENCY_CHECK_PERIOD.
             ''',
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "none",
       fields: [
         { bits:   "0",

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -586,7 +586,7 @@
       desc: '''
             Register write enable for !!CHECK_TRIGGER.
             ''',
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "none",
       fields: [
         { bits:   "0",
@@ -628,7 +628,7 @@
       desc: '''
             Register write enable for !!INTEGRITY_CHECK_PERIOD and !!CONSISTENCY_CHECK_PERIOD.
             ''',
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "none",
       fields: [
         { bits:   "0",

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
@@ -987,7 +987,7 @@ module otp_ctrl_reg_top (
 
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("W0C"),
     .RESVAL  (1'h1)
   ) u_check_trigger_regwen (
     .clk_i   (clk_i    ),
@@ -1048,7 +1048,7 @@ module otp_ctrl_reg_top (
 
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("W0C"),
     .RESVAL  (1'h1)
   ) u_check_regwen (
     .clk_i   (clk_i    ),

--- a/hw/ip/padctrl/data/padctrl.hjson
+++ b/hw/ip/padctrl/data/padctrl.hjson
@@ -34,7 +34,7 @@
     },
   ],
   registers: [
-    { name: "REGEN",
+    { name: "REGWEN",
       desc: '''
             Register write enable for all control registers.
             ''',
@@ -61,7 +61,7 @@
                   hwaccess: "hrw",
                   hwext:    "true",
                   hwqe:     "true",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "ATTR",
                   fields: [
                     { bits: "9:0",
@@ -96,7 +96,7 @@
                   hwaccess: "hrw",
                   hwext:    "true",
                   hwqe:     "true",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "ATTR",
                   fields: [
                     { bits: "9:0",

--- a/hw/ip/padctrl/data/padctrl.hjson.tpl
+++ b/hw/ip/padctrl/data/padctrl.hjson.tpl
@@ -34,7 +34,7 @@
     },
   ],
   registers: [
-    { name: "REGEN",
+    { name: "REGWEN",
       desc: '''
             Register write enable for all control registers.
             ''',
@@ -61,7 +61,7 @@
                   hwaccess: "hrw",
                   hwext:    "true",
                   hwqe:     "true",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "ATTR",
                   fields: [
                     { bits: "9:0",
@@ -96,7 +96,7 @@
                   hwaccess: "hrw",
                   hwext:    "true",
                   hwqe:     "true",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "ATTR",
                   fields: [
                     { bits: "9:0",

--- a/hw/ip/padctrl/rtl/padctrl_reg_pkg.sv
+++ b/hw/ip/padctrl/rtl/padctrl_reg_pkg.sv
@@ -54,7 +54,7 @@ package padctrl_reg_pkg;
   } padctrl_hw2reg_t;
 
   // Register Address
-  parameter logic [BlockAw-1:0] PADCTRL_REGEN_OFFSET = 6'h 0;
+  parameter logic [BlockAw-1:0] PADCTRL_REGWEN_OFFSET = 6'h 0;
   parameter logic [BlockAw-1:0] PADCTRL_DIO_PADS_0_OFFSET = 6'h 4;
   parameter logic [BlockAw-1:0] PADCTRL_DIO_PADS_1_OFFSET = 6'h 8;
   parameter logic [BlockAw-1:0] PADCTRL_MIO_PADS_0_OFFSET = 6'h c;
@@ -67,7 +67,7 @@ package padctrl_reg_pkg;
 
   // Register Index
   typedef enum int {
-    PADCTRL_REGEN,
+    PADCTRL_REGWEN,
     PADCTRL_DIO_PADS_0,
     PADCTRL_DIO_PADS_1,
     PADCTRL_MIO_PADS_0,
@@ -80,7 +80,7 @@ package padctrl_reg_pkg;
 
   // Register width information to check illegal writes
   parameter logic [3:0] PADCTRL_PERMIT [9] = '{
-    4'b 0001, // index[0] PADCTRL_REGEN
+    4'b 0001, // index[0] PADCTRL_REGWEN
     4'b 1111, // index[1] PADCTRL_DIO_PADS_0
     4'b 0011, // index[2] PADCTRL_DIO_PADS_1
     4'b 1111, // index[3] PADCTRL_MIO_PADS_0

--- a/hw/ip/padctrl/rtl/padctrl_reg_top.sv
+++ b/hw/ip/padctrl/rtl/padctrl_reg_top.sv
@@ -71,9 +71,9 @@ module padctrl_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
-  logic regen_qs;
-  logic regen_wd;
-  logic regen_we;
+  logic regwen_qs;
+  logic regwen_wd;
+  logic regwen_we;
   logic [9:0] dio_pads_0_attr_0_qs;
   logic [9:0] dio_pads_0_attr_0_wd;
   logic dio_pads_0_attr_0_we;
@@ -156,19 +156,19 @@ module padctrl_reg_top (
   logic mio_pads_5_re;
 
   // Register instances
-  // R[regen]: V(False)
+  // R[regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_regen (
+  ) u_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (regen_we),
-    .wd     (regen_wd),
+    .we     (regwen_we),
+    .wd     (regwen_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -179,7 +179,7 @@ module padctrl_reg_top (
     .q      (),
 
     // to register interface (read)
-    .qs     (regen_qs)
+    .qs     (regwen_qs)
   );
 
 
@@ -193,7 +193,7 @@ module padctrl_reg_top (
   ) u_dio_pads_0_attr_0 (
     .re     (dio_pads_0_attr_0_re),
     // qualified with register enable
-    .we     (dio_pads_0_attr_0_we & regen_qs),
+    .we     (dio_pads_0_attr_0_we & regwen_qs),
     .wd     (dio_pads_0_attr_0_wd),
     .d      (hw2reg.dio_pads[0].d),
     .qre    (),
@@ -209,7 +209,7 @@ module padctrl_reg_top (
   ) u_dio_pads_0_attr_1 (
     .re     (dio_pads_0_attr_1_re),
     // qualified with register enable
-    .we     (dio_pads_0_attr_1_we & regen_qs),
+    .we     (dio_pads_0_attr_1_we & regwen_qs),
     .wd     (dio_pads_0_attr_1_wd),
     .d      (hw2reg.dio_pads[1].d),
     .qre    (),
@@ -225,7 +225,7 @@ module padctrl_reg_top (
   ) u_dio_pads_0_attr_2 (
     .re     (dio_pads_0_attr_2_re),
     // qualified with register enable
-    .we     (dio_pads_0_attr_2_we & regen_qs),
+    .we     (dio_pads_0_attr_2_we & regwen_qs),
     .wd     (dio_pads_0_attr_2_wd),
     .d      (hw2reg.dio_pads[2].d),
     .qre    (),
@@ -243,7 +243,7 @@ module padctrl_reg_top (
   ) u_dio_pads_1 (
     .re     (dio_pads_1_re),
     // qualified with register enable
-    .we     (dio_pads_1_we & regen_qs),
+    .we     (dio_pads_1_we & regwen_qs),
     .wd     (dio_pads_1_wd),
     .d      (hw2reg.dio_pads[3].d),
     .qre    (),
@@ -263,7 +263,7 @@ module padctrl_reg_top (
   ) u_mio_pads_0_attr_0 (
     .re     (mio_pads_0_attr_0_re),
     // qualified with register enable
-    .we     (mio_pads_0_attr_0_we & regen_qs),
+    .we     (mio_pads_0_attr_0_we & regwen_qs),
     .wd     (mio_pads_0_attr_0_wd),
     .d      (hw2reg.mio_pads[0].d),
     .qre    (),
@@ -279,7 +279,7 @@ module padctrl_reg_top (
   ) u_mio_pads_0_attr_1 (
     .re     (mio_pads_0_attr_1_re),
     // qualified with register enable
-    .we     (mio_pads_0_attr_1_we & regen_qs),
+    .we     (mio_pads_0_attr_1_we & regwen_qs),
     .wd     (mio_pads_0_attr_1_wd),
     .d      (hw2reg.mio_pads[1].d),
     .qre    (),
@@ -295,7 +295,7 @@ module padctrl_reg_top (
   ) u_mio_pads_0_attr_2 (
     .re     (mio_pads_0_attr_2_re),
     // qualified with register enable
-    .we     (mio_pads_0_attr_2_we & regen_qs),
+    .we     (mio_pads_0_attr_2_we & regwen_qs),
     .wd     (mio_pads_0_attr_2_wd),
     .d      (hw2reg.mio_pads[2].d),
     .qre    (),
@@ -314,7 +314,7 @@ module padctrl_reg_top (
   ) u_mio_pads_1_attr_3 (
     .re     (mio_pads_1_attr_3_re),
     // qualified with register enable
-    .we     (mio_pads_1_attr_3_we & regen_qs),
+    .we     (mio_pads_1_attr_3_we & regwen_qs),
     .wd     (mio_pads_1_attr_3_wd),
     .d      (hw2reg.mio_pads[3].d),
     .qre    (),
@@ -330,7 +330,7 @@ module padctrl_reg_top (
   ) u_mio_pads_1_attr_4 (
     .re     (mio_pads_1_attr_4_re),
     // qualified with register enable
-    .we     (mio_pads_1_attr_4_we & regen_qs),
+    .we     (mio_pads_1_attr_4_we & regwen_qs),
     .wd     (mio_pads_1_attr_4_wd),
     .d      (hw2reg.mio_pads[4].d),
     .qre    (),
@@ -346,7 +346,7 @@ module padctrl_reg_top (
   ) u_mio_pads_1_attr_5 (
     .re     (mio_pads_1_attr_5_re),
     // qualified with register enable
-    .we     (mio_pads_1_attr_5_we & regen_qs),
+    .we     (mio_pads_1_attr_5_we & regwen_qs),
     .wd     (mio_pads_1_attr_5_wd),
     .d      (hw2reg.mio_pads[5].d),
     .qre    (),
@@ -365,7 +365,7 @@ module padctrl_reg_top (
   ) u_mio_pads_2_attr_6 (
     .re     (mio_pads_2_attr_6_re),
     // qualified with register enable
-    .we     (mio_pads_2_attr_6_we & regen_qs),
+    .we     (mio_pads_2_attr_6_we & regwen_qs),
     .wd     (mio_pads_2_attr_6_wd),
     .d      (hw2reg.mio_pads[6].d),
     .qre    (),
@@ -381,7 +381,7 @@ module padctrl_reg_top (
   ) u_mio_pads_2_attr_7 (
     .re     (mio_pads_2_attr_7_re),
     // qualified with register enable
-    .we     (mio_pads_2_attr_7_we & regen_qs),
+    .we     (mio_pads_2_attr_7_we & regwen_qs),
     .wd     (mio_pads_2_attr_7_wd),
     .d      (hw2reg.mio_pads[7].d),
     .qre    (),
@@ -397,7 +397,7 @@ module padctrl_reg_top (
   ) u_mio_pads_2_attr_8 (
     .re     (mio_pads_2_attr_8_re),
     // qualified with register enable
-    .we     (mio_pads_2_attr_8_we & regen_qs),
+    .we     (mio_pads_2_attr_8_we & regwen_qs),
     .wd     (mio_pads_2_attr_8_wd),
     .d      (hw2reg.mio_pads[8].d),
     .qre    (),
@@ -416,7 +416,7 @@ module padctrl_reg_top (
   ) u_mio_pads_3_attr_9 (
     .re     (mio_pads_3_attr_9_re),
     // qualified with register enable
-    .we     (mio_pads_3_attr_9_we & regen_qs),
+    .we     (mio_pads_3_attr_9_we & regwen_qs),
     .wd     (mio_pads_3_attr_9_wd),
     .d      (hw2reg.mio_pads[9].d),
     .qre    (),
@@ -432,7 +432,7 @@ module padctrl_reg_top (
   ) u_mio_pads_3_attr_10 (
     .re     (mio_pads_3_attr_10_re),
     // qualified with register enable
-    .we     (mio_pads_3_attr_10_we & regen_qs),
+    .we     (mio_pads_3_attr_10_we & regwen_qs),
     .wd     (mio_pads_3_attr_10_wd),
     .d      (hw2reg.mio_pads[10].d),
     .qre    (),
@@ -448,7 +448,7 @@ module padctrl_reg_top (
   ) u_mio_pads_3_attr_11 (
     .re     (mio_pads_3_attr_11_re),
     // qualified with register enable
-    .we     (mio_pads_3_attr_11_we & regen_qs),
+    .we     (mio_pads_3_attr_11_we & regwen_qs),
     .wd     (mio_pads_3_attr_11_wd),
     .d      (hw2reg.mio_pads[11].d),
     .qre    (),
@@ -467,7 +467,7 @@ module padctrl_reg_top (
   ) u_mio_pads_4_attr_12 (
     .re     (mio_pads_4_attr_12_re),
     // qualified with register enable
-    .we     (mio_pads_4_attr_12_we & regen_qs),
+    .we     (mio_pads_4_attr_12_we & regwen_qs),
     .wd     (mio_pads_4_attr_12_wd),
     .d      (hw2reg.mio_pads[12].d),
     .qre    (),
@@ -483,7 +483,7 @@ module padctrl_reg_top (
   ) u_mio_pads_4_attr_13 (
     .re     (mio_pads_4_attr_13_re),
     // qualified with register enable
-    .we     (mio_pads_4_attr_13_we & regen_qs),
+    .we     (mio_pads_4_attr_13_we & regwen_qs),
     .wd     (mio_pads_4_attr_13_wd),
     .d      (hw2reg.mio_pads[13].d),
     .qre    (),
@@ -499,7 +499,7 @@ module padctrl_reg_top (
   ) u_mio_pads_4_attr_14 (
     .re     (mio_pads_4_attr_14_re),
     // qualified with register enable
-    .we     (mio_pads_4_attr_14_we & regen_qs),
+    .we     (mio_pads_4_attr_14_we & regwen_qs),
     .wd     (mio_pads_4_attr_14_wd),
     .d      (hw2reg.mio_pads[14].d),
     .qre    (),
@@ -517,7 +517,7 @@ module padctrl_reg_top (
   ) u_mio_pads_5 (
     .re     (mio_pads_5_re),
     // qualified with register enable
-    .we     (mio_pads_5_we & regen_qs),
+    .we     (mio_pads_5_we & regwen_qs),
     .wd     (mio_pads_5_wd),
     .d      (hw2reg.mio_pads[15].d),
     .qre    (),
@@ -532,7 +532,7 @@ module padctrl_reg_top (
   logic [8:0] addr_hit;
   always_comb begin
     addr_hit = '0;
-    addr_hit[0] = (reg_addr == PADCTRL_REGEN_OFFSET);
+    addr_hit[0] = (reg_addr == PADCTRL_REGWEN_OFFSET);
     addr_hit[1] = (reg_addr == PADCTRL_DIO_PADS_0_OFFSET);
     addr_hit[2] = (reg_addr == PADCTRL_DIO_PADS_1_OFFSET);
     addr_hit[3] = (reg_addr == PADCTRL_MIO_PADS_0_OFFSET);
@@ -559,8 +559,8 @@ module padctrl_reg_top (
     if (addr_hit[8] && reg_we && (PADCTRL_PERMIT[8] != (PADCTRL_PERMIT[8] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign regen_we = addr_hit[0] & reg_we & ~wr_err;
-  assign regen_wd = reg_wdata[0];
+  assign regwen_we = addr_hit[0] & reg_we & ~wr_err;
+  assign regwen_wd = reg_wdata[0];
 
   assign dio_pads_0_attr_0_we = addr_hit[1] & reg_we & ~wr_err;
   assign dio_pads_0_attr_0_wd = reg_wdata[9:0];
@@ -647,7 +647,7 @@ module padctrl_reg_top (
     reg_rdata_next = '0;
     unique case (1'b1)
       addr_hit[0]: begin
-        reg_rdata_next[0] = regen_qs;
+        reg_rdata_next[0] = regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/ip/pinmux/data/pinmux.hjson
+++ b/hw/ip/pinmux/data/pinmux.hjson
@@ -13,7 +13,7 @@
 #  - n_dio_pads:          Number of dedicated IO pads
 #  - n_wkup_detect:       Number of wakeup condition detectors
 #  - wkup_cnt_width:      Width of wakeup counters
-#
+# 
 {
   name: "PINMUX",
   clock_primary: "clk_i",
@@ -77,6 +77,47 @@
       package: "",
       default: "1'b0"
     },
+    { struct:  "logic",
+      type:    "uni",
+      name:    "usb_wkup_req",
+      act:     "req",
+      package: "",
+      default: "1'b0"
+    },
+    { name:    "usb_out_of_rst",
+      type:    "uni",
+      act:     "rcv",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    },
+    { name:    "usb_aon_wake_en",
+      type:    "uni",
+      act:     "rcv",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    },
+    { name:    "usb_aon_wake_ack",
+      type:    "uni",
+      act:     "rcv",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    },
+    { name:    "usb_suspend",
+      type:    "uni",
+      act:     "rcv",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    },
+    { name:    "usb_state_debug",
+      type:    "uni",
+      act:     "req",
+      package: "usbdev_pkg",
+      struct:  "awk_state",
+    },
   ]
 
   param_list: [
@@ -116,6 +157,43 @@
       default: "8",
       local: "true"
     },
+    { name: "NUsbDevPads",
+      desc: "Number of usbdev pins",
+      type: "int",
+      default: "0",
+      local: "true"
+    },
+    { name: "NDioPadUsbDevStart",
+      desc: "Start position for usbdev pins",
+      type: "int",
+      default: "0",
+      local: "true"
+    },
+    { name: "UsbDpSel",
+      desc: "index of usbdev_dp",
+      type: "int",
+      default: "0",
+      local: "true"
+    },
+    { name: "UsbDnSel",
+      desc: "index of usbdev_dn",
+      type: "int",
+      default: "0",
+      local: "true"
+    },
+    { name: "UsbDpPullUpSel",
+      desc: "index of usbdev_dp_pullup",
+      type: "int",
+      default: "0",
+      local: "true"
+    },
+    { name: "UsbDnPullUpSel",
+      desc: "index of usbdev_dn_pullup",
+      type: "int",
+      default: "0",
+      local: "true"
+    },
+
     // TODO: Enable these once supported by topgen and the C header generation script.
     // These parameters are currently located in pinmux_pkg.sv
     // // If a bit is set to 1 in this vector, this MIO activates low power
@@ -156,7 +234,7 @@
     // TODO(#1412): this register enable signal should be split into multiregs such that
     // each pin / peripheral select can be locked down individually. this needs support
     // for compact, nested multireg enable registers in our regtool.
-    { name: "REGEN",
+    { name: "REGWEN",
       desc: '''
             Register write enable for all control registers.
             ''',
@@ -179,7 +257,7 @@
                   count:    "NMioPeriphIn",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "IN",
                   fields: [
                     { bits: "5:0",
@@ -199,7 +277,7 @@
                   count:    "NMioPads",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "OUT",
                   fields: [
                     { bits: "5:0",
@@ -228,7 +306,7 @@
                   count:    "NMioPads",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "OUT",
                   fields: [
                     { bits: "1:0",
@@ -274,7 +352,7 @@
                   hwaccess: "hrw",
                   hwext:    "true",
                   hwqe:     "true",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "OUT",
                   fields: [
                     { bits: "1:0",
@@ -316,7 +394,7 @@
                   count:    "NWkupDetect",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "DETECTOR",
                   fields: [
                     { bits: "0:0",
@@ -338,7 +416,7 @@
                   count:    "NWkupDetect",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "DETECTOR",
                   fields: [
                     { bits: "2:0",
@@ -403,7 +481,7 @@
                   count:    "NWkupDetect",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "DETECTOR",
                   fields: [
                     { bits: "WkupCntWidth-1:0",
@@ -423,7 +501,7 @@
                   count:    "NWkupDetect",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "DETECTOR",
                   fields: [
                     { bits: "4:0",
@@ -447,7 +525,7 @@
                   hwaccess: "hrw",
                   hwext:    "true",
                   hwqe:     "true",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "DETECTOR",
                   fields: [
                     { bits: "0",
@@ -466,3 +544,4 @@
     },
   ],
 }
+

--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -234,7 +234,7 @@
     // TODO(#1412): this register enable signal should be split into multiregs such that
     // each pin / peripheral select can be locked down individually. this needs support
     // for compact, nested multireg enable registers in our regtool.
-    { name: "REGEN",
+    { name: "REGWEN",
       desc: '''
             Register write enable for all control registers.
             ''',
@@ -257,7 +257,7 @@
                   count:    "NMioPeriphIn",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "IN",
                   fields: [
                     { bits: "${(n_mio_pads+1).bit_length()-1}:0",
@@ -277,7 +277,7 @@
                   count:    "NMioPads",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "OUT",
                   fields: [
                     { bits: "${(n_mio_periph_out+2).bit_length()-1}:0",
@@ -306,7 +306,7 @@
                   count:    "NMioPads",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "OUT",
                   fields: [
                     { bits: "1:0",
@@ -352,7 +352,7 @@
                   hwaccess: "hrw",
                   hwext:    "true",
                   hwqe:     "true",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "OUT",
                   fields: [
                     { bits: "1:0",
@@ -394,7 +394,7 @@
                   count:    "NWkupDetect",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "DETECTOR",
                   fields: [
                     { bits: "0:0",
@@ -416,7 +416,7 @@
                   count:    "NWkupDetect",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "DETECTOR",
                   fields: [
                     { bits: "2:0",
@@ -481,7 +481,7 @@
                   count:    "NWkupDetect",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "DETECTOR",
                   fields: [
                     { bits: "WkupCntWidth-1:0",
@@ -501,7 +501,7 @@
                   count:    "NWkupDetect",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "DETECTOR",
                   fields: [
                     { bits: "${max(n_mio_pads-1, n_dio_periph_in-1).bit_length()-1}:0",
@@ -525,7 +525,7 @@
                   hwaccess: "hrw",
                   hwext:    "true",
                   hwqe:     "true",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "DETECTOR",
                   fields: [
                     { bits: "0",

--- a/hw/ip/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/ip/pinmux/rtl/pinmux_reg_pkg.sv
@@ -13,6 +13,12 @@ package pinmux_reg_pkg;
   parameter int NDioPads = 16;
   parameter int NWkupDetect = 8;
   parameter int WkupCntWidth = 8;
+  parameter int NUsbDevPads = 0;
+  parameter int NDioPadUsbDevStart = 0;
+  parameter int UsbDpSel = 0;
+  parameter int UsbDnSel = 0;
+  parameter int UsbDpPullUpSel = 0;
+  parameter int UsbDnPullUpSel = 0;
 
   // Address width within the block
   parameter int BlockAw = 7;
@@ -100,7 +106,7 @@ package pinmux_reg_pkg;
   } pinmux_hw2reg_t;
 
   // Register Address
-  parameter logic [BlockAw-1:0] PINMUX_REGEN_OFFSET = 7'h 0;
+  parameter logic [BlockAw-1:0] PINMUX_REGWEN_OFFSET = 7'h 0;
   parameter logic [BlockAw-1:0] PINMUX_PERIPH_INSEL_0_OFFSET = 7'h 4;
   parameter logic [BlockAw-1:0] PINMUX_PERIPH_INSEL_1_OFFSET = 7'h 8;
   parameter logic [BlockAw-1:0] PINMUX_PERIPH_INSEL_2_OFFSET = 7'h c;
@@ -136,7 +142,7 @@ package pinmux_reg_pkg;
 
   // Register Index
   typedef enum int {
-    PINMUX_REGEN,
+    PINMUX_REGWEN,
     PINMUX_PERIPH_INSEL_0,
     PINMUX_PERIPH_INSEL_1,
     PINMUX_PERIPH_INSEL_2,
@@ -172,7 +178,7 @@ package pinmux_reg_pkg;
 
   // Register width information to check illegal writes
   parameter logic [3:0] PINMUX_PERMIT [32] = '{
-    4'b 0001, // index[ 0] PINMUX_REGEN
+    4'b 0001, // index[ 0] PINMUX_REGWEN
     4'b 1111, // index[ 1] PINMUX_PERIPH_INSEL_0
     4'b 1111, // index[ 2] PINMUX_PERIPH_INSEL_1
     4'b 1111, // index[ 3] PINMUX_PERIPH_INSEL_2

--- a/hw/ip/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/ip/pinmux/rtl/pinmux_reg_top.sv
@@ -71,9 +71,9 @@ module pinmux_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
-  logic regen_qs;
-  logic regen_wd;
-  logic regen_we;
+  logic regwen_qs;
+  logic regwen_wd;
+  logic regwen_we;
   logic [5:0] periph_insel_0_in_0_qs;
   logic [5:0] periph_insel_0_in_0_wd;
   logic periph_insel_0_in_0_we;
@@ -604,19 +604,19 @@ module pinmux_reg_top (
   logic wkup_cause_cause_7_re;
 
   // Register instances
-  // R[regen]: V(False)
+  // R[regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_regen (
+  ) u_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (regen_we),
-    .wd     (regen_wd),
+    .we     (regwen_we),
+    .wd     (regwen_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -627,7 +627,7 @@ module pinmux_reg_top (
     .q      (),
 
     // to register interface (read)
-    .qs     (regen_qs)
+    .qs     (regwen_qs)
   );
 
 
@@ -645,7 +645,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_0_in_0_we & regen_qs),
+    .we     (periph_insel_0_in_0_we & regwen_qs),
     .wd     (periph_insel_0_in_0_wd),
 
     // from internal hardware
@@ -671,7 +671,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_0_in_1_we & regen_qs),
+    .we     (periph_insel_0_in_1_we & regwen_qs),
     .wd     (periph_insel_0_in_1_wd),
 
     // from internal hardware
@@ -697,7 +697,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_0_in_2_we & regen_qs),
+    .we     (periph_insel_0_in_2_we & regwen_qs),
     .wd     (periph_insel_0_in_2_wd),
 
     // from internal hardware
@@ -723,7 +723,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_0_in_3_we & regen_qs),
+    .we     (periph_insel_0_in_3_we & regwen_qs),
     .wd     (periph_insel_0_in_3_wd),
 
     // from internal hardware
@@ -749,7 +749,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_0_in_4_we & regen_qs),
+    .we     (periph_insel_0_in_4_we & regwen_qs),
     .wd     (periph_insel_0_in_4_wd),
 
     // from internal hardware
@@ -778,7 +778,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_1_in_5_we & regen_qs),
+    .we     (periph_insel_1_in_5_we & regwen_qs),
     .wd     (periph_insel_1_in_5_wd),
 
     // from internal hardware
@@ -804,7 +804,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_1_in_6_we & regen_qs),
+    .we     (periph_insel_1_in_6_we & regwen_qs),
     .wd     (periph_insel_1_in_6_wd),
 
     // from internal hardware
@@ -830,7 +830,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_1_in_7_we & regen_qs),
+    .we     (periph_insel_1_in_7_we & regwen_qs),
     .wd     (periph_insel_1_in_7_wd),
 
     // from internal hardware
@@ -856,7 +856,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_1_in_8_we & regen_qs),
+    .we     (periph_insel_1_in_8_we & regwen_qs),
     .wd     (periph_insel_1_in_8_wd),
 
     // from internal hardware
@@ -882,7 +882,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_1_in_9_we & regen_qs),
+    .we     (periph_insel_1_in_9_we & regwen_qs),
     .wd     (periph_insel_1_in_9_wd),
 
     // from internal hardware
@@ -911,7 +911,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_2_in_10_we & regen_qs),
+    .we     (periph_insel_2_in_10_we & regwen_qs),
     .wd     (periph_insel_2_in_10_wd),
 
     // from internal hardware
@@ -937,7 +937,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_2_in_11_we & regen_qs),
+    .we     (periph_insel_2_in_11_we & regwen_qs),
     .wd     (periph_insel_2_in_11_wd),
 
     // from internal hardware
@@ -963,7 +963,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_2_in_12_we & regen_qs),
+    .we     (periph_insel_2_in_12_we & regwen_qs),
     .wd     (periph_insel_2_in_12_wd),
 
     // from internal hardware
@@ -989,7 +989,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_2_in_13_we & regen_qs),
+    .we     (periph_insel_2_in_13_we & regwen_qs),
     .wd     (periph_insel_2_in_13_wd),
 
     // from internal hardware
@@ -1015,7 +1015,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_2_in_14_we & regen_qs),
+    .we     (periph_insel_2_in_14_we & regwen_qs),
     .wd     (periph_insel_2_in_14_wd),
 
     // from internal hardware
@@ -1044,7 +1044,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_3_in_15_we & regen_qs),
+    .we     (periph_insel_3_in_15_we & regwen_qs),
     .wd     (periph_insel_3_in_15_wd),
 
     // from internal hardware
@@ -1070,7 +1070,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_3_in_16_we & regen_qs),
+    .we     (periph_insel_3_in_16_we & regwen_qs),
     .wd     (periph_insel_3_in_16_wd),
 
     // from internal hardware
@@ -1096,7 +1096,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_3_in_17_we & regen_qs),
+    .we     (periph_insel_3_in_17_we & regwen_qs),
     .wd     (periph_insel_3_in_17_wd),
 
     // from internal hardware
@@ -1122,7 +1122,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_3_in_18_we & regen_qs),
+    .we     (periph_insel_3_in_18_we & regwen_qs),
     .wd     (periph_insel_3_in_18_wd),
 
     // from internal hardware
@@ -1148,7 +1148,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_3_in_19_we & regen_qs),
+    .we     (periph_insel_3_in_19_we & regwen_qs),
     .wd     (periph_insel_3_in_19_wd),
 
     // from internal hardware
@@ -1177,7 +1177,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_4_in_20_we & regen_qs),
+    .we     (periph_insel_4_in_20_we & regwen_qs),
     .wd     (periph_insel_4_in_20_wd),
 
     // from internal hardware
@@ -1203,7 +1203,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_4_in_21_we & regen_qs),
+    .we     (periph_insel_4_in_21_we & regwen_qs),
     .wd     (periph_insel_4_in_21_wd),
 
     // from internal hardware
@@ -1229,7 +1229,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_4_in_22_we & regen_qs),
+    .we     (periph_insel_4_in_22_we & regwen_qs),
     .wd     (periph_insel_4_in_22_wd),
 
     // from internal hardware
@@ -1255,7 +1255,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_4_in_23_we & regen_qs),
+    .we     (periph_insel_4_in_23_we & regwen_qs),
     .wd     (periph_insel_4_in_23_wd),
 
     // from internal hardware
@@ -1281,7 +1281,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_4_in_24_we & regen_qs),
+    .we     (periph_insel_4_in_24_we & regwen_qs),
     .wd     (periph_insel_4_in_24_wd),
 
     // from internal hardware
@@ -1310,7 +1310,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_5_in_25_we & regen_qs),
+    .we     (periph_insel_5_in_25_we & regwen_qs),
     .wd     (periph_insel_5_in_25_wd),
 
     // from internal hardware
@@ -1336,7 +1336,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_5_in_26_we & regen_qs),
+    .we     (periph_insel_5_in_26_we & regwen_qs),
     .wd     (periph_insel_5_in_26_wd),
 
     // from internal hardware
@@ -1362,7 +1362,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_5_in_27_we & regen_qs),
+    .we     (periph_insel_5_in_27_we & regwen_qs),
     .wd     (periph_insel_5_in_27_wd),
 
     // from internal hardware
@@ -1388,7 +1388,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_5_in_28_we & regen_qs),
+    .we     (periph_insel_5_in_28_we & regwen_qs),
     .wd     (periph_insel_5_in_28_wd),
 
     // from internal hardware
@@ -1414,7 +1414,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_5_in_29_we & regen_qs),
+    .we     (periph_insel_5_in_29_we & regwen_qs),
     .wd     (periph_insel_5_in_29_wd),
 
     // from internal hardware
@@ -1443,7 +1443,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_6_in_30_we & regen_qs),
+    .we     (periph_insel_6_in_30_we & regwen_qs),
     .wd     (periph_insel_6_in_30_wd),
 
     // from internal hardware
@@ -1469,7 +1469,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_6_in_31_we & regen_qs),
+    .we     (periph_insel_6_in_31_we & regwen_qs),
     .wd     (periph_insel_6_in_31_wd),
 
     // from internal hardware
@@ -1500,7 +1500,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_0_out_0_we & regen_qs),
+    .we     (mio_outsel_0_out_0_we & regwen_qs),
     .wd     (mio_outsel_0_out_0_wd),
 
     // from internal hardware
@@ -1526,7 +1526,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_0_out_1_we & regen_qs),
+    .we     (mio_outsel_0_out_1_we & regwen_qs),
     .wd     (mio_outsel_0_out_1_wd),
 
     // from internal hardware
@@ -1552,7 +1552,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_0_out_2_we & regen_qs),
+    .we     (mio_outsel_0_out_2_we & regwen_qs),
     .wd     (mio_outsel_0_out_2_wd),
 
     // from internal hardware
@@ -1578,7 +1578,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_0_out_3_we & regen_qs),
+    .we     (mio_outsel_0_out_3_we & regwen_qs),
     .wd     (mio_outsel_0_out_3_wd),
 
     // from internal hardware
@@ -1604,7 +1604,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_0_out_4_we & regen_qs),
+    .we     (mio_outsel_0_out_4_we & regwen_qs),
     .wd     (mio_outsel_0_out_4_wd),
 
     // from internal hardware
@@ -1633,7 +1633,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_1_out_5_we & regen_qs),
+    .we     (mio_outsel_1_out_5_we & regwen_qs),
     .wd     (mio_outsel_1_out_5_wd),
 
     // from internal hardware
@@ -1659,7 +1659,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_1_out_6_we & regen_qs),
+    .we     (mio_outsel_1_out_6_we & regwen_qs),
     .wd     (mio_outsel_1_out_6_wd),
 
     // from internal hardware
@@ -1685,7 +1685,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_1_out_7_we & regen_qs),
+    .we     (mio_outsel_1_out_7_we & regwen_qs),
     .wd     (mio_outsel_1_out_7_wd),
 
     // from internal hardware
@@ -1711,7 +1711,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_1_out_8_we & regen_qs),
+    .we     (mio_outsel_1_out_8_we & regwen_qs),
     .wd     (mio_outsel_1_out_8_wd),
 
     // from internal hardware
@@ -1737,7 +1737,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_1_out_9_we & regen_qs),
+    .we     (mio_outsel_1_out_9_we & regwen_qs),
     .wd     (mio_outsel_1_out_9_wd),
 
     // from internal hardware
@@ -1766,7 +1766,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_2_out_10_we & regen_qs),
+    .we     (mio_outsel_2_out_10_we & regwen_qs),
     .wd     (mio_outsel_2_out_10_wd),
 
     // from internal hardware
@@ -1792,7 +1792,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_2_out_11_we & regen_qs),
+    .we     (mio_outsel_2_out_11_we & regwen_qs),
     .wd     (mio_outsel_2_out_11_wd),
 
     // from internal hardware
@@ -1818,7 +1818,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_2_out_12_we & regen_qs),
+    .we     (mio_outsel_2_out_12_we & regwen_qs),
     .wd     (mio_outsel_2_out_12_wd),
 
     // from internal hardware
@@ -1844,7 +1844,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_2_out_13_we & regen_qs),
+    .we     (mio_outsel_2_out_13_we & regwen_qs),
     .wd     (mio_outsel_2_out_13_wd),
 
     // from internal hardware
@@ -1870,7 +1870,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_2_out_14_we & regen_qs),
+    .we     (mio_outsel_2_out_14_we & regwen_qs),
     .wd     (mio_outsel_2_out_14_wd),
 
     // from internal hardware
@@ -1899,7 +1899,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_3_out_15_we & regen_qs),
+    .we     (mio_outsel_3_out_15_we & regwen_qs),
     .wd     (mio_outsel_3_out_15_wd),
 
     // from internal hardware
@@ -1925,7 +1925,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_3_out_16_we & regen_qs),
+    .we     (mio_outsel_3_out_16_we & regwen_qs),
     .wd     (mio_outsel_3_out_16_wd),
 
     // from internal hardware
@@ -1951,7 +1951,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_3_out_17_we & regen_qs),
+    .we     (mio_outsel_3_out_17_we & regwen_qs),
     .wd     (mio_outsel_3_out_17_wd),
 
     // from internal hardware
@@ -1977,7 +1977,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_3_out_18_we & regen_qs),
+    .we     (mio_outsel_3_out_18_we & regwen_qs),
     .wd     (mio_outsel_3_out_18_wd),
 
     // from internal hardware
@@ -2003,7 +2003,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_3_out_19_we & regen_qs),
+    .we     (mio_outsel_3_out_19_we & regwen_qs),
     .wd     (mio_outsel_3_out_19_wd),
 
     // from internal hardware
@@ -2032,7 +2032,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_4_out_20_we & regen_qs),
+    .we     (mio_outsel_4_out_20_we & regwen_qs),
     .wd     (mio_outsel_4_out_20_wd),
 
     // from internal hardware
@@ -2058,7 +2058,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_4_out_21_we & regen_qs),
+    .we     (mio_outsel_4_out_21_we & regwen_qs),
     .wd     (mio_outsel_4_out_21_wd),
 
     // from internal hardware
@@ -2084,7 +2084,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_4_out_22_we & regen_qs),
+    .we     (mio_outsel_4_out_22_we & regwen_qs),
     .wd     (mio_outsel_4_out_22_wd),
 
     // from internal hardware
@@ -2110,7 +2110,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_4_out_23_we & regen_qs),
+    .we     (mio_outsel_4_out_23_we & regwen_qs),
     .wd     (mio_outsel_4_out_23_wd),
 
     // from internal hardware
@@ -2136,7 +2136,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_4_out_24_we & regen_qs),
+    .we     (mio_outsel_4_out_24_we & regwen_qs),
     .wd     (mio_outsel_4_out_24_wd),
 
     // from internal hardware
@@ -2165,7 +2165,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_5_out_25_we & regen_qs),
+    .we     (mio_outsel_5_out_25_we & regwen_qs),
     .wd     (mio_outsel_5_out_25_wd),
 
     // from internal hardware
@@ -2191,7 +2191,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_5_out_26_we & regen_qs),
+    .we     (mio_outsel_5_out_26_we & regwen_qs),
     .wd     (mio_outsel_5_out_26_wd),
 
     // from internal hardware
@@ -2217,7 +2217,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_5_out_27_we & regen_qs),
+    .we     (mio_outsel_5_out_27_we & regwen_qs),
     .wd     (mio_outsel_5_out_27_wd),
 
     // from internal hardware
@@ -2243,7 +2243,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_5_out_28_we & regen_qs),
+    .we     (mio_outsel_5_out_28_we & regwen_qs),
     .wd     (mio_outsel_5_out_28_wd),
 
     // from internal hardware
@@ -2269,7 +2269,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_5_out_29_we & regen_qs),
+    .we     (mio_outsel_5_out_29_we & regwen_qs),
     .wd     (mio_outsel_5_out_29_wd),
 
     // from internal hardware
@@ -2298,7 +2298,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_6_out_30_we & regen_qs),
+    .we     (mio_outsel_6_out_30_we & regwen_qs),
     .wd     (mio_outsel_6_out_30_wd),
 
     // from internal hardware
@@ -2324,7 +2324,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_6_out_31_we & regen_qs),
+    .we     (mio_outsel_6_out_31_we & regwen_qs),
     .wd     (mio_outsel_6_out_31_wd),
 
     // from internal hardware
@@ -2355,7 +2355,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_0_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_0_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_0_wd),
 
     // from internal hardware
@@ -2381,7 +2381,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_1_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_1_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_1_wd),
 
     // from internal hardware
@@ -2407,7 +2407,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_2_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_2_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_2_wd),
 
     // from internal hardware
@@ -2433,7 +2433,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_3_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_3_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_3_wd),
 
     // from internal hardware
@@ -2459,7 +2459,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_4_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_4_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_4_wd),
 
     // from internal hardware
@@ -2485,7 +2485,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_5_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_5_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_5_wd),
 
     // from internal hardware
@@ -2511,7 +2511,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_6_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_6_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_6_wd),
 
     // from internal hardware
@@ -2537,7 +2537,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_7_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_7_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_7_wd),
 
     // from internal hardware
@@ -2563,7 +2563,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_8_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_8_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_8_wd),
 
     // from internal hardware
@@ -2589,7 +2589,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_9_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_9_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_9_wd),
 
     // from internal hardware
@@ -2615,7 +2615,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_10_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_10_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_10_wd),
 
     // from internal hardware
@@ -2641,7 +2641,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_11_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_11_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_11_wd),
 
     // from internal hardware
@@ -2667,7 +2667,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_12_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_12_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_12_wd),
 
     // from internal hardware
@@ -2693,7 +2693,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_13_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_13_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_13_wd),
 
     // from internal hardware
@@ -2719,7 +2719,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_14_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_14_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_14_wd),
 
     // from internal hardware
@@ -2745,7 +2745,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_15_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_15_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_15_wd),
 
     // from internal hardware
@@ -2774,7 +2774,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_16_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_16_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_16_wd),
 
     // from internal hardware
@@ -2800,7 +2800,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_17_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_17_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_17_wd),
 
     // from internal hardware
@@ -2826,7 +2826,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_18_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_18_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_18_wd),
 
     // from internal hardware
@@ -2852,7 +2852,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_19_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_19_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_19_wd),
 
     // from internal hardware
@@ -2878,7 +2878,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_20_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_20_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_20_wd),
 
     // from internal hardware
@@ -2904,7 +2904,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_21_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_21_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_21_wd),
 
     // from internal hardware
@@ -2930,7 +2930,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_22_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_22_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_22_wd),
 
     // from internal hardware
@@ -2956,7 +2956,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_23_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_23_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_23_wd),
 
     // from internal hardware
@@ -2982,7 +2982,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_24_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_24_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_24_wd),
 
     // from internal hardware
@@ -3008,7 +3008,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_25_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_25_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_25_wd),
 
     // from internal hardware
@@ -3034,7 +3034,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_26_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_26_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_26_wd),
 
     // from internal hardware
@@ -3060,7 +3060,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_27_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_27_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_27_wd),
 
     // from internal hardware
@@ -3086,7 +3086,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_28_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_28_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_28_wd),
 
     // from internal hardware
@@ -3112,7 +3112,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_29_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_29_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_29_wd),
 
     // from internal hardware
@@ -3138,7 +3138,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_30_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_30_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_30_wd),
 
     // from internal hardware
@@ -3164,7 +3164,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_31_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_31_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_31_wd),
 
     // from internal hardware
@@ -3191,7 +3191,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_0 (
     .re     (dio_out_sleep_val_out_0_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_0_we & regen_qs),
+    .we     (dio_out_sleep_val_out_0_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_0_wd),
     .d      (hw2reg.dio_out_sleep_val[0].d),
     .qre    (),
@@ -3207,7 +3207,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_1 (
     .re     (dio_out_sleep_val_out_1_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_1_we & regen_qs),
+    .we     (dio_out_sleep_val_out_1_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_1_wd),
     .d      (hw2reg.dio_out_sleep_val[1].d),
     .qre    (),
@@ -3223,7 +3223,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_2 (
     .re     (dio_out_sleep_val_out_2_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_2_we & regen_qs),
+    .we     (dio_out_sleep_val_out_2_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_2_wd),
     .d      (hw2reg.dio_out_sleep_val[2].d),
     .qre    (),
@@ -3239,7 +3239,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_3 (
     .re     (dio_out_sleep_val_out_3_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_3_we & regen_qs),
+    .we     (dio_out_sleep_val_out_3_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_3_wd),
     .d      (hw2reg.dio_out_sleep_val[3].d),
     .qre    (),
@@ -3255,7 +3255,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_4 (
     .re     (dio_out_sleep_val_out_4_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_4_we & regen_qs),
+    .we     (dio_out_sleep_val_out_4_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_4_wd),
     .d      (hw2reg.dio_out_sleep_val[4].d),
     .qre    (),
@@ -3271,7 +3271,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_5 (
     .re     (dio_out_sleep_val_out_5_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_5_we & regen_qs),
+    .we     (dio_out_sleep_val_out_5_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_5_wd),
     .d      (hw2reg.dio_out_sleep_val[5].d),
     .qre    (),
@@ -3287,7 +3287,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_6 (
     .re     (dio_out_sleep_val_out_6_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_6_we & regen_qs),
+    .we     (dio_out_sleep_val_out_6_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_6_wd),
     .d      (hw2reg.dio_out_sleep_val[6].d),
     .qre    (),
@@ -3303,7 +3303,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_7 (
     .re     (dio_out_sleep_val_out_7_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_7_we & regen_qs),
+    .we     (dio_out_sleep_val_out_7_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_7_wd),
     .d      (hw2reg.dio_out_sleep_val[7].d),
     .qre    (),
@@ -3319,7 +3319,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_8 (
     .re     (dio_out_sleep_val_out_8_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_8_we & regen_qs),
+    .we     (dio_out_sleep_val_out_8_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_8_wd),
     .d      (hw2reg.dio_out_sleep_val[8].d),
     .qre    (),
@@ -3335,7 +3335,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_9 (
     .re     (dio_out_sleep_val_out_9_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_9_we & regen_qs),
+    .we     (dio_out_sleep_val_out_9_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_9_wd),
     .d      (hw2reg.dio_out_sleep_val[9].d),
     .qre    (),
@@ -3351,7 +3351,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_10 (
     .re     (dio_out_sleep_val_out_10_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_10_we & regen_qs),
+    .we     (dio_out_sleep_val_out_10_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_10_wd),
     .d      (hw2reg.dio_out_sleep_val[10].d),
     .qre    (),
@@ -3367,7 +3367,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_11 (
     .re     (dio_out_sleep_val_out_11_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_11_we & regen_qs),
+    .we     (dio_out_sleep_val_out_11_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_11_wd),
     .d      (hw2reg.dio_out_sleep_val[11].d),
     .qre    (),
@@ -3383,7 +3383,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_12 (
     .re     (dio_out_sleep_val_out_12_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_12_we & regen_qs),
+    .we     (dio_out_sleep_val_out_12_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_12_wd),
     .d      (hw2reg.dio_out_sleep_val[12].d),
     .qre    (),
@@ -3399,7 +3399,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_13 (
     .re     (dio_out_sleep_val_out_13_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_13_we & regen_qs),
+    .we     (dio_out_sleep_val_out_13_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_13_wd),
     .d      (hw2reg.dio_out_sleep_val[13].d),
     .qre    (),
@@ -3415,7 +3415,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_14 (
     .re     (dio_out_sleep_val_out_14_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_14_we & regen_qs),
+    .we     (dio_out_sleep_val_out_14_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_14_wd),
     .d      (hw2reg.dio_out_sleep_val[14].d),
     .qre    (),
@@ -3431,7 +3431,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_15 (
     .re     (dio_out_sleep_val_out_15_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_15_we & regen_qs),
+    .we     (dio_out_sleep_val_out_15_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_15_wd),
     .d      (hw2reg.dio_out_sleep_val[15].d),
     .qre    (),
@@ -3456,7 +3456,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_en_en_0_we & regen_qs),
+    .we     (wkup_detector_en_en_0_we & regwen_qs),
     .wd     (wkup_detector_en_en_0_wd),
 
     // from internal hardware
@@ -3482,7 +3482,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_en_en_1_we & regen_qs),
+    .we     (wkup_detector_en_en_1_we & regwen_qs),
     .wd     (wkup_detector_en_en_1_wd),
 
     // from internal hardware
@@ -3508,7 +3508,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_en_en_2_we & regen_qs),
+    .we     (wkup_detector_en_en_2_we & regwen_qs),
     .wd     (wkup_detector_en_en_2_wd),
 
     // from internal hardware
@@ -3534,7 +3534,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_en_en_3_we & regen_qs),
+    .we     (wkup_detector_en_en_3_we & regwen_qs),
     .wd     (wkup_detector_en_en_3_wd),
 
     // from internal hardware
@@ -3560,7 +3560,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_en_en_4_we & regen_qs),
+    .we     (wkup_detector_en_en_4_we & regwen_qs),
     .wd     (wkup_detector_en_en_4_wd),
 
     // from internal hardware
@@ -3586,7 +3586,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_en_en_5_we & regen_qs),
+    .we     (wkup_detector_en_en_5_we & regwen_qs),
     .wd     (wkup_detector_en_en_5_wd),
 
     // from internal hardware
@@ -3612,7 +3612,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_en_en_6_we & regen_qs),
+    .we     (wkup_detector_en_en_6_we & regwen_qs),
     .wd     (wkup_detector_en_en_6_wd),
 
     // from internal hardware
@@ -3638,7 +3638,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_en_en_7_we & regen_qs),
+    .we     (wkup_detector_en_en_7_we & regwen_qs),
     .wd     (wkup_detector_en_en_7_wd),
 
     // from internal hardware
@@ -3669,7 +3669,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_0_mode_0_we & regen_qs),
+    .we     (wkup_detector_0_mode_0_we & regwen_qs),
     .wd     (wkup_detector_0_mode_0_wd),
 
     // from internal hardware
@@ -3695,7 +3695,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_0_filter_0_we & regen_qs),
+    .we     (wkup_detector_0_filter_0_we & regwen_qs),
     .wd     (wkup_detector_0_filter_0_wd),
 
     // from internal hardware
@@ -3721,7 +3721,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_0_miodio_0_we & regen_qs),
+    .we     (wkup_detector_0_miodio_0_we & regwen_qs),
     .wd     (wkup_detector_0_miodio_0_wd),
 
     // from internal hardware
@@ -3750,7 +3750,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_1_mode_1_we & regen_qs),
+    .we     (wkup_detector_1_mode_1_we & regwen_qs),
     .wd     (wkup_detector_1_mode_1_wd),
 
     // from internal hardware
@@ -3776,7 +3776,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_1_filter_1_we & regen_qs),
+    .we     (wkup_detector_1_filter_1_we & regwen_qs),
     .wd     (wkup_detector_1_filter_1_wd),
 
     // from internal hardware
@@ -3802,7 +3802,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_1_miodio_1_we & regen_qs),
+    .we     (wkup_detector_1_miodio_1_we & regwen_qs),
     .wd     (wkup_detector_1_miodio_1_wd),
 
     // from internal hardware
@@ -3831,7 +3831,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_2_mode_2_we & regen_qs),
+    .we     (wkup_detector_2_mode_2_we & regwen_qs),
     .wd     (wkup_detector_2_mode_2_wd),
 
     // from internal hardware
@@ -3857,7 +3857,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_2_filter_2_we & regen_qs),
+    .we     (wkup_detector_2_filter_2_we & regwen_qs),
     .wd     (wkup_detector_2_filter_2_wd),
 
     // from internal hardware
@@ -3883,7 +3883,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_2_miodio_2_we & regen_qs),
+    .we     (wkup_detector_2_miodio_2_we & regwen_qs),
     .wd     (wkup_detector_2_miodio_2_wd),
 
     // from internal hardware
@@ -3912,7 +3912,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_3_mode_3_we & regen_qs),
+    .we     (wkup_detector_3_mode_3_we & regwen_qs),
     .wd     (wkup_detector_3_mode_3_wd),
 
     // from internal hardware
@@ -3938,7 +3938,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_3_filter_3_we & regen_qs),
+    .we     (wkup_detector_3_filter_3_we & regwen_qs),
     .wd     (wkup_detector_3_filter_3_wd),
 
     // from internal hardware
@@ -3964,7 +3964,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_3_miodio_3_we & regen_qs),
+    .we     (wkup_detector_3_miodio_3_we & regwen_qs),
     .wd     (wkup_detector_3_miodio_3_wd),
 
     // from internal hardware
@@ -3993,7 +3993,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_4_mode_4_we & regen_qs),
+    .we     (wkup_detector_4_mode_4_we & regwen_qs),
     .wd     (wkup_detector_4_mode_4_wd),
 
     // from internal hardware
@@ -4019,7 +4019,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_4_filter_4_we & regen_qs),
+    .we     (wkup_detector_4_filter_4_we & regwen_qs),
     .wd     (wkup_detector_4_filter_4_wd),
 
     // from internal hardware
@@ -4045,7 +4045,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_4_miodio_4_we & regen_qs),
+    .we     (wkup_detector_4_miodio_4_we & regwen_qs),
     .wd     (wkup_detector_4_miodio_4_wd),
 
     // from internal hardware
@@ -4074,7 +4074,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_5_mode_5_we & regen_qs),
+    .we     (wkup_detector_5_mode_5_we & regwen_qs),
     .wd     (wkup_detector_5_mode_5_wd),
 
     // from internal hardware
@@ -4100,7 +4100,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_5_filter_5_we & regen_qs),
+    .we     (wkup_detector_5_filter_5_we & regwen_qs),
     .wd     (wkup_detector_5_filter_5_wd),
 
     // from internal hardware
@@ -4126,7 +4126,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_5_miodio_5_we & regen_qs),
+    .we     (wkup_detector_5_miodio_5_we & regwen_qs),
     .wd     (wkup_detector_5_miodio_5_wd),
 
     // from internal hardware
@@ -4155,7 +4155,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_6_mode_6_we & regen_qs),
+    .we     (wkup_detector_6_mode_6_we & regwen_qs),
     .wd     (wkup_detector_6_mode_6_wd),
 
     // from internal hardware
@@ -4181,7 +4181,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_6_filter_6_we & regen_qs),
+    .we     (wkup_detector_6_filter_6_we & regwen_qs),
     .wd     (wkup_detector_6_filter_6_wd),
 
     // from internal hardware
@@ -4207,7 +4207,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_6_miodio_6_we & regen_qs),
+    .we     (wkup_detector_6_miodio_6_we & regwen_qs),
     .wd     (wkup_detector_6_miodio_6_wd),
 
     // from internal hardware
@@ -4236,7 +4236,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_7_mode_7_we & regen_qs),
+    .we     (wkup_detector_7_mode_7_we & regwen_qs),
     .wd     (wkup_detector_7_mode_7_wd),
 
     // from internal hardware
@@ -4262,7 +4262,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_7_filter_7_we & regen_qs),
+    .we     (wkup_detector_7_filter_7_we & regwen_qs),
     .wd     (wkup_detector_7_filter_7_wd),
 
     // from internal hardware
@@ -4288,7 +4288,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_7_miodio_7_we & regen_qs),
+    .we     (wkup_detector_7_miodio_7_we & regwen_qs),
     .wd     (wkup_detector_7_miodio_7_wd),
 
     // from internal hardware
@@ -4319,7 +4319,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_cnt_th_0_th_0_we & regen_qs),
+    .we     (wkup_detector_cnt_th_0_th_0_we & regwen_qs),
     .wd     (wkup_detector_cnt_th_0_th_0_wd),
 
     // from internal hardware
@@ -4345,7 +4345,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_cnt_th_0_th_1_we & regen_qs),
+    .we     (wkup_detector_cnt_th_0_th_1_we & regwen_qs),
     .wd     (wkup_detector_cnt_th_0_th_1_wd),
 
     // from internal hardware
@@ -4371,7 +4371,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_cnt_th_0_th_2_we & regen_qs),
+    .we     (wkup_detector_cnt_th_0_th_2_we & regwen_qs),
     .wd     (wkup_detector_cnt_th_0_th_2_wd),
 
     // from internal hardware
@@ -4397,7 +4397,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_cnt_th_0_th_3_we & regen_qs),
+    .we     (wkup_detector_cnt_th_0_th_3_we & regwen_qs),
     .wd     (wkup_detector_cnt_th_0_th_3_wd),
 
     // from internal hardware
@@ -4426,7 +4426,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_cnt_th_1_th_4_we & regen_qs),
+    .we     (wkup_detector_cnt_th_1_th_4_we & regwen_qs),
     .wd     (wkup_detector_cnt_th_1_th_4_wd),
 
     // from internal hardware
@@ -4452,7 +4452,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_cnt_th_1_th_5_we & regen_qs),
+    .we     (wkup_detector_cnt_th_1_th_5_we & regwen_qs),
     .wd     (wkup_detector_cnt_th_1_th_5_wd),
 
     // from internal hardware
@@ -4478,7 +4478,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_cnt_th_1_th_6_we & regen_qs),
+    .we     (wkup_detector_cnt_th_1_th_6_we & regwen_qs),
     .wd     (wkup_detector_cnt_th_1_th_6_wd),
 
     // from internal hardware
@@ -4504,7 +4504,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_cnt_th_1_th_7_we & regen_qs),
+    .we     (wkup_detector_cnt_th_1_th_7_we & regwen_qs),
     .wd     (wkup_detector_cnt_th_1_th_7_wd),
 
     // from internal hardware
@@ -4535,7 +4535,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_padsel_0_sel_0_we & regen_qs),
+    .we     (wkup_detector_padsel_0_sel_0_we & regwen_qs),
     .wd     (wkup_detector_padsel_0_sel_0_wd),
 
     // from internal hardware
@@ -4561,7 +4561,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_padsel_0_sel_1_we & regen_qs),
+    .we     (wkup_detector_padsel_0_sel_1_we & regwen_qs),
     .wd     (wkup_detector_padsel_0_sel_1_wd),
 
     // from internal hardware
@@ -4587,7 +4587,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_padsel_0_sel_2_we & regen_qs),
+    .we     (wkup_detector_padsel_0_sel_2_we & regwen_qs),
     .wd     (wkup_detector_padsel_0_sel_2_wd),
 
     // from internal hardware
@@ -4613,7 +4613,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_padsel_0_sel_3_we & regen_qs),
+    .we     (wkup_detector_padsel_0_sel_3_we & regwen_qs),
     .wd     (wkup_detector_padsel_0_sel_3_wd),
 
     // from internal hardware
@@ -4639,7 +4639,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_padsel_0_sel_4_we & regen_qs),
+    .we     (wkup_detector_padsel_0_sel_4_we & regwen_qs),
     .wd     (wkup_detector_padsel_0_sel_4_wd),
 
     // from internal hardware
@@ -4665,7 +4665,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_padsel_0_sel_5_we & regen_qs),
+    .we     (wkup_detector_padsel_0_sel_5_we & regwen_qs),
     .wd     (wkup_detector_padsel_0_sel_5_wd),
 
     // from internal hardware
@@ -4694,7 +4694,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_padsel_1_sel_6_we & regen_qs),
+    .we     (wkup_detector_padsel_1_sel_6_we & regwen_qs),
     .wd     (wkup_detector_padsel_1_sel_6_wd),
 
     // from internal hardware
@@ -4720,7 +4720,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_padsel_1_sel_7_we & regen_qs),
+    .we     (wkup_detector_padsel_1_sel_7_we & regwen_qs),
     .wd     (wkup_detector_padsel_1_sel_7_wd),
 
     // from internal hardware
@@ -4747,7 +4747,7 @@ module pinmux_reg_top (
   ) u_wkup_cause_cause_0 (
     .re     (wkup_cause_cause_0_re),
     // qualified with register enable
-    .we     (wkup_cause_cause_0_we & regen_qs),
+    .we     (wkup_cause_cause_0_we & regwen_qs),
     .wd     (wkup_cause_cause_0_wd),
     .d      (hw2reg.wkup_cause[0].d),
     .qre    (),
@@ -4763,7 +4763,7 @@ module pinmux_reg_top (
   ) u_wkup_cause_cause_1 (
     .re     (wkup_cause_cause_1_re),
     // qualified with register enable
-    .we     (wkup_cause_cause_1_we & regen_qs),
+    .we     (wkup_cause_cause_1_we & regwen_qs),
     .wd     (wkup_cause_cause_1_wd),
     .d      (hw2reg.wkup_cause[1].d),
     .qre    (),
@@ -4779,7 +4779,7 @@ module pinmux_reg_top (
   ) u_wkup_cause_cause_2 (
     .re     (wkup_cause_cause_2_re),
     // qualified with register enable
-    .we     (wkup_cause_cause_2_we & regen_qs),
+    .we     (wkup_cause_cause_2_we & regwen_qs),
     .wd     (wkup_cause_cause_2_wd),
     .d      (hw2reg.wkup_cause[2].d),
     .qre    (),
@@ -4795,7 +4795,7 @@ module pinmux_reg_top (
   ) u_wkup_cause_cause_3 (
     .re     (wkup_cause_cause_3_re),
     // qualified with register enable
-    .we     (wkup_cause_cause_3_we & regen_qs),
+    .we     (wkup_cause_cause_3_we & regwen_qs),
     .wd     (wkup_cause_cause_3_wd),
     .d      (hw2reg.wkup_cause[3].d),
     .qre    (),
@@ -4811,7 +4811,7 @@ module pinmux_reg_top (
   ) u_wkup_cause_cause_4 (
     .re     (wkup_cause_cause_4_re),
     // qualified with register enable
-    .we     (wkup_cause_cause_4_we & regen_qs),
+    .we     (wkup_cause_cause_4_we & regwen_qs),
     .wd     (wkup_cause_cause_4_wd),
     .d      (hw2reg.wkup_cause[4].d),
     .qre    (),
@@ -4827,7 +4827,7 @@ module pinmux_reg_top (
   ) u_wkup_cause_cause_5 (
     .re     (wkup_cause_cause_5_re),
     // qualified with register enable
-    .we     (wkup_cause_cause_5_we & regen_qs),
+    .we     (wkup_cause_cause_5_we & regwen_qs),
     .wd     (wkup_cause_cause_5_wd),
     .d      (hw2reg.wkup_cause[5].d),
     .qre    (),
@@ -4843,7 +4843,7 @@ module pinmux_reg_top (
   ) u_wkup_cause_cause_6 (
     .re     (wkup_cause_cause_6_re),
     // qualified with register enable
-    .we     (wkup_cause_cause_6_we & regen_qs),
+    .we     (wkup_cause_cause_6_we & regwen_qs),
     .wd     (wkup_cause_cause_6_wd),
     .d      (hw2reg.wkup_cause[6].d),
     .qre    (),
@@ -4859,7 +4859,7 @@ module pinmux_reg_top (
   ) u_wkup_cause_cause_7 (
     .re     (wkup_cause_cause_7_re),
     // qualified with register enable
-    .we     (wkup_cause_cause_7_we & regen_qs),
+    .we     (wkup_cause_cause_7_we & regwen_qs),
     .wd     (wkup_cause_cause_7_wd),
     .d      (hw2reg.wkup_cause[7].d),
     .qre    (),
@@ -4875,7 +4875,7 @@ module pinmux_reg_top (
   logic [31:0] addr_hit;
   always_comb begin
     addr_hit = '0;
-    addr_hit[ 0] = (reg_addr == PINMUX_REGEN_OFFSET);
+    addr_hit[ 0] = (reg_addr == PINMUX_REGWEN_OFFSET);
     addr_hit[ 1] = (reg_addr == PINMUX_PERIPH_INSEL_0_OFFSET);
     addr_hit[ 2] = (reg_addr == PINMUX_PERIPH_INSEL_1_OFFSET);
     addr_hit[ 3] = (reg_addr == PINMUX_PERIPH_INSEL_2_OFFSET);
@@ -4948,8 +4948,8 @@ module pinmux_reg_top (
     if (addr_hit[31] && reg_we && (PINMUX_PERMIT[31] != (PINMUX_PERMIT[31] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign regen_we = addr_hit[0] & reg_we & ~wr_err;
-  assign regen_wd = reg_wdata[0];
+  assign regwen_we = addr_hit[0] & reg_we & ~wr_err;
+  assign regwen_wd = reg_wdata[0];
 
   assign periph_insel_0_in_0_we = addr_hit[1] & reg_we & ~wr_err;
   assign periph_insel_0_in_0_wd = reg_wdata[5:0];
@@ -5484,7 +5484,7 @@ module pinmux_reg_top (
     reg_rdata_next = '0;
     unique case (1'b1)
       addr_hit[0]: begin
-        reg_rdata_next[0] = regen_qs;
+        reg_rdata_next[0] = regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/ip/pinmux/util/reg_pinmux.py
+++ b/hw/ip/pinmux/util/reg_pinmux.py
@@ -66,7 +66,13 @@ def main():
                        n_dio_periph_out=args.n_dio_periph_out,
                        n_dio_pads=args.n_dio_pads,
                        n_wkup_detect=args.n_wkup_detect,
-                       wkup_cnt_width=args.wkup_cnt_width))
+                       wkup_cnt_width=args.wkup_cnt_width,
+                       usb_start_pos=0,
+                       n_usb_pins=0,
+                       usb_dp_sel=0,
+                       usb_dn_sel=0,
+                       usb_dp_pull_sel=0,
+                       usb_dn_pull_sel=0))
 
     print(out.getvalue())
 

--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -128,7 +128,7 @@
     }
     { name: "CTRL_REGWEN",
       desc: "Lock register for control register.",
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "none",
       fields: [
         { bits: "0"

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_top.sv
@@ -171,7 +171,7 @@ module sram_ctrl_reg_top (
 
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("W0C"),
     .RESVAL  (1'h1)
   ) u_ctrl_regwen (
     .clk_i   (clk_i    ),

--- a/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
@@ -166,11 +166,11 @@
 
   registers: [
 # register locks for alerts and class configs
-    { name: "REGEN",
+    { name: "REGWEN",
       desc: '''
             Register write enable for all control registers.
             ''',
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hro",
       fields: [
         {
@@ -190,7 +190,7 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         {
           # TODO: add PING_CNT_DW parameter here
@@ -210,7 +210,7 @@
                   count:    "NAlerts",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "alert",
                   tags:     [// Enable `alert_en` might cause top-level escalators to trigger
                              // unexpected reset
@@ -230,7 +230,7 @@
                   count:    "NAlerts",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "alert",
                   fields: [
                     {
@@ -273,7 +273,7 @@
                   count:    "N_LOC_ALERT",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "local alert",
                   fields: [
                     { bits: "0",
@@ -290,7 +290,7 @@
                   count:    "N_LOC_ALERT",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "local alert",
                   fields: [
                     {
@@ -330,10 +330,10 @@
 # classes
 
     { name:     "CLASSA_CTRL",
-      desc:     "Escalation control register for alert Class A. Can not be modified if !!REGEN is false."
+      desc:     "Escalation control register for alert Class A. Can not be modified if !!REGWEN is false."
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "0",
           name: "EN",
@@ -395,11 +395,11 @@
         }
       ]
     },
-    { name:     "CLASSA_CLREN",
+    { name:     "CLASSA_REGWEN",
       desc:     '''
                 Clear enable for escalation protocol of Class A alerts.
                 '''
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hwo",
       fields: [
       {   bits:   "0",
@@ -422,11 +422,11 @@
       swaccess: "wo",
       hwaccess: "hro",
       hwqe:     "true",
-      regwen:   "CLASSA_CLREN",
+      regwen:   "CLASSA_REGWEN",
       fields: [
         { bits: "0",
           desc: '''Writing to this register clears the accumulator and aborts escalation
-          (if it has been triggered). This clear is disabled if !!CLASSA_CLREN is false.
+          (if it has been triggered). This clear is disabled if !!CLASSA_REGWEN is false.
           '''
         }
       ]
@@ -434,7 +434,7 @@
     { name:     "CLASSA_ACCUM_CNT",
       desc:     '''
                 Current accumulation value for alert Class A. Software can clear this register
-                with a write to !!CLASSA_CLR register unless !!CLASSA_CLREN is false.
+                with a write to !!CLASSA_CLR register unless !!CLASSA_REGWEN is false.
                 '''
       swaccess: "ro",
       hwaccess: "hwo",
@@ -452,12 +452,12 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "15:0",
           desc: '''Once the accumulation value register is equal to the threshold escalation will
           be triggered on the next alert occurrence within this class A begins. Note that this
-          register can not be modified if !!REGEN is false.
+          register can not be modified if !!REGWEN is false.
           '''
         }
       ]
@@ -468,14 +468,14 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0",
           desc: '''If the interrupt corresponding to this class is not
           handled within the specified amount of cycles, escalation will be triggered.
           Set to a positive value to enable the interrupt timeout for Class A. The timeout is set to zero
           by default, which disables this feature. Note that this register can not be modified if
-          !!REGEN is false.
+          !!REGWEN is false.
           '''
         }
       ]
@@ -486,11 +486,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -500,11 +500,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -514,11 +514,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -528,11 +528,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -552,7 +552,7 @@
           corresponding interrupt bit.
 
           If this class is in any of the escalation phases (e.g. Phase0), escalation protocol can be
-          aborted by writing to !!CLASSA_CLR. Note however that has no effect if !!CLASSA_CLREN
+          aborted by writing to !!CLASSA_CLR. Note however that has no effect if !!CLASSA_REGWEN
           is set to false (either by SW or by HW via the !!CLASSA_CTRL.LOCK feature).
           '''
         }
@@ -587,10 +587,10 @@
     },
 
     { name:     "CLASSB_CTRL",
-      desc:     "Escalation control register for alert Class B. Can not be modified if !!REGEN is false."
+      desc:     "Escalation control register for alert Class B. Can not be modified if !!REGWEN is false."
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "0",
           name: "EN",
@@ -652,11 +652,11 @@
         }
       ]
     },
-    { name:     "CLASSB_CLREN",
+    { name:     "CLASSB_REGWEN",
       desc:     '''
                 Clear enable for escalation protocol of Class B alerts.
                 '''
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hwo",
       fields: [
       {   bits:   "0",
@@ -679,11 +679,11 @@
       swaccess: "wo",
       hwaccess: "hro",
       hwqe:     "true",
-      regwen:   "CLASSB_CLREN",
+      regwen:   "CLASSB_REGWEN",
       fields: [
         { bits: "0",
           desc: '''Writing to this register clears the accumulator and aborts escalation
-          (if it has been triggered). This clear is disabled if !!CLASSB_CLREN is false.
+          (if it has been triggered). This clear is disabled if !!CLASSB_REGWEN is false.
           '''
         }
       ]
@@ -691,7 +691,7 @@
     { name:     "CLASSB_ACCUM_CNT",
       desc:     '''
                 Current accumulation value for alert Class B. Software can clear this register
-                with a write to !!CLASSB_CLR register unless !!CLASSB_CLREN is false.
+                with a write to !!CLASSB_CLR register unless !!CLASSB_REGWEN is false.
                 '''
       swaccess: "ro",
       hwaccess: "hwo",
@@ -709,12 +709,12 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "15:0",
           desc: '''Once the accumulation value register is equal to the threshold escalation will
           be triggered on the next alert occurrence within this class B begins. Note that this
-          register can not be modified if !!REGEN is false.
+          register can not be modified if !!REGWEN is false.
           '''
         }
       ]
@@ -725,14 +725,14 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0",
           desc: '''If the interrupt corresponding to this class is not
           handled within the specified amount of cycles, escalation will be triggered.
           Set to a positive value to enable the interrupt timeout for Class B. The timeout is set to zero
           by default, which disables this feature. Note that this register can not be modified if
-          !!REGEN is false.
+          !!REGWEN is false.
           '''
         }
       ]
@@ -743,11 +743,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -757,11 +757,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -771,11 +771,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -785,11 +785,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -809,7 +809,7 @@
           corresponding interrupt bit.
 
           If this class is in any of the escalation phases (e.g. Phase0), escalation protocol can be
-          aborted by writing to !!CLASSB_CLR. Note however that has no effect if !!CLASSB_CLREN
+          aborted by writing to !!CLASSB_CLR. Note however that has no effect if !!CLASSB_REGWEN
           is set to false (either by SW or by HW via the !!CLASSB_CTRL.LOCK feature).
           '''
         }
@@ -844,10 +844,10 @@
     },
 
     { name:     "CLASSC_CTRL",
-      desc:     "Escalation control register for alert Class C. Can not be modified if !!REGEN is false."
+      desc:     "Escalation control register for alert Class C. Can not be modified if !!REGWEN is false."
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "0",
           name: "EN",
@@ -909,11 +909,11 @@
         }
       ]
     },
-    { name:     "CLASSC_CLREN",
+    { name:     "CLASSC_REGWEN",
       desc:     '''
                 Clear enable for escalation protocol of Class C alerts.
                 '''
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hwo",
       fields: [
       {   bits:   "0",
@@ -936,11 +936,11 @@
       swaccess: "wo",
       hwaccess: "hro",
       hwqe:     "true",
-      regwen:   "CLASSC_CLREN",
+      regwen:   "CLASSC_REGWEN",
       fields: [
         { bits: "0",
           desc: '''Writing to this register clears the accumulator and aborts escalation
-          (if it has been triggered). This clear is disabled if !!CLASSC_CLREN is false.
+          (if it has been triggered). This clear is disabled if !!CLASSC_REGWEN is false.
           '''
         }
       ]
@@ -948,7 +948,7 @@
     { name:     "CLASSC_ACCUM_CNT",
       desc:     '''
                 Current accumulation value for alert Class C. Software can clear this register
-                with a write to !!CLASSC_CLR register unless !!CLASSC_CLREN is false.
+                with a write to !!CLASSC_CLR register unless !!CLASSC_REGWEN is false.
                 '''
       swaccess: "ro",
       hwaccess: "hwo",
@@ -966,12 +966,12 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "15:0",
           desc: '''Once the accumulation value register is equal to the threshold escalation will
           be triggered on the next alert occurrence within this class C begins. Note that this
-          register can not be modified if !!REGEN is false.
+          register can not be modified if !!REGWEN is false.
           '''
         }
       ]
@@ -982,14 +982,14 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0",
           desc: '''If the interrupt corresponding to this class is not
           handled within the specified amount of cycles, escalation will be triggered.
           Set to a positive value to enable the interrupt timeout for Class C. The timeout is set to zero
           by default, which disables this feature. Note that this register can not be modified if
-          !!REGEN is false.
+          !!REGWEN is false.
           '''
         }
       ]
@@ -1000,11 +1000,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -1014,11 +1014,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -1028,11 +1028,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -1042,11 +1042,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -1066,7 +1066,7 @@
           corresponding interrupt bit.
 
           If this class is in any of the escalation phases (e.g. Phase0), escalation protocol can be
-          aborted by writing to !!CLASSC_CLR. Note however that has no effect if !!CLASSC_CLREN
+          aborted by writing to !!CLASSC_CLR. Note however that has no effect if !!CLASSC_REGWEN
           is set to false (either by SW or by HW via the !!CLASSC_CTRL.LOCK feature).
           '''
         }
@@ -1101,10 +1101,10 @@
     },
 
     { name:     "CLASSD_CTRL",
-      desc:     "Escalation control register for alert Class D. Can not be modified if !!REGEN is false."
+      desc:     "Escalation control register for alert Class D. Can not be modified if !!REGWEN is false."
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "0",
           name: "EN",
@@ -1166,11 +1166,11 @@
         }
       ]
     },
-    { name:     "CLASSD_CLREN",
+    { name:     "CLASSD_REGWEN",
       desc:     '''
                 Clear enable for escalation protocol of Class D alerts.
                 '''
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hwo",
       fields: [
       {   bits:   "0",
@@ -1193,11 +1193,11 @@
       swaccess: "wo",
       hwaccess: "hro",
       hwqe:     "true",
-      regwen:   "CLASSD_CLREN",
+      regwen:   "CLASSD_REGWEN",
       fields: [
         { bits: "0",
           desc: '''Writing to this register clears the accumulator and aborts escalation
-          (if it has been triggered). This clear is disabled if !!CLASSD_CLREN is false.
+          (if it has been triggered). This clear is disabled if !!CLASSD_REGWEN is false.
           '''
         }
       ]
@@ -1205,7 +1205,7 @@
     { name:     "CLASSD_ACCUM_CNT",
       desc:     '''
                 Current accumulation value for alert Class D. Software can clear this register
-                with a write to !!CLASSD_CLR register unless !!CLASSD_CLREN is false.
+                with a write to !!CLASSD_CLR register unless !!CLASSD_REGWEN is false.
                 '''
       swaccess: "ro",
       hwaccess: "hwo",
@@ -1223,12 +1223,12 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "15:0",
           desc: '''Once the accumulation value register is equal to the threshold escalation will
           be triggered on the next alert occurrence within this class D begins. Note that this
-          register can not be modified if !!REGEN is false.
+          register can not be modified if !!REGWEN is false.
           '''
         }
       ]
@@ -1239,14 +1239,14 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0",
           desc: '''If the interrupt corresponding to this class is not
           handled within the specified amount of cycles, escalation will be triggered.
           Set to a positive value to enable the interrupt timeout for Class D. The timeout is set to zero
           by default, which disables this feature. Note that this register can not be modified if
-          !!REGEN is false.
+          !!REGWEN is false.
           '''
         }
       ]
@@ -1257,11 +1257,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -1271,11 +1271,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -1285,11 +1285,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -1299,11 +1299,11 @@
                 '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGEN",
+      regwen:   "REGWEN",
       fields: [
         { bits: "31:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
-          modified if !!REGEN is false.'''
+          modified if !!REGWEN is false.'''
         }
       ]
     }
@@ -1323,7 +1323,7 @@
           corresponding interrupt bit.
 
           If this class is in any of the escalation phases (e.g. Phase0), escalation protocol can be
-          aborted by writing to !!CLASSD_CLR. Note however that has no effect if !!CLASSD_CLREN
+          aborted by writing to !!CLASSD_CLR. Note however that has no effect if !!CLASSD_REGWEN
           is set to false (either by SW or by HW via the !!CLASSD_CTRL.LOCK feature).
           '''
         }

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
@@ -76,7 +76,7 @@ package alert_handler_reg_pkg;
 
   typedef struct packed {
     logic        q;
-  } alert_handler_reg2hw_regen_reg_t;
+  } alert_handler_reg2hw_regwen_reg_t;
 
   typedef struct packed {
     logic [23:0] q;
@@ -387,7 +387,7 @@ package alert_handler_reg_pkg;
   typedef struct packed {
     logic        d;
     logic        de;
-  } alert_handler_hw2reg_classa_clren_reg_t;
+  } alert_handler_hw2reg_classa_regwen_reg_t;
 
   typedef struct packed {
     logic [15:0] d;
@@ -404,7 +404,7 @@ package alert_handler_reg_pkg;
   typedef struct packed {
     logic        d;
     logic        de;
-  } alert_handler_hw2reg_classb_clren_reg_t;
+  } alert_handler_hw2reg_classb_regwen_reg_t;
 
   typedef struct packed {
     logic [15:0] d;
@@ -421,7 +421,7 @@ package alert_handler_reg_pkg;
   typedef struct packed {
     logic        d;
     logic        de;
-  } alert_handler_hw2reg_classc_clren_reg_t;
+  } alert_handler_hw2reg_classc_regwen_reg_t;
 
   typedef struct packed {
     logic [15:0] d;
@@ -438,7 +438,7 @@ package alert_handler_reg_pkg;
   typedef struct packed {
     logic        d;
     logic        de;
-  } alert_handler_hw2reg_classd_clren_reg_t;
+  } alert_handler_hw2reg_classd_regwen_reg_t;
 
   typedef struct packed {
     logic [15:0] d;
@@ -460,7 +460,7 @@ package alert_handler_reg_pkg;
     alert_handler_reg2hw_intr_state_reg_t intr_state; // [916:913]
     alert_handler_reg2hw_intr_enable_reg_t intr_enable; // [912:909]
     alert_handler_reg2hw_intr_test_reg_t intr_test; // [908:901]
-    alert_handler_reg2hw_regen_reg_t regen; // [900:900]
+    alert_handler_reg2hw_regwen_reg_t regwen; // [900:900]
     alert_handler_reg2hw_ping_timeout_cyc_reg_t ping_timeout_cyc; // [899:876]
     alert_handler_reg2hw_alert_en_mreg_t [22:0] alert_en; // [875:853]
     alert_handler_reg2hw_alert_class_mreg_t [22:0] alert_class; // [852:807]
@@ -509,19 +509,19 @@ package alert_handler_reg_pkg;
     alert_handler_hw2reg_intr_state_reg_t intr_state; // [273:266]
     alert_handler_hw2reg_alert_cause_mreg_t [22:0] alert_cause; // [265:220]
     alert_handler_hw2reg_loc_alert_cause_mreg_t [3:0] loc_alert_cause; // [219:212]
-    alert_handler_hw2reg_classa_clren_reg_t classa_clren; // [211:210]
+    alert_handler_hw2reg_classa_regwen_reg_t classa_regwen; // [211:210]
     alert_handler_hw2reg_classa_accum_cnt_reg_t classa_accum_cnt; // [209:194]
     alert_handler_hw2reg_classa_esc_cnt_reg_t classa_esc_cnt; // [193:162]
     alert_handler_hw2reg_classa_state_reg_t classa_state; // [161:159]
-    alert_handler_hw2reg_classb_clren_reg_t classb_clren; // [158:157]
+    alert_handler_hw2reg_classb_regwen_reg_t classb_regwen; // [158:157]
     alert_handler_hw2reg_classb_accum_cnt_reg_t classb_accum_cnt; // [156:141]
     alert_handler_hw2reg_classb_esc_cnt_reg_t classb_esc_cnt; // [140:109]
     alert_handler_hw2reg_classb_state_reg_t classb_state; // [108:106]
-    alert_handler_hw2reg_classc_clren_reg_t classc_clren; // [105:104]
+    alert_handler_hw2reg_classc_regwen_reg_t classc_regwen; // [105:104]
     alert_handler_hw2reg_classc_accum_cnt_reg_t classc_accum_cnt; // [103:88]
     alert_handler_hw2reg_classc_esc_cnt_reg_t classc_esc_cnt; // [87:56]
     alert_handler_hw2reg_classc_state_reg_t classc_state; // [55:53]
-    alert_handler_hw2reg_classd_clren_reg_t classd_clren; // [52:51]
+    alert_handler_hw2reg_classd_regwen_reg_t classd_regwen; // [52:51]
     alert_handler_hw2reg_classd_accum_cnt_reg_t classd_accum_cnt; // [50:35]
     alert_handler_hw2reg_classd_esc_cnt_reg_t classd_esc_cnt; // [34:3]
     alert_handler_hw2reg_classd_state_reg_t classd_state; // [2:0]
@@ -531,7 +531,7 @@ package alert_handler_reg_pkg;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_INTR_STATE_OFFSET = 10'h 0;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_INTR_ENABLE_OFFSET = 10'h 4;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_INTR_TEST_OFFSET = 10'h 8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_REGEN_OFFSET = 10'h c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_REGWEN_OFFSET = 10'h c;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_PING_TIMEOUT_CYC_OFFSET = 10'h 10;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_OFFSET = 10'h 20;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_0_OFFSET = 10'h 120;
@@ -541,7 +541,7 @@ package alert_handler_reg_pkg;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_OFFSET = 10'h 324;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_OFFSET = 10'h 328;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_CTRL_OFFSET = 10'h 32c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_CLREN_OFFSET = 10'h 330;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_REGWEN_OFFSET = 10'h 330;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_CLR_OFFSET = 10'h 334;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_ACCUM_CNT_OFFSET = 10'h 338;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_ACCUM_THRESH_OFFSET = 10'h 33c;
@@ -553,7 +553,7 @@ package alert_handler_reg_pkg;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_ESC_CNT_OFFSET = 10'h 354;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_STATE_OFFSET = 10'h 358;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_CTRL_OFFSET = 10'h 35c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_CLREN_OFFSET = 10'h 360;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_REGWEN_OFFSET = 10'h 360;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_CLR_OFFSET = 10'h 364;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_ACCUM_CNT_OFFSET = 10'h 368;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_ACCUM_THRESH_OFFSET = 10'h 36c;
@@ -565,7 +565,7 @@ package alert_handler_reg_pkg;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_ESC_CNT_OFFSET = 10'h 384;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_STATE_OFFSET = 10'h 388;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_CTRL_OFFSET = 10'h 38c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_CLREN_OFFSET = 10'h 390;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_REGWEN_OFFSET = 10'h 390;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_CLR_OFFSET = 10'h 394;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_ACCUM_CNT_OFFSET = 10'h 398;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_ACCUM_THRESH_OFFSET = 10'h 39c;
@@ -577,7 +577,7 @@ package alert_handler_reg_pkg;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_ESC_CNT_OFFSET = 10'h 3b4;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_STATE_OFFSET = 10'h 3b8;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_CTRL_OFFSET = 10'h 3bc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_CLREN_OFFSET = 10'h 3c0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_REGWEN_OFFSET = 10'h 3c0;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_CLR_OFFSET = 10'h 3c4;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_ACCUM_CNT_OFFSET = 10'h 3c8;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_ACCUM_THRESH_OFFSET = 10'h 3cc;
@@ -595,7 +595,7 @@ package alert_handler_reg_pkg;
     ALERT_HANDLER_INTR_STATE,
     ALERT_HANDLER_INTR_ENABLE,
     ALERT_HANDLER_INTR_TEST,
-    ALERT_HANDLER_REGEN,
+    ALERT_HANDLER_REGWEN,
     ALERT_HANDLER_PING_TIMEOUT_CYC,
     ALERT_HANDLER_ALERT_EN,
     ALERT_HANDLER_ALERT_CLASS_0,
@@ -605,7 +605,7 @@ package alert_handler_reg_pkg;
     ALERT_HANDLER_LOC_ALERT_CLASS,
     ALERT_HANDLER_LOC_ALERT_CAUSE,
     ALERT_HANDLER_CLASSA_CTRL,
-    ALERT_HANDLER_CLASSA_CLREN,
+    ALERT_HANDLER_CLASSA_REGWEN,
     ALERT_HANDLER_CLASSA_CLR,
     ALERT_HANDLER_CLASSA_ACCUM_CNT,
     ALERT_HANDLER_CLASSA_ACCUM_THRESH,
@@ -617,7 +617,7 @@ package alert_handler_reg_pkg;
     ALERT_HANDLER_CLASSA_ESC_CNT,
     ALERT_HANDLER_CLASSA_STATE,
     ALERT_HANDLER_CLASSB_CTRL,
-    ALERT_HANDLER_CLASSB_CLREN,
+    ALERT_HANDLER_CLASSB_REGWEN,
     ALERT_HANDLER_CLASSB_CLR,
     ALERT_HANDLER_CLASSB_ACCUM_CNT,
     ALERT_HANDLER_CLASSB_ACCUM_THRESH,
@@ -629,7 +629,7 @@ package alert_handler_reg_pkg;
     ALERT_HANDLER_CLASSB_ESC_CNT,
     ALERT_HANDLER_CLASSB_STATE,
     ALERT_HANDLER_CLASSC_CTRL,
-    ALERT_HANDLER_CLASSC_CLREN,
+    ALERT_HANDLER_CLASSC_REGWEN,
     ALERT_HANDLER_CLASSC_CLR,
     ALERT_HANDLER_CLASSC_ACCUM_CNT,
     ALERT_HANDLER_CLASSC_ACCUM_THRESH,
@@ -641,7 +641,7 @@ package alert_handler_reg_pkg;
     ALERT_HANDLER_CLASSC_ESC_CNT,
     ALERT_HANDLER_CLASSC_STATE,
     ALERT_HANDLER_CLASSD_CTRL,
-    ALERT_HANDLER_CLASSD_CLREN,
+    ALERT_HANDLER_CLASSD_REGWEN,
     ALERT_HANDLER_CLASSD_CLR,
     ALERT_HANDLER_CLASSD_ACCUM_CNT,
     ALERT_HANDLER_CLASSD_ACCUM_THRESH,
@@ -659,7 +659,7 @@ package alert_handler_reg_pkg;
     4'b 0001, // index[ 0] ALERT_HANDLER_INTR_STATE
     4'b 0001, // index[ 1] ALERT_HANDLER_INTR_ENABLE
     4'b 0001, // index[ 2] ALERT_HANDLER_INTR_TEST
-    4'b 0001, // index[ 3] ALERT_HANDLER_REGEN
+    4'b 0001, // index[ 3] ALERT_HANDLER_REGWEN
     4'b 0111, // index[ 4] ALERT_HANDLER_PING_TIMEOUT_CYC
     4'b 0111, // index[ 5] ALERT_HANDLER_ALERT_EN
     4'b 1111, // index[ 6] ALERT_HANDLER_ALERT_CLASS_0
@@ -669,7 +669,7 @@ package alert_handler_reg_pkg;
     4'b 0001, // index[10] ALERT_HANDLER_LOC_ALERT_CLASS
     4'b 0001, // index[11] ALERT_HANDLER_LOC_ALERT_CAUSE
     4'b 0011, // index[12] ALERT_HANDLER_CLASSA_CTRL
-    4'b 0001, // index[13] ALERT_HANDLER_CLASSA_CLREN
+    4'b 0001, // index[13] ALERT_HANDLER_CLASSA_REGWEN
     4'b 0001, // index[14] ALERT_HANDLER_CLASSA_CLR
     4'b 0011, // index[15] ALERT_HANDLER_CLASSA_ACCUM_CNT
     4'b 0011, // index[16] ALERT_HANDLER_CLASSA_ACCUM_THRESH
@@ -681,7 +681,7 @@ package alert_handler_reg_pkg;
     4'b 1111, // index[22] ALERT_HANDLER_CLASSA_ESC_CNT
     4'b 0001, // index[23] ALERT_HANDLER_CLASSA_STATE
     4'b 0011, // index[24] ALERT_HANDLER_CLASSB_CTRL
-    4'b 0001, // index[25] ALERT_HANDLER_CLASSB_CLREN
+    4'b 0001, // index[25] ALERT_HANDLER_CLASSB_REGWEN
     4'b 0001, // index[26] ALERT_HANDLER_CLASSB_CLR
     4'b 0011, // index[27] ALERT_HANDLER_CLASSB_ACCUM_CNT
     4'b 0011, // index[28] ALERT_HANDLER_CLASSB_ACCUM_THRESH
@@ -693,7 +693,7 @@ package alert_handler_reg_pkg;
     4'b 1111, // index[34] ALERT_HANDLER_CLASSB_ESC_CNT
     4'b 0001, // index[35] ALERT_HANDLER_CLASSB_STATE
     4'b 0011, // index[36] ALERT_HANDLER_CLASSC_CTRL
-    4'b 0001, // index[37] ALERT_HANDLER_CLASSC_CLREN
+    4'b 0001, // index[37] ALERT_HANDLER_CLASSC_REGWEN
     4'b 0001, // index[38] ALERT_HANDLER_CLASSC_CLR
     4'b 0011, // index[39] ALERT_HANDLER_CLASSC_ACCUM_CNT
     4'b 0011, // index[40] ALERT_HANDLER_CLASSC_ACCUM_THRESH
@@ -705,7 +705,7 @@ package alert_handler_reg_pkg;
     4'b 1111, // index[46] ALERT_HANDLER_CLASSC_ESC_CNT
     4'b 0001, // index[47] ALERT_HANDLER_CLASSC_STATE
     4'b 0011, // index[48] ALERT_HANDLER_CLASSD_CTRL
-    4'b 0001, // index[49] ALERT_HANDLER_CLASSD_CLREN
+    4'b 0001, // index[49] ALERT_HANDLER_CLASSD_REGWEN
     4'b 0001, // index[50] ALERT_HANDLER_CLASSD_CLR
     4'b 0011, // index[51] ALERT_HANDLER_CLASSD_ACCUM_CNT
     4'b 0011, // index[52] ALERT_HANDLER_CLASSD_ACCUM_THRESH

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
@@ -103,9 +103,9 @@ module alert_handler_reg_top (
   logic intr_test_classc_we;
   logic intr_test_classd_wd;
   logic intr_test_classd_we;
-  logic regen_qs;
-  logic regen_wd;
-  logic regen_we;
+  logic regwen_qs;
+  logic regwen_wd;
+  logic regwen_we;
   logic [23:0] ping_timeout_cyc_qs;
   logic [23:0] ping_timeout_cyc_wd;
   logic ping_timeout_cyc_we;
@@ -382,9 +382,9 @@ module alert_handler_reg_top (
   logic [1:0] classa_ctrl_map_e3_qs;
   logic [1:0] classa_ctrl_map_e3_wd;
   logic classa_ctrl_map_e3_we;
-  logic classa_clren_qs;
-  logic classa_clren_wd;
-  logic classa_clren_we;
+  logic classa_regwen_qs;
+  logic classa_regwen_wd;
+  logic classa_regwen_we;
   logic classa_clr_wd;
   logic classa_clr_we;
   logic [15:0] classa_accum_cnt_qs;
@@ -441,9 +441,9 @@ module alert_handler_reg_top (
   logic [1:0] classb_ctrl_map_e3_qs;
   logic [1:0] classb_ctrl_map_e3_wd;
   logic classb_ctrl_map_e3_we;
-  logic classb_clren_qs;
-  logic classb_clren_wd;
-  logic classb_clren_we;
+  logic classb_regwen_qs;
+  logic classb_regwen_wd;
+  logic classb_regwen_we;
   logic classb_clr_wd;
   logic classb_clr_we;
   logic [15:0] classb_accum_cnt_qs;
@@ -500,9 +500,9 @@ module alert_handler_reg_top (
   logic [1:0] classc_ctrl_map_e3_qs;
   logic [1:0] classc_ctrl_map_e3_wd;
   logic classc_ctrl_map_e3_we;
-  logic classc_clren_qs;
-  logic classc_clren_wd;
-  logic classc_clren_we;
+  logic classc_regwen_qs;
+  logic classc_regwen_wd;
+  logic classc_regwen_we;
   logic classc_clr_wd;
   logic classc_clr_we;
   logic [15:0] classc_accum_cnt_qs;
@@ -559,9 +559,9 @@ module alert_handler_reg_top (
   logic [1:0] classd_ctrl_map_e3_qs;
   logic [1:0] classd_ctrl_map_e3_wd;
   logic classd_ctrl_map_e3_we;
-  logic classd_clren_qs;
-  logic classd_clren_wd;
-  logic classd_clren_we;
+  logic classd_regwen_qs;
+  logic classd_regwen_wd;
+  logic classd_regwen_we;
   logic classd_clr_wd;
   logic classd_clr_we;
   logic [15:0] classd_accum_cnt_qs;
@@ -864,19 +864,19 @@ module alert_handler_reg_top (
   );
 
 
-  // R[regen]: V(False)
+  // R[regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_regen (
+  ) u_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (regen_we),
-    .wd     (regen_wd),
+    .we     (regwen_we),
+    .wd     (regwen_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -884,10 +884,10 @@ module alert_handler_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.regen.q ),
+    .q      (reg2hw.regwen.q ),
 
     // to register interface (read)
-    .qs     (regen_qs)
+    .qs     (regwen_qs)
   );
 
 
@@ -902,7 +902,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (ping_timeout_cyc_we & regen_qs),
+    .we     (ping_timeout_cyc_we & regwen_qs),
     .wd     (ping_timeout_cyc_wd),
 
     // from internal hardware
@@ -932,7 +932,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_0_we & regen_qs),
+    .we     (alert_en_en_a_0_we & regwen_qs),
     .wd     (alert_en_en_a_0_wd),
 
     // from internal hardware
@@ -958,7 +958,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_1_we & regen_qs),
+    .we     (alert_en_en_a_1_we & regwen_qs),
     .wd     (alert_en_en_a_1_wd),
 
     // from internal hardware
@@ -984,7 +984,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_2_we & regen_qs),
+    .we     (alert_en_en_a_2_we & regwen_qs),
     .wd     (alert_en_en_a_2_wd),
 
     // from internal hardware
@@ -1010,7 +1010,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_3_we & regen_qs),
+    .we     (alert_en_en_a_3_we & regwen_qs),
     .wd     (alert_en_en_a_3_wd),
 
     // from internal hardware
@@ -1036,7 +1036,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_4_we & regen_qs),
+    .we     (alert_en_en_a_4_we & regwen_qs),
     .wd     (alert_en_en_a_4_wd),
 
     // from internal hardware
@@ -1062,7 +1062,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_5_we & regen_qs),
+    .we     (alert_en_en_a_5_we & regwen_qs),
     .wd     (alert_en_en_a_5_wd),
 
     // from internal hardware
@@ -1088,7 +1088,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_6_we & regen_qs),
+    .we     (alert_en_en_a_6_we & regwen_qs),
     .wd     (alert_en_en_a_6_wd),
 
     // from internal hardware
@@ -1114,7 +1114,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_7_we & regen_qs),
+    .we     (alert_en_en_a_7_we & regwen_qs),
     .wd     (alert_en_en_a_7_wd),
 
     // from internal hardware
@@ -1140,7 +1140,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_8_we & regen_qs),
+    .we     (alert_en_en_a_8_we & regwen_qs),
     .wd     (alert_en_en_a_8_wd),
 
     // from internal hardware
@@ -1166,7 +1166,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_9_we & regen_qs),
+    .we     (alert_en_en_a_9_we & regwen_qs),
     .wd     (alert_en_en_a_9_wd),
 
     // from internal hardware
@@ -1192,7 +1192,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_10_we & regen_qs),
+    .we     (alert_en_en_a_10_we & regwen_qs),
     .wd     (alert_en_en_a_10_wd),
 
     // from internal hardware
@@ -1218,7 +1218,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_11_we & regen_qs),
+    .we     (alert_en_en_a_11_we & regwen_qs),
     .wd     (alert_en_en_a_11_wd),
 
     // from internal hardware
@@ -1244,7 +1244,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_12_we & regen_qs),
+    .we     (alert_en_en_a_12_we & regwen_qs),
     .wd     (alert_en_en_a_12_wd),
 
     // from internal hardware
@@ -1270,7 +1270,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_13_we & regen_qs),
+    .we     (alert_en_en_a_13_we & regwen_qs),
     .wd     (alert_en_en_a_13_wd),
 
     // from internal hardware
@@ -1296,7 +1296,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_14_we & regen_qs),
+    .we     (alert_en_en_a_14_we & regwen_qs),
     .wd     (alert_en_en_a_14_wd),
 
     // from internal hardware
@@ -1322,7 +1322,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_15_we & regen_qs),
+    .we     (alert_en_en_a_15_we & regwen_qs),
     .wd     (alert_en_en_a_15_wd),
 
     // from internal hardware
@@ -1348,7 +1348,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_16_we & regen_qs),
+    .we     (alert_en_en_a_16_we & regwen_qs),
     .wd     (alert_en_en_a_16_wd),
 
     // from internal hardware
@@ -1374,7 +1374,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_17_we & regen_qs),
+    .we     (alert_en_en_a_17_we & regwen_qs),
     .wd     (alert_en_en_a_17_wd),
 
     // from internal hardware
@@ -1400,7 +1400,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_18_we & regen_qs),
+    .we     (alert_en_en_a_18_we & regwen_qs),
     .wd     (alert_en_en_a_18_wd),
 
     // from internal hardware
@@ -1426,7 +1426,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_19_we & regen_qs),
+    .we     (alert_en_en_a_19_we & regwen_qs),
     .wd     (alert_en_en_a_19_wd),
 
     // from internal hardware
@@ -1452,7 +1452,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_20_we & regen_qs),
+    .we     (alert_en_en_a_20_we & regwen_qs),
     .wd     (alert_en_en_a_20_wd),
 
     // from internal hardware
@@ -1478,7 +1478,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_21_we & regen_qs),
+    .we     (alert_en_en_a_21_we & regwen_qs),
     .wd     (alert_en_en_a_21_wd),
 
     // from internal hardware
@@ -1504,7 +1504,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_en_a_22_we & regen_qs),
+    .we     (alert_en_en_a_22_we & regwen_qs),
     .wd     (alert_en_en_a_22_wd),
 
     // from internal hardware
@@ -1535,7 +1535,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_0_class_a_0_we & regen_qs),
+    .we     (alert_class_0_class_a_0_we & regwen_qs),
     .wd     (alert_class_0_class_a_0_wd),
 
     // from internal hardware
@@ -1561,7 +1561,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_0_class_a_1_we & regen_qs),
+    .we     (alert_class_0_class_a_1_we & regwen_qs),
     .wd     (alert_class_0_class_a_1_wd),
 
     // from internal hardware
@@ -1587,7 +1587,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_0_class_a_2_we & regen_qs),
+    .we     (alert_class_0_class_a_2_we & regwen_qs),
     .wd     (alert_class_0_class_a_2_wd),
 
     // from internal hardware
@@ -1613,7 +1613,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_0_class_a_3_we & regen_qs),
+    .we     (alert_class_0_class_a_3_we & regwen_qs),
     .wd     (alert_class_0_class_a_3_wd),
 
     // from internal hardware
@@ -1639,7 +1639,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_0_class_a_4_we & regen_qs),
+    .we     (alert_class_0_class_a_4_we & regwen_qs),
     .wd     (alert_class_0_class_a_4_wd),
 
     // from internal hardware
@@ -1665,7 +1665,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_0_class_a_5_we & regen_qs),
+    .we     (alert_class_0_class_a_5_we & regwen_qs),
     .wd     (alert_class_0_class_a_5_wd),
 
     // from internal hardware
@@ -1691,7 +1691,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_0_class_a_6_we & regen_qs),
+    .we     (alert_class_0_class_a_6_we & regwen_qs),
     .wd     (alert_class_0_class_a_6_wd),
 
     // from internal hardware
@@ -1717,7 +1717,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_0_class_a_7_we & regen_qs),
+    .we     (alert_class_0_class_a_7_we & regwen_qs),
     .wd     (alert_class_0_class_a_7_wd),
 
     // from internal hardware
@@ -1743,7 +1743,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_0_class_a_8_we & regen_qs),
+    .we     (alert_class_0_class_a_8_we & regwen_qs),
     .wd     (alert_class_0_class_a_8_wd),
 
     // from internal hardware
@@ -1769,7 +1769,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_0_class_a_9_we & regen_qs),
+    .we     (alert_class_0_class_a_9_we & regwen_qs),
     .wd     (alert_class_0_class_a_9_wd),
 
     // from internal hardware
@@ -1795,7 +1795,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_0_class_a_10_we & regen_qs),
+    .we     (alert_class_0_class_a_10_we & regwen_qs),
     .wd     (alert_class_0_class_a_10_wd),
 
     // from internal hardware
@@ -1821,7 +1821,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_0_class_a_11_we & regen_qs),
+    .we     (alert_class_0_class_a_11_we & regwen_qs),
     .wd     (alert_class_0_class_a_11_wd),
 
     // from internal hardware
@@ -1847,7 +1847,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_0_class_a_12_we & regen_qs),
+    .we     (alert_class_0_class_a_12_we & regwen_qs),
     .wd     (alert_class_0_class_a_12_wd),
 
     // from internal hardware
@@ -1873,7 +1873,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_0_class_a_13_we & regen_qs),
+    .we     (alert_class_0_class_a_13_we & regwen_qs),
     .wd     (alert_class_0_class_a_13_wd),
 
     // from internal hardware
@@ -1899,7 +1899,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_0_class_a_14_we & regen_qs),
+    .we     (alert_class_0_class_a_14_we & regwen_qs),
     .wd     (alert_class_0_class_a_14_wd),
 
     // from internal hardware
@@ -1925,7 +1925,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_0_class_a_15_we & regen_qs),
+    .we     (alert_class_0_class_a_15_we & regwen_qs),
     .wd     (alert_class_0_class_a_15_wd),
 
     // from internal hardware
@@ -1954,7 +1954,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_1_class_a_16_we & regen_qs),
+    .we     (alert_class_1_class_a_16_we & regwen_qs),
     .wd     (alert_class_1_class_a_16_wd),
 
     // from internal hardware
@@ -1980,7 +1980,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_1_class_a_17_we & regen_qs),
+    .we     (alert_class_1_class_a_17_we & regwen_qs),
     .wd     (alert_class_1_class_a_17_wd),
 
     // from internal hardware
@@ -2006,7 +2006,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_1_class_a_18_we & regen_qs),
+    .we     (alert_class_1_class_a_18_we & regwen_qs),
     .wd     (alert_class_1_class_a_18_wd),
 
     // from internal hardware
@@ -2032,7 +2032,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_1_class_a_19_we & regen_qs),
+    .we     (alert_class_1_class_a_19_we & regwen_qs),
     .wd     (alert_class_1_class_a_19_wd),
 
     // from internal hardware
@@ -2058,7 +2058,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_1_class_a_20_we & regen_qs),
+    .we     (alert_class_1_class_a_20_we & regwen_qs),
     .wd     (alert_class_1_class_a_20_wd),
 
     // from internal hardware
@@ -2084,7 +2084,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_1_class_a_21_we & regen_qs),
+    .we     (alert_class_1_class_a_21_we & regwen_qs),
     .wd     (alert_class_1_class_a_21_wd),
 
     // from internal hardware
@@ -2110,7 +2110,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_1_class_a_22_we & regen_qs),
+    .we     (alert_class_1_class_a_22_we & regwen_qs),
     .wd     (alert_class_1_class_a_22_wd),
 
     // from internal hardware
@@ -2744,7 +2744,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (loc_alert_en_en_la_0_we & regen_qs),
+    .we     (loc_alert_en_en_la_0_we & regwen_qs),
     .wd     (loc_alert_en_en_la_0_wd),
 
     // from internal hardware
@@ -2770,7 +2770,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (loc_alert_en_en_la_1_we & regen_qs),
+    .we     (loc_alert_en_en_la_1_we & regwen_qs),
     .wd     (loc_alert_en_en_la_1_wd),
 
     // from internal hardware
@@ -2796,7 +2796,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (loc_alert_en_en_la_2_we & regen_qs),
+    .we     (loc_alert_en_en_la_2_we & regwen_qs),
     .wd     (loc_alert_en_en_la_2_wd),
 
     // from internal hardware
@@ -2822,7 +2822,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (loc_alert_en_en_la_3_we & regen_qs),
+    .we     (loc_alert_en_en_la_3_we & regwen_qs),
     .wd     (loc_alert_en_en_la_3_wd),
 
     // from internal hardware
@@ -2853,7 +2853,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (loc_alert_class_class_la_0_we & regen_qs),
+    .we     (loc_alert_class_class_la_0_we & regwen_qs),
     .wd     (loc_alert_class_class_la_0_wd),
 
     // from internal hardware
@@ -2879,7 +2879,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (loc_alert_class_class_la_1_we & regen_qs),
+    .we     (loc_alert_class_class_la_1_we & regwen_qs),
     .wd     (loc_alert_class_class_la_1_wd),
 
     // from internal hardware
@@ -2905,7 +2905,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (loc_alert_class_class_la_2_we & regen_qs),
+    .we     (loc_alert_class_class_la_2_we & regwen_qs),
     .wd     (loc_alert_class_class_la_2_wd),
 
     // from internal hardware
@@ -2931,7 +2931,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (loc_alert_class_class_la_3_we & regen_qs),
+    .we     (loc_alert_class_class_la_3_we & regwen_qs),
     .wd     (loc_alert_class_class_la_3_wd),
 
     // from internal hardware
@@ -3069,7 +3069,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_en_we & regen_qs),
+    .we     (classa_ctrl_en_we & regwen_qs),
     .wd     (classa_ctrl_en_wd),
 
     // from internal hardware
@@ -3095,7 +3095,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_lock_we & regen_qs),
+    .we     (classa_ctrl_lock_we & regwen_qs),
     .wd     (classa_ctrl_lock_wd),
 
     // from internal hardware
@@ -3121,7 +3121,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_en_e0_we & regen_qs),
+    .we     (classa_ctrl_en_e0_we & regwen_qs),
     .wd     (classa_ctrl_en_e0_wd),
 
     // from internal hardware
@@ -3147,7 +3147,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_en_e1_we & regen_qs),
+    .we     (classa_ctrl_en_e1_we & regwen_qs),
     .wd     (classa_ctrl_en_e1_wd),
 
     // from internal hardware
@@ -3173,7 +3173,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_en_e2_we & regen_qs),
+    .we     (classa_ctrl_en_e2_we & regwen_qs),
     .wd     (classa_ctrl_en_e2_wd),
 
     // from internal hardware
@@ -3199,7 +3199,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_en_e3_we & regen_qs),
+    .we     (classa_ctrl_en_e3_we & regwen_qs),
     .wd     (classa_ctrl_en_e3_wd),
 
     // from internal hardware
@@ -3225,7 +3225,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_map_e0_we & regen_qs),
+    .we     (classa_ctrl_map_e0_we & regwen_qs),
     .wd     (classa_ctrl_map_e0_wd),
 
     // from internal hardware
@@ -3251,7 +3251,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_map_e1_we & regen_qs),
+    .we     (classa_ctrl_map_e1_we & regwen_qs),
     .wd     (classa_ctrl_map_e1_wd),
 
     // from internal hardware
@@ -3277,7 +3277,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_map_e2_we & regen_qs),
+    .we     (classa_ctrl_map_e2_we & regwen_qs),
     .wd     (classa_ctrl_map_e2_wd),
 
     // from internal hardware
@@ -3303,7 +3303,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_ctrl_map_e3_we & regen_qs),
+    .we     (classa_ctrl_map_e3_we & regwen_qs),
     .wd     (classa_ctrl_map_e3_wd),
 
     // from internal hardware
@@ -3319,30 +3319,30 @@ module alert_handler_reg_top (
   );
 
 
-  // R[classa_clren]: V(False)
+  // R[classa_regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_classa_clren (
+  ) u_classa_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (classa_clren_we),
-    .wd     (classa_clren_wd),
+    .we     (classa_regwen_we),
+    .wd     (classa_regwen_wd),
 
     // from internal hardware
-    .de     (hw2reg.classa_clren.de),
-    .d      (hw2reg.classa_clren.d ),
+    .de     (hw2reg.classa_regwen.de),
+    .d      (hw2reg.classa_regwen.d ),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (classa_clren_qs)
+    .qs     (classa_regwen_qs)
   );
 
 
@@ -3357,7 +3357,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_clr_we & classa_clren_qs),
+    .we     (classa_clr_we & classa_regwen_qs),
     .wd     (classa_clr_wd),
 
     // from internal hardware
@@ -3399,7 +3399,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_accum_thresh_we & regen_qs),
+    .we     (classa_accum_thresh_we & regwen_qs),
     .wd     (classa_accum_thresh_wd),
 
     // from internal hardware
@@ -3426,7 +3426,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_timeout_cyc_we & regen_qs),
+    .we     (classa_timeout_cyc_we & regwen_qs),
     .wd     (classa_timeout_cyc_wd),
 
     // from internal hardware
@@ -3453,7 +3453,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_phase0_cyc_we & regen_qs),
+    .we     (classa_phase0_cyc_we & regwen_qs),
     .wd     (classa_phase0_cyc_wd),
 
     // from internal hardware
@@ -3480,7 +3480,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_phase1_cyc_we & regen_qs),
+    .we     (classa_phase1_cyc_we & regwen_qs),
     .wd     (classa_phase1_cyc_wd),
 
     // from internal hardware
@@ -3507,7 +3507,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_phase2_cyc_we & regen_qs),
+    .we     (classa_phase2_cyc_we & regwen_qs),
     .wd     (classa_phase2_cyc_wd),
 
     // from internal hardware
@@ -3534,7 +3534,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classa_phase3_cyc_we & regen_qs),
+    .we     (classa_phase3_cyc_we & regwen_qs),
     .wd     (classa_phase3_cyc_wd),
 
     // from internal hardware
@@ -3594,7 +3594,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_en_we & regen_qs),
+    .we     (classb_ctrl_en_we & regwen_qs),
     .wd     (classb_ctrl_en_wd),
 
     // from internal hardware
@@ -3620,7 +3620,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_lock_we & regen_qs),
+    .we     (classb_ctrl_lock_we & regwen_qs),
     .wd     (classb_ctrl_lock_wd),
 
     // from internal hardware
@@ -3646,7 +3646,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_en_e0_we & regen_qs),
+    .we     (classb_ctrl_en_e0_we & regwen_qs),
     .wd     (classb_ctrl_en_e0_wd),
 
     // from internal hardware
@@ -3672,7 +3672,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_en_e1_we & regen_qs),
+    .we     (classb_ctrl_en_e1_we & regwen_qs),
     .wd     (classb_ctrl_en_e1_wd),
 
     // from internal hardware
@@ -3698,7 +3698,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_en_e2_we & regen_qs),
+    .we     (classb_ctrl_en_e2_we & regwen_qs),
     .wd     (classb_ctrl_en_e2_wd),
 
     // from internal hardware
@@ -3724,7 +3724,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_en_e3_we & regen_qs),
+    .we     (classb_ctrl_en_e3_we & regwen_qs),
     .wd     (classb_ctrl_en_e3_wd),
 
     // from internal hardware
@@ -3750,7 +3750,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_map_e0_we & regen_qs),
+    .we     (classb_ctrl_map_e0_we & regwen_qs),
     .wd     (classb_ctrl_map_e0_wd),
 
     // from internal hardware
@@ -3776,7 +3776,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_map_e1_we & regen_qs),
+    .we     (classb_ctrl_map_e1_we & regwen_qs),
     .wd     (classb_ctrl_map_e1_wd),
 
     // from internal hardware
@@ -3802,7 +3802,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_map_e2_we & regen_qs),
+    .we     (classb_ctrl_map_e2_we & regwen_qs),
     .wd     (classb_ctrl_map_e2_wd),
 
     // from internal hardware
@@ -3828,7 +3828,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_ctrl_map_e3_we & regen_qs),
+    .we     (classb_ctrl_map_e3_we & regwen_qs),
     .wd     (classb_ctrl_map_e3_wd),
 
     // from internal hardware
@@ -3844,30 +3844,30 @@ module alert_handler_reg_top (
   );
 
 
-  // R[classb_clren]: V(False)
+  // R[classb_regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_classb_clren (
+  ) u_classb_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (classb_clren_we),
-    .wd     (classb_clren_wd),
+    .we     (classb_regwen_we),
+    .wd     (classb_regwen_wd),
 
     // from internal hardware
-    .de     (hw2reg.classb_clren.de),
-    .d      (hw2reg.classb_clren.d ),
+    .de     (hw2reg.classb_regwen.de),
+    .d      (hw2reg.classb_regwen.d ),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (classb_clren_qs)
+    .qs     (classb_regwen_qs)
   );
 
 
@@ -3882,7 +3882,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_clr_we & classb_clren_qs),
+    .we     (classb_clr_we & classb_regwen_qs),
     .wd     (classb_clr_wd),
 
     // from internal hardware
@@ -3924,7 +3924,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_accum_thresh_we & regen_qs),
+    .we     (classb_accum_thresh_we & regwen_qs),
     .wd     (classb_accum_thresh_wd),
 
     // from internal hardware
@@ -3951,7 +3951,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_timeout_cyc_we & regen_qs),
+    .we     (classb_timeout_cyc_we & regwen_qs),
     .wd     (classb_timeout_cyc_wd),
 
     // from internal hardware
@@ -3978,7 +3978,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_phase0_cyc_we & regen_qs),
+    .we     (classb_phase0_cyc_we & regwen_qs),
     .wd     (classb_phase0_cyc_wd),
 
     // from internal hardware
@@ -4005,7 +4005,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_phase1_cyc_we & regen_qs),
+    .we     (classb_phase1_cyc_we & regwen_qs),
     .wd     (classb_phase1_cyc_wd),
 
     // from internal hardware
@@ -4032,7 +4032,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_phase2_cyc_we & regen_qs),
+    .we     (classb_phase2_cyc_we & regwen_qs),
     .wd     (classb_phase2_cyc_wd),
 
     // from internal hardware
@@ -4059,7 +4059,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classb_phase3_cyc_we & regen_qs),
+    .we     (classb_phase3_cyc_we & regwen_qs),
     .wd     (classb_phase3_cyc_wd),
 
     // from internal hardware
@@ -4119,7 +4119,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_en_we & regen_qs),
+    .we     (classc_ctrl_en_we & regwen_qs),
     .wd     (classc_ctrl_en_wd),
 
     // from internal hardware
@@ -4145,7 +4145,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_lock_we & regen_qs),
+    .we     (classc_ctrl_lock_we & regwen_qs),
     .wd     (classc_ctrl_lock_wd),
 
     // from internal hardware
@@ -4171,7 +4171,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_en_e0_we & regen_qs),
+    .we     (classc_ctrl_en_e0_we & regwen_qs),
     .wd     (classc_ctrl_en_e0_wd),
 
     // from internal hardware
@@ -4197,7 +4197,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_en_e1_we & regen_qs),
+    .we     (classc_ctrl_en_e1_we & regwen_qs),
     .wd     (classc_ctrl_en_e1_wd),
 
     // from internal hardware
@@ -4223,7 +4223,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_en_e2_we & regen_qs),
+    .we     (classc_ctrl_en_e2_we & regwen_qs),
     .wd     (classc_ctrl_en_e2_wd),
 
     // from internal hardware
@@ -4249,7 +4249,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_en_e3_we & regen_qs),
+    .we     (classc_ctrl_en_e3_we & regwen_qs),
     .wd     (classc_ctrl_en_e3_wd),
 
     // from internal hardware
@@ -4275,7 +4275,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_map_e0_we & regen_qs),
+    .we     (classc_ctrl_map_e0_we & regwen_qs),
     .wd     (classc_ctrl_map_e0_wd),
 
     // from internal hardware
@@ -4301,7 +4301,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_map_e1_we & regen_qs),
+    .we     (classc_ctrl_map_e1_we & regwen_qs),
     .wd     (classc_ctrl_map_e1_wd),
 
     // from internal hardware
@@ -4327,7 +4327,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_map_e2_we & regen_qs),
+    .we     (classc_ctrl_map_e2_we & regwen_qs),
     .wd     (classc_ctrl_map_e2_wd),
 
     // from internal hardware
@@ -4353,7 +4353,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_ctrl_map_e3_we & regen_qs),
+    .we     (classc_ctrl_map_e3_we & regwen_qs),
     .wd     (classc_ctrl_map_e3_wd),
 
     // from internal hardware
@@ -4369,30 +4369,30 @@ module alert_handler_reg_top (
   );
 
 
-  // R[classc_clren]: V(False)
+  // R[classc_regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_classc_clren (
+  ) u_classc_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (classc_clren_we),
-    .wd     (classc_clren_wd),
+    .we     (classc_regwen_we),
+    .wd     (classc_regwen_wd),
 
     // from internal hardware
-    .de     (hw2reg.classc_clren.de),
-    .d      (hw2reg.classc_clren.d ),
+    .de     (hw2reg.classc_regwen.de),
+    .d      (hw2reg.classc_regwen.d ),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (classc_clren_qs)
+    .qs     (classc_regwen_qs)
   );
 
 
@@ -4407,7 +4407,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_clr_we & classc_clren_qs),
+    .we     (classc_clr_we & classc_regwen_qs),
     .wd     (classc_clr_wd),
 
     // from internal hardware
@@ -4449,7 +4449,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_accum_thresh_we & regen_qs),
+    .we     (classc_accum_thresh_we & regwen_qs),
     .wd     (classc_accum_thresh_wd),
 
     // from internal hardware
@@ -4476,7 +4476,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_timeout_cyc_we & regen_qs),
+    .we     (classc_timeout_cyc_we & regwen_qs),
     .wd     (classc_timeout_cyc_wd),
 
     // from internal hardware
@@ -4503,7 +4503,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_phase0_cyc_we & regen_qs),
+    .we     (classc_phase0_cyc_we & regwen_qs),
     .wd     (classc_phase0_cyc_wd),
 
     // from internal hardware
@@ -4530,7 +4530,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_phase1_cyc_we & regen_qs),
+    .we     (classc_phase1_cyc_we & regwen_qs),
     .wd     (classc_phase1_cyc_wd),
 
     // from internal hardware
@@ -4557,7 +4557,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_phase2_cyc_we & regen_qs),
+    .we     (classc_phase2_cyc_we & regwen_qs),
     .wd     (classc_phase2_cyc_wd),
 
     // from internal hardware
@@ -4584,7 +4584,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classc_phase3_cyc_we & regen_qs),
+    .we     (classc_phase3_cyc_we & regwen_qs),
     .wd     (classc_phase3_cyc_wd),
 
     // from internal hardware
@@ -4644,7 +4644,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_en_we & regen_qs),
+    .we     (classd_ctrl_en_we & regwen_qs),
     .wd     (classd_ctrl_en_wd),
 
     // from internal hardware
@@ -4670,7 +4670,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_lock_we & regen_qs),
+    .we     (classd_ctrl_lock_we & regwen_qs),
     .wd     (classd_ctrl_lock_wd),
 
     // from internal hardware
@@ -4696,7 +4696,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_en_e0_we & regen_qs),
+    .we     (classd_ctrl_en_e0_we & regwen_qs),
     .wd     (classd_ctrl_en_e0_wd),
 
     // from internal hardware
@@ -4722,7 +4722,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_en_e1_we & regen_qs),
+    .we     (classd_ctrl_en_e1_we & regwen_qs),
     .wd     (classd_ctrl_en_e1_wd),
 
     // from internal hardware
@@ -4748,7 +4748,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_en_e2_we & regen_qs),
+    .we     (classd_ctrl_en_e2_we & regwen_qs),
     .wd     (classd_ctrl_en_e2_wd),
 
     // from internal hardware
@@ -4774,7 +4774,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_en_e3_we & regen_qs),
+    .we     (classd_ctrl_en_e3_we & regwen_qs),
     .wd     (classd_ctrl_en_e3_wd),
 
     // from internal hardware
@@ -4800,7 +4800,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_map_e0_we & regen_qs),
+    .we     (classd_ctrl_map_e0_we & regwen_qs),
     .wd     (classd_ctrl_map_e0_wd),
 
     // from internal hardware
@@ -4826,7 +4826,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_map_e1_we & regen_qs),
+    .we     (classd_ctrl_map_e1_we & regwen_qs),
     .wd     (classd_ctrl_map_e1_wd),
 
     // from internal hardware
@@ -4852,7 +4852,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_map_e2_we & regen_qs),
+    .we     (classd_ctrl_map_e2_we & regwen_qs),
     .wd     (classd_ctrl_map_e2_wd),
 
     // from internal hardware
@@ -4878,7 +4878,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_ctrl_map_e3_we & regen_qs),
+    .we     (classd_ctrl_map_e3_we & regwen_qs),
     .wd     (classd_ctrl_map_e3_wd),
 
     // from internal hardware
@@ -4894,30 +4894,30 @@ module alert_handler_reg_top (
   );
 
 
-  // R[classd_clren]: V(False)
+  // R[classd_regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_classd_clren (
+  ) u_classd_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (classd_clren_we),
-    .wd     (classd_clren_wd),
+    .we     (classd_regwen_we),
+    .wd     (classd_regwen_wd),
 
     // from internal hardware
-    .de     (hw2reg.classd_clren.de),
-    .d      (hw2reg.classd_clren.d ),
+    .de     (hw2reg.classd_regwen.de),
+    .d      (hw2reg.classd_regwen.d ),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (classd_clren_qs)
+    .qs     (classd_regwen_qs)
   );
 
 
@@ -4932,7 +4932,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_clr_we & classd_clren_qs),
+    .we     (classd_clr_we & classd_regwen_qs),
     .wd     (classd_clr_wd),
 
     // from internal hardware
@@ -4974,7 +4974,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_accum_thresh_we & regen_qs),
+    .we     (classd_accum_thresh_we & regwen_qs),
     .wd     (classd_accum_thresh_wd),
 
     // from internal hardware
@@ -5001,7 +5001,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_timeout_cyc_we & regen_qs),
+    .we     (classd_timeout_cyc_we & regwen_qs),
     .wd     (classd_timeout_cyc_wd),
 
     // from internal hardware
@@ -5028,7 +5028,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_phase0_cyc_we & regen_qs),
+    .we     (classd_phase0_cyc_we & regwen_qs),
     .wd     (classd_phase0_cyc_wd),
 
     // from internal hardware
@@ -5055,7 +5055,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_phase1_cyc_we & regen_qs),
+    .we     (classd_phase1_cyc_we & regwen_qs),
     .wd     (classd_phase1_cyc_wd),
 
     // from internal hardware
@@ -5082,7 +5082,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_phase2_cyc_we & regen_qs),
+    .we     (classd_phase2_cyc_we & regwen_qs),
     .wd     (classd_phase2_cyc_wd),
 
     // from internal hardware
@@ -5109,7 +5109,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (classd_phase3_cyc_we & regen_qs),
+    .we     (classd_phase3_cyc_we & regwen_qs),
     .wd     (classd_phase3_cyc_wd),
 
     // from internal hardware
@@ -5165,7 +5165,7 @@ module alert_handler_reg_top (
     addr_hit[ 0] = (reg_addr == ALERT_HANDLER_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == ALERT_HANDLER_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == ALERT_HANDLER_INTR_TEST_OFFSET);
-    addr_hit[ 3] = (reg_addr == ALERT_HANDLER_REGEN_OFFSET);
+    addr_hit[ 3] = (reg_addr == ALERT_HANDLER_REGWEN_OFFSET);
     addr_hit[ 4] = (reg_addr == ALERT_HANDLER_PING_TIMEOUT_CYC_OFFSET);
     addr_hit[ 5] = (reg_addr == ALERT_HANDLER_ALERT_EN_OFFSET);
     addr_hit[ 6] = (reg_addr == ALERT_HANDLER_ALERT_CLASS_0_OFFSET);
@@ -5175,7 +5175,7 @@ module alert_handler_reg_top (
     addr_hit[10] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_OFFSET);
     addr_hit[11] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_OFFSET);
     addr_hit[12] = (reg_addr == ALERT_HANDLER_CLASSA_CTRL_OFFSET);
-    addr_hit[13] = (reg_addr == ALERT_HANDLER_CLASSA_CLREN_OFFSET);
+    addr_hit[13] = (reg_addr == ALERT_HANDLER_CLASSA_REGWEN_OFFSET);
     addr_hit[14] = (reg_addr == ALERT_HANDLER_CLASSA_CLR_OFFSET);
     addr_hit[15] = (reg_addr == ALERT_HANDLER_CLASSA_ACCUM_CNT_OFFSET);
     addr_hit[16] = (reg_addr == ALERT_HANDLER_CLASSA_ACCUM_THRESH_OFFSET);
@@ -5187,7 +5187,7 @@ module alert_handler_reg_top (
     addr_hit[22] = (reg_addr == ALERT_HANDLER_CLASSA_ESC_CNT_OFFSET);
     addr_hit[23] = (reg_addr == ALERT_HANDLER_CLASSA_STATE_OFFSET);
     addr_hit[24] = (reg_addr == ALERT_HANDLER_CLASSB_CTRL_OFFSET);
-    addr_hit[25] = (reg_addr == ALERT_HANDLER_CLASSB_CLREN_OFFSET);
+    addr_hit[25] = (reg_addr == ALERT_HANDLER_CLASSB_REGWEN_OFFSET);
     addr_hit[26] = (reg_addr == ALERT_HANDLER_CLASSB_CLR_OFFSET);
     addr_hit[27] = (reg_addr == ALERT_HANDLER_CLASSB_ACCUM_CNT_OFFSET);
     addr_hit[28] = (reg_addr == ALERT_HANDLER_CLASSB_ACCUM_THRESH_OFFSET);
@@ -5199,7 +5199,7 @@ module alert_handler_reg_top (
     addr_hit[34] = (reg_addr == ALERT_HANDLER_CLASSB_ESC_CNT_OFFSET);
     addr_hit[35] = (reg_addr == ALERT_HANDLER_CLASSB_STATE_OFFSET);
     addr_hit[36] = (reg_addr == ALERT_HANDLER_CLASSC_CTRL_OFFSET);
-    addr_hit[37] = (reg_addr == ALERT_HANDLER_CLASSC_CLREN_OFFSET);
+    addr_hit[37] = (reg_addr == ALERT_HANDLER_CLASSC_REGWEN_OFFSET);
     addr_hit[38] = (reg_addr == ALERT_HANDLER_CLASSC_CLR_OFFSET);
     addr_hit[39] = (reg_addr == ALERT_HANDLER_CLASSC_ACCUM_CNT_OFFSET);
     addr_hit[40] = (reg_addr == ALERT_HANDLER_CLASSC_ACCUM_THRESH_OFFSET);
@@ -5211,7 +5211,7 @@ module alert_handler_reg_top (
     addr_hit[46] = (reg_addr == ALERT_HANDLER_CLASSC_ESC_CNT_OFFSET);
     addr_hit[47] = (reg_addr == ALERT_HANDLER_CLASSC_STATE_OFFSET);
     addr_hit[48] = (reg_addr == ALERT_HANDLER_CLASSD_CTRL_OFFSET);
-    addr_hit[49] = (reg_addr == ALERT_HANDLER_CLASSD_CLREN_OFFSET);
+    addr_hit[49] = (reg_addr == ALERT_HANDLER_CLASSD_REGWEN_OFFSET);
     addr_hit[50] = (reg_addr == ALERT_HANDLER_CLASSD_CLR_OFFSET);
     addr_hit[51] = (reg_addr == ALERT_HANDLER_CLASSD_ACCUM_CNT_OFFSET);
     addr_hit[52] = (reg_addr == ALERT_HANDLER_CLASSD_ACCUM_THRESH_OFFSET);
@@ -5327,8 +5327,8 @@ module alert_handler_reg_top (
   assign intr_test_classd_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_classd_wd = reg_wdata[3];
 
-  assign regen_we = addr_hit[3] & reg_we & ~wr_err;
-  assign regen_wd = reg_wdata[0];
+  assign regwen_we = addr_hit[3] & reg_we & ~wr_err;
+  assign regwen_wd = reg_wdata[0];
 
   assign ping_timeout_cyc_we = addr_hit[4] & reg_we & ~wr_err;
   assign ping_timeout_cyc_wd = reg_wdata[23:0];
@@ -5606,8 +5606,8 @@ module alert_handler_reg_top (
   assign classa_ctrl_map_e3_we = addr_hit[12] & reg_we & ~wr_err;
   assign classa_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classa_clren_we = addr_hit[13] & reg_we & ~wr_err;
-  assign classa_clren_wd = reg_wdata[0];
+  assign classa_regwen_we = addr_hit[13] & reg_we & ~wr_err;
+  assign classa_regwen_wd = reg_wdata[0];
 
   assign classa_clr_we = addr_hit[14] & reg_we & ~wr_err;
   assign classa_clr_wd = reg_wdata[0];
@@ -5666,8 +5666,8 @@ module alert_handler_reg_top (
   assign classb_ctrl_map_e3_we = addr_hit[24] & reg_we & ~wr_err;
   assign classb_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classb_clren_we = addr_hit[25] & reg_we & ~wr_err;
-  assign classb_clren_wd = reg_wdata[0];
+  assign classb_regwen_we = addr_hit[25] & reg_we & ~wr_err;
+  assign classb_regwen_wd = reg_wdata[0];
 
   assign classb_clr_we = addr_hit[26] & reg_we & ~wr_err;
   assign classb_clr_wd = reg_wdata[0];
@@ -5726,8 +5726,8 @@ module alert_handler_reg_top (
   assign classc_ctrl_map_e3_we = addr_hit[36] & reg_we & ~wr_err;
   assign classc_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classc_clren_we = addr_hit[37] & reg_we & ~wr_err;
-  assign classc_clren_wd = reg_wdata[0];
+  assign classc_regwen_we = addr_hit[37] & reg_we & ~wr_err;
+  assign classc_regwen_wd = reg_wdata[0];
 
   assign classc_clr_we = addr_hit[38] & reg_we & ~wr_err;
   assign classc_clr_wd = reg_wdata[0];
@@ -5786,8 +5786,8 @@ module alert_handler_reg_top (
   assign classd_ctrl_map_e3_we = addr_hit[48] & reg_we & ~wr_err;
   assign classd_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classd_clren_we = addr_hit[49] & reg_we & ~wr_err;
-  assign classd_clren_wd = reg_wdata[0];
+  assign classd_regwen_we = addr_hit[49] & reg_we & ~wr_err;
+  assign classd_regwen_wd = reg_wdata[0];
 
   assign classd_clr_we = addr_hit[50] & reg_we & ~wr_err;
   assign classd_clr_wd = reg_wdata[0];
@@ -5842,7 +5842,7 @@ module alert_handler_reg_top (
       end
 
       addr_hit[3]: begin
-        reg_rdata_next[0] = regen_qs;
+        reg_rdata_next[0] = regwen_qs;
       end
 
       addr_hit[4]: begin
@@ -5965,7 +5965,7 @@ module alert_handler_reg_top (
       end
 
       addr_hit[13]: begin
-        reg_rdata_next[0] = classa_clren_qs;
+        reg_rdata_next[0] = classa_regwen_qs;
       end
 
       addr_hit[14]: begin
@@ -6022,7 +6022,7 @@ module alert_handler_reg_top (
       end
 
       addr_hit[25]: begin
-        reg_rdata_next[0] = classb_clren_qs;
+        reg_rdata_next[0] = classb_regwen_qs;
       end
 
       addr_hit[26]: begin
@@ -6079,7 +6079,7 @@ module alert_handler_reg_top (
       end
 
       addr_hit[37]: begin
-        reg_rdata_next[0] = classc_clren_qs;
+        reg_rdata_next[0] = classc_regwen_qs;
       end
 
       addr_hit[38]: begin
@@ -6136,7 +6136,7 @@ module alert_handler_reg_top (
       end
 
       addr_hit[49]: begin
-        reg_rdata_next[0] = classd_clren_qs;
+        reg_rdata_next[0] = classd_regwen_qs;
       end
 
       addr_hit[50]: begin

--- a/hw/top_earlgrey/ip/padctrl/data/autogen/padctrl.hjson
+++ b/hw/top_earlgrey/ip/padctrl/data/autogen/padctrl.hjson
@@ -42,7 +42,7 @@
     },
   ],
   registers: [
-    { name: "REGEN",
+    { name: "REGWEN",
       desc: '''
             Register write enable for all control registers.
             ''',
@@ -69,7 +69,7 @@
                   hwaccess: "hrw",
                   hwext:    "true",
                   hwqe:     "true",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "ATTR",
                   fields: [
                     { bits: "9:0",
@@ -104,7 +104,7 @@
                   hwaccess: "hrw",
                   hwext:    "true",
                   hwqe:     "true",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "ATTR",
                   fields: [
                     { bits: "9:0",

--- a/hw/top_earlgrey/ip/padctrl/rtl/autogen/padctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/padctrl/rtl/autogen/padctrl_reg_pkg.sv
@@ -54,7 +54,7 @@ package padctrl_reg_pkg;
   } padctrl_hw2reg_t;
 
   // Register Address
-  parameter logic [BlockAw-1:0] PADCTRL_REGEN_OFFSET = 7'h 0;
+  parameter logic [BlockAw-1:0] PADCTRL_REGWEN_OFFSET = 7'h 0;
   parameter logic [BlockAw-1:0] PADCTRL_DIO_PADS_0_OFFSET = 7'h 4;
   parameter logic [BlockAw-1:0] PADCTRL_DIO_PADS_1_OFFSET = 7'h 8;
   parameter logic [BlockAw-1:0] PADCTRL_DIO_PADS_2_OFFSET = 7'h c;
@@ -75,7 +75,7 @@ package padctrl_reg_pkg;
 
   // Register Index
   typedef enum int {
-    PADCTRL_REGEN,
+    PADCTRL_REGWEN,
     PADCTRL_DIO_PADS_0,
     PADCTRL_DIO_PADS_1,
     PADCTRL_DIO_PADS_2,
@@ -96,7 +96,7 @@ package padctrl_reg_pkg;
 
   // Register width information to check illegal writes
   parameter logic [3:0] PADCTRL_PERMIT [17] = '{
-    4'b 0001, // index[ 0] PADCTRL_REGEN
+    4'b 0001, // index[ 0] PADCTRL_REGWEN
     4'b 1111, // index[ 1] PADCTRL_DIO_PADS_0
     4'b 1111, // index[ 2] PADCTRL_DIO_PADS_1
     4'b 1111, // index[ 3] PADCTRL_DIO_PADS_2

--- a/hw/top_earlgrey/ip/padctrl/rtl/autogen/padctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/padctrl/rtl/autogen/padctrl_reg_top.sv
@@ -71,9 +71,9 @@ module padctrl_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
-  logic regen_qs;
-  logic regen_wd;
-  logic regen_we;
+  logic regwen_qs;
+  logic regwen_wd;
+  logic regwen_we;
   logic [9:0] dio_pads_0_attr_0_qs;
   logic [9:0] dio_pads_0_attr_0_wd;
   logic dio_pads_0_attr_0_we;
@@ -264,19 +264,19 @@ module padctrl_reg_top (
   logic mio_pads_10_attr_31_re;
 
   // Register instances
-  // R[regen]: V(False)
+  // R[regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_regen (
+  ) u_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (regen_we),
-    .wd     (regen_wd),
+    .we     (regwen_we),
+    .wd     (regwen_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -287,7 +287,7 @@ module padctrl_reg_top (
     .q      (),
 
     // to register interface (read)
-    .qs     (regen_qs)
+    .qs     (regwen_qs)
   );
 
 
@@ -301,7 +301,7 @@ module padctrl_reg_top (
   ) u_dio_pads_0_attr_0 (
     .re     (dio_pads_0_attr_0_re),
     // qualified with register enable
-    .we     (dio_pads_0_attr_0_we & regen_qs),
+    .we     (dio_pads_0_attr_0_we & regwen_qs),
     .wd     (dio_pads_0_attr_0_wd),
     .d      (hw2reg.dio_pads[0].d),
     .qre    (),
@@ -317,7 +317,7 @@ module padctrl_reg_top (
   ) u_dio_pads_0_attr_1 (
     .re     (dio_pads_0_attr_1_re),
     // qualified with register enable
-    .we     (dio_pads_0_attr_1_we & regen_qs),
+    .we     (dio_pads_0_attr_1_we & regwen_qs),
     .wd     (dio_pads_0_attr_1_wd),
     .d      (hw2reg.dio_pads[1].d),
     .qre    (),
@@ -333,7 +333,7 @@ module padctrl_reg_top (
   ) u_dio_pads_0_attr_2 (
     .re     (dio_pads_0_attr_2_re),
     // qualified with register enable
-    .we     (dio_pads_0_attr_2_we & regen_qs),
+    .we     (dio_pads_0_attr_2_we & regwen_qs),
     .wd     (dio_pads_0_attr_2_wd),
     .d      (hw2reg.dio_pads[2].d),
     .qre    (),
@@ -352,7 +352,7 @@ module padctrl_reg_top (
   ) u_dio_pads_1_attr_3 (
     .re     (dio_pads_1_attr_3_re),
     // qualified with register enable
-    .we     (dio_pads_1_attr_3_we & regen_qs),
+    .we     (dio_pads_1_attr_3_we & regwen_qs),
     .wd     (dio_pads_1_attr_3_wd),
     .d      (hw2reg.dio_pads[3].d),
     .qre    (),
@@ -368,7 +368,7 @@ module padctrl_reg_top (
   ) u_dio_pads_1_attr_4 (
     .re     (dio_pads_1_attr_4_re),
     // qualified with register enable
-    .we     (dio_pads_1_attr_4_we & regen_qs),
+    .we     (dio_pads_1_attr_4_we & regwen_qs),
     .wd     (dio_pads_1_attr_4_wd),
     .d      (hw2reg.dio_pads[4].d),
     .qre    (),
@@ -384,7 +384,7 @@ module padctrl_reg_top (
   ) u_dio_pads_1_attr_5 (
     .re     (dio_pads_1_attr_5_re),
     // qualified with register enable
-    .we     (dio_pads_1_attr_5_we & regen_qs),
+    .we     (dio_pads_1_attr_5_we & regwen_qs),
     .wd     (dio_pads_1_attr_5_wd),
     .d      (hw2reg.dio_pads[5].d),
     .qre    (),
@@ -403,7 +403,7 @@ module padctrl_reg_top (
   ) u_dio_pads_2_attr_6 (
     .re     (dio_pads_2_attr_6_re),
     // qualified with register enable
-    .we     (dio_pads_2_attr_6_we & regen_qs),
+    .we     (dio_pads_2_attr_6_we & regwen_qs),
     .wd     (dio_pads_2_attr_6_wd),
     .d      (hw2reg.dio_pads[6].d),
     .qre    (),
@@ -419,7 +419,7 @@ module padctrl_reg_top (
   ) u_dio_pads_2_attr_7 (
     .re     (dio_pads_2_attr_7_re),
     // qualified with register enable
-    .we     (dio_pads_2_attr_7_we & regen_qs),
+    .we     (dio_pads_2_attr_7_we & regwen_qs),
     .wd     (dio_pads_2_attr_7_wd),
     .d      (hw2reg.dio_pads[7].d),
     .qre    (),
@@ -435,7 +435,7 @@ module padctrl_reg_top (
   ) u_dio_pads_2_attr_8 (
     .re     (dio_pads_2_attr_8_re),
     // qualified with register enable
-    .we     (dio_pads_2_attr_8_we & regen_qs),
+    .we     (dio_pads_2_attr_8_we & regwen_qs),
     .wd     (dio_pads_2_attr_8_wd),
     .d      (hw2reg.dio_pads[8].d),
     .qre    (),
@@ -454,7 +454,7 @@ module padctrl_reg_top (
   ) u_dio_pads_3_attr_9 (
     .re     (dio_pads_3_attr_9_re),
     // qualified with register enable
-    .we     (dio_pads_3_attr_9_we & regen_qs),
+    .we     (dio_pads_3_attr_9_we & regwen_qs),
     .wd     (dio_pads_3_attr_9_wd),
     .d      (hw2reg.dio_pads[9].d),
     .qre    (),
@@ -470,7 +470,7 @@ module padctrl_reg_top (
   ) u_dio_pads_3_attr_10 (
     .re     (dio_pads_3_attr_10_re),
     // qualified with register enable
-    .we     (dio_pads_3_attr_10_we & regen_qs),
+    .we     (dio_pads_3_attr_10_we & regwen_qs),
     .wd     (dio_pads_3_attr_10_wd),
     .d      (hw2reg.dio_pads[10].d),
     .qre    (),
@@ -486,7 +486,7 @@ module padctrl_reg_top (
   ) u_dio_pads_3_attr_11 (
     .re     (dio_pads_3_attr_11_re),
     // qualified with register enable
-    .we     (dio_pads_3_attr_11_we & regen_qs),
+    .we     (dio_pads_3_attr_11_we & regwen_qs),
     .wd     (dio_pads_3_attr_11_wd),
     .d      (hw2reg.dio_pads[11].d),
     .qre    (),
@@ -505,7 +505,7 @@ module padctrl_reg_top (
   ) u_dio_pads_4_attr_12 (
     .re     (dio_pads_4_attr_12_re),
     // qualified with register enable
-    .we     (dio_pads_4_attr_12_we & regen_qs),
+    .we     (dio_pads_4_attr_12_we & regwen_qs),
     .wd     (dio_pads_4_attr_12_wd),
     .d      (hw2reg.dio_pads[12].d),
     .qre    (),
@@ -521,7 +521,7 @@ module padctrl_reg_top (
   ) u_dio_pads_4_attr_13 (
     .re     (dio_pads_4_attr_13_re),
     // qualified with register enable
-    .we     (dio_pads_4_attr_13_we & regen_qs),
+    .we     (dio_pads_4_attr_13_we & regwen_qs),
     .wd     (dio_pads_4_attr_13_wd),
     .d      (hw2reg.dio_pads[13].d),
     .qre    (),
@@ -537,7 +537,7 @@ module padctrl_reg_top (
   ) u_dio_pads_4_attr_14 (
     .re     (dio_pads_4_attr_14_re),
     // qualified with register enable
-    .we     (dio_pads_4_attr_14_we & regen_qs),
+    .we     (dio_pads_4_attr_14_we & regwen_qs),
     .wd     (dio_pads_4_attr_14_wd),
     .d      (hw2reg.dio_pads[14].d),
     .qre    (),
@@ -558,7 +558,7 @@ module padctrl_reg_top (
   ) u_mio_pads_0_attr_0 (
     .re     (mio_pads_0_attr_0_re),
     // qualified with register enable
-    .we     (mio_pads_0_attr_0_we & regen_qs),
+    .we     (mio_pads_0_attr_0_we & regwen_qs),
     .wd     (mio_pads_0_attr_0_wd),
     .d      (hw2reg.mio_pads[0].d),
     .qre    (),
@@ -574,7 +574,7 @@ module padctrl_reg_top (
   ) u_mio_pads_0_attr_1 (
     .re     (mio_pads_0_attr_1_re),
     // qualified with register enable
-    .we     (mio_pads_0_attr_1_we & regen_qs),
+    .we     (mio_pads_0_attr_1_we & regwen_qs),
     .wd     (mio_pads_0_attr_1_wd),
     .d      (hw2reg.mio_pads[1].d),
     .qre    (),
@@ -590,7 +590,7 @@ module padctrl_reg_top (
   ) u_mio_pads_0_attr_2 (
     .re     (mio_pads_0_attr_2_re),
     // qualified with register enable
-    .we     (mio_pads_0_attr_2_we & regen_qs),
+    .we     (mio_pads_0_attr_2_we & regwen_qs),
     .wd     (mio_pads_0_attr_2_wd),
     .d      (hw2reg.mio_pads[2].d),
     .qre    (),
@@ -609,7 +609,7 @@ module padctrl_reg_top (
   ) u_mio_pads_1_attr_3 (
     .re     (mio_pads_1_attr_3_re),
     // qualified with register enable
-    .we     (mio_pads_1_attr_3_we & regen_qs),
+    .we     (mio_pads_1_attr_3_we & regwen_qs),
     .wd     (mio_pads_1_attr_3_wd),
     .d      (hw2reg.mio_pads[3].d),
     .qre    (),
@@ -625,7 +625,7 @@ module padctrl_reg_top (
   ) u_mio_pads_1_attr_4 (
     .re     (mio_pads_1_attr_4_re),
     // qualified with register enable
-    .we     (mio_pads_1_attr_4_we & regen_qs),
+    .we     (mio_pads_1_attr_4_we & regwen_qs),
     .wd     (mio_pads_1_attr_4_wd),
     .d      (hw2reg.mio_pads[4].d),
     .qre    (),
@@ -641,7 +641,7 @@ module padctrl_reg_top (
   ) u_mio_pads_1_attr_5 (
     .re     (mio_pads_1_attr_5_re),
     // qualified with register enable
-    .we     (mio_pads_1_attr_5_we & regen_qs),
+    .we     (mio_pads_1_attr_5_we & regwen_qs),
     .wd     (mio_pads_1_attr_5_wd),
     .d      (hw2reg.mio_pads[5].d),
     .qre    (),
@@ -660,7 +660,7 @@ module padctrl_reg_top (
   ) u_mio_pads_2_attr_6 (
     .re     (mio_pads_2_attr_6_re),
     // qualified with register enable
-    .we     (mio_pads_2_attr_6_we & regen_qs),
+    .we     (mio_pads_2_attr_6_we & regwen_qs),
     .wd     (mio_pads_2_attr_6_wd),
     .d      (hw2reg.mio_pads[6].d),
     .qre    (),
@@ -676,7 +676,7 @@ module padctrl_reg_top (
   ) u_mio_pads_2_attr_7 (
     .re     (mio_pads_2_attr_7_re),
     // qualified with register enable
-    .we     (mio_pads_2_attr_7_we & regen_qs),
+    .we     (mio_pads_2_attr_7_we & regwen_qs),
     .wd     (mio_pads_2_attr_7_wd),
     .d      (hw2reg.mio_pads[7].d),
     .qre    (),
@@ -692,7 +692,7 @@ module padctrl_reg_top (
   ) u_mio_pads_2_attr_8 (
     .re     (mio_pads_2_attr_8_re),
     // qualified with register enable
-    .we     (mio_pads_2_attr_8_we & regen_qs),
+    .we     (mio_pads_2_attr_8_we & regwen_qs),
     .wd     (mio_pads_2_attr_8_wd),
     .d      (hw2reg.mio_pads[8].d),
     .qre    (),
@@ -711,7 +711,7 @@ module padctrl_reg_top (
   ) u_mio_pads_3_attr_9 (
     .re     (mio_pads_3_attr_9_re),
     // qualified with register enable
-    .we     (mio_pads_3_attr_9_we & regen_qs),
+    .we     (mio_pads_3_attr_9_we & regwen_qs),
     .wd     (mio_pads_3_attr_9_wd),
     .d      (hw2reg.mio_pads[9].d),
     .qre    (),
@@ -727,7 +727,7 @@ module padctrl_reg_top (
   ) u_mio_pads_3_attr_10 (
     .re     (mio_pads_3_attr_10_re),
     // qualified with register enable
-    .we     (mio_pads_3_attr_10_we & regen_qs),
+    .we     (mio_pads_3_attr_10_we & regwen_qs),
     .wd     (mio_pads_3_attr_10_wd),
     .d      (hw2reg.mio_pads[10].d),
     .qre    (),
@@ -743,7 +743,7 @@ module padctrl_reg_top (
   ) u_mio_pads_3_attr_11 (
     .re     (mio_pads_3_attr_11_re),
     // qualified with register enable
-    .we     (mio_pads_3_attr_11_we & regen_qs),
+    .we     (mio_pads_3_attr_11_we & regwen_qs),
     .wd     (mio_pads_3_attr_11_wd),
     .d      (hw2reg.mio_pads[11].d),
     .qre    (),
@@ -762,7 +762,7 @@ module padctrl_reg_top (
   ) u_mio_pads_4_attr_12 (
     .re     (mio_pads_4_attr_12_re),
     // qualified with register enable
-    .we     (mio_pads_4_attr_12_we & regen_qs),
+    .we     (mio_pads_4_attr_12_we & regwen_qs),
     .wd     (mio_pads_4_attr_12_wd),
     .d      (hw2reg.mio_pads[12].d),
     .qre    (),
@@ -778,7 +778,7 @@ module padctrl_reg_top (
   ) u_mio_pads_4_attr_13 (
     .re     (mio_pads_4_attr_13_re),
     // qualified with register enable
-    .we     (mio_pads_4_attr_13_we & regen_qs),
+    .we     (mio_pads_4_attr_13_we & regwen_qs),
     .wd     (mio_pads_4_attr_13_wd),
     .d      (hw2reg.mio_pads[13].d),
     .qre    (),
@@ -794,7 +794,7 @@ module padctrl_reg_top (
   ) u_mio_pads_4_attr_14 (
     .re     (mio_pads_4_attr_14_re),
     // qualified with register enable
-    .we     (mio_pads_4_attr_14_we & regen_qs),
+    .we     (mio_pads_4_attr_14_we & regwen_qs),
     .wd     (mio_pads_4_attr_14_wd),
     .d      (hw2reg.mio_pads[14].d),
     .qre    (),
@@ -813,7 +813,7 @@ module padctrl_reg_top (
   ) u_mio_pads_5_attr_15 (
     .re     (mio_pads_5_attr_15_re),
     // qualified with register enable
-    .we     (mio_pads_5_attr_15_we & regen_qs),
+    .we     (mio_pads_5_attr_15_we & regwen_qs),
     .wd     (mio_pads_5_attr_15_wd),
     .d      (hw2reg.mio_pads[15].d),
     .qre    (),
@@ -829,7 +829,7 @@ module padctrl_reg_top (
   ) u_mio_pads_5_attr_16 (
     .re     (mio_pads_5_attr_16_re),
     // qualified with register enable
-    .we     (mio_pads_5_attr_16_we & regen_qs),
+    .we     (mio_pads_5_attr_16_we & regwen_qs),
     .wd     (mio_pads_5_attr_16_wd),
     .d      (hw2reg.mio_pads[16].d),
     .qre    (),
@@ -845,7 +845,7 @@ module padctrl_reg_top (
   ) u_mio_pads_5_attr_17 (
     .re     (mio_pads_5_attr_17_re),
     // qualified with register enable
-    .we     (mio_pads_5_attr_17_we & regen_qs),
+    .we     (mio_pads_5_attr_17_we & regwen_qs),
     .wd     (mio_pads_5_attr_17_wd),
     .d      (hw2reg.mio_pads[17].d),
     .qre    (),
@@ -864,7 +864,7 @@ module padctrl_reg_top (
   ) u_mio_pads_6_attr_18 (
     .re     (mio_pads_6_attr_18_re),
     // qualified with register enable
-    .we     (mio_pads_6_attr_18_we & regen_qs),
+    .we     (mio_pads_6_attr_18_we & regwen_qs),
     .wd     (mio_pads_6_attr_18_wd),
     .d      (hw2reg.mio_pads[18].d),
     .qre    (),
@@ -880,7 +880,7 @@ module padctrl_reg_top (
   ) u_mio_pads_6_attr_19 (
     .re     (mio_pads_6_attr_19_re),
     // qualified with register enable
-    .we     (mio_pads_6_attr_19_we & regen_qs),
+    .we     (mio_pads_6_attr_19_we & regwen_qs),
     .wd     (mio_pads_6_attr_19_wd),
     .d      (hw2reg.mio_pads[19].d),
     .qre    (),
@@ -896,7 +896,7 @@ module padctrl_reg_top (
   ) u_mio_pads_6_attr_20 (
     .re     (mio_pads_6_attr_20_re),
     // qualified with register enable
-    .we     (mio_pads_6_attr_20_we & regen_qs),
+    .we     (mio_pads_6_attr_20_we & regwen_qs),
     .wd     (mio_pads_6_attr_20_wd),
     .d      (hw2reg.mio_pads[20].d),
     .qre    (),
@@ -915,7 +915,7 @@ module padctrl_reg_top (
   ) u_mio_pads_7_attr_21 (
     .re     (mio_pads_7_attr_21_re),
     // qualified with register enable
-    .we     (mio_pads_7_attr_21_we & regen_qs),
+    .we     (mio_pads_7_attr_21_we & regwen_qs),
     .wd     (mio_pads_7_attr_21_wd),
     .d      (hw2reg.mio_pads[21].d),
     .qre    (),
@@ -931,7 +931,7 @@ module padctrl_reg_top (
   ) u_mio_pads_7_attr_22 (
     .re     (mio_pads_7_attr_22_re),
     // qualified with register enable
-    .we     (mio_pads_7_attr_22_we & regen_qs),
+    .we     (mio_pads_7_attr_22_we & regwen_qs),
     .wd     (mio_pads_7_attr_22_wd),
     .d      (hw2reg.mio_pads[22].d),
     .qre    (),
@@ -947,7 +947,7 @@ module padctrl_reg_top (
   ) u_mio_pads_7_attr_23 (
     .re     (mio_pads_7_attr_23_re),
     // qualified with register enable
-    .we     (mio_pads_7_attr_23_we & regen_qs),
+    .we     (mio_pads_7_attr_23_we & regwen_qs),
     .wd     (mio_pads_7_attr_23_wd),
     .d      (hw2reg.mio_pads[23].d),
     .qre    (),
@@ -966,7 +966,7 @@ module padctrl_reg_top (
   ) u_mio_pads_8_attr_24 (
     .re     (mio_pads_8_attr_24_re),
     // qualified with register enable
-    .we     (mio_pads_8_attr_24_we & regen_qs),
+    .we     (mio_pads_8_attr_24_we & regwen_qs),
     .wd     (mio_pads_8_attr_24_wd),
     .d      (hw2reg.mio_pads[24].d),
     .qre    (),
@@ -982,7 +982,7 @@ module padctrl_reg_top (
   ) u_mio_pads_8_attr_25 (
     .re     (mio_pads_8_attr_25_re),
     // qualified with register enable
-    .we     (mio_pads_8_attr_25_we & regen_qs),
+    .we     (mio_pads_8_attr_25_we & regwen_qs),
     .wd     (mio_pads_8_attr_25_wd),
     .d      (hw2reg.mio_pads[25].d),
     .qre    (),
@@ -998,7 +998,7 @@ module padctrl_reg_top (
   ) u_mio_pads_8_attr_26 (
     .re     (mio_pads_8_attr_26_re),
     // qualified with register enable
-    .we     (mio_pads_8_attr_26_we & regen_qs),
+    .we     (mio_pads_8_attr_26_we & regwen_qs),
     .wd     (mio_pads_8_attr_26_wd),
     .d      (hw2reg.mio_pads[26].d),
     .qre    (),
@@ -1017,7 +1017,7 @@ module padctrl_reg_top (
   ) u_mio_pads_9_attr_27 (
     .re     (mio_pads_9_attr_27_re),
     // qualified with register enable
-    .we     (mio_pads_9_attr_27_we & regen_qs),
+    .we     (mio_pads_9_attr_27_we & regwen_qs),
     .wd     (mio_pads_9_attr_27_wd),
     .d      (hw2reg.mio_pads[27].d),
     .qre    (),
@@ -1033,7 +1033,7 @@ module padctrl_reg_top (
   ) u_mio_pads_9_attr_28 (
     .re     (mio_pads_9_attr_28_re),
     // qualified with register enable
-    .we     (mio_pads_9_attr_28_we & regen_qs),
+    .we     (mio_pads_9_attr_28_we & regwen_qs),
     .wd     (mio_pads_9_attr_28_wd),
     .d      (hw2reg.mio_pads[28].d),
     .qre    (),
@@ -1049,7 +1049,7 @@ module padctrl_reg_top (
   ) u_mio_pads_9_attr_29 (
     .re     (mio_pads_9_attr_29_re),
     // qualified with register enable
-    .we     (mio_pads_9_attr_29_we & regen_qs),
+    .we     (mio_pads_9_attr_29_we & regwen_qs),
     .wd     (mio_pads_9_attr_29_wd),
     .d      (hw2reg.mio_pads[29].d),
     .qre    (),
@@ -1068,7 +1068,7 @@ module padctrl_reg_top (
   ) u_mio_pads_10_attr_30 (
     .re     (mio_pads_10_attr_30_re),
     // qualified with register enable
-    .we     (mio_pads_10_attr_30_we & regen_qs),
+    .we     (mio_pads_10_attr_30_we & regwen_qs),
     .wd     (mio_pads_10_attr_30_wd),
     .d      (hw2reg.mio_pads[30].d),
     .qre    (),
@@ -1084,7 +1084,7 @@ module padctrl_reg_top (
   ) u_mio_pads_10_attr_31 (
     .re     (mio_pads_10_attr_31_re),
     // qualified with register enable
-    .we     (mio_pads_10_attr_31_we & regen_qs),
+    .we     (mio_pads_10_attr_31_we & regwen_qs),
     .wd     (mio_pads_10_attr_31_wd),
     .d      (hw2reg.mio_pads[31].d),
     .qre    (),
@@ -1100,7 +1100,7 @@ module padctrl_reg_top (
   logic [16:0] addr_hit;
   always_comb begin
     addr_hit = '0;
-    addr_hit[ 0] = (reg_addr == PADCTRL_REGEN_OFFSET);
+    addr_hit[ 0] = (reg_addr == PADCTRL_REGWEN_OFFSET);
     addr_hit[ 1] = (reg_addr == PADCTRL_DIO_PADS_0_OFFSET);
     addr_hit[ 2] = (reg_addr == PADCTRL_DIO_PADS_1_OFFSET);
     addr_hit[ 3] = (reg_addr == PADCTRL_DIO_PADS_2_OFFSET);
@@ -1143,8 +1143,8 @@ module padctrl_reg_top (
     if (addr_hit[16] && reg_we && (PADCTRL_PERMIT[16] != (PADCTRL_PERMIT[16] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign regen_we = addr_hit[0] & reg_we & ~wr_err;
-  assign regen_wd = reg_wdata[0];
+  assign regwen_we = addr_hit[0] & reg_we & ~wr_err;
+  assign regwen_wd = reg_wdata[0];
 
   assign dio_pads_0_attr_0_we = addr_hit[1] & reg_we & ~wr_err;
   assign dio_pads_0_attr_0_wd = reg_wdata[9:0];
@@ -1339,7 +1339,7 @@ module padctrl_reg_top (
     reg_rdata_next = '0;
     unique case (1'b1)
       addr_hit[0]: begin
-        reg_rdata_next[0] = regen_qs;
+        reg_rdata_next[0] = regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -242,7 +242,7 @@
     // TODO(#1412): this register enable signal should be split into multiregs such that
     // each pin / peripheral select can be locked down individually. this needs support
     // for compact, nested multireg enable registers in our regtool.
-    { name: "REGEN",
+    { name: "REGWEN",
       desc: '''
             Register write enable for all control registers.
             ''',
@@ -265,7 +265,7 @@
                   count:    "NMioPeriphIn",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "IN",
                   fields: [
                     { bits: "5:0",
@@ -285,7 +285,7 @@
                   count:    "NMioPads",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "OUT",
                   fields: [
                     { bits: "5:0",
@@ -314,7 +314,7 @@
                   count:    "NMioPads",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "OUT",
                   fields: [
                     { bits: "1:0",
@@ -360,7 +360,7 @@
                   hwaccess: "hrw",
                   hwext:    "true",
                   hwqe:     "true",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "OUT",
                   fields: [
                     { bits: "1:0",
@@ -402,7 +402,7 @@
                   count:    "NWkupDetect",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "DETECTOR",
                   fields: [
                     { bits: "0:0",
@@ -424,7 +424,7 @@
                   count:    "NWkupDetect",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "DETECTOR",
                   fields: [
                     { bits: "2:0",
@@ -489,7 +489,7 @@
                   count:    "NWkupDetect",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "DETECTOR",
                   fields: [
                     { bits: "WkupCntWidth-1:0",
@@ -509,7 +509,7 @@
                   count:    "NWkupDetect",
                   swaccess: "rw",
                   hwaccess: "hro",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "DETECTOR",
                   fields: [
                     { bits: "4:0",
@@ -533,7 +533,7 @@
                   hwaccess: "hrw",
                   hwext:    "true",
                   hwqe:     "true",
-                  regwen:   "REGEN",
+                  regwen:   "REGWEN",
                   cname:    "DETECTOR",
                   fields: [
                     { bits: "0",

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
@@ -106,7 +106,7 @@ package pinmux_reg_pkg;
   } pinmux_hw2reg_t;
 
   // Register Address
-  parameter logic [BlockAw-1:0] PINMUX_REGEN_OFFSET = 8'h 0;
+  parameter logic [BlockAw-1:0] PINMUX_REGWEN_OFFSET = 8'h 0;
   parameter logic [BlockAw-1:0] PINMUX_PERIPH_INSEL_0_OFFSET = 8'h 4;
   parameter logic [BlockAw-1:0] PINMUX_PERIPH_INSEL_1_OFFSET = 8'h 8;
   parameter logic [BlockAw-1:0] PINMUX_PERIPH_INSEL_2_OFFSET = 8'h c;
@@ -144,7 +144,7 @@ package pinmux_reg_pkg;
 
   // Register Index
   typedef enum int {
-    PINMUX_REGEN,
+    PINMUX_REGWEN,
     PINMUX_PERIPH_INSEL_0,
     PINMUX_PERIPH_INSEL_1,
     PINMUX_PERIPH_INSEL_2,
@@ -182,7 +182,7 @@ package pinmux_reg_pkg;
 
   // Register width information to check illegal writes
   parameter logic [3:0] PINMUX_PERMIT [34] = '{
-    4'b 0001, // index[ 0] PINMUX_REGEN
+    4'b 0001, // index[ 0] PINMUX_REGWEN
     4'b 1111, // index[ 1] PINMUX_PERIPH_INSEL_0
     4'b 1111, // index[ 2] PINMUX_PERIPH_INSEL_1
     4'b 1111, // index[ 3] PINMUX_PERIPH_INSEL_2

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
@@ -71,9 +71,9 @@ module pinmux_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
-  logic regen_qs;
-  logic regen_wd;
-  logic regen_we;
+  logic regwen_qs;
+  logic regwen_wd;
+  logic regwen_we;
   logic [5:0] periph_insel_0_in_0_qs;
   logic [5:0] periph_insel_0_in_0_wd;
   logic periph_insel_0_in_0_we;
@@ -627,19 +627,19 @@ module pinmux_reg_top (
   logic wkup_cause_cause_7_re;
 
   // Register instances
-  // R[regen]: V(False)
+  // R[regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_regen (
+  ) u_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (regen_we),
-    .wd     (regen_wd),
+    .we     (regwen_we),
+    .wd     (regwen_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -650,7 +650,7 @@ module pinmux_reg_top (
     .q      (),
 
     // to register interface (read)
-    .qs     (regen_qs)
+    .qs     (regwen_qs)
   );
 
 
@@ -668,7 +668,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_0_in_0_we & regen_qs),
+    .we     (periph_insel_0_in_0_we & regwen_qs),
     .wd     (periph_insel_0_in_0_wd),
 
     // from internal hardware
@@ -694,7 +694,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_0_in_1_we & regen_qs),
+    .we     (periph_insel_0_in_1_we & regwen_qs),
     .wd     (periph_insel_0_in_1_wd),
 
     // from internal hardware
@@ -720,7 +720,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_0_in_2_we & regen_qs),
+    .we     (periph_insel_0_in_2_we & regwen_qs),
     .wd     (periph_insel_0_in_2_wd),
 
     // from internal hardware
@@ -746,7 +746,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_0_in_3_we & regen_qs),
+    .we     (periph_insel_0_in_3_we & regwen_qs),
     .wd     (periph_insel_0_in_3_wd),
 
     // from internal hardware
@@ -772,7 +772,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_0_in_4_we & regen_qs),
+    .we     (periph_insel_0_in_4_we & regwen_qs),
     .wd     (periph_insel_0_in_4_wd),
 
     // from internal hardware
@@ -801,7 +801,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_1_in_5_we & regen_qs),
+    .we     (periph_insel_1_in_5_we & regwen_qs),
     .wd     (periph_insel_1_in_5_wd),
 
     // from internal hardware
@@ -827,7 +827,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_1_in_6_we & regen_qs),
+    .we     (periph_insel_1_in_6_we & regwen_qs),
     .wd     (periph_insel_1_in_6_wd),
 
     // from internal hardware
@@ -853,7 +853,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_1_in_7_we & regen_qs),
+    .we     (periph_insel_1_in_7_we & regwen_qs),
     .wd     (periph_insel_1_in_7_wd),
 
     // from internal hardware
@@ -879,7 +879,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_1_in_8_we & regen_qs),
+    .we     (periph_insel_1_in_8_we & regwen_qs),
     .wd     (periph_insel_1_in_8_wd),
 
     // from internal hardware
@@ -905,7 +905,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_1_in_9_we & regen_qs),
+    .we     (periph_insel_1_in_9_we & regwen_qs),
     .wd     (periph_insel_1_in_9_wd),
 
     // from internal hardware
@@ -934,7 +934,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_2_in_10_we & regen_qs),
+    .we     (periph_insel_2_in_10_we & regwen_qs),
     .wd     (periph_insel_2_in_10_wd),
 
     // from internal hardware
@@ -960,7 +960,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_2_in_11_we & regen_qs),
+    .we     (periph_insel_2_in_11_we & regwen_qs),
     .wd     (periph_insel_2_in_11_wd),
 
     // from internal hardware
@@ -986,7 +986,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_2_in_12_we & regen_qs),
+    .we     (periph_insel_2_in_12_we & regwen_qs),
     .wd     (periph_insel_2_in_12_wd),
 
     // from internal hardware
@@ -1012,7 +1012,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_2_in_13_we & regen_qs),
+    .we     (periph_insel_2_in_13_we & regwen_qs),
     .wd     (periph_insel_2_in_13_wd),
 
     // from internal hardware
@@ -1038,7 +1038,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_2_in_14_we & regen_qs),
+    .we     (periph_insel_2_in_14_we & regwen_qs),
     .wd     (periph_insel_2_in_14_wd),
 
     // from internal hardware
@@ -1067,7 +1067,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_3_in_15_we & regen_qs),
+    .we     (periph_insel_3_in_15_we & regwen_qs),
     .wd     (periph_insel_3_in_15_wd),
 
     // from internal hardware
@@ -1093,7 +1093,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_3_in_16_we & regen_qs),
+    .we     (periph_insel_3_in_16_we & regwen_qs),
     .wd     (periph_insel_3_in_16_wd),
 
     // from internal hardware
@@ -1119,7 +1119,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_3_in_17_we & regen_qs),
+    .we     (periph_insel_3_in_17_we & regwen_qs),
     .wd     (periph_insel_3_in_17_wd),
 
     // from internal hardware
@@ -1145,7 +1145,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_3_in_18_we & regen_qs),
+    .we     (periph_insel_3_in_18_we & regwen_qs),
     .wd     (periph_insel_3_in_18_wd),
 
     // from internal hardware
@@ -1171,7 +1171,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_3_in_19_we & regen_qs),
+    .we     (periph_insel_3_in_19_we & regwen_qs),
     .wd     (periph_insel_3_in_19_wd),
 
     // from internal hardware
@@ -1200,7 +1200,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_4_in_20_we & regen_qs),
+    .we     (periph_insel_4_in_20_we & regwen_qs),
     .wd     (periph_insel_4_in_20_wd),
 
     // from internal hardware
@@ -1226,7 +1226,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_4_in_21_we & regen_qs),
+    .we     (periph_insel_4_in_21_we & regwen_qs),
     .wd     (periph_insel_4_in_21_wd),
 
     // from internal hardware
@@ -1252,7 +1252,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_4_in_22_we & regen_qs),
+    .we     (periph_insel_4_in_22_we & regwen_qs),
     .wd     (periph_insel_4_in_22_wd),
 
     // from internal hardware
@@ -1278,7 +1278,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_4_in_23_we & regen_qs),
+    .we     (periph_insel_4_in_23_we & regwen_qs),
     .wd     (periph_insel_4_in_23_wd),
 
     // from internal hardware
@@ -1304,7 +1304,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_4_in_24_we & regen_qs),
+    .we     (periph_insel_4_in_24_we & regwen_qs),
     .wd     (periph_insel_4_in_24_wd),
 
     // from internal hardware
@@ -1333,7 +1333,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_5_in_25_we & regen_qs),
+    .we     (periph_insel_5_in_25_we & regwen_qs),
     .wd     (periph_insel_5_in_25_wd),
 
     // from internal hardware
@@ -1359,7 +1359,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_5_in_26_we & regen_qs),
+    .we     (periph_insel_5_in_26_we & regwen_qs),
     .wd     (periph_insel_5_in_26_wd),
 
     // from internal hardware
@@ -1385,7 +1385,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_5_in_27_we & regen_qs),
+    .we     (periph_insel_5_in_27_we & regwen_qs),
     .wd     (periph_insel_5_in_27_wd),
 
     // from internal hardware
@@ -1411,7 +1411,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_5_in_28_we & regen_qs),
+    .we     (periph_insel_5_in_28_we & regwen_qs),
     .wd     (periph_insel_5_in_28_wd),
 
     // from internal hardware
@@ -1437,7 +1437,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_5_in_29_we & regen_qs),
+    .we     (periph_insel_5_in_29_we & regwen_qs),
     .wd     (periph_insel_5_in_29_wd),
 
     // from internal hardware
@@ -1466,7 +1466,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_6_in_30_we & regen_qs),
+    .we     (periph_insel_6_in_30_we & regwen_qs),
     .wd     (periph_insel_6_in_30_wd),
 
     // from internal hardware
@@ -1492,7 +1492,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_6_in_31_we & regen_qs),
+    .we     (periph_insel_6_in_31_we & regwen_qs),
     .wd     (periph_insel_6_in_31_wd),
 
     // from internal hardware
@@ -1518,7 +1518,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_6_in_32_we & regen_qs),
+    .we     (periph_insel_6_in_32_we & regwen_qs),
     .wd     (periph_insel_6_in_32_wd),
 
     // from internal hardware
@@ -1544,7 +1544,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_6_in_33_we & regen_qs),
+    .we     (periph_insel_6_in_33_we & regwen_qs),
     .wd     (periph_insel_6_in_33_wd),
 
     // from internal hardware
@@ -1570,7 +1570,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_6_in_34_we & regen_qs),
+    .we     (periph_insel_6_in_34_we & regwen_qs),
     .wd     (periph_insel_6_in_34_wd),
 
     // from internal hardware
@@ -1599,7 +1599,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_7_in_35_we & regen_qs),
+    .we     (periph_insel_7_in_35_we & regwen_qs),
     .wd     (periph_insel_7_in_35_wd),
 
     // from internal hardware
@@ -1625,7 +1625,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_7_in_36_we & regen_qs),
+    .we     (periph_insel_7_in_36_we & regwen_qs),
     .wd     (periph_insel_7_in_36_wd),
 
     // from internal hardware
@@ -1651,7 +1651,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_7_in_37_we & regen_qs),
+    .we     (periph_insel_7_in_37_we & regwen_qs),
     .wd     (periph_insel_7_in_37_wd),
 
     // from internal hardware
@@ -1677,7 +1677,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_7_in_38_we & regen_qs),
+    .we     (periph_insel_7_in_38_we & regwen_qs),
     .wd     (periph_insel_7_in_38_wd),
 
     // from internal hardware
@@ -1703,7 +1703,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_7_in_39_we & regen_qs),
+    .we     (periph_insel_7_in_39_we & regwen_qs),
     .wd     (periph_insel_7_in_39_wd),
 
     // from internal hardware
@@ -1731,7 +1731,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (periph_insel_8_we & regen_qs),
+    .we     (periph_insel_8_we & regwen_qs),
     .wd     (periph_insel_8_wd),
 
     // from internal hardware
@@ -1761,7 +1761,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_0_out_0_we & regen_qs),
+    .we     (mio_outsel_0_out_0_we & regwen_qs),
     .wd     (mio_outsel_0_out_0_wd),
 
     // from internal hardware
@@ -1787,7 +1787,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_0_out_1_we & regen_qs),
+    .we     (mio_outsel_0_out_1_we & regwen_qs),
     .wd     (mio_outsel_0_out_1_wd),
 
     // from internal hardware
@@ -1813,7 +1813,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_0_out_2_we & regen_qs),
+    .we     (mio_outsel_0_out_2_we & regwen_qs),
     .wd     (mio_outsel_0_out_2_wd),
 
     // from internal hardware
@@ -1839,7 +1839,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_0_out_3_we & regen_qs),
+    .we     (mio_outsel_0_out_3_we & regwen_qs),
     .wd     (mio_outsel_0_out_3_wd),
 
     // from internal hardware
@@ -1865,7 +1865,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_0_out_4_we & regen_qs),
+    .we     (mio_outsel_0_out_4_we & regwen_qs),
     .wd     (mio_outsel_0_out_4_wd),
 
     // from internal hardware
@@ -1894,7 +1894,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_1_out_5_we & regen_qs),
+    .we     (mio_outsel_1_out_5_we & regwen_qs),
     .wd     (mio_outsel_1_out_5_wd),
 
     // from internal hardware
@@ -1920,7 +1920,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_1_out_6_we & regen_qs),
+    .we     (mio_outsel_1_out_6_we & regwen_qs),
     .wd     (mio_outsel_1_out_6_wd),
 
     // from internal hardware
@@ -1946,7 +1946,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_1_out_7_we & regen_qs),
+    .we     (mio_outsel_1_out_7_we & regwen_qs),
     .wd     (mio_outsel_1_out_7_wd),
 
     // from internal hardware
@@ -1972,7 +1972,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_1_out_8_we & regen_qs),
+    .we     (mio_outsel_1_out_8_we & regwen_qs),
     .wd     (mio_outsel_1_out_8_wd),
 
     // from internal hardware
@@ -1998,7 +1998,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_1_out_9_we & regen_qs),
+    .we     (mio_outsel_1_out_9_we & regwen_qs),
     .wd     (mio_outsel_1_out_9_wd),
 
     // from internal hardware
@@ -2027,7 +2027,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_2_out_10_we & regen_qs),
+    .we     (mio_outsel_2_out_10_we & regwen_qs),
     .wd     (mio_outsel_2_out_10_wd),
 
     // from internal hardware
@@ -2053,7 +2053,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_2_out_11_we & regen_qs),
+    .we     (mio_outsel_2_out_11_we & regwen_qs),
     .wd     (mio_outsel_2_out_11_wd),
 
     // from internal hardware
@@ -2079,7 +2079,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_2_out_12_we & regen_qs),
+    .we     (mio_outsel_2_out_12_we & regwen_qs),
     .wd     (mio_outsel_2_out_12_wd),
 
     // from internal hardware
@@ -2105,7 +2105,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_2_out_13_we & regen_qs),
+    .we     (mio_outsel_2_out_13_we & regwen_qs),
     .wd     (mio_outsel_2_out_13_wd),
 
     // from internal hardware
@@ -2131,7 +2131,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_2_out_14_we & regen_qs),
+    .we     (mio_outsel_2_out_14_we & regwen_qs),
     .wd     (mio_outsel_2_out_14_wd),
 
     // from internal hardware
@@ -2160,7 +2160,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_3_out_15_we & regen_qs),
+    .we     (mio_outsel_3_out_15_we & regwen_qs),
     .wd     (mio_outsel_3_out_15_wd),
 
     // from internal hardware
@@ -2186,7 +2186,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_3_out_16_we & regen_qs),
+    .we     (mio_outsel_3_out_16_we & regwen_qs),
     .wd     (mio_outsel_3_out_16_wd),
 
     // from internal hardware
@@ -2212,7 +2212,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_3_out_17_we & regen_qs),
+    .we     (mio_outsel_3_out_17_we & regwen_qs),
     .wd     (mio_outsel_3_out_17_wd),
 
     // from internal hardware
@@ -2238,7 +2238,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_3_out_18_we & regen_qs),
+    .we     (mio_outsel_3_out_18_we & regwen_qs),
     .wd     (mio_outsel_3_out_18_wd),
 
     // from internal hardware
@@ -2264,7 +2264,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_3_out_19_we & regen_qs),
+    .we     (mio_outsel_3_out_19_we & regwen_qs),
     .wd     (mio_outsel_3_out_19_wd),
 
     // from internal hardware
@@ -2293,7 +2293,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_4_out_20_we & regen_qs),
+    .we     (mio_outsel_4_out_20_we & regwen_qs),
     .wd     (mio_outsel_4_out_20_wd),
 
     // from internal hardware
@@ -2319,7 +2319,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_4_out_21_we & regen_qs),
+    .we     (mio_outsel_4_out_21_we & regwen_qs),
     .wd     (mio_outsel_4_out_21_wd),
 
     // from internal hardware
@@ -2345,7 +2345,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_4_out_22_we & regen_qs),
+    .we     (mio_outsel_4_out_22_we & regwen_qs),
     .wd     (mio_outsel_4_out_22_wd),
 
     // from internal hardware
@@ -2371,7 +2371,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_4_out_23_we & regen_qs),
+    .we     (mio_outsel_4_out_23_we & regwen_qs),
     .wd     (mio_outsel_4_out_23_wd),
 
     // from internal hardware
@@ -2397,7 +2397,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_4_out_24_we & regen_qs),
+    .we     (mio_outsel_4_out_24_we & regwen_qs),
     .wd     (mio_outsel_4_out_24_wd),
 
     // from internal hardware
@@ -2426,7 +2426,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_5_out_25_we & regen_qs),
+    .we     (mio_outsel_5_out_25_we & regwen_qs),
     .wd     (mio_outsel_5_out_25_wd),
 
     // from internal hardware
@@ -2452,7 +2452,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_5_out_26_we & regen_qs),
+    .we     (mio_outsel_5_out_26_we & regwen_qs),
     .wd     (mio_outsel_5_out_26_wd),
 
     // from internal hardware
@@ -2478,7 +2478,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_5_out_27_we & regen_qs),
+    .we     (mio_outsel_5_out_27_we & regwen_qs),
     .wd     (mio_outsel_5_out_27_wd),
 
     // from internal hardware
@@ -2504,7 +2504,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_5_out_28_we & regen_qs),
+    .we     (mio_outsel_5_out_28_we & regwen_qs),
     .wd     (mio_outsel_5_out_28_wd),
 
     // from internal hardware
@@ -2530,7 +2530,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_5_out_29_we & regen_qs),
+    .we     (mio_outsel_5_out_29_we & regwen_qs),
     .wd     (mio_outsel_5_out_29_wd),
 
     // from internal hardware
@@ -2559,7 +2559,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_6_out_30_we & regen_qs),
+    .we     (mio_outsel_6_out_30_we & regwen_qs),
     .wd     (mio_outsel_6_out_30_wd),
 
     // from internal hardware
@@ -2585,7 +2585,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_outsel_6_out_31_we & regen_qs),
+    .we     (mio_outsel_6_out_31_we & regwen_qs),
     .wd     (mio_outsel_6_out_31_wd),
 
     // from internal hardware
@@ -2616,7 +2616,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_0_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_0_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_0_wd),
 
     // from internal hardware
@@ -2642,7 +2642,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_1_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_1_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_1_wd),
 
     // from internal hardware
@@ -2668,7 +2668,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_2_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_2_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_2_wd),
 
     // from internal hardware
@@ -2694,7 +2694,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_3_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_3_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_3_wd),
 
     // from internal hardware
@@ -2720,7 +2720,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_4_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_4_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_4_wd),
 
     // from internal hardware
@@ -2746,7 +2746,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_5_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_5_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_5_wd),
 
     // from internal hardware
@@ -2772,7 +2772,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_6_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_6_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_6_wd),
 
     // from internal hardware
@@ -2798,7 +2798,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_7_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_7_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_7_wd),
 
     // from internal hardware
@@ -2824,7 +2824,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_8_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_8_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_8_wd),
 
     // from internal hardware
@@ -2850,7 +2850,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_9_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_9_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_9_wd),
 
     // from internal hardware
@@ -2876,7 +2876,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_10_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_10_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_10_wd),
 
     // from internal hardware
@@ -2902,7 +2902,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_11_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_11_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_11_wd),
 
     // from internal hardware
@@ -2928,7 +2928,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_12_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_12_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_12_wd),
 
     // from internal hardware
@@ -2954,7 +2954,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_13_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_13_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_13_wd),
 
     // from internal hardware
@@ -2980,7 +2980,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_14_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_14_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_14_wd),
 
     // from internal hardware
@@ -3006,7 +3006,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_0_out_15_we & regen_qs),
+    .we     (mio_out_sleep_val_0_out_15_we & regwen_qs),
     .wd     (mio_out_sleep_val_0_out_15_wd),
 
     // from internal hardware
@@ -3035,7 +3035,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_16_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_16_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_16_wd),
 
     // from internal hardware
@@ -3061,7 +3061,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_17_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_17_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_17_wd),
 
     // from internal hardware
@@ -3087,7 +3087,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_18_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_18_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_18_wd),
 
     // from internal hardware
@@ -3113,7 +3113,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_19_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_19_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_19_wd),
 
     // from internal hardware
@@ -3139,7 +3139,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_20_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_20_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_20_wd),
 
     // from internal hardware
@@ -3165,7 +3165,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_21_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_21_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_21_wd),
 
     // from internal hardware
@@ -3191,7 +3191,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_22_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_22_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_22_wd),
 
     // from internal hardware
@@ -3217,7 +3217,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_23_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_23_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_23_wd),
 
     // from internal hardware
@@ -3243,7 +3243,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_24_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_24_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_24_wd),
 
     // from internal hardware
@@ -3269,7 +3269,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_25_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_25_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_25_wd),
 
     // from internal hardware
@@ -3295,7 +3295,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_26_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_26_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_26_wd),
 
     // from internal hardware
@@ -3321,7 +3321,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_27_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_27_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_27_wd),
 
     // from internal hardware
@@ -3347,7 +3347,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_28_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_28_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_28_wd),
 
     // from internal hardware
@@ -3373,7 +3373,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_29_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_29_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_29_wd),
 
     // from internal hardware
@@ -3399,7 +3399,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_30_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_30_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_30_wd),
 
     // from internal hardware
@@ -3425,7 +3425,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val_1_out_31_we & regen_qs),
+    .we     (mio_out_sleep_val_1_out_31_we & regwen_qs),
     .wd     (mio_out_sleep_val_1_out_31_wd),
 
     // from internal hardware
@@ -3452,7 +3452,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_0 (
     .re     (dio_out_sleep_val_out_0_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_0_we & regen_qs),
+    .we     (dio_out_sleep_val_out_0_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_0_wd),
     .d      (hw2reg.dio_out_sleep_val[0].d),
     .qre    (),
@@ -3468,7 +3468,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_1 (
     .re     (dio_out_sleep_val_out_1_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_1_we & regen_qs),
+    .we     (dio_out_sleep_val_out_1_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_1_wd),
     .d      (hw2reg.dio_out_sleep_val[1].d),
     .qre    (),
@@ -3484,7 +3484,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_2 (
     .re     (dio_out_sleep_val_out_2_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_2_we & regen_qs),
+    .we     (dio_out_sleep_val_out_2_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_2_wd),
     .d      (hw2reg.dio_out_sleep_val[2].d),
     .qre    (),
@@ -3500,7 +3500,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_3 (
     .re     (dio_out_sleep_val_out_3_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_3_we & regen_qs),
+    .we     (dio_out_sleep_val_out_3_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_3_wd),
     .d      (hw2reg.dio_out_sleep_val[3].d),
     .qre    (),
@@ -3516,7 +3516,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_4 (
     .re     (dio_out_sleep_val_out_4_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_4_we & regen_qs),
+    .we     (dio_out_sleep_val_out_4_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_4_wd),
     .d      (hw2reg.dio_out_sleep_val[4].d),
     .qre    (),
@@ -3532,7 +3532,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_5 (
     .re     (dio_out_sleep_val_out_5_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_5_we & regen_qs),
+    .we     (dio_out_sleep_val_out_5_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_5_wd),
     .d      (hw2reg.dio_out_sleep_val[5].d),
     .qre    (),
@@ -3548,7 +3548,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_6 (
     .re     (dio_out_sleep_val_out_6_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_6_we & regen_qs),
+    .we     (dio_out_sleep_val_out_6_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_6_wd),
     .d      (hw2reg.dio_out_sleep_val[6].d),
     .qre    (),
@@ -3564,7 +3564,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_7 (
     .re     (dio_out_sleep_val_out_7_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_7_we & regen_qs),
+    .we     (dio_out_sleep_val_out_7_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_7_wd),
     .d      (hw2reg.dio_out_sleep_val[7].d),
     .qre    (),
@@ -3580,7 +3580,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_8 (
     .re     (dio_out_sleep_val_out_8_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_8_we & regen_qs),
+    .we     (dio_out_sleep_val_out_8_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_8_wd),
     .d      (hw2reg.dio_out_sleep_val[8].d),
     .qre    (),
@@ -3596,7 +3596,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_9 (
     .re     (dio_out_sleep_val_out_9_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_9_we & regen_qs),
+    .we     (dio_out_sleep_val_out_9_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_9_wd),
     .d      (hw2reg.dio_out_sleep_val[9].d),
     .qre    (),
@@ -3612,7 +3612,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_10 (
     .re     (dio_out_sleep_val_out_10_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_10_we & regen_qs),
+    .we     (dio_out_sleep_val_out_10_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_10_wd),
     .d      (hw2reg.dio_out_sleep_val[10].d),
     .qre    (),
@@ -3628,7 +3628,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_11 (
     .re     (dio_out_sleep_val_out_11_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_11_we & regen_qs),
+    .we     (dio_out_sleep_val_out_11_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_11_wd),
     .d      (hw2reg.dio_out_sleep_val[11].d),
     .qre    (),
@@ -3644,7 +3644,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_12 (
     .re     (dio_out_sleep_val_out_12_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_12_we & regen_qs),
+    .we     (dio_out_sleep_val_out_12_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_12_wd),
     .d      (hw2reg.dio_out_sleep_val[12].d),
     .qre    (),
@@ -3660,7 +3660,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_13 (
     .re     (dio_out_sleep_val_out_13_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_13_we & regen_qs),
+    .we     (dio_out_sleep_val_out_13_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_13_wd),
     .d      (hw2reg.dio_out_sleep_val[13].d),
     .qre    (),
@@ -3676,7 +3676,7 @@ module pinmux_reg_top (
   ) u_dio_out_sleep_val_out_14 (
     .re     (dio_out_sleep_val_out_14_re),
     // qualified with register enable
-    .we     (dio_out_sleep_val_out_14_we & regen_qs),
+    .we     (dio_out_sleep_val_out_14_we & regwen_qs),
     .wd     (dio_out_sleep_val_out_14_wd),
     .d      (hw2reg.dio_out_sleep_val[14].d),
     .qre    (),
@@ -3701,7 +3701,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_en_en_0_we & regen_qs),
+    .we     (wkup_detector_en_en_0_we & regwen_qs),
     .wd     (wkup_detector_en_en_0_wd),
 
     // from internal hardware
@@ -3727,7 +3727,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_en_en_1_we & regen_qs),
+    .we     (wkup_detector_en_en_1_we & regwen_qs),
     .wd     (wkup_detector_en_en_1_wd),
 
     // from internal hardware
@@ -3753,7 +3753,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_en_en_2_we & regen_qs),
+    .we     (wkup_detector_en_en_2_we & regwen_qs),
     .wd     (wkup_detector_en_en_2_wd),
 
     // from internal hardware
@@ -3779,7 +3779,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_en_en_3_we & regen_qs),
+    .we     (wkup_detector_en_en_3_we & regwen_qs),
     .wd     (wkup_detector_en_en_3_wd),
 
     // from internal hardware
@@ -3805,7 +3805,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_en_en_4_we & regen_qs),
+    .we     (wkup_detector_en_en_4_we & regwen_qs),
     .wd     (wkup_detector_en_en_4_wd),
 
     // from internal hardware
@@ -3831,7 +3831,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_en_en_5_we & regen_qs),
+    .we     (wkup_detector_en_en_5_we & regwen_qs),
     .wd     (wkup_detector_en_en_5_wd),
 
     // from internal hardware
@@ -3857,7 +3857,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_en_en_6_we & regen_qs),
+    .we     (wkup_detector_en_en_6_we & regwen_qs),
     .wd     (wkup_detector_en_en_6_wd),
 
     // from internal hardware
@@ -3883,7 +3883,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_en_en_7_we & regen_qs),
+    .we     (wkup_detector_en_en_7_we & regwen_qs),
     .wd     (wkup_detector_en_en_7_wd),
 
     // from internal hardware
@@ -3914,7 +3914,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_0_mode_0_we & regen_qs),
+    .we     (wkup_detector_0_mode_0_we & regwen_qs),
     .wd     (wkup_detector_0_mode_0_wd),
 
     // from internal hardware
@@ -3940,7 +3940,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_0_filter_0_we & regen_qs),
+    .we     (wkup_detector_0_filter_0_we & regwen_qs),
     .wd     (wkup_detector_0_filter_0_wd),
 
     // from internal hardware
@@ -3966,7 +3966,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_0_miodio_0_we & regen_qs),
+    .we     (wkup_detector_0_miodio_0_we & regwen_qs),
     .wd     (wkup_detector_0_miodio_0_wd),
 
     // from internal hardware
@@ -3995,7 +3995,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_1_mode_1_we & regen_qs),
+    .we     (wkup_detector_1_mode_1_we & regwen_qs),
     .wd     (wkup_detector_1_mode_1_wd),
 
     // from internal hardware
@@ -4021,7 +4021,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_1_filter_1_we & regen_qs),
+    .we     (wkup_detector_1_filter_1_we & regwen_qs),
     .wd     (wkup_detector_1_filter_1_wd),
 
     // from internal hardware
@@ -4047,7 +4047,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_1_miodio_1_we & regen_qs),
+    .we     (wkup_detector_1_miodio_1_we & regwen_qs),
     .wd     (wkup_detector_1_miodio_1_wd),
 
     // from internal hardware
@@ -4076,7 +4076,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_2_mode_2_we & regen_qs),
+    .we     (wkup_detector_2_mode_2_we & regwen_qs),
     .wd     (wkup_detector_2_mode_2_wd),
 
     // from internal hardware
@@ -4102,7 +4102,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_2_filter_2_we & regen_qs),
+    .we     (wkup_detector_2_filter_2_we & regwen_qs),
     .wd     (wkup_detector_2_filter_2_wd),
 
     // from internal hardware
@@ -4128,7 +4128,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_2_miodio_2_we & regen_qs),
+    .we     (wkup_detector_2_miodio_2_we & regwen_qs),
     .wd     (wkup_detector_2_miodio_2_wd),
 
     // from internal hardware
@@ -4157,7 +4157,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_3_mode_3_we & regen_qs),
+    .we     (wkup_detector_3_mode_3_we & regwen_qs),
     .wd     (wkup_detector_3_mode_3_wd),
 
     // from internal hardware
@@ -4183,7 +4183,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_3_filter_3_we & regen_qs),
+    .we     (wkup_detector_3_filter_3_we & regwen_qs),
     .wd     (wkup_detector_3_filter_3_wd),
 
     // from internal hardware
@@ -4209,7 +4209,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_3_miodio_3_we & regen_qs),
+    .we     (wkup_detector_3_miodio_3_we & regwen_qs),
     .wd     (wkup_detector_3_miodio_3_wd),
 
     // from internal hardware
@@ -4238,7 +4238,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_4_mode_4_we & regen_qs),
+    .we     (wkup_detector_4_mode_4_we & regwen_qs),
     .wd     (wkup_detector_4_mode_4_wd),
 
     // from internal hardware
@@ -4264,7 +4264,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_4_filter_4_we & regen_qs),
+    .we     (wkup_detector_4_filter_4_we & regwen_qs),
     .wd     (wkup_detector_4_filter_4_wd),
 
     // from internal hardware
@@ -4290,7 +4290,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_4_miodio_4_we & regen_qs),
+    .we     (wkup_detector_4_miodio_4_we & regwen_qs),
     .wd     (wkup_detector_4_miodio_4_wd),
 
     // from internal hardware
@@ -4319,7 +4319,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_5_mode_5_we & regen_qs),
+    .we     (wkup_detector_5_mode_5_we & regwen_qs),
     .wd     (wkup_detector_5_mode_5_wd),
 
     // from internal hardware
@@ -4345,7 +4345,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_5_filter_5_we & regen_qs),
+    .we     (wkup_detector_5_filter_5_we & regwen_qs),
     .wd     (wkup_detector_5_filter_5_wd),
 
     // from internal hardware
@@ -4371,7 +4371,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_5_miodio_5_we & regen_qs),
+    .we     (wkup_detector_5_miodio_5_we & regwen_qs),
     .wd     (wkup_detector_5_miodio_5_wd),
 
     // from internal hardware
@@ -4400,7 +4400,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_6_mode_6_we & regen_qs),
+    .we     (wkup_detector_6_mode_6_we & regwen_qs),
     .wd     (wkup_detector_6_mode_6_wd),
 
     // from internal hardware
@@ -4426,7 +4426,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_6_filter_6_we & regen_qs),
+    .we     (wkup_detector_6_filter_6_we & regwen_qs),
     .wd     (wkup_detector_6_filter_6_wd),
 
     // from internal hardware
@@ -4452,7 +4452,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_6_miodio_6_we & regen_qs),
+    .we     (wkup_detector_6_miodio_6_we & regwen_qs),
     .wd     (wkup_detector_6_miodio_6_wd),
 
     // from internal hardware
@@ -4481,7 +4481,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_7_mode_7_we & regen_qs),
+    .we     (wkup_detector_7_mode_7_we & regwen_qs),
     .wd     (wkup_detector_7_mode_7_wd),
 
     // from internal hardware
@@ -4507,7 +4507,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_7_filter_7_we & regen_qs),
+    .we     (wkup_detector_7_filter_7_we & regwen_qs),
     .wd     (wkup_detector_7_filter_7_wd),
 
     // from internal hardware
@@ -4533,7 +4533,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_7_miodio_7_we & regen_qs),
+    .we     (wkup_detector_7_miodio_7_we & regwen_qs),
     .wd     (wkup_detector_7_miodio_7_wd),
 
     // from internal hardware
@@ -4564,7 +4564,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_cnt_th_0_th_0_we & regen_qs),
+    .we     (wkup_detector_cnt_th_0_th_0_we & regwen_qs),
     .wd     (wkup_detector_cnt_th_0_th_0_wd),
 
     // from internal hardware
@@ -4590,7 +4590,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_cnt_th_0_th_1_we & regen_qs),
+    .we     (wkup_detector_cnt_th_0_th_1_we & regwen_qs),
     .wd     (wkup_detector_cnt_th_0_th_1_wd),
 
     // from internal hardware
@@ -4616,7 +4616,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_cnt_th_0_th_2_we & regen_qs),
+    .we     (wkup_detector_cnt_th_0_th_2_we & regwen_qs),
     .wd     (wkup_detector_cnt_th_0_th_2_wd),
 
     // from internal hardware
@@ -4642,7 +4642,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_cnt_th_0_th_3_we & regen_qs),
+    .we     (wkup_detector_cnt_th_0_th_3_we & regwen_qs),
     .wd     (wkup_detector_cnt_th_0_th_3_wd),
 
     // from internal hardware
@@ -4671,7 +4671,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_cnt_th_1_th_4_we & regen_qs),
+    .we     (wkup_detector_cnt_th_1_th_4_we & regwen_qs),
     .wd     (wkup_detector_cnt_th_1_th_4_wd),
 
     // from internal hardware
@@ -4697,7 +4697,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_cnt_th_1_th_5_we & regen_qs),
+    .we     (wkup_detector_cnt_th_1_th_5_we & regwen_qs),
     .wd     (wkup_detector_cnt_th_1_th_5_wd),
 
     // from internal hardware
@@ -4723,7 +4723,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_cnt_th_1_th_6_we & regen_qs),
+    .we     (wkup_detector_cnt_th_1_th_6_we & regwen_qs),
     .wd     (wkup_detector_cnt_th_1_th_6_wd),
 
     // from internal hardware
@@ -4749,7 +4749,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_cnt_th_1_th_7_we & regen_qs),
+    .we     (wkup_detector_cnt_th_1_th_7_we & regwen_qs),
     .wd     (wkup_detector_cnt_th_1_th_7_wd),
 
     // from internal hardware
@@ -4780,7 +4780,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_padsel_0_sel_0_we & regen_qs),
+    .we     (wkup_detector_padsel_0_sel_0_we & regwen_qs),
     .wd     (wkup_detector_padsel_0_sel_0_wd),
 
     // from internal hardware
@@ -4806,7 +4806,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_padsel_0_sel_1_we & regen_qs),
+    .we     (wkup_detector_padsel_0_sel_1_we & regwen_qs),
     .wd     (wkup_detector_padsel_0_sel_1_wd),
 
     // from internal hardware
@@ -4832,7 +4832,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_padsel_0_sel_2_we & regen_qs),
+    .we     (wkup_detector_padsel_0_sel_2_we & regwen_qs),
     .wd     (wkup_detector_padsel_0_sel_2_wd),
 
     // from internal hardware
@@ -4858,7 +4858,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_padsel_0_sel_3_we & regen_qs),
+    .we     (wkup_detector_padsel_0_sel_3_we & regwen_qs),
     .wd     (wkup_detector_padsel_0_sel_3_wd),
 
     // from internal hardware
@@ -4884,7 +4884,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_padsel_0_sel_4_we & regen_qs),
+    .we     (wkup_detector_padsel_0_sel_4_we & regwen_qs),
     .wd     (wkup_detector_padsel_0_sel_4_wd),
 
     // from internal hardware
@@ -4910,7 +4910,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_padsel_0_sel_5_we & regen_qs),
+    .we     (wkup_detector_padsel_0_sel_5_we & regwen_qs),
     .wd     (wkup_detector_padsel_0_sel_5_wd),
 
     // from internal hardware
@@ -4939,7 +4939,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_padsel_1_sel_6_we & regen_qs),
+    .we     (wkup_detector_padsel_1_sel_6_we & regwen_qs),
     .wd     (wkup_detector_padsel_1_sel_6_wd),
 
     // from internal hardware
@@ -4965,7 +4965,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wkup_detector_padsel_1_sel_7_we & regen_qs),
+    .we     (wkup_detector_padsel_1_sel_7_we & regwen_qs),
     .wd     (wkup_detector_padsel_1_sel_7_wd),
 
     // from internal hardware
@@ -4992,7 +4992,7 @@ module pinmux_reg_top (
   ) u_wkup_cause_cause_0 (
     .re     (wkup_cause_cause_0_re),
     // qualified with register enable
-    .we     (wkup_cause_cause_0_we & regen_qs),
+    .we     (wkup_cause_cause_0_we & regwen_qs),
     .wd     (wkup_cause_cause_0_wd),
     .d      (hw2reg.wkup_cause[0].d),
     .qre    (),
@@ -5008,7 +5008,7 @@ module pinmux_reg_top (
   ) u_wkup_cause_cause_1 (
     .re     (wkup_cause_cause_1_re),
     // qualified with register enable
-    .we     (wkup_cause_cause_1_we & regen_qs),
+    .we     (wkup_cause_cause_1_we & regwen_qs),
     .wd     (wkup_cause_cause_1_wd),
     .d      (hw2reg.wkup_cause[1].d),
     .qre    (),
@@ -5024,7 +5024,7 @@ module pinmux_reg_top (
   ) u_wkup_cause_cause_2 (
     .re     (wkup_cause_cause_2_re),
     // qualified with register enable
-    .we     (wkup_cause_cause_2_we & regen_qs),
+    .we     (wkup_cause_cause_2_we & regwen_qs),
     .wd     (wkup_cause_cause_2_wd),
     .d      (hw2reg.wkup_cause[2].d),
     .qre    (),
@@ -5040,7 +5040,7 @@ module pinmux_reg_top (
   ) u_wkup_cause_cause_3 (
     .re     (wkup_cause_cause_3_re),
     // qualified with register enable
-    .we     (wkup_cause_cause_3_we & regen_qs),
+    .we     (wkup_cause_cause_3_we & regwen_qs),
     .wd     (wkup_cause_cause_3_wd),
     .d      (hw2reg.wkup_cause[3].d),
     .qre    (),
@@ -5056,7 +5056,7 @@ module pinmux_reg_top (
   ) u_wkup_cause_cause_4 (
     .re     (wkup_cause_cause_4_re),
     // qualified with register enable
-    .we     (wkup_cause_cause_4_we & regen_qs),
+    .we     (wkup_cause_cause_4_we & regwen_qs),
     .wd     (wkup_cause_cause_4_wd),
     .d      (hw2reg.wkup_cause[4].d),
     .qre    (),
@@ -5072,7 +5072,7 @@ module pinmux_reg_top (
   ) u_wkup_cause_cause_5 (
     .re     (wkup_cause_cause_5_re),
     // qualified with register enable
-    .we     (wkup_cause_cause_5_we & regen_qs),
+    .we     (wkup_cause_cause_5_we & regwen_qs),
     .wd     (wkup_cause_cause_5_wd),
     .d      (hw2reg.wkup_cause[5].d),
     .qre    (),
@@ -5088,7 +5088,7 @@ module pinmux_reg_top (
   ) u_wkup_cause_cause_6 (
     .re     (wkup_cause_cause_6_re),
     // qualified with register enable
-    .we     (wkup_cause_cause_6_we & regen_qs),
+    .we     (wkup_cause_cause_6_we & regwen_qs),
     .wd     (wkup_cause_cause_6_wd),
     .d      (hw2reg.wkup_cause[6].d),
     .qre    (),
@@ -5104,7 +5104,7 @@ module pinmux_reg_top (
   ) u_wkup_cause_cause_7 (
     .re     (wkup_cause_cause_7_re),
     // qualified with register enable
-    .we     (wkup_cause_cause_7_we & regen_qs),
+    .we     (wkup_cause_cause_7_we & regwen_qs),
     .wd     (wkup_cause_cause_7_wd),
     .d      (hw2reg.wkup_cause[7].d),
     .qre    (),
@@ -5120,7 +5120,7 @@ module pinmux_reg_top (
   logic [33:0] addr_hit;
   always_comb begin
     addr_hit = '0;
-    addr_hit[ 0] = (reg_addr == PINMUX_REGEN_OFFSET);
+    addr_hit[ 0] = (reg_addr == PINMUX_REGWEN_OFFSET);
     addr_hit[ 1] = (reg_addr == PINMUX_PERIPH_INSEL_0_OFFSET);
     addr_hit[ 2] = (reg_addr == PINMUX_PERIPH_INSEL_1_OFFSET);
     addr_hit[ 3] = (reg_addr == PINMUX_PERIPH_INSEL_2_OFFSET);
@@ -5197,8 +5197,8 @@ module pinmux_reg_top (
     if (addr_hit[33] && reg_we && (PINMUX_PERMIT[33] != (PINMUX_PERMIT[33] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign regen_we = addr_hit[0] & reg_we & ~wr_err;
-  assign regen_wd = reg_wdata[0];
+  assign regwen_we = addr_hit[0] & reg_we & ~wr_err;
+  assign regwen_wd = reg_wdata[0];
 
   assign periph_insel_0_in_0_we = addr_hit[1] & reg_we & ~wr_err;
   assign periph_insel_0_in_0_wd = reg_wdata[5:0];
@@ -5756,7 +5756,7 @@ module pinmux_reg_top (
     reg_rdata_next = '0;
     unique case (1'b1)
       addr_hit[0]: begin
-        reg_rdata_next[0] = regen_qs;
+        reg_rdata_next[0] = regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/sw/device/lib/dif/dif_alert_handler.c
+++ b/sw/device/lib/dif/dif_alert_handler.c
@@ -451,9 +451,9 @@ dif_alert_handler_result_t dif_alert_handler_lock(
     return kDifAlertHandlerBadArg;
   }
 
-  uint32_t reg = bitfield_bit32_write(0, ALERT_HANDLER_REGEN_REGEN_BIT, true);
-  mmio_region_write32(handler->params.base_addr, ALERT_HANDLER_REGEN_REG_OFFSET,
-                      reg);
+  uint32_t reg = bitfield_bit32_write(0, ALERT_HANDLER_REGWEN_REGWEN_BIT, true);
+  mmio_region_write32(handler->params.base_addr,
+                      ALERT_HANDLER_REGWEN_REG_OFFSET, reg);
 
   return kDifAlertHandlerOk;
 }
@@ -465,9 +465,9 @@ dif_alert_handler_result_t dif_alert_handler_is_locked(
   }
 
   uint32_t reg = mmio_region_read32(handler->params.base_addr,
-                                    ALERT_HANDLER_REGEN_REG_OFFSET);
+                                    ALERT_HANDLER_REGWEN_REG_OFFSET);
   // Note that "true" indicates "enabled", so we negated to get "locked".
-  *is_locked = !bitfield_bit32_read(reg, ALERT_HANDLER_REGEN_REGEN_BIT);
+  *is_locked = !bitfield_bit32_read(reg, ALERT_HANDLER_REGWEN_REGWEN_BIT);
 
   return kDifAlertHandlerOk;
 }
@@ -720,16 +720,16 @@ static bool get_clear_enable_reg_offset(dif_alert_handler_class_t class,
                                         ptrdiff_t *reg_offset) {
   switch (class) {
     case kDifAlertHandlerClassA:
-      *reg_offset = ALERT_HANDLER_CLASSA_CLREN_REG_OFFSET;
+      *reg_offset = ALERT_HANDLER_CLASSA_REGWEN_REG_OFFSET;
       break;
     case kDifAlertHandlerClassB:
-      *reg_offset = ALERT_HANDLER_CLASSB_CLREN_REG_OFFSET;
+      *reg_offset = ALERT_HANDLER_CLASSB_REGWEN_REG_OFFSET;
       break;
     case kDifAlertHandlerClassC:
-      *reg_offset = ALERT_HANDLER_CLASSC_CLREN_REG_OFFSET;
+      *reg_offset = ALERT_HANDLER_CLASSC_REGWEN_REG_OFFSET;
       break;
     case kDifAlertHandlerClassD:
-      *reg_offset = ALERT_HANDLER_CLASSD_CLREN_REG_OFFSET;
+      *reg_offset = ALERT_HANDLER_CLASSD_REGWEN_REG_OFFSET;
       break;
     default:
       return false;
@@ -751,7 +751,7 @@ dif_alert_handler_result_t dif_alert_handler_escalation_can_clear(
 
   uint32_t reg = mmio_region_read32(handler->params.base_addr, reg_offset);
   *can_clear =
-      bitfield_bit32_read(reg, ALERT_HANDLER_CLASSA_CLREN_CLASSA_CLREN_BIT);
+      bitfield_bit32_read(reg, ALERT_HANDLER_CLASSA_REGWEN_CLASSA_REGWEN_BIT);
 
   return kDifAlertHandlerOk;
 }
@@ -768,7 +768,7 @@ dif_alert_handler_result_t dif_alert_handler_escalation_disable_clearing(
   }
 
   uint32_t reg = bitfield_bit32_write(
-      0, ALERT_HANDLER_CLASSA_CLREN_CLASSA_CLREN_BIT, true);
+      0, ALERT_HANDLER_CLASSA_REGWEN_CLASSA_REGWEN_BIT, true);
   mmio_region_write32(handler->params.base_addr, reg_offset, reg);
 
   return kDifAlertHandlerOk;

--- a/sw/device/tests/dif/dif_alert_handler_unittest.cc
+++ b/sw/device/tests/dif/dif_alert_handler_unittest.cc
@@ -98,7 +98,7 @@ TEST_F(ConfigTest, Locked) {
       .ping_timeout = 0,
   };
 
-  EXPECT_READ32(ALERT_HANDLER_REGEN_REG_OFFSET, 0);
+  EXPECT_READ32(ALERT_HANDLER_REGWEN_REG_OFFSET, 0);
 
   EXPECT_EQ(dif_alert_handler_configure(&handler_, config),
             kDifAlertHandlerConfigLocked);
@@ -109,8 +109,8 @@ TEST_F(ConfigTest, NoClassInit) {
       .ping_timeout = 50,
   };
 
-  EXPECT_READ32(ALERT_HANDLER_REGEN_REG_OFFSET,
-                {{ALERT_HANDLER_REGEN_REGEN_BIT, true}});
+  EXPECT_READ32(ALERT_HANDLER_REGWEN_REG_OFFSET,
+                {{ALERT_HANDLER_REGWEN_REGWEN_BIT, true}});
 
   EXPECT_WRITE32(
       ALERT_HANDLER_PING_TIMEOUT_CYC_REG_OFFSET,
@@ -207,8 +207,8 @@ TEST_F(ConfigTest, ClassInit) {
       .classes_len = classes.size(),
   };
 
-  EXPECT_READ32(ALERT_HANDLER_REGEN_REG_OFFSET,
-                {{ALERT_HANDLER_REGEN_REGEN_BIT, true}});
+  EXPECT_READ32(ALERT_HANDLER_REGWEN_REG_OFFSET,
+                {{ALERT_HANDLER_REGWEN_REGWEN_BIT, true}});
 
   // Unfortunately, we can't use EXPECT_MASK for these reads and writes,
   // since there are not sequenced exactly.
@@ -569,20 +569,20 @@ class LockTest : public AlertTest {};
 TEST_F(LockTest, IsLocked) {
   bool flag;
 
-  EXPECT_READ32(ALERT_HANDLER_REGEN_REG_OFFSET,
-                {{ALERT_HANDLER_REGEN_REGEN_BIT, true}});
+  EXPECT_READ32(ALERT_HANDLER_REGWEN_REG_OFFSET,
+                {{ALERT_HANDLER_REGWEN_REGWEN_BIT, true}});
   EXPECT_EQ(dif_alert_handler_is_locked(&handler_, &flag), kDifAlertHandlerOk);
   EXPECT_FALSE(flag);
 
-  EXPECT_READ32(ALERT_HANDLER_REGEN_REG_OFFSET,
-                {{ALERT_HANDLER_REGEN_REGEN_BIT, false}});
+  EXPECT_READ32(ALERT_HANDLER_REGWEN_REG_OFFSET,
+                {{ALERT_HANDLER_REGWEN_REGWEN_BIT, false}});
   EXPECT_EQ(dif_alert_handler_is_locked(&handler_, &flag), kDifAlertHandlerOk);
   EXPECT_TRUE(flag);
 }
 
 TEST_F(LockTest, Lock) {
-  EXPECT_WRITE32(ALERT_HANDLER_REGEN_REG_OFFSET,
-                 {{ALERT_HANDLER_REGEN_REGEN_BIT, true}});
+  EXPECT_WRITE32(ALERT_HANDLER_REGWEN_REG_OFFSET,
+                 {{ALERT_HANDLER_REGWEN_REGWEN_BIT, true}});
   EXPECT_EQ(dif_alert_handler_lock(&handler_), kDifAlertHandlerOk);
 }
 
@@ -811,13 +811,13 @@ class EscalationTest : public AlertTest {};
 TEST_F(EscalationTest, CanClear) {
   bool flag;
 
-  EXPECT_READ32(ALERT_HANDLER_CLASSB_CLREN_REG_OFFSET, true);
+  EXPECT_READ32(ALERT_HANDLER_CLASSB_REGWEN_REG_OFFSET, true);
   EXPECT_EQ(dif_alert_handler_escalation_can_clear(
                 &handler_, kDifAlertHandlerClassB, &flag),
             kDifAlertHandlerOk);
   EXPECT_TRUE(flag);
 
-  EXPECT_READ32(ALERT_HANDLER_CLASSA_CLREN_REG_OFFSET, false);
+  EXPECT_READ32(ALERT_HANDLER_CLASSA_REGWEN_REG_OFFSET, false);
   EXPECT_EQ(dif_alert_handler_escalation_can_clear(
                 &handler_, kDifAlertHandlerClassA, &flag),
             kDifAlertHandlerOk);
@@ -825,7 +825,7 @@ TEST_F(EscalationTest, CanClear) {
 }
 
 TEST_F(EscalationTest, Disable) {
-  EXPECT_WRITE32(ALERT_HANDLER_CLASSC_CLREN_REG_OFFSET, true);
+  EXPECT_WRITE32(ALERT_HANDLER_CLASSC_REGWEN_REG_OFFSET, true);
   EXPECT_EQ(dif_alert_handler_escalation_disable_clearing(
                 &handler_, kDifAlertHandlerClassC),
             kDifAlertHandlerOk);


### PR DESCRIPTION
This changes standardizes the CSR register write enables as discussed on #1922.

In particular, it enforces the naming convention that regwen registers must be called either `REGWEN` or have the `_REGWEN` suffix, and it enforces that SW access must be set to `rw0c`.

This PR also aligns all affected designs such that they pass these checks.