### PR TITLE
[util] Fix enum description in register table

### DIFF
--- a/util/reggen/gen_html.py
+++ b/util/reggen/gen_html.py
@@ -193,7 +193,8 @@ def gen_html_register(outfile, reg, comp, width, rnames, toc, toclvl):
             "</td>")
         genout(outfile, "<td class=\"regfn\">" + fname + "</td>")
         if field.desc is not None:
-            genout(outfile, render_td(field.desc, rnames, 'regde'))
+            genout(outfile,
+                   render_td(field.desc, rnames, 'regde', field.enum is None))
         else:
             genout(outfile, "<td>\n")
 
@@ -209,7 +210,8 @@ def gen_html_register(outfile, reg, comp, width, rnames, toc, toclvl):
             genout(outfile, "    </table>")
             if field.has_incomplete_enum():
                 genout(outfile, "Other values are reserved.")
-        genout(outfile, "</td></tr>\n")
+            genout(outfile, "</td>")
+        genout(outfile, "</tr>\n")
         nextbit = fieldlsb + field.bits.width()
 
     genout(outfile, "</table>\n<br>\n")

--- a/util/reggen/html_helpers.py
+++ b/util/reggen/html_helpers.py
@@ -71,7 +71,7 @@ def _expand_paragraph(s, rnames):
     return ''.join(expanded_parts)
 
 
-def render_td(s, rnames, td_class):
+def render_td(s, rnames, td_class, close_td=True):
     '''Expand a description field and put it in a <td>.
 
     Returns a string. See _get_desc_paras for the format that gets expanded.
@@ -79,5 +79,5 @@ def render_td(s, rnames, td_class):
     '''
     desc_paras = expand_paras(s, rnames)
     class_attr = '' if td_class is None else ' class="{}"'.format(td_class)
-    return ('<td{}><p>{}</p></td>'
-            .format(class_attr, '</p><p>'.join(desc_paras)))
+    return ('<td{}><p>{}</p>{}'.format(class_attr, '</p><p>'.join(desc_paras),
+                                       "</td>" if close_td else ""))


### PR DESCRIPTION
Allow to not close the cell.
This makes it possible for the following structures to be included in
the same element.
Also remove an additional closing tag.

Currently it might look like this:
![2021-02-18-212340](https://user-images.githubusercontent.com/8666134/108422304-ab241080-7236-11eb-830b-194d65ccc584.png)

With the fix:
![2021-02-18-212355](https://user-images.githubusercontent.com/8666134/108422306-ac553d80-7236-11eb-8188-ae8eaa2d46a1.png)

I am not sure if that is the best looking solution, but it fixes the broken end of the tables.