### PR TITLE
[aes] Update development stages

### DIFF
--- a/hw/ip/aes/data/aes.prj.hjson
+++ b/hw/ip/aes/data/aes.prj.hjson
@@ -7,8 +7,10 @@
     design_spec:        "hw/ip/aes/doc",
     dv_doc:            "hw/ip/aes/doc/dv",
     hw_checklist:       "hw/ip/aes/doc/checklist",
+    sw_checklist:       "sw/device/lib/dif/dif_aes",
     version:            "1.0",
     life_stage:         "L1",
     design_stage:       "D1",
     verification_stage: "V1",
+    dif_stage:          "S0",
 }

--- a/hw/ip/aes/data/aes.prj.hjson
+++ b/hw/ip/aes/data/aes.prj.hjson
@@ -5,7 +5,7 @@
 {
     name:               "aes",
     design_spec:        "hw/ip/aes/doc",
-    dv_doc:            "hw/ip/aes/doc/dv",
+    dv_doc:             "hw/ip/aes/doc/dv",
     hw_checklist:       "hw/ip/aes/doc/checklist",
     sw_checklist:       "sw/device/lib/dif/dif_aes",
     version:            "1.0",
@@ -13,4 +13,5 @@
     design_stage:       "D1",
     verification_stage: "V1",
     dif_stage:          "S0",
+    notes:              "D2 except for SEC_CM_IMPLEMENTED; SCA/FI hardening in progress",
 }

--- a/hw/ip/aes/doc/checklist.md
+++ b/hw/ip/aes/doc/checklist.md
@@ -35,24 +35,24 @@ Code Quality  | [LINT_SETUP][]                 | Done        |
 
 Type          | Item                    | Resolution  | Note/Collaterals
 --------------|-------------------------|-------------|------------------
-Documentation | [NEW_FEATURES][]        | Not Started |
-Documentation | [BLOCK_DIAGRAM][]       | Not Started |
+Documentation | [NEW_FEATURES][]        | In progress | Security review pending
+Documentation | [BLOCK_DIAGRAM][]       | In progress | Security review pending
 Documentation | [DOC_INTERFACE][]       | Done        |
-Documentation | [MISSING_FUNC][]        | Not Started |
-Documentation | [FEATURE_FROZEN][]      | Not Started |
-RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_CHECK][]          | Not Started |
+Documentation | [MISSING_FUNC][]        | Done        |
+Documentation | [FEATURE_FROZEN][]      | Done        |
+RTL           | [FEATURE_COMPLETE][]    | Done        |
+RTL           | [AREA_CHECK][]          | Done        |
 RTL           | [PORT_FROZEN][]         | Done        |
-RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
+RTL           | [ARCHITECTURE_FROZEN][] | In progress | SCA/FI hardening in progress
 RTL           | [REVIEW_TODO][]         | Done        |
-RTL           | [STYLE_X][]             | Not Started |
-Code Quality  | [LINT_PASS][]           | Not Started |
-Code Quality  | [CDC_SETUP][]           | Not Started |
-Code Quality  | [FPGA_TIMING][]         | Not Started |
+RTL           | [STYLE_X][]             | Done        |
+Code Quality  | [LINT_PASS][]           | Done        |
+Code Quality  | [CDC_SETUP][]           | Waived      | CDC flow is not available yet.
+Code Quality  | [FPGA_TIMING][]         | Done        |
 Code Quality  | [CDC_SYNCMACRO][]       | Done        |
-Security      | [SEC_CM_IMPLEMENTED][]  | Not Started |
+Security      | [SEC_CM_IMPLEMENTED][]  | In progress | SCA/FI hardening in progress
 Security      | [SEC_NON_RESET_FLOPS][] | Done        |
-Security      | [SEC_SHADOW_REGS][]     | Not Started |
+Security      | [SEC_SHADOW_REGS][]     | Done        |
 Security      | [SEC_RND_CNST][]        | Done        |
 
 [NEW_FEATURES]:        {{<relref "/doc/project/checklist.md#new_features" >}}

--- a/sw/device/lib/dif/dif_aes.md
+++ b/sw/device/lib/dif/dif_aes.md
@@ -1,0 +1,67 @@
+---
+title: "AES DIF Checklist"
+---
+
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [AES DIF]({{< relref "hw/ip/aes/doc" >}}).
+All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
+
+## DIF Checklist
+
+### S1
+
+Type           | Item                 | Resolution  | Note/Collaterals
+---------------|----------------------|-------------|------------------
+Implementation | [DIF_EXISTS][]       | Done        |
+Implementation | [DIF_USED_IN_TREE][] | In progress |
+Tests          | [DIF_TEST_UNIT][]    | Not started |
+Tests          | [DIF_TEST_SMOKE][]   | Done        |
+
+[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
+[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
+[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
+[DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
+
+### S2
+
+Type           | Item                        | Resolution  | Note/Collaterals
+---------------|-----------------------------|-------------|------------------
+Implementation | [DIF_FEATURES][]            | Not Started |
+Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_HW_PARAMS][]           | Not Started |
+Documentation  | [DIF_DOC_HW][]              | Not Started |
+Documentation  | [DIF_DOC_API][]             | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
+Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Implementation | [DIF_USED_TOCK][]           | Not Started |
+Review         | HW IP Usage Reviewer(s)     | Not Started |
+
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
+[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif_hw_usage_reviewed" >}}
+[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
+[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif_hw_params" >}}
+[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif_doc_api" >}}
+[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
+[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif_used_tock" >}}
+
+### S3
+
+Type           | Item                             | Resolution  | Note/Collaterals
+---------------|----------------------------------|-------------|------------------
+Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
+Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
+Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
+Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Review         | [DIF_TODO_COMPLETE][]            | Not Started |
+Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
+Review         | Reviewer(s)                      | Not Started |
+Review         | Signoff date                     | Not Started |
+
+[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
+[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
+[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif_review_c_stable" >}}
+[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_test_unit_complete" >}}
+[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}
+[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif_review_tock_stable" >}}


### PR DESCRIPTION
This PR is updates the design stages of AES to represent the current state (once #5427 is merged). In addition, the PR also adds the checklist for the DIF.