### PR TITLE
[spi_device, dv] Refactor spi_agent to support spi_host rtl

### DIFF
--- a/hw/dv/sv/spi_agent/spi_agent_cfg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_cfg.sv
@@ -4,19 +4,22 @@
 
 class spi_agent_cfg extends dv_base_agent_cfg;
 
-  // agent cfg knobs
-  bit             en_monitor_collect_trans = 1'b1; // enable monitor to collect trans on-the-fly
-  bit             en_monitor_checks        = 1'b1; // enable checkers in monitor
+  // enable checkers in monitor
+  bit en_monitor_checks = 1'b1;
 
   // host mode cfg knobs
-  time            sck_period_ps = 50_000; // 20MHz
-  bit             sck_polarity;       // aka CPOL
-  bit             sck_phase;          // aka CPHA
-  bit             host_bit_dir;       // 1 - lsb -> msb, 0 - msb -> lsb
-  bit             device_bit_dir;     // 1 - lsb -> msb, 0 - msb -> lsb
-  bit             sck_on;             // keep sck on
+  time sck_period_ps = 50_000; // 20MHz
+  bit sck_polarity;       // aka CPOL
+  bit sck_phase;          // aka CPHA
+  bit host_bit_dir;       // 1 - lsb -> msb, 0 - msb -> lsb
+  bit device_bit_dir;     // 1 - lsb -> msb, 0 - msb -> lsb
+  bit sck_on;             // keep sck on
+
+  // spi mode knob
+  spi_mode_e spi_mode;
+
   // how many bytes monitor samples per transaction
-  int             num_bytes_per_trans_in_mon = 4;
+  int num_bytes_per_trans_in_mon = 4;
 
   // enable randomly injecting extra delay between 2 sck/word
   bit  en_extra_dly_btw_sck;
@@ -31,20 +34,21 @@ class spi_agent_cfg extends dv_base_agent_cfg;
   uint extra_dly_chance_pc_btw_word = 5;    // percentage of extra delay btw each word
 
   // interface handle used by driver, monitor & the sequencer
-  virtual spi_if  vif;
+  virtual spi_if vif;
 
   `uvm_object_utils_begin(spi_agent_cfg)
-    `uvm_field_int (sck_period_ps,    UVM_DEFAULT)
-    `uvm_field_int (sck_polarity,     UVM_DEFAULT)
-    `uvm_field_int (sck_phase,        UVM_DEFAULT)
-    `uvm_field_int (host_bit_dir,     UVM_DEFAULT)
-    `uvm_field_int (device_bit_dir,   UVM_DEFAULT)
+    `uvm_field_int (sck_period_ps,  UVM_DEFAULT)
+    `uvm_field_int (sck_polarity,   UVM_DEFAULT)
+    `uvm_field_int (sck_phase,      UVM_DEFAULT)
+    `uvm_field_int (host_bit_dir,   UVM_DEFAULT)
+    `uvm_field_int (device_bit_dir, UVM_DEFAULT)
     `uvm_field_int (en_extra_dly_btw_sck,         UVM_DEFAULT)
     `uvm_field_int (max_extra_dly_ns_btw_sck,     UVM_DEFAULT)
     `uvm_field_int (extra_dly_chance_pc_btw_sck,  UVM_DEFAULT)
     `uvm_field_int (en_extra_dly_btw_word,        UVM_DEFAULT)
     `uvm_field_int (max_extra_dly_ns_btw_word,    UVM_DEFAULT)
     `uvm_field_int (extra_dly_chance_pc_btw_word, UVM_DEFAULT)
+    `uvm_field_enum(spi_mode_e, spi_mode,         UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new
@@ -72,4 +76,4 @@ class spi_agent_cfg extends dv_base_agent_cfg;
     else              @(negedge vif.sck);
   endtask
 
-endclass
+endclass : spi_agent_cfg

--- a/hw/dv/sv/spi_agent/spi_agent_pkg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_pkg.sv
@@ -27,6 +27,13 @@ package spi_agent_pkg;
     SamplingEdge
   } sck_edge_type_e;
 
+  // spi mode
+  typedef enum {
+    Single = 0,  // Full duplex, tx: sio[0], rx: sio[1]
+    Dual   = 1,  // Half duplex, tx and rx: sio[1:0]
+    Quad   = 2   // Half duplex, tx and rx: sio[3:0]
+  } spi_mode_e;
+
   // functions
 
   // package sources

--- a/hw/dv/sv/spi_agent/spi_device_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_device_driver.sv
@@ -10,7 +10,7 @@ class spi_device_driver extends spi_driver;
     forever begin
       @(negedge cfg.vif.rst_n);
       under_reset = 1'b1;
