### PR TITLE
[spi_device] Make SPI high-Z when Idle

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -414,6 +414,7 @@ module spi_device (
     .data_i       (p2s_data),
     .data_sent_o  (p2s_sent),
 
+    .csb_i        (cio_csb_i),
     .s_en_o       (p2s_s_en),
     .s_o          (p2s_so),
 

--- a/hw/ip/spi_device/rtl/spi_p2s.sv
+++ b/hw/ip/spi_device/rtl/spi_p2s.sv
@@ -16,6 +16,7 @@ module spi_p2s
   output logic     data_sent_o,
 
   // SPI interface
+  input  logic       csb_i, // for line floating
   output logic [3:0] s_en_o,
   output logic [3:0] s_o,
 
@@ -88,7 +89,7 @@ module spi_p2s
     endcase
   end
 
-  assign s_en_o = out_enable;
+  assign s_en_o = (csb_i) ? 4'b 0000 : out_enable ;
 
   // `data_sent`
   // Popping signal is a little bit tricky if p2s supports Quad IO


### PR DESCRIPTION
When CSb is not asserted, make SPI high-Z explicitly.
