### PR TITLE
[top/dv] fix CSR test failures

### DIFF
--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -216,6 +216,8 @@
           desc: "Raised if the watchdog timer has hit the bark threshold",
         }
       ]
+      tags: [// interrupt could be updated by HW
+        "excl:CsrNonInitTests:CsrExclWriteCheck"],
     },
     { name: "INTR_ENABLE",
       desc: "Dummy interrupt enable register.  This is only here because of #5260.  DO NOT USE",
@@ -265,6 +267,8 @@
           desc: "AON timer requested wakeup, write 0 to clear",
         }
       ]
+      tags: [// this could be updated by HW
+        "excl:CsrNonInitTests:CsrExclWriteCheck"],
     },
   ],
 }

--- a/hw/ip/uart/data/uart.hjson
+++ b/hw/ip/uart/data/uart.hjson
@@ -140,13 +140,17 @@
           name: "RXIDLE"
           desc: "RX is idle"
           resval: "1",
-          tags: [// check idle in directed test only
-            "excl:CsrNonInitTests:CsrExclCheck"]
+          tags: [// check idle in other tests only. In top-level, RX pin is driven by 0 when it's
+                 // not selected at pinmux
+            "excl:CsrAllTests:CsrExclCheck"]
         }
         { bits: "5"
           name: "RXEMPTY"
           desc: "RX FIFO is empty"
           resval: "1"
+          tags: [// check idle in other tests only. In top-level, RX pin is driven by 0 when it's
+                 // not selected at pinmux
+            "excl:CsrAllTests:CsrExclCheck"]
         }
       ]
     }


### PR DESCRIPTION
1. exclude HW update csr check in aon_timer
2. exclude RX status CSR for uart

Signed-off-by: Weicai Yang <weicai@google.com>