### PR TITLE
[packages] Fix CentOS package names

### DIFF
--- a/yum-requirements.txt
+++ b/yum-requirements.txt
@@ -11,36 +11,34 @@
 # Keep it sorted.
 autoconf
 bison
-build-essential
-clang-format
 curl
+devtoolset-7
 doxygen
+elfutils-libelf-devel
 flex
-g++
+gcc-c++
 git
-libelf1
-libelf-dev
-libftdi1-2
-libftdi1-dev
-libssl-dev
-libusb-1.0-0
-lsb-release
+libftdi-devel
+libusb-devel
+libxslt-devel
+# Need to run `scl enable llvm-toolset-7 bash` for below to take effect.
+llvm-toolset-7
 make
 # A requirement of the prebuilt clang toolchain.
 ncurses
 ninja-build
 openssl11-libs
 openssl11-devel
-pkgconf
+pkgconfig
 python3
 python3-pip
 python3-setuptools
 python3-wheel
 # The pip-installed version does not come with LibYAML support by default,
 # which significantly speeds up the parsing/dumping of YAML files.
-python3-yaml
+python3-pyyaml
+redhat-lsb-core
 srecord
 tree
-xsltproc
-zlib1g-dev
-xz-utils
+xz-libs
+zlib-devel


### PR DESCRIPTION
Some of the packages listed in `yum-requirements.txt` seem incorrect.
This PR fixes that. I unfortunately do not have access to a CentOS
machine to test these. They were pointed out by our IT. Our workflows
are in the process of switching over to a new dispatch system, so there
may be more fixes needed. In the meantime, if someone could test these,
that will be great.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>