### PR TITLE
[dv/hmac] Fix hmac vector parsing

### DIFF
--- a/hw/dv/sv/test_vectors/test_vectors_pkg.sv
+++ b/hw/dv/sv/test_vectors/test_vectors_pkg.sv
@@ -219,8 +219,9 @@ package test_vectors_pkg;
   // as the single consistency in all NIST test vectors is that the output data is the last entry of
   // each test vector description.
   function automatic void get_hash_test_vectors(
-    string test_name,
-    ref test_vectors_t parsed_vectors[]
+    string             test_name,
+    ref test_vectors_t parsed_vectors[],
+    input bit          reverse_key = 1
   );
     int fd;
     bit [7:0] bytes[];
@@ -328,6 +329,8 @@ package test_vectors_pkg;
           end
           "Key": begin
             str_to_bytes(entry_data, bytes);
+            // If no keyword `KeyLen` but has `Key`, use the default key len: 256 bits
+            if (vector.key_length_word == 0) vector.key_length_word = 8;
             vector.keys = new[vector.key_length_word];
             for (int i = 0; i < vector.key_length_word; i++) begin
               bit [7:0] key_bytes[] = new[4];
@@ -335,7 +338,8 @@ package test_vectors_pkg;
               for (int j = 0; j < 4; j++) begin
                 key_bytes[j] = bytes[i*4 + j];
               end
-              vector.keys[i] = {<< byte {key_bytes}};
+              if (reverse_key) vector.keys[i] = {<< byte {key_bytes}};
+              else             vector.keys[i] = {>> byte {key_bytes}};
 
               // Streaming operations using the `with` syntax is currently unsupported by
               // the Verible linter (Issue #5280).

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_test_vectors_sha_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_test_vectors_sha_vseq.sv
@@ -27,7 +27,9 @@ class hmac_test_vectors_sha_vseq extends hmac_base_vseq;
 
     foreach (vector_list[i]) begin
       // import function from the test_vectors_pkg to parse the sha vector file
-      test_vectors_pkg::get_hash_test_vectors(vector_list[i], parsed_vectors);
+      test_vectors_pkg::get_hash_test_vectors(.test_name(vector_list[i]),
+                                              .parsed_vectors(parsed_vectors),
+                                              .reverse_key(0));
       parsed_vectors.shuffle();
 
       // if in smoke_regression mode, to reduce the run time, we will randomly pick 2 vectors to
@@ -41,8 +43,8 @@ class hmac_test_vectors_sha_vseq extends hmac_base_vseq;
         hmac_init(.hmac_en(hmac_en), .endian_swap(1'b0), .digest_swap(1'b0));
 
         `uvm_info(`gtn, $sformatf("%s, starting seq %0d, msg size = %0d",
-                                  test_vectors_pkg::sha_file_list[i], j,
-                                  parsed_vectors[j].msg_length_byte), UVM_MEDIUM)
+                                  vector_list[i], j, parsed_vectors[j].msg_length_byte),
+                                  UVM_MEDIUM)
 
         if ($urandom_range(0, 1) && !hmac_en) begin
           `DV_CHECK_RANDOMIZE_FATAL(this) // only key is randomized


### PR DESCRIPTION
This PR fixes the regression failure on hmac NIST vector parsing. 

1. The hmac vector does not have `KeyLen` keyword, but still has `Key`. The
current parsing logic will set the key to 0 in this case.
2. Hmac nist vector does not need to reserve input key, but kmac vector needs it.
So this PR adds a flag for user to decide if they want to reverse the key.

Signed-off-by: Cindy Chen <chencindy@google.com>