### PR TITLE
[otbn] Provide options to dump registers in OTBN ISS

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/standalone.py
+++ b/hw/ip/otbn/dv/otbnsim/standalone.py
@@ -14,7 +14,19 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('elf')
     parser.add_argument('-v', '--verbose', action='store_true')
-    parser.add_argument('--dmem-dump')
+    parser.add_argument(
+        '--dump-dmem',
+        metavar="FILE",
+        type=argparse.FileType('wb'),
+        help="after execution, write the data memory contents to this file")
+    parser.add_argument(
+        '--dump-regs',
+        metavar="FILE",
+        type=argparse.FileType('w'),
+        default=sys.stdout,
+        help=
+        "after execution, write the GPR and WDR contents to this file (default: STDOUT)"
+    )
 
     args = parser.parse_args()
 
@@ -25,14 +37,14 @@ def main() -> int:
     sim.state.start()
     sim.run(verbose=args.verbose)
 
-    if args.dmem_dump is not None:
-        try:
-            with open(args.dmem_dump, 'wb') as dmem_file:
-                dmem_file.write(sim.dump_data())
-        except OSError as err:
-            sys.stderr.write('Failed to write DMEM to {!r}: {}.'
-                             .format(args.dmem_dump, err))
-            return 1
+    if args.dump_dmem is not None:
+        args.dump_dmem.write(sim.dump_data())
+
+    if args.dump_regs is not None:
+        for idx, value in enumerate(sim.state.gprs.peek_unsigned_values()):
+            args.dump_regs.write(' x{:<2} = 0x{:08x}\n'.format(idx, value))
+        for idx, value in enumerate(sim.state.wdrs.peek_unsigned_values()):
+            args.dump_regs.write(' w{:<2} = 0x{:064x}\n'.format(idx, value))
 
     return 0
 


### PR DESCRIPTION
Provide a `--dump-regs` option to the standalone OTBN simulation to dump
all GPR and WDR values after the operation completes.