### PR TITLE
[DV][FCOV] Minor updates to #5414

### DIFF
--- a/hw/dv/sv/dv_utils/dv_fcov_macros.core
+++ b/hw/dv/sv/dv_utils/dv_fcov_macros.core
@@ -2,8 +2,8 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:dv:dv_fcov"
-description: "DV FCOV utilities"
+name: "lowrisc:dv:dv_fcov_macros"
+description: "DV FCOV macros"
 
 filesets:
   files_fcov:

--- a/hw/dv/sv/dv_utils/dv_fcov_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_fcov_macros.svh
@@ -2,49 +2,94 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Include FCOV RTL by default. Exclude it for synthesis and where explicitly requested (by defining
-// EXCLUDE_FCOV).
+// Include FCOV RTL by default. Disable it for synthesis and where explicitly requested (by defining
+// DV_FCOV_DISABLE).
 `ifdef SYNTHESIS
-  `define EXCLUDE_FCOV
+  `define DV_FCOV_DISABLE
 `elsif YOSYS
-  `define EXCLUDE_FCOV
+  `define DV_FCOV_DISABLE
+`endif
+
+// Disable instantiations of FCOV coverpoints or covergroups.
+`ifdef VERILATOR
+  `define DV_FCOV_DISABLE_CP
+`elsif DV_FCOV_DISABLE
+  `define DV_FCOV_DISABLE_CP
+`endif
+
+// Instantiates a covergroup in an interface or module.
+//
+// This macro assumes that a covergroup of the same name as the NAME_ arg is defined in the
+// interface or module. It just adds some extra signals and logic to control the creation of the
+// covergroup instance with ~bit en_<cg_name>~. This defaults to 0. It is ORed with the external
+// COND_ signal. The testbench can modify it at t = 0 based on the test being run.
+// NOTE: This is not meant to be invoked inside a class.
+//
+// NAME_ : Name of the covergroup.
+// COND_ : External condition / expr that controls the creation of the covergroup.
+// ARGS_ : Arguments to covergroup instance, if any. Args MUST BE wrapped in (..).
+`ifndef DV_FCOV_INSTANTIATE_CG
+`ifdef DV_FCOV_DISABLE_CP
+  `define DV_FCOV_INSTANTIATE_CG(NAME_, COND_ = 1'b1, ARGS_ = ())
+`else
+  `define DV_FCOV_INSTANTIATE_CG(NAME_, COND_ = 1'b1, ARGS_ = ()) \
+    bit en_``NAME_ = 1'b0; \
+    NAME_ NAME_``_inst; \
+    initial begin \
+      /* The #1 delay below allows any part of the tb to control the conditions first at t = 0. */ \
+      #1; \
+      if ((en_``NAME_) || (COND_)) begin \
+        $display("%0t: (%0s:%0d) [%m] %0s", $time, `__FILE__, `__LINE__, \
+                 {"Creating covergroup ", `"NAME_`"}); \
+        NAME_``_inst = new``ARGS_; \
+      end \
+    end
+`endif
+`endif
+
+// Creates a coverpoint for an expression where only the expression true case is of interest for
+// coverage (e.g. where the expression indicates an event has occured).
+`ifndef DV_FCOV_EXPR_SEEN
+`ifdef DV_FCOV_DISABLE_CP
+  `define DV_FCOV_EXPR_SEEN(NAME_, EXPR_)
+`else
+  `define DV_FCOV_EXPR_SEEN(NAME_, EXPR_) cp_``NAME_: coverpoint EXPR_ { bins seen = {1}; }
+`endif
 `endif
 
 // Coverage support is not always available but it's useful to include extra fcov signals for
 // linting purposes. They need to be marked as unused to avoid warnings.
-`ifndef FCOV_MARK_UNUSED
-  `define FCOV_MARK_UNUSED(TYPE_, NAME_) \
+`ifndef DV_FCOV_MARK_UNUSED
+  `define DV_FCOV_MARK_UNUSED(TYPE_, NAME_) \
     TYPE_ unused_fcov_``NAME_; \
     assign unused_fcov_``NAME_ = fcov_``NAME_;
 `endif
 
 // Define a signal and expression in the design for capture in functional coverage
