### PR TITLE
[otbn] Fix missing operation docs for bn.sel

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -776,7 +776,7 @@ class BNRSHI(OTBNInsn):
         state.wdrs.get_reg(self.wrd).write_unsigned(result)
 
 
-class BNRSEL(OTBNInsn):
+class BNSEL(OTBNInsn):
     insn = insn_for_mnemonic('bn.sel', 5)
 
     def __init__(self, raw: int, op_vals: Dict[str, int]):
@@ -995,7 +995,7 @@ INSN_CLASSES = [
     BNSUB, BNSUBB, BNSUBI, BNSUBM,
     BNAND, BNOR, BNNOT, BNXOR,
     BNRSHI,
-    BNRSEL,
+    BNSEL,
     BNCMP, BNCMPB,
     BNLID, BNSID,
     BNMOV, BNMOVR,


### PR DESCRIPTION
The class name had a spare "r" in it (probably a copy-paste error from
when I copied it from BNRSHI above). This doesn't matter in any way
for the ISS, because decoding and tracing is driven by the "insn"
class field (which had the right name). But it *does* matter for the
connection with document extraction, which means that the BN.SEL entry
in the docs was missing its Operation section.
