### PR TITLE
[util] fixed check_tool_requirements.py shebang

### DIFF
--- a/util/check_tool_requirements.py
+++ b/util/check_tool_requirements.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Signed-off-by: Arnon Sharlin <arnon.sharlin@opentitan.org>

/usr/bin/python3 is not present on all systems.
Changed shebang to /usr/bin/env python3