### PR TITLE
[otbn] Extract instruction operation documentation from Python implementation

### DIFF
--- a/hw/ip/otbn/data/base-insns.yml
+++ b/hw/ip/otbn/data/base-insns.yml
@@ -383,10 +383,6 @@
   lsu:
     type: csr
     target: [csr]
-  operation: |
-    gpr_s_val = GPR[grs1]
-    GPR[grd] = CSR[csr]
-    CSR[csr] |= gpr_s_val
 
 - mnemonic: csrrw
   rv32i: true
@@ -408,13 +404,6 @@
   lsu:
     type: csr
     target: [csr]
-  operation: |
-    gpr_s_val = GPR[grs1]
-
-    if d != 0:
-      GPR[grd] = CSR[csr]
-
-    CSR[csr] = gpr_s_val
 
 - mnemonic: ecall
   rv32i: true

--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -37,12 +37,6 @@
     Adds two WDR values, writes the result to the destination WDR and updates
     flags. The content of the second source WDR can be shifted by an unsigned
     immediate before it is consumed by the operation.
-  operation: |
-    b_shifted = ShiftReg(wrs2, shift_type, shift_bits)
-    (result, flags_out) = AddWithCarry(wrs1, b_shifted, "0")
-
-    WDR[wrd] = result
-    FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnaf
     mapping:
@@ -63,12 +57,6 @@
     destination WDR, and updates the flags. The content of the second source
     WDR can be shifted by an unsigned immediate before it is consumed by the
     operation.
-  operation: |
-    b_shifted = ShiftReg(wrs2, shift_type, shift_bits)
-    (result, flags_out) = AddWithCarry(wrs1, b_shifted, FLAGS[flag_group].C)
-
-    WDR[wrd] = result
-    FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnaf
     mapping:
@@ -96,11 +84,6 @@
   doc: |
     Adds a zero-extended unsigned immediate to the value of a WDR, writes the
     result to the destination WDR, and updates the flags.
-  operation: |
-    (result, flags_out) = AddWithCarry(wrs1, imm, "0")
-
-    WDR[wrd] = result
-    FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnai
     mapping:
@@ -125,13 +108,6 @@
     The intermediate result is small enough if both inputs are less than `MOD`.
 
     Flags are not used or saved.
-  operation: |
-    result = wrs1 + wrs2
-
-    if result >= MOD:
-      result = result - MOD
-
-    WDR[wrd] = result & ((1 << 256) - 1)
   encoding:
     scheme: bnam
     mapping:
@@ -192,16 +168,6 @@
     Multiplies two `WLEN/4` WDR values, shifts the product by `acc_shift_imm` bits, and adds the result to the accumulator.
 
     For versions of the instruction with writeback, see `BN.MULQACC.WO` and `BN.MULQACC.SO`.
-  operation: |
-    a_qw = GetQuarterWord(wrs1, wrs1_qwsel)
-    b_qw = GetQuarterWord(wrs2, wrs2_qwsel)
-
-    mul_res = a_qw * b_qw
-
-    if zero_acc:
-      ACC = 0
-
-    ACC = ACC + (mul_res << acc_shift_imm)
   encoding:
     scheme: bnaq
     mapping:
@@ -235,22 +201,6 @@
   doc: |
     Multiplies two `WLEN/4` WDR values, shifts the product by `acc_shift_imm` bits, and adds the result to the accumulator.
     Writes the resulting accumulator to `wrd`.
-    Updates the M, L and Z flags of `flag_group`.
-  operation: |
-    a_qw = GetQuarterWord(wrs1, wrs1_qwsel)
-    b_qw = GetQuarterWord(wrs2, wrs2_qwsel)
-
-    mul_res = a_qw * b_qw
-
-    if zero_acc:
-      ACC = 0
-
-    ACC = ACC + (mul_res << acc_shift_imm)
-
-    WDR[wrd] = ACC
-    FLAGS[flag_group].M = ACC[WLEN-1]
-    FLAGS[flag_group].L = ACC[0]
-    FLAGS[flag_group].Z = (ACC == 0)
   encoding:
     scheme: bnaq
     mapping:
