### PR TITLE
[lint] Remove comportable waivers from non-comportable IPs

### DIFF
--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -74,7 +74,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim/prim_buf.core
+++ b/hw/ip/prim/prim_buf.core
@@ -31,7 +31,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 generate:
   impl:

--- a/hw/ip/prim/prim_clock_buf.core
+++ b/hw/ip/prim/prim_clock_buf.core
@@ -31,7 +31,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 generate:
   impl:

--- a/hw/ip/prim/prim_clock_gating.core
+++ b/hw/ip/prim/prim_clock_gating.core
@@ -31,7 +31,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 generate:
   impl:

--- a/hw/ip/prim/prim_clock_inv.core
+++ b/hw/ip/prim/prim_clock_inv.core
@@ -31,7 +31,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 generate:
   impl:

--- a/hw/ip/prim/prim_clock_mux2.core
+++ b/hw/ip/prim/prim_clock_mux2.core
@@ -31,7 +31,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 generate:
   impl:

--- a/hw/ip/prim/prim_dom_and_2share.core
+++ b/hw/ip/prim/prim_dom_and_2share.core
@@ -33,7 +33,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 
 targets:

--- a/hw/ip/prim/prim_flash.core
+++ b/hw/ip/prim/prim_flash.core
@@ -36,7 +36,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 generate:
   impl:

--- a/hw/ip/prim/prim_flop.core
+++ b/hw/ip/prim/prim_flop.core
@@ -30,7 +30,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 generate:
   impl:

--- a/hw/ip/prim/prim_flop_2sync.core
+++ b/hw/ip/prim/prim_flop_2sync.core
@@ -30,7 +30,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 
 generate:

--- a/hw/ip/prim/prim_lc_dec.core
+++ b/hw/ip/prim/prim_lc_dec.core
@@ -33,7 +33,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default: &default_target

--- a/hw/ip/prim/prim_lc_sender.core
+++ b/hw/ip/prim/prim_lc_sender.core
@@ -34,7 +34,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default: &default_target

--- a/hw/ip/prim/prim_lc_sync.core
+++ b/hw/ip/prim/prim_lc_sync.core
@@ -35,7 +35,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default: &default_target

--- a/hw/ip/prim/prim_lfsr.core
+++ b/hw/ip/prim/prim_lfsr.core
@@ -32,7 +32,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default: &default_target

--- a/hw/ip/prim/prim_otp.core
+++ b/hw/ip/prim/prim_otp.core
@@ -31,7 +31,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 generate:
   impl:

--- a/hw/ip/prim/prim_otp_pkg.core
+++ b/hw/ip/prim/prim_otp_pkg.core
@@ -29,7 +29,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default: &default_target

--- a/hw/ip/prim/prim_pad_wrapper.core
+++ b/hw/ip/prim/prim_pad_wrapper.core
@@ -31,7 +31,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 generate:
   impl:

--- a/hw/ip/prim/prim_ram_1p.core
+++ b/hw/ip/prim/prim_ram_1p.core
@@ -31,7 +31,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 generate:
   impl:

--- a/hw/ip/prim/prim_ram_1p_adv.core
+++ b/hw/ip/prim/prim_ram_1p_adv.core
@@ -34,7 +34,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim/prim_ram_2p.core
+++ b/hw/ip/prim/prim_ram_2p.core
@@ -31,7 +31,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 generate:
   impl:

--- a/hw/ip/prim/prim_rom.core
+++ b/hw/ip/prim/prim_rom.core
@@ -31,7 +31,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 generate:
   impl:

--- a/hw/ip/prim/prim_usb_diff_rx.core
+++ b/hw/ip/prim/prim_usb_diff_rx.core
@@ -31,7 +31,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 generate:
   impl:

