### PR TITLE
[prim] Fix Verilator lint warnings in prim_secded_xx_xx_dec.sv

### DIFF
--- a/hw/ip/prim/rtl/prim_secded_22_16_dec.sv
+++ b/hw/ip/prim/rtl/prim_secded_22_16_dec.sv
@@ -40,7 +40,8 @@ module prim_secded_22_16_dec (
   assign d_o[15] = (syndrome_o == 6'h15) ^ in[15];
 
   // err_o calc. bit0: single error, bit1: double error
-  assign err_o[0] = ^syndrome_o;
-  assign err_o[1] = ~err_o[0] & (|syndrome_o);
+  // Verilator tends to throw UNOPTFLAT warnings if bit1 depends on bit0.
+  assign err_o[0] =   ^syndrome_o;
+  assign err_o[1] = ~(^syndrome_o) & (|syndrome_o);
 
 endmodule : prim_secded_22_16_dec

--- a/hw/ip/prim/rtl/prim_secded_28_22_dec.sv
+++ b/hw/ip/prim/rtl/prim_secded_28_22_dec.sv
@@ -46,7 +46,8 @@ module prim_secded_28_22_dec (
   assign d_o[21] = (syndrome_o == 6'h1f) ^ in[21];
 
   // err_o calc. bit0: single error, bit1: double error
-  assign err_o[0] = ^syndrome_o;
-  assign err_o[1] = ~err_o[0] & (|syndrome_o);
+  // Verilator tends to throw UNOPTFLAT warnings if bit1 depends on bit0.
+  assign err_o[0] =   ^syndrome_o;
+  assign err_o[1] = ~(^syndrome_o) & (|syndrome_o);
 
 endmodule : prim_secded_28_22_dec

--- a/hw/ip/prim/rtl/prim_secded_39_32_dec.sv
+++ b/hw/ip/prim/rtl/prim_secded_39_32_dec.sv
@@ -57,7 +57,8 @@ module prim_secded_39_32_dec (
   assign d_o[31] = (syndrome_o == 7'h1a) ^ in[31];
 
   // err_o calc. bit0: single error, bit1: double error
-  assign err_o[0] = ^syndrome_o;
-  assign err_o[1] = ~err_o[0] & (|syndrome_o);
+  // Verilator tends to throw UNOPTFLAT warnings if bit1 depends on bit0.
+  assign err_o[0] =   ^syndrome_o;
+  assign err_o[1] = ~(^syndrome_o) & (|syndrome_o);
 
 endmodule : prim_secded_39_32_dec

--- a/hw/ip/prim/rtl/prim_secded_64_57_dec.sv
+++ b/hw/ip/prim/rtl/prim_secded_64_57_dec.sv
@@ -82,7 +82,8 @@ module prim_secded_64_57_dec (
   assign d_o[56] = (syndrome_o == 7'h7f) ^ in[56];
 
   // err_o calc. bit0: single error, bit1: double error
-  assign err_o[0] = ^syndrome_o;
-  assign err_o[1] = ~err_o[0] & (|syndrome_o);
+  // Verilator tends to throw UNOPTFLAT warnings if bit1 depends on bit0.
+  assign err_o[0] =   ^syndrome_o;
+  assign err_o[1] = ~(^syndrome_o) & (|syndrome_o);
 
 endmodule : prim_secded_64_57_dec

--- a/hw/ip/prim/rtl/prim_secded_72_64_dec.sv
+++ b/hw/ip/prim/rtl/prim_secded_72_64_dec.sv
@@ -90,7 +90,8 @@ module prim_secded_72_64_dec (
   assign d_o[63] = (syndrome_o == 8'hd5) ^ in[63];
 
   // err_o calc. bit0: single error, bit1: double error
-  assign err_o[0] = ^syndrome_o;
-  assign err_o[1] = ~err_o[0] & (|syndrome_o);
+  // Verilator tends to throw UNOPTFLAT warnings if bit1 depends on bit0.
+  assign err_o[0] =   ^syndrome_o;
+  assign err_o[1] = ~(^syndrome_o) & (|syndrome_o);
 
 endmodule : prim_secded_72_64_dec

--- a/util/design/secded_gen.py
+++ b/util/design/secded_gen.py
@@ -114,8 +114,9 @@ def print_dec(n, k, m, codes, codetype):
         outstr += "  assign err_o[1] = |syndrome_o[%d:0] & ~syndrome_o[%d];\n" % (
             m - 2, m - 1)
     else:
-        outstr += "  assign err_o[0] = ^syndrome_o;\n"
-        outstr += "  assign err_o[1] = ~err_o[0] & (|syndrome_o);\n"
+        outstr += "  // Verilator tends to throw UNOPTFLAT warnings if bit1 depends on bit0.\n"
+        outstr += "  assign err_o[0] =   ^syndrome_o;\n"
+        outstr += "  assign err_o[1] = ~(^syndrome_o) & (|syndrome_o);\n"
     return outstr
 
 


### PR DESCRIPTION
Since transmission integrity has been enabled a couple of days ago, we are seeing the following Verilator lint warning in practially all devices:
```
%Warning-UNOPTFLAT: ../src/lowrisc_tlul_payload_chk_0.1/rtl/tlul_payload_chk.sv:19:15: Signal unoptimizable: Feedback to clock or circular logic: 'ip_name.u_reg.u_chk.err'
```
However, there is no circular logic. It seems that the problem actually originates inside the used `prim_secdec_xx_xx_dec.sv` primitives and this PR solves it by avoiding that Error Bit 1 depends on Error Bit 0.