### PR TITLE
[dv] Provide license diagnostic info for VCS

### DIFF
--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -192,6 +192,7 @@
 
   // Vars that need to exported to the env.
   exports: [
+    { FLEXLM_DIAGNOSTICS: 4 },
     { VCS_ARCH_OVERRIDE: "linux" },
     { VCS_LIC_EXPIRE_WARNING: 1 }
   ]


### PR DESCRIPTION
This switch provides additional diagnostic info if there is a failure to
checkout a license. It at least tells us that a build/run failed due to
license checkout error rather than barfing up an esoteric stack trace.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>