### PR TITLE
[sw, dif] Fix spelling of 'occurred' in all DIFs and template

### DIFF
--- a/sw/device/lib/dif/dif_alert_handler.h
+++ b/sw/device/lib/dif/dif_alert_handler.h
@@ -90,7 +90,7 @@ typedef enum dif_alert_handler_result {
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
-   * When this value is returned, no hardware operations occured.
+   * When this value is returned, no hardware operations occurred.
    */
   kDifAlertHandlerBadArg = 2,
 } dif_alert_handler_result_t;
@@ -111,7 +111,7 @@ typedef enum dif_alert_handler_config_result {
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
-   * When this value is returned, no hardware operations occured.
+   * When this value is returned, no hardware operations occurred.
    */
   kDifAlertHandlerConfigBadArg = kDifAlertHandlerBadArg,
   /**

--- a/sw/device/lib/dif/dif_clkmgr.h
+++ b/sw/device/lib/dif/dif_clkmgr.h
@@ -101,7 +101,7 @@ typedef enum dif_clkmgr_result {
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
-   * When this value is returned, no hardware operations occured.
+   * When this value is returned, no hardware operations occurred.
    */
   kDifClkmgrBadArg = 2,
 } dif_clkmgr_result_t;

--- a/sw/device/lib/dif/dif_gpio.h
+++ b/sw/device/lib/dif/dif_gpio.h
@@ -78,7 +78,7 @@ typedef enum dif_gpio_result {
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
-   * When this value is returned, no hardware operations occured.
+   * When this value is returned, no hardware operations occurred.
    */
   kDifGpioBadArg = 2,
 } dif_gpio_result_t;

--- a/sw/device/lib/dif/dif_lc_ctrl.h
+++ b/sw/device/lib/dif/dif_lc_ctrl.h
@@ -36,8 +36,8 @@ typedef enum dif_lc_ctrl_status_code {
    */
   kDifLcCtrlStatusCodeSuccess,
   /**
-   * Indicates that too many hardware transitions have occured, and the hardware
-   * will not transition the lifecycle any further.
+   * Indicates that too many hardware transitions have occurred, and the
+   * hardware will not transition the lifecycle any further.
    */
   kDifLcCtrlStatusCodeTooManyTransitions,
   /**
@@ -240,7 +240,7 @@ typedef enum dif_lc_ctrl_result {
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
-   * When this value is returned, no hardware operations occured.
+   * When this value is returned, no hardware operations occurred.
    */
   kDifLcCtrlBadArg = 2,
 } dif_lc_ctrl_result_t;
