### PR TITLE
[site] Generate complete DIF description

### DIFF
--- a/util/difgen/gen_dif_listing.py
+++ b/util/difgen/gen_dif_listing.py
@@ -7,6 +7,7 @@ Generate HTML documentation for Device Interface Functions (DIFs)
 
 import logging as log
 import subprocess
+import re
 
 import xml.etree.ElementTree as ET
 
@@ -123,5 +124,12 @@ def _get_text_or_empty(element, xpath):
     if inner is None:
         return ""
 
-    # If there's no inner text, return ""
-    return inner.text or ""
+    # Create a string from all subelements
+    text = ET.tostring(inner, encoding="unicode", method="html")
+    # Code highlighting is supported for the tag 'code' use it instead of
+    # 'computeroutput'
+    text = text.replace("<computeroutput>",
+            "<code>").replace("</computeroutput>", "</code>")
+    # Manually remove the enclosing tags
+    text = re.sub("^<[^<]+>(.*)</.+>$", "\\1", text.strip())
+    return text or ""


### PR DESCRIPTION
Currently the text produced for the DIF description stops at the first
subelement. This is apparent if the description contains a variable
enclosed in backticks. The text up to this variable is returned but not
the rest.

Instead of using the `text` member of the element, which only contains
the text up to the first subelement according to the ET documentation,
create the string manually.

Create the string for the XML element and process the result for usage
in HTML.

Another option to create the string would be to use `itertext` to get
the text of all subelements, but properties would be lost so no `code`
highlighting would be possible.

Fixes #5001

Signed-off-by: Tobias Wölfel <tobias.woelfel@mailbox.org>