### PR TITLE
[entropy_src/rtl] one-way health test threshold registers

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -239,208 +239,288 @@ param_list: [
     { name: "REPCNT_THRESHOLDS",
       desc: "Repetition count test thresholds register",
       swaccess: "rw",
-      hwaccess: "hro",
+      hwaccess: "hrw",
+      hwext: "true",
+      hwqe:  "true",
       regwen:   "REGWEN",
+      tags: [// Exclude from writes to these field because they are one-way updates
+             "excl:CsrAllTests:CsrExclWrite"]
       fields: [
         { bits: "15:0",
-          name: "FIPS_REPCNT_THRESH",
+          name: "FIPS_THRESH",
           desc: '''This is the threshold size for the repetition count health test.
                    This value is used in normal mode when entropy is being tested in
                    FIPS/CC compliance mode.
-                   The default value is 32
+                   This register must be written before the module is enabled.
+                   Writing to this register will only update the register if the
+                   written value is less than the current value of this register.
+                   A read from this register always reflects the current value.
                 '''
-          resval: "0x0020"
+          resval: "0xFFFF"
         }
         { bits: "31:16",
-          name: "BYPASS_REPCNT_THRESH",
+          name: "BYPASS_THRESH",
           desc: '''This is the threshold size for the repetition count health test
                    running in bypass mode. This mode is active after reset for the
                    first and only test run, or when this mode is programmed by firmware.
-                   The default value is 32
+                   This register must be written before the module is enabled.
+                   Writing to this register will only update the register if the
+                   written value is less than the current value of this register.
+                   A read from this register always reflects the current value.
                 '''
-          resval: "0x0020"
+          resval: "0xFFFF"
         }
       ]
     },
     { name: "ADAPTP_HI_THRESHOLDS",
       desc: "Adaptive proportion test high thresholds register",
       swaccess: "rw",
-      hwaccess: "hro",
+      hwaccess: "hrw",
+      hwext: "true",
+      hwqe:  "true",
       regwen:   "REGWEN",
+      tags: [// Exclude from writes to these field because they are one-way updates
+             "excl:CsrAllTests:CsrExclWrite"]
       fields: [
         { bits: "15:0",
-          name: "FIPS_ADAPTP_HI_THRESH",
+          name: "FIPS_THRESH",
           desc: '''This is the threshold size for the adaptive proportion health test.
                    This value is used in normal mode when entropy is being tested in
                    FIPS/CC compliance mode.
-                   The default value is 598.
+                   This register must be written before the module is enabled.
+                   Writing to this register will only update the register if the
+                   written value is less than the current value of this register.
+                   A read from this register always reflects the current value.
                 '''
-          resval: "0x0256"
+          resval: "0xFFFF"
         }
         { bits: "31:16",
-          name: "BYPASS_ADAPTP_HI_THRESH",
+          name: "BYPASS_THRESH",
           desc: '''This is the threshold size for the adaptive proportion health test
                    running in bypass mode. This mode is active after reset for the
                    first and only test run, or when this mode is programmed by firmware.
-                   The default value is .375 of the FIPS threshold.
+                   This register must be written before the module is enabled.
+                   Writing to this register will only update the register if the
+                   written value is less than the current value of this register.
+                   A read from this register always reflects the current value.
                 '''
-          resval: "0x00e0"
+          resval: "0xFFFF"
         }
       ]
     },
     { name: "ADAPTP_LO_THRESHOLDS",
       desc: "Adaptive proportion test low thresholds register",
       swaccess: "rw",
-      hwaccess: "hro",
+      hwaccess: "hrw",
+      hwext: "true",
+      hwqe:  "true",
       regwen:   "REGWEN",
+      tags: [// Exclude from writes to these field because they are one-way updates
+             "excl:CsrAllTests:CsrExclWrite"]
       fields: [
         { bits: "15:0",
-          name: "FIPS_ADAPTP_LO_THRESH",
+          name: "FIPS_THRESH",
           desc: '''This is the threshold size for the adaptive proportion health test.
                    This value is used in normal mode when entropy is being tested in
                    FIPS/CC compliance mode.
-                   The default value is 426.
+                   This register must be written before the module is enabled.
+                   Writing to this register will only update the register if the
+                   written value is greater than the current value of this register.
+                   A read from this register always reflects the current value.
                 '''
-          resval: "0x01aa"
+          resval: "0x0000"
         }
         { bits: "31:16",
-          name: "BYPASS_ADAPTP_LO_THRESH",
+          name: "BYPASS_THRESH",
           desc: '''This is the threshold size for the adaptive proportion health test
                    running in bypass mode. This mode is active after reset for the
                    first and only test run, or when this mode is programmed by firmware.
-                   The default value is .375 of the FIPS threshold.
+                   This register must be written before the module is enabled.
+                   Writing to this register will only update the register if the
+                   written value is greater than the current value of this register.
+                   A read from this register always reflects the current value.
                 '''
-          resval: "0x00a0"
+          resval: "0x0000"
         }
       ]
     },
     { name: "BUCKET_THRESHOLDS",
       desc: "Bucket test thresholds register",
       swaccess: "rw",
-      hwaccess: "hro",
+      hwaccess: "hrw",
+      hwext: "true",
+      hwqe:  "true",
       regwen:   "REGWEN",
+      tags: [// Exclude from writes to these field because they are one-way updates
+             "excl:CsrAllTests:CsrExclWrite"]
       fields: [
         { bits: "15:0",
-          name: "FIPS_BUCKET_THRESH",
+          name: "FIPS_THRESH",
           desc: '''This is the threshold size for the bucket health test.
                    This value is used in normal mode when entropy is being tested in
                    FIPS/CC compliance mode.
-                   The default value is 32.
+                   This register must be written before the module is enabled.
+                   Writing to this register will only update the register if the
+                   written value is less than the current value of this register.
+                   A read from this register always reflects the current value.
                 '''
-          resval: "0x0020"
+          resval: "0xFFFF"
         }
         { bits: "31:16",
-          name: "BYPASS_BUCKET_THRESH",
+          name: "BYPASS_THRESH",
           desc: '''This is the threshold size for the bucket health test
                    running in bypass mode. This mode is active after reset for the
                    first and only test run, or when this mode is programmed by firmware.
-                   The default value is 32.
+                   This register must be written before the module is enabled.
+                   Writing to this register will only update the register if the
+                   written value is less than the current value of this register.
+                   A read from this register always reflects the current value.
                 '''
-          resval: "0x0020"
+          resval: "0xFFFF"
         }
       ]
     },
     { name: "MARKOV_HI_THRESHOLDS",
       desc: "Markov test high thresholds register",
       swaccess: "rw",
-      hwaccess: "hro",
+      hwaccess: "hrw",
+      hwext: "true",
+      hwqe:  "true",
       regwen:   "REGWEN",
+      tags: [// Exclude from writes to these field because they are one-way updates
+             "excl:CsrAllTests:CsrExclWrite"]
       fields: [
         { bits: "15:0",
-          name: "FIPS_MARKOV_HI_THRESH",
+          name: "FIPS_THRESH",
           desc: '''This is the threshold size for the Markov health test.
                    This value is used in normal mode when entropy is being tested in
                    FIPS/CC compliance mode.
-                   The default value is 256.
+                   This register must be written before the module is enabled.
+                   Writing to this register will only update the register if the
+                   written value is less than the current value of this register.
+                   A read from this register always reflects the current value.
                 '''
-          resval: "0x0100"
+          resval: "0xFFFF"
         }
         { bits: "31:16",
-          name: "BYPASS_MARKOV_HI_THRESH",
+          name: "BYPASS_THRESH",
           desc: '''This is the threshold size for the Markov health test
                    running in bypass mode. This mode is active after reset for the
                    first and only test run, or when this mode is programmed by firmware.
-                   The default value is .375 of the FIPS threshold.
+                   This register must be written before the module is enabled.
+                   Writing to this register will only update the register if the
+                   written value is less than the current value of this register.
+                   A read from this register always reflects the current value.
                 '''
-          resval: "0x0060"
-        }
+          resval: "0xFFFF"
+       }
       ]
     },
     { name: "MARKOV_LO_THRESHOLDS",
       desc: "Markov test low thresholds register",
       swaccess: "rw",
-      hwaccess: "hro",
+      hwaccess: "hrw",
+      hwext: "true",
+      hwqe:  "true",
       regwen:   "REGWEN",
+      tags: [// Exclude from writes to these field because they are one-way updates
+             "excl:CsrAllTests:CsrExclWrite"]
       fields: [
         { bits: "15:0",
-          name: "FIPS_MARKOV_LO_THRESH",
+          name: "FIPS_THRESH",
           desc: '''This is the threshold size for the Markov health test.
                    This value is used in normal mode when entropy is being tested in
                    FIPS/CC compliance mode.
-                   The default value is 16.
+                   This register must be written before the module is enabled.
+                   Writing to this register will only update the register if the
+                   written value is greater than the current value of this register.
+                   A read from this register always reflects the current value.
                 '''
-          resval: "0x0010"
+          resval: "0x0000"
         }
         { bits: "31:16",
-          name: "BYPASS_MARKOV_LO_THRESH",
+          name: "BYPASS_THRESH",
           desc: '''This is the threshold size for the Markov health test
                    running in bypass mode. This mode is active after reset for the
                    first and only test run, or when this mode is programmed by firmware.
-                   The default value is .375 of the FIPS threshold.
+                   This register must be written before the module is enabled.
+                   Writing to this register will only update the register if the
+                   written value is greater than the current value of this register.
+                   A read from this register always reflects the current value.
                 '''
-          resval: "0x006"
+          resval: "0x0000"
         }
       ]
     },
     { name: "EXTHT_HI_THRESHOLDS",
       desc: "External health test high thresholds register",
       swaccess: "rw",
-      hwaccess: "hro",
+      hwaccess: "hrw",
+      hwext: "true",
+      hwqe:  "true",
       regwen:   "REGWEN",
+      tags: [// Exclude from writes to these field because they are one-way updates
+             "excl:CsrAllTests:CsrExclWrite"]
       fields: [
         { bits: "15:0",
-          name: "FIPS_EXTHT_HI_THRESH",
+          name: "FIPS_THRESH",
           desc: '''This is the threshold size for the external health test.
                    This value is used in normal mode when entropy is being tested in
                    FIPS/CC compliance mode.
-                   The default value is 0.
+                   This register must be written before the module is enabled.
+                   Writing to this register will only update the register if the
+                   written value is less than the current value of this register.
+                   A read from this register always reflects the current value.
                 '''
-          resval: "0x0"
+          resval: "0xFFFF"
         }
         { bits: "31:16",
-          name: "BYPASS_EXTHT_HI_THRESH",
+          name: "BYPASS_THRESH",
           desc: '''This is the threshold size for the external health test
                    running in bypass mode. This mode is active after reset for the
                    first and only test run, or when this mode is programmed by firmware.
-                   The default value is 0.
+                   This register must be written before the module is enabled.
+                   Writing to this register will only update the register if the
+                   written value is less than the current value of this register.
+                   A read from this register always reflects the current value.
                 '''
-          resval: "0x0"
+          resval: "0xFFFF"
         }
       ]
     },
     { name: "EXTHT_LO_THRESHOLDS",
       desc: "External health test low thresholds register",
       swaccess: "rw",
-      hwaccess: "hro",
+      hwaccess: "hrw",
+      hwext: "true",
+      hwqe:  "true",
       regwen:   "REGWEN",
+      tags: [// Exclude from writes to these field because they are one-way updates
+             "excl:CsrAllTests:CsrExclWrite"]
       fields: [
         { bits: "15:0",
-          name: "FIPS_EXTHT_LO_THRESH",
+          name: "FIPS_THRESH",
           desc: '''This is the threshold size for the external health test.
                    This value is used in normal mode when entropy is being tested in
                    FIPS/CC compliance mode.
-                   The default value is 0.
+                   This register must be written before the module is enabled.
+                   Writing to this register will only update the register if the
+                   written value is greater than the current value of this register.
+                   A read from this register always reflects the current value.
                 '''
-          resval: "0x0"
+          resval: "0x0000"
         }
         { bits: "31:16",
-          name: "BYPASS_EXTHT_LO_THRESH",
+          name: "BYPASS_THRESH",
           desc: '''This is the threshold size for the external health test
                    running in bypass mode. This mode is active after reset for the
                    first and only test run, or when this mode is programmed by firmware.
-                   The default value is 0.
+                   This register must be written before the module is enabled.
+                   Writing to this register will only update the register if the
+                   written value is greater than the current value of this register.
+                   A read from this register always reflects the current value.
                 '''
-          resval: "0x0"
+          resval: "0x0000"
         }
       ]
     },
