### PR TITLE
[dvsim] Use builtins wherever possible

### DIFF
--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -14,7 +14,7 @@ import hjson
 from CfgJson import set_target_attribute
 from Scheduler import Scheduler
 from utils import (VERBOSE, find_and_substitute_wildcards, md_results_to_html,
-                   subst_wildcards)
+                   rm_path, subst_wildcards)
 
 
 # Interface class for extensions.
@@ -209,11 +209,8 @@ class FlowCfg():
             self.cfgs.append(self.create_instance(mk_config, temp_cfg_file))
 
             # Delete the temp_cfg_file once the instance is created
-            try:
-                log.log(VERBOSE, "Deleting temp cfg file:\n%s", temp_cfg_file)
-                os.system("/bin/rm -rf " + temp_cfg_file)
-            except IOError:
-                log.error("Failed to remove temp cfg file:\n%s", temp_cfg_file)
+            log.log(VERBOSE, "Deleting temp cfg file:\n%s", temp_cfg_file)
+            rm_path(temp_cfg_file, ignore_error=True)
 
         else:
             log.error(
@@ -549,11 +546,10 @@ class FlowCfg():
             md_results_to_html(self.results_title, self.css_file,
                                publish_results_md))
         f.close()
-        rm_cmd += "/bin/rm -rf " + results_html_file + "; "
 
         log.info("Publishing results to %s", results_page_url)
         cmd = (self.results_server_cmd + " cp " + results_html_file + " " +
-               self.results_server_page + "; " + rm_cmd)
+               self.results_server_page)
         log.log(VERBOSE, cmd)
         try:
             cmd_output = subprocess.run(args=cmd,
@@ -563,6 +559,7 @@ class FlowCfg():
             log.log(VERBOSE, cmd_output.stdout.decode("utf-8"))
         except Exception as e:
             log.error("%s: Failed to publish results:\n\"%s\"", e, str(cmd))
+        rm_path(results_html_file)
 
     def publish_results(self):
         '''Public facing API for publishing results to the opentitan web
@@ -589,11 +586,10 @@ class FlowCfg():
             md_results_to_html(self.results_title, self.css_file,
                                self.results_summary_md))
         f.close()
-        rm_cmd = "/bin/rm -rf " + results_html_file + "; "
 
         log.info("Publishing results summary to %s", results_page_url)
         cmd = (self.results_server_cmd + " cp " + results_html_file + " " +
-               self.results_summary_server_page + "; " + rm_cmd)
+               self.results_summary_server_page)
         log.log(VERBOSE, cmd)
         try:
             cmd_output = subprocess.run(args=cmd,
@@ -603,6 +599,7 @@ class FlowCfg():
             log.log(VERBOSE, cmd_output.stdout.decode("utf-8"))
         except Exception as e:
             log.error("%s: Failed to publish results:\n\"%s\"", e, str(cmd))
+        rm_path(results_html_file)
 
     def has_errors(self):
         return self.errors_seen

--- a/util/dvsim/OneShotCfg.py
+++ b/util/dvsim/OneShotCfg.py
@@ -7,12 +7,12 @@ Class describing a one-shot build configuration object
 
 import logging as log
 import os
-import sys
 from collections import OrderedDict
 
 from Deploy import CompileOneShot
 from FlowCfg import FlowCfg
 from Modes import BuildModes, Modes
+from utils import rm_path
 
 
 class OneShotCfg(FlowCfg):
@@ -110,13 +110,9 @@ class OneShotCfg(FlowCfg):
 
     # Purge the output directories. This operates on self.
     def _purge(self):
-        if self.scratch_path:
-            try:
-                log.info("Purging scratch path %s", self.scratch_path)
-                os.system("/bin/rm -rf " + self.scratch_path)
-            except IOError:
-                log.error('Failed to purge scratch directory %s',
-                          self.scratch_path)
+        assert self.scratch_path
+        log.info("Purging scratch path %s", self.scratch_path)
+        rm_path(self.scratch_path)
 
     def _create_objects(self):
         # Create build and run modes objects
@@ -142,21 +138,9 @@ class OneShotCfg(FlowCfg):
     def _create_dirs(self):
         '''Create initial set of directories
         '''
-        # Invoking system calls has a performance penalty.
-        # Construct a single command line chained with '&&' to invoke
-        # the system call only once, rather than multiple times.
-        create_link_dirs_cmd = ""
         for link in self.links.keys():
-            create_link_dirs_cmd += "/bin/rm -rf " + self.links[link] + " && "
-            create_link_dirs_cmd += "mkdir -p " + self.links[link] + " && "
-        create_link_dirs_cmd += " true"
-
-        try:
-            os.system(create_link_dirs_cmd)
-        except IOError:
-            log.error("Error running when running the cmd \"%s\"",
-                      create_link_dirs_cmd)
-            sys.exit(1)
+            rm_path(self.links[link])
+            os.makedirs(self.links[link])
 
     def _create_deploy_objects(self):
         '''Create deploy objects from build modes


### PR DESCRIPTION
This change gets rid of `os.system` calls, `grep`s and other things that
are better achieved by using python built-ins.

Apart from that, there are lint fixes and other very minor changes.

Split from #5203, with comments addressed. 

Signed-off-by: Srikrishna Iyer <sriyer@google.com>