### PR TITLE
[dv/kmac] reduce length of long_msg test

### DIFF
--- a/hw/ip/kmac/dv/env/seq_lib/kmac_long_msg_and_output_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_long_msg_and_output_vseq.sv
@@ -18,14 +18,14 @@ class kmac_long_msg_and_output_vseq extends kmac_smoke_vseq;
     };
   }
 
-  // up to 100KB (102,400B) input message
+  // keep the max msg size at 10KB to avoid major performance issues
   constraint msg_c {
     msg.size() dist {
-      0                   :/ 1,
-      [1       : 10_000]  :/ 4,
-      [10_001  : 75_000]  :/ 12,
-      [75_001  : 100_000] :/ 2,
-      [100_001 : 102_400] :/ 1
+      0               :/ 1,
+      [1    : 2500]   :/ 1,
+      [2501 : 5000]   :/ 1,
+      [5001 : 7500]   :/ 3,
+      [5001 : 10_000] :/ 4
     };
   }
 


### PR DESCRIPTION
this PR reduces the input message size to reduce the runtime of the
`long_msg_and_output` test in nightly regressions.

Signed-off-by: Udi Jonnalagadda <udij@google.com>