@@ -451,11 +531,11 @@ param_list: [
       hwext: "true",
       fields: [
         { bits: "15:0",
-          name: "FIPS_REPCNT_HI_WATERMARK",
+          name: "FIPS_WATERMARK",
           desc: "High watermark value of the REPCNT test in FIPS mode."
         }
         { bits: "31:16",
-          name: "BYPASS_REPCNT_HI_WATERMARK",
+          name: "BYPASS_WATERMARK",
           desc: "High watermark value of the REPCNT test in bypass mode."
         }
       ]
@@ -467,11 +547,11 @@ param_list: [
       hwext: "true",
       fields: [
         { bits: "15:0",
-          name: "FIPS_ADAPTP_HI_WATERMARK",
+          name: "FIPS_WATERMARK",
           desc: "High watermark value of the adaptive proportion test in FIPS mode."
         }
         { bits: "31:16",
-          name: "BYPASS_ADAPTP_HI_WATERMARK",
+          name: "BYPASS_WATERMARK",
           desc: "High watermark value of the adaptive proportion test in bypass mode."
         }
       ]
@@ -483,12 +563,14 @@ param_list: [
       hwext: "true",
       fields: [
         { bits: "15:0",
-          name: "FIPS_ADAPTP_LO_WATERMARK",
+          name: "FIPS_WATERMARK",
           desc: "Low watermark value of the adaptive proportion test in FIPS mode."
+          resval: "0xFFFF"
         }
         { bits: "31:16",
-          name: "BYPASS_ADAPTP_LO_WATERMARK",
+          name: "BYPASS_WATERMARK",
           desc: "Low watermark value of the adaptive proportion test in bypass mode."
+          resval: "0xFFFF"
         }
       ]
     },
@@ -499,11 +581,11 @@ param_list: [
       hwext: "true",
       fields: [
         { bits: "15:0",
-          name: "FIPS_EXTHT_HI_WATERMARK",
+          name: "FIPS_WATERMARK",
           desc: "High watermark value of the external health test in FIPS mode."
         }
         { bits: "31:16",
-          name: "BYPASS_EXTHT_HI_WATERMARK",
+          name: "BYPASS_WATERMARK",
           desc: "High watermark value of the external health test in bypass mode."
         }
       ]
@@ -515,12 +597,14 @@ param_list: [
       hwext: "true",
       fields: [
         { bits: "15:0",
-          name: "FIPS_EXTHT_LO_WATERMARK",
+          name: "FIPS_WATERMARK",
           desc: "Low watermark value of the external health test in FIPS mode."
+          resval: "0xFFFF"
         }
         { bits: "31:16",
-          name: "BYPASS_EXTHT_LO_WATERMARK",
+          name: "BYPASS_WATERMARK",
           desc: "Low watermark value of the external health test in bypass mode."
+          resval: "0xFFFF"
         }
       ]
     },
@@ -531,11 +615,11 @@ param_list: [
       hwext: "true",
       fields: [
         { bits: "15:0",
-          name: "FIPS_BUCKET_HI_WATERMARK",
+          name: "FIPS_WATERMARK",
           desc: "High watermark value of the bucket test in FIPS mode."
         }
         { bits: "31:16",
-          name: "BYPASS_BUCKET_HI_WATERMARK",
+          name: "BYPASS_WATERMARK",
           desc: "High watermark value of the bucket test in bypass mode."
         }
       ]
@@ -547,11 +631,11 @@ param_list: [
       hwext: "true",
       fields: [
         { bits: "15:0",
-          name: "FIPS_MARKOV_HI_WATERMARK",
+          name: "FIPS_WATERMARK",
           desc: "High watermark value of the Markov test in FIPS mode."
         }
         { bits: "31:16",
-          name: "BYPASS_MARKOV_HI_WATERMARK",
+          name: "BYPASS_WATERMARK",
           desc: "High watermark value of the Markov test in bypass mode."
         }
       ]
@@ -563,12 +647,14 @@ param_list: [
       hwext: "true",
       fields: [
         { bits: "15:0",
-          name: "FIPS_MARKOV_LO_WATERMARK",
+          name: "FIPS_WATERMARK",
           desc: "Low watermark value of the Markov test in FIPS mode."
+          resval: "0xFFFF"
         }
         { bits: "31:16",
-          name: "BYPASS_MARKOV_LO_WATERMARK",
+          name: "BYPASS_WATERMARK",
           desc: "Low watermark value of the Markov test in bypass mode."
+          resval: "0xFFFF"
         }
       ]
     },

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -140,8 +140,13 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic [HalfRegWidth-1:0] health_test_fips_window;
   logic [HalfRegWidth-1:0] health_test_bypass_window;
   logic [HalfRegWidth-1:0] health_test_window;
+
   logic [HalfRegWidth-1:0] repcnt_fips_threshold;
+  logic [HalfRegWidth-1:0] repcnt_fips_threshold_oneway;
+  logic                    repcnt_fips_threshold_wr;
   logic [HalfRegWidth-1:0] repcnt_bypass_threshold;
+  logic [HalfRegWidth-1:0] repcnt_bypass_threshold_oneway;
+  logic                    repcnt_bypass_threshold_wr;
   logic [HalfRegWidth-1:0] repcnt_threshold;
   logic [HalfRegWidth-1:0] repcnt_event_cnt;
   logic [HalfRegWidth-1:0] repcnt_event_hwm_fips;
@@ -151,10 +156,18 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic                     repcnt_fail_pulse;
 
   logic [HalfRegWidth-1:0] adaptp_hi_fips_threshold;
+  logic [HalfRegWidth-1:0] adaptp_hi_fips_threshold_oneway;
+  logic                    adaptp_hi_fips_threshold_wr;
   logic [HalfRegWidth-1:0] adaptp_hi_bypass_threshold;
+  logic [HalfRegWidth-1:0] adaptp_hi_bypass_threshold_oneway;
+  logic                    adaptp_hi_bypass_threshold_wr;
   logic [HalfRegWidth-1:0] adaptp_hi_threshold;
   logic [HalfRegWidth-1:0] adaptp_lo_fips_threshold;
+  logic [HalfRegWidth-1:0] adaptp_lo_fips_threshold_oneway;
+  logic                    adaptp_lo_fips_threshold_wr;
   logic [HalfRegWidth-1:0] adaptp_lo_bypass_threshold;
+  logic [HalfRegWidth-1:0] adaptp_lo_bypass_threshold_oneway;
+  logic                    adaptp_lo_bypass_threshold_wr;
   logic [HalfRegWidth-1:0] adaptp_lo_threshold;
   logic [HalfRegWidth-1:0] adaptp_event_cnt;
   logic [HalfRegWidth-1:0] adaptp_hi_event_hwm_fips;
@@ -169,7 +182,11 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic                     adaptp_lo_fail_pulse;
 
   logic [HalfRegWidth-1:0] bucket_fips_threshold;
+  logic [HalfRegWidth-1:0] bucket_fips_threshold_oneway;
+  logic                    bucket_fips_threshold_wr;
   logic [HalfRegWidth-1:0] bucket_bypass_threshold;
+  logic [HalfRegWidth-1:0] bucket_bypass_threshold_oneway;
+  logic                    bucket_bypass_threshold_wr;
   logic [HalfRegWidth-1:0] bucket_threshold;
   logic [HalfRegWidth-1:0] bucket_event_cnt;
   logic [HalfRegWidth-1:0] bucket_event_hwm_fips;
@@ -179,10 +196,18 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic                     bucket_fail_pulse;
 
   logic [HalfRegWidth-1:0] markov_hi_fips_threshold;
+  logic [HalfRegWidth-1:0] markov_hi_fips_threshold_oneway;
+  logic                    markov_hi_fips_threshold_wr;
   logic [HalfRegWidth-1:0] markov_hi_bypass_threshold;
+  logic [HalfRegWidth-1:0] markov_hi_bypass_threshold_oneway;
+  logic                    markov_hi_bypass_threshold_wr;
   logic [HalfRegWidth-1:0] markov_hi_threshold;
   logic [HalfRegWidth-1:0] markov_lo_fips_threshold;
+  logic [HalfRegWidth-1:0] markov_lo_fips_threshold_oneway;
+  logic                    markov_lo_fips_threshold_wr;
   logic [HalfRegWidth-1:0] markov_lo_bypass_threshold;
+  logic [HalfRegWidth-1:0] markov_lo_bypass_threshold_oneway;
+  logic                    markov_lo_bypass_threshold_wr;
   logic [HalfRegWidth-1:0] markov_lo_threshold;
   logic [HalfRegWidth-1:0] markov_hi_event_cnt;
   logic [HalfRegWidth-1:0] markov_lo_event_cnt;
@@ -198,10 +223,18 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic                     markov_lo_fail_pulse;
 
   logic [HalfRegWidth-1:0] extht_hi_fips_threshold;
+  logic [HalfRegWidth-1:0] extht_hi_fips_threshold_oneway;
+  logic                    extht_hi_fips_threshold_wr;
   logic [HalfRegWidth-1:0] extht_hi_bypass_threshold;
+  logic [HalfRegWidth-1:0] extht_hi_bypass_threshold_oneway;
+  logic                    extht_hi_bypass_threshold_wr;
   logic [HalfRegWidth-1:0] extht_hi_threshold;
   logic [HalfRegWidth-1:0] extht_lo_fips_threshold;
+  logic [HalfRegWidth-1:0] extht_lo_fips_threshold_oneway;
+  logic                    extht_lo_fips_threshold_wr;
   logic [HalfRegWidth-1:0] extht_lo_bypass_threshold;
+  logic [HalfRegWidth-1:0] extht_lo_bypass_threshold_oneway;
+  logic                    extht_lo_bypass_threshold_wr;
   logic [HalfRegWidth-1:0] extht_lo_threshold;
   logic [HalfRegWidth-1:0] extht_event_cnt;
   logic [HalfRegWidth-1:0] extht_hi_event_hwm_fips;
@@ -607,50 +640,327 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign health_test_fips_window = reg2hw.health_test_windows.fips_window.q;
   assign health_test_bypass_window = reg2hw.health_test_windows.bypass_window.q;
 
-  assign repcnt_fips_threshold = reg2hw.repcnt_thresholds.fips_repcnt_thresh.q;
-  assign repcnt_bypass_threshold = reg2hw.repcnt_thresholds.bypass_repcnt_thresh.q;
+  assign repcnt_fips_threshold = reg2hw.repcnt_thresholds.fips_thresh.q;
+  assign repcnt_fips_threshold_wr = reg2hw.repcnt_thresholds.fips_thresh.qe;
+  assign hw2reg.repcnt_thresholds.fips_thresh.d = repcnt_fips_threshold_oneway;
+  assign repcnt_bypass_threshold = reg2hw.repcnt_thresholds.bypass_thresh.q;
+  assign repcnt_bypass_threshold_wr = reg2hw.repcnt_thresholds.bypass_thresh.qe;
+  assign hw2reg.repcnt_thresholds.bypass_thresh.d = repcnt_bypass_threshold_oneway;
 
 
-  assign adaptp_hi_fips_threshold = reg2hw.adaptp_hi_thresholds.fips_adaptp_hi_thresh.q;
-  assign adaptp_hi_bypass_threshold = reg2hw.adaptp_hi_thresholds.bypass_adaptp_hi_thresh.q;
+  assign adaptp_hi_fips_threshold = reg2hw.adaptp_hi_thresholds.fips_thresh.q;
+  assign adaptp_hi_fips_threshold_wr = reg2hw.adaptp_hi_thresholds.fips_thresh.qe;
+  assign hw2reg.adaptp_hi_thresholds.fips_thresh.d = adaptp_hi_fips_threshold_oneway;
+  assign adaptp_hi_bypass_threshold = reg2hw.adaptp_hi_thresholds.bypass_thresh.q;
+  assign adaptp_hi_bypass_threshold_wr = reg2hw.adaptp_hi_thresholds.bypass_thresh.qe;
+  assign hw2reg.adaptp_hi_thresholds.bypass_thresh.d = adaptp_hi_bypass_threshold_oneway;
 
-  assign adaptp_lo_fips_threshold = reg2hw.adaptp_lo_thresholds.fips_adaptp_lo_thresh.q;
-  assign adaptp_lo_bypass_threshold = reg2hw.adaptp_lo_thresholds.bypass_adaptp_lo_thresh.q;
-
-
-  assign bucket_fips_threshold = reg2hw.bucket_thresholds.fips_bucket_thresh.q;
-  assign bucket_bypass_threshold = reg2hw.bucket_thresholds.bypass_bucket_thresh.q;
-
-
-  assign markov_hi_fips_threshold = reg2hw.markov_hi_thresholds.fips_markov_hi_thresh.q;
-  assign markov_hi_bypass_threshold = reg2hw.markov_hi_thresholds.bypass_markov_hi_thresh.q;
-
-  assign markov_lo_fips_threshold = reg2hw.markov_lo_thresholds.fips_markov_lo_thresh.q;
-  assign markov_lo_bypass_threshold = reg2hw.markov_lo_thresholds.bypass_markov_lo_thresh.q;
+  assign adaptp_lo_fips_threshold = reg2hw.adaptp_lo_thresholds.fips_thresh.q;
+  assign adaptp_lo_fips_threshold_wr = reg2hw.adaptp_lo_thresholds.fips_thresh.qe;
+  assign hw2reg.adaptp_lo_thresholds.fips_thresh.d = adaptp_lo_fips_threshold_oneway;
+  assign adaptp_lo_bypass_threshold = reg2hw.adaptp_lo_thresholds.bypass_thresh.q;
+  assign adaptp_lo_bypass_threshold_wr = reg2hw.adaptp_lo_thresholds.bypass_thresh.qe;
+  assign hw2reg.adaptp_lo_thresholds.bypass_thresh.d = adaptp_lo_bypass_threshold_oneway;
 
 
-  assign extht_hi_fips_threshold = reg2hw.extht_hi_thresholds.fips_extht_hi_thresh.q;
-  assign extht_hi_bypass_threshold = reg2hw.extht_hi_thresholds.bypass_extht_hi_thresh.q;
+  assign bucket_fips_threshold = reg2hw.bucket_thresholds.fips_thresh.q;
+  assign bucket_fips_threshold_wr = reg2hw.bucket_thresholds.fips_thresh.qe;
+  assign hw2reg.bucket_thresholds.fips_thresh.d = bucket_fips_threshold_oneway;
+  assign bucket_bypass_threshold = reg2hw.bucket_thresholds.bypass_thresh.q;
+  assign bucket_bypass_threshold_wr = reg2hw.bucket_thresholds.bypass_thresh.qe;
+  assign hw2reg.bucket_thresholds.bypass_thresh.d = bucket_bypass_threshold_oneway;
 
-  assign extht_lo_fips_threshold = reg2hw.extht_lo_thresholds.fips_extht_lo_thresh.q;
-  assign extht_lo_bypass_threshold = reg2hw.extht_lo_thresholds.bypass_extht_lo_thresh.q;
+
+  assign markov_hi_fips_threshold = reg2hw.markov_hi_thresholds.fips_thresh.q;
+  assign markov_hi_fips_threshold_wr = reg2hw.markov_hi_thresholds.fips_thresh.qe;
+  assign hw2reg.markov_hi_thresholds.fips_thresh.d = markov_hi_fips_threshold_oneway;
+  assign markov_hi_bypass_threshold = reg2hw.markov_hi_thresholds.bypass_thresh.q;
+  assign markov_hi_bypass_threshold_wr = reg2hw.markov_hi_thresholds.bypass_thresh.qe;
+  assign hw2reg.markov_hi_thresholds.bypass_thresh.d = markov_hi_bypass_threshold_oneway;
+
+  assign markov_lo_fips_threshold = reg2hw.markov_lo_thresholds.fips_thresh.q;
+  assign markov_lo_fips_threshold_wr = reg2hw.markov_lo_thresholds.fips_thresh.qe;
+  assign hw2reg.markov_lo_thresholds.fips_thresh.d = markov_lo_fips_threshold_oneway;
+  assign markov_lo_bypass_threshold = reg2hw.markov_lo_thresholds.bypass_thresh.q;
+  assign markov_lo_bypass_threshold_wr = reg2hw.markov_lo_thresholds.bypass_thresh.qe;
+  assign hw2reg.markov_lo_thresholds.bypass_thresh.d = markov_lo_bypass_threshold_oneway;
+
+
+  assign extht_hi_fips_threshold = reg2hw.extht_hi_thresholds.fips_thresh.q;
+  assign extht_hi_fips_threshold_wr = reg2hw.extht_hi_thresholds.fips_thresh.qe;
+  assign hw2reg.extht_hi_thresholds.fips_thresh.d = extht_hi_fips_threshold_oneway;
+  assign extht_hi_bypass_threshold = reg2hw.extht_hi_thresholds.bypass_thresh.q;
+  assign extht_hi_bypass_threshold_wr = reg2hw.extht_hi_thresholds.bypass_thresh.qe;
+  assign hw2reg.extht_hi_thresholds.bypass_thresh.d = extht_hi_bypass_threshold_oneway;
+
+  assign extht_lo_fips_threshold = reg2hw.extht_lo_thresholds.fips_thresh.q;
+  assign extht_lo_fips_threshold_wr = reg2hw.extht_lo_thresholds.fips_thresh.qe;
+  assign hw2reg.extht_lo_thresholds.fips_thresh.d = extht_lo_fips_threshold_oneway;
+  assign extht_lo_bypass_threshold = reg2hw.extht_lo_thresholds.bypass_thresh.q;
+  assign extht_lo_bypass_threshold_wr = reg2hw.extht_lo_thresholds.bypass_thresh.qe;
+  assign hw2reg.extht_lo_thresholds.bypass_thresh.d = extht_lo_bypass_threshold_oneway;
+
 
 
   assign health_test_window = es_bypass_mode ? health_test_bypass_window : health_test_fips_window;
-  assign repcnt_threshold = es_bypass_mode ? repcnt_bypass_threshold : repcnt_fips_threshold;
-  assign adaptp_hi_threshold = es_bypass_mode ? adaptp_hi_bypass_threshold :
-         adaptp_hi_fips_threshold;
-  assign adaptp_lo_threshold = es_bypass_mode ? adaptp_lo_bypass_threshold :
-         adaptp_lo_fips_threshold;
-  assign bucket_threshold = es_bypass_mode ? bucket_bypass_threshold : bucket_fips_threshold;
-  assign markov_hi_threshold = es_bypass_mode ? markov_hi_bypass_threshold :
-         markov_hi_fips_threshold;
-  assign markov_lo_threshold = es_bypass_mode ? markov_lo_bypass_threshold :
-         markov_lo_fips_threshold;
-  assign extht_hi_threshold = es_bypass_mode ? extht_hi_bypass_threshold :
-         extht_hi_fips_threshold;
-  assign extht_lo_threshold = es_bypass_mode ? extht_lo_bypass_threshold :
-         extht_lo_fips_threshold;
+
+  //------------------------------
+  // repcnt one-way thresholds
+  //------------------------------
+  assign repcnt_threshold = es_bypass_mode ? repcnt_bypass_threshold_oneway :
+         repcnt_fips_threshold_oneway;
+
+  entropy_src_watermark_reg #(
+    .RegWidth(HalfRegWidth),
+    .HighWatermark(0)
+  ) u_entropy_src_watermark_reg_repcnt_thresh_fips (
+    .clk_i               (clk_i),
+    .rst_ni              (rst_ni),
+    .clear_i             (1'b0),
+    .active_i            (!es_enable),
+    .event_i             (repcnt_fips_threshold_wr),
+    .value_i             (repcnt_fips_threshold),
+    .value_o             (repcnt_fips_threshold_oneway)
+  );
+
+  entropy_src_watermark_reg #(
+    .RegWidth(HalfRegWidth),
+    .HighWatermark(0)
+  ) u_entropy_src_watermark_reg_repcnt_thresh_bypass (
+    .clk_i               (clk_i),
+    .rst_ni              (rst_ni),
+    .clear_i             (1'b0),
+    .active_i            (!es_enable),
+    .event_i             (repcnt_bypass_threshold_wr),
+    .value_i             (repcnt_bypass_threshold),
+    .value_o             (repcnt_bypass_threshold_oneway)
+  );
+
+
+  //------------------------------
+  // adaptp one-way thresholds
+  //------------------------------
+  assign adaptp_hi_threshold = es_bypass_mode ? adaptp_hi_bypass_threshold_oneway :
+         adaptp_hi_fips_threshold_oneway;
+
+  entropy_src_watermark_reg #(
+    .RegWidth(HalfRegWidth),
+    .HighWatermark(0)
+  ) u_entropy_src_watermark_reg_adaptp_hi_thresh_fips (
+    .clk_i               (clk_i),
+    .rst_ni              (rst_ni),
+    .clear_i             (1'b0),
+    .active_i            (!es_enable),
+    .event_i             (adaptp_hi_fips_threshold_wr),
+    .value_i             (adaptp_hi_fips_threshold),
+    .value_o             (adaptp_hi_fips_threshold_oneway)
+  );
+
+  entropy_src_watermark_reg #(
+    .RegWidth(HalfRegWidth),
+    .HighWatermark(0)
+  ) u_entropy_src_watermark_reg_adaptp_hi_thresh_bypass (
+    .clk_i               (clk_i),
+    .rst_ni              (rst_ni),
+    .clear_i             (1'b0),
+    .active_i            (!es_enable),
+    .event_i             (adaptp_hi_bypass_threshold_wr),
+    .value_i             (adaptp_hi_bypass_threshold),
+    .value_o             (adaptp_hi_bypass_threshold_oneway)
+  );
+
+  assign adaptp_lo_threshold = es_bypass_mode ? adaptp_lo_bypass_threshold_oneway :
+         adaptp_lo_fips_threshold_oneway;
+
+  entropy_src_watermark_reg #(
+    .RegWidth(HalfRegWidth),
+    .HighWatermark(1)
+  ) u_entropy_src_watermark_reg_adaptp_lo_thresh_fips (
+    .clk_i               (clk_i),
+    .rst_ni              (rst_ni),
+    .clear_i             (1'b0),
+    .active_i            (!es_enable),
+    .event_i             (adaptp_lo_fips_threshold_wr),
+    .value_i             (adaptp_lo_fips_threshold),
+    .value_o             (adaptp_lo_fips_threshold_oneway)
+  );
+
+  entropy_src_watermark_reg #(
+    .RegWidth(HalfRegWidth),
+    .HighWatermark(1)
+  ) u_entropy_src_watermark_reg_adaptp_lo_thresh_bypass (
+    .clk_i               (clk_i),
+    .rst_ni              (rst_ni),
+    .clear_i             (1'b0),
+    .active_i            (!es_enable),
+    .event_i             (adaptp_lo_bypass_threshold_wr),
+    .value_i             (adaptp_lo_bypass_threshold),
+    .value_o             (adaptp_lo_bypass_threshold_oneway)
+  );
+
+
+  //------------------------------
+  // bucket one-way thresholds
+  //------------------------------
+  assign bucket_threshold = es_bypass_mode ? bucket_bypass_threshold_oneway :
+         bucket_fips_threshold_oneway;
+
+  entropy_src_watermark_reg #(
+    .RegWidth(HalfRegWidth),
+    .HighWatermark(0)
+  ) u_entropy_src_watermark_reg_bucket_thresh_fips (
+    .clk_i               (clk_i),
+    .rst_ni              (rst_ni),
+    .clear_i             (1'b0),
+    .active_i            (!es_enable),
+    .event_i             (bucket_fips_threshold_wr),
+    .value_i             (bucket_fips_threshold),
+    .value_o             (bucket_fips_threshold_oneway)
+  );
+
+  entropy_src_watermark_reg #(
+    .RegWidth(HalfRegWidth),
+    .HighWatermark(0)
+  ) u_entropy_src_watermark_reg_bucket_thresh_bypass (
+    .clk_i               (clk_i),
+    .rst_ni              (rst_ni),
+    .clear_i             (1'b0),
+    .active_i            (!es_enable),
+    .event_i             (bucket_bypass_threshold_wr),
+    .value_i             (bucket_bypass_threshold),
+    .value_o             (bucket_bypass_threshold_oneway)
+  );
+
+
+  //------------------------------
+  // markov one-way thresholds
+  //------------------------------
+  assign markov_hi_threshold = es_bypass_mode ? markov_hi_bypass_threshold_oneway :
+         markov_hi_fips_threshold_oneway;
+
+  entropy_src_watermark_reg #(
+    .RegWidth(HalfRegWidth),
+    .HighWatermark(0)
+  ) u_entropy_src_watermark_reg_markov_hi_thresh_fips (
+    .clk_i               (clk_i),
+    .rst_ni              (rst_ni),
+    .clear_i             (1'b0),
+    .active_i            (!es_enable),
+    .event_i             (markov_hi_fips_threshold_wr),
+    .value_i             (markov_hi_fips_threshold),
+    .value_o             (markov_hi_fips_threshold_oneway)
+  );
+
+  entropy_src_watermark_reg #(
+    .RegWidth(HalfRegWidth),
+    .HighWatermark(0)
+  ) u_entropy_src_watermark_reg_markov_hi_thresh_bypass (
+    .clk_i               (clk_i),
+    .rst_ni              (rst_ni),
+    .clear_i             (1'b0),
+    .active_i            (!es_enable),
+    .event_i             (markov_hi_bypass_threshold_wr),
+    .value_i             (markov_hi_bypass_threshold),
+    .value_o             (markov_hi_bypass_threshold_oneway)
+  );
+
+  assign markov_lo_threshold = es_bypass_mode ? markov_lo_bypass_threshold_oneway :
+         markov_lo_fips_threshold_oneway;
+
+  entropy_src_watermark_reg #(
+    .RegWidth(HalfRegWidth),
+    .HighWatermark(1)
+  ) u_entropy_src_watermark_reg_markov_lo_thresh_fips (
+    .clk_i               (clk_i),
+    .rst_ni              (rst_ni),
+    .clear_i             (1'b0),
+    .active_i            (!es_enable),
+    .event_i             (markov_lo_fips_threshold_wr),
+    .value_i             (markov_lo_fips_threshold),
+    .value_o             (markov_lo_fips_threshold_oneway)
+  );
+
+  entropy_src_watermark_reg #(
+    .RegWidth(HalfRegWidth),
+    .HighWatermark(1)
+  ) u_entropy_src_watermark_reg_markov_lo_thresh_bypass (
+    .clk_i               (clk_i),
+    .rst_ni              (rst_ni),
+    .clear_i             (1'b0),
+    .active_i            (!es_enable),
+    .event_i             (markov_lo_bypass_threshold_wr),
+    .value_i             (markov_lo_bypass_threshold),
+    .value_o             (markov_lo_bypass_threshold_oneway)
+  );
+
+
+  //------------------------------
+  // extht one-way thresholds
+  //------------------------------
+  assign extht_hi_threshold = es_bypass_mode ? extht_hi_bypass_threshold_oneway :
+         extht_hi_fips_threshold_oneway;
+
+  entropy_src_watermark_reg #(
+    .RegWidth(HalfRegWidth),
+    .HighWatermark(0)
+  ) u_entropy_src_watermark_reg_extht_hi_thresh_fips (
+    .clk_i               (clk_i),
+    .rst_ni              (rst_ni),
+    .clear_i             (1'b0),
+    .active_i            (!es_enable),
+    .event_i             (extht_hi_fips_threshold_wr),
+    .value_i             (extht_hi_fips_threshold),
+    .value_o             (extht_hi_fips_threshold_oneway)
+  );
+
+  entropy_src_watermark_reg #(
+    .RegWidth(HalfRegWidth),
+    .HighWatermark(0)
+  ) u_entropy_src_watermark_reg_extht_hi_thresh_bypass (
+    .clk_i               (clk_i),
+    .rst_ni              (rst_ni),
+    .clear_i             (1'b0),
+    .active_i            (!es_enable),
+    .event_i             (extht_hi_bypass_threshold_wr),
+    .value_i             (extht_hi_bypass_threshold),
+    .value_o             (extht_hi_bypass_threshold_oneway)
+  );
+
+
+  assign extht_lo_threshold = es_bypass_mode ? extht_lo_bypass_threshold_oneway :
+         extht_lo_fips_threshold_oneway;
+
+  entropy_src_watermark_reg #(
+    .RegWidth(HalfRegWidth),
+    .HighWatermark(1)
+  ) u_entropy_src_watermark_reg_extht_lo_thresh_fips (
+    .clk_i               (clk_i),
+    .rst_ni              (rst_ni),
+    .clear_i             (1'b0),
+    .active_i            (!es_enable),
+    .event_i             (extht_lo_fips_threshold_wr),
+    .value_i             (extht_lo_fips_threshold),
+    .value_o             (extht_lo_fips_threshold_oneway)
+  );
+
+  entropy_src_watermark_reg #(
+    .RegWidth(HalfRegWidth),
+    .HighWatermark(1)
+  ) u_entropy_src_watermark_reg_extht_lo_thresh_bypass (
+    .clk_i               (clk_i),
+    .rst_ni              (rst_ni),
+    .clear_i             (1'b0),
+    .active_i            (!es_enable),
+    .event_i             (extht_lo_bypass_threshold_wr),
+    .value_i             (extht_lo_bypass_threshold),
+    .value_o             (extht_lo_bypass_threshold_oneway)
+  );
+
+
+
+  //------------------------------
+  // misc control settings
+  //------------------------------
 
   assign event_es_health_test_failed = recov_alert_event;
 
@@ -735,8 +1045,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .value_o             (repcnt_total_fails)
   );
 
-  assign hw2reg.repcnt_hi_watermarks.fips_repcnt_hi_watermark.d = repcnt_event_hwm_fips;
-  assign hw2reg.repcnt_hi_watermarks.bypass_repcnt_hi_watermark.d = repcnt_event_hwm_bypass;
+  assign hw2reg.repcnt_hi_watermarks.fips_watermark.d = repcnt_event_hwm_fips;
+  assign hw2reg.repcnt_hi_watermarks.bypass_watermark.d = repcnt_event_hwm_bypass;
   assign hw2reg.repcnt_total_fails.d = repcnt_total_fails;
 
   //--------------------------------------------
@@ -800,8 +1110,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
   );
 
 
-  assign hw2reg.adaptp_hi_watermarks.fips_adaptp_hi_watermark.d = adaptp_hi_event_hwm_fips;
-  assign hw2reg.adaptp_hi_watermarks.bypass_adaptp_hi_watermark.d = adaptp_hi_event_hwm_bypass;
+  assign hw2reg.adaptp_hi_watermarks.fips_watermark.d = adaptp_hi_event_hwm_fips;
+  assign hw2reg.adaptp_hi_watermarks.bypass_watermark.d = adaptp_hi_event_hwm_bypass;
   assign hw2reg.adaptp_hi_total_fails.d = adaptp_hi_total_fails;
 
 
@@ -842,8 +1152,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .value_o             (adaptp_lo_total_fails)
   );
 
-  assign hw2reg.adaptp_lo_watermarks.fips_adaptp_lo_watermark.d = adaptp_lo_event_hwm_fips;
-  assign hw2reg.adaptp_lo_watermarks.bypass_adaptp_lo_watermark.d = adaptp_lo_event_hwm_bypass;
+  assign hw2reg.adaptp_lo_watermarks.fips_watermark.d = adaptp_lo_event_hwm_fips;
+  assign hw2reg.adaptp_lo_watermarks.bypass_watermark.d = adaptp_lo_event_hwm_bypass;
   assign hw2reg.adaptp_lo_total_fails.d = adaptp_lo_total_fails;
 
 
@@ -904,8 +1214,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .value_o             (bucket_total_fails)
   );
 
-  assign hw2reg.bucket_hi_watermarks.fips_bucket_hi_watermark.d = bucket_event_hwm_fips;
-  assign hw2reg.bucket_hi_watermarks.bypass_bucket_hi_watermark.d = bucket_event_hwm_bypass;
+  assign hw2reg.bucket_hi_watermarks.fips_watermark.d = bucket_event_hwm_fips;
+  assign hw2reg.bucket_hi_watermarks.bypass_watermark.d = bucket_event_hwm_bypass;
   assign hw2reg.bucket_total_fails.d = bucket_total_fails;
 
 
@@ -969,14 +1279,14 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .value_o             (markov_hi_total_fails)
   );
 
