### PR TITLE
[top, ast] Generate open source ast registers in topgen

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3674,7 +3674,7 @@
         rst_edn_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40150000
-      generated: "true"
+      attr: templated
       localparam:
       {
         EscCntDw: 32
@@ -3863,7 +3863,7 @@
       }
       domain: Aon
       base_addr: 0x40400000
-      generated: "true"
+      attr: templated
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_powerup
@@ -4103,7 +4103,7 @@
       }
       domain: Aon
       base_addr: 0x40410000
-      generated: "true"
+      attr: templated
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_powerup
@@ -4236,7 +4236,7 @@
       }
       domain: Aon
       base_addr: 0x40420000
-      generated: "true"
+      attr: templated
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_powerup
@@ -4428,7 +4428,7 @@
       }
       domain: Aon
       base_addr: 0x40460000
-      generated: "true"
+      attr: templated
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_powerup
@@ -4665,7 +4665,7 @@
       }
       domain: Aon
       base_addr: 0x40470000
-      generated: "true"
+      attr: templated
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_timers
@@ -4771,6 +4771,55 @@
       ]
     }
     {
+      name: ast
+      type: ast
+      clock_srcs:
+      {
+        clk_i: io_div4
+      }
+      clock_group: secure
+      clock_reset_export:
+      [
+        ast
+      ]
+      reset_connections:
+      {
+        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
+      }
+      base_addr: 0x40480000
+      attr: reggen_only
+      clock_connections:
+      {
+        clk_i: clkmgr_aon_clocks.clk_io_div4_secure
+      }
+      domain: "0"
+      size: 0x1000
+      bus_device: tlul
+      bus_host: none
+      available_input_list: []
+      available_output_list: []
+      available_inout_list: []
+      param_list: []
+      interrupt_list: []
+      alert_list: []
+      wakeup_list: []
+      reset_request_list: []
+      scan: "false"
+      scan_reset: "false"
+      inter_signal_list:
+      [
+        {
+          struct: tl
+          package: tlul_pkg
+          type: req_rsp
+          act: rsp
+          name: tl
+          inst_name: ast
+          index: -1
+        }
+      ]
+    }
+    {
       name: sensor_ctrl_aon
       type: sensor_ctrl
       clock_srcs:
@@ -4788,7 +4837,7 @@
       }
       domain: Aon
       base_addr: 0x40490000
-      top_only: "true"
+      attr: reggen_top
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_secure
@@ -5135,7 +5184,7 @@
         rst_otp_ni: rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x41000000
-      generated: "true"
+      attr: templated
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_infra
@@ -5516,7 +5565,7 @@
         rst_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x41010000
-      generated: "true"
+      attr: templated
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_secure
@@ -8079,7 +8128,7 @@
       sensor_ctrl_aon.ast_status: sensor_ctrl_ast_status
       usbdev.usb_ref_val: ""
       usbdev.usb_ref_pulse: ""
-      peri.tl_ast_wrapper: ast_tl
+      peri.tl_ast: ast_tl
       otp_ctrl.otp_ast_pwr_seq: ""
       otp_ctrl.otp_ast_pwr_seq_h: ""
       eflash.flash_bist_enable: flash_bist_enable
@@ -8797,7 +8846,7 @@
           lc_ctrl
           sensor_ctrl_aon
           alert_handler
-          ast_wrapper
+          ast
           sram_ctrl_ret_aon
           aon_timer_aon
         ]
@@ -9266,12 +9315,12 @@
           pipeline_byp: "true"
         }
         {
-          name: ast_wrapper
+          name: ast
           type: device
           clock: clk_peri_i
           reset: rst_peri_ni
           pipeline: "false"
-          stub: true
+          inst_type: ast
           addr_range:
           [
             {
@@ -9280,6 +9329,7 @@
             }
           ]
           xbar: false
+          stub: true
           pipeline_byp: "true"
         }
       ]
@@ -9602,7 +9652,7 @@
         {
           struct: tl
           type: req_rsp
-          name: tl_ast_wrapper
+          name: tl_ast
           act: req
           package: tlul_pkg
           inst_name: peri
@@ -12361,6 +12411,10 @@
         aon_peri
         usb_peri
       ]
