### PR TITLE
[aes] Drive random netlist constants from top_*_rnd_cnst_pkg.sv

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -8,6 +8,7 @@
   clock_primary: "clk_i",
   bus_device: "tlul",
   param_list: [
+    # Regular parameters
     { name:    "AES192Enable",
       type:    "bit",
       default: "1'b1",
@@ -66,41 +67,38 @@
       local:   "false",
       expose:  "false"
     },
+    # Random netlist constants
     { name:    "RndCnstClearingLfsrSeed",
       type:    "aes_pkg::clearing_lfsr_seed_t",
-      default: "aes_pkg::RndCnstClearingLfsrSeedDefault",
       desc:    '''
         Default seed of the PRNG used for register clearing.
       '''
-      local:   "false",
-      expose:  "false"
+      randcount: "64",
+      randtype:  "data"
     },
     { name:    "RndCnstClearingLfsrPerm",
       type:    "aes_pkg::clearing_lfsr_perm_t",
-      default: "aes_pkg::RndCnstClearingLfsrPermDefault",
       desc:    '''
         Permutation applied to the LFSR of the PRNG used for clearing.
       '''
-      local:   "false",
-      expose:  "false"
+      randcount: "64",
+      randtype:  "perm"
     },
     { name:    "RndCnstMaskingLfsrSeed",
       type:    "aes_pkg::masking_lfsr_seed_t",
-      default: "aes_pkg::RndCnstMaskingLfsrSeedDefault",
       desc:    '''
         Default seed of the PRNG used for masking.
       '''
-      local:   "false",
-      expose:  "false"
+      randcount: "160",
+      randtype:  "data"
     },
     { name:    "RndCnstMskgChunkLfsrPerm",
       type:    "aes_pkg::mskg_chunk_lfsr_perm_t",
-      default: "aes_pkg::RndCnstMskgChunkLfsrPermDefault",
       desc:    '''
         Permutation applied to the LFSR chunks of the PRNG used for masking.
       '''
-      local:   "false",
-      expose:  "false"
+      randcount: "32",
+      randtype:  "perm"
     },
     # Note: All parameters below are local, they are not actually configurable.
     # Selecting values different from the default values below might cause undefined behavior.

--- a/hw/ip/aes/doc/checklist.md
+++ b/hw/ip/aes/doc/checklist.md
@@ -53,7 +53,7 @@ Code Quality  | [CDC_SYNCMACRO][]       | Not Started |
 Security      | [SEC_CM_IMPLEMENTED][]  | Not Started |
 Security      | [SEC_NON_RESET_FLOPS][] | Done        |
 Security      | [SEC_SHADOW_REGS][]     | Not Started |
-Security      | [SEC_RND_CNST][]        | Not Started |
+Security      | [SEC_RND_CNST][]        | Done        |
 
 [NEW_FEATURES]:        {{<relref "/doc/project/checklist.md#new_features" >}}
 [BLOCK_DIAGRAM]:       {{<relref "/doc/project/checklist.md#block_diagram" >}}

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -5558,46 +5558,50 @@
         {
           name: RndCnstClearingLfsrSeed
           type: aes_pkg::clearing_lfsr_seed_t
-          default: aes_pkg::RndCnstClearingLfsrSeedDefault
           desc: Default seed of the PRNG used for register clearing.
+          randcount: "64"
+          randtype: data
           local: "false"
+          default: 0xf4c3471c5def7861
           expose: "false"
-          randcount: "0"
-          randtype: none
           name_top: RndCnstAesClearingLfsrSeed
+          randwidth: 64
         }
         {
           name: RndCnstClearingLfsrPerm
           type: aes_pkg::clearing_lfsr_perm_t
-          default: aes_pkg::RndCnstClearingLfsrPermDefault
           desc: Permutation applied to the LFSR of the PRNG used for clearing.
+          randcount: "64"
+          randtype: perm
           local: "false"
+          default: 0x26ac29e186c1f4dc6f959d6ed08dc044a0f3f1519e8dca131275df1e48bbf964ac772e613d0320adaebf38552dd822e6
           expose: "false"
-          randcount: "0"
-          randtype: none
           name_top: RndCnstAesClearingLfsrPerm
+          randwidth: 384
         }
         {
           name: RndCnstMaskingLfsrSeed
           type: aes_pkg::masking_lfsr_seed_t
-          default: aes_pkg::RndCnstMaskingLfsrSeedDefault
           desc: Default seed of the PRNG used for masking.
+          randcount: "160"
+          randtype: data
           local: "false"
+          default: 0x19e5a91389b9fe0d3b818e46ce7d846469a3b8e3
           expose: "false"
-          randcount: "0"
-          randtype: none
           name_top: RndCnstAesMaskingLfsrSeed
+          randwidth: 160
         }
         {
           name: RndCnstMskgChunkLfsrPerm
           type: aes_pkg::mskg_chunk_lfsr_perm_t
-          default: aes_pkg::RndCnstMskgChunkLfsrPermDefault
           desc: Permutation applied to the LFSR chunks of the PRNG used for masking.
+          randcount: "32"
+          randtype: perm
           local: "false"
+          default: 0x23f6ba7ea92aa0e8e3b900f826cee835bc1648fa
           expose: "false"
-          randcount: "0"
-          randtype: none
           name_top: RndCnstAesMskgChunkLfsrPerm
+          randwidth: 160
         }
       ]
       interrupt_list: []

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1791,10 +1791,10 @@ module top_earlgrey #(
     .SecStartTriggerDelay(SecAesStartTriggerDelay),
     .SecAllowForcingMasks(SecAesAllowForcingMasks),
     .AlertAsyncOn({aes_reg_pkg::NumAlerts{1'b1}}),
-    .RndCnstClearingLfsrSeed(aes_pkg::RndCnstClearingLfsrSeedDefault),
-    .RndCnstClearingLfsrPerm(aes_pkg::RndCnstClearingLfsrPermDefault),
-    .RndCnstMaskingLfsrSeed(aes_pkg::RndCnstMaskingLfsrSeedDefault),
-    .RndCnstMskgChunkLfsrPerm(aes_pkg::RndCnstMskgChunkLfsrPermDefault)
+    .RndCnstClearingLfsrSeed(RndCnstAesClearingLfsrSeed),
+    .RndCnstClearingLfsrPerm(RndCnstAesClearingLfsrPerm),
+    .RndCnstMaskingLfsrSeed(RndCnstAesMaskingLfsrSeed),
+    .RndCnstMskgChunkLfsrPerm(RndCnstAesMskgChunkLfsrPerm)
   ) u_aes (
 
       // [15]: recov_ctrl_update_err

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -94,6 +94,30 @@ package top_earlgrey_rnd_cnst_pkg;
   };
 
   ////////////////////////////////////////////
+  // aes
+  ////////////////////////////////////////////
+  // Default seed of the PRNG used for register clearing.
+  parameter aes_pkg::clearing_lfsr_seed_t RndCnstAesClearingLfsrSeed = {
+    64'hF4C3471C5DEF7861
+  };
+
+  // Permutation applied to the LFSR of the PRNG used for clearing.
+  parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingLfsrPerm = {
+    128'h26AC29E186C1F4DC6F959D6ED08DC044,
+    256'hA0F3F1519E8DCA131275DF1E48BBF964AC772E613D0320ADAEBF38552DD822E6
+  };
+
+  // Default seed of the PRNG used for masking.
+  parameter aes_pkg::masking_lfsr_seed_t RndCnstAesMaskingLfsrSeed = {
+    160'h19E5A91389B9FE0D3B818E46CE7D846469A3B8E3
+  };
+
+  // Permutation applied to the LFSR chunks of the PRNG used for masking.
+  parameter aes_pkg::mskg_chunk_lfsr_perm_t RndCnstAesMskgChunkLfsrPerm = {
+    160'h23F6BA7EA92AA0E8E3B900F826CEE835BC1648FA
+  };
+
+  ////////////////////////////////////////////
   // keymgr
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed


### PR DESCRIPTION
Previously, these constants were exposed to the top level but driven by the default values defined in aes_pkg.sv.