### PR TITLE
[dvsim] Very small update to Timer.

### DIFF
--- a/util/dvsim/Scheduler.py
+++ b/util/dvsim/Scheduler.py
@@ -223,7 +223,6 @@ class TargetScheduler:
         old_handler = signal(SIGINT, on_sigint)
 
         try:
-            first_time = True
             while True:
                 if stop_now.is_set():
                     # We've had an interrupt. Kill any jobs that are running,
@@ -234,9 +233,8 @@ class TargetScheduler:
                 hms = timer.hms()
                 changed = self._poll(hms)
                 self._dispatch(hms, old_results)
-                if self._check_if_done(timer, hms, changed or first_time):
+                if self._check_if_done(timer, hms, changed):
                     break
-                first_time = False
 
                 # This is essentially sleep(1) to wait a second between each
                 # polling loop. But we do it with a bounded wait on stop_now so

--- a/util/dvsim/Scheduler.py
+++ b/util/dvsim/Scheduler.py
@@ -2,15 +2,14 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-
-from collections import OrderedDict
 import logging as log
-from signal import SIGINT, signal
 import threading
+from collections import OrderedDict
+from signal import SIGINT, signal
 
-from utils import VERBOSE
 from Deploy import DeployError
 from Timer import Timer
+from utils import VERBOSE
 
 
 class TargetScheduler:
@@ -63,12 +62,12 @@ class TargetScheduler:
                 # Still running
                 continue
             elif status == 'P':
-                log.log(VERBOSE, "[%s]: [%s]: [status] [%s: P]",
-                        hms, item.target, item.identifier)
+                log.log(VERBOSE, "[%s]: [%s]: [status] [%s: P]", hms,
+                        item.target, item.identifier)
                 to_pass.append(item)
             else:
-                log.error("[%s]: [%s]: [status] [%s: F]",
-                          hms, item.target, item.identifier)
+                log.error("[%s]: [%s]: [status] [%s: F]", hms, item.target,
+                          item.identifier)
                 to_fail.append(item)
 
         for item in to_pass:
@@ -131,8 +130,7 @@ class TargetScheduler:
         if not to_dispatch:
             return
 
-        log.log(VERBOSE, "[%s]: [%s]: [dispatch]:\n%s",
-                hms, self.name,
+        log.log(VERBOSE, "[%s]: [%s]: [dispatch]:\n%s", hms, self.name,
                 ", ".join(item.identifier for item in to_dispatch))
 
         for item in to_dispatch:
@@ -179,14 +177,11 @@ class TargetScheduler:
             width = len(str(total_cnt))
 
             field_fmt = '{{:0{}d}}'.format(width)
-            msg_fmt = ('[Q: {0}, D: {0}, P: {0}, F: {0}, K: {0}, T: {0}]'
-                       .format(field_fmt))
-            msg = msg_fmt.format(len(self._queued),
-                                 len(self._running),
-                                 len(self._passed),
-                                 len(self._failed),
-                                 len(self._killed),
-                                 total_cnt)
+            msg_fmt = ('[Q: {0}, D: {0}, P: {0}, F: {0}, K: {0}, T: {0}]'.
+                       format(field_fmt))
+            msg = msg_fmt.format(len(self._queued), len(self._running),
+                                 len(self._passed), len(self._failed),
+                                 len(self._killed), total_cnt)
             log.info("[%s]: [%s]: %s", hms, self.name, msg)
 
         return not (self._queued or self._running)

--- a/util/dvsim/Timer.py
+++ b/util/dvsim/Timer.py
@@ -18,6 +18,7 @@ class Timer:
     def __init__(self):
         self.start = time.monotonic()
         self.next_print = self.start + Timer.print_interval
+        self.first_print = True
 
     def period(self):
         '''Return the float time in seconds since start'''
@@ -40,6 +41,11 @@ class Timer:
 
         '''
         now = time.monotonic()
+
+        if self.first_print:
+            self.first_print = False
+            return True
+
         if now < self.next_print:
             return False
 


### PR DESCRIPTION
This adds `Timer::first_print` as a class instance attribute which will
return true the first time `check_time()` is invoked. In relation to
this, the `first_time` variable in `Scheduler::run()` is removed.

The rest of the changes are fixes made by the linter, hopefully they are
not too intrusive.

This is split out from PR #5203. 

Signed-off-by: Srikrishna Iyer <sriyer@google.com>