### PR TITLE
[sw, mask_rom] Initialise Pinmux

### DIFF
--- a/sw/device/mask_rom/mask_rom.c
+++ b/sw/device/mask_rom/mask_rom.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include "sw/device/lib/base/stdasm.h"
+#include "sw/device/lib/pinmux.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/rom_exts/rom_ext_manifest_parser.h"
 
@@ -19,6 +20,8 @@ static const uint32_t kRomExtIdentifierExpected = 0x4552544F;
 typedef void(boot_fn)(void);
 
 void mask_rom_boot(void) {
+  pinmux_init();
+
   rom_ext_manifest_t rom_ext = rom_ext_get_parameters(kRomExtManifestSlotA);
 
   // Check we have a valid ROM_EXT

--- a/sw/device/mask_rom/meson.build
+++ b/sw/device/mask_rom/meson.build
@@ -27,8 +27,9 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
     dependencies: [
       chip_info_h,
       device_lib,
+      rom_ext_manifest_parser,
+      sw_lib_pinmux,
       sw_lib_crt,
-      rom_ext_manifest_parser
     ],
   )
 


### PR DESCRIPTION
UART pins used to be dedicated, however with recent changes these
became multiplexible. This means that in order to get any uart output
in Mask ROM or ROM_EXT - the corresponding pins must be configured.

This change adds call to pinmux_init at the beginning of
mask_rom_boot. This ensures that the UART pins are configured in both
Mask ROM and ROM_EXT.

NOTE:
DIF Pinmux is work in progress, however it is expected that Mask ROM
will use the DIF directly to configure the pins. This also means that
sw_lib_pinmux will cease to exist.

Signed-off-by: Silvestrs Timofejevs <silvestrst@lowrisc.org>