### PR TITLE
[i2c, dv] Fix nightly dv regression run and update the scoreboard

### DIFF
--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -177,6 +177,7 @@ class i2c_base_vseq extends cip_base_vseq #(
     `uvm_info(`gfn, $sformatf("\n  %s monitor and scoreboard",
         cfg.en_scb ? "enable" : "disable"), UVM_DEBUG)
     num_runs.rand_mode(0);
+    num_trans_c.constraint_mode(0);
     super.pre_start();
   endtask : pre_start
 
@@ -386,7 +387,7 @@ class i2c_base_vseq extends cip_base_vseq #(
       str = {str, $sformatf("\n  %s, %s, i2c_seq_cfg", msg, get_name())};
       str = {str, $sformatf("\n    en_scb                %b", cfg.en_scb)};
       str = {str, $sformatf("\n    en_monitor            %b", cfg.m_i2c_agent_cfg.en_monitor)};
-      str = {str, $sformatf("\n    do_dut_init           %b", do_dut_init)};
+      str = {str, $sformatf("\n    do_apply_reset        %b", do_apply_reset)};
       str = {str, $sformatf("\n    en_fmt_overflow       %b", cfg.seq_cfg.en_fmt_overflow)};
       str = {str, $sformatf("\n    en_rx_overflow        %b", cfg.seq_cfg.en_rx_overflow)};
       str = {str, $sformatf("\n    en_rx_watermark       %b", cfg.seq_cfg.en_rx_watermark)};

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_error_intr_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_error_intr_vseq.sv
@@ -29,7 +29,6 @@ class i2c_error_intr_vseq extends i2c_rx_tx_vseq;
   virtual task body();
     `uvm_info(`gfn, "\n--> start of i2c_error_intr_vseq", UVM_DEBUG)
     initialization();
-    do_apply_reset = 1'b1;
     for (int i = 1; i <= num_runs; i++) begin
       `uvm_info(`gfn, $sformatf("\n  run simulation %0d/%0d", i, num_runs), UVM_DEBUG)
       fork

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_stress_all_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_stress_all_vseq.sv
@@ -4,7 +4,10 @@
 
 // combine all i2c seqs (except below vseqs) in one seq to run sequentially
 // 1. override_vseq requires scb and monitor to be disabled
-// 1. csr seq, which requires scb to be disabled
+// 2. csr seq, which requires scb to be disabled
+// 3. i2c_error_intr_vseq can issue internal reset
+//    so it is excluded/included w.r.t stress_all_with_rand_reset/stress_all test
+
 class i2c_stress_all_vseq extends i2c_rx_tx_vseq;
   `uvm_object_utils(i2c_stress_all_vseq)
 
@@ -13,20 +16,29 @@ class i2c_stress_all_vseq extends i2c_rx_tx_vseq;
   local string str, seq_name;
   local int    seq_run_hist[string];
 
-  string seq_names[] = {
+  string seq_names[$] = {
     "i2c_common_vseq",      // for intr_test
     "i2c_smoke_vseq",
     "i2c_fifo_full_vseq",
     "i2c_fifo_overflow_vseq",
     "i2c_fifo_watermark_vseq",
     "i2c_stretch_timeout_vseq",
-    "i2c_perf_vseq",
-    "i2c_error_intr_vseq"
+    "i2c_perf_vseq"
   };
+
+  virtual task pre_start();
+    super.pre_start();
+    // if stress_all test is run then i2c_error_intr_vseq is pushed into seq_names queue
+    // otherwise it is excluded for stress_all_with_rand_reset test
+    if (common_seq_type != "stress_all_with_rand_reset") begin
+      uint size = seq_names.size();
+      seq_names.push_back("i2c_error_intr_vseq");
+    end
+  endtask : pre_start;
 
   virtual task body();
 
-    `uvm_info(`gfn, "\n=> start i2c_stress_all_vseq", UVM_DEBUG)
+    `uvm_info(`gfn, "\n\n=> start i2c_stress_all_vseq", UVM_DEBUG)
     print_seq_names(seq_names);
     for (int i = 1; i <= seq_names.size(); i++) begin
       seq_run_hist[seq_names[i-1]] = 0;
@@ -38,22 +50,22 @@ class i2c_stress_all_vseq extends i2c_rx_tx_vseq;
       uint           seq_idx = $urandom_range(0, seq_names.size() - 1);
 
       seq_name = seq_names[seq_idx];
-      `uvm_info(`gfn, $sformatf("\n\n=> start stressing vseq %s (%0d/%0d)",
+      `uvm_info(`gfn, $sformatf("\n  -> start stressing vseq %s (%0d/%0d)",
           seq_name, i, num_runs), UVM_DEBUG)
       seq = create_seq_by_name(seq_name);
       `downcast(i2c_vseq, seq)
 
       // if upper seq disables do_apply_reset for this seq, then can't issue reset
       // as upper seq may drive reset
-      `uvm_info(`gfn, $sformatf("\n  *do_apply_reset %0b", do_apply_reset), UVM_DEBUG)
+      `uvm_info(`gfn, $sformatf("\n  do_apply_reset %b", do_apply_reset), UVM_DEBUG)
       if (do_apply_reset) begin
         i2c_vseq.do_apply_reset = $urandom_range(0, 1);
         if (i2c_vseq.do_apply_reset) begin
-          `uvm_info(`gfn, "\n  *reset is randomly issued with stress_test", UVM_DEBUG)
+          `uvm_info(`gfn, "\n  reset is randomly issued with stress_test", UVM_DEBUG)
         end
       end else begin
         i2c_vseq.do_apply_reset = 0;
-        `uvm_info(`gfn, "\n  *upper_seq may drive reset thus not issue reset", UVM_DEBUG)
+        `uvm_info(`gfn, "\n  reset may be driven by upper_seq thus not be issued", UVM_DEBUG)
       end
 
       i2c_vseq.set_sequencer(p_sequencer);
@@ -75,7 +87,7 @@ class i2c_stress_all_vseq extends i2c_rx_tx_vseq;
       // run vseq
       i2c_vseq.start(p_sequencer);
       seq_run_hist[seq_name]++;
-      `uvm_info(`gfn, $sformatf("\n  end stressing vseq %s", seq_name), UVM_DEBUG)
+      `uvm_info(`gfn, $sformatf("\n  -> end stressing vseq %s\n", seq_name), UVM_DEBUG)
       wait(cfg.m_i2c_agent_cfg.vif.rst_ni);
     end
     wait_host_for_idle();


### PR DESCRIPTION
Fix nightly DV regression run and update the scoreboard

  - scoreboard: enable do_read_check and stop compare transaction when reset occurs
  - stress_all_with_rand_reset: exclude error_intr_vseq from vseq list since it can issue its own internal reset

Signed-off-by: Tung Hoang <hoang.tung@wdc.com>