### PR TITLE
[regtool] Add reset values for hwext registers to reg_pkg

### DIFF
--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -257,6 +257,33 @@ package aes_reg_pkg;
   parameter logic [BlockAw-1:0] AES_TRIGGER_OFFSET = 7'h 78;
   parameter logic [BlockAw-1:0] AES_STATUS_OFFSET = 7'h 7c;
 
+  // Reset values for hwext registers
+  parameter logic [1:0] AES_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] AES_KEY_SHARE0_0_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_KEY_SHARE0_1_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_KEY_SHARE0_2_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_KEY_SHARE0_3_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_KEY_SHARE0_4_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_KEY_SHARE0_5_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_KEY_SHARE0_6_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_KEY_SHARE0_7_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_KEY_SHARE1_0_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_KEY_SHARE1_1_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_KEY_SHARE1_2_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_KEY_SHARE1_3_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_KEY_SHARE1_4_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_KEY_SHARE1_5_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_KEY_SHARE1_6_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_KEY_SHARE1_7_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_IV_0_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_IV_1_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_IV_2_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_IV_3_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_DATA_OUT_0_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_DATA_OUT_1_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_DATA_OUT_2_RESVAL = 32'h 0;
+  parameter logic [31:0] AES_DATA_OUT_3_RESVAL = 32'h 0;
+  parameter logic [11:0] AES_CTRL_SHADOWED_RESVAL = 12'h c0;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_pkg.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_pkg.sv
@@ -588,6 +588,20 @@ package alert_handler_reg_pkg;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_ESC_CNT_OFFSET = 10'h 3e4;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_STATE_OFFSET = 10'h 3e8;
 
+  // Reset values for hwext registers
+  parameter logic [3:0] ALERT_HANDLER_INTR_TEST_RESVAL = 4'h 0;
+  parameter logic [15:0] ALERT_HANDLER_CLASSA_ACCUM_CNT_RESVAL = 16'h 0;
+  parameter logic [31:0] ALERT_HANDLER_CLASSA_ESC_CNT_RESVAL = 32'h 0;
+  parameter logic [2:0] ALERT_HANDLER_CLASSA_STATE_RESVAL = 3'h 0;
+  parameter logic [15:0] ALERT_HANDLER_CLASSB_ACCUM_CNT_RESVAL = 16'h 0;
+  parameter logic [31:0] ALERT_HANDLER_CLASSB_ESC_CNT_RESVAL = 32'h 0;
+  parameter logic [2:0] ALERT_HANDLER_CLASSB_STATE_RESVAL = 3'h 0;
+  parameter logic [15:0] ALERT_HANDLER_CLASSC_ACCUM_CNT_RESVAL = 16'h 0;
+  parameter logic [31:0] ALERT_HANDLER_CLASSC_ESC_CNT_RESVAL = 32'h 0;
+  parameter logic [2:0] ALERT_HANDLER_CLASSC_STATE_RESVAL = 3'h 0;
+  parameter logic [15:0] ALERT_HANDLER_CLASSD_ACCUM_CNT_RESVAL = 16'h 0;
+  parameter logic [31:0] ALERT_HANDLER_CLASSD_ESC_CNT_RESVAL = 32'h 0;
+  parameter logic [2:0] ALERT_HANDLER_CLASSD_STATE_RESVAL = 3'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/clkmgr/rtl/clkmgr_reg_pkg.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr_reg_pkg.sv
@@ -66,7 +66,6 @@ package clkmgr_reg_pkg;
   parameter logic [BlockAw-1:0] CLKMGR_CLK_HINTS_OFFSET = 4'h 4;
   parameter logic [BlockAw-1:0] CLKMGR_CLK_HINTS_STATUS_OFFSET = 4'h 8;
 
-
   // Register Index
   typedef enum int {
     CLKMGR_CLK_ENABLES,

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -328,6 +328,12 @@ package csrng_reg_pkg;
   parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_OFFSET = 6'h 38;
   parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_TEST_OFFSET = 6'h 3c;
 
+  // Reset values for hwext registers
+  parameter logic [3:0] CSRNG_INTR_TEST_RESVAL = 4'h 0;
+  parameter logic [0:0] CSRNG_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [1:0] CSRNG_GENBITS_VLD_RESVAL = 2'h 0;
+  parameter logic [31:0] CSRNG_GENBITS_RESVAL = 32'h 0;
+  parameter logic [31:0] CSRNG_INT_STATE_VAL_RESVAL = 32'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/edn/rtl/edn_reg_pkg.sv
+++ b/hw/ip/edn/rtl/edn_reg_pkg.sv
@@ -186,6 +186,11 @@ package edn_reg_pkg;
   parameter logic [BlockAw-1:0] EDN_MAX_NUM_REQS_BETWEEN_RESEEDS_OFFSET = 6'h 28;
   parameter logic [BlockAw-1:0] EDN_ERR_CODE_OFFSET = 6'h 2c;
 
+  // Reset values for hwext registers
+  parameter logic [1:0] EDN_INTR_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] EDN_SW_CMD_REQ_RESVAL = 32'h 0;
+  parameter logic [31:0] EDN_RESEED_CMD_RESVAL = 32'h 0;
+  parameter logic [31:0] EDN_GENERATE_CMD_RESVAL = 32'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -540,6 +540,32 @@ package entropy_src_reg_pkg;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_SEED_OFFSET = 8'h b0;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_OFFSET = 8'h b4;
 
