### PR TITLE
[top] Connect pwrmgr functions to pinmux and aon_timer

### DIFF
--- a/hw/ip/aon_timer/rtl/aon_timer.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer.sv
@@ -21,9 +21,11 @@ module aon_timer (
   output logic                intr_wdog_timer_bark_o,
 
   // clk_aon_i domain
-  input  logic                sleep_mode_i, // TODO where will this come from?
   output logic                aon_timer_wkup_req_o,
-  output logic                aon_timer_rst_req_o
+  output logic                aon_timer_rst_req_o,
+
+  // async domain
+  input  logic                sleep_mode_i
 );
 
   import aon_timer_reg_pkg::*;
@@ -260,10 +262,20 @@ module aon_timer (
   // Timer Core //
   ////////////////
 
+  logic sleep_mode;
+  prim_flop_2sync #(
+    .Width(1)
+  ) u_sync_sleep_mode (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+    .d_i     (sleep_mode_i),
+    .q_o     (sleep_mode)
+  );
+
   aon_timer_core u_core (
     .clk_aon_i,
     .rst_aon_ni,
-    .sleep_mode_i,
+    .sleep_mode_i              (sleep_mode),
     .lc_escalate_en_i          (lc_escalate_en),
     .wkup_enable_o             (wkup_enable),
     .wkup_prescaler_o          (wkup_prescaler),

--- a/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
@@ -92,6 +92,19 @@
       package: "",
     },
 
+    { struct:  "logic",
+      type:    "uni",
+      name:    "strap",
+      act:     "req",
+      package: "",
+    },
+
+    { struct:  "logic",
+      type:    "uni",
+      name:    "low_power",
+      act:     "req",
+      package: "",
+    },
   ],
 
   param_list: [

--- a/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
@@ -190,6 +190,7 @@ package pwrmgr_pkg;
     FastPwrStateReleaseLcRst,
     FastPwrStateOtpInit,
     FastPwrStateLcInit,
+    FastPwrStateStrap,
     FastPwrStateFlashInit,
     FastPwrStateAckPwrUp,
     FastPwrStateActive,

--- a/hw/ip/pwrmgr/rtl/pwrmgr_wake_info.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_wake_info.sv
@@ -23,13 +23,25 @@ module pwrmgr_wake_info import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
 
   logic record_en;
 
+  // detect rising edge of start_capture_i
+  logic start_capture_q1, start_capture;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      start_capture_q1 <= 1'b1;
+    end else begin
+      start_capture_q1 <= start_capture_i;
+    end
+  end
+
+  assign start_capture = start_capture_i & ~start_capture_q1;
+
   // generate the record enbale signal
   // HW enables the recording
   // Software can suppress the recording or disable it
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       record_en <= 1'b0;
-    end else if (start_capture_i && !record_dis_i) begin
+    end else if (start_capture && !record_dis_i) begin
       // if not disabled by software
       // a recording enable puls by HW starts recording
       record_en <= 1'b1;

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -127,7 +127,6 @@
         clocks:
         {
           clk_io_div4_secure: io_div4
-          clk_aon_secure: aon
           clk_main_secure: main
         }
       }
@@ -3974,6 +3973,34 @@
           index: -1
         }
         {
+          struct: logic
+          type: uni
+          name: strap
+          act: req
+          package: ""
+          inst_name: pwrmgr_aon
+          width: 1
+          default: ""
+          end_idx: -1
+          top_type: broadcast
+          top_signame: pwrmgr_aon_strap
+          index: -1
+        }
+        {
+          struct: logic
+          type: uni
+          name: low_power
+          act: req
+          package: ""
+          inst_name: pwrmgr_aon
+          width: 1
+          default: ""
+          end_idx: -1
+          top_type: broadcast
+          top_signame: pwrmgr_aon_low_power
+          index: -1
+        }
+        {
           struct: tl
           package: tlul_pkg
           type: req_rsp
@@ -4325,7 +4352,7 @@
         clk_i: io_div4
         clk_aon_i: aon
       }
-      clock_group: secure
+      clock_group: powerup
       reset_connections:
       {
         rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]
@@ -4336,8 +4363,8 @@
       generated: "true"
       clock_connections:
       {
-        clk_i: clkmgr_aon_clocks.clk_io_div4_secure
-        clk_aon_i: clkmgr_aon_clocks.clk_aon_secure
+        clk_i: clkmgr_aon_clocks.clk_io_div4_powerup
+        clk_aon_i: clkmgr_aon_clocks.clk_aon_powerup
       }
       size: 0x1000
       bus_device: tlul
@@ -4437,6 +4464,8 @@
           package: ""
           default: 1'b0
           inst_name: pinmux_aon