-`ifndef FCOV_SIGNAL
-`ifdef EXCLUDE_FCOV
-  // Macro has no effect
-  `define FCOV_SIGNAL(TYPE_, NAME_, EXPR_)
+`ifndef DV_FCOV_SIGNAL
+`ifdef DV_FCOV_DISABLE
+  `define DV_FCOV_SIGNAL(TYPE_, NAME_, EXPR_)
 `else
-  `define FCOV_SIGNAL(TYPE_, NAME_, EXPR_) \
+  `define DV_FCOV_SIGNAL(TYPE_, NAME_, EXPR_) \
     TYPE_ fcov_``NAME_; \
     assign fcov_``NAME_ = EXPR_; \
-    `FCOV_MARK_UNUSED(TYPE_, NAME_)
+    `DV_FCOV_MARK_UNUSED(TYPE_, NAME_)
 `endif
 `endif
 
 // Define a signal and expression in the design for capture in functional coverage depending on
 // design configuration. The input GEN_COND_ must be a constant or parameter.
-`ifndef FCOV_SIGNAL_GEN_IF
-`ifdef EXCLUDE_FCOV
-  // Macro does nothing
-  `define FCOV_SIGNAL_GEN_IF(TYPE_, NAME_, EXPR_, GEN_COND_, DEFAULT_ = '0)
+`ifndef DV_FCOV_SIGNAL_GEN_IF
+`ifdef DV_FCOV_DISABLE
+  `define DV_FCOV_SIGNAL_GEN_IF(TYPE_, NAME_, EXPR_, GEN_COND_, DEFAULT_ = '0)
 `else
-  `define FCOV_SIGNAL_GEN_IF(TYPE_, NAME_, EXPR_, GEN_COND_, DEFAULT_ = '0) \
+  `define DV_FCOV_SIGNAL_GEN_IF(TYPE_, NAME_, EXPR_, GEN_COND_, DEFAULT_ = '0) \
     TYPE_ fcov_``NAME_; \
     if (GEN_COND_) begin : g_fcov_``NAME_ \
       assign fcov_``NAME_ = EXPR_; \
     end else begin : g_no_fcov_``NAME_ \
       assign fcov_``NAME_ = DEFAULT_; \
     end \
-    `FCOV_MARK_UNUSED(TYPE_, NAME_)
+    `DV_FCOV_MARK_UNUSED(TYPE_, NAME_)
 `endif
 `endif

--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-`ifndef __DV_MACROS_SVH__
-`define __DV_MACROS_SVH__
-
 `ifdef UVM
   `include "uvm_macros.svh"
 `endif
@@ -495,49 +492,3 @@
 `endif
 
 `endif // UVM
-
-// Instantiates a covergroup in an interface or module.
-//
-// This macro assumes that a covergroup of the same name as the __CG_NAME arg is defined in the
-// interface or module. It just adds some extra signals and logic to control the creation of the
-// covergroup instance with ~bit en_<cg_name>~. This defaults to 0. It is ORed with the external
-// __COND signal. The testbench can modify it at t = 0 based on the test being run.
-// NOTE: This is not meant to be invoked inside a class.
-//
-// __CG_NAME : Name of the covergroup.
-// __COND    : External condition / expr that controls the creation of the covergroup.
-// __CG_ARGS : Arguments to covergroup instance, if any. Args MUST BE wrapped in (..).
-`ifndef DV_INSTANTIATE_CG
-`define DV_INSTANTIATE_CG(__CG_NAME, __COND = 1'b1, __CG_ARGS = ()) \
-  bit en_``__CG_NAME = 1'b0; \
-  __CG_NAME __CG_NAME``_inst; \
-  initial begin \
-    /* The #1 delay below allows any part of the tb to control the conditions first at t = 0. */ \
-    #1; \
-    if ((en_``__CG_NAME) || (__COND)) begin \
-      `dv_info({"Creating covergroup ", `"__CG_NAME`"}, uvm_pkg::UVM_MEDIUM) \
-      __CG_NAME``_inst = new``__CG_ARGS; \
-    end \
-  end
-`endif
-
-// Creates a SVA cover that can be used in a covergroup.
-//
-// This macro creates an unnamed SVA cover from the expression `__sva` and an event with the name
-// `__ev_name`. When the SVA cover is hit, the event is triggered. A coverpoint can cover the
-// `triggered` property of the event.
-`ifndef DV_FCOV_SVA
-`define DV_FCOV_SVA(__ev_name, __sva, __clk = clk_i, __rst = rst_ni) \
-  event __ev_name; \
-  cover property (@(posedge __clk) disable iff (__rst == 0) (__sva)) begin \
-    -> __ev_name; \
-  end
-`endif
-
-// Creates a coverpoint for an expression where only the expression true case is of interest for
-// coverage (e.g. where the expression indicates an event has occured).
-`ifndef DV_FCOV_EXPR_SEEN
-`define DV_FCOV_EXPR_SEEN(__cp_name, __expr) __cp_name: coverpoint __expr { bins seen = {1}; }
-`endif
-
-`endif // __DV_MACROS_SVH__

--- a/hw/dv/sv/dv_utils/dv_utils.core
+++ b/hw/dv/sv/dv_utils/dv_utils.core
@@ -9,6 +9,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:dv:dv_macros
+      - lowrisc:dv:dv_fcov_macros
       - lowrisc:dv:common_ifs
       - lowrisc:prim:assert:0.1
       - lowrisc:opentitan:bus_params_pkg

--- a/hw/ip/uart/dv/cov/uart_cov_if.sv
+++ b/hw/ip/uart/dv/cov/uart_cov_if.sv
@@ -9,6 +9,7 @@ interface uart_cov_if (
 
   import uvm_pkg::*;
   import dv_utils_pkg::*;
+  `include "dv_fcov_macros.svh"
 
   bit en_full_cov = 1'b1;
   bit en_intg_cov = 1'b1;
@@ -50,6 +51,6 @@ interface uart_cov_if (
     cp_rx_enable:     coverpoint m_uart_cov_vifs_wrap.uart_core_cov_vif.rx_enable;
     cr_tx_rx_enable:  cross cp_tx_enable, cp_rx_enable;
   endgroup
-  `DV_INSTANTIATE_CG(uart_op_cg, en_full_cov)
+  `DV_FCOV_INSTANTIATE_CG(uart_op_cg, en_full_cov)
 
 endinterface


### PR DESCRIPTION
Followup changes to #5414. Hopefully Ibex can be easily updated with just search and replace. 

- Prefix all macros in `dv_fcov_macros.svh` with `DV_FCOV`
  - Makes it clear where to lookup their definition

- Remove DV_FCOV_SVA - this is already defined as `COVER` in prim_assert

- Move DV_FCOV_EXPR_SEEN to `dv_fcov_macros.svh` since it will be used
only in DV code.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>