### PR TITLE
[dv/alert_handler] fix regression error

### DIFF
--- a/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -199,7 +199,7 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
   virtual function void alert_accum_cal(int class_i);
     bit [TL_DW-1:0] accum_thresh = get_class_accum_thresh(class_i);
     realtime curr_time = $realtime();
-    if (curr_time != last_triggered_alert_per_class[class_i]) begin
+    if (curr_time != last_triggered_alert_per_class[class_i] && !cfg.under_reset) begin
       last_triggered_alert_per_class[class_i] = curr_time;
       // avoid accum_cnt saturate
       if (accum_cnter_per_class[class_i] < 'hffff) begin

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -80,10 +80,13 @@ class alert_handler_base_vseq extends cip_base_vseq #(
     if (!regwen[3]) csr_wr(.csr(ral.classd_regwen), .value($urandom_range(0, 1)));
   endtask
 
-  // write regen register if do_lock_config is set. If not set, 50% of chance to write value 0
-  // to regen register.
+  // If do_lock_config is set, write value 0 to rewgen register.
+  // If not set, this task has 50% of chance to write value 1 to regwen register.
+  // Please note that writing 1 to regwen won't lock any lockable regs.
   virtual task lock_config(bit do_lock_config);
-    if (do_lock_config || $urandom_range(0,1)) csr_wr(.csr(ral.regwen), .value(do_lock_config));
+    if (do_lock_config || $urandom_range(0, 1)) begin
+      csr_wr(.csr(ral.regwen), .value(!do_lock_config));
+    end
   endtask
 
   virtual task drive_alert(bit[NUM_ALERTS-1:0] alert_trigger, bit[NUM_ALERTS-1:0] alert_int_err);


### PR DESCRIPTION
Two regression error fixes regarding alert_handler:
1. Regwen switch from W1C to W0C, so writing 0 to the regwen will lock
the lockable regs.
2. Adding a reset when check escalation length, because reset is async
and monitor counts on posedge while scb counts on negedge. If reset is
in between the clock edge, there might be mismatch.

Signed-off-by: Cindy Chen <chencindy@google.com>