@@ -299,29 +249,6 @@
     If `wrd_hwsel` is one (so the instruction is updating the upper half-word of `wrd`), it updates the `M` and `Z` flags and leaves `L` unchanged.
     The `M` flag is set iff the top bit of the shifted-out result is zero.
     The `Z` flag is left unchanged if the shifted-out result is zero and cleared if not.
-  operation: |
-    a_qw = GetQuarterWord(wrs1, wrs1_qwsel)
-    b_qw = GetQuarterWord(wrs2, wrs2_qwsel)
-
-    mul_res = a_qw * b_qw
-
-    if zero_acc:
-      ACC = 0
-
-    ACC = ACC + (mul_res << acc_shift_imm)
-
-    shifted = ACC[WLEN/2-1:0]
-    ACC = ACC >> (WLEN/2)
-
-    if wrd_hwsel == 'L':
-      WDR[wrd][WLEN/2-1:0] = shifted
-      FLAGS[flag_group].L = shifted[0]
-      FLAGS[flag_group].Z = (shifted == 0)
-    elif wrd_hwsel == 'U':
-      WDR[wrd][WLEN-1:WLEN/2] = shifted
-      FLAGS[flag_group].M = shifted[WLEN/2-1]
-      if (shifted != 0):
-        FLAGS[flag_group].Z = 0
   encoding:
     scheme: bnaq
     mapping:
@@ -352,12 +279,6 @@
   doc: |
     Subtracts the second WDR value from the first one, writes the result to the destination WDR and updates flags.
     The content of the second source WDR can be shifted by an unsigned immediate before it is consumed by the operation.
-  operation: |
-    b_shifted = ShiftReg(wrs2, shift_type, shift_bits)
-    (result, flags_out) = SubtractWithBorrow(wrs1, b_shifted, 0)
-
-    WDR[wrd] = result
-    FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnaf
     mapping:
@@ -376,12 +297,6 @@
   doc: |
     Subtracts the second WDR value and the Carry from the first one, writes the result to the destination WDR, and updates the flags.
     The content of the second source WDR can be shifted by an unsigned immediate before it is consumed by the operation.
-  operation: |
-    b_shifted = ShiftReg(wrs2, shift_type, shift_bits)
-    (result, flags_out) = SubtractWithBorrow(wrs1, b_shifted, FLAGS[flag_group].C)
-
-    WDR[wrd] = result
-    FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnaf
     mapping:
@@ -408,11 +323,6 @@
   doc: |
     Subtracts a zero-extended unsigned immediate from the value of a WDR,
     writes the result to the destination WDR, and updates the flags.
-  operation: |
-    (result, flags_out) = SubtractWithBorrow(wrs1, imm, 0)
-
-    WDR[wrd] = result
-    FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnai
     mapping:
@@ -437,13 +347,6 @@
     This is guaranteed if both inputs are less than `MOD`.
 
     Flags are not used or saved.
-  operation: |
-    result = wrs1 - wrs2
-
-    if result < 0:
-      result = MOD + result
-
-    WDR[wrd] = result & ((1 << 256) - 1)
   encoding:
     scheme: bnam
     mapping:
@@ -472,13 +375,6 @@
     Takes the values stored in registers referenced by `wrs1` and `wrs2` and stores the result in the register referenced by `wrd`.
     The content of the second source register can be shifted by an immediate before it is consumed by the operation.
     The M, L and Z flags in flag group 0 are updated with the result of the operation.
-  operation: |
-    b_shifted = ShiftReg(wrs2, shift_type, shift_bits)
-    result = wrs1 & b_shifted
-
-    WDR[wrd] = result
-    flags_out = FlagsForResult(result)
-    FLAGS[flag_group] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[flag_group].C}
   encoding:
     scheme: bna
     mapping:
@@ -499,13 +395,6 @@
     Takes the values stored in WDRs referenced by `wrs1` and `wrs2` and stores the result in the WDR referenced by `wrd`.
     The content of the second source WDR can be shifted by an immediate before it is consumed by the operation.
     The M, L and Z flags in flag group 0 are updated with the result of the operation.
