### PR TITLE
[fpga] Add timestamp for bitstream identification via USR_ACCESS reg

### DIFF
--- a/hw/top_earlgrey/util/vivado_hook_write_bitstream_pre.tcl
+++ b/hw/top_earlgrey/util/vivado_hook_write_bitstream_pre.tcl
@@ -13,3 +13,6 @@ send_msg "Designcheck 1-2" INFO "Slack is ${slack_ns} ns."
 if [expr {$slack_ns < 0}] {
   send_msg "Designcheck 1-3" ERROR "Timing failed. Slack is ${slack_ns} ns."
 }
+
+# Enable bitstream identification via USR_ACCESS register.
+set_property BITSTREAM.CONFIG.USR_ACCESS TIMESTAMP [current_design]


### PR DESCRIPTION
This PR modifies the bitstream generation to add a timestamp in the USR_ACCESS register for later identification. This is useful to find out which bitstream is currently loaded on a running FPGA.

We would primarily use this feature for the SCA setup but it doesn't hurt to enable it also for non-SCA targets. This is related to lowRISC/ot-sca#39.