### PR TITLE
[i2c, rtl] Lint errors caused by full_o wiring

### DIFF
--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -84,7 +84,6 @@ module  i2c_core (
   logic        fmt_fifo_rvalid;
   logic        fmt_fifo_rready;
   logic [12:0] fmt_fifo_rdata;
-  logic        fmt_fifo_full;
   logic [7:0]  fmt_byte;
   logic        fmt_flag_start_before;
   logic        fmt_flag_stop_after;
@@ -104,7 +103,6 @@ module  i2c_core (
   logic        rx_fifo_rvalid;
   logic        rx_fifo_rready;
   logic [7:0]  rx_fifo_rdata;
-  logic        rx_fifo_full;
 
   logic        fmt_watermark_d;
   logic        fmt_watermark_q;
@@ -118,7 +116,6 @@ module  i2c_core (
   logic        tx_fifo_rvalid;
   logic        tx_fifo_rready;
   logic [7:0]  tx_fifo_rdata;
-  logic        tx_fifo_full;
 
   logic        acq_fifo_wvalid;
   logic        acq_fifo_wready;
@@ -127,7 +124,6 @@ module  i2c_core (
   logic        acq_fifo_rvalid;
   logic        acq_fifo_rready;
   logic [9:0]  acq_fifo_rdata;
-  logic        acq_fifo_full;
 
   logic        i2c_fifo_txrst;
   logic        i2c_fifo_acqrst;
@@ -303,7 +299,7 @@ module  i2c_core (
     .rvalid_o(fmt_fifo_rvalid),
     .rready_i(fmt_fifo_rready),
     .rdata_o (fmt_fifo_rdata),
-    .full_o  (fmt_fifo_full)
+    .full_o  ()
   );
 
   assign rx_fifo_rready = reg2hw.rdata.re;
@@ -323,7 +319,7 @@ module  i2c_core (
     .rvalid_o(rx_fifo_rvalid),
     .rready_i(rx_fifo_rready),
     .rdata_o (rx_fifo_rdata),
-    .full_o  (rx_fifo_full)
+    .full_o  ()
   );
 
   // Target TX and ACQ FIFOs
@@ -348,7 +344,7 @@ module  i2c_core (
     .rvalid_o(tx_fifo_rvalid),
     .rready_i(tx_fifo_rready),
     .rdata_o (tx_fifo_rdata),
-    .full_o  (tx_fifo_full)
+    .full_o  ()
   );
 
   assign acq_fifo_rready = reg2hw.acqdata.abyte.re & reg2hw.acqdata.signal.re;
@@ -368,7 +364,7 @@ module  i2c_core (
     .rvalid_o(acq_fifo_rvalid),
     .rready_i(acq_fifo_rready),
     .rdata_o (acq_fifo_rdata),
-    .full_o  (acq_fifo_full)
+    .full_o  ()
   );
 
   i2c_fsm u_i2c_fsm (


### PR DESCRIPTION
Fixed lint errors cause by full_o output wiring of prim_fifo_sync

Signed-off-by: Igor Kouznetsov <igor.kouznetsov@wdc.com>