+  // Reset values for hwext registers
+  parameter logic [2:0] ENTROPY_SRC_INTR_TEST_RESVAL = 3'h 0;
+  parameter logic [0:0] ENTROPY_SRC_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] ENTROPY_SRC_ENTROPY_DATA_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_REPCNT_HI_WATERMARKS_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_ADAPTP_HI_WATERMARKS_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_ADAPTP_LO_WATERMARKS_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_EXTHT_HI_WATERMARKS_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_EXTHT_LO_WATERMARKS_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_BUCKET_HI_WATERMARKS_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_MARKOV_HI_WATERMARKS_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_MARKOV_LO_WATERMARKS_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_REPCNT_TOTAL_FAILS_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_ADAPTP_HI_TOTAL_FAILS_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_ADAPTP_LO_TOTAL_FAILS_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_BUCKET_TOTAL_FAILS_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_MARKOV_HI_TOTAL_FAILS_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_MARKOV_LO_TOTAL_FAILS_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_EXTHT_HI_TOTAL_FAILS_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_EXTHT_LO_TOTAL_FAILS_RESVAL = 32'h 0;
+  parameter logic [27:0] ENTROPY_SRC_ALERT_FAIL_COUNTS_RESVAL = 28'h 0;
+  parameter logic [7:0] ENTROPY_SRC_EXTHT_FAIL_COUNTS_RESVAL = 8'h 0;
+  parameter logic [31:0] ENTROPY_SRC_FW_OV_RD_DATA_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_FW_OV_WR_DATA_RESVAL = 32'h 0;
+  parameter logic [6:0] ENTROPY_SRC_FW_OV_FIFO_STS_RESVAL = 7'h 0;
+  parameter logic [31:0] ENTROPY_SRC_DEBUG_STATUS_RESVAL = 32'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -627,6 +627,11 @@ package flash_ctrl_reg_pkg;
   parameter logic [BlockAw-1:0] FLASH_CTRL_FIFO_LVL_OFFSET = 9'h 164;
   parameter logic [BlockAw-1:0] FLASH_CTRL_FIFO_RST_OFFSET = 9'h 168;
 
+  // Reset values for hwext registers
+  parameter logic [4:0] FLASH_CTRL_INTR_TEST_RESVAL = 5'h 0;
+  parameter logic [2:0] FLASH_CTRL_ALERT_TEST_RESVAL = 3'h 0;
+  parameter logic [0:0] FLASH_CTRL_CTRL_REGWEN_RESVAL = 1'h 1;
+
   // Window parameter
   parameter logic [BlockAw-1:0] FLASH_CTRL_PROG_FIFO_OFFSET = 9'h 16c;
   parameter logic [BlockAw-1:0] FLASH_CTRL_PROG_FIFO_SIZE   = 9'h 4;

--- a/hw/ip/gpio/rtl/gpio_reg_pkg.sv
+++ b/hw/ip/gpio/rtl/gpio_reg_pkg.sv
@@ -206,6 +206,14 @@ package gpio_reg_pkg;
   parameter logic [BlockAw-1:0] GPIO_INTR_CTRL_EN_LVLLOW_OFFSET = 6'h 34;
   parameter logic [BlockAw-1:0] GPIO_CTRL_EN_INPUT_FILTER_OFFSET = 6'h 38;
 
+  // Reset values for hwext registers
+  parameter logic [31:0] GPIO_INTR_TEST_RESVAL = 32'h 0;
+  parameter logic [31:0] GPIO_DIRECT_OUT_RESVAL = 32'h 0;
+  parameter logic [31:0] GPIO_MASKED_OUT_LOWER_RESVAL = 32'h 0;
+  parameter logic [31:0] GPIO_MASKED_OUT_UPPER_RESVAL = 32'h 0;
+  parameter logic [31:0] GPIO_DIRECT_OE_RESVAL = 32'h 0;
+  parameter logic [31:0] GPIO_MASKED_OE_LOWER_RESVAL = 32'h 0;
+  parameter logic [31:0] GPIO_MASKED_OE_UPPER_RESVAL = 32'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/hmac/rtl/hmac_reg_pkg.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_pkg.sv
@@ -216,6 +216,29 @@ package hmac_reg_pkg;
   parameter logic [BlockAw-1:0] HMAC_MSG_LENGTH_LOWER_OFFSET = 12'h 60;
   parameter logic [BlockAw-1:0] HMAC_MSG_LENGTH_UPPER_OFFSET = 12'h 64;
 
