### PR TITLE
[usbdev] Minor adjustments to aon wake behavior

### DIFF
--- a/hw/ip/pinmux/rtl/pinmux.sv
+++ b/hw/ip/pinmux/rtl/pinmux.sv
@@ -185,6 +185,12 @@ module pinmux
     .clk_aon_i,
     .rst_aon_ni,
 
+    // input signals for usb entering low power
+    // This will be different per system integration.
+    // It specifically refers to situations where the system
+    // containing usb has gone to low power.
+    .low_power_alw_i(sleep_en_i),
+
     // input signals for resume detection
     .usb_dp_async_alw_i(dio_to_periph_o[UsbDpSel]),
     .usb_dn_async_alw_i(dio_to_periph_o[UsbDnSel]),
@@ -192,7 +198,7 @@ module pinmux
     .usb_dnpullup_en_alw_i(dio_oe_o[UsbDnPullUpSel]),
 
     // tie this to something from usbdev to indicate its out of reset
-    .usb_out_of_rst_alw_i(usb_out_of_rst_i),
+    .usb_out_of_rst_upwr_i(usb_out_of_rst_i),
     .usb_aon_wake_en_upwr_i(usb_aon_wake_en_i),
     .usb_aon_woken_upwr_i(usb_aon_wake_ack_i),
     .usb_suspended_upwr_i(usb_suspend_i),

