### PR TITLE
[dv/kmac] randomly read digest after hashing

### DIFF
--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -135,13 +135,17 @@ class kmac_smoke_vseq extends kmac_base_vseq;
       issue_cmd(CmdDone);
       `uvm_info(`gfn, "done", UVM_HIGH)
 
-      // TODO: randomly read out the digest after issuing Done command, expect both shares = 0
+      // randomly read out both digests after issuing Done cmd.
+      if ($urandom_range(0, 1)) begin
+        read_digest_chunk(KMAC_STATE_SHARE0_BASE, 200);
+        read_digest_chunk(KMAC_STATE_SHARE1_BASE, 200);
+      end else begin
+        // If we don't read out the state window again, wait a few clocks before dropping the
+        // sideload key (if applicable).
+        cfg.clk_rst_vif.wait_clks(5);
+      end
 
       // Drop the sideloaded key if it was provided to the DUT.
-        //
-      // TODO - wait a few clks before doing this so scb can check the digest.
-      //        Remove this when the previous TODO(random read out digest) is implemented.
-      cfg.clk_rst_vif.wait_clks(5);
       if (kmac_en && (en_sideload || provide_sideload_key)) begin
         cfg.sideload_vif.drive_sideload_key(0);
       end


### PR DESCRIPTION
This PR adds functionality for the test sequence to randomly read out
the state digest after finishing a hash, to check that the digest is no
longer readable.

Signed-off-by: Udi Jonnalagadda <udij@google.com>