+  // Reset values for hwext registers
+  parameter logic [2:0] HMAC_INTR_TEST_RESVAL = 3'h 0;
+  parameter logic [3:0] HMAC_CFG_RESVAL = 4'h 4;
+  parameter logic [1:0] HMAC_CMD_RESVAL = 2'h 0;
+  parameter logic [8:0] HMAC_STATUS_RESVAL = 9'h 1;
+  parameter logic [31:0] HMAC_WIPE_SECRET_RESVAL = 32'h 0;
+  parameter logic [31:0] HMAC_KEY_0_RESVAL = 32'h 0;
+  parameter logic [31:0] HMAC_KEY_1_RESVAL = 32'h 0;
+  parameter logic [31:0] HMAC_KEY_2_RESVAL = 32'h 0;
+  parameter logic [31:0] HMAC_KEY_3_RESVAL = 32'h 0;
+  parameter logic [31:0] HMAC_KEY_4_RESVAL = 32'h 0;
+  parameter logic [31:0] HMAC_KEY_5_RESVAL = 32'h 0;
+  parameter logic [31:0] HMAC_KEY_6_RESVAL = 32'h 0;
+  parameter logic [31:0] HMAC_KEY_7_RESVAL = 32'h 0;
+  parameter logic [31:0] HMAC_DIGEST_0_RESVAL = 32'h 0;
+  parameter logic [31:0] HMAC_DIGEST_1_RESVAL = 32'h 0;
+  parameter logic [31:0] HMAC_DIGEST_2_RESVAL = 32'h 0;
+  parameter logic [31:0] HMAC_DIGEST_3_RESVAL = 32'h 0;
+  parameter logic [31:0] HMAC_DIGEST_4_RESVAL = 32'h 0;
+  parameter logic [31:0] HMAC_DIGEST_5_RESVAL = 32'h 0;
+  parameter logic [31:0] HMAC_DIGEST_6_RESVAL = 32'h 0;
+  parameter logic [31:0] HMAC_DIGEST_7_RESVAL = 32'h 0;
+
   // Window parameter
   parameter logic [BlockAw-1:0] HMAC_MSG_FIFO_OFFSET = 12'h 800;
   parameter logic [BlockAw-1:0] HMAC_MSG_FIFO_SIZE   = 12'h 800;

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -565,6 +565,13 @@ package i2c_reg_pkg;
   parameter logic [BlockAw-1:0] I2C_STRETCH_CTRL_OFFSET = 7'h 50;
   parameter logic [BlockAw-1:0] I2C_HOST_TIMEOUT_CTRL_OFFSET = 7'h 54;
 
+  // Reset values for hwext registers
+  parameter logic [15:0] I2C_INTR_TEST_RESVAL = 16'h 0;
+  parameter logic [9:0] I2C_STATUS_RESVAL = 10'h 33c;
+  parameter logic [7:0] I2C_RDATA_RESVAL = 8'h 0;
+  parameter logic [29:0] I2C_FIFO_STATUS_RESVAL = 30'h 0;
+  parameter logic [31:0] I2C_VAL_RESVAL = 32'h 0;
+  parameter logic [9:0] I2C_ACQDATA_RESVAL = 10'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
@@ -248,6 +248,11 @@ package keymgr_reg_pkg;
   parameter logic [BlockAw-1:0] KEYMGR_OP_STATUS_OFFSET = 8'h a4;
   parameter logic [BlockAw-1:0] KEYMGR_ERR_CODE_OFFSET = 8'h a8;
 
+  // Reset values for hwext registers
+  parameter logic [0:0] KEYMGR_INTR_TEST_RESVAL = 1'h 0;
+  parameter logic [1:0] KEYMGR_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [0:0] KEYMGR_CFG_REGWEN_RESVAL = 1'h 1;
+  parameter logic [0:0] KEYMGR_SW_BINDING_REGWEN_RESVAL = 1'h 1;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -274,6 +274,44 @@ package kmac_reg_pkg;
   parameter logic [BlockAw-1:0] KMAC_PREFIX_10_OFFSET = 12'h d4;
   parameter logic [BlockAw-1:0] KMAC_ERR_CODE_OFFSET = 12'h d8;
 
