### PR TITLE
[dvsim] Add design_source flag to FuseSoC

### DIFF
--- a/hw/top_earlgrey/dv/vendor_chip_sim_cfg_sample.hjson
+++ b/hw/top_earlgrey/dv/vendor_chip_sim_cfg_sample.hjson
@@ -10,6 +10,10 @@
   // Import the chip_sim_cfg.hjson to run the chip level simulations.
   import_cfgs: ["{proj_root}/hw/top_earlgrey/dv/chip_sim_cfg.hjson"]
 
+  // Pass the fileset_vendor flag to FuseSoC to swap the open source files with vendor
+  // implementations.
+  sv_flist_gen_opts: ["--flag=fileset_partner"]
+
   // Override the required keys to customize the simulation flow. For instance,
   // the FuseSoC core file or the search paths provided to FuseSoC to find the
   // dependencies can be overridden to customize the design / testbench, while


### PR DESCRIPTION
This adds the `--fileset_partner` flag to FuseSoC as an example
to `vendor_chip_sim_cfg_example.hjson`.

By default, the open source implementation is selected (using the
negation of `fileset_partner` flag). If `fileset_partner` flag is set,
FuseSoC selects that implementation instead.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>