### PR TITLE
[dv/tools] Updated Coverage flow for xcelium

### DIFF
--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -140,8 +140,9 @@
   cover_reg_top_vcs_cov_cfg_file: "-cm_hier {dv_root}/tools/vcs/cover_reg_top.cfg"
 
   // Project defaults for Xcelium
-  // xcelium_cov_cfg_file: "{{build_mode}_xcelium_cov_cfg_file}"
-  // xcelium_cov_refine_files: ["{dv_root}/tools/xcelium/common_cov.vRefine"]
+  xcelium_cov_cfg_file: "{dv_root}/tools/xcelium/xcelium.ccf"
+  xcelium_cov_refine_files: []
+  xcelium_common_excl_file: ["{dv_root}/tools/xcelium/exclude.tcl"]
 
   // Build-specific coverage cfg files for Xcelium.
   // default_xcelium_cov_cfg_file: "-covfile {dv_root}/tools/xcelium/cover.ccf"

--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -116,7 +116,8 @@
                      "-64bit",
                      "-licqueue",
                      "-load {cov_merge_db_dir}",
-                     "{xcelium_cov_refine_files}"]
+                     "-init {xcelium_common_excl_file}",
+                     " {eval_cmd} echo {xcelium_cov_refine_files} | sed -E 's/(\\S+)/-load_refinement \\1/g' "]
 
   // pass and fail patterns
   build_fail_patterns: ["\\*E.*$"]
@@ -134,8 +135,8 @@
                    "-coverage {cov_metrics}",
                    // Limit the scope of coverage collection to the DUT.
                    "-covdut {dut}",
-                   // Set the coverage configuration file.
-                   "{xcelium_cov_cfg_file}"]
+                   // Set the coverage configuration file
+                   "-covfile {xcelium_cov_cfg_file}"]
       run_opts:   [// Coverage database output location.
                    "-covworkdir {cov_work_dir}",
                    // Set the scope to the build mode name.

--- a/hw/dv/tools/xcelium/exclude.tcl
+++ b/hw/dv/tools/xcelium/exclude.tcl
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+exclude -inst $::env(DUT_TOP) -toggle 'tl_i.a_user.parity'
+exclude -inst $::env(DUT_TOP) -toggle 'tl_i.a_user.parity_en'
+exclude -inst $::env(DUT_TOP) -toggle 'tl_i.a_param'
+exclude -inst $::env(DUT_TOP) -toggle 'tl_o.d_param'
+exclude -inst $::env(DUT_TOP) -toggle 'tl_o.d_sink'
+exclude -inst $::env(DUT_TOP) -toggle 'tl_o.d_user'
+exclude -inst $::env(DUT_TOP) -toggle 'tl_i.a_user.rsvd1'

--- a/hw/dv/tools/xcelium/xcelium.ccf
+++ b/hw/dv/tools/xcelium/xcelium.ccf
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// only collect toggle coverage on dut
+deselect_coverage -toggle -instance tb.dut.*...
+
+// only collect toggle coverage on ports
+set_toggle_portsonly
+
+// enable toggle scoring of structs and multidim arrays + MDA structs
+set_toggle_scoring -sv_mda -sv_mda_of_struct
+
+// filter glitches
+set_toggle_strobe 0ps
+
+//  Filter unreachable/statically constant blocks
+set_com -log


### PR DESCRIPTION
Hi @sriyerg
so I added the ccf and the vRefine files
and I also put in a cmd so that each module can add its own refine file.

I didn't actually exclude anything yet. so the file is just a placeholder.

the ccf file should match what you have done for vcs more or less.
I didn't find the command for static signals. and I figured we cross that bridge once we run into a problem.

take a look and tell me what you think