-  assign hw2reg.markov_hi_watermarks.fips_markov_hi_watermark.d = markov_hi_event_hwm_fips;
-  assign hw2reg.markov_hi_watermarks.bypass_markov_hi_watermark.d = markov_hi_event_hwm_bypass;
+  assign hw2reg.markov_hi_watermarks.fips_watermark.d = markov_hi_event_hwm_fips;
+  assign hw2reg.markov_hi_watermarks.bypass_watermark.d = markov_hi_event_hwm_bypass;
   assign hw2reg.markov_hi_total_fails.d = markov_hi_total_fails;
 
 
   entropy_src_watermark_reg #(
     .RegWidth(HalfRegWidth),
-    .HighWatermark(1)
+    .HighWatermark(0)
   ) u_entropy_src_watermark_reg_markov_lo_fips (
     .clk_i               (clk_i),
     .rst_ni              (rst_ni),
@@ -989,7 +1299,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   entropy_src_watermark_reg #(
     .RegWidth(HalfRegWidth),
-    .HighWatermark(1)
+    .HighWatermark(0)
   ) u_entropy_src_watermark_reg_markov_lo_bypass (
     .clk_i               (clk_i),
     .rst_ni              (rst_ni),
@@ -1011,8 +1321,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .value_o             (markov_lo_total_fails)
   );
 
-  assign hw2reg.markov_lo_watermarks.fips_markov_lo_watermark.d = markov_lo_event_hwm_fips;
-  assign hw2reg.markov_lo_watermarks.bypass_markov_lo_watermark.d = markov_lo_event_hwm_bypass;
+  assign hw2reg.markov_lo_watermarks.fips_watermark.d = markov_lo_event_hwm_fips;
+  assign hw2reg.markov_lo_watermarks.bypass_watermark.d = markov_lo_event_hwm_bypass;
   assign hw2reg.markov_lo_total_fails.d = markov_lo_total_fails;
 
 
@@ -1073,8 +1383,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
   );
 
 
-  assign hw2reg.extht_hi_watermarks.fips_extht_hi_watermark.d = extht_hi_event_hwm_fips;
-  assign hw2reg.extht_hi_watermarks.bypass_extht_hi_watermark.d = extht_hi_event_hwm_bypass;
+  assign hw2reg.extht_hi_watermarks.fips_watermark.d = extht_hi_event_hwm_fips;
+  assign hw2reg.extht_hi_watermarks.bypass_watermark.d = extht_hi_event_hwm_bypass;
   assign hw2reg.extht_hi_total_fails.d = extht_hi_total_fails;
 
 
@@ -1115,8 +1425,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .value_o             (extht_lo_total_fails)
   );
 
-  assign hw2reg.extht_lo_watermarks.fips_extht_lo_watermark.d = extht_lo_event_hwm_fips;
-  assign hw2reg.extht_lo_watermarks.bypass_extht_lo_watermark.d = extht_lo_event_hwm_bypass;
+  assign hw2reg.extht_lo_watermarks.fips_watermark.d = extht_lo_event_hwm_fips;
+  assign hw2reg.extht_lo_watermarks.bypass_watermark.d = extht_lo_event_hwm_bypass;
   assign hw2reg.extht_lo_total_fails.d = extht_lo_total_fails;
 
 

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -133,73 +133,89 @@ package entropy_src_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [15:0] q;
-    } fips_repcnt_thresh;
+      logic        qe;
+    } fips_thresh;
     struct packed {
       logic [15:0] q;
-    } bypass_repcnt_thresh;
+      logic        qe;
+    } bypass_thresh;
   } entropy_src_reg2hw_repcnt_thresholds_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] q;
-    } fips_adaptp_hi_thresh;
+      logic        qe;
+    } fips_thresh;
     struct packed {
       logic [15:0] q;
-    } bypass_adaptp_hi_thresh;
+      logic        qe;
+    } bypass_thresh;
   } entropy_src_reg2hw_adaptp_hi_thresholds_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] q;
-    } fips_adaptp_lo_thresh;
+      logic        qe;
+    } fips_thresh;
     struct packed {
       logic [15:0] q;
-    } bypass_adaptp_lo_thresh;
+      logic        qe;
+    } bypass_thresh;
   } entropy_src_reg2hw_adaptp_lo_thresholds_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] q;
-    } fips_bucket_thresh;
+      logic        qe;
+    } fips_thresh;
     struct packed {
       logic [15:0] q;
-    } bypass_bucket_thresh;
+      logic        qe;
+    } bypass_thresh;
   } entropy_src_reg2hw_bucket_thresholds_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] q;
-    } fips_markov_hi_thresh;
+      logic        qe;
+    } fips_thresh;
     struct packed {
       logic [15:0] q;
-    } bypass_markov_hi_thresh;
+      logic        qe;
+    } bypass_thresh;
   } entropy_src_reg2hw_markov_hi_thresholds_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] q;
-    } fips_markov_lo_thresh;
+      logic        qe;
+    } fips_thresh;
     struct packed {
       logic [15:0] q;
-    } bypass_markov_lo_thresh;
+      logic        qe;
+    } bypass_thresh;
   } entropy_src_reg2hw_markov_lo_thresholds_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] q;
-    } fips_extht_hi_thresh;
+      logic        qe;
+    } fips_thresh;
     struct packed {
       logic [15:0] q;
-    } bypass_extht_hi_thresh;
+      logic        qe;
+    } bypass_thresh;
   } entropy_src_reg2hw_extht_hi_thresholds_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] q;
-    } fips_extht_lo_thresh;
+      logic        qe;
+    } fips_thresh;
     struct packed {
       logic [15:0] q;
-    } bypass_extht_lo_thresh;
+      logic        qe;
+    } bypass_thresh;
   } entropy_src_reg2hw_extht_lo_thresholds_reg_t;
 
   typedef struct packed {
@@ -264,73 +280,145 @@ package entropy_src_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_repcnt_hi_watermark;
+    } fips_thresh;
     struct packed {
       logic [15:0] d;
-    } bypass_repcnt_hi_watermark;
+    } bypass_thresh;
+  } entropy_src_hw2reg_repcnt_thresholds_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } fips_thresh;
+    struct packed {
+      logic [15:0] d;
+    } bypass_thresh;
+  } entropy_src_hw2reg_adaptp_hi_thresholds_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } fips_thresh;
+    struct packed {
+      logic [15:0] d;
+    } bypass_thresh;
+  } entropy_src_hw2reg_adaptp_lo_thresholds_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } fips_thresh;
+    struct packed {
+      logic [15:0] d;
+    } bypass_thresh;
+  } entropy_src_hw2reg_bucket_thresholds_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } fips_thresh;
+    struct packed {
+      logic [15:0] d;
+    } bypass_thresh;
+  } entropy_src_hw2reg_markov_hi_thresholds_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } fips_thresh;
+    struct packed {
+      logic [15:0] d;
+    } bypass_thresh;
+  } entropy_src_hw2reg_markov_lo_thresholds_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } fips_thresh;
+    struct packed {
+      logic [15:0] d;
+    } bypass_thresh;
+  } entropy_src_hw2reg_extht_hi_thresholds_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } fips_thresh;
+    struct packed {
+      logic [15:0] d;
+    } bypass_thresh;
+  } entropy_src_hw2reg_extht_lo_thresholds_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } fips_watermark;
+    struct packed {
+      logic [15:0] d;
+    } bypass_watermark;
   } entropy_src_hw2reg_repcnt_hi_watermarks_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_adaptp_hi_watermark;
