### PR TITLE
[dv/macros] Add fcov macros from Ibex

### DIFF
--- a/hw/dv/sv/dv_utils/dv_fcov.core
+++ b/hw/dv/sv/dv_utils/dv_fcov.core
@@ -1,0 +1,17 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:dv_fcov"
+description: "DV FCOV utilities"
+
+filesets:
+  files_fcov:
+    files:
+      - dv_fcov_macros.svh: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_fcov

--- a/hw/dv/sv/dv_utils/dv_fcov_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_fcov_macros.svh
@@ -1,0 +1,50 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Include FCOV RTL by default. Exclude it for synthesis and where explicitly requested (by defining
+// EXCLUDE_FCOV).
+`ifdef SYNTHESIS
+  `define EXCLUDE_FCOV
+`elsif YOSYS
+  `define EXCLUDE_FCOV
+`endif
+
+// Coverage support is not always available but it's useful to include extra fcov signals for
+// linting purposes. They need to be marked as unused to avoid warnings.
+`ifndef FCOV_MARK_UNUSED
+  `define FCOV_MARK_UNUSED(TYPE_, NAME_) \
+    TYPE_ unused_fcov_``NAME_; \
+    assign unused_fcov_``NAME_ = fcov_``NAME_;
+`endif
+
+// Define a signal and expression in the design for capture in functional coverage
+`ifndef FCOV_SIGNAL
+`ifdef EXCLUDE_FCOV
+  // Macro has no effect
+  `define FCOV_SIGNAL(TYPE_, NAME_, EXPR_)
+`else
+  `define FCOV_SIGNAL(TYPE_, NAME_, EXPR_) \
+    TYPE_ fcov_``NAME_; \
+    assign fcov_``NAME_ = EXPR_; \
+    `FCOV_MARK_UNUSED(TYPE_, NAME_)
+`endif
+`endif
+
+// Define a signal and expression in the design for capture in functional coverage depending on
+// design configuration. The input GEN_COND_ must be a constant or parameter.
+`ifndef FCOV_SIGNAL_GEN_IF
+`ifdef EXCLUDE_FCOV
+  // Macro does nothing
+  `define FCOV_SIGNAL_GEN_IF(TYPE_, NAME_, EXPR_, GEN_COND_, DEFAULT_ = '0)
+`else
+  `define FCOV_SIGNAL_GEN_IF(TYPE_, NAME_, EXPR_, GEN_COND_, DEFAULT_ = '0) \
+    TYPE_ fcov_``NAME_; \
+    if (GEN_COND_) begin : g_fcov_``NAME_ \
+      assign fcov_``NAME_ = EXPR_; \
+    end else begin : g_no_fcov_``NAME_ \
+      assign fcov_``NAME_ = DEFAULT_; \
+    end \
+    `FCOV_MARK_UNUSED(TYPE_, NAME_)
+`endif
+`endif

--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -521,4 +521,23 @@
   end
 `endif
 
+// Creates a SVA cover that can be used in a covergroup.
+//
+// This macro creates an unnamed SVA cover from the expression `__sva` and an event with the name
+// `__ev_name`. When the SVA cover is hit, the event is triggered. A coverpoint can cover the
+// `triggered` property of the event.
+`ifndef DV_FCOV_SVA
+`define DV_FCOV_SVA(__ev_name, __sva, __clk = clk_i, __rst = rst_ni) \
+  event __ev_name; \
+  cover property (@(posedge __clk) disable iff (__rst == 0) (__sva)) begin \
+    -> __ev_name; \
+  end
+`endif
+
+// Creates a coverpoint for an expression where only the expression true case is of interest for
+// coverage (e.g. where the expression indicates an event has occured).
+`ifndef DV_FCOV_EXPR_SEEN
+`define DV_FCOV_EXPR_SEEN(__cp_name, __expr) __cp_name: coverpoint __expr { bins seen = {1}; }
+`endif
+
 `endif // __DV_MACROS_SVH__


### PR DESCRIPTION
These macros are currently added separately in the Ibex repo (some
applied as a vendoring-in patch and some in a separate directory). This
has caused some issues recently with vendoring Ibex back into OT. This
commit brings them all into one place, and allows other OT blocks to use
these macros if desired.

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>