### PR TITLE
[rv_dm] Update and fix lint warnings

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -65,7 +65,7 @@ module otbn_core_model
   localparam int ImemSizeWords = ImemSizeByte / 4;
   localparam int DmemSizeWords = DmemSizeByte / (WLEN / 8);
 
-  `ASSERT_INIT(StartAddr32_A, ImemAddrWidth <= 32);
+  `ASSERT_INIT(StartAddr32_A, ImemAddrWidth <= 32)
   logic [31:0] start_addr_32;
   assign start_addr_32 = {{32 - ImemAddrWidth{1'b0}}, start_addr_i};
 

--- a/hw/ip/rv_dm/lint/rv_dm.waiver
+++ b/hw/ip/rv_dm/lint/rv_dm.waiver
@@ -4,6 +4,15 @@
 #
 # waiver file for rv_dm lint
 
+# rv_dm
+waive -rules HIER_NET_NOT_READ -location {rv_dm.sv} -regexp {Net 'hartsel\[19:1\]' in module 'rv_dm'} \
+      -comment "These bits are not used since the system has only one hart."
+waive -rules IFDEF_CODE -location {rv_dm.sv} -regexp {DMIDirectTAP} \
+      -comment "That's fine."
+waive -rules CLOCK_MUX  -location {rv_dm.sv} \
+      -regexp {Clock 'tck_muxed' is driven by a multiplexer here, used as a clock} \
+      -comment "The signal is coming out of a prim_clock_mux2 block."
+
 # dmi_jtag_tap
 waive -rules CLOCK_MUX -location {dmi_jtag_tap.sv} -regexp {Clock 'tck_n' is driven by a multiplexer here, used as a clock at dmi_jtag_tap.sv} \
       -comment "This is permissible for now, but should be revised as soon as ASIC targets come into play."
@@ -27,6 +36,10 @@ waive -rules NOT_READ -location {dm_csrs.sv} -regexp {Signal 'dmcontrol.(clrrese
       -comment "These signals are not needed by dm_csrs module"
 waive -rules NOT_READ -location {dm_csrs.sv} -regexp {Signal 'a_abstractcs.(busy|datacount|progbufsize|zero[0-3])' is not read from} \
       -comment "These signals are not needed by dm_csrs module"
+waive -rules ARITH_CONTEXT -location {dm_csrs.sv} \
+      -regexp {Bitlength of arithmetic operation '{dm_csr_addr} - {dm::Data0}' is self-determined in this context} \
+      -comment "Values from the same enum can safely be subtracted."
+
 
 # dm_mem
 waive -rules INPUT_NOT_READ -location {dm_mem.sv} -regexp {Input port 'hartsel_i\[19:1\]' is not read from.*} \
@@ -37,14 +50,6 @@ waive -rules ONE_BRANCH    -location {dm_mem.sv} -regexp {unique case statement 
       -comment "easier to write this way for extendability"
 waive -rules NOT_READ -location {dm_mem.sv} -regexp {Signal 'ac_ar.(regno.13.|zero1)' is not read from in module 'dm_mem'} \
       -comment "These bits and fields are not used, but all other bits and fields are used"
-
-# tlul_adapter_host
-waive -rules HIER_BRANCH_NOT_READ -location {tlul_adapter_host.sv} -regexp {Net '(clk_i|rst_ni)' is not read from in module 'tlul_adapter_host'} \
-      -comment "These 2 signals are only used by assertions"
-waive -rules INPUT_NOT_READ       -location {tlul_adapter_host.sv} -regexp {Input port 'tl_i.d_(error|opcode|param|sink|size|source|user)' is not read from} \
-      -comment "Not all fields of response needed"
-waive -rules HIER_NET_NOT_READ -location {rv_dm.sv} -regexp {Connected net 'tl_i.d_(error|opcode|param|sink|size|source|user).*' at tlul_adapter_host.* is not read from} \
-      -comment "Not all fields of response needed"
 
 # dm_sba
 waive -rules HIER_BRANCH_NOT_READ  -location {dm_sba.sv}            -regexp {Net 'dmactive_i' is not read from in module 'dm_sba'} \
@@ -62,16 +67,8 @@ waive -rules INPUT_NOT_READ -location {debug_rom.sv} -regexp {Input port 'addr_i
 waive -rules HIER_NET_NOT_READ -location {dm_mem.sv} -regexp {Connected net 'addr_i.(2:0|31:8).' at debug_rom.sv} \
       -comment "These bits are not used, but the remaining address bits are used"
 
-# rv_dm
-waive -rules HIER_NET_NOT_READ -location {rv_dm.sv} -regexp {Net 'hartsel\[19:1\]' in module 'rv_dm'} \
-      -comment "These bits are not used since the system has only one hart."
 # dmi_jtag
 waive -rules HIER_NET_NOT_READ -location {dmi_jtag.sv} -regexp {Net 'dmi_resp.resp' is not read from in module 'dmi_jtag'} \
       -comment "This part of the struct is not read from within this module."
-# dmi_jtag
 waive -rules NOT_READ -location {dmi_jtag.sv} -regexp {Signal 'dmi_resp.resp' is not read from in module 'dmi_jtag'} \
       -comment "This part of the struct is not read from within this module."
-
-# tlul_adapter_host
-waive -rules INPUT_NOT_READ -location {tlul_adapter_host.sv} -regexp {Input port '(clk_i|rst_ni)' is not read from in module 'tlul_adapter_host'} \
-      -comment "The clock and reset signals are only used inside an assertion in this module"

--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -219,6 +219,9 @@ module rv_dm #(
   // DBG doesn't handle error responses so raise assertion if we see one
   `ASSERT(dbgNoErrorResponse, host_r_valid |-> !host_r_err)
 
+  logic unused_host_r_err;
+  assign unused_host_r_err = host_r_err;
+
   localparam int unsigned AddressWidthWords = BusWidth - $clog2(BusWidth/8);
 
   logic                         req;

--- a/hw/ip/rv_dm/rv_dm.core
+++ b/hw/ip/rv_dm/rv_dm.core
@@ -15,7 +15,7 @@ filesets:
       - lowrisc:prim:clock_mux2
       - lowrisc:tlul:adapter_host
       - pulp-platform:riscv-dbg:0.1
-      - lowrisc:ip:lc_ctrl_pkg
+      - lowrisc:prim:lc_sync
     files:
       - rtl/rv_dm.sv
     file_type: systemVerilogSource

--- a/hw/ip/tlul/lint/tlul_adapter_host.waiver
+++ b/hw/ip/tlul/lint/tlul_adapter_host.waiver
@@ -4,3 +4,11 @@
 #
 # waiver file for TLUL elements lint
 
+waive -rules {HIER_BRANCH_NOT_READ INPUT_NOT_READ} \
+      -location {tlul_adapter_host.sv} \
+      -regexp {'(clk_i|rst_ni)' is not read from} \
+      -comment "These 2 signals are only used by assertions"
+waive -rules {HIER_NET_NOT_READ INPUT_NOT_READ} \
+      -location {tlul_adapter_host.sv} \
+      -regexp {'tl_i.d_(error|opcode|param|sink|size|source|user)' is not read from} \
+      -comment "Not all fields of response needed"

--- a/hw/ip/tlul/rtl/tlul_adapter_host.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_host.sv
@@ -140,6 +140,6 @@ module tlul_adapter_host import tlul_pkg::*; #(
     end
   end
 
-  `ASSERT(DontExceeedMaxReqs, req_i |-> outstanding_reqs_d <= MAX_REQS);
+  `ASSERT(DontExceeedMaxReqs, req_i |-> outstanding_reqs_d <= MAX_REQS)
 `endif
 endmodule

--- a/hw/ip/tlul/rtl/tlul_assert.sv
+++ b/hw/ip/tlul/rtl/tlul_assert.sv
@@ -255,7 +255,7 @@ module tlul_assert #(
 
   initial begin : p_dbw
     // widths up to 64bit / 8 Byte are supported
-    `ASSERT_I(TlDbw_A, TL_DBW <= 8);
+    `ASSERT_I(TlDbw_A, TL_DBW <= 8)
   end
 
   // make sure all "pending" bits are 0 at the end of the sim

--- a/hw/vendor/patches/pulp_riscv_dbg/0001-Fix-various-lint-warnings.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0001-Fix-various-lint-warnings.patch
@@ -1,12 +1,67 @@
-From 50425c66be52b7d97071e285e6899ed4e33484f1 Mon Sep 17 00:00:00 2001
+From 50b4c6afc918c715a9884048e687d15801426cc1 Mon Sep 17 00:00:00 2001
 From: Michael Schaffner <msf@google.com>
 Date: Mon, 13 Jul 2020 19:25:04 -0700
-Subject: [PATCH 1/2] Style lint cleanup to make Verible lint happy
+Subject: [PATCH 1/2] Fix various lint warnings
+
+Fix style and width lint warnings emitted by Verible Lint and Verilator
+Lint.
+
+The debug rom has been regenerated from the assembly files with `make
+GCC=riscv32-unknown-elf-gcc OBJCOPY=riscv32-unknown-elf-objcopy
+OBJDUMP=riscv32-unknown-elf-objdump`.
 
 Signed-off-by: Michael Schaffner <msf@google.com>
+Signed-off-by: Philipp Wagner <phw@lowrisc.org>
 
+diff --git a/debug_rom/debug_rom.sv b/debug_rom/debug_rom.sv
+index a0e0208..0299db6 100644
+--- a/debug_rom/debug_rom.sv
++++ b/debug_rom/debug_rom.sv
+@@ -23,7 +23,8 @@ module debug_rom (
+ 
+   localparam int unsigned RomSize = 19;
+ 
+-  const logic [RomSize-1:0][63:0] mem = {
++  logic [RomSize-1:0][63:0] mem;
++  assign mem = {
+     64'h00000000_7b200073,
+     64'h7b202473_7b302573,
+     64'h10852423_f1402473,
+diff --git a/debug_rom/debug_rom_one_scratch.sv b/debug_rom/debug_rom_one_scratch.sv
+index 78d47be..af7e67c 100644
+--- a/debug_rom/debug_rom_one_scratch.sv
++++ b/debug_rom/debug_rom_one_scratch.sv
+@@ -23,7 +23,8 @@ module debug_rom_one_scratch (
+ 
+   localparam int unsigned RomSize = 13;
+ 
+-  const logic [RomSize-1:0][63:0] mem = {
++  logic [RomSize-1:0][63:0] mem;
++  assign mem = {
+     64'h00000000_7b200073,
+     64'h7b202473_10802423,
+     64'hf1402473_ab1ff06f,
+diff --git a/debug_rom/gen_rom.py b/debug_rom/gen_rom.py
+index b3ce019..b8cb60b 100755
+--- a/debug_rom/gen_rom.py
++++ b/debug_rom/gen_rom.py
+@@ -50,7 +50,8 @@ module $filename (
+ 
+   localparam int unsigned RomSize = $size;
+ 
+-  const logic [RomSize-1:0][63:0] mem = {
++  logic [RomSize-1:0][63:0] mem;
++  assign mem = {
+ $content
+   };
+ 
+@@ -131,4 +132,3 @@ with open(filename + ".sv", "w") as f:
+     f.write(license)
+     s = Template(module)
+     f.write(s.substitute(filename=filename, size=int(len(rom)/8), content=rom_str))
+-
 diff --git a/src/dm_csrs.sv b/src/dm_csrs.sv
-index 78fd32a..f131392 100644
+index 73722a3..4b0f254 100644
 --- a/src/dm_csrs.sv
 +++ b/src/dm_csrs.sv
 @@ -91,8 +91,8 @@ module dm_csrs #(
@@ -15,12 +70,109 @@ index 78fd32a..f131392 100644
  
 -  localparam dm::dm_csr_e DataEnd = dm::dm_csr_e'(dm::Data0 + {4'b0, dm::DataCount} - 8'h01);
 -  localparam dm::dm_csr_e ProgBufEnd = dm::dm_csr_e'(dm::ProgBuf0 + {4'b0, dm::ProgBufSize} - 8'h01);
-+  localparam dm::dm_csr_e DataEnd = dm::dm_csr_e'(dm::Data0 + {4'b0, dm::DataCount} - 8'h1);
-+  localparam dm::dm_csr_e ProgBufEnd = dm::dm_csr_e'(dm::ProgBuf0 + {4'b0, dm::ProgBufSize} - 8'h1);
++  localparam dm::dm_csr_e DataEnd = dm::dm_csr_e'(dm::Data0 + {4'h0, dm::DataCount} - 8'h1);
++  localparam dm::dm_csr_e ProgBufEnd = dm::dm_csr_e'(dm::ProgBuf0 + {4'h0, dm::ProgBufSize} - 8'h1);
  
    logic [31:0] haltsum0, haltsum1, haltsum2, haltsum3;
    logic [((NrHarts-1)/2**5 + 1) * 32 - 1 : 0] halted;
-@@ -521,7 +521,7 @@ module dm_csrs #(
+@@ -211,10 +211,18 @@ module dm_csrs #(
+   end
+ 
+   // helper variables
++  dm::dm_csr_e dm_csr_addr;
+   dm::sbcs_t sbcs;
+   dm::dmcontrol_t dmcontrol;
+   dm::abstractcs_t a_abstractcs;
+-  logic [4:0] autoexecdata_idx;
++  logic [3:0] autoexecdata_idx; // 0 == Data0 ... 11 == Data11
++
++  // Get the data index, i.e. 0 for dm::Data0 up to 11 for dm::Data11
++  assign dm_csr_addr = dm::dm_csr_e'({1'b0, dmi_req_i.addr});
++  // Xilinx Vivado 2020.1 does not allow subtraction of two enums; do the subtraction with logic
++  // types instead.
++  assign autoexecdata_idx = 4'({dm_csr_addr} - {dm::Data0});
++
+   always_comb begin : csr_read_write
+     // --------------------
+     // Static Values (R/O)
+@@ -271,7 +279,7 @@ module dm_csrs #(
+     sbaddr_d            = 64'(sbaddress_i);
+     sbdata_d            = sbdata_q;
+ 
+-    resp_queue_data         = 32'b0;
++    resp_queue_data         = 32'h0;
+     cmd_valid_d             = 1'b0;
+     sbaddress_write_valid_o = 1'b0;
+     sbdata_read_valid_o     = 1'b0;
+@@ -283,24 +291,17 @@ module dm_csrs #(
+     dmcontrol    = '0;
+     a_abstractcs = '0;
+ 
+-    autoexecdata_idx    = dmi_req_i.addr[4:0] - 5'(dm::Data0);
+-
+-    // localparam int unsigned DataCountAlign = $clog2(dm::DataCount);
+     // reads
+     if (dmi_req_ready_o && dmi_req_valid_i && dtm_op == dm::DTM_READ) begin
+-      unique case ({1'b0, dmi_req_i.addr}) inside
++      unique case (dm_csr_addr) inside
+         [(dm::Data0):DataEnd]: begin
+-          // logic [$clog2(dm::DataCount)-1:0] resp_queue_idx;
+-          // resp_queue_idx = dmi_req_i.addr[4:0] - int'(dm::Data0);
+           resp_queue_data = data_q[$clog2(dm::DataCount)'(autoexecdata_idx)];
+           if (!cmdbusy_i) begin
+             // check whether we need to re-execute the command (just give a cmd_valid)
+-            if (autoexecdata_idx < $bits(abstractauto_q.autoexecdata)) begin
+-              cmd_valid_d = abstractauto_q.autoexecdata[autoexecdata_idx];
+-            end
+-          //An abstract command was executing while one of the data registers was read
++            cmd_valid_d = abstractauto_q.autoexecdata[autoexecdata_idx];
++          // An abstract command was executing while one of the data registers was read
+           end else if (cmderr_q == dm::CmdErrNone) begin
+-              cmderr_d = dm::CmdErrBusy;
++            cmderr_d = dm::CmdErrBusy;
+           end
+         end
+         dm::DMControl:    resp_queue_data = dmcontrol_q;
+@@ -316,8 +317,8 @@ module dm_csrs #(
+             // check whether we need to re-execute the command (just give a cmd_valid)
+             // range of autoexecprogbuf is 31:16
+             cmd_valid_d = abstractauto_q.autoexecprogbuf[{1'b1, dmi_req_i.addr[3:0]}];
+-  
+-          //An abstract command was executing while one of the progbuf registers was read
++
++          // An abstract command was executing while one of the progbuf registers was read
+           end else if (cmderr_q == dm::CmdErrNone) begin
+             cmderr_d = dm::CmdErrBusy;
+           end
+@@ -358,16 +359,14 @@ module dm_csrs #(
+ 
+     // write
+     if (dmi_req_ready_o && dmi_req_valid_i && dtm_op == dm::DTM_WRITE) begin
+-      unique case (dm::dm_csr_e'({1'b0, dmi_req_i.addr})) inside
++      unique case (dm_csr_addr) inside
+         [(dm::Data0):DataEnd]: begin
+           if (dm::DataCount > 0) begin
+             // attempts to write them while busy is set does not change their value
+             if (!cmdbusy_i) begin
+               data_d[dmi_req_i.addr[$clog2(dm::DataCount)-1:0]] = dmi_req_i.data;
+               // check whether we need to re-execute the command (just give a cmd_valid)
+-              if (autoexecdata_idx < $bits(abstractauto_q.autoexecdata)) begin
+-                cmd_valid_d = abstractauto_q.autoexecdata[autoexecdata_idx];
+-              end
++              cmd_valid_d = abstractauto_q.autoexecdata[autoexecdata_idx];
+             //An abstract command was executing while one of the data registers was written
+             end else if (cmderr_q == dm::CmdErrNone) begin
+               cmderr_d = dm::CmdErrBusy;
+@@ -412,7 +411,7 @@ module dm_csrs #(
+         dm::AbstractAuto: begin
+           // this field can only be written legally when there is no command executing
+           if (!cmdbusy_i) begin
+-            abstractauto_d                 = 32'b0;
++            abstractauto_d                 = 32'h0;
+             abstractauto_d.autoexecdata    = 12'(dmi_req_i.data[dm::DataCount-1:0]);
+             abstractauto_d.autoexecprogbuf = 16'(dmi_req_i.data[dm::ProgBufSize-1+16:16]);
+           end else if (cmderr_q == dm::CmdErrNone) begin
+@@ -526,7 +525,7 @@ module dm_csrs #(
        dmcontrol_d.resumereq = 1'b0;
      end
      // static values for dcsr
@@ -29,8 +181,17 @@ index 78fd32a..f131392 100644
      sbcs_d.sbbusy               = sbbusy_i;
      sbcs_d.sbasize              = $bits(sbcs_d.sbasize)'(BusWidth);
      sbcs_d.sbaccess128          = 1'b0;
+@@ -543,7 +542,7 @@ module dm_csrs #(
+     // default assignment
+     haltreq_o = '0;
+     resumereq_o = '0;
+-    if (selected_hart < (HartSelLen+1)'(NrHarts)) begin
++    if (selected_hart <= HartSelLen'(NrHarts-1)) begin
+       haltreq_o[selected_hart]   = dmcontrol_q.haltreq;
+       resumereq_o[selected_hart] = dmcontrol_q.resumereq;
+     end
 diff --git a/src/dm_mem.sv b/src/dm_mem.sv
-index 6f0da5e..550b7cc 100755
+index 302998b..178259f 100755
 --- a/src/dm_mem.sv
 +++ b/src/dm_mem.sv
 @@ -336,7 +336,8 @@ module dm_mem #(
@@ -47,15 +208,15 @@ index 6f0da5e..550b7cc 100755
            end
          end else if (32'(ac_ar.aarsize) < MaxAar && ac_ar.transfer && !ac_ar.write) begin
            // store a0 in dscratch1
--          abstract_cmd[0][31:0]  = HasSndScratch ? dm::csrr(dm::CSR_DSCRATCH1, LoadBaseAddr) : dm::nop();
+-          abstract_cmd[0][31:0]  = HasSndScratch ? dm::csrw(dm::CSR_DSCRATCH1, LoadBaseAddr) : dm::nop();
 +          abstract_cmd[0][31:0]  = HasSndScratch ?
-+                                   dm::csrr(dm::CSR_DSCRATCH1, LoadBaseAddr) :
++                                   dm::csrw(dm::CSR_DSCRATCH1, LoadBaseAddr) :
 +                                   dm::nop();
            // this range is reserved
            if (ac_ar.regno[15:14] != '0) begin
                abstract_cmd[0][31:0] = dm::ebreak(); // we leave asap
 diff --git a/src/dm_obi_top.sv b/src/dm_obi_top.sv
-index 635f37e..190830c 100644
+index 2f7ee7a..b1906ec 100644
 --- a/src/dm_obi_top.sv
 +++ b/src/dm_obi_top.sv
 @@ -61,42 +61,48 @@
@@ -82,12 +243,13 @@ index 635f37e..190830c 100644
 -  output logic                  dmactive_o,                             // debug module is active
 -  output logic [NrHarts-1:0]    debug_req_o,                            // async debug request
 -  input  logic [NrHarts-1:0]    unavailable_i,                          // communicate whether the hart is unavailable (e.g.: power down)
+-  input  dm::hartinfo_t [NrHarts-1:0] hartinfo_i,
 +  output logic                  ndmreset_o,      // non-debug module reset
 +  output logic                  dmactive_o,      // debug module is active
 +  output logic [NrHarts-1:0]    debug_req_o,     // async debug request
 +  // communicate whether the hart is unavailable (e.g.: power down)
 +  input  logic [NrHarts-1:0]    unavailable_i,
-   dm::hartinfo_t [NrHarts-1:0]  hartinfo_i,
++  input  dm::hartinfo_t [NrHarts-1:0]  hartinfo_i,
  
    input  logic                  slave_req_i,
 -  output logic                  slave_gnt_o,                            // OBI grant for slave_req_i (not present on dm_top)
@@ -161,10 +323,10 @@ index 635f37e..190830c 100644
    assign slave_rid_o = slave_rid_q;
  
 diff --git a/src/dm_pkg.sv b/src/dm_pkg.sv
-index de75c3e..1b7d0f5 100644
+index dbbc031..971f128 100644
 --- a/src/dm_pkg.sv
 +++ b/src/dm_pkg.sv
-@@ -201,7 +201,7 @@ package dm;
+@@ -215,7 +215,7 @@ package dm;
      logic         sbaccess8;
    } sbcs_t;
  
@@ -174,33 +336,47 @@ index de75c3e..1b7d0f5 100644
    typedef struct packed {
      logic [6:0]  addr;
 diff --git a/src/dm_sba.sv b/src/dm_sba.sv
-index f605088..c97f956 100644
+index 8f98cdc..98c586c 100644
 --- a/src/dm_sba.sv
 +++ b/src/dm_sba.sv
-@@ -104,7 +104,7 @@ module dm_sba #(
-             be[int'({be_idx[$high(be_idx):1], 1'b0}) +: 2] = '1;
-           end
-           3'b010: begin
--            if (BusWidth == 32'd64) be[int'({be_idx[$high(be_idx)], 2'b0}) +: 4] = '1;
-+            if (BusWidth == 32'd64) be[int'({be_idx[$high(be_idx)], 2'h0}) +: 4] = '1;
-             else                    be = '1;
-           end
-           3'b011: be = '1;
-@@ -117,7 +117,7 @@ module dm_sba #(
-         if (sbdata_valid_o) begin
-           state_d = Idle;
-           // auto-increment address
--          if (sbautoincrement_i) sbaddress_o = sbaddress_i + (32'b1 << sbaccess_i);
-+          if (sbautoincrement_i) sbaddress_o = sbaddress_i + (32'h1 << sbaccess_i);
-         end
+@@ -77,7 +77,7 @@ module dm_sba #(
+         be_mask[int'({be_idx[$high(be_idx):1], 1'b0}) +: 2] = '1;
        end
- 
+       3'b010: begin
+-        if (BusWidth == 32'd64) be_mask[int'({be_idx[$high(be_idx)], 2'b0}) +: 4] = '1;
++        if (BusWidth == 32'd64) be_mask[int'({be_idx[$high(be_idx)], 2'h0}) +: 4] = '1;
+         else                    be_mask = '1;
+       end
+       3'b011: be_mask = '1;
 @@ -125,7 +125,7 @@ module dm_sba #(
          if (sbdata_valid_o) begin
-           state_d = Idle;
+           state_d = dm::Idle;
            // auto-increment address
 -          if (sbautoincrement_i) sbaddress_o = sbaddress_i + (32'b1 << sbaccess_i);
 +          if (sbautoincrement_i) sbaddress_o = sbaddress_i + (32'h1 << sbaccess_i);
          end
        end
  
+@@ -133,7 +133,7 @@ module dm_sba #(
+         if (sbdata_valid_o) begin
+           state_d = dm::Idle;
+           // auto-increment address
+-          if (sbautoincrement_i) sbaddress_o = sbaddress_i + (32'b1 << sbaccess_i);
++          if (sbautoincrement_i) sbaddress_o = sbaddress_i + (32'h1 << sbaccess_i);
+         end
+       end
+ 
+diff --git a/tb/boot_rom.sv b/tb/boot_rom.sv
+index 3610af4..7c214d9 100644
+--- a/tb/boot_rom.sv
++++ b/tb/boot_rom.sv
+@@ -20,7 +20,8 @@ module boot_rom (
+     localparam int          RomSize    = 2;
+     localparam logic [31:0] entry_addr = 32'h1c00_0080;
+ 
+-    const logic [RomSize-1:0][31:0] mem = {
++    logic [RomSize-1:0][31:0] mem;
++    assign mem = {
+         dm_tb_pkg::jalr(5'h0, 5'h1, entry_addr[11:0]),
+         dm_tb_pkg::lui(5'h1, entry_addr[31:12])
+     };

--- a/hw/vendor/patches/pulp_riscv_dbg/0002-Use-lowrisc-instead-of-PULP-primitives.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0002-Use-lowrisc-instead-of-PULP-primitives.patch
@@ -1,4 +1,4 @@
-From c9bb351a0d0f915b0f66cf0bee38afedbea3c02c Mon Sep 17 00:00:00 2001
+From 433e1909f3775ea6a742d8b461d1ff1223c8ef46 Mon Sep 17 00:00:00 2001
 From: Philipp Wagner <phw@lowrisc.org>
 Date: Fri, 22 Feb 2019 14:48:46 +0000
 Subject: [PATCH 2/2] Use lowrisc instead of PULP primitives
@@ -6,7 +6,7 @@ Subject: [PATCH 2/2] Use lowrisc instead of PULP primitives
 Signed-off-by: Michael Schaffner <msf@google.com>
 
 diff --git a/src/dm_csrs.sv b/src/dm_csrs.sv
-index f131392..e4698eb 100644
+index 4b0f254..8f12ac4 100644
 --- a/src/dm_csrs.sv
 +++ b/src/dm_csrs.sv
 @@ -78,6 +78,7 @@ module dm_csrs #(
@@ -27,7 +27,7 @@ index f131392..e4698eb 100644
 -  logic        resp_queue_pop;
    logic [31:0] resp_queue_data;
  
-   localparam dm::dm_csr_e DataEnd = dm::dm_csr_e'(dm::Data0 + {4'b0, dm::DataCount} - 8'h1);
+   localparam dm::dm_csr_e DataEnd = dm::dm_csr_e'(dm::Data0 + {4'h0, dm::DataCount} - 8'h1);
 @@ -180,9 +177,6 @@ module dm_csrs #(
  
    // a successful response returns zero
@@ -38,7 +38,7 @@ index f131392..e4698eb 100644
    // SBA
    assign sbautoincrement_o = sbcs_q.sbautoincrement;
    assign sbreadonaddr_o    = sbcs_q.sbreadonaddr;
-@@ -550,27 +544,28 @@ module dm_csrs #(
+@@ -554,27 +548,28 @@ module dm_csrs #(
    assign progbuf_o   = progbuf_q;
    assign data_o      = data_q;
  
@@ -156,7 +156,7 @@ index 4665c91..1299b09 100644
  
  endmodule : dmi_cdc
 diff --git a/src/dmi_jtag_tap.sv b/src/dmi_jtag_tap.sv
-index 3d11145..94b51d6 100644
+index c2e8d6e..5f10e6c 100644
 --- a/src/dmi_jtag_tap.sv
 +++ b/src/dmi_jtag_tap.sv
 @@ -216,18 +216,14 @@ module dmi_jtag_tap #(

--- a/hw/vendor/pulp_riscv_dbg.lock.hjson
+++ b/hw/vendor/pulp_riscv_dbg.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/pulp-platform/riscv-dbg
-    rev: 834853c0c68fc48d032a3e256e563f2b0bd28492
+    rev: e67a0a79e9268c13c4232fc2887692404d75a069
   }
 }

--- a/hw/vendor/pulp_riscv_dbg/Bender.yml
+++ b/hw/vendor/pulp_riscv_dbg/Bender.yml
@@ -5,7 +5,7 @@ sources:
   files:
     - src/dm_pkg.sv
     - debug_rom/debug_rom.sv
-    - debug_rom/debug_rom_snd_scratch.sv
+    - debug_rom/debug_rom_one_scratch.sv
     - src/dm_csrs.sv
     - src/dm_mem.sv
     - src/dm_top.sv

--- a/hw/vendor/pulp_riscv_dbg/CHANGELOG.md
+++ b/hw/vendor/pulp_riscv_dbg/CHANGELOG.md
@@ -5,18 +5,36 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
+### Changed
+### Fixed
+
+## [0.4.0] - 2020-11-06
+### Added
+- Added parameter ReadByteEnable that may be disabled to revert SBA _be_ behavior to 0 on reads
 - Optional wrapper `dm_obi_top.sv` that wraps `dm_top` providing an OBI compliant interface
 - `tb` that runs dm in conjunction with ri5cy and OpenOCD
 - `.travis-ci.yml` running `tb` with verilator
 
 ### Changed
-- Made second scratch register optional (default is two) from [@zarubaf](https://github.com/zarubaf
+- Made second scratch register optional (default is two) from [@zarubaf](https://github.com/zarubaf)
+- Use latest version of CV32E40P in testbench (#82) [@Silabs-ArjanB](https://github.com/Silabs-ArjanB)
+- Move assertions into separate module (#82) [@Silabs-ArjanB](https://github.com/Silabs-ArjanB)
 
 ### Fixed
+- Fix for SBA _be_ when reading to match the request size from (#70) [@jm4rtin](https://github.com/jm4rtin)
 - Off-by-one error in data and progbuf end address from [@pbing](https://github.com/pbing)
 - Haltsum1-3 calculation
+- A DMI read of SBAddress0 andSBAddress0 will (wrongly) trigger SBBUSYERROR when
+  the system bus master is busy (#93) [@Silabs-ArjanB](https://github.com/Silabs-ArjanB)
+- When the two scratch mode is being used, a0 was loaded instead of saved into
+  scratch1 (#90) [@Silabs-ArjanB](https://github.com/Silabs-ArjanB)
+- dmireset can be accidentally triggered (#89) [@Silabs-ArjanB](https://github.com/Silabs-ArjanB)
+- enumeration lint issue in ProgBuf (#84) [@Silabs-ArjanB](https://github.com/Silabs-ArjanB)
+- Fix faulty assertion because of bad `hartinfo_i` in testbench (#82)
+  [@Silabs-ArjanB](https://github.com/Silabs-ArjanB)
+- Return `CmdErrBusy` if accessing data or progbuf while command was executing
+  (#79) [@noytzach](https://github.com/noytzach)
 
 ## [0.3.0] - 2020-01-23
 

--- a/hw/vendor/pulp_riscv_dbg/debug_rom/debug_rom.sv
+++ b/hw/vendor/pulp_riscv_dbg/debug_rom/debug_rom.sv
@@ -23,7 +23,8 @@ module debug_rom (
 
   localparam int unsigned RomSize = 19;
 
-  const logic [RomSize-1:0][63:0] mem = {
+  logic [RomSize-1:0][63:0] mem;
+  assign mem = {
     64'h00000000_7b200073,
     64'h7b202473_7b302573,
     64'h10852423_f1402473,

--- a/hw/vendor/pulp_riscv_dbg/debug_rom/debug_rom_one_scratch.sv
+++ b/hw/vendor/pulp_riscv_dbg/debug_rom/debug_rom_one_scratch.sv
@@ -23,7 +23,8 @@ module debug_rom_one_scratch (
 
   localparam int unsigned RomSize = 13;
 
-  const logic [RomSize-1:0][63:0] mem = {
+  logic [RomSize-1:0][63:0] mem;
+  assign mem = {
     64'h00000000_7b200073,
     64'h7b202473_10802423,
     64'hf1402473_ab1ff06f,

--- a/hw/vendor/pulp_riscv_dbg/debug_rom/gen_rom.py
+++ b/hw/vendor/pulp_riscv_dbg/debug_rom/gen_rom.py
@@ -50,7 +50,8 @@ module $filename (
 
   localparam int unsigned RomSize = $size;
 
-  const logic [RomSize-1:0][63:0] mem = {
+  logic [RomSize-1:0][63:0] mem;
+  assign mem = {
 $content
   };
 
@@ -131,4 +132,3 @@ with open(filename + ".sv", "w") as f:
     f.write(license)
     s = Template(module)
     f.write(s.substitute(filename=filename, size=int(len(rom)/8), content=rom_str))
-

--- a/hw/vendor/pulp_riscv_dbg/src/dm_csrs.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dm_csrs.sv
@@ -88,8 +88,8 @@ module dm_csrs #(
 
   logic [31:0] resp_queue_data;
 
-  localparam dm::dm_csr_e DataEnd = dm::dm_csr_e'(dm::Data0 + {4'b0, dm::DataCount} - 8'h1);
-  localparam dm::dm_csr_e ProgBufEnd = dm::dm_csr_e'(dm::ProgBuf0 + {4'b0, dm::ProgBufSize} - 8'h1);
+  localparam dm::dm_csr_e DataEnd = dm::dm_csr_e'(dm::Data0 + {4'h0, dm::DataCount} - 8'h1);
+  localparam dm::dm_csr_e ProgBufEnd = dm::dm_csr_e'(dm::ProgBuf0 + {4'h0, dm::ProgBufSize} - 8'h1);
 
   logic [31:0] haltsum0, haltsum1, haltsum2, haltsum3;
   logic [((NrHarts-1)/2**5 + 1) * 32 - 1 : 0] halted;
@@ -205,10 +205,18 @@ module dm_csrs #(
   end
 
   // helper variables
+  dm::dm_csr_e dm_csr_addr;
   dm::sbcs_t sbcs;
   dm::dmcontrol_t dmcontrol;
   dm::abstractcs_t a_abstractcs;
-  logic [4:0] autoexecdata_idx;
+  logic [3:0] autoexecdata_idx; // 0 == Data0 ... 11 == Data11
+
+  // Get the data index, i.e. 0 for dm::Data0 up to 11 for dm::Data11
+  assign dm_csr_addr = dm::dm_csr_e'({1'b0, dmi_req_i.addr});
+  // Xilinx Vivado 2020.1 does not allow subtraction of two enums; do the subtraction with logic
+  // types instead.
+  assign autoexecdata_idx = 4'({dm_csr_addr} - {dm::Data0});
+
   always_comb begin : csr_read_write
     // --------------------
     // Static Values (R/O)
@@ -265,7 +273,7 @@ module dm_csrs #(
     sbaddr_d            = 64'(sbaddress_i);
     sbdata_d            = sbdata_q;
 
-    resp_queue_data         = 32'b0;
+    resp_queue_data         = 32'h0;
     cmd_valid_d             = 1'b0;
     sbaddress_write_valid_o = 1'b0;
     sbdata_read_valid_o     = 1'b0;
@@ -277,21 +285,17 @@ module dm_csrs #(
     dmcontrol    = '0;
     a_abstractcs = '0;
 
-    autoexecdata_idx    = dmi_req_i.addr[4:0] - 5'(dm::Data0);
-
-    // localparam int unsigned DataCountAlign = $clog2(dm::DataCount);
     // reads
     if (dmi_req_ready_o && dmi_req_valid_i && dtm_op == dm::DTM_READ) begin
-      unique case ({1'b0, dmi_req_i.addr}) inside
+      unique case (dm_csr_addr) inside
         [(dm::Data0):DataEnd]: begin
-          // logic [$clog2(dm::DataCount)-1:0] resp_queue_idx;
-          // resp_queue_idx = dmi_req_i.addr[4:0] - int'(dm::Data0);
           resp_queue_data = data_q[$clog2(dm::DataCount)'(autoexecdata_idx)];
           if (!cmdbusy_i) begin
             // check whether we need to re-execute the command (just give a cmd_valid)
-            if (autoexecdata_idx < $bits(abstractauto_q.autoexecdata)) begin
-              cmd_valid_d = abstractauto_q.autoexecdata[autoexecdata_idx];
-            end
+            cmd_valid_d = abstractauto_q.autoexecdata[autoexecdata_idx];
+          // An abstract command was executing while one of the data registers was read
+          end else if (cmderr_q == dm::CmdErrNone) begin
+            cmderr_d = dm::CmdErrBusy;
           end
         end
         dm::DMControl:    resp_queue_data = dmcontrol_q;
@@ -307,6 +311,10 @@ module dm_csrs #(
             // check whether we need to re-execute the command (just give a cmd_valid)
             // range of autoexecprogbuf is 31:16
             cmd_valid_d = abstractauto_q.autoexecprogbuf[{1'b1, dmi_req_i.addr[3:0]}];
+
+          // An abstract command was executing while one of the progbuf registers was read
+          end else if (cmderr_q == dm::CmdErrNone) begin
+            cmderr_d = dm::CmdErrBusy;
           end
         end
         dm::HaltSum0: resp_queue_data = haltsum0;
@@ -317,24 +325,14 @@ module dm_csrs #(
           resp_queue_data = sbcs_q;
         end
         dm::SBAddress0: begin
-          // access while the SBA was busy
-          if (sbbusy_i) begin
-            sbcs_d.sbbusyerror = 1'b1;
-          end else begin
-            resp_queue_data = sbaddr_q[31:0];
-          end
+          resp_queue_data = sbaddr_q[31:0];
         end
         dm::SBAddress1: begin
-          // access while the SBA was busy
-          if (sbbusy_i) begin
-            sbcs_d.sbbusyerror = 1'b1;
-          end else begin
-            resp_queue_data = sbaddr_q[63:32];
-          end
+          resp_queue_data = sbaddr_q[63:32];
         end
         dm::SBData0: begin
           // access while the SBA was busy
-          if (sbbusy_i) begin
+          if (sbbusy_i || sbcs_q.sbbusyerror) begin
             sbcs_d.sbbusyerror = 1'b1;
           end else begin
             sbdata_read_valid_o = (sbcs_q.sberror == '0);
@@ -343,7 +341,7 @@ module dm_csrs #(
         end
         dm::SBData1: begin
           // access while the SBA was busy
-          if (sbbusy_i) begin
+          if (sbbusy_i || sbcs_q.sbbusyerror) begin
             sbcs_d.sbbusyerror = 1'b1;
           end else begin
             resp_queue_data = sbdata_q[63:32];
@@ -355,14 +353,17 @@ module dm_csrs #(
 
     // write
     if (dmi_req_ready_o && dmi_req_valid_i && dtm_op == dm::DTM_WRITE) begin
-      unique case (dm::dm_csr_e'({1'b0, dmi_req_i.addr})) inside
+      unique case (dm_csr_addr) inside
         [(dm::Data0):DataEnd]: begin
-          // attempts to write them while busy is set does not change their value
-          if (!cmdbusy_i && dm::DataCount > 0) begin
-            data_d[dmi_req_i.addr[$clog2(dm::DataCount)-1:0]] = dmi_req_i.data;
-            // check whether we need to re-execute the command (just give a cmd_valid)
-            if (autoexecdata_idx < $bits(abstractauto_q.autoexecdata)) begin
+          if (dm::DataCount > 0) begin
+            // attempts to write them while busy is set does not change their value
+            if (!cmdbusy_i) begin
+              data_d[dmi_req_i.addr[$clog2(dm::DataCount)-1:0]] = dmi_req_i.data;
+              // check whether we need to re-execute the command (just give a cmd_valid)
               cmd_valid_d = abstractauto_q.autoexecdata[autoexecdata_idx];
+            //An abstract command was executing while one of the data registers was written
+            end else if (cmderr_q == dm::CmdErrNone) begin
+              cmderr_d = dm::CmdErrBusy;
             end
           end
         end
@@ -404,7 +405,7 @@ module dm_csrs #(
         dm::AbstractAuto: begin
           // this field can only be written legally when there is no command executing
           if (!cmdbusy_i) begin
-            abstractauto_d                 = 32'b0;
+            abstractauto_d                 = 32'h0;
             abstractauto_d.autoexecdata    = 12'(dmi_req_i.data[dm::DataCount-1:0]);
             abstractauto_d.autoexecprogbuf = 16'(dmi_req_i.data[dm::ProgBufSize-1+16:16]);
           end else if (cmderr_q == dm::CmdErrNone) begin
@@ -420,6 +421,9 @@ module dm_csrs #(
             // was busy
             // range of autoexecprogbuf is 31:16
             cmd_valid_d = abstractauto_q.autoexecprogbuf[{1'b1, dmi_req_i.addr[3:0]}];
+          //An abstract command was executing while one of the progbuf registers was written
+          end else if (cmderr_q == dm::CmdErrNone) begin
+            cmderr_d = dm::CmdErrBusy;
           end
         end
         dm::SBCS: begin
@@ -436,7 +440,7 @@ module dm_csrs #(
         end
         dm::SBAddress0: begin
           // access while the SBA was busy
-          if (sbbusy_i) begin
+          if (sbbusy_i || sbcs_q.sbbusyerror) begin
             sbcs_d.sbbusyerror = 1'b1;
           end else begin
             sbaddr_d[31:0] = dmi_req_i.data;
@@ -445,7 +449,7 @@ module dm_csrs #(
         end
         dm::SBAddress1: begin
           // access while the SBA was busy
-          if (sbbusy_i) begin
+          if (sbbusy_i || sbcs_q.sbbusyerror) begin
             sbcs_d.sbbusyerror = 1'b1;
           end else begin
             sbaddr_d[63:32] = dmi_req_i.data;
@@ -453,7 +457,7 @@ module dm_csrs #(
         end
         dm::SBData0: begin
           // access while the SBA was busy
-          if (sbbusy_i) begin
+          if (sbbusy_i || sbcs_q.sbbusyerror) begin
            sbcs_d.sbbusyerror = 1'b1;
           end else begin
             sbdata_d[31:0] = dmi_req_i.data;
@@ -462,7 +466,7 @@ module dm_csrs #(
         end
         dm::SBData1: begin
           // access while the SBA was busy
-          if (sbbusy_i) begin
+          if (sbbusy_i || sbcs_q.sbbusyerror) begin
            sbcs_d.sbbusyerror = 1'b1;
           end else begin
             sbdata_d[63:32] = dmi_req_i.data;
@@ -532,7 +536,7 @@ module dm_csrs #(
     // default assignment
     haltreq_o = '0;
     resumereq_o = '0;
-    if (selected_hart < (HartSelLen+1)'(NrHarts)) begin
+    if (selected_hart <= HartSelLen'(NrHarts-1)) begin
       haltreq_o[selected_hart]   = dmcontrol_q.haltreq;
       resumereq_o[selected_hart] = dmcontrol_q.resumereq;
     end
@@ -624,20 +628,5 @@ module dm_csrs #(
       end
     end
   end
-
-  ///////////////////////////////////////////////////////
-  // assertions
-  ///////////////////////////////////////////////////////
-
-  //pragma translate_off
-  `ifndef VERILATOR
-  haltsum: assert property (
-      @(posedge clk_i) disable iff (!rst_ni)
-          (dmi_req_ready_o && dmi_req_valid_i && dtm_op == dm::DTM_READ) |->
-              !({1'b0, dmi_req_i.addr} inside
-                  {dm::HaltSum0, dm::HaltSum1, dm::HaltSum2, dm::HaltSum3}))
-      else $warning("Haltsums have not been properly tested yet.");
-  `endif
-  //pragma translate_on
 
 endmodule : dm_csrs

--- a/hw/vendor/pulp_riscv_dbg/src/dm_mem.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dm_mem.sv
@@ -355,7 +355,7 @@ module dm_mem #(
       dm::AccessRegister: begin
         if (32'(ac_ar.aarsize) < MaxAar && ac_ar.transfer && ac_ar.write) begin
           // store a0 in dscratch1
-          abstract_cmd[0][31:0] = HasSndScratch ? dm::csrr(dm::CSR_DSCRATCH1, 5'd10) : dm::nop();
+          abstract_cmd[0][31:0] = HasSndScratch ? dm::csrw(dm::CSR_DSCRATCH1, 5'd10) : dm::nop();
           // this range is reserved
           if (ac_ar.regno[15:14] != '0) begin
             abstract_cmd[0][31:0] = dm::ebreak(); // we leave asap
@@ -397,7 +397,7 @@ module dm_mem #(
         end else if (32'(ac_ar.aarsize) < MaxAar && ac_ar.transfer && !ac_ar.write) begin
           // store a0 in dscratch1
           abstract_cmd[0][31:0]  = HasSndScratch ?
-                                   dm::csrr(dm::CSR_DSCRATCH1, LoadBaseAddr) :
+                                   dm::csrw(dm::CSR_DSCRATCH1, LoadBaseAddr) :
                                    dm::nop();
           // this range is reserved
           if (ac_ar.regno[15:14] != '0) begin

--- a/hw/vendor/pulp_riscv_dbg/src/dm_obi_top.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dm_obi_top.sv
@@ -78,7 +78,7 @@ module dm_obi_top #(
   output logic [NrHarts-1:0]    debug_req_o,     // async debug request
   // communicate whether the hart is unavailable (e.g.: power down)
   input  logic [NrHarts-1:0]    unavailable_i,
-  dm::hartinfo_t [NrHarts-1:0]  hartinfo_i,
+  input  dm::hartinfo_t [NrHarts-1:0]  hartinfo_i,
 
   input  logic                  slave_req_i,
   // OBI grant for slave_req_i (not present on dm_top)

--- a/hw/vendor/pulp_riscv_dbg/src/dm_pkg.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dm_pkg.sv
@@ -62,6 +62,20 @@ package dm;
     DevTreeAddr3 = 8'h1C,
     NextDM       = 8'h1D,
     ProgBuf0     = 8'h20,
+    ProgBuf1     = 8'h21,
+    ProgBuf2     = 8'h22,
+    ProgBuf3     = 8'h23,
+    ProgBuf4     = 8'h24,
+    ProgBuf5     = 8'h25,
+    ProgBuf6     = 8'h26,
+    ProgBuf7     = 8'h27,
+    ProgBuf8     = 8'h28,
+    ProgBuf9     = 8'h29,
+    ProgBuf10    = 8'h2A,
+    ProgBuf11    = 8'h2B,
+    ProgBuf12    = 8'h2C,
+    ProgBuf13    = 8'h2D,
+    ProgBuf14    = 8'h2E,
     ProgBuf15    = 8'h2F,
     AuthData     = 8'h30,
     HaltSum2     = 8'h34,
@@ -300,6 +314,14 @@ package dm;
     CSR_INSTRET        = 12'hC02
   } csr_reg_t;
 
+  // SBA state
+  typedef enum logic [2:0] {
+    Idle,
+    Read,
+    Write,
+    WaitRead,
+    WaitWrite
+  } sba_state_e;
 
   // Instruction Generation Helpers
   function automatic logic [31:0] jal (logic [4:0]  rd,

--- a/hw/vendor/pulp_riscv_dbg/src/dm_sba.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dm_sba.sv
@@ -16,7 +16,8 @@
 *
 */
 module dm_sba #(
-  parameter int unsigned BusWidth = 32
+  parameter int unsigned BusWidth = 32,
+  parameter bit          ReadByteEnable = 1
 ) (
   input  logic                   clk_i,       // Clock
   input  logic                   rst_ni,
@@ -52,17 +53,37 @@ module dm_sba #(
   output logic [2:0]             sberror_o // bus error occurred
 );
 
-  typedef enum logic [2:0] { Idle, Read, Write, WaitRead, WaitWrite } state_e;
-  state_e state_d, state_q;
+  dm::sba_state_e state_d, state_q;
 
   logic [BusWidth-1:0]           address;
   logic                          req;
   logic                          gnt;
   logic                          we;
   logic [BusWidth/8-1:0]         be;
+  logic [BusWidth/8-1:0]         be_mask;
   logic [$clog2(BusWidth/8)-1:0] be_idx;
 
-  assign sbbusy_o = logic'(state_q != Idle);
+  assign sbbusy_o = logic'(state_q != dm::Idle);
+
+  always_comb begin : p_be_mask
+    be_mask = '0;
+
+    // generate byte enable mask
+    unique case (sbaccess_i)
+      3'b000: begin
+        be_mask[be_idx] = '1;
+      end
+      3'b001: begin
+        be_mask[int'({be_idx[$high(be_idx):1], 1'b0}) +: 2] = '1;
+      end
+      3'b010: begin
+        if (BusWidth == 32'd64) be_mask[int'({be_idx[$high(be_idx)], 2'h0}) +: 4] = '1;
+        else                    be_mask = '1;
+      end
+      3'b011: be_mask = '1;
+      default: ;
+    endcase
+  end
 
   always_comb begin : p_fsm
     req     = 1'b0;
@@ -78,64 +99,51 @@ module dm_sba #(
     state_d = state_q;
 
     unique case (state_q)
-      Idle: begin
+      dm::Idle: begin
         // debugger requested a read
-        if (sbaddress_write_valid_i && sbreadonaddr_i)  state_d = Read;
+        if (sbaddress_write_valid_i && sbreadonaddr_i)  state_d = dm::Read;
         // debugger requested a write
-        if (sbdata_write_valid_i) state_d = Write;
+        if (sbdata_write_valid_i) state_d = dm::Write;
         // perform another read
-        if (sbdata_read_valid_i && sbreadondata_i) state_d = Read;
+        if (sbdata_read_valid_i && sbreadondata_i) state_d = dm::Read;
       end
 
-      Read: begin
+      dm::Read: begin
         req = 1'b1;
-        if (gnt) state_d = WaitRead;
+        if (ReadByteEnable) be = be_mask;
+        if (gnt) state_d = dm::WaitRead;
       end
 
-      Write: begin
+      dm::Write: begin
         req = 1'b1;
         we  = 1'b1;
-        // generate byte enable mask
-        unique case (sbaccess_i)
-          3'b000: begin
-            be[be_idx] = '1;
-          end
-          3'b001: begin
-            be[int'({be_idx[$high(be_idx):1], 1'b0}) +: 2] = '1;
-          end
-          3'b010: begin
-            if (BusWidth == 32'd64) be[int'({be_idx[$high(be_idx)], 2'h0}) +: 4] = '1;
-            else                    be = '1;
-          end
-          3'b011: be = '1;
-          default: ;
-        endcase
-        if (gnt) state_d = WaitWrite;
+        be = be_mask;
+        if (gnt) state_d = dm::WaitWrite;
       end
 
-      WaitRead: begin
+      dm::WaitRead: begin
         if (sbdata_valid_o) begin
-          state_d = Idle;
+          state_d = dm::Idle;
           // auto-increment address
           if (sbautoincrement_i) sbaddress_o = sbaddress_i + (32'h1 << sbaccess_i);
         end
       end
 
-      WaitWrite: begin
+      dm::WaitWrite: begin
         if (sbdata_valid_o) begin
-          state_d = Idle;
+          state_d = dm::Idle;
           // auto-increment address
           if (sbautoincrement_i) sbaddress_o = sbaddress_i + (32'h1 << sbaccess_i);
         end
       end
 
-      default: state_d = Idle; // catch parasitic state
+      default: state_d = dm::Idle; // catch parasitic state
     endcase
 
     // handle error case
-    if (sbaccess_i > 3 && state_q != Idle) begin
+    if (sbaccess_i > 3 && state_q != dm::Idle) begin
       req             = 1'b0;
-      state_d         = Idle;
+      state_d         = dm::Idle;
       sberror_valid_o = 1'b1;
       sberror_o       = 3'd3;
     end
@@ -144,7 +152,7 @@ module dm_sba #(
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
     if (!rst_ni) begin
-      state_q <= Idle;
+      state_q <= dm::Idle;
     end else begin
       state_q <= state_d;
     end
@@ -158,15 +166,5 @@ module dm_sba #(
   assign gnt             = master_gnt_i;
   assign sbdata_valid_o  = master_r_valid_i;
   assign sbdata_o        = master_r_rdata_i[BusWidth-1:0];
-
-
-  //pragma translate_off
-  `ifndef VERILATOR
-    // maybe bump severity to $error if not handled at runtime
-    dm_sba_access_size: assert property(@(posedge clk_i) disable iff (dmactive_i !== 1'b0)
-        (state_d != Idle) |-> (sbaccess_i < 4))
-            else $warning ("accesses > 8 byte not supported at the moment");
-  `endif
-  //pragma translate_on
 
 endmodule : dm_sba

--- a/hw/vendor/pulp_riscv_dbg/src/dmi_jtag.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dmi_jtag.sv
@@ -131,8 +131,15 @@ module dmi_jtag #(
 
       Write: begin
         dmi_req_valid = 1'b1;
-        // got a valid answer go back to idle
+        // request sent, wait for response before going back to idle
         if (dmi_req_ready) begin
+          state_d = WaitWriteValid;
+        end
+      end
+
+      WaitWriteValid: begin
+        // got a valid answer go back to idle
+        if (dmi_resp_valid) begin
           state_d = Idle;
         end
       end
@@ -162,7 +169,7 @@ module dmi_jtag #(
       error_d = DMIBusy;
     end
     // clear sticky error flag
-    if (dmi_reset && dtmcs_select) begin
+    if (update_dr && dmi_reset && dtmcs_select) begin
       error_d = DMINoError;
     end
   end

--- a/hw/vendor/pulp_riscv_dbg/src/dmi_jtag_tap.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dmi_jtag_tap.sv
@@ -156,7 +156,7 @@ module dmi_jtag_tap #(
                       dmireset     : 1'b0,
                       zero0        : '0,
                       idle         : 3'd1, // 1: Enter Run-Test/Idle and leave it immediately
-                      dmistat      : dmi_error_i, // 0: No error, 1: Op failed, 2: too fast
+                      dmistat      : dmi_error_i, // 0: No error, 2: Op failed, 3: too fast
                       abits        : 6'd7, // The size of address in dmi
                       version      : 4'd1  // Version described in spec version 0.13 (and later?)
                     };

--- a/hw/vendor/pulp_riscv_dbg/sva/dm_csrs_sva.sv
+++ b/hw/vendor/pulp_riscv_dbg/sva/dm_csrs_sva.sv
@@ -1,0 +1,55 @@
+// Copyright 2020 Silicon Labs, Inc.
+//
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License").
+//
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+//
+// You may obtain a copy of the License at:
+//
+//     https://solderpad.org/licenses/SHL-2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+// Engineer:       Arjan Bink - arjan.bink@silabs.com                         //
+//                                                                            //
+// Design Name:    dm_csrs_sva                                                //
+// Language:       SystemVerilog                                              //
+//                                                                            //
+// Description:    SystemVerilog assertions for dm_csrs                       //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+module dm_csrs_sva #(
+  parameter int unsigned        NrHarts          = 1,
+  parameter int unsigned        BusWidth         = 32,
+  parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}}
+)(
+  input logic           clk_i,
+  input logic           rst_ni,
+  input logic           dmi_req_valid_i,
+  input logic           dmi_req_ready_o,
+  input dm::dmi_req_t   dmi_req_i,
+  input dm::dtm_op_e    dtm_op
+);
+
+  ///////////////////////////////////////////////////////
+  // Assertions
+  ///////////////////////////////////////////////////////
+
+  haltsum: assert property (
+      @(posedge clk_i) disable iff (!rst_ni)
+          (dmi_req_ready_o && dmi_req_valid_i && dtm_op == dm::DTM_READ) |->
+              !({1'b0, dmi_req_i.addr} inside
+                  {dm::HaltSum0, dm::HaltSum1, dm::HaltSum2, dm::HaltSum3}))
+      else $warning("Haltsums have not been properly tested yet.");
+
+endmodule: dm_csrs_sva

--- a/hw/vendor/pulp_riscv_dbg/sva/dm_sba_sva.sv
+++ b/hw/vendor/pulp_riscv_dbg/sva/dm_sba_sva.sv
@@ -1,0 +1,50 @@
+// Copyright 2020 Silicon Labs, Inc.
+//
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License").
+//
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+//
+// You may obtain a copy of the License at:
+//
+//     https://solderpad.org/licenses/SHL-2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+// Engineer:       Arjan Bink - arjan.bink@silabs.com                         //
+//                                                                            //
+// Design Name:    dm_sba_sva                                                 //
+// Language:       SystemVerilog                                              //
+//                                                                            //
+// Description:    SystemVerilog assertions for dm_sba                        //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+module dm_sba_sva #(
+  parameter int unsigned BusWidth = 32,
+  parameter bit          ReadByteEnable = 1
+)(
+  input logic           clk_i,
+  input logic           dmactive_i,
+  input logic [2:0]     sbaccess_i,
+  input dm::sba_state_e state_d
+);
+
+  ///////////////////////////////////////////////////////
+  // Assertions
+  ///////////////////////////////////////////////////////
+
+  // maybe bump severity to $error if not handled at runtime
+  dm_sba_access_size: assert property(@(posedge clk_i) disable iff (dmactive_i !== 1'b0)
+      (state_d != dm::Idle) |-> (sbaccess_i < 4))
+          else $warning ("accesses > 8 byte not supported at the moment");
+
+endmodule: dm_sba_sva

--- a/hw/vendor/pulp_riscv_dbg/sva/dm_top_sva.sv
+++ b/hw/vendor/pulp_riscv_dbg/sva/dm_top_sva.sv
@@ -1,0 +1,65 @@
+// Copyright 2020 Silicon Labs, Inc.
+//
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License").
+//
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+//
+// You may obtain a copy of the License at:
+//
+//     https://solderpad.org/licenses/SHL-2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+// Engineer:       Arjan Bink - arjan.bink@silabs.com                         //
+//                                                                            //
+// Design Name:    dm_top_sva                                                 //
+// Language:       SystemVerilog                                              //
+//                                                                            //
+// Description:    SystemVerilog assertions for dm_top                        //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+module dm_top_sva
+#(
+  parameter int unsigned        NrHarts          = 1,
+  parameter int unsigned        BusWidth         = 32,
+  parameter int unsigned        DmBaseAddress    = 'h1000,
+  parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}},
+  parameter bit                 ReadByteEnable   = 1
+)(
+  input logic           clk_i,
+  input logic           rst_ni,
+  input dm::hartinfo_t [NrHarts-1:0] hartinfo_i
+);
+
+  ///////////////////////////////////////////////////////
+  // Assertions
+  ///////////////////////////////////////////////////////
+
+  // Check that BusWidth is supported
+  bus_width: assert property (
+      @(posedge clk_i) disable iff (!rst_ni)
+          (1'b1) |-> (BusWidth == 32 || BusWidth == 64))
+      else $fatal(1, "DM needs a bus width of either 32 or 64 bits");
+
+  // Fail if the DM is not located on the zero page and one hart doesn't have two scratch registers.
+  genvar i;
+  generate for (i = 0; i < NrHarts; i++)
+    begin
+      hart_info: assert property (
+          @(posedge clk_i) disable iff (!rst_ni)
+              (1'b1) |-> ((DmBaseAddress > 0 && hartinfo_i[i].nscratch >= 2) || (DmBaseAddress == 0 && hartinfo_i[i].nscratch >= 1)))
+          else $fatal(1, "If the DM is not located at the zero page each hart needs at least two scratch registers %d %d",i, hartinfo_i[i].nscratch);
+    end
+  endgenerate
+
+endmodule: dm_top_sva

--- a/hw/vendor/pulp_riscv_dbg/tb/Makefile
+++ b/hw/vendor/pulp_riscv_dbg/tb/Makefile
@@ -61,6 +61,9 @@ RTLSRC_TB		:= boot_rom.sv \
 				dp_ram.sv \
 				mm_ram.sv \
 				SimJTAG.sv \
+				../sva/dm_top_sva.sv \
+				../sva/dm_csrs_sva.sv \
+				../sva/dm_sba_sva.sv \
 				tb_test_env.sv \
 				tb_top.sv
 
@@ -68,45 +71,44 @@ RTLSRC_VERI_TB          := boot_rom.sv \
 				dp_ram.sv \
 				mm_ram.sv \
 				SimJTAG.sv \
-				tb_test_env.sv \
 				tb_top_verilator.sv
 
 RTLSRC_INCDIR           := riscv/rtl/include
 
 RTLSRC_FPNEW_PKG	:= fpnew/src/fpnew_pkg.sv
 RTLSRC_RISCV_PKG	+= $(addprefix riscv/rtl/include/,\
-				apu_core_package.sv riscv_defines.sv \
-				riscv_tracer_defines.sv)
+				cv32e40p_apu_core_pkg.sv cv32e40p_pkg.sv \
+				../../bhv/include/cv32e40p_tracer_pkg.sv)
 RTLSRC_DM_PKG		+= ../src/dm_pkg.sv
 
 RTLSRC_PKG 		= $(RTLSRC_FPNEW_PKG) dm_tb_pkg.sv $(RTLSRC_RISCV_PKG) $(RTLSRC_DM_PKG)
 RTLSRC_RISCV		:= $(addprefix riscv/rtl/,\
-				cv32e40p_sim_clock_gating.sv \
-				register_file_test_wrap.sv \
-				riscv_tracer.sv \
-				riscv_register_file.sv \
-				riscv_alu.sv \
-				riscv_alu_basic.sv \
-				riscv_alu_div.sv \
-				riscv_compressed_decoder.sv \
-				riscv_controller.sv \
-				riscv_cs_registers.sv \
-				riscv_decoder.sv \
-				riscv_int_controller.sv \
-				riscv_ex_stage.sv \
-				riscv_hwloop_controller.sv \
-				riscv_hwloop_regs.sv \
-				riscv_id_stage.sv \
-				riscv_if_stage.sv \
-				riscv_load_store_unit.sv \
-				riscv_mult.sv \
-				riscv_prefetch_buffer.sv \
-				riscv_prefetch_L0_buffer.sv \
-				riscv_core.sv \
-				riscv_apu_disp.sv \
-				riscv_fetch_fifo.sv \
-				riscv_L0_buffer.sv \
-				riscv_pmp.sv)
+				../bhv/cv32e40p_sim_clock_gate.sv \
+				../bhv/cv32e40p_tracer.sv \
+				cv32e40p_if_stage.sv \
+				cv32e40p_cs_registers.sv \
+				cv32e40p_register_file_ff.sv \
+				cv32e40p_load_store_unit.sv \
+				cv32e40p_id_stage.sv \
+				cv32e40p_aligner.sv \
+				cv32e40p_decoder.sv \
+				cv32e40p_compressed_decoder.sv \
+				cv32e40p_fifo.sv \
+				cv32e40p_prefetch_buffer.sv \
+				cv32e40p_hwloop_regs.sv \
+				cv32e40p_mult.sv \
+				cv32e40p_int_controller.sv \
+				cv32e40p_ex_stage.sv \
+				cv32e40p_alu_div.sv \
+				cv32e40p_alu.sv \
+				cv32e40p_ff_one.sv \
+				cv32e40p_popcnt.sv \
+				cv32e40p_apu_disp.sv \
+				cv32e40p_controller.sv \
+				cv32e40p_obi_interface.sv \
+				cv32e40p_prefetch_controller.sv \
+				cv32e40p_sleep_unit.sv \
+				cv32e40p_core.sv)
 RTLSRC_COMMON           := $(addprefix common_cells/src/,\
 				cdc_2phase.sv fifo_v2.sv fifo_v3.sv\
 				rstgen.sv rstgen_bypass.sv)
@@ -122,7 +124,7 @@ RTLSRC_DEBUG		+= $(addprefix ../src/,\
 RTLSRC			+= $(RTLSRC_RISCV) $(RTLSRC_COMMON) $(RTLSRC_TECH) $(RTLSRC_DEBUG)
 
 # versions for this tb
-RI5CY_SHA               = d049690e7867291830631db7dbeb47c92718ed9e
+CV32E40P_SHA            = f9d63290eea738cb0a6fbf1e77bbd18555015a03
 FPU_SHA                 = v0.6.1
 COMMON_SHA              = 337f54a7cdfdad78b124cbdd2a627db3e0939141
 TECH_SHA                = b35652608124b7ea813818b14a00ca76edd7599d
@@ -228,7 +230,7 @@ $(RTLSRC_TECH):
 
 $(RTLSRC_RISCV_PKG) $(RTLSRC_RISCV):
 	git clone https://github.com/openhwgroup/cv32e40p.git riscv
-	cd riscv/ && git checkout $(RI5CY_SHA)
+	cd riscv/ && git checkout $(CV32E40P_SHA)
 
 # openocd server
 remote_bitbang/librbs_veri.so: INCLUDE_DIRS =./ $(VSIM_HOME)/include

--- a/hw/vendor/pulp_riscv_dbg/tb/boot_rom.sv
+++ b/hw/vendor/pulp_riscv_dbg/tb/boot_rom.sv
@@ -20,7 +20,8 @@ module boot_rom (
     localparam int          RomSize    = 2;
     localparam logic [31:0] entry_addr = 32'h1c00_0080;
 
-    const logic [RomSize-1:0][31:0] mem = {
+    logic [RomSize-1:0][31:0] mem;
+    assign mem = {
         dm_tb_pkg::jalr(5'h0, 5'h1, entry_addr[11:0]),
         dm_tb_pkg::lui(5'h1, entry_addr[31:12])
     };

--- a/hw/vendor/pulp_riscv_dbg/tb/tb_test_env.sv
+++ b/hw/vendor/pulp_riscv_dbg/tb/tb_test_env.sv
@@ -15,7 +15,6 @@ module tb_test_env #(
     parameter int unsigned INSTR_RDATA_WIDTH = 32,
     parameter int unsigned RAM_ADDR_WIDTH = 20,
     parameter logic [31:0] BOOT_ADDR = 'h80,
-    parameter bit          PULP_SECURE = 1,
     parameter bit          JTAG_BOOT = 1,
     parameter int unsigned OPENOCD_PORT = 0,
     parameter bit          A_EXTENSION = 0
@@ -35,9 +34,10 @@ module tb_test_env #(
     localparam CLUSTER_ID         = 6'd0;
     localparam CORE_ID            = 4'd0;
 
-    localparam CORE_MHARTID       = {CLUSTER_ID, 1'b0, CORE_ID};
+    localparam CORE_MHARTID       = {21'b0, CLUSTER_ID, 1'b0, CORE_ID};
     localparam NrHarts                               = 1;
     localparam logic [NrHarts-1:0] SELECTABLE_HARTS  = 1 << CORE_MHARTID;
+    localparam HARTINFO           = {8'h0, 4'h2, 3'b0, 1'b1, dm::DataCount, dm::DataAddr};
 
     // signals connecting core to memory
     logic                        instr_req;
@@ -99,30 +99,29 @@ module tb_test_env #(
     logic [0:4]                  irq_id_in;
     logic                        irq_ack;
     logic [0:4]                  irq_id_out;
-    logic                        irq_sec;
 
     // make jtag bridge work
     assign sim_jtag_enable = JTAG_BOOT;
 
-    // interrupts (only timer for now)
-    assign irq_sec = '0;
-
     // instantiate the core
-    riscv_core #(
-        .INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH),
-        .PULP_SECURE(PULP_SECURE),
-        .A_EXTENSION(A_EXTENSION),
-        .FPU(0)
+    cv32e40p_core #(
+        .PULP_XPULP             ( 0                     ),
+        .PULP_CLUSTER           ( 0                     ),
+        .FPU                    ( 0                     ),
+        .PULP_ZFINX             ( 0                     ),
+        .NUM_MHPMCOUNTERS       ( 1                     )
     ) riscv_core_i (
         .clk_i                  ( clk_i                 ),
         .rst_ni                 ( ndmreset_n            ),
 
-        .clock_en_i             ( '1                    ),
-        .test_en_i              ( '0                    ),
+        .pulp_clock_en_i        ( '1                    ),
+        .scan_cg_en_i           ( '0                    ),
 
         .boot_addr_i            ( BOOT_ADDR             ),
-        .core_id_i              ( CORE_ID               ),
-        .cluster_id_i           ( CLUSTER_ID            ),
+        .mtvec_addr_i           ( 32'h00000000          ),
+        .dm_halt_addr_i         ( 32'h1A110800          ),
+        .hart_id_i              ( CORE_MHARTID          ),
+        .dm_exception_addr_i    ( 32'h00000000          ),
 
         .instr_addr_o           ( instr_addr            ),
         .instr_req_o            ( instr_req             ),
@@ -138,7 +137,6 @@ module tb_test_env #(
         .data_rdata_i           ( data_rdata            ),
         .data_gnt_i             ( data_gnt              ),
         .data_rvalid_i          ( data_rvalid           ),
-        .data_atop_o            (                       ),
 
         .apu_master_req_o       (                       ),
         .apu_master_ready_o     (                       ),
@@ -151,27 +149,14 @@ module tb_test_env #(
         .apu_master_result_i    (                       ),
         .apu_master_flags_i     (                       ),
 
-
-        .irq_software_i         ( 1'b0                  ),
-        .irq_timer_i            ( 1'b0                  ),
-        .irq_external_i         ( 1'b0                  ),
-        .irq_fast_i             ( 15'b0                 ),
-        .irq_nmi_i              ( 1'b0                  ),
-        .irq_fastx_i            ( 32'b0                 ),
-
+        .irq_i                  ( 32'b0                 ),
         .irq_ack_o              ( irq_ack               ),
         .irq_id_o               ( irq_id_out            ),
-        .irq_sec_i              ( irq_sec               ),
-
-        .sec_lvl_o              ( sec_lvl_o             ),
 
         .debug_req_i            ( dm_debug_req[CORE_MHARTID] ),
 
         .fetch_enable_i         ( fetch_enable_i        ),
-        .core_busy_o            ( core_busy_o           ),
-
-        .ext_perf_counters_i    (                       ),
-        .fregfile_disable_i     ( 1'b0                  )
+        .core_sleep_o           ( core_sleep_o          )
     );
 
     // this handles read to RAM and memory mapped pseudo peripherals
@@ -265,7 +250,7 @@ module tb_test_env #(
        .dmactive_o        (                   ), // active debug session TODO
        .debug_req_o       ( dm_debug_req      ),
        .unavailable_i     ( ~SELECTABLE_HARTS ),
-       .hartinfo_i        ( '0                ),
+       .hartinfo_i        ( HARTINFO          ),
 
        .slave_req_i       ( dm_req            ),
        .slave_we_i        ( dm_we             ),
@@ -291,6 +276,34 @@ module tb_test_env #(
        .dmi_resp_ready_i  ( jtag_resp_ready   ),
        .dmi_resp_o        ( debug_resp        )
     );
+
+    ///////////////////////////////////////////////////////
+    // Bind RTL assertions to Debug Module
+    ///////////////////////////////////////////////////////
+
+    bind dm_top
+      dm_top_sva
+      #(
+       .NrHarts           ( NrHarts           ),
+       .BusWidth          ( BusWidth          ),
+       .SelectableHarts   ( SelectableHarts   ))
+       i_dm_top_sva (.*);
+
+    bind dm_csrs
+      dm_csrs_sva
+      #(
+       .NrHarts           ( NrHarts           ),
+       .BusWidth          ( BusWidth          ),
+       .SelectableHarts   ( SelectableHarts   ))
+       i_dm_csrs_sva (.*);
+
+    bind dm_sba
+      dm_sba_sva
+      #(
+       .BusWidth          ( BusWidth          ),
+       .ReadByteEnable    ( ReadByteEnable    ))
+       i_dm_sba_sva (.*);
+
 
     // grant in the same cycle
     assign dm_gnt = dm_req;

--- a/hw/vendor/pulp_riscv_dbg/tb/tb_top.sv
+++ b/hw/vendor/pulp_riscv_dbg/tb/tb_top.sv
@@ -124,7 +124,6 @@ module tb_top #(
         .INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH),
         .RAM_ADDR_WIDTH (RAM_ADDR_WIDTH),
         .BOOT_ADDR (BOOT_ADDR),
-        .PULP_SECURE (1),
         .JTAG_BOOT (JTAG_BOOT),
         .OPENOCD_PORT (OPENOCD_PORT)
     ) tb_test_env_i(

--- a/hw/vendor/pulp_riscv_dbg/tb/waves.tcl
+++ b/hw/vendor/pulp_riscv_dbg/tb/waves.tcl
@@ -23,8 +23,7 @@
 # }
 
 # add fc
-set rvcores [find instances -recursive -bydu riscv_core -nodu]
-set fpuprivate [find instances -recursive -bydu fpu_private]
+set rvcores [find instances -recursive -bydu cv32e40p_core -nodu]
 set tb_top [find instances -recursive -bydu tb_top -nod]
 set mm_ram [find instances -recursive -bydu mm_ram -nod]
 set dp_ram [find instances -recursive -bydu dp_ram -nod]
@@ -48,32 +47,22 @@ if {$dp_ram ne ""} {
 }
 
 if {$rvcores ne ""} {
-  set rvprefetch [find instances -recursive -bydu riscv_prefetch_L0_buffer -nodu]
-
   add wave -group "Core"                                     $rvcores/*
-  add wave -group "IF Stage" -group "Hwlp Ctrl"              $rvcores/if_stage_i/hwloop_controller_i/*
-  if {$rvprefetch ne ""} {
-    add wave -group "IF Stage" -group "Prefetch" -group "L0"   $rvcores/if_stage_i/prefetch_128/prefetch_buffer_i/L0_buffer_i/*
-    add wave -group "IF Stage" -group "Prefetch"               $rvcores/if_stage_i/prefetch_128/prefetch_buffer_i/*
-  } {
-    add wave -group "IF Stage" -group "Prefetch" -group "FIFO" $rvcores/if_stage_i/prefetch_32/prefetch_buffer_i/fifo_i/*
-    add wave -group "IF Stage" -group "Prefetch"               $rvcores/if_stage_i/prefetch_32/prefetch_buffer_i/*
-  }
+  add wave -group "IF Stage" -group "Prefetch"               $rvcores/if_stage_i/prefetch_buffer_i/*
+  add wave -group "IF Stage" -group "Prefetch" -group "FIFO" $rvcores/if_stage_i/prefetch_buffer_i/fifo_i/*
+  add wave -group "IF Stage" -group "Prefetch" -group "OBI"  $rvcores/if_stage_i/prefetch_buffer_i/instruction_obi_i/*
   add wave -group "IF Stage"                                 $rvcores/if_stage_i/*
+  add wave -group "Aligner"                                  $rvcores/if_stage_i/aligner_i/*
+  add wave -group "RVCDecoder"                               $rvcores/if_stage_i/compressed_decoder_i/*
   add wave -group "ID Stage"                                 $rvcores/id_stage_i/*
-  add wave -group "RF"                                       $rvcores/id_stage_i/registers_i/riscv_register_file_i/mem
-  add wave -group "RF_FP"                                    $rvcores/id_stage_i/registers_i/riscv_register_file_i/mem_fp
+  add wave -group "RF"                                       $rvcores/id_stage_i/register_file_i/mem
+  add wave -group "RF_FP"                                    $rvcores/id_stage_i/register_file_i/mem_fp
   add wave -group "Decoder"                                  $rvcores/id_stage_i/decoder_i/*
   add wave -group "Controller"                               $rvcores/id_stage_i/controller_i/*
   add wave -group "Int Ctrl"                                 $rvcores/id_stage_i/int_controller_i/*
-  add wave -group "Hwloop Regs"                              $rvcores/id_stage_i/hwloop_regs_i/*
   add wave -group "EX Stage" -group "ALU"                    $rvcores/ex_stage_i/alu_i/*
-  add wave -group "EX Stage" -group "ALU_DIV"                $rvcores/ex_stage_i/alu_i/int_div/div_i/*
+  add wave -group "EX Stage" -group "ALU_DIV"                $rvcores/ex_stage_i/alu_i/alu_div_i/*
   add wave -group "EX Stage" -group "MUL"                    $rvcores/ex_stage_i/mult_i/*
-  if {$fpuprivate ne ""} {
-    add wave -group "EX Stage" -group "APU_DISP"             $rvcores/ex_stage_i/genblk1/apu_disp_i/*
-    add wave -group "EX Stage" -group "FPU"                  $rvcores/ex_stage_i/genblk1/genblk1/fpu_i/*
-  }
   add wave -group "EX Stage"                                 $rvcores/ex_stage_i/*
   add wave -group "LSU"                                      $rvcores/load_store_unit_i/*
   add wave -group "CSR"                                      $rvcores/cs_registers_i/*


### PR DESCRIPTION
Update to latest upstream version of rv_dm, and fix some more lint warnings we get in Verible and Verilator lint.