### PR TITLE
[tlul] Update verilator waiver for tlul_err_resp

### DIFF
--- a/hw/ip/tlul/lint/tlul_socket_1n.vlt
+++ b/hw/ip/tlul/lint/tlul_socket_1n.vlt
@@ -8,4 +8,4 @@
 lint_off -rule UNUSED -file "*/rtl/tlul_socket_1n.sv" -match "Bits of signal are not used: 'tl_t_p'[0]"
 
 // error response does not require command/address information
-lint_off -rule UNUSED -file "*/rtl/tlul_err_resp.sv" -match "Bits of signal are not used: 'tl_h_i'[97:95,84:1]"
+lint_off -rule UNUSED -file "*/rtl/tlul_err_resp.sv" -match "Bits of signal are not used: 'tl_h_i'[92:90,79:1]"


### PR DESCRIPTION
Commit 041c683 fixed the d_size response from `tlul_err_resp` and, in
doing so, read some more bits from `tl_h_i`. This commit updates the
Verilator waiver so that it matches the warning message again.

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>