### PR TITLE
[dv/otp_ctrl] ECC uncorrectable error

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -20,7 +20,9 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
   otp_ctrl_vif otp_ctrl_vif;
 
   bit backdoor_clear_mem;
-  otp_ecc_err_e ecc_err;
+
+  // This value is updated in sequence when backdoor inject ECC error
+  otp_ecc_err_e ecc_err = OtpNoEccErr;
 
   `uvm_object_utils_begin(otp_ctrl_env_cfg)
   `uvm_object_utils_end

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_errs_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_errs_vseq.sv
@@ -10,9 +10,12 @@ class otp_ctrl_macro_errs_vseq extends otp_ctrl_dai_errs_vseq;
 
   `uvm_object_new
 
-  // TODO: currently only support correctable errors
   constraint ecc_err_c {
-    $countones(ecc_err_mask) dist  {0 :/ 1, 1 :/ 1};
+    // TODO: currently only max to 2 error bits, once implemetned ECC in mem_bkdr_if, we can
+    // fully randomize num of error bits
+    $countones(ecc_err_mask) dist  {0 :/ 2,
+                                    1 :/ 1,
+                                    2 :/ 1};
   }
 
 endclass


### PR DESCRIPTION
This PR adds suppor to trigger ECC uncorrectable error. Currently only
allow 2 errors per word. Once the ECC is integrity in mem_bkdr_if, we
can fully randomize the error.

Signed-off-by: Cindy Chen <chencindy@google.com>