### PR TITLE
[systemtest] Test basic debug interaction in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,7 @@
 
 variables:
   VERILATOR_VERSION: 4.104
+  OPENOCD_VERSION: 0.11.0
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   VERIBLE_VERSION: v0.0-808-g1e17daa
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases

--- a/ci/install-package-dependencies.yml
+++ b/ci/install-package-dependencies.yml
@@ -43,6 +43,7 @@ steps:
 
       cp apt-requirements.txt apt-requirements-ci.txt
       echo "verilator-$(VERILATOR_VERSION)" >> apt-requirements-ci.txt
+      echo "openocd-$(OPENOCD_VERSION)" >> apt-requirements-ci.txt
       echo rsync >> apt-requirements-ci.txt
       cat apt-requirements-ci.txt
 

--- a/hw/dv/dpi/uartdpi/uartdpi.c
+++ b/hw/dv/dpi/uartdpi/uartdpi.c
@@ -62,16 +62,16 @@ void *uartdpi_create(const char *name, const char *log_file_path) {
         fprintf(stderr, "UART: Unable to open log file at %s: %s\n",
                 log_file_path, strerror(errno));
       } else {
+        // Switch log file output to line buffering to ensure lines written to
+        // the UART device show up in the log file as soon as a newline
+        // character is written.
+        rv = setvbuf(log_file, NULL, _IOLBF, 0);
+        assert(rv == 0);
+
         ctx->log_file = log_file;
         printf("UART: Additionally writing all UART output to '%s'.\n",
                log_file_path);
       }
-
-      // Switch log file output to line buffering to ensure lines written to
-      // the UART device show up in the log file as soon as a newline character
-      // is written.
-      rv = setvbuf(log_file, NULL, _IOLBF, 0);
-      assert(rv == 0);
     }
   }
 

--- a/test/systemtest/conftest.py
+++ b/test/systemtest/conftest.py
@@ -4,10 +4,13 @@
 
 import logging
 import os
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
 import yaml
+
 from . import utils
 
 log = logging.getLogger(__name__)
@@ -33,7 +36,7 @@ def localconf():
     if 'OPENTITAN_TEST_LOCALCONF' in os.environ:
         localconf_yaml_file = Path(os.environ['OPENTITAN_TEST_LOCALCONF'])
         log.info("Attempting to use configuration file set in "
-            "OPENTITAN_TEST_LOCALCONF.")
+                 "OPENTITAN_TEST_LOCALCONF.")
     else:
         XDG_CONFIG_HOME = Path(os.getenv(
             'XDG_CONFIG_HOME', os.path.join(os.environ['HOME'], '.config')))
@@ -66,3 +69,19 @@ def bin_dir(topsrcdir):
 
     assert bin_dir.is_dir()
     return bin_dir
+
+
+@pytest.fixture(scope="session")
+def openocd():
+    """ Return the path to the openocd binary. """
+    openocd_bin = shutil.which('openocd')
+    assert openocd_bin
+
+    proc = subprocess.run([openocd_bin, '--version'],
+                          check=True,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT,
+                          encoding="utf8")
+    log.info("Using OpenOCD at {}: '{}'".format(openocd_bin,
+                                                proc.stdout.splitlines()[0]))
+    return Path(openocd_bin)

--- a/test/systemtest/utils.py
+++ b/test/systemtest/utils.py
@@ -82,7 +82,8 @@ class Process:
         # the string indicating a successful startup.
         # see discussion at http://www.pixelbeat.org/programming/stdio_buffering/
         cmd = ['stdbuf', '-oL'] + self.cmd
-        self.logger.info("Running command " + ' '.join(cmd))
+        self.logger.info("Running command " +
+                         ' '.join(shlex.quote(w) for w in cmd))
 
         logfile_stdout = os.path.join(self.logdir,
                                       "{}.stdout".format(cmd_name))

--- a/test/systemtest/utils.py
+++ b/test/systemtest/utils.py
@@ -464,7 +464,8 @@ def match_line(line, pattern, filter_func=None):
     1. A regular expression (any object with a match attribute, or a re.Pattern
        object in Python 3.7+). In this case, the pattern is matched against all
        lines and the result of re.match(pattern) (a re.Match object since
-       Python 3.7) is returned.
+       Python 3.7) is returned. Note that re.match() always matches from the
+       beginning of the line.
     2. A string. In this case pattern is compared to each line with
        startswith(), and the full matching line is returned on a match.
     If no match is found None is returned.

--- a/util/openocd/interface/nexysvideo-ft2232.cfg
+++ b/util/openocd/interface/nexysvideo-ft2232.cfg
@@ -9,7 +9,7 @@
 # Up to 30 MHz are supported by the FT2232H
 adapter_khz 30000
 
-interface ftdi
+adapter driver ftdi
 transport select jtag
 
 ftdi_vid_pid 0x0403 0x6010

--- a/util/openocd/interface/sim-jtagdpi.cfg
+++ b/util/openocd/interface/sim-jtagdpi.cfg
@@ -2,10 +2,10 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# "JTAG adapter" for simulation, exposed to OpenOCD through a TCP socket 
-# speaking the remote_bitbang protocol. The adapter is implemented as 
+# "JTAG adapter" for simulation, exposed to OpenOCD through a TCP socket
+# speaking the remote_bitbang protocol. The adapter is implemented as
 # SystemVerilog DPI module.
 
-interface remote_bitbang
+adapter driver remote_bitbang
 remote_bitbang_port 44853
 remote_bitbang_host localhost


### PR DESCRIPTION
This PR provides the groundwork for more automated tests of the debug subsystem. In this first iteration, it installs OpenOCD in CI, adds a systemtest to connect to earl grey running in a Verilator simulation, and checks that the JTAG TAP and the hart of the system is detected properly.

I'll follow up with more tests that also target FPGA and test more debugger interaction with the core (through GDB), as well as bus access (through the DM SBA module).