### PR TITLE
[dv/otp_ctrl] add fifo flush in scb's reset function

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -548,6 +548,16 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
 
   virtual function void reset(string kind = "HARD");
     super.reset(kind);
+    // flush fifos
+    otbn_fifo.flush();
+    flash_addr_fifo.flush();
+    flash_data_fifo.flush();
+    lc_prog_fifo.flush();
+    lc_token_fifo.flush();
+    for (int i = 0; i < NumSramKeyReqSlots; i++) begin
+      sram_fifos[i].flush();
+    end
+
     under_chk = 0;
     // reset local fifos queues and variables
     // digest values are updated after a power cycle


### PR DESCRIPTION
This PR adds a logic to flush all scb's analysis port fifo during reset.

Signed-off-by: Cindy Chen <chencindy@google.com>