### PR TITLE
[dv/rv_timer] improve nightly regression runtime

### DIFF
--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_stress_all_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_stress_all_vseq.sv
@@ -10,6 +10,12 @@ class rv_timer_stress_all_vseq extends rv_timer_base_vseq;
 
   `uvm_object_new
 
+  // avoid simulation running for too long
+  constraint num_trans_c {
+    num_trans inside {[1:10]};
+  }
+
+
   task body();
     string seq_names[] = {"rv_timer_random_vseq",
                           "rv_timer_disabled_vseq",

--- a/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
+++ b/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
@@ -60,7 +60,6 @@
       uvm_test_seq: rv_timer_cfg_update_on_fly_vseq
       // 10ms
       run_opts: ["+zero_delays=1", "+test_timeout_ns=10000000000"]
-      reseed: 200
     }
 
     {


### PR DESCRIPTION
After checking the regression runtime, I found some rv_timer test running for
more than 5 hours:
1. rv_timer stress all tests. Each sub-test runs around 2000s, and total
num_trans is [1:20], so could easily run 40_000s. I reduced num_trans to
[1:10].

2. reduce reseed for rv_timer_cfg_on_the_fly sequence from 200 to 50. I
will monitor the coverage and make sure there is no drop.

Signed-off-by: Cindy Chen <chencindy@google.com>