### PR TITLE
[fpv] Fix FPV compile errors

### DIFF
--- a/hw/ip/rv_dm/rv_dm.core
+++ b/hw/ip/rv_dm/rv_dm.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:ip:jtag_pkg
       - lowrisc:ip:tlul
       - lowrisc:prim:all
+      - lowrisc:prim:lc_sync
       - lowrisc:tlul:adapter_host
       - pulp-platform:riscv-dbg:0.1
       - lowrisc:ip:lc_ctrl_pkg

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -124,7 +124,7 @@ module sram_ctrl
   // Lifecycle Escalation Synchronization //
   //////////////////////////////////////////
 
-  lc_ctrl_pkg::lc_tx_t escalate_en;
+  lc_ctrl_pkg::lc_tx_t [0:0] escalate_en;
   prim_lc_sync #(
     .NumCopies (1)
   ) u_prim_lc_sync (


### PR DESCRIPTION
1. sram_ctrl compile error comes from prim_lc_sync. It requires input
to be an array, even though the size is 1.

2. RV_DM compile error comes from missing `prim_lc_sync` package.

Signed-off-by: Cindy Chen <chencindy@google.com>