### PR TITLE
[dv/kmac] add NIST vector tests for kmac

### DIFF
--- a/hw/dv/sv/test_vectors/test_vectors_pkg.sv
+++ b/hw/dv/sv/test_vectors/test_vectors_pkg.sv
@@ -324,7 +324,10 @@ package test_vectors_pkg;
           end
           "Key": begin
             str_to_bytes(entry_data, bytes);
-            vector.keys = {>>byte{bytes}};
+            vector.keys = new[vector.key_length_word];
+            for (int i = 0; i < vector.key_length_word; i++) begin
+              vector.keys[i] = {<< byte {bytes with [i*4 +: 4]}};
+            end
           end
           "Outputlen", "OutputLen": begin
             // Output digest length in bits

--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -69,8 +69,8 @@
             the output against the expected digest values.
             '''
       milestone: V2
-      tests: ["{name}_sha3_test_vectors", "{name}_shake_test_vectors", "{name}_test_vectors",
-      "{name}_xof_test_vectors"]
+      tests: ["{name}_test_vectors_sha3", "{name}_test_vectors_shake", "{name}_test_vectors_kmac",
+              "{name}_test_vectors_kmac_xof"]
     }
     {
       name: sideload

--- a/hw/ip/kmac/dv/env/kmac_env.core
+++ b/hw/ip/kmac/dv/env/kmac_env.core
@@ -28,6 +28,11 @@ filesets:
       - seq_lib/kmac_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_long_msg_and_output_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_sideload_vseq.sv: {is_include_file: true}
+      - seq_lib/kmac_test_vectors_base_vseq.sv: {is_include_file: true}
+      - seq_lib/kmac_test_vectors_sha3_vseq.sv: {is_include_file: true}
+      - seq_lib/kmac_test_vectors_shake_vseq.sv: {is_include_file: true}
+      - seq_lib/kmac_test_vectors_kmac_vseq.sv: {is_include_file: true}
+      - seq_lib/kmac_test_vectors_kmac_xof_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -80,6 +80,9 @@ class kmac_smoke_vseq extends kmac_base_vseq;
 
     `uvm_info(`gfn, $sformatf("Starting %0d message hashes", num_trans), UVM_LOW)
     for (int i = 0; i < num_trans; i++) begin
+      bit [7:0] share0[];
+      bit [7:0] share1[];
+
       `uvm_info(`gfn, $sformatf("iteration: %0d", i), UVM_HIGH)
 
       `DV_CHECK_RANDOMIZE_FATAL(this)
@@ -129,7 +132,7 @@ class kmac_smoke_vseq extends kmac_base_vseq;
       wait_for_kmac_done();
 
       // Read the output digest, scb will check digest
-      read_digest_shares(output_len, cfg.enable_masking);
+      read_digest_shares(output_len, cfg.enable_masking, share0, share1);
 
       // issue the Done cmd to tell KMAC to clear internal state
       issue_cmd(CmdDone);

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_test_vectors_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_test_vectors_base_vseq.sv
@@ -1,0 +1,128 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class kmac_test_vectors_base_vseq extends kmac_smoke_vseq;
+
+  `uvm_object_utils(kmac_test_vectors_base_vseq)
+  `uvm_object_new
+
+  string test_list[];
+
+  virtual task pre_start();
+    msg_c.constraint_mode(0);
+    super.pre_start();
+  endtask
+
+  task body();
+    test_vectors_pkg::test_vectors_t vectors[];
+
+    foreach (test_list[i]) begin
+      // parse each test vector file
+      test_vectors_pkg::get_hash_test_vectors(test_list[i], vectors);
+
+      `uvm_info(`gfn, $sformatf("Starting %0s test vectors", test_list[i]), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("Preparing %0d test vectors...", vectors.size()), UVM_HIGH)
+
+      // Run a basic hash operation for each parsed test vector
+      foreach (vectors[j]) begin
+        // `compare_digest()` passes three arrays by reference, one of which is contained
+        // inside of the vectors[j] struct.
+        //
+        // Hierarchical references to an array inside a struct is not supported by VCS,
+        // so
+        bit [7:0] exp_digest[] = vectors[j].exp_digest;
+        bit [7:0] share0[];
+        bit [7:0] share1[];
+
+        `uvm_info(`gfn, $sformatf("vectors[%0d]: %0p", j, vectors[j]), UVM_HIGH)
+
+        // Use this hook to set the appropriate configuration options
+        randomize_cfg(vectors[j]);
+
+        msg = vectors[j].msg;
+
+        kmac_init();
+
+        if (kmac_en) begin
+          // set the prefix
+          str_utils_pkg::str_to_bytes(vectors[j].customization_str, custom_str_arr);
+          `uvm_info(`gfn,
+                    $sformatf("[kmac_test_vector] custom_str: %0s",
+                              vectors[j].customization_str),
+                    UVM_HIGH)
+          `uvm_info(`gfn,
+                    $sformatf("[kmac_test_vector] custom_str_arr: %0p", custom_str_arr),
+                    UVM_HIGH)
+          set_prefix();
+
+          // write the key shares
+          for (int k = 0; k < KMAC_NUM_SHARES; k++) begin
+            for (int l = 0; l < KMAC_NUM_KEYS_PER_SHARE; l++) begin
+              if (k == 0 && l < vectors[j].key_length_word) begin
+                key_share[k][l] = vectors[j].keys[l];
+              end else begin
+                key_share[k][l] = '0;
+              end
+            end
+          end
+          write_key_shares();
+
+          // provide entropy if masked
+          if (cfg.enable_masking && entropy_mode == EntropyModeSw) begin
+            provide_sw_entropy();
+          end
+        end
+
+        issue_cmd(CmdStart);
+
+        write_msg(vectors[j].msg, 1);
+
+        if (kmac_en) begin
+          right_encode(xof_en ? 0 : output_len * 8, output_len_enc);
+          write_msg(output_len_enc, 1);
+        end
+
+        issue_cmd(CmdProcess);
+
+        wait_for_kmac_done();
+
+        read_digest_shares(output_len, cfg.enable_masking, share0, share1);
+
+        `uvm_info(`gfn, $sformatf("share0: %0p", share0), UVM_HIGH)
+        `uvm_info(`gfn, $sformatf("share1: %0p", share1), UVM_HIGH)
+
+        issue_cmd(CmdDone);
+
+        compare_digest(exp_digest, share0, share1, cfg.enable_masking);
+      end
+    end
+  endtask
+
+  // This function is used to randomize the KMAC settings
+  // based on the test vector config
+  virtual function void randomize_cfg(test_vectors_pkg::test_vectors_t vector);
+    `uvm_fatal(`gfn, "Should not be called in the base class")
+  endfunction
+
+  virtual function void compare_digest(const ref bit [7:0] exp_digest[],
+                                       const ref bit [7:0] act_share0[],
+                                       const ref bit [7:0] act_share1[],
+                                       input bit en_masking);
+    bit [7:0] act_digest[] = new[output_len];
+
+    for (int i = 0; i < output_len; i++) begin
+      if (en_masking) begin
+        act_digest[i] = act_share0[i] ^ act_share1[i];
+      end else begin
+        act_digest[i] = act_share0[i];
+      end
+
+      // Compare the values
+      `DV_CHECK_EQ_FATAL(exp_digest[i], act_digest[i],
+          $sformatf("Mismatch between exp_digest[%0d] and act_digest[%0d]", i, i))
+    end
+
+  endfunction
+
+endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_test_vectors_kmac_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_test_vectors_kmac_vseq.sv
@@ -1,0 +1,46 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class kmac_test_vectors_kmac_vseq extends kmac_test_vectors_base_vseq;
+
+  `uvm_object_utils(kmac_test_vectors_kmac_vseq)
+  `uvm_object_new
+
+  bit is_xof_test_vectors = 0;
+
+  virtual task pre_start();
+    test_list = (is_xof_test_vectors) ? test_vectors_pkg::kmac_xof_file_list :
+                                        test_vectors_pkg::kmac_file_list;
+    custom_str_len_c.constraint_mode(0);
+    super.pre_start();
+  endtask
+
+  virtual function void randomize_cfg(test_vectors_pkg::test_vectors_t vector);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(this,
+      hash_mode == sha3_pkg::CShake;
+      kmac_en == 1;
+      xof_en == is_xof_test_vectors;
+      output_len == vector.digest_length_byte;
+      if (vector.security_strength == 128) {
+        strength == sha3_pkg::L128;
+      } else if (vector.security_strength == 256) {
+        strength == sha3_pkg::L256;
+      }
+      // set key_len CSR
+      if (vector.key_length_word * 32 == 128) {
+        key_len == Key128;
+      } else if (vector.key_length_word * 32 == 192) {
+        key_len == Key192;
+      } else if (vector.key_length_word * 32 == 256) {
+        key_len == Key256;
+      } else if (vector.key_length_word * 32 == 384) {
+        key_len == Key384;
+      } else if (vector.key_length_word * 32 == 512) {
+        key_len == Key512;
+      }
+      custom_str_len == vector.customization_str.len();
+    )
+  endfunction
+
+endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_test_vectors_kmac_xof_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_test_vectors_kmac_xof_vseq.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class kmac_test_vectors_kmac_xof_vseq extends kmac_test_vectors_kmac_vseq;
+
+  `uvm_object_utils(kmac_test_vectors_kmac_xof_vseq)
+  `uvm_object_new
+
+  virtual task pre_start();
+    is_xof_test_vectors = 1;
+    super.pre_start();
+  endtask
+
+endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_test_vectors_sha3_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_test_vectors_sha3_vseq.sv
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class kmac_test_vectors_sha3_vseq extends kmac_test_vectors_base_vseq;
+
+  `uvm_object_utils(kmac_test_vectors_sha3_vseq)
+  `uvm_object_new
+
+  virtual task pre_start();
+    test_list = test_vectors_pkg::sha3_file_list;
+    super.pre_start();
+  endtask
+
+  virtual function void randomize_cfg(test_vectors_pkg::test_vectors_t vector);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(this,
+      hash_mode == sha3_pkg::Sha3;
+      kmac_en == 0;
+      output_len == vector.digest_length_byte;
+    )
+  endfunction
+
+endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_test_vectors_shake_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_test_vectors_shake_vseq.sv
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class kmac_test_vectors_shake_vseq extends kmac_test_vectors_base_vseq;
+
+  `uvm_object_utils(kmac_test_vectors_shake_vseq)
+  `uvm_object_new
+
+  virtual task pre_start();
+    test_list = test_vectors_pkg::shake_file_list;
+    super.pre_start();
+  endtask
+
+  virtual function void randomize_cfg(test_vectors_pkg::test_vectors_t vector);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(this,
+      hash_mode == sha3_pkg::Shake;
+      kmac_en == 0;
+      output_len == vector.digest_length_byte;
+      if (vector.security_strength == 128) {
+        strength == sha3_pkg::L128;
+      } else if (vector.security_strength == 256) {
+        strength == sha3_pkg::L256;
+      }
+    )
+  endfunction
+
+endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
@@ -7,3 +7,8 @@
 `include "kmac_common_vseq.sv"
 `include "kmac_long_msg_and_output_vseq.sv"
 `include "kmac_sideload_vseq.sv"
+`include "kmac_test_vectors_base_vseq.sv"
+`include "kmac_test_vectors_sha3_vseq.sv"
+`include "kmac_test_vectors_shake_vseq.sv"
+`include "kmac_test_vectors_kmac_vseq.sv"
+`include "kmac_test_vectors_kmac_xof_vseq.sv"

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -80,6 +80,26 @@
       name: "{variant}_sideload"
       uvm_test_seq: kmac_sideload_vseq
     }
+    {
+      name: "{variant}_test_vectors_sha3"
+      uvm_test_seq: kmac_test_vectors_sha3_vseq
+      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]
+    }
+    {
+      name: "{variant}_test_vectors_shake"
+      uvm_test_seq: kmac_test_vectors_shake_vseq
+      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]
+    }
+    {
+      name: "{variant}_test_vectors_kmac"
+      uvm_test_seq: kmac_test_vectors_kmac_vseq
+      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]
+    }
+    {
+      name: "{variant}_test_vectors_kmac_xof"
+      uvm_test_seq: kmac_test_vectors_kmac_xof_vseq
+      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
This PR implements all of the NIST vector tests
(sha3, shake, kmac, kmac_xof) as described in the testplan.

The digests will be checked in the scoreboard by default, but we also compare against the
expected digest provided in the test vectors.

Signed-off-by: Udi Jonnalagadda <udij@google.com>