-  operation: |
-    b_shifted = ShiftReg(wrs2, shift_type, shift_bits)
-    result = wrs1 | b_shifted
-
-    WDR[wrd] = result
-    flags_out = FlagsForResult(result)
-    FLAGS[flag_group] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[flag_group].C}
   encoding:
     scheme: bna
     mapping:
@@ -533,13 +422,6 @@
     Negates the value in `wrs` and stores the result in the register referenced by `wrd`.
     The source value can be shifted by an immediate before it is consumed by the operation.
     The M, L and Z flags in flag group 0 are updated with the result of the operation.
-  operation: |
-    a_shifted = ShiftReg(wrs1, shift_type, shift_bits)
-    result = ~a_shifted
-
-    WDR[wrd] = result
-    flags_out = FlagsForResult(result)
-    FLAGS[flag_group] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[flag_group].C}
   encoding:
     scheme: bnan
     mapping:
@@ -559,13 +441,6 @@
     Takes the values stored in WDRs referenced by `wrs1` and `wrs2` and stores the result in the WDR referenced by `wrd`.
     The content of the second source WDR can be shifted by an immediate before it is consumed by the operation.
     The M, L and Z flags in flag group 0 are updated with the result of the operation.
-  operation: |
-    b_shifted = ShiftReg(wrs2, shift_type, shift_bits)
-    result = wrs1 ^ b_shifted
-
-    WDR[wrd] = result
-    flags_out = FlagsForResult(result)
-    FLAGS[flag_group] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[flag_group].C}
   encoding:
     scheme: bna
     mapping:
@@ -595,8 +470,6 @@
   doc: |
     Concatenates the content of WDRs referenced by `wrs1` and `wrs2` (`wrs1` forms the upper part), shifts it right by an immediate value and truncates to WLEN bit.
     The result is stored in the WDR referenced by `wrd`.
-  operation: |
-    WDR[wrd] = (((wrs1 << WLEN) | wrs2) >> imm)[WLEN-1:0]
   encoding:
     scheme: bnr
     mapping:
@@ -628,10 +501,6 @@
     <wrd>, <wrs1>, <wrs2>, [FG<flag_group>.]<flag>
   doc: |
     Returns in the destination WDR the value of the first source WDR if the flag in the chosen flag group is set, otherwise returns the value of the second source WDR.
-  operation: |
-    flag_is_set = FLAGS[flag_group].get(flag)
-
-    WDR[wrd] = wrs1 if flag_is_set else wrs2
   encoding:
     scheme: bns
     mapping:
@@ -656,11 +525,6 @@
   doc: |
     Subtracts the second WDR value from the first one and updates flags.
     This instruction is identical to BN.SUB, except that no result register is written.
-  operation: |
-    b_shifted = ShiftReg(wrs2, shift_type, shift_bits)
-    (, flags_out) = SubtractWithBorrow(wrs1, b_shifted, 0)
-
-    FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnc
     mapping:
@@ -678,10 +542,6 @@
   doc: |
     Subtracts the second WDR value from the first one and updates flags.
     This instruction is identical to BN.SUBB, except that no result register is written.
-  operation: |
-    (, flags_out) = SubtractWithBorrow(wrs1, wrs2, FLAGS[flag_group].C)
-
-    FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnc
     mapping:
@@ -740,24 +600,6 @@
     The memory address must be aligned to WLEN bits.
     Any address that is unaligned or is above the top of memory results in an error (setting bit `bad_data_addr` in `ERR_BITS`).
   cycles: 2
-  operation: |
-    mem_addr = GPR[grs1] + offset
-    wdr_dest = GPR[grd]
-
-    if grs1_inc and grd_inc:
-        raise IllegalInsn()
-
-    if mem_addr % (WLEN / 8) or mem_addr + WLEN > DMEM_SIZE:
-        raise BadDataAddr()
-
-    mem_index = mem_addr // (WLEN / 8)
-
-    WDR[wdr_dest] = LoadWlenWordFromMemory(mem_index)
-
-    if grs1_inc:
-        GPR[grs1] = GPR[grs1] + (WLEN / 8)
-    if grd_inc:
-        GPR[grd] = (GPR[grd] + 1) & 0x1f
   lsu:
     type: mem-load
     target: [offset, grs1]
