### PR TITLE
[ci] Move "slow lint" commands into script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,21 +86,7 @@ jobs:
     vmImage: ubuntu-18.04
   steps:
   - template: ci/install-package-dependencies.yml
-  - bash: |
-      # Here we look for all *.vendor.hjson files in the repo to re-vendor them.
-      # We exclude the following:
-      # - Any in 'hw/vendor/lowrisc_ibex', because that directory is vendored.
-      find . \
-        -not \( -path './hw/vendor/lowrisc_ibex' -prune \) \
-        -name '*.vendor.hjson' \
-        | xargs -n1 util/vendor.py --verbose \
-        && git diff --exit-code
-      if [[ $? != 0 ]]; then
-        echo -n "##vso[task.logissue type=error]"
-        echo "Vendored repositories not up-to-date. Run util/vendor.py to fix."
-        exit 1
-      fi
-    condition: always()
+  - bash: ci/scripts/check-vendoring.sh
     displayName: Check vendored directories are up-to-date
 
 - job: sw_build

--- a/ci/jobs/slow-lint.sh
+++ b/ci/jobs/slow-lint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# A wrapper that duplicates the code for the quick lint job in
+# azure-pipelines.yml. The two should be kept in sync.
+#
+# This doesn't install dependencies, but should otherwise behave the
+# same as what CI would do on a pull request.
+
+set -e
+
+echo "### Check vendored directories are up-to-date"
+ci/scripts/check-vendoring.sh

--- a/ci/scripts/check-vendoring.sh
+++ b/ci/scripts/check-vendoring.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Check vendored repositories are up to date
+
+set -e
+
+# Here we look for all *.vendor.hjson files in the repo and re-vendor them.
+#
+# We exclude the following:
+# - Any in 'hw/vendor/lowrisc_ibex', because that directory is vendored.
+find . \
+     -not \( -path './hw/vendor/lowrisc_ibex' -prune \) \
+     -name '*.vendor.hjson' -print0 | \
+    xargs -0 -n1 util/vendor.py --verbose || {
+
+    echo >&2 "Failed to run vendor script"
+    exit 1
+}
+
+git diff --exit-code || {
+    echo >&2 -n "##vso[task.logissue type=error]"
+    echo >&2 "Vendored repositories not up-to-date. Run util/vendor.py to fix."
+    exit 1
+}


### PR DESCRIPTION
This should work the same as before, but is easier to run locally.
Also, the job is no longer marked as "always()", which means it won't
run if installing the package dependencies fails (which caused rather
confusing error messages).