+  // Reset values for hwext registers
+  parameter logic [2:0] KMAC_INTR_TEST_RESVAL = 3'h 0;
+  parameter logic [0:0] KMAC_CFG_REGWEN_RESVAL = 1'h 1;
+  parameter logic [3:0] KMAC_CMD_RESVAL = 4'h 0;
+  parameter logic [15:0] KMAC_STATUS_RESVAL = 16'h 4001;
+  parameter logic [31:0] KMAC_KEY_SHARE0_0_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE0_1_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE0_2_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE0_3_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE0_4_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE0_5_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE0_6_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE0_7_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE0_8_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE0_9_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE0_10_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE0_11_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE0_12_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE0_13_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE0_14_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE0_15_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE1_0_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE1_1_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE1_2_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE1_3_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE1_4_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE1_5_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE1_6_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE1_7_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE1_8_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE1_9_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE1_10_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE1_11_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE1_12_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE1_13_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE1_14_RESVAL = 32'h 0;
+  parameter logic [31:0] KMAC_KEY_SHARE1_15_RESVAL = 32'h 0;
+
   // Window parameter
   parameter logic [BlockAw-1:0] KMAC_STATE_OFFSET = 12'h 400;
   parameter logic [BlockAw-1:0] KMAC_STATE_SIZE   = 12'h 200;

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
@@ -164,6 +164,28 @@ package lc_ctrl_reg_pkg;
   parameter logic [BlockAw-1:0] LC_CTRL_DEVICE_ID_6_OFFSET = 7'h 4c;
   parameter logic [BlockAw-1:0] LC_CTRL_DEVICE_ID_7_OFFSET = 7'h 50;
 
+  // Reset values for hwext registers
+  parameter logic [1:0] LC_CTRL_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [8:0] LC_CTRL_STATUS_RESVAL = 9'h 0;
+  parameter logic [7:0] LC_CTRL_CLAIM_TRANSITION_IF_RESVAL = 8'h 0;
+  parameter logic [0:0] LC_CTRL_TRANSITION_REGWEN_RESVAL = 1'h 0;
+  parameter logic [0:0] LC_CTRL_TRANSITION_CMD_RESVAL = 1'h 0;
+  parameter logic [31:0] LC_CTRL_TRANSITION_TOKEN_0_RESVAL = 32'h 0;
+  parameter logic [31:0] LC_CTRL_TRANSITION_TOKEN_1_RESVAL = 32'h 0;
+  parameter logic [31:0] LC_CTRL_TRANSITION_TOKEN_2_RESVAL = 32'h 0;
+  parameter logic [31:0] LC_CTRL_TRANSITION_TOKEN_3_RESVAL = 32'h 0;
+  parameter logic [3:0] LC_CTRL_TRANSITION_TARGET_RESVAL = 4'h 0;
+  parameter logic [3:0] LC_CTRL_LC_STATE_RESVAL = 4'h 0;
+  parameter logic [4:0] LC_CTRL_LC_TRANSITION_CNT_RESVAL = 5'h 0;
+  parameter logic [1:0] LC_CTRL_LC_ID_STATE_RESVAL = 2'h 0;
+  parameter logic [31:0] LC_CTRL_DEVICE_ID_0_RESVAL = 32'h 0;
+  parameter logic [31:0] LC_CTRL_DEVICE_ID_1_RESVAL = 32'h 0;
+  parameter logic [31:0] LC_CTRL_DEVICE_ID_2_RESVAL = 32'h 0;
+  parameter logic [31:0] LC_CTRL_DEVICE_ID_3_RESVAL = 32'h 0;
+  parameter logic [31:0] LC_CTRL_DEVICE_ID_4_RESVAL = 32'h 0;
+  parameter logic [31:0] LC_CTRL_DEVICE_ID_5_RESVAL = 32'h 0;
+  parameter logic [31:0] LC_CTRL_DEVICE_ID_6_RESVAL = 32'h 0;
+  parameter logic [31:0] LC_CTRL_DEVICE_ID_7_RESVAL = 32'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/nmi_gen/rtl/nmi_gen_reg_pkg.sv
+++ b/hw/ip/nmi_gen/rtl/nmi_gen_reg_pkg.sv
@@ -89,6 +89,8 @@ package nmi_gen_reg_pkg;
   parameter logic [BlockAw-1:0] NMI_GEN_INTR_ENABLE_OFFSET = 4'h 4;
   parameter logic [BlockAw-1:0] NMI_GEN_INTR_TEST_OFFSET = 4'h 8;
 
+  // Reset values for hwext registers
+  parameter logic [2:0] NMI_GEN_INTR_TEST_RESVAL = 3'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -142,6 +142,12 @@ package otbn_reg_pkg;
   parameter logic [BlockAw-1:0] OTBN_START_ADDR_OFFSET = 16'h 1c;
   parameter logic [BlockAw-1:0] OTBN_FATAL_ALERT_CAUSE_OFFSET = 16'h 20;
 
+  // Reset values for hwext registers
+  parameter logic [0:0] OTBN_INTR_TEST_RESVAL = 1'h 0;
+  parameter logic [1:0] OTBN_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [0:0] OTBN_CMD_RESVAL = 1'h 0;
+  parameter logic [0:0] OTBN_STATUS_RESVAL = 1'h 0;
+
   // Window parameter
   parameter logic [BlockAw-1:0] OTBN_IMEM_OFFSET = 16'h 4000;
   parameter logic [BlockAw-1:0] OTBN_IMEM_SIZE   = 16'h 1000;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -339,6 +339,29 @@ package otp_ctrl_reg_pkg;
   parameter logic [BlockAw-1:0] OTP_CTRL_SECRET2_DIGEST_0_OFFSET = 14'h 7c;
   parameter logic [BlockAw-1:0] OTP_CTRL_SECRET2_DIGEST_1_OFFSET = 14'h 80;
 
