### PR TITLE
[lint] Increase threshold for max number of bits in an array

### DIFF
--- a/hw/lint/tools/ascentlint/ascentlint-config.tcl
+++ b/hw/lint/tools/ascentlint/ascentlint-config.tcl
@@ -7,3 +7,9 @@ set RI_INSTALL [file dirname [exec which ascentlint]]
 
 # source the policy file containing the lowrisc lint rules
 source "$RI_INSTALL/../Ascent/Lint/lib/policies/lowRISC/LRLR-v1.0.policy"
+
+# increase this from 8k (default) to 32k such that large arrays like
+# regfiles can be analyzed and linted.
+set ri_max_total_range_bits 32768
+set ri_max_single_range_bits 32768
+


### PR DESCRIPTION
We have large regfiles in our design that have a size of 8kbit or more, such as the OTBN regfile.
AscentLint has an internal threshold that prevents the tool from linting such large arrays.
This commit increases the AscentLint-internal threshold for analyzing such large arrays to 32kbit in order to get the affected designs lint clean.

Signed-off-by: Michael Schaffner <msf@google.com>