+    } fips_watermark;
     struct packed {
       logic [15:0] d;
-    } bypass_adaptp_hi_watermark;
+    } bypass_watermark;
   } entropy_src_hw2reg_adaptp_hi_watermarks_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_adaptp_lo_watermark;
+    } fips_watermark;
     struct packed {
       logic [15:0] d;
-    } bypass_adaptp_lo_watermark;
+    } bypass_watermark;
   } entropy_src_hw2reg_adaptp_lo_watermarks_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_extht_hi_watermark;
+    } fips_watermark;
     struct packed {
       logic [15:0] d;
-    } bypass_extht_hi_watermark;
+    } bypass_watermark;
   } entropy_src_hw2reg_extht_hi_watermarks_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_extht_lo_watermark;
+    } fips_watermark;
     struct packed {
       logic [15:0] d;
-    } bypass_extht_lo_watermark;
+    } bypass_watermark;
   } entropy_src_hw2reg_extht_lo_watermarks_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_bucket_hi_watermark;
+    } fips_watermark;
     struct packed {
       logic [15:0] d;
-    } bypass_bucket_hi_watermark;
+    } bypass_watermark;
   } entropy_src_hw2reg_bucket_hi_watermarks_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_markov_hi_watermark;
+    } fips_watermark;
     struct packed {
       logic [15:0] d;
-    } bypass_markov_hi_watermark;
+    } bypass_watermark;
   } entropy_src_hw2reg_markov_hi_watermarks_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_markov_lo_watermark;
