### PR TITLE
[dv] Fix stress_all with reset

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -312,6 +312,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   endfunction
 
   virtual function void reset(string kind = "HARD");
+    super.reset(kind);
     tl_a_chan_fifo.flush();
     tl_d_chan_fifo.flush();
     if (cfg.has_edn) edn_fifo.flush();

--- a/hw/dv/sv/dv_lib/dv_base_scoreboard.sv
+++ b/hw/dv/sv/dv_lib/dv_base_scoreboard.sv
@@ -50,7 +50,9 @@ class dv_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
   virtual function void reset(string kind = "HARD");
     // reset the ral model
-    if (cfg.has_ral) ral.reset(kind);
+    if (cfg.has_ral) begin
+      foreach (cfg.ral_models[i]) cfg.ral_models[i].reset(kind);
+    end
   endfunction
 
   virtual function void pre_abort();

--- a/hw/dv/sv/dv_lib/dv_base_vseq.sv
+++ b/hw/dv/sv/dv_lib/dv_base_vseq.sv
@@ -88,9 +88,6 @@ class dv_base_vseq #(type RAL_T               = dv_base_reg_block,
     if (kind == "HARD") begin
       cfg.clk_rst_vif.apply_reset();
     end
-    if (cfg.has_ral) begin
-      foreach (cfg.ral_models[i]) cfg.ral_models[i].reset(kind);
-    end
   endtask
 
   virtual task wait_for_reset(string reset_kind     = "HARD",

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_stress_all_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_stress_all_vseq.sv
@@ -24,10 +24,10 @@ class keymgr_stress_all_vseq extends keymgr_base_vseq;
                           "keymgr_sideload_vseq",
                           "keymgr_random_vseq",
                           "keymgr_direct_to_disabled_vseq",
-                          "keymgr_sw_invalid_input_vseq"
+                          "keymgr_sw_invalid_input_vseq",
                           // TODO, add this later
                           // "keymgr_hwsw_invalid_input_vseq",
-                          //"keymgr_lc_disable_vseq",
+                          "keymgr_lc_disable_vseq"
                           };
     for (int i = 1; i <= num_trans; i++) begin
       uvm_sequence     seq;
@@ -51,6 +51,7 @@ class keymgr_stress_all_vseq extends keymgr_base_vseq;
         common_vseq.common_seq_type = "intr_test";
       end
 
+      `uvm_info(`gfn, $sformatf("Seq %s start", seq_names[seq_idx]), UVM_HIGH)
       keymgr_vseq.start(p_sequencer);
 
       // this is for keymgr_stress_all_with_rand_reset


### PR DESCRIPTION
1. #5097 added flushing item every 1ns durin reset, but at the last 1ns
before getting out of reset, we may still receive a new item. If this
case, it's not flushed out
Updated it to flush constantly during reset
2. reset ral in one place

Signed-off-by: Weicai Yang <weicai@google.com>