### PR TITLE
[dv/tools] Bug fix to common.tcl tb_top section.

### DIFF
--- a/hw/dv/tools/common.tcl
+++ b/hw/dv/tools/common.tcl
@@ -17,8 +17,9 @@ if {[info exists ::env(WAVES)]} {
 }
 
 set tb_top "tb"
-if {[info exists ::(TB_TOP)]} {
+if {[info exists ::env(TB_TOP)]} {
   set tb_top "$::env(TB_TOP)"
+} else {
   puts "WARNING: TB_TOP environment variable not set - using \"tb\" as the
         top level testbench hierarchy."
 }


### PR DESCRIPTION
Hi,
Bug fixed with Sri to hw/dv/tools/common.tcl:
- Because missing **env**, the **if** statement always came false.
- Because **else** statement was missing - Warning message never showed in the log.


Signed-off-by: Eitan Shapira <eitan.shapira@nuvoton.com>