### PR TITLE
[ci] Remove --fork-point from git merge-base command

### DIFF
--- a/ci/scripts/check-licence-headers.sh
+++ b/ci/scripts/check-licence-headers.sh
@@ -16,7 +16,7 @@ if [ $# != 1 ]; then
 fi
 tgt_branch="$1"
 
-merge_base="$(git merge-base --fork-point origin/$tgt_branch)" || {
+merge_base="$(git merge-base origin/$tgt_branch HEAD)" || {
     echo >&2 "Failed to find fork point for origin/$tgt_branch."
     exit 1
 }

--- a/ci/scripts/clang-format.sh
+++ b/ci/scripts/clang-format.sh
@@ -16,7 +16,7 @@ if [ $# != 1 ]; then
 fi
 tgt_branch="$1"
 
-merge_base="$(git merge-base --fork-point origin/$tgt_branch)" || {
+merge_base="$(git merge-base origin/$tgt_branch HEAD)" || {
     echo >&2 "Failed to find fork point for origin/$tgt_branch."
     exit 1
 }

--- a/ci/scripts/get-build-type.sh
+++ b/ci/scripts/get-build-type.sh
@@ -22,7 +22,7 @@ has_otbn_changes=1
 if [[ "$build_reason" = "PullRequest" ]]; then
     # Conservative way of checking for documentation-only and OTBN changes.
     # Only relevant for pipelines triggered from pull requests
-    merge_base="$(git merge-base --fork-point origin/$tgt_branch)" || {
+    merge_base="$(git merge-base HEAD origin/$tgt_branch)" || {
         echo >&2 "Failed to find fork point for origin/$tgt_branch."
         exit 1
     }

--- a/ci/scripts/include-guard.sh
+++ b/ci/scripts/include-guard.sh
@@ -16,7 +16,7 @@ if [ $# != 1 ]; then
 fi
 tgt_branch="$1"
 
-merge_base="$(git merge-base --fork-point origin/$tgt_branch)" || {
+merge_base="$(git merge-base origin/$tgt_branch HEAD)" || {
     echo >&2 "Failed to find fork point for origin/$tgt_branch."
     exit 1
 }

--- a/ci/scripts/lint-commits.sh
+++ b/ci/scripts/lint-commits.sh
@@ -14,7 +14,7 @@ if [ $# != 1 ]; then
 fi
 tgt_branch="$1"
 
-merge_base="$(git merge-base --fork-point origin/$tgt_branch)" || {
+merge_base="$(git merge-base origin/$tgt_branch HEAD)" || {
     echo >&2 "Failed to find fork point for origin/$tgt_branch."
     exit 1
 }

--- a/ci/scripts/python-lint.sh
+++ b/ci/scripts/python-lint.sh
@@ -16,7 +16,7 @@ if [ $# != 1 ]; then
 fi
 tgt_branch="$1"
 
-merge_base="$(git merge-base --fork-point origin/$tgt_branch)" || {
+merge_base="$(git merge-base origin/$tgt_branch HEAD)" || {
     echo >&2 "Failed to find fork point for origin/$tgt_branch."
     exit 1
 }


### PR DESCRIPTION
This enables a complicated mode for git merge-base, which tries to
cope with situations where the branch from which we
forked (origin/master) has had rewrites. It seems that it fails
occasionally, leading to rather mysterious CI errors.

Since we don't rewrite the master branch, just use vanilla merge-base.
