### PR TITLE
[dv/otp_ctrl] non-sticky interrupt check

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -21,16 +21,19 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
                        lc_creator_seed_sw_rw_en_i, lc_seed_hw_rd_en_i;
 
   // connect with lc_prog push-pull interface
-  logic                lc_prog_req, lc_prog_err, lc_prog_req_dly1;
+  logic                lc_prog_req, lc_prog_err;
+  logic                lc_prog_err_dly1, lc_prog_no_intr_check;
 
-  // delay one clock cycle for lc_prog_req, this will be used in scb to check lci_err status
+  // Lc_err takes one clock cycle to propogate to intr signal. So avoid intr check if it happens
+  // during the transition.
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      lc_prog_req_dly1 <= 0;
+      lc_prog_err_dly1 <= 0;
     end else begin
-      lc_prog_req_dly1 <= lc_prog_req;
+      lc_prog_err_dly1 <= lc_prog_err;
     end
   end
+  assign lc_prog_no_intr_check = lc_prog_err | lc_prog_err_dly1;
 
   // TODO: for lc_tx, except esc_en signal, all value different from On is treated as Off,
   // technically we can randomize values here once scb supports

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -397,18 +397,14 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
     case (csr.get_name())
       // add individual case item for each csr
       "intr_state": begin
-        if (data_phase_read) begin
+        if (data_phase_read && do_read_check) begin
           bit [TL_DW-1:0] intr_en           = `gmv(ral.intr_enable);
           bit [NumOtpCtrlIntr-1:0] intr_exp = `gmv(ral.intr_state);
 
-          // TODO: check with designer if otp_error is sticky
-          do_read_check = 0;
-          if (do_read_check) begin
-            foreach (intr_exp[i]) begin
-              otp_intr_e intr = otp_intr_e'(i);
-              `DV_CHECK_CASE_EQ(cfg.intr_vif.pins[i], (intr_en[i] & intr_exp[i]),
-                                $sformatf("Interrupt_pin: %0s", intr.name));
-            end
+          foreach (intr_exp[i]) begin
+            otp_intr_e intr = otp_intr_e'(i);
+            `DV_CHECK_CASE_EQ(cfg.intr_vif.pins[i], (intr_en[i] & intr_exp[i]),
+                              $sformatf("Interrupt_pin: %0s", intr.name));
           end
         end
       end


### PR DESCRIPTION
This PR enables interrupt check in scb according to the updates in PR #5358 
To avoid scb doing cycle accurate prediction, this PR also adds a delay
if lc_prog error is found, then we will wait one clock cycle to check
interrupts.

Signed-off-by: Cindy Chen <chencindy@google.com>