+  // Reset values for hwext registers
+  parameter logic [1:0] OTP_CTRL_INTR_TEST_RESVAL = 2'h 0;
+  parameter logic [1:0] OTP_CTRL_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [14:0] OTP_CTRL_STATUS_RESVAL = 15'h 0;
+  parameter logic [26:0] OTP_CTRL_ERR_CODE_RESVAL = 27'h 0;
+  parameter logic [0:0] OTP_CTRL_DIRECT_ACCESS_REGWEN_RESVAL = 1'h 1;
+  parameter logic [2:0] OTP_CTRL_DIRECT_ACCESS_CMD_RESVAL = 3'h 0;
+  parameter logic [31:0] OTP_CTRL_DIRECT_ACCESS_RDATA_0_RESVAL = 32'h 0;
+  parameter logic [31:0] OTP_CTRL_DIRECT_ACCESS_RDATA_1_RESVAL = 32'h 0;
+  parameter logic [1:0] OTP_CTRL_CHECK_TRIGGER_RESVAL = 2'h 0;
+  parameter logic [31:0] OTP_CTRL_CREATOR_SW_CFG_DIGEST_0_RESVAL = 32'h 0;
+  parameter logic [31:0] OTP_CTRL_CREATOR_SW_CFG_DIGEST_1_RESVAL = 32'h 0;
+  parameter logic [31:0] OTP_CTRL_OWNER_SW_CFG_DIGEST_0_RESVAL = 32'h 0;
+  parameter logic [31:0] OTP_CTRL_OWNER_SW_CFG_DIGEST_1_RESVAL = 32'h 0;
+  parameter logic [31:0] OTP_CTRL_HW_CFG_DIGEST_0_RESVAL = 32'h 0;
+  parameter logic [31:0] OTP_CTRL_HW_CFG_DIGEST_1_RESVAL = 32'h 0;
+  parameter logic [31:0] OTP_CTRL_SECRET0_DIGEST_0_RESVAL = 32'h 0;
+  parameter logic [31:0] OTP_CTRL_SECRET0_DIGEST_1_RESVAL = 32'h 0;
+  parameter logic [31:0] OTP_CTRL_SECRET1_DIGEST_0_RESVAL = 32'h 0;
+  parameter logic [31:0] OTP_CTRL_SECRET1_DIGEST_1_RESVAL = 32'h 0;
+  parameter logic [31:0] OTP_CTRL_SECRET2_DIGEST_0_RESVAL = 32'h 0;
+  parameter logic [31:0] OTP_CTRL_SECRET2_DIGEST_1_RESVAL = 32'h 0;
+
   // Window parameter
   parameter logic [BlockAw-1:0] OTP_CTRL_SW_CFG_WINDOW_OFFSET = 14'h 1000;
   parameter logic [BlockAw-1:0] OTP_CTRL_SW_CFG_WINDOW_SIZE   = 14'h 800;

--- a/hw/ip/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/ip/pinmux/rtl/pinmux_reg_pkg.sv
@@ -569,6 +569,56 @@ package pinmux_reg_pkg;
   parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_7_OFFSET = 11'h 66c;
   parameter logic [BlockAw-1:0] PINMUX_WKUP_CAUSE_OFFSET = 11'h 670;
 
+  // Reset values for hwext registers
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_0_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_1_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_2_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_3_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_4_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_5_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_6_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_7_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_8_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_9_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_10_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_11_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_12_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_13_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_14_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_15_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_16_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_17_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_18_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_19_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_20_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_21_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_22_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_23_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_24_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_25_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_26_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_27_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_28_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_29_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_30_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_31_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_0_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_1_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_2_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_3_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_4_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_5_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_6_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_7_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_8_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_9_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_10_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_11_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_12_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_13_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_14_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_15_RESVAL = 10'h 0;
+  parameter logic [7:0] PINMUX_WKUP_CAUSE_RESVAL = 8'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_reg_pkg.sv
@@ -171,6 +171,10 @@ package pwrmgr_reg_pkg;
   parameter logic [BlockAw-1:0] PWRMGR_WAKE_INFO_CAPTURE_DIS_OFFSET = 6'h 30;
   parameter logic [BlockAw-1:0] PWRMGR_WAKE_INFO_OFFSET = 6'h 34;
 
+  // Reset values for hwext registers
+  parameter logic [0:0] PWRMGR_INTR_TEST_RESVAL = 1'h 0;
+  parameter logic [0:0] PWRMGR_CTRL_CFG_REGWEN_RESVAL = 1'h 1;
+  parameter logic [2:0] PWRMGR_WAKE_INFO_RESVAL = 3'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/rstmgr/rtl/rstmgr_reg_pkg.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_reg_pkg.sv
@@ -106,6 +106,10 @@ package rstmgr_reg_pkg;
   parameter logic [BlockAw-1:0] RSTMGR_SW_RST_REGEN_OFFSET = 5'h 10;
   parameter logic [BlockAw-1:0] RSTMGR_SW_RST_CTRL_N_OFFSET = 5'h 14;
 
