### PR TITLE
[reggen] Define a Window type to represent (memory) windows

### DIFF
--- a/hw/ip/otbn/util/shared/otbn_reggen.py
+++ b/hw/ip/otbn/util/shared/otbn_reggen.py
@@ -6,13 +6,10 @@
 
 import os
 import sys
-from typing import List, Mapping, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import hjson  # type: ignore
 
-# An hjson dict is actually an OrderedDict, but typing/mypy support for that is
-# a little spotty, so we'll use a generic Mapping type.
-HjsonDict = Mapping[str, object]
 
 # We use reggen to read the hjson file. Since that lives somewhere completely
 # different from this script (and there aren't __init__.py files scattered all
@@ -23,8 +20,9 @@ try:
                               '..', '..', '..', '..', '..', 'util')
     sys.path = [_UTIL_PATH] + _OLD_SYS_PATH
     from reggen.validate import checking_dict, validate   # type: ignore
-    import reggen.register  # type: ignore
     import reggen.field  # type: ignore
+    import reggen.register  # type: ignore
+    import reggen.window  # type: ignore
 finally:
     sys.path = _OLD_SYS_PATH
 
@@ -32,14 +30,16 @@ finally:
 # transitively without having to mess around with sys.path.
 Register = reggen.register.Register
 Field = reggen.field.Field
+Window = reggen.window.Window
 
-_LR_RETVAL = None  # type: Optional[Tuple[int, List[HjsonDict]]]
+_LR_RETVAL = None  # type: Optional[Tuple[int, List[object]]]
 
 
-def load_registers() -> Tuple[int, List[HjsonDict]]:
+def load_registers() -> Tuple[int, List[object]]:
     '''Load otbn.hjson with reggen
 
-    Return its register width and list of registers. Memoized.
+    Returns (width, regs) where width is the register width and regs is a
+    list of Register, MultiRegister or Window objects. Memoized.
 
     '''
     global _LR_RETVAL
@@ -74,6 +74,5 @@ def load_registers() -> Tuple[int, List[HjsonDict]]:
     # dictionaries, so we can assert the type safely.
     registers = obj['registers']
     assert isinstance(registers, list)
-
     _LR_RETVAL = (reg_byte_width, registers)
     return _LR_RETVAL

--- a/util/reggen/data.py
+++ b/util/reggen/data.py
@@ -18,15 +18,6 @@ def get_basename(name):
     return name[0:match.start()]
 
 
-class Window():
-    def __init__(self):
-        self.base_addr = 0
-        self.byte_write = 0
-        self.limit_addr = 0
-        self.n_bits = 0
-        self.tags = []
-
-
 class Block():
     def __init__(self):
         self.width = 32

--- a/util/reggen/gen_cheader.py
+++ b/util/reggen/gen_cheader.py
@@ -14,6 +14,7 @@ import warnings
 
 from .register import Register
 from .multi_register import MultiRegister
+from .window import Window
 
 
 def genout(outfile, msg):
@@ -143,15 +144,15 @@ def gen_cdefine_register(outstr, reg, comp, width, rnames, existing_defines):
 
 
 def gen_cdefine_window(outstr, win, comp, regwidth, rnames, existing_defines):
-    wname = win['name']
-    offset = win['genoffset']
+    wname = win.name or "Window at + {:#x}".format(win.offset)
+    offset = win.offset
 
-    genout(outstr, format_comment('Memory area: ' + first_line(win['desc'])))
+    genout(outstr, format_comment('Memory area: ' + first_line(win.desc)))
     defname = as_define(comp + '_' + wname)
     genout(
         outstr,
         gen_define(defname + '_REG_OFFSET', [], hex(offset), existing_defines))
-    items = int(win['items'])
+    items = win.items
     genout(
         outstr,
         gen_define(defname + '_SIZE_WORDS', [], str(items), existing_defines))
@@ -160,7 +161,7 @@ def gen_cdefine_window(outstr, win, comp, regwidth, rnames, existing_defines):
         outstr,
         gen_define(defname + '_SIZE_BYTES', [], str(items), existing_defines))
 
-    wid = win['genvalidbits']
+    wid = win.validbits
     if (wid != regwidth):
         mask = (1 << wid) - 1
         genout(outstr,
@@ -339,9 +340,8 @@ def gen_cdefines(regs, outfile, src_lic, src_copy):
                                  existing_defines)
             continue
 
