### PR TITLE
[otbn] Improvements to extracted documentation

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -125,7 +125,7 @@ class ANDI(RV32RegImm):
 
     def execute(self, state: OTBNState) -> None:
         val1 = state.gprs.get_reg(self.grs1).read_unsigned()
-        val2 = self.as_u32(self.imm)
+        val2 = self.to_2s_complement(self.imm)
         result = val1 & val2
         state.gprs.get_reg(self.grd).write_unsigned(result)
 
@@ -145,7 +145,7 @@ class ORI(RV32RegImm):
 
     def execute(self, state: OTBNState) -> None:
         val1 = state.gprs.get_reg(self.grs1).read_unsigned()
-        val2 = self.as_u32(self.imm)
+        val2 = self.to_2s_complement(self.imm)
         result = val1 | val2
         state.gprs.get_reg(self.grd).write_unsigned(result)
 
@@ -165,7 +165,7 @@ class XORI(RV32RegImm):
 
     def execute(self, state: OTBNState) -> None:
         val1 = state.gprs.get_reg(self.grs1).read_unsigned()
-        val2 = self.as_u32(self.imm)
+        val2 = self.to_2s_complement(self.imm)
         result = val1 ^ val2
         state.gprs.get_reg(self.grd).write_unsigned(result)
 

--- a/hw/ip/otbn/dv/otbnsim/sim/isa.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/isa.py
@@ -107,7 +107,7 @@ class OTBNInsn:
         return disasm
 
     @staticmethod
-    def as_u32(value: int) -> int:
+    def to_2s_complement(value: int) -> int:
         '''Interpret the signed value as a 2's complement u32'''
         assert -(1 << 31) <= value < (1 << 31)
         return (1 << 32) + value if value < 0 else value

--- a/hw/ip/otbn/util/docs/get_impl.py
+++ b/hw/ip/otbn/util/docs/get_impl.py
@@ -66,6 +66,18 @@ class ImplTransformer(cst.CSTTransformer):
         self.cur_class = None
         return updated
 
+    def leave_Attribute(self,
+                        orig: cst.Attribute,
+                        updated: cst.Attribute) -> cst.BaseExpression:
+        # Strip out "self." references. In the ISS code, a field in the
+        # instruction appears as self.field_name. In the documentation, we can
+        # treat all the instruction fields as being in scope.
+        if ((isinstance(updated.value, cst.Name) and
+             updated.value.value == 'self')):
+            return updated.attr
+
+        return updated
+
     def leave_FunctionDef(self,
                           orig: cst.FunctionDef,
                           updated: cst.FunctionDef) -> cst.BaseStatement:


### PR DESCRIPTION
This follows up on some of the ideas for improvements that @imphil [suggested on the initial PR](https://github.com/lowRISC/opentitan/pull/5180#issuecomment-778145339).

The base instruction set now looks reasonably nice, except for `ECALL`, `LOOP` and `LOOPI`. There's quite a bit of tidying-up left to do on the big number side.