### PR TITLE
[dv/otp] backdoor ECC correctable error seq

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -145,7 +145,7 @@
             - If error is unrecoverable, ensure that OTP entered terminal state
             '''
       milestone: V2
-      tests: []
+      tests: ["otp_ctrl_macro_errs"]
     }
     {
       name: otp_ctrl_errors

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -28,6 +28,7 @@ filesets:
       - seq_lib/otp_ctrl_lc_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_dai_lock_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_dai_errs_vseq.sv: {is_include_file: true}
+      - seq_lib/otp_ctrl_macro_errs_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_parallel_base_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_regwen_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_parallel_key_req_vseq.sv: {is_include_file: true}

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -20,6 +20,7 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
   otp_ctrl_vif otp_ctrl_vif;
 
   bit backdoor_clear_mem;
+  otp_ecc_err_e ecc_err;
 
   `uvm_object_utils_begin(otp_ctrl_env_cfg)
   `uvm_object_utils_end

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -121,6 +121,12 @@ package otp_ctrl_env_pkg;
     OtpCreatorSwCfgErr  = 15'b000_0000_0000_0001
   } otp_status_e;
 
+  typedef enum bit [1:0] {
+    OtpNoEccErr,
+    OtpEccCorrErr,
+    OtpEccUncorrErr
+  } otp_ecc_err_e;
+
   typedef virtual mem_bkdr_if mem_bkdr_vif;
   typedef virtual otp_ctrl_if otp_ctrl_vif;
 

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -429,7 +429,13 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
                   bit [TL_AW-1:0] otp_addr = get_scb_otp_addr();
                   predict_rdata(is_secret(dai_addr) || is_digest(dai_addr),
                                 otp_a[otp_addr], otp_a[otp_addr+1]);
-                  predict_dai_idle_status_wo_err();
+                  if (cfg.ecc_err == OtpNoEccErr) begin
+                    predict_dai_idle_status_wo_err();
+                  end else if (cfg.ecc_err == OtpEccCorrErr) begin
+                    predict_status_err(.dai_err(1));
+                  end else begin
+                    // TODO: trigger alert and goes to terminal stage
+                  end
                 end
               end
               DaiWrite: begin

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_errs_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_errs_vseq.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// otp_ctrl_marco_errs_vseq is create OTP macro errors including:
+// - ECC correctable errors
+// - ECC uncorrectable errors
+class otp_ctrl_macro_errs_vseq extends otp_ctrl_dai_errs_vseq;
+  `uvm_object_utils(otp_ctrl_macro_errs_vseq)
+
+  `uvm_object_new
+
+  // TODO: currently only support correctable errors
+  constraint ecc_err_c {
+    $countones(ecc_err_mask) dist  {0 :/ 1, 1 :/ 1};
+  }
+
+endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -22,13 +22,12 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
   rand bit                           check_regwen_val, check_trigger_regwen_val;
   rand bit [TL_DW-1:0]               check_timeout_val;
   rand bit [1:0]                     check_trigger_val;
+  rand bit [TL_DW-1:0]               ecc_err_mask;
 
   constraint no_access_err_c {access_locked_parts == 0;}
 
   // LC partition does not allow DAI access
-  constraint partition_index_c {
-    part_idx inside {[CreatorSwCfgIdx:Secret2Idx]};
-  }
+  constraint partition_index_c {part_idx inside {[CreatorSwCfgIdx:Secret2Idx]};}
 
   constraint dai_wr_legal_addr_c {
     if (part_idx == CreatorSwCfgIdx) dai_addr inside `PART_ADDR_RANGE(CreatorSwCfgIdx);
@@ -59,6 +58,8 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
   constraint check_timeout_val_c {
     check_timeout_val inside {0, [100_000:'1]};
   }
+
+  constraint ecc_err_c {ecc_err_mask == 0;}
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);
@@ -116,7 +117,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
         if ($urandom_range(0, 1)) begin
           // OTP read via DAI, check data in scb
-          dai_rd(dai_addr, rdata0, rdata1);
+          dai_rd(dai_addr, ecc_err_mask, rdata0, rdata1);
         end
 
         // if write sw partitions, check tlul window

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
@@ -10,6 +10,7 @@
 `include "otp_ctrl_lc_vseq.sv"
 `include "otp_ctrl_dai_lock_vseq.sv"
 `include "otp_ctrl_dai_errs_vseq.sv"
+`include "otp_ctrl_macro_errs_vseq.sv"
 `include "otp_ctrl_parallel_base_vseq.sv"
 `include "otp_ctrl_parallel_key_req_vseq.sv"
 `include "otp_ctrl_regwen_vseq.sv"

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -81,6 +81,11 @@
     }
 
     {
+      name: otp_ctrl_macro_errs
+      uvm_test_seq: otp_ctrl_macro_errs_vseq
+    }
+
+    {
       name: otp_ctrl_parallel_key_req
       uvm_test_seq: otp_ctrl_parallel_key_req_vseq
     }


### PR DESCRIPTION
This PR implements a backdoor method to inject 1 bit ECC error. This
error is categorized as correctable macro error, so status will show
error bit but won't fire fatal alert.

Signed-off-by: Cindy Chen <chencindy@google.com>