### PR TITLE
[top] Widen top level memories to include ecc

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -7332,6 +7332,7 @@
       base_addr: 0x00008000
       swaccess: ro
       size: 0x4000
+      integ_width: 7
       inter_signal_list:
       [
         {
@@ -7369,6 +7370,7 @@
       base_addr: 0x10000000
       size: 0x20000
       byte_write: "true"
+      integ_width: 7
       exec: "1"
       inter_signal_list:
       [
@@ -7432,6 +7434,7 @@
       base_addr: 0x40600000
       size: 0x1000
       byte_write: "true"
+      integ_width: 7
       exec: "0"
       inter_signal_list:
       [

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -539,7 +539,9 @@
       type: "rom",
       base_addr: "0x00008000",
       swaccess: "ro",
-      size: "0x4000"
+      size: "0x4000",
+      // data integrity width
+      integ_width: 7,
       inter_signal_list: [
         { struct: "tl"
           package: "tlul_pkg"
@@ -557,6 +559,8 @@
       base_addr: "0x10000000",
       size: "0x20000",
       byte_write: "true",
+      // data integrity width
+      integ_width: 7,
       exec: "1",
       inter_signal_list: [
         { struct: "tl"
@@ -589,6 +593,8 @@
       base_addr: "0x40600000",
       size: "0x1000",
       byte_write: "true",
+      // data integrity width
+      integ_width: 7,
       exec: "0",
       inter_signal_list: [
         { struct: "tl"

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -343,6 +343,7 @@ module top_${top["name"]} #(
   % if m["type"] == "ram_1p_scr":
 <%
      data_width = int(top["datawidth"])
+     full_data_width = data_width + int(m["integ_width"])
      dw_byte = data_width // 8
      addr_width = ((int(m["size"], 0) // dw_byte) -1).bit_length()
      sram_depth = (int(m["size"], 0) // dw_byte)
@@ -353,9 +354,9 @@ module top_${top["name"]} #(
   logic ${lib.bitarray(1,          max_char)} ${m["name"]}_gnt;
   logic ${lib.bitarray(1,          max_char)} ${m["name"]}_we;
   logic ${lib.bitarray(addr_width, max_char)} ${m["name"]}_addr;
-  logic ${lib.bitarray(data_width, max_char)} ${m["name"]}_wdata;
-  logic ${lib.bitarray(data_width, max_char)} ${m["name"]}_wmask;
-  logic ${lib.bitarray(data_width, max_char)} ${m["name"]}_rdata;
+  logic ${lib.bitarray(full_data_width, max_char)} ${m["name"]}_wdata;
+  logic ${lib.bitarray(full_data_width, max_char)} ${m["name"]}_wmask;
+  logic ${lib.bitarray(full_data_width, max_char)} ${m["name"]}_rdata;
   logic ${lib.bitarray(1,          max_char)} ${m["name"]}_rvalid;
   logic ${lib.bitarray(2,          max_char)} ${m["name"]}_rerror;
 
@@ -379,15 +380,15 @@ module top_${top["name"]} #(
     .addr_o      (${m["name"]}_addr),
     .wdata_o     (${m["name"]}_wdata),
     .wmask_o     (${m["name"]}_wmask),
-    .rdata_i     (${m["name"]}_rdata),
+    .rdata_i     (${m["name"]}_rdata[${data_width-1}:0]),
     .rvalid_i    (${m["name"]}_rvalid),
     .rerror_i    (${m["name"]}_rerror)
   );
 
   prim_ram_1p_scr #(
-    .Width(${data_width}),
+    .Width(${full_data_width}),
     .Depth(${sram_depth}),
-    .EnableParity(1),
+    .EnableParity(0),
     .CfgWidth(8)
   ) u_ram1p_${m["name"]} (
     % for key in clocks:
@@ -405,8 +406,8 @@ module top_${top["name"]} #(
     .gnt_o    (${m["name"]}_gnt),
     .write_i  (${m["name"]}_we),
     .addr_i   (${m["name"]}_addr),
-    .wdata_i  (${m["name"]}_wdata),
-    .wmask_i  (${m["name"]}_wmask),
+    .wdata_i  (${full_data_width}'(${m["name"]}_wdata)),
+    .wmask_i  (${full_data_width}'(${m["name"]}_wmask)),
     .rdata_o  (${m["name"]}_rdata),
     .rvalid_o (${m["name"]}_rvalid),
     .rerror_o (${m["name"]}_rerror),
@@ -419,6 +420,7 @@ module top_${top["name"]} #(
   % elif m["type"] == "rom":
 <%
      data_width = int(top["datawidth"])
+     full_data_width = data_width + int(m['integ_width'])
      dw_byte = data_width // 8
      addr_width = ((int(m["size"], 0) // dw_byte) -1).bit_length()
      rom_depth = (int(m["size"], 0) // dw_byte)
@@ -427,7 +429,7 @@ module top_${top["name"]} #(
   // ROM device
   logic ${lib.bitarray(1,          max_char)} ${m["name"]}_req;
   logic ${lib.bitarray(addr_width, max_char)} ${m["name"]}_addr;
-  logic ${lib.bitarray(data_width, max_char)} ${m["name"]}_rdata;
+  logic ${lib.bitarray(full_data_width, max_char)} ${m["name"]}_rdata;
   logic ${lib.bitarray(1,          max_char)} ${m["name"]}_rvalid;
 
   tlul_adapter_sram #(
@@ -452,13 +454,13 @@ module top_${top["name"]} #(
     .addr_o      (${m["name"]}_addr),
     .wdata_o     (),
     .wmask_o     (),
-    .rdata_i     (${m["name"]}_rdata),
+    .rdata_i     (${m["name"]}_rdata[${data_width-1}:0]),
     .rvalid_i    (${m["name"]}_rvalid),
     .rerror_i    (2'b00)
   );
 
   prim_rom_adv #(
-    .Width(${data_width}),
+    .Width(${full_data_width}),
     .Depth(${rom_depth}),
     .MemInitFile(BootRomInitFile)
   ) u_rom_${m["name"]} (

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -726,7 +726,7 @@ module top_earlgrey #(
   // ROM device
   logic        rom_req;
   logic [11:0] rom_addr;
-  logic [31:0] rom_rdata;
+  logic [38:0] rom_rdata;
   logic        rom_rvalid;
 
   tlul_adapter_sram #(
@@ -747,13 +747,13 @@ module top_earlgrey #(
     .addr_o      (rom_addr),
     .wdata_o     (),
     .wmask_o     (),
-    .rdata_i     (rom_rdata),
+    .rdata_i     (rom_rdata[31:0]),
     .rvalid_i    (rom_rvalid),
     .rerror_i    (2'b00)
   );
 
   prim_rom_adv #(
-    .Width(32),
+    .Width(39),
     .Depth(4096),
     .MemInitFile(BootRomInitFile)
   ) u_rom_rom (
@@ -771,9 +771,9 @@ module top_earlgrey #(
   logic        ram_main_gnt;
   logic        ram_main_we;
   logic [14:0] ram_main_addr;
-  logic [31:0] ram_main_wdata;
-  logic [31:0] ram_main_wmask;
-  logic [31:0] ram_main_rdata;
+  logic [38:0] ram_main_wdata;
+  logic [38:0] ram_main_wmask;
+  logic [38:0] ram_main_rdata;
   logic        ram_main_rvalid;
   logic [1:0]  ram_main_rerror;
 
@@ -793,15 +793,15 @@ module top_earlgrey #(
     .addr_o      (ram_main_addr),
     .wdata_o     (ram_main_wdata),
     .wmask_o     (ram_main_wmask),
-    .rdata_i     (ram_main_rdata),
+    .rdata_i     (ram_main_rdata[31:0]),
     .rvalid_i    (ram_main_rvalid),
     .rerror_i    (ram_main_rerror)
   );
 
   prim_ram_1p_scr #(
-    .Width(32),
+    .Width(39),
     .Depth(32768),
-    .EnableParity(1),
+    .EnableParity(0),
     .CfgWidth(8)
   ) u_ram1p_ram_main (
     .clk_i   (clkmgr_aon_clocks.clk_main_infra),
@@ -815,8 +815,8 @@ module top_earlgrey #(
     .gnt_o    (ram_main_gnt),
     .write_i  (ram_main_we),
     .addr_i   (ram_main_addr),
-    .wdata_i  (ram_main_wdata),
-    .wmask_i  (ram_main_wmask),
+    .wdata_i  (39'(ram_main_wdata)),
+    .wmask_i  (39'(ram_main_wmask)),
     .rdata_o  (ram_main_rdata),
     .rvalid_o (ram_main_rvalid),
     .rerror_o (ram_main_rerror),
@@ -831,9 +831,9 @@ module top_earlgrey #(
   logic        ram_ret_aon_gnt;
   logic        ram_ret_aon_we;
   logic [9:0] ram_ret_aon_addr;
-  logic [31:0] ram_ret_aon_wdata;
-  logic [31:0] ram_ret_aon_wmask;
-  logic [31:0] ram_ret_aon_rdata;
+  logic [38:0] ram_ret_aon_wdata;
+  logic [38:0] ram_ret_aon_wmask;
+  logic [38:0] ram_ret_aon_rdata;
   logic        ram_ret_aon_rvalid;
   logic [1:0]  ram_ret_aon_rerror;
 
@@ -853,15 +853,15 @@ module top_earlgrey #(
     .addr_o      (ram_ret_aon_addr),
     .wdata_o     (ram_ret_aon_wdata),
     .wmask_o     (ram_ret_aon_wmask),
-    .rdata_i     (ram_ret_aon_rdata),
+    .rdata_i     (ram_ret_aon_rdata[31:0]),
     .rvalid_i    (ram_ret_aon_rvalid),
     .rerror_i    (ram_ret_aon_rerror)
   );
 
   prim_ram_1p_scr #(
-    .Width(32),
+    .Width(39),
     .Depth(1024),
-    .EnableParity(1),
+    .EnableParity(0),
     .CfgWidth(8)
   ) u_ram1p_ram_ret_aon (
     .clk_i   (clkmgr_aon_clocks.clk_io_div4_infra),
@@ -875,8 +875,8 @@ module top_earlgrey #(
     .gnt_o    (ram_ret_aon_gnt),
     .write_i  (ram_ret_aon_we),
     .addr_i   (ram_ret_aon_addr),
-    .wdata_i  (ram_ret_aon_wdata),
-    .wmask_i  (ram_ret_aon_wmask),
+    .wdata_i  (39'(ram_ret_aon_wdata)),
+    .wmask_i  (39'(ram_ret_aon_wmask)),
     .rdata_o  (ram_ret_aon_rdata),
     .rvalid_o (ram_ret_aon_rvalid),
     .rerror_o (ram_ret_aon_rerror),

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -389,7 +389,8 @@
       type: "rom",
       base_addr: "0x00008000",
       swaccess: "ro",
-      size: "0x4000"
+      size: "0x4000",
+      integ_width: 7,
       inter_signal_list: [
         { struct: "tl"
           package: "tlul_pkg"
@@ -407,6 +408,7 @@
       base_addr: "0x10000000",
       size: "0x10000",
       byte_write: "true",
+      integ_width: 7,
       exec: "1",
       inter_signal_list: [
         { struct: "tl"
@@ -439,6 +441,7 @@
       base_addr: "0x40600000",
       size: "0x1000",
       byte_write: "true",
+      integ_width: 7,
       exec: "0",
       inter_signal_list: [
         { struct: "tl"


### PR DESCRIPTION
- Enlarge memories to include ECC
- Disable parity generation
- tlul_adapter level and above still assume previous width
- Follow-on PR will introduce more changes upstream