-        assert isinstance(x, dict)
-        if 'window' in x:
-            gen_cdefine_window(outstr, x['window'], component, regwidth,
+        if isinstance(x, Window):
+            gen_cdefine_window(outstr, x, component, regwidth,
                                rnames, existing_defines)
             continue
 

--- a/util/reggen/gen_selfdoc.py
+++ b/util/reggen/gen_selfdoc.py
@@ -6,7 +6,9 @@ Generates the documentation for the register tool
 
 """
 from .access import SWACCESS_PERMITTED, HWACCESS_PERMITTED
-from reggen import validate, enum_entry, field, register, multi_register
+from reggen import (validate,
+                    enum_entry, field,
+                    register, multi_register, window)
 
 
 def genout(outfile, msg):
@@ -291,12 +293,10 @@ def document(outfile):
 
     genout(outfile, window_intro)
     doc_tbl_head(outfile, 1)
-    for x in validate.window_required:
-        doc_tbl_line(outfile, x, 'r', validate.window_required[x])
-    for x in validate.window_optional:
-        doc_tbl_line(outfile, x, 'o', validate.window_optional[x])
-    for x in validate.window_added:
-        doc_tbl_line(outfile, x, 'a', validate.window_added[x])
+    for k, v in window.REQUIRED_FIELDS.items():
+        doc_tbl_line(outfile, k, 'r', v)
+    for k, v in window.OPTIONAL_FIELDS.items():
+        doc_tbl_line(outfile, k, 'o', v)
 
     genout(outfile, multi_intro)
     doc_tbl_head(outfile, 1)

--- a/util/reggen/lib.py
+++ b/util/reggen/lib.py
@@ -226,6 +226,12 @@ def check_xint(obj: object, what: str) -> Optional[int]:
 def expand_parameter(params: List[Dict[str, object]],
                      value: str,
                      when: str) -> int:
+    # Check whether the 'parameter' is already an integer: if so, return that.
+    try:
+        return int(value, 0)
+    except ValueError:
+        pass
+
     found = None
     for param in params:
         if param['name'] == value:

--- a/util/reggen/reg_pkg.sv.tpl
+++ b/util/reggen/reg_pkg.sv.tpl
@@ -264,8 +264,13 @@ def field_resname(reg, field):
 % if len(block.wins) > 0:
   // Window parameter
 % for i,w in enumerate(block.wins):
-  parameter logic [BlockAw-1:0] ${ublock}_${w.name.upper()}_OFFSET = ${block.addr_width}'h ${"%x" % w.base_addr};
-  parameter logic [BlockAw-1:0] ${ublock}_${w.name.upper()}_SIZE   = ${block.addr_width}'h ${"%x" % (w.limit_addr - w.base_addr)};
+<%
+    win_pfx = '{}_{}'.format(ublock, w.name.upper())
+    base_txt_val = "{}'h {:x}".format(block.addr_width, w.offset)
+    size_txt_val = "{}'h {:x}".format(block.addr_width, w.size_in_bytes)
+%>\
+  parameter logic [BlockAw-1:0] ${win_pfx}_OFFSET = ${base_txt_val};
+  parameter logic [BlockAw-1:0] ${win_pfx}_SIZE   = ${size_txt_val};
 % endfor
 
 % endif

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -109,11 +109,15 @@ module ${block.name}_reg_top (
 
     // TODO: Can below codes be unique case () inside ?
   % for i,w in enumerate(block.wins):
-      % if w.limit_addr == 2**block.addr_width:
-    if (tl_i.a_address[AW-1:0] >= ${w.base_addr}) begin
-      // Exceed or meet the address range. Removed the comparison of limit addr ${"'h %x" % w.limit_addr}
+<%
+    base_addr = w.offset
+    limit_addr = w.offset + w.size_in_bytes
+%>\
+      % if limit_addr == 2**block.addr_width:
+    if (tl_i.a_address[AW-1:0] >= ${base_addr}) begin
+      // Exceed or meet the address range. Removed the comparison of limit addr 'h ${'{:x}'.format(limit_addr)}
       % else:
-    if (tl_i.a_address[AW-1:0] >= ${w.base_addr} && tl_i.a_address[AW-1:0] < ${w.limit_addr}) begin
+    if (tl_i.a_address[AW-1:0] >= ${base_addr} && tl_i.a_address[AW-1:0] < ${limit_addr}) begin
       % endif
       reg_steer = ${i};
     end

--- a/util/reggen/uvm_reg.sv.tpl
+++ b/util/reggen/uvm_reg.sv.tpl
@@ -155,9 +155,9 @@ package ${block.name}_ral_pkg;
 % for w in block.wins:
 <%
   mem_name = w.name.lower()
-  mem_right = w.dvrights.upper()
-  mem_n_bits = w.n_bits
-  mem_size = int((w.limit_addr - w.base_addr) / (mem_n_bits / 8))
+  mem_right = w.swaccess.dv_rights()
+  mem_n_bits = w.validbits
+  mem_size = w.items
 %>\
   // Class: ${gen_dv.mcname(block, w)}
   class ${gen_dv.mcname(block, w)} extends ${dv_base_prefix}_mem;
@@ -286,28 +286,16 @@ package ${block.name}_ral_pkg;
 % for w in block.wins:
 <%
   mem_name = w.name.lower()
-  mem_right = w.dvrights.upper()
-  mem_offset = str(block.width) + "'h" + "%x" % w.base_addr
-  mem_n_bits = w.n_bits
-  mem_size = int((w.limit_addr - w.base_addr) / (mem_n_bits / 8))
-  mem_tags = w.tags
+  mem_right = w.swaccess.dv_rights()
+  mem_offset = str(block.width) + "'h" + "%x" % w.offset
+  mem_n_bits = w.validbits
+  mem_size = w.items
 %>\
       ${mem_name} = ${gen_dv.mcname(block, w)}::type_id::create("${mem_name}");
       ${mem_name}.configure(.parent(this));
       default_map.add_mem(.mem(${mem_name}),
                           .offset(${mem_offset}),
                           .rights("${mem_right}"));
-  % if mem_tags:
-      // create memory tags
-    % for mem_tag in mem_tags:
-<%
-  tag = mem_tag.split(":")
-%>\
-      % if tag[0] == "excl":
-      csr_excl.add_excl(${mem_name}.get_full_name(), ${tag[2]}, ${tag[1]});
-      % endif
-    % endfor
-  % endif
 % endfor
     endfunction : build
 

--- a/util/reggen/window.py
+++ b/util/reggen/window.py
@@ -1,0 +1,162 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Dict, List, Optional
+
+from .access import SWAccess
+from .lib import (check_keys, check_str, check_bool, check_int,
+                  expand_parameter)
+
+REQUIRED_FIELDS = {
+    'desc': ['t', "description of the window"],
+    'items': ['d', "size in fieldaccess width words of the window"],
+    'swaccess': ['s', "software access permitted"],
+}
+
+# TODO potential for additional optional to give more type info?
+# eg sram-hw-port: "none", "sync", "async"
+OPTIONAL_FIELDS = {
+    'name': ['s', "Name of the window"],
+    'byte-write': [
+        's', "True if byte writes are supported. "
+        "Defaults to false if not present."
+    ],
+    'validbits': [
+        'd', "Number of valid data bits within "
+        "regwidth sized word. "
+        "Defaults to regwidth. If "
+        "smaller than the regwidth then in each "
+        "word of the window bits "
+        "[regwidth-1:validbits] are unused and "
+        "bits [validbits-1:0] are valid."
+    ],
+    'unusual': [
+        's', "True if window has unusual parameters "
+        "(set to prevent Unusual: errors)."
+        "Defaults to false if not present."
+    ]
+}
+
+
+class Window:
+    '''A class representing a memory window'''
+    def __init__(self,
+                 name: Optional[str],
+                 desc: str,
+                 unusual: bool,
+                 byte_write: bool,
+                 validbits: int,
+                 items: int,
+                 size_in_bytes: int,
+                 offset: int,
+                 swaccess: SWAccess):
+        assert 0 < validbits
+        assert 0 < items <= size_in_bytes
+
+        self.name = name
+        self.desc = desc
+        self.unusual = unusual
+        self.byte_write = byte_write
+        self.validbits = validbits
+        self.items = items
+        self.size_in_bytes = size_in_bytes
+        self.offset = offset
+        self.swaccess = swaccess
+
+        # Check that offset has been adjusted so that the first item in the
+        # window has all zeros in the low bits.
+        po2_size = 1 << (self.size_in_bytes - 1).bit_length()
+        assert not (offset & (po2_size - 1))
+
+    @staticmethod
+    def from_raw(offset: int,
+                 reg_width: int,
+                 params: List[Dict[str, object]],
+                 raw: object) -> 'Window':
+        rd = check_keys(raw, 'window',
+                        list(REQUIRED_FIELDS.keys()),
+                        list(OPTIONAL_FIELDS.keys()))
+
+        r_name = rd.get('name')
+        wind_desc = 'window at offset {:#x}'.format(offset)
+        if r_name is None:
+            name = None
+        else:
+            name = check_str(r_name, wind_desc)
+            wind_desc = '{!r} {}'.format(name, wind_desc)
+
+        desc = check_str(rd['desc'], 'desc field for ' + wind_desc)
+
+        unusual = check_bool(rd.get('unusual', False),
+                             'unusual field for ' + wind_desc)
+        byte_write = check_bool(rd.get('byte-write', False),
+                                'byte-write field for ' + wind_desc)
+
+        validbits = check_int(rd.get('validbits', reg_width),
+                              'validbits field for ' + wind_desc)
+        if validbits <= 0:
+            raise ValueError('validbits field for {} is not positive.'
+                             .format(wind_desc))
+        if validbits > reg_width:
+            raise ValueError('validbits field for {} is {}, '
+                             'which is greater than {}, the register width.'
+                             .format(wind_desc, validbits, reg_width))
+
+        r_items = check_str(rd['items'], 'items field for ' + wind_desc)
+        items = expand_parameter(params, r_items,
+                                 'expanding items field for ' + wind_desc)
+        if items <= 0:
+            raise ValueError("Items field for {} is {}, "
+                             "which isn't positive."
+                             .format(wind_desc, items))
+
+        assert reg_width % 8 == 0
+        size_in_bytes = items * (reg_width // 8)
+
+        # Round size_in_bytes up to the next power of 2. The calculation is
+        # like clog2 calculations in SystemVerilog, where we start with the
+        # last index, rather than the number of elements.
+        assert size_in_bytes > 0
+        po2_size = 1 << (size_in_bytes - 1).bit_length()
+
+        # A size that isn't a power of 2 is not allowed unless the unusual flag
+        # is set.
+        if po2_size != size_in_bytes and not unusual:
+            raise ValueError('Items field for {} is {}, which gives a size of '
+                             '{} bytes. This is not a power of 2 (next power '
+                             'of 2 is {}). If you want to do this even so, '
+                             'set the "unusual" flag.'
+                             .format(wind_desc, items,
+                                     size_in_bytes, po2_size))
+
+        # Adjust offset if necessary to make sure the base address of the first
+        # item in the window has all zeros in the low bits.
+        addr_mask = po2_size - 1
+        if offset & addr_mask:
+            offset = (offset | addr_mask) + 1
+        offset = offset
+
+        swaccess = SWAccess(wind_desc, rd['swaccess'])
+        if not (swaccess.value[4] or unusual):
+            raise ValueError('swaccess field for {} is {}, which is an '
+                             'unusual access type for a window. If you want '
+                             'to do this, set the "unusual" flag.'
+                             .format(wind_desc, swaccess.key))
+
+        return Window(name, desc, unusual, byte_write,
+                      validbits, items, size_in_bytes, offset, swaccess)
+
+    def _asdict(self) -> Dict[str, object]:
+        rd = {
+            'desc': self.desc,
+            'items': self.items,
+            'swaccess': self.swaccess.key,
+            'byte-write': self.byte_write,
+            'validbits': self.validbits,
+            'unusual': self.unusual
+        }
+        if self.name is not None:
+            rd['name'] = self.name
+
+        return {'window': rd}


### PR DESCRIPTION
This also removes the Window class from reggen/data.py: we'll use the
new Window class everywhere.

There's a bit of code to handle window tags at the bottom of
uvm_reg.sv.tpl that goes away completely (windows don't have tags, so
this was dead code).

A note about testing: I've been doing before/after comparisons with [this script](https://gist.github.com/rswarbrick/7c009343d9dc586914e55bd3c1d6ff4a) to make it likely that I'll catch anything that breaks. With this patch, the only changes are to the selfdoc (removing some genFOO fields) and some field re-ordering in the generated hjson.