### PR TITLE
[csrng] Select Canright S-Box implementation for AES cipher core

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -8,7 +8,7 @@
   param_list: [
     { name: "SBoxImpl",
       type: "aes_pkg::sbox_impl_e",
-      default: "aes_pkg::SBoxImplLut",
+      default: "aes_pkg::SBoxImplCanright",
       desc: "Selection of the S-Box implementation. See aes_pkg.sv.",
       local: "false",
       expose: "true"

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -6107,7 +6107,7 @@
         {
           name: SBoxImpl
           type: aes_pkg::sbox_impl_e
-          default: aes_pkg::SBoxImplLut
+          default: aes_pkg::SBoxImplCanright
           desc: Selection of the S-Box implementation. See aes_pkg.sv.
           local: "false"
           expose: "true"

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -18,7 +18,7 @@ module top_earlgrey #(
   parameter bit SecAesAllowForcingMasks = 1'b0,
   parameter bit KmacEnMasking = 0,
   parameter int KmacReuseShare = 0,
-  parameter aes_pkg::sbox_impl_e CsrngSBoxImpl = aes_pkg::SBoxImplLut,
+  parameter aes_pkg::sbox_impl_e CsrngSBoxImpl = aes_pkg::SBoxImplCanright,
   parameter otbn_pkg::regfile_e OtbnRegFile = otbn_pkg::RegFileFF,
 
   // Manually defined parameters

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -389,6 +389,7 @@ module top_earlgrey_nexysvideo #(
     .AesSBoxImpl(aes_pkg::SBoxImplLut),
     .SecAesStartTriggerDelay(0),
     .SecAesAllowForcingMasks(1'b0),
+    .CsrngSBoxImpl(aes_pkg::SBoxImplLut),
     .IbexRegFile(ibex_pkg::RegFileFPGA),
     .IbexPipeLine(1),
     .OtbnRegFile(otbn_pkg::RegFileFPGA),


### PR DESCRIPTION
While checking top_earlgrey for ways to save FPGA logic utilization, I noted that CSRNG always uses the LUT-based S-Box for the embedded AES cipher core. This is good for FPGAs but for ASICs, the unmasked Canright S-Box should be used.

Therefore, this PR changes the default selection for the S-Box inside the embedded AES cipher core from the LUT-based implementation to the unmasked Canright design. This should reduce the area footprint of CSRNG a little bit. The LUT-based implementation can explicitly be selected when working with FPGA targets.