+      ast:
+      [
+        io_div4_secure
+      ]
       sensor_ctrl_aon:
       [
         io_div4_secure
@@ -12409,6 +12463,10 @@
         sys_io_div4
         sys_aon
         usb
+      ]
+      ast:
+      [
+        sys_io_div4
       ]
       sensor_ctrl_aon:
       [
@@ -14065,6 +14123,15 @@
         index: -1
       }
       {
+        struct: tl
+        package: tlul_pkg
+        type: req_rsp
+        act: rsp
+        name: tl
+        inst_name: ast
+        index: -1
+      }
+      {
         struct: ast_alert
         type: req_rsp
         name: ast_alert
@@ -15705,7 +15772,7 @@
       {
         struct: tl
         type: req_rsp
-        name: tl_ast_wrapper
+        name: tl_ast
         act: req
         package: tlul_pkg
         inst_name: peri

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -203,8 +203,13 @@
   // `module` defines the peripherals.
   // Details are coming from each modules' config file `ip.hjson`
   // TODO: Define parameter here
-  // generated: A module is templated and generated as part of topgen
-  // top_only: A module is not templated but is specific to 'top_*' instead of 'ip'
+  // attr: There are a few types of modules supported
+     //   normal(default): Normal, non-templated modules that will be instantiated
+     //   templated:   These modules are templated and must be run through topgen
+     //   reggen_top:  These modules are not templated, but need to have reggen run
+     //                because they live exclusively in hw/top_* instead of hw/ip_*.
+     //                These modules are also instantiated in the top level.
+     //   reggen_only: Similar to reggen_top, but are not instantiated in the top level.
   module: [
     { name: "uart0",    // instance name
       type: "uart",     // Must be matched to the ip name in `ip.hson` (_reg, _cfg permitted)
@@ -357,7 +362,7 @@
       clock_group: "timers",
       reset_connections: {rst_ni: "sys_io_div4", rst_edn_ni: "sys"},
       base_addr: "0x40150000",
-      generated: "true"         // Indicate this module is generated in the topgen
+      attr: "templated",
       localparam: {
         EscCntDw:  32,
         AccuCntDw: 16,
@@ -380,7 +385,7 @@
       reset_connections: {rst_ni: "por", rst_slow_ni: "por_aon"},
       domain: "Aon",
       base_addr: "0x40400000",
-      generated: "true"         // Indicate this module is generated in the topgen
+      attr: "templated",
 
     },
     { name: "rstmgr_aon",
@@ -391,7 +396,7 @@
       reset_connections: {rst_ni: "rst_ni"},
       domain: "Aon",
       base_addr: "0x40410000",
-      generated: "true"         // Indicate this module is generated in the topgen
+      attr: "templated",
     },
     { name: "clkmgr_aon",
       type: "clkmgr",
@@ -401,7 +406,7 @@
                           rst_io_div2_ni: "por_io_div2", rst_io_div4_ni: "por_io_div4"},
       domain: "Aon",
       base_addr: "0x40420000",
-      generated: "true"
+      attr: "templated",
     },
     { name: "pinmux_aon",
       type: "pinmux",
@@ -410,7 +415,7 @@
       reset_connections: {rst_ni: "sys_io_div4", rst_aon_ni: "sys_aon"},
       domain: "Aon",
       base_addr: "0x40460000",
-      generated: "true"
+      attr: "templated",
     },
     { name: "aon_timer_aon",
       type: "aon_timer",
@@ -419,7 +424,16 @@
       reset_connections: {rst_ni: "sys_io_div4", rst_aon_ni: "sys_aon"},
       domain: "Aon",
       base_addr: "0x40470000",
-      generated: "true"
+      attr: "templated",
+    },
+    { name: "ast",
+      type: "ast",
+      clock_srcs: {clk_i: "io_div4"},
+      clock_group: "secure",
+      clock_reset_export: ["ast"],
+      reset_connections: {rst_ni: "sys_io_div4"},
+      base_addr: "0x40480000",
+      attr: "reggen_only",
     },
     { name: "sensor_ctrl_aon",
       type: "sensor_ctrl",
@@ -429,7 +443,7 @@
       reset_connections: {rst_ni: "sys_io_div4"},
       domain: "Aon",
       base_addr: "0x40490000",
-      top_only: "true"
+      attr: "reggen_top",
     },
     { name: "sram_ctrl_ret_aon",
       type: "sram_ctrl",
@@ -445,7 +459,7 @@
       clock_group: "infra",
       reset_connections: {rst_ni: "lc", rst_otp_ni: "lc_io_div4"},
       base_addr: "0x41000000",
-      generated: "true" // Indicate this module is generated in the topgen
+      attr: "templated",
     },
     { name: "rv_plic",
       type: "rv_plic",
@@ -453,7 +467,7 @@
       clock_group: "secure",
       reset_connections: {rst_ni: "sys"},
       base_addr: "0x41010000",
-      generated: "true"         // Indicate this module is generated in the topgen
+      attr: "templated",
     },
     { name: "aes",
       type: "aes",
@@ -829,7 +843,7 @@
         'sensor_ctrl_aon.ast_status'   : 'sensor_ctrl_ast_status',
         'usbdev.usb_ref_val'           : '',
         'usbdev.usb_ref_pulse'         : '',
-        'peri.tl_ast_wrapper'          : 'ast_tl',
+        'peri.tl_ast'                  : 'ast_tl',
         'otp_ctrl.otp_ast_pwr_seq'     : '',
         'otp_ctrl.otp_ast_pwr_seq_h'   : '',
         'eflash.flash_bist_enable'     : 'flash_bist_enable',

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -37,6 +37,9 @@ unused_im_defs, undriven_im_defs = lib.get_dangling_im_def(top["inter_signal"]["
 module top_${top["name"]} #(
   // Auto-inferred parameters
 % for m in top["module"]:
+  % if not lib.is_inst(m):
+<% continue %>
+  % endif
   % for p_exp in filter(lambda p: p["expose"] == "true", m["param_list"]):
   parameter ${p_exp["type"]} ${p_exp["name_top"]} = ${p_exp["default"]},
   % endfor
@@ -117,6 +120,9 @@ module top_${top["name"]} #(
   logic [${num_dio - 1}:0] dio_d2p;
   logic [${num_dio - 1}:0] dio_d2p_en;
 % for m in top["module"]:
+  % if not lib.is_inst(m):
+<% continue %>
+  % endif
   // ${m["name"]}
   % for p_in in m["available_input_list"] + m["available_inout_list"]:
     ## assume it passed validate and have available input list always
@@ -147,6 +153,9 @@ module top_${top["name"]} #(
   logic [${interrupt_num-1}:0]  intr_vector;
   // Interrupt source list
 % for m in top["module"]:
+    % if not lib.is_inst(m):
+<% continue %>
+    % endif
     % for intr in m["interrupt_list"] if "interrupt_list" in m else []:
         % if "width" in intr and int(intr["width"]) != 1:
   logic [${int(intr["width"])-1}:0] intr_${m["name"]}_${intr["name"]};
@@ -548,6 +557,9 @@ module top_${top["name"]} #(
 <% alert_idx = 0 %>
 % for m in top["module"]:
 <%
+if not lib.is_inst(m):
+     continue
+
 port_list = m["available_input_list"] + m["available_output_list"] + m["available_inout_list"]
 if len(port_list) == 0:
     max_sigwidth = 0

--- a/hw/top_earlgrey/data/xbar_peri.hjson
+++ b/hw/top_earlgrey/data/xbar_peri.hjson
@@ -165,26 +165,18 @@
       reset:     "rst_peri_ni",
       pipeline:  "false",
     }
-    { name:      "ast_wrapper",
+    { name:      "ast",
       type:      "device",
       clock:     "clk_peri_i",
       reset:     "rst_peri_ni",
       pipeline:  "false",
-      stub:      true,
-      addr_range:
-      [
-        {
-          base_addr: 0x40480000
-          size_byte: 0x1000
-        }
-      ]
     },
   ],
   connections: {
     main:  ["uart0", "uart1", "uart2", "uart3", "i2c0", "i2c1", "i2c2", "pattgen",
             "gpio", "spi_device", "spi_host0", "spi_host1", "rv_timer", "usbdev",
             "pwrmgr_aon", "rstmgr_aon", "clkmgr_aon", "pinmux_aon", "ram_ret_aon",
-            "otp_ctrl", "lc_ctrl", "sensor_ctrl_aon", "alert_handler", "ast_wrapper",
+            "otp_ctrl", "lc_ctrl", "sensor_ctrl_aon", "alert_handler", "ast",
             "sram_ctrl_ret_aon", "aon_timer_aon"],
   },
 }

--- a/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
@@ -74,7 +74,7 @@ tl_if sensor_ctrl_aon_tl_if(clk_io_div4, rst_n);
 tl_if alert_handler_tl_if(clk_io_div4, rst_n);
 tl_if sram_ctrl_ret_aon_tl_if(clk_io_div4, rst_n);
 tl_if aon_timer_aon_tl_if(clk_io_div4, rst_n);
-tl_if ast_wrapper_tl_if(clk_io_div4, rst_n);
+tl_if ast_tl_if(clk_io_div4, rst_n);
 
 initial begin
   bit xbar_mode;
@@ -144,7 +144,7 @@ initial begin
     `DRIVE_CHIP_TL_DEVICE_IF(alert_handler, alert_handler, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(sram_ctrl_ret_aon, sram_ctrl_ret_aon, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(aon_timer_aon, aon_timer_aon, tl)
-    `DRIVE_CHIP_TL_EXT_DEVICE_IF(ast_wrapper, ast_tl)
+    `DRIVE_CHIP_TL_EXT_DEVICE_IF(ast, ast_tl)
   end
 end
 

--- a/hw/top_earlgrey/dv/autogen/xbar_env_pkg__params.sv
+++ b/hw/top_earlgrey/dv/autogen/xbar_env_pkg__params.sv
@@ -130,7 +130,7 @@ tl_device_t xbar_devices[$] = '{
     '{"aon_timer_aon", '{
         '{32'h40470000, 32'h40470fff}
     }},
-    '{"ast_wrapper", '{
+    '{"ast", '{
         '{32'h40480000, 32'h40480fff}
     }}};
 
@@ -170,7 +170,7 @@ tl_host_t xbar_hosts[$] = '{
         "lc_ctrl",
         "sensor_ctrl_aon",
         "alert_handler",
-        "ast_wrapper",
+        "ast",
         "sram_ctrl_ret_aon",
         "aon_timer_aon",
         "flash_ctrl",
@@ -213,7 +213,7 @@ tl_host_t xbar_hosts[$] = '{
         "lc_ctrl",
         "sensor_ctrl_aon",
         "alert_handler",
-        "ast_wrapper",
+        "ast",
         "sram_ctrl_ret_aon",
         "aon_timer_aon",
         "flash_ctrl",

--- a/hw/top_earlgrey/ip/ast/rtl/ast_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_reg_pkg.sv
@@ -6,13 +6,12 @@
 
 package ast_reg_pkg;
 
+  // Address width within the block
+  parameter int BlockAw = 3;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////
-  typedef struct packed {
-    logic [7:0]  q;
-  } ast_reg2hw_revid_reg_t;
-
   typedef struct packed {
     logic [31:0] q;
   } ast_reg2hw_rwtype0_reg_t;
@@ -43,7 +42,6 @@ package ast_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    ast_reg2hw_revid_reg_t revid; // [50:43]
     ast_reg2hw_rwtype0_reg_t rwtype0; // [42:11]
     ast_reg2hw_rwtype1_reg_t rwtype1; // [10:0]
   } ast_reg2hw_t;
@@ -56,23 +54,19 @@ package ast_reg_pkg;
   } ast_hw2reg_t;
 
   // Register Address
-  parameter logic [3:0] AST_REVID_OFFSET = 4'h 0;
-  parameter logic [3:0] AST_RWTYPE0_OFFSET = 4'h 4;
-  parameter logic [3:0] AST_RWTYPE1_OFFSET = 4'h 8;
-
+  parameter logic [BlockAw-1:0] AST_RWTYPE0_OFFSET = 3'h 0;
+  parameter logic [BlockAw-1:0] AST_RWTYPE1_OFFSET = 3'h 4;
 
   // Register Index
   typedef enum int {
-    AST_REVID,
     AST_RWTYPE0,
     AST_RWTYPE1
   } ast_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] AST_PERMIT [3] = '{
-    4'b 0001, // index[0] AST_REVID
-    4'b 1111, // index[1] AST_RWTYPE0
-    4'b 0011  // index[2] AST_RWTYPE1
+  parameter logic [3:0] AST_PERMIT [2] = '{
+    4'b 1111, // index[0] AST_RWTYPE0
+    4'b 0011  // index[1] AST_RWTYPE1
   };
 endpackage
 

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -629,6 +629,7 @@ module clkmgr import clkmgr_pkg::*; (
   assign clocks_ast_o.clk_ast_usbdev_io_div4_peri = clocks_o.clk_io_div4_peri;
   assign clocks_ast_o.clk_ast_usbdev_aon_peri = clocks_o.clk_aon_peri;
   assign clocks_ast_o.clk_ast_usbdev_usb_peri = clocks_o.clk_usb_peri;
+  assign clocks_ast_o.clk_ast_ast_io_div4_secure = clocks_o.clk_io_div4_secure;
   assign clocks_ast_o.clk_ast_sensor_ctrl_aon_io_div4_secure = clocks_o.clk_io_div4_secure;
   assign clocks_ast_o.clk_ast_entropy_src_main_secure = clocks_o.clk_main_secure;
   assign clocks_ast_o.clk_ast_edn0_main_secure = clocks_o.clk_main_secure;

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -49,6 +49,7 @@ package clkmgr_pkg;
     logic clk_ast_usbdev_io_div4_peri;
     logic clk_ast_usbdev_aon_peri;
     logic clk_ast_usbdev_usb_peri;
+    logic clk_ast_ast_io_div4_secure;
     logic clk_ast_sensor_ctrl_aon_io_div4_secure;
     logic clk_ast_entropy_src_main_secure;
     logic clk_ast_edn0_main_secure;

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -747,6 +747,7 @@ module rstmgr import rstmgr_pkg::*; (
   assign resets_ast_o.rst_ast_usbdev_sys_io_div4_n = resets_o.rst_sys_io_div4_n;
   assign resets_ast_o.rst_ast_usbdev_sys_aon_n = resets_o.rst_sys_aon_n;
   assign resets_ast_o.rst_ast_usbdev_usb_n = resets_o.rst_usb_n;
+  assign resets_ast_o.rst_ast_ast_sys_io_div4_n = resets_o.rst_sys_io_div4_n;
   assign resets_ast_o.rst_ast_sensor_ctrl_aon_sys_io_div4_n = resets_o.rst_sys_io_div4_n;
   assign resets_ast_o.rst_ast_entropy_src_sys_n = resets_o.rst_sys_n;
   assign resets_ast_o.rst_ast_edn0_sys_n = resets_o.rst_sys_n;

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_pkg.sv
@@ -65,6 +65,7 @@ package rstmgr_pkg;
     logic [PowerDomains-1:0] rst_ast_usbdev_sys_io_div4_n;
     logic [PowerDomains-1:0] rst_ast_usbdev_sys_aon_n;
     logic [PowerDomains-1:0] rst_ast_usbdev_usb_n;
+    logic [PowerDomains-1:0] rst_ast_ast_sys_io_div4_n;
     logic [PowerDomains-1:0] rst_ast_sensor_ctrl_aon_sys_io_div4_n;
     logic [PowerDomains-1:0] rst_ast_entropy_src_sys_n;
     logic [PowerDomains-1:0] rst_ast_edn0_sys_n;

--- a/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
@@ -50,7 +50,7 @@
       lc_ctrl
       sensor_ctrl_aon
       alert_handler
-      ast_wrapper
+      ast
       sram_ctrl_ret_aon
       aon_timer_aon
     ]
@@ -519,12 +519,12 @@
       pipeline_byp: "true"
     }
     {
-      name: ast_wrapper
+      name: ast
       type: device
       clock: clk_peri_i
       reset: rst_peri_ni
       pipeline: "false"
-      stub: true
+      inst_type: ast
       addr_range:
       [
         {
@@ -533,6 +533,7 @@
         }
       ]
       xbar: false
+      stub: true
       pipeline_byp: "true"
     }
   ]

--- a/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.hjson
@@ -171,7 +171,7 @@
     }
     { struct: "tl"
       type:   "req_rsp"
-      name:   "tl_ast_wrapper"
+      name:   "tl_ast"
       act:    "req"
       package: "tlul_pkg"
     }

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/tb__xbar_connect.sv
@@ -42,4 +42,4 @@ initial force dut.rst_peri_ni = rst_n;
 `CONNECT_TL_DEVICE_IF(alert_handler, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(sram_ctrl_ret_aon, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(aon_timer_aon, dut, clk_peri_i, rst_n)
-`CONNECT_TL_DEVICE_IF(ast_wrapper, dut, clk_peri_i, rst_n)
+`CONNECT_TL_DEVICE_IF(ast, dut, clk_peri_i, rst_n)

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_cover.cfg
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_cover.cfg
@@ -105,10 +105,10 @@
 -node tb.dut tl_aon_timer_aon_o.a_address[21:19]
 -node tb.dut tl_aon_timer_aon_o.a_address[29:23]
 -node tb.dut tl_aon_timer_aon_o.a_address[31:31]
--node tb.dut tl_ast_wrapper_o.a_address[18:12]
--node tb.dut tl_ast_wrapper_o.a_address[21:20]
--node tb.dut tl_ast_wrapper_o.a_address[29:23]
--node tb.dut tl_ast_wrapper_o.a_address[31:31]
+-node tb.dut tl_ast_o.a_address[18:12]
+-node tb.dut tl_ast_o.a_address[21:20]
+-node tb.dut tl_ast_o.a_address[29:23]
+-node tb.dut tl_ast_o.a_address[31:31]
 
 begin tgl
   -tree tb

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_env_pkg__params.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_env_pkg__params.sv
@@ -82,7 +82,7 @@ tl_device_t xbar_devices[$] = '{
     '{"aon_timer_aon", '{
         '{32'h40470000, 32'h40470fff}
     }},
-    '{"ast_wrapper", '{
+    '{"ast", '{
         '{32'h40480000, 32'h40480fff}
 }}};
 
@@ -112,7 +112,7 @@ tl_host_t xbar_hosts[$] = '{
         "lc_ctrl",
         "sensor_ctrl_aon",
         "alert_handler",
-        "ast_wrapper",
+        "ast",
         "sram_ctrl_ret_aon",
         "aon_timer_aon"}}
 };

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_bind.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_bind.sv
@@ -164,11 +164,11 @@ module xbar_peri_bind;
     .h2d    (tl_aon_timer_aon_o),
     .d2h    (tl_aon_timer_aon_i)
   );
