### PR TITLE
[USB] Advance USB to D1

### DIFF
--- a/hw/ip/usbdev/data/usbdev.prj.hjson
+++ b/hw/ip/usbdev/data/usbdev.prj.hjson
@@ -9,7 +9,7 @@
     sw_checklist:       "sw/device/lib/dif/dif_usbdev",
     version:            "0.5",
     life_stage:         "L1",
-    design_stage:       "D0",
+    design_stage:       "D1",
     verification_stage: "V0",
     dif_stage:          "S0",
 }

--- a/hw/ip/usbdev/doc/checklist.md
+++ b/hw/ip/usbdev/doc/checklist.md
@@ -18,7 +18,7 @@ RTL           | [IP_TOP][]                     | Done        |
 RTL           | [IP_INSTANTIABLE][]            | Done        |
 RTL           | [PHYSICAL_MACROS_DEFINED_80][] | Done        |
 RTL           | [FUNC_IMPLEMENTED][]           | Done        |
-RTL           | [ASSERT_KNOWN_ADDED][]         | Not Started |
+RTL           | [ASSERT_KNOWN_ADDED][]         | Done        |
 Code Quality  | [LINT_SETUP][]                 | Done        |
 
 [SPEC_COMPLETE]:              {{<relref "/doc/project/checklist.md#spec_complete" >}}


### PR DESCRIPTION
The final checklist item (ASSERT_KNOWN on outputs) is now complete, so
usbdev can now move to D1.

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>