### PR TITLE
[keymgr/dv] Update for fatal alert

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -518,7 +518,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
     bit [TL_DW-1:0] err = get_err_code();
     void'(ral.err_code.predict(err));
 
-    if (get_fault_err()) set_exp_alert("fatal_fault_err");
+    if (get_fault_err()) set_exp_alert("fatal_fault_err", .is_fatal(1));
     if (get_op_err()) set_exp_alert("recov_operation_err");
 
     `uvm_info(`gfn, $sformatf("at %s, %s is issued and error code is 'b%0b",

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_hwsw_invalid_input_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_hwsw_invalid_input_vseq.sv
@@ -27,4 +27,13 @@ class keymgr_hwsw_invalid_input_vseq extends keymgr_sw_invalid_input_vseq;
     return 0;
   endfunction
 
+  task post_start();
+    super.post_start();
+
+    // fatal alert will be triggered in this seq. Issue reset if reset is allowed, otherwise, reset
+    // will be called in upper vseq
+    #10_000ns;
+    if (do_apply_reset) apply_reset();
+  endtask
+
 endclass : keymgr_hwsw_invalid_input_vseq


### PR DESCRIPTION
design changed fault alert to fatal, update scb to match it
and add reset at the end of seq which triggers fatal alert

Signed-off-by: Weicai Yang <weicai@google.com>