@@ -815,24 +657,6 @@
 
     The memory address must be aligned to WLEN bits.
     Any address that is unaligned or is above the top of memory results in an error (setting bit `bad_data_addr` in `ERR_BITS`).
-  operation: |
-    mem_addr = GPR[grs1] + offset
-    wdr_src = GPR[grs2]
-
-    if grs1_inc and grs2_inc:
-        raise IllegalInsn()
-
-    if mem_addr % (WLEN / 8) or mem_addr + WLEN > DMEM_SIZE:
-        raise BadDataAddr()
-
-    mem_index = mem_addr // (WLEN / 8)
-
-    StoreWlenWordToMemory(mem_index, WDR[wdr_src])
-
-    if grs1_inc:
-        GPR[grs1] = GPR[grs1] + (WLEN / 8)
-    if grs2_inc:
-        GPR[grs2] = (GPR[grs2] + 1) & 0x1f
   lsu:
     type: mem-store
     target: [offset, grs1]
@@ -850,7 +674,6 @@
 - mnemonic: bn.mov
   synopsis: Copy content between WDRs (direct addressing)
   operands: [wrd, wrs]
-  operation: WDR[wrd] = WDR[wrs]
   encoding:
     scheme: bnmov
     mapping:
@@ -888,16 +711,6 @@
 
     - If `grd_inc` is set, `grd` is updated to be `(*grd + 1) & 0x1f`.
     - If `grs_inc` is set, `grs` is updated to be `(*grs + 1) & 0x1f`.
-  operation: |
-    WDR[GPR[grd]] = WDR[GPR[grs]]
-
-    if grd_inc and grs_inc:
-        raise IllegalInsn()
-
-    if grs_inc:
-      GPR[grs] = GPR[grs] + 1
-    if grd_inc:
-      GPR[grd] = GPR[grd] + 1
   encoding:
     scheme: bnmovr
     mapping:
@@ -916,8 +729,6 @@
   doc: |
     Reads a WSR to a WDR.
     If `wsr` isn't the index of a valid WSR, this halts with an error (TODO: Specify error code).
-  operation: |
-    WDR[wrd] = WSR[wsr]
   encoding:
     scheme: wcsr
     mapping:
@@ -940,8 +751,6 @@
   doc: |
     Writes a WDR to a WSR.
     If `wsr` isn't the index of a valid WSR, this halts with an error (TODO: Specify error code).
-  operation: |
-    WSR[wsr] = WDR[wrs]
   encoding:
     scheme: wcsr
     mapping:

--- a/hw/ip/otbn/util/Makefile
+++ b/hw/ip/otbn/util/Makefile
@@ -15,7 +15,7 @@ lint-build-dir := $(build-dir)/lint
 $(build-dir) $(lint-build-dir):
 	mkdir -p $@
 