--- a/hw/ip/pwrmgr/pwrmgr.core
+++ b/hw/ip/pwrmgr/pwrmgr.core
@@ -9,6 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:tlul
+      - lowrisc:prim:all
       - lowrisc:ip:pwrmgr_pkg
     files:
       - rtl/pwrmgr.sv

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -763,6 +763,9 @@
           desc: '''
                 Enable the usb resume wake function.  When this is set, a resume indication from
                 a usb host can be used to drive a wake from sleep event.
+
+                Note this function is meant to be set as a mode and not toggled on/off every time
+                usb enters / exit suspend.
                 '''
         }
         {

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -1073,7 +1073,8 @@ module usbdev import usbdev_pkg::*; (
 
   assign usb_aon_wake_en_o = reg2hw.wake_config.wake_en.q;
   assign usb_aon_wake_ack_o = reg2hw.wake_config.wake_ack.q;
-  assign usb_suspend_o = usb_event_link_suspend;
+  // re-use I/O version to allow software override if needed
+  assign usb_suspend_o = cio_suspend_o;
 
   /////////////////////////////////////////
   // capture async debug info            //

--- a/hw/ip/usbdev/rtl/usbdev_aon_wake.sv
+++ b/hw/ip/usbdev/rtl/usbdev_aon_wake.sv
@@ -44,7 +44,7 @@ module usbdev_aon_wake import usbdev_pkg::*;(
   // note the _upwr signals are only valid when usb_out_of_rst_upwr_i is set
   assign suspend_req_async = usb_aon_wake_en_upwr_i & usb_suspended_upwr_i & usb_out_of_rst_upwr_i;
   assign wake_ack_async = usb_aon_woken_upwr_i & usb_out_of_rst_upwr_i;
-  assign low_power_async = low_power_alw_i & usb_out_of_rst_upwr_i;
+  assign low_power_async = low_power_alw_i & ~usb_out_of_rst_upwr_i;
 
   // The suspend_req / wake ack / low power construction come from multiple clock domains.
   // As a result the 2 flop sync could glitch for up to 1 cycle.  Place a filter after

--- a/hw/ip/usbdev/rtl/usbdev_aon_wake.sv
+++ b/hw/ip/usbdev/rtl/usbdev_aon_wake.sv
@@ -9,8 +9,8 @@ module usbdev_aon_wake import usbdev_pkg::*;(
   input  logic clk_aon_i,
   input  logic rst_aon_ni,
 
-  // signals tagged _upwr_ are only valid when this is set
-  input  logic usb_out_of_rst_alw_i,
+  // the system to which usb belongs has entered low power
+  input  logic low_power_alw_i,
 
   // These come from the chip pin
   input  logic usb_dp_async_alw_i,
@@ -21,6 +21,7 @@ module usbdev_aon_wake import usbdev_pkg::*;(
   input  logic usb_dnpullup_en_alw_i,
 
   // Register signals from IP
+  input  logic usb_out_of_rst_upwr_i,
   input  logic usb_aon_wake_en_upwr_i,
   input  logic usb_aon_woken_upwr_i,
 
@@ -36,25 +37,45 @@ module usbdev_aon_wake import usbdev_pkg::*;(
 
   awk_state_e astate_d, astate_q;
 
-  logic trigger_async, trigger;
+  logic suspend_req_async, suspend_req;
   logic wake_ack_async, wake_ack;
+  logic low_power_async, low_power;
 
-  // note the _upwr signals are only valid when usb_out_of_rst_alw_i is set
-  assign trigger_async = usb_aon_wake_en_upwr_i & usb_suspended_upwr_i & usb_out_of_rst_alw_i;
-  assign wake_ack_async = usb_aon_woken_upwr_i & usb_out_of_rst_alw_i;
+  // note the _upwr signals are only valid when usb_out_of_rst_upwr_i is set
+  assign suspend_req_async = usb_aon_wake_en_upwr_i & usb_suspended_upwr_i & usb_out_of_rst_upwr_i;
+  assign wake_ack_async = usb_aon_woken_upwr_i & usb_out_of_rst_upwr_i;
+  assign low_power_async = low_power_alw_i & usb_out_of_rst_upwr_i;
 
+  // The suspend_req / wake ack / low power construction come from multiple clock domains.
+  // As a result the 2 flop sync could glitch for up to 1 cycle.  Place a filter after
+  // the two flop sync to passthrough the value only when stable.
+  logic [2:0] filter_cdc_in, filter_cdc_out;
   prim_flop_2sync #(
-    .Width (2)
-  ) cdc_trigger (
+    .Width (3)
+  ) u_cdc_suspend_req (
     .clk_i  (clk_aon_i),
     .rst_ni (rst_aon_ni),
-    .d_i    ({trigger_async, wake_ack_async}),
-    .q_o    ({trigger, wake_ack})
+    .d_i    ({low_power_async, suspend_req_async, wake_ack_async}),
+    .q_o    (filter_cdc_in)
   );
+
+  for (genvar i = 0; i < 3; i++) begin : gen_filters
+    prim_filter #(
+      .Cycles(2)
+    ) u_filter (
+      .clk_i(clk_aon_i),
+      .rst_ni(rst_aon_ni),
+      .enable_i(1'b1),
+      .filter_i(filter_cdc_in[i]),
+      .filter_o(filter_cdc_out[i])
+    );
+  end
+
+  assign {low_power, suspend_req, wake_ack} = filter_cdc_out;
 
 
   logic notidle_async;
-  logic notidle_filtered;
+  logic wake_req;
   // In suspend it is the device pullup that sets the line state
   // so if the input value differs then the host is doing something
   // This covers both host generated wake (J->K) and host generated reset (J->SE0)
@@ -69,7 +90,7 @@ module usbdev_aon_wake import usbdev_pkg::*;(
     .rst_ni   (rst_aon_ni),
     .enable_i (1'b1),
     .filter_i (notidle_async),
-    .filter_o (notidle_filtered)
+    .filter_o (wake_req)
   );
 
   always_comb begin : proc_awk_fsm
@@ -78,41 +99,52 @@ module usbdev_aon_wake import usbdev_pkg::*;(
     unique case (astate_q)
       // No aon suspend entry has been requested or detected
       AwkIdle: begin
-        if (trigger) begin
+        if (suspend_req) begin
           astate_d = AwkTrigUon;
         end
       end
 
-      // Suspend has been triggered but the USB IP power is still on
+      // Suspend has been requested but the USB IP is still alive.
+      // If the system progresses into low power, wait for wakeup request.
+      // If before the system progresses into low power the suspend request is lost,
+      // go manage the interruption
       AwkTrigUon: begin
-        if (notidle_filtered) begin
-          // USP IP may manage the wake
-          astate_d = AwkWokenUon;
-        end else if (!usb_out_of_rst_alw_i) begin
+        // We are trying to juggle when the usb is no longer detecting resumes.
+        // This could be when the usb is in reset, or when the system cuts off
+        // clocking to usb.
+        // If low power and the suspend request drop at the same time (race condition),
+        // prioritize low power since the system is already committed to enter low power.
+        if (low_power) begin
           astate_d = AwkTrigUoff;
-        end
-      end
-
-      // Suspend has been triggered and the USB IP is powered off
-      AwkTrigUoff: begin
-        if (notidle_filtered) begin
-          astate_d = AwkWoken;
+        end else if (!suspend_req) begin
+          astate_d = AwkWokenUon;
         end
       end
 
       // The link went not-idle before the USB IP powered off
       // It could be about to power down, it could manage the wake, or this was a glitch
+      // If wake_ack is seen, that means software already handled the resume.
+      // If suspend_req is seen again, it means th1e !suspend_req seen was just a glitch
+      // If low power conditions are seen, this means even though there was a glitch / resume,
+      // the system went to low power anyways, we should now follow the normal resume routine.
       AwkWokenUon: begin
         if (wake_ack) begin
           astate_d = AwkIdle;
-        end else if (trigger) begin
+        end else if (suspend_req) begin
           astate_d = AwkTrigUon;
-        end else if (!usb_out_of_rst_alw_i) begin
+        end else if (low_power) begin
+          astate_d = AwkTrigUoff;
+        end
+      end
+
+      // Suspend has been enetered and the USB IP is in low power
+      AwkTrigUoff: begin
+        if (wake_req) begin
           astate_d = AwkWoken;
         end
       end
 
-      // The USB IP was powered down and the link went not-idle, time to wake up
+      // The USB IP was in low power and the link went not-idle, time to wake up
       AwkWoken: begin
         if (wake_ack) begin
           astate_d = AwkIdle;


### PR DESCRIPTION
- Instead of using notidle to transition to AwkWokenUon, use !trigger instead.
  This ensures that we are seeing usbdev's view of resume handling instead
  of the asynchronous pin state.

- Add pinmux's low power indication to usbdev_aon_wake detection.  Low power
  is a system wide indication that we have entered low and the usbdev module
  can no longer responsd to a "resume" pin state. This signal may remove
  the need for usb_out_of_rst, but that is kept for now.

- Move usb_suspend_o output to cio_suspend_o.  This allows the software to
  arbitrarily override the value of suspend for testing purposes.

Signed-off-by: Timothy Chen <timothytim@google.com>