+    } fips_watermark;
     struct packed {
       logic [15:0] d;
-    } bypass_markov_lo_watermark;
+    } bypass_watermark;
   } entropy_src_hw2reg_markov_lo_watermarks_reg_t;
 
   typedef struct packed {
@@ -455,24 +543,24 @@ package entropy_src_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    entropy_src_reg2hw_intr_state_reg_t intr_state; // [457:455]
-    entropy_src_reg2hw_intr_enable_reg_t intr_enable; // [454:452]
-    entropy_src_reg2hw_intr_test_reg_t intr_test; // [451:446]
-    entropy_src_reg2hw_alert_test_reg_t alert_test; // [445:442]
-    entropy_src_reg2hw_regwen_reg_t regwen; // [441:441]
-    entropy_src_reg2hw_conf_reg_t conf; // [440:429]
-    entropy_src_reg2hw_rate_reg_t rate; // [428:413]
-    entropy_src_reg2hw_entropy_control_reg_t entropy_control; // [412:411]
-    entropy_src_reg2hw_entropy_data_reg_t entropy_data; // [410:378]
-    entropy_src_reg2hw_health_test_windows_reg_t health_test_windows; // [377:346]
-    entropy_src_reg2hw_repcnt_thresholds_reg_t repcnt_thresholds; // [345:314]
-    entropy_src_reg2hw_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [313:282]
-    entropy_src_reg2hw_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [281:250]
-    entropy_src_reg2hw_bucket_thresholds_reg_t bucket_thresholds; // [249:218]
-    entropy_src_reg2hw_markov_hi_thresholds_reg_t markov_hi_thresholds; // [217:186]
-    entropy_src_reg2hw_markov_lo_thresholds_reg_t markov_lo_thresholds; // [185:154]
-    entropy_src_reg2hw_extht_hi_thresholds_reg_t extht_hi_thresholds; // [153:122]
-    entropy_src_reg2hw_extht_lo_thresholds_reg_t extht_lo_thresholds; // [121:90]
+    entropy_src_reg2hw_intr_state_reg_t intr_state; // [473:471]
+    entropy_src_reg2hw_intr_enable_reg_t intr_enable; // [470:468]
+    entropy_src_reg2hw_intr_test_reg_t intr_test; // [467:462]
+    entropy_src_reg2hw_alert_test_reg_t alert_test; // [461:458]
+    entropy_src_reg2hw_regwen_reg_t regwen; // [457:457]
+    entropy_src_reg2hw_conf_reg_t conf; // [456:445]
+    entropy_src_reg2hw_rate_reg_t rate; // [444:429]
+    entropy_src_reg2hw_entropy_control_reg_t entropy_control; // [428:427]
+    entropy_src_reg2hw_entropy_data_reg_t entropy_data; // [426:394]
+    entropy_src_reg2hw_health_test_windows_reg_t health_test_windows; // [393:362]
+    entropy_src_reg2hw_repcnt_thresholds_reg_t repcnt_thresholds; // [361:328]
+    entropy_src_reg2hw_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [327:294]
+    entropy_src_reg2hw_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [293:260]
+    entropy_src_reg2hw_bucket_thresholds_reg_t bucket_thresholds; // [259:226]
+    entropy_src_reg2hw_markov_hi_thresholds_reg_t markov_hi_thresholds; // [225:192]
+    entropy_src_reg2hw_markov_lo_thresholds_reg_t markov_lo_thresholds; // [191:158]
+    entropy_src_reg2hw_extht_hi_thresholds_reg_t extht_hi_thresholds; // [157:124]
+    entropy_src_reg2hw_extht_lo_thresholds_reg_t extht_lo_thresholds; // [123:90]
     entropy_src_reg2hw_alert_threshold_reg_t alert_threshold; // [89:86]
     entropy_src_reg2hw_fw_ov_control_reg_t fw_ov_control; // [85:83]
     entropy_src_reg2hw_fw_ov_rd_data_reg_t fw_ov_rd_data; // [82:50]
@@ -486,8 +574,16 @@ package entropy_src_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    entropy_src_hw2reg_intr_state_reg_t intr_state; // [643:638]
-    entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [637:606]
+    entropy_src_hw2reg_intr_state_reg_t intr_state; // [899:894]
+    entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [893:862]
+    entropy_src_hw2reg_repcnt_thresholds_reg_t repcnt_thresholds; // [861:830]
+    entropy_src_hw2reg_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [829:798]
+    entropy_src_hw2reg_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [797:766]
+    entropy_src_hw2reg_bucket_thresholds_reg_t bucket_thresholds; // [765:734]
+    entropy_src_hw2reg_markov_hi_thresholds_reg_t markov_hi_thresholds; // [733:702]
+    entropy_src_hw2reg_markov_lo_thresholds_reg_t markov_lo_thresholds; // [701:670]
+    entropy_src_hw2reg_extht_hi_thresholds_reg_t extht_hi_thresholds; // [669:638]
+    entropy_src_hw2reg_extht_lo_thresholds_reg_t extht_lo_thresholds; // [637:606]
     entropy_src_hw2reg_repcnt_hi_watermarks_reg_t repcnt_hi_watermarks; // [605:574]
     entropy_src_hw2reg_adaptp_hi_watermarks_reg_t adaptp_hi_watermarks; // [573:542]
     entropy_src_hw2reg_adaptp_lo_watermarks_reg_t adaptp_lo_watermarks; // [541:510]
@@ -570,14 +666,44 @@ package entropy_src_reg_pkg;
   parameter logic [0:0] ENTROPY_SRC_ALERT_TEST_RECOV_ALERT_RESVAL = 1'h 0;
   parameter logic [0:0] ENTROPY_SRC_ALERT_TEST_FATAL_ALERT_RESVAL = 1'h 0;
   parameter logic [31:0] ENTROPY_SRC_ENTROPY_DATA_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_REPCNT_THRESHOLDS_RESVAL = 32'h ffffffff;
+  parameter logic [15:0] ENTROPY_SRC_REPCNT_THRESHOLDS_FIPS_THRESH_RESVAL = 16'h ffff;
+  parameter logic [15:0] ENTROPY_SRC_REPCNT_THRESHOLDS_BYPASS_THRESH_RESVAL = 16'h ffff;
+  parameter logic [31:0] ENTROPY_SRC_ADAPTP_HI_THRESHOLDS_RESVAL = 32'h ffffffff;
+  parameter logic [15:0] ENTROPY_SRC_ADAPTP_HI_THRESHOLDS_FIPS_THRESH_RESVAL = 16'h ffff;
+  parameter logic [15:0] ENTROPY_SRC_ADAPTP_HI_THRESHOLDS_BYPASS_THRESH_RESVAL = 16'h ffff;
+  parameter logic [31:0] ENTROPY_SRC_ADAPTP_LO_THRESHOLDS_RESVAL = 32'h 0;
+  parameter logic [15:0] ENTROPY_SRC_ADAPTP_LO_THRESHOLDS_FIPS_THRESH_RESVAL = 16'h 0;
+  parameter logic [15:0] ENTROPY_SRC_ADAPTP_LO_THRESHOLDS_BYPASS_THRESH_RESVAL = 16'h 0;
+  parameter logic [31:0] ENTROPY_SRC_BUCKET_THRESHOLDS_RESVAL = 32'h ffffffff;
+  parameter logic [15:0] ENTROPY_SRC_BUCKET_THRESHOLDS_FIPS_THRESH_RESVAL = 16'h ffff;
+  parameter logic [15:0] ENTROPY_SRC_BUCKET_THRESHOLDS_BYPASS_THRESH_RESVAL = 16'h ffff;
+  parameter logic [31:0] ENTROPY_SRC_MARKOV_HI_THRESHOLDS_RESVAL = 32'h ffffffff;
+  parameter logic [15:0] ENTROPY_SRC_MARKOV_HI_THRESHOLDS_FIPS_THRESH_RESVAL = 16'h ffff;
+  parameter logic [15:0] ENTROPY_SRC_MARKOV_HI_THRESHOLDS_BYPASS_THRESH_RESVAL = 16'h ffff;
+  parameter logic [31:0] ENTROPY_SRC_MARKOV_LO_THRESHOLDS_RESVAL = 32'h 0;
+  parameter logic [15:0] ENTROPY_SRC_MARKOV_LO_THRESHOLDS_FIPS_THRESH_RESVAL = 16'h 0;
+  parameter logic [15:0] ENTROPY_SRC_MARKOV_LO_THRESHOLDS_BYPASS_THRESH_RESVAL = 16'h 0;
+  parameter logic [31:0] ENTROPY_SRC_EXTHT_HI_THRESHOLDS_RESVAL = 32'h ffffffff;
+  parameter logic [15:0] ENTROPY_SRC_EXTHT_HI_THRESHOLDS_FIPS_THRESH_RESVAL = 16'h ffff;
+  parameter logic [15:0] ENTROPY_SRC_EXTHT_HI_THRESHOLDS_BYPASS_THRESH_RESVAL = 16'h ffff;
+  parameter logic [31:0] ENTROPY_SRC_EXTHT_LO_THRESHOLDS_RESVAL = 32'h 0;
+  parameter logic [15:0] ENTROPY_SRC_EXTHT_LO_THRESHOLDS_FIPS_THRESH_RESVAL = 16'h 0;
+  parameter logic [15:0] ENTROPY_SRC_EXTHT_LO_THRESHOLDS_BYPASS_THRESH_RESVAL = 16'h 0;
   parameter logic [31:0] ENTROPY_SRC_REPCNT_HI_WATERMARKS_RESVAL = 32'h 0;
   parameter logic [31:0] ENTROPY_SRC_ADAPTP_HI_WATERMARKS_RESVAL = 32'h 0;
-  parameter logic [31:0] ENTROPY_SRC_ADAPTP_LO_WATERMARKS_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_ADAPTP_LO_WATERMARKS_RESVAL = 32'h ffffffff;
+  parameter logic [15:0] ENTROPY_SRC_ADAPTP_LO_WATERMARKS_FIPS_WATERMARK_RESVAL = 16'h ffff;
+  parameter logic [15:0] ENTROPY_SRC_ADAPTP_LO_WATERMARKS_BYPASS_WATERMARK_RESVAL = 16'h ffff;
   parameter logic [31:0] ENTROPY_SRC_EXTHT_HI_WATERMARKS_RESVAL = 32'h 0;
-  parameter logic [31:0] ENTROPY_SRC_EXTHT_LO_WATERMARKS_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_EXTHT_LO_WATERMARKS_RESVAL = 32'h ffffffff;
+  parameter logic [15:0] ENTROPY_SRC_EXTHT_LO_WATERMARKS_FIPS_WATERMARK_RESVAL = 16'h ffff;
+  parameter logic [15:0] ENTROPY_SRC_EXTHT_LO_WATERMARKS_BYPASS_WATERMARK_RESVAL = 16'h ffff;
   parameter logic [31:0] ENTROPY_SRC_BUCKET_HI_WATERMARKS_RESVAL = 32'h 0;
   parameter logic [31:0] ENTROPY_SRC_MARKOV_HI_WATERMARKS_RESVAL = 32'h 0;
-  parameter logic [31:0] ENTROPY_SRC_MARKOV_LO_WATERMARKS_RESVAL = 32'h 0;
+  parameter logic [31:0] ENTROPY_SRC_MARKOV_LO_WATERMARKS_RESVAL = 32'h ffffffff;
+  parameter logic [15:0] ENTROPY_SRC_MARKOV_LO_WATERMARKS_FIPS_WATERMARK_RESVAL = 16'h ffff;
+  parameter logic [15:0] ENTROPY_SRC_MARKOV_LO_WATERMARKS_BYPASS_WATERMARK_RESVAL = 16'h ffff;
   parameter logic [31:0] ENTROPY_SRC_REPCNT_TOTAL_FAILS_RESVAL = 32'h 0;
   parameter logic [31:0] ENTROPY_SRC_ADAPTP_HI_TOTAL_FAILS_RESVAL = 32'h 0;
   parameter logic [31:0] ENTROPY_SRC_ADAPTP_LO_TOTAL_FAILS_RESVAL = 32'h 0;

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -180,86 +180,102 @@ module entropy_src_reg_top (
   logic [15:0] health_test_windows_bypass_window_qs;
   logic [15:0] health_test_windows_bypass_window_wd;
   logic health_test_windows_bypass_window_we;
-  logic [15:0] repcnt_thresholds_fips_repcnt_thresh_qs;
-  logic [15:0] repcnt_thresholds_fips_repcnt_thresh_wd;
-  logic repcnt_thresholds_fips_repcnt_thresh_we;
-  logic [15:0] repcnt_thresholds_bypass_repcnt_thresh_qs;
-  logic [15:0] repcnt_thresholds_bypass_repcnt_thresh_wd;
-  logic repcnt_thresholds_bypass_repcnt_thresh_we;
-  logic [15:0] adaptp_hi_thresholds_fips_adaptp_hi_thresh_qs;
-  logic [15:0] adaptp_hi_thresholds_fips_adaptp_hi_thresh_wd;
-  logic adaptp_hi_thresholds_fips_adaptp_hi_thresh_we;
-  logic [15:0] adaptp_hi_thresholds_bypass_adaptp_hi_thresh_qs;
-  logic [15:0] adaptp_hi_thresholds_bypass_adaptp_hi_thresh_wd;
-  logic adaptp_hi_thresholds_bypass_adaptp_hi_thresh_we;
-  logic [15:0] adaptp_lo_thresholds_fips_adaptp_lo_thresh_qs;
-  logic [15:0] adaptp_lo_thresholds_fips_adaptp_lo_thresh_wd;
-  logic adaptp_lo_thresholds_fips_adaptp_lo_thresh_we;
-  logic [15:0] adaptp_lo_thresholds_bypass_adaptp_lo_thresh_qs;
-  logic [15:0] adaptp_lo_thresholds_bypass_adaptp_lo_thresh_wd;
-  logic adaptp_lo_thresholds_bypass_adaptp_lo_thresh_we;
-  logic [15:0] bucket_thresholds_fips_bucket_thresh_qs;
-  logic [15:0] bucket_thresholds_fips_bucket_thresh_wd;
-  logic bucket_thresholds_fips_bucket_thresh_we;
-  logic [15:0] bucket_thresholds_bypass_bucket_thresh_qs;
-  logic [15:0] bucket_thresholds_bypass_bucket_thresh_wd;
-  logic bucket_thresholds_bypass_bucket_thresh_we;
-  logic [15:0] markov_hi_thresholds_fips_markov_hi_thresh_qs;
-  logic [15:0] markov_hi_thresholds_fips_markov_hi_thresh_wd;
-  logic markov_hi_thresholds_fips_markov_hi_thresh_we;
-  logic [15:0] markov_hi_thresholds_bypass_markov_hi_thresh_qs;
-  logic [15:0] markov_hi_thresholds_bypass_markov_hi_thresh_wd;
-  logic markov_hi_thresholds_bypass_markov_hi_thresh_we;
-  logic [15:0] markov_lo_thresholds_fips_markov_lo_thresh_qs;
-  logic [15:0] markov_lo_thresholds_fips_markov_lo_thresh_wd;
-  logic markov_lo_thresholds_fips_markov_lo_thresh_we;
-  logic [15:0] markov_lo_thresholds_bypass_markov_lo_thresh_qs;
-  logic [15:0] markov_lo_thresholds_bypass_markov_lo_thresh_wd;
-  logic markov_lo_thresholds_bypass_markov_lo_thresh_we;
-  logic [15:0] extht_hi_thresholds_fips_extht_hi_thresh_qs;
-  logic [15:0] extht_hi_thresholds_fips_extht_hi_thresh_wd;
-  logic extht_hi_thresholds_fips_extht_hi_thresh_we;
-  logic [15:0] extht_hi_thresholds_bypass_extht_hi_thresh_qs;
-  logic [15:0] extht_hi_thresholds_bypass_extht_hi_thresh_wd;
-  logic extht_hi_thresholds_bypass_extht_hi_thresh_we;
-  logic [15:0] extht_lo_thresholds_fips_extht_lo_thresh_qs;
-  logic [15:0] extht_lo_thresholds_fips_extht_lo_thresh_wd;
-  logic extht_lo_thresholds_fips_extht_lo_thresh_we;
-  logic [15:0] extht_lo_thresholds_bypass_extht_lo_thresh_qs;
-  logic [15:0] extht_lo_thresholds_bypass_extht_lo_thresh_wd;
-  logic extht_lo_thresholds_bypass_extht_lo_thresh_we;
-  logic [15:0] repcnt_hi_watermarks_fips_repcnt_hi_watermark_qs;
-  logic repcnt_hi_watermarks_fips_repcnt_hi_watermark_re;
-  logic [15:0] repcnt_hi_watermarks_bypass_repcnt_hi_watermark_qs;
-  logic repcnt_hi_watermarks_bypass_repcnt_hi_watermark_re;
-  logic [15:0] adaptp_hi_watermarks_fips_adaptp_hi_watermark_qs;
-  logic adaptp_hi_watermarks_fips_adaptp_hi_watermark_re;
-  logic [15:0] adaptp_hi_watermarks_bypass_adaptp_hi_watermark_qs;
-  logic adaptp_hi_watermarks_bypass_adaptp_hi_watermark_re;
-  logic [15:0] adaptp_lo_watermarks_fips_adaptp_lo_watermark_qs;
-  logic adaptp_lo_watermarks_fips_adaptp_lo_watermark_re;
-  logic [15:0] adaptp_lo_watermarks_bypass_adaptp_lo_watermark_qs;
-  logic adaptp_lo_watermarks_bypass_adaptp_lo_watermark_re;
-  logic [15:0] extht_hi_watermarks_fips_extht_hi_watermark_qs;
-  logic extht_hi_watermarks_fips_extht_hi_watermark_re;
-  logic [15:0] extht_hi_watermarks_bypass_extht_hi_watermark_qs;
-  logic extht_hi_watermarks_bypass_extht_hi_watermark_re;
-  logic [15:0] extht_lo_watermarks_fips_extht_lo_watermark_qs;
-  logic extht_lo_watermarks_fips_extht_lo_watermark_re;
-  logic [15:0] extht_lo_watermarks_bypass_extht_lo_watermark_qs;
-  logic extht_lo_watermarks_bypass_extht_lo_watermark_re;
-  logic [15:0] bucket_hi_watermarks_fips_bucket_hi_watermark_qs;
-  logic bucket_hi_watermarks_fips_bucket_hi_watermark_re;
-  logic [15:0] bucket_hi_watermarks_bypass_bucket_hi_watermark_qs;
-  logic bucket_hi_watermarks_bypass_bucket_hi_watermark_re;
-  logic [15:0] markov_hi_watermarks_fips_markov_hi_watermark_qs;
-  logic markov_hi_watermarks_fips_markov_hi_watermark_re;
-  logic [15:0] markov_hi_watermarks_bypass_markov_hi_watermark_qs;
-  logic markov_hi_watermarks_bypass_markov_hi_watermark_re;
-  logic [15:0] markov_lo_watermarks_fips_markov_lo_watermark_qs;
-  logic markov_lo_watermarks_fips_markov_lo_watermark_re;
-  logic [15:0] markov_lo_watermarks_bypass_markov_lo_watermark_qs;
-  logic markov_lo_watermarks_bypass_markov_lo_watermark_re;
+  logic [15:0] repcnt_thresholds_fips_thresh_qs;
+  logic [15:0] repcnt_thresholds_fips_thresh_wd;
+  logic repcnt_thresholds_fips_thresh_we;
+  logic repcnt_thresholds_fips_thresh_re;
+  logic [15:0] repcnt_thresholds_bypass_thresh_qs;
+  logic [15:0] repcnt_thresholds_bypass_thresh_wd;
+  logic repcnt_thresholds_bypass_thresh_we;
+  logic repcnt_thresholds_bypass_thresh_re;
+  logic [15:0] adaptp_hi_thresholds_fips_thresh_qs;
+  logic [15:0] adaptp_hi_thresholds_fips_thresh_wd;
+  logic adaptp_hi_thresholds_fips_thresh_we;
+  logic adaptp_hi_thresholds_fips_thresh_re;
+  logic [15:0] adaptp_hi_thresholds_bypass_thresh_qs;
+  logic [15:0] adaptp_hi_thresholds_bypass_thresh_wd;
+  logic adaptp_hi_thresholds_bypass_thresh_we;
+  logic adaptp_hi_thresholds_bypass_thresh_re;
+  logic [15:0] adaptp_lo_thresholds_fips_thresh_qs;
+  logic [15:0] adaptp_lo_thresholds_fips_thresh_wd;
+  logic adaptp_lo_thresholds_fips_thresh_we;
+  logic adaptp_lo_thresholds_fips_thresh_re;
+  logic [15:0] adaptp_lo_thresholds_bypass_thresh_qs;
+  logic [15:0] adaptp_lo_thresholds_bypass_thresh_wd;
+  logic adaptp_lo_thresholds_bypass_thresh_we;
+  logic adaptp_lo_thresholds_bypass_thresh_re;
+  logic [15:0] bucket_thresholds_fips_thresh_qs;
+  logic [15:0] bucket_thresholds_fips_thresh_wd;
+  logic bucket_thresholds_fips_thresh_we;
+  logic bucket_thresholds_fips_thresh_re;
+  logic [15:0] bucket_thresholds_bypass_thresh_qs;
+  logic [15:0] bucket_thresholds_bypass_thresh_wd;
+  logic bucket_thresholds_bypass_thresh_we;
+  logic bucket_thresholds_bypass_thresh_re;
+  logic [15:0] markov_hi_thresholds_fips_thresh_qs;
+  logic [15:0] markov_hi_thresholds_fips_thresh_wd;
+  logic markov_hi_thresholds_fips_thresh_we;
+  logic markov_hi_thresholds_fips_thresh_re;
+  logic [15:0] markov_hi_thresholds_bypass_thresh_qs;
+  logic [15:0] markov_hi_thresholds_bypass_thresh_wd;
+  logic markov_hi_thresholds_bypass_thresh_we;
+  logic markov_hi_thresholds_bypass_thresh_re;
+  logic [15:0] markov_lo_thresholds_fips_thresh_qs;
+  logic [15:0] markov_lo_thresholds_fips_thresh_wd;
+  logic markov_lo_thresholds_fips_thresh_we;
+  logic markov_lo_thresholds_fips_thresh_re;
+  logic [15:0] markov_lo_thresholds_bypass_thresh_qs;
+  logic [15:0] markov_lo_thresholds_bypass_thresh_wd;
+  logic markov_lo_thresholds_bypass_thresh_we;
+  logic markov_lo_thresholds_bypass_thresh_re;
+  logic [15:0] extht_hi_thresholds_fips_thresh_qs;
+  logic [15:0] extht_hi_thresholds_fips_thresh_wd;
+  logic extht_hi_thresholds_fips_thresh_we;
+  logic extht_hi_thresholds_fips_thresh_re;
+  logic [15:0] extht_hi_thresholds_bypass_thresh_qs;
+  logic [15:0] extht_hi_thresholds_bypass_thresh_wd;
+  logic extht_hi_thresholds_bypass_thresh_we;
+  logic extht_hi_thresholds_bypass_thresh_re;
+  logic [15:0] extht_lo_thresholds_fips_thresh_qs;
+  logic [15:0] extht_lo_thresholds_fips_thresh_wd;
+  logic extht_lo_thresholds_fips_thresh_we;
+  logic extht_lo_thresholds_fips_thresh_re;
+  logic [15:0] extht_lo_thresholds_bypass_thresh_qs;
+  logic [15:0] extht_lo_thresholds_bypass_thresh_wd;
+  logic extht_lo_thresholds_bypass_thresh_we;
+  logic extht_lo_thresholds_bypass_thresh_re;
+  logic [15:0] repcnt_hi_watermarks_fips_watermark_qs;
+  logic repcnt_hi_watermarks_fips_watermark_re;
+  logic [15:0] repcnt_hi_watermarks_bypass_watermark_qs;
+  logic repcnt_hi_watermarks_bypass_watermark_re;
+  logic [15:0] adaptp_hi_watermarks_fips_watermark_qs;
+  logic adaptp_hi_watermarks_fips_watermark_re;
+  logic [15:0] adaptp_hi_watermarks_bypass_watermark_qs;
+  logic adaptp_hi_watermarks_bypass_watermark_re;
+  logic [15:0] adaptp_lo_watermarks_fips_watermark_qs;
+  logic adaptp_lo_watermarks_fips_watermark_re;
+  logic [15:0] adaptp_lo_watermarks_bypass_watermark_qs;
+  logic adaptp_lo_watermarks_bypass_watermark_re;
+  logic [15:0] extht_hi_watermarks_fips_watermark_qs;
+  logic extht_hi_watermarks_fips_watermark_re;
+  logic [15:0] extht_hi_watermarks_bypass_watermark_qs;
+  logic extht_hi_watermarks_bypass_watermark_re;
+  logic [15:0] extht_lo_watermarks_fips_watermark_qs;
+  logic extht_lo_watermarks_fips_watermark_re;
+  logic [15:0] extht_lo_watermarks_bypass_watermark_qs;
+  logic extht_lo_watermarks_bypass_watermark_re;
+  logic [15:0] bucket_hi_watermarks_fips_watermark_qs;
+  logic bucket_hi_watermarks_fips_watermark_re;
+  logic [15:0] bucket_hi_watermarks_bypass_watermark_qs;
+  logic bucket_hi_watermarks_bypass_watermark_re;
+  logic [15:0] markov_hi_watermarks_fips_watermark_qs;
+  logic markov_hi_watermarks_fips_watermark_re;
+  logic [15:0] markov_hi_watermarks_bypass_watermark_qs;
+  logic markov_hi_watermarks_bypass_watermark_re;
+  logic [15:0] markov_lo_watermarks_fips_watermark_qs;
+  logic markov_lo_watermarks_fips_watermark_re;
+  logic [15:0] markov_lo_watermarks_bypass_watermark_qs;
+  logic markov_lo_watermarks_bypass_watermark_re;
   logic [31:0] repcnt_total_fails_qs;
   logic repcnt_total_fails_re;
   logic [31:0] adaptp_hi_total_fails_qs;
@@ -1031,691 +1047,531 @@ module entropy_src_reg_top (
   );
 
 
-  // R[repcnt_thresholds]: V(False)
+  // R[repcnt_thresholds]: V(True)
 
-  //   F[fips_repcnt_thresh]: 15:0
-  prim_subreg #(
-    .DW      (16),
-    .SWACCESS("RW"),
-    .RESVAL  (16'h20)
-  ) u_repcnt_thresholds_fips_repcnt_thresh (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (repcnt_thresholds_fips_repcnt_thresh_we & regwen_qs),
-    .wd     (repcnt_thresholds_fips_repcnt_thresh_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.repcnt_thresholds.fips_repcnt_thresh.q ),
-
-    // to register interface (read)
-    .qs     (repcnt_thresholds_fips_repcnt_thresh_qs)
+  //   F[fips_thresh]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_repcnt_thresholds_fips_thresh (
+    .re     (repcnt_thresholds_fips_thresh_re),
+    // qualified with register enable
+    .we     (repcnt_thresholds_fips_thresh_we & regwen_qs),
+    .wd     (repcnt_thresholds_fips_thresh_wd),
+    .d      (hw2reg.repcnt_thresholds.fips_thresh.d),
+    .qre    (),
+    .qe     (reg2hw.repcnt_thresholds.fips_thresh.qe),
+    .q      (reg2hw.repcnt_thresholds.fips_thresh.q ),
+    .qs     (repcnt_thresholds_fips_thresh_qs)
   );
 
 
-  //   F[bypass_repcnt_thresh]: 31:16
-  prim_subreg #(
-    .DW      (16),
-    .SWACCESS("RW"),
-    .RESVAL  (16'h20)
-  ) u_repcnt_thresholds_bypass_repcnt_thresh (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (repcnt_thresholds_bypass_repcnt_thresh_we & regwen_qs),
-    .wd     (repcnt_thresholds_bypass_repcnt_thresh_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.repcnt_thresholds.bypass_repcnt_thresh.q ),
-
-    // to register interface (read)
-    .qs     (repcnt_thresholds_bypass_repcnt_thresh_qs)
+  //   F[bypass_thresh]: 31:16
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_repcnt_thresholds_bypass_thresh (
+    .re     (repcnt_thresholds_bypass_thresh_re),
+    // qualified with register enable
+    .we     (repcnt_thresholds_bypass_thresh_we & regwen_qs),
+    .wd     (repcnt_thresholds_bypass_thresh_wd),
+    .d      (hw2reg.repcnt_thresholds.bypass_thresh.d),
+    .qre    (),
+    .qe     (reg2hw.repcnt_thresholds.bypass_thresh.qe),
+    .q      (reg2hw.repcnt_thresholds.bypass_thresh.q ),
+    .qs     (repcnt_thresholds_bypass_thresh_qs)
   );
 
 
-  // R[adaptp_hi_thresholds]: V(False)
+  // R[adaptp_hi_thresholds]: V(True)
 
-  //   F[fips_adaptp_hi_thresh]: 15:0
-  prim_subreg #(
-    .DW      (16),
-    .SWACCESS("RW"),
-    .RESVAL  (16'h256)
-  ) u_adaptp_hi_thresholds_fips_adaptp_hi_thresh (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (adaptp_hi_thresholds_fips_adaptp_hi_thresh_we & regwen_qs),
-    .wd     (adaptp_hi_thresholds_fips_adaptp_hi_thresh_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adaptp_hi_thresholds.fips_adaptp_hi_thresh.q ),
-
-    // to register interface (read)
-    .qs     (adaptp_hi_thresholds_fips_adaptp_hi_thresh_qs)
+  //   F[fips_thresh]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_adaptp_hi_thresholds_fips_thresh (
+    .re     (adaptp_hi_thresholds_fips_thresh_re),
+    // qualified with register enable
+    .we     (adaptp_hi_thresholds_fips_thresh_we & regwen_qs),
+    .wd     (adaptp_hi_thresholds_fips_thresh_wd),
+    .d      (hw2reg.adaptp_hi_thresholds.fips_thresh.d),
+    .qre    (),
+    .qe     (reg2hw.adaptp_hi_thresholds.fips_thresh.qe),
+    .q      (reg2hw.adaptp_hi_thresholds.fips_thresh.q ),
+    .qs     (adaptp_hi_thresholds_fips_thresh_qs)
   );
 
 
-  //   F[bypass_adaptp_hi_thresh]: 31:16
-  prim_subreg #(
-    .DW      (16),
-    .SWACCESS("RW"),
-    .RESVAL  (16'he0)
-  ) u_adaptp_hi_thresholds_bypass_adaptp_hi_thresh (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (adaptp_hi_thresholds_bypass_adaptp_hi_thresh_we & regwen_qs),
-    .wd     (adaptp_hi_thresholds_bypass_adaptp_hi_thresh_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adaptp_hi_thresholds.bypass_adaptp_hi_thresh.q ),
-
-    // to register interface (read)
-    .qs     (adaptp_hi_thresholds_bypass_adaptp_hi_thresh_qs)
+  //   F[bypass_thresh]: 31:16
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_adaptp_hi_thresholds_bypass_thresh (
+    .re     (adaptp_hi_thresholds_bypass_thresh_re),
+    // qualified with register enable
+    .we     (adaptp_hi_thresholds_bypass_thresh_we & regwen_qs),
+    .wd     (adaptp_hi_thresholds_bypass_thresh_wd),
+    .d      (hw2reg.adaptp_hi_thresholds.bypass_thresh.d),
+    .qre    (),
+    .qe     (reg2hw.adaptp_hi_thresholds.bypass_thresh.qe),
+    .q      (reg2hw.adaptp_hi_thresholds.bypass_thresh.q ),
+    .qs     (adaptp_hi_thresholds_bypass_thresh_qs)
   );
 
 
-  // R[adaptp_lo_thresholds]: V(False)
+  // R[adaptp_lo_thresholds]: V(True)
 
-  //   F[fips_adaptp_lo_thresh]: 15:0
-  prim_subreg #(
-    .DW      (16),
-    .SWACCESS("RW"),
-    .RESVAL  (16'h1aa)
-  ) u_adaptp_lo_thresholds_fips_adaptp_lo_thresh (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (adaptp_lo_thresholds_fips_adaptp_lo_thresh_we & regwen_qs),
-    .wd     (adaptp_lo_thresholds_fips_adaptp_lo_thresh_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adaptp_lo_thresholds.fips_adaptp_lo_thresh.q ),
-
-    // to register interface (read)
-    .qs     (adaptp_lo_thresholds_fips_adaptp_lo_thresh_qs)
+  //   F[fips_thresh]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_adaptp_lo_thresholds_fips_thresh (
+    .re     (adaptp_lo_thresholds_fips_thresh_re),
+    // qualified with register enable
+    .we     (adaptp_lo_thresholds_fips_thresh_we & regwen_qs),
+    .wd     (adaptp_lo_thresholds_fips_thresh_wd),
+    .d      (hw2reg.adaptp_lo_thresholds.fips_thresh.d),
+    .qre    (),
+    .qe     (reg2hw.adaptp_lo_thresholds.fips_thresh.qe),
+    .q      (reg2hw.adaptp_lo_thresholds.fips_thresh.q ),
+    .qs     (adaptp_lo_thresholds_fips_thresh_qs)
   );
 
 
-  //   F[bypass_adaptp_lo_thresh]: 31:16
-  prim_subreg #(
-    .DW      (16),
-    .SWACCESS("RW"),
-    .RESVAL  (16'ha0)
-  ) u_adaptp_lo_thresholds_bypass_adaptp_lo_thresh (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (adaptp_lo_thresholds_bypass_adaptp_lo_thresh_we & regwen_qs),
-    .wd     (adaptp_lo_thresholds_bypass_adaptp_lo_thresh_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adaptp_lo_thresholds.bypass_adaptp_lo_thresh.q ),
-
-    // to register interface (read)
-    .qs     (adaptp_lo_thresholds_bypass_adaptp_lo_thresh_qs)
+  //   F[bypass_thresh]: 31:16
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_adaptp_lo_thresholds_bypass_thresh (
+    .re     (adaptp_lo_thresholds_bypass_thresh_re),
+    // qualified with register enable
+    .we     (adaptp_lo_thresholds_bypass_thresh_we & regwen_qs),
+    .wd     (adaptp_lo_thresholds_bypass_thresh_wd),
+    .d      (hw2reg.adaptp_lo_thresholds.bypass_thresh.d),
+    .qre    (),
+    .qe     (reg2hw.adaptp_lo_thresholds.bypass_thresh.qe),
+    .q      (reg2hw.adaptp_lo_thresholds.bypass_thresh.q ),
+    .qs     (adaptp_lo_thresholds_bypass_thresh_qs)
   );
 
 
-  // R[bucket_thresholds]: V(False)
+  // R[bucket_thresholds]: V(True)
 
-  //   F[fips_bucket_thresh]: 15:0
-  prim_subreg #(
-    .DW      (16),
-    .SWACCESS("RW"),
-    .RESVAL  (16'h20)
-  ) u_bucket_thresholds_fips_bucket_thresh (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (bucket_thresholds_fips_bucket_thresh_we & regwen_qs),
-    .wd     (bucket_thresholds_fips_bucket_thresh_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.bucket_thresholds.fips_bucket_thresh.q ),
-
-    // to register interface (read)
-    .qs     (bucket_thresholds_fips_bucket_thresh_qs)
+  //   F[fips_thresh]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_bucket_thresholds_fips_thresh (
+    .re     (bucket_thresholds_fips_thresh_re),
+    // qualified with register enable
+    .we     (bucket_thresholds_fips_thresh_we & regwen_qs),
+    .wd     (bucket_thresholds_fips_thresh_wd),
+    .d      (hw2reg.bucket_thresholds.fips_thresh.d),
+    .qre    (),
+    .qe     (reg2hw.bucket_thresholds.fips_thresh.qe),
+    .q      (reg2hw.bucket_thresholds.fips_thresh.q ),
+    .qs     (bucket_thresholds_fips_thresh_qs)
   );
 
 
-  //   F[bypass_bucket_thresh]: 31:16
-  prim_subreg #(
-    .DW      (16),
-    .SWACCESS("RW"),
-    .RESVAL  (16'h20)
-  ) u_bucket_thresholds_bypass_bucket_thresh (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (bucket_thresholds_bypass_bucket_thresh_we & regwen_qs),
-    .wd     (bucket_thresholds_bypass_bucket_thresh_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.bucket_thresholds.bypass_bucket_thresh.q ),
-
-    // to register interface (read)
-    .qs     (bucket_thresholds_bypass_bucket_thresh_qs)
+  //   F[bypass_thresh]: 31:16
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_bucket_thresholds_bypass_thresh (
+    .re     (bucket_thresholds_bypass_thresh_re),
+    // qualified with register enable
+    .we     (bucket_thresholds_bypass_thresh_we & regwen_qs),
+    .wd     (bucket_thresholds_bypass_thresh_wd),
+    .d      (hw2reg.bucket_thresholds.bypass_thresh.d),
+    .qre    (),
+    .qe     (reg2hw.bucket_thresholds.bypass_thresh.qe),
+    .q      (reg2hw.bucket_thresholds.bypass_thresh.q ),
+    .qs     (bucket_thresholds_bypass_thresh_qs)
   );
 
 
-  // R[markov_hi_thresholds]: V(False)
+  // R[markov_hi_thresholds]: V(True)
 
-  //   F[fips_markov_hi_thresh]: 15:0
-  prim_subreg #(
-    .DW      (16),
-    .SWACCESS("RW"),
-    .RESVAL  (16'h100)
-  ) u_markov_hi_thresholds_fips_markov_hi_thresh (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (markov_hi_thresholds_fips_markov_hi_thresh_we & regwen_qs),
-    .wd     (markov_hi_thresholds_fips_markov_hi_thresh_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.markov_hi_thresholds.fips_markov_hi_thresh.q ),
-
-    // to register interface (read)
-    .qs     (markov_hi_thresholds_fips_markov_hi_thresh_qs)
+  //   F[fips_thresh]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_markov_hi_thresholds_fips_thresh (
+    .re     (markov_hi_thresholds_fips_thresh_re),
+    // qualified with register enable
+    .we     (markov_hi_thresholds_fips_thresh_we & regwen_qs),
+    .wd     (markov_hi_thresholds_fips_thresh_wd),
+    .d      (hw2reg.markov_hi_thresholds.fips_thresh.d),
+    .qre    (),
+    .qe     (reg2hw.markov_hi_thresholds.fips_thresh.qe),
+    .q      (reg2hw.markov_hi_thresholds.fips_thresh.q ),
+    .qs     (markov_hi_thresholds_fips_thresh_qs)
   );
 
 
-  //   F[bypass_markov_hi_thresh]: 31:16
-  prim_subreg #(
-    .DW      (16),
-    .SWACCESS("RW"),
-    .RESVAL  (16'h60)
-  ) u_markov_hi_thresholds_bypass_markov_hi_thresh (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (markov_hi_thresholds_bypass_markov_hi_thresh_we & regwen_qs),
-    .wd     (markov_hi_thresholds_bypass_markov_hi_thresh_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.markov_hi_thresholds.bypass_markov_hi_thresh.q ),
-
-    // to register interface (read)
-    .qs     (markov_hi_thresholds_bypass_markov_hi_thresh_qs)
+  //   F[bypass_thresh]: 31:16
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_markov_hi_thresholds_bypass_thresh (
+    .re     (markov_hi_thresholds_bypass_thresh_re),
+    // qualified with register enable
+    .we     (markov_hi_thresholds_bypass_thresh_we & regwen_qs),
+    .wd     (markov_hi_thresholds_bypass_thresh_wd),
+    .d      (hw2reg.markov_hi_thresholds.bypass_thresh.d),
+    .qre    (),
+    .qe     (reg2hw.markov_hi_thresholds.bypass_thresh.qe),
+    .q      (reg2hw.markov_hi_thresholds.bypass_thresh.q ),
+    .qs     (markov_hi_thresholds_bypass_thresh_qs)
   );
 
 
-  // R[markov_lo_thresholds]: V(False)
+  // R[markov_lo_thresholds]: V(True)
 
-  //   F[fips_markov_lo_thresh]: 15:0
-  prim_subreg #(
-    .DW      (16),
-    .SWACCESS("RW"),
-    .RESVAL  (16'h10)
-  ) u_markov_lo_thresholds_fips_markov_lo_thresh (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (markov_lo_thresholds_fips_markov_lo_thresh_we & regwen_qs),
-    .wd     (markov_lo_thresholds_fips_markov_lo_thresh_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.markov_lo_thresholds.fips_markov_lo_thresh.q ),
-
-    // to register interface (read)
-    .qs     (markov_lo_thresholds_fips_markov_lo_thresh_qs)
+  //   F[fips_thresh]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_markov_lo_thresholds_fips_thresh (
+    .re     (markov_lo_thresholds_fips_thresh_re),
+    // qualified with register enable
+    .we     (markov_lo_thresholds_fips_thresh_we & regwen_qs),
+    .wd     (markov_lo_thresholds_fips_thresh_wd),
+    .d      (hw2reg.markov_lo_thresholds.fips_thresh.d),
+    .qre    (),
+    .qe     (reg2hw.markov_lo_thresholds.fips_thresh.qe),
+    .q      (reg2hw.markov_lo_thresholds.fips_thresh.q ),
+    .qs     (markov_lo_thresholds_fips_thresh_qs)
   );
 
 
-  //   F[bypass_markov_lo_thresh]: 31:16
-  prim_subreg #(
-    .DW      (16),
-    .SWACCESS("RW"),
-    .RESVAL  (16'h6)
-  ) u_markov_lo_thresholds_bypass_markov_lo_thresh (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (markov_lo_thresholds_bypass_markov_lo_thresh_we & regwen_qs),
-    .wd     (markov_lo_thresholds_bypass_markov_lo_thresh_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.markov_lo_thresholds.bypass_markov_lo_thresh.q ),
-
-    // to register interface (read)
-    .qs     (markov_lo_thresholds_bypass_markov_lo_thresh_qs)
+  //   F[bypass_thresh]: 31:16
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_markov_lo_thresholds_bypass_thresh (
+    .re     (markov_lo_thresholds_bypass_thresh_re),
+    // qualified with register enable
+    .we     (markov_lo_thresholds_bypass_thresh_we & regwen_qs),
+    .wd     (markov_lo_thresholds_bypass_thresh_wd),
+    .d      (hw2reg.markov_lo_thresholds.bypass_thresh.d),
+    .qre    (),
+    .qe     (reg2hw.markov_lo_thresholds.bypass_thresh.qe),
+    .q      (reg2hw.markov_lo_thresholds.bypass_thresh.q ),
+    .qs     (markov_lo_thresholds_bypass_thresh_qs)
   );
 
 
-  // R[extht_hi_thresholds]: V(False)
+  // R[extht_hi_thresholds]: V(True)
 
-  //   F[fips_extht_hi_thresh]: 15:0
-  prim_subreg #(
-    .DW      (16),
-    .SWACCESS("RW"),
-    .RESVAL  (16'h0)
-  ) u_extht_hi_thresholds_fips_extht_hi_thresh (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (extht_hi_thresholds_fips_extht_hi_thresh_we & regwen_qs),
-    .wd     (extht_hi_thresholds_fips_extht_hi_thresh_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.extht_hi_thresholds.fips_extht_hi_thresh.q ),
-
-    // to register interface (read)
-    .qs     (extht_hi_thresholds_fips_extht_hi_thresh_qs)
+  //   F[fips_thresh]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_extht_hi_thresholds_fips_thresh (
+    .re     (extht_hi_thresholds_fips_thresh_re),
+    // qualified with register enable
+    .we     (extht_hi_thresholds_fips_thresh_we & regwen_qs),
+    .wd     (extht_hi_thresholds_fips_thresh_wd),
+    .d      (hw2reg.extht_hi_thresholds.fips_thresh.d),
+    .qre    (),
+    .qe     (reg2hw.extht_hi_thresholds.fips_thresh.qe),
+    .q      (reg2hw.extht_hi_thresholds.fips_thresh.q ),
+    .qs     (extht_hi_thresholds_fips_thresh_qs)
   );
 
 
-  //   F[bypass_extht_hi_thresh]: 31:16
-  prim_subreg #(
-    .DW      (16),
-    .SWACCESS("RW"),
-    .RESVAL  (16'h0)
-  ) u_extht_hi_thresholds_bypass_extht_hi_thresh (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (extht_hi_thresholds_bypass_extht_hi_thresh_we & regwen_qs),
-    .wd     (extht_hi_thresholds_bypass_extht_hi_thresh_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.extht_hi_thresholds.bypass_extht_hi_thresh.q ),
-
-    // to register interface (read)
-    .qs     (extht_hi_thresholds_bypass_extht_hi_thresh_qs)
+  //   F[bypass_thresh]: 31:16
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_extht_hi_thresholds_bypass_thresh (
+    .re     (extht_hi_thresholds_bypass_thresh_re),
+    // qualified with register enable
+    .we     (extht_hi_thresholds_bypass_thresh_we & regwen_qs),
+    .wd     (extht_hi_thresholds_bypass_thresh_wd),
+    .d      (hw2reg.extht_hi_thresholds.bypass_thresh.d),
+    .qre    (),
+    .qe     (reg2hw.extht_hi_thresholds.bypass_thresh.qe),
+    .q      (reg2hw.extht_hi_thresholds.bypass_thresh.q ),
+    .qs     (extht_hi_thresholds_bypass_thresh_qs)
   );
 
 
-  // R[extht_lo_thresholds]: V(False)
+  // R[extht_lo_thresholds]: V(True)
 
-  //   F[fips_extht_lo_thresh]: 15:0
-  prim_subreg #(
-    .DW      (16),
-    .SWACCESS("RW"),
-    .RESVAL  (16'h0)
-  ) u_extht_lo_thresholds_fips_extht_lo_thresh (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (extht_lo_thresholds_fips_extht_lo_thresh_we & regwen_qs),
-    .wd     (extht_lo_thresholds_fips_extht_lo_thresh_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.extht_lo_thresholds.fips_extht_lo_thresh.q ),
-
-    // to register interface (read)
-    .qs     (extht_lo_thresholds_fips_extht_lo_thresh_qs)
+  //   F[fips_thresh]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_extht_lo_thresholds_fips_thresh (
+    .re     (extht_lo_thresholds_fips_thresh_re),
+    // qualified with register enable
+    .we     (extht_lo_thresholds_fips_thresh_we & regwen_qs),
+    .wd     (extht_lo_thresholds_fips_thresh_wd),
+    .d      (hw2reg.extht_lo_thresholds.fips_thresh.d),
+    .qre    (),
+    .qe     (reg2hw.extht_lo_thresholds.fips_thresh.qe),
+    .q      (reg2hw.extht_lo_thresholds.fips_thresh.q ),
+    .qs     (extht_lo_thresholds_fips_thresh_qs)
   );
 
 
-  //   F[bypass_extht_lo_thresh]: 31:16
-  prim_subreg #(
-    .DW      (16),
-    .SWACCESS("RW"),
-    .RESVAL  (16'h0)
-  ) u_extht_lo_thresholds_bypass_extht_lo_thresh (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (extht_lo_thresholds_bypass_extht_lo_thresh_we & regwen_qs),
-    .wd     (extht_lo_thresholds_bypass_extht_lo_thresh_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.extht_lo_thresholds.bypass_extht_lo_thresh.q ),
-
-    // to register interface (read)
-    .qs     (extht_lo_thresholds_bypass_extht_lo_thresh_qs)
+  //   F[bypass_thresh]: 31:16
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_extht_lo_thresholds_bypass_thresh (
+    .re     (extht_lo_thresholds_bypass_thresh_re),
+    // qualified with register enable
+    .we     (extht_lo_thresholds_bypass_thresh_we & regwen_qs),
+    .wd     (extht_lo_thresholds_bypass_thresh_wd),
+    .d      (hw2reg.extht_lo_thresholds.bypass_thresh.d),
+    .qre    (),
+    .qe     (reg2hw.extht_lo_thresholds.bypass_thresh.qe),
+    .q      (reg2hw.extht_lo_thresholds.bypass_thresh.q ),
+    .qs     (extht_lo_thresholds_bypass_thresh_qs)
   );
 
 
   // R[repcnt_hi_watermarks]: V(True)
 
-  //   F[fips_repcnt_hi_watermark]: 15:0
+  //   F[fips_watermark]: 15:0
   prim_subreg_ext #(
     .DW    (16)
-  ) u_repcnt_hi_watermarks_fips_repcnt_hi_watermark (
-    .re     (repcnt_hi_watermarks_fips_repcnt_hi_watermark_re),
+  ) u_repcnt_hi_watermarks_fips_watermark (
+    .re     (repcnt_hi_watermarks_fips_watermark_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.repcnt_hi_watermarks.fips_repcnt_hi_watermark.d),
+    .d      (hw2reg.repcnt_hi_watermarks.fips_watermark.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (repcnt_hi_watermarks_fips_repcnt_hi_watermark_qs)
+    .qs     (repcnt_hi_watermarks_fips_watermark_qs)
   );
 
 
-  //   F[bypass_repcnt_hi_watermark]: 31:16
+  //   F[bypass_watermark]: 31:16
   prim_subreg_ext #(
     .DW    (16)
-  ) u_repcnt_hi_watermarks_bypass_repcnt_hi_watermark (
-    .re     (repcnt_hi_watermarks_bypass_repcnt_hi_watermark_re),
+  ) u_repcnt_hi_watermarks_bypass_watermark (
+    .re     (repcnt_hi_watermarks_bypass_watermark_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.repcnt_hi_watermarks.bypass_repcnt_hi_watermark.d),
+    .d      (hw2reg.repcnt_hi_watermarks.bypass_watermark.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (repcnt_hi_watermarks_bypass_repcnt_hi_watermark_qs)
+    .qs     (repcnt_hi_watermarks_bypass_watermark_qs)
   );
 
 
   // R[adaptp_hi_watermarks]: V(True)
 
-  //   F[fips_adaptp_hi_watermark]: 15:0
+  //   F[fips_watermark]: 15:0
   prim_subreg_ext #(
     .DW    (16)
-  ) u_adaptp_hi_watermarks_fips_adaptp_hi_watermark (
-    .re     (adaptp_hi_watermarks_fips_adaptp_hi_watermark_re),
+  ) u_adaptp_hi_watermarks_fips_watermark (
+    .re     (adaptp_hi_watermarks_fips_watermark_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.adaptp_hi_watermarks.fips_adaptp_hi_watermark.d),
+    .d      (hw2reg.adaptp_hi_watermarks.fips_watermark.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (adaptp_hi_watermarks_fips_adaptp_hi_watermark_qs)
+    .qs     (adaptp_hi_watermarks_fips_watermark_qs)
   );
 
 
-  //   F[bypass_adaptp_hi_watermark]: 31:16
+  //   F[bypass_watermark]: 31:16
   prim_subreg_ext #(
     .DW    (16)
-  ) u_adaptp_hi_watermarks_bypass_adaptp_hi_watermark (
-    .re     (adaptp_hi_watermarks_bypass_adaptp_hi_watermark_re),
+  ) u_adaptp_hi_watermarks_bypass_watermark (
+    .re     (adaptp_hi_watermarks_bypass_watermark_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.adaptp_hi_watermarks.bypass_adaptp_hi_watermark.d),
+    .d      (hw2reg.adaptp_hi_watermarks.bypass_watermark.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (adaptp_hi_watermarks_bypass_adaptp_hi_watermark_qs)
+    .qs     (adaptp_hi_watermarks_bypass_watermark_qs)
   );
 
 
   // R[adaptp_lo_watermarks]: V(True)
 
-  //   F[fips_adaptp_lo_watermark]: 15:0
+  //   F[fips_watermark]: 15:0
   prim_subreg_ext #(
     .DW    (16)
-  ) u_adaptp_lo_watermarks_fips_adaptp_lo_watermark (
-    .re     (adaptp_lo_watermarks_fips_adaptp_lo_watermark_re),
+  ) u_adaptp_lo_watermarks_fips_watermark (
+    .re     (adaptp_lo_watermarks_fips_watermark_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.adaptp_lo_watermarks.fips_adaptp_lo_watermark.d),
+    .d      (hw2reg.adaptp_lo_watermarks.fips_watermark.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (adaptp_lo_watermarks_fips_adaptp_lo_watermark_qs)
+    .qs     (adaptp_lo_watermarks_fips_watermark_qs)
   );
 
 
-  //   F[bypass_adaptp_lo_watermark]: 31:16
+  //   F[bypass_watermark]: 31:16
   prim_subreg_ext #(
     .DW    (16)
-  ) u_adaptp_lo_watermarks_bypass_adaptp_lo_watermark (
-    .re     (adaptp_lo_watermarks_bypass_adaptp_lo_watermark_re),
+  ) u_adaptp_lo_watermarks_bypass_watermark (
+    .re     (adaptp_lo_watermarks_bypass_watermark_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.adaptp_lo_watermarks.bypass_adaptp_lo_watermark.d),
+    .d      (hw2reg.adaptp_lo_watermarks.bypass_watermark.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (adaptp_lo_watermarks_bypass_adaptp_lo_watermark_qs)
+    .qs     (adaptp_lo_watermarks_bypass_watermark_qs)
   );
 
 
   // R[extht_hi_watermarks]: V(True)
 
-  //   F[fips_extht_hi_watermark]: 15:0
+  //   F[fips_watermark]: 15:0
   prim_subreg_ext #(
     .DW    (16)
-  ) u_extht_hi_watermarks_fips_extht_hi_watermark (
-    .re     (extht_hi_watermarks_fips_extht_hi_watermark_re),
+  ) u_extht_hi_watermarks_fips_watermark (
+    .re     (extht_hi_watermarks_fips_watermark_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.extht_hi_watermarks.fips_extht_hi_watermark.d),
+    .d      (hw2reg.extht_hi_watermarks.fips_watermark.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (extht_hi_watermarks_fips_extht_hi_watermark_qs)
+    .qs     (extht_hi_watermarks_fips_watermark_qs)
   );
 
 
-  //   F[bypass_extht_hi_watermark]: 31:16
+  //   F[bypass_watermark]: 31:16
   prim_subreg_ext #(
     .DW    (16)
-  ) u_extht_hi_watermarks_bypass_extht_hi_watermark (
-    .re     (extht_hi_watermarks_bypass_extht_hi_watermark_re),
+  ) u_extht_hi_watermarks_bypass_watermark (
+    .re     (extht_hi_watermarks_bypass_watermark_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.extht_hi_watermarks.bypass_extht_hi_watermark.d),
+    .d      (hw2reg.extht_hi_watermarks.bypass_watermark.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (extht_hi_watermarks_bypass_extht_hi_watermark_qs)
+    .qs     (extht_hi_watermarks_bypass_watermark_qs)
   );
 
 
   // R[extht_lo_watermarks]: V(True)
 
-  //   F[fips_extht_lo_watermark]: 15:0
+  //   F[fips_watermark]: 15:0
   prim_subreg_ext #(
     .DW    (16)
-  ) u_extht_lo_watermarks_fips_extht_lo_watermark (
-    .re     (extht_lo_watermarks_fips_extht_lo_watermark_re),
+  ) u_extht_lo_watermarks_fips_watermark (
+    .re     (extht_lo_watermarks_fips_watermark_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.extht_lo_watermarks.fips_extht_lo_watermark.d),
+    .d      (hw2reg.extht_lo_watermarks.fips_watermark.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (extht_lo_watermarks_fips_extht_lo_watermark_qs)
+    .qs     (extht_lo_watermarks_fips_watermark_qs)
   );
 
 
-  //   F[bypass_extht_lo_watermark]: 31:16
+  //   F[bypass_watermark]: 31:16
   prim_subreg_ext #(
     .DW    (16)
-  ) u_extht_lo_watermarks_bypass_extht_lo_watermark (
-    .re     (extht_lo_watermarks_bypass_extht_lo_watermark_re),
+  ) u_extht_lo_watermarks_bypass_watermark (
+    .re     (extht_lo_watermarks_bypass_watermark_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.extht_lo_watermarks.bypass_extht_lo_watermark.d),
+    .d      (hw2reg.extht_lo_watermarks.bypass_watermark.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (extht_lo_watermarks_bypass_extht_lo_watermark_qs)
+    .qs     (extht_lo_watermarks_bypass_watermark_qs)
   );
 
 
   // R[bucket_hi_watermarks]: V(True)
 
-  //   F[fips_bucket_hi_watermark]: 15:0
+  //   F[fips_watermark]: 15:0
   prim_subreg_ext #(
     .DW    (16)
-  ) u_bucket_hi_watermarks_fips_bucket_hi_watermark (
-    .re     (bucket_hi_watermarks_fips_bucket_hi_watermark_re),
+  ) u_bucket_hi_watermarks_fips_watermark (
+    .re     (bucket_hi_watermarks_fips_watermark_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.bucket_hi_watermarks.fips_bucket_hi_watermark.d),
+    .d      (hw2reg.bucket_hi_watermarks.fips_watermark.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (bucket_hi_watermarks_fips_bucket_hi_watermark_qs)
+    .qs     (bucket_hi_watermarks_fips_watermark_qs)
   );
 
 
-  //   F[bypass_bucket_hi_watermark]: 31:16
+  //   F[bypass_watermark]: 31:16
   prim_subreg_ext #(
     .DW    (16)
-  ) u_bucket_hi_watermarks_bypass_bucket_hi_watermark (
-    .re     (bucket_hi_watermarks_bypass_bucket_hi_watermark_re),
+  ) u_bucket_hi_watermarks_bypass_watermark (
+    .re     (bucket_hi_watermarks_bypass_watermark_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.bucket_hi_watermarks.bypass_bucket_hi_watermark.d),
+    .d      (hw2reg.bucket_hi_watermarks.bypass_watermark.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (bucket_hi_watermarks_bypass_bucket_hi_watermark_qs)
+    .qs     (bucket_hi_watermarks_bypass_watermark_qs)
   );
 
 
   // R[markov_hi_watermarks]: V(True)
 
-  //   F[fips_markov_hi_watermark]: 15:0
+  //   F[fips_watermark]: 15:0
   prim_subreg_ext #(
     .DW    (16)
-  ) u_markov_hi_watermarks_fips_markov_hi_watermark (
-    .re     (markov_hi_watermarks_fips_markov_hi_watermark_re),
+  ) u_markov_hi_watermarks_fips_watermark (
+    .re     (markov_hi_watermarks_fips_watermark_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.markov_hi_watermarks.fips_markov_hi_watermark.d),
+    .d      (hw2reg.markov_hi_watermarks.fips_watermark.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (markov_hi_watermarks_fips_markov_hi_watermark_qs)
+    .qs     (markov_hi_watermarks_fips_watermark_qs)
   );
 
 
-  //   F[bypass_markov_hi_watermark]: 31:16
+  //   F[bypass_watermark]: 31:16
   prim_subreg_ext #(
     .DW    (16)
-  ) u_markov_hi_watermarks_bypass_markov_hi_watermark (
-    .re     (markov_hi_watermarks_bypass_markov_hi_watermark_re),
+  ) u_markov_hi_watermarks_bypass_watermark (
+    .re     (markov_hi_watermarks_bypass_watermark_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.markov_hi_watermarks.bypass_markov_hi_watermark.d),
+    .d      (hw2reg.markov_hi_watermarks.bypass_watermark.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (markov_hi_watermarks_bypass_markov_hi_watermark_qs)
+    .qs     (markov_hi_watermarks_bypass_watermark_qs)
   );
 
 
   // R[markov_lo_watermarks]: V(True)
 
-  //   F[fips_markov_lo_watermark]: 15:0
+  //   F[fips_watermark]: 15:0
   prim_subreg_ext #(
     .DW    (16)
-  ) u_markov_lo_watermarks_fips_markov_lo_watermark (
-    .re     (markov_lo_watermarks_fips_markov_lo_watermark_re),
+  ) u_markov_lo_watermarks_fips_watermark (
+    .re     (markov_lo_watermarks_fips_watermark_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.markov_lo_watermarks.fips_markov_lo_watermark.d),
+    .d      (hw2reg.markov_lo_watermarks.fips_watermark.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (markov_lo_watermarks_fips_markov_lo_watermark_qs)
+    .qs     (markov_lo_watermarks_fips_watermark_qs)
   );
 
 
-  //   F[bypass_markov_lo_watermark]: 31:16
+  //   F[bypass_watermark]: 31:16
   prim_subreg_ext #(
     .DW    (16)
-  ) u_markov_lo_watermarks_bypass_markov_lo_watermark (
-    .re     (markov_lo_watermarks_bypass_markov_lo_watermark_re),
+  ) u_markov_lo_watermarks_bypass_watermark (
+    .re     (markov_lo_watermarks_bypass_watermark_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.markov_lo_watermarks.bypass_markov_lo_watermark.d),
+    .d      (hw2reg.markov_lo_watermarks.bypass_watermark.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (markov_lo_watermarks_bypass_markov_lo_watermark_qs)
+    .qs     (markov_lo_watermarks_bypass_watermark_qs)
   );
 
 
@@ -2650,85 +2506,101 @@ module entropy_src_reg_top (
   assign health_test_windows_bypass_window_we = addr_hit[10] & reg_we & !reg_error;
   assign health_test_windows_bypass_window_wd = reg_wdata[31:16];
 
-  assign repcnt_thresholds_fips_repcnt_thresh_we = addr_hit[11] & reg_we & !reg_error;
-  assign repcnt_thresholds_fips_repcnt_thresh_wd = reg_wdata[15:0];
+  assign repcnt_thresholds_fips_thresh_we = addr_hit[11] & reg_we & !reg_error;
+  assign repcnt_thresholds_fips_thresh_wd = reg_wdata[15:0];
+  assign repcnt_thresholds_fips_thresh_re = addr_hit[11] & reg_re & !reg_error;
 
-  assign repcnt_thresholds_bypass_repcnt_thresh_we = addr_hit[11] & reg_we & !reg_error;
-  assign repcnt_thresholds_bypass_repcnt_thresh_wd = reg_wdata[31:16];
+  assign repcnt_thresholds_bypass_thresh_we = addr_hit[11] & reg_we & !reg_error;
+  assign repcnt_thresholds_bypass_thresh_wd = reg_wdata[31:16];
+  assign repcnt_thresholds_bypass_thresh_re = addr_hit[11] & reg_re & !reg_error;
 
-  assign adaptp_hi_thresholds_fips_adaptp_hi_thresh_we = addr_hit[12] & reg_we & !reg_error;
-  assign adaptp_hi_thresholds_fips_adaptp_hi_thresh_wd = reg_wdata[15:0];
+  assign adaptp_hi_thresholds_fips_thresh_we = addr_hit[12] & reg_we & !reg_error;
+  assign adaptp_hi_thresholds_fips_thresh_wd = reg_wdata[15:0];
+  assign adaptp_hi_thresholds_fips_thresh_re = addr_hit[12] & reg_re & !reg_error;
 
-  assign adaptp_hi_thresholds_bypass_adaptp_hi_thresh_we = addr_hit[12] & reg_we & !reg_error;
-  assign adaptp_hi_thresholds_bypass_adaptp_hi_thresh_wd = reg_wdata[31:16];
+  assign adaptp_hi_thresholds_bypass_thresh_we = addr_hit[12] & reg_we & !reg_error;
+  assign adaptp_hi_thresholds_bypass_thresh_wd = reg_wdata[31:16];
+  assign adaptp_hi_thresholds_bypass_thresh_re = addr_hit[12] & reg_re & !reg_error;
 
-  assign adaptp_lo_thresholds_fips_adaptp_lo_thresh_we = addr_hit[13] & reg_we & !reg_error;
-  assign adaptp_lo_thresholds_fips_adaptp_lo_thresh_wd = reg_wdata[15:0];
+  assign adaptp_lo_thresholds_fips_thresh_we = addr_hit[13] & reg_we & !reg_error;
+  assign adaptp_lo_thresholds_fips_thresh_wd = reg_wdata[15:0];
+  assign adaptp_lo_thresholds_fips_thresh_re = addr_hit[13] & reg_re & !reg_error;
 
-  assign adaptp_lo_thresholds_bypass_adaptp_lo_thresh_we = addr_hit[13] & reg_we & !reg_error;
-  assign adaptp_lo_thresholds_bypass_adaptp_lo_thresh_wd = reg_wdata[31:16];
+  assign adaptp_lo_thresholds_bypass_thresh_we = addr_hit[13] & reg_we & !reg_error;
+  assign adaptp_lo_thresholds_bypass_thresh_wd = reg_wdata[31:16];
+  assign adaptp_lo_thresholds_bypass_thresh_re = addr_hit[13] & reg_re & !reg_error;
 
-  assign bucket_thresholds_fips_bucket_thresh_we = addr_hit[14] & reg_we & !reg_error;
-  assign bucket_thresholds_fips_bucket_thresh_wd = reg_wdata[15:0];
+  assign bucket_thresholds_fips_thresh_we = addr_hit[14] & reg_we & !reg_error;
+  assign bucket_thresholds_fips_thresh_wd = reg_wdata[15:0];
+  assign bucket_thresholds_fips_thresh_re = addr_hit[14] & reg_re & !reg_error;
 
-  assign bucket_thresholds_bypass_bucket_thresh_we = addr_hit[14] & reg_we & !reg_error;
-  assign bucket_thresholds_bypass_bucket_thresh_wd = reg_wdata[31:16];
+  assign bucket_thresholds_bypass_thresh_we = addr_hit[14] & reg_we & !reg_error;
+  assign bucket_thresholds_bypass_thresh_wd = reg_wdata[31:16];
+  assign bucket_thresholds_bypass_thresh_re = addr_hit[14] & reg_re & !reg_error;
 
-  assign markov_hi_thresholds_fips_markov_hi_thresh_we = addr_hit[15] & reg_we & !reg_error;
-  assign markov_hi_thresholds_fips_markov_hi_thresh_wd = reg_wdata[15:0];
+  assign markov_hi_thresholds_fips_thresh_we = addr_hit[15] & reg_we & !reg_error;
+  assign markov_hi_thresholds_fips_thresh_wd = reg_wdata[15:0];
+  assign markov_hi_thresholds_fips_thresh_re = addr_hit[15] & reg_re & !reg_error;
 
-  assign markov_hi_thresholds_bypass_markov_hi_thresh_we = addr_hit[15] & reg_we & !reg_error;
-  assign markov_hi_thresholds_bypass_markov_hi_thresh_wd = reg_wdata[31:16];
+  assign markov_hi_thresholds_bypass_thresh_we = addr_hit[15] & reg_we & !reg_error;
+  assign markov_hi_thresholds_bypass_thresh_wd = reg_wdata[31:16];
+  assign markov_hi_thresholds_bypass_thresh_re = addr_hit[15] & reg_re & !reg_error;
 
-  assign markov_lo_thresholds_fips_markov_lo_thresh_we = addr_hit[16] & reg_we & !reg_error;
-  assign markov_lo_thresholds_fips_markov_lo_thresh_wd = reg_wdata[15:0];
+  assign markov_lo_thresholds_fips_thresh_we = addr_hit[16] & reg_we & !reg_error;
+  assign markov_lo_thresholds_fips_thresh_wd = reg_wdata[15:0];
+  assign markov_lo_thresholds_fips_thresh_re = addr_hit[16] & reg_re & !reg_error;
 
-  assign markov_lo_thresholds_bypass_markov_lo_thresh_we = addr_hit[16] & reg_we & !reg_error;
-  assign markov_lo_thresholds_bypass_markov_lo_thresh_wd = reg_wdata[31:16];
+  assign markov_lo_thresholds_bypass_thresh_we = addr_hit[16] & reg_we & !reg_error;
+  assign markov_lo_thresholds_bypass_thresh_wd = reg_wdata[31:16];
+  assign markov_lo_thresholds_bypass_thresh_re = addr_hit[16] & reg_re & !reg_error;
 
-  assign extht_hi_thresholds_fips_extht_hi_thresh_we = addr_hit[17] & reg_we & !reg_error;
-  assign extht_hi_thresholds_fips_extht_hi_thresh_wd = reg_wdata[15:0];
+  assign extht_hi_thresholds_fips_thresh_we = addr_hit[17] & reg_we & !reg_error;
+  assign extht_hi_thresholds_fips_thresh_wd = reg_wdata[15:0];
+  assign extht_hi_thresholds_fips_thresh_re = addr_hit[17] & reg_re & !reg_error;
 
-  assign extht_hi_thresholds_bypass_extht_hi_thresh_we = addr_hit[17] & reg_we & !reg_error;
-  assign extht_hi_thresholds_bypass_extht_hi_thresh_wd = reg_wdata[31:16];
+  assign extht_hi_thresholds_bypass_thresh_we = addr_hit[17] & reg_we & !reg_error;
+  assign extht_hi_thresholds_bypass_thresh_wd = reg_wdata[31:16];
+  assign extht_hi_thresholds_bypass_thresh_re = addr_hit[17] & reg_re & !reg_error;
 
-  assign extht_lo_thresholds_fips_extht_lo_thresh_we = addr_hit[18] & reg_we & !reg_error;
-  assign extht_lo_thresholds_fips_extht_lo_thresh_wd = reg_wdata[15:0];
+  assign extht_lo_thresholds_fips_thresh_we = addr_hit[18] & reg_we & !reg_error;
+  assign extht_lo_thresholds_fips_thresh_wd = reg_wdata[15:0];
+  assign extht_lo_thresholds_fips_thresh_re = addr_hit[18] & reg_re & !reg_error;
 
-  assign extht_lo_thresholds_bypass_extht_lo_thresh_we = addr_hit[18] & reg_we & !reg_error;
-  assign extht_lo_thresholds_bypass_extht_lo_thresh_wd = reg_wdata[31:16];
+  assign extht_lo_thresholds_bypass_thresh_we = addr_hit[18] & reg_we & !reg_error;
+  assign extht_lo_thresholds_bypass_thresh_wd = reg_wdata[31:16];
+  assign extht_lo_thresholds_bypass_thresh_re = addr_hit[18] & reg_re & !reg_error;
 
-  assign repcnt_hi_watermarks_fips_repcnt_hi_watermark_re = addr_hit[19] & reg_re & !reg_error;
+  assign repcnt_hi_watermarks_fips_watermark_re = addr_hit[19] & reg_re & !reg_error;
 
-  assign repcnt_hi_watermarks_bypass_repcnt_hi_watermark_re = addr_hit[19] & reg_re & !reg_error;
+  assign repcnt_hi_watermarks_bypass_watermark_re = addr_hit[19] & reg_re & !reg_error;
 
-  assign adaptp_hi_watermarks_fips_adaptp_hi_watermark_re = addr_hit[20] & reg_re & !reg_error;
+  assign adaptp_hi_watermarks_fips_watermark_re = addr_hit[20] & reg_re & !reg_error;
 
-  assign adaptp_hi_watermarks_bypass_adaptp_hi_watermark_re = addr_hit[20] & reg_re & !reg_error;
+  assign adaptp_hi_watermarks_bypass_watermark_re = addr_hit[20] & reg_re & !reg_error;
 
-  assign adaptp_lo_watermarks_fips_adaptp_lo_watermark_re = addr_hit[21] & reg_re & !reg_error;
+  assign adaptp_lo_watermarks_fips_watermark_re = addr_hit[21] & reg_re & !reg_error;
 
-  assign adaptp_lo_watermarks_bypass_adaptp_lo_watermark_re = addr_hit[21] & reg_re & !reg_error;
+  assign adaptp_lo_watermarks_bypass_watermark_re = addr_hit[21] & reg_re & !reg_error;
 
-  assign extht_hi_watermarks_fips_extht_hi_watermark_re = addr_hit[22] & reg_re & !reg_error;
+  assign extht_hi_watermarks_fips_watermark_re = addr_hit[22] & reg_re & !reg_error;
 
-  assign extht_hi_watermarks_bypass_extht_hi_watermark_re = addr_hit[22] & reg_re & !reg_error;
+  assign extht_hi_watermarks_bypass_watermark_re = addr_hit[22] & reg_re & !reg_error;
 
-  assign extht_lo_watermarks_fips_extht_lo_watermark_re = addr_hit[23] & reg_re & !reg_error;
+  assign extht_lo_watermarks_fips_watermark_re = addr_hit[23] & reg_re & !reg_error;
 
-  assign extht_lo_watermarks_bypass_extht_lo_watermark_re = addr_hit[23] & reg_re & !reg_error;
+  assign extht_lo_watermarks_bypass_watermark_re = addr_hit[23] & reg_re & !reg_error;
 
-  assign bucket_hi_watermarks_fips_bucket_hi_watermark_re = addr_hit[24] & reg_re & !reg_error;
+  assign bucket_hi_watermarks_fips_watermark_re = addr_hit[24] & reg_re & !reg_error;
 
-  assign bucket_hi_watermarks_bypass_bucket_hi_watermark_re = addr_hit[24] & reg_re & !reg_error;
+  assign bucket_hi_watermarks_bypass_watermark_re = addr_hit[24] & reg_re & !reg_error;
 
-  assign markov_hi_watermarks_fips_markov_hi_watermark_re = addr_hit[25] & reg_re & !reg_error;
+  assign markov_hi_watermarks_fips_watermark_re = addr_hit[25] & reg_re & !reg_error;
 
-  assign markov_hi_watermarks_bypass_markov_hi_watermark_re = addr_hit[25] & reg_re & !reg_error;
+  assign markov_hi_watermarks_bypass_watermark_re = addr_hit[25] & reg_re & !reg_error;
 
-  assign markov_lo_watermarks_fips_markov_lo_watermark_re = addr_hit[26] & reg_re & !reg_error;
+  assign markov_lo_watermarks_fips_watermark_re = addr_hit[26] & reg_re & !reg_error;
 
-  assign markov_lo_watermarks_bypass_markov_lo_watermark_re = addr_hit[26] & reg_re & !reg_error;
+  assign markov_lo_watermarks_bypass_watermark_re = addr_hit[26] & reg_re & !reg_error;
 
   assign repcnt_total_fails_re = addr_hit[27] & reg_re & !reg_error;
 
@@ -2873,83 +2745,83 @@ module entropy_src_reg_top (
       end
 
       addr_hit[11]: begin
-        reg_rdata_next[15:0] = repcnt_thresholds_fips_repcnt_thresh_qs;
-        reg_rdata_next[31:16] = repcnt_thresholds_bypass_repcnt_thresh_qs;
+        reg_rdata_next[15:0] = repcnt_thresholds_fips_thresh_qs;
+        reg_rdata_next[31:16] = repcnt_thresholds_bypass_thresh_qs;
       end
 
       addr_hit[12]: begin
-        reg_rdata_next[15:0] = adaptp_hi_thresholds_fips_adaptp_hi_thresh_qs;
-        reg_rdata_next[31:16] = adaptp_hi_thresholds_bypass_adaptp_hi_thresh_qs;
+        reg_rdata_next[15:0] = adaptp_hi_thresholds_fips_thresh_qs;
+        reg_rdata_next[31:16] = adaptp_hi_thresholds_bypass_thresh_qs;
       end
 
       addr_hit[13]: begin
-        reg_rdata_next[15:0] = adaptp_lo_thresholds_fips_adaptp_lo_thresh_qs;
-        reg_rdata_next[31:16] = adaptp_lo_thresholds_bypass_adaptp_lo_thresh_qs;
+        reg_rdata_next[15:0] = adaptp_lo_thresholds_fips_thresh_qs;
+        reg_rdata_next[31:16] = adaptp_lo_thresholds_bypass_thresh_qs;
       end
 
       addr_hit[14]: begin
-        reg_rdata_next[15:0] = bucket_thresholds_fips_bucket_thresh_qs;
-        reg_rdata_next[31:16] = bucket_thresholds_bypass_bucket_thresh_qs;
+        reg_rdata_next[15:0] = bucket_thresholds_fips_thresh_qs;
+        reg_rdata_next[31:16] = bucket_thresholds_bypass_thresh_qs;
       end
 
       addr_hit[15]: begin
-        reg_rdata_next[15:0] = markov_hi_thresholds_fips_markov_hi_thresh_qs;
-        reg_rdata_next[31:16] = markov_hi_thresholds_bypass_markov_hi_thresh_qs;
+        reg_rdata_next[15:0] = markov_hi_thresholds_fips_thresh_qs;
+        reg_rdata_next[31:16] = markov_hi_thresholds_bypass_thresh_qs;
       end
 
       addr_hit[16]: begin
-        reg_rdata_next[15:0] = markov_lo_thresholds_fips_markov_lo_thresh_qs;
-        reg_rdata_next[31:16] = markov_lo_thresholds_bypass_markov_lo_thresh_qs;
+        reg_rdata_next[15:0] = markov_lo_thresholds_fips_thresh_qs;
+        reg_rdata_next[31:16] = markov_lo_thresholds_bypass_thresh_qs;
       end
 
       addr_hit[17]: begin
-        reg_rdata_next[15:0] = extht_hi_thresholds_fips_extht_hi_thresh_qs;
-        reg_rdata_next[31:16] = extht_hi_thresholds_bypass_extht_hi_thresh_qs;
+        reg_rdata_next[15:0] = extht_hi_thresholds_fips_thresh_qs;
+        reg_rdata_next[31:16] = extht_hi_thresholds_bypass_thresh_qs;
       end
 
       addr_hit[18]: begin
-        reg_rdata_next[15:0] = extht_lo_thresholds_fips_extht_lo_thresh_qs;
-        reg_rdata_next[31:16] = extht_lo_thresholds_bypass_extht_lo_thresh_qs;
+        reg_rdata_next[15:0] = extht_lo_thresholds_fips_thresh_qs;
+        reg_rdata_next[31:16] = extht_lo_thresholds_bypass_thresh_qs;
       end
 
       addr_hit[19]: begin
-        reg_rdata_next[15:0] = repcnt_hi_watermarks_fips_repcnt_hi_watermark_qs;
-        reg_rdata_next[31:16] = repcnt_hi_watermarks_bypass_repcnt_hi_watermark_qs;
+        reg_rdata_next[15:0] = repcnt_hi_watermarks_fips_watermark_qs;
+        reg_rdata_next[31:16] = repcnt_hi_watermarks_bypass_watermark_qs;
       end
 
       addr_hit[20]: begin
-        reg_rdata_next[15:0] = adaptp_hi_watermarks_fips_adaptp_hi_watermark_qs;
-        reg_rdata_next[31:16] = adaptp_hi_watermarks_bypass_adaptp_hi_watermark_qs;
+        reg_rdata_next[15:0] = adaptp_hi_watermarks_fips_watermark_qs;
+        reg_rdata_next[31:16] = adaptp_hi_watermarks_bypass_watermark_qs;
       end
 
       addr_hit[21]: begin
-        reg_rdata_next[15:0] = adaptp_lo_watermarks_fips_adaptp_lo_watermark_qs;
-        reg_rdata_next[31:16] = adaptp_lo_watermarks_bypass_adaptp_lo_watermark_qs;
+        reg_rdata_next[15:0] = adaptp_lo_watermarks_fips_watermark_qs;
+        reg_rdata_next[31:16] = adaptp_lo_watermarks_bypass_watermark_qs;
       end
 
       addr_hit[22]: begin
-        reg_rdata_next[15:0] = extht_hi_watermarks_fips_extht_hi_watermark_qs;
-        reg_rdata_next[31:16] = extht_hi_watermarks_bypass_extht_hi_watermark_qs;
+        reg_rdata_next[15:0] = extht_hi_watermarks_fips_watermark_qs;
+        reg_rdata_next[31:16] = extht_hi_watermarks_bypass_watermark_qs;
       end
 
       addr_hit[23]: begin
-        reg_rdata_next[15:0] = extht_lo_watermarks_fips_extht_lo_watermark_qs;
-        reg_rdata_next[31:16] = extht_lo_watermarks_bypass_extht_lo_watermark_qs;
+        reg_rdata_next[15:0] = extht_lo_watermarks_fips_watermark_qs;
+        reg_rdata_next[31:16] = extht_lo_watermarks_bypass_watermark_qs;
       end
 
       addr_hit[24]: begin
-        reg_rdata_next[15:0] = bucket_hi_watermarks_fips_bucket_hi_watermark_qs;
-        reg_rdata_next[31:16] = bucket_hi_watermarks_bypass_bucket_hi_watermark_qs;
+        reg_rdata_next[15:0] = bucket_hi_watermarks_fips_watermark_qs;
+        reg_rdata_next[31:16] = bucket_hi_watermarks_bypass_watermark_qs;
       end
 
       addr_hit[25]: begin
-        reg_rdata_next[15:0] = markov_hi_watermarks_fips_markov_hi_watermark_qs;
-        reg_rdata_next[31:16] = markov_hi_watermarks_bypass_markov_hi_watermark_qs;
+        reg_rdata_next[15:0] = markov_hi_watermarks_fips_watermark_qs;
+        reg_rdata_next[31:16] = markov_hi_watermarks_bypass_watermark_qs;
       end
 
       addr_hit[26]: begin
-        reg_rdata_next[15:0] = markov_lo_watermarks_fips_markov_lo_watermark_qs;
-        reg_rdata_next[31:16] = markov_lo_watermarks_bypass_markov_lo_watermark_qs;
+        reg_rdata_next[15:0] = markov_lo_watermarks_fips_watermark_qs;
+        reg_rdata_next[31:16] = markov_lo_watermarks_bypass_watermark_qs;
       end
 
       addr_hit[27]: begin

--- a/hw/ip/entropy_src/rtl/entropy_src_watermark_reg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_watermark_reg.sv
@@ -22,27 +22,32 @@ module entropy_src_watermark_reg #(
 
   // signals
   logic [RegWidth-1:0] event_cntr_change;
+  logic [RegWidth-1:0] reg_reset;
 
   // flops
   logic [RegWidth-1:0] event_cntr_q, event_cntr_d;
 
   always_ff @(posedge clk_i or negedge rst_ni)
     if (!rst_ni) begin
-      event_cntr_q       <= '0;
+      event_cntr_q       <= reg_reset;
     end else begin
       event_cntr_q       <= event_cntr_d;
     end
 
-  assign event_cntr_d = (!active_i || clear_i) ? '0 :
+  assign event_cntr_d = (!active_i || clear_i) ? reg_reset :
                         event_i ? event_cntr_change :
                         event_cntr_q;
 
   // Set mode of this counter to be either a high or low watermark
   if (HighWatermark) begin : gen_hi_wm
 
+    assign reg_reset = {RegWidth{1'b0}};
+
     assign event_cntr_change = (value_i > event_cntr_q) ? (value_i) : event_cntr_q;
 
   end else begin : gen_lo_wm
+
+    assign reg_reset = {RegWidth{1'b1}};
 
     assign event_cntr_change = (value_i < event_cntr_q) ? (value_i) : event_cntr_q;
 


### PR DESCRIPTION
Feature that restricts updating heath test thresholds in only a restricted direction.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>