### PR TITLE
[dv/flash_ctrl] Changes to integrate vendor environment

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
@@ -2,13 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class flash_ctrl_env extends cip_base_env #(
-    .CFG_T              (flash_ctrl_env_cfg),
+class flash_ctrl_env #(type CFG_T = flash_ctrl_env_cfg)
+                       extends cip_base_env #(
+    .CFG_T              (CFG_T),
     .COV_T              (flash_ctrl_env_cov),
     .VIRTUAL_SEQUENCER_T(flash_ctrl_virtual_sequencer),
     .SCOREBOARD_T       (flash_ctrl_scoreboard)
   );
-  `uvm_component_utils(flash_ctrl_env)
+  `uvm_component_param_utils(flash_ctrl_env #(CFG_T))
 
   tl_agent        m_eflash_tl_agent;
   tl_reg_adapter  m_eflash_tl_reg_adapter;
@@ -29,8 +30,8 @@ class flash_ctrl_env extends cip_base_env #(
     end
 
     // get the vifs from config db
-    begin
-      flash_part_e part = part.first();
+    if(`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin // If using open-source flash
+      flash_dv_part_e part = part.first(); 
       for (int i = 0; i < part.num(); i++, part = part.next()) begin
         foreach (cfg.mem_bkdr_vifs[, bank]) begin
           string vif_name = $sformatf("mem_bkdr_vifs[%0s][%0d]", part.name(), bank);
@@ -41,6 +42,7 @@ class flash_ctrl_env extends cip_base_env #(
         end
       end
     end
+
 
     // create components
     m_eflash_tl_agent = tl_agent::type_id::create("m_eflash_tl_agent", this);

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -5,7 +5,7 @@
 class flash_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(flash_ctrl_reg_block));
 
   // vifs
-  mem_bkdr_vif mem_bkdr_vifs[flash_part_e][flash_ctrl_pkg::NumBanks];
+  mem_bkdr_vif mem_bkdr_vifs[flash_dv_part_e][flash_ctrl_pkg::NumBanks];
 
   // ext component cfgs
   rand tl_agent_cfg m_eflash_tl_agent_cfg;
@@ -41,6 +41,131 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(flash_ctrl_reg_block)
         num_interrupts = ral.intr_state.get_n_used_bits();
       end
     end
-  endfunction
+  endfunction : initialize
+
+  
+  // --------------------------------------------
+  // Back-door access methods
+  // --------------------------------------------
+
+
+  virtual function void flash_mem_bkdr_init(flash_dv_part_e part = FlashPartData,
+                                            flash_mem_init_e flash_mem_init);
+    case (flash_mem_init)
+      FlashMemInitSet: begin
+        foreach (mem_bkdr_vifs[part][i]) mem_bkdr_vifs[part][i].set_mem();
+      end
+      FlashMemInitClear: begin
+        foreach (mem_bkdr_vifs[part][i]) mem_bkdr_vifs[part][i].clear_mem();
+      end
+      FlashMemInitRandomize: begin
+        foreach (mem_bkdr_vifs[part][i]) mem_bkdr_vifs[part][i].randomize_mem();
+      end
+      FlashMemInitInvalidate: begin
+        foreach (mem_bkdr_vifs[part][i]) mem_bkdr_vifs[part][i].invalidate_mem();
+      end
+    endcase
+  endfunction : flash_mem_bkdr_init
+
+  // Reads flash mem contents via backdoor.
+  // The addr arg need not be word aligned- its the same addr programmed into the `control` CSR.
+  // TODO: support for partition.
+  virtual function void flash_mem_bkdr_read(flash_op_t flash_op,
+                                            ref logic [TL_DW-1:0] data[$]);
+    flash_mem_addr_attrs addr_attrs = new(flash_op.addr);
+    data.delete();
+    for (int i = 0; i < flash_op.num_words; i++) begin
+      data[i] = mem_bkdr_vifs[flash_op.partition][addr_attrs.bank].read32(
+          addr_attrs.bank_addr);
+      `uvm_info(`gfn, $sformatf("flash_mem_bkdr_read: {%s} = 0x%0h",
+                              addr_attrs.sprint(), data[i]), UVM_MEDIUM)
+      addr_attrs.incr(TL_DBW);
+    end
+  endfunction : flash_mem_bkdr_read
+
+
+  // Writes the flash mem contents via backdoor.
+  // The addr arg need not be word aligned- its the same addr programmed into the `control` CSR.
+  // TODO: support for partition.
+  virtual function void flash_mem_bkdr_write(flash_op_t flash_op,
+                                             flash_mem_init_e flash_mem_init,
+                                             logic [TL_DW-1:0] data[$] = {});
+    flash_mem_addr_attrs addr_attrs = new(flash_op.addr);
+    logic [TL_DW-1:0] wr_data;
+    case (flash_mem_init)
+      FlashMemInitCustom: begin
+        flash_op.num_words = data.size();
+      end
+      FlashMemInitSet: begin
+        wr_data = {TL_DW{1'b1}};
+      end
+      FlashMemInitClear: begin
+        wr_data = {TL_DW{1'b0}};
+      end
+      FlashMemInitInvalidate: begin
+        wr_data = {TL_DW{1'bx}};
+      end
+    endcase
+    for (int i = 0; i < flash_op.num_words; i++) begin
+      logic [TL_DW-1:0] loc_data;
+      if(flash_mem_init == FlashMemInitCustom)
+        loc_data = data[i];
+      else if (flash_mem_init == FlashMemInitRandomize)
+        loc_data = $urandom;
+      else
+        loc_data = wr_data;
+      mem_bkdr_vifs[flash_op.partition][addr_attrs.bank].write32(
+                addr_attrs.bank_addr, loc_data);
+      `uvm_info(`gfn, $sformatf("flash_mem_bkdr_write: {%s} = 0x%0h",
+                               addr_attrs.sprint(), loc_data), UVM_MEDIUM)
+      addr_attrs.incr(TL_DBW);
+    end
+  endfunction : flash_mem_bkdr_write
+
+  // Checks flash mem contents via backdoor.
+  // The addr arg need not be word aligned- its the same addr programmed into the `control` CSR.
+  // TODO: support for partition.
+  virtual function void flash_mem_bkdr_read_check(flash_op_t flash_op,
+                                                  const ref bit [TL_DW-1:0] exp_data[$]);
+    logic [TL_DW-1:0] data[$];
+    flash_mem_bkdr_read(flash_op, data);
+    foreach (data[i]) begin
+      `DV_CHECK_CASE_EQ(data[i], exp_data[i])
+    end
+  endfunction : flash_mem_bkdr_read_check
+
+  // Ensure that the flash page / bank has indeed been erased.
+  virtual function void flash_mem_bkdr_erase_check(flash_op_t flash_op);
+    flash_mem_addr_attrs    addr_attrs = new(flash_op.addr);
+    bit [TL_AW-1:0]         erase_check_addr;
+    uint                    num_words;
+
+    case (flash_op.erase_type)
+      flash_ctrl_pkg::FlashErasePage: begin
+        erase_check_addr = addr_attrs.page_start_addr;
+        num_words = FlashNumBusWordsPerPage;
+      end
+      flash_ctrl_pkg::FlashEraseBank: begin
+        // TODO: check if bank erase was supported
+        erase_check_addr = addr_attrs.bank_start_addr;
+        num_words = FlashNumBusWordsPerBank;
+      end
+      default: begin
+        `uvm_fatal(`gfn, $sformatf("Invalid erase_type: %0s", flash_op.erase_type.name()))
+      end
+    endcase
+    `uvm_info(`gfn, $sformatf("flash_mem_bkdr_erase_check: addr = 0x%0h, num_words = %0d",
+                              erase_check_addr, num_words), UVM_MEDIUM)
+
+    for (int i = 0; i < num_words; i++) begin
+      logic [TL_DW-1:0] data;
+      data = mem_bkdr_vifs[flash_op.partition][addr_attrs.bank].read32(erase_check_addr);
+      `uvm_info(`gfn, $sformatf("flash_mem_bkdr_erase_check: bank: %0d, addr: 0x%0h, data: 0x%0h",
+                                addr_attrs.bank, erase_check_addr, data), UVM_MEDIUM)
+      `DV_CHECK_CASE_EQ(data, '1)
+      erase_check_addr += TL_DBW;
+    end
+  endfunction : flash_mem_bkdr_erase_check
+
 
 endclass

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -62,6 +62,14 @@ package flash_ctrl_env_pkg;
     FlashMemInitInvalidate  // Initialize with Xs.
   } flash_mem_init_e;
 
+  // Partition select for DV
+  typedef enum logic [flash_ctrl_pkg::InfoTypes:0] { // Data partition and all info partitions
+    FlashPartData  = 0,
+    FlashPartInfo  = 1,
+    FlashPartInfo1 = 2,
+    FlashPartRed   = 4
+  } flash_dv_part_e;
+
   typedef struct packed {
     bit           en;         // enable this region
     bit           read_en;    // enable reads
@@ -73,7 +81,7 @@ package flash_ctrl_env_pkg;
   } flash_mp_region_cfg_t;
 
   typedef struct packed {
-    flash_part_e    partition;  // data or info partition
+    flash_dv_part_e partition;  // data or one of the info partitions
     flash_erase_e   erase_type; // erase page or the whole bank
     flash_op_e      op;         // read / program or erase
     uint            num_words;  // number of words to read or program (TL_DW)

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -38,7 +38,13 @@ class flash_ctrl_seq_cfg extends uvm_object;
   uint max_flash_ops_per_cfg = 50;
 
   // Flash ctrl op randomization knobs.
-  uint op_on_data_partition_pc = 100;
+  
+  // Partition select. Make sure to keep sum equals to 100.
+  uint op_on_data_partition_pc = 100; // Choose data partition.
+  uint op_on_info_partition_pc = 0;   // Choose info partition.
+  uint op_on_info1_partition_pc = 0;  // Choose info1 partition.
+  uint op_on_red_partition_pc = 0;    // Choose redundancy partition.
+
   uint op_erase_type_bank_pc = 0;
   uint op_max_words = 512;
   bit  op_allow_invalid = 1'b0;

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim.core
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim.core
@@ -24,12 +24,17 @@ filesets:
     file_type: systemVerilogSource
 
 targets:
-  sim: &sim_target
+  default: &default_target
     toplevel: tb
     filesets:
       - files_rtl
       - files_dv
+
+  sim:
+    <<: *default_target
     default_tool: vcs
 
   lint:
-    <<: *sim_target
+    <<: *default_target
+
+

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -44,7 +44,7 @@ module tb;
     .flash_ctrl_tl_o    (tl_if.d2h),
 
     .flash_power_ready_h_i (1'b1  ),
-    .flash_power_down_h_i  (1'b0  ),
+    .flash_power_down_h_i  (flash_power_down_h  ),
     .flash_bist_enable_i   (lc_ctrl_pkg::Off),
 
     .eflash_tl_i        (eflash_tl_if.h2d),
@@ -74,30 +74,65 @@ module tb;
     .alert_tx_o         (alert_tx       )
   );
 
-  // bind mem_bkdr_if
+  // -----------------------------------
+  // Create edge in flash_power_down_h_i
+  //   eshapira - 30-Dec-20
+  logic init;
+  assign flash_power_down_h = (init ? 1'b1 : 1'b0);
+  initial begin
+    init = 1'b1;
+    #(1us);
+    init = 1'b0;
+  end
+
+
+  // -----------------------------------
+  //
+
   `define FLASH_DATA_MEM_HIER(i) \
       dut.u_flash_eflash.u_flash.gen_generic.u_impl_generic.gen_prim_flash_banks[``i``].u_prim_flash_bank.u_mem
+  `define FLASH_INFO_MEM_HIER(i, j) \
+        dut.u_flash_eflash.u_flash.gen_generic.u_impl_generic.gen_prim_flash_banks[``i``].u_prim_flash_bank.gen_info_types[``j``].u_info_mem
 
-  `define FLASH_INFO_MEM_HIER(i) \
-      dut.u_flash_eflash.u_flash.gen_generic.u_impl_generic.gen_prim_flash_banks[``i``].u_prim_flash_bank.gen_info_types[0].u_info_mem
 
   for (genvar i = 0; i < flash_ctrl_pkg::NumBanks; i++) begin : gen_mem_bkdr_if_i
-    bind `FLASH_DATA_MEM_HIER(i) mem_bkdr_if mem_bkdr_if();
-    bind `FLASH_INFO_MEM_HIER(i) mem_bkdr_if mem_bkdr_if();
-    initial begin
-      flash_part_e part;
-      part = flash_ctrl_pkg::FlashPartData;
-      uvm_config_db#(mem_bkdr_vif)::set(null, "*.env", $sformatf("mem_bkdr_vifs[%0s][%0d]",
-          part.name(), i), `FLASH_DATA_MEM_HIER(i).mem_bkdr_if);
 
-      part = flash_ctrl_pkg::FlashPartInfo;
-      uvm_config_db#(mem_bkdr_vif)::set(null, "*.env", $sformatf("mem_bkdr_vifs[%0s][%0d]",
-          part.name(), i), `FLASH_INFO_MEM_HIER(i).mem_bkdr_if);
-    end
+    if(`PRIM_DEFAULT_IMPL==prim_pkg::ImplGeneric) begin : gen_generic // If using open-source flash
+
+      flash_dv_part_e part = part.first();
+
+      bind `FLASH_DATA_MEM_HIER(i) mem_bkdr_if mem_bkdr_if();
+      for(genvar j = 0; j < flash_ctrl_pkg::InfoTypes; j++)
+        bind `FLASH_INFO_MEM_HIER(i, j) mem_bkdr_if mem_bkdr_if();
+
+      initial begin
+
+        uvm_config_db#(mem_bkdr_vif)::set(null, "*.env", $sformatf("mem_bkdr_vifs[%0s][%0d]",
+            part.name(), i), `FLASH_DATA_MEM_HIER(i).mem_bkdr_if);
+        part = part.next();
+        uvm_config_db#(mem_bkdr_vif)::set(null, "*.env", $sformatf("mem_bkdr_vifs[%0s][%0d]",
+              part.name(), i), `FLASH_INFO_MEM_HIER(i, 0).mem_bkdr_if);
+        part = part.next();
+        uvm_config_db#(mem_bkdr_vif)::set(null, "*.env", $sformatf("mem_bkdr_vifs[%0s][%0d]",
+              part.name(), i), `FLASH_INFO_MEM_HIER(i, 1).mem_bkdr_if);
+        part = part.next();
+        uvm_config_db#(mem_bkdr_vif)::set(null, "*.env", $sformatf("mem_bkdr_vifs[%0s][%0d]",
+              part.name(), i), `FLASH_INFO_MEM_HIER(i, 2).mem_bkdr_if);
+
+      end
+
+    end : gen_generic
+
   end : gen_mem_bkdr_if_i
+
+
+
 
   `undef FLASH_DATA_MEM_HIER
   `undef FLASH_INFO_MEM_HIER
+
+  // -----------------------------------
+
 
   // Connect the interrupts
   assign interrupts[FlashCtrlIntrProgEmpty] = intr_prog_empty;


### PR DESCRIPTION
Hi,

Following review, this is the first version of **flash_ctrl** DV env to integrate with **vendor** DV env.

Description of changes:
* Moved back-door methods from **flash_ctrl_base_vseq** to **flash_ctrl_env_cfg** in order to enable override of the interfaces by vendor.
* Added parametrized config type (**CFG_T**) to **flash_ctrl_env** to make easy override by extended class **vendor_flash_ctrl_env**.
* Added partition type **flash_dv_part_e** to **flash_ctrl_env_pkg** to better match dv requirements and added first support to more partitions - **info1** and **redundancy**.
* Added setting and getting of **mem_bkdr_if** in **tb** and **flash_ctrl_env** repectively to be depended on **PRIM_DEFAULT_IMPL** value (**if PRIM_DEFAULT_IMPL  == prim_pkg::ImplGeneric** ) to avoid those line when **vendor** use the **tb**.
* Added override possibility of default timeout to **wait_flash_op_done** task in **flash_ctrl_base_vseq** to allow values bigger then 10ms (mainly for **erases** that can be much longer in **vendor**).
*  Changed **flash_ctrl_sim.core** following review with **Sri** and **Michael**.
*  Added falling edge in **flash_power_down_h** signal in **tb** (this edge detection is affecting simulation).

Signed-off-by: Eitan Shapira <eitan.shapira@nuvoton.com>