### PR TITLE
[reggen] Fix layout in register table

### DIFF
--- a/util/reggen/gen_html.py
+++ b/util/reggen/gen_html.py
@@ -155,8 +155,8 @@ def gen_html_register(outfile, reg, comp, width, rnames, toc, toclvl):
                    wen=regwen_div))
     if desc_body:
         genout(outfile,
-               '<tr><td colspan=5><p>{}</p></td></tr>'
-               .format('</p><p>'.join(desc_body)))
+               '<tr><td colspan=5>{}</td></tr>'
+               .format(''.join(desc_body)))
 
     if toc is not None:
         toc.append((toclvl, comp + "." + rname, "Reg_" + rname.lower()))
@@ -192,24 +192,31 @@ def gen_html_register(outfile, reg, comp, width, rnames, toc, toclvl):
             ('x' if field.resval is None else hex(field.resval)) +
             "</td>")
         genout(outfile, "<td class=\"regfn\">" + fname + "</td>")
+
+        # Collect up any description and enum table
+        desc_parts = []
+
         if field.desc is not None:
-            genout(outfile, render_td(field.desc, rnames, 'regde'))
-        else:
-            genout(outfile, "<td>\n")
+            desc_parts += expand_paras(field.desc, rnames)
 
         if field.enum is not None:
-            genout(outfile, "    <table>")
+            desc_parts.append('<table>')
             for enum in field.enum:
-                ename = enum.name
-                genout(outfile, "    <tr><td>" + str(enum.value) + "</td>")
-                genout(outfile, "<td>" + ename + "</td>")
-                genout(outfile, render_td(enum.desc, rnames, None))
-                genout(outfile, "</tr>\n")
-
-            genout(outfile, "    </table>")
+                enum_desc_paras = expand_paras(enum.desc, rnames)
+                desc_parts.append('<tr>'
+                                  '<td>{val}</td>'
+                                  '<td>{name}</td>'
+                                  '<td>{desc}</td>'
+                                  '</tr>\n'
+                                  .format(val=enum.value,
+                                          name=enum.name,
+                                          desc=''.join(enum_desc_paras)))
+            desc_parts.append('</table>')
             if field.has_incomplete_enum():
-                genout(outfile, "Other values are reserved.")
-        genout(outfile, "</td></tr>\n")
+                desc_parts.append("<p>Other values are reserved.</p>")
+
+        genout(outfile,
+               '<td class="regde">{}</td>'.format(''.join(desc_parts)))
         nextbit = fieldlsb + field.bits.width()
 
     genout(outfile, "</table>\n<br>\n")

--- a/util/reggen/html_helpers.py
+++ b/util/reggen/html_helpers.py
@@ -68,7 +68,7 @@ def _expand_paragraph(s, rnames):
         part = re.sub(r"\*([^*]+?)\*", r'<I>\1</I>', part)
         expanded_parts.append(part)
 
-    return ''.join(expanded_parts)
+    return '<p>{}</p>'.format(''.join(expanded_parts))
 
 
 def render_td(s, rnames, td_class):
@@ -79,5 +79,4 @@ def render_td(s, rnames, td_class):
     '''
     desc_paras = expand_paras(s, rnames)
     class_attr = '' if td_class is None else ' class="{}"'.format(td_class)
-    return ('<td{}><p>{}</p></td>'
-            .format(class_attr, '</p><p>'.join(desc_paras)))
+    return '<td{}>{}</td>'.format(class_attr, ''.join(desc_paras))


### PR DESCRIPTION
I messed this up in commit 94926ae (by closing the <td> containing a
register description when there was an enum to follow).

This patch fixes that and, I think, simplifies the logic a bit. Now,
we collect up "desc_parts", which contains any register description
and any enum. The surrounding <td> ... </td> get added together at the
end. Doing it this way should avoid things coming unstuck again in the
future.
