### PR TITLE
[top / spi] Add scan clock to spi_device external clock

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 { name: "SPI_DEVICE",
   clock_primary: "clk_i",
+  other_clock_list: [
+    "scan_clk_i"
+  ],
   bus_device: "tlul",
   available_input_list: [
     { name: "sck", desc: "SPI Clock" },

--- a/hw/ip/spi_device/lint/spi_device.waiver
+++ b/hw/ip/spi_device/lint/spi_device.waiver
@@ -4,6 +4,8 @@
 #
 # waiver file for SPI Device
 
+set_clock_drivers prim_clock_buf prim_clock_mux2
+
 waive -rules HIER_NET_NOT_READ -location {spi_device.sv} -regexp {[nN]et.*a_(address|param|user).*not read from} \
       -comment "several TLUL signals are not used by register file"
 waive -rules HIER_NET_NOT_READ -location {spi_device.sv} -regexp {Net .reg2hw.*.qe. is not read from} \

--- a/hw/ip/spi_device/rtl/spi_device_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_pkg.sv
@@ -99,6 +99,7 @@ package spi_device_pkg;
     CsbRstMuxSel,
     TxRstMuxSel,
     RxRstMuxSel,
+    ClkMuxSel,
     ScanModeUseLast
   } scan_mode_e;
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -139,6 +139,7 @@
         clocks:
         {
           clk_io_div4_peri: io_div4
+          clk_io_div2_peri: io_div2
           clk_aon_peri: aon
           clk_usb_peri: usb
         }
@@ -1178,6 +1179,7 @@
       clock_srcs:
       {
         clk_i: io_div4
+        scan_clk_i: io_div2
       }
       clock_group: peri
       reset_connections:
@@ -1188,6 +1190,7 @@
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
+        scan_clk_i: clkmgr_aon_clocks.clk_io_div2_peri
       }
       domain: "0"
       size: 0x2000

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -275,7 +275,7 @@
     }
     { name: "spi_device",
       type: "spi_device",
-      clock_srcs: {clk_i: "io_div4"},
+      clock_srcs: {clk_i: "io_div4", scan_clk_i: "io_div2"},
       clock_group: "peri",
       reset_connections: {rst_ni: "spi_device"},
       base_addr: "0x40050000",

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -153,6 +153,15 @@
         }
         {
           bits: "1",
+          name: "CLK_IO_DIV2_PERI_EN",
+          resval: 1,
+          desc: '''
+            0 CLK_IO_DIV2_PERI is disabled.
+            1 CLK_IO_DIV2_PERI is enabled.
+          '''
+        }
+        {
+          bits: "2",
           name: "CLK_USB_PERI_EN",
           resval: 1,
           desc: '''

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -383,6 +383,7 @@ module clkmgr import clkmgr_pkg::*; (
   ////////////////////////////////////////////////////
 
   logic clk_io_div4_peri_sw_en;
+  logic clk_io_div2_peri_sw_en;
   logic clk_usb_peri_sw_en;
 
   prim_flop_2sync #(
@@ -412,6 +413,35 @@ module clkmgr import clkmgr_pkg::*; (
     .en_i(clk_io_div4_peri_sw_en & clk_io_div4_en),
     .test_en_i(clk_io_div4_peri_scanmode == lc_ctrl_pkg::On),
     .clk_o(clocks_o.clk_io_div4_peri)
+  );
+
+  prim_flop_2sync #(
+    .Width(1)
+  ) u_clk_io_div2_peri_sw_en_sync (
+    .clk_i(clk_io_div2_i),
+    .rst_ni(rst_io_div2_ni),
+    .d_i(reg2hw.clk_enables.clk_io_div2_peri_en.q),
+    .q_o(clk_io_div2_peri_sw_en)
+  );
+
+  lc_ctrl_pkg::lc_tx_t clk_io_div2_peri_scanmode;
+  prim_lc_sync #(
+    .NumCopies(1),
+    .AsyncOn(0)
+  ) u_clk_io_div2_peri_scanmode_sync  (
+    .clk_i,
+    .rst_ni,
+    .lc_en_i(scanmode_i),
+    .lc_en_o(clk_io_div2_peri_scanmode)
+  );
+
+  prim_clock_gating #(
+    .NoFpgaGate(1'b1)
+  ) u_clk_io_div2_peri_cg (
+    .clk_i(clk_io_div2_root),
+    .en_i(clk_io_div2_peri_sw_en & clk_io_div2_en),
+    .test_en_i(clk_io_div2_peri_scanmode == lc_ctrl_pkg::On),
+    .clk_o(clocks_o.clk_io_div2_peri)
   );
 
   prim_flop_2sync #(

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -41,6 +41,7 @@ package clkmgr_pkg;
   logic clk_main_timers;
   logic clk_proc_main;
   logic clk_io_div4_peri;
+  logic clk_io_div2_peri;
   logic clk_usb_peri;
 
   } clkmgr_out_t;

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
@@ -25,6 +25,9 @@ package clkmgr_reg_pkg;
     } clk_io_div4_peri_en;
     struct packed {
       logic        q;
+    } clk_io_div2_peri_en;
+    struct packed {
+      logic        q;
     } clk_usb_peri_en;
   } clkmgr_reg2hw_clk_enables_reg_t;
 
@@ -68,8 +71,8 @@ package clkmgr_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [6:6]
-    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [5:4]
+    clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [7:7]
+    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [6:4]
     clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [3:0]
   } clkmgr_reg2hw_t;
 

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -77,6 +77,9 @@ module clkmgr_reg_top (
   logic clk_enables_clk_io_div4_peri_en_qs;
   logic clk_enables_clk_io_div4_peri_en_wd;
   logic clk_enables_clk_io_div4_peri_en_we;
+  logic clk_enables_clk_io_div2_peri_en_qs;
+  logic clk_enables_clk_io_div2_peri_en_wd;
+  logic clk_enables_clk_io_div2_peri_en_we;
   logic clk_enables_clk_usb_peri_en_qs;
   logic clk_enables_clk_usb_peri_en_wd;
   logic clk_enables_clk_usb_peri_en_we;
@@ -153,7 +156,33 @@ module clkmgr_reg_top (
   );
 
 
-  //   F[clk_usb_peri_en]: 1:1
+  //   F[clk_io_div2_peri_en]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h1)
+  ) u_clk_enables_clk_io_div2_peri_en (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (clk_enables_clk_io_div2_peri_en_we),
+    .wd     (clk_enables_clk_io_div2_peri_en_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.clk_enables.clk_io_div2_peri_en.q ),
+
+    // to register interface (read)
+    .qs     (clk_enables_clk_io_div2_peri_en_qs)
+  );
+
+
+  //   F[clk_usb_peri_en]: 2:2
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
@@ -415,8 +444,11 @@ module clkmgr_reg_top (
   assign clk_enables_clk_io_div4_peri_en_we = addr_hit[1] & reg_we & ~wr_err;
   assign clk_enables_clk_io_div4_peri_en_wd = reg_wdata[0];
 
+  assign clk_enables_clk_io_div2_peri_en_we = addr_hit[1] & reg_we & ~wr_err;
+  assign clk_enables_clk_io_div2_peri_en_wd = reg_wdata[1];
+
   assign clk_enables_clk_usb_peri_en_we = addr_hit[1] & reg_we & ~wr_err;
-  assign clk_enables_clk_usb_peri_en_wd = reg_wdata[1];
+  assign clk_enables_clk_usb_peri_en_wd = reg_wdata[2];
 
   assign clk_hints_clk_main_aes_hint_we = addr_hit[2] & reg_we & ~wr_err;
   assign clk_hints_clk_main_aes_hint_wd = reg_wdata[0];
@@ -444,7 +476,8 @@ module clkmgr_reg_top (
 
       addr_hit[1]: begin
         reg_rdata_next[0] = clk_enables_clk_io_div4_peri_en_qs;
-        reg_rdata_next[1] = clk_enables_clk_usb_peri_en_qs;
+        reg_rdata_next[1] = clk_enables_clk_io_div2_peri_en_qs;
+        reg_rdata_next[2] = clk_enables_clk_usb_peri_en_qs;
       end
 
       addr_hit[2]: begin

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1088,6 +1088,7 @@ module top_earlgrey #(
 
       // Clock and reset connections
       .clk_i (clkmgr_aon_clocks.clk_io_div4_peri),
+      .scan_clk_i (clkmgr_aon_clocks.clk_io_div2_peri),
       .rst_ni (rstmgr_aon_resets.rst_spi_device_n[rstmgr_pkg::Domain0Sel])
   );
 

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -1287,8 +1287,9 @@ typedef enum top_earlgrey_power_manager_reset_requests {
  */
 typedef enum top_earlgrey_gateable_clocks {
   kTopEarlgreyGateableClocksIoDiv4Peri = 0, /**< Clock clk_io_div4_peri in group peri */
-  kTopEarlgreyGateableClocksUsbPeri = 1, /**< Clock clk_usb_peri in group peri */
-  kTopEarlgreyGateableClocksLast = 1, /**< \internal Last Valid Gateable Clock */
+  kTopEarlgreyGateableClocksIoDiv2Peri = 1, /**< Clock clk_io_div2_peri in group peri */
+  kTopEarlgreyGateableClocksUsbPeri = 2, /**< Clock clk_usb_peri in group peri */
+  kTopEarlgreyGateableClocksLast = 2, /**< \internal Last Valid Gateable Clock */
 } top_earlgrey_gateable_clocks_t;
 
 /**

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -226,7 +226,7 @@
     }
     { name: "spi_device",
       type: "spi_device",
-      clock_srcs: {clk_i: "io_div4"},
+      clock_srcs: {clk_i: "io_div4", scan_clk_i: "io_div2"},
       clock_group: "peri",
       reset_connections: {rst_ni: "spi_device"},
       base_addr: "0x40050000",


### PR DESCRIPTION
Address #5276 

This ensures the subset of flops running on the external clock can be
scanned.

Signed-off-by: Timothy Chen <timothytim@google.com>