### PR TITLE
[fpv ] JasperGold script update

### DIFF
--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -36,37 +36,55 @@ elaborate -bbox_a 3600 -top $env(FPV_TOP) -enable_sva_isunknown
 # select primary clock and reset condition (use ! for active-low reset)
 # note: -both_edges is needed below because the TL-UL protocol checker
 # tlul_assert.sv operates on the negedge clock
+# even clock this sampled at both_edges, input should only change at posedge clock cycle
 # TODO: create each FPV_TOP's individual config file
 
 if {$env(FPV_TOP) == "rv_dm"} {
   clock clk_i -both_edges
   clock jtag_req_i.tck
+  clock -rate {testmode_i, unavailable_i, tl_d_i, tl_h_i} clk_i
+  clock -rate {jtag_req_i.tms, jtag_req_i.tdi} jtag_req_i.tck
   reset -expr {!rst_ni !jtag_req_i.trst_n}
+
 } elseif {$env(FPV_TOP) == "spi_device"} {
   clock clk_i -both_edges
   clock cio_sck_i
+  clock -rate {scanmode_i, tl_i} clk_i
+  clock -rate {cio_csb_i, cio_sdi_i} cio_sck_i
   reset -expr {!rst_ni cio_csb_i}
-} elseif {$env(FPV_TOP) == "usb_fs_nb_pe"} {
-  clock clk_48mhz_i
-  reset -expr {!rst_ni}
+
 } elseif {$env(FPV_TOP) == "usbuart"} {
   clock clk_i -both_edges
   clock clk_usb_48mhz_i
-  reset -expr {!rst_ni}
+  clock -rate {tl_i, usb_state_debug_i} clk_i
+  clock -rate {cio_usb_dp_i, cio_usb_dn_i, cio_usb_sense_i} clk_usb_48mhz_i
+  reset -expr {!rst_ni !rst_usb_48mhz_ni}
+
 } elseif {$env(FPV_TOP) == "usbdev"} {
   clock clk_i -both_edges
+  clock clk_aon_i
   clock clk_usb_48mhz_i
-  reset -expr {!rst_ni}
-} elseif {$env(FPV_TOP) == "top_earlgrey_asic"} {
-  clock IO_CLK -both_edges
-  clock IO_CLK_USB_48MHZ
-  reset -expr {!IO_RST_N}
-} elseif {$env(FPV_TOP) == "xbar_main"} {
-  clock clk_main_i -both_edges
-  reset -expr {!rst_main_ni}
+  clock -rate {tl_i} clk_i
+  clock -rate {cio_d_i, cio_dp_i, cio_dn_i, cio_sense_i} clk_usb_48mhz_i
+  reset -expr {!rst_ni !rst_aon_ni !rst_usb_48mhz_ni}
+
+  # top_earlgrey is mainly used for connectivity test
+} elseif {$env(FPV_TOP) == "top_earlgrey"} {
+  clock clk_i -both_edges
+  clock jtag_tck_i
+  # TODO: check this once pinmux/padring is updated
+  clock -rate -default clk_i
+  reset -expr {!rst_ni !jtag_trst_ni}
+
+# TODO: work with the block owner and re-define FPV checkings for xbar
+# } elseif {$env(FPV_TOP) == "xbar_main"} {
+#   clock clk_main_i -both_edges
+#   reset -expr {!rst_main_ni}
+
 } else {
   clock clk_i -both_edges
   reset -expr {!rst_ni}
+  clock -rate -default clk_i
 }
 
 # use counter abstractions to reduce the run time:
@@ -74,6 +92,7 @@ if {$env(FPV_TOP) == "rv_dm"} {
 # hmac sha2: does not check any calculation results, so 64 rounds of calculation can be abstracted
 if {$env(FPV_TOP) == "alert_handler"} {
   abstract -counter -env i_ping_timer.cnt_q
+
 } elseif {$env(FPV_TOP) == "hmac"} {
   abstract -counter -env u_sha2.round
   # disable these assertions because they are unreachable when the fifo is WO
@@ -81,6 +100,7 @@ if {$env(FPV_TOP) == "alert_handler"} {
   assert -disable {*hmac.u_tlul_adapter.u_*fifo.DataKnown_A}
   assert -disable {*hmac.u_tlul_adapter.rvalidHighReqFifoEmpty}
   assert -disable {*hmac.u_tlul_adapter.rvalidHighWhenRspFifoFull}
+
 } elseif {$env(FPV_TOP) == "flash_ctrl"} {
   # disable these assertions because they are unreachable when the fifo is WO
   assert -disable {*flash_ctrl.u_to_prog_fifo.u_*fifo.depthShallNotExceedParamDepth}

--- a/hw/ip/usbdev/dv/sva/usbdev_sva.core
+++ b/hw/ip/usbdev/dv/sva/usbdev_sva.core
@@ -13,6 +13,10 @@ filesets:
       - usbdev_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:usbdev
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,15 @@ generate:
       depend: lowrisc:ip:usbdev
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: usbdev

--- a/hw/ip/usbuart/dv/sva/usbuart_sva.core
+++ b/hw/ip/usbuart/dv/sva/usbuart_sva.core
@@ -13,6 +13,10 @@ filesets:
       - usbuart_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:usbuart
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,15 @@ generate:
       depend: lowrisc:ip:usbuart
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: usbuart

--- a/hw/ip/usbuart/usbuart.core
+++ b/hw/ip/usbuart/usbuart.core
@@ -46,11 +46,6 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
 
-  files_formal:
-    files:
-      - dv/tb/usbuart_bind.sv
-    file_type: systemVerilogSource
-
 parameters:
   SYNTHESIS:
     datatype: bool
@@ -63,14 +58,7 @@ targets:
       - tool_verilator   ? (files_verilator_waiver)
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
-      - target_formal    ? (files_formal)
       - files_rtl
-    toplevel: usbuart
-
-  formal:
-    filesets:
-      - files_rtl
-      - files_formal
     toplevel: usbuart
 
   lint:

--- a/hw/top_earlgrey/fpv/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/fpv/top_earlgrey_fpv_cfgs.hjson
@@ -271,5 +271,17 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                cov: false
              }
+             {
+               name: usbdev
+               fusesoc_core: lowrisc:dv:usbdev_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
+             }
+             {
+               name: usbuart
+               fusesoc_core: lowrisc:dv:usbuart_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
+             }
             ]
 }


### PR DESCRIPTION
There are two commits in this PR:
1. Add usbuart and usbdev to batch script
2. The JapserGold 2020.12 version includes a feature to randomize input
data at both pos/nedgedge clocks if -both-edge switch is enabled. But
our design's data should only be randomized at one clock edge.
This PR fixes it by adding a `-rate` to constraint only randomize at
posedge clock.