### PR TITLE
[util] Fix argument checks for sparse-fsm-encode.py

### DIFF
--- a/util/design/sparse-fsm-encode.py
+++ b/util/design/sparse-fsm-encode.py
@@ -97,13 +97,18 @@ def main():
                 "at least a byte (8 bits) wide. You chose %d." % (args.n, ))
             sys.exit(1)
 
+    if args.m < 2:
+        log.error(
+            'Number of states %d must be at least 2.' % (args.m))
+        sys.exit(1)
+
     if args.m > 2**args.n:
         log.error(
             'Statespace 2^%d not large enough to accommodate %d states.' %
             (args.n, args.m))
         sys.exit(1)
 
-    if args.d >= args.n:
+    if (args.d >= args.n) and not(args.d == args.n and args.m == 2):
         log.error(
             'State is only %d bits wide, which is not enough to fulfill a '
             'minimum Hamming distance constraint of %d. ' % (args.n, args.d))


### PR DESCRIPTION
This PR changes two argument checks for the `sparse-fsm-encode.py` script:
1. Abort if the number of requested states is below 2. The script doesn't support this case and previously aborted because of a division or modulo by 0.
2. If the number of requested states is 2, the encodings with x bits and a minimum Hamming distance of x exists and the script is able to find them. Previously, the script would abort and print an error message.