-      cfg.vif.sdo <= 1'b0;
+      cfg.vif.sio <= 'hz;
       @(posedge cfg.vif.rst_n);
       under_reset = 1'b0;
     end

--- a/hw/dv/sv/spi_agent/spi_if.sv
+++ b/hw/dv/sv/spi_agent/spi_if.sv
@@ -2,13 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-interface spi_if (input rst_n);
+interface spi_if (
+  input rst_n
+);
 
   // standard spi interface pins
-  logic sck;
-  logic csb;
-  logic sdo;
-  logic sdi;
+  logic       sck;
+  logic [3:0] csb;
+  logic [3:0] sio;
 
   // debug signals
   logic [7:0] host_byte;
@@ -19,4 +20,4 @@ interface spi_if (input rst_n);
   bit         sck_polarity;
   bit         sck_phase;
 
-endinterface
+endinterface : spi_if

--- a/hw/dv/sv/spi_agent/spi_sequencer.sv
+++ b/hw/dv/sv/spi_agent/spi_sequencer.sv
@@ -7,4 +7,4 @@ class spi_sequencer extends dv_base_sequencer#(spi_item, spi_agent_cfg);
 
   `uvm_component_new
 
-endclass
+endclass : spi_sequencer

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -105,8 +105,8 @@ class spi_device_base_vseq extends cip_base_vseq #(
   endtask
 
   // NOTE on terminology
-  // from spi_device IP perspective, tx is data sent out over sdo (device traffic from the IP),
-  // rx is data received over sdi (host traffic from SPI agent)
+  // from spi_device IP perspective, tx is data sent out over sio[0] (device traffic from the IP),
+  // rx is data received over sio[1] (host traffic from SPI agent)
 
   // TODO: use spi_device_pkg spi_mode enum instead
   virtual task spi_device_init();

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_fifo_underflow_overflow_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_fifo_underflow_overflow_vseq.sv
@@ -10,7 +10,7 @@ class spi_device_fifo_underflow_overflow_vseq extends spi_device_txrx_vseq;
 
   virtual task body();
     allow_underflow_overflow = 1;
-    // when underflow, sdo may be unknown, disable checking it
+    // when underflow, sio may be unknown, disable checking it
     cfg.m_spi_agent_cfg.en_monitor_checks = 0;
     super.body();
     cfg.m_spi_agent_cfg.en_monitor_checks = 1;

--- a/hw/ip/spi_device/dv/tb/tb.sv
+++ b/hw/ip/spi_device/dv/tb/tb.sv
@@ -33,10 +33,10 @@ module tb;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
+  tl_if tl_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(.pins(interrupts));
   pins_if #(1) devmode_if(devmode);
-  tl_if tl_if(.clk(clk), .rst_n(rst_n));
-  spi_if spi_if(.rst_n(rst_n));
+  spi_if  spi_if(.rst_n(rst_n));
 
   // dut
   spi_device dut (
@@ -61,11 +61,11 @@ module tb;
     .scanmode_i     (lc_ctrl_pkg::Off)
   );
 
-  assign sck          = spi_if.sck;
-  assign csb          = spi_if.csb;
+  assign sck           = spi_if.sck;
+  assign csb           = spi_if.csb[0];
   // TODO: quad SPI mode is currently not yet implemented
-  assign sd_in        = {3'b000, spi_if.sdi};
-  assign spi_if.sdo   = sd_out_en[1] ? sd_out[1] : 1'bz;
+  assign sd_in         = {3'b000, spi_if.sio[0]};
+  assign spi_if.sio[1] = sd_out_en[1] ? sd_out[1] : 1'bz;
 
   assign interrupts[RxFifoFull]      = intr_rxf;
   assign interrupts[RxFifoGeLevel]   = intr_rxlvl;

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -180,8 +180,8 @@ module tb;
 
   assign spi_device_sck     = spi_if.sck;
   assign spi_device_csb     = spi_if.csb;
-  assign spi_device_sdi_i   = spi_if.sdi;
-  assign spi_if.sdo         = spi_device_sdo_o;
+  assign spi_device_sdi_i   = spi_if.sio[0];
+  assign spi_if.sio[1]      = spi_device_sdo_o;
 
   // TODO: Replace this weak pull to a known value with initialization
   // in the agent/interface.


### PR DESCRIPTION
Refactor spi_agent to support spi_host rtl

  - Extend spi_if to provide 4 channels required by spi_host rtl
  - Replace uni-direction sdi and sdo ports by bi-direction sio ports in spi_if
  - Update spi_device and top_earlgrey testbench with new ports

Signed-off-by: Tung Hoang <hoang.tung@wdc.com>