+  // Reset values for hwext registers
+  parameter logic [3:0] RSTMGR_ALERT_INFO_ATTR_RESVAL = 4'h 0;
+  parameter logic [31:0] RSTMGR_ALERT_INFO_RESVAL = 32'h 0;
+  parameter logic [1:0] RSTMGR_SW_RST_CTRL_N_RESVAL = 2'h 3;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/rv_plic/rtl/rv_plic_reg_pkg.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic_reg_pkg.sv
@@ -268,6 +268,8 @@ package rv_plic_reg_pkg;
   parameter logic [BlockAw-1:0] RV_PLIC_CC0_OFFSET = 9'h 108;
   parameter logic [BlockAw-1:0] RV_PLIC_MSIP0_OFFSET = 9'h 10c;
 
+  // Reset values for hwext registers
+  parameter logic [5:0] RV_PLIC_CC0_RESVAL = 6'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
@@ -112,6 +112,8 @@ package rv_timer_reg_pkg;
   parameter logic [BlockAw-1:0] RV_TIMER_INTR_STATE0_OFFSET = 9'h 118;
   parameter logic [BlockAw-1:0] RV_TIMER_INTR_TEST0_OFFSET = 9'h 11c;
 
+  // Reset values for hwext registers
+  parameter logic [0:0] RV_TIMER_INTR_TEST0_RESVAL = 1'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -267,6 +267,11 @@ package spi_device_reg_pkg;
   parameter logic [BlockAw-1:0] SPI_DEVICE_RXF_ADDR_OFFSET = 13'h 28;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TXF_ADDR_OFFSET = 13'h 2c;
 
+  // Reset values for hwext registers
+  parameter logic [5:0] SPI_DEVICE_INTR_TEST_RESVAL = 6'h 0;
+  parameter logic [23:0] SPI_DEVICE_ASYNC_FIFO_LEVEL_RESVAL = 24'h 0;
+  parameter logic [5:0] SPI_DEVICE_STATUS_RESVAL = 6'h 3a;
+
   // Window parameter
   parameter logic [BlockAw-1:0] SPI_DEVICE_BUFFER_OFFSET = 13'h 1000;
   parameter logic [BlockAw-1:0] SPI_DEVICE_BUFFER_SIZE   = 13'h 1000;

--- a/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
@@ -65,7 +65,6 @@ package spi_host_reg_pkg;
   // Register Address
   parameter logic [BlockAw-1:0] SPI_HOST_CONTROL_OFFSET = 2'h 0;
 
