### PR TITLE
[topgen] Demote message about xbar connections from warning to info

### DIFF
--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -330,7 +330,7 @@ def xbar_adddevice(top, xbar, device):
 
         # case 1: Crossbar handling
         if device in xbar_list:
-            log.warning(
+            log.info(
                 "device {} in Xbar {} is connected to another Xbar".format(
                     device, xbar["name"]))
             assert len(nodeobj) == 1


### PR DESCRIPTION
This is just how we wire up our chip at the moment, so a warning
doesn't seem like the right thing to do!

Fixes #5282.