-  bind xbar_peri tlul_assert #(.EndpointType("Host")) tlul_assert_device_ast_wrapper (
+  bind xbar_peri tlul_assert #(.EndpointType("Host")) tlul_assert_device_ast (
     .clk_i  (clk_peri_i),
     .rst_ni (rst_peri_ni),
-    .h2d    (tl_ast_wrapper_o),
-    .d2h    (tl_ast_wrapper_i)
+    .h2d    (tl_ast_o),
+    .d2h    (tl_ast_i)
   );
 
 endmodule

--- a/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/tl_peri_pkg.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/tl_peri_pkg.sv
@@ -31,7 +31,7 @@ package tl_peri_pkg;
   localparam logic [31:0] ADDR_SPACE_ALERT_HANDLER     = 32'h 40150000;
   localparam logic [31:0] ADDR_SPACE_SRAM_CTRL_RET_AON = 32'h 40500000;
   localparam logic [31:0] ADDR_SPACE_AON_TIMER_AON     = 32'h 40470000;
-  localparam logic [31:0] ADDR_SPACE_AST_WRAPPER       = 32'h 40480000;
+  localparam logic [31:0] ADDR_SPACE_AST               = 32'h 40480000;
 
   localparam logic [31:0] ADDR_MASK_UART0             = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_UART1             = 32'h 00000fff;
