### PR TITLE
[otbn] Add parameter defaults to otbn_trace_if

### DIFF
--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -26,8 +26,8 @@
  */
 interface otbn_trace_if
 #(
-  parameter int ImemAddrWidth,
-  parameter int DmemAddrWidth,
+  parameter int ImemAddrWidth = 12,
+  parameter int DmemAddrWidth = 12,
   parameter otbn_pkg::regfile_e RegFile = otbn_pkg::RegFileFF
 )(
   input logic clk_i,


### PR DESCRIPTION
Xcellium requires these.

Fixes #5355

Signed-off-by: Greg Chadwick <gac@lowrisc.org>