### PR TITLE
[topgen] Add "port" to list of optional keys at top-level

### DIFF
--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -70,6 +70,7 @@ top_optional = {
     ],
     'pinmux': ['g', 'pinmux definition if doesn\'t exist, tool uses defaults'],
     'power': ['g', 'power domains supported by the design'],
+    'port': ['g', 'assign special attributes to specific ports']
 }
 
 top_added = {}


### PR DESCRIPTION
Commit 075ed379b9 added this to top_earlgrey.hjson but forgot to add
it to the schema in topgen.

This is a spurious warning that we need to sort out before we can merge #5026.