### PR TITLE
[keymgr/dv] Add checking for EDN req

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -314,6 +314,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   virtual function void reset(string kind = "HARD");
     tl_a_chan_fifo.flush();
     tl_d_chan_fifo.flush();
+    if (cfg.has_edn) edn_fifo.flush();
     foreach(cfg.list_of_alerts[i]) begin
       alert_fifos[cfg.list_of_alerts[i]].flush();
       exp_alert[cfg.list_of_alerts[i]]             = 0;

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -63,6 +63,11 @@ class keymgr_base_vseq extends cip_base_vseq #(
 
     `DV_CHECK_RANDOMIZE_FATAL(ral.intr_enable)
     csr_update(.csr(ral.intr_enable));
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(ral.reseed_interval.val,
+                                   value dist {[50:100]   :/ 1,
+                                               [101:1000] :/ 1,
+                                               [1001:$]   :/ 1};)
+    csr_update(.csr(ral.reseed_interval));
   endtask : keymgr_init
 
   // advance to next state and generate output, clear output

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_stress_all_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_stress_all_vseq.sv
@@ -10,11 +10,11 @@ class keymgr_stress_all_vseq extends keymgr_base_vseq;
 
   `uvm_object_new
 
-  // keymgr_init is done in each sub-vseq
+  // dut_init/keymgr_init is done in each sub-vseq
   // some vseq like keymgr_common_vseq should not invoke keymgr_init.
-  // Let sub-vseq do keymgr_init and don't do it in stress_all
+  // Let sub-vseq do dut_init/keymgr_init and don't do it in stress_all
   virtual task pre_start();
-    do_keymgr_init = 1'b0;
+    do_dut_init = 1'b0;
     super.pre_start();
   endtask
 
@@ -40,8 +40,8 @@ class keymgr_stress_all_vseq extends keymgr_base_vseq;
       // at the end of each vseq, design has enterred StDisabled, need to reset to recover
       // if upper seq disables do_apply_reset for this seq, then can't issue reset
       // as upper seq may drive reset
-      if (do_apply_reset && i > 1) keymgr_vseq.do_apply_reset = 1;
-      else                         keymgr_vseq.do_apply_reset = 0;
+      if (do_apply_reset) keymgr_vseq.do_apply_reset = 1;
+      else                keymgr_vseq.do_apply_reset = 0;
 
       keymgr_vseq.set_sequencer(p_sequencer);
       `DV_CHECK_RANDOMIZE_FATAL(keymgr_vseq)

--- a/hw/ip/keymgr/dv/tb.sv
+++ b/hw/ip/keymgr/dv/tb.sv
@@ -34,6 +34,11 @@ module tb;
   // edn_clk, edn_rst_n and edn_if are defined and driven in below macro
   `DV_EDN_IF_CONNECT
 
+  assign keymgr_if.edn_clk   = edn_if.clk;
+  assign keymgr_if.edn_rst_n = edn_if.rst_n;
+  assign keymgr_if.edn_req   = edn_if.req;
+  assign keymgr_if.edn_ack   = edn_if.ack;
+
   // dut
   keymgr dut (
     .clk_i                (clk        ),

--- a/hw/ip/keymgr/dv/tests/keymgr_base_test.sv
+++ b/hw/ip/keymgr/dv/tests/keymgr_base_test.sv
@@ -17,4 +17,10 @@ class keymgr_base_test extends cip_base_test #(
   // the base class also looks up UVM_TEST_SEQ plusarg to create and run that seq in
   // the run_phase; as such, nothing more needs to be done
 
+  virtual task run_phase(uvm_phase phase);
+    // keymgr requests entropy periodically, if seq is done, don't need to add any delay due to
+    // activity from EDN interface which may prevent sim from finishing
+    drain_time_ns = 0;
+    super.run_phase(phase);
+  endtask
 endclass : keymgr_base_test


### PR DESCRIPTION
1. check EDN req when advance to StInit and check req periodically after
2. remove drain_time as req may occur repeatively in a short time
3. randomize reseed_interval in base vseq
4. skip doing dut_init in stress_all upper seq, do it in sub-seq.
Further update for #5173

Signed-off-by: Weicai Yang <weicai@google.com>