### PR TITLE
[csrng] Select Canright S-Box implementation for AES cipher core

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -8,7 +8,7 @@
   param_list: [
     { name: "SBoxImpl",
       type: "aes_pkg::sbox_impl_e",
-      default: "aes_pkg::SBoxImplLut",
+      default: "aes_pkg::SBoxImplCanright",
       desc: "Selection of the S-Box implementation. See aes_pkg.sv.",
       local: "false",
       expose: "true"

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -6259,7 +6259,7 @@
         {
           name: SBoxImpl
           type: aes_pkg::sbox_impl_e
-          default: aes_pkg::SBoxImplLut
+          default: aes_pkg::SBoxImplCanright
           desc: Selection of the S-Box implementation. See aes_pkg.sv.
           local: "false"
           expose: "true"

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -19,7 +19,7 @@ module top_earlgrey #(
   parameter bit SecAesAllowForcingMasks = 1'b0,
   parameter bit KmacEnMasking = 0,
   parameter int KmacReuseShare = 0,
-  parameter aes_pkg::sbox_impl_e CsrngSBoxImpl = aes_pkg::SBoxImplLut,
+  parameter aes_pkg::sbox_impl_e CsrngSBoxImpl = aes_pkg::SBoxImplCanright,
   parameter bit SramCtrlMainInstrExec = 1,
   parameter otbn_pkg::regfile_e OtbnRegFile = otbn_pkg::RegFileFF,
 


### PR DESCRIPTION
This PR changes the default selection for the S-Box implementation inside the embedded AES cipher core from the LUT-based implementation the unmasked Canright design. This is more suitable for ASIC implementations because of the lower area footprint. The LUT-based implementation should be used for FPGA targets only.

The same change got already merged with lowRISC/OpenTitan#5215 but it got accidentally reverted when rebasing lowRISC/OpenTitan#5195.
