### PR TITLE
[ast] Added fileset_partner flag to cores depending on ast

### DIFF
--- a/hw/top_earlgrey/ip/sensor_ctrl/sensor_ctrl_pkg.core
+++ b/hw/top_earlgrey/ip/sensor_ctrl/sensor_ctrl_pkg.core
@@ -9,7 +9,8 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:constants:top_pkg
-      - lowrisc:systems:ast_pkg
+      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
+      - "fileset_partner ? (partner:systems:ast_pkg)"
       - lowrisc:systems:sensor_ctrl_reg
     files:
       - rtl/sensor_ctrl_pkg.sv

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -46,7 +46,8 @@ filesets:
       - lowrisc:ip:pwrmgr
       - lowrisc:systems:clkmgr
       - lowrisc:systems:sensor_ctrl
-      - lowrisc:systems:ast_pkg
+      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
+      - "fileset_partner ? (partner:systems:ast_pkg)"
       - lowrisc:tlul:headers
       - lowrisc:prim:all
     files:

--- a/hw/top_earlgrey/top_earlgrey_asic.core
+++ b/hw/top_earlgrey/top_earlgrey_asic.core
@@ -9,7 +9,8 @@ filesets:
     depend:
       - lowrisc:systems:top_earlgrey:0.1
       - lowrisc:systems:top_earlgrey_pkg
-      - lowrisc:systems:ast
+      - "!fileset_partner ? (lowrisc:systems:ast)"
+      - "fileset_partner ? (partner:systems:ast)"
       - lowrisc:ibex:ibex_tracer:0.1
     files:
       - rtl/top_earlgrey_asic.sv


### PR DESCRIPTION
Signed-off-by: Arnon Sharlin <arnon.sharlin@opentitan.org>

With the fileset_partner flag Nuvoton can compile either the OS AST and the Nuvoton AST