-pylibs := $(wildcard shared/*.py)
+pylibs := $(wildcard shared/*.py docs/*.py)
 pyscripts := yaml_to_doc.py otbn-as otbn-ld otbn-objdump
 
 lint-stamps := $(foreach s,$(pyscripts),$(lint-build-dir)/$(s).stamp)

--- a/hw/ip/otbn/util/docs/get_impl.py
+++ b/hw/ip/otbn/util/docs/get_impl.py
@@ -5,32 +5,206 @@
 from typing import Dict, Optional, Sequence
 
 import libcst as cst
+from libcst._nodes.internal import CodegenState
 
 
-class ImplVisitor(cst.CSTVisitor):
+class RegRef(cst.Subscript):
+    '''An expression class to represent references to the register file'''
+    gprs = cst.Name('GPRs')
+    wdrs = cst.Name('WDRs')
+
+    is_wide: bool
+    idx: cst.BaseExpression
+
+    def __init__(self, is_wide: bool, idx: cst.BaseExpression):
+        # We want to do a computation when defining the fields in the base
+        # class (value and slice). That means we can't use the automatically
+        # generated init method from dataclass (nor can we use it's
+        # __post_init__ hook: that would happen too late).
+        #
+        # However, we also want to store fields ourselves (is_wide and idx). We
+        # can't just do something like "self.is_wide = is_wide", because that
+        # crashes into the frozen setattr that the base class defines. Instead,
+        # we have to use object.__setattr__ directly.
+        sub_elt = cst.SubscriptElement(slice=cst.Index(value=idx))
+        super().__init__(value=(RegRef.wdrs if is_wide else RegRef.gprs),
+                         slice=[sub_elt])
+        object.__setattr__(self, 'is_wide', is_wide)
+        object.__setattr__(self, 'idx', idx)
+
+    def _visit_and_replace_children(self,
+                                    visitor: cst.CSTVisitorT) -> 'RegRef':
+        new_idx = self.idx.visit(visitor)
+        if isinstance(new_idx, cst.RemovalSentinel):
+            raise ValueError('Cannot remove index of a RegRef')
+        return RegRef(self.is_wide, new_idx)
+
+    def _codegen_impl(self, state: CodegenState) -> None:
+        reg_bank = 'WDRs' if self.is_wide else 'GPRs'
+        state.add_token(reg_bank)
+        state.add_token('[')
+        with state.record_syntactic_position(self):
+            self.idx._codegen(state)
+        state.add_token(']')
+
+
+class ImplTransformer(cst.CSTTransformer):
     '''An AST visitor used to extract documentation from the ISS'''
     def __init__(self) -> None:
         self.impls = {}  # type: Dict[str, Sequence[cst.BaseStatement]]
 
         self.cur_class = None  # type: Optional[str]
 
-    def visit_ClassDef(self, node: cst.ClassDef) -> None:
+    def visit_ClassDef(self, node: cst.ClassDef) -> Optional[bool]:
         assert self.cur_class is None
         self.cur_class = node.name.value
+        return None
 
-    def leave_ClassDef(self, node: cst.ClassDef) -> None:
+    def leave_ClassDef(self,
+                       orig: cst.ClassDef,
+                       updated: cst.ClassDef) -> cst.BaseStatement:
         self.cur_class = None
+        return updated
 
-    def leave_FunctionDef(self, node: cst.FunctionDef) -> None:
+    def leave_FunctionDef(self,
+                          orig: cst.FunctionDef,
+                          updated: cst.FunctionDef) -> cst.BaseStatement:
         if ((self.cur_class is None or
-             node.name.value != 'execute' or
+             updated.name.value != 'execute' or
              self.cur_class in self.impls)):
-            return
+            return updated
 
         # The body of a function definition is always an IndentedBlock. Strip
         # that out to get at the statements inside.
-        assert isinstance(node.body, cst.IndentedBlock)
-        self.impls[self.cur_class] = node.body.body
+        assert isinstance(updated.body, cst.IndentedBlock)
+        self.impls[self.cur_class] = updated.body.body
+        return updated
+
+    @staticmethod
+    def match_get_reg(call: cst.BaseExpression) -> Optional[RegRef]:
+        '''Extract a RegRef from state.gprs.get_reg(foo)
+
+        Returns None if this isn't a match.
+
+        '''
+        if not isinstance(call, cst.Call):
+            return None
+
+        # We expect a single argument (which we take as the index)
+        if len(call.args) != 1:
+            return None
+
+        getreg_idx = call.args[0].value
+
+        # All we need to do still is check that call.func is an
+        # attribute representing state.gprs.get_reg or state.wdrs.get_reg.
+        if ((not isinstance(call.func, cst.Attribute) or
+             call.func.attr.value != 'get_reg')):
+            return None
+
+        state_dot_reg = call.func.value
+        if not isinstance(state_dot_reg, cst.Attribute):
+            return None
+
+        # Finally, state_dot_reg should be either state.gprs or state.wdrs
+        if not (isinstance(state_dot_reg.value, cst.Name) and
+                state_dot_reg.value.value == 'state'):
+            return None
+
+        regfile_name = state_dot_reg.attr.value
+        if regfile_name == 'gprs':
+            is_wide = False
+        elif regfile_name == 'wdrs':
+            is_wide = True
+        else:
+            return None
+
+        return RegRef(is_wide, getreg_idx)
+
+    def leave_Call(self,
+                   orig: cst.Call,
+                   updated: cst.Call) -> cst.BaseExpression:
+        # Detect
+        #
+        #    state.gprs.get_reg(FOO).read_unsigned()
+        #    state.gprs.get_reg(FOO).read_signed()
+        #
+        # and replace it with the expressions
+        #
+        #    GPRs[FOO]
+        #    from_2s_complement(GPRs[FOO])
+        #
+        # respectively.
+
+        # In either case, we expect updated.func to be some long attribute
+        # (representing state.gprs.get_reg(FOO).read_X). For unsigned or
+        # signed, we can check that it is indeed an Attribute and that
+        # updated.args is empty (neither function takes arguments).
+        if updated.args or not isinstance(updated.func, cst.Attribute):
+            return updated
+
+        # Now, check whether we're calling one of the functions we're
+        # interested in.
+        if updated.func.attr.value == 'read_signed':
+            signed = True
+        elif updated.func.attr.value == 'read_unsigned':
+            signed = False
+        else:
+            return updated
+
+        # Check that updated.func.value really does represent something of the
+        # form "state.gprs.get_reg(FOO)".
+        ret = ImplTransformer.match_get_reg(updated.func.value)
+        if ret is None:
+            return updated
+
+        if signed:
+            # If this is a call to read_signed, we want to wrap the returned
+            # value in a call to a fake sign decode function.
+            return cst.Call(func=cst.Name('from_2s_complement'),
+                            args=[cst.Arg(value=ret)])
+        else:
+            return ret
+
+    def leave_Expr(self,
+                   orig: cst.Expr,
+                   updated: cst.Expr) -> cst.BaseSmallStatement:
+        # This is called when leaving statements that are just expressions. We
+        # use it to spot
+        #
+        #   state.gprs.get_reg(foo).write_unsigned(bar)
+        #   state.gprs.get_reg(foo).write_signed(bar)
+        #
+        # and turn it into
+        #
+        #   GPRs[FOO] = bar
+        #   GPRs[FOO] = to_2s_complement(bar)
+
+        if not isinstance(updated.value, cst.Call):
+            return updated
+
+        call = updated.value
+        if len(call.args) != 1 or not isinstance(call.func, cst.Attribute):
+            return updated
+
+        value = call.args[0].value
+
+        if call.func.attr.value == 'write_unsigned':
+            rhs = value
+        elif call.func.attr.value == 'write_signed':
+            rhs = cst.Call(func=cst.Name('to_2s_complement'),
+                           args=[cst.Arg(value=value)])
+        else:
+            return updated
+
+        # We expect call.func.value to be match state.gprs.get_reg(foo).
+        # Extract the RegRef if we can.
+        reg_ref = ImplTransformer.match_get_reg(call.func.value)
+        if reg_ref is None:
+            return updated
+
+        return cst.Assign(targets=[cst.AssignTarget(target=reg_ref)],
+                          value=rhs)
 
 
 def read_implementation(path: str) -> Dict[str, str]:
@@ -45,7 +219,7 @@ def read_implementation(path: str) -> Dict[str, str]:
         node = cst.parse_module(handle.read())
 
     # Extract the function bodies
-    visitor = ImplVisitor()
+    visitor = ImplTransformer()
     node.visit(visitor)
 
     # Render the function bodies

--- a/hw/ip/otbn/util/docs/get_impl.py
+++ b/hw/ip/otbn/util/docs/get_impl.py
@@ -1,0 +1,53 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Dict, Optional, Sequence
+
+import libcst as cst
+
+
+class ImplVisitor(cst.CSTVisitor):
+    '''An AST visitor used to extract documentation from the ISS'''
+    def __init__(self) -> None:
+        self.impls = {}  # type: Dict[str, Sequence[cst.BaseStatement]]
+
+        self.cur_class = None  # type: Optional[str]
+
+    def visit_ClassDef(self, node: cst.ClassDef) -> None:
+        assert self.cur_class is None
+        self.cur_class = node.name.value
+
+    def leave_ClassDef(self, node: cst.ClassDef) -> None:
+        self.cur_class = None
+
+    def leave_FunctionDef(self, node: cst.FunctionDef) -> None:
+        if ((self.cur_class is None or
+             node.name.value != 'execute' or
+             self.cur_class in self.impls)):
+            return
+
+        # The body of a function definition is always an IndentedBlock. Strip
+        # that out to get at the statements inside.
+        assert isinstance(node.body, cst.IndentedBlock)
+        self.impls[self.cur_class] = node.body.body
+
+
+def read_implementation(path: str) -> Dict[str, str]:
+    '''Read the implementation at path (probably insn.py)
+
+    Returns a dictionary from instruction class name to its pseudo-code
+    implementation. An instruction class name looks like ADDI (for addi) or
+    BNADDM (for bn.addm).
+
+    '''
+    with open(path, 'r') as handle:
+        node = cst.parse_module(handle.read())
+
+    # Extract the function bodies
+    visitor = ImplVisitor()
+    node.visit(visitor)
+
+    # Render the function bodies
+    return {cls: ''.join(node.code_for_node(stmt) for stmt in body)
+            for cls, body in visitor.impls.items()}

--- a/hw/ip/otbn/util/shared/insn_yaml.py
+++ b/hw/ip/otbn/util/shared/insn_yaml.py
@@ -27,7 +27,7 @@ class Insn:
                         ['mnemonic', 'operands'],
                         ['group', 'rv32i', 'synopsis',
                          'syntax', 'doc', 'note', 'trailing-doc',
-                         'operation', 'encoding', 'glued-ops',
+                         'encoding', 'glued-ops',
                          'literal-pseudo-op', 'python-pseudo-op', 'lsu',
                          'straight-line', 'cycles'])
 
@@ -86,7 +86,6 @@ class Insn:
         self.doc = get_optional_str(yd, 'doc', what)
         self.note = get_optional_str(yd, 'note', what)
         self.trailing_doc = get_optional_str(yd, 'trailing-doc', what)
-        self.operation = get_optional_str(yd, 'operation', what)
 
         raw_syntax = get_optional_str(yd, 'syntax', what)
         if raw_syntax is not None:

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -8,6 +8,7 @@ gitpython
 hjson
 ipyxact >= 0.2.4
 isort
+libcst
 livereload
 mako
 meson >= 0.53.0, <= 0.54 # minimum matches version in meson.build

--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -330,9 +330,11 @@ def generate_otbn_isa():
     otbn_dir = SRCTREE_TOP / 'hw/ip/otbn'
     script = otbn_dir / 'util/yaml_to_doc.py'
     yaml_file = otbn_dir / 'data/insns.yml'
+    impl_file = otbn_dir / 'dv/otbnsim/sim/insn.py'
 
     out_dir = config['outdir-generated'].joinpath('otbn-isa')
-    subprocess.run([str(script), str(yaml_file), str(out_dir)], check=True)
+    subprocess.run([str(script), str(yaml_file), str(impl_file), str(out_dir)],
+                   check=True)
 
 
 def hugo_match_version(hugo_bin_path, version):


### PR DESCRIPTION
Here's an example of what the result looks like:

![ss](https://user-images.githubusercontent.com/104845/107501062-da7bb300-6b8e-11eb-9a48-26d2fa7c04ff.png)

Assuming we go with this rewriting approach (which I think we should), there are some obvious further rewrites for things like flag setting. We might also consider using `<=` (like the SystemVerilog non-blocking assignment syntax) for state updates, but that does rather collide with less-than-or-equal. Maybe there's a nice unicode symbol?

I'm not marking this as closing #2618, because we probably want to add a bit more rewriting first.