### PR TITLE
[keymgr/dv] Add invalid cmd/fsm vseq

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_env.core
+++ b/hw/ip/keymgr/dv/env/keymgr_env.core
@@ -30,6 +30,7 @@ filesets:
       - seq_lib/keymgr_sw_invalid_input_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_hwsw_invalid_input_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_kmac_rsp_err_vseq.sv: {is_include_file: true}
+      - seq_lib/keymgr_cmd_invalid_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
@@ -31,6 +31,7 @@ package keymgr_env_pkg;
     NumKeyMgrIntr
   } keymgr_intr_e;
 
+  string msg_id = "keymgr_env_pkg";
   // functions
   // state is incremental, if it's not in defined enum, consider as StDisabled
   function automatic keymgr_pkg::keymgr_working_state_e get_next_state(
@@ -40,10 +41,8 @@ package keymgr_env_pkg;
     if (next_state >= int'(keymgr_pkg::StDisabled)) begin
       return keymgr_pkg::StDisabled;
     end else begin
-      return next_state;
+      `downcast(get_next_state, next_state, , , msg_id);
     end
-
-
   endfunction
 
   // package sources

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -91,11 +91,13 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
       forever begin
         keymgr_kmac_item item;
         req_fifo.get(item);
+        if (!cfg.en_scb) continue;
         process_kmac_data_req(item);
       end
       forever begin
         keymgr_kmac_item item;
         rsp_fifo.get(item);
+        if (!cfg.en_scb) continue;
         process_kmac_data_rsp(item);
       end
       forever begin

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -13,6 +13,8 @@ class keymgr_base_vseq extends cip_base_vseq #(
   // various knobs to enable certain routines
   bit do_keymgr_init = 1'b1;
   bit do_wait_for_init_done = 1'b1;
+  bit do_reset_at_end_of_seq = 1'b0;
+  bit seq_check_en = 1'b1;
 
   // do operations at StReset
   rand bit do_op_before_init;
@@ -257,5 +259,16 @@ class keymgr_base_vseq extends cip_base_vseq #(
   virtual function bit get_check_en();
     return cfg.keymgr_vif.keymgr_en == lc_ctrl_pkg::On && !cfg.under_reset;
   endfunction
+
+  task post_start();
+    super.post_start();
+
+    // If fatal alert will be triggered in this seq, issue reset if reset is allowed, otherwise,
+    // reset will be called in upper vseq
+    if (do_reset_at_end_of_seq) begin
+      #10_000ns;
+      if (do_apply_reset) apply_reset();
+    end
+  endtask
 
 endclass : keymgr_base_vseq

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_cmd_invalid_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_cmd_invalid_vseq.sv
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// force design to trigger cmd/state invalid error
+// randomly force design FSM/CMD, which causes design behaves very unpredictable
+// so, disable the scb and check fatal alert occurs and state is updated correctly after the err
+class keymgr_cmd_invalid_vseq extends keymgr_lc_disable_vseq;
+  `uvm_object_utils(keymgr_cmd_invalid_vseq)
+  `uvm_object_new
+
+  virtual task trigger_error(ref bit regular_vseq_done);
+    cfg.en_scb = 0;
+
+    // forcing internal design may cause uninitialized reg to be used, disable these checking
+    $assertoff(0, "tb.keymgr_kmac_intf");
+    $assertoff(0, "tb.dut.tlul_assert_device.gen_device.dDataKnown_A");
+    cfg.keymgr_vif.force_cmd_err();
+
+    // if it's in StDisabled, do an OP to ensure fault error occurs
+    if (current_state == keymgr_pkg::StDisabled) begin
+      wait(regular_vseq_done);
+      keymgr_operations(.clr_output(0), .wait_done(0));
+    end
+
+    repeat (100) @(cfg.m_alert_agent_cfg["fatal_fault_err"].vif.alert_tx.alert_p);
+    csr_rd_check(.ptr(ral.working_state), .compare_value(keymgr_pkg::StDisabled));
+  endtask : trigger_error
+
+  // disable checker in seq, only check in scb
+  virtual function bit get_check_en();
+    return 0;
+  endfunction
+
+  task post_start();
+    // fatal alert will be triggered, need reset to clear it
+    do_reset_at_end_of_seq = 1;
+    super.post_start();
+    cfg.en_scb = 1;
+    $assertoff(1, "tb.keymgr_kmac_intf");
+    $assertoff(1, "tb.dut.tlul_assert_device.gen_device.dDataKnown_A");
+  endtask
+endclass : keymgr_cmd_invalid_vseq

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_kmac_rsp_err_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_kmac_rsp_err_vseq.sv
@@ -23,6 +23,9 @@ class keymgr_kmac_rsp_err_vseq extends keymgr_hwsw_invalid_input_vseq;
 
   task pre_start();
     cfg.m_keymgr_kmac_agent_cfg.error_rsp_pct = 20;
+
+    // fatal alert will be triggered, need reset to clear it
+    do_reset_at_end_of_seq = 1;
     super.pre_start();
   endtask
 

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_vseq_list.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_vseq_list.sv
@@ -13,4 +13,5 @@
 `include "keymgr_sw_invalid_input_vseq.sv"
 `include "keymgr_hwsw_invalid_input_vseq.sv"
 `include "keymgr_kmac_rsp_err_vseq.sv"
+`include "keymgr_cmd_invalid_vseq.sv"
 `include "keymgr_stress_all_vseq.sv"

--- a/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
+++ b/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
@@ -96,6 +96,11 @@
     }
 
     {
+      name: keymgr_cmd_invalid
+      uvm_test_seq: keymgr_cmd_invalid_vseq
+    }
+
+    {
       name: keymgr_stress_all
       uvm_test_seq: keymgr_stress_all_vseq
     }

--- a/hw/ip/keymgr/dv/tb.sv
+++ b/hw/ip/keymgr/dv/tb.sv
@@ -57,7 +57,7 @@ module tb;
     .edn_o                (edn_if.req),
     .edn_i                ({edn_if.ack, edn_if.d_data}),
     .flash_i              (keymgr_if.flash),
-    .intr_op_done_o       (interrupts),
+    .intr_op_done_o       (interrupts[0]),
     .alert_rx_i           (alert_rx   ),
     .alert_tx_o           (alert_tx   ),
     .tl_i                 (tl_if.h2d  ),


### PR DESCRIPTION
force design internal signal cmd/fsm to trigger fault error
disable scb in this seq as kmac transaction may be terminated earlier

Signed-off-by: Weicai Yang <weicai@google.com>