@@ -261,7 +261,7 @@ typedef enum dif_lc_ctrl_attempts_result {
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
-   * When this value is returned, no hardware operations occured.
+   * When this value is returned, no hardware operations occurred.
    */
   kDifLcCtrlAttemptsBadArg = kDifLcCtrlBadArg,
   /**
@@ -287,7 +287,7 @@ typedef enum dif_lc_ctrl_mutex_result {
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
-   * When this value is returned, no hardware operations occured.
+   * When this value is returned, no hardware operations occurred.
    */
   kDifLcCtrlMutexBadArg = kDifLcCtrlBadArg,
 

--- a/sw/device/lib/dif/dif_otp_ctrl.h
+++ b/sw/device/lib/dif/dif_otp_ctrl.h
@@ -157,7 +157,7 @@ typedef enum dif_otp_ctrl_result {
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
-   * When this value is returned, no hardware operations occured.
+   * When this value is returned, no hardware operations occurred.
    */
   kDifOtpCtrlBadArg = 2,
 } dif_otp_ctrl_result_t;
@@ -178,7 +178,7 @@ typedef enum dif_otp_ctrl_lockable_result {
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
-   * When this value is returned, no hardware operations occured.
+   * When this value is returned, no hardware operations occurred.
    */
   kDifOtpCtrlLockableBadArg = kDifOtpCtrlBadArg,
   /**
@@ -204,7 +204,7 @@ typedef enum dif_otp_ctrl_dai_result {
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
-   * When this value is returned, no hardware operations occured.
+   * When this value is returned, no hardware operations occurred.
    */
   kDifOtpCtrlDaiBadArg = kDifOtpCtrlBadArg,
   /**
@@ -242,7 +242,7 @@ typedef enum dif_otp_ctrl_digest_result {
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
-   * When this value is returned, no hardware operations occured.
+   * When this value is returned, no hardware operations occurred.
    */
   kDifOtpCtrlDigestBadArg = kDifOtpCtrlBadArg,
   /**
@@ -261,7 +261,7 @@ typedef enum dif_otp_ctrl_irq {
    */
   kDifOtpCtrlIrqDone,
   /**
-   * Indicates that an error has occured in the OTP controller.
+   * Indicates that an error has occurred in the OTP controller.
    */
   kDifOtpCtrlIrqError,
 } dif_otp_ctrl_irq_t;
@@ -286,40 +286,40 @@ typedef enum dif_otp_ctrl_status_code {
   // Note furthermore that these enum variants are intended as bit indices, so
   // their values should not be randomized.
   /**
-   * Indicates an error occured in the `CreatorSwCfg` partition.
+   * Indicates an error occurred in the `CreatorSwCfg` partition.
    */
   kDifOtpCtrlStatusCodeCreatorSwCfgError = 0,
   /**
-   * Indicates an error occured in the `OwnerSwCfg` partition.
+   * Indicates an error occurred in the `OwnerSwCfg` partition.
    */
   kDifOtpCtrlStatusCodeOwnerSwCfgError,
   /**
-   * Indicates an error occured in the `HwCfg` partition.
+   * Indicates an error occurred in the `HwCfg` partition.
    */
   kDifOtpCtrlStatusCodeHwCfgError,
   /**
-   * Indicates an error occured in the `LifeCycle` partition.
+   * Indicates an error occurred in the `LifeCycle` partition.
    */
   kDifOtpCtrlStatusCodeLifeCycleError,
   /**
-   * Indicates an error occured in the `Secret0` partition.
+   * Indicates an error occurred in the `Secret0` partition.
    */
   kDifOtpCtrlStatusCodeSecret0Error,
   /**
-   * Indicates an error occured in the `Secret1` partition.
+   * Indicates an error occurred in the `Secret1` partition.
    */
   kDifOtpCtrlStatusCodeSecret1Error,
   /**
-   * Indicates an error occured in the `Secret2` partition.
+   * Indicates an error occurred in the `Secret2` partition.
    */
   kDifOtpCtrlStatusCodeSecret2Error,
 
   /**
-   * Indicates an error occured in the direct access interface.
+   * Indicates an error occurred in the direct access interface.
    */
   kDifOtpCtrlStatusCodeDaiError,
   /**
-   * Indicates an error occured in the lifecycle interface.
+   * Indicates an error occurred in the lifecycle interface.
    */
   kDifOtpCtrlStatusCodeLciError,
 

--- a/sw/device/lib/dif/dif_plic.h
+++ b/sw/device/lib/dif/dif_plic.h
@@ -83,7 +83,7 @@ typedef enum dif_plic_result {
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
-   * When this value is returned, no hardware operations occured.
+   * When this value is returned, no hardware operations occurred.
    */
   kDifPlicBadArg = 2,
 } dif_plic_result_t;

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -133,7 +133,7 @@ typedef enum dif_spi_device_result {
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
-   * When this value is returned, no hardware operations occured.
+   * When this value is returned, no hardware operations occurred.
    */
   kDifSpiDeviceBadArg = 2,
 } dif_spi_device_result_t;
@@ -159,11 +159,11 @@ typedef enum dif_spi_device_irq {
    */
   kDifSpiDeviceIrqRxError,
   /**
-   * Indicates that overflow has occured in the RX FIFO.
+   * Indicates that overflow has occurred in the RX FIFO.
    */
   kDifSpiDeviceIrqRxOverflow,
   /**
-   * Indicates that underflow has occured in the RX FIFO.
+   * Indicates that underflow has occurred in the RX FIFO.
    */
   kDifSpiDeviceIrqTxUnderflow,
 } dif_spi_device_irq_t;

--- a/sw/device/lib/dif/dif_template.h.tpl
+++ b/sw/device/lib/dif/dif_template.h.tpl
@@ -103,7 +103,7 @@ typedef enum dif_${ip_snake}_result {
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
-   * When this value is returned, no hardware operations occured.
+   * When this value is returned, no hardware operations occurred.
    */
   kDif${ip_camel}BadArg = 2,
   /**

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -112,7 +112,7 @@ typedef enum dif_uart_result {
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
-   * When this value is returned, no hardware operations occured.
+   * When this value is returned, no hardware operations occurred.
    */
   kDifUartBadArg = 2,
 } dif_uart_result_t;
@@ -133,7 +133,7 @@ typedef enum dif_uart_config_result {
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
-   * When this value is returned, no hardware operations occured.
+   * When this value is returned, no hardware operations occurred.
    */
   kDifUartConfigBadArg = kDifUartBadArg,
   /**


### PR DESCRIPTION
Pointed out by @silvestrst in PR #5361.