--- a/hw/ip/prim_generic/prim_generic_buf.core
+++ b/hw/ip/prim_generic/prim_generic_buf.core
@@ -29,7 +29,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim_generic/prim_generic_clock_buf.core
+++ b/hw/ip/prim_generic/prim_generic_clock_buf.core
@@ -29,7 +29,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim_generic/prim_generic_clock_gating.core
+++ b/hw/ip/prim_generic/prim_generic_clock_gating.core
@@ -31,7 +31,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim_generic/prim_generic_clock_inv.core
+++ b/hw/ip/prim_generic/prim_generic_clock_inv.core
@@ -34,7 +34,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim_generic/prim_generic_clock_mux2.core
+++ b/hw/ip/prim_generic/prim_generic_clock_mux2.core
@@ -33,7 +33,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim_generic/prim_generic_flash.core
+++ b/hw/ip/prim_generic/prim_generic_flash.core
@@ -36,7 +36,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim_generic/prim_generic_flop.core
+++ b/hw/ip/prim_generic/prim_generic_flop.core
@@ -29,7 +29,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim_generic/prim_generic_flop_2sync.core
+++ b/hw/ip/prim_generic/prim_generic_flop_2sync.core
@@ -29,7 +29,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim_generic/prim_generic_pad_wrapper.core
+++ b/hw/ip/prim_generic/prim_generic_pad_wrapper.core
@@ -33,7 +33,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim_generic/prim_generic_ram_1p.core
+++ b/hw/ip/prim_generic/prim_generic_ram_1p.core
@@ -34,7 +34,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim_generic/prim_generic_ram_2p.core
+++ b/hw/ip/prim_generic/prim_generic_ram_2p.core
@@ -34,7 +34,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim_generic/prim_generic_rom.core
+++ b/hw/ip/prim_generic/prim_generic_rom.core
@@ -34,7 +34,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim_generic/prim_generic_usb_diff_rx.core
+++ b/hw/ip/prim_generic/prim_generic_usb_diff_rx.core
@@ -31,7 +31,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim_xilinx/prim_xilinx_buf.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_buf.core
@@ -27,7 +27,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim_xilinx/prim_xilinx_clock_buf.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_clock_buf.core
@@ -31,7 +31,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim_xilinx/prim_xilinx_clock_gating.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_clock_gating.core
@@ -31,7 +31,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim_xilinx/prim_xilinx_clock_mux2.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_clock_mux2.core
@@ -31,7 +31,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim_xilinx/prim_xilinx_flop.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_flop.core
@@ -29,7 +29,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/prim_xilinx/prim_xilinx_pad_wrapper.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_pad_wrapper.core
@@ -31,7 +31,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/rv_core_ibex/rv_core_ibex.core
+++ b/hw/ip/rv_core_ibex/rv_core_ibex.core
@@ -23,7 +23,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
     files:
       - lint/rv_core_ibex.vlt
     file_type: vlt
@@ -32,7 +31,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
     files:
       - lint/rv_core_ibex.waiver
     file_type: waiver
@@ -41,7 +39,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 parameters:
   SYNTHESIS:

--- a/hw/ip/rv_dm/rv_dm.core
+++ b/hw/ip/rv_dm/rv_dm.core
@@ -24,7 +24,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      #- lowrisc:lint:comportable
     files:
       - lint/rv_dm.vlt
     file_type: vlt
@@ -33,7 +32,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      #- lowrisc:lint:comportable
     files:
       - lint/rv_dm.waiver
     file_type: waiver
@@ -42,7 +40,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 parameters:
   NrHarts:

--- a/hw/ip/tlul/adapter_host.core
+++ b/hw/ip/tlul/adapter_host.core
@@ -35,7 +35,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 parameters:
   SYNTHESIS:

--- a/hw/ip/tlul/adapter_reg.core
+++ b/hw/ip/tlul/adapter_reg.core
@@ -35,7 +35,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 parameters:
   SYNTHESIS:

--- a/hw/ip/tlul/adapter_sram.core
+++ b/hw/ip/tlul/adapter_sram.core
@@ -35,7 +35,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 parameters:
   SYNTHESIS:

--- a/hw/ip/tlul/common.core
+++ b/hw/ip/tlul/common.core
@@ -39,7 +39,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 targets:
   default:

--- a/hw/ip/tlul/payload_chk.core
+++ b/hw/ip/tlul/payload_chk.core
@@ -32,7 +32,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 parameters:
   SYNTHESIS:

--- a/hw/ip/tlul/socket_1n.core
+++ b/hw/ip/tlul/socket_1n.core
@@ -36,7 +36,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 parameters:
   SYNTHESIS:

--- a/hw/ip/tlul/socket_m1.core
+++ b/hw/ip/tlul/socket_m1.core
@@ -35,7 +35,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 parameters:
   SYNTHESIS:

--- a/hw/ip/tlul/sram2tlul.core
+++ b/hw/ip/tlul/sram2tlul.core
@@ -34,7 +34,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 parameters:
   SYNTHESIS:

--- a/hw/ip/usb_fs_nb_pe/usbfs_nb_pe.core
+++ b/hw/ip/usb_fs_nb_pe/usbfs_nb_pe.core
@@ -22,7 +22,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
     files:
       - lint/usb_fs_nb_pe.vlt
     file_type: vlt
@@ -31,7 +30,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
     files:
       - lint/usb_fs_nb_pe.waiver
     file_type: waiver
@@ -40,7 +38,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-      - lowrisc:lint:comportable
 
 parameters:
   SYNTHESIS:


### PR DESCRIPTION
This removes unnecessary comportable waivers from IPs that didn't need them (these just create tool warnings).

Signed-off-by: Michael Schaffner <msf@opentitan.org>