### PR TITLE
[dv/verilator] Ignore foundry dir

### DIFF
--- a/hw/dv/tools/dvsim/verilator.hjson
+++ b/hw/dv/tools/dvsim/verilator.hjson
@@ -43,6 +43,10 @@
   ]
   // -- END --
 
+  // Remove {proj_root}/hw/foundry from FuseSoC cores search if it exists.
+  pre_build_cmds: ['''[ -d {proj_root}/hw/foundry ] && \
+                      touch {proj_root}/hw/foundry/FUSESOC_IGNORE''']
+
   build_cmd:  "fusesoc {fusesoc_cores_root_dirs} run"
   ex_name:    "{eval_cmd} echo \"{fusesoc_core}\" | cut -d: -f3"
   run_cmd:    "{build_dir}/sim-verilator/V{ex_name}"


### PR DESCRIPTION
We place the foundry directory at `hw/foundry`. Sources in that
directory are causing Verilator compile to fail. Since we cannot modify
those easily, its easier to just remove it from the cores search path.
Verilator sims will not be run with the foundry sources anyway.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>