@@ -58,7 +58,7 @@ package tl_peri_pkg;
   localparam logic [31:0] ADDR_MASK_ALERT_HANDLER     = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_SRAM_CTRL_RET_AON = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_AON_TIMER_AON     = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_AST_WRAPPER       = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_AST               = 32'h 00000fff;
 
   localparam int N_HOST   = 1;
   localparam int N_DEVICE = 26;
@@ -89,7 +89,7 @@ package tl_peri_pkg;
     TlAlertHandler = 22,
     TlSramCtrlRetAon = 23,
     TlAonTimerAon = 24,
-    TlAstWrapper = 25
+    TlAst = 25
   } tl_device_e;
 
   typedef enum int {

--- a/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/xbar_peri.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/xbar_peri.sv
@@ -31,7 +31,7 @@
 //     -> lc_ctrl
 //     -> sensor_ctrl_aon
 //     -> alert_handler
-//     -> ast_wrapper
+//     -> ast
 //     -> sram_ctrl_ret_aon
 //     -> aon_timer_aon
 
@@ -94,8 +94,8 @@ module xbar_peri (
   input  tlul_pkg::tl_d2h_t tl_sram_ctrl_ret_aon_i,
   output tlul_pkg::tl_h2d_t tl_aon_timer_aon_o,
   input  tlul_pkg::tl_d2h_t tl_aon_timer_aon_i,
-  output tlul_pkg::tl_h2d_t tl_ast_wrapper_o,
-  input  tlul_pkg::tl_d2h_t tl_ast_wrapper_i,
+  output tlul_pkg::tl_h2d_t tl_ast_o,
+  input  tlul_pkg::tl_d2h_t tl_ast_i,
 
   input lc_ctrl_pkg::lc_tx_t scanmode_i
 );
@@ -189,8 +189,8 @@ module xbar_peri (
   assign tl_alert_handler_o = tl_s1n_27_ds_h2d[22];
   assign tl_s1n_27_ds_d2h[22] = tl_alert_handler_i;
 
-  assign tl_ast_wrapper_o = tl_s1n_27_ds_h2d[23];
-  assign tl_s1n_27_ds_d2h[23] = tl_ast_wrapper_i;
+  assign tl_ast_o = tl_s1n_27_ds_h2d[23];
+  assign tl_s1n_27_ds_d2h[23] = tl_ast_i;
 
   assign tl_sram_ctrl_ret_aon_o = tl_s1n_27_ds_h2d[24];
   assign tl_s1n_27_ds_d2h[24] = tl_sram_ctrl_ret_aon_i;
@@ -273,7 +273,7 @@ module xbar_peri (
     end else if ((tl_s1n_27_us_h2d.a_address & ~(ADDR_MASK_ALERT_HANDLER)) == ADDR_SPACE_ALERT_HANDLER) begin
       dev_sel_s1n_27 = 5'd22;
 
-    end else if ((tl_s1n_27_us_h2d.a_address & ~(ADDR_MASK_AST_WRAPPER)) == ADDR_SPACE_AST_WRAPPER) begin
+    end else if ((tl_s1n_27_us_h2d.a_address & ~(ADDR_MASK_AST)) == ADDR_SPACE_AST) begin
       dev_sel_s1n_27 = 5'd23;
 
     end else if ((tl_s1n_27_us_h2d.a_address & ~(ADDR_MASK_SRAM_CTRL_RET_AON)) == ADDR_SPACE_SRAM_CTRL_RET_AON) begin

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -2422,9 +2422,9 @@ module top_earlgrey #(
     .tl_aon_timer_aon_o(aon_timer_aon_tl_req),
     .tl_aon_timer_aon_i(aon_timer_aon_tl_rsp),
 
-    // port: tl_ast_wrapper
-    .tl_ast_wrapper_o(ast_tl_req_o),
-    .tl_ast_wrapper_i(ast_tl_rsp_i),
+    // port: tl_ast
+    .tl_ast_o(ast_tl_req_o),
+    .tl_ast_i(ast_tl_rsp_i),
 
 
     .scanmode_i

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
@@ -232,6 +232,16 @@ package top_earlgrey_pkg;
   parameter int unsigned TOP_EARLGREY_AON_TIMER_AON_SIZE_BYTES = 32'h1000;
 
   /**
+   * Peripheral base address for ast in top earlgrey.
+   */
+  parameter int unsigned TOP_EARLGREY_AST_BASE_ADDR = 32'h40480000;
+
+  /**
+   * Peripheral size in bytes for ast in top earlgrey.
+   */
+  parameter int unsigned TOP_EARLGREY_AST_SIZE_BYTES = 32'h1000;
+
+  /**
    * Peripheral base address for sensor_ctrl_aon in top earlgrey.
    */
   parameter int unsigned TOP_EARLGREY_SENSOR_CTRL_AON_BASE_ADDR = 32'h40490000;

--- a/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
@@ -446,12 +446,15 @@ module top_earlgrey_asic (
   logic unused_usb_usb_rst;
   logic [PowerDomains-1:0] unused_usb_sys_io_div4_rst;
   logic [PowerDomains-1:0] unused_usb_sys_aon_rst;
+  logic unused_ast_sys_io_div4_rst;
   logic unused_sensor_ctrl_sys_io_div4_rst;
   logic unused_entropy_sys_rst;
   logic unused_edn_sys_rst;
   assign unused_usb_usb_rst = rsts_ast.rst_ast_usbdev_usb_n[DomainAonSel];
   assign unused_usb_sys_io_div4_rst = rsts_ast.rst_ast_usbdev_sys_io_div4_n;
   assign unused_usb_sys_aon_rst = rsts_ast.rst_ast_usbdev_sys_aon_n;
+  assign unused_ast_sys_io_div4_rst =
+    rsts_ast.rst_ast_ast_sys_io_div4_n[Domain0Sel];
   assign unused_sensor_ctrl_sys_io_div4_rst =
     rsts_ast.rst_ast_sensor_ctrl_aon_sys_io_div4_n[Domain0Sel];
   assign unused_entropy_sys_rst = rsts_ast.rst_ast_entropy_src_sys_n[DomainAonSel];
@@ -479,8 +482,8 @@ module top_earlgrey_asic (
     .rst_ast_es_ni         ( rsts_ast.rst_ast_edn0_sys_n[Domain0Sel] ),
     .clk_ast_rng_i         ( clks_ast.clk_ast_entropy_src_main_secure ),
     .rst_ast_rng_ni        ( rsts_ast.rst_ast_entropy_src_sys_n[Domain0Sel] ),
-    .clk_ast_tlul_i        ( clks_ast.clk_ast_sensor_ctrl_aon_io_div4_secure ),
-    .rst_ast_tlul_ni       ( rsts_ast.rst_ast_sensor_ctrl_aon_sys_io_div4_n[DomainAonSel] ),
+    .clk_ast_tlul_i        ( clks_ast.clk_ast_ast_io_div4_secure ),
+    .rst_ast_tlul_ni       ( rsts_ast.rst_ast_ast_sys_io_div4_n[DomainAonSel] ),
     .clk_ast_usb_i         ( clks_ast.clk_ast_usbdev_usb_peri ),
     .rst_ast_usb_ni        ( rsts_ast.rst_ast_usbdev_usb_n[Domain0Sel] ),
     .clk_ast_ext_i         ( ext_clk ),

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -422,6 +422,24 @@ extern "C" {
 #define TOP_EARLGREY_AON_TIMER_AON_SIZE_BYTES 0x1000u
 
 /**
+ * Peripheral base address for ast in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_AST_BASE_ADDR 0x40480000u
+
+/**
+ * Peripheral size for ast in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_AST_BASE_ADDR and
+ * `TOP_EARLGREY_AST_BASE_ADDR + TOP_EARLGREY_AST_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_AST_SIZE_BYTES 0x1000u
+
+/**
  * Peripheral base address for sensor_ctrl_aon in top earlgrey.
  *
  * This should be used with #mmio_region_from_addr to access the memory-mapped

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -198,9 +198,13 @@
 
   // `module` defines the peripherals.
   // Details are coming from each modules' config file `ip.hjson`
-  // TODO: Define parameter here
-  // generated: A module is templated and generated as part of topgen
-  // top_only: A module is not templated but is specific to 'top_*' instead of 'ip'
+  // attr: There are a few types of modules supported
+     //   normal(default): Normal, non-templated modules that will be instantiated
+     //   templated: These modules are templated and must be run through topgen
+     //   reggen_top: These modules are not templated, but need to have reggen run
+     //              because they live exclusively in hw/top_* instead of hw/ip_*.
+     //              These modules are also instantiated as others.
+     //   reggen_only: Similar to reggen_top, but are not instantiated in the top level.
   module: [
     { name: "uart0",    // instance name
       type: "uart",     // Must be matched to the ip name in `ip.hson` (_reg, _cfg permitted)
@@ -266,7 +270,7 @@
       clock_group: "timers",
       reset_connections: {rst_ni: "sys_io_div4", rst_edn_ni: "sys"},
       base_addr: "0x40150000",
-      generated: "true"         // Indicate this module is generated in the topgen
+      attr: "templated"         // Indicate this module is generated in the topgen
       localparam: {
         EscCntDw:  32,
         AccuCntDw: 16,
@@ -289,7 +293,7 @@
       reset_connections: {rst_ni: "por", rst_slow_ni: "por_aon"},
       domain: "Aon",
       base_addr: "0x40400000",
-      generated: "true"         // Indicate this module is generated in the topgen
+      attr: "templated"         // Indicate this module is generated in the topgen
 
     },
     { name: "rstmgr_aon",
@@ -300,7 +304,7 @@
       reset_connections: {rst_ni: "rst_ni"},
       domain: "Aon",
       base_addr: "0x40410000",
-      generated: "true"         // Indicate this module is generated in the topgen
+      attr: "templated"         // Indicate this module is generated in the topgen
     },
     { name: "clkmgr_aon",
       type: "clkmgr",
@@ -310,7 +314,7 @@
                           rst_io_div2_ni: "por_io_div2", rst_io_div4_ni: "por_io_div4"},
       domain: "Aon",
       base_addr: "0x40420000",
-      generated: "true"
+      attr: "templated"
     },
     { name: "pinmux_aon",
       type: "pinmux",
@@ -320,7 +324,7 @@
       reset_connections: {rst_ni: "sys_io_div4", rst_aon_ni: "sys_aon"},
       domain: "Aon",
       base_addr: "0x40460000",
-      generated: "true"
+      attr: "templated"
     },
     { name: "sensor_ctrl_aon",
       type: "sensor_ctrl",
@@ -330,7 +334,7 @@
       reset_connections: {rst_ni: "sys_io_div4"},
       domain: "Aon",
       base_addr: "0x40500000",
-      top_only: "true"
+      attr: "reggen_top",
     },
     { name: "sram_ctrl_ret_aon",
       type: "sram_ctrl",
@@ -346,7 +350,7 @@
       clock_group: "infra",
       reset_connections: {rst_ni: "lc", rst_otp_ni: "lc_io_div4"},
       base_addr: "0x41000000",
-      generated: "true" // Indicate this module is generated in the topgen
+      attr: "templated" // Indicate this module is generated in the topgen
     },
     { name: "rv_plic",
       type: "rv_plic",
@@ -354,7 +358,7 @@
       clock_group: "secure",
       reset_connections: {rst_ni: "sys"},
       base_addr: "0x41010000",
-      generated: "true"         // Indicate this module is generated in the topgen
+      attr: "templated"         // Indicate this module is generated in the topgen
     },
     { name: "aes",
       type: "aes",
@@ -618,7 +622,6 @@
         'sensor_ctrl_aon.ast_status'   : 'sensor_ctrl_ast_status',
         'usbdev.usb_ref_val'           : '',
         'usbdev.usb_ref_pulse'         : '',
-        'peri.tl_ast_wrapper'          : 'ast_tl',
         'eflash.flash_bist_enable'     : 'flash_bist_enable',
         'eflash.flash_power_down_h'    : 'flash_power_down_h',
         'eflash.flash_power_ready_h'   : 'flash_power_ready_h',

--- a/hw/top_englishbreakfast/data/xbar_peri.hjson
+++ b/hw/top_englishbreakfast/data/xbar_peri.hjson
@@ -113,25 +113,17 @@
       reset:     "rst_peri_ni",
       pipeline:  "false",
     }
-    { name:      "ast_wrapper",
-      type:      "device",
-      clock:     "clk_peri_i",
-      reset:     "rst_peri_ni",
-      pipeline:  "false",
-      stub:      true,
-      addr_range:
-      [
-        {
-          base_addr: 0x40490000
-          size_byte: 0x1000
-        }
-      ]
-    },
+//    { name:      "ast",
+//      type:      "device",
+//      clock:     "clk_peri_i",
+//      reset:     "rst_peri_ni",
+//      pipeline:  "false",
+//    },
   ],
   connections: {
     main:  ["uart0", "gpio", "spi_device", "spi_host0", "rv_timer", "usbdev",
             "pwrmgr_aon", "rstmgr_aon", "clkmgr_aon", "pinmux_aon", "ram_ret_aon",
-            "lc_ctrl", "sensor_ctrl_aon", "alert_handler", "nmi_gen", "ast_wrapper",
+            "lc_ctrl", "sensor_ctrl_aon", "alert_handler", "nmi_gen",
             "sram_ctrl_ret_aon"],
   },
 }

--- a/hw/top_englishbreakfast/rtl/top_englishbreakfast_cw305.sv
+++ b/hw/top_englishbreakfast/rtl/top_englishbreakfast_cw305.sv
@@ -345,8 +345,6 @@ module top_englishbreakfast_cw305 #(
     .sensor_ctrl_ast_status_i     ( ast_base_status ),
     .usbdev_usb_ref_val_o         (                 ),
     .usbdev_usb_ref_pulse_o       (                 ),
-    .ast_tl_req_o                 (                 ),
-    .ast_tl_rsp_i                 ( '0              ),
     .flash_bist_enable_i          ( 1'b0            ),
     .flash_power_down_h_i         ( 1'b0            ),
     .flash_power_ready_h_i        ( 1'b1            ),

--- a/hw/top_englishbreakfast/rtl/top_englishbreakfast_verilator.sv
+++ b/hw/top_englishbreakfast/rtl/top_englishbreakfast_verilator.sv
@@ -142,8 +142,6 @@ module top_englishbreakfast_verilator (
     .sensor_ctrl_ast_status_i     ( ast_base_status ),
     .usbdev_usb_ref_val_o         (                 ),
     .usbdev_usb_ref_pulse_o       (                 ),
-    .ast_tl_req_o                 (                 ),
-    .ast_tl_rsp_i                 ( '0              ),
     .flash_power_down_h_i         ( '0              ),
     .flash_power_ready_h_i        ( 1'b1            ),
 

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -22,6 +22,7 @@ import tlgen
 from reggen import access, gen_dv, gen_rtl, validate, window
 from topgen import amend_clocks, get_hjsonobj_xbars
 from topgen import intermodule as im
+from topgen import lib as lib
 from topgen import merge_top, search_ips, validate_top
 from topgen.c import TopGenC
 
@@ -872,7 +873,7 @@ def _process_top(topcfg, args, cfg_path, out_path, pass_idx):
     # These modules are generated through topgen
     generated_list = [
         module['type'] for module in topcfg['module']
-        if 'generated' in module and module['generated'] == 'true'
+        if lib.is_templated(module)
     ]
     log.info("Filtered list is {}".format(generated_list))
 
@@ -880,7 +881,7 @@ def _process_top(topcfg, args, cfg_path, out_path, pass_idx):
     # and therefore not part of "hw/ip"
     top_only_list = [
         module['type'] for module in topcfg['module']
-        if 'top_only' in module and module['top_only'] == 'true'
+        if lib.is_top_reggen(module)
     ]
     log.info("Filtered list is {}".format(top_only_list))
 

--- a/util/topgen/intermodule.py
+++ b/util/topgen/intermodule.py
@@ -128,7 +128,7 @@ def autoconnect_xbar(topcfg: OrderedDict, xbar: OrderedDict):
         # check if name exists in ["module", "memory"]
         ips = [
             x for x in topcfg["module"] + topcfg["memory"]
-            if x["name"] == port["name"]
+            if x["name"] == port["name"] and lib.is_inst(x)
         ]
 
         assert len(ips) <= 1
@@ -555,7 +555,7 @@ def find_otherside_modules(topcfg: OrderedDict, m,
         ('main', 'tl_cored'): ('rv_core_ibex', 'tl_d'),
         ('main', 'tl_dm_sba'): ('dm_top', 'tl_h'),
         ('main', 'tl_debug_mem'): ('dm_top', 'tl_d'),
-        ('peri', 'tl_ast_wrapper'): ('ast', 'tl')
+        ('peri', 'tl_ast'): ('ast', 'tl')
     }
     for pair in special_inst_names:
         if pair == (m, s):

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -274,3 +274,49 @@ def get_unused_resets(top):
 
     log.debug("Unused resets are {}".format(unused_resets))
     return unused_resets
+
+
+def is_templated(module):
+    """Returns an indication where a particular module is templated
+    """
+    if "attr" not in module:
+        return False
+    elif module["attr"] in ["templated"]:
+        return True
+    else:
+        return False
+
+
+def is_top_reggen(module):
+    """Returns an indication where a particular module is NOT templated
+       and requires top level specific reggen
+    """
+    if "attr" not in module:
+        return False
+    elif module["attr"] in ["reggen_top", "reggen_only"]:
+        return True
+    else:
+        return False
+
+
+def is_inst(module):
+    """Returns an indication where a particular module should be instantiated
+       in the top level
+    """
+    top_level_module = False
+    top_level_mem = False
+
+    if "attr" not in module:
+        top_level_module = True
+    elif module["attr"] in ["normal", "templated", "reggen_top"]:
+        top_level_module = True
+    elif module["attr"] in ["reggen_only"]:
+        top_level_module = False
+    else:
+        raise ValueError('Attribute {} in {} is not valid'
+                         .format(module['attr'], module['name']))
+
+    if module['type'] in ['rom', 'ram_1p_scr', 'eflash']:
+        top_level_mem = True
+
+    return top_level_mem or top_level_module

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -377,28 +377,10 @@ def xbar_adddevice(top, xbar, device):
         # case 3: not defined
         else:
             # Crossbar check
-            if len(nodeobj) == 0:
-                log.error("""
-                    Device %s doesn't exist in 'module', 'memory', predefined,
-                    or as a node object
-                    """ % device)
-            else:
-                node = nodeobj[0]
-                node["xbar"] = False
-                required_keys = ["addr_range"]
-                if "stub" in node and node["stub"]:
-                    log.info("""
-                        Device %s definition is a stub and does not exist in
-                        'module', 'memory' or predefined
-                        """ % device)
-
-                    if all(key in required_keys for key in node.keys()):
-                        log.error(
-                            "{}, The xbar only node is missing fields, see {}".
-                            format(node['name'], required_keys))
-                    process_pipeline_var(node)
-                else:
-                    log.error("Device {} definition is not a stub!")
+            log.error("""
+            Device %s doesn't exist in 'module', 'memory', predefined,
+            or as a node object
+            """ % device)
 
             return
 
@@ -417,7 +399,7 @@ def xbar_adddevice(top, xbar, device):
             "pipeline": "true",
             "pipeline_byp": "true",
             "xbar": True if device in xbar_list else False,
-            "stub": False
+            "stub": not lib.is_inst(deviceobj[0])
         })  # yapf: disable
 
     else:
@@ -429,7 +411,7 @@ def xbar_adddevice(top, xbar, device):
                          ("size_byte", deviceobj[0]["size"])])
         ]
         node["xbar"] = True if device in xbar_list else False
-        node["stub"] = False
+        node["stub"] = not lib.is_inst(deviceobj[0])
         process_pipeline_var(node)
 
 
@@ -678,7 +660,6 @@ def amend_resets(top):
        intermodule.
     """
 
-    rstmgr = [m for m in top['module'] if m['type'] == 'rstmgr']
     rstmgr_name = _find_module_name(top['module'], 'rstmgr')
 
     # Generate exported reset list
@@ -705,7 +686,7 @@ def amend_resets(top):
     # add entry to inter_module automatically
     for intf in top['exported_rsts']:
         top['inter_module']['external']['{}.resets_{}'.format(
-            rstmgr_name,intf)] = "rsts_{}".format(intf)
+            rstmgr_name, intf)] = "rsts_{}".format(intf)
     """Discover the full path and selection to each reset connection.
        This is done by modifying the reset connection of each end point.
     """


### PR DESCRIPTION
- generate open source ast registers as part of topgen
- remove the need for xbar_peri to hardcode ast address
- introduce different module attributes to distinguish
  between normal modules, templated modules, and top specific
  modules like sensor_ctrl and ast