-
   // Register Index
   typedef enum int {
     SPI_HOST_CONTROL

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
@@ -77,6 +77,10 @@ package sram_ctrl_reg_pkg;
   parameter logic [BlockAw-1:0] SRAM_CTRL_CTRL_OFFSET = 5'h 14;
   parameter logic [BlockAw-1:0] SRAM_CTRL_ERROR_ADDRESS_OFFSET = 5'h 18;
 
+  // Reset values for hwext registers
+  parameter logic [0:0] SRAM_CTRL_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [3:0] SRAM_CTRL_STATUS_RESVAL = 4'h 0;
+  parameter logic [0:0] SRAM_CTRL_CTRL_RESVAL = 1'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/trial1/rtl/trial1_reg_pkg.sv
+++ b/hw/ip/trial1/rtl/trial1_reg_pkg.sv
@@ -283,6 +283,9 @@ package trial1_reg_pkg;
   parameter logic [BlockAw-1:0] TRIAL1_ROTYPE2_OFFSET = 10'h 238;
   parameter logic [BlockAw-1:0] TRIAL1_RWTYPE7_OFFSET = 10'h 23c;
 
+  // Reset values for hwext registers
+  parameter logic [31:0] TRIAL1_RWTYPE6_RESVAL = 32'h c8c8c8c8;
+  parameter logic [31:0] TRIAL1_ROTYPE1_RESVAL = 32'h 66aa66aa;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/uart/rtl/uart_reg_pkg.sv
+++ b/hw/ip/uart/rtl/uart_reg_pkg.sv
@@ -333,6 +333,12 @@ package uart_reg_pkg;
   parameter logic [BlockAw-1:0] UART_VAL_OFFSET = 6'h 28;
   parameter logic [BlockAw-1:0] UART_TIMEOUT_CTRL_OFFSET = 6'h 2c;
 
+  // Reset values for hwext registers
+  parameter logic [7:0] UART_INTR_TEST_RESVAL = 8'h 0;
+  parameter logic [5:0] UART_STATUS_RESVAL = 6'h 3c;
+  parameter logic [7:0] UART_RDATA_RESVAL = 8'h 0;
+  parameter logic [21:0] UART_FIFO_STATUS_RESVAL = 22'h 0;
+  parameter logic [15:0] UART_VAL_RESVAL = 16'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -581,6 +581,12 @@ package usbdev_reg_pkg;
   parameter logic [BlockAw-1:0] USBDEV_WAKE_CONFIG_OFFSET = 12'h 70;
   parameter logic [BlockAw-1:0] USBDEV_WAKE_DEBUG_OFFSET = 12'h 74;
 
+  // Reset values for hwext registers
+  parameter logic [16:0] USBDEV_INTR_TEST_RESVAL = 17'h 0;
+  parameter logic [31:0] USBDEV_USBSTAT_RESVAL = 32'h 80000000;
+  parameter logic [23:0] USBDEV_RXFIFO_RESVAL = 24'h 0;
+  parameter logic [16:0] USBDEV_PHY_PINS_SENSE_RESVAL = 17'h 0;
+
   // Window parameter
   parameter logic [BlockAw-1:0] USBDEV_BUFFER_OFFSET = 12'h 800;
   parameter logic [BlockAw-1:0] USBDEV_BUFFER_SIZE   = 12'h 800;

--- a/hw/ip/usbuart/rtl/usbuart_reg_pkg.sv
+++ b/hw/ip/usbuart/rtl/usbuart_reg_pkg.sv
@@ -341,6 +341,14 @@ package usbuart_reg_pkg;
   parameter logic [BlockAw-1:0] USBUART_USBSTAT_OFFSET = 6'h 30;
   parameter logic [BlockAw-1:0] USBUART_USBPARAM_OFFSET = 6'h 34;
 
+  // Reset values for hwext registers
+  parameter logic [7:0] USBUART_INTR_TEST_RESVAL = 8'h 0;
+  parameter logic [5:0] USBUART_STATUS_RESVAL = 6'h 0;
+  parameter logic [7:0] USBUART_RDATA_RESVAL = 8'h 0;
+  parameter logic [21:0] USBUART_FIFO_STATUS_RESVAL = 22'h 0;
+  parameter logic [15:0] USBUART_VAL_RESVAL = 16'h 0;
+  parameter logic [22:0] USBUART_USBSTAT_RESVAL = 23'h 0;
+  parameter logic [17:0] USBUART_USBPARAM_RESVAL = 18'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
@@ -589,6 +589,20 @@ package alert_handler_reg_pkg;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_ESC_CNT_OFFSET = 10'h 3e4;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_STATE_OFFSET = 10'h 3e8;
 
+  // Reset values for hwext registers
+  parameter logic [3:0] ALERT_HANDLER_INTR_TEST_RESVAL = 4'h 0;
+  parameter logic [15:0] ALERT_HANDLER_CLASSA_ACCUM_CNT_RESVAL = 16'h 0;
+  parameter logic [31:0] ALERT_HANDLER_CLASSA_ESC_CNT_RESVAL = 32'h 0;
+  parameter logic [2:0] ALERT_HANDLER_CLASSA_STATE_RESVAL = 3'h 0;
+  parameter logic [15:0] ALERT_HANDLER_CLASSB_ACCUM_CNT_RESVAL = 16'h 0;
+  parameter logic [31:0] ALERT_HANDLER_CLASSB_ESC_CNT_RESVAL = 32'h 0;
+  parameter logic [2:0] ALERT_HANDLER_CLASSB_STATE_RESVAL = 3'h 0;
+  parameter logic [15:0] ALERT_HANDLER_CLASSC_ACCUM_CNT_RESVAL = 16'h 0;
+  parameter logic [31:0] ALERT_HANDLER_CLASSC_ESC_CNT_RESVAL = 32'h 0;
+  parameter logic [2:0] ALERT_HANDLER_CLASSC_STATE_RESVAL = 3'h 0;
+  parameter logic [15:0] ALERT_HANDLER_CLASSD_ACCUM_CNT_RESVAL = 16'h 0;
+  parameter logic [31:0] ALERT_HANDLER_CLASSD_ESC_CNT_RESVAL = 32'h 0;
+  parameter logic [2:0] ALERT_HANDLER_CLASSD_STATE_RESVAL = 3'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
@@ -86,7 +86,6 @@ package clkmgr_reg_pkg;
   parameter logic [BlockAw-1:0] CLKMGR_CLK_HINTS_OFFSET = 4'h 8;
   parameter logic [BlockAw-1:0] CLKMGR_CLK_HINTS_STATUS_OFFSET = 4'h c;
 
-
   // Register Index
   typedef enum int {
     CLKMGR_JITTER_ENABLE,

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
@@ -627,6 +627,11 @@ package flash_ctrl_reg_pkg;
   parameter logic [BlockAw-1:0] FLASH_CTRL_FIFO_LVL_OFFSET = 9'h 164;
   parameter logic [BlockAw-1:0] FLASH_CTRL_FIFO_RST_OFFSET = 9'h 168;
 
+  // Reset values for hwext registers
+  parameter logic [4:0] FLASH_CTRL_INTR_TEST_RESVAL = 5'h 0;
+  parameter logic [2:0] FLASH_CTRL_ALERT_TEST_RESVAL = 3'h 0;
+  parameter logic [0:0] FLASH_CTRL_CTRL_REGWEN_RESVAL = 1'h 1;
+
   // Window parameter
   parameter logic [BlockAw-1:0] FLASH_CTRL_PROG_FIFO_OFFSET = 9'h 16c;
   parameter logic [BlockAw-1:0] FLASH_CTRL_PROG_FIFO_SIZE   = 9'h 4;

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
@@ -580,6 +580,55 @@ package pinmux_reg_pkg;
   parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_7_OFFSET = 11'h 698;
   parameter logic [BlockAw-1:0] PINMUX_WKUP_CAUSE_OFFSET = 11'h 69c;
 
+  // Reset values for hwext registers
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_0_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_1_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_2_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_3_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_4_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_5_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_6_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_7_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_8_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_9_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_10_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_11_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_12_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_13_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_14_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_15_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_16_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_17_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_18_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_19_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_20_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_21_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_22_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_23_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_24_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_25_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_26_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_27_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_28_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_29_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_30_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_31_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_0_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_1_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_2_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_3_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_4_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_5_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_6_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_7_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_8_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_9_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_10_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_11_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_12_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_13_RESVAL = 10'h 0;
+  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_14_RESVAL = 10'h 0;
+  parameter logic [7:0] PINMUX_WKUP_CAUSE_RESVAL = 8'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_pkg.sv
@@ -180,6 +180,10 @@ package pwrmgr_reg_pkg;
   parameter logic [BlockAw-1:0] PWRMGR_WAKE_INFO_CAPTURE_DIS_OFFSET = 6'h 34;
   parameter logic [BlockAw-1:0] PWRMGR_WAKE_INFO_OFFSET = 6'h 38;
 
+  // Reset values for hwext registers
+  parameter logic [0:0] PWRMGR_INTR_TEST_RESVAL = 1'h 0;
+  parameter logic [0:0] PWRMGR_CTRL_CFG_REGWEN_RESVAL = 1'h 1;
+  parameter logic [3:0] PWRMGR_WAKE_INFO_RESVAL = 4'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
@@ -138,6 +138,12 @@ package rstmgr_reg_pkg;
   parameter logic [BlockAw-1:0] RSTMGR_SW_RST_REGEN_OFFSET = 6'h 1c;
   parameter logic [BlockAw-1:0] RSTMGR_SW_RST_CTRL_N_OFFSET = 6'h 20;
 
+  // Reset values for hwext registers
+  parameter logic [3:0] RSTMGR_ALERT_INFO_ATTR_RESVAL = 4'h 0;
+  parameter logic [31:0] RSTMGR_ALERT_INFO_RESVAL = 32'h 0;
+  parameter logic [3:0] RSTMGR_CPU_INFO_ATTR_RESVAL = 4'h 0;
+  parameter logic [31:0] RSTMGR_CPU_INFO_RESVAL = 32'h 0;
+  parameter logic [4:0] RSTMGR_SW_RST_CTRL_N_RESVAL = 5'h 1f;
 
   // Register Index
   typedef enum int {

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
@@ -1124,6 +1124,8 @@ package rv_plic_reg_pkg;
   parameter logic [BlockAw-1:0] RV_PLIC_CC0_OFFSET = 10'h 31c;
   parameter logic [BlockAw-1:0] RV_PLIC_MSIP0_OFFSET = 10'h 320;
 
+  // Reset values for hwext registers
+  parameter logic [7:0] RV_PLIC_CC0_RESVAL = 8'h 0;
 
   // Register Index
   typedef enum int {

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_pkg.sv
@@ -105,6 +105,8 @@ package sensor_ctrl_reg_pkg;
   parameter logic [BlockAw-1:0] SENSOR_CTRL_ALERT_STATE_OFFSET = 5'h 10;
   parameter logic [BlockAw-1:0] SENSOR_CTRL_STATUS_OFFSET = 5'h 14;
 
+  // Reset values for hwext registers
+  parameter logic [6:0] SENSOR_CTRL_ALERT_TEST_RESVAL = 7'h 0;
 
   // Register Index
   typedef enum int {


### PR DESCRIPTION
The result (for AES) looks like

    // Default values for hwext registers
    parameter logic [1:0] AES_ALERT_TEST_DEFAULT = 2'h 0;
    parameter logic [31:0] AES_KEY_SHARE0_0_DEFAULT = 32'h 0;
    parameter logic [31:0] AES_KEY_SHARE0_1_DEFAULT = 32'h 0;
    parameter logic [31:0] AES_KEY_SHARE0_2_DEFAULT = 32'h 0;
    ...

Doing this means that design code can look in FOO_reg_pkg to set its
reset value as declared in the hjson, avoiding needing to duplicate
any constants by hand.

Fixes #5086.