### PR TITLE
[fpv] TLUL_pkg compile error

### DIFF
--- a/hw/ip/tlul/rtl/tlul_pkg.sv
+++ b/hw/ip/tlul/rtl/tlul_pkg.sv
@@ -81,6 +81,7 @@ package tlul_pkg;
   localparam tl_d2h_t TL_D2H_DEFAULT = '{
     a_ready:  1'b1,
     d_opcode: tl_d_op_e'('0),
+    d_user:   tl_d_user_t'(0),
     default:  '0
   };
 endpackage


### PR DESCRIPTION
This PR fixes a small compile error due to enum casting in tlul_pkg.

Signed-off-by: Cindy Chen <chencindy@google.com>