### PR TITLE
[spi_device] Add Sram size to register definition

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -23,6 +23,14 @@
   ],
   scan: "true",       // Enable `scanmode_i` port
   scan_reset: "true", // Enable `scan_rst_ni` port
+  param_list: [
+    { name:    "SramDepth"
+      desc:    "Sram Entries. Word size is 32bit width."
+      type:    "int unsigned"
+      default: "1024"
+      local:   "true"
+    }
+  ]
   regwidth: "32",
   registers: [
     { name: "CONTROL",
@@ -275,7 +283,7 @@
     { skipto: "0x1000" }
     { window: {
         name: "buffer",
-        items: "1024",
+        items: "SramDepth",
         validbits: "32",
         byte-write: "false",
         unusual: "false"

--- a/hw/ip/spi_device/rtl/spi_device_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_pkg.sv
@@ -89,9 +89,9 @@ package spi_device_pkg;
 
   // Sram Depth is set to 1024 to satisfy DPSRAM parameter even though
   // SramTotalDepth above is 928.
-  parameter int unsigned SramDepth = 1024;
+  //parameter int unsigned SramDepth = 1024;
 
-  parameter int unsigned SramAw = $clog2(SramDepth);
+  parameter int unsigned SramAw = $clog2(spi_device_reg_pkg::SramDepth);
 
   // spi device scanmode usage
   typedef enum logic [2:0] {

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -6,6 +6,9 @@
 
 package spi_device_reg_pkg;
 
+  // Param list
+  parameter int unsigned SramDepth = 1024;
+
   // Address width within the block
   parameter int BlockAw = 13;
 


### PR DESCRIPTION
Addressing the comment in PR #5068 . This PR defines `SramDepth` in `spi_device.hjson` so that it can be used to generate DIF register header.
