### PR TITLE
[reggen] Fix check_name() regex in reggen/lib.py

### DIFF
--- a/hw/ip/alert_handler/data/alert_handler.hjson
+++ b/hw/ip/alert_handler/data/alert_handler.hjson
@@ -266,7 +266,7 @@
                   swaccess: "rw",
                   hwaccess: "hro",
                   regwen:   "REGWEN",
-                  cname:    "local alert",
+                  cname:    "LOC_ALERT",
                   fields: [
                     { bits: "0",
                       name: "EN_LA",
@@ -283,7 +283,7 @@
                   swaccess: "rw",
                   hwaccess: "hro",
                   regwen:   "REGWEN",
-                  cname:    "local alert",
+                  cname:    "LOC_ALERT",
                   fields: [
                     {
                       # TODO: bitwidth should be parameterized with CLASS_DW

--- a/hw/ip/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip/alert_handler/data/alert_handler.hjson.tpl
@@ -260,7 +260,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
                   swaccess: "rw",
                   hwaccess: "hro",
                   regwen:   "REGWEN",
-                  cname:    "local alert",
+                  cname:    "LOC_ALERT",
                   fields: [
                     { bits: "0",
                       name: "EN_LA",
@@ -277,7 +277,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
                   swaccess: "rw",
                   hwaccess: "hro",
                   regwen:   "REGWEN",
-                  cname:    "local alert",
+                  cname:    "LOC_ALERT",
                   fields: [
                     {
                       # TODO: bitwidth should be parameterized with CLASS_DW

--- a/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
@@ -274,7 +274,7 @@
                   swaccess: "rw",
                   hwaccess: "hro",
                   regwen:   "REGWEN",
-                  cname:    "local alert",
+                  cname:    "LOC_ALERT",
                   fields: [
                     { bits: "0",
                       name: "EN_LA",
@@ -291,7 +291,7 @@
                   swaccess: "rw",
                   hwaccess: "hro",
                   regwen:   "REGWEN",
-                  cname:    "local alert",
+                  cname:    "LOC_ALERT",
                   fields: [
                     {
                       # TODO: bitwidth should be parameterized with CLASS_DW

--- a/util/reggen/lib.py
+++ b/util/reggen/lib.py
@@ -112,7 +112,7 @@ def check_name(obj: object, what: str) -> str:
 
     # Allow the usual symbol constituents (alphanumeric plus underscore; no
     # leading numbers)
-    if not re.match(r'[a-zA-Z_][a-zA-Z_0-9]*', as_str):
+    if not re.match(r'[a-zA-Z_][a-zA-Z_0-9]*$', as_str):
         raise ValueError("{} is {!r}, which isn't a valid symbol in "
                          "C / Verilog, so isn't allowed as a name."
                          .format(what, as_str))


### PR DESCRIPTION
Also fix the one example where we had something that's supposed to
look like a symbol and in fact contained a space.
