### PR TITLE
[tlul] Fix "unused" name for AscentLint too

### DIFF
--- a/hw/ip/tlul/rtl/tlul_err_resp.sv
+++ b/hw/ip/tlul/rtl/tlul_err_resp.sv
@@ -57,7 +57,7 @@ module tlul_err_resp (
   end
 
   // Waive unused bits of tl_h_i
-  logic tl_h_unused = &{1'b0,
+  logic unused_tl_h = &{1'b0,
                         tl_h_i.a_param, tl_h_i.a_address, tl_h_i.a_mask,
                         tl_h_i.a_data, tl_h_i.a_user, tl_h_i.d_ready};
 


### PR DESCRIPTION
It seems that Verilator is happy to treat `foo_unused` as a hint that
the signal is unused, but AscentLint requires the name to start with
`unused` instead.
