### PR TITLE
[otbn] Fix a race between initial blocks in otbn.sv and otbn_core_model.sv

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -34,10 +34,6 @@ module otbn_core_model
   input  logic  clk_i,
   input  logic  rst_ni,
 
-  // Enable the model. This signal is a "runtime parameter", it is only honored if set in an initial
-  // block.
-  input logic   enable_i,
-
   input  logic  start_i, // start the operation
   output bit    done_o,  // operation done
 
@@ -79,21 +75,13 @@ module otbn_core_model
 `endif
 
   // Create and destroy an object through which we can talk to the ISS.
-  // If enable_i is not set, do not initialize the ISS (and, by consequence, do not start the Python
-  // process).
-  chandle model_handle = chandle_null;
+  chandle model_handle;
   initial begin
-    if (enable_i) begin
-      model_handle = otbn_model_init();
-      assert(model_handle != chandle_null);
-      $display("OTBN: Model enabled.");
-    end
+    model_handle = otbn_model_init();
+    assert(model_handle != chandle_null);
   end
   final begin
-    if (model_handle != chandle_null) begin
-      otbn_model_destroy(model_handle);
-      model_handle = chandle_null;
-    end
+    otbn_model_destroy(model_handle);
   end
 
   // A packed "status" value. This gets assigned by DPI function calls that need to update both
@@ -115,7 +103,7 @@ module otbn_core_model
   bit [31:0] raw_err_bits_d, raw_err_bits_q;
   bit unused_raw_err_bits;
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni || !enable_i) begin
+    if (!rst_ni) begin
       // Clear status (stop running, and forget any errors)
       status <= 0;
       raw_err_bits_q <= 0;

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -82,8 +82,6 @@ module tb;
     .clk_i        (model_if.clk_i),
     .rst_ni       (model_if.rst_ni),
 
-    .enable_i     (1'b1),
-
     .start_i      (model_if.start),
     .done_o       (model_if.done),
     .start_addr_i (model_if.start_addr),

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
@@ -93,7 +93,8 @@ class OtbnTraceUtil : public SimCtrlExtension {
 int main(int argc, char **argv) {
   otbn_top_sim top;
 
-  VerilatorMemUtil memutil(new OtbnMemUtil("TOP.otbn_top_sim"));
+  OtbnMemUtil otbn_memutil("TOP.otbn_top_sim");
+  VerilatorMemUtil memutil(&otbn_memutil);
   OtbnTraceUtil traceutil;
 
   VerilatorSimCtrl &simctrl = VerilatorSimCtrl::GetInstance();

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -221,8 +221,6 @@ module otbn_top_sim (
     .clk_i        ( IO_CLK ),
     .rst_ni       ( IO_RST_N ),
 
-    .enable_i     ( 1'b1 ),
-
     .start_i      ( otbn_start ),
     .done_o       ( otbn_model_done ),
 

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -507,8 +507,6 @@ module otbn
       .clk_i,
       .rst_ni,
 
-      .enable_i (otbn_use_model),
-
       .start_i (start_model),
       .done_o (done_model),
 


### PR DESCRIPTION
As reported in #5377. The first commit in the PR fixes a silly memory leak (that I found when using Valgrind to check things were destroyed properly with the other commit). The second commit is the interesting one. Commit message:

**[otbn] Remove enable_i input from otbn_core_model**

The previous code had a race in the `initial` blocks when used in
`otbn.sv`. The obvious way to fix this in the SystemVerilog code would
be to call `otbn_model_init()` just before we first call
`otbn_model_step`. Unfortunately, you can't do that (for Verilator, at
least) because that ends up mixing blocking and non-blocking
assignments.

Rather than think hard about how to do this properly in Verilog, we
can just put in a simple layer of indirection in the C++ and only
start the subprocess when we see `start_i` for the first time.

Fixes #5377.