### PR TITLE
[dv/otp_ctrl] enable checking for interrupts and collect coverage

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -103,22 +103,22 @@ package otp_ctrl_env_pkg;
     NumOtpCtrlIntr
   } otp_intr_e;
 
-  typedef enum bit [14:0] {
-    OtpCheckPending     = 15'b100_0000_0000_0000,
-    OtpDaiIdle          = 15'b010_0000_0000_0000,
-    OtpDerivKeyFsmErr   = 15'b001_0000_0000_0000,
-    OtpScramblingFsmErr = 15'b000_1000_0000_0000,
-    OtpLfsrFsmErr       = 15'b000_0100_0000_0000,
-    OtpTimeoutErr       = 15'b000_0010_0000_0000,
-    OtpLciErr           = 15'b000_0001_0000_0000,
-    OtpDaiErr           = 15'b000_0000_1000_0000,
-    OtpLifeCycleErr     = 15'b000_0000_0100_0000,
-    OtpSecret2Err       = 15'b000_0000_0010_0000,
-    OtpSecret1Err       = 15'b000_0000_0001_0000,
-    OtpSecret0Err       = 15'b000_0000_0000_1000,
-    OtpHwCfgErr         = 15'b000_0000_0000_0100,
-    OtpOwnerSwCfgErr    = 15'b000_0000_0000_0010,
-    OtpCreatorSwCfgErr  = 15'b000_0000_0000_0001
+  typedef enum bit [4:0] {
+    OtpCreatorSwCfgErrIdx,
+    OtpOwnerSwCfgErrIdx,
+    OtpHwCfgErrIdx,
+    OtpSecret0ErrIdx,
+    OtpSecret1ErrIdx,
+    OtpSecret2ErrIdx,
+    OtpLifeCycleErrIdx,
+    OtpDaiErrIdx,
+    OtpLciErrIdx,
+    OtpTimeoutErrIdx,
+    OtpLfsrFsmErrIdx,
+    OtpScramblingFsmErrIdx,
+    OtpDerivKeyFsmErrIdx,
+    OtpDaiIdleIdx,
+    OtpCheckPendingIdx
   } otp_status_e;
 
   typedef enum bit [1:0] {

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -82,7 +82,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
         if (i > 1) dut_init();
         // after otp-init done, check status
         cfg.clk_rst_vif.wait_clks(1);
-        csr_rd_check(.ptr(ral.status), .compare_value(OtpDaiIdle));
+        csr_rd_check(.ptr(ral.status.dai_idle), .compare_value(1));
       end
       do_otp_ctrl_init = 0;
 
@@ -134,7 +134,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
       end
 
       if (do_lc_trans) begin
-        req_lc_transition();
+        req_lc_transition(do_lc_trans);
         req_lc_token();
       end
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_wake_up_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_wake_up_vseq.sv
@@ -23,7 +23,7 @@ class otp_ctrl_wake_up_vseq extends otp_ctrl_base_vseq;
     // check status
     cfg.clk_rst_vif.wait_clks(1);
     csr_wr(ral.intr_enable, (1'b1 << NumOtpCtrlIntr) - 1);
-    csr_rd_check(.ptr(ral.status), .compare_value(OtpDaiIdle));
+    csr_rd_check(.ptr(ral.status.dai_idle), .compare_value(1));
 
     // write seq
     csr_wr(ral.direct_access_address, rand_addr);


### PR DESCRIPTION
This PR is related to interrupts:
1. Support checking for interrupt related registers (except intr_state
waiting for designer's confirmation)
2. Ignored checking for status field `dai_idle` during dai operation,
because scb does not accurately predict which cycle dai operation
finishes.
Also move status prediction to addr_read_phase instead of
data_read_phase.
3. Change status `enum` from value to index because it is easier to use
index in scb.

Signed-off-by: Cindy Chen <chencindy@google.com>