### PR TITLE
[top/dv] Fix backdoor override

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -104,8 +104,10 @@ package chip_env_pkg;
       string line;
       int out_file_d = 0;
       string out_file = $sformatf("%0s.dat", symbol);
-      string cmd = $sformatf("/usr/bin/readelf -s %0s | grep %0s | awk \'{print $2\" \"$3}\' > %0s",
-                             elf_file, symbol, out_file);
+      string cmd = $sformatf(
+          // use `--wide` to avoid truncating the output, in case of long symbol name
+          "/usr/bin/readelf -s --wide %0s | grep %0s | awk \'{print $2\" \"$3}\' > %0s",
+          elf_file, symbol, out_file);
 
       // TODO #3838: shell pipes are bad 'mkay?
       ret = $system(cmd);


### PR DESCRIPTION
readelf may trancate the symbol name if long is over 85 chars
Since we need to find the symbol name `exp_spi_device_rx_data` to
replace the value, we can't trancate it

Before the fix:
>  1512: 20003698   128 OBJECT  LOCAL  DEFAULT    6 exp_spi_device_r[...]

After:
>  1512: 20003698   128 OBJECT  LOCAL  DEFAULT    6 exp_spi_device_rx_data

Signed-off-by: Weicai Yang <weicai@google.com>