+          width: 1
+          top_signame: pwrmgr_aon_low_power
           index: -1
         }
         {
@@ -4447,6 +4476,8 @@
           package: ""
           default: 1'b0
           inst_name: pinmux_aon
+          width: 1
+          top_signame: pwrmgr_aon_strap
           index: -1
         }
         {
@@ -4650,8 +4681,10 @@
           act: rcv
           package: ""
           struct: logic
-          width: "1"
+          width: 1
           inst_name: aon_timer_aon
+          default: ""
+          top_signame: pwrmgr_aon_low_power
           index: -1
         }
         {
@@ -7619,6 +7652,15 @@
       pwrmgr_aon.pwr_lc:
       [
         lc_ctrl.pwr_lc
+      ]
+      pwrmgr_aon.strap:
+      [
+        pinmux_aon.strap_en
+      ]
+      pwrmgr_aon.low_power:
+      [
+        pinmux_aon.sleep_en
+        aon_timer_aon.sleep_mode
       ]
       rv_core_ibex.crashdump:
       [
@@ -13410,6 +13452,34 @@
         index: -1
       }
       {
+        struct: logic
+        type: uni
+        name: strap
+        act: req
+        package: ""
+        inst_name: pwrmgr_aon
+        width: 1
+        default: ""
+        end_idx: -1
+        top_type: broadcast
+        top_signame: pwrmgr_aon_strap
+        index: -1
+      }
+      {
+        struct: logic
+        type: uni
+        name: low_power
+        act: req
+        package: ""
+        inst_name: pwrmgr_aon
+        width: 1
+        default: ""
+        end_idx: -1
+        top_type: broadcast
+        top_signame: pwrmgr_aon_low_power
+        index: -1
+      }
+      {
         struct: tl
         package: tlul_pkg
         type: req_rsp
@@ -13735,6 +13805,8 @@
         package: ""
         default: 1'b0
         inst_name: pinmux_aon
+        width: 1
+        top_signame: pwrmgr_aon_low_power
         index: -1
       }
       {
@@ -13745,6 +13817,8 @@
         package: ""
         default: 1'b0
         inst_name: pinmux_aon
+        width: 1
+        top_signame: pwrmgr_aon_strap
         index: -1
       }
       {
@@ -13886,8 +13960,10 @@
         act: rcv
         package: ""
         struct: logic
-        width: "1"
+        width: 1
         inst_name: aon_timer_aon
+        default: ""
+        top_signame: pwrmgr_aon_low_power
         index: -1
       }
       {
@@ -16279,6 +16355,28 @@
         end_idx: -1
         act: req
         suffix: rsp
+        default: ""
+      }
+      {
+        package: ""
+        struct: logic
+        signame: pwrmgr_aon_strap
+        width: 1
+        type: uni
+        end_idx: -1
+        act: req
+        suffix: ""
+        default: ""
+      }
+      {
+        package: ""
+        struct: logic
+        signame: pwrmgr_aon_low_power
+        width: 1
+        type: uni
+        end_idx: -1
+        act: req
+        suffix: ""
         default: ""
       }
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -85,7 +85,7 @@
     // The proc group is not peripheral, and directly hardwired
 
     groups: [
-      // the powerup group is used exclusively by clk/pwr/rstmgr
+      // the powerup group is used exclusively by clk/pwr/rstmgr/pinmux
       { name: "powerup", src:"top", sw_cg: "no"                   }
       { name: "trans",   src:"top", sw_cg: "hint", unique: "yes", }
       { name: "infra",   src:"top", sw_cg: "no",                  }
@@ -406,7 +406,7 @@
     { name: "pinmux_aon",
       type: "pinmux",
       clock_srcs: {clk_i: "io_div4", clk_aon_i: "aon"},
-      clock_group: "secure",
+      clock_group: "powerup",
       reset_connections: {rst_ni: "sys_io_div4", rst_aon_ni: "sys_aon"},
       domain: "Aon",
       base_addr: "0x40460000",
@@ -730,6 +730,8 @@
       'pwrmgr_aon.pwr_clk'      : ['clkmgr_aon.pwr'],
       'pwrmgr_aon.pwr_otp'      : ['otp_ctrl.pwr_otp'],
       'pwrmgr_aon.pwr_lc'       : ['lc_ctrl.pwr_lc'],
+      'pwrmgr_aon.strap'        : ['pinmux_aon.strap_en'],
+      'pwrmgr_aon.low_power'    : ['pinmux_aon.sleep_en','aon_timer_aon.sleep_mode'],
       'flash_ctrl.keymgr'       : ['keymgr.flash'],
       'alert_handler.crashdump' : ['rstmgr_aon.alert_dump'],
       'rv_core_ibex.crashdump'  : ['rstmgr_aon.cpu_dump'],

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -178,10 +178,6 @@ module clkmgr import clkmgr_pkg::*; (
     .clk_i(clk_io_div2_i),
     .clk_o(clocks_o.clk_io_div2_powerup)
   );
-  prim_clock_buf u_clk_aon_secure_buf (
-    .clk_i(clk_aon_i),
-    .clk_o(clocks_o.clk_aon_secure)
-  );
   prim_clock_buf u_clk_aon_peri_buf (
     .clk_i(clk_aon_i),
     .clk_o(clocks_o.clk_aon_peri)

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -26,7 +26,6 @@ package clkmgr_pkg;
   logic clk_io_powerup;
   logic clk_usb_powerup;
   logic clk_io_div2_powerup;
-  logic clk_aon_secure;
   logic clk_aon_peri;
   logic clk_aon_timers;
   logic clk_main_aes;

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
@@ -98,6 +98,19 @@
       package: "",
     },
 
+    { struct:  "logic",
+      type:    "uni",
+      name:    "strap",
+      act:     "req",
+      package: "",
+    },
+
+    { struct:  "logic",
+      type:    "uni",
+      name:    "low_power",
+      act:     "req",
+      package: "",
+    },
   ],
 
   param_list: [

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -430,6 +430,8 @@ module top_earlgrey #(
   pwrmgr_pkg::pwr_otp_rsp_t       pwrmgr_aon_pwr_otp_rsp;
   pwrmgr_pkg::pwr_lc_req_t       pwrmgr_aon_pwr_lc_req;
   pwrmgr_pkg::pwr_lc_rsp_t       pwrmgr_aon_pwr_lc_rsp;
+  logic       pwrmgr_aon_strap;
+  logic       pwrmgr_aon_low_power;
   rv_core_ibex_pkg::crashdump_t       rv_core_ibex_crashdump;
   logic       usbdev_usb_out_of_rst;
   logic       usbdev_usb_aon_wake_en;
@@ -1521,6 +1523,8 @@ module top_earlgrey #(
       .pwr_cpu_i(pwrmgr_aon_pwr_cpu),
       .wakeups_i(pwrmgr_aon_wakeups),
       .rstreqs_i(pwrmgr_aon_rstreqs),
+      .strap_o(pwrmgr_aon_strap),
+      .low_power_o(pwrmgr_aon_low_power),
       .tl_i(pwrmgr_aon_tl_req),
       .tl_o(pwrmgr_aon_tl_rsp),
 
@@ -1598,8 +1602,8 @@ module top_earlgrey #(
       .dft_jtag_o(),
       .dft_jtag_i(jtag_pkg::JTAG_RSP_DEFAULT),
       .dft_strap_test_o(),
-      .sleep_en_i(1'b0),
-      .strap_en_i(1'b0),
+      .sleep_en_i(pwrmgr_aon_low_power),
+      .strap_en_i(pwrmgr_aon_strap),
       .aon_wkup_req_o(pwrmgr_aon_wakeups[0]),
       .usb_wkup_req_o(pwrmgr_aon_wakeups[1]),
       .usb_out_of_rst_i(usbdev_usb_out_of_rst),
@@ -1630,8 +1634,8 @@ module top_earlgrey #(
 
 
       // Clock and reset connections
-      .clk_i (clkmgr_aon_clocks.clk_io_div4_secure),
-      .clk_aon_i (clkmgr_aon_clocks.clk_aon_secure),
+      .clk_i (clkmgr_aon_clocks.clk_io_div4_powerup),
+      .clk_aon_i (clkmgr_aon_clocks.clk_aon_powerup),
       .rst_ni (rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]),
       .rst_aon_ni (rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::DomainAonSel])
   );
@@ -1646,7 +1650,7 @@ module top_earlgrey #(
       .aon_timer_wkup_req_o(pwrmgr_aon_wakeups[2]),
       .aon_timer_rst_req_o(pwrmgr_aon_rstreqs),
       .lc_escalate_en_i(lc_ctrl_pkg::Off),
-      .sleep_mode_i('0),
+      .sleep_mode_i(pwrmgr_aon_low_power),
       .tl_i(aon_timer_aon_tl_req),
       .tl_o(aon_timer_aon_tl_rsp),
 


### PR DESCRIPTION
- Add strap_o output to control strap timing after life cycle control initialization
- Add low_power_o output to inform each module we are in low power mode
- Swithc pinmux to powerup clock group to ensure it has clocks to handle the low power indication
- Addresses #5198 

Signed-off-by: Timothy Chen <timothytim@google.com>