### PR TITLE
[fpga] Raise severity of create_clock failures to error

### DIFF
--- a/hw/top_earlgrey/util/vivado_hook_synth_design_pre.tcl
+++ b/hw/top_earlgrey/util/vivado_hook_synth_design_pre.tcl
@@ -11,3 +11,9 @@ set_msg_config -id {[Synth 8-4445]} -new_severity ERROR
 # Abort upon inferring latches. This is normally just a warning. We want to avoid that
 # code inferring latches ends up in the repo in the first place.
 set_msg_config -id {[Synth 8-327]} -new_severity ERROR
+
+# Abort if a create_clock command fails. This typically happens if anchor points for clock
+# constraints inside the design change. The failure is normally just reported as a critical
+# warning in batch mode which is easily overlooked. The design might still work but some clocks
+# will be unconstrained which can lead to other problems later on.
+set_msg_config -id {[Vivado 12-4739]} -new_severity ERROR


### PR DESCRIPTION
By default, such failures are just reported as critical warnings in batch mode which are easily overlooked. Such failures usually occur if clock constraints get outdated, e.g., because anchor points change. The design might still work but some clocks will be unconstrained which can lead to other problems later on.

Therefore, this PR raises the severity of such failures from critical warning to error. As a result, synthesis is aborted immediately. Alternatively, we could try to report the resulting clock groups after implementation and check if all specified clock groups are actually generated. However, this would require us to maintain also the list of clock groups to check and is probably more fragile.

This is related to lowRISC/OpenTitan#5254.
