### PR TITLE
[aon_timer] Minor REGWEN alignment due to newest guidance

### DIFF
--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -80,7 +80,7 @@
     },
     { name: "WDOG_REGWEN",
       desc: "Watchdog Timer Write Enable Register",
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hro",
       fields: [
         { bits: "0",


### PR DESCRIPTION
This somehow slipped through our CI checks and causes documentation builds to fail.
This probably happened since no md file has been touched in the PR that introduced the REGWEN checks in reggen.

Signed-off-by: Michael Schaffner <msf@opentitan.org>