### PR TITLE
[csrng/rtl] internal state read timing improvements

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -212,6 +212,46 @@
         }
       ]
     },
+    { name: "HALT_MAIN_SM",
+      desc: "Halt the CSRNG main state machine register",
+      swaccess: "wo",
+      hwaccess: "hro",
+      regwen: "REGWEN",
+      fields: [
+        {
+            bits: "0",
+            name: "HALT_MAIN_SM",
+            desc: '''
+                  Setting this bit halts the main state machine that processes
+                  csrng application commands. The purpose of this register is to
+                  allow reading the internal state registers in a controlled manner.
+                  After this bit is set, the status bit should be polled to determine if the
+                  state machine has halted. Once halted, the internal state can be read
+                  out. To resume operation, this bit should be reset.
+                  '''
+        },
+      ]
+    },
+    { name: "MAIN_SM_STS",
+      desc: "CSRNG main state machine status register",
+      swaccess: "ro",
+      hwaccess: "hwo",
+      fields: [
+        { bits: "0",
+          name: "MAIN_SM_STS",
+          desc: '''
+                This bit indicates when the CSRNG main state machine has been halted.
+                When the halt bit is set, this bit should be polled until this
+                status bit is set. When set, it is safe to read the internal state
+                registers. When the halt bit is cleared, this register can be
+                polled to make sure the main state machine is operational again.
+                '''
+          tags: [// Internal HW can modify status register
+                 "excl:CsrAllTests:CsrExclCheck"]
+          resval: "0"
+        }
+      ]
+    },
     { name: "INT_STATE_NUM",
       desc: "Internal state number register",
       swaccess: "rw",

--- a/hw/ip/csrng/rtl/csrng.sv
+++ b/hw/ip/csrng/rtl/csrng.sv
@@ -10,7 +10,7 @@ module csrng
  import csrng_pkg::*;
  import csrng_reg_pkg::*;
 #(
-  parameter aes_pkg::sbox_impl_e SBoxImpl = aes_pkg::SBoxImplLut,
+  parameter aes_pkg::sbox_impl_e SBoxImpl = aes_pkg::SBoxImplCanright,
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
   parameter int NHwApps = 2
 ) (

--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -114,7 +114,8 @@ module csrng_cmd_stage import csrng_pkg::*; #(
   prim_fifo_sync #(
     .Width(CmdFifoWidth),
     .Pass(0),
-    .Depth(CmdFifoDepth)
+    .Depth(CmdFifoDepth),
+    .OutputZeroIfEmpty(1'b0)
   ) u_prim_fifo_cmd (
     .clk_i          (clk_i),
     .rst_ni         (rst_ni),
@@ -320,7 +321,8 @@ module csrng_cmd_stage import csrng_pkg::*; #(
   prim_fifo_sync #(
     .Width(GenBitsFifoWidth),
     .Pass(0),
-    .Depth(GenBitsFifoDepth)
+    .Depth(GenBitsFifoDepth),
+    .OutputZeroIfEmpty(1'b1) // Set to 1 to prevent triggering the output assert check for x's
   ) u_prim_fifo_genbits (
     .clk_i          (clk_i),
     .rst_ni         (rst_ni),

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -125,7 +125,6 @@ module csrng_core import csrng_pkg::*; #(
   logic                   update_req;
   logic                   uninstant_req;
   logic [3:0]             fifo_sel;
-  logic                   state_db_rd_req;
   logic                   ctr_drbg_cmd_req;
   logic                   ctr_drbg_gen_req;
   logic                   ctr_drbg_gen_req_rdy;
@@ -297,6 +296,8 @@ module csrng_core import csrng_pkg::*; #(
   logic                    state_db_reg_rd_id_pulse;
   logic [StateId-1:0]      state_db_reg_rd_id;
   logic [31:0]             state_db_reg_rd_val;
+  logic                    halt_main_sm;
+  logic                    main_sm_sts;
 
   logic [30:0]             err_code_test_bit;
 
@@ -306,6 +307,9 @@ module csrng_core import csrng_pkg::*; #(
   logic        flag0_q, flag0_d;
   logic        statedb_wr_select_q, statedb_wr_select_d;
   logic        genbits_stage_fips_sw_q, genbits_stage_fips_sw_d;
+  logic        lc_hw_debug_not_on_q, lc_hw_debug_not_on_d;
+  logic        lc_hw_debug_on_q, lc_hw_debug_on_d;
+  logic        cmd_req_dly_q, cmd_req_dly_d;
 
   always_ff @(posedge clk_i or negedge rst_ni)
     if (!rst_ni) begin
@@ -314,12 +318,18 @@ module csrng_core import csrng_pkg::*; #(
       flag0_q <= '0;
       statedb_wr_select_q <= '0;
       genbits_stage_fips_sw_q <= '0;
+      lc_hw_debug_not_on_q <= '0;
+      lc_hw_debug_on_q <= '0;
+      cmd_req_dly_q <= '0;
     end else begin
       acmd_q  <= acmd_d;
       shid_q  <= shid_d;
       flag0_q <= flag0_d;
       statedb_wr_select_q <= statedb_wr_select_d;
       genbits_stage_fips_sw_q <= genbits_stage_fips_sw_d;
+      lc_hw_debug_not_on_q <= lc_hw_debug_not_on_d;
+      lc_hw_debug_on_q <= lc_hw_debug_on_d;
+      cmd_req_dly_q <= cmd_req_dly_d;
     end
 
   //--------------------------------------------
@@ -776,7 +786,9 @@ module csrng_core import csrng_pkg::*; #(
   assign shid = acmd_bus[15:12];
 
   assign acmd_d = acmd_sop ? acmd_bus[2:0] : acmd_q;
-  assign shid_d = acmd_sop ? shid : shid_q;
+  assign shid_d = acmd_sop ? shid :
+         state_db_reg_rd_id_pulse ? state_db_reg_rd_id :
+         shid_q;
   assign flag0_d = acmd_sop ? flag0 : flag0_q;
 
   // sm to process all instantiation requests
@@ -796,9 +808,10 @@ module csrng_core import csrng_pkg::*; #(
     .generate_req_o(generate_req),
     .update_req_o(update_req),
     .uninstant_req_o(uninstant_req),
+    .halt_main_sm_i(halt_main_sm),
+    .main_sm_halted_o(main_sm_sts),
     .main_sm_err_o(main_sm_err)
   );
-
 
   // interrupt for sw app interface only
   assign event_cs_cmd_req_done = cmd_stage_ack[NApps-1];
@@ -850,15 +863,19 @@ module csrng_core import csrng_pkg::*; #(
   // of each csrng instance. The state
   // is updated after each command.
 
-  assign state_db_rd_req = reseed_req || generate_req || update_req;
-
   assign cmd_result_wr_req = cmd_result_ack && (cmd_result_ccmd != GEN);
 
   // register read access
   assign state_db_reg_rd_sel = reg2hw.int_state_val.re;
   assign state_db_reg_rd_id = reg2hw.int_state_num.q;
   assign state_db_reg_rd_id_pulse = reg2hw.int_state_num.qe;
-  assign hw2reg.int_state_val.d = cs_enable ? state_db_reg_rd_val : '0;
+  assign hw2reg.int_state_val.d = state_db_reg_rd_val;
+
+  // main sm control
+  assign halt_main_sm = reg2hw.halt_main_sm.q;
+  assign hw2reg.main_sm_sts.de = 1'b1;
+  assign hw2reg.main_sm_sts.d = main_sm_sts;
+
 
   csrng_state_db #(
     .NApps(NApps),
@@ -871,7 +888,6 @@ module csrng_core import csrng_pkg::*; #(
     .clk_i(clk_i),
     .rst_ni(rst_ni),
     .state_db_enable_i(cs_enable),
-    .state_db_rd_req_i(state_db_rd_req),
     .state_db_rd_inst_id_i(shid_q),
     .state_db_rd_key_o(state_db_rd_key),
     .state_db_rd_v_o(state_db_rd_v),
@@ -889,9 +905,8 @@ module csrng_core import csrng_pkg::*; #(
     .state_db_wr_res_ctr_i(state_db_wr_rc),
     .state_db_wr_sts_i(state_db_wr_sts),
 
-    .state_db_lc_en_i(lc_hw_debug_on),
+    .state_db_lc_en_i(lc_hw_debug_on_q),
     .state_db_reg_rd_sel_i(state_db_reg_rd_sel),
-    .state_db_reg_rd_id_i(state_db_reg_rd_id),
     .state_db_reg_rd_id_pulse_i(state_db_reg_rd_id_pulse),
     .state_db_reg_rd_val_o(state_db_reg_rd_val),
     .state_db_sts_ack_o(state_db_sts_ack),
@@ -960,9 +975,10 @@ module csrng_core import csrng_pkg::*; #(
 
 
 
-  assign ctr_drbg_cmd_req =
+  assign cmd_req_dly_d =
          instant_req || reseed_req || generate_req || update_req || uninstant_req;
 
+  assign ctr_drbg_cmd_req = cmd_req_dly_q;
 
   csrng_ctr_drbg_cmd #(
     .Cmd(Cmd),
@@ -1131,6 +1147,9 @@ module csrng_core import csrng_pkg::*; #(
   assign      lc_hw_debug_not_on = (lc_hw_debug_en_out[0] != lc_ctrl_pkg::On);
   assign      lc_hw_debug_on = (lc_hw_debug_en_out[1] == lc_ctrl_pkg::On);
 
+  // flop for better timing
+  assign      lc_hw_debug_not_on_d = lc_hw_debug_not_on;
+  assign      lc_hw_debug_on_d = lc_hw_debug_on;
 
   //-------------------------------------
   // csrng_block_encrypt instantiation
@@ -1153,7 +1172,7 @@ module csrng_core import csrng_pkg::*; #(
     .rst_ni(rst_ni),
     .block_encrypt_bypass_i(!aes_cipher_enable),
     .block_encrypt_enable_i(cs_enable),
-    .block_encrypt_lc_hw_debug_not_on_i(lc_hw_debug_not_on),
+    .block_encrypt_lc_hw_debug_not_on_i(lc_hw_debug_not_on_q),
     .block_encrypt_req_i(benblk_arb_vld),
     .block_encrypt_rdy_o(benblk_arb_rdy),
     .block_encrypt_key_i(benblk_arb_key),

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_cmd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_cmd.sv
@@ -123,7 +123,8 @@ module csrng_ctr_drbg_cmd import csrng_pkg::*; #(
   prim_fifo_sync #(
     .Width(CmdreqFifoWidth),
     .Pass(0),
-    .Depth(CmdreqFifoDepth)
+    .Depth(CmdreqFifoDepth),
+    .OutputZeroIfEmpty(1'b0)
   ) u_prim_fifo_sync_cmdreq (
     .clk_i          (clk_i),
     .rst_ni         (rst_ni),
@@ -211,7 +212,8 @@ module csrng_ctr_drbg_cmd import csrng_pkg::*; #(
   prim_fifo_sync #(
     .Width(RCStageFifoWidth),
     .Pass(0),
-    .Depth(RCStageFifoDepth)
+    .Depth(RCStageFifoDepth),
+    .OutputZeroIfEmpty(1'b0)
   ) u_prim_fifo_sync_rcstage (
     .clk_i          (clk_i),
     .rst_ni         (rst_ni),
@@ -246,7 +248,8 @@ module csrng_ctr_drbg_cmd import csrng_pkg::*; #(
   prim_fifo_sync #(
     .Width(KeyVRCFifoWidth),
     .Pass(0),
-    .Depth(KeyVRCFifoDepth)
+    .Depth(KeyVRCFifoDepth),
+    .OutputZeroIfEmpty(1'b0)
   ) u_prim_fifo_sync_keyvrc (
     .clk_i          (clk_i),
     .rst_ni         (rst_ni),

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
@@ -229,7 +229,8 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
   prim_fifo_sync #(
     .Width(GenreqFifoWidth),
     .Pass(0),
-    .Depth(GenreqFifoDepth)
+    .Depth(GenreqFifoDepth),
+    .OutputZeroIfEmpty(1'b0)
   ) u_prim_fifo_sync_genreq (
     .clk_i          (clk_i),
     .rst_ni         (rst_ni),
@@ -346,7 +347,8 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
   prim_fifo_sync #(
     .Width(AdstageFifoWidth),
     .Pass(0),
-    .Depth(AdstageFifoDepth)
+    .Depth(AdstageFifoDepth),
+    .OutputZeroIfEmpty(1'b0)
   ) u_prim_fifo_sync_adstage (
     .clk_i          (clk_i),
     .rst_ni         (rst_ni),
@@ -379,7 +381,8 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
   prim_fifo_sync #(
     .Width(BlkEncAckFifoWidth),
     .Pass(0),
-    .Depth(BlkEncAckFifoDepth)
+    .Depth(BlkEncAckFifoDepth),
+    .OutputZeroIfEmpty(1'b0)
   ) u_prim_fifo_sync_bencack (
     .clk_i    (clk_i),
     .rst_ni   (rst_ni),
@@ -431,7 +434,8 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
   prim_fifo_sync #(
     .Width(RCStageFifoWidth),
     .Pass(0),
-    .Depth(RCStageFifoDepth)
+    .Depth(RCStageFifoDepth),
+    .OutputZeroIfEmpty(1'b0)
   ) u_prim_fifo_sync_rcstage (
     .clk_i          (clk_i),
     .rst_ni         (rst_ni),
@@ -467,7 +471,8 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
   prim_fifo_sync #(
     .Width(GenbitsFifoWidth),
     .Pass(0),
-    .Depth(GenbitsFifoDepth)
+    .Depth(GenbitsFifoDepth),
+    .OutputZeroIfEmpty(1'b0)
   ) u_prim_fifo_sync_genbits (
     .clk_i          (clk_i),
     .rst_ni         (rst_ni),

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
@@ -263,7 +263,8 @@ module csrng_ctr_drbg_upd #(
   prim_fifo_sync #(
     .Width(UpdReqFifoWidth),
     .Pass(0),
-    .Depth(UpdReqFifoDepth)
+    .Depth(UpdReqFifoDepth),
+    .OutputZeroIfEmpty(1'b0)
   ) u_prim_fifo_sync_updreq (
     .clk_i    (clk_i),
     .rst_ni   (rst_ni),
@@ -365,7 +366,8 @@ module csrng_ctr_drbg_upd #(
   prim_fifo_sync #(
     .Width(BlkEncReqFifoWidth),
     .Pass(0),
-    .Depth(BlkEncReqFifoDepth)
+    .Depth(BlkEncReqFifoDepth),
+    .OutputZeroIfEmpty(1'b0)
   ) u_prim_fifo_sync_bencreq (
     .clk_i    (clk_i),
     .rst_ni   (rst_ni),
@@ -406,7 +408,8 @@ module csrng_ctr_drbg_upd #(
   prim_fifo_sync #(
     .Width(BlkEncAckFifoWidth),
     .Pass(0),
-    .Depth(BlkEncAckFifoDepth)
+    .Depth(BlkEncAckFifoDepth),
+    .OutputZeroIfEmpty(1'b0)
   ) u_prim_fifo_sync_bencack (
     .clk_i    (clk_i),
     .rst_ni   (rst_ni),
@@ -439,7 +442,8 @@ module csrng_ctr_drbg_upd #(
   prim_fifo_sync #(
     .Width(PDataFifoWidth),
     .Pass(0),
-    .Depth(PDataFifoDepth)
+    .Depth(PDataFifoDepth),
+    .OutputZeroIfEmpty(1'b0)
   ) u_prim_fifo_sync_pdata (
     .clk_i    (clk_i),
     .rst_ni   (rst_ni),
@@ -539,7 +543,8 @@ module csrng_ctr_drbg_upd #(
   prim_fifo_sync #(
     .Width(FinalFifoWidth),
     .Pass(0),
-    .Depth(FinalFifoDepth)
+    .Depth(FinalFifoDepth),
+    .OutputZeroIfEmpty(1'b0)
   ) u_prim_fifo_sync_final (
     .clk_i    (clk_i),
     .rst_ni   (rst_ni),

--- a/hw/ip/csrng/rtl/csrng_main_sm.sv
+++ b/hw/ip/csrng/rtl/csrng_main_sm.sv
@@ -24,43 +24,46 @@ module csrng_main_sm import csrng_pkg::*; (
   output logic               generate_req_o,
   output logic               update_req_o,
   output logic               uninstant_req_o,
+  input logic                halt_main_sm_i,
+  output logic               main_sm_halted_o,
   output logic               main_sm_err_o
 );
 
 // Encoding generated with:
-// $ ./util/design/sparse-fsm-encode.py -d 3 -m 10 -n 8 \
-//      -s 845453599 --language=sv
+// $ ./util/design/sparse-fsm-encode.py -d 3 -m 11 -n 8 \
+//      -s 2773294212 --language=sv
 //
 // Hamming distance histogram:
 //
 //  0: --
 //  1: --
 //  2: --
-//  3: ||||||||||||||| (26.67%)
-//  4: |||||||||||||||||||| (35.56%)
-//  5: ||||||||||||||| (26.67%)
-//  6: ||||| (8.89%)
-//  7: --
-//  8: | (2.22%)
+//  3: |||||||||||||||| (29.09%)
+//  4: |||||||||||||||||||| (34.55%)
+//  5: |||||||||| (18.18%)
+//  6: |||||||| (14.55%)
+//  7: || (3.64%)
+//  8: --
 //
 // Minimum Hamming distance: 3
-// Maximum Hamming distance: 8
-// Minimum Hamming weight: 2
+// Maximum Hamming distance: 7
+// Minimum Hamming weight: 1
 // Maximum Hamming weight: 7
 //
 
   localparam int StateWidth = 8;
   typedef    enum logic [StateWidth-1:0] {
-    Idle    =      8'b10111111, // idle
-    InstantPrep  = 8'b11011101, // instantiate prep
-    InstantReq   = 8'b00010100, // instantiate request (takes adata or entropy)
-    ReseedPrep   = 8'b11000001, // reseed prep
-    ReseedReq    = 8'b01100100, // reseed request (takes adata and entropy and Key,V,RC)
-    GenerateReq  = 8'b10101100, // generate request (takes adata? and Key,V,RC)
-    UpdatePrep   = 8'b11010010, // update prep
-    UpdateReq    = 8'b11111000, // update request (takes adata and Key,V,RC)
-    UninstantReq = 8'b11101011, // uninstantiate request (no input)
-    Error        = 8'b00001010  // error state, results in fatal alert
+    Idle    =      8'b10100100, // idle
+    InstantPrep  = 8'b10011100, // instantiate prep
+    InstantReq   = 8'b00010010, // instantiate request (takes adata or entropy)
+    ReseedPrep   = 8'b10101001, // reseed prep
+    ReseedReq    = 8'b11010011, // reseed request (takes adata and entropy and Key,V,RC)
+    GenerateReq  = 8'b11101010, // generate request (takes adata? and Key,V,RC)
+    UpdatePrep   = 8'b00000001, // update prep
+    UpdateReq    = 8'b01010101, // update request (takes adata and Key,V,RC)
+    UninstantReq = 8'b00001110, // uninstantiate request (no input)
+    SMHalted     = 8'b01011000, // state machine halted
+    Error        = 8'b11111101  // error state, results in fatal alert
   } state_e;
 
   state_e state_d, state_q;
@@ -90,28 +93,33 @@ module csrng_main_sm import csrng_pkg::*; (
     generate_req_o = 1'b0;
     update_req_o = 1'b0;
     uninstant_req_o = 1'b0;
+    main_sm_halted_o = 1'b0;
     main_sm_err_o = 1'b0;
     unique case (state_q)
       Idle: begin
-        if (ctr_drbg_cmd_req_rdy_i) begin
-          if (acmd_avail_i) begin
-            acmd_accept_o = 1'b1;
-            if (acmd_i == INS) begin
-              if (acmd_eop_i) begin
-                state_d = InstantPrep;
+        if (halt_main_sm_i) begin
+          state_d = SMHalted;
+        end else begin
+          if (ctr_drbg_cmd_req_rdy_i) begin
+            if (acmd_avail_i) begin
+              acmd_accept_o = 1'b1;
+              if (acmd_i == INS) begin
+                if (acmd_eop_i) begin
+                  state_d = InstantPrep;
+                end
+              end else if (acmd_i == RES) begin
+                if (acmd_eop_i) begin
+                  state_d = ReseedPrep;
+                end
+              end else if (acmd_i == GEN) begin
+                state_d = GenerateReq;
+              end else if (acmd_i == UPD) begin
+                if (acmd_eop_i) begin
+                  state_d = UpdatePrep;
+                end
+              end else if (acmd_i == UNI) begin
+                state_d = UninstantReq;
               end
-            end else if (acmd_i == RES) begin
-              if (acmd_eop_i) begin
-                state_d = ReseedPrep;
-              end
-            end else if (acmd_i == GEN) begin
-              state_d = GenerateReq;
-            end else if (acmd_i == UPD) begin
-              if (acmd_eop_i) begin
-                state_d = UpdatePrep;
-              end
-            end else if (acmd_i == UNI) begin
-              state_d = UninstantReq;
             end
           end
         end
@@ -161,6 +169,12 @@ module csrng_main_sm import csrng_pkg::*; (
       UninstantReq: begin
         uninstant_req_o = 1'b1;
         state_d = Idle;
+      end
+      SMHalted: begin
+        main_sm_halted_o = 1'b1;
+        if (!halt_main_sm_i) begin
+          state_d = Idle;
+        end
       end
       Error: begin
         main_sm_err_o = 1'b1;

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -11,7 +11,7 @@ package csrng_reg_pkg;
   parameter int NumAlerts = 1;
 
   // Address width within the block
-  parameter int BlockAw = 6;
+  parameter int BlockAw = 7;
 
   ////////////////////////////
   // Typedefs for registers //
@@ -97,6 +97,10 @@ package csrng_reg_pkg;
   } csrng_reg2hw_genbits_reg_t;
 
   typedef struct packed {
+    logic        q;
+  } csrng_reg2hw_halt_main_sm_reg_t;
+
+  typedef struct packed {
     logic [3:0]  q;
     logic        qe;
   } csrng_reg2hw_int_state_num_reg_t;
@@ -165,6 +169,11 @@ package csrng_reg_pkg;
   typedef struct packed {
     logic [31:0] d;
   } csrng_hw2reg_genbits_reg_t;
+
+  typedef struct packed {
+    logic        d;
+    logic        de;
+  } csrng_hw2reg_main_sm_sts_reg_t;
 
   typedef struct packed {
     logic [31:0] d;
@@ -283,14 +292,15 @@ package csrng_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    csrng_reg2hw_intr_state_reg_t intr_state; // [134:131]
-    csrng_reg2hw_intr_enable_reg_t intr_enable; // [130:127]
-    csrng_reg2hw_intr_test_reg_t intr_test; // [126:119]
-    csrng_reg2hw_alert_test_reg_t alert_test; // [118:117]
-    csrng_reg2hw_regwen_reg_t regwen; // [116:116]
-    csrng_reg2hw_ctrl_reg_t ctrl; // [115:110]
-    csrng_reg2hw_cmd_req_reg_t cmd_req; // [109:77]
-    csrng_reg2hw_genbits_reg_t genbits; // [76:44]
+    csrng_reg2hw_intr_state_reg_t intr_state; // [135:132]
+    csrng_reg2hw_intr_enable_reg_t intr_enable; // [131:128]
+    csrng_reg2hw_intr_test_reg_t intr_test; // [127:120]
+    csrng_reg2hw_alert_test_reg_t alert_test; // [119:118]
+    csrng_reg2hw_regwen_reg_t regwen; // [117:117]
+    csrng_reg2hw_ctrl_reg_t ctrl; // [116:111]
+    csrng_reg2hw_cmd_req_reg_t cmd_req; // [110:78]
+    csrng_reg2hw_genbits_reg_t genbits; // [77:45]
+    csrng_reg2hw_halt_main_sm_reg_t halt_main_sm; // [44:44]
     csrng_reg2hw_int_state_num_reg_t int_state_num; // [43:39]
     csrng_reg2hw_int_state_val_reg_t int_state_val; // [38:6]
     csrng_reg2hw_err_code_test_reg_t err_code_test; // [5:0]
@@ -300,33 +310,36 @@ package csrng_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    csrng_hw2reg_intr_state_reg_t intr_state; // [170:163]
-    csrng_hw2reg_sum_sts_reg_t sum_sts; // [162:136]
-    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [135:132]
-    csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [131:130]
-    csrng_hw2reg_genbits_reg_t genbits; // [129:98]
+    csrng_hw2reg_intr_state_reg_t intr_state; // [172:165]
+    csrng_hw2reg_sum_sts_reg_t sum_sts; // [164:138]
+    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [137:134]
+    csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [133:132]
+    csrng_hw2reg_genbits_reg_t genbits; // [131:100]
+    csrng_hw2reg_main_sm_sts_reg_t main_sm_sts; // [99:98]
     csrng_hw2reg_int_state_val_reg_t int_state_val; // [97:66]
     csrng_hw2reg_hw_exc_sts_reg_t hw_exc_sts; // [65:50]
     csrng_hw2reg_err_code_reg_t err_code; // [49:0]
   } csrng_hw2reg_t;
 
   // Register Address
-  parameter logic [BlockAw-1:0] CSRNG_INTR_STATE_OFFSET = 6'h 0;
-  parameter logic [BlockAw-1:0] CSRNG_INTR_ENABLE_OFFSET = 6'h 4;
-  parameter logic [BlockAw-1:0] CSRNG_INTR_TEST_OFFSET = 6'h 8;
-  parameter logic [BlockAw-1:0] CSRNG_ALERT_TEST_OFFSET = 6'h c;
-  parameter logic [BlockAw-1:0] CSRNG_REGWEN_OFFSET = 6'h 10;
-  parameter logic [BlockAw-1:0] CSRNG_CTRL_OFFSET = 6'h 14;
-  parameter logic [BlockAw-1:0] CSRNG_SUM_STS_OFFSET = 6'h 18;
-  parameter logic [BlockAw-1:0] CSRNG_CMD_REQ_OFFSET = 6'h 1c;
-  parameter logic [BlockAw-1:0] CSRNG_SW_CMD_STS_OFFSET = 6'h 20;
-  parameter logic [BlockAw-1:0] CSRNG_GENBITS_VLD_OFFSET = 6'h 24;
-  parameter logic [BlockAw-1:0] CSRNG_GENBITS_OFFSET = 6'h 28;
-  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_NUM_OFFSET = 6'h 2c;
-  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_VAL_OFFSET = 6'h 30;
-  parameter logic [BlockAw-1:0] CSRNG_HW_EXC_STS_OFFSET = 6'h 34;
-  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_OFFSET = 6'h 38;
-  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_TEST_OFFSET = 6'h 3c;
+  parameter logic [BlockAw-1:0] CSRNG_INTR_STATE_OFFSET = 7'h 0;
+  parameter logic [BlockAw-1:0] CSRNG_INTR_ENABLE_OFFSET = 7'h 4;
+  parameter logic [BlockAw-1:0] CSRNG_INTR_TEST_OFFSET = 7'h 8;
+  parameter logic [BlockAw-1:0] CSRNG_ALERT_TEST_OFFSET = 7'h c;
+  parameter logic [BlockAw-1:0] CSRNG_REGWEN_OFFSET = 7'h 10;
+  parameter logic [BlockAw-1:0] CSRNG_CTRL_OFFSET = 7'h 14;
+  parameter logic [BlockAw-1:0] CSRNG_SUM_STS_OFFSET = 7'h 18;
+  parameter logic [BlockAw-1:0] CSRNG_CMD_REQ_OFFSET = 7'h 1c;
+  parameter logic [BlockAw-1:0] CSRNG_SW_CMD_STS_OFFSET = 7'h 20;
+  parameter logic [BlockAw-1:0] CSRNG_GENBITS_VLD_OFFSET = 7'h 24;
+  parameter logic [BlockAw-1:0] CSRNG_GENBITS_OFFSET = 7'h 28;
+  parameter logic [BlockAw-1:0] CSRNG_HALT_MAIN_SM_OFFSET = 7'h 2c;
+  parameter logic [BlockAw-1:0] CSRNG_MAIN_SM_STS_OFFSET = 7'h 30;
+  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_NUM_OFFSET = 7'h 34;
+  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_VAL_OFFSET = 7'h 38;
+  parameter logic [BlockAw-1:0] CSRNG_HW_EXC_STS_OFFSET = 7'h 3c;
+  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_OFFSET = 7'h 40;
+  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_TEST_OFFSET = 7'h 44;
 
   // Reset values for hwext registers and their fields
   parameter logic [3:0] CSRNG_INTR_TEST_RESVAL = 4'h 0;
@@ -353,6 +366,8 @@ package csrng_reg_pkg;
     CSRNG_SW_CMD_STS,
     CSRNG_GENBITS_VLD,
     CSRNG_GENBITS,
+    CSRNG_HALT_MAIN_SM,
+    CSRNG_MAIN_SM_STS,
     CSRNG_INT_STATE_NUM,
     CSRNG_INT_STATE_VAL,
     CSRNG_HW_EXC_STS,
@@ -361,7 +376,7 @@ package csrng_reg_pkg;
   } csrng_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] CSRNG_PERMIT [16] = '{
+  parameter logic [3:0] CSRNG_PERMIT [18] = '{
     4'b 0001, // index[ 0] CSRNG_INTR_STATE
     4'b 0001, // index[ 1] CSRNG_INTR_ENABLE
     4'b 0001, // index[ 2] CSRNG_INTR_TEST
@@ -373,11 +388,13 @@ package csrng_reg_pkg;
     4'b 0001, // index[ 8] CSRNG_SW_CMD_STS
     4'b 0001, // index[ 9] CSRNG_GENBITS_VLD
     4'b 1111, // index[10] CSRNG_GENBITS
-    4'b 0001, // index[11] CSRNG_INT_STATE_NUM
-    4'b 1111, // index[12] CSRNG_INT_STATE_VAL
-    4'b 0011, // index[13] CSRNG_HW_EXC_STS
-    4'b 1111, // index[14] CSRNG_ERR_CODE
-    4'b 0001  // index[15] CSRNG_ERR_CODE_TEST
+    4'b 0001, // index[11] CSRNG_HALT_MAIN_SM
+    4'b 0001, // index[12] CSRNG_MAIN_SM_STS
+    4'b 0001, // index[13] CSRNG_INT_STATE_NUM
+    4'b 1111, // index[14] CSRNG_INT_STATE_VAL
+    4'b 0011, // index[15] CSRNG_HW_EXC_STS
+    4'b 1111, // index[16] CSRNG_ERR_CODE
+    4'b 0001  // index[17] CSRNG_ERR_CODE_TEST
   };
 endpackage
 


### PR DESCRIPTION
Re-structed the read flow for the internal state array.
Added parameter to prim_fifo_sync to remove output mux.
Added simple flops to break up configuration paths.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>