### PR TITLE
[tlul] Adapter reg fix

### DIFF
--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -1146,122 +1146,122 @@ module aes_reg_top (
     if (addr_hit[31] && reg_we && (AES_PERMIT[31] != (AES_PERMIT[31] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign alert_test_recov_ctrl_update_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign alert_test_recov_ctrl_update_err_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_ctrl_update_err_wd = reg_wdata[0];
 
-  assign alert_test_fatal_fault_we = addr_hit[0] & reg_we & ~wr_err;
+  assign alert_test_fatal_fault_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_fatal_fault_wd = reg_wdata[1];
 
-  assign key_share0_0_we = addr_hit[1] & reg_we & ~wr_err;
+  assign key_share0_0_we = addr_hit[1] & reg_we & !reg_error;
   assign key_share0_0_wd = reg_wdata[31:0];
 
-  assign key_share0_1_we = addr_hit[2] & reg_we & ~wr_err;
+  assign key_share0_1_we = addr_hit[2] & reg_we & !reg_error;
   assign key_share0_1_wd = reg_wdata[31:0];
 
-  assign key_share0_2_we = addr_hit[3] & reg_we & ~wr_err;
+  assign key_share0_2_we = addr_hit[3] & reg_we & !reg_error;
   assign key_share0_2_wd = reg_wdata[31:0];
 
-  assign key_share0_3_we = addr_hit[4] & reg_we & ~wr_err;
+  assign key_share0_3_we = addr_hit[4] & reg_we & !reg_error;
   assign key_share0_3_wd = reg_wdata[31:0];
 
-  assign key_share0_4_we = addr_hit[5] & reg_we & ~wr_err;
+  assign key_share0_4_we = addr_hit[5] & reg_we & !reg_error;
   assign key_share0_4_wd = reg_wdata[31:0];
 
-  assign key_share0_5_we = addr_hit[6] & reg_we & ~wr_err;
+  assign key_share0_5_we = addr_hit[6] & reg_we & !reg_error;
   assign key_share0_5_wd = reg_wdata[31:0];
 
-  assign key_share0_6_we = addr_hit[7] & reg_we & ~wr_err;
+  assign key_share0_6_we = addr_hit[7] & reg_we & !reg_error;
   assign key_share0_6_wd = reg_wdata[31:0];
 
-  assign key_share0_7_we = addr_hit[8] & reg_we & ~wr_err;
+  assign key_share0_7_we = addr_hit[8] & reg_we & !reg_error;
   assign key_share0_7_wd = reg_wdata[31:0];
 
-  assign key_share1_0_we = addr_hit[9] & reg_we & ~wr_err;
+  assign key_share1_0_we = addr_hit[9] & reg_we & !reg_error;
   assign key_share1_0_wd = reg_wdata[31:0];
 
-  assign key_share1_1_we = addr_hit[10] & reg_we & ~wr_err;
+  assign key_share1_1_we = addr_hit[10] & reg_we & !reg_error;
   assign key_share1_1_wd = reg_wdata[31:0];
 
-  assign key_share1_2_we = addr_hit[11] & reg_we & ~wr_err;
+  assign key_share1_2_we = addr_hit[11] & reg_we & !reg_error;
   assign key_share1_2_wd = reg_wdata[31:0];
 
-  assign key_share1_3_we = addr_hit[12] & reg_we & ~wr_err;
+  assign key_share1_3_we = addr_hit[12] & reg_we & !reg_error;
   assign key_share1_3_wd = reg_wdata[31:0];
 
-  assign key_share1_4_we = addr_hit[13] & reg_we & ~wr_err;
+  assign key_share1_4_we = addr_hit[13] & reg_we & !reg_error;
   assign key_share1_4_wd = reg_wdata[31:0];
 
-  assign key_share1_5_we = addr_hit[14] & reg_we & ~wr_err;
+  assign key_share1_5_we = addr_hit[14] & reg_we & !reg_error;
   assign key_share1_5_wd = reg_wdata[31:0];
 
-  assign key_share1_6_we = addr_hit[15] & reg_we & ~wr_err;
+  assign key_share1_6_we = addr_hit[15] & reg_we & !reg_error;
   assign key_share1_6_wd = reg_wdata[31:0];
 
-  assign key_share1_7_we = addr_hit[16] & reg_we & ~wr_err;
+  assign key_share1_7_we = addr_hit[16] & reg_we & !reg_error;
   assign key_share1_7_wd = reg_wdata[31:0];
 
-  assign iv_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign iv_0_we = addr_hit[17] & reg_we & !reg_error;
   assign iv_0_wd = reg_wdata[31:0];
 
-  assign iv_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign iv_1_we = addr_hit[18] & reg_we & !reg_error;
   assign iv_1_wd = reg_wdata[31:0];
 
-  assign iv_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign iv_2_we = addr_hit[19] & reg_we & !reg_error;
   assign iv_2_wd = reg_wdata[31:0];
 
-  assign iv_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign iv_3_we = addr_hit[20] & reg_we & !reg_error;
   assign iv_3_wd = reg_wdata[31:0];
 
-  assign data_in_0_we = addr_hit[21] & reg_we & ~wr_err;
+  assign data_in_0_we = addr_hit[21] & reg_we & !reg_error;
   assign data_in_0_wd = reg_wdata[31:0];
 
-  assign data_in_1_we = addr_hit[22] & reg_we & ~wr_err;
+  assign data_in_1_we = addr_hit[22] & reg_we & !reg_error;
   assign data_in_1_wd = reg_wdata[31:0];
 
-  assign data_in_2_we = addr_hit[23] & reg_we & ~wr_err;
+  assign data_in_2_we = addr_hit[23] & reg_we & !reg_error;
   assign data_in_2_wd = reg_wdata[31:0];
 
-  assign data_in_3_we = addr_hit[24] & reg_we & ~wr_err;
+  assign data_in_3_we = addr_hit[24] & reg_we & !reg_error;
   assign data_in_3_wd = reg_wdata[31:0];
 
-  assign data_out_0_re = addr_hit[25] && reg_re;
+  assign data_out_0_re = addr_hit[25] & reg_re & !reg_error;
 
-  assign data_out_1_re = addr_hit[26] && reg_re;
+  assign data_out_1_re = addr_hit[26] & reg_re & !reg_error;
 
-  assign data_out_2_re = addr_hit[27] && reg_re;
+  assign data_out_2_re = addr_hit[27] & reg_re & !reg_error;
 
-  assign data_out_3_re = addr_hit[28] && reg_re;
+  assign data_out_3_re = addr_hit[28] & reg_re & !reg_error;
 
-  assign ctrl_shadowed_operation_we = addr_hit[29] & reg_we & ~wr_err;
+  assign ctrl_shadowed_operation_we = addr_hit[29] & reg_we & !reg_error;
   assign ctrl_shadowed_operation_wd = reg_wdata[0];
-  assign ctrl_shadowed_operation_re = addr_hit[29] && reg_re;
+  assign ctrl_shadowed_operation_re = addr_hit[29] & reg_re & !reg_error;
 
-  assign ctrl_shadowed_mode_we = addr_hit[29] & reg_we & ~wr_err;
+  assign ctrl_shadowed_mode_we = addr_hit[29] & reg_we & !reg_error;
   assign ctrl_shadowed_mode_wd = reg_wdata[6:1];
-  assign ctrl_shadowed_mode_re = addr_hit[29] && reg_re;
+  assign ctrl_shadowed_mode_re = addr_hit[29] & reg_re & !reg_error;
 
-  assign ctrl_shadowed_key_len_we = addr_hit[29] & reg_we & ~wr_err;
+  assign ctrl_shadowed_key_len_we = addr_hit[29] & reg_we & !reg_error;
   assign ctrl_shadowed_key_len_wd = reg_wdata[9:7];
-  assign ctrl_shadowed_key_len_re = addr_hit[29] && reg_re;
+  assign ctrl_shadowed_key_len_re = addr_hit[29] & reg_re & !reg_error;
 
-  assign ctrl_shadowed_manual_operation_we = addr_hit[29] & reg_we & ~wr_err;
+  assign ctrl_shadowed_manual_operation_we = addr_hit[29] & reg_we & !reg_error;
   assign ctrl_shadowed_manual_operation_wd = reg_wdata[10];
-  assign ctrl_shadowed_manual_operation_re = addr_hit[29] && reg_re;
+  assign ctrl_shadowed_manual_operation_re = addr_hit[29] & reg_re & !reg_error;
 
-  assign ctrl_shadowed_force_zero_masks_we = addr_hit[29] & reg_we & ~wr_err;
+  assign ctrl_shadowed_force_zero_masks_we = addr_hit[29] & reg_we & !reg_error;
   assign ctrl_shadowed_force_zero_masks_wd = reg_wdata[11];
-  assign ctrl_shadowed_force_zero_masks_re = addr_hit[29] && reg_re;
+  assign ctrl_shadowed_force_zero_masks_re = addr_hit[29] & reg_re & !reg_error;
 
-  assign trigger_start_we = addr_hit[30] & reg_we & ~wr_err;
+  assign trigger_start_we = addr_hit[30] & reg_we & !reg_error;
   assign trigger_start_wd = reg_wdata[0];
 
-  assign trigger_key_iv_data_in_clear_we = addr_hit[30] & reg_we & ~wr_err;
+  assign trigger_key_iv_data_in_clear_we = addr_hit[30] & reg_we & !reg_error;
   assign trigger_key_iv_data_in_clear_wd = reg_wdata[1];
 
-  assign trigger_data_out_clear_we = addr_hit[30] & reg_we & ~wr_err;
+  assign trigger_data_out_clear_we = addr_hit[30] & reg_we & !reg_error;
   assign trigger_data_out_clear_wd = reg_wdata[2];
 
-  assign trigger_prng_reseed_we = addr_hit[30] & reg_we & ~wr_err;
+  assign trigger_prng_reseed_we = addr_hit[30] & reg_we & !reg_error;
   assign trigger_prng_reseed_wd = reg_wdata[3];
 
 

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_top.sv
@@ -3647,359 +3647,359 @@ module alert_handler_reg_top (
     if (addr_hit[58] && reg_we && (ALERT_HANDLER_PERMIT[58] != (ALERT_HANDLER_PERMIT[58] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_classa_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_classa_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_classa_wd = reg_wdata[0];
 
-  assign intr_state_classb_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_classb_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_classb_wd = reg_wdata[1];
 
-  assign intr_state_classc_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_classc_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_classc_wd = reg_wdata[2];
 
-  assign intr_state_classd_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_classd_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_classd_wd = reg_wdata[3];
 
-  assign intr_enable_classa_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_classa_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_classa_wd = reg_wdata[0];
 
-  assign intr_enable_classb_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_classb_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_classb_wd = reg_wdata[1];
 
-  assign intr_enable_classc_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_classc_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_classc_wd = reg_wdata[2];
 
-  assign intr_enable_classd_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_classd_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_classd_wd = reg_wdata[3];
 
-  assign intr_test_classa_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_classa_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_classa_wd = reg_wdata[0];
 
-  assign intr_test_classb_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_classb_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_classb_wd = reg_wdata[1];
 
-  assign intr_test_classc_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_classc_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_classc_wd = reg_wdata[2];
 
-  assign intr_test_classd_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_classd_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_classd_wd = reg_wdata[3];
 
-  assign regwen_we = addr_hit[3] & reg_we & ~wr_err;
+  assign regwen_we = addr_hit[3] & reg_we & !reg_error;
   assign regwen_wd = reg_wdata[0];
 
-  assign ping_timeout_cyc_we = addr_hit[4] & reg_we & ~wr_err;
+  assign ping_timeout_cyc_we = addr_hit[4] & reg_we & !reg_error;
   assign ping_timeout_cyc_wd = reg_wdata[23:0];
 
-  assign alert_en_en_a_0_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_0_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_0_wd = reg_wdata[0];
 
-  assign alert_en_en_a_1_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_1_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_1_wd = reg_wdata[1];
 
-  assign alert_en_en_a_2_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_2_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_2_wd = reg_wdata[2];
 
-  assign alert_en_en_a_3_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_3_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_3_wd = reg_wdata[3];
 
-  assign alert_class_class_a_0_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_class_a_0_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_class_a_0_wd = reg_wdata[1:0];
 
-  assign alert_class_class_a_1_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_class_a_1_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_class_a_1_wd = reg_wdata[3:2];
 
-  assign alert_class_class_a_2_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_class_a_2_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_class_a_2_wd = reg_wdata[5:4];
 
-  assign alert_class_class_a_3_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_class_a_3_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_class_a_3_wd = reg_wdata[7:6];
 
-  assign alert_cause_a_0_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_cause_a_0_we = addr_hit[7] & reg_we & !reg_error;
   assign alert_cause_a_0_wd = reg_wdata[0];
 
-  assign alert_cause_a_1_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_cause_a_1_we = addr_hit[7] & reg_we & !reg_error;
   assign alert_cause_a_1_wd = reg_wdata[1];
 
-  assign alert_cause_a_2_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_cause_a_2_we = addr_hit[7] & reg_we & !reg_error;
   assign alert_cause_a_2_wd = reg_wdata[2];
 
-  assign alert_cause_a_3_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_cause_a_3_we = addr_hit[7] & reg_we & !reg_error;
   assign alert_cause_a_3_wd = reg_wdata[3];
 
-  assign loc_alert_en_en_la_0_we = addr_hit[8] & reg_we & ~wr_err;
+  assign loc_alert_en_en_la_0_we = addr_hit[8] & reg_we & !reg_error;
   assign loc_alert_en_en_la_0_wd = reg_wdata[0];
 
-  assign loc_alert_en_en_la_1_we = addr_hit[8] & reg_we & ~wr_err;
+  assign loc_alert_en_en_la_1_we = addr_hit[8] & reg_we & !reg_error;
   assign loc_alert_en_en_la_1_wd = reg_wdata[1];
 
-  assign loc_alert_en_en_la_2_we = addr_hit[8] & reg_we & ~wr_err;
+  assign loc_alert_en_en_la_2_we = addr_hit[8] & reg_we & !reg_error;
   assign loc_alert_en_en_la_2_wd = reg_wdata[2];
 
-  assign loc_alert_en_en_la_3_we = addr_hit[8] & reg_we & ~wr_err;
+  assign loc_alert_en_en_la_3_we = addr_hit[8] & reg_we & !reg_error;
   assign loc_alert_en_en_la_3_wd = reg_wdata[3];
 
-  assign loc_alert_class_class_la_0_we = addr_hit[9] & reg_we & ~wr_err;
+  assign loc_alert_class_class_la_0_we = addr_hit[9] & reg_we & !reg_error;
   assign loc_alert_class_class_la_0_wd = reg_wdata[1:0];
 
-  assign loc_alert_class_class_la_1_we = addr_hit[9] & reg_we & ~wr_err;
+  assign loc_alert_class_class_la_1_we = addr_hit[9] & reg_we & !reg_error;
   assign loc_alert_class_class_la_1_wd = reg_wdata[3:2];
 
-  assign loc_alert_class_class_la_2_we = addr_hit[9] & reg_we & ~wr_err;
+  assign loc_alert_class_class_la_2_we = addr_hit[9] & reg_we & !reg_error;
   assign loc_alert_class_class_la_2_wd = reg_wdata[5:4];
 
-  assign loc_alert_class_class_la_3_we = addr_hit[9] & reg_we & ~wr_err;
+  assign loc_alert_class_class_la_3_we = addr_hit[9] & reg_we & !reg_error;
   assign loc_alert_class_class_la_3_wd = reg_wdata[7:6];
 
-  assign loc_alert_cause_la_0_we = addr_hit[10] & reg_we & ~wr_err;
+  assign loc_alert_cause_la_0_we = addr_hit[10] & reg_we & !reg_error;
   assign loc_alert_cause_la_0_wd = reg_wdata[0];
 
-  assign loc_alert_cause_la_1_we = addr_hit[10] & reg_we & ~wr_err;
+  assign loc_alert_cause_la_1_we = addr_hit[10] & reg_we & !reg_error;
   assign loc_alert_cause_la_1_wd = reg_wdata[1];
 
-  assign loc_alert_cause_la_2_we = addr_hit[10] & reg_we & ~wr_err;
+  assign loc_alert_cause_la_2_we = addr_hit[10] & reg_we & !reg_error;
   assign loc_alert_cause_la_2_wd = reg_wdata[2];
 
-  assign loc_alert_cause_la_3_we = addr_hit[10] & reg_we & ~wr_err;
+  assign loc_alert_cause_la_3_we = addr_hit[10] & reg_we & !reg_error;
   assign loc_alert_cause_la_3_wd = reg_wdata[3];
 
-  assign classa_ctrl_en_we = addr_hit[11] & reg_we & ~wr_err;
+  assign classa_ctrl_en_we = addr_hit[11] & reg_we & !reg_error;
   assign classa_ctrl_en_wd = reg_wdata[0];
 
-  assign classa_ctrl_lock_we = addr_hit[11] & reg_we & ~wr_err;
+  assign classa_ctrl_lock_we = addr_hit[11] & reg_we & !reg_error;
   assign classa_ctrl_lock_wd = reg_wdata[1];
 
-  assign classa_ctrl_en_e0_we = addr_hit[11] & reg_we & ~wr_err;
+  assign classa_ctrl_en_e0_we = addr_hit[11] & reg_we & !reg_error;
   assign classa_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classa_ctrl_en_e1_we = addr_hit[11] & reg_we & ~wr_err;
+  assign classa_ctrl_en_e1_we = addr_hit[11] & reg_we & !reg_error;
   assign classa_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classa_ctrl_en_e2_we = addr_hit[11] & reg_we & ~wr_err;
+  assign classa_ctrl_en_e2_we = addr_hit[11] & reg_we & !reg_error;
   assign classa_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classa_ctrl_en_e3_we = addr_hit[11] & reg_we & ~wr_err;
+  assign classa_ctrl_en_e3_we = addr_hit[11] & reg_we & !reg_error;
   assign classa_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classa_ctrl_map_e0_we = addr_hit[11] & reg_we & ~wr_err;
+  assign classa_ctrl_map_e0_we = addr_hit[11] & reg_we & !reg_error;
   assign classa_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classa_ctrl_map_e1_we = addr_hit[11] & reg_we & ~wr_err;
+  assign classa_ctrl_map_e1_we = addr_hit[11] & reg_we & !reg_error;
   assign classa_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classa_ctrl_map_e2_we = addr_hit[11] & reg_we & ~wr_err;
+  assign classa_ctrl_map_e2_we = addr_hit[11] & reg_we & !reg_error;
   assign classa_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classa_ctrl_map_e3_we = addr_hit[11] & reg_we & ~wr_err;
+  assign classa_ctrl_map_e3_we = addr_hit[11] & reg_we & !reg_error;
   assign classa_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classa_regwen_we = addr_hit[12] & reg_we & ~wr_err;
+  assign classa_regwen_we = addr_hit[12] & reg_we & !reg_error;
   assign classa_regwen_wd = reg_wdata[0];
 
-  assign classa_clr_we = addr_hit[13] & reg_we & ~wr_err;
+  assign classa_clr_we = addr_hit[13] & reg_we & !reg_error;
   assign classa_clr_wd = reg_wdata[0];
 
-  assign classa_accum_cnt_re = addr_hit[14] && reg_re;
+  assign classa_accum_cnt_re = addr_hit[14] & reg_re & !reg_error;
 
-  assign classa_accum_thresh_we = addr_hit[15] & reg_we & ~wr_err;
+  assign classa_accum_thresh_we = addr_hit[15] & reg_we & !reg_error;
   assign classa_accum_thresh_wd = reg_wdata[15:0];
 
-  assign classa_timeout_cyc_we = addr_hit[16] & reg_we & ~wr_err;
+  assign classa_timeout_cyc_we = addr_hit[16] & reg_we & !reg_error;
   assign classa_timeout_cyc_wd = reg_wdata[31:0];
 
-  assign classa_phase0_cyc_we = addr_hit[17] & reg_we & ~wr_err;
+  assign classa_phase0_cyc_we = addr_hit[17] & reg_we & !reg_error;
   assign classa_phase0_cyc_wd = reg_wdata[31:0];
 
-  assign classa_phase1_cyc_we = addr_hit[18] & reg_we & ~wr_err;
+  assign classa_phase1_cyc_we = addr_hit[18] & reg_we & !reg_error;
   assign classa_phase1_cyc_wd = reg_wdata[31:0];
 
-  assign classa_phase2_cyc_we = addr_hit[19] & reg_we & ~wr_err;
+  assign classa_phase2_cyc_we = addr_hit[19] & reg_we & !reg_error;
   assign classa_phase2_cyc_wd = reg_wdata[31:0];
 
-  assign classa_phase3_cyc_we = addr_hit[20] & reg_we & ~wr_err;
+  assign classa_phase3_cyc_we = addr_hit[20] & reg_we & !reg_error;
   assign classa_phase3_cyc_wd = reg_wdata[31:0];
 
-  assign classa_esc_cnt_re = addr_hit[21] && reg_re;
+  assign classa_esc_cnt_re = addr_hit[21] & reg_re & !reg_error;
 
-  assign classa_state_re = addr_hit[22] && reg_re;
+  assign classa_state_re = addr_hit[22] & reg_re & !reg_error;
 
-  assign classb_ctrl_en_we = addr_hit[23] & reg_we & ~wr_err;
+  assign classb_ctrl_en_we = addr_hit[23] & reg_we & !reg_error;
   assign classb_ctrl_en_wd = reg_wdata[0];
 
-  assign classb_ctrl_lock_we = addr_hit[23] & reg_we & ~wr_err;
+  assign classb_ctrl_lock_we = addr_hit[23] & reg_we & !reg_error;
   assign classb_ctrl_lock_wd = reg_wdata[1];
 
-  assign classb_ctrl_en_e0_we = addr_hit[23] & reg_we & ~wr_err;
+  assign classb_ctrl_en_e0_we = addr_hit[23] & reg_we & !reg_error;
   assign classb_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classb_ctrl_en_e1_we = addr_hit[23] & reg_we & ~wr_err;
+  assign classb_ctrl_en_e1_we = addr_hit[23] & reg_we & !reg_error;
   assign classb_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classb_ctrl_en_e2_we = addr_hit[23] & reg_we & ~wr_err;
+  assign classb_ctrl_en_e2_we = addr_hit[23] & reg_we & !reg_error;
   assign classb_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classb_ctrl_en_e3_we = addr_hit[23] & reg_we & ~wr_err;
+  assign classb_ctrl_en_e3_we = addr_hit[23] & reg_we & !reg_error;
   assign classb_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classb_ctrl_map_e0_we = addr_hit[23] & reg_we & ~wr_err;
+  assign classb_ctrl_map_e0_we = addr_hit[23] & reg_we & !reg_error;
   assign classb_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classb_ctrl_map_e1_we = addr_hit[23] & reg_we & ~wr_err;
+  assign classb_ctrl_map_e1_we = addr_hit[23] & reg_we & !reg_error;
   assign classb_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classb_ctrl_map_e2_we = addr_hit[23] & reg_we & ~wr_err;
+  assign classb_ctrl_map_e2_we = addr_hit[23] & reg_we & !reg_error;
   assign classb_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classb_ctrl_map_e3_we = addr_hit[23] & reg_we & ~wr_err;
+  assign classb_ctrl_map_e3_we = addr_hit[23] & reg_we & !reg_error;
   assign classb_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classb_regwen_we = addr_hit[24] & reg_we & ~wr_err;
+  assign classb_regwen_we = addr_hit[24] & reg_we & !reg_error;
   assign classb_regwen_wd = reg_wdata[0];
 
-  assign classb_clr_we = addr_hit[25] & reg_we & ~wr_err;
+  assign classb_clr_we = addr_hit[25] & reg_we & !reg_error;
   assign classb_clr_wd = reg_wdata[0];
 
-  assign classb_accum_cnt_re = addr_hit[26] && reg_re;
+  assign classb_accum_cnt_re = addr_hit[26] & reg_re & !reg_error;
 
-  assign classb_accum_thresh_we = addr_hit[27] & reg_we & ~wr_err;
+  assign classb_accum_thresh_we = addr_hit[27] & reg_we & !reg_error;
   assign classb_accum_thresh_wd = reg_wdata[15:0];
 
-  assign classb_timeout_cyc_we = addr_hit[28] & reg_we & ~wr_err;
+  assign classb_timeout_cyc_we = addr_hit[28] & reg_we & !reg_error;
   assign classb_timeout_cyc_wd = reg_wdata[31:0];
 
-  assign classb_phase0_cyc_we = addr_hit[29] & reg_we & ~wr_err;
+  assign classb_phase0_cyc_we = addr_hit[29] & reg_we & !reg_error;
   assign classb_phase0_cyc_wd = reg_wdata[31:0];
 
-  assign classb_phase1_cyc_we = addr_hit[30] & reg_we & ~wr_err;
+  assign classb_phase1_cyc_we = addr_hit[30] & reg_we & !reg_error;
   assign classb_phase1_cyc_wd = reg_wdata[31:0];
 
-  assign classb_phase2_cyc_we = addr_hit[31] & reg_we & ~wr_err;
+  assign classb_phase2_cyc_we = addr_hit[31] & reg_we & !reg_error;
   assign classb_phase2_cyc_wd = reg_wdata[31:0];
 
-  assign classb_phase3_cyc_we = addr_hit[32] & reg_we & ~wr_err;
+  assign classb_phase3_cyc_we = addr_hit[32] & reg_we & !reg_error;
   assign classb_phase3_cyc_wd = reg_wdata[31:0];
 
-  assign classb_esc_cnt_re = addr_hit[33] && reg_re;
+  assign classb_esc_cnt_re = addr_hit[33] & reg_re & !reg_error;
 
-  assign classb_state_re = addr_hit[34] && reg_re;
+  assign classb_state_re = addr_hit[34] & reg_re & !reg_error;
 
-  assign classc_ctrl_en_we = addr_hit[35] & reg_we & ~wr_err;
+  assign classc_ctrl_en_we = addr_hit[35] & reg_we & !reg_error;
   assign classc_ctrl_en_wd = reg_wdata[0];
 
-  assign classc_ctrl_lock_we = addr_hit[35] & reg_we & ~wr_err;
+  assign classc_ctrl_lock_we = addr_hit[35] & reg_we & !reg_error;
   assign classc_ctrl_lock_wd = reg_wdata[1];
 
-  assign classc_ctrl_en_e0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign classc_ctrl_en_e0_we = addr_hit[35] & reg_we & !reg_error;
   assign classc_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classc_ctrl_en_e1_we = addr_hit[35] & reg_we & ~wr_err;
+  assign classc_ctrl_en_e1_we = addr_hit[35] & reg_we & !reg_error;
   assign classc_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classc_ctrl_en_e2_we = addr_hit[35] & reg_we & ~wr_err;
+  assign classc_ctrl_en_e2_we = addr_hit[35] & reg_we & !reg_error;
   assign classc_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classc_ctrl_en_e3_we = addr_hit[35] & reg_we & ~wr_err;
+  assign classc_ctrl_en_e3_we = addr_hit[35] & reg_we & !reg_error;
   assign classc_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classc_ctrl_map_e0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign classc_ctrl_map_e0_we = addr_hit[35] & reg_we & !reg_error;
   assign classc_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classc_ctrl_map_e1_we = addr_hit[35] & reg_we & ~wr_err;
+  assign classc_ctrl_map_e1_we = addr_hit[35] & reg_we & !reg_error;
   assign classc_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classc_ctrl_map_e2_we = addr_hit[35] & reg_we & ~wr_err;
+  assign classc_ctrl_map_e2_we = addr_hit[35] & reg_we & !reg_error;
   assign classc_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classc_ctrl_map_e3_we = addr_hit[35] & reg_we & ~wr_err;
+  assign classc_ctrl_map_e3_we = addr_hit[35] & reg_we & !reg_error;
   assign classc_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classc_regwen_we = addr_hit[36] & reg_we & ~wr_err;
+  assign classc_regwen_we = addr_hit[36] & reg_we & !reg_error;
   assign classc_regwen_wd = reg_wdata[0];
 
-  assign classc_clr_we = addr_hit[37] & reg_we & ~wr_err;
+  assign classc_clr_we = addr_hit[37] & reg_we & !reg_error;
   assign classc_clr_wd = reg_wdata[0];
 
-  assign classc_accum_cnt_re = addr_hit[38] && reg_re;
+  assign classc_accum_cnt_re = addr_hit[38] & reg_re & !reg_error;
 
-  assign classc_accum_thresh_we = addr_hit[39] & reg_we & ~wr_err;
+  assign classc_accum_thresh_we = addr_hit[39] & reg_we & !reg_error;
   assign classc_accum_thresh_wd = reg_wdata[15:0];
 
-  assign classc_timeout_cyc_we = addr_hit[40] & reg_we & ~wr_err;
+  assign classc_timeout_cyc_we = addr_hit[40] & reg_we & !reg_error;
   assign classc_timeout_cyc_wd = reg_wdata[31:0];
 
-  assign classc_phase0_cyc_we = addr_hit[41] & reg_we & ~wr_err;
+  assign classc_phase0_cyc_we = addr_hit[41] & reg_we & !reg_error;
   assign classc_phase0_cyc_wd = reg_wdata[31:0];
 
-  assign classc_phase1_cyc_we = addr_hit[42] & reg_we & ~wr_err;
+  assign classc_phase1_cyc_we = addr_hit[42] & reg_we & !reg_error;
   assign classc_phase1_cyc_wd = reg_wdata[31:0];
 
-  assign classc_phase2_cyc_we = addr_hit[43] & reg_we & ~wr_err;
+  assign classc_phase2_cyc_we = addr_hit[43] & reg_we & !reg_error;
   assign classc_phase2_cyc_wd = reg_wdata[31:0];
 
-  assign classc_phase3_cyc_we = addr_hit[44] & reg_we & ~wr_err;
+  assign classc_phase3_cyc_we = addr_hit[44] & reg_we & !reg_error;
   assign classc_phase3_cyc_wd = reg_wdata[31:0];
 
-  assign classc_esc_cnt_re = addr_hit[45] && reg_re;
+  assign classc_esc_cnt_re = addr_hit[45] & reg_re & !reg_error;
 
-  assign classc_state_re = addr_hit[46] && reg_re;
+  assign classc_state_re = addr_hit[46] & reg_re & !reg_error;
 
-  assign classd_ctrl_en_we = addr_hit[47] & reg_we & ~wr_err;
+  assign classd_ctrl_en_we = addr_hit[47] & reg_we & !reg_error;
   assign classd_ctrl_en_wd = reg_wdata[0];
 
-  assign classd_ctrl_lock_we = addr_hit[47] & reg_we & ~wr_err;
+  assign classd_ctrl_lock_we = addr_hit[47] & reg_we & !reg_error;
   assign classd_ctrl_lock_wd = reg_wdata[1];
 
-  assign classd_ctrl_en_e0_we = addr_hit[47] & reg_we & ~wr_err;
+  assign classd_ctrl_en_e0_we = addr_hit[47] & reg_we & !reg_error;
   assign classd_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classd_ctrl_en_e1_we = addr_hit[47] & reg_we & ~wr_err;
+  assign classd_ctrl_en_e1_we = addr_hit[47] & reg_we & !reg_error;
   assign classd_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classd_ctrl_en_e2_we = addr_hit[47] & reg_we & ~wr_err;
+  assign classd_ctrl_en_e2_we = addr_hit[47] & reg_we & !reg_error;
   assign classd_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classd_ctrl_en_e3_we = addr_hit[47] & reg_we & ~wr_err;
+  assign classd_ctrl_en_e3_we = addr_hit[47] & reg_we & !reg_error;
   assign classd_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classd_ctrl_map_e0_we = addr_hit[47] & reg_we & ~wr_err;
+  assign classd_ctrl_map_e0_we = addr_hit[47] & reg_we & !reg_error;
   assign classd_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classd_ctrl_map_e1_we = addr_hit[47] & reg_we & ~wr_err;
+  assign classd_ctrl_map_e1_we = addr_hit[47] & reg_we & !reg_error;
   assign classd_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classd_ctrl_map_e2_we = addr_hit[47] & reg_we & ~wr_err;
+  assign classd_ctrl_map_e2_we = addr_hit[47] & reg_we & !reg_error;
   assign classd_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classd_ctrl_map_e3_we = addr_hit[47] & reg_we & ~wr_err;
+  assign classd_ctrl_map_e3_we = addr_hit[47] & reg_we & !reg_error;
   assign classd_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classd_regwen_we = addr_hit[48] & reg_we & ~wr_err;
+  assign classd_regwen_we = addr_hit[48] & reg_we & !reg_error;
   assign classd_regwen_wd = reg_wdata[0];
 
-  assign classd_clr_we = addr_hit[49] & reg_we & ~wr_err;
+  assign classd_clr_we = addr_hit[49] & reg_we & !reg_error;
   assign classd_clr_wd = reg_wdata[0];
 
-  assign classd_accum_cnt_re = addr_hit[50] && reg_re;
+  assign classd_accum_cnt_re = addr_hit[50] & reg_re & !reg_error;
 
-  assign classd_accum_thresh_we = addr_hit[51] & reg_we & ~wr_err;
+  assign classd_accum_thresh_we = addr_hit[51] & reg_we & !reg_error;
   assign classd_accum_thresh_wd = reg_wdata[15:0];
 
-  assign classd_timeout_cyc_we = addr_hit[52] & reg_we & ~wr_err;
+  assign classd_timeout_cyc_we = addr_hit[52] & reg_we & !reg_error;
   assign classd_timeout_cyc_wd = reg_wdata[31:0];
 
-  assign classd_phase0_cyc_we = addr_hit[53] & reg_we & ~wr_err;
+  assign classd_phase0_cyc_we = addr_hit[53] & reg_we & !reg_error;
   assign classd_phase0_cyc_wd = reg_wdata[31:0];
 
-  assign classd_phase1_cyc_we = addr_hit[54] & reg_we & ~wr_err;
+  assign classd_phase1_cyc_we = addr_hit[54] & reg_we & !reg_error;
   assign classd_phase1_cyc_wd = reg_wdata[31:0];
 
-  assign classd_phase2_cyc_we = addr_hit[55] & reg_we & ~wr_err;
+  assign classd_phase2_cyc_we = addr_hit[55] & reg_we & !reg_error;
   assign classd_phase2_cyc_wd = reg_wdata[31:0];
 
-  assign classd_phase3_cyc_we = addr_hit[56] & reg_we & ~wr_err;
+  assign classd_phase3_cyc_we = addr_hit[56] & reg_we & !reg_error;
   assign classd_phase3_cyc_wd = reg_wdata[31:0];
 
-  assign classd_esc_cnt_re = addr_hit[57] && reg_re;
+  assign classd_esc_cnt_re = addr_hit[57] & reg_re & !reg_error;
 
-  assign classd_state_re = addr_hit[58] && reg_re;
+  assign classd_state_re = addr_hit[58] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
@@ -495,68 +495,68 @@ module aon_timer_reg_top (
     if (addr_hit[11] && reg_we && (AON_TIMER_PERMIT[11] != (AON_TIMER_PERMIT[11] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign wkup_ctrl_enable_we = addr_hit[0] & reg_we & ~wr_err;
+  assign wkup_ctrl_enable_we = addr_hit[0] & reg_we & !reg_error;
   assign wkup_ctrl_enable_wd = reg_wdata[0];
-  assign wkup_ctrl_enable_re = addr_hit[0] && reg_re;
+  assign wkup_ctrl_enable_re = addr_hit[0] & reg_re & !reg_error;
 
-  assign wkup_ctrl_prescaler_we = addr_hit[0] & reg_we & ~wr_err;
+  assign wkup_ctrl_prescaler_we = addr_hit[0] & reg_we & !reg_error;
   assign wkup_ctrl_prescaler_wd = reg_wdata[12:1];
-  assign wkup_ctrl_prescaler_re = addr_hit[0] && reg_re;
+  assign wkup_ctrl_prescaler_re = addr_hit[0] & reg_re & !reg_error;
 
-  assign wkup_thold_we = addr_hit[1] & reg_we & ~wr_err;
+  assign wkup_thold_we = addr_hit[1] & reg_we & !reg_error;
   assign wkup_thold_wd = reg_wdata[31:0];
-  assign wkup_thold_re = addr_hit[1] && reg_re;
+  assign wkup_thold_re = addr_hit[1] & reg_re & !reg_error;
 
-  assign wkup_count_we = addr_hit[2] & reg_we & ~wr_err;
+  assign wkup_count_we = addr_hit[2] & reg_we & !reg_error;
   assign wkup_count_wd = reg_wdata[31:0];
-  assign wkup_count_re = addr_hit[2] && reg_re;
+  assign wkup_count_re = addr_hit[2] & reg_re & !reg_error;
 
-  assign wdog_regwen_we = addr_hit[3] & reg_we & ~wr_err;
+  assign wdog_regwen_we = addr_hit[3] & reg_we & !reg_error;
   assign wdog_regwen_wd = reg_wdata[0];
 
-  assign wdog_ctrl_enable_we = addr_hit[4] & reg_we & ~wr_err;
+  assign wdog_ctrl_enable_we = addr_hit[4] & reg_we & !reg_error;
   assign wdog_ctrl_enable_wd = reg_wdata[0];
-  assign wdog_ctrl_enable_re = addr_hit[4] && reg_re;
+  assign wdog_ctrl_enable_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign wdog_ctrl_pause_in_sleep_we = addr_hit[4] & reg_we & ~wr_err;
+  assign wdog_ctrl_pause_in_sleep_we = addr_hit[4] & reg_we & !reg_error;
   assign wdog_ctrl_pause_in_sleep_wd = reg_wdata[1];
-  assign wdog_ctrl_pause_in_sleep_re = addr_hit[4] && reg_re;
+  assign wdog_ctrl_pause_in_sleep_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign wdog_bark_thold_we = addr_hit[5] & reg_we & ~wr_err;
+  assign wdog_bark_thold_we = addr_hit[5] & reg_we & !reg_error;
   assign wdog_bark_thold_wd = reg_wdata[31:0];
-  assign wdog_bark_thold_re = addr_hit[5] && reg_re;
+  assign wdog_bark_thold_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign wdog_bite_thold_we = addr_hit[6] & reg_we & ~wr_err;
+  assign wdog_bite_thold_we = addr_hit[6] & reg_we & !reg_error;
   assign wdog_bite_thold_wd = reg_wdata[31:0];
-  assign wdog_bite_thold_re = addr_hit[6] && reg_re;
+  assign wdog_bite_thold_re = addr_hit[6] & reg_re & !reg_error;
 
-  assign wdog_count_we = addr_hit[7] & reg_we & ~wr_err;
+  assign wdog_count_we = addr_hit[7] & reg_we & !reg_error;
   assign wdog_count_wd = reg_wdata[31:0];
-  assign wdog_count_re = addr_hit[7] && reg_re;
+  assign wdog_count_re = addr_hit[7] & reg_re & !reg_error;
 
-  assign intr_state_wkup_timer_expired_we = addr_hit[8] & reg_we & ~wr_err;
+  assign intr_state_wkup_timer_expired_we = addr_hit[8] & reg_we & !reg_error;
   assign intr_state_wkup_timer_expired_wd = reg_wdata[0];
 
-  assign intr_state_wdog_timer_expired_we = addr_hit[8] & reg_we & ~wr_err;
+  assign intr_state_wdog_timer_expired_we = addr_hit[8] & reg_we & !reg_error;
   assign intr_state_wdog_timer_expired_wd = reg_wdata[1];
 
-  assign intr_enable_wkup_timer_expired_we = addr_hit[9] & reg_we & ~wr_err;
+  assign intr_enable_wkup_timer_expired_we = addr_hit[9] & reg_we & !reg_error;
   assign intr_enable_wkup_timer_expired_wd = reg_wdata[0];
-  assign intr_enable_wkup_timer_expired_re = addr_hit[9] && reg_re;
+  assign intr_enable_wkup_timer_expired_re = addr_hit[9] & reg_re & !reg_error;
 
-  assign intr_enable_wdog_timer_expired_we = addr_hit[9] & reg_we & ~wr_err;
+  assign intr_enable_wdog_timer_expired_we = addr_hit[9] & reg_we & !reg_error;
   assign intr_enable_wdog_timer_expired_wd = reg_wdata[1];
-  assign intr_enable_wdog_timer_expired_re = addr_hit[9] && reg_re;
+  assign intr_enable_wdog_timer_expired_re = addr_hit[9] & reg_re & !reg_error;
 
-  assign intr_test_wkup_timer_expired_we = addr_hit[10] & reg_we & ~wr_err;
+  assign intr_test_wkup_timer_expired_we = addr_hit[10] & reg_we & !reg_error;
   assign intr_test_wkup_timer_expired_wd = reg_wdata[0];
 
-  assign intr_test_wdog_timer_expired_we = addr_hit[10] & reg_we & ~wr_err;
+  assign intr_test_wdog_timer_expired_we = addr_hit[10] & reg_we & !reg_error;
   assign intr_test_wdog_timer_expired_wd = reg_wdata[1];
 
-  assign wkup_cause_we = addr_hit[11] & reg_we & ~wr_err;
+  assign wkup_cause_we = addr_hit[11] & reg_we & !reg_error;
   assign wkup_cause_wd = reg_wdata[0];
-  assign wkup_cause_re = addr_hit[11] && reg_re;
+  assign wkup_cause_re = addr_hit[11] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/ip/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr_reg_top.sv
@@ -281,16 +281,16 @@ module clkmgr_reg_top (
     if (addr_hit[2] && reg_we && (CLKMGR_PERMIT[2] != (CLKMGR_PERMIT[2] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign clk_enables_clk_fixed_peri_en_we = addr_hit[0] & reg_we & ~wr_err;
+  assign clk_enables_clk_fixed_peri_en_we = addr_hit[0] & reg_we & !reg_error;
   assign clk_enables_clk_fixed_peri_en_wd = reg_wdata[0];
 
-  assign clk_enables_clk_usb_48mhz_peri_en_we = addr_hit[0] & reg_we & ~wr_err;
+  assign clk_enables_clk_usb_48mhz_peri_en_we = addr_hit[0] & reg_we & !reg_error;
   assign clk_enables_clk_usb_48mhz_peri_en_wd = reg_wdata[1];
 
-  assign clk_hints_clk_main_aes_hint_we = addr_hit[1] & reg_we & ~wr_err;
+  assign clk_hints_clk_main_aes_hint_we = addr_hit[1] & reg_we & !reg_error;
   assign clk_hints_clk_main_aes_hint_wd = reg_wdata[0];
 
-  assign clk_hints_clk_main_hmac_hint_we = addr_hit[1] & reg_we & ~wr_err;
+  assign clk_hints_clk_main_hmac_hint_we = addr_hit[1] & reg_we & !reg_error;
   assign clk_hints_clk_main_hmac_hint_wd = reg_wdata[1];
 
 

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -1585,80 +1585,80 @@ module csrng_reg_top (
     if (addr_hit[17] && reg_we && (CSRNG_PERMIT[17] != (CSRNG_PERMIT[17] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_cs_cmd_req_done_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_cs_cmd_req_done_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_cs_cmd_req_done_wd = reg_wdata[0];
 
-  assign intr_state_cs_entropy_req_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_cs_entropy_req_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_cs_entropy_req_wd = reg_wdata[1];
 
-  assign intr_state_cs_hw_inst_exc_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_cs_hw_inst_exc_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_cs_hw_inst_exc_wd = reg_wdata[2];
 
-  assign intr_state_cs_fatal_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_cs_fatal_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_cs_fatal_err_wd = reg_wdata[3];
 
-  assign intr_enable_cs_cmd_req_done_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_cs_cmd_req_done_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_cs_cmd_req_done_wd = reg_wdata[0];
 
-  assign intr_enable_cs_entropy_req_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_cs_entropy_req_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_cs_entropy_req_wd = reg_wdata[1];
 
-  assign intr_enable_cs_hw_inst_exc_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_cs_hw_inst_exc_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_cs_hw_inst_exc_wd = reg_wdata[2];
 
-  assign intr_enable_cs_fatal_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_cs_fatal_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_cs_fatal_err_wd = reg_wdata[3];
 
-  assign intr_test_cs_cmd_req_done_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_cs_cmd_req_done_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_cs_cmd_req_done_wd = reg_wdata[0];
 
-  assign intr_test_cs_entropy_req_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_cs_entropy_req_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_cs_entropy_req_wd = reg_wdata[1];
 
-  assign intr_test_cs_hw_inst_exc_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_cs_hw_inst_exc_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_cs_hw_inst_exc_wd = reg_wdata[2];
 
-  assign intr_test_cs_fatal_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_cs_fatal_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_cs_fatal_err_wd = reg_wdata[3];
 
-  assign alert_test_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_wd = reg_wdata[0];
 
-  assign regwen_we = addr_hit[4] & reg_we & ~wr_err;
+  assign regwen_we = addr_hit[4] & reg_we & !reg_error;
   assign regwen_wd = reg_wdata[0];
 
-  assign ctrl_enable_we = addr_hit[5] & reg_we & ~wr_err;
+  assign ctrl_enable_we = addr_hit[5] & reg_we & !reg_error;
   assign ctrl_enable_wd = reg_wdata[0];
 
-  assign ctrl_aes_cipher_disable_we = addr_hit[5] & reg_we & ~wr_err;
+  assign ctrl_aes_cipher_disable_we = addr_hit[5] & reg_we & !reg_error;
   assign ctrl_aes_cipher_disable_wd = reg_wdata[1];
 
-  assign ctrl_fifo_depth_sts_sel_we = addr_hit[5] & reg_we & ~wr_err;
+  assign ctrl_fifo_depth_sts_sel_we = addr_hit[5] & reg_we & !reg_error;
   assign ctrl_fifo_depth_sts_sel_wd = reg_wdata[19:16];
 
 
 
-  assign cmd_req_we = addr_hit[7] & reg_we & ~wr_err;
+  assign cmd_req_we = addr_hit[7] & reg_we & !reg_error;
   assign cmd_req_wd = reg_wdata[31:0];
 
 
 
-  assign genbits_vld_genbits_vld_re = addr_hit[9] && reg_re;
+  assign genbits_vld_genbits_vld_re = addr_hit[9] & reg_re & !reg_error;
 
-  assign genbits_vld_genbits_fips_re = addr_hit[9] && reg_re;
+  assign genbits_vld_genbits_fips_re = addr_hit[9] & reg_re & !reg_error;
 
-  assign genbits_re = addr_hit[10] && reg_re;
+  assign genbits_re = addr_hit[10] & reg_re & !reg_error;
 
-  assign halt_main_sm_we = addr_hit[11] & reg_we & ~wr_err;
+  assign halt_main_sm_we = addr_hit[11] & reg_we & !reg_error;
   assign halt_main_sm_wd = reg_wdata[0];
 
 
-  assign int_state_num_we = addr_hit[13] & reg_we & ~wr_err;
+  assign int_state_num_we = addr_hit[13] & reg_we & !reg_error;
   assign int_state_num_wd = reg_wdata[3:0];
 
-  assign int_state_val_re = addr_hit[14] && reg_re;
+  assign int_state_val_re = addr_hit[14] & reg_re & !reg_error;
 
-  assign hw_exc_sts_we = addr_hit[15] & reg_we & ~wr_err;
+  assign hw_exc_sts_we = addr_hit[15] & reg_we & !reg_error;
   assign hw_exc_sts_wd = reg_wdata[14:0];
 
 
@@ -1686,7 +1686,7 @@ module csrng_reg_top (
 
 
 
-  assign err_code_test_we = addr_hit[17] & reg_we & ~wr_err;
+  assign err_code_test_we = addr_hit[17] & reg_we & !reg_error;
   assign err_code_test_wd = reg_wdata[4:0];
 
   // Read data return

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -895,63 +895,63 @@ module edn_reg_top (
     if (addr_hit[13] && reg_we && (EDN_PERMIT[13] != (EDN_PERMIT[13] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_edn_cmd_req_done_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_edn_cmd_req_done_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_edn_cmd_req_done_wd = reg_wdata[0];
 
-  assign intr_state_edn_fatal_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_edn_fatal_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_edn_fatal_err_wd = reg_wdata[1];
 
-  assign intr_enable_edn_cmd_req_done_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_edn_cmd_req_done_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_edn_cmd_req_done_wd = reg_wdata[0];
 
-  assign intr_enable_edn_fatal_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_edn_fatal_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_edn_fatal_err_wd = reg_wdata[1];
 
-  assign intr_test_edn_cmd_req_done_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_edn_cmd_req_done_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_edn_cmd_req_done_wd = reg_wdata[0];
 
-  assign intr_test_edn_fatal_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_edn_fatal_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_edn_fatal_err_wd = reg_wdata[1];
 
-  assign alert_test_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_wd = reg_wdata[0];
 
-  assign regwen_we = addr_hit[4] & reg_we & ~wr_err;
+  assign regwen_we = addr_hit[4] & reg_we & !reg_error;
   assign regwen_wd = reg_wdata[0];
 
-  assign ctrl_edn_enable_we = addr_hit[5] & reg_we & ~wr_err;
+  assign ctrl_edn_enable_we = addr_hit[5] & reg_we & !reg_error;
   assign ctrl_edn_enable_wd = reg_wdata[0];
 
-  assign ctrl_cmd_fifo_rst_we = addr_hit[5] & reg_we & ~wr_err;
+  assign ctrl_cmd_fifo_rst_we = addr_hit[5] & reg_we & !reg_error;
   assign ctrl_cmd_fifo_rst_wd = reg_wdata[1];
 
-  assign ctrl_auto_req_mode_we = addr_hit[5] & reg_we & ~wr_err;
+  assign ctrl_auto_req_mode_we = addr_hit[5] & reg_we & !reg_error;
   assign ctrl_auto_req_mode_wd = reg_wdata[2];
 
-  assign ctrl_boot_req_dis_we = addr_hit[5] & reg_we & ~wr_err;
+  assign ctrl_boot_req_dis_we = addr_hit[5] & reg_we & !reg_error;
   assign ctrl_boot_req_dis_wd = reg_wdata[3];
 
-  assign sum_sts_req_mode_sm_sts_we = addr_hit[6] & reg_we & ~wr_err;
+  assign sum_sts_req_mode_sm_sts_we = addr_hit[6] & reg_we & !reg_error;
   assign sum_sts_req_mode_sm_sts_wd = reg_wdata[0];
 
-  assign sum_sts_boot_inst_ack_we = addr_hit[6] & reg_we & ~wr_err;
+  assign sum_sts_boot_inst_ack_we = addr_hit[6] & reg_we & !reg_error;
   assign sum_sts_boot_inst_ack_wd = reg_wdata[1];
 
-  assign sum_sts_internal_use_we = addr_hit[6] & reg_we & ~wr_err;
+  assign sum_sts_internal_use_we = addr_hit[6] & reg_we & !reg_error;
   assign sum_sts_internal_use_wd = reg_wdata[31];
 
-  assign sw_cmd_req_we = addr_hit[7] & reg_we & ~wr_err;
+  assign sw_cmd_req_we = addr_hit[7] & reg_we & !reg_error;
   assign sw_cmd_req_wd = reg_wdata[31:0];
 
 
 
-  assign reseed_cmd_we = addr_hit[9] & reg_we & ~wr_err;
+  assign reseed_cmd_we = addr_hit[9] & reg_we & !reg_error;
   assign reseed_cmd_wd = reg_wdata[31:0];
 
-  assign generate_cmd_we = addr_hit[10] & reg_we & ~wr_err;
+  assign generate_cmd_we = addr_hit[10] & reg_we & !reg_error;
   assign generate_cmd_wd = reg_wdata[31:0];
 
-  assign max_num_reqs_between_reseeds_we = addr_hit[11] & reg_we & ~wr_err;
+  assign max_num_reqs_between_reseeds_we = addr_hit[11] & reg_we & !reg_error;
   assign max_num_reqs_between_reseeds_wd = reg_wdata[31:0];
 
 
@@ -961,7 +961,7 @@ module edn_reg_top (
 
 
 
-  assign err_code_test_we = addr_hit[13] & reg_we & ~wr_err;
+  assign err_code_test_we = addr_hit[13] & reg_we & !reg_error;
   assign err_code_test_wd = reg_wdata[4:0];
 
   // Read data return

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -2550,233 +2550,233 @@ module entropy_src_reg_top (
     if (addr_hit[46] && reg_we && (ENTROPY_SRC_PERMIT[46] != (ENTROPY_SRC_PERMIT[46] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_es_entropy_valid_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_es_entropy_valid_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_es_entropy_valid_wd = reg_wdata[0];
 
-  assign intr_state_es_health_test_failed_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_es_health_test_failed_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_es_health_test_failed_wd = reg_wdata[1];
 
-  assign intr_state_es_fatal_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_es_fatal_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_es_fatal_err_wd = reg_wdata[2];
 
-  assign intr_enable_es_entropy_valid_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_es_entropy_valid_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_es_entropy_valid_wd = reg_wdata[0];
 
-  assign intr_enable_es_health_test_failed_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_es_health_test_failed_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_es_health_test_failed_wd = reg_wdata[1];
 
-  assign intr_enable_es_fatal_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_es_fatal_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_es_fatal_err_wd = reg_wdata[2];
 
-  assign intr_test_es_entropy_valid_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_es_entropy_valid_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_es_entropy_valid_wd = reg_wdata[0];
 
-  assign intr_test_es_health_test_failed_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_es_health_test_failed_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_es_health_test_failed_wd = reg_wdata[1];
 
-  assign intr_test_es_fatal_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_es_fatal_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_es_fatal_err_wd = reg_wdata[2];
 
-  assign alert_test_recov_alert_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_recov_alert_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_recov_alert_wd = reg_wdata[0];
 
-  assign alert_test_fatal_alert_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_fatal_alert_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_fatal_alert_wd = reg_wdata[1];
 
-  assign regwen_we = addr_hit[4] & reg_we & ~wr_err;
+  assign regwen_we = addr_hit[4] & reg_we & !reg_error;
   assign regwen_wd = reg_wdata[0];
 
 
 
 
-  assign conf_enable_we = addr_hit[6] & reg_we & ~wr_err;
+  assign conf_enable_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_enable_wd = reg_wdata[1:0];
 
-  assign conf_boot_bypass_disable_we = addr_hit[6] & reg_we & ~wr_err;
+  assign conf_boot_bypass_disable_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_boot_bypass_disable_wd = reg_wdata[3];
 
-  assign conf_repcnt_disable_we = addr_hit[6] & reg_we & ~wr_err;
+  assign conf_repcnt_disable_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_repcnt_disable_wd = reg_wdata[4];
 
-  assign conf_adaptp_disable_we = addr_hit[6] & reg_we & ~wr_err;
+  assign conf_adaptp_disable_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_adaptp_disable_wd = reg_wdata[5];
 
-  assign conf_bucket_disable_we = addr_hit[6] & reg_we & ~wr_err;
+  assign conf_bucket_disable_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_bucket_disable_wd = reg_wdata[6];
 
-  assign conf_markov_disable_we = addr_hit[6] & reg_we & ~wr_err;
+  assign conf_markov_disable_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_markov_disable_wd = reg_wdata[7];
 
-  assign conf_health_test_clr_we = addr_hit[6] & reg_we & ~wr_err;
+  assign conf_health_test_clr_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_health_test_clr_wd = reg_wdata[8];
 
-  assign conf_rng_bit_en_we = addr_hit[6] & reg_we & ~wr_err;
+  assign conf_rng_bit_en_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_rng_bit_en_wd = reg_wdata[9];
 
-  assign conf_rng_bit_sel_we = addr_hit[6] & reg_we & ~wr_err;
+  assign conf_rng_bit_sel_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_rng_bit_sel_wd = reg_wdata[11:10];
 
-  assign conf_extht_enable_we = addr_hit[6] & reg_we & ~wr_err;
+  assign conf_extht_enable_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_extht_enable_wd = reg_wdata[12];
 
-  assign rate_we = addr_hit[7] & reg_we & ~wr_err;
+  assign rate_we = addr_hit[7] & reg_we & !reg_error;
   assign rate_wd = reg_wdata[15:0];
 
-  assign entropy_control_es_route_we = addr_hit[8] & reg_we & ~wr_err;
+  assign entropy_control_es_route_we = addr_hit[8] & reg_we & !reg_error;
   assign entropy_control_es_route_wd = reg_wdata[0];
 
-  assign entropy_control_es_type_we = addr_hit[8] & reg_we & ~wr_err;
+  assign entropy_control_es_type_we = addr_hit[8] & reg_we & !reg_error;
   assign entropy_control_es_type_wd = reg_wdata[1];
 
-  assign entropy_data_re = addr_hit[9] && reg_re;
+  assign entropy_data_re = addr_hit[9] & reg_re & !reg_error;
 
-  assign health_test_windows_fips_window_we = addr_hit[10] & reg_we & ~wr_err;
+  assign health_test_windows_fips_window_we = addr_hit[10] & reg_we & !reg_error;
   assign health_test_windows_fips_window_wd = reg_wdata[15:0];
 
-  assign health_test_windows_bypass_window_we = addr_hit[10] & reg_we & ~wr_err;
+  assign health_test_windows_bypass_window_we = addr_hit[10] & reg_we & !reg_error;
   assign health_test_windows_bypass_window_wd = reg_wdata[31:16];
 
-  assign repcnt_thresholds_fips_repcnt_thresh_we = addr_hit[11] & reg_we & ~wr_err;
+  assign repcnt_thresholds_fips_repcnt_thresh_we = addr_hit[11] & reg_we & !reg_error;
   assign repcnt_thresholds_fips_repcnt_thresh_wd = reg_wdata[15:0];
 
-  assign repcnt_thresholds_bypass_repcnt_thresh_we = addr_hit[11] & reg_we & ~wr_err;
+  assign repcnt_thresholds_bypass_repcnt_thresh_we = addr_hit[11] & reg_we & !reg_error;
   assign repcnt_thresholds_bypass_repcnt_thresh_wd = reg_wdata[31:16];
 
-  assign adaptp_hi_thresholds_fips_adaptp_hi_thresh_we = addr_hit[12] & reg_we & ~wr_err;
+  assign adaptp_hi_thresholds_fips_adaptp_hi_thresh_we = addr_hit[12] & reg_we & !reg_error;
   assign adaptp_hi_thresholds_fips_adaptp_hi_thresh_wd = reg_wdata[15:0];
 
-  assign adaptp_hi_thresholds_bypass_adaptp_hi_thresh_we = addr_hit[12] & reg_we & ~wr_err;
+  assign adaptp_hi_thresholds_bypass_adaptp_hi_thresh_we = addr_hit[12] & reg_we & !reg_error;
   assign adaptp_hi_thresholds_bypass_adaptp_hi_thresh_wd = reg_wdata[31:16];
 
-  assign adaptp_lo_thresholds_fips_adaptp_lo_thresh_we = addr_hit[13] & reg_we & ~wr_err;
+  assign adaptp_lo_thresholds_fips_adaptp_lo_thresh_we = addr_hit[13] & reg_we & !reg_error;
   assign adaptp_lo_thresholds_fips_adaptp_lo_thresh_wd = reg_wdata[15:0];
 
-  assign adaptp_lo_thresholds_bypass_adaptp_lo_thresh_we = addr_hit[13] & reg_we & ~wr_err;
+  assign adaptp_lo_thresholds_bypass_adaptp_lo_thresh_we = addr_hit[13] & reg_we & !reg_error;
   assign adaptp_lo_thresholds_bypass_adaptp_lo_thresh_wd = reg_wdata[31:16];
 
-  assign bucket_thresholds_fips_bucket_thresh_we = addr_hit[14] & reg_we & ~wr_err;
+  assign bucket_thresholds_fips_bucket_thresh_we = addr_hit[14] & reg_we & !reg_error;
   assign bucket_thresholds_fips_bucket_thresh_wd = reg_wdata[15:0];
 
-  assign bucket_thresholds_bypass_bucket_thresh_we = addr_hit[14] & reg_we & ~wr_err;
+  assign bucket_thresholds_bypass_bucket_thresh_we = addr_hit[14] & reg_we & !reg_error;
   assign bucket_thresholds_bypass_bucket_thresh_wd = reg_wdata[31:16];
 
-  assign markov_hi_thresholds_fips_markov_hi_thresh_we = addr_hit[15] & reg_we & ~wr_err;
+  assign markov_hi_thresholds_fips_markov_hi_thresh_we = addr_hit[15] & reg_we & !reg_error;
   assign markov_hi_thresholds_fips_markov_hi_thresh_wd = reg_wdata[15:0];
 
-  assign markov_hi_thresholds_bypass_markov_hi_thresh_we = addr_hit[15] & reg_we & ~wr_err;
+  assign markov_hi_thresholds_bypass_markov_hi_thresh_we = addr_hit[15] & reg_we & !reg_error;
   assign markov_hi_thresholds_bypass_markov_hi_thresh_wd = reg_wdata[31:16];
 
-  assign markov_lo_thresholds_fips_markov_lo_thresh_we = addr_hit[16] & reg_we & ~wr_err;
+  assign markov_lo_thresholds_fips_markov_lo_thresh_we = addr_hit[16] & reg_we & !reg_error;
   assign markov_lo_thresholds_fips_markov_lo_thresh_wd = reg_wdata[15:0];
 
-  assign markov_lo_thresholds_bypass_markov_lo_thresh_we = addr_hit[16] & reg_we & ~wr_err;
+  assign markov_lo_thresholds_bypass_markov_lo_thresh_we = addr_hit[16] & reg_we & !reg_error;
   assign markov_lo_thresholds_bypass_markov_lo_thresh_wd = reg_wdata[31:16];
 
-  assign extht_hi_thresholds_fips_extht_hi_thresh_we = addr_hit[17] & reg_we & ~wr_err;
+  assign extht_hi_thresholds_fips_extht_hi_thresh_we = addr_hit[17] & reg_we & !reg_error;
   assign extht_hi_thresholds_fips_extht_hi_thresh_wd = reg_wdata[15:0];
 
-  assign extht_hi_thresholds_bypass_extht_hi_thresh_we = addr_hit[17] & reg_we & ~wr_err;
+  assign extht_hi_thresholds_bypass_extht_hi_thresh_we = addr_hit[17] & reg_we & !reg_error;
   assign extht_hi_thresholds_bypass_extht_hi_thresh_wd = reg_wdata[31:16];
 
-  assign extht_lo_thresholds_fips_extht_lo_thresh_we = addr_hit[18] & reg_we & ~wr_err;
+  assign extht_lo_thresholds_fips_extht_lo_thresh_we = addr_hit[18] & reg_we & !reg_error;
   assign extht_lo_thresholds_fips_extht_lo_thresh_wd = reg_wdata[15:0];
 
-  assign extht_lo_thresholds_bypass_extht_lo_thresh_we = addr_hit[18] & reg_we & ~wr_err;
+  assign extht_lo_thresholds_bypass_extht_lo_thresh_we = addr_hit[18] & reg_we & !reg_error;
   assign extht_lo_thresholds_bypass_extht_lo_thresh_wd = reg_wdata[31:16];
 
-  assign repcnt_hi_watermarks_fips_repcnt_hi_watermark_re = addr_hit[19] && reg_re;
+  assign repcnt_hi_watermarks_fips_repcnt_hi_watermark_re = addr_hit[19] & reg_re & !reg_error;
 
-  assign repcnt_hi_watermarks_bypass_repcnt_hi_watermark_re = addr_hit[19] && reg_re;
+  assign repcnt_hi_watermarks_bypass_repcnt_hi_watermark_re = addr_hit[19] & reg_re & !reg_error;
 
-  assign adaptp_hi_watermarks_fips_adaptp_hi_watermark_re = addr_hit[20] && reg_re;
+  assign adaptp_hi_watermarks_fips_adaptp_hi_watermark_re = addr_hit[20] & reg_re & !reg_error;
 
-  assign adaptp_hi_watermarks_bypass_adaptp_hi_watermark_re = addr_hit[20] && reg_re;
+  assign adaptp_hi_watermarks_bypass_adaptp_hi_watermark_re = addr_hit[20] & reg_re & !reg_error;
 
-  assign adaptp_lo_watermarks_fips_adaptp_lo_watermark_re = addr_hit[21] && reg_re;
+  assign adaptp_lo_watermarks_fips_adaptp_lo_watermark_re = addr_hit[21] & reg_re & !reg_error;
 
-  assign adaptp_lo_watermarks_bypass_adaptp_lo_watermark_re = addr_hit[21] && reg_re;
+  assign adaptp_lo_watermarks_bypass_adaptp_lo_watermark_re = addr_hit[21] & reg_re & !reg_error;
 
-  assign extht_hi_watermarks_fips_extht_hi_watermark_re = addr_hit[22] && reg_re;
+  assign extht_hi_watermarks_fips_extht_hi_watermark_re = addr_hit[22] & reg_re & !reg_error;
 
-  assign extht_hi_watermarks_bypass_extht_hi_watermark_re = addr_hit[22] && reg_re;
+  assign extht_hi_watermarks_bypass_extht_hi_watermark_re = addr_hit[22] & reg_re & !reg_error;
 
-  assign extht_lo_watermarks_fips_extht_lo_watermark_re = addr_hit[23] && reg_re;
+  assign extht_lo_watermarks_fips_extht_lo_watermark_re = addr_hit[23] & reg_re & !reg_error;
 
-  assign extht_lo_watermarks_bypass_extht_lo_watermark_re = addr_hit[23] && reg_re;
+  assign extht_lo_watermarks_bypass_extht_lo_watermark_re = addr_hit[23] & reg_re & !reg_error;
 
-  assign bucket_hi_watermarks_fips_bucket_hi_watermark_re = addr_hit[24] && reg_re;
+  assign bucket_hi_watermarks_fips_bucket_hi_watermark_re = addr_hit[24] & reg_re & !reg_error;
 
-  assign bucket_hi_watermarks_bypass_bucket_hi_watermark_re = addr_hit[24] && reg_re;
+  assign bucket_hi_watermarks_bypass_bucket_hi_watermark_re = addr_hit[24] & reg_re & !reg_error;
 
-  assign markov_hi_watermarks_fips_markov_hi_watermark_re = addr_hit[25] && reg_re;
+  assign markov_hi_watermarks_fips_markov_hi_watermark_re = addr_hit[25] & reg_re & !reg_error;
 
-  assign markov_hi_watermarks_bypass_markov_hi_watermark_re = addr_hit[25] && reg_re;
+  assign markov_hi_watermarks_bypass_markov_hi_watermark_re = addr_hit[25] & reg_re & !reg_error;
 
-  assign markov_lo_watermarks_fips_markov_lo_watermark_re = addr_hit[26] && reg_re;
+  assign markov_lo_watermarks_fips_markov_lo_watermark_re = addr_hit[26] & reg_re & !reg_error;
 
-  assign markov_lo_watermarks_bypass_markov_lo_watermark_re = addr_hit[26] && reg_re;
+  assign markov_lo_watermarks_bypass_markov_lo_watermark_re = addr_hit[26] & reg_re & !reg_error;
 
-  assign repcnt_total_fails_re = addr_hit[27] && reg_re;
+  assign repcnt_total_fails_re = addr_hit[27] & reg_re & !reg_error;
 
-  assign adaptp_hi_total_fails_re = addr_hit[28] && reg_re;
+  assign adaptp_hi_total_fails_re = addr_hit[28] & reg_re & !reg_error;
 
-  assign adaptp_lo_total_fails_re = addr_hit[29] && reg_re;
+  assign adaptp_lo_total_fails_re = addr_hit[29] & reg_re & !reg_error;
 
-  assign bucket_total_fails_re = addr_hit[30] && reg_re;
+  assign bucket_total_fails_re = addr_hit[30] & reg_re & !reg_error;
 
-  assign markov_hi_total_fails_re = addr_hit[31] && reg_re;
+  assign markov_hi_total_fails_re = addr_hit[31] & reg_re & !reg_error;
 
-  assign markov_lo_total_fails_re = addr_hit[32] && reg_re;
+  assign markov_lo_total_fails_re = addr_hit[32] & reg_re & !reg_error;
 
-  assign extht_hi_total_fails_re = addr_hit[33] && reg_re;
+  assign extht_hi_total_fails_re = addr_hit[33] & reg_re & !reg_error;
 
-  assign extht_lo_total_fails_re = addr_hit[34] && reg_re;
+  assign extht_lo_total_fails_re = addr_hit[34] & reg_re & !reg_error;
 
-  assign alert_threshold_we = addr_hit[35] & reg_we & ~wr_err;
+  assign alert_threshold_we = addr_hit[35] & reg_we & !reg_error;
   assign alert_threshold_wd = reg_wdata[3:0];
 
-  assign alert_fail_counts_any_fail_count_re = addr_hit[36] && reg_re;
+  assign alert_fail_counts_any_fail_count_re = addr_hit[36] & reg_re & !reg_error;
 
-  assign alert_fail_counts_repcnt_fail_count_re = addr_hit[36] && reg_re;
+  assign alert_fail_counts_repcnt_fail_count_re = addr_hit[36] & reg_re & !reg_error;
 
-  assign alert_fail_counts_adaptp_hi_fail_count_re = addr_hit[36] && reg_re;
+  assign alert_fail_counts_adaptp_hi_fail_count_re = addr_hit[36] & reg_re & !reg_error;
 
-  assign alert_fail_counts_adaptp_lo_fail_count_re = addr_hit[36] && reg_re;
+  assign alert_fail_counts_adaptp_lo_fail_count_re = addr_hit[36] & reg_re & !reg_error;
 
-  assign alert_fail_counts_bucket_fail_count_re = addr_hit[36] && reg_re;
+  assign alert_fail_counts_bucket_fail_count_re = addr_hit[36] & reg_re & !reg_error;
 
-  assign alert_fail_counts_markov_hi_fail_count_re = addr_hit[36] && reg_re;
+  assign alert_fail_counts_markov_hi_fail_count_re = addr_hit[36] & reg_re & !reg_error;
 
-  assign alert_fail_counts_markov_lo_fail_count_re = addr_hit[36] && reg_re;
+  assign alert_fail_counts_markov_lo_fail_count_re = addr_hit[36] & reg_re & !reg_error;
 
-  assign extht_fail_counts_extht_hi_fail_count_re = addr_hit[37] && reg_re;
+  assign extht_fail_counts_extht_hi_fail_count_re = addr_hit[37] & reg_re & !reg_error;
 
-  assign extht_fail_counts_extht_lo_fail_count_re = addr_hit[37] && reg_re;
+  assign extht_fail_counts_extht_lo_fail_count_re = addr_hit[37] & reg_re & !reg_error;
 
-  assign fw_ov_control_fw_ov_mode_we = addr_hit[38] & reg_we & ~wr_err;
+  assign fw_ov_control_fw_ov_mode_we = addr_hit[38] & reg_we & !reg_error;
   assign fw_ov_control_fw_ov_mode_wd = reg_wdata[0];
 
-  assign fw_ov_control_fw_ov_fifo_reg_rd_we = addr_hit[38] & reg_we & ~wr_err;
+  assign fw_ov_control_fw_ov_fifo_reg_rd_we = addr_hit[38] & reg_we & !reg_error;
   assign fw_ov_control_fw_ov_fifo_reg_rd_wd = reg_wdata[1];
 
-  assign fw_ov_control_fw_ov_fifo_reg_wr_we = addr_hit[38] & reg_we & ~wr_err;
+  assign fw_ov_control_fw_ov_fifo_reg_wr_we = addr_hit[38] & reg_we & !reg_error;
   assign fw_ov_control_fw_ov_fifo_reg_wr_wd = reg_wdata[2];
 
-  assign fw_ov_rd_data_re = addr_hit[39] && reg_re;
+  assign fw_ov_rd_data_re = addr_hit[39] & reg_re & !reg_error;
 
-  assign fw_ov_wr_data_we = addr_hit[40] & reg_we & ~wr_err;
+  assign fw_ov_wr_data_we = addr_hit[40] & reg_we & !reg_error;
   assign fw_ov_wr_data_wd = reg_wdata[31:0];
 
-  assign fw_ov_fifo_sts_re = addr_hit[41] && reg_re;
+  assign fw_ov_fifo_sts_re = addr_hit[41] & reg_re & !reg_error;
 
-  assign pre_cond_fifo_depth_we = addr_hit[42] & reg_we & ~wr_err;
+  assign pre_cond_fifo_depth_we = addr_hit[42] & reg_we & !reg_error;
   assign pre_cond_fifo_depth_wd = reg_wdata[6:0];
 
-  assign debug_status_entropy_fifo_depth_re = addr_hit[43] && reg_re;
+  assign debug_status_entropy_fifo_depth_re = addr_hit[43] & reg_re & !reg_error;
 
-  assign debug_status_diag_re = addr_hit[43] && reg_re;
+  assign debug_status_diag_re = addr_hit[43] & reg_re & !reg_error;
 
-  assign seed_we = addr_hit[44] & reg_we & ~wr_err;
+  assign seed_we = addr_hit[44] & reg_we & !reg_error;
   assign seed_wd = reg_wdata[3:0];
 
 
@@ -2787,7 +2787,7 @@ module entropy_src_reg_top (
 
 
 
-  assign err_code_test_we = addr_hit[46] & reg_we & ~wr_err;
+  assign err_code_test_we = addr_hit[46] & reg_we & !reg_error;
   assign err_code_test_wd = reg_wdata[4:0];
 
   // Read data return

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
@@ -10585,990 +10585,990 @@ module flash_ctrl_reg_top (
     if (addr_hit[90] && reg_we && (FLASH_CTRL_PERMIT[90] != (FLASH_CTRL_PERMIT[90] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_prog_empty_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_prog_empty_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_prog_empty_wd = reg_wdata[0];
 
-  assign intr_state_prog_lvl_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_prog_lvl_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_prog_lvl_wd = reg_wdata[1];
 
-  assign intr_state_rd_full_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rd_full_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rd_full_wd = reg_wdata[2];
 
-  assign intr_state_rd_lvl_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rd_lvl_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rd_lvl_wd = reg_wdata[3];
 
-  assign intr_state_op_done_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_op_done_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_op_done_wd = reg_wdata[4];
 
-  assign intr_enable_prog_empty_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_prog_empty_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_prog_empty_wd = reg_wdata[0];
 
-  assign intr_enable_prog_lvl_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_prog_lvl_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_prog_lvl_wd = reg_wdata[1];
 
-  assign intr_enable_rd_full_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rd_full_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rd_full_wd = reg_wdata[2];
 
-  assign intr_enable_rd_lvl_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rd_lvl_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rd_lvl_wd = reg_wdata[3];
 
-  assign intr_enable_op_done_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_op_done_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_op_done_wd = reg_wdata[4];
 
-  assign intr_test_prog_empty_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_prog_empty_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_prog_empty_wd = reg_wdata[0];
 
-  assign intr_test_prog_lvl_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_prog_lvl_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_prog_lvl_wd = reg_wdata[1];
 
-  assign intr_test_rd_full_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rd_full_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rd_full_wd = reg_wdata[2];
 
-  assign intr_test_rd_lvl_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rd_lvl_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rd_lvl_wd = reg_wdata[3];
 
-  assign intr_test_op_done_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_op_done_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_op_done_wd = reg_wdata[4];
 
-  assign alert_test_recov_err_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_recov_err_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_recov_err_wd = reg_wdata[0];
 
-  assign alert_test_recov_mp_err_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_recov_mp_err_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_recov_mp_err_wd = reg_wdata[1];
 
-  assign alert_test_recov_ecc_err_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_recov_ecc_err_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_recov_ecc_err_wd = reg_wdata[2];
 
-  assign ctrl_regwen_re = addr_hit[4] && reg_re;
+  assign ctrl_regwen_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign control_start_we = addr_hit[5] & reg_we & ~wr_err;
+  assign control_start_we = addr_hit[5] & reg_we & !reg_error;
   assign control_start_wd = reg_wdata[0];
 
-  assign control_op_we = addr_hit[5] & reg_we & ~wr_err;
+  assign control_op_we = addr_hit[5] & reg_we & !reg_error;
   assign control_op_wd = reg_wdata[5:4];
 
-  assign control_prog_sel_we = addr_hit[5] & reg_we & ~wr_err;
+  assign control_prog_sel_we = addr_hit[5] & reg_we & !reg_error;
   assign control_prog_sel_wd = reg_wdata[6];
 
-  assign control_erase_sel_we = addr_hit[5] & reg_we & ~wr_err;
+  assign control_erase_sel_we = addr_hit[5] & reg_we & !reg_error;
   assign control_erase_sel_wd = reg_wdata[7];
 
-  assign control_partition_sel_we = addr_hit[5] & reg_we & ~wr_err;
+  assign control_partition_sel_we = addr_hit[5] & reg_we & !reg_error;
   assign control_partition_sel_wd = reg_wdata[8];
 
-  assign control_info_sel_we = addr_hit[5] & reg_we & ~wr_err;
+  assign control_info_sel_we = addr_hit[5] & reg_we & !reg_error;
   assign control_info_sel_wd = reg_wdata[10:9];
 
-  assign control_num_we = addr_hit[5] & reg_we & ~wr_err;
+  assign control_num_we = addr_hit[5] & reg_we & !reg_error;
   assign control_num_wd = reg_wdata[27:16];
 
-  assign addr_we = addr_hit[6] & reg_we & ~wr_err;
+  assign addr_we = addr_hit[6] & reg_we & !reg_error;
   assign addr_wd = reg_wdata[31:0];
 
-  assign prog_type_en_normal_we = addr_hit[7] & reg_we & ~wr_err;
+  assign prog_type_en_normal_we = addr_hit[7] & reg_we & !reg_error;
   assign prog_type_en_normal_wd = reg_wdata[0];
 
-  assign prog_type_en_repair_we = addr_hit[7] & reg_we & ~wr_err;
+  assign prog_type_en_repair_we = addr_hit[7] & reg_we & !reg_error;
   assign prog_type_en_repair_wd = reg_wdata[1];
 
-  assign erase_suspend_we = addr_hit[8] & reg_we & ~wr_err;
+  assign erase_suspend_we = addr_hit[8] & reg_we & !reg_error;
   assign erase_suspend_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_0_we = addr_hit[9] & reg_we & ~wr_err;
+  assign region_cfg_regwen_0_we = addr_hit[9] & reg_we & !reg_error;
   assign region_cfg_regwen_0_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_1_we = addr_hit[10] & reg_we & ~wr_err;
+  assign region_cfg_regwen_1_we = addr_hit[10] & reg_we & !reg_error;
   assign region_cfg_regwen_1_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_2_we = addr_hit[11] & reg_we & ~wr_err;
+  assign region_cfg_regwen_2_we = addr_hit[11] & reg_we & !reg_error;
   assign region_cfg_regwen_2_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_3_we = addr_hit[12] & reg_we & ~wr_err;
+  assign region_cfg_regwen_3_we = addr_hit[12] & reg_we & !reg_error;
   assign region_cfg_regwen_3_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_4_we = addr_hit[13] & reg_we & ~wr_err;
+  assign region_cfg_regwen_4_we = addr_hit[13] & reg_we & !reg_error;
   assign region_cfg_regwen_4_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_5_we = addr_hit[14] & reg_we & ~wr_err;
+  assign region_cfg_regwen_5_we = addr_hit[14] & reg_we & !reg_error;
   assign region_cfg_regwen_5_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_6_we = addr_hit[15] & reg_we & ~wr_err;
+  assign region_cfg_regwen_6_we = addr_hit[15] & reg_we & !reg_error;
   assign region_cfg_regwen_6_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_7_we = addr_hit[16] & reg_we & ~wr_err;
+  assign region_cfg_regwen_7_we = addr_hit[16] & reg_we & !reg_error;
   assign region_cfg_regwen_7_wd = reg_wdata[0];
 
-  assign mp_region_cfg_0_en_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_en_0_we = addr_hit[17] & reg_we & !reg_error;
   assign mp_region_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign mp_region_cfg_0_rd_en_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_rd_en_0_we = addr_hit[17] & reg_we & !reg_error;
   assign mp_region_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign mp_region_cfg_0_prog_en_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_prog_en_0_we = addr_hit[17] & reg_we & !reg_error;
   assign mp_region_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign mp_region_cfg_0_erase_en_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_erase_en_0_we = addr_hit[17] & reg_we & !reg_error;
   assign mp_region_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign mp_region_cfg_0_scramble_en_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_scramble_en_0_we = addr_hit[17] & reg_we & !reg_error;
   assign mp_region_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign mp_region_cfg_0_ecc_en_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_ecc_en_0_we = addr_hit[17] & reg_we & !reg_error;
   assign mp_region_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign mp_region_cfg_0_he_en_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_he_en_0_we = addr_hit[17] & reg_we & !reg_error;
   assign mp_region_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign mp_region_cfg_0_base_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_base_0_we = addr_hit[17] & reg_we & !reg_error;
   assign mp_region_cfg_0_base_0_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_0_size_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_size_0_we = addr_hit[17] & reg_we & !reg_error;
   assign mp_region_cfg_0_size_0_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_1_en_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_en_1_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign mp_region_cfg_1_rd_en_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_rd_en_1_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign mp_region_cfg_1_prog_en_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_prog_en_1_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign mp_region_cfg_1_erase_en_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_erase_en_1_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign mp_region_cfg_1_scramble_en_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_scramble_en_1_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign mp_region_cfg_1_ecc_en_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_ecc_en_1_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign mp_region_cfg_1_he_en_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_he_en_1_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign mp_region_cfg_1_base_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_base_1_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_1_base_1_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_1_size_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_size_1_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_1_size_1_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_2_en_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_en_2_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign mp_region_cfg_2_rd_en_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_rd_en_2_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign mp_region_cfg_2_prog_en_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_prog_en_2_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign mp_region_cfg_2_erase_en_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_erase_en_2_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign mp_region_cfg_2_scramble_en_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_scramble_en_2_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign mp_region_cfg_2_ecc_en_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_ecc_en_2_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign mp_region_cfg_2_he_en_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_he_en_2_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_2_he_en_2_wd = reg_wdata[6];
 
-  assign mp_region_cfg_2_base_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_base_2_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_2_base_2_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_2_size_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_size_2_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_2_size_2_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_3_en_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_en_3_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign mp_region_cfg_3_rd_en_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_rd_en_3_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign mp_region_cfg_3_prog_en_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_prog_en_3_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign mp_region_cfg_3_erase_en_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_erase_en_3_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign mp_region_cfg_3_scramble_en_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_scramble_en_3_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign mp_region_cfg_3_ecc_en_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_ecc_en_3_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign mp_region_cfg_3_he_en_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_he_en_3_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_3_he_en_3_wd = reg_wdata[6];
 
-  assign mp_region_cfg_3_base_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_base_3_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_3_base_3_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_3_size_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_size_3_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_3_size_3_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_4_en_4_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_en_4_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign mp_region_cfg_4_rd_en_4_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_rd_en_4_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign mp_region_cfg_4_prog_en_4_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_prog_en_4_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign mp_region_cfg_4_erase_en_4_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_erase_en_4_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign mp_region_cfg_4_scramble_en_4_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_scramble_en_4_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign mp_region_cfg_4_ecc_en_4_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_ecc_en_4_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign mp_region_cfg_4_he_en_4_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_he_en_4_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_4_he_en_4_wd = reg_wdata[6];
 
-  assign mp_region_cfg_4_base_4_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_base_4_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_4_base_4_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_4_size_4_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_size_4_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_4_size_4_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_5_en_5_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_en_5_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign mp_region_cfg_5_rd_en_5_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_rd_en_5_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign mp_region_cfg_5_prog_en_5_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_prog_en_5_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign mp_region_cfg_5_erase_en_5_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_erase_en_5_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign mp_region_cfg_5_scramble_en_5_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_scramble_en_5_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign mp_region_cfg_5_ecc_en_5_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_ecc_en_5_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign mp_region_cfg_5_he_en_5_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_he_en_5_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_5_he_en_5_wd = reg_wdata[6];
 
-  assign mp_region_cfg_5_base_5_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_base_5_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_5_base_5_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_5_size_5_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_size_5_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_5_size_5_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_6_en_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_en_6_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign mp_region_cfg_6_rd_en_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_rd_en_6_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign mp_region_cfg_6_prog_en_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_prog_en_6_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign mp_region_cfg_6_erase_en_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_erase_en_6_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign mp_region_cfg_6_scramble_en_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_scramble_en_6_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign mp_region_cfg_6_ecc_en_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_ecc_en_6_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign mp_region_cfg_6_he_en_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_he_en_6_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_6_he_en_6_wd = reg_wdata[6];
 
-  assign mp_region_cfg_6_base_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_base_6_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_6_base_6_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_6_size_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_size_6_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_6_size_6_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_7_en_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_en_7_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign mp_region_cfg_7_rd_en_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_rd_en_7_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign mp_region_cfg_7_prog_en_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_prog_en_7_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign mp_region_cfg_7_erase_en_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_erase_en_7_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign mp_region_cfg_7_scramble_en_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_scramble_en_7_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign mp_region_cfg_7_ecc_en_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_ecc_en_7_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign mp_region_cfg_7_he_en_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_he_en_7_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_7_he_en_7_wd = reg_wdata[6];
 
-  assign mp_region_cfg_7_base_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_base_7_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_7_base_7_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_7_size_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_size_7_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_7_size_7_wd = reg_wdata[26:17];
 
-  assign default_region_rd_en_we = addr_hit[25] & reg_we & ~wr_err;
+  assign default_region_rd_en_we = addr_hit[25] & reg_we & !reg_error;
   assign default_region_rd_en_wd = reg_wdata[0];
 
-  assign default_region_prog_en_we = addr_hit[25] & reg_we & ~wr_err;
+  assign default_region_prog_en_we = addr_hit[25] & reg_we & !reg_error;
   assign default_region_prog_en_wd = reg_wdata[1];
 
-  assign default_region_erase_en_we = addr_hit[25] & reg_we & ~wr_err;
+  assign default_region_erase_en_we = addr_hit[25] & reg_we & !reg_error;
   assign default_region_erase_en_wd = reg_wdata[2];
 
-  assign default_region_scramble_en_we = addr_hit[25] & reg_we & ~wr_err;
+  assign default_region_scramble_en_we = addr_hit[25] & reg_we & !reg_error;
   assign default_region_scramble_en_wd = reg_wdata[3];
 
-  assign default_region_ecc_en_we = addr_hit[25] & reg_we & ~wr_err;
+  assign default_region_ecc_en_we = addr_hit[25] & reg_we & !reg_error;
   assign default_region_ecc_en_wd = reg_wdata[4];
 
-  assign default_region_he_en_we = addr_hit[25] & reg_we & ~wr_err;
+  assign default_region_he_en_we = addr_hit[25] & reg_we & !reg_error;
   assign default_region_he_en_wd = reg_wdata[5];
 
-  assign bank0_info0_regwen_0_we = addr_hit[26] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_0_we = addr_hit[26] & reg_we & !reg_error;
   assign bank0_info0_regwen_0_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_1_we = addr_hit[27] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_1_we = addr_hit[27] & reg_we & !reg_error;
   assign bank0_info0_regwen_1_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_2_we = addr_hit[28] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_2_we = addr_hit[28] & reg_we & !reg_error;
   assign bank0_info0_regwen_2_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_3_we = addr_hit[29] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_3_we = addr_hit[29] & reg_we & !reg_error;
   assign bank0_info0_regwen_3_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_4_we = addr_hit[30] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_4_we = addr_hit[30] & reg_we & !reg_error;
   assign bank0_info0_regwen_4_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_5_we = addr_hit[31] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_5_we = addr_hit[31] & reg_we & !reg_error;
   assign bank0_info0_regwen_5_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_6_we = addr_hit[32] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_6_we = addr_hit[32] & reg_we & !reg_error;
   assign bank0_info0_regwen_6_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_7_we = addr_hit[33] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_7_we = addr_hit[33] & reg_we & !reg_error;
   assign bank0_info0_regwen_7_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_8_we = addr_hit[34] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_8_we = addr_hit[34] & reg_we & !reg_error;
   assign bank0_info0_regwen_8_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_9_we = addr_hit[35] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_9_we = addr_hit[35] & reg_we & !reg_error;
   assign bank0_info0_regwen_9_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_0_en_0_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_en_0_we = addr_hit[36] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_0_rd_en_0_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_rd_en_0_we = addr_hit[36] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_0_prog_en_0_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_prog_en_0_we = addr_hit[36] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_0_erase_en_0_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_erase_en_0_we = addr_hit[36] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_0_scramble_en_0_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_scramble_en_0_we = addr_hit[36] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_0_ecc_en_0_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_ecc_en_0_we = addr_hit[36] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_0_he_en_0_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_he_en_0_we = addr_hit[36] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_1_en_1_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_en_1_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_1_rd_en_1_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_rd_en_1_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_1_prog_en_1_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_prog_en_1_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_1_erase_en_1_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_erase_en_1_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_1_scramble_en_1_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_scramble_en_1_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_1_ecc_en_1_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_ecc_en_1_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_1_he_en_1_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_he_en_1_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_2_en_2_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_en_2_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_2_rd_en_2_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_rd_en_2_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_2_prog_en_2_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_prog_en_2_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_2_erase_en_2_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_erase_en_2_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_2_scramble_en_2_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_scramble_en_2_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_2_ecc_en_2_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_ecc_en_2_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_2_he_en_2_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_he_en_2_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_he_en_2_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_3_en_3_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_en_3_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_3_rd_en_3_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_rd_en_3_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_3_prog_en_3_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_prog_en_3_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_3_erase_en_3_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_erase_en_3_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_3_scramble_en_3_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_scramble_en_3_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_3_ecc_en_3_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_ecc_en_3_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_3_he_en_3_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_he_en_3_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_he_en_3_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_4_en_4_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_en_4_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_4_rd_en_4_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_rd_en_4_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_4_prog_en_4_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_prog_en_4_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_4_erase_en_4_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_erase_en_4_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_4_scramble_en_4_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_scramble_en_4_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_4_ecc_en_4_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_ecc_en_4_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_4_he_en_4_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_he_en_4_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_he_en_4_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_5_en_5_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_en_5_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_5_rd_en_5_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_rd_en_5_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_5_prog_en_5_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_prog_en_5_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_5_erase_en_5_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_erase_en_5_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_5_scramble_en_5_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_scramble_en_5_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_5_ecc_en_5_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_ecc_en_5_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_5_he_en_5_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_he_en_5_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_he_en_5_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_6_en_6_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_en_6_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_6_rd_en_6_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_rd_en_6_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_6_prog_en_6_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_prog_en_6_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_6_erase_en_6_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_erase_en_6_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_6_scramble_en_6_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_scramble_en_6_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_6_ecc_en_6_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_ecc_en_6_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_6_he_en_6_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_he_en_6_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_he_en_6_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_7_en_7_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_en_7_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_7_rd_en_7_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_rd_en_7_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_7_prog_en_7_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_prog_en_7_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_7_erase_en_7_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_erase_en_7_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_7_scramble_en_7_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_scramble_en_7_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_7_ecc_en_7_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_ecc_en_7_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_7_he_en_7_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_he_en_7_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_he_en_7_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_8_en_8_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_en_8_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_en_8_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_8_rd_en_8_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_rd_en_8_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_rd_en_8_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_8_prog_en_8_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_prog_en_8_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_prog_en_8_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_8_erase_en_8_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_erase_en_8_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_erase_en_8_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_8_scramble_en_8_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_scramble_en_8_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_scramble_en_8_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_8_ecc_en_8_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_ecc_en_8_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_ecc_en_8_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_8_he_en_8_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_he_en_8_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_he_en_8_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_9_en_9_we = addr_hit[45] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_en_9_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_en_9_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_9_rd_en_9_we = addr_hit[45] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_rd_en_9_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_rd_en_9_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_9_prog_en_9_we = addr_hit[45] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_prog_en_9_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_prog_en_9_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_9_erase_en_9_we = addr_hit[45] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_erase_en_9_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_erase_en_9_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_9_scramble_en_9_we = addr_hit[45] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_scramble_en_9_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_scramble_en_9_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_9_ecc_en_9_we = addr_hit[45] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_ecc_en_9_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_ecc_en_9_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_9_he_en_9_we = addr_hit[45] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_he_en_9_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_he_en_9_wd = reg_wdata[6];
 
-  assign bank0_info1_regwen_we = addr_hit[46] & reg_we & ~wr_err;
+  assign bank0_info1_regwen_we = addr_hit[46] & reg_we & !reg_error;
   assign bank0_info1_regwen_wd = reg_wdata[0];
 
-  assign bank0_info1_page_cfg_en_0_we = addr_hit[47] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_en_0_we = addr_hit[47] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_en_0_wd = reg_wdata[0];
 
-  assign bank0_info1_page_cfg_rd_en_0_we = addr_hit[47] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_rd_en_0_we = addr_hit[47] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info1_page_cfg_prog_en_0_we = addr_hit[47] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_prog_en_0_we = addr_hit[47] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info1_page_cfg_erase_en_0_we = addr_hit[47] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_erase_en_0_we = addr_hit[47] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info1_page_cfg_scramble_en_0_we = addr_hit[47] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_scramble_en_0_we = addr_hit[47] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info1_page_cfg_ecc_en_0_we = addr_hit[47] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_ecc_en_0_we = addr_hit[47] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info1_page_cfg_he_en_0_we = addr_hit[47] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_he_en_0_we = addr_hit[47] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_he_en_0_wd = reg_wdata[6];
 
-  assign bank0_info2_regwen_0_we = addr_hit[48] & reg_we & ~wr_err;
+  assign bank0_info2_regwen_0_we = addr_hit[48] & reg_we & !reg_error;
   assign bank0_info2_regwen_0_wd = reg_wdata[0];
 
-  assign bank0_info2_regwen_1_we = addr_hit[49] & reg_we & ~wr_err;
+  assign bank0_info2_regwen_1_we = addr_hit[49] & reg_we & !reg_error;
   assign bank0_info2_regwen_1_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_0_en_0_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_en_0_we = addr_hit[50] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_0_rd_en_0_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_rd_en_0_we = addr_hit[50] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info2_page_cfg_0_prog_en_0_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_prog_en_0_we = addr_hit[50] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info2_page_cfg_0_erase_en_0_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_erase_en_0_we = addr_hit[50] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info2_page_cfg_0_scramble_en_0_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_scramble_en_0_we = addr_hit[50] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info2_page_cfg_0_ecc_en_0_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_ecc_en_0_we = addr_hit[50] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info2_page_cfg_0_he_en_0_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_he_en_0_we = addr_hit[50] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign bank0_info2_page_cfg_1_en_1_we = addr_hit[51] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_en_1_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_1_rd_en_1_we = addr_hit[51] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_rd_en_1_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank0_info2_page_cfg_1_prog_en_1_we = addr_hit[51] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_prog_en_1_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank0_info2_page_cfg_1_erase_en_1_we = addr_hit[51] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_erase_en_1_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank0_info2_page_cfg_1_scramble_en_1_we = addr_hit[51] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_scramble_en_1_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank0_info2_page_cfg_1_ecc_en_1_we = addr_hit[51] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_ecc_en_1_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank0_info2_page_cfg_1_he_en_1_we = addr_hit[51] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_he_en_1_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign bank1_info0_regwen_0_we = addr_hit[52] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_0_we = addr_hit[52] & reg_we & !reg_error;
   assign bank1_info0_regwen_0_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_1_we = addr_hit[53] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_1_we = addr_hit[53] & reg_we & !reg_error;
   assign bank1_info0_regwen_1_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_2_we = addr_hit[54] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_2_we = addr_hit[54] & reg_we & !reg_error;
   assign bank1_info0_regwen_2_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_3_we = addr_hit[55] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_3_we = addr_hit[55] & reg_we & !reg_error;
   assign bank1_info0_regwen_3_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_4_we = addr_hit[56] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_4_we = addr_hit[56] & reg_we & !reg_error;
   assign bank1_info0_regwen_4_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_5_we = addr_hit[57] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_5_we = addr_hit[57] & reg_we & !reg_error;
   assign bank1_info0_regwen_5_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_6_we = addr_hit[58] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_6_we = addr_hit[58] & reg_we & !reg_error;
   assign bank1_info0_regwen_6_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_7_we = addr_hit[59] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_7_we = addr_hit[59] & reg_we & !reg_error;
   assign bank1_info0_regwen_7_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_8_we = addr_hit[60] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_8_we = addr_hit[60] & reg_we & !reg_error;
   assign bank1_info0_regwen_8_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_9_we = addr_hit[61] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_9_we = addr_hit[61] & reg_we & !reg_error;
   assign bank1_info0_regwen_9_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_0_en_0_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_en_0_we = addr_hit[62] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_0_rd_en_0_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_rd_en_0_we = addr_hit[62] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_0_prog_en_0_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_prog_en_0_we = addr_hit[62] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_0_erase_en_0_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_erase_en_0_we = addr_hit[62] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_0_scramble_en_0_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_scramble_en_0_we = addr_hit[62] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_0_ecc_en_0_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_ecc_en_0_we = addr_hit[62] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_0_he_en_0_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_he_en_0_we = addr_hit[62] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_1_en_1_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_en_1_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_1_rd_en_1_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_rd_en_1_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_1_prog_en_1_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_prog_en_1_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_1_erase_en_1_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_erase_en_1_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_1_scramble_en_1_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_scramble_en_1_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_1_ecc_en_1_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_ecc_en_1_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_1_he_en_1_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_he_en_1_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_2_en_2_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_en_2_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_2_rd_en_2_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_rd_en_2_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_2_prog_en_2_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_prog_en_2_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_2_erase_en_2_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_erase_en_2_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_2_scramble_en_2_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_scramble_en_2_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_2_ecc_en_2_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_ecc_en_2_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_2_he_en_2_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_he_en_2_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_he_en_2_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_3_en_3_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_en_3_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_3_rd_en_3_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_rd_en_3_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_3_prog_en_3_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_prog_en_3_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_3_erase_en_3_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_erase_en_3_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_3_scramble_en_3_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_scramble_en_3_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_3_ecc_en_3_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_ecc_en_3_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_3_he_en_3_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_he_en_3_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_he_en_3_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_4_en_4_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_en_4_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_4_rd_en_4_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_rd_en_4_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_4_prog_en_4_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_prog_en_4_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_4_erase_en_4_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_erase_en_4_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_4_scramble_en_4_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_scramble_en_4_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_4_ecc_en_4_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_ecc_en_4_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_4_he_en_4_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_he_en_4_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_he_en_4_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_5_en_5_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_en_5_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_5_rd_en_5_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_rd_en_5_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_5_prog_en_5_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_prog_en_5_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_5_erase_en_5_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_erase_en_5_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_5_scramble_en_5_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_scramble_en_5_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_5_ecc_en_5_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_ecc_en_5_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_5_he_en_5_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_he_en_5_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_he_en_5_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_6_en_6_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_en_6_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_6_rd_en_6_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_rd_en_6_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_6_prog_en_6_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_prog_en_6_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_6_erase_en_6_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_erase_en_6_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_6_scramble_en_6_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_scramble_en_6_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_6_ecc_en_6_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_ecc_en_6_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_6_he_en_6_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_he_en_6_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_he_en_6_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_7_en_7_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_en_7_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_7_rd_en_7_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_rd_en_7_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_7_prog_en_7_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_prog_en_7_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_7_erase_en_7_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_erase_en_7_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_7_scramble_en_7_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_scramble_en_7_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_7_ecc_en_7_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_ecc_en_7_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_7_he_en_7_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_he_en_7_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_he_en_7_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_8_en_8_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_en_8_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_en_8_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_8_rd_en_8_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_rd_en_8_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_rd_en_8_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_8_prog_en_8_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_prog_en_8_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_prog_en_8_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_8_erase_en_8_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_erase_en_8_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_erase_en_8_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_8_scramble_en_8_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_scramble_en_8_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_scramble_en_8_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_8_ecc_en_8_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_ecc_en_8_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_ecc_en_8_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_8_he_en_8_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_he_en_8_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_he_en_8_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_9_en_9_we = addr_hit[71] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_en_9_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_en_9_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_9_rd_en_9_we = addr_hit[71] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_rd_en_9_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_rd_en_9_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_9_prog_en_9_we = addr_hit[71] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_prog_en_9_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_prog_en_9_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_9_erase_en_9_we = addr_hit[71] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_erase_en_9_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_erase_en_9_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_9_scramble_en_9_we = addr_hit[71] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_scramble_en_9_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_scramble_en_9_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_9_ecc_en_9_we = addr_hit[71] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_ecc_en_9_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_ecc_en_9_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_9_he_en_9_we = addr_hit[71] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_he_en_9_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_he_en_9_wd = reg_wdata[6];
 
-  assign bank1_info1_regwen_we = addr_hit[72] & reg_we & ~wr_err;
+  assign bank1_info1_regwen_we = addr_hit[72] & reg_we & !reg_error;
   assign bank1_info1_regwen_wd = reg_wdata[0];
 
-  assign bank1_info1_page_cfg_en_0_we = addr_hit[73] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_en_0_we = addr_hit[73] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_en_0_wd = reg_wdata[0];
 
-  assign bank1_info1_page_cfg_rd_en_0_we = addr_hit[73] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_rd_en_0_we = addr_hit[73] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info1_page_cfg_prog_en_0_we = addr_hit[73] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_prog_en_0_we = addr_hit[73] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info1_page_cfg_erase_en_0_we = addr_hit[73] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_erase_en_0_we = addr_hit[73] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info1_page_cfg_scramble_en_0_we = addr_hit[73] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_scramble_en_0_we = addr_hit[73] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info1_page_cfg_ecc_en_0_we = addr_hit[73] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_ecc_en_0_we = addr_hit[73] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info1_page_cfg_he_en_0_we = addr_hit[73] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_he_en_0_we = addr_hit[73] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_he_en_0_wd = reg_wdata[6];
 
-  assign bank1_info2_regwen_0_we = addr_hit[74] & reg_we & ~wr_err;
+  assign bank1_info2_regwen_0_we = addr_hit[74] & reg_we & !reg_error;
   assign bank1_info2_regwen_0_wd = reg_wdata[0];
 
-  assign bank1_info2_regwen_1_we = addr_hit[75] & reg_we & ~wr_err;
+  assign bank1_info2_regwen_1_we = addr_hit[75] & reg_we & !reg_error;
   assign bank1_info2_regwen_1_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_0_en_0_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_en_0_we = addr_hit[76] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_0_rd_en_0_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_rd_en_0_we = addr_hit[76] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info2_page_cfg_0_prog_en_0_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_prog_en_0_we = addr_hit[76] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info2_page_cfg_0_erase_en_0_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_erase_en_0_we = addr_hit[76] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info2_page_cfg_0_scramble_en_0_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_scramble_en_0_we = addr_hit[76] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info2_page_cfg_0_ecc_en_0_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_ecc_en_0_we = addr_hit[76] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info2_page_cfg_0_he_en_0_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_he_en_0_we = addr_hit[76] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign bank1_info2_page_cfg_1_en_1_we = addr_hit[77] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_en_1_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_1_rd_en_1_we = addr_hit[77] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_rd_en_1_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank1_info2_page_cfg_1_prog_en_1_we = addr_hit[77] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_prog_en_1_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank1_info2_page_cfg_1_erase_en_1_we = addr_hit[77] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_erase_en_1_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank1_info2_page_cfg_1_scramble_en_1_we = addr_hit[77] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_scramble_en_1_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank1_info2_page_cfg_1_ecc_en_1_we = addr_hit[77] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_ecc_en_1_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank1_info2_page_cfg_1_he_en_1_we = addr_hit[77] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_he_en_1_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign bank_cfg_regwen_we = addr_hit[78] & reg_we & ~wr_err;
+  assign bank_cfg_regwen_we = addr_hit[78] & reg_we & !reg_error;
   assign bank_cfg_regwen_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en_0_we = addr_hit[79] & reg_we & ~wr_err;
+  assign mp_bank_cfg_erase_en_0_we = addr_hit[79] & reg_we & !reg_error;
   assign mp_bank_cfg_erase_en_0_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en_1_we = addr_hit[79] & reg_we & ~wr_err;
+  assign mp_bank_cfg_erase_en_1_we = addr_hit[79] & reg_we & !reg_error;
   assign mp_bank_cfg_erase_en_1_wd = reg_wdata[1];
 
-  assign op_status_done_we = addr_hit[80] & reg_we & ~wr_err;
+  assign op_status_done_we = addr_hit[80] & reg_we & !reg_error;
   assign op_status_done_wd = reg_wdata[0];
 
-  assign op_status_err_we = addr_hit[80] & reg_we & ~wr_err;
+  assign op_status_err_we = addr_hit[80] & reg_we & !reg_error;
   assign op_status_err_wd = reg_wdata[1];
 
 
@@ -11576,43 +11576,43 @@ module flash_ctrl_reg_top (
 
 
 
-  assign err_code_flash_err_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_flash_err_we = addr_hit[82] & reg_we & !reg_error;
   assign err_code_flash_err_wd = reg_wdata[0];
 
-  assign err_code_flash_alert_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_flash_alert_we = addr_hit[82] & reg_we & !reg_error;
   assign err_code_flash_alert_wd = reg_wdata[1];
 
-  assign err_code_mp_err_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_mp_err_we = addr_hit[82] & reg_we & !reg_error;
   assign err_code_mp_err_wd = reg_wdata[2];
 
-  assign err_code_ecc_single_err_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_ecc_single_err_we = addr_hit[82] & reg_we & !reg_error;
   assign err_code_ecc_single_err_wd = reg_wdata[3];
 
-  assign err_code_ecc_multi_err_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_ecc_multi_err_we = addr_hit[82] & reg_we & !reg_error;
   assign err_code_ecc_multi_err_wd = reg_wdata[4];
 
 
 
 
-  assign phy_alert_cfg_alert_ack_we = addr_hit[86] & reg_we & ~wr_err;
+  assign phy_alert_cfg_alert_ack_we = addr_hit[86] & reg_we & !reg_error;
   assign phy_alert_cfg_alert_ack_wd = reg_wdata[0];
 
-  assign phy_alert_cfg_alert_trig_we = addr_hit[86] & reg_we & ~wr_err;
+  assign phy_alert_cfg_alert_trig_we = addr_hit[86] & reg_we & !reg_error;
   assign phy_alert_cfg_alert_trig_wd = reg_wdata[1];
 
 
 
 
-  assign scratch_we = addr_hit[88] & reg_we & ~wr_err;
+  assign scratch_we = addr_hit[88] & reg_we & !reg_error;
   assign scratch_wd = reg_wdata[31:0];
 
-  assign fifo_lvl_prog_we = addr_hit[89] & reg_we & ~wr_err;
+  assign fifo_lvl_prog_we = addr_hit[89] & reg_we & !reg_error;
   assign fifo_lvl_prog_wd = reg_wdata[4:0];
 
-  assign fifo_lvl_rd_we = addr_hit[89] & reg_we & ~wr_err;
+  assign fifo_lvl_rd_we = addr_hit[89] & reg_we & !reg_error;
   assign fifo_lvl_rd_wd = reg_wdata[12:8];
 
-  assign fifo_rst_we = addr_hit[90] & reg_we & ~wr_err;
+  assign fifo_rst_we = addr_hit[90] & reg_we & !reg_error;
   assign fifo_rst_wd = reg_wdata[0];
 
   // Read data return

--- a/hw/ip/gpio/rtl/gpio_reg_top.sv
+++ b/hw/ip/gpio/rtl/gpio_reg_top.sv
@@ -582,67 +582,67 @@ module gpio_reg_top (
     if (addr_hit[14] && reg_we && (GPIO_PERMIT[14] != (GPIO_PERMIT[14] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_wd = reg_wdata[31:0];
 
-  assign intr_enable_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_wd = reg_wdata[31:0];
 
-  assign intr_test_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_wd = reg_wdata[31:0];
 
 
-  assign direct_out_we = addr_hit[4] & reg_we & ~wr_err;
+  assign direct_out_we = addr_hit[4] & reg_we & !reg_error;
   assign direct_out_wd = reg_wdata[31:0];
-  assign direct_out_re = addr_hit[4] && reg_re;
+  assign direct_out_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign masked_out_lower_data_we = addr_hit[5] & reg_we & ~wr_err;
+  assign masked_out_lower_data_we = addr_hit[5] & reg_we & !reg_error;
   assign masked_out_lower_data_wd = reg_wdata[15:0];
-  assign masked_out_lower_data_re = addr_hit[5] && reg_re;
+  assign masked_out_lower_data_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign masked_out_lower_mask_we = addr_hit[5] & reg_we & ~wr_err;
+  assign masked_out_lower_mask_we = addr_hit[5] & reg_we & !reg_error;
   assign masked_out_lower_mask_wd = reg_wdata[31:16];
 
-  assign masked_out_upper_data_we = addr_hit[6] & reg_we & ~wr_err;
+  assign masked_out_upper_data_we = addr_hit[6] & reg_we & !reg_error;
   assign masked_out_upper_data_wd = reg_wdata[15:0];
-  assign masked_out_upper_data_re = addr_hit[6] && reg_re;
+  assign masked_out_upper_data_re = addr_hit[6] & reg_re & !reg_error;
 
-  assign masked_out_upper_mask_we = addr_hit[6] & reg_we & ~wr_err;
+  assign masked_out_upper_mask_we = addr_hit[6] & reg_we & !reg_error;
   assign masked_out_upper_mask_wd = reg_wdata[31:16];
 
-  assign direct_oe_we = addr_hit[7] & reg_we & ~wr_err;
+  assign direct_oe_we = addr_hit[7] & reg_we & !reg_error;
   assign direct_oe_wd = reg_wdata[31:0];
-  assign direct_oe_re = addr_hit[7] && reg_re;
+  assign direct_oe_re = addr_hit[7] & reg_re & !reg_error;
 
-  assign masked_oe_lower_data_we = addr_hit[8] & reg_we & ~wr_err;
+  assign masked_oe_lower_data_we = addr_hit[8] & reg_we & !reg_error;
   assign masked_oe_lower_data_wd = reg_wdata[15:0];
-  assign masked_oe_lower_data_re = addr_hit[8] && reg_re;
+  assign masked_oe_lower_data_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign masked_oe_lower_mask_we = addr_hit[8] & reg_we & ~wr_err;
+  assign masked_oe_lower_mask_we = addr_hit[8] & reg_we & !reg_error;
   assign masked_oe_lower_mask_wd = reg_wdata[31:16];
-  assign masked_oe_lower_mask_re = addr_hit[8] && reg_re;
+  assign masked_oe_lower_mask_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign masked_oe_upper_data_we = addr_hit[9] & reg_we & ~wr_err;
+  assign masked_oe_upper_data_we = addr_hit[9] & reg_we & !reg_error;
   assign masked_oe_upper_data_wd = reg_wdata[15:0];
-  assign masked_oe_upper_data_re = addr_hit[9] && reg_re;
+  assign masked_oe_upper_data_re = addr_hit[9] & reg_re & !reg_error;
 
-  assign masked_oe_upper_mask_we = addr_hit[9] & reg_we & ~wr_err;
+  assign masked_oe_upper_mask_we = addr_hit[9] & reg_we & !reg_error;
   assign masked_oe_upper_mask_wd = reg_wdata[31:16];
-  assign masked_oe_upper_mask_re = addr_hit[9] && reg_re;
+  assign masked_oe_upper_mask_re = addr_hit[9] & reg_re & !reg_error;
 
-  assign intr_ctrl_en_rising_we = addr_hit[10] & reg_we & ~wr_err;
+  assign intr_ctrl_en_rising_we = addr_hit[10] & reg_we & !reg_error;
   assign intr_ctrl_en_rising_wd = reg_wdata[31:0];
 
-  assign intr_ctrl_en_falling_we = addr_hit[11] & reg_we & ~wr_err;
+  assign intr_ctrl_en_falling_we = addr_hit[11] & reg_we & !reg_error;
   assign intr_ctrl_en_falling_wd = reg_wdata[31:0];
 
-  assign intr_ctrl_en_lvlhigh_we = addr_hit[12] & reg_we & ~wr_err;
+  assign intr_ctrl_en_lvlhigh_we = addr_hit[12] & reg_we & !reg_error;
   assign intr_ctrl_en_lvlhigh_wd = reg_wdata[31:0];
 
-  assign intr_ctrl_en_lvllow_we = addr_hit[13] & reg_we & ~wr_err;
+  assign intr_ctrl_en_lvllow_we = addr_hit[13] & reg_we & !reg_error;
   assign intr_ctrl_en_lvllow_wd = reg_wdata[31:0];
 
-  assign ctrl_en_input_filter_we = addr_hit[14] & reg_we & ~wr_err;
+  assign ctrl_en_input_filter_we = addr_hit[14] & reg_we & !reg_error;
   assign ctrl_en_input_filter_wd = reg_wdata[31:0];
 
   // Read data return

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -991,104 +991,104 @@ module hmac_reg_top (
     if (addr_hit[25] && reg_we && (HMAC_PERMIT[25] != (HMAC_PERMIT[25] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_hmac_done_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_hmac_done_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_hmac_done_wd = reg_wdata[0];
 
-  assign intr_state_fifo_empty_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_fifo_empty_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_fifo_empty_wd = reg_wdata[1];
 
-  assign intr_state_hmac_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_hmac_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_hmac_err_wd = reg_wdata[2];
 
-  assign intr_enable_hmac_done_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_hmac_done_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_hmac_done_wd = reg_wdata[0];
 
-  assign intr_enable_fifo_empty_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_fifo_empty_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_fifo_empty_wd = reg_wdata[1];
 
-  assign intr_enable_hmac_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_hmac_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_hmac_err_wd = reg_wdata[2];
 
-  assign intr_test_hmac_done_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_hmac_done_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_hmac_done_wd = reg_wdata[0];
 
-  assign intr_test_fifo_empty_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_fifo_empty_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_fifo_empty_wd = reg_wdata[1];
 
-  assign intr_test_hmac_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_hmac_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_hmac_err_wd = reg_wdata[2];
 
-  assign cfg_hmac_en_we = addr_hit[3] & reg_we & ~wr_err;
+  assign cfg_hmac_en_we = addr_hit[3] & reg_we & !reg_error;
   assign cfg_hmac_en_wd = reg_wdata[0];
-  assign cfg_hmac_en_re = addr_hit[3] && reg_re;
+  assign cfg_hmac_en_re = addr_hit[3] & reg_re & !reg_error;
 
-  assign cfg_sha_en_we = addr_hit[3] & reg_we & ~wr_err;
+  assign cfg_sha_en_we = addr_hit[3] & reg_we & !reg_error;
   assign cfg_sha_en_wd = reg_wdata[1];
-  assign cfg_sha_en_re = addr_hit[3] && reg_re;
+  assign cfg_sha_en_re = addr_hit[3] & reg_re & !reg_error;
 
-  assign cfg_endian_swap_we = addr_hit[3] & reg_we & ~wr_err;
+  assign cfg_endian_swap_we = addr_hit[3] & reg_we & !reg_error;
   assign cfg_endian_swap_wd = reg_wdata[2];
-  assign cfg_endian_swap_re = addr_hit[3] && reg_re;
+  assign cfg_endian_swap_re = addr_hit[3] & reg_re & !reg_error;
 
-  assign cfg_digest_swap_we = addr_hit[3] & reg_we & ~wr_err;
+  assign cfg_digest_swap_we = addr_hit[3] & reg_we & !reg_error;
   assign cfg_digest_swap_wd = reg_wdata[3];
-  assign cfg_digest_swap_re = addr_hit[3] && reg_re;
+  assign cfg_digest_swap_re = addr_hit[3] & reg_re & !reg_error;
 
-  assign cmd_hash_start_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cmd_hash_start_we = addr_hit[4] & reg_we & !reg_error;
   assign cmd_hash_start_wd = reg_wdata[0];
 
-  assign cmd_hash_process_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cmd_hash_process_we = addr_hit[4] & reg_we & !reg_error;
   assign cmd_hash_process_wd = reg_wdata[1];
 
-  assign status_fifo_empty_re = addr_hit[5] && reg_re;
+  assign status_fifo_empty_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign status_fifo_full_re = addr_hit[5] && reg_re;
+  assign status_fifo_full_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign status_fifo_depth_re = addr_hit[5] && reg_re;
+  assign status_fifo_depth_re = addr_hit[5] & reg_re & !reg_error;
 
 
-  assign wipe_secret_we = addr_hit[7] & reg_we & ~wr_err;
+  assign wipe_secret_we = addr_hit[7] & reg_we & !reg_error;
   assign wipe_secret_wd = reg_wdata[31:0];
 
-  assign key_0_we = addr_hit[8] & reg_we & ~wr_err;
+  assign key_0_we = addr_hit[8] & reg_we & !reg_error;
   assign key_0_wd = reg_wdata[31:0];
 
-  assign key_1_we = addr_hit[9] & reg_we & ~wr_err;
+  assign key_1_we = addr_hit[9] & reg_we & !reg_error;
   assign key_1_wd = reg_wdata[31:0];
 
-  assign key_2_we = addr_hit[10] & reg_we & ~wr_err;
+  assign key_2_we = addr_hit[10] & reg_we & !reg_error;
   assign key_2_wd = reg_wdata[31:0];
 
-  assign key_3_we = addr_hit[11] & reg_we & ~wr_err;
+  assign key_3_we = addr_hit[11] & reg_we & !reg_error;
   assign key_3_wd = reg_wdata[31:0];
 
-  assign key_4_we = addr_hit[12] & reg_we & ~wr_err;
+  assign key_4_we = addr_hit[12] & reg_we & !reg_error;
   assign key_4_wd = reg_wdata[31:0];
 
-  assign key_5_we = addr_hit[13] & reg_we & ~wr_err;
+  assign key_5_we = addr_hit[13] & reg_we & !reg_error;
   assign key_5_wd = reg_wdata[31:0];
 
-  assign key_6_we = addr_hit[14] & reg_we & ~wr_err;
+  assign key_6_we = addr_hit[14] & reg_we & !reg_error;
   assign key_6_wd = reg_wdata[31:0];
 
-  assign key_7_we = addr_hit[15] & reg_we & ~wr_err;
+  assign key_7_we = addr_hit[15] & reg_we & !reg_error;
   assign key_7_wd = reg_wdata[31:0];
 
-  assign digest_0_re = addr_hit[16] && reg_re;
+  assign digest_0_re = addr_hit[16] & reg_re & !reg_error;
 
-  assign digest_1_re = addr_hit[17] && reg_re;
+  assign digest_1_re = addr_hit[17] & reg_re & !reg_error;
 
-  assign digest_2_re = addr_hit[18] && reg_re;
+  assign digest_2_re = addr_hit[18] & reg_re & !reg_error;
 
-  assign digest_3_re = addr_hit[19] && reg_re;
+  assign digest_3_re = addr_hit[19] & reg_re & !reg_error;
 
-  assign digest_4_re = addr_hit[20] && reg_re;
+  assign digest_4_re = addr_hit[20] & reg_re & !reg_error;
 
-  assign digest_5_re = addr_hit[21] && reg_re;
+  assign digest_5_re = addr_hit[21] & reg_re & !reg_error;
 
-  assign digest_6_re = addr_hit[22] && reg_re;
+  assign digest_6_re = addr_hit[22] & reg_re & !reg_error;
 
-  assign digest_7_re = addr_hit[23] && reg_re;
+  assign digest_7_re = addr_hit[23] & reg_re & !reg_error;
 
 
 

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -2818,303 +2818,303 @@ module i2c_reg_top (
     if (addr_hit[21] && reg_we && (I2C_PERMIT[21] != (I2C_PERMIT[21] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_fmt_watermark_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_fmt_watermark_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_fmt_watermark_wd = reg_wdata[0];
 
-  assign intr_state_rx_watermark_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_watermark_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_watermark_wd = reg_wdata[1];
 
-  assign intr_state_fmt_overflow_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_fmt_overflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_fmt_overflow_wd = reg_wdata[2];
 
-  assign intr_state_rx_overflow_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_overflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_overflow_wd = reg_wdata[3];
 
-  assign intr_state_nak_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_nak_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_nak_wd = reg_wdata[4];
 
-  assign intr_state_scl_interference_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_scl_interference_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_scl_interference_wd = reg_wdata[5];
 
-  assign intr_state_sda_interference_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_sda_interference_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_sda_interference_wd = reg_wdata[6];
 
-  assign intr_state_stretch_timeout_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_stretch_timeout_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_stretch_timeout_wd = reg_wdata[7];
 
-  assign intr_state_sda_unstable_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_sda_unstable_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_sda_unstable_wd = reg_wdata[8];
 
-  assign intr_state_trans_complete_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_trans_complete_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_trans_complete_wd = reg_wdata[9];
 
-  assign intr_state_tx_empty_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_tx_empty_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_tx_empty_wd = reg_wdata[10];
 
-  assign intr_state_tx_nonempty_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_tx_nonempty_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_tx_nonempty_wd = reg_wdata[11];
 
-  assign intr_state_tx_overflow_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_tx_overflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_tx_overflow_wd = reg_wdata[12];
 
-  assign intr_state_acq_overflow_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_acq_overflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_acq_overflow_wd = reg_wdata[13];
 
-  assign intr_state_ack_stop_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_ack_stop_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_ack_stop_wd = reg_wdata[14];
 
-  assign intr_state_host_timeout_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_host_timeout_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_host_timeout_wd = reg_wdata[15];
 
-  assign intr_enable_fmt_watermark_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_fmt_watermark_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_fmt_watermark_wd = reg_wdata[0];
 
-  assign intr_enable_rx_watermark_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_watermark_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_watermark_wd = reg_wdata[1];
 
-  assign intr_enable_fmt_overflow_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_fmt_overflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_fmt_overflow_wd = reg_wdata[2];
 
-  assign intr_enable_rx_overflow_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_overflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_overflow_wd = reg_wdata[3];
 
-  assign intr_enable_nak_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_nak_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_nak_wd = reg_wdata[4];
 
-  assign intr_enable_scl_interference_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_scl_interference_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_scl_interference_wd = reg_wdata[5];
 
-  assign intr_enable_sda_interference_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_sda_interference_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_sda_interference_wd = reg_wdata[6];
 
-  assign intr_enable_stretch_timeout_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_stretch_timeout_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_stretch_timeout_wd = reg_wdata[7];
 
-  assign intr_enable_sda_unstable_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_sda_unstable_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_sda_unstable_wd = reg_wdata[8];
 
-  assign intr_enable_trans_complete_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_trans_complete_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_trans_complete_wd = reg_wdata[9];
 
-  assign intr_enable_tx_empty_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_tx_empty_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_tx_empty_wd = reg_wdata[10];
 
-  assign intr_enable_tx_nonempty_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_tx_nonempty_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_tx_nonempty_wd = reg_wdata[11];
 
-  assign intr_enable_tx_overflow_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_tx_overflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_tx_overflow_wd = reg_wdata[12];
 
-  assign intr_enable_acq_overflow_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_acq_overflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_acq_overflow_wd = reg_wdata[13];
 
-  assign intr_enable_ack_stop_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_ack_stop_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_ack_stop_wd = reg_wdata[14];
 
-  assign intr_enable_host_timeout_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_host_timeout_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_host_timeout_wd = reg_wdata[15];
 
-  assign intr_test_fmt_watermark_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_fmt_watermark_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_fmt_watermark_wd = reg_wdata[0];
 
-  assign intr_test_rx_watermark_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_watermark_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_watermark_wd = reg_wdata[1];
 
-  assign intr_test_fmt_overflow_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_fmt_overflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_fmt_overflow_wd = reg_wdata[2];
 
-  assign intr_test_rx_overflow_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_overflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_overflow_wd = reg_wdata[3];
 
-  assign intr_test_nak_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_nak_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_nak_wd = reg_wdata[4];
 
-  assign intr_test_scl_interference_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_scl_interference_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_scl_interference_wd = reg_wdata[5];
 
-  assign intr_test_sda_interference_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_sda_interference_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_sda_interference_wd = reg_wdata[6];
 
-  assign intr_test_stretch_timeout_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_stretch_timeout_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_stretch_timeout_wd = reg_wdata[7];
 
-  assign intr_test_sda_unstable_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_sda_unstable_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_sda_unstable_wd = reg_wdata[8];
 
-  assign intr_test_trans_complete_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_trans_complete_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_trans_complete_wd = reg_wdata[9];
 
-  assign intr_test_tx_empty_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_tx_empty_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_tx_empty_wd = reg_wdata[10];
 
-  assign intr_test_tx_nonempty_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_tx_nonempty_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_tx_nonempty_wd = reg_wdata[11];
 
-  assign intr_test_tx_overflow_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_tx_overflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_tx_overflow_wd = reg_wdata[12];
 
-  assign intr_test_acq_overflow_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_acq_overflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_acq_overflow_wd = reg_wdata[13];
 
-  assign intr_test_ack_stop_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_ack_stop_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_ack_stop_wd = reg_wdata[14];
 
-  assign intr_test_host_timeout_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_host_timeout_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_host_timeout_wd = reg_wdata[15];
 
-  assign ctrl_enablehost_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_enablehost_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_enablehost_wd = reg_wdata[0];
 
-  assign ctrl_enabletarget_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_enabletarget_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_enabletarget_wd = reg_wdata[1];
 
-  assign status_fmtfull_re = addr_hit[4] && reg_re;
+  assign status_fmtfull_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_rxfull_re = addr_hit[4] && reg_re;
+  assign status_rxfull_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_fmtempty_re = addr_hit[4] && reg_re;
+  assign status_fmtempty_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_hostidle_re = addr_hit[4] && reg_re;
+  assign status_hostidle_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_targetidle_re = addr_hit[4] && reg_re;
+  assign status_targetidle_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_rxempty_re = addr_hit[4] && reg_re;
+  assign status_rxempty_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_txfull_re = addr_hit[4] && reg_re;
+  assign status_txfull_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_acqfull_re = addr_hit[4] && reg_re;
+  assign status_acqfull_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_txempty_re = addr_hit[4] && reg_re;
+  assign status_txempty_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_acqempty_re = addr_hit[4] && reg_re;
+  assign status_acqempty_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign rdata_re = addr_hit[5] && reg_re;
+  assign rdata_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign fdata_fbyte_we = addr_hit[6] & reg_we & ~wr_err;
+  assign fdata_fbyte_we = addr_hit[6] & reg_we & !reg_error;
   assign fdata_fbyte_wd = reg_wdata[7:0];
 
-  assign fdata_start_we = addr_hit[6] & reg_we & ~wr_err;
+  assign fdata_start_we = addr_hit[6] & reg_we & !reg_error;
   assign fdata_start_wd = reg_wdata[8];
 
-  assign fdata_stop_we = addr_hit[6] & reg_we & ~wr_err;
+  assign fdata_stop_we = addr_hit[6] & reg_we & !reg_error;
   assign fdata_stop_wd = reg_wdata[9];
 
-  assign fdata_read_we = addr_hit[6] & reg_we & ~wr_err;
+  assign fdata_read_we = addr_hit[6] & reg_we & !reg_error;
   assign fdata_read_wd = reg_wdata[10];
 
-  assign fdata_rcont_we = addr_hit[6] & reg_we & ~wr_err;
+  assign fdata_rcont_we = addr_hit[6] & reg_we & !reg_error;
   assign fdata_rcont_wd = reg_wdata[11];
 
-  assign fdata_nakok_we = addr_hit[6] & reg_we & ~wr_err;
+  assign fdata_nakok_we = addr_hit[6] & reg_we & !reg_error;
   assign fdata_nakok_wd = reg_wdata[12];
 
-  assign fifo_ctrl_rxrst_we = addr_hit[7] & reg_we & ~wr_err;
+  assign fifo_ctrl_rxrst_we = addr_hit[7] & reg_we & !reg_error;
   assign fifo_ctrl_rxrst_wd = reg_wdata[0];
 
-  assign fifo_ctrl_fmtrst_we = addr_hit[7] & reg_we & ~wr_err;
+  assign fifo_ctrl_fmtrst_we = addr_hit[7] & reg_we & !reg_error;
   assign fifo_ctrl_fmtrst_wd = reg_wdata[1];
 
-  assign fifo_ctrl_rxilvl_we = addr_hit[7] & reg_we & ~wr_err;
+  assign fifo_ctrl_rxilvl_we = addr_hit[7] & reg_we & !reg_error;
   assign fifo_ctrl_rxilvl_wd = reg_wdata[4:2];
 
-  assign fifo_ctrl_fmtilvl_we = addr_hit[7] & reg_we & ~wr_err;
+  assign fifo_ctrl_fmtilvl_we = addr_hit[7] & reg_we & !reg_error;
   assign fifo_ctrl_fmtilvl_wd = reg_wdata[6:5];
 
-  assign fifo_ctrl_acqrst_we = addr_hit[7] & reg_we & ~wr_err;
+  assign fifo_ctrl_acqrst_we = addr_hit[7] & reg_we & !reg_error;
   assign fifo_ctrl_acqrst_wd = reg_wdata[7];
 
-  assign fifo_ctrl_txrst_we = addr_hit[7] & reg_we & ~wr_err;
+  assign fifo_ctrl_txrst_we = addr_hit[7] & reg_we & !reg_error;
   assign fifo_ctrl_txrst_wd = reg_wdata[8];
 
-  assign fifo_status_fmtlvl_re = addr_hit[8] && reg_re;
+  assign fifo_status_fmtlvl_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign fifo_status_txlvl_re = addr_hit[8] && reg_re;
+  assign fifo_status_txlvl_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign fifo_status_rxlvl_re = addr_hit[8] && reg_re;
+  assign fifo_status_rxlvl_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign fifo_status_acqlvl_re = addr_hit[8] && reg_re;
+  assign fifo_status_acqlvl_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign ovrd_txovrden_we = addr_hit[9] & reg_we & ~wr_err;
+  assign ovrd_txovrden_we = addr_hit[9] & reg_we & !reg_error;
   assign ovrd_txovrden_wd = reg_wdata[0];
 
-  assign ovrd_sclval_we = addr_hit[9] & reg_we & ~wr_err;
+  assign ovrd_sclval_we = addr_hit[9] & reg_we & !reg_error;
   assign ovrd_sclval_wd = reg_wdata[1];
 
-  assign ovrd_sdaval_we = addr_hit[9] & reg_we & ~wr_err;
+  assign ovrd_sdaval_we = addr_hit[9] & reg_we & !reg_error;
   assign ovrd_sdaval_wd = reg_wdata[2];
 
-  assign val_scl_rx_re = addr_hit[10] && reg_re;
+  assign val_scl_rx_re = addr_hit[10] & reg_re & !reg_error;
 
-  assign val_sda_rx_re = addr_hit[10] && reg_re;
+  assign val_sda_rx_re = addr_hit[10] & reg_re & !reg_error;
 
-  assign timing0_thigh_we = addr_hit[11] & reg_we & ~wr_err;
+  assign timing0_thigh_we = addr_hit[11] & reg_we & !reg_error;
   assign timing0_thigh_wd = reg_wdata[15:0];
 
-  assign timing0_tlow_we = addr_hit[11] & reg_we & ~wr_err;
+  assign timing0_tlow_we = addr_hit[11] & reg_we & !reg_error;
   assign timing0_tlow_wd = reg_wdata[31:16];
 
-  assign timing1_t_r_we = addr_hit[12] & reg_we & ~wr_err;
+  assign timing1_t_r_we = addr_hit[12] & reg_we & !reg_error;
   assign timing1_t_r_wd = reg_wdata[15:0];
 
-  assign timing1_t_f_we = addr_hit[12] & reg_we & ~wr_err;
+  assign timing1_t_f_we = addr_hit[12] & reg_we & !reg_error;
   assign timing1_t_f_wd = reg_wdata[31:16];
 
-  assign timing2_tsu_sta_we = addr_hit[13] & reg_we & ~wr_err;
+  assign timing2_tsu_sta_we = addr_hit[13] & reg_we & !reg_error;
   assign timing2_tsu_sta_wd = reg_wdata[15:0];
 
-  assign timing2_thd_sta_we = addr_hit[13] & reg_we & ~wr_err;
+  assign timing2_thd_sta_we = addr_hit[13] & reg_we & !reg_error;
   assign timing2_thd_sta_wd = reg_wdata[31:16];
 
-  assign timing3_tsu_dat_we = addr_hit[14] & reg_we & ~wr_err;
+  assign timing3_tsu_dat_we = addr_hit[14] & reg_we & !reg_error;
   assign timing3_tsu_dat_wd = reg_wdata[15:0];
 
-  assign timing3_thd_dat_we = addr_hit[14] & reg_we & ~wr_err;
+  assign timing3_thd_dat_we = addr_hit[14] & reg_we & !reg_error;
   assign timing3_thd_dat_wd = reg_wdata[31:16];
 
-  assign timing4_tsu_sto_we = addr_hit[15] & reg_we & ~wr_err;
+  assign timing4_tsu_sto_we = addr_hit[15] & reg_we & !reg_error;
   assign timing4_tsu_sto_wd = reg_wdata[15:0];
 
-  assign timing4_t_buf_we = addr_hit[15] & reg_we & ~wr_err;
+  assign timing4_t_buf_we = addr_hit[15] & reg_we & !reg_error;
   assign timing4_t_buf_wd = reg_wdata[31:16];
 
-  assign timeout_ctrl_val_we = addr_hit[16] & reg_we & ~wr_err;
+  assign timeout_ctrl_val_we = addr_hit[16] & reg_we & !reg_error;
   assign timeout_ctrl_val_wd = reg_wdata[30:0];
 
-  assign timeout_ctrl_en_we = addr_hit[16] & reg_we & ~wr_err;
+  assign timeout_ctrl_en_we = addr_hit[16] & reg_we & !reg_error;
   assign timeout_ctrl_en_wd = reg_wdata[31];
 
-  assign target_id_address0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign target_id_address0_we = addr_hit[17] & reg_we & !reg_error;
   assign target_id_address0_wd = reg_wdata[6:0];
 
-  assign target_id_mask0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign target_id_mask0_we = addr_hit[17] & reg_we & !reg_error;
   assign target_id_mask0_wd = reg_wdata[13:7];
 
-  assign target_id_address1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign target_id_address1_we = addr_hit[17] & reg_we & !reg_error;
   assign target_id_address1_wd = reg_wdata[20:14];
 
-  assign target_id_mask1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign target_id_mask1_we = addr_hit[17] & reg_we & !reg_error;
   assign target_id_mask1_wd = reg_wdata[27:21];
 
-  assign acqdata_abyte_re = addr_hit[18] && reg_re;
+  assign acqdata_abyte_re = addr_hit[18] & reg_re & !reg_error;
 
-  assign acqdata_signal_re = addr_hit[18] && reg_re;
+  assign acqdata_signal_re = addr_hit[18] & reg_re & !reg_error;
 
-  assign txdata_we = addr_hit[19] & reg_we & ~wr_err;
+  assign txdata_we = addr_hit[19] & reg_we & !reg_error;
   assign txdata_wd = reg_wdata[7:0];
 
-  assign stretch_ctrl_enableaddr_we = addr_hit[20] & reg_we & ~wr_err;
+  assign stretch_ctrl_enableaddr_we = addr_hit[20] & reg_we & !reg_error;
   assign stretch_ctrl_enableaddr_wd = reg_wdata[0];
 
-  assign stretch_ctrl_enabletx_we = addr_hit[20] & reg_we & ~wr_err;
+  assign stretch_ctrl_enabletx_we = addr_hit[20] & reg_we & !reg_error;
   assign stretch_ctrl_enabletx_wd = reg_wdata[1];
 
-  assign stretch_ctrl_enableacq_we = addr_hit[20] & reg_we & ~wr_err;
+  assign stretch_ctrl_enableacq_we = addr_hit[20] & reg_we & !reg_error;
   assign stretch_ctrl_enableacq_wd = reg_wdata[2];
 
-  assign stretch_ctrl_stop_we = addr_hit[20] & reg_we & ~wr_err;
+  assign stretch_ctrl_stop_we = addr_hit[20] & reg_we & !reg_error;
   assign stretch_ctrl_stop_wd = reg_wdata[3];
 
-  assign host_timeout_ctrl_we = addr_hit[21] & reg_we & ~wr_err;
+  assign host_timeout_ctrl_we = addr_hit[21] & reg_we & !reg_error;
   assign host_timeout_ctrl_wd = reg_wdata[31:0];
 
   // Read data return

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -1603,149 +1603,149 @@ module keymgr_reg_top (
     if (addr_hit[42] && reg_we && (KEYMGR_PERMIT[42] != (KEYMGR_PERMIT[42] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_wd = reg_wdata[0];
 
-  assign intr_enable_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_wd = reg_wdata[0];
 
-  assign intr_test_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_wd = reg_wdata[0];
 
-  assign alert_test_fatal_fault_err_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_fatal_fault_err_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_fatal_fault_err_wd = reg_wdata[0];
 
-  assign alert_test_recov_operation_err_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_recov_operation_err_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_recov_operation_err_wd = reg_wdata[1];
 
-  assign cfg_regwen_re = addr_hit[4] && reg_re;
+  assign cfg_regwen_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign control_start_we = addr_hit[5] & reg_we & ~wr_err;
+  assign control_start_we = addr_hit[5] & reg_we & !reg_error;
   assign control_start_wd = reg_wdata[0];
 
-  assign control_operation_we = addr_hit[5] & reg_we & ~wr_err;
+  assign control_operation_we = addr_hit[5] & reg_we & !reg_error;
   assign control_operation_wd = reg_wdata[6:4];
 
-  assign control_dest_sel_we = addr_hit[5] & reg_we & ~wr_err;
+  assign control_dest_sel_we = addr_hit[5] & reg_we & !reg_error;
   assign control_dest_sel_wd = reg_wdata[13:12];
 
-  assign sideload_clear_we = addr_hit[6] & reg_we & ~wr_err;
+  assign sideload_clear_we = addr_hit[6] & reg_we & !reg_error;
   assign sideload_clear_wd = reg_wdata[0];
 
-  assign reseed_interval_we = addr_hit[7] & reg_we & ~wr_err;
+  assign reseed_interval_we = addr_hit[7] & reg_we & !reg_error;
   assign reseed_interval_wd = reg_wdata[15:0];
 
-  assign sw_binding_regwen_we = addr_hit[8] & reg_we & ~wr_err;
+  assign sw_binding_regwen_we = addr_hit[8] & reg_we & !reg_error;
   assign sw_binding_regwen_wd = reg_wdata[0];
-  assign sw_binding_regwen_re = addr_hit[8] && reg_re;
+  assign sw_binding_regwen_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign sw_binding_0_we = addr_hit[9] & reg_we & ~wr_err;
+  assign sw_binding_0_we = addr_hit[9] & reg_we & !reg_error;
   assign sw_binding_0_wd = reg_wdata[31:0];
 
-  assign sw_binding_1_we = addr_hit[10] & reg_we & ~wr_err;
+  assign sw_binding_1_we = addr_hit[10] & reg_we & !reg_error;
   assign sw_binding_1_wd = reg_wdata[31:0];
 
-  assign sw_binding_2_we = addr_hit[11] & reg_we & ~wr_err;
+  assign sw_binding_2_we = addr_hit[11] & reg_we & !reg_error;
   assign sw_binding_2_wd = reg_wdata[31:0];
 
-  assign sw_binding_3_we = addr_hit[12] & reg_we & ~wr_err;
+  assign sw_binding_3_we = addr_hit[12] & reg_we & !reg_error;
   assign sw_binding_3_wd = reg_wdata[31:0];
 
-  assign salt_0_we = addr_hit[13] & reg_we & ~wr_err;
+  assign salt_0_we = addr_hit[13] & reg_we & !reg_error;
   assign salt_0_wd = reg_wdata[31:0];
 
-  assign salt_1_we = addr_hit[14] & reg_we & ~wr_err;
+  assign salt_1_we = addr_hit[14] & reg_we & !reg_error;
   assign salt_1_wd = reg_wdata[31:0];
 
-  assign salt_2_we = addr_hit[15] & reg_we & ~wr_err;
+  assign salt_2_we = addr_hit[15] & reg_we & !reg_error;
   assign salt_2_wd = reg_wdata[31:0];
 
-  assign salt_3_we = addr_hit[16] & reg_we & ~wr_err;
+  assign salt_3_we = addr_hit[16] & reg_we & !reg_error;
   assign salt_3_wd = reg_wdata[31:0];
 
-  assign key_version_we = addr_hit[17] & reg_we & ~wr_err;
+  assign key_version_we = addr_hit[17] & reg_we & !reg_error;
   assign key_version_wd = reg_wdata[31:0];
 
-  assign max_creator_key_ver_regwen_we = addr_hit[18] & reg_we & ~wr_err;
+  assign max_creator_key_ver_regwen_we = addr_hit[18] & reg_we & !reg_error;
   assign max_creator_key_ver_regwen_wd = reg_wdata[0];
 
-  assign max_creator_key_ver_we = addr_hit[19] & reg_we & ~wr_err;
+  assign max_creator_key_ver_we = addr_hit[19] & reg_we & !reg_error;
   assign max_creator_key_ver_wd = reg_wdata[31:0];
 
-  assign max_owner_int_key_ver_regwen_we = addr_hit[20] & reg_we & ~wr_err;
+  assign max_owner_int_key_ver_regwen_we = addr_hit[20] & reg_we & !reg_error;
   assign max_owner_int_key_ver_regwen_wd = reg_wdata[0];
 
-  assign max_owner_int_key_ver_we = addr_hit[21] & reg_we & ~wr_err;
+  assign max_owner_int_key_ver_we = addr_hit[21] & reg_we & !reg_error;
   assign max_owner_int_key_ver_wd = reg_wdata[31:0];
 
-  assign max_owner_key_ver_regwen_we = addr_hit[22] & reg_we & ~wr_err;
+  assign max_owner_key_ver_regwen_we = addr_hit[22] & reg_we & !reg_error;
   assign max_owner_key_ver_regwen_wd = reg_wdata[0];
 
-  assign max_owner_key_ver_we = addr_hit[23] & reg_we & ~wr_err;
+  assign max_owner_key_ver_we = addr_hit[23] & reg_we & !reg_error;
   assign max_owner_key_ver_wd = reg_wdata[31:0];
 
-  assign sw_share0_output_0_we = addr_hit[24] & reg_re;
+  assign sw_share0_output_0_we = addr_hit[24] & reg_re & !reg_error;
   assign sw_share0_output_0_wd = '1;
 
-  assign sw_share0_output_1_we = addr_hit[25] & reg_re;
+  assign sw_share0_output_1_we = addr_hit[25] & reg_re & !reg_error;
   assign sw_share0_output_1_wd = '1;
 
-  assign sw_share0_output_2_we = addr_hit[26] & reg_re;
+  assign sw_share0_output_2_we = addr_hit[26] & reg_re & !reg_error;
   assign sw_share0_output_2_wd = '1;
 
-  assign sw_share0_output_3_we = addr_hit[27] & reg_re;
+  assign sw_share0_output_3_we = addr_hit[27] & reg_re & !reg_error;
   assign sw_share0_output_3_wd = '1;
 
-  assign sw_share0_output_4_we = addr_hit[28] & reg_re;
+  assign sw_share0_output_4_we = addr_hit[28] & reg_re & !reg_error;
   assign sw_share0_output_4_wd = '1;
 
-  assign sw_share0_output_5_we = addr_hit[29] & reg_re;
+  assign sw_share0_output_5_we = addr_hit[29] & reg_re & !reg_error;
   assign sw_share0_output_5_wd = '1;
 
-  assign sw_share0_output_6_we = addr_hit[30] & reg_re;
+  assign sw_share0_output_6_we = addr_hit[30] & reg_re & !reg_error;
   assign sw_share0_output_6_wd = '1;
 
-  assign sw_share0_output_7_we = addr_hit[31] & reg_re;
+  assign sw_share0_output_7_we = addr_hit[31] & reg_re & !reg_error;
   assign sw_share0_output_7_wd = '1;
 
-  assign sw_share1_output_0_we = addr_hit[32] & reg_re;
+  assign sw_share1_output_0_we = addr_hit[32] & reg_re & !reg_error;
   assign sw_share1_output_0_wd = '1;
 
-  assign sw_share1_output_1_we = addr_hit[33] & reg_re;
+  assign sw_share1_output_1_we = addr_hit[33] & reg_re & !reg_error;
   assign sw_share1_output_1_wd = '1;
 
-  assign sw_share1_output_2_we = addr_hit[34] & reg_re;
+  assign sw_share1_output_2_we = addr_hit[34] & reg_re & !reg_error;
   assign sw_share1_output_2_wd = '1;
 
-  assign sw_share1_output_3_we = addr_hit[35] & reg_re;
+  assign sw_share1_output_3_we = addr_hit[35] & reg_re & !reg_error;
   assign sw_share1_output_3_wd = '1;
 
-  assign sw_share1_output_4_we = addr_hit[36] & reg_re;
+  assign sw_share1_output_4_we = addr_hit[36] & reg_re & !reg_error;
   assign sw_share1_output_4_wd = '1;
 
-  assign sw_share1_output_5_we = addr_hit[37] & reg_re;
+  assign sw_share1_output_5_we = addr_hit[37] & reg_re & !reg_error;
   assign sw_share1_output_5_wd = '1;
 
-  assign sw_share1_output_6_we = addr_hit[38] & reg_re;
+  assign sw_share1_output_6_we = addr_hit[38] & reg_re & !reg_error;
   assign sw_share1_output_6_wd = '1;
 
-  assign sw_share1_output_7_we = addr_hit[39] & reg_re;
+  assign sw_share1_output_7_we = addr_hit[39] & reg_re & !reg_error;
   assign sw_share1_output_7_wd = '1;
 
 
-  assign op_status_we = addr_hit[41] & reg_we & ~wr_err;
+  assign op_status_we = addr_hit[41] & reg_we & !reg_error;
   assign op_status_wd = reg_wdata[1:0];
 
-  assign err_code_invalid_op_we = addr_hit[42] & reg_we & ~wr_err;
+  assign err_code_invalid_op_we = addr_hit[42] & reg_we & !reg_error;
   assign err_code_invalid_op_wd = reg_wdata[0];
 
-  assign err_code_invalid_cmd_we = addr_hit[42] & reg_we & ~wr_err;
+  assign err_code_invalid_cmd_we = addr_hit[42] & reg_we & !reg_error;
   assign err_code_invalid_cmd_wd = reg_wdata[1];
 
-  assign err_code_invalid_kmac_input_we = addr_hit[42] & reg_we & ~wr_err;
+  assign err_code_invalid_kmac_input_we = addr_hit[42] & reg_we & !reg_error;
   assign err_code_invalid_kmac_input_wd = reg_wdata[2];
 
-  assign err_code_invalid_kmac_data_we = addr_hit[42] & reg_we & ~wr_err;
+  assign err_code_invalid_kmac_data_we = addr_hit[42] & reg_we & !reg_error;
   assign err_code_invalid_kmac_data_wd = reg_wdata[3];
 
   // Read data return

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -2015,222 +2015,222 @@ module kmac_reg_top (
     if (addr_hit[54] && reg_we && (KMAC_PERMIT[54] != (KMAC_PERMIT[54] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_kmac_done_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_kmac_done_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_kmac_done_wd = reg_wdata[0];
 
-  assign intr_state_fifo_empty_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_fifo_empty_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_fifo_empty_wd = reg_wdata[1];
 
-  assign intr_state_kmac_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_kmac_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_kmac_err_wd = reg_wdata[2];
 
-  assign intr_enable_kmac_done_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_kmac_done_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_kmac_done_wd = reg_wdata[0];
 
-  assign intr_enable_fifo_empty_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_fifo_empty_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_fifo_empty_wd = reg_wdata[1];
 
-  assign intr_enable_kmac_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_kmac_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_kmac_err_wd = reg_wdata[2];
 
-  assign intr_test_kmac_done_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_kmac_done_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_kmac_done_wd = reg_wdata[0];
 
-  assign intr_test_fifo_empty_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_fifo_empty_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_fifo_empty_wd = reg_wdata[1];
 
-  assign intr_test_kmac_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_kmac_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_kmac_err_wd = reg_wdata[2];
 
-  assign cfg_regwen_re = addr_hit[3] && reg_re;
+  assign cfg_regwen_re = addr_hit[3] & reg_re & !reg_error;
 
-  assign cfg_kmac_en_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cfg_kmac_en_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_kmac_en_wd = reg_wdata[0];
 
-  assign cfg_kstrength_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cfg_kstrength_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_kstrength_wd = reg_wdata[3:1];
 
-  assign cfg_mode_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cfg_mode_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_mode_wd = reg_wdata[5:4];
 
-  assign cfg_msg_endianness_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cfg_msg_endianness_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_msg_endianness_wd = reg_wdata[8];
 
-  assign cfg_state_endianness_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cfg_state_endianness_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_state_endianness_wd = reg_wdata[9];
 
-  assign cfg_sideload_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cfg_sideload_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_sideload_wd = reg_wdata[12];
 
-  assign cfg_entropy_mode_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cfg_entropy_mode_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_entropy_mode_wd = reg_wdata[17:16];
 
-  assign cfg_entropy_fast_process_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cfg_entropy_fast_process_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_entropy_fast_process_wd = reg_wdata[19];
 
-  assign cfg_entropy_ready_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cfg_entropy_ready_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_entropy_ready_wd = reg_wdata[24];
 
-  assign cfg_err_processed_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cfg_err_processed_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_err_processed_wd = reg_wdata[25];
 
-  assign cmd_we = addr_hit[5] & reg_we & ~wr_err;
+  assign cmd_we = addr_hit[5] & reg_we & !reg_error;
   assign cmd_wd = reg_wdata[3:0];
 
-  assign status_sha3_idle_re = addr_hit[6] && reg_re;
+  assign status_sha3_idle_re = addr_hit[6] & reg_re & !reg_error;
 
-  assign status_sha3_absorb_re = addr_hit[6] && reg_re;
+  assign status_sha3_absorb_re = addr_hit[6] & reg_re & !reg_error;
 
-  assign status_sha3_squeeze_re = addr_hit[6] && reg_re;
+  assign status_sha3_squeeze_re = addr_hit[6] & reg_re & !reg_error;
 
-  assign status_fifo_depth_re = addr_hit[6] && reg_re;
+  assign status_fifo_depth_re = addr_hit[6] & reg_re & !reg_error;
 
-  assign status_fifo_empty_re = addr_hit[6] && reg_re;
+  assign status_fifo_empty_re = addr_hit[6] & reg_re & !reg_error;
 
-  assign status_fifo_full_re = addr_hit[6] && reg_re;
+  assign status_fifo_full_re = addr_hit[6] & reg_re & !reg_error;
 
-  assign entropy_period_entropy_timer_we = addr_hit[7] & reg_we & ~wr_err;
+  assign entropy_period_entropy_timer_we = addr_hit[7] & reg_we & !reg_error;
   assign entropy_period_entropy_timer_wd = reg_wdata[15:0];
 
-  assign entropy_period_wait_timer_we = addr_hit[7] & reg_we & ~wr_err;
+  assign entropy_period_wait_timer_we = addr_hit[7] & reg_we & !reg_error;
   assign entropy_period_wait_timer_wd = reg_wdata[31:16];
 
-  assign entropy_seed_lower_we = addr_hit[8] & reg_we & ~wr_err;
+  assign entropy_seed_lower_we = addr_hit[8] & reg_we & !reg_error;
   assign entropy_seed_lower_wd = reg_wdata[31:0];
 
-  assign entropy_seed_upper_we = addr_hit[9] & reg_we & ~wr_err;
+  assign entropy_seed_upper_we = addr_hit[9] & reg_we & !reg_error;
   assign entropy_seed_upper_wd = reg_wdata[31:0];
 
-  assign key_share0_0_we = addr_hit[10] & reg_we & ~wr_err;
+  assign key_share0_0_we = addr_hit[10] & reg_we & !reg_error;
   assign key_share0_0_wd = reg_wdata[31:0];
 
-  assign key_share0_1_we = addr_hit[11] & reg_we & ~wr_err;
+  assign key_share0_1_we = addr_hit[11] & reg_we & !reg_error;
   assign key_share0_1_wd = reg_wdata[31:0];
 
-  assign key_share0_2_we = addr_hit[12] & reg_we & ~wr_err;
+  assign key_share0_2_we = addr_hit[12] & reg_we & !reg_error;
   assign key_share0_2_wd = reg_wdata[31:0];
 
-  assign key_share0_3_we = addr_hit[13] & reg_we & ~wr_err;
+  assign key_share0_3_we = addr_hit[13] & reg_we & !reg_error;
   assign key_share0_3_wd = reg_wdata[31:0];
 
-  assign key_share0_4_we = addr_hit[14] & reg_we & ~wr_err;
+  assign key_share0_4_we = addr_hit[14] & reg_we & !reg_error;
   assign key_share0_4_wd = reg_wdata[31:0];
 
-  assign key_share0_5_we = addr_hit[15] & reg_we & ~wr_err;
+  assign key_share0_5_we = addr_hit[15] & reg_we & !reg_error;
   assign key_share0_5_wd = reg_wdata[31:0];
 
-  assign key_share0_6_we = addr_hit[16] & reg_we & ~wr_err;
+  assign key_share0_6_we = addr_hit[16] & reg_we & !reg_error;
   assign key_share0_6_wd = reg_wdata[31:0];
 
-  assign key_share0_7_we = addr_hit[17] & reg_we & ~wr_err;
+  assign key_share0_7_we = addr_hit[17] & reg_we & !reg_error;
   assign key_share0_7_wd = reg_wdata[31:0];
 
-  assign key_share0_8_we = addr_hit[18] & reg_we & ~wr_err;
+  assign key_share0_8_we = addr_hit[18] & reg_we & !reg_error;
   assign key_share0_8_wd = reg_wdata[31:0];
 
-  assign key_share0_9_we = addr_hit[19] & reg_we & ~wr_err;
+  assign key_share0_9_we = addr_hit[19] & reg_we & !reg_error;
   assign key_share0_9_wd = reg_wdata[31:0];
 
-  assign key_share0_10_we = addr_hit[20] & reg_we & ~wr_err;
+  assign key_share0_10_we = addr_hit[20] & reg_we & !reg_error;
   assign key_share0_10_wd = reg_wdata[31:0];
 
-  assign key_share0_11_we = addr_hit[21] & reg_we & ~wr_err;
+  assign key_share0_11_we = addr_hit[21] & reg_we & !reg_error;
   assign key_share0_11_wd = reg_wdata[31:0];
 
-  assign key_share0_12_we = addr_hit[22] & reg_we & ~wr_err;
+  assign key_share0_12_we = addr_hit[22] & reg_we & !reg_error;
   assign key_share0_12_wd = reg_wdata[31:0];
 
-  assign key_share0_13_we = addr_hit[23] & reg_we & ~wr_err;
+  assign key_share0_13_we = addr_hit[23] & reg_we & !reg_error;
   assign key_share0_13_wd = reg_wdata[31:0];
 
-  assign key_share0_14_we = addr_hit[24] & reg_we & ~wr_err;
+  assign key_share0_14_we = addr_hit[24] & reg_we & !reg_error;
   assign key_share0_14_wd = reg_wdata[31:0];
 
-  assign key_share0_15_we = addr_hit[25] & reg_we & ~wr_err;
+  assign key_share0_15_we = addr_hit[25] & reg_we & !reg_error;
   assign key_share0_15_wd = reg_wdata[31:0];
 
-  assign key_share1_0_we = addr_hit[26] & reg_we & ~wr_err;
+  assign key_share1_0_we = addr_hit[26] & reg_we & !reg_error;
   assign key_share1_0_wd = reg_wdata[31:0];
 
-  assign key_share1_1_we = addr_hit[27] & reg_we & ~wr_err;
+  assign key_share1_1_we = addr_hit[27] & reg_we & !reg_error;
   assign key_share1_1_wd = reg_wdata[31:0];
 
-  assign key_share1_2_we = addr_hit[28] & reg_we & ~wr_err;
+  assign key_share1_2_we = addr_hit[28] & reg_we & !reg_error;
   assign key_share1_2_wd = reg_wdata[31:0];
 
-  assign key_share1_3_we = addr_hit[29] & reg_we & ~wr_err;
+  assign key_share1_3_we = addr_hit[29] & reg_we & !reg_error;
   assign key_share1_3_wd = reg_wdata[31:0];
 
-  assign key_share1_4_we = addr_hit[30] & reg_we & ~wr_err;
+  assign key_share1_4_we = addr_hit[30] & reg_we & !reg_error;
   assign key_share1_4_wd = reg_wdata[31:0];
 
-  assign key_share1_5_we = addr_hit[31] & reg_we & ~wr_err;
+  assign key_share1_5_we = addr_hit[31] & reg_we & !reg_error;
   assign key_share1_5_wd = reg_wdata[31:0];
 
-  assign key_share1_6_we = addr_hit[32] & reg_we & ~wr_err;
+  assign key_share1_6_we = addr_hit[32] & reg_we & !reg_error;
   assign key_share1_6_wd = reg_wdata[31:0];
 
-  assign key_share1_7_we = addr_hit[33] & reg_we & ~wr_err;
+  assign key_share1_7_we = addr_hit[33] & reg_we & !reg_error;
   assign key_share1_7_wd = reg_wdata[31:0];
 
-  assign key_share1_8_we = addr_hit[34] & reg_we & ~wr_err;
+  assign key_share1_8_we = addr_hit[34] & reg_we & !reg_error;
   assign key_share1_8_wd = reg_wdata[31:0];
 
-  assign key_share1_9_we = addr_hit[35] & reg_we & ~wr_err;
+  assign key_share1_9_we = addr_hit[35] & reg_we & !reg_error;
   assign key_share1_9_wd = reg_wdata[31:0];
 
-  assign key_share1_10_we = addr_hit[36] & reg_we & ~wr_err;
+  assign key_share1_10_we = addr_hit[36] & reg_we & !reg_error;
   assign key_share1_10_wd = reg_wdata[31:0];
 
-  assign key_share1_11_we = addr_hit[37] & reg_we & ~wr_err;
+  assign key_share1_11_we = addr_hit[37] & reg_we & !reg_error;
   assign key_share1_11_wd = reg_wdata[31:0];
 
-  assign key_share1_12_we = addr_hit[38] & reg_we & ~wr_err;
+  assign key_share1_12_we = addr_hit[38] & reg_we & !reg_error;
   assign key_share1_12_wd = reg_wdata[31:0];
 
-  assign key_share1_13_we = addr_hit[39] & reg_we & ~wr_err;
+  assign key_share1_13_we = addr_hit[39] & reg_we & !reg_error;
   assign key_share1_13_wd = reg_wdata[31:0];
 
-  assign key_share1_14_we = addr_hit[40] & reg_we & ~wr_err;
+  assign key_share1_14_we = addr_hit[40] & reg_we & !reg_error;
   assign key_share1_14_wd = reg_wdata[31:0];
 
-  assign key_share1_15_we = addr_hit[41] & reg_we & ~wr_err;
+  assign key_share1_15_we = addr_hit[41] & reg_we & !reg_error;
   assign key_share1_15_wd = reg_wdata[31:0];
 
-  assign key_len_we = addr_hit[42] & reg_we & ~wr_err;
+  assign key_len_we = addr_hit[42] & reg_we & !reg_error;
   assign key_len_wd = reg_wdata[2:0];
 
-  assign prefix_0_we = addr_hit[43] & reg_we & ~wr_err;
+  assign prefix_0_we = addr_hit[43] & reg_we & !reg_error;
   assign prefix_0_wd = reg_wdata[31:0];
 
-  assign prefix_1_we = addr_hit[44] & reg_we & ~wr_err;
+  assign prefix_1_we = addr_hit[44] & reg_we & !reg_error;
   assign prefix_1_wd = reg_wdata[31:0];
 
-  assign prefix_2_we = addr_hit[45] & reg_we & ~wr_err;
+  assign prefix_2_we = addr_hit[45] & reg_we & !reg_error;
   assign prefix_2_wd = reg_wdata[31:0];
 
-  assign prefix_3_we = addr_hit[46] & reg_we & ~wr_err;
+  assign prefix_3_we = addr_hit[46] & reg_we & !reg_error;
   assign prefix_3_wd = reg_wdata[31:0];
 
-  assign prefix_4_we = addr_hit[47] & reg_we & ~wr_err;
+  assign prefix_4_we = addr_hit[47] & reg_we & !reg_error;
   assign prefix_4_wd = reg_wdata[31:0];
 
-  assign prefix_5_we = addr_hit[48] & reg_we & ~wr_err;
+  assign prefix_5_we = addr_hit[48] & reg_we & !reg_error;
   assign prefix_5_wd = reg_wdata[31:0];
 
-  assign prefix_6_we = addr_hit[49] & reg_we & ~wr_err;
+  assign prefix_6_we = addr_hit[49] & reg_we & !reg_error;
   assign prefix_6_wd = reg_wdata[31:0];
 
-  assign prefix_7_we = addr_hit[50] & reg_we & ~wr_err;
+  assign prefix_7_we = addr_hit[50] & reg_we & !reg_error;
   assign prefix_7_wd = reg_wdata[31:0];
 
-  assign prefix_8_we = addr_hit[51] & reg_we & ~wr_err;
+  assign prefix_8_we = addr_hit[51] & reg_we & !reg_error;
   assign prefix_8_wd = reg_wdata[31:0];
 
-  assign prefix_9_we = addr_hit[52] & reg_we & ~wr_err;
+  assign prefix_9_we = addr_hit[52] & reg_we & !reg_error;
   assign prefix_9_wd = reg_wdata[31:0];
 
-  assign prefix_10_we = addr_hit[53] & reg_we & ~wr_err;
+  assign prefix_10_we = addr_hit[53] & reg_we & !reg_error;
   assign prefix_10_wd = reg_wdata[31:0];
 
 

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
@@ -698,80 +698,80 @@ module lc_ctrl_reg_top (
     if (addr_hit[20] && reg_we && (LC_CTRL_PERMIT[20] != (LC_CTRL_PERMIT[20] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign alert_test_fatal_prog_error_we = addr_hit[0] & reg_we & ~wr_err;
+  assign alert_test_fatal_prog_error_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_fatal_prog_error_wd = reg_wdata[0];
 
-  assign alert_test_fatal_state_error_we = addr_hit[0] & reg_we & ~wr_err;
+  assign alert_test_fatal_state_error_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_fatal_state_error_wd = reg_wdata[1];
 
-  assign status_ready_re = addr_hit[1] && reg_re;
+  assign status_ready_re = addr_hit[1] & reg_re & !reg_error;
 
-  assign status_transition_successful_re = addr_hit[1] && reg_re;
+  assign status_transition_successful_re = addr_hit[1] & reg_re & !reg_error;
 
-  assign status_transition_count_error_re = addr_hit[1] && reg_re;
+  assign status_transition_count_error_re = addr_hit[1] & reg_re & !reg_error;
 
-  assign status_transition_error_re = addr_hit[1] && reg_re;
+  assign status_transition_error_re = addr_hit[1] & reg_re & !reg_error;
 
-  assign status_token_error_re = addr_hit[1] && reg_re;
+  assign status_token_error_re = addr_hit[1] & reg_re & !reg_error;
 
-  assign status_flash_rma_error_re = addr_hit[1] && reg_re;
+  assign status_flash_rma_error_re = addr_hit[1] & reg_re & !reg_error;
 
-  assign status_otp_error_re = addr_hit[1] && reg_re;
+  assign status_otp_error_re = addr_hit[1] & reg_re & !reg_error;
 
-  assign status_state_error_re = addr_hit[1] && reg_re;
+  assign status_state_error_re = addr_hit[1] & reg_re & !reg_error;
 
-  assign status_otp_partition_error_re = addr_hit[1] && reg_re;
+  assign status_otp_partition_error_re = addr_hit[1] & reg_re & !reg_error;
 
-  assign claim_transition_if_we = addr_hit[2] & reg_we & ~wr_err;
+  assign claim_transition_if_we = addr_hit[2] & reg_we & !reg_error;
   assign claim_transition_if_wd = reg_wdata[7:0];
-  assign claim_transition_if_re = addr_hit[2] && reg_re;
+  assign claim_transition_if_re = addr_hit[2] & reg_re & !reg_error;
 
-  assign transition_regwen_re = addr_hit[3] && reg_re;
+  assign transition_regwen_re = addr_hit[3] & reg_re & !reg_error;
 
-  assign transition_cmd_we = addr_hit[4] & reg_we & ~wr_err;
+  assign transition_cmd_we = addr_hit[4] & reg_we & !reg_error;
   assign transition_cmd_wd = reg_wdata[0];
 
-  assign transition_token_0_we = addr_hit[5] & reg_we & ~wr_err;
+  assign transition_token_0_we = addr_hit[5] & reg_we & !reg_error;
   assign transition_token_0_wd = reg_wdata[31:0];
-  assign transition_token_0_re = addr_hit[5] && reg_re;
+  assign transition_token_0_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign transition_token_1_we = addr_hit[6] & reg_we & ~wr_err;
+  assign transition_token_1_we = addr_hit[6] & reg_we & !reg_error;
   assign transition_token_1_wd = reg_wdata[31:0];
-  assign transition_token_1_re = addr_hit[6] && reg_re;
+  assign transition_token_1_re = addr_hit[6] & reg_re & !reg_error;
 
-  assign transition_token_2_we = addr_hit[7] & reg_we & ~wr_err;
+  assign transition_token_2_we = addr_hit[7] & reg_we & !reg_error;
   assign transition_token_2_wd = reg_wdata[31:0];
-  assign transition_token_2_re = addr_hit[7] && reg_re;
+  assign transition_token_2_re = addr_hit[7] & reg_re & !reg_error;
 
-  assign transition_token_3_we = addr_hit[8] & reg_we & ~wr_err;
+  assign transition_token_3_we = addr_hit[8] & reg_we & !reg_error;
   assign transition_token_3_wd = reg_wdata[31:0];
-  assign transition_token_3_re = addr_hit[8] && reg_re;
+  assign transition_token_3_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign transition_target_we = addr_hit[9] & reg_we & ~wr_err;
+  assign transition_target_we = addr_hit[9] & reg_we & !reg_error;
   assign transition_target_wd = reg_wdata[3:0];
-  assign transition_target_re = addr_hit[9] && reg_re;
+  assign transition_target_re = addr_hit[9] & reg_re & !reg_error;
 
-  assign lc_state_re = addr_hit[10] && reg_re;
+  assign lc_state_re = addr_hit[10] & reg_re & !reg_error;
 
-  assign lc_transition_cnt_re = addr_hit[11] && reg_re;
+  assign lc_transition_cnt_re = addr_hit[11] & reg_re & !reg_error;
 
-  assign lc_id_state_re = addr_hit[12] && reg_re;
+  assign lc_id_state_re = addr_hit[12] & reg_re & !reg_error;
 
-  assign device_id_0_re = addr_hit[13] && reg_re;
+  assign device_id_0_re = addr_hit[13] & reg_re & !reg_error;
 
-  assign device_id_1_re = addr_hit[14] && reg_re;
+  assign device_id_1_re = addr_hit[14] & reg_re & !reg_error;
 
-  assign device_id_2_re = addr_hit[15] && reg_re;
+  assign device_id_2_re = addr_hit[15] & reg_re & !reg_error;
 
-  assign device_id_3_re = addr_hit[16] && reg_re;
+  assign device_id_3_re = addr_hit[16] & reg_re & !reg_error;
 
-  assign device_id_4_re = addr_hit[17] && reg_re;
+  assign device_id_4_re = addr_hit[17] & reg_re & !reg_error;
 
-  assign device_id_5_re = addr_hit[18] && reg_re;
+  assign device_id_5_re = addr_hit[18] & reg_re & !reg_error;
 
-  assign device_id_6_re = addr_hit[19] && reg_re;
+  assign device_id_6_re = addr_hit[19] & reg_re & !reg_error;
 
-  assign device_id_7_re = addr_hit[20] && reg_re;
+  assign device_id_7_re = addr_hit[20] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/ip/nmi_gen/rtl/nmi_gen_reg_top.sv
+++ b/hw/ip/nmi_gen/rtl/nmi_gen_reg_top.sv
@@ -338,31 +338,31 @@ module nmi_gen_reg_top (
     if (addr_hit[2] && reg_we && (NMI_GEN_PERMIT[2] != (NMI_GEN_PERMIT[2] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_esc0_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_esc0_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_esc0_wd = reg_wdata[0];
 
-  assign intr_state_esc1_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_esc1_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_esc1_wd = reg_wdata[1];
 
-  assign intr_state_esc2_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_esc2_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_esc2_wd = reg_wdata[2];
 
-  assign intr_enable_esc0_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_esc0_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_esc0_wd = reg_wdata[0];
 
-  assign intr_enable_esc1_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_esc1_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_esc1_wd = reg_wdata[1];
 
-  assign intr_enable_esc2_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_esc2_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_esc2_wd = reg_wdata[2];
 
-  assign intr_test_esc0_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_esc0_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_esc0_wd = reg_wdata[0];
 
-  assign intr_test_esc1_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_esc1_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_esc1_wd = reg_wdata[1];
 
-  assign intr_test_esc2_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_esc2_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_esc2_wd = reg_wdata[2];
 
   // Read data return

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -640,25 +640,25 @@ module otbn_reg_top (
     if (addr_hit[8] && reg_we && (OTBN_PERMIT[8] != (OTBN_PERMIT[8] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_wd = reg_wdata[0];
 
-  assign intr_enable_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_wd = reg_wdata[0];
 
-  assign intr_test_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_wd = reg_wdata[0];
 
-  assign alert_test_fatal_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_fatal_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_fatal_wd = reg_wdata[0];
 
-  assign alert_test_recov_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_recov_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_recov_wd = reg_wdata[1];
 
-  assign cmd_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cmd_we = addr_hit[4] & reg_we & !reg_error;
   assign cmd_wd = reg_wdata[0];
 
-  assign status_re = addr_hit[5] && reg_re;
+  assign status_re = addr_hit[5] & reg_re & !reg_error;
 
 
 
@@ -668,7 +668,7 @@ module otbn_reg_top (
 
 
 
-  assign start_addr_we = addr_hit[7] & reg_we & ~wr_err;
+  assign start_addr_we = addr_hit[7] & reg_we & !reg_error;
   assign start_addr_wd = reg_wdata[31:0];
 
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
@@ -1507,152 +1507,152 @@ module otp_ctrl_reg_top (
     if (addr_hit[32] && reg_we && (OTP_CTRL_PERMIT[32] != (OTP_CTRL_PERMIT[32] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_otp_operation_done_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_otp_operation_done_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_otp_operation_done_wd = reg_wdata[0];
 
-  assign intr_state_otp_error_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_otp_error_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_otp_error_wd = reg_wdata[1];
 
-  assign intr_enable_otp_operation_done_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_otp_operation_done_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_otp_operation_done_wd = reg_wdata[0];
 
-  assign intr_enable_otp_error_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_otp_error_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_otp_error_wd = reg_wdata[1];
 
-  assign intr_test_otp_operation_done_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_otp_operation_done_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_otp_operation_done_wd = reg_wdata[0];
 
-  assign intr_test_otp_error_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_otp_error_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_otp_error_wd = reg_wdata[1];
 
-  assign alert_test_fatal_macro_error_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_fatal_macro_error_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_fatal_macro_error_wd = reg_wdata[0];
 
-  assign alert_test_fatal_check_error_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_fatal_check_error_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_fatal_check_error_wd = reg_wdata[1];
 
-  assign status_creator_sw_cfg_error_re = addr_hit[4] && reg_re;
+  assign status_creator_sw_cfg_error_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_owner_sw_cfg_error_re = addr_hit[4] && reg_re;
+  assign status_owner_sw_cfg_error_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_hw_cfg_error_re = addr_hit[4] && reg_re;
+  assign status_hw_cfg_error_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_secret0_error_re = addr_hit[4] && reg_re;
+  assign status_secret0_error_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_secret1_error_re = addr_hit[4] && reg_re;
+  assign status_secret1_error_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_secret2_error_re = addr_hit[4] && reg_re;
+  assign status_secret2_error_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_life_cycle_error_re = addr_hit[4] && reg_re;
+  assign status_life_cycle_error_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_dai_error_re = addr_hit[4] && reg_re;
+  assign status_dai_error_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_lci_error_re = addr_hit[4] && reg_re;
+  assign status_lci_error_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_timeout_error_re = addr_hit[4] && reg_re;
+  assign status_timeout_error_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_lfsr_fsm_error_re = addr_hit[4] && reg_re;
+  assign status_lfsr_fsm_error_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_scrambling_fsm_error_re = addr_hit[4] && reg_re;
+  assign status_scrambling_fsm_error_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_key_deriv_fsm_error_re = addr_hit[4] && reg_re;
+  assign status_key_deriv_fsm_error_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_dai_idle_re = addr_hit[4] && reg_re;
+  assign status_dai_idle_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_check_pending_re = addr_hit[4] && reg_re;
+  assign status_check_pending_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign err_code_err_code_0_re = addr_hit[5] && reg_re;
+  assign err_code_err_code_0_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign err_code_err_code_1_re = addr_hit[5] && reg_re;
+  assign err_code_err_code_1_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign err_code_err_code_2_re = addr_hit[5] && reg_re;
+  assign err_code_err_code_2_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign err_code_err_code_3_re = addr_hit[5] && reg_re;
+  assign err_code_err_code_3_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign err_code_err_code_4_re = addr_hit[5] && reg_re;
+  assign err_code_err_code_4_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign err_code_err_code_5_re = addr_hit[5] && reg_re;
+  assign err_code_err_code_5_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign err_code_err_code_6_re = addr_hit[5] && reg_re;
+  assign err_code_err_code_6_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign err_code_err_code_7_re = addr_hit[5] && reg_re;
+  assign err_code_err_code_7_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign err_code_err_code_8_re = addr_hit[5] && reg_re;
+  assign err_code_err_code_8_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign direct_access_regwen_re = addr_hit[6] && reg_re;
+  assign direct_access_regwen_re = addr_hit[6] & reg_re & !reg_error;
 
-  assign direct_access_cmd_rd_we = addr_hit[7] & reg_we & ~wr_err;
+  assign direct_access_cmd_rd_we = addr_hit[7] & reg_we & !reg_error;
   assign direct_access_cmd_rd_wd = reg_wdata[0];
 
-  assign direct_access_cmd_wr_we = addr_hit[7] & reg_we & ~wr_err;
+  assign direct_access_cmd_wr_we = addr_hit[7] & reg_we & !reg_error;
   assign direct_access_cmd_wr_wd = reg_wdata[1];
 
-  assign direct_access_cmd_digest_we = addr_hit[7] & reg_we & ~wr_err;
+  assign direct_access_cmd_digest_we = addr_hit[7] & reg_we & !reg_error;
   assign direct_access_cmd_digest_wd = reg_wdata[2];
 
-  assign direct_access_address_we = addr_hit[8] & reg_we & ~wr_err;
+  assign direct_access_address_we = addr_hit[8] & reg_we & !reg_error;
   assign direct_access_address_wd = reg_wdata[10:0];
 
-  assign direct_access_wdata_0_we = addr_hit[9] & reg_we & ~wr_err;
+  assign direct_access_wdata_0_we = addr_hit[9] & reg_we & !reg_error;
   assign direct_access_wdata_0_wd = reg_wdata[31:0];
 
-  assign direct_access_wdata_1_we = addr_hit[10] & reg_we & ~wr_err;
+  assign direct_access_wdata_1_we = addr_hit[10] & reg_we & !reg_error;
   assign direct_access_wdata_1_wd = reg_wdata[31:0];
 
-  assign direct_access_rdata_0_re = addr_hit[11] && reg_re;
+  assign direct_access_rdata_0_re = addr_hit[11] & reg_re & !reg_error;
 
-  assign direct_access_rdata_1_re = addr_hit[12] && reg_re;
+  assign direct_access_rdata_1_re = addr_hit[12] & reg_re & !reg_error;
 
-  assign check_trigger_regwen_we = addr_hit[13] & reg_we & ~wr_err;
+  assign check_trigger_regwen_we = addr_hit[13] & reg_we & !reg_error;
   assign check_trigger_regwen_wd = reg_wdata[0];
 
-  assign check_trigger_integrity_we = addr_hit[14] & reg_we & ~wr_err;
+  assign check_trigger_integrity_we = addr_hit[14] & reg_we & !reg_error;
   assign check_trigger_integrity_wd = reg_wdata[0];
 
-  assign check_trigger_consistency_we = addr_hit[14] & reg_we & ~wr_err;
+  assign check_trigger_consistency_we = addr_hit[14] & reg_we & !reg_error;
   assign check_trigger_consistency_wd = reg_wdata[1];
 
-  assign check_regwen_we = addr_hit[15] & reg_we & ~wr_err;
+  assign check_regwen_we = addr_hit[15] & reg_we & !reg_error;
   assign check_regwen_wd = reg_wdata[0];
 
-  assign check_timeout_we = addr_hit[16] & reg_we & ~wr_err;
+  assign check_timeout_we = addr_hit[16] & reg_we & !reg_error;
   assign check_timeout_wd = reg_wdata[31:0];
 
-  assign integrity_check_period_we = addr_hit[17] & reg_we & ~wr_err;
+  assign integrity_check_period_we = addr_hit[17] & reg_we & !reg_error;
   assign integrity_check_period_wd = reg_wdata[31:0];
 
-  assign consistency_check_period_we = addr_hit[18] & reg_we & ~wr_err;
+  assign consistency_check_period_we = addr_hit[18] & reg_we & !reg_error;
   assign consistency_check_period_wd = reg_wdata[31:0];
 
-  assign creator_sw_cfg_read_lock_we = addr_hit[19] & reg_we & ~wr_err;
+  assign creator_sw_cfg_read_lock_we = addr_hit[19] & reg_we & !reg_error;
   assign creator_sw_cfg_read_lock_wd = reg_wdata[0];
 
-  assign owner_sw_cfg_read_lock_we = addr_hit[20] & reg_we & ~wr_err;
+  assign owner_sw_cfg_read_lock_we = addr_hit[20] & reg_we & !reg_error;
   assign owner_sw_cfg_read_lock_wd = reg_wdata[0];
 
-  assign creator_sw_cfg_digest_0_re = addr_hit[21] && reg_re;
+  assign creator_sw_cfg_digest_0_re = addr_hit[21] & reg_re & !reg_error;
 
-  assign creator_sw_cfg_digest_1_re = addr_hit[22] && reg_re;
+  assign creator_sw_cfg_digest_1_re = addr_hit[22] & reg_re & !reg_error;
 
-  assign owner_sw_cfg_digest_0_re = addr_hit[23] && reg_re;
+  assign owner_sw_cfg_digest_0_re = addr_hit[23] & reg_re & !reg_error;
 
-  assign owner_sw_cfg_digest_1_re = addr_hit[24] && reg_re;
+  assign owner_sw_cfg_digest_1_re = addr_hit[24] & reg_re & !reg_error;
 
-  assign hw_cfg_digest_0_re = addr_hit[25] && reg_re;
+  assign hw_cfg_digest_0_re = addr_hit[25] & reg_re & !reg_error;
 
-  assign hw_cfg_digest_1_re = addr_hit[26] && reg_re;
+  assign hw_cfg_digest_1_re = addr_hit[26] & reg_re & !reg_error;
 
-  assign secret0_digest_0_re = addr_hit[27] && reg_re;
+  assign secret0_digest_0_re = addr_hit[27] & reg_re & !reg_error;
 
-  assign secret0_digest_1_re = addr_hit[28] && reg_re;
+  assign secret0_digest_1_re = addr_hit[28] & reg_re & !reg_error;
 
-  assign secret1_digest_0_re = addr_hit[29] && reg_re;
+  assign secret1_digest_0_re = addr_hit[29] & reg_re & !reg_error;
 
-  assign secret1_digest_1_re = addr_hit[30] && reg_re;
+  assign secret1_digest_1_re = addr_hit[30] & reg_re & !reg_error;
 
-  assign secret2_digest_0_re = addr_hit[31] && reg_re;
+  assign secret2_digest_0_re = addr_hit[31] & reg_re & !reg_error;
 
-  assign secret2_digest_1_re = addr_hit[32] && reg_re;
+  assign secret2_digest_1_re = addr_hit[32] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/ip/pattgen/rtl/pattgen_reg_top.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_top.sv
@@ -699,64 +699,64 @@ module pattgen_reg_top (
     if (addr_hit[10] && reg_we && (PATTGEN_PERMIT[10] != (PATTGEN_PERMIT[10] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_done_ch0_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_done_ch0_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_done_ch0_wd = reg_wdata[0];
 
-  assign intr_state_done_ch1_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_done_ch1_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_done_ch1_wd = reg_wdata[1];
 
-  assign intr_enable_done_ch0_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_done_ch0_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_done_ch0_wd = reg_wdata[0];
 
-  assign intr_enable_done_ch1_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_done_ch1_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_done_ch1_wd = reg_wdata[1];
 
-  assign intr_test_done_ch0_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_done_ch0_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_done_ch0_wd = reg_wdata[0];
 
-  assign intr_test_done_ch1_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_done_ch1_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_done_ch1_wd = reg_wdata[1];
 
-  assign ctrl_enable_ch0_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_enable_ch0_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_enable_ch0_wd = reg_wdata[0];
 
-  assign ctrl_enable_ch1_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_enable_ch1_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_enable_ch1_wd = reg_wdata[1];
 
-  assign ctrl_polarity_ch0_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_polarity_ch0_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_polarity_ch0_wd = reg_wdata[2];
 
-  assign ctrl_polarity_ch1_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_polarity_ch1_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_polarity_ch1_wd = reg_wdata[3];
 
-  assign prediv_ch0_we = addr_hit[4] & reg_we & ~wr_err;
+  assign prediv_ch0_we = addr_hit[4] & reg_we & !reg_error;
   assign prediv_ch0_wd = reg_wdata[31:0];
 
-  assign prediv_ch1_we = addr_hit[5] & reg_we & ~wr_err;
+  assign prediv_ch1_we = addr_hit[5] & reg_we & !reg_error;
   assign prediv_ch1_wd = reg_wdata[31:0];
 
-  assign data_ch0_0_we = addr_hit[6] & reg_we & ~wr_err;
+  assign data_ch0_0_we = addr_hit[6] & reg_we & !reg_error;
   assign data_ch0_0_wd = reg_wdata[31:0];
 
-  assign data_ch0_1_we = addr_hit[7] & reg_we & ~wr_err;
+  assign data_ch0_1_we = addr_hit[7] & reg_we & !reg_error;
   assign data_ch0_1_wd = reg_wdata[31:0];
 
-  assign data_ch1_0_we = addr_hit[8] & reg_we & ~wr_err;
+  assign data_ch1_0_we = addr_hit[8] & reg_we & !reg_error;
   assign data_ch1_0_wd = reg_wdata[31:0];
 
-  assign data_ch1_1_we = addr_hit[9] & reg_we & ~wr_err;
+  assign data_ch1_1_we = addr_hit[9] & reg_we & !reg_error;
   assign data_ch1_1_wd = reg_wdata[31:0];
 
-  assign size_len_ch0_we = addr_hit[10] & reg_we & ~wr_err;
+  assign size_len_ch0_we = addr_hit[10] & reg_we & !reg_error;
   assign size_len_ch0_wd = reg_wdata[5:0];
 
-  assign size_reps_ch0_we = addr_hit[10] & reg_we & ~wr_err;
+  assign size_reps_ch0_we = addr_hit[10] & reg_we & !reg_error;
   assign size_reps_ch0_wd = reg_wdata[15:6];
 
-  assign size_len_ch1_we = addr_hit[10] & reg_we & ~wr_err;
+  assign size_len_ch1_we = addr_hit[10] & reg_we & !reg_error;
   assign size_len_ch1_wd = reg_wdata[21:16];
 
-  assign size_reps_ch1_we = addr_hit[10] & reg_we & ~wr_err;
+  assign size_reps_ch1_we = addr_hit[10] & reg_we & !reg_error;
   assign size_reps_ch1_wd = reg_wdata[31:22];
 
   // Read data return

--- a/hw/ip/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/ip/pinmux/rtl/pinmux_reg_top.sv
@@ -14872,1507 +14872,1507 @@ module pinmux_reg_top (
     if (addr_hit[412] && reg_we && (PINMUX_PERMIT[412] != (PINMUX_PERMIT[412] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign mio_periph_insel_regwen_0_we = addr_hit[0] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_0_we = addr_hit[0] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_0_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_1_we = addr_hit[1] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_1_we = addr_hit[1] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_1_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_2_we = addr_hit[2] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_2_we = addr_hit[2] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_2_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_3_we = addr_hit[3] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_3_we = addr_hit[3] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_3_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_4_we = addr_hit[4] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_4_we = addr_hit[4] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_4_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_5_we = addr_hit[5] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_5_we = addr_hit[5] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_5_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_6_we = addr_hit[6] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_6_we = addr_hit[6] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_6_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_7_we = addr_hit[7] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_7_we = addr_hit[7] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_7_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_8_we = addr_hit[8] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_8_we = addr_hit[8] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_8_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_9_we = addr_hit[9] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_9_we = addr_hit[9] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_9_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_10_we = addr_hit[10] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_10_we = addr_hit[10] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_10_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_11_we = addr_hit[11] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_11_we = addr_hit[11] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_11_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_12_we = addr_hit[12] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_12_we = addr_hit[12] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_12_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_13_we = addr_hit[13] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_13_we = addr_hit[13] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_13_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_14_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_14_we = addr_hit[14] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_14_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_15_we = addr_hit[15] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_15_we = addr_hit[15] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_15_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_16_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_16_we = addr_hit[16] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_16_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_17_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_17_we = addr_hit[17] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_17_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_18_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_18_we = addr_hit[18] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_18_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_19_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_19_we = addr_hit[19] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_19_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_20_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_20_we = addr_hit[20] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_20_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_21_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_21_we = addr_hit[21] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_21_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_22_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_22_we = addr_hit[22] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_22_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_23_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_23_we = addr_hit[23] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_23_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_24_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_24_we = addr_hit[24] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_24_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_25_we = addr_hit[25] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_25_we = addr_hit[25] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_25_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_26_we = addr_hit[26] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_26_we = addr_hit[26] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_26_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_27_we = addr_hit[27] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_27_we = addr_hit[27] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_27_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_28_we = addr_hit[28] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_28_we = addr_hit[28] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_28_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_29_we = addr_hit[29] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_29_we = addr_hit[29] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_29_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_30_we = addr_hit[30] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_30_we = addr_hit[30] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_30_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_31_we = addr_hit[31] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_31_we = addr_hit[31] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_31_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_32_we = addr_hit[32] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_32_we = addr_hit[32] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_32_wd = reg_wdata[0];
 
-  assign mio_periph_insel_0_we = addr_hit[33] & reg_we & ~wr_err;
+  assign mio_periph_insel_0_we = addr_hit[33] & reg_we & !reg_error;
   assign mio_periph_insel_0_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_1_we = addr_hit[34] & reg_we & ~wr_err;
+  assign mio_periph_insel_1_we = addr_hit[34] & reg_we & !reg_error;
   assign mio_periph_insel_1_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_2_we = addr_hit[35] & reg_we & ~wr_err;
+  assign mio_periph_insel_2_we = addr_hit[35] & reg_we & !reg_error;
   assign mio_periph_insel_2_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_3_we = addr_hit[36] & reg_we & ~wr_err;
+  assign mio_periph_insel_3_we = addr_hit[36] & reg_we & !reg_error;
   assign mio_periph_insel_3_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_4_we = addr_hit[37] & reg_we & ~wr_err;
+  assign mio_periph_insel_4_we = addr_hit[37] & reg_we & !reg_error;
   assign mio_periph_insel_4_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_5_we = addr_hit[38] & reg_we & ~wr_err;
+  assign mio_periph_insel_5_we = addr_hit[38] & reg_we & !reg_error;
   assign mio_periph_insel_5_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_6_we = addr_hit[39] & reg_we & ~wr_err;
+  assign mio_periph_insel_6_we = addr_hit[39] & reg_we & !reg_error;
   assign mio_periph_insel_6_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_7_we = addr_hit[40] & reg_we & ~wr_err;
+  assign mio_periph_insel_7_we = addr_hit[40] & reg_we & !reg_error;
   assign mio_periph_insel_7_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_8_we = addr_hit[41] & reg_we & ~wr_err;
+  assign mio_periph_insel_8_we = addr_hit[41] & reg_we & !reg_error;
   assign mio_periph_insel_8_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_9_we = addr_hit[42] & reg_we & ~wr_err;
+  assign mio_periph_insel_9_we = addr_hit[42] & reg_we & !reg_error;
   assign mio_periph_insel_9_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_10_we = addr_hit[43] & reg_we & ~wr_err;
+  assign mio_periph_insel_10_we = addr_hit[43] & reg_we & !reg_error;
   assign mio_periph_insel_10_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_11_we = addr_hit[44] & reg_we & ~wr_err;
+  assign mio_periph_insel_11_we = addr_hit[44] & reg_we & !reg_error;
   assign mio_periph_insel_11_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_12_we = addr_hit[45] & reg_we & ~wr_err;
+  assign mio_periph_insel_12_we = addr_hit[45] & reg_we & !reg_error;
   assign mio_periph_insel_12_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_13_we = addr_hit[46] & reg_we & ~wr_err;
+  assign mio_periph_insel_13_we = addr_hit[46] & reg_we & !reg_error;
   assign mio_periph_insel_13_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_14_we = addr_hit[47] & reg_we & ~wr_err;
+  assign mio_periph_insel_14_we = addr_hit[47] & reg_we & !reg_error;
   assign mio_periph_insel_14_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_15_we = addr_hit[48] & reg_we & ~wr_err;
+  assign mio_periph_insel_15_we = addr_hit[48] & reg_we & !reg_error;
   assign mio_periph_insel_15_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_16_we = addr_hit[49] & reg_we & ~wr_err;
+  assign mio_periph_insel_16_we = addr_hit[49] & reg_we & !reg_error;
   assign mio_periph_insel_16_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_17_we = addr_hit[50] & reg_we & ~wr_err;
+  assign mio_periph_insel_17_we = addr_hit[50] & reg_we & !reg_error;
   assign mio_periph_insel_17_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_18_we = addr_hit[51] & reg_we & ~wr_err;
+  assign mio_periph_insel_18_we = addr_hit[51] & reg_we & !reg_error;
   assign mio_periph_insel_18_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_19_we = addr_hit[52] & reg_we & ~wr_err;
+  assign mio_periph_insel_19_we = addr_hit[52] & reg_we & !reg_error;
   assign mio_periph_insel_19_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_20_we = addr_hit[53] & reg_we & ~wr_err;
+  assign mio_periph_insel_20_we = addr_hit[53] & reg_we & !reg_error;
   assign mio_periph_insel_20_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_21_we = addr_hit[54] & reg_we & ~wr_err;
+  assign mio_periph_insel_21_we = addr_hit[54] & reg_we & !reg_error;
   assign mio_periph_insel_21_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_22_we = addr_hit[55] & reg_we & ~wr_err;
+  assign mio_periph_insel_22_we = addr_hit[55] & reg_we & !reg_error;
   assign mio_periph_insel_22_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_23_we = addr_hit[56] & reg_we & ~wr_err;
+  assign mio_periph_insel_23_we = addr_hit[56] & reg_we & !reg_error;
   assign mio_periph_insel_23_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_24_we = addr_hit[57] & reg_we & ~wr_err;
+  assign mio_periph_insel_24_we = addr_hit[57] & reg_we & !reg_error;
   assign mio_periph_insel_24_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_25_we = addr_hit[58] & reg_we & ~wr_err;
+  assign mio_periph_insel_25_we = addr_hit[58] & reg_we & !reg_error;
   assign mio_periph_insel_25_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_26_we = addr_hit[59] & reg_we & ~wr_err;
+  assign mio_periph_insel_26_we = addr_hit[59] & reg_we & !reg_error;
   assign mio_periph_insel_26_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_27_we = addr_hit[60] & reg_we & ~wr_err;
+  assign mio_periph_insel_27_we = addr_hit[60] & reg_we & !reg_error;
   assign mio_periph_insel_27_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_28_we = addr_hit[61] & reg_we & ~wr_err;
+  assign mio_periph_insel_28_we = addr_hit[61] & reg_we & !reg_error;
   assign mio_periph_insel_28_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_29_we = addr_hit[62] & reg_we & ~wr_err;
+  assign mio_periph_insel_29_we = addr_hit[62] & reg_we & !reg_error;
   assign mio_periph_insel_29_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_30_we = addr_hit[63] & reg_we & ~wr_err;
+  assign mio_periph_insel_30_we = addr_hit[63] & reg_we & !reg_error;
   assign mio_periph_insel_30_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_31_we = addr_hit[64] & reg_we & ~wr_err;
+  assign mio_periph_insel_31_we = addr_hit[64] & reg_we & !reg_error;
   assign mio_periph_insel_31_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_32_we = addr_hit[65] & reg_we & ~wr_err;
+  assign mio_periph_insel_32_we = addr_hit[65] & reg_we & !reg_error;
   assign mio_periph_insel_32_wd = reg_wdata[5:0];
 
-  assign mio_outsel_regwen_0_we = addr_hit[66] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_0_we = addr_hit[66] & reg_we & !reg_error;
   assign mio_outsel_regwen_0_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_1_we = addr_hit[67] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_1_we = addr_hit[67] & reg_we & !reg_error;
   assign mio_outsel_regwen_1_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_2_we = addr_hit[68] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_2_we = addr_hit[68] & reg_we & !reg_error;
   assign mio_outsel_regwen_2_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_3_we = addr_hit[69] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_3_we = addr_hit[69] & reg_we & !reg_error;
   assign mio_outsel_regwen_3_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_4_we = addr_hit[70] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_4_we = addr_hit[70] & reg_we & !reg_error;
   assign mio_outsel_regwen_4_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_5_we = addr_hit[71] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_5_we = addr_hit[71] & reg_we & !reg_error;
   assign mio_outsel_regwen_5_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_6_we = addr_hit[72] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_6_we = addr_hit[72] & reg_we & !reg_error;
   assign mio_outsel_regwen_6_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_7_we = addr_hit[73] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_7_we = addr_hit[73] & reg_we & !reg_error;
   assign mio_outsel_regwen_7_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_8_we = addr_hit[74] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_8_we = addr_hit[74] & reg_we & !reg_error;
   assign mio_outsel_regwen_8_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_9_we = addr_hit[75] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_9_we = addr_hit[75] & reg_we & !reg_error;
   assign mio_outsel_regwen_9_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_10_we = addr_hit[76] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_10_we = addr_hit[76] & reg_we & !reg_error;
   assign mio_outsel_regwen_10_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_11_we = addr_hit[77] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_11_we = addr_hit[77] & reg_we & !reg_error;
   assign mio_outsel_regwen_11_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_12_we = addr_hit[78] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_12_we = addr_hit[78] & reg_we & !reg_error;
   assign mio_outsel_regwen_12_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_13_we = addr_hit[79] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_13_we = addr_hit[79] & reg_we & !reg_error;
   assign mio_outsel_regwen_13_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_14_we = addr_hit[80] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_14_we = addr_hit[80] & reg_we & !reg_error;
   assign mio_outsel_regwen_14_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_15_we = addr_hit[81] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_15_we = addr_hit[81] & reg_we & !reg_error;
   assign mio_outsel_regwen_15_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_16_we = addr_hit[82] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_16_we = addr_hit[82] & reg_we & !reg_error;
   assign mio_outsel_regwen_16_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_17_we = addr_hit[83] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_17_we = addr_hit[83] & reg_we & !reg_error;
   assign mio_outsel_regwen_17_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_18_we = addr_hit[84] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_18_we = addr_hit[84] & reg_we & !reg_error;
   assign mio_outsel_regwen_18_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_19_we = addr_hit[85] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_19_we = addr_hit[85] & reg_we & !reg_error;
   assign mio_outsel_regwen_19_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_20_we = addr_hit[86] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_20_we = addr_hit[86] & reg_we & !reg_error;
   assign mio_outsel_regwen_20_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_21_we = addr_hit[87] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_21_we = addr_hit[87] & reg_we & !reg_error;
   assign mio_outsel_regwen_21_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_22_we = addr_hit[88] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_22_we = addr_hit[88] & reg_we & !reg_error;
   assign mio_outsel_regwen_22_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_23_we = addr_hit[89] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_23_we = addr_hit[89] & reg_we & !reg_error;
   assign mio_outsel_regwen_23_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_24_we = addr_hit[90] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_24_we = addr_hit[90] & reg_we & !reg_error;
   assign mio_outsel_regwen_24_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_25_we = addr_hit[91] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_25_we = addr_hit[91] & reg_we & !reg_error;
   assign mio_outsel_regwen_25_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_26_we = addr_hit[92] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_26_we = addr_hit[92] & reg_we & !reg_error;
   assign mio_outsel_regwen_26_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_27_we = addr_hit[93] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_27_we = addr_hit[93] & reg_we & !reg_error;
   assign mio_outsel_regwen_27_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_28_we = addr_hit[94] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_28_we = addr_hit[94] & reg_we & !reg_error;
   assign mio_outsel_regwen_28_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_29_we = addr_hit[95] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_29_we = addr_hit[95] & reg_we & !reg_error;
   assign mio_outsel_regwen_29_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_30_we = addr_hit[96] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_30_we = addr_hit[96] & reg_we & !reg_error;
   assign mio_outsel_regwen_30_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_31_we = addr_hit[97] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_31_we = addr_hit[97] & reg_we & !reg_error;
   assign mio_outsel_regwen_31_wd = reg_wdata[0];
 
-  assign mio_outsel_0_we = addr_hit[98] & reg_we & ~wr_err;
+  assign mio_outsel_0_we = addr_hit[98] & reg_we & !reg_error;
   assign mio_outsel_0_wd = reg_wdata[5:0];
 
-  assign mio_outsel_1_we = addr_hit[99] & reg_we & ~wr_err;
+  assign mio_outsel_1_we = addr_hit[99] & reg_we & !reg_error;
   assign mio_outsel_1_wd = reg_wdata[5:0];
 
-  assign mio_outsel_2_we = addr_hit[100] & reg_we & ~wr_err;
+  assign mio_outsel_2_we = addr_hit[100] & reg_we & !reg_error;
   assign mio_outsel_2_wd = reg_wdata[5:0];
 
-  assign mio_outsel_3_we = addr_hit[101] & reg_we & ~wr_err;
+  assign mio_outsel_3_we = addr_hit[101] & reg_we & !reg_error;
   assign mio_outsel_3_wd = reg_wdata[5:0];
 
-  assign mio_outsel_4_we = addr_hit[102] & reg_we & ~wr_err;
+  assign mio_outsel_4_we = addr_hit[102] & reg_we & !reg_error;
   assign mio_outsel_4_wd = reg_wdata[5:0];
 
-  assign mio_outsel_5_we = addr_hit[103] & reg_we & ~wr_err;
+  assign mio_outsel_5_we = addr_hit[103] & reg_we & !reg_error;
   assign mio_outsel_5_wd = reg_wdata[5:0];
 
-  assign mio_outsel_6_we = addr_hit[104] & reg_we & ~wr_err;
+  assign mio_outsel_6_we = addr_hit[104] & reg_we & !reg_error;
   assign mio_outsel_6_wd = reg_wdata[5:0];
 
-  assign mio_outsel_7_we = addr_hit[105] & reg_we & ~wr_err;
+  assign mio_outsel_7_we = addr_hit[105] & reg_we & !reg_error;
   assign mio_outsel_7_wd = reg_wdata[5:0];
 
-  assign mio_outsel_8_we = addr_hit[106] & reg_we & ~wr_err;
+  assign mio_outsel_8_we = addr_hit[106] & reg_we & !reg_error;
   assign mio_outsel_8_wd = reg_wdata[5:0];
 
-  assign mio_outsel_9_we = addr_hit[107] & reg_we & ~wr_err;
+  assign mio_outsel_9_we = addr_hit[107] & reg_we & !reg_error;
   assign mio_outsel_9_wd = reg_wdata[5:0];
 
-  assign mio_outsel_10_we = addr_hit[108] & reg_we & ~wr_err;
+  assign mio_outsel_10_we = addr_hit[108] & reg_we & !reg_error;
   assign mio_outsel_10_wd = reg_wdata[5:0];
 
-  assign mio_outsel_11_we = addr_hit[109] & reg_we & ~wr_err;
+  assign mio_outsel_11_we = addr_hit[109] & reg_we & !reg_error;
   assign mio_outsel_11_wd = reg_wdata[5:0];
 
-  assign mio_outsel_12_we = addr_hit[110] & reg_we & ~wr_err;
+  assign mio_outsel_12_we = addr_hit[110] & reg_we & !reg_error;
   assign mio_outsel_12_wd = reg_wdata[5:0];
 
-  assign mio_outsel_13_we = addr_hit[111] & reg_we & ~wr_err;
+  assign mio_outsel_13_we = addr_hit[111] & reg_we & !reg_error;
   assign mio_outsel_13_wd = reg_wdata[5:0];
 
-  assign mio_outsel_14_we = addr_hit[112] & reg_we & ~wr_err;
+  assign mio_outsel_14_we = addr_hit[112] & reg_we & !reg_error;
   assign mio_outsel_14_wd = reg_wdata[5:0];
 
-  assign mio_outsel_15_we = addr_hit[113] & reg_we & ~wr_err;
+  assign mio_outsel_15_we = addr_hit[113] & reg_we & !reg_error;
   assign mio_outsel_15_wd = reg_wdata[5:0];
 
-  assign mio_outsel_16_we = addr_hit[114] & reg_we & ~wr_err;
+  assign mio_outsel_16_we = addr_hit[114] & reg_we & !reg_error;
   assign mio_outsel_16_wd = reg_wdata[5:0];
 
-  assign mio_outsel_17_we = addr_hit[115] & reg_we & ~wr_err;
+  assign mio_outsel_17_we = addr_hit[115] & reg_we & !reg_error;
   assign mio_outsel_17_wd = reg_wdata[5:0];
 
-  assign mio_outsel_18_we = addr_hit[116] & reg_we & ~wr_err;
+  assign mio_outsel_18_we = addr_hit[116] & reg_we & !reg_error;
   assign mio_outsel_18_wd = reg_wdata[5:0];
 
-  assign mio_outsel_19_we = addr_hit[117] & reg_we & ~wr_err;
+  assign mio_outsel_19_we = addr_hit[117] & reg_we & !reg_error;
   assign mio_outsel_19_wd = reg_wdata[5:0];
 
-  assign mio_outsel_20_we = addr_hit[118] & reg_we & ~wr_err;
+  assign mio_outsel_20_we = addr_hit[118] & reg_we & !reg_error;
   assign mio_outsel_20_wd = reg_wdata[5:0];
 
-  assign mio_outsel_21_we = addr_hit[119] & reg_we & ~wr_err;
+  assign mio_outsel_21_we = addr_hit[119] & reg_we & !reg_error;
   assign mio_outsel_21_wd = reg_wdata[5:0];
 
-  assign mio_outsel_22_we = addr_hit[120] & reg_we & ~wr_err;
+  assign mio_outsel_22_we = addr_hit[120] & reg_we & !reg_error;
   assign mio_outsel_22_wd = reg_wdata[5:0];
 
-  assign mio_outsel_23_we = addr_hit[121] & reg_we & ~wr_err;
+  assign mio_outsel_23_we = addr_hit[121] & reg_we & !reg_error;
   assign mio_outsel_23_wd = reg_wdata[5:0];
 
-  assign mio_outsel_24_we = addr_hit[122] & reg_we & ~wr_err;
+  assign mio_outsel_24_we = addr_hit[122] & reg_we & !reg_error;
   assign mio_outsel_24_wd = reg_wdata[5:0];
 
-  assign mio_outsel_25_we = addr_hit[123] & reg_we & ~wr_err;
+  assign mio_outsel_25_we = addr_hit[123] & reg_we & !reg_error;
   assign mio_outsel_25_wd = reg_wdata[5:0];
 
-  assign mio_outsel_26_we = addr_hit[124] & reg_we & ~wr_err;
+  assign mio_outsel_26_we = addr_hit[124] & reg_we & !reg_error;
   assign mio_outsel_26_wd = reg_wdata[5:0];
 
-  assign mio_outsel_27_we = addr_hit[125] & reg_we & ~wr_err;
+  assign mio_outsel_27_we = addr_hit[125] & reg_we & !reg_error;
   assign mio_outsel_27_wd = reg_wdata[5:0];
 
-  assign mio_outsel_28_we = addr_hit[126] & reg_we & ~wr_err;
+  assign mio_outsel_28_we = addr_hit[126] & reg_we & !reg_error;
   assign mio_outsel_28_wd = reg_wdata[5:0];
 
-  assign mio_outsel_29_we = addr_hit[127] & reg_we & ~wr_err;
+  assign mio_outsel_29_we = addr_hit[127] & reg_we & !reg_error;
   assign mio_outsel_29_wd = reg_wdata[5:0];
 
-  assign mio_outsel_30_we = addr_hit[128] & reg_we & ~wr_err;
+  assign mio_outsel_30_we = addr_hit[128] & reg_we & !reg_error;
   assign mio_outsel_30_wd = reg_wdata[5:0];
 
-  assign mio_outsel_31_we = addr_hit[129] & reg_we & ~wr_err;
+  assign mio_outsel_31_we = addr_hit[129] & reg_we & !reg_error;
   assign mio_outsel_31_wd = reg_wdata[5:0];
 
-  assign mio_pad_attr_regwen_0_we = addr_hit[130] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_0_we = addr_hit[130] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_0_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_1_we = addr_hit[131] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_1_we = addr_hit[131] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_1_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_2_we = addr_hit[132] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_2_we = addr_hit[132] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_2_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_3_we = addr_hit[133] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_3_we = addr_hit[133] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_3_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_4_we = addr_hit[134] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_4_we = addr_hit[134] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_4_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_5_we = addr_hit[135] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_5_we = addr_hit[135] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_5_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_6_we = addr_hit[136] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_6_we = addr_hit[136] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_6_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_7_we = addr_hit[137] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_7_we = addr_hit[137] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_7_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_8_we = addr_hit[138] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_8_we = addr_hit[138] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_8_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_9_we = addr_hit[139] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_9_we = addr_hit[139] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_9_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_10_we = addr_hit[140] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_10_we = addr_hit[140] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_10_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_11_we = addr_hit[141] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_11_we = addr_hit[141] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_11_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_12_we = addr_hit[142] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_12_we = addr_hit[142] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_12_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_13_we = addr_hit[143] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_13_we = addr_hit[143] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_13_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_14_we = addr_hit[144] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_14_we = addr_hit[144] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_14_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_15_we = addr_hit[145] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_15_we = addr_hit[145] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_15_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_16_we = addr_hit[146] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_16_we = addr_hit[146] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_16_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_17_we = addr_hit[147] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_17_we = addr_hit[147] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_17_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_18_we = addr_hit[148] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_18_we = addr_hit[148] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_18_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_19_we = addr_hit[149] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_19_we = addr_hit[149] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_19_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_20_we = addr_hit[150] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_20_we = addr_hit[150] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_20_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_21_we = addr_hit[151] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_21_we = addr_hit[151] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_21_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_22_we = addr_hit[152] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_22_we = addr_hit[152] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_22_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_23_we = addr_hit[153] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_23_we = addr_hit[153] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_23_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_24_we = addr_hit[154] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_24_we = addr_hit[154] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_24_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_25_we = addr_hit[155] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_25_we = addr_hit[155] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_25_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_26_we = addr_hit[156] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_26_we = addr_hit[156] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_26_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_27_we = addr_hit[157] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_27_we = addr_hit[157] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_27_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_28_we = addr_hit[158] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_28_we = addr_hit[158] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_28_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_29_we = addr_hit[159] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_29_we = addr_hit[159] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_29_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_30_we = addr_hit[160] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_30_we = addr_hit[160] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_30_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_31_we = addr_hit[161] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_31_we = addr_hit[161] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_31_wd = reg_wdata[0];
 
-  assign mio_pad_attr_0_we = addr_hit[162] & reg_we & ~wr_err;
+  assign mio_pad_attr_0_we = addr_hit[162] & reg_we & !reg_error;
   assign mio_pad_attr_0_wd = reg_wdata[9:0];
-  assign mio_pad_attr_0_re = addr_hit[162] && reg_re;
+  assign mio_pad_attr_0_re = addr_hit[162] & reg_re & !reg_error;
 
-  assign mio_pad_attr_1_we = addr_hit[163] & reg_we & ~wr_err;
+  assign mio_pad_attr_1_we = addr_hit[163] & reg_we & !reg_error;
   assign mio_pad_attr_1_wd = reg_wdata[9:0];
-  assign mio_pad_attr_1_re = addr_hit[163] && reg_re;
+  assign mio_pad_attr_1_re = addr_hit[163] & reg_re & !reg_error;
 
-  assign mio_pad_attr_2_we = addr_hit[164] & reg_we & ~wr_err;
+  assign mio_pad_attr_2_we = addr_hit[164] & reg_we & !reg_error;
   assign mio_pad_attr_2_wd = reg_wdata[9:0];
-  assign mio_pad_attr_2_re = addr_hit[164] && reg_re;
+  assign mio_pad_attr_2_re = addr_hit[164] & reg_re & !reg_error;
 
-  assign mio_pad_attr_3_we = addr_hit[165] & reg_we & ~wr_err;
+  assign mio_pad_attr_3_we = addr_hit[165] & reg_we & !reg_error;
   assign mio_pad_attr_3_wd = reg_wdata[9:0];
-  assign mio_pad_attr_3_re = addr_hit[165] && reg_re;
+  assign mio_pad_attr_3_re = addr_hit[165] & reg_re & !reg_error;
 
-  assign mio_pad_attr_4_we = addr_hit[166] & reg_we & ~wr_err;
+  assign mio_pad_attr_4_we = addr_hit[166] & reg_we & !reg_error;
   assign mio_pad_attr_4_wd = reg_wdata[9:0];
-  assign mio_pad_attr_4_re = addr_hit[166] && reg_re;
+  assign mio_pad_attr_4_re = addr_hit[166] & reg_re & !reg_error;
 
-  assign mio_pad_attr_5_we = addr_hit[167] & reg_we & ~wr_err;
+  assign mio_pad_attr_5_we = addr_hit[167] & reg_we & !reg_error;
   assign mio_pad_attr_5_wd = reg_wdata[9:0];
-  assign mio_pad_attr_5_re = addr_hit[167] && reg_re;
+  assign mio_pad_attr_5_re = addr_hit[167] & reg_re & !reg_error;
 
-  assign mio_pad_attr_6_we = addr_hit[168] & reg_we & ~wr_err;
+  assign mio_pad_attr_6_we = addr_hit[168] & reg_we & !reg_error;
   assign mio_pad_attr_6_wd = reg_wdata[9:0];
-  assign mio_pad_attr_6_re = addr_hit[168] && reg_re;
+  assign mio_pad_attr_6_re = addr_hit[168] & reg_re & !reg_error;
 
-  assign mio_pad_attr_7_we = addr_hit[169] & reg_we & ~wr_err;
+  assign mio_pad_attr_7_we = addr_hit[169] & reg_we & !reg_error;
   assign mio_pad_attr_7_wd = reg_wdata[9:0];
-  assign mio_pad_attr_7_re = addr_hit[169] && reg_re;
+  assign mio_pad_attr_7_re = addr_hit[169] & reg_re & !reg_error;
 
-  assign mio_pad_attr_8_we = addr_hit[170] & reg_we & ~wr_err;
+  assign mio_pad_attr_8_we = addr_hit[170] & reg_we & !reg_error;
   assign mio_pad_attr_8_wd = reg_wdata[9:0];
-  assign mio_pad_attr_8_re = addr_hit[170] && reg_re;
+  assign mio_pad_attr_8_re = addr_hit[170] & reg_re & !reg_error;
 
-  assign mio_pad_attr_9_we = addr_hit[171] & reg_we & ~wr_err;
+  assign mio_pad_attr_9_we = addr_hit[171] & reg_we & !reg_error;
   assign mio_pad_attr_9_wd = reg_wdata[9:0];
-  assign mio_pad_attr_9_re = addr_hit[171] && reg_re;
+  assign mio_pad_attr_9_re = addr_hit[171] & reg_re & !reg_error;
 
-  assign mio_pad_attr_10_we = addr_hit[172] & reg_we & ~wr_err;
+  assign mio_pad_attr_10_we = addr_hit[172] & reg_we & !reg_error;
   assign mio_pad_attr_10_wd = reg_wdata[9:0];
-  assign mio_pad_attr_10_re = addr_hit[172] && reg_re;
+  assign mio_pad_attr_10_re = addr_hit[172] & reg_re & !reg_error;
 
-  assign mio_pad_attr_11_we = addr_hit[173] & reg_we & ~wr_err;
+  assign mio_pad_attr_11_we = addr_hit[173] & reg_we & !reg_error;
   assign mio_pad_attr_11_wd = reg_wdata[9:0];
-  assign mio_pad_attr_11_re = addr_hit[173] && reg_re;
+  assign mio_pad_attr_11_re = addr_hit[173] & reg_re & !reg_error;
 
-  assign mio_pad_attr_12_we = addr_hit[174] & reg_we & ~wr_err;
+  assign mio_pad_attr_12_we = addr_hit[174] & reg_we & !reg_error;
   assign mio_pad_attr_12_wd = reg_wdata[9:0];
-  assign mio_pad_attr_12_re = addr_hit[174] && reg_re;
+  assign mio_pad_attr_12_re = addr_hit[174] & reg_re & !reg_error;
 
-  assign mio_pad_attr_13_we = addr_hit[175] & reg_we & ~wr_err;
+  assign mio_pad_attr_13_we = addr_hit[175] & reg_we & !reg_error;
   assign mio_pad_attr_13_wd = reg_wdata[9:0];
-  assign mio_pad_attr_13_re = addr_hit[175] && reg_re;
+  assign mio_pad_attr_13_re = addr_hit[175] & reg_re & !reg_error;
 
-  assign mio_pad_attr_14_we = addr_hit[176] & reg_we & ~wr_err;
+  assign mio_pad_attr_14_we = addr_hit[176] & reg_we & !reg_error;
   assign mio_pad_attr_14_wd = reg_wdata[9:0];
-  assign mio_pad_attr_14_re = addr_hit[176] && reg_re;
+  assign mio_pad_attr_14_re = addr_hit[176] & reg_re & !reg_error;
 
-  assign mio_pad_attr_15_we = addr_hit[177] & reg_we & ~wr_err;
+  assign mio_pad_attr_15_we = addr_hit[177] & reg_we & !reg_error;
   assign mio_pad_attr_15_wd = reg_wdata[9:0];
-  assign mio_pad_attr_15_re = addr_hit[177] && reg_re;
+  assign mio_pad_attr_15_re = addr_hit[177] & reg_re & !reg_error;
 
-  assign mio_pad_attr_16_we = addr_hit[178] & reg_we & ~wr_err;
+  assign mio_pad_attr_16_we = addr_hit[178] & reg_we & !reg_error;
   assign mio_pad_attr_16_wd = reg_wdata[9:0];
-  assign mio_pad_attr_16_re = addr_hit[178] && reg_re;
+  assign mio_pad_attr_16_re = addr_hit[178] & reg_re & !reg_error;
 
-  assign mio_pad_attr_17_we = addr_hit[179] & reg_we & ~wr_err;
+  assign mio_pad_attr_17_we = addr_hit[179] & reg_we & !reg_error;
   assign mio_pad_attr_17_wd = reg_wdata[9:0];
-  assign mio_pad_attr_17_re = addr_hit[179] && reg_re;
+  assign mio_pad_attr_17_re = addr_hit[179] & reg_re & !reg_error;
 
-  assign mio_pad_attr_18_we = addr_hit[180] & reg_we & ~wr_err;
+  assign mio_pad_attr_18_we = addr_hit[180] & reg_we & !reg_error;
   assign mio_pad_attr_18_wd = reg_wdata[9:0];
-  assign mio_pad_attr_18_re = addr_hit[180] && reg_re;
+  assign mio_pad_attr_18_re = addr_hit[180] & reg_re & !reg_error;
 
-  assign mio_pad_attr_19_we = addr_hit[181] & reg_we & ~wr_err;
+  assign mio_pad_attr_19_we = addr_hit[181] & reg_we & !reg_error;
   assign mio_pad_attr_19_wd = reg_wdata[9:0];
-  assign mio_pad_attr_19_re = addr_hit[181] && reg_re;
+  assign mio_pad_attr_19_re = addr_hit[181] & reg_re & !reg_error;
 
-  assign mio_pad_attr_20_we = addr_hit[182] & reg_we & ~wr_err;
+  assign mio_pad_attr_20_we = addr_hit[182] & reg_we & !reg_error;
   assign mio_pad_attr_20_wd = reg_wdata[9:0];
-  assign mio_pad_attr_20_re = addr_hit[182] && reg_re;
+  assign mio_pad_attr_20_re = addr_hit[182] & reg_re & !reg_error;
 
-  assign mio_pad_attr_21_we = addr_hit[183] & reg_we & ~wr_err;
+  assign mio_pad_attr_21_we = addr_hit[183] & reg_we & !reg_error;
   assign mio_pad_attr_21_wd = reg_wdata[9:0];
-  assign mio_pad_attr_21_re = addr_hit[183] && reg_re;
+  assign mio_pad_attr_21_re = addr_hit[183] & reg_re & !reg_error;
 
-  assign mio_pad_attr_22_we = addr_hit[184] & reg_we & ~wr_err;
+  assign mio_pad_attr_22_we = addr_hit[184] & reg_we & !reg_error;
   assign mio_pad_attr_22_wd = reg_wdata[9:0];
-  assign mio_pad_attr_22_re = addr_hit[184] && reg_re;
+  assign mio_pad_attr_22_re = addr_hit[184] & reg_re & !reg_error;
 
-  assign mio_pad_attr_23_we = addr_hit[185] & reg_we & ~wr_err;
+  assign mio_pad_attr_23_we = addr_hit[185] & reg_we & !reg_error;
   assign mio_pad_attr_23_wd = reg_wdata[9:0];
-  assign mio_pad_attr_23_re = addr_hit[185] && reg_re;
+  assign mio_pad_attr_23_re = addr_hit[185] & reg_re & !reg_error;
 
-  assign mio_pad_attr_24_we = addr_hit[186] & reg_we & ~wr_err;
+  assign mio_pad_attr_24_we = addr_hit[186] & reg_we & !reg_error;
   assign mio_pad_attr_24_wd = reg_wdata[9:0];
-  assign mio_pad_attr_24_re = addr_hit[186] && reg_re;
+  assign mio_pad_attr_24_re = addr_hit[186] & reg_re & !reg_error;
 
-  assign mio_pad_attr_25_we = addr_hit[187] & reg_we & ~wr_err;
+  assign mio_pad_attr_25_we = addr_hit[187] & reg_we & !reg_error;
   assign mio_pad_attr_25_wd = reg_wdata[9:0];
-  assign mio_pad_attr_25_re = addr_hit[187] && reg_re;
+  assign mio_pad_attr_25_re = addr_hit[187] & reg_re & !reg_error;
 
-  assign mio_pad_attr_26_we = addr_hit[188] & reg_we & ~wr_err;
+  assign mio_pad_attr_26_we = addr_hit[188] & reg_we & !reg_error;
   assign mio_pad_attr_26_wd = reg_wdata[9:0];
-  assign mio_pad_attr_26_re = addr_hit[188] && reg_re;
+  assign mio_pad_attr_26_re = addr_hit[188] & reg_re & !reg_error;
 
-  assign mio_pad_attr_27_we = addr_hit[189] & reg_we & ~wr_err;
+  assign mio_pad_attr_27_we = addr_hit[189] & reg_we & !reg_error;
   assign mio_pad_attr_27_wd = reg_wdata[9:0];
-  assign mio_pad_attr_27_re = addr_hit[189] && reg_re;
+  assign mio_pad_attr_27_re = addr_hit[189] & reg_re & !reg_error;
 
-  assign mio_pad_attr_28_we = addr_hit[190] & reg_we & ~wr_err;
+  assign mio_pad_attr_28_we = addr_hit[190] & reg_we & !reg_error;
   assign mio_pad_attr_28_wd = reg_wdata[9:0];
-  assign mio_pad_attr_28_re = addr_hit[190] && reg_re;
+  assign mio_pad_attr_28_re = addr_hit[190] & reg_re & !reg_error;
 
-  assign mio_pad_attr_29_we = addr_hit[191] & reg_we & ~wr_err;
+  assign mio_pad_attr_29_we = addr_hit[191] & reg_we & !reg_error;
   assign mio_pad_attr_29_wd = reg_wdata[9:0];
-  assign mio_pad_attr_29_re = addr_hit[191] && reg_re;
+  assign mio_pad_attr_29_re = addr_hit[191] & reg_re & !reg_error;
 
-  assign mio_pad_attr_30_we = addr_hit[192] & reg_we & ~wr_err;
+  assign mio_pad_attr_30_we = addr_hit[192] & reg_we & !reg_error;
   assign mio_pad_attr_30_wd = reg_wdata[9:0];
-  assign mio_pad_attr_30_re = addr_hit[192] && reg_re;
+  assign mio_pad_attr_30_re = addr_hit[192] & reg_re & !reg_error;
 
-  assign mio_pad_attr_31_we = addr_hit[193] & reg_we & ~wr_err;
+  assign mio_pad_attr_31_we = addr_hit[193] & reg_we & !reg_error;
   assign mio_pad_attr_31_wd = reg_wdata[9:0];
-  assign mio_pad_attr_31_re = addr_hit[193] && reg_re;
+  assign mio_pad_attr_31_re = addr_hit[193] & reg_re & !reg_error;
 
-  assign dio_pad_attr_regwen_0_we = addr_hit[194] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_0_we = addr_hit[194] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_0_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_1_we = addr_hit[195] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_1_we = addr_hit[195] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_1_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_2_we = addr_hit[196] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_2_we = addr_hit[196] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_2_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_3_we = addr_hit[197] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_3_we = addr_hit[197] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_3_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_4_we = addr_hit[198] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_4_we = addr_hit[198] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_4_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_5_we = addr_hit[199] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_5_we = addr_hit[199] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_5_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_6_we = addr_hit[200] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_6_we = addr_hit[200] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_6_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_7_we = addr_hit[201] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_7_we = addr_hit[201] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_7_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_8_we = addr_hit[202] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_8_we = addr_hit[202] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_8_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_9_we = addr_hit[203] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_9_we = addr_hit[203] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_9_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_10_we = addr_hit[204] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_10_we = addr_hit[204] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_10_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_11_we = addr_hit[205] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_11_we = addr_hit[205] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_11_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_12_we = addr_hit[206] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_12_we = addr_hit[206] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_12_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_13_we = addr_hit[207] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_13_we = addr_hit[207] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_13_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_14_we = addr_hit[208] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_14_we = addr_hit[208] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_14_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_15_we = addr_hit[209] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_15_we = addr_hit[209] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_15_wd = reg_wdata[0];
 
-  assign dio_pad_attr_0_we = addr_hit[210] & reg_we & ~wr_err;
+  assign dio_pad_attr_0_we = addr_hit[210] & reg_we & !reg_error;
   assign dio_pad_attr_0_wd = reg_wdata[9:0];
-  assign dio_pad_attr_0_re = addr_hit[210] && reg_re;
+  assign dio_pad_attr_0_re = addr_hit[210] & reg_re & !reg_error;
 
-  assign dio_pad_attr_1_we = addr_hit[211] & reg_we & ~wr_err;
+  assign dio_pad_attr_1_we = addr_hit[211] & reg_we & !reg_error;
   assign dio_pad_attr_1_wd = reg_wdata[9:0];
-  assign dio_pad_attr_1_re = addr_hit[211] && reg_re;
+  assign dio_pad_attr_1_re = addr_hit[211] & reg_re & !reg_error;
 
-  assign dio_pad_attr_2_we = addr_hit[212] & reg_we & ~wr_err;
+  assign dio_pad_attr_2_we = addr_hit[212] & reg_we & !reg_error;
   assign dio_pad_attr_2_wd = reg_wdata[9:0];
-  assign dio_pad_attr_2_re = addr_hit[212] && reg_re;
+  assign dio_pad_attr_2_re = addr_hit[212] & reg_re & !reg_error;
 
-  assign dio_pad_attr_3_we = addr_hit[213] & reg_we & ~wr_err;
+  assign dio_pad_attr_3_we = addr_hit[213] & reg_we & !reg_error;
   assign dio_pad_attr_3_wd = reg_wdata[9:0];
-  assign dio_pad_attr_3_re = addr_hit[213] && reg_re;
+  assign dio_pad_attr_3_re = addr_hit[213] & reg_re & !reg_error;
 
-  assign dio_pad_attr_4_we = addr_hit[214] & reg_we & ~wr_err;
+  assign dio_pad_attr_4_we = addr_hit[214] & reg_we & !reg_error;
   assign dio_pad_attr_4_wd = reg_wdata[9:0];
-  assign dio_pad_attr_4_re = addr_hit[214] && reg_re;
+  assign dio_pad_attr_4_re = addr_hit[214] & reg_re & !reg_error;
 
-  assign dio_pad_attr_5_we = addr_hit[215] & reg_we & ~wr_err;
+  assign dio_pad_attr_5_we = addr_hit[215] & reg_we & !reg_error;
   assign dio_pad_attr_5_wd = reg_wdata[9:0];
-  assign dio_pad_attr_5_re = addr_hit[215] && reg_re;
+  assign dio_pad_attr_5_re = addr_hit[215] & reg_re & !reg_error;
 
-  assign dio_pad_attr_6_we = addr_hit[216] & reg_we & ~wr_err;
+  assign dio_pad_attr_6_we = addr_hit[216] & reg_we & !reg_error;
   assign dio_pad_attr_6_wd = reg_wdata[9:0];
-  assign dio_pad_attr_6_re = addr_hit[216] && reg_re;
+  assign dio_pad_attr_6_re = addr_hit[216] & reg_re & !reg_error;
 
-  assign dio_pad_attr_7_we = addr_hit[217] & reg_we & ~wr_err;
+  assign dio_pad_attr_7_we = addr_hit[217] & reg_we & !reg_error;
   assign dio_pad_attr_7_wd = reg_wdata[9:0];
-  assign dio_pad_attr_7_re = addr_hit[217] && reg_re;
+  assign dio_pad_attr_7_re = addr_hit[217] & reg_re & !reg_error;
 
-  assign dio_pad_attr_8_we = addr_hit[218] & reg_we & ~wr_err;
+  assign dio_pad_attr_8_we = addr_hit[218] & reg_we & !reg_error;
   assign dio_pad_attr_8_wd = reg_wdata[9:0];
-  assign dio_pad_attr_8_re = addr_hit[218] && reg_re;
+  assign dio_pad_attr_8_re = addr_hit[218] & reg_re & !reg_error;
 
-  assign dio_pad_attr_9_we = addr_hit[219] & reg_we & ~wr_err;
+  assign dio_pad_attr_9_we = addr_hit[219] & reg_we & !reg_error;
   assign dio_pad_attr_9_wd = reg_wdata[9:0];
-  assign dio_pad_attr_9_re = addr_hit[219] && reg_re;
+  assign dio_pad_attr_9_re = addr_hit[219] & reg_re & !reg_error;
 
-  assign dio_pad_attr_10_we = addr_hit[220] & reg_we & ~wr_err;
+  assign dio_pad_attr_10_we = addr_hit[220] & reg_we & !reg_error;
   assign dio_pad_attr_10_wd = reg_wdata[9:0];
-  assign dio_pad_attr_10_re = addr_hit[220] && reg_re;
+  assign dio_pad_attr_10_re = addr_hit[220] & reg_re & !reg_error;
 
-  assign dio_pad_attr_11_we = addr_hit[221] & reg_we & ~wr_err;
+  assign dio_pad_attr_11_we = addr_hit[221] & reg_we & !reg_error;
   assign dio_pad_attr_11_wd = reg_wdata[9:0];
-  assign dio_pad_attr_11_re = addr_hit[221] && reg_re;
+  assign dio_pad_attr_11_re = addr_hit[221] & reg_re & !reg_error;
 
-  assign dio_pad_attr_12_we = addr_hit[222] & reg_we & ~wr_err;
+  assign dio_pad_attr_12_we = addr_hit[222] & reg_we & !reg_error;
   assign dio_pad_attr_12_wd = reg_wdata[9:0];
-  assign dio_pad_attr_12_re = addr_hit[222] && reg_re;
+  assign dio_pad_attr_12_re = addr_hit[222] & reg_re & !reg_error;
 
-  assign dio_pad_attr_13_we = addr_hit[223] & reg_we & ~wr_err;
+  assign dio_pad_attr_13_we = addr_hit[223] & reg_we & !reg_error;
   assign dio_pad_attr_13_wd = reg_wdata[9:0];
-  assign dio_pad_attr_13_re = addr_hit[223] && reg_re;
+  assign dio_pad_attr_13_re = addr_hit[223] & reg_re & !reg_error;
 
-  assign dio_pad_attr_14_we = addr_hit[224] & reg_we & ~wr_err;
+  assign dio_pad_attr_14_we = addr_hit[224] & reg_we & !reg_error;
   assign dio_pad_attr_14_wd = reg_wdata[9:0];
-  assign dio_pad_attr_14_re = addr_hit[224] && reg_re;
+  assign dio_pad_attr_14_re = addr_hit[224] & reg_re & !reg_error;
 
-  assign dio_pad_attr_15_we = addr_hit[225] & reg_we & ~wr_err;
+  assign dio_pad_attr_15_we = addr_hit[225] & reg_we & !reg_error;
   assign dio_pad_attr_15_wd = reg_wdata[9:0];
-  assign dio_pad_attr_15_re = addr_hit[225] && reg_re;
+  assign dio_pad_attr_15_re = addr_hit[225] & reg_re & !reg_error;
 
-  assign mio_pad_sleep_status_en_0_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_0_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_0_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_status_en_1_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_1_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_1_wd = reg_wdata[1];
 
-  assign mio_pad_sleep_status_en_2_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_2_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_2_wd = reg_wdata[2];
 
-  assign mio_pad_sleep_status_en_3_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_3_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_3_wd = reg_wdata[3];
 
-  assign mio_pad_sleep_status_en_4_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_4_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_4_wd = reg_wdata[4];
 
-  assign mio_pad_sleep_status_en_5_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_5_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_5_wd = reg_wdata[5];
 
-  assign mio_pad_sleep_status_en_6_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_6_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_6_wd = reg_wdata[6];
 
-  assign mio_pad_sleep_status_en_7_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_7_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_7_wd = reg_wdata[7];
 
-  assign mio_pad_sleep_status_en_8_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_8_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_8_wd = reg_wdata[8];
 
-  assign mio_pad_sleep_status_en_9_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_9_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_9_wd = reg_wdata[9];
 
-  assign mio_pad_sleep_status_en_10_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_10_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_10_wd = reg_wdata[10];
 
-  assign mio_pad_sleep_status_en_11_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_11_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_11_wd = reg_wdata[11];
 
-  assign mio_pad_sleep_status_en_12_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_12_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_12_wd = reg_wdata[12];
 
-  assign mio_pad_sleep_status_en_13_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_13_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_13_wd = reg_wdata[13];
 
-  assign mio_pad_sleep_status_en_14_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_14_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_14_wd = reg_wdata[14];
 
-  assign mio_pad_sleep_status_en_15_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_15_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_15_wd = reg_wdata[15];
 
-  assign mio_pad_sleep_status_en_16_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_16_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_16_wd = reg_wdata[16];
 
-  assign mio_pad_sleep_status_en_17_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_17_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_17_wd = reg_wdata[17];
 
-  assign mio_pad_sleep_status_en_18_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_18_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_18_wd = reg_wdata[18];
 
-  assign mio_pad_sleep_status_en_19_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_19_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_19_wd = reg_wdata[19];
 
-  assign mio_pad_sleep_status_en_20_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_20_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_20_wd = reg_wdata[20];
 
-  assign mio_pad_sleep_status_en_21_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_21_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_21_wd = reg_wdata[21];
 
-  assign mio_pad_sleep_status_en_22_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_22_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_22_wd = reg_wdata[22];
 
-  assign mio_pad_sleep_status_en_23_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_23_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_23_wd = reg_wdata[23];
 
-  assign mio_pad_sleep_status_en_24_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_24_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_24_wd = reg_wdata[24];
 
-  assign mio_pad_sleep_status_en_25_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_25_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_25_wd = reg_wdata[25];
 
-  assign mio_pad_sleep_status_en_26_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_26_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_26_wd = reg_wdata[26];
 
-  assign mio_pad_sleep_status_en_27_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_27_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_27_wd = reg_wdata[27];
 
-  assign mio_pad_sleep_status_en_28_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_28_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_28_wd = reg_wdata[28];
 
-  assign mio_pad_sleep_status_en_29_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_29_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_29_wd = reg_wdata[29];
 
-  assign mio_pad_sleep_status_en_30_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_30_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_30_wd = reg_wdata[30];
 
-  assign mio_pad_sleep_status_en_31_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_en_31_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_31_wd = reg_wdata[31];
 
-  assign mio_pad_sleep_regwen_0_we = addr_hit[227] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_0_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_0_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_1_we = addr_hit[228] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_1_we = addr_hit[228] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_1_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_2_we = addr_hit[229] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_2_we = addr_hit[229] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_2_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_3_we = addr_hit[230] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_3_we = addr_hit[230] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_3_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_4_we = addr_hit[231] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_4_we = addr_hit[231] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_4_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_5_we = addr_hit[232] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_5_we = addr_hit[232] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_5_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_6_we = addr_hit[233] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_6_we = addr_hit[233] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_6_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_7_we = addr_hit[234] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_7_we = addr_hit[234] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_7_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_8_we = addr_hit[235] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_8_we = addr_hit[235] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_8_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_9_we = addr_hit[236] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_9_we = addr_hit[236] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_9_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_10_we = addr_hit[237] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_10_we = addr_hit[237] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_10_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_11_we = addr_hit[238] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_11_we = addr_hit[238] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_11_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_12_we = addr_hit[239] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_12_we = addr_hit[239] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_12_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_13_we = addr_hit[240] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_13_we = addr_hit[240] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_13_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_14_we = addr_hit[241] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_14_we = addr_hit[241] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_14_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_15_we = addr_hit[242] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_15_we = addr_hit[242] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_15_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_16_we = addr_hit[243] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_16_we = addr_hit[243] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_16_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_17_we = addr_hit[244] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_17_we = addr_hit[244] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_17_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_18_we = addr_hit[245] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_18_we = addr_hit[245] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_18_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_19_we = addr_hit[246] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_19_we = addr_hit[246] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_19_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_20_we = addr_hit[247] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_20_we = addr_hit[247] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_20_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_21_we = addr_hit[248] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_21_we = addr_hit[248] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_21_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_22_we = addr_hit[249] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_22_we = addr_hit[249] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_22_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_23_we = addr_hit[250] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_23_we = addr_hit[250] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_23_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_24_we = addr_hit[251] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_24_we = addr_hit[251] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_24_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_25_we = addr_hit[252] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_25_we = addr_hit[252] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_25_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_26_we = addr_hit[253] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_26_we = addr_hit[253] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_26_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_27_we = addr_hit[254] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_27_we = addr_hit[254] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_27_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_28_we = addr_hit[255] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_28_we = addr_hit[255] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_28_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_29_we = addr_hit[256] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_29_we = addr_hit[256] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_29_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_30_we = addr_hit[257] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_30_we = addr_hit[257] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_30_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_31_we = addr_hit[258] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_31_we = addr_hit[258] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_31_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_0_we = addr_hit[259] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_0_we = addr_hit[259] & reg_we & !reg_error;
   assign mio_pad_sleep_en_0_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_1_we = addr_hit[260] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_1_we = addr_hit[260] & reg_we & !reg_error;
   assign mio_pad_sleep_en_1_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_2_we = addr_hit[261] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_2_we = addr_hit[261] & reg_we & !reg_error;
   assign mio_pad_sleep_en_2_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_3_we = addr_hit[262] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_3_we = addr_hit[262] & reg_we & !reg_error;
   assign mio_pad_sleep_en_3_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_4_we = addr_hit[263] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_4_we = addr_hit[263] & reg_we & !reg_error;
   assign mio_pad_sleep_en_4_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_5_we = addr_hit[264] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_5_we = addr_hit[264] & reg_we & !reg_error;
   assign mio_pad_sleep_en_5_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_6_we = addr_hit[265] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_6_we = addr_hit[265] & reg_we & !reg_error;
   assign mio_pad_sleep_en_6_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_7_we = addr_hit[266] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_7_we = addr_hit[266] & reg_we & !reg_error;
   assign mio_pad_sleep_en_7_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_8_we = addr_hit[267] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_8_we = addr_hit[267] & reg_we & !reg_error;
   assign mio_pad_sleep_en_8_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_9_we = addr_hit[268] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_9_we = addr_hit[268] & reg_we & !reg_error;
   assign mio_pad_sleep_en_9_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_10_we = addr_hit[269] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_10_we = addr_hit[269] & reg_we & !reg_error;
   assign mio_pad_sleep_en_10_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_11_we = addr_hit[270] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_11_we = addr_hit[270] & reg_we & !reg_error;
   assign mio_pad_sleep_en_11_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_12_we = addr_hit[271] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_12_we = addr_hit[271] & reg_we & !reg_error;
   assign mio_pad_sleep_en_12_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_13_we = addr_hit[272] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_13_we = addr_hit[272] & reg_we & !reg_error;
   assign mio_pad_sleep_en_13_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_14_we = addr_hit[273] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_14_we = addr_hit[273] & reg_we & !reg_error;
   assign mio_pad_sleep_en_14_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_15_we = addr_hit[274] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_15_we = addr_hit[274] & reg_we & !reg_error;
   assign mio_pad_sleep_en_15_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_16_we = addr_hit[275] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_16_we = addr_hit[275] & reg_we & !reg_error;
   assign mio_pad_sleep_en_16_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_17_we = addr_hit[276] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_17_we = addr_hit[276] & reg_we & !reg_error;
   assign mio_pad_sleep_en_17_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_18_we = addr_hit[277] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_18_we = addr_hit[277] & reg_we & !reg_error;
   assign mio_pad_sleep_en_18_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_19_we = addr_hit[278] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_19_we = addr_hit[278] & reg_we & !reg_error;
   assign mio_pad_sleep_en_19_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_20_we = addr_hit[279] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_20_we = addr_hit[279] & reg_we & !reg_error;
   assign mio_pad_sleep_en_20_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_21_we = addr_hit[280] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_21_we = addr_hit[280] & reg_we & !reg_error;
   assign mio_pad_sleep_en_21_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_22_we = addr_hit[281] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_22_we = addr_hit[281] & reg_we & !reg_error;
   assign mio_pad_sleep_en_22_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_23_we = addr_hit[282] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_23_we = addr_hit[282] & reg_we & !reg_error;
   assign mio_pad_sleep_en_23_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_24_we = addr_hit[283] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_24_we = addr_hit[283] & reg_we & !reg_error;
   assign mio_pad_sleep_en_24_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_25_we = addr_hit[284] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_25_we = addr_hit[284] & reg_we & !reg_error;
   assign mio_pad_sleep_en_25_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_26_we = addr_hit[285] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_26_we = addr_hit[285] & reg_we & !reg_error;
   assign mio_pad_sleep_en_26_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_27_we = addr_hit[286] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_27_we = addr_hit[286] & reg_we & !reg_error;
   assign mio_pad_sleep_en_27_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_28_we = addr_hit[287] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_28_we = addr_hit[287] & reg_we & !reg_error;
   assign mio_pad_sleep_en_28_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_29_we = addr_hit[288] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_29_we = addr_hit[288] & reg_we & !reg_error;
   assign mio_pad_sleep_en_29_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_30_we = addr_hit[289] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_30_we = addr_hit[289] & reg_we & !reg_error;
   assign mio_pad_sleep_en_30_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_31_we = addr_hit[290] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_31_we = addr_hit[290] & reg_we & !reg_error;
   assign mio_pad_sleep_en_31_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_mode_0_we = addr_hit[291] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_0_we = addr_hit[291] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_0_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_1_we = addr_hit[292] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_1_we = addr_hit[292] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_1_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_2_we = addr_hit[293] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_2_we = addr_hit[293] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_2_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_3_we = addr_hit[294] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_3_we = addr_hit[294] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_3_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_4_we = addr_hit[295] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_4_we = addr_hit[295] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_4_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_5_we = addr_hit[296] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_5_we = addr_hit[296] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_5_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_6_we = addr_hit[297] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_6_we = addr_hit[297] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_6_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_7_we = addr_hit[298] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_7_we = addr_hit[298] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_7_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_8_we = addr_hit[299] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_8_we = addr_hit[299] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_8_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_9_we = addr_hit[300] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_9_we = addr_hit[300] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_9_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_10_we = addr_hit[301] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_10_we = addr_hit[301] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_10_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_11_we = addr_hit[302] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_11_we = addr_hit[302] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_11_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_12_we = addr_hit[303] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_12_we = addr_hit[303] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_12_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_13_we = addr_hit[304] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_13_we = addr_hit[304] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_13_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_14_we = addr_hit[305] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_14_we = addr_hit[305] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_14_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_15_we = addr_hit[306] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_15_we = addr_hit[306] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_15_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_16_we = addr_hit[307] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_16_we = addr_hit[307] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_16_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_17_we = addr_hit[308] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_17_we = addr_hit[308] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_17_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_18_we = addr_hit[309] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_18_we = addr_hit[309] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_18_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_19_we = addr_hit[310] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_19_we = addr_hit[310] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_19_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_20_we = addr_hit[311] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_20_we = addr_hit[311] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_20_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_21_we = addr_hit[312] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_21_we = addr_hit[312] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_21_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_22_we = addr_hit[313] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_22_we = addr_hit[313] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_22_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_23_we = addr_hit[314] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_23_we = addr_hit[314] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_23_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_24_we = addr_hit[315] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_24_we = addr_hit[315] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_24_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_25_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_25_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_25_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_26_we = addr_hit[317] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_26_we = addr_hit[317] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_26_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_27_we = addr_hit[318] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_27_we = addr_hit[318] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_27_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_28_we = addr_hit[319] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_28_we = addr_hit[319] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_28_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_29_we = addr_hit[320] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_29_we = addr_hit[320] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_29_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_30_we = addr_hit[321] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_30_we = addr_hit[321] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_30_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_31_we = addr_hit[322] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_31_we = addr_hit[322] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_31_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_status_en_0_we = addr_hit[323] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_0_we = addr_hit[323] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_0_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_status_en_1_we = addr_hit[323] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_1_we = addr_hit[323] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_1_wd = reg_wdata[1];
 
-  assign dio_pad_sleep_status_en_2_we = addr_hit[323] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_2_we = addr_hit[323] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_2_wd = reg_wdata[2];
 
-  assign dio_pad_sleep_status_en_3_we = addr_hit[323] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_3_we = addr_hit[323] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_3_wd = reg_wdata[3];
 
-  assign dio_pad_sleep_status_en_4_we = addr_hit[323] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_4_we = addr_hit[323] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_4_wd = reg_wdata[4];
 
-  assign dio_pad_sleep_status_en_5_we = addr_hit[323] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_5_we = addr_hit[323] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_5_wd = reg_wdata[5];
 
-  assign dio_pad_sleep_status_en_6_we = addr_hit[323] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_6_we = addr_hit[323] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_6_wd = reg_wdata[6];
 
-  assign dio_pad_sleep_status_en_7_we = addr_hit[323] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_7_we = addr_hit[323] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_7_wd = reg_wdata[7];
 
-  assign dio_pad_sleep_status_en_8_we = addr_hit[323] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_8_we = addr_hit[323] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_8_wd = reg_wdata[8];
 
-  assign dio_pad_sleep_status_en_9_we = addr_hit[323] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_9_we = addr_hit[323] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_9_wd = reg_wdata[9];
 
-  assign dio_pad_sleep_status_en_10_we = addr_hit[323] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_10_we = addr_hit[323] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_10_wd = reg_wdata[10];
 
-  assign dio_pad_sleep_status_en_11_we = addr_hit[323] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_11_we = addr_hit[323] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_11_wd = reg_wdata[11];
 
-  assign dio_pad_sleep_status_en_12_we = addr_hit[323] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_12_we = addr_hit[323] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_12_wd = reg_wdata[12];
 
-  assign dio_pad_sleep_status_en_13_we = addr_hit[323] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_13_we = addr_hit[323] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_13_wd = reg_wdata[13];
 
-  assign dio_pad_sleep_status_en_14_we = addr_hit[323] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_14_we = addr_hit[323] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_14_wd = reg_wdata[14];
 
-  assign dio_pad_sleep_status_en_15_we = addr_hit[323] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_15_we = addr_hit[323] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_15_wd = reg_wdata[15];
 
-  assign dio_pad_sleep_regwen_0_we = addr_hit[324] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_0_we = addr_hit[324] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_0_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_1_we = addr_hit[325] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_1_we = addr_hit[325] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_1_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_2_we = addr_hit[326] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_2_we = addr_hit[326] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_2_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_3_we = addr_hit[327] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_3_we = addr_hit[327] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_3_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_4_we = addr_hit[328] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_4_we = addr_hit[328] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_4_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_5_we = addr_hit[329] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_5_we = addr_hit[329] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_5_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_6_we = addr_hit[330] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_6_we = addr_hit[330] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_6_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_7_we = addr_hit[331] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_7_we = addr_hit[331] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_7_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_8_we = addr_hit[332] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_8_we = addr_hit[332] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_8_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_9_we = addr_hit[333] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_9_we = addr_hit[333] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_9_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_10_we = addr_hit[334] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_10_we = addr_hit[334] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_10_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_11_we = addr_hit[335] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_11_we = addr_hit[335] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_11_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_12_we = addr_hit[336] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_12_we = addr_hit[336] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_12_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_13_we = addr_hit[337] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_13_we = addr_hit[337] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_13_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_14_we = addr_hit[338] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_14_we = addr_hit[338] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_14_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_15_we = addr_hit[339] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_15_we = addr_hit[339] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_15_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_0_we = addr_hit[340] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_0_we = addr_hit[340] & reg_we & !reg_error;
   assign dio_pad_sleep_en_0_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_1_we = addr_hit[341] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_1_we = addr_hit[341] & reg_we & !reg_error;
   assign dio_pad_sleep_en_1_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_2_we = addr_hit[342] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_2_we = addr_hit[342] & reg_we & !reg_error;
   assign dio_pad_sleep_en_2_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_3_we = addr_hit[343] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_3_we = addr_hit[343] & reg_we & !reg_error;
   assign dio_pad_sleep_en_3_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_4_we = addr_hit[344] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_4_we = addr_hit[344] & reg_we & !reg_error;
   assign dio_pad_sleep_en_4_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_5_we = addr_hit[345] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_5_we = addr_hit[345] & reg_we & !reg_error;
   assign dio_pad_sleep_en_5_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_6_we = addr_hit[346] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_6_we = addr_hit[346] & reg_we & !reg_error;
   assign dio_pad_sleep_en_6_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_7_we = addr_hit[347] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_7_we = addr_hit[347] & reg_we & !reg_error;
   assign dio_pad_sleep_en_7_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_8_we = addr_hit[348] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_8_we = addr_hit[348] & reg_we & !reg_error;
   assign dio_pad_sleep_en_8_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_9_we = addr_hit[349] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_9_we = addr_hit[349] & reg_we & !reg_error;
   assign dio_pad_sleep_en_9_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_10_we = addr_hit[350] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_10_we = addr_hit[350] & reg_we & !reg_error;
   assign dio_pad_sleep_en_10_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_11_we = addr_hit[351] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_11_we = addr_hit[351] & reg_we & !reg_error;
   assign dio_pad_sleep_en_11_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_12_we = addr_hit[352] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_12_we = addr_hit[352] & reg_we & !reg_error;
   assign dio_pad_sleep_en_12_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_13_we = addr_hit[353] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_13_we = addr_hit[353] & reg_we & !reg_error;
   assign dio_pad_sleep_en_13_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_14_we = addr_hit[354] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_14_we = addr_hit[354] & reg_we & !reg_error;
   assign dio_pad_sleep_en_14_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_15_we = addr_hit[355] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_15_we = addr_hit[355] & reg_we & !reg_error;
   assign dio_pad_sleep_en_15_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_mode_0_we = addr_hit[356] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_0_we = addr_hit[356] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_0_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_1_we = addr_hit[357] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_1_we = addr_hit[357] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_1_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_2_we = addr_hit[358] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_2_we = addr_hit[358] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_2_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_3_we = addr_hit[359] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_3_we = addr_hit[359] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_3_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_4_we = addr_hit[360] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_4_we = addr_hit[360] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_4_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_5_we = addr_hit[361] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_5_we = addr_hit[361] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_5_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_6_we = addr_hit[362] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_6_we = addr_hit[362] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_6_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_7_we = addr_hit[363] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_7_we = addr_hit[363] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_7_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_8_we = addr_hit[364] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_8_we = addr_hit[364] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_8_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_9_we = addr_hit[365] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_9_we = addr_hit[365] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_9_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_10_we = addr_hit[366] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_10_we = addr_hit[366] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_10_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_11_we = addr_hit[367] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_11_we = addr_hit[367] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_11_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_12_we = addr_hit[368] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_12_we = addr_hit[368] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_12_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_13_we = addr_hit[369] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_13_we = addr_hit[369] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_13_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_14_we = addr_hit[370] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_14_we = addr_hit[370] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_14_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_15_we = addr_hit[371] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_15_we = addr_hit[371] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_15_wd = reg_wdata[1:0];
 
-  assign wkup_detector_regwen_0_we = addr_hit[372] & reg_we & ~wr_err;
+  assign wkup_detector_regwen_0_we = addr_hit[372] & reg_we & !reg_error;
   assign wkup_detector_regwen_0_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_1_we = addr_hit[373] & reg_we & ~wr_err;
+  assign wkup_detector_regwen_1_we = addr_hit[373] & reg_we & !reg_error;
   assign wkup_detector_regwen_1_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_2_we = addr_hit[374] & reg_we & ~wr_err;
+  assign wkup_detector_regwen_2_we = addr_hit[374] & reg_we & !reg_error;
   assign wkup_detector_regwen_2_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_3_we = addr_hit[375] & reg_we & ~wr_err;
+  assign wkup_detector_regwen_3_we = addr_hit[375] & reg_we & !reg_error;
   assign wkup_detector_regwen_3_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_4_we = addr_hit[376] & reg_we & ~wr_err;
+  assign wkup_detector_regwen_4_we = addr_hit[376] & reg_we & !reg_error;
   assign wkup_detector_regwen_4_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_5_we = addr_hit[377] & reg_we & ~wr_err;
+  assign wkup_detector_regwen_5_we = addr_hit[377] & reg_we & !reg_error;
   assign wkup_detector_regwen_5_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_6_we = addr_hit[378] & reg_we & ~wr_err;
+  assign wkup_detector_regwen_6_we = addr_hit[378] & reg_we & !reg_error;
   assign wkup_detector_regwen_6_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_7_we = addr_hit[379] & reg_we & ~wr_err;
+  assign wkup_detector_regwen_7_we = addr_hit[379] & reg_we & !reg_error;
   assign wkup_detector_regwen_7_wd = reg_wdata[0];
 
-  assign wkup_detector_en_0_we = addr_hit[380] & reg_we & ~wr_err;
+  assign wkup_detector_en_0_we = addr_hit[380] & reg_we & !reg_error;
   assign wkup_detector_en_0_wd = reg_wdata[0];
 
-  assign wkup_detector_en_1_we = addr_hit[381] & reg_we & ~wr_err;
+  assign wkup_detector_en_1_we = addr_hit[381] & reg_we & !reg_error;
   assign wkup_detector_en_1_wd = reg_wdata[0];
 
-  assign wkup_detector_en_2_we = addr_hit[382] & reg_we & ~wr_err;
+  assign wkup_detector_en_2_we = addr_hit[382] & reg_we & !reg_error;
   assign wkup_detector_en_2_wd = reg_wdata[0];
 
-  assign wkup_detector_en_3_we = addr_hit[383] & reg_we & ~wr_err;
+  assign wkup_detector_en_3_we = addr_hit[383] & reg_we & !reg_error;
   assign wkup_detector_en_3_wd = reg_wdata[0];
 
-  assign wkup_detector_en_4_we = addr_hit[384] & reg_we & ~wr_err;
+  assign wkup_detector_en_4_we = addr_hit[384] & reg_we & !reg_error;
   assign wkup_detector_en_4_wd = reg_wdata[0];
 
-  assign wkup_detector_en_5_we = addr_hit[385] & reg_we & ~wr_err;
+  assign wkup_detector_en_5_we = addr_hit[385] & reg_we & !reg_error;
   assign wkup_detector_en_5_wd = reg_wdata[0];
 
-  assign wkup_detector_en_6_we = addr_hit[386] & reg_we & ~wr_err;
+  assign wkup_detector_en_6_we = addr_hit[386] & reg_we & !reg_error;
   assign wkup_detector_en_6_wd = reg_wdata[0];
 
-  assign wkup_detector_en_7_we = addr_hit[387] & reg_we & ~wr_err;
+  assign wkup_detector_en_7_we = addr_hit[387] & reg_we & !reg_error;
   assign wkup_detector_en_7_wd = reg_wdata[0];
 
-  assign wkup_detector_0_mode_0_we = addr_hit[388] & reg_we & ~wr_err;
+  assign wkup_detector_0_mode_0_we = addr_hit[388] & reg_we & !reg_error;
   assign wkup_detector_0_mode_0_wd = reg_wdata[2:0];
 
-  assign wkup_detector_0_filter_0_we = addr_hit[388] & reg_we & ~wr_err;
+  assign wkup_detector_0_filter_0_we = addr_hit[388] & reg_we & !reg_error;
   assign wkup_detector_0_filter_0_wd = reg_wdata[3];
 
-  assign wkup_detector_0_miodio_0_we = addr_hit[388] & reg_we & ~wr_err;
+  assign wkup_detector_0_miodio_0_we = addr_hit[388] & reg_we & !reg_error;
   assign wkup_detector_0_miodio_0_wd = reg_wdata[4];
 
-  assign wkup_detector_1_mode_1_we = addr_hit[389] & reg_we & ~wr_err;
+  assign wkup_detector_1_mode_1_we = addr_hit[389] & reg_we & !reg_error;
   assign wkup_detector_1_mode_1_wd = reg_wdata[2:0];
 
-  assign wkup_detector_1_filter_1_we = addr_hit[389] & reg_we & ~wr_err;
+  assign wkup_detector_1_filter_1_we = addr_hit[389] & reg_we & !reg_error;
   assign wkup_detector_1_filter_1_wd = reg_wdata[3];
 
-  assign wkup_detector_1_miodio_1_we = addr_hit[389] & reg_we & ~wr_err;
+  assign wkup_detector_1_miodio_1_we = addr_hit[389] & reg_we & !reg_error;
   assign wkup_detector_1_miodio_1_wd = reg_wdata[4];
 
-  assign wkup_detector_2_mode_2_we = addr_hit[390] & reg_we & ~wr_err;
+  assign wkup_detector_2_mode_2_we = addr_hit[390] & reg_we & !reg_error;
   assign wkup_detector_2_mode_2_wd = reg_wdata[2:0];
 
-  assign wkup_detector_2_filter_2_we = addr_hit[390] & reg_we & ~wr_err;
+  assign wkup_detector_2_filter_2_we = addr_hit[390] & reg_we & !reg_error;
   assign wkup_detector_2_filter_2_wd = reg_wdata[3];
 
-  assign wkup_detector_2_miodio_2_we = addr_hit[390] & reg_we & ~wr_err;
+  assign wkup_detector_2_miodio_2_we = addr_hit[390] & reg_we & !reg_error;
   assign wkup_detector_2_miodio_2_wd = reg_wdata[4];
 
-  assign wkup_detector_3_mode_3_we = addr_hit[391] & reg_we & ~wr_err;
+  assign wkup_detector_3_mode_3_we = addr_hit[391] & reg_we & !reg_error;
   assign wkup_detector_3_mode_3_wd = reg_wdata[2:0];
 
-  assign wkup_detector_3_filter_3_we = addr_hit[391] & reg_we & ~wr_err;
+  assign wkup_detector_3_filter_3_we = addr_hit[391] & reg_we & !reg_error;
   assign wkup_detector_3_filter_3_wd = reg_wdata[3];
 
-  assign wkup_detector_3_miodio_3_we = addr_hit[391] & reg_we & ~wr_err;
+  assign wkup_detector_3_miodio_3_we = addr_hit[391] & reg_we & !reg_error;
   assign wkup_detector_3_miodio_3_wd = reg_wdata[4];
 
-  assign wkup_detector_4_mode_4_we = addr_hit[392] & reg_we & ~wr_err;
+  assign wkup_detector_4_mode_4_we = addr_hit[392] & reg_we & !reg_error;
   assign wkup_detector_4_mode_4_wd = reg_wdata[2:0];
 
-  assign wkup_detector_4_filter_4_we = addr_hit[392] & reg_we & ~wr_err;
+  assign wkup_detector_4_filter_4_we = addr_hit[392] & reg_we & !reg_error;
   assign wkup_detector_4_filter_4_wd = reg_wdata[3];
 
-  assign wkup_detector_4_miodio_4_we = addr_hit[392] & reg_we & ~wr_err;
+  assign wkup_detector_4_miodio_4_we = addr_hit[392] & reg_we & !reg_error;
   assign wkup_detector_4_miodio_4_wd = reg_wdata[4];
 
-  assign wkup_detector_5_mode_5_we = addr_hit[393] & reg_we & ~wr_err;
+  assign wkup_detector_5_mode_5_we = addr_hit[393] & reg_we & !reg_error;
   assign wkup_detector_5_mode_5_wd = reg_wdata[2:0];
 
-  assign wkup_detector_5_filter_5_we = addr_hit[393] & reg_we & ~wr_err;
+  assign wkup_detector_5_filter_5_we = addr_hit[393] & reg_we & !reg_error;
   assign wkup_detector_5_filter_5_wd = reg_wdata[3];
 
-  assign wkup_detector_5_miodio_5_we = addr_hit[393] & reg_we & ~wr_err;
+  assign wkup_detector_5_miodio_5_we = addr_hit[393] & reg_we & !reg_error;
   assign wkup_detector_5_miodio_5_wd = reg_wdata[4];
 
-  assign wkup_detector_6_mode_6_we = addr_hit[394] & reg_we & ~wr_err;
+  assign wkup_detector_6_mode_6_we = addr_hit[394] & reg_we & !reg_error;
   assign wkup_detector_6_mode_6_wd = reg_wdata[2:0];
 
-  assign wkup_detector_6_filter_6_we = addr_hit[394] & reg_we & ~wr_err;
+  assign wkup_detector_6_filter_6_we = addr_hit[394] & reg_we & !reg_error;
   assign wkup_detector_6_filter_6_wd = reg_wdata[3];
 
-  assign wkup_detector_6_miodio_6_we = addr_hit[394] & reg_we & ~wr_err;
+  assign wkup_detector_6_miodio_6_we = addr_hit[394] & reg_we & !reg_error;
   assign wkup_detector_6_miodio_6_wd = reg_wdata[4];
 
-  assign wkup_detector_7_mode_7_we = addr_hit[395] & reg_we & ~wr_err;
+  assign wkup_detector_7_mode_7_we = addr_hit[395] & reg_we & !reg_error;
   assign wkup_detector_7_mode_7_wd = reg_wdata[2:0];
 
-  assign wkup_detector_7_filter_7_we = addr_hit[395] & reg_we & ~wr_err;
+  assign wkup_detector_7_filter_7_we = addr_hit[395] & reg_we & !reg_error;
   assign wkup_detector_7_filter_7_wd = reg_wdata[3];
 
-  assign wkup_detector_7_miodio_7_we = addr_hit[395] & reg_we & ~wr_err;
+  assign wkup_detector_7_miodio_7_we = addr_hit[395] & reg_we & !reg_error;
   assign wkup_detector_7_miodio_7_wd = reg_wdata[4];
 
-  assign wkup_detector_cnt_th_0_we = addr_hit[396] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th_0_we = addr_hit[396] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_0_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_1_we = addr_hit[397] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th_1_we = addr_hit[397] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_1_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_2_we = addr_hit[398] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th_2_we = addr_hit[398] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_2_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_3_we = addr_hit[399] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th_3_we = addr_hit[399] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_3_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_4_we = addr_hit[400] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th_4_we = addr_hit[400] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_4_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_5_we = addr_hit[401] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th_5_we = addr_hit[401] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_5_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_6_we = addr_hit[402] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th_6_we = addr_hit[402] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_6_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_7_we = addr_hit[403] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th_7_we = addr_hit[403] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_7_wd = reg_wdata[7:0];
 
-  assign wkup_detector_padsel_0_we = addr_hit[404] & reg_we & ~wr_err;
+  assign wkup_detector_padsel_0_we = addr_hit[404] & reg_we & !reg_error;
   assign wkup_detector_padsel_0_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_1_we = addr_hit[405] & reg_we & ~wr_err;
+  assign wkup_detector_padsel_1_we = addr_hit[405] & reg_we & !reg_error;
   assign wkup_detector_padsel_1_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_2_we = addr_hit[406] & reg_we & ~wr_err;
+  assign wkup_detector_padsel_2_we = addr_hit[406] & reg_we & !reg_error;
   assign wkup_detector_padsel_2_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_3_we = addr_hit[407] & reg_we & ~wr_err;
+  assign wkup_detector_padsel_3_we = addr_hit[407] & reg_we & !reg_error;
   assign wkup_detector_padsel_3_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_4_we = addr_hit[408] & reg_we & ~wr_err;
+  assign wkup_detector_padsel_4_we = addr_hit[408] & reg_we & !reg_error;
   assign wkup_detector_padsel_4_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_5_we = addr_hit[409] & reg_we & ~wr_err;
+  assign wkup_detector_padsel_5_we = addr_hit[409] & reg_we & !reg_error;
   assign wkup_detector_padsel_5_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_6_we = addr_hit[410] & reg_we & ~wr_err;
+  assign wkup_detector_padsel_6_we = addr_hit[410] & reg_we & !reg_error;
   assign wkup_detector_padsel_6_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_7_we = addr_hit[411] & reg_we & ~wr_err;
+  assign wkup_detector_padsel_7_we = addr_hit[411] & reg_we & !reg_error;
   assign wkup_detector_padsel_7_wd = reg_wdata[5:0];
 
-  assign wkup_cause_cause_0_we = addr_hit[412] & reg_we & ~wr_err;
+  assign wkup_cause_cause_0_we = addr_hit[412] & reg_we & !reg_error;
   assign wkup_cause_cause_0_wd = reg_wdata[0];
-  assign wkup_cause_cause_0_re = addr_hit[412] && reg_re;
+  assign wkup_cause_cause_0_re = addr_hit[412] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_1_we = addr_hit[412] & reg_we & ~wr_err;
+  assign wkup_cause_cause_1_we = addr_hit[412] & reg_we & !reg_error;
   assign wkup_cause_cause_1_wd = reg_wdata[1];
-  assign wkup_cause_cause_1_re = addr_hit[412] && reg_re;
+  assign wkup_cause_cause_1_re = addr_hit[412] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_2_we = addr_hit[412] & reg_we & ~wr_err;
+  assign wkup_cause_cause_2_we = addr_hit[412] & reg_we & !reg_error;
   assign wkup_cause_cause_2_wd = reg_wdata[2];
-  assign wkup_cause_cause_2_re = addr_hit[412] && reg_re;
+  assign wkup_cause_cause_2_re = addr_hit[412] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_3_we = addr_hit[412] & reg_we & ~wr_err;
+  assign wkup_cause_cause_3_we = addr_hit[412] & reg_we & !reg_error;
   assign wkup_cause_cause_3_wd = reg_wdata[3];
-  assign wkup_cause_cause_3_re = addr_hit[412] && reg_re;
+  assign wkup_cause_cause_3_re = addr_hit[412] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_4_we = addr_hit[412] & reg_we & ~wr_err;
+  assign wkup_cause_cause_4_we = addr_hit[412] & reg_we & !reg_error;
   assign wkup_cause_cause_4_wd = reg_wdata[4];
-  assign wkup_cause_cause_4_re = addr_hit[412] && reg_re;
+  assign wkup_cause_cause_4_re = addr_hit[412] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_5_we = addr_hit[412] & reg_we & ~wr_err;
+  assign wkup_cause_cause_5_we = addr_hit[412] & reg_we & !reg_error;
   assign wkup_cause_cause_5_wd = reg_wdata[5];
-  assign wkup_cause_cause_5_re = addr_hit[412] && reg_re;
+  assign wkup_cause_cause_5_re = addr_hit[412] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_6_we = addr_hit[412] & reg_we & ~wr_err;
+  assign wkup_cause_cause_6_we = addr_hit[412] & reg_we & !reg_error;
   assign wkup_cause_cause_6_wd = reg_wdata[6];
-  assign wkup_cause_cause_6_re = addr_hit[412] && reg_re;
+  assign wkup_cause_cause_6_re = addr_hit[412] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_7_we = addr_hit[412] & reg_we & ~wr_err;
+  assign wkup_cause_cause_7_we = addr_hit[412] & reg_we & !reg_error;
   assign wkup_cause_cause_7_wd = reg_wdata[7];
-  assign wkup_cause_cause_7_re = addr_hit[412] && reg_re;
+  assign wkup_cause_cause_7_re = addr_hit[412] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -702,66 +702,66 @@ module pwrmgr_reg_top (
     if (addr_hit[13] && reg_we && (PWRMGR_PERMIT[13] != (PWRMGR_PERMIT[13] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_wd = reg_wdata[0];
 
-  assign intr_enable_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_wd = reg_wdata[0];
 
-  assign intr_test_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_wd = reg_wdata[0];
 
-  assign ctrl_cfg_regwen_re = addr_hit[3] && reg_re;
+  assign ctrl_cfg_regwen_re = addr_hit[3] & reg_re & !reg_error;
 
-  assign control_low_power_hint_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_low_power_hint_we = addr_hit[4] & reg_we & !reg_error;
   assign control_low_power_hint_wd = reg_wdata[0];
 
-  assign control_core_clk_en_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_core_clk_en_we = addr_hit[4] & reg_we & !reg_error;
   assign control_core_clk_en_wd = reg_wdata[4];
 
-  assign control_io_clk_en_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_io_clk_en_we = addr_hit[4] & reg_we & !reg_error;
   assign control_io_clk_en_wd = reg_wdata[5];
 
-  assign control_usb_clk_en_lp_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_usb_clk_en_lp_we = addr_hit[4] & reg_we & !reg_error;
   assign control_usb_clk_en_lp_wd = reg_wdata[6];
 
-  assign control_usb_clk_en_active_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_usb_clk_en_active_we = addr_hit[4] & reg_we & !reg_error;
   assign control_usb_clk_en_active_wd = reg_wdata[7];
 
-  assign control_main_pd_n_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_main_pd_n_we = addr_hit[4] & reg_we & !reg_error;
   assign control_main_pd_n_wd = reg_wdata[8];
 
-  assign cfg_cdc_sync_we = addr_hit[5] & reg_we & ~wr_err;
+  assign cfg_cdc_sync_we = addr_hit[5] & reg_we & !reg_error;
   assign cfg_cdc_sync_wd = reg_wdata[0];
 
-  assign wakeup_en_regwen_we = addr_hit[6] & reg_we & ~wr_err;
+  assign wakeup_en_regwen_we = addr_hit[6] & reg_we & !reg_error;
   assign wakeup_en_regwen_wd = reg_wdata[0];
 
-  assign wakeup_en_we = addr_hit[7] & reg_we & ~wr_err;
+  assign wakeup_en_we = addr_hit[7] & reg_we & !reg_error;
   assign wakeup_en_wd = reg_wdata[0];
 
 
-  assign reset_en_regwen_we = addr_hit[9] & reg_we & ~wr_err;
+  assign reset_en_regwen_we = addr_hit[9] & reg_we & !reg_error;
   assign reset_en_regwen_wd = reg_wdata[0];
 
-  assign reset_en_we = addr_hit[10] & reg_we & ~wr_err;
+  assign reset_en_we = addr_hit[10] & reg_we & !reg_error;
   assign reset_en_wd = reg_wdata[0];
 
 
-  assign wake_info_capture_dis_we = addr_hit[12] & reg_we & ~wr_err;
+  assign wake_info_capture_dis_we = addr_hit[12] & reg_we & !reg_error;
   assign wake_info_capture_dis_wd = reg_wdata[0];
 
-  assign wake_info_reasons_we = addr_hit[13] & reg_we & ~wr_err;
+  assign wake_info_reasons_we = addr_hit[13] & reg_we & !reg_error;
   assign wake_info_reasons_wd = reg_wdata[0];
-  assign wake_info_reasons_re = addr_hit[13] && reg_re;
+  assign wake_info_reasons_re = addr_hit[13] & reg_re & !reg_error;
 
-  assign wake_info_fall_through_we = addr_hit[13] & reg_we & ~wr_err;
+  assign wake_info_fall_through_we = addr_hit[13] & reg_we & !reg_error;
   assign wake_info_fall_through_wd = reg_wdata[1];
-  assign wake_info_fall_through_re = addr_hit[13] && reg_re;
+  assign wake_info_fall_through_re = addr_hit[13] & reg_re & !reg_error;
 
-  assign wake_info_abort_we = addr_hit[13] & reg_we & ~wr_err;
+  assign wake_info_abort_we = addr_hit[13] & reg_we & !reg_error;
   assign wake_info_abort_wd = reg_wdata[2];
-  assign wake_info_abort_re = addr_hit[13] && reg_re;
+  assign wake_info_abort_re = addr_hit[13] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/ip/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_reg_top.sv
@@ -433,41 +433,41 @@ module rstmgr_reg_top (
     if (addr_hit[5] && reg_we && (RSTMGR_PERMIT[5] != (RSTMGR_PERMIT[5] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign reset_info_por_we = addr_hit[0] & reg_we & ~wr_err;
+  assign reset_info_por_we = addr_hit[0] & reg_we & !reg_error;
   assign reset_info_por_wd = reg_wdata[0];
 
-  assign reset_info_low_power_exit_we = addr_hit[0] & reg_we & ~wr_err;
+  assign reset_info_low_power_exit_we = addr_hit[0] & reg_we & !reg_error;
   assign reset_info_low_power_exit_wd = reg_wdata[1];
 
-  assign reset_info_ndm_reset_we = addr_hit[0] & reg_we & ~wr_err;
+  assign reset_info_ndm_reset_we = addr_hit[0] & reg_we & !reg_error;
   assign reset_info_ndm_reset_wd = reg_wdata[2];
 
-  assign reset_info_hw_req_we = addr_hit[0] & reg_we & ~wr_err;
+  assign reset_info_hw_req_we = addr_hit[0] & reg_we & !reg_error;
   assign reset_info_hw_req_wd = reg_wdata[3];
 
-  assign alert_info_ctrl_en_we = addr_hit[1] & reg_we & ~wr_err;
+  assign alert_info_ctrl_en_we = addr_hit[1] & reg_we & !reg_error;
   assign alert_info_ctrl_en_wd = reg_wdata[0];
 
-  assign alert_info_ctrl_index_we = addr_hit[1] & reg_we & ~wr_err;
+  assign alert_info_ctrl_index_we = addr_hit[1] & reg_we & !reg_error;
   assign alert_info_ctrl_index_wd = reg_wdata[7:4];
 
-  assign alert_info_attr_re = addr_hit[2] && reg_re;
+  assign alert_info_attr_re = addr_hit[2] & reg_re & !reg_error;
 
-  assign alert_info_re = addr_hit[3] && reg_re;
+  assign alert_info_re = addr_hit[3] & reg_re & !reg_error;
 
-  assign sw_rst_regen_en_0_we = addr_hit[4] & reg_we & ~wr_err;
+  assign sw_rst_regen_en_0_we = addr_hit[4] & reg_we & !reg_error;
   assign sw_rst_regen_en_0_wd = reg_wdata[0];
 
-  assign sw_rst_regen_en_1_we = addr_hit[4] & reg_we & ~wr_err;
+  assign sw_rst_regen_en_1_we = addr_hit[4] & reg_we & !reg_error;
   assign sw_rst_regen_en_1_wd = reg_wdata[1];
 
-  assign sw_rst_ctrl_n_val_0_we = addr_hit[5] & reg_we & ~wr_err;
+  assign sw_rst_ctrl_n_val_0_we = addr_hit[5] & reg_we & !reg_error;
   assign sw_rst_ctrl_n_val_0_wd = reg_wdata[0];
-  assign sw_rst_ctrl_n_val_0_re = addr_hit[5] && reg_re;
+  assign sw_rst_ctrl_n_val_0_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign sw_rst_ctrl_n_val_1_we = addr_hit[5] & reg_we & ~wr_err;
+  assign sw_rst_ctrl_n_val_1_we = addr_hit[5] & reg_we & !reg_error;
   assign sw_rst_ctrl_n_val_1_wd = reg_wdata[1];
-  assign sw_rst_ctrl_n_val_1_re = addr_hit[5] && reg_re;
+  assign sw_rst_ctrl_n_val_1_re = addr_hit[5] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/ip/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic_reg_top.sv
@@ -3952,302 +3952,302 @@ module rv_plic_reg_top (
 
 
 
-  assign le_le_0_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_0_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_0_wd = reg_wdata[0];
 
-  assign le_le_1_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_1_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_1_wd = reg_wdata[1];
 
-  assign le_le_2_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_2_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_2_wd = reg_wdata[2];
 
-  assign le_le_3_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_3_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_3_wd = reg_wdata[3];
 
-  assign le_le_4_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_4_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_4_wd = reg_wdata[4];
 
-  assign le_le_5_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_5_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_5_wd = reg_wdata[5];
 
-  assign le_le_6_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_6_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_6_wd = reg_wdata[6];
 
-  assign le_le_7_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_7_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_7_wd = reg_wdata[7];
 
-  assign le_le_8_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_8_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_8_wd = reg_wdata[8];
 
-  assign le_le_9_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_9_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_9_wd = reg_wdata[9];
 
-  assign le_le_10_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_10_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_10_wd = reg_wdata[10];
 
-  assign le_le_11_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_11_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_11_wd = reg_wdata[11];
 
-  assign le_le_12_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_12_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_12_wd = reg_wdata[12];
 
-  assign le_le_13_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_13_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_13_wd = reg_wdata[13];
 
-  assign le_le_14_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_14_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_14_wd = reg_wdata[14];
 
-  assign le_le_15_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_15_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_15_wd = reg_wdata[15];
 
-  assign le_le_16_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_16_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_16_wd = reg_wdata[16];
 
-  assign le_le_17_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_17_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_17_wd = reg_wdata[17];
 
-  assign le_le_18_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_18_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_18_wd = reg_wdata[18];
 
-  assign le_le_19_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_19_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_19_wd = reg_wdata[19];
 
-  assign le_le_20_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_20_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_20_wd = reg_wdata[20];
 
-  assign le_le_21_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_21_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_21_wd = reg_wdata[21];
 
-  assign le_le_22_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_22_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_22_wd = reg_wdata[22];
 
-  assign le_le_23_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_23_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_23_wd = reg_wdata[23];
 
-  assign le_le_24_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_24_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_24_wd = reg_wdata[24];
 
-  assign le_le_25_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_25_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_25_wd = reg_wdata[25];
 
-  assign le_le_26_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_26_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_26_wd = reg_wdata[26];
 
-  assign le_le_27_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_27_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_27_wd = reg_wdata[27];
 
-  assign le_le_28_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_28_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_28_wd = reg_wdata[28];
 
-  assign le_le_29_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_29_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_29_wd = reg_wdata[29];
 
-  assign le_le_30_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_30_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_30_wd = reg_wdata[30];
 
-  assign le_le_31_we = addr_hit[1] & reg_we & ~wr_err;
+  assign le_le_31_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_31_wd = reg_wdata[31];
 
-  assign prio0_we = addr_hit[2] & reg_we & ~wr_err;
+  assign prio0_we = addr_hit[2] & reg_we & !reg_error;
   assign prio0_wd = reg_wdata[2:0];
 
-  assign prio1_we = addr_hit[3] & reg_we & ~wr_err;
+  assign prio1_we = addr_hit[3] & reg_we & !reg_error;
   assign prio1_wd = reg_wdata[2:0];
 
-  assign prio2_we = addr_hit[4] & reg_we & ~wr_err;
+  assign prio2_we = addr_hit[4] & reg_we & !reg_error;
   assign prio2_wd = reg_wdata[2:0];
 
-  assign prio3_we = addr_hit[5] & reg_we & ~wr_err;
+  assign prio3_we = addr_hit[5] & reg_we & !reg_error;
   assign prio3_wd = reg_wdata[2:0];
 
-  assign prio4_we = addr_hit[6] & reg_we & ~wr_err;
+  assign prio4_we = addr_hit[6] & reg_we & !reg_error;
   assign prio4_wd = reg_wdata[2:0];
 
-  assign prio5_we = addr_hit[7] & reg_we & ~wr_err;
+  assign prio5_we = addr_hit[7] & reg_we & !reg_error;
   assign prio5_wd = reg_wdata[2:0];
 
-  assign prio6_we = addr_hit[8] & reg_we & ~wr_err;
+  assign prio6_we = addr_hit[8] & reg_we & !reg_error;
   assign prio6_wd = reg_wdata[2:0];
 
-  assign prio7_we = addr_hit[9] & reg_we & ~wr_err;
+  assign prio7_we = addr_hit[9] & reg_we & !reg_error;
   assign prio7_wd = reg_wdata[2:0];
 
-  assign prio8_we = addr_hit[10] & reg_we & ~wr_err;
+  assign prio8_we = addr_hit[10] & reg_we & !reg_error;
   assign prio8_wd = reg_wdata[2:0];
 
-  assign prio9_we = addr_hit[11] & reg_we & ~wr_err;
+  assign prio9_we = addr_hit[11] & reg_we & !reg_error;
   assign prio9_wd = reg_wdata[2:0];
 
-  assign prio10_we = addr_hit[12] & reg_we & ~wr_err;
+  assign prio10_we = addr_hit[12] & reg_we & !reg_error;
   assign prio10_wd = reg_wdata[2:0];
 
-  assign prio11_we = addr_hit[13] & reg_we & ~wr_err;
+  assign prio11_we = addr_hit[13] & reg_we & !reg_error;
   assign prio11_wd = reg_wdata[2:0];
 
-  assign prio12_we = addr_hit[14] & reg_we & ~wr_err;
+  assign prio12_we = addr_hit[14] & reg_we & !reg_error;
   assign prio12_wd = reg_wdata[2:0];
 
-  assign prio13_we = addr_hit[15] & reg_we & ~wr_err;
+  assign prio13_we = addr_hit[15] & reg_we & !reg_error;
   assign prio13_wd = reg_wdata[2:0];
 
-  assign prio14_we = addr_hit[16] & reg_we & ~wr_err;
+  assign prio14_we = addr_hit[16] & reg_we & !reg_error;
   assign prio14_wd = reg_wdata[2:0];
 
-  assign prio15_we = addr_hit[17] & reg_we & ~wr_err;
+  assign prio15_we = addr_hit[17] & reg_we & !reg_error;
   assign prio15_wd = reg_wdata[2:0];
 
-  assign prio16_we = addr_hit[18] & reg_we & ~wr_err;
+  assign prio16_we = addr_hit[18] & reg_we & !reg_error;
   assign prio16_wd = reg_wdata[2:0];
 
-  assign prio17_we = addr_hit[19] & reg_we & ~wr_err;
+  assign prio17_we = addr_hit[19] & reg_we & !reg_error;
   assign prio17_wd = reg_wdata[2:0];
 
-  assign prio18_we = addr_hit[20] & reg_we & ~wr_err;
+  assign prio18_we = addr_hit[20] & reg_we & !reg_error;
   assign prio18_wd = reg_wdata[2:0];
 
-  assign prio19_we = addr_hit[21] & reg_we & ~wr_err;
+  assign prio19_we = addr_hit[21] & reg_we & !reg_error;
   assign prio19_wd = reg_wdata[2:0];
 
-  assign prio20_we = addr_hit[22] & reg_we & ~wr_err;
+  assign prio20_we = addr_hit[22] & reg_we & !reg_error;
   assign prio20_wd = reg_wdata[2:0];
 
-  assign prio21_we = addr_hit[23] & reg_we & ~wr_err;
+  assign prio21_we = addr_hit[23] & reg_we & !reg_error;
   assign prio21_wd = reg_wdata[2:0];
 
-  assign prio22_we = addr_hit[24] & reg_we & ~wr_err;
+  assign prio22_we = addr_hit[24] & reg_we & !reg_error;
   assign prio22_wd = reg_wdata[2:0];
 
-  assign prio23_we = addr_hit[25] & reg_we & ~wr_err;
+  assign prio23_we = addr_hit[25] & reg_we & !reg_error;
   assign prio23_wd = reg_wdata[2:0];
 
-  assign prio24_we = addr_hit[26] & reg_we & ~wr_err;
+  assign prio24_we = addr_hit[26] & reg_we & !reg_error;
   assign prio24_wd = reg_wdata[2:0];
 
-  assign prio25_we = addr_hit[27] & reg_we & ~wr_err;
+  assign prio25_we = addr_hit[27] & reg_we & !reg_error;
   assign prio25_wd = reg_wdata[2:0];
 
-  assign prio26_we = addr_hit[28] & reg_we & ~wr_err;
+  assign prio26_we = addr_hit[28] & reg_we & !reg_error;
   assign prio26_wd = reg_wdata[2:0];
 
-  assign prio27_we = addr_hit[29] & reg_we & ~wr_err;
+  assign prio27_we = addr_hit[29] & reg_we & !reg_error;
   assign prio27_wd = reg_wdata[2:0];
 
-  assign prio28_we = addr_hit[30] & reg_we & ~wr_err;
+  assign prio28_we = addr_hit[30] & reg_we & !reg_error;
   assign prio28_wd = reg_wdata[2:0];
 
-  assign prio29_we = addr_hit[31] & reg_we & ~wr_err;
+  assign prio29_we = addr_hit[31] & reg_we & !reg_error;
   assign prio29_wd = reg_wdata[2:0];
 
-  assign prio30_we = addr_hit[32] & reg_we & ~wr_err;
+  assign prio30_we = addr_hit[32] & reg_we & !reg_error;
   assign prio30_wd = reg_wdata[2:0];
 
-  assign prio31_we = addr_hit[33] & reg_we & ~wr_err;
+  assign prio31_we = addr_hit[33] & reg_we & !reg_error;
   assign prio31_wd = reg_wdata[2:0];
 
-  assign ie0_e_0_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_0_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_0_wd = reg_wdata[0];
 
-  assign ie0_e_1_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_1_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_1_wd = reg_wdata[1];
 
-  assign ie0_e_2_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_2_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_2_wd = reg_wdata[2];
 
-  assign ie0_e_3_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_3_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_3_wd = reg_wdata[3];
 
-  assign ie0_e_4_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_4_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_4_wd = reg_wdata[4];
 
-  assign ie0_e_5_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_5_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_5_wd = reg_wdata[5];
 
-  assign ie0_e_6_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_6_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_6_wd = reg_wdata[6];
 
-  assign ie0_e_7_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_7_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_7_wd = reg_wdata[7];
 
-  assign ie0_e_8_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_8_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_8_wd = reg_wdata[8];
 
-  assign ie0_e_9_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_9_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_9_wd = reg_wdata[9];
 
-  assign ie0_e_10_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_10_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_10_wd = reg_wdata[10];
 
-  assign ie0_e_11_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_11_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_11_wd = reg_wdata[11];
 
-  assign ie0_e_12_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_12_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_12_wd = reg_wdata[12];
 
-  assign ie0_e_13_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_13_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_13_wd = reg_wdata[13];
 
-  assign ie0_e_14_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_14_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_14_wd = reg_wdata[14];
 
-  assign ie0_e_15_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_15_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_15_wd = reg_wdata[15];
 
-  assign ie0_e_16_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_16_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_16_wd = reg_wdata[16];
 
-  assign ie0_e_17_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_17_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_17_wd = reg_wdata[17];
 
-  assign ie0_e_18_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_18_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_18_wd = reg_wdata[18];
 
-  assign ie0_e_19_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_19_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_19_wd = reg_wdata[19];
 
-  assign ie0_e_20_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_20_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_20_wd = reg_wdata[20];
 
-  assign ie0_e_21_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_21_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_21_wd = reg_wdata[21];
 
-  assign ie0_e_22_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_22_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_22_wd = reg_wdata[22];
 
-  assign ie0_e_23_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_23_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_23_wd = reg_wdata[23];
 
-  assign ie0_e_24_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_24_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_24_wd = reg_wdata[24];
 
-  assign ie0_e_25_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_25_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_25_wd = reg_wdata[25];
 
-  assign ie0_e_26_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_26_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_26_wd = reg_wdata[26];
 
-  assign ie0_e_27_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_27_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_27_wd = reg_wdata[27];
 
-  assign ie0_e_28_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_28_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_28_wd = reg_wdata[28];
 
-  assign ie0_e_29_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_29_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_29_wd = reg_wdata[29];
 
-  assign ie0_e_30_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_30_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_30_wd = reg_wdata[30];
 
-  assign ie0_e_31_we = addr_hit[34] & reg_we & ~wr_err;
+  assign ie0_e_31_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_31_wd = reg_wdata[31];
 
-  assign threshold0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign threshold0_we = addr_hit[35] & reg_we & !reg_error;
   assign threshold0_wd = reg_wdata[2:0];
 
-  assign cc0_we = addr_hit[36] & reg_we & ~wr_err;
+  assign cc0_we = addr_hit[36] & reg_we & !reg_error;
   assign cc0_wd = reg_wdata[5:0];
-  assign cc0_re = addr_hit[36] && reg_re;
+  assign cc0_re = addr_hit[36] & reg_re & !reg_error;
 
-  assign msip0_we = addr_hit[37] & reg_we & ~wr_err;
+  assign msip0_we = addr_hit[37] & reg_we & !reg_error;
   assign msip0_wd = reg_wdata[0];
 
   // Read data return

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
@@ -415,34 +415,34 @@ module rv_timer_reg_top (
     if (addr_hit[8] && reg_we && (RV_TIMER_PERMIT[8] != (RV_TIMER_PERMIT[8] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign ctrl_we = addr_hit[0] & reg_we & ~wr_err;
+  assign ctrl_we = addr_hit[0] & reg_we & !reg_error;
   assign ctrl_wd = reg_wdata[0];
 
-  assign cfg0_prescale_we = addr_hit[1] & reg_we & ~wr_err;
+  assign cfg0_prescale_we = addr_hit[1] & reg_we & !reg_error;
   assign cfg0_prescale_wd = reg_wdata[11:0];
 
-  assign cfg0_step_we = addr_hit[1] & reg_we & ~wr_err;
+  assign cfg0_step_we = addr_hit[1] & reg_we & !reg_error;
   assign cfg0_step_wd = reg_wdata[23:16];
 
-  assign timer_v_lower0_we = addr_hit[2] & reg_we & ~wr_err;
+  assign timer_v_lower0_we = addr_hit[2] & reg_we & !reg_error;
   assign timer_v_lower0_wd = reg_wdata[31:0];
 
-  assign timer_v_upper0_we = addr_hit[3] & reg_we & ~wr_err;
+  assign timer_v_upper0_we = addr_hit[3] & reg_we & !reg_error;
   assign timer_v_upper0_wd = reg_wdata[31:0];
 
-  assign compare_lower0_0_we = addr_hit[4] & reg_we & ~wr_err;
+  assign compare_lower0_0_we = addr_hit[4] & reg_we & !reg_error;
   assign compare_lower0_0_wd = reg_wdata[31:0];
 
-  assign compare_upper0_0_we = addr_hit[5] & reg_we & ~wr_err;
+  assign compare_upper0_0_we = addr_hit[5] & reg_we & !reg_error;
   assign compare_upper0_0_wd = reg_wdata[31:0];
 
-  assign intr_enable0_we = addr_hit[6] & reg_we & ~wr_err;
+  assign intr_enable0_we = addr_hit[6] & reg_we & !reg_error;
   assign intr_enable0_wd = reg_wdata[0];
 
-  assign intr_state0_we = addr_hit[7] & reg_we & ~wr_err;
+  assign intr_state0_we = addr_hit[7] & reg_we & !reg_error;
   assign intr_state0_wd = reg_wdata[0];
 
-  assign intr_test0_we = addr_hit[8] & reg_we & ~wr_err;
+  assign intr_test0_we = addr_hit[8] & reg_we & !reg_error;
   assign intr_test0_wd = reg_wdata[0];
 
   // Read data return

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -1329,127 +1329,127 @@ module spi_device_reg_top (
     if (addr_hit[11] && reg_we && (SPI_DEVICE_PERMIT[11] != (SPI_DEVICE_PERMIT[11] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_rxf_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rxf_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rxf_wd = reg_wdata[0];
 
-  assign intr_state_rxlvl_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rxlvl_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rxlvl_wd = reg_wdata[1];
 
-  assign intr_state_txlvl_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_txlvl_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_txlvl_wd = reg_wdata[2];
 
-  assign intr_state_rxerr_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rxerr_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rxerr_wd = reg_wdata[3];
 
-  assign intr_state_rxoverflow_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rxoverflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rxoverflow_wd = reg_wdata[4];
 
-  assign intr_state_txunderflow_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_txunderflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_txunderflow_wd = reg_wdata[5];
 
-  assign intr_enable_rxf_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rxf_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rxf_wd = reg_wdata[0];
 
-  assign intr_enable_rxlvl_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rxlvl_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rxlvl_wd = reg_wdata[1];
 
-  assign intr_enable_txlvl_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_txlvl_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_txlvl_wd = reg_wdata[2];
 
-  assign intr_enable_rxerr_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rxerr_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rxerr_wd = reg_wdata[3];
 
-  assign intr_enable_rxoverflow_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rxoverflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rxoverflow_wd = reg_wdata[4];
 
-  assign intr_enable_txunderflow_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_txunderflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_txunderflow_wd = reg_wdata[5];
 
-  assign intr_test_rxf_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rxf_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rxf_wd = reg_wdata[0];
 
-  assign intr_test_rxlvl_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rxlvl_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rxlvl_wd = reg_wdata[1];
 
-  assign intr_test_txlvl_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_txlvl_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_txlvl_wd = reg_wdata[2];
 
-  assign intr_test_rxerr_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rxerr_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rxerr_wd = reg_wdata[3];
 
-  assign intr_test_rxoverflow_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rxoverflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rxoverflow_wd = reg_wdata[4];
 
-  assign intr_test_txunderflow_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_txunderflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_txunderflow_wd = reg_wdata[5];
 
-  assign control_abort_we = addr_hit[3] & reg_we & ~wr_err;
+  assign control_abort_we = addr_hit[3] & reg_we & !reg_error;
   assign control_abort_wd = reg_wdata[0];
 
-  assign control_mode_we = addr_hit[3] & reg_we & ~wr_err;
+  assign control_mode_we = addr_hit[3] & reg_we & !reg_error;
   assign control_mode_wd = reg_wdata[5:4];
 
-  assign control_rst_txfifo_we = addr_hit[3] & reg_we & ~wr_err;
+  assign control_rst_txfifo_we = addr_hit[3] & reg_we & !reg_error;
   assign control_rst_txfifo_wd = reg_wdata[16];
 
-  assign control_rst_rxfifo_we = addr_hit[3] & reg_we & ~wr_err;
+  assign control_rst_rxfifo_we = addr_hit[3] & reg_we & !reg_error;
   assign control_rst_rxfifo_wd = reg_wdata[17];
 
-  assign cfg_cpol_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cfg_cpol_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_cpol_wd = reg_wdata[0];
 
-  assign cfg_cpha_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cfg_cpha_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_cpha_wd = reg_wdata[1];
 
-  assign cfg_tx_order_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cfg_tx_order_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_tx_order_wd = reg_wdata[2];
 
-  assign cfg_rx_order_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cfg_rx_order_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_rx_order_wd = reg_wdata[3];
 
-  assign cfg_timer_v_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cfg_timer_v_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_timer_v_wd = reg_wdata[15:8];
 
-  assign fifo_level_rxlvl_we = addr_hit[5] & reg_we & ~wr_err;
+  assign fifo_level_rxlvl_we = addr_hit[5] & reg_we & !reg_error;
   assign fifo_level_rxlvl_wd = reg_wdata[15:0];
 
-  assign fifo_level_txlvl_we = addr_hit[5] & reg_we & ~wr_err;
+  assign fifo_level_txlvl_we = addr_hit[5] & reg_we & !reg_error;
   assign fifo_level_txlvl_wd = reg_wdata[31:16];
 
-  assign async_fifo_level_rxlvl_re = addr_hit[6] && reg_re;
+  assign async_fifo_level_rxlvl_re = addr_hit[6] & reg_re & !reg_error;
 
-  assign async_fifo_level_txlvl_re = addr_hit[6] && reg_re;
+  assign async_fifo_level_txlvl_re = addr_hit[6] & reg_re & !reg_error;
 
-  assign status_rxf_full_re = addr_hit[7] && reg_re;
+  assign status_rxf_full_re = addr_hit[7] & reg_re & !reg_error;
 
-  assign status_rxf_empty_re = addr_hit[7] && reg_re;
+  assign status_rxf_empty_re = addr_hit[7] & reg_re & !reg_error;
 
-  assign status_txf_full_re = addr_hit[7] && reg_re;
+  assign status_txf_full_re = addr_hit[7] & reg_re & !reg_error;
 
-  assign status_txf_empty_re = addr_hit[7] && reg_re;
+  assign status_txf_empty_re = addr_hit[7] & reg_re & !reg_error;
 
-  assign status_abort_done_re = addr_hit[7] && reg_re;
+  assign status_abort_done_re = addr_hit[7] & reg_re & !reg_error;
 
-  assign status_csb_re = addr_hit[7] && reg_re;
+  assign status_csb_re = addr_hit[7] & reg_re & !reg_error;
 
-  assign rxf_ptr_rptr_we = addr_hit[8] & reg_we & ~wr_err;
+  assign rxf_ptr_rptr_we = addr_hit[8] & reg_we & !reg_error;
   assign rxf_ptr_rptr_wd = reg_wdata[15:0];
 
 
 
-  assign txf_ptr_wptr_we = addr_hit[9] & reg_we & ~wr_err;
+  assign txf_ptr_wptr_we = addr_hit[9] & reg_we & !reg_error;
   assign txf_ptr_wptr_wd = reg_wdata[31:16];
 
-  assign rxf_addr_base_we = addr_hit[10] & reg_we & ~wr_err;
+  assign rxf_addr_base_we = addr_hit[10] & reg_we & !reg_error;
   assign rxf_addr_base_wd = reg_wdata[15:0];
 
-  assign rxf_addr_limit_we = addr_hit[10] & reg_we & ~wr_err;
+  assign rxf_addr_limit_we = addr_hit[10] & reg_we & !reg_error;
   assign rxf_addr_limit_wd = reg_wdata[31:16];
 
-  assign txf_addr_base_we = addr_hit[11] & reg_we & ~wr_err;
+  assign txf_addr_base_we = addr_hit[11] & reg_we & !reg_error;
   assign txf_addr_base_wd = reg_wdata[15:0];
 
-  assign txf_addr_limit_we = addr_hit[11] & reg_we & ~wr_err;
+  assign txf_addr_limit_we = addr_hit[11] & reg_we & !reg_error;
   assign txf_addr_limit_wd = reg_wdata[31:16];
 
   // Read data return

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -1776,49 +1776,49 @@ module spi_host_reg_top (
     if (addr_hit[10] && reg_we && (SPI_HOST_PERMIT[10] != (SPI_HOST_PERMIT[10] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_error_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_error_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_error_wd = reg_wdata[0];
 
-  assign intr_state_spi_event_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_spi_event_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_spi_event_wd = reg_wdata[1];
 
-  assign intr_enable_error_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_error_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_error_wd = reg_wdata[0];
 
-  assign intr_enable_spi_event_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_spi_event_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_spi_event_wd = reg_wdata[1];
 
-  assign intr_test_error_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_error_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_error_wd = reg_wdata[0];
 
-  assign intr_test_spi_event_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_spi_event_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_spi_event_wd = reg_wdata[1];
 
-  assign control_manual_cs_we = addr_hit[3] & reg_we & ~wr_err;
+  assign control_manual_cs_we = addr_hit[3] & reg_we & !reg_error;
   assign control_manual_cs_wd = reg_wdata[7:0];
 
-  assign control_mancs_en_we = addr_hit[3] & reg_we & ~wr_err;
+  assign control_mancs_en_we = addr_hit[3] & reg_we & !reg_error;
   assign control_mancs_en_wd = reg_wdata[8];
 
-  assign control_rx_watermark_we = addr_hit[3] & reg_we & ~wr_err;
+  assign control_rx_watermark_we = addr_hit[3] & reg_we & !reg_error;
   assign control_rx_watermark_wd = reg_wdata[15:9];
 
-  assign control_tx_watermark_we = addr_hit[3] & reg_we & ~wr_err;
+  assign control_tx_watermark_we = addr_hit[3] & reg_we & !reg_error;
   assign control_tx_watermark_wd = reg_wdata[24:16];
 
-  assign control_passthru_we = addr_hit[3] & reg_we & ~wr_err;
+  assign control_passthru_we = addr_hit[3] & reg_we & !reg_error;
   assign control_passthru_wd = reg_wdata[27];
 
-  assign control_rst_rxfifo_we = addr_hit[3] & reg_we & ~wr_err;
+  assign control_rst_rxfifo_we = addr_hit[3] & reg_we & !reg_error;
   assign control_rst_rxfifo_wd = reg_wdata[28];
 
-  assign control_rst_txfifo_we = addr_hit[3] & reg_we & ~wr_err;
+  assign control_rst_txfifo_we = addr_hit[3] & reg_we & !reg_error;
   assign control_rst_txfifo_wd = reg_wdata[29];
 
-  assign control_rst_fsm_we = addr_hit[3] & reg_we & ~wr_err;
+  assign control_rst_fsm_we = addr_hit[3] & reg_we & !reg_error;
   assign control_rst_fsm_wd = reg_wdata[30];
 
-  assign control_spien_we = addr_hit[3] & reg_we & ~wr_err;
+  assign control_spien_we = addr_hit[3] & reg_we & !reg_error;
   assign control_spien_wd = reg_wdata[31];
 
 
@@ -1834,90 +1834,90 @@ module spi_host_reg_top (
 
 
 
-  assign configopts_clkdiv_0_we = addr_hit[5] & reg_we & ~wr_err;
+  assign configopts_clkdiv_0_we = addr_hit[5] & reg_we & !reg_error;
   assign configopts_clkdiv_0_wd = reg_wdata[15:0];
 
-  assign configopts_csnidle_0_we = addr_hit[5] & reg_we & ~wr_err;
+  assign configopts_csnidle_0_we = addr_hit[5] & reg_we & !reg_error;
   assign configopts_csnidle_0_wd = reg_wdata[19:16];
 
-  assign configopts_csntrail_0_we = addr_hit[5] & reg_we & ~wr_err;
+  assign configopts_csntrail_0_we = addr_hit[5] & reg_we & !reg_error;
   assign configopts_csntrail_0_wd = reg_wdata[23:20];
 
-  assign configopts_csnlead_0_we = addr_hit[5] & reg_we & ~wr_err;
+  assign configopts_csnlead_0_we = addr_hit[5] & reg_we & !reg_error;
   assign configopts_csnlead_0_wd = reg_wdata[27:24];
 
-  assign configopts_csaat_0_we = addr_hit[5] & reg_we & ~wr_err;
+  assign configopts_csaat_0_we = addr_hit[5] & reg_we & !reg_error;
   assign configopts_csaat_0_wd = reg_wdata[28];
 
-  assign configopts_fullcyc_0_we = addr_hit[5] & reg_we & ~wr_err;
+  assign configopts_fullcyc_0_we = addr_hit[5] & reg_we & !reg_error;
   assign configopts_fullcyc_0_wd = reg_wdata[29];
 
-  assign configopts_cpha_0_we = addr_hit[5] & reg_we & ~wr_err;
+  assign configopts_cpha_0_we = addr_hit[5] & reg_we & !reg_error;
   assign configopts_cpha_0_wd = reg_wdata[30];
 
-  assign configopts_cpol_0_we = addr_hit[5] & reg_we & ~wr_err;
+  assign configopts_cpol_0_we = addr_hit[5] & reg_we & !reg_error;
   assign configopts_cpol_0_wd = reg_wdata[31];
 
-  assign command_tx1_cnt_0_we = addr_hit[6] & reg_we & ~wr_err;
+  assign command_tx1_cnt_0_we = addr_hit[6] & reg_we & !reg_error;
   assign command_tx1_cnt_0_wd = reg_wdata[3:0];
 
-  assign command_txn_cnt_0_we = addr_hit[6] & reg_we & ~wr_err;
+  assign command_txn_cnt_0_we = addr_hit[6] & reg_we & !reg_error;
   assign command_txn_cnt_0_wd = reg_wdata[12:4];
 
-  assign command_dummy_cycles_0_we = addr_hit[6] & reg_we & ~wr_err;
+  assign command_dummy_cycles_0_we = addr_hit[6] & reg_we & !reg_error;
   assign command_dummy_cycles_0_wd = reg_wdata[16:13];
 
-  assign command_rx_cnt_0_we = addr_hit[6] & reg_we & ~wr_err;
+  assign command_rx_cnt_0_we = addr_hit[6] & reg_we & !reg_error;
   assign command_rx_cnt_0_wd = reg_wdata[25:17];
 
-  assign command_fulldplx_0_we = addr_hit[6] & reg_we & ~wr_err;
+  assign command_fulldplx_0_we = addr_hit[6] & reg_we & !reg_error;
   assign command_fulldplx_0_wd = reg_wdata[26];
 
-  assign command_highz_0_we = addr_hit[6] & reg_we & ~wr_err;
+  assign command_highz_0_we = addr_hit[6] & reg_we & !reg_error;
   assign command_highz_0_wd = reg_wdata[27];
 
-  assign command_speed_0_we = addr_hit[6] & reg_we & ~wr_err;
+  assign command_speed_0_we = addr_hit[6] & reg_we & !reg_error;
   assign command_speed_0_wd = reg_wdata[30:29];
 
-  assign command_go_0_we = addr_hit[6] & reg_we & ~wr_err;
+  assign command_go_0_we = addr_hit[6] & reg_we & !reg_error;
   assign command_go_0_wd = reg_wdata[31];
 
-  assign rxdata_re = addr_hit[7] && reg_re;
+  assign rxdata_re = addr_hit[7] & reg_re & !reg_error;
 
-  assign error_enable_cmderr_we = addr_hit[8] & reg_we & ~wr_err;
+  assign error_enable_cmderr_we = addr_hit[8] & reg_we & !reg_error;
   assign error_enable_cmderr_wd = reg_wdata[0];
 
-  assign error_enable_overflow_we = addr_hit[8] & reg_we & ~wr_err;
+  assign error_enable_overflow_we = addr_hit[8] & reg_we & !reg_error;
   assign error_enable_overflow_wd = reg_wdata[1];
 
-  assign error_enable_underflow_we = addr_hit[8] & reg_we & ~wr_err;
+  assign error_enable_underflow_we = addr_hit[8] & reg_we & !reg_error;
   assign error_enable_underflow_wd = reg_wdata[2];
 
-  assign error_status_cmderr_we = addr_hit[9] & reg_we & ~wr_err;
+  assign error_status_cmderr_we = addr_hit[9] & reg_we & !reg_error;
   assign error_status_cmderr_wd = reg_wdata[0];
 
-  assign error_status_overflow_we = addr_hit[9] & reg_we & ~wr_err;
+  assign error_status_overflow_we = addr_hit[9] & reg_we & !reg_error;
   assign error_status_overflow_wd = reg_wdata[1];
 
-  assign error_status_underflow_we = addr_hit[9] & reg_we & ~wr_err;
+  assign error_status_underflow_we = addr_hit[9] & reg_we & !reg_error;
   assign error_status_underflow_wd = reg_wdata[2];
 
-  assign event_enable_rxfull_we = addr_hit[10] & reg_we & ~wr_err;
+  assign event_enable_rxfull_we = addr_hit[10] & reg_we & !reg_error;
   assign event_enable_rxfull_wd = reg_wdata[2];
 
-  assign event_enable_txempty_we = addr_hit[10] & reg_we & ~wr_err;
+  assign event_enable_txempty_we = addr_hit[10] & reg_we & !reg_error;
   assign event_enable_txempty_wd = reg_wdata[3];
 
-  assign event_enable_rxwm_we = addr_hit[10] & reg_we & ~wr_err;
+  assign event_enable_rxwm_we = addr_hit[10] & reg_we & !reg_error;
   assign event_enable_rxwm_wd = reg_wdata[4];
 
-  assign event_enable_txwm_we = addr_hit[10] & reg_we & ~wr_err;
+  assign event_enable_txwm_we = addr_hit[10] & reg_we & !reg_error;
   assign event_enable_txwm_wd = reg_wdata[5];
 
-  assign event_enable_ready_we = addr_hit[10] & reg_we & ~wr_err;
+  assign event_enable_ready_we = addr_hit[10] & reg_we & !reg_error;
   assign event_enable_ready_wd = reg_wdata[6];
 
-  assign event_enable_idle_we = addr_hit[10] & reg_we & ~wr_err;
+  assign event_enable_idle_we = addr_hit[10] & reg_we & !reg_error;
   assign event_enable_idle_wd = reg_wdata[7];
 
   // Read data return

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_top.sv
@@ -339,27 +339,27 @@ module sram_ctrl_reg_top (
     if (addr_hit[6] && reg_we && (SRAM_CTRL_PERMIT[6] != (SRAM_CTRL_PERMIT[6] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign alert_test_we = addr_hit[0] & reg_we & ~wr_err;
+  assign alert_test_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_wd = reg_wdata[0];
 
-  assign status_error_re = addr_hit[1] && reg_re;
+  assign status_error_re = addr_hit[1] & reg_re & !reg_error;
 
-  assign status_escalated_re = addr_hit[1] && reg_re;
+  assign status_escalated_re = addr_hit[1] & reg_re & !reg_error;
 
-  assign status_scr_key_valid_re = addr_hit[1] && reg_re;
+  assign status_scr_key_valid_re = addr_hit[1] & reg_re & !reg_error;
 
-  assign status_scr_key_seed_valid_re = addr_hit[1] && reg_re;
+  assign status_scr_key_seed_valid_re = addr_hit[1] & reg_re & !reg_error;
 
-  assign exec_regwen_we = addr_hit[2] & reg_we & ~wr_err;
+  assign exec_regwen_we = addr_hit[2] & reg_we & !reg_error;
   assign exec_regwen_wd = reg_wdata[0];
 
-  assign exec_we = addr_hit[3] & reg_we & ~wr_err;
+  assign exec_we = addr_hit[3] & reg_we & !reg_error;
   assign exec_wd = reg_wdata[2:0];
 
-  assign ctrl_regwen_we = addr_hit[4] & reg_we & ~wr_err;
+  assign ctrl_regwen_we = addr_hit[4] & reg_we & !reg_error;
   assign ctrl_regwen_wd = reg_wdata[0];
 
-  assign ctrl_we = addr_hit[5] & reg_we & ~wr_err;
+  assign ctrl_we = addr_hit[5] & reg_we & !reg_error;
   assign ctrl_wd = reg_wdata[0];
 
 

--- a/hw/ip/tlul/rtl/tlul_adapter_reg.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_reg.sv
@@ -90,7 +90,7 @@ module tlul_adapter_reg import tlul_pkg::*; #(
       rdata  <= '0;
       error <= 1'b0;
     end else if (a_ack) begin
-      rdata <= (err_internal) ? '1 : rdata_i;
+      rdata <= (error_i || err_internal) ? '1 : rdata_i;
       error <= error_i | err_internal;
     end
   end

--- a/hw/ip/trial1/rtl/trial1_reg_top.sv
+++ b/hw/ip/trial1/rtl/trial1_reg_top.sv
@@ -1076,97 +1076,97 @@ module trial1_reg_top (
     if (addr_hit[19] && reg_we && (TRIAL1_PERMIT[19] != (TRIAL1_PERMIT[19] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign rwtype0_we = addr_hit[0] & reg_we & ~wr_err;
+  assign rwtype0_we = addr_hit[0] & reg_we & !reg_error;
   assign rwtype0_wd = reg_wdata[31:0];
 
-  assign rwtype1_field0_we = addr_hit[1] & reg_we & ~wr_err;
+  assign rwtype1_field0_we = addr_hit[1] & reg_we & !reg_error;
   assign rwtype1_field0_wd = reg_wdata[0];
 
-  assign rwtype1_field1_we = addr_hit[1] & reg_we & ~wr_err;
+  assign rwtype1_field1_we = addr_hit[1] & reg_we & !reg_error;
   assign rwtype1_field1_wd = reg_wdata[1];
 
-  assign rwtype1_field4_we = addr_hit[1] & reg_we & ~wr_err;
+  assign rwtype1_field4_we = addr_hit[1] & reg_we & !reg_error;
   assign rwtype1_field4_wd = reg_wdata[4];
 
-  assign rwtype1_field15_8_we = addr_hit[1] & reg_we & ~wr_err;
+  assign rwtype1_field15_8_we = addr_hit[1] & reg_we & !reg_error;
   assign rwtype1_field15_8_wd = reg_wdata[15:8];
 
-  assign rwtype2_we = addr_hit[2] & reg_we & ~wr_err;
+  assign rwtype2_we = addr_hit[2] & reg_we & !reg_error;
   assign rwtype2_wd = reg_wdata[31:0];
 
-  assign rwtype3_field0_we = addr_hit[3] & reg_we & ~wr_err;
+  assign rwtype3_field0_we = addr_hit[3] & reg_we & !reg_error;
   assign rwtype3_field0_wd = reg_wdata[15:0];
 
-  assign rwtype3_field1_we = addr_hit[3] & reg_we & ~wr_err;
+  assign rwtype3_field1_we = addr_hit[3] & reg_we & !reg_error;
   assign rwtype3_field1_wd = reg_wdata[31:16];
 
-  assign rwtype4_field0_we = addr_hit[4] & reg_we & ~wr_err;
+  assign rwtype4_field0_we = addr_hit[4] & reg_we & !reg_error;
   assign rwtype4_field0_wd = reg_wdata[15:0];
 
-  assign rwtype4_field1_we = addr_hit[4] & reg_we & ~wr_err;
+  assign rwtype4_field1_we = addr_hit[4] & reg_we & !reg_error;
   assign rwtype4_field1_wd = reg_wdata[31:16];
 
 
-  assign w1ctype0_we = addr_hit[6] & reg_we & ~wr_err;
+  assign w1ctype0_we = addr_hit[6] & reg_we & !reg_error;
   assign w1ctype0_wd = reg_wdata[31:0];
 
-  assign w1ctype1_field0_we = addr_hit[7] & reg_we & ~wr_err;
+  assign w1ctype1_field0_we = addr_hit[7] & reg_we & !reg_error;
   assign w1ctype1_field0_wd = reg_wdata[15:0];
 
-  assign w1ctype1_field1_we = addr_hit[7] & reg_we & ~wr_err;
+  assign w1ctype1_field1_we = addr_hit[7] & reg_we & !reg_error;
   assign w1ctype1_field1_wd = reg_wdata[31:16];
 
-  assign w1ctype2_we = addr_hit[8] & reg_we & ~wr_err;
+  assign w1ctype2_we = addr_hit[8] & reg_we & !reg_error;
   assign w1ctype2_wd = reg_wdata[31:0];
 
-  assign w1stype2_we = addr_hit[9] & reg_we & ~wr_err;
+  assign w1stype2_we = addr_hit[9] & reg_we & !reg_error;
   assign w1stype2_wd = reg_wdata[31:0];
 
-  assign w0ctype2_we = addr_hit[10] & reg_we & ~wr_err;
+  assign w0ctype2_we = addr_hit[10] & reg_we & !reg_error;
   assign w0ctype2_wd = reg_wdata[31:0];
 
-  assign r0w1ctype2_we = addr_hit[11] & reg_we & ~wr_err;
+  assign r0w1ctype2_we = addr_hit[11] & reg_we & !reg_error;
   assign r0w1ctype2_wd = reg_wdata[31:0];
 
-  assign rctype0_we = addr_hit[12] & reg_re;
+  assign rctype0_we = addr_hit[12] & reg_re & !reg_error;
   assign rctype0_wd = '1;
 
-  assign wotype0_we = addr_hit[13] & reg_we & ~wr_err;
+  assign wotype0_we = addr_hit[13] & reg_we & !reg_error;
   assign wotype0_wd = reg_wdata[31:0];
 
-  assign mixtype0_field0_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mixtype0_field0_we = addr_hit[14] & reg_we & !reg_error;
   assign mixtype0_field0_wd = reg_wdata[3:0];
 
-  assign mixtype0_field1_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mixtype0_field1_we = addr_hit[14] & reg_we & !reg_error;
   assign mixtype0_field1_wd = reg_wdata[7:4];
 
 
 
-  assign mixtype0_field4_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mixtype0_field4_we = addr_hit[14] & reg_we & !reg_error;
   assign mixtype0_field4_wd = reg_wdata[19:16];
 
-  assign mixtype0_field5_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mixtype0_field5_we = addr_hit[14] & reg_we & !reg_error;
   assign mixtype0_field5_wd = reg_wdata[23:20];
 
-  assign mixtype0_field6_we = addr_hit[14] & reg_re;
+  assign mixtype0_field6_we = addr_hit[14] & reg_re & !reg_error;
   assign mixtype0_field6_wd = '1;
 
-  assign mixtype0_field7_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mixtype0_field7_we = addr_hit[14] & reg_we & !reg_error;
   assign mixtype0_field7_wd = reg_wdata[31:28];
 
-  assign rwtype5_we = addr_hit[15] & reg_we & ~wr_err;
+  assign rwtype5_we = addr_hit[15] & reg_we & !reg_error;
   assign rwtype5_wd = reg_wdata[31:0];
 
-  assign rwtype6_we = addr_hit[16] & reg_we & ~wr_err;
+  assign rwtype6_we = addr_hit[16] & reg_we & !reg_error;
   assign rwtype6_wd = reg_wdata[31:0];
-  assign rwtype6_re = addr_hit[16] && reg_re;
+  assign rwtype6_re = addr_hit[16] & reg_re & !reg_error;
 
-  assign rotype1_re = addr_hit[17] && reg_re;
-
-
+  assign rotype1_re = addr_hit[17] & reg_re & !reg_error;
 
 
-  assign rwtype7_we = addr_hit[19] & reg_we & ~wr_err;
+
+
+  assign rwtype7_we = addr_hit[19] & reg_we & !reg_error;
   assign rwtype7_wd = reg_wdata[31:0];
 
   // Read data return

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -1432,150 +1432,150 @@ module uart_reg_top (
     if (addr_hit[11] && reg_we && (UART_PERMIT[11] != (UART_PERMIT[11] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_tx_watermark_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_tx_watermark_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_tx_watermark_wd = reg_wdata[0];
 
-  assign intr_state_rx_watermark_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_watermark_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_watermark_wd = reg_wdata[1];
 
-  assign intr_state_tx_empty_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_tx_empty_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_tx_empty_wd = reg_wdata[2];
 
-  assign intr_state_rx_overflow_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_overflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_overflow_wd = reg_wdata[3];
 
-  assign intr_state_rx_frame_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_frame_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_frame_err_wd = reg_wdata[4];
 
-  assign intr_state_rx_break_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_break_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_break_err_wd = reg_wdata[5];
 
-  assign intr_state_rx_timeout_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_timeout_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_timeout_wd = reg_wdata[6];
 
-  assign intr_state_rx_parity_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_parity_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_parity_err_wd = reg_wdata[7];
 
-  assign intr_enable_tx_watermark_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_tx_watermark_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_tx_watermark_wd = reg_wdata[0];
 
-  assign intr_enable_rx_watermark_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_watermark_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_watermark_wd = reg_wdata[1];
 
-  assign intr_enable_tx_empty_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_tx_empty_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_tx_empty_wd = reg_wdata[2];
 
-  assign intr_enable_rx_overflow_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_overflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_overflow_wd = reg_wdata[3];
 
-  assign intr_enable_rx_frame_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_frame_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_frame_err_wd = reg_wdata[4];
 
-  assign intr_enable_rx_break_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_break_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_break_err_wd = reg_wdata[5];
 
-  assign intr_enable_rx_timeout_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_timeout_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_timeout_wd = reg_wdata[6];
 
-  assign intr_enable_rx_parity_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_parity_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_parity_err_wd = reg_wdata[7];
 
-  assign intr_test_tx_watermark_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_tx_watermark_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_tx_watermark_wd = reg_wdata[0];
 
-  assign intr_test_rx_watermark_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_watermark_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_watermark_wd = reg_wdata[1];
 
-  assign intr_test_tx_empty_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_tx_empty_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_tx_empty_wd = reg_wdata[2];
 
-  assign intr_test_rx_overflow_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_overflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_overflow_wd = reg_wdata[3];
 
-  assign intr_test_rx_frame_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_frame_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_frame_err_wd = reg_wdata[4];
 
-  assign intr_test_rx_break_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_break_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_break_err_wd = reg_wdata[5];
 
-  assign intr_test_rx_timeout_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_timeout_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_timeout_wd = reg_wdata[6];
 
-  assign intr_test_rx_parity_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_parity_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_parity_err_wd = reg_wdata[7];
 
-  assign ctrl_tx_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_tx_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_tx_wd = reg_wdata[0];
 
-  assign ctrl_rx_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_rx_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_rx_wd = reg_wdata[1];
 
-  assign ctrl_nf_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_nf_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_nf_wd = reg_wdata[2];
 
-  assign ctrl_slpbk_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_slpbk_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_slpbk_wd = reg_wdata[4];
 
-  assign ctrl_llpbk_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_llpbk_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_llpbk_wd = reg_wdata[5];
 
-  assign ctrl_parity_en_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_parity_en_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_parity_en_wd = reg_wdata[6];
 
-  assign ctrl_parity_odd_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_parity_odd_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_parity_odd_wd = reg_wdata[7];
 
-  assign ctrl_rxblvl_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_rxblvl_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_rxblvl_wd = reg_wdata[9:8];
 
-  assign ctrl_nco_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_nco_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_nco_wd = reg_wdata[31:16];
 
-  assign status_txfull_re = addr_hit[4] && reg_re;
+  assign status_txfull_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_rxfull_re = addr_hit[4] && reg_re;
+  assign status_rxfull_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_txempty_re = addr_hit[4] && reg_re;
+  assign status_txempty_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_txidle_re = addr_hit[4] && reg_re;
+  assign status_txidle_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_rxidle_re = addr_hit[4] && reg_re;
+  assign status_rxidle_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_rxempty_re = addr_hit[4] && reg_re;
+  assign status_rxempty_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign rdata_re = addr_hit[5] && reg_re;
+  assign rdata_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign wdata_we = addr_hit[6] & reg_we & ~wr_err;
+  assign wdata_we = addr_hit[6] & reg_we & !reg_error;
   assign wdata_wd = reg_wdata[7:0];
 
-  assign fifo_ctrl_rxrst_we = addr_hit[7] & reg_we & ~wr_err;
+  assign fifo_ctrl_rxrst_we = addr_hit[7] & reg_we & !reg_error;
   assign fifo_ctrl_rxrst_wd = reg_wdata[0];
 
-  assign fifo_ctrl_txrst_we = addr_hit[7] & reg_we & ~wr_err;
+  assign fifo_ctrl_txrst_we = addr_hit[7] & reg_we & !reg_error;
   assign fifo_ctrl_txrst_wd = reg_wdata[1];
 
-  assign fifo_ctrl_rxilvl_we = addr_hit[7] & reg_we & ~wr_err;
+  assign fifo_ctrl_rxilvl_we = addr_hit[7] & reg_we & !reg_error;
   assign fifo_ctrl_rxilvl_wd = reg_wdata[4:2];
 
-  assign fifo_ctrl_txilvl_we = addr_hit[7] & reg_we & ~wr_err;
+  assign fifo_ctrl_txilvl_we = addr_hit[7] & reg_we & !reg_error;
   assign fifo_ctrl_txilvl_wd = reg_wdata[6:5];
 
-  assign fifo_status_txlvl_re = addr_hit[8] && reg_re;
+  assign fifo_status_txlvl_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign fifo_status_rxlvl_re = addr_hit[8] && reg_re;
+  assign fifo_status_rxlvl_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign ovrd_txen_we = addr_hit[9] & reg_we & ~wr_err;
+  assign ovrd_txen_we = addr_hit[9] & reg_we & !reg_error;
   assign ovrd_txen_wd = reg_wdata[0];
 
-  assign ovrd_txval_we = addr_hit[9] & reg_we & ~wr_err;
+  assign ovrd_txval_we = addr_hit[9] & reg_we & !reg_error;
   assign ovrd_txval_wd = reg_wdata[1];
 
-  assign val_re = addr_hit[10] && reg_re;
+  assign val_re = addr_hit[10] & reg_re & !reg_error;
 
-  assign timeout_ctrl_val_we = addr_hit[11] & reg_we & ~wr_err;
+  assign timeout_ctrl_val_we = addr_hit[11] & reg_we & !reg_error;
   assign timeout_ctrl_val_wd = reg_wdata[23:0];
 
-  assign timeout_ctrl_en_we = addr_hit[11] & reg_we & ~wr_err;
+  assign timeout_ctrl_en_we = addr_hit[11] & reg_we & !reg_error;
   assign timeout_ctrl_en_wd = reg_wdata[31];
 
   // Read data return

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -6096,630 +6096,630 @@ module usbdev_reg_top (
     if (addr_hit[29] && reg_we && (USBDEV_PERMIT[29] != (USBDEV_PERMIT[29] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_pkt_received_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_pkt_received_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_pkt_received_wd = reg_wdata[0];
 
-  assign intr_state_pkt_sent_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_pkt_sent_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_pkt_sent_wd = reg_wdata[1];
 
-  assign intr_state_disconnected_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_disconnected_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_disconnected_wd = reg_wdata[2];
 
-  assign intr_state_host_lost_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_host_lost_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_host_lost_wd = reg_wdata[3];
 
-  assign intr_state_link_reset_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_link_reset_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_link_reset_wd = reg_wdata[4];
 
-  assign intr_state_link_suspend_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_link_suspend_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_link_suspend_wd = reg_wdata[5];
 
-  assign intr_state_link_resume_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_link_resume_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_link_resume_wd = reg_wdata[6];
 
-  assign intr_state_av_empty_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_av_empty_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_av_empty_wd = reg_wdata[7];
 
-  assign intr_state_rx_full_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_full_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_full_wd = reg_wdata[8];
 
-  assign intr_state_av_overflow_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_av_overflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_av_overflow_wd = reg_wdata[9];
 
-  assign intr_state_link_in_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_link_in_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_link_in_err_wd = reg_wdata[10];
 
-  assign intr_state_rx_crc_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_crc_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_crc_err_wd = reg_wdata[11];
 
-  assign intr_state_rx_pid_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_pid_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_pid_err_wd = reg_wdata[12];
 
-  assign intr_state_rx_bitstuff_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_bitstuff_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_bitstuff_err_wd = reg_wdata[13];
 
-  assign intr_state_frame_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_frame_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_frame_wd = reg_wdata[14];
 
-  assign intr_state_connected_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_connected_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_connected_wd = reg_wdata[15];
 
-  assign intr_state_link_out_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_link_out_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_link_out_err_wd = reg_wdata[16];
 
-  assign intr_enable_pkt_received_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_pkt_received_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_pkt_received_wd = reg_wdata[0];
 
-  assign intr_enable_pkt_sent_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_pkt_sent_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_pkt_sent_wd = reg_wdata[1];
 
-  assign intr_enable_disconnected_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_disconnected_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_disconnected_wd = reg_wdata[2];
 
-  assign intr_enable_host_lost_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_host_lost_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_host_lost_wd = reg_wdata[3];
 
-  assign intr_enable_link_reset_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_link_reset_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_link_reset_wd = reg_wdata[4];
 
-  assign intr_enable_link_suspend_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_link_suspend_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_link_suspend_wd = reg_wdata[5];
 
-  assign intr_enable_link_resume_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_link_resume_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_link_resume_wd = reg_wdata[6];
 
-  assign intr_enable_av_empty_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_av_empty_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_av_empty_wd = reg_wdata[7];
 
-  assign intr_enable_rx_full_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_full_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_full_wd = reg_wdata[8];
 
-  assign intr_enable_av_overflow_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_av_overflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_av_overflow_wd = reg_wdata[9];
 
-  assign intr_enable_link_in_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_link_in_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_link_in_err_wd = reg_wdata[10];
 
-  assign intr_enable_rx_crc_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_crc_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_crc_err_wd = reg_wdata[11];
 
-  assign intr_enable_rx_pid_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_pid_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_pid_err_wd = reg_wdata[12];
 
-  assign intr_enable_rx_bitstuff_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_bitstuff_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_bitstuff_err_wd = reg_wdata[13];
 
-  assign intr_enable_frame_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_frame_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_frame_wd = reg_wdata[14];
 
-  assign intr_enable_connected_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_connected_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_connected_wd = reg_wdata[15];
 
-  assign intr_enable_link_out_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_link_out_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_link_out_err_wd = reg_wdata[16];
 
-  assign intr_test_pkt_received_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_pkt_received_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_pkt_received_wd = reg_wdata[0];
 
-  assign intr_test_pkt_sent_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_pkt_sent_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_pkt_sent_wd = reg_wdata[1];
 
-  assign intr_test_disconnected_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_disconnected_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_disconnected_wd = reg_wdata[2];
 
-  assign intr_test_host_lost_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_host_lost_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_host_lost_wd = reg_wdata[3];
 
-  assign intr_test_link_reset_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_link_reset_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_link_reset_wd = reg_wdata[4];
 
-  assign intr_test_link_suspend_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_link_suspend_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_link_suspend_wd = reg_wdata[5];
 
-  assign intr_test_link_resume_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_link_resume_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_link_resume_wd = reg_wdata[6];
 
-  assign intr_test_av_empty_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_av_empty_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_av_empty_wd = reg_wdata[7];
 
-  assign intr_test_rx_full_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_full_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_full_wd = reg_wdata[8];
 
-  assign intr_test_av_overflow_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_av_overflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_av_overflow_wd = reg_wdata[9];
 
-  assign intr_test_link_in_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_link_in_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_link_in_err_wd = reg_wdata[10];
 
-  assign intr_test_rx_crc_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_crc_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_crc_err_wd = reg_wdata[11];
 
-  assign intr_test_rx_pid_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_pid_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_pid_err_wd = reg_wdata[12];
 
-  assign intr_test_rx_bitstuff_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_bitstuff_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_bitstuff_err_wd = reg_wdata[13];
 
-  assign intr_test_frame_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_frame_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_frame_wd = reg_wdata[14];
 
-  assign intr_test_connected_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_connected_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_connected_wd = reg_wdata[15];
 
-  assign intr_test_link_out_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_link_out_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_link_out_err_wd = reg_wdata[16];
 
-  assign usbctrl_enable_we = addr_hit[3] & reg_we & ~wr_err;
+  assign usbctrl_enable_we = addr_hit[3] & reg_we & !reg_error;
   assign usbctrl_enable_wd = reg_wdata[0];
 
-  assign usbctrl_device_address_we = addr_hit[3] & reg_we & ~wr_err;
+  assign usbctrl_device_address_we = addr_hit[3] & reg_we & !reg_error;
   assign usbctrl_device_address_wd = reg_wdata[22:16];
 
-  assign usbstat_frame_re = addr_hit[4] && reg_re;
+  assign usbstat_frame_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign usbstat_host_lost_re = addr_hit[4] && reg_re;
+  assign usbstat_host_lost_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign usbstat_link_state_re = addr_hit[4] && reg_re;
+  assign usbstat_link_state_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign usbstat_sense_re = addr_hit[4] && reg_re;
+  assign usbstat_sense_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign usbstat_av_depth_re = addr_hit[4] && reg_re;
+  assign usbstat_av_depth_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign usbstat_av_full_re = addr_hit[4] && reg_re;
+  assign usbstat_av_full_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign usbstat_rx_depth_re = addr_hit[4] && reg_re;
+  assign usbstat_rx_depth_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign usbstat_rx_empty_re = addr_hit[4] && reg_re;
+  assign usbstat_rx_empty_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign avbuffer_we = addr_hit[5] & reg_we & ~wr_err;
+  assign avbuffer_we = addr_hit[5] & reg_we & !reg_error;
   assign avbuffer_wd = reg_wdata[4:0];
 
-  assign rxfifo_buffer_re = addr_hit[6] && reg_re;
+  assign rxfifo_buffer_re = addr_hit[6] & reg_re & !reg_error;
 
-  assign rxfifo_size_re = addr_hit[6] && reg_re;
+  assign rxfifo_size_re = addr_hit[6] & reg_re & !reg_error;
 
-  assign rxfifo_setup_re = addr_hit[6] && reg_re;
+  assign rxfifo_setup_re = addr_hit[6] & reg_re & !reg_error;
 
-  assign rxfifo_ep_re = addr_hit[6] && reg_re;
+  assign rxfifo_ep_re = addr_hit[6] & reg_re & !reg_error;
 
-  assign rxenable_setup_setup_0_we = addr_hit[7] & reg_we & ~wr_err;
+  assign rxenable_setup_setup_0_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_0_wd = reg_wdata[0];
 
-  assign rxenable_setup_setup_1_we = addr_hit[7] & reg_we & ~wr_err;
+  assign rxenable_setup_setup_1_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_1_wd = reg_wdata[1];
 
-  assign rxenable_setup_setup_2_we = addr_hit[7] & reg_we & ~wr_err;
+  assign rxenable_setup_setup_2_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_2_wd = reg_wdata[2];
 
-  assign rxenable_setup_setup_3_we = addr_hit[7] & reg_we & ~wr_err;
+  assign rxenable_setup_setup_3_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_3_wd = reg_wdata[3];
 
-  assign rxenable_setup_setup_4_we = addr_hit[7] & reg_we & ~wr_err;
+  assign rxenable_setup_setup_4_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_4_wd = reg_wdata[4];
 
-  assign rxenable_setup_setup_5_we = addr_hit[7] & reg_we & ~wr_err;
+  assign rxenable_setup_setup_5_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_5_wd = reg_wdata[5];
 
-  assign rxenable_setup_setup_6_we = addr_hit[7] & reg_we & ~wr_err;
+  assign rxenable_setup_setup_6_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_6_wd = reg_wdata[6];
 
-  assign rxenable_setup_setup_7_we = addr_hit[7] & reg_we & ~wr_err;
+  assign rxenable_setup_setup_7_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_7_wd = reg_wdata[7];
 
-  assign rxenable_setup_setup_8_we = addr_hit[7] & reg_we & ~wr_err;
+  assign rxenable_setup_setup_8_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_8_wd = reg_wdata[8];
 
-  assign rxenable_setup_setup_9_we = addr_hit[7] & reg_we & ~wr_err;
+  assign rxenable_setup_setup_9_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_9_wd = reg_wdata[9];
 
-  assign rxenable_setup_setup_10_we = addr_hit[7] & reg_we & ~wr_err;
+  assign rxenable_setup_setup_10_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_10_wd = reg_wdata[10];
 
-  assign rxenable_setup_setup_11_we = addr_hit[7] & reg_we & ~wr_err;
+  assign rxenable_setup_setup_11_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_11_wd = reg_wdata[11];
 
-  assign rxenable_out_out_0_we = addr_hit[8] & reg_we & ~wr_err;
+  assign rxenable_out_out_0_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_0_wd = reg_wdata[0];
 
-  assign rxenable_out_out_1_we = addr_hit[8] & reg_we & ~wr_err;
+  assign rxenable_out_out_1_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_1_wd = reg_wdata[1];
 
-  assign rxenable_out_out_2_we = addr_hit[8] & reg_we & ~wr_err;
+  assign rxenable_out_out_2_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_2_wd = reg_wdata[2];
 
-  assign rxenable_out_out_3_we = addr_hit[8] & reg_we & ~wr_err;
+  assign rxenable_out_out_3_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_3_wd = reg_wdata[3];
 
-  assign rxenable_out_out_4_we = addr_hit[8] & reg_we & ~wr_err;
+  assign rxenable_out_out_4_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_4_wd = reg_wdata[4];
 
-  assign rxenable_out_out_5_we = addr_hit[8] & reg_we & ~wr_err;
+  assign rxenable_out_out_5_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_5_wd = reg_wdata[5];
 
-  assign rxenable_out_out_6_we = addr_hit[8] & reg_we & ~wr_err;
+  assign rxenable_out_out_6_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_6_wd = reg_wdata[6];
 
-  assign rxenable_out_out_7_we = addr_hit[8] & reg_we & ~wr_err;
+  assign rxenable_out_out_7_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_7_wd = reg_wdata[7];
 
-  assign rxenable_out_out_8_we = addr_hit[8] & reg_we & ~wr_err;
+  assign rxenable_out_out_8_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_8_wd = reg_wdata[8];
 
-  assign rxenable_out_out_9_we = addr_hit[8] & reg_we & ~wr_err;
+  assign rxenable_out_out_9_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_9_wd = reg_wdata[9];
 
-  assign rxenable_out_out_10_we = addr_hit[8] & reg_we & ~wr_err;
+  assign rxenable_out_out_10_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_10_wd = reg_wdata[10];
 
-  assign rxenable_out_out_11_we = addr_hit[8] & reg_we & ~wr_err;
+  assign rxenable_out_out_11_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_11_wd = reg_wdata[11];
 
-  assign in_sent_sent_0_we = addr_hit[9] & reg_we & ~wr_err;
+  assign in_sent_sent_0_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_0_wd = reg_wdata[0];
 
-  assign in_sent_sent_1_we = addr_hit[9] & reg_we & ~wr_err;
+  assign in_sent_sent_1_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_1_wd = reg_wdata[1];
 
-  assign in_sent_sent_2_we = addr_hit[9] & reg_we & ~wr_err;
+  assign in_sent_sent_2_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_2_wd = reg_wdata[2];
 
-  assign in_sent_sent_3_we = addr_hit[9] & reg_we & ~wr_err;
+  assign in_sent_sent_3_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_3_wd = reg_wdata[3];
 
-  assign in_sent_sent_4_we = addr_hit[9] & reg_we & ~wr_err;
+  assign in_sent_sent_4_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_4_wd = reg_wdata[4];
 
-  assign in_sent_sent_5_we = addr_hit[9] & reg_we & ~wr_err;
+  assign in_sent_sent_5_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_5_wd = reg_wdata[5];
 
-  assign in_sent_sent_6_we = addr_hit[9] & reg_we & ~wr_err;
+  assign in_sent_sent_6_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_6_wd = reg_wdata[6];
 
-  assign in_sent_sent_7_we = addr_hit[9] & reg_we & ~wr_err;
+  assign in_sent_sent_7_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_7_wd = reg_wdata[7];
 
-  assign in_sent_sent_8_we = addr_hit[9] & reg_we & ~wr_err;
+  assign in_sent_sent_8_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_8_wd = reg_wdata[8];
 
-  assign in_sent_sent_9_we = addr_hit[9] & reg_we & ~wr_err;
+  assign in_sent_sent_9_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_9_wd = reg_wdata[9];
 
-  assign in_sent_sent_10_we = addr_hit[9] & reg_we & ~wr_err;
+  assign in_sent_sent_10_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_10_wd = reg_wdata[10];
 
-  assign in_sent_sent_11_we = addr_hit[9] & reg_we & ~wr_err;
+  assign in_sent_sent_11_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_11_wd = reg_wdata[11];
 
-  assign stall_stall_0_we = addr_hit[10] & reg_we & ~wr_err;
+  assign stall_stall_0_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_0_wd = reg_wdata[0];
 
-  assign stall_stall_1_we = addr_hit[10] & reg_we & ~wr_err;
+  assign stall_stall_1_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_1_wd = reg_wdata[1];
 
-  assign stall_stall_2_we = addr_hit[10] & reg_we & ~wr_err;
+  assign stall_stall_2_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_2_wd = reg_wdata[2];
 
-  assign stall_stall_3_we = addr_hit[10] & reg_we & ~wr_err;
+  assign stall_stall_3_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_3_wd = reg_wdata[3];
 
-  assign stall_stall_4_we = addr_hit[10] & reg_we & ~wr_err;
+  assign stall_stall_4_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_4_wd = reg_wdata[4];
 
-  assign stall_stall_5_we = addr_hit[10] & reg_we & ~wr_err;
+  assign stall_stall_5_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_5_wd = reg_wdata[5];
 
-  assign stall_stall_6_we = addr_hit[10] & reg_we & ~wr_err;
+  assign stall_stall_6_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_6_wd = reg_wdata[6];
 
-  assign stall_stall_7_we = addr_hit[10] & reg_we & ~wr_err;
+  assign stall_stall_7_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_7_wd = reg_wdata[7];
 
-  assign stall_stall_8_we = addr_hit[10] & reg_we & ~wr_err;
+  assign stall_stall_8_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_8_wd = reg_wdata[8];
 
-  assign stall_stall_9_we = addr_hit[10] & reg_we & ~wr_err;
+  assign stall_stall_9_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_9_wd = reg_wdata[9];
 
-  assign stall_stall_10_we = addr_hit[10] & reg_we & ~wr_err;
+  assign stall_stall_10_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_10_wd = reg_wdata[10];
 
-  assign stall_stall_11_we = addr_hit[10] & reg_we & ~wr_err;
+  assign stall_stall_11_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_11_wd = reg_wdata[11];
 
-  assign configin_0_buffer_0_we = addr_hit[11] & reg_we & ~wr_err;
+  assign configin_0_buffer_0_we = addr_hit[11] & reg_we & !reg_error;
   assign configin_0_buffer_0_wd = reg_wdata[4:0];
 
-  assign configin_0_size_0_we = addr_hit[11] & reg_we & ~wr_err;
+  assign configin_0_size_0_we = addr_hit[11] & reg_we & !reg_error;
   assign configin_0_size_0_wd = reg_wdata[14:8];
 
-  assign configin_0_pend_0_we = addr_hit[11] & reg_we & ~wr_err;
+  assign configin_0_pend_0_we = addr_hit[11] & reg_we & !reg_error;
   assign configin_0_pend_0_wd = reg_wdata[30];
 
-  assign configin_0_rdy_0_we = addr_hit[11] & reg_we & ~wr_err;
+  assign configin_0_rdy_0_we = addr_hit[11] & reg_we & !reg_error;
   assign configin_0_rdy_0_wd = reg_wdata[31];
 
-  assign configin_1_buffer_1_we = addr_hit[12] & reg_we & ~wr_err;
+  assign configin_1_buffer_1_we = addr_hit[12] & reg_we & !reg_error;
   assign configin_1_buffer_1_wd = reg_wdata[4:0];
 
-  assign configin_1_size_1_we = addr_hit[12] & reg_we & ~wr_err;
+  assign configin_1_size_1_we = addr_hit[12] & reg_we & !reg_error;
   assign configin_1_size_1_wd = reg_wdata[14:8];
 
-  assign configin_1_pend_1_we = addr_hit[12] & reg_we & ~wr_err;
+  assign configin_1_pend_1_we = addr_hit[12] & reg_we & !reg_error;
   assign configin_1_pend_1_wd = reg_wdata[30];
 
-  assign configin_1_rdy_1_we = addr_hit[12] & reg_we & ~wr_err;
+  assign configin_1_rdy_1_we = addr_hit[12] & reg_we & !reg_error;
   assign configin_1_rdy_1_wd = reg_wdata[31];
 
-  assign configin_2_buffer_2_we = addr_hit[13] & reg_we & ~wr_err;
+  assign configin_2_buffer_2_we = addr_hit[13] & reg_we & !reg_error;
   assign configin_2_buffer_2_wd = reg_wdata[4:0];
 
-  assign configin_2_size_2_we = addr_hit[13] & reg_we & ~wr_err;
+  assign configin_2_size_2_we = addr_hit[13] & reg_we & !reg_error;
   assign configin_2_size_2_wd = reg_wdata[14:8];
 
-  assign configin_2_pend_2_we = addr_hit[13] & reg_we & ~wr_err;
+  assign configin_2_pend_2_we = addr_hit[13] & reg_we & !reg_error;
   assign configin_2_pend_2_wd = reg_wdata[30];
 
-  assign configin_2_rdy_2_we = addr_hit[13] & reg_we & ~wr_err;
+  assign configin_2_rdy_2_we = addr_hit[13] & reg_we & !reg_error;
   assign configin_2_rdy_2_wd = reg_wdata[31];
 
-  assign configin_3_buffer_3_we = addr_hit[14] & reg_we & ~wr_err;
+  assign configin_3_buffer_3_we = addr_hit[14] & reg_we & !reg_error;
   assign configin_3_buffer_3_wd = reg_wdata[4:0];
 
-  assign configin_3_size_3_we = addr_hit[14] & reg_we & ~wr_err;
+  assign configin_3_size_3_we = addr_hit[14] & reg_we & !reg_error;
   assign configin_3_size_3_wd = reg_wdata[14:8];
 
-  assign configin_3_pend_3_we = addr_hit[14] & reg_we & ~wr_err;
+  assign configin_3_pend_3_we = addr_hit[14] & reg_we & !reg_error;
   assign configin_3_pend_3_wd = reg_wdata[30];
 
-  assign configin_3_rdy_3_we = addr_hit[14] & reg_we & ~wr_err;
+  assign configin_3_rdy_3_we = addr_hit[14] & reg_we & !reg_error;
   assign configin_3_rdy_3_wd = reg_wdata[31];
 
-  assign configin_4_buffer_4_we = addr_hit[15] & reg_we & ~wr_err;
+  assign configin_4_buffer_4_we = addr_hit[15] & reg_we & !reg_error;
   assign configin_4_buffer_4_wd = reg_wdata[4:0];
 
-  assign configin_4_size_4_we = addr_hit[15] & reg_we & ~wr_err;
+  assign configin_4_size_4_we = addr_hit[15] & reg_we & !reg_error;
   assign configin_4_size_4_wd = reg_wdata[14:8];
 
-  assign configin_4_pend_4_we = addr_hit[15] & reg_we & ~wr_err;
+  assign configin_4_pend_4_we = addr_hit[15] & reg_we & !reg_error;
   assign configin_4_pend_4_wd = reg_wdata[30];
 
-  assign configin_4_rdy_4_we = addr_hit[15] & reg_we & ~wr_err;
+  assign configin_4_rdy_4_we = addr_hit[15] & reg_we & !reg_error;
   assign configin_4_rdy_4_wd = reg_wdata[31];
 
-  assign configin_5_buffer_5_we = addr_hit[16] & reg_we & ~wr_err;
+  assign configin_5_buffer_5_we = addr_hit[16] & reg_we & !reg_error;
   assign configin_5_buffer_5_wd = reg_wdata[4:0];
 
-  assign configin_5_size_5_we = addr_hit[16] & reg_we & ~wr_err;
+  assign configin_5_size_5_we = addr_hit[16] & reg_we & !reg_error;
   assign configin_5_size_5_wd = reg_wdata[14:8];
 
-  assign configin_5_pend_5_we = addr_hit[16] & reg_we & ~wr_err;
+  assign configin_5_pend_5_we = addr_hit[16] & reg_we & !reg_error;
   assign configin_5_pend_5_wd = reg_wdata[30];
 
-  assign configin_5_rdy_5_we = addr_hit[16] & reg_we & ~wr_err;
+  assign configin_5_rdy_5_we = addr_hit[16] & reg_we & !reg_error;
   assign configin_5_rdy_5_wd = reg_wdata[31];
 
-  assign configin_6_buffer_6_we = addr_hit[17] & reg_we & ~wr_err;
+  assign configin_6_buffer_6_we = addr_hit[17] & reg_we & !reg_error;
   assign configin_6_buffer_6_wd = reg_wdata[4:0];
 
-  assign configin_6_size_6_we = addr_hit[17] & reg_we & ~wr_err;
+  assign configin_6_size_6_we = addr_hit[17] & reg_we & !reg_error;
   assign configin_6_size_6_wd = reg_wdata[14:8];
 
-  assign configin_6_pend_6_we = addr_hit[17] & reg_we & ~wr_err;
+  assign configin_6_pend_6_we = addr_hit[17] & reg_we & !reg_error;
   assign configin_6_pend_6_wd = reg_wdata[30];
 
-  assign configin_6_rdy_6_we = addr_hit[17] & reg_we & ~wr_err;
+  assign configin_6_rdy_6_we = addr_hit[17] & reg_we & !reg_error;
   assign configin_6_rdy_6_wd = reg_wdata[31];
 
-  assign configin_7_buffer_7_we = addr_hit[18] & reg_we & ~wr_err;
+  assign configin_7_buffer_7_we = addr_hit[18] & reg_we & !reg_error;
   assign configin_7_buffer_7_wd = reg_wdata[4:0];
 
-  assign configin_7_size_7_we = addr_hit[18] & reg_we & ~wr_err;
+  assign configin_7_size_7_we = addr_hit[18] & reg_we & !reg_error;
   assign configin_7_size_7_wd = reg_wdata[14:8];
 
-  assign configin_7_pend_7_we = addr_hit[18] & reg_we & ~wr_err;
+  assign configin_7_pend_7_we = addr_hit[18] & reg_we & !reg_error;
   assign configin_7_pend_7_wd = reg_wdata[30];
 
-  assign configin_7_rdy_7_we = addr_hit[18] & reg_we & ~wr_err;
+  assign configin_7_rdy_7_we = addr_hit[18] & reg_we & !reg_error;
   assign configin_7_rdy_7_wd = reg_wdata[31];
 
-  assign configin_8_buffer_8_we = addr_hit[19] & reg_we & ~wr_err;
+  assign configin_8_buffer_8_we = addr_hit[19] & reg_we & !reg_error;
   assign configin_8_buffer_8_wd = reg_wdata[4:0];
 
-  assign configin_8_size_8_we = addr_hit[19] & reg_we & ~wr_err;
+  assign configin_8_size_8_we = addr_hit[19] & reg_we & !reg_error;
   assign configin_8_size_8_wd = reg_wdata[14:8];
 
-  assign configin_8_pend_8_we = addr_hit[19] & reg_we & ~wr_err;
+  assign configin_8_pend_8_we = addr_hit[19] & reg_we & !reg_error;
   assign configin_8_pend_8_wd = reg_wdata[30];
 
-  assign configin_8_rdy_8_we = addr_hit[19] & reg_we & ~wr_err;
+  assign configin_8_rdy_8_we = addr_hit[19] & reg_we & !reg_error;
   assign configin_8_rdy_8_wd = reg_wdata[31];
 
-  assign configin_9_buffer_9_we = addr_hit[20] & reg_we & ~wr_err;
+  assign configin_9_buffer_9_we = addr_hit[20] & reg_we & !reg_error;
   assign configin_9_buffer_9_wd = reg_wdata[4:0];
 
-  assign configin_9_size_9_we = addr_hit[20] & reg_we & ~wr_err;
+  assign configin_9_size_9_we = addr_hit[20] & reg_we & !reg_error;
   assign configin_9_size_9_wd = reg_wdata[14:8];
 
-  assign configin_9_pend_9_we = addr_hit[20] & reg_we & ~wr_err;
+  assign configin_9_pend_9_we = addr_hit[20] & reg_we & !reg_error;
   assign configin_9_pend_9_wd = reg_wdata[30];
 
-  assign configin_9_rdy_9_we = addr_hit[20] & reg_we & ~wr_err;
+  assign configin_9_rdy_9_we = addr_hit[20] & reg_we & !reg_error;
   assign configin_9_rdy_9_wd = reg_wdata[31];
 
-  assign configin_10_buffer_10_we = addr_hit[21] & reg_we & ~wr_err;
+  assign configin_10_buffer_10_we = addr_hit[21] & reg_we & !reg_error;
   assign configin_10_buffer_10_wd = reg_wdata[4:0];
 
-  assign configin_10_size_10_we = addr_hit[21] & reg_we & ~wr_err;
+  assign configin_10_size_10_we = addr_hit[21] & reg_we & !reg_error;
   assign configin_10_size_10_wd = reg_wdata[14:8];
 
-  assign configin_10_pend_10_we = addr_hit[21] & reg_we & ~wr_err;
+  assign configin_10_pend_10_we = addr_hit[21] & reg_we & !reg_error;
   assign configin_10_pend_10_wd = reg_wdata[30];
 
-  assign configin_10_rdy_10_we = addr_hit[21] & reg_we & ~wr_err;
+  assign configin_10_rdy_10_we = addr_hit[21] & reg_we & !reg_error;
   assign configin_10_rdy_10_wd = reg_wdata[31];
 
-  assign configin_11_buffer_11_we = addr_hit[22] & reg_we & ~wr_err;
+  assign configin_11_buffer_11_we = addr_hit[22] & reg_we & !reg_error;
   assign configin_11_buffer_11_wd = reg_wdata[4:0];
 
-  assign configin_11_size_11_we = addr_hit[22] & reg_we & ~wr_err;
+  assign configin_11_size_11_we = addr_hit[22] & reg_we & !reg_error;
   assign configin_11_size_11_wd = reg_wdata[14:8];
 
-  assign configin_11_pend_11_we = addr_hit[22] & reg_we & ~wr_err;
+  assign configin_11_pend_11_we = addr_hit[22] & reg_we & !reg_error;
   assign configin_11_pend_11_wd = reg_wdata[30];
 
-  assign configin_11_rdy_11_we = addr_hit[22] & reg_we & ~wr_err;
+  assign configin_11_rdy_11_we = addr_hit[22] & reg_we & !reg_error;
   assign configin_11_rdy_11_wd = reg_wdata[31];
 
-  assign iso_iso_0_we = addr_hit[23] & reg_we & ~wr_err;
+  assign iso_iso_0_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_0_wd = reg_wdata[0];
 
-  assign iso_iso_1_we = addr_hit[23] & reg_we & ~wr_err;
+  assign iso_iso_1_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_1_wd = reg_wdata[1];
 
-  assign iso_iso_2_we = addr_hit[23] & reg_we & ~wr_err;
+  assign iso_iso_2_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_2_wd = reg_wdata[2];
 
-  assign iso_iso_3_we = addr_hit[23] & reg_we & ~wr_err;
+  assign iso_iso_3_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_3_wd = reg_wdata[3];
 
-  assign iso_iso_4_we = addr_hit[23] & reg_we & ~wr_err;
+  assign iso_iso_4_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_4_wd = reg_wdata[4];
 
-  assign iso_iso_5_we = addr_hit[23] & reg_we & ~wr_err;
+  assign iso_iso_5_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_5_wd = reg_wdata[5];
 
-  assign iso_iso_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign iso_iso_6_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_6_wd = reg_wdata[6];
 
-  assign iso_iso_7_we = addr_hit[23] & reg_we & ~wr_err;
+  assign iso_iso_7_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_7_wd = reg_wdata[7];
 
-  assign iso_iso_8_we = addr_hit[23] & reg_we & ~wr_err;
+  assign iso_iso_8_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_8_wd = reg_wdata[8];
 
-  assign iso_iso_9_we = addr_hit[23] & reg_we & ~wr_err;
+  assign iso_iso_9_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_9_wd = reg_wdata[9];
 
-  assign iso_iso_10_we = addr_hit[23] & reg_we & ~wr_err;
+  assign iso_iso_10_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_10_wd = reg_wdata[10];
 
-  assign iso_iso_11_we = addr_hit[23] & reg_we & ~wr_err;
+  assign iso_iso_11_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_11_wd = reg_wdata[11];
 
-  assign data_toggle_clear_clear_0_we = addr_hit[24] & reg_we & ~wr_err;
+  assign data_toggle_clear_clear_0_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_0_wd = reg_wdata[0];
 
-  assign data_toggle_clear_clear_1_we = addr_hit[24] & reg_we & ~wr_err;
+  assign data_toggle_clear_clear_1_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_1_wd = reg_wdata[1];
 
-  assign data_toggle_clear_clear_2_we = addr_hit[24] & reg_we & ~wr_err;
+  assign data_toggle_clear_clear_2_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_2_wd = reg_wdata[2];
 
-  assign data_toggle_clear_clear_3_we = addr_hit[24] & reg_we & ~wr_err;
+  assign data_toggle_clear_clear_3_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_3_wd = reg_wdata[3];
 
-  assign data_toggle_clear_clear_4_we = addr_hit[24] & reg_we & ~wr_err;
+  assign data_toggle_clear_clear_4_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_4_wd = reg_wdata[4];
 
-  assign data_toggle_clear_clear_5_we = addr_hit[24] & reg_we & ~wr_err;
+  assign data_toggle_clear_clear_5_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_5_wd = reg_wdata[5];
 
-  assign data_toggle_clear_clear_6_we = addr_hit[24] & reg_we & ~wr_err;
+  assign data_toggle_clear_clear_6_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_6_wd = reg_wdata[6];
 
-  assign data_toggle_clear_clear_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign data_toggle_clear_clear_7_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_7_wd = reg_wdata[7];
 
-  assign data_toggle_clear_clear_8_we = addr_hit[24] & reg_we & ~wr_err;
+  assign data_toggle_clear_clear_8_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_8_wd = reg_wdata[8];
 
-  assign data_toggle_clear_clear_9_we = addr_hit[24] & reg_we & ~wr_err;
+  assign data_toggle_clear_clear_9_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_9_wd = reg_wdata[9];
 
-  assign data_toggle_clear_clear_10_we = addr_hit[24] & reg_we & ~wr_err;
+  assign data_toggle_clear_clear_10_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_10_wd = reg_wdata[10];
 
-  assign data_toggle_clear_clear_11_we = addr_hit[24] & reg_we & ~wr_err;
+  assign data_toggle_clear_clear_11_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_11_wd = reg_wdata[11];
 
-  assign phy_pins_sense_rx_dp_i_re = addr_hit[25] && reg_re;
+  assign phy_pins_sense_rx_dp_i_re = addr_hit[25] & reg_re & !reg_error;
 
-  assign phy_pins_sense_rx_dn_i_re = addr_hit[25] && reg_re;
+  assign phy_pins_sense_rx_dn_i_re = addr_hit[25] & reg_re & !reg_error;
 
-  assign phy_pins_sense_rx_d_i_re = addr_hit[25] && reg_re;
+  assign phy_pins_sense_rx_d_i_re = addr_hit[25] & reg_re & !reg_error;
 
-  assign phy_pins_sense_tx_dp_o_re = addr_hit[25] && reg_re;
+  assign phy_pins_sense_tx_dp_o_re = addr_hit[25] & reg_re & !reg_error;
 
-  assign phy_pins_sense_tx_dn_o_re = addr_hit[25] && reg_re;
+  assign phy_pins_sense_tx_dn_o_re = addr_hit[25] & reg_re & !reg_error;
 
-  assign phy_pins_sense_tx_d_o_re = addr_hit[25] && reg_re;
+  assign phy_pins_sense_tx_d_o_re = addr_hit[25] & reg_re & !reg_error;
 
-  assign phy_pins_sense_tx_se0_o_re = addr_hit[25] && reg_re;
+  assign phy_pins_sense_tx_se0_o_re = addr_hit[25] & reg_re & !reg_error;
 
-  assign phy_pins_sense_tx_oe_o_re = addr_hit[25] && reg_re;
+  assign phy_pins_sense_tx_oe_o_re = addr_hit[25] & reg_re & !reg_error;
 
-  assign phy_pins_sense_suspend_o_re = addr_hit[25] && reg_re;
+  assign phy_pins_sense_suspend_o_re = addr_hit[25] & reg_re & !reg_error;
 
-  assign phy_pins_sense_pwr_sense_re = addr_hit[25] && reg_re;
+  assign phy_pins_sense_pwr_sense_re = addr_hit[25] & reg_re & !reg_error;
 
-  assign phy_pins_drive_dp_o_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_dp_o_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_dp_o_wd = reg_wdata[0];
 
-  assign phy_pins_drive_dn_o_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_dn_o_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_dn_o_wd = reg_wdata[1];
 
-  assign phy_pins_drive_d_o_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_d_o_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_d_o_wd = reg_wdata[2];
 
-  assign phy_pins_drive_se0_o_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_se0_o_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_se0_o_wd = reg_wdata[3];
 
-  assign phy_pins_drive_oe_o_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_oe_o_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_oe_o_wd = reg_wdata[4];
 
-  assign phy_pins_drive_tx_mode_se_o_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_tx_mode_se_o_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_tx_mode_se_o_wd = reg_wdata[5];
 
-  assign phy_pins_drive_dp_pullup_en_o_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_dp_pullup_en_o_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_dp_pullup_en_o_wd = reg_wdata[6];
 
-  assign phy_pins_drive_dn_pullup_en_o_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_dn_pullup_en_o_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_dn_pullup_en_o_wd = reg_wdata[7];
 
-  assign phy_pins_drive_suspend_o_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_suspend_o_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_suspend_o_wd = reg_wdata[8];
 
-  assign phy_pins_drive_en_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_en_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_en_wd = reg_wdata[16];
 
-  assign phy_config_rx_differential_mode_we = addr_hit[27] & reg_we & ~wr_err;
+  assign phy_config_rx_differential_mode_we = addr_hit[27] & reg_we & !reg_error;
   assign phy_config_rx_differential_mode_wd = reg_wdata[0];
 
-  assign phy_config_tx_differential_mode_we = addr_hit[27] & reg_we & ~wr_err;
+  assign phy_config_tx_differential_mode_we = addr_hit[27] & reg_we & !reg_error;
   assign phy_config_tx_differential_mode_wd = reg_wdata[1];
 
-  assign phy_config_eop_single_bit_we = addr_hit[27] & reg_we & ~wr_err;
+  assign phy_config_eop_single_bit_we = addr_hit[27] & reg_we & !reg_error;
   assign phy_config_eop_single_bit_wd = reg_wdata[2];
 
-  assign phy_config_override_pwr_sense_en_we = addr_hit[27] & reg_we & ~wr_err;
+  assign phy_config_override_pwr_sense_en_we = addr_hit[27] & reg_we & !reg_error;
   assign phy_config_override_pwr_sense_en_wd = reg_wdata[3];
 
-  assign phy_config_override_pwr_sense_val_we = addr_hit[27] & reg_we & ~wr_err;
+  assign phy_config_override_pwr_sense_val_we = addr_hit[27] & reg_we & !reg_error;
   assign phy_config_override_pwr_sense_val_wd = reg_wdata[4];
 
-  assign phy_config_pinflip_we = addr_hit[27] & reg_we & ~wr_err;
+  assign phy_config_pinflip_we = addr_hit[27] & reg_we & !reg_error;
   assign phy_config_pinflip_wd = reg_wdata[5];
 
-  assign phy_config_usb_ref_disable_we = addr_hit[27] & reg_we & ~wr_err;
+  assign phy_config_usb_ref_disable_we = addr_hit[27] & reg_we & !reg_error;
   assign phy_config_usb_ref_disable_wd = reg_wdata[6];
 
-  assign phy_config_tx_osc_test_mode_we = addr_hit[27] & reg_we & ~wr_err;
+  assign phy_config_tx_osc_test_mode_we = addr_hit[27] & reg_we & !reg_error;
   assign phy_config_tx_osc_test_mode_wd = reg_wdata[7];
 
-  assign wake_config_wake_en_we = addr_hit[28] & reg_we & ~wr_err;
+  assign wake_config_wake_en_we = addr_hit[28] & reg_we & !reg_error;
   assign wake_config_wake_en_wd = reg_wdata[0];
 
-  assign wake_config_wake_ack_we = addr_hit[28] & reg_we & ~wr_err;
+  assign wake_config_wake_ack_we = addr_hit[28] & reg_we & !reg_error;
   assign wake_config_wake_ack_wd = reg_wdata[1];
 
 

--- a/hw/ip/usbuart/rtl/usbuart_reg_top.sv
+++ b/hw/ip/usbuart/rtl/usbuart_reg_top.sv
@@ -1546,163 +1546,163 @@ module usbuart_reg_top (
     if (addr_hit[13] && reg_we && (USBUART_PERMIT[13] != (USBUART_PERMIT[13] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_tx_watermark_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_tx_watermark_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_tx_watermark_wd = reg_wdata[0];
 
-  assign intr_state_rx_watermark_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_watermark_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_watermark_wd = reg_wdata[1];
 
-  assign intr_state_tx_overflow_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_tx_overflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_tx_overflow_wd = reg_wdata[2];
 
-  assign intr_state_rx_overflow_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_overflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_overflow_wd = reg_wdata[3];
 
-  assign intr_state_rx_frame_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_frame_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_frame_err_wd = reg_wdata[4];
 
-  assign intr_state_rx_break_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_break_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_break_err_wd = reg_wdata[5];
 
-  assign intr_state_rx_timeout_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_timeout_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_timeout_wd = reg_wdata[6];
 
-  assign intr_state_rx_parity_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rx_parity_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_parity_err_wd = reg_wdata[7];
 
-  assign intr_enable_tx_watermark_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_tx_watermark_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_tx_watermark_wd = reg_wdata[0];
 
-  assign intr_enable_rx_watermark_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_watermark_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_watermark_wd = reg_wdata[1];
 
-  assign intr_enable_tx_overflow_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_tx_overflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_tx_overflow_wd = reg_wdata[2];
 
-  assign intr_enable_rx_overflow_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_overflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_overflow_wd = reg_wdata[3];
 
-  assign intr_enable_rx_frame_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_frame_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_frame_err_wd = reg_wdata[4];
 
-  assign intr_enable_rx_break_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_break_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_break_err_wd = reg_wdata[5];
 
-  assign intr_enable_rx_timeout_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_timeout_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_timeout_wd = reg_wdata[6];
 
-  assign intr_enable_rx_parity_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rx_parity_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_parity_err_wd = reg_wdata[7];
 
-  assign intr_test_tx_watermark_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_tx_watermark_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_tx_watermark_wd = reg_wdata[0];
 
-  assign intr_test_rx_watermark_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_watermark_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_watermark_wd = reg_wdata[1];
 
-  assign intr_test_tx_overflow_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_tx_overflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_tx_overflow_wd = reg_wdata[2];
 
-  assign intr_test_rx_overflow_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_overflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_overflow_wd = reg_wdata[3];
 
-  assign intr_test_rx_frame_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_frame_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_frame_err_wd = reg_wdata[4];
 
-  assign intr_test_rx_break_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_break_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_break_err_wd = reg_wdata[5];
 
-  assign intr_test_rx_timeout_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_timeout_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_timeout_wd = reg_wdata[6];
 
-  assign intr_test_rx_parity_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rx_parity_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_parity_err_wd = reg_wdata[7];
 
-  assign ctrl_tx_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_tx_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_tx_wd = reg_wdata[0];
 
-  assign ctrl_rx_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_rx_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_rx_wd = reg_wdata[1];
 
-  assign ctrl_nf_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_nf_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_nf_wd = reg_wdata[2];
 
-  assign ctrl_slpbk_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_slpbk_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_slpbk_wd = reg_wdata[4];
 
-  assign ctrl_llpbk_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_llpbk_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_llpbk_wd = reg_wdata[5];
 
-  assign ctrl_parity_en_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_parity_en_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_parity_en_wd = reg_wdata[6];
 
-  assign ctrl_parity_odd_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_parity_odd_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_parity_odd_wd = reg_wdata[7];
 
-  assign ctrl_rxblvl_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_rxblvl_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_rxblvl_wd = reg_wdata[9:8];
 
-  assign ctrl_nco_we = addr_hit[3] & reg_we & ~wr_err;
+  assign ctrl_nco_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_nco_wd = reg_wdata[31:16];
 
-  assign status_txfull_re = addr_hit[4] && reg_re;
+  assign status_txfull_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_rxfull_re = addr_hit[4] && reg_re;
+  assign status_rxfull_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_txempty_re = addr_hit[4] && reg_re;
+  assign status_txempty_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_txidle_re = addr_hit[4] && reg_re;
+  assign status_txidle_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_rxidle_re = addr_hit[4] && reg_re;
+  assign status_rxidle_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign status_rxempty_re = addr_hit[4] && reg_re;
+  assign status_rxempty_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign rdata_re = addr_hit[5] && reg_re;
+  assign rdata_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign wdata_we = addr_hit[6] & reg_we & ~wr_err;
+  assign wdata_we = addr_hit[6] & reg_we & !reg_error;
   assign wdata_wd = reg_wdata[7:0];
 
-  assign fifo_ctrl_rxrst_we = addr_hit[7] & reg_we & ~wr_err;
+  assign fifo_ctrl_rxrst_we = addr_hit[7] & reg_we & !reg_error;
   assign fifo_ctrl_rxrst_wd = reg_wdata[0];
 
-  assign fifo_ctrl_txrst_we = addr_hit[7] & reg_we & ~wr_err;
+  assign fifo_ctrl_txrst_we = addr_hit[7] & reg_we & !reg_error;
   assign fifo_ctrl_txrst_wd = reg_wdata[1];
 
-  assign fifo_ctrl_rxilvl_we = addr_hit[7] & reg_we & ~wr_err;
+  assign fifo_ctrl_rxilvl_we = addr_hit[7] & reg_we & !reg_error;
   assign fifo_ctrl_rxilvl_wd = reg_wdata[4:2];
 
-  assign fifo_ctrl_txilvl_we = addr_hit[7] & reg_we & ~wr_err;
+  assign fifo_ctrl_txilvl_we = addr_hit[7] & reg_we & !reg_error;
   assign fifo_ctrl_txilvl_wd = reg_wdata[6:5];
 
-  assign fifo_status_txlvl_re = addr_hit[8] && reg_re;
+  assign fifo_status_txlvl_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign fifo_status_rxlvl_re = addr_hit[8] && reg_re;
+  assign fifo_status_rxlvl_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign ovrd_txen_we = addr_hit[9] & reg_we & ~wr_err;
+  assign ovrd_txen_we = addr_hit[9] & reg_we & !reg_error;
   assign ovrd_txen_wd = reg_wdata[0];
 
-  assign ovrd_txval_we = addr_hit[9] & reg_we & ~wr_err;
+  assign ovrd_txval_we = addr_hit[9] & reg_we & !reg_error;
   assign ovrd_txval_wd = reg_wdata[1];
 
-  assign val_re = addr_hit[10] && reg_re;
+  assign val_re = addr_hit[10] & reg_re & !reg_error;
 
-  assign timeout_ctrl_val_we = addr_hit[11] & reg_we & ~wr_err;
+  assign timeout_ctrl_val_we = addr_hit[11] & reg_we & !reg_error;
   assign timeout_ctrl_val_wd = reg_wdata[23:0];
 
-  assign timeout_ctrl_en_we = addr_hit[11] & reg_we & ~wr_err;
+  assign timeout_ctrl_en_we = addr_hit[11] & reg_we & !reg_error;
   assign timeout_ctrl_en_wd = reg_wdata[31];
 
-  assign usbstat_frame_re = addr_hit[12] && reg_re;
+  assign usbstat_frame_re = addr_hit[12] & reg_re & !reg_error;
 
-  assign usbstat_host_timeout_re = addr_hit[12] && reg_re;
+  assign usbstat_host_timeout_re = addr_hit[12] & reg_re & !reg_error;
 
-  assign usbstat_host_lost_re = addr_hit[12] && reg_re;
+  assign usbstat_host_lost_re = addr_hit[12] & reg_re & !reg_error;
 
-  assign usbstat_device_address_re = addr_hit[12] && reg_re;
+  assign usbstat_device_address_re = addr_hit[12] & reg_re & !reg_error;
 
-  assign usbparam_baud_req_re = addr_hit[13] && reg_re;
+  assign usbparam_baud_req_re = addr_hit[13] & reg_re & !reg_error;
 
-  assign usbparam_parity_req_re = addr_hit[13] && reg_re;
+  assign usbparam_parity_req_re = addr_hit[13] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
@@ -5653,566 +5653,566 @@ module alert_handler_reg_top (
     if (addr_hit[59] && reg_we && (ALERT_HANDLER_PERMIT[59] != (ALERT_HANDLER_PERMIT[59] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_classa_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_classa_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_classa_wd = reg_wdata[0];
 
-  assign intr_state_classb_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_classb_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_classb_wd = reg_wdata[1];
 
-  assign intr_state_classc_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_classc_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_classc_wd = reg_wdata[2];
 
-  assign intr_state_classd_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_classd_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_classd_wd = reg_wdata[3];
 
-  assign intr_enable_classa_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_classa_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_classa_wd = reg_wdata[0];
 
-  assign intr_enable_classb_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_classb_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_classb_wd = reg_wdata[1];
 
-  assign intr_enable_classc_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_classc_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_classc_wd = reg_wdata[2];
 
-  assign intr_enable_classd_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_classd_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_classd_wd = reg_wdata[3];
 
-  assign intr_test_classa_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_classa_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_classa_wd = reg_wdata[0];
 
-  assign intr_test_classb_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_classb_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_classb_wd = reg_wdata[1];
 
-  assign intr_test_classc_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_classc_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_classc_wd = reg_wdata[2];
 
-  assign intr_test_classd_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_classd_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_classd_wd = reg_wdata[3];
 
-  assign regwen_we = addr_hit[3] & reg_we & ~wr_err;
+  assign regwen_we = addr_hit[3] & reg_we & !reg_error;
   assign regwen_wd = reg_wdata[0];
 
-  assign ping_timeout_cyc_we = addr_hit[4] & reg_we & ~wr_err;
+  assign ping_timeout_cyc_we = addr_hit[4] & reg_we & !reg_error;
   assign ping_timeout_cyc_wd = reg_wdata[23:0];
 
-  assign alert_en_en_a_0_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_0_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_0_wd = reg_wdata[0];
 
-  assign alert_en_en_a_1_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_1_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_1_wd = reg_wdata[1];
 
-  assign alert_en_en_a_2_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_2_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_2_wd = reg_wdata[2];
 
-  assign alert_en_en_a_3_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_3_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_3_wd = reg_wdata[3];
 
-  assign alert_en_en_a_4_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_4_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_4_wd = reg_wdata[4];
 
-  assign alert_en_en_a_5_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_5_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_5_wd = reg_wdata[5];
 
-  assign alert_en_en_a_6_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_6_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_6_wd = reg_wdata[6];
 
-  assign alert_en_en_a_7_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_7_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_7_wd = reg_wdata[7];
 
-  assign alert_en_en_a_8_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_8_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_8_wd = reg_wdata[8];
 
-  assign alert_en_en_a_9_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_9_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_9_wd = reg_wdata[9];
 
-  assign alert_en_en_a_10_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_10_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_10_wd = reg_wdata[10];
 
-  assign alert_en_en_a_11_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_11_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_11_wd = reg_wdata[11];
 
-  assign alert_en_en_a_12_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_12_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_12_wd = reg_wdata[12];
 
-  assign alert_en_en_a_13_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_13_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_13_wd = reg_wdata[13];
 
-  assign alert_en_en_a_14_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_14_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_14_wd = reg_wdata[14];
 
-  assign alert_en_en_a_15_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_15_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_15_wd = reg_wdata[15];
 
-  assign alert_en_en_a_16_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_16_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_16_wd = reg_wdata[16];
 
-  assign alert_en_en_a_17_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_17_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_17_wd = reg_wdata[17];
 
-  assign alert_en_en_a_18_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_18_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_18_wd = reg_wdata[18];
 
-  assign alert_en_en_a_19_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_19_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_19_wd = reg_wdata[19];
 
-  assign alert_en_en_a_20_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_20_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_20_wd = reg_wdata[20];
 
-  assign alert_en_en_a_21_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_21_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_21_wd = reg_wdata[21];
 
-  assign alert_en_en_a_22_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_22_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_22_wd = reg_wdata[22];
 
-  assign alert_en_en_a_23_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_23_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_23_wd = reg_wdata[23];
 
-  assign alert_en_en_a_24_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_24_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_24_wd = reg_wdata[24];
 
-  assign alert_en_en_a_25_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_25_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_25_wd = reg_wdata[25];
 
-  assign alert_en_en_a_26_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a_26_we = addr_hit[5] & reg_we & !reg_error;
   assign alert_en_en_a_26_wd = reg_wdata[26];
 
-  assign alert_class_0_class_a_0_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_0_class_a_0_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_0_class_a_0_wd = reg_wdata[1:0];
 
-  assign alert_class_0_class_a_1_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_0_class_a_1_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_0_class_a_1_wd = reg_wdata[3:2];
 
-  assign alert_class_0_class_a_2_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_0_class_a_2_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_0_class_a_2_wd = reg_wdata[5:4];
 
-  assign alert_class_0_class_a_3_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_0_class_a_3_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_0_class_a_3_wd = reg_wdata[7:6];
 
-  assign alert_class_0_class_a_4_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_0_class_a_4_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_0_class_a_4_wd = reg_wdata[9:8];
 
-  assign alert_class_0_class_a_5_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_0_class_a_5_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_0_class_a_5_wd = reg_wdata[11:10];
 
-  assign alert_class_0_class_a_6_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_0_class_a_6_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_0_class_a_6_wd = reg_wdata[13:12];
 
-  assign alert_class_0_class_a_7_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_0_class_a_7_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_0_class_a_7_wd = reg_wdata[15:14];
 
-  assign alert_class_0_class_a_8_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_0_class_a_8_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_0_class_a_8_wd = reg_wdata[17:16];
 
-  assign alert_class_0_class_a_9_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_0_class_a_9_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_0_class_a_9_wd = reg_wdata[19:18];
 
-  assign alert_class_0_class_a_10_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_0_class_a_10_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_0_class_a_10_wd = reg_wdata[21:20];
 
-  assign alert_class_0_class_a_11_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_0_class_a_11_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_0_class_a_11_wd = reg_wdata[23:22];
 
-  assign alert_class_0_class_a_12_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_0_class_a_12_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_0_class_a_12_wd = reg_wdata[25:24];
 
-  assign alert_class_0_class_a_13_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_0_class_a_13_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_0_class_a_13_wd = reg_wdata[27:26];
 
-  assign alert_class_0_class_a_14_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_0_class_a_14_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_0_class_a_14_wd = reg_wdata[29:28];
 
-  assign alert_class_0_class_a_15_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_0_class_a_15_we = addr_hit[6] & reg_we & !reg_error;
   assign alert_class_0_class_a_15_wd = reg_wdata[31:30];
 
-  assign alert_class_1_class_a_16_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_class_1_class_a_16_we = addr_hit[7] & reg_we & !reg_error;
   assign alert_class_1_class_a_16_wd = reg_wdata[1:0];
 
-  assign alert_class_1_class_a_17_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_class_1_class_a_17_we = addr_hit[7] & reg_we & !reg_error;
   assign alert_class_1_class_a_17_wd = reg_wdata[3:2];
 
-  assign alert_class_1_class_a_18_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_class_1_class_a_18_we = addr_hit[7] & reg_we & !reg_error;
   assign alert_class_1_class_a_18_wd = reg_wdata[5:4];
 
-  assign alert_class_1_class_a_19_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_class_1_class_a_19_we = addr_hit[7] & reg_we & !reg_error;
   assign alert_class_1_class_a_19_wd = reg_wdata[7:6];
 
-  assign alert_class_1_class_a_20_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_class_1_class_a_20_we = addr_hit[7] & reg_we & !reg_error;
   assign alert_class_1_class_a_20_wd = reg_wdata[9:8];
 
-  assign alert_class_1_class_a_21_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_class_1_class_a_21_we = addr_hit[7] & reg_we & !reg_error;
   assign alert_class_1_class_a_21_wd = reg_wdata[11:10];
 
-  assign alert_class_1_class_a_22_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_class_1_class_a_22_we = addr_hit[7] & reg_we & !reg_error;
   assign alert_class_1_class_a_22_wd = reg_wdata[13:12];
 
-  assign alert_class_1_class_a_23_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_class_1_class_a_23_we = addr_hit[7] & reg_we & !reg_error;
   assign alert_class_1_class_a_23_wd = reg_wdata[15:14];
 
-  assign alert_class_1_class_a_24_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_class_1_class_a_24_we = addr_hit[7] & reg_we & !reg_error;
   assign alert_class_1_class_a_24_wd = reg_wdata[17:16];
 
-  assign alert_class_1_class_a_25_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_class_1_class_a_25_we = addr_hit[7] & reg_we & !reg_error;
   assign alert_class_1_class_a_25_wd = reg_wdata[19:18];
 
-  assign alert_class_1_class_a_26_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_class_1_class_a_26_we = addr_hit[7] & reg_we & !reg_error;
   assign alert_class_1_class_a_26_wd = reg_wdata[21:20];
 
-  assign alert_cause_a_0_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_0_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_0_wd = reg_wdata[0];
 
-  assign alert_cause_a_1_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_1_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_1_wd = reg_wdata[1];
 
-  assign alert_cause_a_2_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_2_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_2_wd = reg_wdata[2];
 
-  assign alert_cause_a_3_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_3_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_3_wd = reg_wdata[3];
 
-  assign alert_cause_a_4_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_4_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_4_wd = reg_wdata[4];
 
-  assign alert_cause_a_5_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_5_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_5_wd = reg_wdata[5];
 
-  assign alert_cause_a_6_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_6_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_6_wd = reg_wdata[6];
 
-  assign alert_cause_a_7_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_7_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_7_wd = reg_wdata[7];
 
-  assign alert_cause_a_8_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_8_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_8_wd = reg_wdata[8];
 
-  assign alert_cause_a_9_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_9_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_9_wd = reg_wdata[9];
 
-  assign alert_cause_a_10_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_10_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_10_wd = reg_wdata[10];
 
-  assign alert_cause_a_11_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_11_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_11_wd = reg_wdata[11];
 
-  assign alert_cause_a_12_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_12_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_12_wd = reg_wdata[12];
 
-  assign alert_cause_a_13_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_13_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_13_wd = reg_wdata[13];
 
-  assign alert_cause_a_14_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_14_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_14_wd = reg_wdata[14];
 
-  assign alert_cause_a_15_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_15_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_15_wd = reg_wdata[15];
 
-  assign alert_cause_a_16_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_16_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_16_wd = reg_wdata[16];
 
-  assign alert_cause_a_17_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_17_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_17_wd = reg_wdata[17];
 
-  assign alert_cause_a_18_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_18_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_18_wd = reg_wdata[18];
 
-  assign alert_cause_a_19_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_19_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_19_wd = reg_wdata[19];
 
-  assign alert_cause_a_20_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_20_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_20_wd = reg_wdata[20];
 
-  assign alert_cause_a_21_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_21_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_21_wd = reg_wdata[21];
 
-  assign alert_cause_a_22_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_22_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_22_wd = reg_wdata[22];
 
-  assign alert_cause_a_23_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_23_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_23_wd = reg_wdata[23];
 
-  assign alert_cause_a_24_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_24_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_24_wd = reg_wdata[24];
 
-  assign alert_cause_a_25_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_25_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_25_wd = reg_wdata[25];
 
-  assign alert_cause_a_26_we = addr_hit[8] & reg_we & ~wr_err;
+  assign alert_cause_a_26_we = addr_hit[8] & reg_we & !reg_error;
   assign alert_cause_a_26_wd = reg_wdata[26];
 
-  assign loc_alert_en_en_la_0_we = addr_hit[9] & reg_we & ~wr_err;
+  assign loc_alert_en_en_la_0_we = addr_hit[9] & reg_we & !reg_error;
   assign loc_alert_en_en_la_0_wd = reg_wdata[0];
 
-  assign loc_alert_en_en_la_1_we = addr_hit[9] & reg_we & ~wr_err;
+  assign loc_alert_en_en_la_1_we = addr_hit[9] & reg_we & !reg_error;
   assign loc_alert_en_en_la_1_wd = reg_wdata[1];
 
-  assign loc_alert_en_en_la_2_we = addr_hit[9] & reg_we & ~wr_err;
+  assign loc_alert_en_en_la_2_we = addr_hit[9] & reg_we & !reg_error;
   assign loc_alert_en_en_la_2_wd = reg_wdata[2];
 
-  assign loc_alert_en_en_la_3_we = addr_hit[9] & reg_we & ~wr_err;
+  assign loc_alert_en_en_la_3_we = addr_hit[9] & reg_we & !reg_error;
   assign loc_alert_en_en_la_3_wd = reg_wdata[3];
 
-  assign loc_alert_class_class_la_0_we = addr_hit[10] & reg_we & ~wr_err;
+  assign loc_alert_class_class_la_0_we = addr_hit[10] & reg_we & !reg_error;
   assign loc_alert_class_class_la_0_wd = reg_wdata[1:0];
 
-  assign loc_alert_class_class_la_1_we = addr_hit[10] & reg_we & ~wr_err;
+  assign loc_alert_class_class_la_1_we = addr_hit[10] & reg_we & !reg_error;
   assign loc_alert_class_class_la_1_wd = reg_wdata[3:2];
 
-  assign loc_alert_class_class_la_2_we = addr_hit[10] & reg_we & ~wr_err;
+  assign loc_alert_class_class_la_2_we = addr_hit[10] & reg_we & !reg_error;
   assign loc_alert_class_class_la_2_wd = reg_wdata[5:4];
 
-  assign loc_alert_class_class_la_3_we = addr_hit[10] & reg_we & ~wr_err;
+  assign loc_alert_class_class_la_3_we = addr_hit[10] & reg_we & !reg_error;
   assign loc_alert_class_class_la_3_wd = reg_wdata[7:6];
 
-  assign loc_alert_cause_la_0_we = addr_hit[11] & reg_we & ~wr_err;
+  assign loc_alert_cause_la_0_we = addr_hit[11] & reg_we & !reg_error;
   assign loc_alert_cause_la_0_wd = reg_wdata[0];
 
-  assign loc_alert_cause_la_1_we = addr_hit[11] & reg_we & ~wr_err;
+  assign loc_alert_cause_la_1_we = addr_hit[11] & reg_we & !reg_error;
   assign loc_alert_cause_la_1_wd = reg_wdata[1];
 
-  assign loc_alert_cause_la_2_we = addr_hit[11] & reg_we & ~wr_err;
+  assign loc_alert_cause_la_2_we = addr_hit[11] & reg_we & !reg_error;
   assign loc_alert_cause_la_2_wd = reg_wdata[2];
 
-  assign loc_alert_cause_la_3_we = addr_hit[11] & reg_we & ~wr_err;
+  assign loc_alert_cause_la_3_we = addr_hit[11] & reg_we & !reg_error;
   assign loc_alert_cause_la_3_wd = reg_wdata[3];
 
-  assign classa_ctrl_en_we = addr_hit[12] & reg_we & ~wr_err;
+  assign classa_ctrl_en_we = addr_hit[12] & reg_we & !reg_error;
   assign classa_ctrl_en_wd = reg_wdata[0];
 
-  assign classa_ctrl_lock_we = addr_hit[12] & reg_we & ~wr_err;
+  assign classa_ctrl_lock_we = addr_hit[12] & reg_we & !reg_error;
   assign classa_ctrl_lock_wd = reg_wdata[1];
 
-  assign classa_ctrl_en_e0_we = addr_hit[12] & reg_we & ~wr_err;
+  assign classa_ctrl_en_e0_we = addr_hit[12] & reg_we & !reg_error;
   assign classa_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classa_ctrl_en_e1_we = addr_hit[12] & reg_we & ~wr_err;
+  assign classa_ctrl_en_e1_we = addr_hit[12] & reg_we & !reg_error;
   assign classa_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classa_ctrl_en_e2_we = addr_hit[12] & reg_we & ~wr_err;
+  assign classa_ctrl_en_e2_we = addr_hit[12] & reg_we & !reg_error;
   assign classa_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classa_ctrl_en_e3_we = addr_hit[12] & reg_we & ~wr_err;
+  assign classa_ctrl_en_e3_we = addr_hit[12] & reg_we & !reg_error;
   assign classa_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classa_ctrl_map_e0_we = addr_hit[12] & reg_we & ~wr_err;
+  assign classa_ctrl_map_e0_we = addr_hit[12] & reg_we & !reg_error;
   assign classa_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classa_ctrl_map_e1_we = addr_hit[12] & reg_we & ~wr_err;
+  assign classa_ctrl_map_e1_we = addr_hit[12] & reg_we & !reg_error;
   assign classa_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classa_ctrl_map_e2_we = addr_hit[12] & reg_we & ~wr_err;
+  assign classa_ctrl_map_e2_we = addr_hit[12] & reg_we & !reg_error;
   assign classa_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classa_ctrl_map_e3_we = addr_hit[12] & reg_we & ~wr_err;
+  assign classa_ctrl_map_e3_we = addr_hit[12] & reg_we & !reg_error;
   assign classa_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classa_regwen_we = addr_hit[13] & reg_we & ~wr_err;
+  assign classa_regwen_we = addr_hit[13] & reg_we & !reg_error;
   assign classa_regwen_wd = reg_wdata[0];
 
-  assign classa_clr_we = addr_hit[14] & reg_we & ~wr_err;
+  assign classa_clr_we = addr_hit[14] & reg_we & !reg_error;
   assign classa_clr_wd = reg_wdata[0];
 
-  assign classa_accum_cnt_re = addr_hit[15] && reg_re;
+  assign classa_accum_cnt_re = addr_hit[15] & reg_re & !reg_error;
 
-  assign classa_accum_thresh_we = addr_hit[16] & reg_we & ~wr_err;
+  assign classa_accum_thresh_we = addr_hit[16] & reg_we & !reg_error;
   assign classa_accum_thresh_wd = reg_wdata[15:0];
 
-  assign classa_timeout_cyc_we = addr_hit[17] & reg_we & ~wr_err;
+  assign classa_timeout_cyc_we = addr_hit[17] & reg_we & !reg_error;
   assign classa_timeout_cyc_wd = reg_wdata[31:0];
 
-  assign classa_phase0_cyc_we = addr_hit[18] & reg_we & ~wr_err;
+  assign classa_phase0_cyc_we = addr_hit[18] & reg_we & !reg_error;
   assign classa_phase0_cyc_wd = reg_wdata[31:0];
 
-  assign classa_phase1_cyc_we = addr_hit[19] & reg_we & ~wr_err;
+  assign classa_phase1_cyc_we = addr_hit[19] & reg_we & !reg_error;
   assign classa_phase1_cyc_wd = reg_wdata[31:0];
 
-  assign classa_phase2_cyc_we = addr_hit[20] & reg_we & ~wr_err;
+  assign classa_phase2_cyc_we = addr_hit[20] & reg_we & !reg_error;
   assign classa_phase2_cyc_wd = reg_wdata[31:0];
 
-  assign classa_phase3_cyc_we = addr_hit[21] & reg_we & ~wr_err;
+  assign classa_phase3_cyc_we = addr_hit[21] & reg_we & !reg_error;
   assign classa_phase3_cyc_wd = reg_wdata[31:0];
 
-  assign classa_esc_cnt_re = addr_hit[22] && reg_re;
+  assign classa_esc_cnt_re = addr_hit[22] & reg_re & !reg_error;
 
-  assign classa_state_re = addr_hit[23] && reg_re;
+  assign classa_state_re = addr_hit[23] & reg_re & !reg_error;
 
-  assign classb_ctrl_en_we = addr_hit[24] & reg_we & ~wr_err;
+  assign classb_ctrl_en_we = addr_hit[24] & reg_we & !reg_error;
   assign classb_ctrl_en_wd = reg_wdata[0];
 
-  assign classb_ctrl_lock_we = addr_hit[24] & reg_we & ~wr_err;
+  assign classb_ctrl_lock_we = addr_hit[24] & reg_we & !reg_error;
   assign classb_ctrl_lock_wd = reg_wdata[1];
 
-  assign classb_ctrl_en_e0_we = addr_hit[24] & reg_we & ~wr_err;
+  assign classb_ctrl_en_e0_we = addr_hit[24] & reg_we & !reg_error;
   assign classb_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classb_ctrl_en_e1_we = addr_hit[24] & reg_we & ~wr_err;
+  assign classb_ctrl_en_e1_we = addr_hit[24] & reg_we & !reg_error;
   assign classb_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classb_ctrl_en_e2_we = addr_hit[24] & reg_we & ~wr_err;
+  assign classb_ctrl_en_e2_we = addr_hit[24] & reg_we & !reg_error;
   assign classb_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classb_ctrl_en_e3_we = addr_hit[24] & reg_we & ~wr_err;
+  assign classb_ctrl_en_e3_we = addr_hit[24] & reg_we & !reg_error;
   assign classb_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classb_ctrl_map_e0_we = addr_hit[24] & reg_we & ~wr_err;
+  assign classb_ctrl_map_e0_we = addr_hit[24] & reg_we & !reg_error;
   assign classb_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classb_ctrl_map_e1_we = addr_hit[24] & reg_we & ~wr_err;
+  assign classb_ctrl_map_e1_we = addr_hit[24] & reg_we & !reg_error;
   assign classb_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classb_ctrl_map_e2_we = addr_hit[24] & reg_we & ~wr_err;
+  assign classb_ctrl_map_e2_we = addr_hit[24] & reg_we & !reg_error;
   assign classb_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classb_ctrl_map_e3_we = addr_hit[24] & reg_we & ~wr_err;
+  assign classb_ctrl_map_e3_we = addr_hit[24] & reg_we & !reg_error;
   assign classb_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classb_regwen_we = addr_hit[25] & reg_we & ~wr_err;
+  assign classb_regwen_we = addr_hit[25] & reg_we & !reg_error;
   assign classb_regwen_wd = reg_wdata[0];
 
-  assign classb_clr_we = addr_hit[26] & reg_we & ~wr_err;
+  assign classb_clr_we = addr_hit[26] & reg_we & !reg_error;
   assign classb_clr_wd = reg_wdata[0];
 
-  assign classb_accum_cnt_re = addr_hit[27] && reg_re;
+  assign classb_accum_cnt_re = addr_hit[27] & reg_re & !reg_error;
 
-  assign classb_accum_thresh_we = addr_hit[28] & reg_we & ~wr_err;
+  assign classb_accum_thresh_we = addr_hit[28] & reg_we & !reg_error;
   assign classb_accum_thresh_wd = reg_wdata[15:0];
 
-  assign classb_timeout_cyc_we = addr_hit[29] & reg_we & ~wr_err;
+  assign classb_timeout_cyc_we = addr_hit[29] & reg_we & !reg_error;
   assign classb_timeout_cyc_wd = reg_wdata[31:0];
 
-  assign classb_phase0_cyc_we = addr_hit[30] & reg_we & ~wr_err;
+  assign classb_phase0_cyc_we = addr_hit[30] & reg_we & !reg_error;
   assign classb_phase0_cyc_wd = reg_wdata[31:0];
 
-  assign classb_phase1_cyc_we = addr_hit[31] & reg_we & ~wr_err;
+  assign classb_phase1_cyc_we = addr_hit[31] & reg_we & !reg_error;
   assign classb_phase1_cyc_wd = reg_wdata[31:0];
 
-  assign classb_phase2_cyc_we = addr_hit[32] & reg_we & ~wr_err;
+  assign classb_phase2_cyc_we = addr_hit[32] & reg_we & !reg_error;
   assign classb_phase2_cyc_wd = reg_wdata[31:0];
 
-  assign classb_phase3_cyc_we = addr_hit[33] & reg_we & ~wr_err;
+  assign classb_phase3_cyc_we = addr_hit[33] & reg_we & !reg_error;
   assign classb_phase3_cyc_wd = reg_wdata[31:0];
 
-  assign classb_esc_cnt_re = addr_hit[34] && reg_re;
+  assign classb_esc_cnt_re = addr_hit[34] & reg_re & !reg_error;
 
-  assign classb_state_re = addr_hit[35] && reg_re;
+  assign classb_state_re = addr_hit[35] & reg_re & !reg_error;
 
-  assign classc_ctrl_en_we = addr_hit[36] & reg_we & ~wr_err;
+  assign classc_ctrl_en_we = addr_hit[36] & reg_we & !reg_error;
   assign classc_ctrl_en_wd = reg_wdata[0];
 
-  assign classc_ctrl_lock_we = addr_hit[36] & reg_we & ~wr_err;
+  assign classc_ctrl_lock_we = addr_hit[36] & reg_we & !reg_error;
   assign classc_ctrl_lock_wd = reg_wdata[1];
 
-  assign classc_ctrl_en_e0_we = addr_hit[36] & reg_we & ~wr_err;
+  assign classc_ctrl_en_e0_we = addr_hit[36] & reg_we & !reg_error;
   assign classc_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classc_ctrl_en_e1_we = addr_hit[36] & reg_we & ~wr_err;
+  assign classc_ctrl_en_e1_we = addr_hit[36] & reg_we & !reg_error;
   assign classc_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classc_ctrl_en_e2_we = addr_hit[36] & reg_we & ~wr_err;
+  assign classc_ctrl_en_e2_we = addr_hit[36] & reg_we & !reg_error;
   assign classc_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classc_ctrl_en_e3_we = addr_hit[36] & reg_we & ~wr_err;
+  assign classc_ctrl_en_e3_we = addr_hit[36] & reg_we & !reg_error;
   assign classc_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classc_ctrl_map_e0_we = addr_hit[36] & reg_we & ~wr_err;
+  assign classc_ctrl_map_e0_we = addr_hit[36] & reg_we & !reg_error;
   assign classc_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classc_ctrl_map_e1_we = addr_hit[36] & reg_we & ~wr_err;
+  assign classc_ctrl_map_e1_we = addr_hit[36] & reg_we & !reg_error;
   assign classc_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classc_ctrl_map_e2_we = addr_hit[36] & reg_we & ~wr_err;
+  assign classc_ctrl_map_e2_we = addr_hit[36] & reg_we & !reg_error;
   assign classc_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classc_ctrl_map_e3_we = addr_hit[36] & reg_we & ~wr_err;
+  assign classc_ctrl_map_e3_we = addr_hit[36] & reg_we & !reg_error;
   assign classc_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classc_regwen_we = addr_hit[37] & reg_we & ~wr_err;
+  assign classc_regwen_we = addr_hit[37] & reg_we & !reg_error;
   assign classc_regwen_wd = reg_wdata[0];
 
-  assign classc_clr_we = addr_hit[38] & reg_we & ~wr_err;
+  assign classc_clr_we = addr_hit[38] & reg_we & !reg_error;
   assign classc_clr_wd = reg_wdata[0];
 
-  assign classc_accum_cnt_re = addr_hit[39] && reg_re;
+  assign classc_accum_cnt_re = addr_hit[39] & reg_re & !reg_error;
 
-  assign classc_accum_thresh_we = addr_hit[40] & reg_we & ~wr_err;
+  assign classc_accum_thresh_we = addr_hit[40] & reg_we & !reg_error;
   assign classc_accum_thresh_wd = reg_wdata[15:0];
 
-  assign classc_timeout_cyc_we = addr_hit[41] & reg_we & ~wr_err;
+  assign classc_timeout_cyc_we = addr_hit[41] & reg_we & !reg_error;
   assign classc_timeout_cyc_wd = reg_wdata[31:0];
 
-  assign classc_phase0_cyc_we = addr_hit[42] & reg_we & ~wr_err;
+  assign classc_phase0_cyc_we = addr_hit[42] & reg_we & !reg_error;
   assign classc_phase0_cyc_wd = reg_wdata[31:0];
 
-  assign classc_phase1_cyc_we = addr_hit[43] & reg_we & ~wr_err;
+  assign classc_phase1_cyc_we = addr_hit[43] & reg_we & !reg_error;
   assign classc_phase1_cyc_wd = reg_wdata[31:0];
 
-  assign classc_phase2_cyc_we = addr_hit[44] & reg_we & ~wr_err;
+  assign classc_phase2_cyc_we = addr_hit[44] & reg_we & !reg_error;
   assign classc_phase2_cyc_wd = reg_wdata[31:0];
 
-  assign classc_phase3_cyc_we = addr_hit[45] & reg_we & ~wr_err;
+  assign classc_phase3_cyc_we = addr_hit[45] & reg_we & !reg_error;
   assign classc_phase3_cyc_wd = reg_wdata[31:0];
 
-  assign classc_esc_cnt_re = addr_hit[46] && reg_re;
+  assign classc_esc_cnt_re = addr_hit[46] & reg_re & !reg_error;
 
-  assign classc_state_re = addr_hit[47] && reg_re;
+  assign classc_state_re = addr_hit[47] & reg_re & !reg_error;
 
-  assign classd_ctrl_en_we = addr_hit[48] & reg_we & ~wr_err;
+  assign classd_ctrl_en_we = addr_hit[48] & reg_we & !reg_error;
   assign classd_ctrl_en_wd = reg_wdata[0];
 
-  assign classd_ctrl_lock_we = addr_hit[48] & reg_we & ~wr_err;
+  assign classd_ctrl_lock_we = addr_hit[48] & reg_we & !reg_error;
   assign classd_ctrl_lock_wd = reg_wdata[1];
 
-  assign classd_ctrl_en_e0_we = addr_hit[48] & reg_we & ~wr_err;
+  assign classd_ctrl_en_e0_we = addr_hit[48] & reg_we & !reg_error;
   assign classd_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classd_ctrl_en_e1_we = addr_hit[48] & reg_we & ~wr_err;
+  assign classd_ctrl_en_e1_we = addr_hit[48] & reg_we & !reg_error;
   assign classd_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classd_ctrl_en_e2_we = addr_hit[48] & reg_we & ~wr_err;
+  assign classd_ctrl_en_e2_we = addr_hit[48] & reg_we & !reg_error;
   assign classd_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classd_ctrl_en_e3_we = addr_hit[48] & reg_we & ~wr_err;
+  assign classd_ctrl_en_e3_we = addr_hit[48] & reg_we & !reg_error;
   assign classd_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classd_ctrl_map_e0_we = addr_hit[48] & reg_we & ~wr_err;
+  assign classd_ctrl_map_e0_we = addr_hit[48] & reg_we & !reg_error;
   assign classd_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classd_ctrl_map_e1_we = addr_hit[48] & reg_we & ~wr_err;
+  assign classd_ctrl_map_e1_we = addr_hit[48] & reg_we & !reg_error;
   assign classd_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classd_ctrl_map_e2_we = addr_hit[48] & reg_we & ~wr_err;
+  assign classd_ctrl_map_e2_we = addr_hit[48] & reg_we & !reg_error;
   assign classd_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classd_ctrl_map_e3_we = addr_hit[48] & reg_we & ~wr_err;
+  assign classd_ctrl_map_e3_we = addr_hit[48] & reg_we & !reg_error;
   assign classd_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classd_regwen_we = addr_hit[49] & reg_we & ~wr_err;
+  assign classd_regwen_we = addr_hit[49] & reg_we & !reg_error;
   assign classd_regwen_wd = reg_wdata[0];
 
-  assign classd_clr_we = addr_hit[50] & reg_we & ~wr_err;
+  assign classd_clr_we = addr_hit[50] & reg_we & !reg_error;
   assign classd_clr_wd = reg_wdata[0];
 
-  assign classd_accum_cnt_re = addr_hit[51] && reg_re;
+  assign classd_accum_cnt_re = addr_hit[51] & reg_re & !reg_error;
 
-  assign classd_accum_thresh_we = addr_hit[52] & reg_we & ~wr_err;
+  assign classd_accum_thresh_we = addr_hit[52] & reg_we & !reg_error;
   assign classd_accum_thresh_wd = reg_wdata[15:0];
 
-  assign classd_timeout_cyc_we = addr_hit[53] & reg_we & ~wr_err;
+  assign classd_timeout_cyc_we = addr_hit[53] & reg_we & !reg_error;
   assign classd_timeout_cyc_wd = reg_wdata[31:0];
 
-  assign classd_phase0_cyc_we = addr_hit[54] & reg_we & ~wr_err;
+  assign classd_phase0_cyc_we = addr_hit[54] & reg_we & !reg_error;
   assign classd_phase0_cyc_wd = reg_wdata[31:0];
 
-  assign classd_phase1_cyc_we = addr_hit[55] & reg_we & ~wr_err;
+  assign classd_phase1_cyc_we = addr_hit[55] & reg_we & !reg_error;
   assign classd_phase1_cyc_wd = reg_wdata[31:0];
 
-  assign classd_phase2_cyc_we = addr_hit[56] & reg_we & ~wr_err;
+  assign classd_phase2_cyc_we = addr_hit[56] & reg_we & !reg_error;
   assign classd_phase2_cyc_wd = reg_wdata[31:0];
 
-  assign classd_phase3_cyc_we = addr_hit[57] & reg_we & ~wr_err;
+  assign classd_phase3_cyc_we = addr_hit[57] & reg_we & !reg_error;
   assign classd_phase3_cyc_wd = reg_wdata[31:0];
 
-  assign classd_esc_cnt_re = addr_hit[58] && reg_re;
+  assign classd_esc_cnt_re = addr_hit[58] & reg_re & !reg_error;
 
-  assign classd_state_re = addr_hit[59] && reg_re;
+  assign classd_state_re = addr_hit[59] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
@@ -283,19 +283,19 @@ module ast_reg_top (
   end
 
 
-  assign rwtype0_we = addr_hit[1] & reg_we & ~wr_err;
+  assign rwtype0_we = addr_hit[1] & reg_we & !reg_error;
   assign rwtype0_wd = reg_wdata[31:0];
 
-  assign rwtype1_field0_we = addr_hit[2] & reg_we & ~wr_err;
+  assign rwtype1_field0_we = addr_hit[2] & reg_we & !reg_error;
   assign rwtype1_field0_wd = reg_wdata[0];
 
-  assign rwtype1_field1_we = addr_hit[2] & reg_we & ~wr_err;
+  assign rwtype1_field1_we = addr_hit[2] & reg_we & !reg_error;
   assign rwtype1_field1_wd = reg_wdata[1];
 
-  assign rwtype1_field4_we = addr_hit[2] & reg_we & ~wr_err;
+  assign rwtype1_field4_we = addr_hit[2] & reg_we & !reg_error;
   assign rwtype1_field4_wd = reg_wdata[4];
 
-  assign rwtype1_field15_8_we = addr_hit[2] & reg_we & ~wr_err;
+  assign rwtype1_field15_8_we = addr_hit[2] & reg_we & !reg_error;
   assign rwtype1_field15_8_wd = reg_wdata[15:8];
 
   // Read data return

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -452,28 +452,28 @@ module clkmgr_reg_top (
     if (addr_hit[3] && reg_we && (CLKMGR_PERMIT[3] != (CLKMGR_PERMIT[3] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign jitter_enable_we = addr_hit[0] & reg_we & ~wr_err;
+  assign jitter_enable_we = addr_hit[0] & reg_we & !reg_error;
   assign jitter_enable_wd = reg_wdata[0];
 
-  assign clk_enables_clk_io_div4_peri_en_we = addr_hit[1] & reg_we & ~wr_err;
+  assign clk_enables_clk_io_div4_peri_en_we = addr_hit[1] & reg_we & !reg_error;
   assign clk_enables_clk_io_div4_peri_en_wd = reg_wdata[0];
 
-  assign clk_enables_clk_io_div2_peri_en_we = addr_hit[1] & reg_we & ~wr_err;
+  assign clk_enables_clk_io_div2_peri_en_we = addr_hit[1] & reg_we & !reg_error;
   assign clk_enables_clk_io_div2_peri_en_wd = reg_wdata[1];
 
-  assign clk_enables_clk_usb_peri_en_we = addr_hit[1] & reg_we & ~wr_err;
+  assign clk_enables_clk_usb_peri_en_we = addr_hit[1] & reg_we & !reg_error;
   assign clk_enables_clk_usb_peri_en_wd = reg_wdata[2];
 
-  assign clk_hints_clk_main_aes_hint_we = addr_hit[2] & reg_we & ~wr_err;
+  assign clk_hints_clk_main_aes_hint_we = addr_hit[2] & reg_we & !reg_error;
   assign clk_hints_clk_main_aes_hint_wd = reg_wdata[0];
 
-  assign clk_hints_clk_main_hmac_hint_we = addr_hit[2] & reg_we & ~wr_err;
+  assign clk_hints_clk_main_hmac_hint_we = addr_hit[2] & reg_we & !reg_error;
   assign clk_hints_clk_main_hmac_hint_wd = reg_wdata[1];
 
-  assign clk_hints_clk_main_kmac_hint_we = addr_hit[2] & reg_we & ~wr_err;
+  assign clk_hints_clk_main_kmac_hint_we = addr_hit[2] & reg_we & !reg_error;
   assign clk_hints_clk_main_kmac_hint_wd = reg_wdata[2];
 
-  assign clk_hints_clk_main_otbn_hint_we = addr_hit[2] & reg_we & ~wr_err;
+  assign clk_hints_clk_main_otbn_hint_we = addr_hit[2] & reg_we & !reg_error;
   assign clk_hints_clk_main_otbn_hint_wd = reg_wdata[3];
 
 

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_top.sv
@@ -10585,990 +10585,990 @@ module flash_ctrl_reg_top (
     if (addr_hit[90] && reg_we && (FLASH_CTRL_PERMIT[90] != (FLASH_CTRL_PERMIT[90] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_prog_empty_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_prog_empty_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_prog_empty_wd = reg_wdata[0];
 
-  assign intr_state_prog_lvl_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_prog_lvl_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_prog_lvl_wd = reg_wdata[1];
 
-  assign intr_state_rd_full_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rd_full_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rd_full_wd = reg_wdata[2];
 
-  assign intr_state_rd_lvl_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_rd_lvl_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rd_lvl_wd = reg_wdata[3];
 
-  assign intr_state_op_done_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_op_done_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_op_done_wd = reg_wdata[4];
 
-  assign intr_enable_prog_empty_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_prog_empty_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_prog_empty_wd = reg_wdata[0];
 
-  assign intr_enable_prog_lvl_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_prog_lvl_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_prog_lvl_wd = reg_wdata[1];
 
-  assign intr_enable_rd_full_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rd_full_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rd_full_wd = reg_wdata[2];
 
-  assign intr_enable_rd_lvl_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_rd_lvl_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rd_lvl_wd = reg_wdata[3];
 
-  assign intr_enable_op_done_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_op_done_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_op_done_wd = reg_wdata[4];
 
-  assign intr_test_prog_empty_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_prog_empty_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_prog_empty_wd = reg_wdata[0];
 
-  assign intr_test_prog_lvl_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_prog_lvl_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_prog_lvl_wd = reg_wdata[1];
 
-  assign intr_test_rd_full_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rd_full_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rd_full_wd = reg_wdata[2];
 
-  assign intr_test_rd_lvl_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_rd_lvl_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rd_lvl_wd = reg_wdata[3];
 
-  assign intr_test_op_done_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_op_done_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_op_done_wd = reg_wdata[4];
 
-  assign alert_test_recov_err_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_recov_err_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_recov_err_wd = reg_wdata[0];
 
-  assign alert_test_recov_mp_err_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_recov_mp_err_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_recov_mp_err_wd = reg_wdata[1];
 
-  assign alert_test_recov_ecc_err_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_recov_ecc_err_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_recov_ecc_err_wd = reg_wdata[2];
 
-  assign ctrl_regwen_re = addr_hit[4] && reg_re;
+  assign ctrl_regwen_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign control_start_we = addr_hit[5] & reg_we & ~wr_err;
+  assign control_start_we = addr_hit[5] & reg_we & !reg_error;
   assign control_start_wd = reg_wdata[0];
 
-  assign control_op_we = addr_hit[5] & reg_we & ~wr_err;
+  assign control_op_we = addr_hit[5] & reg_we & !reg_error;
   assign control_op_wd = reg_wdata[5:4];
 
-  assign control_prog_sel_we = addr_hit[5] & reg_we & ~wr_err;
+  assign control_prog_sel_we = addr_hit[5] & reg_we & !reg_error;
   assign control_prog_sel_wd = reg_wdata[6];
 
-  assign control_erase_sel_we = addr_hit[5] & reg_we & ~wr_err;
+  assign control_erase_sel_we = addr_hit[5] & reg_we & !reg_error;
   assign control_erase_sel_wd = reg_wdata[7];
 
-  assign control_partition_sel_we = addr_hit[5] & reg_we & ~wr_err;
+  assign control_partition_sel_we = addr_hit[5] & reg_we & !reg_error;
   assign control_partition_sel_wd = reg_wdata[8];
 
-  assign control_info_sel_we = addr_hit[5] & reg_we & ~wr_err;
+  assign control_info_sel_we = addr_hit[5] & reg_we & !reg_error;
   assign control_info_sel_wd = reg_wdata[10:9];
 
-  assign control_num_we = addr_hit[5] & reg_we & ~wr_err;
+  assign control_num_we = addr_hit[5] & reg_we & !reg_error;
   assign control_num_wd = reg_wdata[27:16];
 
-  assign addr_we = addr_hit[6] & reg_we & ~wr_err;
+  assign addr_we = addr_hit[6] & reg_we & !reg_error;
   assign addr_wd = reg_wdata[31:0];
 
-  assign prog_type_en_normal_we = addr_hit[7] & reg_we & ~wr_err;
+  assign prog_type_en_normal_we = addr_hit[7] & reg_we & !reg_error;
   assign prog_type_en_normal_wd = reg_wdata[0];
 
-  assign prog_type_en_repair_we = addr_hit[7] & reg_we & ~wr_err;
+  assign prog_type_en_repair_we = addr_hit[7] & reg_we & !reg_error;
   assign prog_type_en_repair_wd = reg_wdata[1];
 
-  assign erase_suspend_we = addr_hit[8] & reg_we & ~wr_err;
+  assign erase_suspend_we = addr_hit[8] & reg_we & !reg_error;
   assign erase_suspend_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_0_we = addr_hit[9] & reg_we & ~wr_err;
+  assign region_cfg_regwen_0_we = addr_hit[9] & reg_we & !reg_error;
   assign region_cfg_regwen_0_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_1_we = addr_hit[10] & reg_we & ~wr_err;
+  assign region_cfg_regwen_1_we = addr_hit[10] & reg_we & !reg_error;
   assign region_cfg_regwen_1_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_2_we = addr_hit[11] & reg_we & ~wr_err;
+  assign region_cfg_regwen_2_we = addr_hit[11] & reg_we & !reg_error;
   assign region_cfg_regwen_2_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_3_we = addr_hit[12] & reg_we & ~wr_err;
+  assign region_cfg_regwen_3_we = addr_hit[12] & reg_we & !reg_error;
   assign region_cfg_regwen_3_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_4_we = addr_hit[13] & reg_we & ~wr_err;
+  assign region_cfg_regwen_4_we = addr_hit[13] & reg_we & !reg_error;
   assign region_cfg_regwen_4_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_5_we = addr_hit[14] & reg_we & ~wr_err;
+  assign region_cfg_regwen_5_we = addr_hit[14] & reg_we & !reg_error;
   assign region_cfg_regwen_5_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_6_we = addr_hit[15] & reg_we & ~wr_err;
+  assign region_cfg_regwen_6_we = addr_hit[15] & reg_we & !reg_error;
   assign region_cfg_regwen_6_wd = reg_wdata[0];
 
-  assign region_cfg_regwen_7_we = addr_hit[16] & reg_we & ~wr_err;
+  assign region_cfg_regwen_7_we = addr_hit[16] & reg_we & !reg_error;
   assign region_cfg_regwen_7_wd = reg_wdata[0];
 
-  assign mp_region_cfg_0_en_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_en_0_we = addr_hit[17] & reg_we & !reg_error;
   assign mp_region_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign mp_region_cfg_0_rd_en_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_rd_en_0_we = addr_hit[17] & reg_we & !reg_error;
   assign mp_region_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign mp_region_cfg_0_prog_en_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_prog_en_0_we = addr_hit[17] & reg_we & !reg_error;
   assign mp_region_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign mp_region_cfg_0_erase_en_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_erase_en_0_we = addr_hit[17] & reg_we & !reg_error;
   assign mp_region_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign mp_region_cfg_0_scramble_en_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_scramble_en_0_we = addr_hit[17] & reg_we & !reg_error;
   assign mp_region_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign mp_region_cfg_0_ecc_en_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_ecc_en_0_we = addr_hit[17] & reg_we & !reg_error;
   assign mp_region_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign mp_region_cfg_0_he_en_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_he_en_0_we = addr_hit[17] & reg_we & !reg_error;
   assign mp_region_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign mp_region_cfg_0_base_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_base_0_we = addr_hit[17] & reg_we & !reg_error;
   assign mp_region_cfg_0_base_0_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_0_size_0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_size_0_we = addr_hit[17] & reg_we & !reg_error;
   assign mp_region_cfg_0_size_0_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_1_en_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_en_1_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign mp_region_cfg_1_rd_en_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_rd_en_1_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign mp_region_cfg_1_prog_en_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_prog_en_1_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign mp_region_cfg_1_erase_en_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_erase_en_1_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign mp_region_cfg_1_scramble_en_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_scramble_en_1_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign mp_region_cfg_1_ecc_en_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_ecc_en_1_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign mp_region_cfg_1_he_en_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_he_en_1_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign mp_region_cfg_1_base_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_base_1_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_1_base_1_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_1_size_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_size_1_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_1_size_1_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_2_en_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_en_2_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign mp_region_cfg_2_rd_en_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_rd_en_2_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign mp_region_cfg_2_prog_en_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_prog_en_2_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign mp_region_cfg_2_erase_en_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_erase_en_2_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign mp_region_cfg_2_scramble_en_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_scramble_en_2_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign mp_region_cfg_2_ecc_en_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_ecc_en_2_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign mp_region_cfg_2_he_en_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_he_en_2_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_2_he_en_2_wd = reg_wdata[6];
 
-  assign mp_region_cfg_2_base_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_base_2_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_2_base_2_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_2_size_2_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_size_2_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_2_size_2_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_3_en_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_en_3_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign mp_region_cfg_3_rd_en_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_rd_en_3_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign mp_region_cfg_3_prog_en_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_prog_en_3_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign mp_region_cfg_3_erase_en_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_erase_en_3_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign mp_region_cfg_3_scramble_en_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_scramble_en_3_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign mp_region_cfg_3_ecc_en_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_ecc_en_3_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign mp_region_cfg_3_he_en_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_he_en_3_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_3_he_en_3_wd = reg_wdata[6];
 
-  assign mp_region_cfg_3_base_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_base_3_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_3_base_3_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_3_size_3_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_size_3_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_3_size_3_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_4_en_4_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_en_4_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign mp_region_cfg_4_rd_en_4_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_rd_en_4_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign mp_region_cfg_4_prog_en_4_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_prog_en_4_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign mp_region_cfg_4_erase_en_4_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_erase_en_4_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign mp_region_cfg_4_scramble_en_4_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_scramble_en_4_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign mp_region_cfg_4_ecc_en_4_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_ecc_en_4_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign mp_region_cfg_4_he_en_4_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_he_en_4_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_4_he_en_4_wd = reg_wdata[6];
 
-  assign mp_region_cfg_4_base_4_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_base_4_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_4_base_4_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_4_size_4_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_size_4_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_4_size_4_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_5_en_5_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_en_5_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign mp_region_cfg_5_rd_en_5_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_rd_en_5_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign mp_region_cfg_5_prog_en_5_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_prog_en_5_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign mp_region_cfg_5_erase_en_5_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_erase_en_5_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign mp_region_cfg_5_scramble_en_5_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_scramble_en_5_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign mp_region_cfg_5_ecc_en_5_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_ecc_en_5_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign mp_region_cfg_5_he_en_5_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_he_en_5_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_5_he_en_5_wd = reg_wdata[6];
 
-  assign mp_region_cfg_5_base_5_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_base_5_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_5_base_5_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_5_size_5_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_size_5_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_5_size_5_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_6_en_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_en_6_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign mp_region_cfg_6_rd_en_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_rd_en_6_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign mp_region_cfg_6_prog_en_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_prog_en_6_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign mp_region_cfg_6_erase_en_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_erase_en_6_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign mp_region_cfg_6_scramble_en_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_scramble_en_6_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign mp_region_cfg_6_ecc_en_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_ecc_en_6_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign mp_region_cfg_6_he_en_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_he_en_6_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_6_he_en_6_wd = reg_wdata[6];
 
-  assign mp_region_cfg_6_base_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_base_6_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_6_base_6_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_6_size_6_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_size_6_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_6_size_6_wd = reg_wdata[26:17];
 
-  assign mp_region_cfg_7_en_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_en_7_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign mp_region_cfg_7_rd_en_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_rd_en_7_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign mp_region_cfg_7_prog_en_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_prog_en_7_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign mp_region_cfg_7_erase_en_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_erase_en_7_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign mp_region_cfg_7_scramble_en_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_scramble_en_7_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign mp_region_cfg_7_ecc_en_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_ecc_en_7_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign mp_region_cfg_7_he_en_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_he_en_7_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_7_he_en_7_wd = reg_wdata[6];
 
-  assign mp_region_cfg_7_base_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_base_7_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_7_base_7_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_7_size_7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_size_7_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_7_size_7_wd = reg_wdata[26:17];
 
-  assign default_region_rd_en_we = addr_hit[25] & reg_we & ~wr_err;
+  assign default_region_rd_en_we = addr_hit[25] & reg_we & !reg_error;
   assign default_region_rd_en_wd = reg_wdata[0];
 
-  assign default_region_prog_en_we = addr_hit[25] & reg_we & ~wr_err;
+  assign default_region_prog_en_we = addr_hit[25] & reg_we & !reg_error;
   assign default_region_prog_en_wd = reg_wdata[1];
 
-  assign default_region_erase_en_we = addr_hit[25] & reg_we & ~wr_err;
+  assign default_region_erase_en_we = addr_hit[25] & reg_we & !reg_error;
   assign default_region_erase_en_wd = reg_wdata[2];
 
-  assign default_region_scramble_en_we = addr_hit[25] & reg_we & ~wr_err;
+  assign default_region_scramble_en_we = addr_hit[25] & reg_we & !reg_error;
   assign default_region_scramble_en_wd = reg_wdata[3];
 
-  assign default_region_ecc_en_we = addr_hit[25] & reg_we & ~wr_err;
+  assign default_region_ecc_en_we = addr_hit[25] & reg_we & !reg_error;
   assign default_region_ecc_en_wd = reg_wdata[4];
 
-  assign default_region_he_en_we = addr_hit[25] & reg_we & ~wr_err;
+  assign default_region_he_en_we = addr_hit[25] & reg_we & !reg_error;
   assign default_region_he_en_wd = reg_wdata[5];
 
-  assign bank0_info0_regwen_0_we = addr_hit[26] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_0_we = addr_hit[26] & reg_we & !reg_error;
   assign bank0_info0_regwen_0_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_1_we = addr_hit[27] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_1_we = addr_hit[27] & reg_we & !reg_error;
   assign bank0_info0_regwen_1_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_2_we = addr_hit[28] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_2_we = addr_hit[28] & reg_we & !reg_error;
   assign bank0_info0_regwen_2_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_3_we = addr_hit[29] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_3_we = addr_hit[29] & reg_we & !reg_error;
   assign bank0_info0_regwen_3_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_4_we = addr_hit[30] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_4_we = addr_hit[30] & reg_we & !reg_error;
   assign bank0_info0_regwen_4_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_5_we = addr_hit[31] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_5_we = addr_hit[31] & reg_we & !reg_error;
   assign bank0_info0_regwen_5_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_6_we = addr_hit[32] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_6_we = addr_hit[32] & reg_we & !reg_error;
   assign bank0_info0_regwen_6_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_7_we = addr_hit[33] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_7_we = addr_hit[33] & reg_we & !reg_error;
   assign bank0_info0_regwen_7_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_8_we = addr_hit[34] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_8_we = addr_hit[34] & reg_we & !reg_error;
   assign bank0_info0_regwen_8_wd = reg_wdata[0];
 
-  assign bank0_info0_regwen_9_we = addr_hit[35] & reg_we & ~wr_err;
+  assign bank0_info0_regwen_9_we = addr_hit[35] & reg_we & !reg_error;
   assign bank0_info0_regwen_9_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_0_en_0_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_en_0_we = addr_hit[36] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_0_rd_en_0_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_rd_en_0_we = addr_hit[36] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_0_prog_en_0_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_prog_en_0_we = addr_hit[36] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_0_erase_en_0_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_erase_en_0_we = addr_hit[36] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_0_scramble_en_0_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_scramble_en_0_we = addr_hit[36] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_0_ecc_en_0_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_ecc_en_0_we = addr_hit[36] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_0_he_en_0_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_he_en_0_we = addr_hit[36] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_1_en_1_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_en_1_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_1_rd_en_1_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_rd_en_1_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_1_prog_en_1_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_prog_en_1_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_1_erase_en_1_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_erase_en_1_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_1_scramble_en_1_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_scramble_en_1_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_1_ecc_en_1_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_ecc_en_1_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_1_he_en_1_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_he_en_1_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_2_en_2_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_en_2_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_2_rd_en_2_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_rd_en_2_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_2_prog_en_2_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_prog_en_2_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_2_erase_en_2_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_erase_en_2_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_2_scramble_en_2_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_scramble_en_2_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_2_ecc_en_2_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_ecc_en_2_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_2_he_en_2_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_he_en_2_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_he_en_2_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_3_en_3_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_en_3_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_3_rd_en_3_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_rd_en_3_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_3_prog_en_3_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_prog_en_3_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_3_erase_en_3_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_erase_en_3_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_3_scramble_en_3_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_scramble_en_3_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_3_ecc_en_3_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_ecc_en_3_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_3_he_en_3_we = addr_hit[39] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_he_en_3_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_he_en_3_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_4_en_4_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_en_4_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_4_rd_en_4_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_rd_en_4_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_4_prog_en_4_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_prog_en_4_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_4_erase_en_4_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_erase_en_4_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_4_scramble_en_4_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_scramble_en_4_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_4_ecc_en_4_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_ecc_en_4_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_4_he_en_4_we = addr_hit[40] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_4_he_en_4_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_he_en_4_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_5_en_5_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_en_5_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_5_rd_en_5_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_rd_en_5_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_5_prog_en_5_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_prog_en_5_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_5_erase_en_5_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_erase_en_5_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_5_scramble_en_5_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_scramble_en_5_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_5_ecc_en_5_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_ecc_en_5_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_5_he_en_5_we = addr_hit[41] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_5_he_en_5_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_he_en_5_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_6_en_6_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_en_6_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_6_rd_en_6_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_rd_en_6_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_6_prog_en_6_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_prog_en_6_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_6_erase_en_6_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_erase_en_6_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_6_scramble_en_6_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_scramble_en_6_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_6_ecc_en_6_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_ecc_en_6_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_6_he_en_6_we = addr_hit[42] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_6_he_en_6_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_he_en_6_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_7_en_7_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_en_7_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_7_rd_en_7_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_rd_en_7_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_7_prog_en_7_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_prog_en_7_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_7_erase_en_7_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_erase_en_7_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_7_scramble_en_7_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_scramble_en_7_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_7_ecc_en_7_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_ecc_en_7_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_7_he_en_7_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_7_he_en_7_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_he_en_7_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_8_en_8_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_en_8_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_en_8_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_8_rd_en_8_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_rd_en_8_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_rd_en_8_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_8_prog_en_8_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_prog_en_8_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_prog_en_8_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_8_erase_en_8_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_erase_en_8_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_erase_en_8_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_8_scramble_en_8_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_scramble_en_8_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_scramble_en_8_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_8_ecc_en_8_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_ecc_en_8_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_ecc_en_8_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_8_he_en_8_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_8_he_en_8_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_he_en_8_wd = reg_wdata[6];
 
-  assign bank0_info0_page_cfg_9_en_9_we = addr_hit[45] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_en_9_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_en_9_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_9_rd_en_9_we = addr_hit[45] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_rd_en_9_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_rd_en_9_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_9_prog_en_9_we = addr_hit[45] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_prog_en_9_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_prog_en_9_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_9_erase_en_9_we = addr_hit[45] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_erase_en_9_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_erase_en_9_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_9_scramble_en_9_we = addr_hit[45] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_scramble_en_9_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_scramble_en_9_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_9_ecc_en_9_we = addr_hit[45] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_ecc_en_9_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_ecc_en_9_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_9_he_en_9_we = addr_hit[45] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_9_he_en_9_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_he_en_9_wd = reg_wdata[6];
 
-  assign bank0_info1_regwen_we = addr_hit[46] & reg_we & ~wr_err;
+  assign bank0_info1_regwen_we = addr_hit[46] & reg_we & !reg_error;
   assign bank0_info1_regwen_wd = reg_wdata[0];
 
-  assign bank0_info1_page_cfg_en_0_we = addr_hit[47] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_en_0_we = addr_hit[47] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_en_0_wd = reg_wdata[0];
 
-  assign bank0_info1_page_cfg_rd_en_0_we = addr_hit[47] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_rd_en_0_we = addr_hit[47] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info1_page_cfg_prog_en_0_we = addr_hit[47] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_prog_en_0_we = addr_hit[47] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info1_page_cfg_erase_en_0_we = addr_hit[47] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_erase_en_0_we = addr_hit[47] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info1_page_cfg_scramble_en_0_we = addr_hit[47] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_scramble_en_0_we = addr_hit[47] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info1_page_cfg_ecc_en_0_we = addr_hit[47] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_ecc_en_0_we = addr_hit[47] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info1_page_cfg_he_en_0_we = addr_hit[47] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_he_en_0_we = addr_hit[47] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_he_en_0_wd = reg_wdata[6];
 
-  assign bank0_info2_regwen_0_we = addr_hit[48] & reg_we & ~wr_err;
+  assign bank0_info2_regwen_0_we = addr_hit[48] & reg_we & !reg_error;
   assign bank0_info2_regwen_0_wd = reg_wdata[0];
 
-  assign bank0_info2_regwen_1_we = addr_hit[49] & reg_we & ~wr_err;
+  assign bank0_info2_regwen_1_we = addr_hit[49] & reg_we & !reg_error;
   assign bank0_info2_regwen_1_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_0_en_0_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_en_0_we = addr_hit[50] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_0_rd_en_0_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_rd_en_0_we = addr_hit[50] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info2_page_cfg_0_prog_en_0_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_prog_en_0_we = addr_hit[50] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info2_page_cfg_0_erase_en_0_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_erase_en_0_we = addr_hit[50] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info2_page_cfg_0_scramble_en_0_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_scramble_en_0_we = addr_hit[50] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info2_page_cfg_0_ecc_en_0_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_ecc_en_0_we = addr_hit[50] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info2_page_cfg_0_he_en_0_we = addr_hit[50] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_0_he_en_0_we = addr_hit[50] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign bank0_info2_page_cfg_1_en_1_we = addr_hit[51] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_en_1_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_1_rd_en_1_we = addr_hit[51] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_rd_en_1_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank0_info2_page_cfg_1_prog_en_1_we = addr_hit[51] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_prog_en_1_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank0_info2_page_cfg_1_erase_en_1_we = addr_hit[51] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_erase_en_1_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank0_info2_page_cfg_1_scramble_en_1_we = addr_hit[51] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_scramble_en_1_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank0_info2_page_cfg_1_ecc_en_1_we = addr_hit[51] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_ecc_en_1_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank0_info2_page_cfg_1_he_en_1_we = addr_hit[51] & reg_we & ~wr_err;
+  assign bank0_info2_page_cfg_1_he_en_1_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign bank1_info0_regwen_0_we = addr_hit[52] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_0_we = addr_hit[52] & reg_we & !reg_error;
   assign bank1_info0_regwen_0_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_1_we = addr_hit[53] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_1_we = addr_hit[53] & reg_we & !reg_error;
   assign bank1_info0_regwen_1_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_2_we = addr_hit[54] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_2_we = addr_hit[54] & reg_we & !reg_error;
   assign bank1_info0_regwen_2_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_3_we = addr_hit[55] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_3_we = addr_hit[55] & reg_we & !reg_error;
   assign bank1_info0_regwen_3_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_4_we = addr_hit[56] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_4_we = addr_hit[56] & reg_we & !reg_error;
   assign bank1_info0_regwen_4_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_5_we = addr_hit[57] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_5_we = addr_hit[57] & reg_we & !reg_error;
   assign bank1_info0_regwen_5_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_6_we = addr_hit[58] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_6_we = addr_hit[58] & reg_we & !reg_error;
   assign bank1_info0_regwen_6_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_7_we = addr_hit[59] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_7_we = addr_hit[59] & reg_we & !reg_error;
   assign bank1_info0_regwen_7_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_8_we = addr_hit[60] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_8_we = addr_hit[60] & reg_we & !reg_error;
   assign bank1_info0_regwen_8_wd = reg_wdata[0];
 
-  assign bank1_info0_regwen_9_we = addr_hit[61] & reg_we & ~wr_err;
+  assign bank1_info0_regwen_9_we = addr_hit[61] & reg_we & !reg_error;
   assign bank1_info0_regwen_9_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_0_en_0_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_en_0_we = addr_hit[62] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_0_rd_en_0_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_rd_en_0_we = addr_hit[62] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_0_prog_en_0_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_prog_en_0_we = addr_hit[62] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_0_erase_en_0_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_erase_en_0_we = addr_hit[62] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_0_scramble_en_0_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_scramble_en_0_we = addr_hit[62] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_0_ecc_en_0_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_ecc_en_0_we = addr_hit[62] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_0_he_en_0_we = addr_hit[62] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_he_en_0_we = addr_hit[62] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_1_en_1_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_en_1_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_1_rd_en_1_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_rd_en_1_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_1_prog_en_1_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_prog_en_1_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_1_erase_en_1_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_erase_en_1_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_1_scramble_en_1_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_scramble_en_1_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_1_ecc_en_1_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_ecc_en_1_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_1_he_en_1_we = addr_hit[63] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_he_en_1_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_2_en_2_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_en_2_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_2_rd_en_2_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_rd_en_2_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_2_prog_en_2_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_prog_en_2_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_2_erase_en_2_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_erase_en_2_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_2_scramble_en_2_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_scramble_en_2_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_2_ecc_en_2_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_ecc_en_2_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_2_he_en_2_we = addr_hit[64] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_he_en_2_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_he_en_2_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_3_en_3_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_en_3_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_3_rd_en_3_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_rd_en_3_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_3_prog_en_3_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_prog_en_3_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_3_erase_en_3_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_erase_en_3_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_3_scramble_en_3_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_scramble_en_3_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_3_ecc_en_3_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_ecc_en_3_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_3_he_en_3_we = addr_hit[65] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_he_en_3_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_he_en_3_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_4_en_4_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_en_4_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_4_rd_en_4_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_rd_en_4_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_4_prog_en_4_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_prog_en_4_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_4_erase_en_4_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_erase_en_4_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_4_scramble_en_4_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_scramble_en_4_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_4_ecc_en_4_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_ecc_en_4_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_4_he_en_4_we = addr_hit[66] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_4_he_en_4_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_he_en_4_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_5_en_5_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_en_5_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_5_rd_en_5_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_rd_en_5_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_5_prog_en_5_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_prog_en_5_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_5_erase_en_5_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_erase_en_5_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_5_scramble_en_5_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_scramble_en_5_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_5_ecc_en_5_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_ecc_en_5_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_5_he_en_5_we = addr_hit[67] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_5_he_en_5_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_he_en_5_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_6_en_6_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_en_6_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_6_rd_en_6_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_rd_en_6_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_6_prog_en_6_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_prog_en_6_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_6_erase_en_6_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_erase_en_6_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_6_scramble_en_6_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_scramble_en_6_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_6_ecc_en_6_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_ecc_en_6_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_6_he_en_6_we = addr_hit[68] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_6_he_en_6_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_he_en_6_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_7_en_7_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_en_7_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_7_rd_en_7_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_rd_en_7_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_7_prog_en_7_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_prog_en_7_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_7_erase_en_7_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_erase_en_7_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_7_scramble_en_7_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_scramble_en_7_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_7_ecc_en_7_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_ecc_en_7_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_7_he_en_7_we = addr_hit[69] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_7_he_en_7_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_he_en_7_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_8_en_8_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_en_8_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_en_8_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_8_rd_en_8_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_rd_en_8_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_rd_en_8_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_8_prog_en_8_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_prog_en_8_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_prog_en_8_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_8_erase_en_8_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_erase_en_8_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_erase_en_8_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_8_scramble_en_8_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_scramble_en_8_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_scramble_en_8_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_8_ecc_en_8_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_ecc_en_8_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_ecc_en_8_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_8_he_en_8_we = addr_hit[70] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_8_he_en_8_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_he_en_8_wd = reg_wdata[6];
 
-  assign bank1_info0_page_cfg_9_en_9_we = addr_hit[71] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_en_9_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_en_9_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_9_rd_en_9_we = addr_hit[71] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_rd_en_9_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_rd_en_9_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_9_prog_en_9_we = addr_hit[71] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_prog_en_9_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_prog_en_9_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_9_erase_en_9_we = addr_hit[71] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_erase_en_9_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_erase_en_9_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_9_scramble_en_9_we = addr_hit[71] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_scramble_en_9_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_scramble_en_9_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_9_ecc_en_9_we = addr_hit[71] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_ecc_en_9_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_ecc_en_9_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_9_he_en_9_we = addr_hit[71] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_9_he_en_9_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_he_en_9_wd = reg_wdata[6];
 
-  assign bank1_info1_regwen_we = addr_hit[72] & reg_we & ~wr_err;
+  assign bank1_info1_regwen_we = addr_hit[72] & reg_we & !reg_error;
   assign bank1_info1_regwen_wd = reg_wdata[0];
 
-  assign bank1_info1_page_cfg_en_0_we = addr_hit[73] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_en_0_we = addr_hit[73] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_en_0_wd = reg_wdata[0];
 
-  assign bank1_info1_page_cfg_rd_en_0_we = addr_hit[73] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_rd_en_0_we = addr_hit[73] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info1_page_cfg_prog_en_0_we = addr_hit[73] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_prog_en_0_we = addr_hit[73] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info1_page_cfg_erase_en_0_we = addr_hit[73] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_erase_en_0_we = addr_hit[73] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info1_page_cfg_scramble_en_0_we = addr_hit[73] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_scramble_en_0_we = addr_hit[73] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info1_page_cfg_ecc_en_0_we = addr_hit[73] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_ecc_en_0_we = addr_hit[73] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info1_page_cfg_he_en_0_we = addr_hit[73] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_he_en_0_we = addr_hit[73] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_he_en_0_wd = reg_wdata[6];
 
-  assign bank1_info2_regwen_0_we = addr_hit[74] & reg_we & ~wr_err;
+  assign bank1_info2_regwen_0_we = addr_hit[74] & reg_we & !reg_error;
   assign bank1_info2_regwen_0_wd = reg_wdata[0];
 
-  assign bank1_info2_regwen_1_we = addr_hit[75] & reg_we & ~wr_err;
+  assign bank1_info2_regwen_1_we = addr_hit[75] & reg_we & !reg_error;
   assign bank1_info2_regwen_1_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_0_en_0_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_en_0_we = addr_hit[76] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_0_rd_en_0_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_rd_en_0_we = addr_hit[76] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info2_page_cfg_0_prog_en_0_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_prog_en_0_we = addr_hit[76] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info2_page_cfg_0_erase_en_0_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_erase_en_0_we = addr_hit[76] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info2_page_cfg_0_scramble_en_0_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_scramble_en_0_we = addr_hit[76] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info2_page_cfg_0_ecc_en_0_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_ecc_en_0_we = addr_hit[76] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info2_page_cfg_0_he_en_0_we = addr_hit[76] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_0_he_en_0_we = addr_hit[76] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign bank1_info2_page_cfg_1_en_1_we = addr_hit[77] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_en_1_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_1_rd_en_1_we = addr_hit[77] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_rd_en_1_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank1_info2_page_cfg_1_prog_en_1_we = addr_hit[77] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_prog_en_1_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank1_info2_page_cfg_1_erase_en_1_we = addr_hit[77] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_erase_en_1_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank1_info2_page_cfg_1_scramble_en_1_we = addr_hit[77] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_scramble_en_1_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank1_info2_page_cfg_1_ecc_en_1_we = addr_hit[77] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_ecc_en_1_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank1_info2_page_cfg_1_he_en_1_we = addr_hit[77] & reg_we & ~wr_err;
+  assign bank1_info2_page_cfg_1_he_en_1_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign bank_cfg_regwen_we = addr_hit[78] & reg_we & ~wr_err;
+  assign bank_cfg_regwen_we = addr_hit[78] & reg_we & !reg_error;
   assign bank_cfg_regwen_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en_0_we = addr_hit[79] & reg_we & ~wr_err;
+  assign mp_bank_cfg_erase_en_0_we = addr_hit[79] & reg_we & !reg_error;
   assign mp_bank_cfg_erase_en_0_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en_1_we = addr_hit[79] & reg_we & ~wr_err;
+  assign mp_bank_cfg_erase_en_1_we = addr_hit[79] & reg_we & !reg_error;
   assign mp_bank_cfg_erase_en_1_wd = reg_wdata[1];
 
-  assign op_status_done_we = addr_hit[80] & reg_we & ~wr_err;
+  assign op_status_done_we = addr_hit[80] & reg_we & !reg_error;
   assign op_status_done_wd = reg_wdata[0];
 
-  assign op_status_err_we = addr_hit[80] & reg_we & ~wr_err;
+  assign op_status_err_we = addr_hit[80] & reg_we & !reg_error;
   assign op_status_err_wd = reg_wdata[1];
 
 
@@ -11576,43 +11576,43 @@ module flash_ctrl_reg_top (
 
 
 
-  assign err_code_flash_err_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_flash_err_we = addr_hit[82] & reg_we & !reg_error;
   assign err_code_flash_err_wd = reg_wdata[0];
 
-  assign err_code_flash_alert_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_flash_alert_we = addr_hit[82] & reg_we & !reg_error;
   assign err_code_flash_alert_wd = reg_wdata[1];
 
-  assign err_code_mp_err_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_mp_err_we = addr_hit[82] & reg_we & !reg_error;
   assign err_code_mp_err_wd = reg_wdata[2];
 
-  assign err_code_ecc_single_err_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_ecc_single_err_we = addr_hit[82] & reg_we & !reg_error;
   assign err_code_ecc_single_err_wd = reg_wdata[3];
 
-  assign err_code_ecc_multi_err_we = addr_hit[82] & reg_we & ~wr_err;
+  assign err_code_ecc_multi_err_we = addr_hit[82] & reg_we & !reg_error;
   assign err_code_ecc_multi_err_wd = reg_wdata[4];
 
 
 
 
-  assign phy_alert_cfg_alert_ack_we = addr_hit[86] & reg_we & ~wr_err;
+  assign phy_alert_cfg_alert_ack_we = addr_hit[86] & reg_we & !reg_error;
   assign phy_alert_cfg_alert_ack_wd = reg_wdata[0];
 
-  assign phy_alert_cfg_alert_trig_we = addr_hit[86] & reg_we & ~wr_err;
+  assign phy_alert_cfg_alert_trig_we = addr_hit[86] & reg_we & !reg_error;
   assign phy_alert_cfg_alert_trig_wd = reg_wdata[1];
 
 
 
 
-  assign scratch_we = addr_hit[88] & reg_we & ~wr_err;
+  assign scratch_we = addr_hit[88] & reg_we & !reg_error;
   assign scratch_wd = reg_wdata[31:0];
 
-  assign fifo_lvl_prog_we = addr_hit[89] & reg_we & ~wr_err;
+  assign fifo_lvl_prog_we = addr_hit[89] & reg_we & !reg_error;
   assign fifo_lvl_prog_wd = reg_wdata[4:0];
 
-  assign fifo_lvl_rd_we = addr_hit[89] & reg_we & ~wr_err;
+  assign fifo_lvl_rd_we = addr_hit[89] & reg_we & !reg_error;
   assign fifo_lvl_rd_wd = reg_wdata[12:8];
 
-  assign fifo_rst_we = addr_hit[90] & reg_we & ~wr_err;
+  assign fifo_rst_we = addr_hit[90] & reg_we & !reg_error;
   assign fifo_rst_wd = reg_wdata[0];
 
   // Read data return

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
@@ -19729,1998 +19729,1998 @@ module pinmux_reg_top (
     if (addr_hit[554] && reg_we && (PINMUX_PERMIT[554] != (PINMUX_PERMIT[554] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign mio_periph_insel_regwen_0_we = addr_hit[0] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_0_we = addr_hit[0] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_0_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_1_we = addr_hit[1] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_1_we = addr_hit[1] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_1_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_2_we = addr_hit[2] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_2_we = addr_hit[2] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_2_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_3_we = addr_hit[3] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_3_we = addr_hit[3] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_3_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_4_we = addr_hit[4] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_4_we = addr_hit[4] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_4_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_5_we = addr_hit[5] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_5_we = addr_hit[5] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_5_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_6_we = addr_hit[6] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_6_we = addr_hit[6] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_6_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_7_we = addr_hit[7] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_7_we = addr_hit[7] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_7_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_8_we = addr_hit[8] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_8_we = addr_hit[8] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_8_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_9_we = addr_hit[9] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_9_we = addr_hit[9] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_9_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_10_we = addr_hit[10] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_10_we = addr_hit[10] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_10_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_11_we = addr_hit[11] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_11_we = addr_hit[11] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_11_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_12_we = addr_hit[12] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_12_we = addr_hit[12] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_12_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_13_we = addr_hit[13] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_13_we = addr_hit[13] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_13_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_14_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_14_we = addr_hit[14] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_14_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_15_we = addr_hit[15] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_15_we = addr_hit[15] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_15_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_16_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_16_we = addr_hit[16] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_16_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_17_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_17_we = addr_hit[17] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_17_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_18_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_18_we = addr_hit[18] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_18_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_19_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_19_we = addr_hit[19] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_19_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_20_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_20_we = addr_hit[20] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_20_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_21_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_21_we = addr_hit[21] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_21_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_22_we = addr_hit[22] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_22_we = addr_hit[22] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_22_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_23_we = addr_hit[23] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_23_we = addr_hit[23] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_23_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_24_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_24_we = addr_hit[24] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_24_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_25_we = addr_hit[25] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_25_we = addr_hit[25] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_25_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_26_we = addr_hit[26] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_26_we = addr_hit[26] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_26_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_27_we = addr_hit[27] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_27_we = addr_hit[27] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_27_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_28_we = addr_hit[28] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_28_we = addr_hit[28] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_28_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_29_we = addr_hit[29] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_29_we = addr_hit[29] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_29_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_30_we = addr_hit[30] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_30_we = addr_hit[30] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_30_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_31_we = addr_hit[31] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_31_we = addr_hit[31] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_31_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_32_we = addr_hit[32] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_32_we = addr_hit[32] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_32_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_33_we = addr_hit[33] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_33_we = addr_hit[33] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_33_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_34_we = addr_hit[34] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_34_we = addr_hit[34] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_34_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_35_we = addr_hit[35] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_35_we = addr_hit[35] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_35_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_36_we = addr_hit[36] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_36_we = addr_hit[36] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_36_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_37_we = addr_hit[37] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_37_we = addr_hit[37] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_37_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_38_we = addr_hit[38] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_38_we = addr_hit[38] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_38_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_39_we = addr_hit[39] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_39_we = addr_hit[39] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_39_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_40_we = addr_hit[40] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_40_we = addr_hit[40] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_40_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_41_we = addr_hit[41] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_41_we = addr_hit[41] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_41_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_42_we = addr_hit[42] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_42_we = addr_hit[42] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_42_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_43_we = addr_hit[43] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_43_we = addr_hit[43] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_43_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_44_we = addr_hit[44] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_44_we = addr_hit[44] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_44_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_45_we = addr_hit[45] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_45_we = addr_hit[45] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_45_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_46_we = addr_hit[46] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_46_we = addr_hit[46] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_46_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_47_we = addr_hit[47] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_47_we = addr_hit[47] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_47_wd = reg_wdata[0];
 
-  assign mio_periph_insel_regwen_48_we = addr_hit[48] & reg_we & ~wr_err;
+  assign mio_periph_insel_regwen_48_we = addr_hit[48] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_48_wd = reg_wdata[0];
 
-  assign mio_periph_insel_0_we = addr_hit[49] & reg_we & ~wr_err;
+  assign mio_periph_insel_0_we = addr_hit[49] & reg_we & !reg_error;
   assign mio_periph_insel_0_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_1_we = addr_hit[50] & reg_we & ~wr_err;
+  assign mio_periph_insel_1_we = addr_hit[50] & reg_we & !reg_error;
   assign mio_periph_insel_1_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_2_we = addr_hit[51] & reg_we & ~wr_err;
+  assign mio_periph_insel_2_we = addr_hit[51] & reg_we & !reg_error;
   assign mio_periph_insel_2_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_3_we = addr_hit[52] & reg_we & ~wr_err;
+  assign mio_periph_insel_3_we = addr_hit[52] & reg_we & !reg_error;
   assign mio_periph_insel_3_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_4_we = addr_hit[53] & reg_we & ~wr_err;
+  assign mio_periph_insel_4_we = addr_hit[53] & reg_we & !reg_error;
   assign mio_periph_insel_4_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_5_we = addr_hit[54] & reg_we & ~wr_err;
+  assign mio_periph_insel_5_we = addr_hit[54] & reg_we & !reg_error;
   assign mio_periph_insel_5_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_6_we = addr_hit[55] & reg_we & ~wr_err;
+  assign mio_periph_insel_6_we = addr_hit[55] & reg_we & !reg_error;
   assign mio_periph_insel_6_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_7_we = addr_hit[56] & reg_we & ~wr_err;
+  assign mio_periph_insel_7_we = addr_hit[56] & reg_we & !reg_error;
   assign mio_periph_insel_7_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_8_we = addr_hit[57] & reg_we & ~wr_err;
+  assign mio_periph_insel_8_we = addr_hit[57] & reg_we & !reg_error;
   assign mio_periph_insel_8_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_9_we = addr_hit[58] & reg_we & ~wr_err;
+  assign mio_periph_insel_9_we = addr_hit[58] & reg_we & !reg_error;
   assign mio_periph_insel_9_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_10_we = addr_hit[59] & reg_we & ~wr_err;
+  assign mio_periph_insel_10_we = addr_hit[59] & reg_we & !reg_error;
   assign mio_periph_insel_10_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_11_we = addr_hit[60] & reg_we & ~wr_err;
+  assign mio_periph_insel_11_we = addr_hit[60] & reg_we & !reg_error;
   assign mio_periph_insel_11_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_12_we = addr_hit[61] & reg_we & ~wr_err;
+  assign mio_periph_insel_12_we = addr_hit[61] & reg_we & !reg_error;
   assign mio_periph_insel_12_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_13_we = addr_hit[62] & reg_we & ~wr_err;
+  assign mio_periph_insel_13_we = addr_hit[62] & reg_we & !reg_error;
   assign mio_periph_insel_13_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_14_we = addr_hit[63] & reg_we & ~wr_err;
+  assign mio_periph_insel_14_we = addr_hit[63] & reg_we & !reg_error;
   assign mio_periph_insel_14_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_15_we = addr_hit[64] & reg_we & ~wr_err;
+  assign mio_periph_insel_15_we = addr_hit[64] & reg_we & !reg_error;
   assign mio_periph_insel_15_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_16_we = addr_hit[65] & reg_we & ~wr_err;
+  assign mio_periph_insel_16_we = addr_hit[65] & reg_we & !reg_error;
   assign mio_periph_insel_16_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_17_we = addr_hit[66] & reg_we & ~wr_err;
+  assign mio_periph_insel_17_we = addr_hit[66] & reg_we & !reg_error;
   assign mio_periph_insel_17_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_18_we = addr_hit[67] & reg_we & ~wr_err;
+  assign mio_periph_insel_18_we = addr_hit[67] & reg_we & !reg_error;
   assign mio_periph_insel_18_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_19_we = addr_hit[68] & reg_we & ~wr_err;
+  assign mio_periph_insel_19_we = addr_hit[68] & reg_we & !reg_error;
   assign mio_periph_insel_19_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_20_we = addr_hit[69] & reg_we & ~wr_err;
+  assign mio_periph_insel_20_we = addr_hit[69] & reg_we & !reg_error;
   assign mio_periph_insel_20_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_21_we = addr_hit[70] & reg_we & ~wr_err;
+  assign mio_periph_insel_21_we = addr_hit[70] & reg_we & !reg_error;
   assign mio_periph_insel_21_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_22_we = addr_hit[71] & reg_we & ~wr_err;
+  assign mio_periph_insel_22_we = addr_hit[71] & reg_we & !reg_error;
   assign mio_periph_insel_22_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_23_we = addr_hit[72] & reg_we & ~wr_err;
+  assign mio_periph_insel_23_we = addr_hit[72] & reg_we & !reg_error;
   assign mio_periph_insel_23_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_24_we = addr_hit[73] & reg_we & ~wr_err;
+  assign mio_periph_insel_24_we = addr_hit[73] & reg_we & !reg_error;
   assign mio_periph_insel_24_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_25_we = addr_hit[74] & reg_we & ~wr_err;
+  assign mio_periph_insel_25_we = addr_hit[74] & reg_we & !reg_error;
   assign mio_periph_insel_25_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_26_we = addr_hit[75] & reg_we & ~wr_err;
+  assign mio_periph_insel_26_we = addr_hit[75] & reg_we & !reg_error;
   assign mio_periph_insel_26_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_27_we = addr_hit[76] & reg_we & ~wr_err;
+  assign mio_periph_insel_27_we = addr_hit[76] & reg_we & !reg_error;
   assign mio_periph_insel_27_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_28_we = addr_hit[77] & reg_we & ~wr_err;
+  assign mio_periph_insel_28_we = addr_hit[77] & reg_we & !reg_error;
   assign mio_periph_insel_28_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_29_we = addr_hit[78] & reg_we & ~wr_err;
+  assign mio_periph_insel_29_we = addr_hit[78] & reg_we & !reg_error;
   assign mio_periph_insel_29_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_30_we = addr_hit[79] & reg_we & ~wr_err;
+  assign mio_periph_insel_30_we = addr_hit[79] & reg_we & !reg_error;
   assign mio_periph_insel_30_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_31_we = addr_hit[80] & reg_we & ~wr_err;
+  assign mio_periph_insel_31_we = addr_hit[80] & reg_we & !reg_error;
   assign mio_periph_insel_31_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_32_we = addr_hit[81] & reg_we & ~wr_err;
+  assign mio_periph_insel_32_we = addr_hit[81] & reg_we & !reg_error;
   assign mio_periph_insel_32_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_33_we = addr_hit[82] & reg_we & ~wr_err;
+  assign mio_periph_insel_33_we = addr_hit[82] & reg_we & !reg_error;
   assign mio_periph_insel_33_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_34_we = addr_hit[83] & reg_we & ~wr_err;
+  assign mio_periph_insel_34_we = addr_hit[83] & reg_we & !reg_error;
   assign mio_periph_insel_34_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_35_we = addr_hit[84] & reg_we & ~wr_err;
+  assign mio_periph_insel_35_we = addr_hit[84] & reg_we & !reg_error;
   assign mio_periph_insel_35_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_36_we = addr_hit[85] & reg_we & ~wr_err;
+  assign mio_periph_insel_36_we = addr_hit[85] & reg_we & !reg_error;
   assign mio_periph_insel_36_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_37_we = addr_hit[86] & reg_we & ~wr_err;
+  assign mio_periph_insel_37_we = addr_hit[86] & reg_we & !reg_error;
   assign mio_periph_insel_37_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_38_we = addr_hit[87] & reg_we & ~wr_err;
+  assign mio_periph_insel_38_we = addr_hit[87] & reg_we & !reg_error;
   assign mio_periph_insel_38_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_39_we = addr_hit[88] & reg_we & ~wr_err;
+  assign mio_periph_insel_39_we = addr_hit[88] & reg_we & !reg_error;
   assign mio_periph_insel_39_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_40_we = addr_hit[89] & reg_we & ~wr_err;
+  assign mio_periph_insel_40_we = addr_hit[89] & reg_we & !reg_error;
   assign mio_periph_insel_40_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_41_we = addr_hit[90] & reg_we & ~wr_err;
+  assign mio_periph_insel_41_we = addr_hit[90] & reg_we & !reg_error;
   assign mio_periph_insel_41_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_42_we = addr_hit[91] & reg_we & ~wr_err;
+  assign mio_periph_insel_42_we = addr_hit[91] & reg_we & !reg_error;
   assign mio_periph_insel_42_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_43_we = addr_hit[92] & reg_we & ~wr_err;
+  assign mio_periph_insel_43_we = addr_hit[92] & reg_we & !reg_error;
   assign mio_periph_insel_43_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_44_we = addr_hit[93] & reg_we & ~wr_err;
+  assign mio_periph_insel_44_we = addr_hit[93] & reg_we & !reg_error;
   assign mio_periph_insel_44_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_45_we = addr_hit[94] & reg_we & ~wr_err;
+  assign mio_periph_insel_45_we = addr_hit[94] & reg_we & !reg_error;
   assign mio_periph_insel_45_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_46_we = addr_hit[95] & reg_we & ~wr_err;
+  assign mio_periph_insel_46_we = addr_hit[95] & reg_we & !reg_error;
   assign mio_periph_insel_46_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_47_we = addr_hit[96] & reg_we & ~wr_err;
+  assign mio_periph_insel_47_we = addr_hit[96] & reg_we & !reg_error;
   assign mio_periph_insel_47_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_48_we = addr_hit[97] & reg_we & ~wr_err;
+  assign mio_periph_insel_48_we = addr_hit[97] & reg_we & !reg_error;
   assign mio_periph_insel_48_wd = reg_wdata[5:0];
 
-  assign mio_outsel_regwen_0_we = addr_hit[98] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_0_we = addr_hit[98] & reg_we & !reg_error;
   assign mio_outsel_regwen_0_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_1_we = addr_hit[99] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_1_we = addr_hit[99] & reg_we & !reg_error;
   assign mio_outsel_regwen_1_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_2_we = addr_hit[100] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_2_we = addr_hit[100] & reg_we & !reg_error;
   assign mio_outsel_regwen_2_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_3_we = addr_hit[101] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_3_we = addr_hit[101] & reg_we & !reg_error;
   assign mio_outsel_regwen_3_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_4_we = addr_hit[102] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_4_we = addr_hit[102] & reg_we & !reg_error;
   assign mio_outsel_regwen_4_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_5_we = addr_hit[103] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_5_we = addr_hit[103] & reg_we & !reg_error;
   assign mio_outsel_regwen_5_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_6_we = addr_hit[104] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_6_we = addr_hit[104] & reg_we & !reg_error;
   assign mio_outsel_regwen_6_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_7_we = addr_hit[105] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_7_we = addr_hit[105] & reg_we & !reg_error;
   assign mio_outsel_regwen_7_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_8_we = addr_hit[106] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_8_we = addr_hit[106] & reg_we & !reg_error;
   assign mio_outsel_regwen_8_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_9_we = addr_hit[107] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_9_we = addr_hit[107] & reg_we & !reg_error;
   assign mio_outsel_regwen_9_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_10_we = addr_hit[108] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_10_we = addr_hit[108] & reg_we & !reg_error;
   assign mio_outsel_regwen_10_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_11_we = addr_hit[109] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_11_we = addr_hit[109] & reg_we & !reg_error;
   assign mio_outsel_regwen_11_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_12_we = addr_hit[110] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_12_we = addr_hit[110] & reg_we & !reg_error;
   assign mio_outsel_regwen_12_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_13_we = addr_hit[111] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_13_we = addr_hit[111] & reg_we & !reg_error;
   assign mio_outsel_regwen_13_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_14_we = addr_hit[112] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_14_we = addr_hit[112] & reg_we & !reg_error;
   assign mio_outsel_regwen_14_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_15_we = addr_hit[113] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_15_we = addr_hit[113] & reg_we & !reg_error;
   assign mio_outsel_regwen_15_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_16_we = addr_hit[114] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_16_we = addr_hit[114] & reg_we & !reg_error;
   assign mio_outsel_regwen_16_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_17_we = addr_hit[115] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_17_we = addr_hit[115] & reg_we & !reg_error;
   assign mio_outsel_regwen_17_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_18_we = addr_hit[116] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_18_we = addr_hit[116] & reg_we & !reg_error;
   assign mio_outsel_regwen_18_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_19_we = addr_hit[117] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_19_we = addr_hit[117] & reg_we & !reg_error;
   assign mio_outsel_regwen_19_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_20_we = addr_hit[118] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_20_we = addr_hit[118] & reg_we & !reg_error;
   assign mio_outsel_regwen_20_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_21_we = addr_hit[119] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_21_we = addr_hit[119] & reg_we & !reg_error;
   assign mio_outsel_regwen_21_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_22_we = addr_hit[120] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_22_we = addr_hit[120] & reg_we & !reg_error;
   assign mio_outsel_regwen_22_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_23_we = addr_hit[121] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_23_we = addr_hit[121] & reg_we & !reg_error;
   assign mio_outsel_regwen_23_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_24_we = addr_hit[122] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_24_we = addr_hit[122] & reg_we & !reg_error;
   assign mio_outsel_regwen_24_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_25_we = addr_hit[123] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_25_we = addr_hit[123] & reg_we & !reg_error;
   assign mio_outsel_regwen_25_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_26_we = addr_hit[124] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_26_we = addr_hit[124] & reg_we & !reg_error;
   assign mio_outsel_regwen_26_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_27_we = addr_hit[125] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_27_we = addr_hit[125] & reg_we & !reg_error;
   assign mio_outsel_regwen_27_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_28_we = addr_hit[126] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_28_we = addr_hit[126] & reg_we & !reg_error;
   assign mio_outsel_regwen_28_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_29_we = addr_hit[127] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_29_we = addr_hit[127] & reg_we & !reg_error;
   assign mio_outsel_regwen_29_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_30_we = addr_hit[128] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_30_we = addr_hit[128] & reg_we & !reg_error;
   assign mio_outsel_regwen_30_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_31_we = addr_hit[129] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_31_we = addr_hit[129] & reg_we & !reg_error;
   assign mio_outsel_regwen_31_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_32_we = addr_hit[130] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_32_we = addr_hit[130] & reg_we & !reg_error;
   assign mio_outsel_regwen_32_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_33_we = addr_hit[131] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_33_we = addr_hit[131] & reg_we & !reg_error;
   assign mio_outsel_regwen_33_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_34_we = addr_hit[132] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_34_we = addr_hit[132] & reg_we & !reg_error;
   assign mio_outsel_regwen_34_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_35_we = addr_hit[133] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_35_we = addr_hit[133] & reg_we & !reg_error;
   assign mio_outsel_regwen_35_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_36_we = addr_hit[134] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_36_we = addr_hit[134] & reg_we & !reg_error;
   assign mio_outsel_regwen_36_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_37_we = addr_hit[135] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_37_we = addr_hit[135] & reg_we & !reg_error;
   assign mio_outsel_regwen_37_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_38_we = addr_hit[136] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_38_we = addr_hit[136] & reg_we & !reg_error;
   assign mio_outsel_regwen_38_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_39_we = addr_hit[137] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_39_we = addr_hit[137] & reg_we & !reg_error;
   assign mio_outsel_regwen_39_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_40_we = addr_hit[138] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_40_we = addr_hit[138] & reg_we & !reg_error;
   assign mio_outsel_regwen_40_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_41_we = addr_hit[139] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_41_we = addr_hit[139] & reg_we & !reg_error;
   assign mio_outsel_regwen_41_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_42_we = addr_hit[140] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_42_we = addr_hit[140] & reg_we & !reg_error;
   assign mio_outsel_regwen_42_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_43_we = addr_hit[141] & reg_we & ~wr_err;
+  assign mio_outsel_regwen_43_we = addr_hit[141] & reg_we & !reg_error;
   assign mio_outsel_regwen_43_wd = reg_wdata[0];
 
-  assign mio_outsel_0_we = addr_hit[142] & reg_we & ~wr_err;
+  assign mio_outsel_0_we = addr_hit[142] & reg_we & !reg_error;
   assign mio_outsel_0_wd = reg_wdata[5:0];
 
-  assign mio_outsel_1_we = addr_hit[143] & reg_we & ~wr_err;
+  assign mio_outsel_1_we = addr_hit[143] & reg_we & !reg_error;
   assign mio_outsel_1_wd = reg_wdata[5:0];
 
-  assign mio_outsel_2_we = addr_hit[144] & reg_we & ~wr_err;
+  assign mio_outsel_2_we = addr_hit[144] & reg_we & !reg_error;
   assign mio_outsel_2_wd = reg_wdata[5:0];
 
-  assign mio_outsel_3_we = addr_hit[145] & reg_we & ~wr_err;
+  assign mio_outsel_3_we = addr_hit[145] & reg_we & !reg_error;
   assign mio_outsel_3_wd = reg_wdata[5:0];
 
-  assign mio_outsel_4_we = addr_hit[146] & reg_we & ~wr_err;
+  assign mio_outsel_4_we = addr_hit[146] & reg_we & !reg_error;
   assign mio_outsel_4_wd = reg_wdata[5:0];
 
-  assign mio_outsel_5_we = addr_hit[147] & reg_we & ~wr_err;
+  assign mio_outsel_5_we = addr_hit[147] & reg_we & !reg_error;
   assign mio_outsel_5_wd = reg_wdata[5:0];
 
-  assign mio_outsel_6_we = addr_hit[148] & reg_we & ~wr_err;
+  assign mio_outsel_6_we = addr_hit[148] & reg_we & !reg_error;
   assign mio_outsel_6_wd = reg_wdata[5:0];
 
-  assign mio_outsel_7_we = addr_hit[149] & reg_we & ~wr_err;
+  assign mio_outsel_7_we = addr_hit[149] & reg_we & !reg_error;
   assign mio_outsel_7_wd = reg_wdata[5:0];
 
-  assign mio_outsel_8_we = addr_hit[150] & reg_we & ~wr_err;
+  assign mio_outsel_8_we = addr_hit[150] & reg_we & !reg_error;
   assign mio_outsel_8_wd = reg_wdata[5:0];
 
-  assign mio_outsel_9_we = addr_hit[151] & reg_we & ~wr_err;
+  assign mio_outsel_9_we = addr_hit[151] & reg_we & !reg_error;
   assign mio_outsel_9_wd = reg_wdata[5:0];
 
-  assign mio_outsel_10_we = addr_hit[152] & reg_we & ~wr_err;
+  assign mio_outsel_10_we = addr_hit[152] & reg_we & !reg_error;
   assign mio_outsel_10_wd = reg_wdata[5:0];
 
-  assign mio_outsel_11_we = addr_hit[153] & reg_we & ~wr_err;
+  assign mio_outsel_11_we = addr_hit[153] & reg_we & !reg_error;
   assign mio_outsel_11_wd = reg_wdata[5:0];
 
-  assign mio_outsel_12_we = addr_hit[154] & reg_we & ~wr_err;
+  assign mio_outsel_12_we = addr_hit[154] & reg_we & !reg_error;
   assign mio_outsel_12_wd = reg_wdata[5:0];
 
-  assign mio_outsel_13_we = addr_hit[155] & reg_we & ~wr_err;
+  assign mio_outsel_13_we = addr_hit[155] & reg_we & !reg_error;
   assign mio_outsel_13_wd = reg_wdata[5:0];
 
-  assign mio_outsel_14_we = addr_hit[156] & reg_we & ~wr_err;
+  assign mio_outsel_14_we = addr_hit[156] & reg_we & !reg_error;
   assign mio_outsel_14_wd = reg_wdata[5:0];
 
-  assign mio_outsel_15_we = addr_hit[157] & reg_we & ~wr_err;
+  assign mio_outsel_15_we = addr_hit[157] & reg_we & !reg_error;
   assign mio_outsel_15_wd = reg_wdata[5:0];
 
-  assign mio_outsel_16_we = addr_hit[158] & reg_we & ~wr_err;
+  assign mio_outsel_16_we = addr_hit[158] & reg_we & !reg_error;
   assign mio_outsel_16_wd = reg_wdata[5:0];
 
-  assign mio_outsel_17_we = addr_hit[159] & reg_we & ~wr_err;
+  assign mio_outsel_17_we = addr_hit[159] & reg_we & !reg_error;
   assign mio_outsel_17_wd = reg_wdata[5:0];
 
-  assign mio_outsel_18_we = addr_hit[160] & reg_we & ~wr_err;
+  assign mio_outsel_18_we = addr_hit[160] & reg_we & !reg_error;
   assign mio_outsel_18_wd = reg_wdata[5:0];
 
-  assign mio_outsel_19_we = addr_hit[161] & reg_we & ~wr_err;
+  assign mio_outsel_19_we = addr_hit[161] & reg_we & !reg_error;
   assign mio_outsel_19_wd = reg_wdata[5:0];
 
-  assign mio_outsel_20_we = addr_hit[162] & reg_we & ~wr_err;
+  assign mio_outsel_20_we = addr_hit[162] & reg_we & !reg_error;
   assign mio_outsel_20_wd = reg_wdata[5:0];
 
-  assign mio_outsel_21_we = addr_hit[163] & reg_we & ~wr_err;
+  assign mio_outsel_21_we = addr_hit[163] & reg_we & !reg_error;
   assign mio_outsel_21_wd = reg_wdata[5:0];
 
-  assign mio_outsel_22_we = addr_hit[164] & reg_we & ~wr_err;
+  assign mio_outsel_22_we = addr_hit[164] & reg_we & !reg_error;
   assign mio_outsel_22_wd = reg_wdata[5:0];
 
-  assign mio_outsel_23_we = addr_hit[165] & reg_we & ~wr_err;
+  assign mio_outsel_23_we = addr_hit[165] & reg_we & !reg_error;
   assign mio_outsel_23_wd = reg_wdata[5:0];
 
-  assign mio_outsel_24_we = addr_hit[166] & reg_we & ~wr_err;
+  assign mio_outsel_24_we = addr_hit[166] & reg_we & !reg_error;
   assign mio_outsel_24_wd = reg_wdata[5:0];
 
-  assign mio_outsel_25_we = addr_hit[167] & reg_we & ~wr_err;
+  assign mio_outsel_25_we = addr_hit[167] & reg_we & !reg_error;
   assign mio_outsel_25_wd = reg_wdata[5:0];
 
-  assign mio_outsel_26_we = addr_hit[168] & reg_we & ~wr_err;
+  assign mio_outsel_26_we = addr_hit[168] & reg_we & !reg_error;
   assign mio_outsel_26_wd = reg_wdata[5:0];
 
-  assign mio_outsel_27_we = addr_hit[169] & reg_we & ~wr_err;
+  assign mio_outsel_27_we = addr_hit[169] & reg_we & !reg_error;
   assign mio_outsel_27_wd = reg_wdata[5:0];
 
-  assign mio_outsel_28_we = addr_hit[170] & reg_we & ~wr_err;
+  assign mio_outsel_28_we = addr_hit[170] & reg_we & !reg_error;
   assign mio_outsel_28_wd = reg_wdata[5:0];
 
-  assign mio_outsel_29_we = addr_hit[171] & reg_we & ~wr_err;
+  assign mio_outsel_29_we = addr_hit[171] & reg_we & !reg_error;
   assign mio_outsel_29_wd = reg_wdata[5:0];
 
-  assign mio_outsel_30_we = addr_hit[172] & reg_we & ~wr_err;
+  assign mio_outsel_30_we = addr_hit[172] & reg_we & !reg_error;
   assign mio_outsel_30_wd = reg_wdata[5:0];
 
-  assign mio_outsel_31_we = addr_hit[173] & reg_we & ~wr_err;
+  assign mio_outsel_31_we = addr_hit[173] & reg_we & !reg_error;
   assign mio_outsel_31_wd = reg_wdata[5:0];
 
-  assign mio_outsel_32_we = addr_hit[174] & reg_we & ~wr_err;
+  assign mio_outsel_32_we = addr_hit[174] & reg_we & !reg_error;
   assign mio_outsel_32_wd = reg_wdata[5:0];
 
-  assign mio_outsel_33_we = addr_hit[175] & reg_we & ~wr_err;
+  assign mio_outsel_33_we = addr_hit[175] & reg_we & !reg_error;
   assign mio_outsel_33_wd = reg_wdata[5:0];
 
-  assign mio_outsel_34_we = addr_hit[176] & reg_we & ~wr_err;
+  assign mio_outsel_34_we = addr_hit[176] & reg_we & !reg_error;
   assign mio_outsel_34_wd = reg_wdata[5:0];
 
-  assign mio_outsel_35_we = addr_hit[177] & reg_we & ~wr_err;
+  assign mio_outsel_35_we = addr_hit[177] & reg_we & !reg_error;
   assign mio_outsel_35_wd = reg_wdata[5:0];
 
-  assign mio_outsel_36_we = addr_hit[178] & reg_we & ~wr_err;
+  assign mio_outsel_36_we = addr_hit[178] & reg_we & !reg_error;
   assign mio_outsel_36_wd = reg_wdata[5:0];
 
-  assign mio_outsel_37_we = addr_hit[179] & reg_we & ~wr_err;
+  assign mio_outsel_37_we = addr_hit[179] & reg_we & !reg_error;
   assign mio_outsel_37_wd = reg_wdata[5:0];
 
-  assign mio_outsel_38_we = addr_hit[180] & reg_we & ~wr_err;
+  assign mio_outsel_38_we = addr_hit[180] & reg_we & !reg_error;
   assign mio_outsel_38_wd = reg_wdata[5:0];
 
-  assign mio_outsel_39_we = addr_hit[181] & reg_we & ~wr_err;
+  assign mio_outsel_39_we = addr_hit[181] & reg_we & !reg_error;
   assign mio_outsel_39_wd = reg_wdata[5:0];
 
-  assign mio_outsel_40_we = addr_hit[182] & reg_we & ~wr_err;
+  assign mio_outsel_40_we = addr_hit[182] & reg_we & !reg_error;
   assign mio_outsel_40_wd = reg_wdata[5:0];
 
-  assign mio_outsel_41_we = addr_hit[183] & reg_we & ~wr_err;
+  assign mio_outsel_41_we = addr_hit[183] & reg_we & !reg_error;
   assign mio_outsel_41_wd = reg_wdata[5:0];
 
-  assign mio_outsel_42_we = addr_hit[184] & reg_we & ~wr_err;
+  assign mio_outsel_42_we = addr_hit[184] & reg_we & !reg_error;
   assign mio_outsel_42_wd = reg_wdata[5:0];
 
-  assign mio_outsel_43_we = addr_hit[185] & reg_we & ~wr_err;
+  assign mio_outsel_43_we = addr_hit[185] & reg_we & !reg_error;
   assign mio_outsel_43_wd = reg_wdata[5:0];
 
-  assign mio_pad_attr_regwen_0_we = addr_hit[186] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_0_we = addr_hit[186] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_0_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_1_we = addr_hit[187] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_1_we = addr_hit[187] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_1_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_2_we = addr_hit[188] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_2_we = addr_hit[188] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_2_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_3_we = addr_hit[189] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_3_we = addr_hit[189] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_3_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_4_we = addr_hit[190] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_4_we = addr_hit[190] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_4_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_5_we = addr_hit[191] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_5_we = addr_hit[191] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_5_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_6_we = addr_hit[192] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_6_we = addr_hit[192] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_6_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_7_we = addr_hit[193] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_7_we = addr_hit[193] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_7_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_8_we = addr_hit[194] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_8_we = addr_hit[194] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_8_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_9_we = addr_hit[195] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_9_we = addr_hit[195] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_9_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_10_we = addr_hit[196] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_10_we = addr_hit[196] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_10_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_11_we = addr_hit[197] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_11_we = addr_hit[197] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_11_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_12_we = addr_hit[198] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_12_we = addr_hit[198] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_12_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_13_we = addr_hit[199] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_13_we = addr_hit[199] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_13_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_14_we = addr_hit[200] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_14_we = addr_hit[200] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_14_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_15_we = addr_hit[201] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_15_we = addr_hit[201] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_15_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_16_we = addr_hit[202] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_16_we = addr_hit[202] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_16_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_17_we = addr_hit[203] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_17_we = addr_hit[203] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_17_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_18_we = addr_hit[204] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_18_we = addr_hit[204] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_18_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_19_we = addr_hit[205] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_19_we = addr_hit[205] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_19_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_20_we = addr_hit[206] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_20_we = addr_hit[206] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_20_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_21_we = addr_hit[207] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_21_we = addr_hit[207] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_21_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_22_we = addr_hit[208] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_22_we = addr_hit[208] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_22_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_23_we = addr_hit[209] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_23_we = addr_hit[209] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_23_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_24_we = addr_hit[210] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_24_we = addr_hit[210] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_24_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_25_we = addr_hit[211] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_25_we = addr_hit[211] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_25_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_26_we = addr_hit[212] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_26_we = addr_hit[212] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_26_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_27_we = addr_hit[213] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_27_we = addr_hit[213] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_27_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_28_we = addr_hit[214] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_28_we = addr_hit[214] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_28_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_29_we = addr_hit[215] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_29_we = addr_hit[215] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_29_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_30_we = addr_hit[216] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_30_we = addr_hit[216] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_30_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_31_we = addr_hit[217] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_31_we = addr_hit[217] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_31_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_32_we = addr_hit[218] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_32_we = addr_hit[218] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_32_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_33_we = addr_hit[219] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_33_we = addr_hit[219] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_33_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_34_we = addr_hit[220] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_34_we = addr_hit[220] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_34_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_35_we = addr_hit[221] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_35_we = addr_hit[221] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_35_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_36_we = addr_hit[222] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_36_we = addr_hit[222] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_36_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_37_we = addr_hit[223] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_37_we = addr_hit[223] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_37_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_38_we = addr_hit[224] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_38_we = addr_hit[224] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_38_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_39_we = addr_hit[225] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_39_we = addr_hit[225] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_39_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_40_we = addr_hit[226] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_40_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_40_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_41_we = addr_hit[227] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_41_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_41_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_42_we = addr_hit[228] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_42_we = addr_hit[228] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_42_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_43_we = addr_hit[229] & reg_we & ~wr_err;
+  assign mio_pad_attr_regwen_43_we = addr_hit[229] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_43_wd = reg_wdata[0];
 
-  assign mio_pad_attr_0_we = addr_hit[230] & reg_we & ~wr_err;
+  assign mio_pad_attr_0_we = addr_hit[230] & reg_we & !reg_error;
   assign mio_pad_attr_0_wd = reg_wdata[9:0];
-  assign mio_pad_attr_0_re = addr_hit[230] && reg_re;
+  assign mio_pad_attr_0_re = addr_hit[230] & reg_re & !reg_error;
 
-  assign mio_pad_attr_1_we = addr_hit[231] & reg_we & ~wr_err;
+  assign mio_pad_attr_1_we = addr_hit[231] & reg_we & !reg_error;
   assign mio_pad_attr_1_wd = reg_wdata[9:0];
-  assign mio_pad_attr_1_re = addr_hit[231] && reg_re;
+  assign mio_pad_attr_1_re = addr_hit[231] & reg_re & !reg_error;
 
-  assign mio_pad_attr_2_we = addr_hit[232] & reg_we & ~wr_err;
+  assign mio_pad_attr_2_we = addr_hit[232] & reg_we & !reg_error;
   assign mio_pad_attr_2_wd = reg_wdata[9:0];
-  assign mio_pad_attr_2_re = addr_hit[232] && reg_re;
+  assign mio_pad_attr_2_re = addr_hit[232] & reg_re & !reg_error;
 
-  assign mio_pad_attr_3_we = addr_hit[233] & reg_we & ~wr_err;
+  assign mio_pad_attr_3_we = addr_hit[233] & reg_we & !reg_error;
   assign mio_pad_attr_3_wd = reg_wdata[9:0];
-  assign mio_pad_attr_3_re = addr_hit[233] && reg_re;
+  assign mio_pad_attr_3_re = addr_hit[233] & reg_re & !reg_error;
 
-  assign mio_pad_attr_4_we = addr_hit[234] & reg_we & ~wr_err;
+  assign mio_pad_attr_4_we = addr_hit[234] & reg_we & !reg_error;
   assign mio_pad_attr_4_wd = reg_wdata[9:0];
-  assign mio_pad_attr_4_re = addr_hit[234] && reg_re;
+  assign mio_pad_attr_4_re = addr_hit[234] & reg_re & !reg_error;
 
-  assign mio_pad_attr_5_we = addr_hit[235] & reg_we & ~wr_err;
+  assign mio_pad_attr_5_we = addr_hit[235] & reg_we & !reg_error;
   assign mio_pad_attr_5_wd = reg_wdata[9:0];
-  assign mio_pad_attr_5_re = addr_hit[235] && reg_re;
+  assign mio_pad_attr_5_re = addr_hit[235] & reg_re & !reg_error;
 
-  assign mio_pad_attr_6_we = addr_hit[236] & reg_we & ~wr_err;
+  assign mio_pad_attr_6_we = addr_hit[236] & reg_we & !reg_error;
   assign mio_pad_attr_6_wd = reg_wdata[9:0];
-  assign mio_pad_attr_6_re = addr_hit[236] && reg_re;
+  assign mio_pad_attr_6_re = addr_hit[236] & reg_re & !reg_error;
 
-  assign mio_pad_attr_7_we = addr_hit[237] & reg_we & ~wr_err;
+  assign mio_pad_attr_7_we = addr_hit[237] & reg_we & !reg_error;
   assign mio_pad_attr_7_wd = reg_wdata[9:0];
-  assign mio_pad_attr_7_re = addr_hit[237] && reg_re;
+  assign mio_pad_attr_7_re = addr_hit[237] & reg_re & !reg_error;
 
-  assign mio_pad_attr_8_we = addr_hit[238] & reg_we & ~wr_err;
+  assign mio_pad_attr_8_we = addr_hit[238] & reg_we & !reg_error;
   assign mio_pad_attr_8_wd = reg_wdata[9:0];
-  assign mio_pad_attr_8_re = addr_hit[238] && reg_re;
+  assign mio_pad_attr_8_re = addr_hit[238] & reg_re & !reg_error;
 
-  assign mio_pad_attr_9_we = addr_hit[239] & reg_we & ~wr_err;
+  assign mio_pad_attr_9_we = addr_hit[239] & reg_we & !reg_error;
   assign mio_pad_attr_9_wd = reg_wdata[9:0];
-  assign mio_pad_attr_9_re = addr_hit[239] && reg_re;
+  assign mio_pad_attr_9_re = addr_hit[239] & reg_re & !reg_error;
 
-  assign mio_pad_attr_10_we = addr_hit[240] & reg_we & ~wr_err;
+  assign mio_pad_attr_10_we = addr_hit[240] & reg_we & !reg_error;
   assign mio_pad_attr_10_wd = reg_wdata[9:0];
-  assign mio_pad_attr_10_re = addr_hit[240] && reg_re;
+  assign mio_pad_attr_10_re = addr_hit[240] & reg_re & !reg_error;
 
-  assign mio_pad_attr_11_we = addr_hit[241] & reg_we & ~wr_err;
+  assign mio_pad_attr_11_we = addr_hit[241] & reg_we & !reg_error;
   assign mio_pad_attr_11_wd = reg_wdata[9:0];
-  assign mio_pad_attr_11_re = addr_hit[241] && reg_re;
+  assign mio_pad_attr_11_re = addr_hit[241] & reg_re & !reg_error;
 
-  assign mio_pad_attr_12_we = addr_hit[242] & reg_we & ~wr_err;
+  assign mio_pad_attr_12_we = addr_hit[242] & reg_we & !reg_error;
   assign mio_pad_attr_12_wd = reg_wdata[9:0];
-  assign mio_pad_attr_12_re = addr_hit[242] && reg_re;
+  assign mio_pad_attr_12_re = addr_hit[242] & reg_re & !reg_error;
 
-  assign mio_pad_attr_13_we = addr_hit[243] & reg_we & ~wr_err;
+  assign mio_pad_attr_13_we = addr_hit[243] & reg_we & !reg_error;
   assign mio_pad_attr_13_wd = reg_wdata[9:0];
-  assign mio_pad_attr_13_re = addr_hit[243] && reg_re;
+  assign mio_pad_attr_13_re = addr_hit[243] & reg_re & !reg_error;
 
-  assign mio_pad_attr_14_we = addr_hit[244] & reg_we & ~wr_err;
+  assign mio_pad_attr_14_we = addr_hit[244] & reg_we & !reg_error;
   assign mio_pad_attr_14_wd = reg_wdata[9:0];
-  assign mio_pad_attr_14_re = addr_hit[244] && reg_re;
+  assign mio_pad_attr_14_re = addr_hit[244] & reg_re & !reg_error;
 
-  assign mio_pad_attr_15_we = addr_hit[245] & reg_we & ~wr_err;
+  assign mio_pad_attr_15_we = addr_hit[245] & reg_we & !reg_error;
   assign mio_pad_attr_15_wd = reg_wdata[9:0];
-  assign mio_pad_attr_15_re = addr_hit[245] && reg_re;
+  assign mio_pad_attr_15_re = addr_hit[245] & reg_re & !reg_error;
 
-  assign mio_pad_attr_16_we = addr_hit[246] & reg_we & ~wr_err;
+  assign mio_pad_attr_16_we = addr_hit[246] & reg_we & !reg_error;
   assign mio_pad_attr_16_wd = reg_wdata[9:0];
-  assign mio_pad_attr_16_re = addr_hit[246] && reg_re;
+  assign mio_pad_attr_16_re = addr_hit[246] & reg_re & !reg_error;
 
-  assign mio_pad_attr_17_we = addr_hit[247] & reg_we & ~wr_err;
+  assign mio_pad_attr_17_we = addr_hit[247] & reg_we & !reg_error;
   assign mio_pad_attr_17_wd = reg_wdata[9:0];
-  assign mio_pad_attr_17_re = addr_hit[247] && reg_re;
+  assign mio_pad_attr_17_re = addr_hit[247] & reg_re & !reg_error;
 
-  assign mio_pad_attr_18_we = addr_hit[248] & reg_we & ~wr_err;
+  assign mio_pad_attr_18_we = addr_hit[248] & reg_we & !reg_error;
   assign mio_pad_attr_18_wd = reg_wdata[9:0];
-  assign mio_pad_attr_18_re = addr_hit[248] && reg_re;
+  assign mio_pad_attr_18_re = addr_hit[248] & reg_re & !reg_error;
 
-  assign mio_pad_attr_19_we = addr_hit[249] & reg_we & ~wr_err;
+  assign mio_pad_attr_19_we = addr_hit[249] & reg_we & !reg_error;
   assign mio_pad_attr_19_wd = reg_wdata[9:0];
-  assign mio_pad_attr_19_re = addr_hit[249] && reg_re;
+  assign mio_pad_attr_19_re = addr_hit[249] & reg_re & !reg_error;
 
-  assign mio_pad_attr_20_we = addr_hit[250] & reg_we & ~wr_err;
+  assign mio_pad_attr_20_we = addr_hit[250] & reg_we & !reg_error;
   assign mio_pad_attr_20_wd = reg_wdata[9:0];
-  assign mio_pad_attr_20_re = addr_hit[250] && reg_re;
+  assign mio_pad_attr_20_re = addr_hit[250] & reg_re & !reg_error;
 
-  assign mio_pad_attr_21_we = addr_hit[251] & reg_we & ~wr_err;
+  assign mio_pad_attr_21_we = addr_hit[251] & reg_we & !reg_error;
   assign mio_pad_attr_21_wd = reg_wdata[9:0];
-  assign mio_pad_attr_21_re = addr_hit[251] && reg_re;
+  assign mio_pad_attr_21_re = addr_hit[251] & reg_re & !reg_error;
 
-  assign mio_pad_attr_22_we = addr_hit[252] & reg_we & ~wr_err;
+  assign mio_pad_attr_22_we = addr_hit[252] & reg_we & !reg_error;
   assign mio_pad_attr_22_wd = reg_wdata[9:0];
-  assign mio_pad_attr_22_re = addr_hit[252] && reg_re;
+  assign mio_pad_attr_22_re = addr_hit[252] & reg_re & !reg_error;
 
-  assign mio_pad_attr_23_we = addr_hit[253] & reg_we & ~wr_err;
+  assign mio_pad_attr_23_we = addr_hit[253] & reg_we & !reg_error;
   assign mio_pad_attr_23_wd = reg_wdata[9:0];
-  assign mio_pad_attr_23_re = addr_hit[253] && reg_re;
+  assign mio_pad_attr_23_re = addr_hit[253] & reg_re & !reg_error;
 
-  assign mio_pad_attr_24_we = addr_hit[254] & reg_we & ~wr_err;
+  assign mio_pad_attr_24_we = addr_hit[254] & reg_we & !reg_error;
   assign mio_pad_attr_24_wd = reg_wdata[9:0];
-  assign mio_pad_attr_24_re = addr_hit[254] && reg_re;
+  assign mio_pad_attr_24_re = addr_hit[254] & reg_re & !reg_error;
 
-  assign mio_pad_attr_25_we = addr_hit[255] & reg_we & ~wr_err;
+  assign mio_pad_attr_25_we = addr_hit[255] & reg_we & !reg_error;
   assign mio_pad_attr_25_wd = reg_wdata[9:0];
-  assign mio_pad_attr_25_re = addr_hit[255] && reg_re;
+  assign mio_pad_attr_25_re = addr_hit[255] & reg_re & !reg_error;
 
-  assign mio_pad_attr_26_we = addr_hit[256] & reg_we & ~wr_err;
+  assign mio_pad_attr_26_we = addr_hit[256] & reg_we & !reg_error;
   assign mio_pad_attr_26_wd = reg_wdata[9:0];
-  assign mio_pad_attr_26_re = addr_hit[256] && reg_re;
+  assign mio_pad_attr_26_re = addr_hit[256] & reg_re & !reg_error;
 
-  assign mio_pad_attr_27_we = addr_hit[257] & reg_we & ~wr_err;
+  assign mio_pad_attr_27_we = addr_hit[257] & reg_we & !reg_error;
   assign mio_pad_attr_27_wd = reg_wdata[9:0];
-  assign mio_pad_attr_27_re = addr_hit[257] && reg_re;
+  assign mio_pad_attr_27_re = addr_hit[257] & reg_re & !reg_error;
 
-  assign mio_pad_attr_28_we = addr_hit[258] & reg_we & ~wr_err;
+  assign mio_pad_attr_28_we = addr_hit[258] & reg_we & !reg_error;
   assign mio_pad_attr_28_wd = reg_wdata[9:0];
-  assign mio_pad_attr_28_re = addr_hit[258] && reg_re;
+  assign mio_pad_attr_28_re = addr_hit[258] & reg_re & !reg_error;
 
-  assign mio_pad_attr_29_we = addr_hit[259] & reg_we & ~wr_err;
+  assign mio_pad_attr_29_we = addr_hit[259] & reg_we & !reg_error;
   assign mio_pad_attr_29_wd = reg_wdata[9:0];
-  assign mio_pad_attr_29_re = addr_hit[259] && reg_re;
+  assign mio_pad_attr_29_re = addr_hit[259] & reg_re & !reg_error;
 
-  assign mio_pad_attr_30_we = addr_hit[260] & reg_we & ~wr_err;
+  assign mio_pad_attr_30_we = addr_hit[260] & reg_we & !reg_error;
   assign mio_pad_attr_30_wd = reg_wdata[9:0];
-  assign mio_pad_attr_30_re = addr_hit[260] && reg_re;
+  assign mio_pad_attr_30_re = addr_hit[260] & reg_re & !reg_error;
 
-  assign mio_pad_attr_31_we = addr_hit[261] & reg_we & ~wr_err;
+  assign mio_pad_attr_31_we = addr_hit[261] & reg_we & !reg_error;
   assign mio_pad_attr_31_wd = reg_wdata[9:0];
-  assign mio_pad_attr_31_re = addr_hit[261] && reg_re;
+  assign mio_pad_attr_31_re = addr_hit[261] & reg_re & !reg_error;
 
-  assign mio_pad_attr_32_we = addr_hit[262] & reg_we & ~wr_err;
+  assign mio_pad_attr_32_we = addr_hit[262] & reg_we & !reg_error;
   assign mio_pad_attr_32_wd = reg_wdata[9:0];
-  assign mio_pad_attr_32_re = addr_hit[262] && reg_re;
+  assign mio_pad_attr_32_re = addr_hit[262] & reg_re & !reg_error;
 
-  assign mio_pad_attr_33_we = addr_hit[263] & reg_we & ~wr_err;
+  assign mio_pad_attr_33_we = addr_hit[263] & reg_we & !reg_error;
   assign mio_pad_attr_33_wd = reg_wdata[9:0];
-  assign mio_pad_attr_33_re = addr_hit[263] && reg_re;
+  assign mio_pad_attr_33_re = addr_hit[263] & reg_re & !reg_error;
 
-  assign mio_pad_attr_34_we = addr_hit[264] & reg_we & ~wr_err;
+  assign mio_pad_attr_34_we = addr_hit[264] & reg_we & !reg_error;
   assign mio_pad_attr_34_wd = reg_wdata[9:0];
-  assign mio_pad_attr_34_re = addr_hit[264] && reg_re;
+  assign mio_pad_attr_34_re = addr_hit[264] & reg_re & !reg_error;
 
-  assign mio_pad_attr_35_we = addr_hit[265] & reg_we & ~wr_err;
+  assign mio_pad_attr_35_we = addr_hit[265] & reg_we & !reg_error;
   assign mio_pad_attr_35_wd = reg_wdata[9:0];
-  assign mio_pad_attr_35_re = addr_hit[265] && reg_re;
+  assign mio_pad_attr_35_re = addr_hit[265] & reg_re & !reg_error;
 
-  assign mio_pad_attr_36_we = addr_hit[266] & reg_we & ~wr_err;
+  assign mio_pad_attr_36_we = addr_hit[266] & reg_we & !reg_error;
   assign mio_pad_attr_36_wd = reg_wdata[9:0];
-  assign mio_pad_attr_36_re = addr_hit[266] && reg_re;
+  assign mio_pad_attr_36_re = addr_hit[266] & reg_re & !reg_error;
 
-  assign mio_pad_attr_37_we = addr_hit[267] & reg_we & ~wr_err;
+  assign mio_pad_attr_37_we = addr_hit[267] & reg_we & !reg_error;
   assign mio_pad_attr_37_wd = reg_wdata[9:0];
-  assign mio_pad_attr_37_re = addr_hit[267] && reg_re;
+  assign mio_pad_attr_37_re = addr_hit[267] & reg_re & !reg_error;
 
-  assign mio_pad_attr_38_we = addr_hit[268] & reg_we & ~wr_err;
+  assign mio_pad_attr_38_we = addr_hit[268] & reg_we & !reg_error;
   assign mio_pad_attr_38_wd = reg_wdata[9:0];
-  assign mio_pad_attr_38_re = addr_hit[268] && reg_re;
+  assign mio_pad_attr_38_re = addr_hit[268] & reg_re & !reg_error;
 
-  assign mio_pad_attr_39_we = addr_hit[269] & reg_we & ~wr_err;
+  assign mio_pad_attr_39_we = addr_hit[269] & reg_we & !reg_error;
   assign mio_pad_attr_39_wd = reg_wdata[9:0];
-  assign mio_pad_attr_39_re = addr_hit[269] && reg_re;
+  assign mio_pad_attr_39_re = addr_hit[269] & reg_re & !reg_error;
 
-  assign mio_pad_attr_40_we = addr_hit[270] & reg_we & ~wr_err;
+  assign mio_pad_attr_40_we = addr_hit[270] & reg_we & !reg_error;
   assign mio_pad_attr_40_wd = reg_wdata[9:0];
-  assign mio_pad_attr_40_re = addr_hit[270] && reg_re;
+  assign mio_pad_attr_40_re = addr_hit[270] & reg_re & !reg_error;
 
-  assign mio_pad_attr_41_we = addr_hit[271] & reg_we & ~wr_err;
+  assign mio_pad_attr_41_we = addr_hit[271] & reg_we & !reg_error;
   assign mio_pad_attr_41_wd = reg_wdata[9:0];
-  assign mio_pad_attr_41_re = addr_hit[271] && reg_re;
+  assign mio_pad_attr_41_re = addr_hit[271] & reg_re & !reg_error;
 
-  assign mio_pad_attr_42_we = addr_hit[272] & reg_we & ~wr_err;
+  assign mio_pad_attr_42_we = addr_hit[272] & reg_we & !reg_error;
   assign mio_pad_attr_42_wd = reg_wdata[9:0];
-  assign mio_pad_attr_42_re = addr_hit[272] && reg_re;
+  assign mio_pad_attr_42_re = addr_hit[272] & reg_re & !reg_error;
 
-  assign mio_pad_attr_43_we = addr_hit[273] & reg_we & ~wr_err;
+  assign mio_pad_attr_43_we = addr_hit[273] & reg_we & !reg_error;
   assign mio_pad_attr_43_wd = reg_wdata[9:0];
-  assign mio_pad_attr_43_re = addr_hit[273] && reg_re;
+  assign mio_pad_attr_43_re = addr_hit[273] & reg_re & !reg_error;
 
-  assign dio_pad_attr_regwen_0_we = addr_hit[274] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_0_we = addr_hit[274] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_0_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_1_we = addr_hit[275] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_1_we = addr_hit[275] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_1_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_2_we = addr_hit[276] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_2_we = addr_hit[276] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_2_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_3_we = addr_hit[277] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_3_we = addr_hit[277] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_3_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_4_we = addr_hit[278] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_4_we = addr_hit[278] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_4_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_5_we = addr_hit[279] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_5_we = addr_hit[279] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_5_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_6_we = addr_hit[280] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_6_we = addr_hit[280] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_6_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_7_we = addr_hit[281] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_7_we = addr_hit[281] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_7_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_8_we = addr_hit[282] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_8_we = addr_hit[282] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_8_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_9_we = addr_hit[283] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_9_we = addr_hit[283] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_9_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_10_we = addr_hit[284] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_10_we = addr_hit[284] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_10_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_11_we = addr_hit[285] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_11_we = addr_hit[285] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_11_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_12_we = addr_hit[286] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_12_we = addr_hit[286] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_12_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_13_we = addr_hit[287] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_13_we = addr_hit[287] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_13_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_14_we = addr_hit[288] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_14_we = addr_hit[288] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_14_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_15_we = addr_hit[289] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_15_we = addr_hit[289] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_15_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_16_we = addr_hit[290] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_16_we = addr_hit[290] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_16_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_17_we = addr_hit[291] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_17_we = addr_hit[291] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_17_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_18_we = addr_hit[292] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_18_we = addr_hit[292] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_18_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_19_we = addr_hit[293] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_19_we = addr_hit[293] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_19_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_20_we = addr_hit[294] & reg_we & ~wr_err;
+  assign dio_pad_attr_regwen_20_we = addr_hit[294] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_20_wd = reg_wdata[0];
 
-  assign dio_pad_attr_0_we = addr_hit[295] & reg_we & ~wr_err;
+  assign dio_pad_attr_0_we = addr_hit[295] & reg_we & !reg_error;
   assign dio_pad_attr_0_wd = reg_wdata[9:0];
-  assign dio_pad_attr_0_re = addr_hit[295] && reg_re;
+  assign dio_pad_attr_0_re = addr_hit[295] & reg_re & !reg_error;
 
-  assign dio_pad_attr_1_we = addr_hit[296] & reg_we & ~wr_err;
+  assign dio_pad_attr_1_we = addr_hit[296] & reg_we & !reg_error;
   assign dio_pad_attr_1_wd = reg_wdata[9:0];
-  assign dio_pad_attr_1_re = addr_hit[296] && reg_re;
+  assign dio_pad_attr_1_re = addr_hit[296] & reg_re & !reg_error;
 
-  assign dio_pad_attr_2_we = addr_hit[297] & reg_we & ~wr_err;
+  assign dio_pad_attr_2_we = addr_hit[297] & reg_we & !reg_error;
   assign dio_pad_attr_2_wd = reg_wdata[9:0];
-  assign dio_pad_attr_2_re = addr_hit[297] && reg_re;
+  assign dio_pad_attr_2_re = addr_hit[297] & reg_re & !reg_error;
 
-  assign dio_pad_attr_3_we = addr_hit[298] & reg_we & ~wr_err;
+  assign dio_pad_attr_3_we = addr_hit[298] & reg_we & !reg_error;
   assign dio_pad_attr_3_wd = reg_wdata[9:0];
-  assign dio_pad_attr_3_re = addr_hit[298] && reg_re;
+  assign dio_pad_attr_3_re = addr_hit[298] & reg_re & !reg_error;
 
-  assign dio_pad_attr_4_we = addr_hit[299] & reg_we & ~wr_err;
+  assign dio_pad_attr_4_we = addr_hit[299] & reg_we & !reg_error;
   assign dio_pad_attr_4_wd = reg_wdata[9:0];
-  assign dio_pad_attr_4_re = addr_hit[299] && reg_re;
+  assign dio_pad_attr_4_re = addr_hit[299] & reg_re & !reg_error;
 
-  assign dio_pad_attr_5_we = addr_hit[300] & reg_we & ~wr_err;
+  assign dio_pad_attr_5_we = addr_hit[300] & reg_we & !reg_error;
   assign dio_pad_attr_5_wd = reg_wdata[9:0];
-  assign dio_pad_attr_5_re = addr_hit[300] && reg_re;
+  assign dio_pad_attr_5_re = addr_hit[300] & reg_re & !reg_error;
 
-  assign dio_pad_attr_6_we = addr_hit[301] & reg_we & ~wr_err;
+  assign dio_pad_attr_6_we = addr_hit[301] & reg_we & !reg_error;
   assign dio_pad_attr_6_wd = reg_wdata[9:0];
-  assign dio_pad_attr_6_re = addr_hit[301] && reg_re;
+  assign dio_pad_attr_6_re = addr_hit[301] & reg_re & !reg_error;
 
-  assign dio_pad_attr_7_we = addr_hit[302] & reg_we & ~wr_err;
+  assign dio_pad_attr_7_we = addr_hit[302] & reg_we & !reg_error;
   assign dio_pad_attr_7_wd = reg_wdata[9:0];
-  assign dio_pad_attr_7_re = addr_hit[302] && reg_re;
+  assign dio_pad_attr_7_re = addr_hit[302] & reg_re & !reg_error;
 
-  assign dio_pad_attr_8_we = addr_hit[303] & reg_we & ~wr_err;
+  assign dio_pad_attr_8_we = addr_hit[303] & reg_we & !reg_error;
   assign dio_pad_attr_8_wd = reg_wdata[9:0];
-  assign dio_pad_attr_8_re = addr_hit[303] && reg_re;
+  assign dio_pad_attr_8_re = addr_hit[303] & reg_re & !reg_error;
 
-  assign dio_pad_attr_9_we = addr_hit[304] & reg_we & ~wr_err;
+  assign dio_pad_attr_9_we = addr_hit[304] & reg_we & !reg_error;
   assign dio_pad_attr_9_wd = reg_wdata[9:0];
-  assign dio_pad_attr_9_re = addr_hit[304] && reg_re;
+  assign dio_pad_attr_9_re = addr_hit[304] & reg_re & !reg_error;
 
-  assign dio_pad_attr_10_we = addr_hit[305] & reg_we & ~wr_err;
+  assign dio_pad_attr_10_we = addr_hit[305] & reg_we & !reg_error;
   assign dio_pad_attr_10_wd = reg_wdata[9:0];
-  assign dio_pad_attr_10_re = addr_hit[305] && reg_re;
+  assign dio_pad_attr_10_re = addr_hit[305] & reg_re & !reg_error;
 
-  assign dio_pad_attr_11_we = addr_hit[306] & reg_we & ~wr_err;
+  assign dio_pad_attr_11_we = addr_hit[306] & reg_we & !reg_error;
   assign dio_pad_attr_11_wd = reg_wdata[9:0];
-  assign dio_pad_attr_11_re = addr_hit[306] && reg_re;
+  assign dio_pad_attr_11_re = addr_hit[306] & reg_re & !reg_error;
 
-  assign dio_pad_attr_12_we = addr_hit[307] & reg_we & ~wr_err;
+  assign dio_pad_attr_12_we = addr_hit[307] & reg_we & !reg_error;
   assign dio_pad_attr_12_wd = reg_wdata[9:0];
-  assign dio_pad_attr_12_re = addr_hit[307] && reg_re;
+  assign dio_pad_attr_12_re = addr_hit[307] & reg_re & !reg_error;
 
-  assign dio_pad_attr_13_we = addr_hit[308] & reg_we & ~wr_err;
+  assign dio_pad_attr_13_we = addr_hit[308] & reg_we & !reg_error;
   assign dio_pad_attr_13_wd = reg_wdata[9:0];
-  assign dio_pad_attr_13_re = addr_hit[308] && reg_re;
+  assign dio_pad_attr_13_re = addr_hit[308] & reg_re & !reg_error;
 
-  assign dio_pad_attr_14_we = addr_hit[309] & reg_we & ~wr_err;
+  assign dio_pad_attr_14_we = addr_hit[309] & reg_we & !reg_error;
   assign dio_pad_attr_14_wd = reg_wdata[9:0];
-  assign dio_pad_attr_14_re = addr_hit[309] && reg_re;
+  assign dio_pad_attr_14_re = addr_hit[309] & reg_re & !reg_error;
 
-  assign dio_pad_attr_15_we = addr_hit[310] & reg_we & ~wr_err;
+  assign dio_pad_attr_15_we = addr_hit[310] & reg_we & !reg_error;
   assign dio_pad_attr_15_wd = reg_wdata[9:0];
-  assign dio_pad_attr_15_re = addr_hit[310] && reg_re;
+  assign dio_pad_attr_15_re = addr_hit[310] & reg_re & !reg_error;
 
-  assign dio_pad_attr_16_we = addr_hit[311] & reg_we & ~wr_err;
+  assign dio_pad_attr_16_we = addr_hit[311] & reg_we & !reg_error;
   assign dio_pad_attr_16_wd = reg_wdata[9:0];
-  assign dio_pad_attr_16_re = addr_hit[311] && reg_re;
+  assign dio_pad_attr_16_re = addr_hit[311] & reg_re & !reg_error;
 
-  assign dio_pad_attr_17_we = addr_hit[312] & reg_we & ~wr_err;
+  assign dio_pad_attr_17_we = addr_hit[312] & reg_we & !reg_error;
   assign dio_pad_attr_17_wd = reg_wdata[9:0];
-  assign dio_pad_attr_17_re = addr_hit[312] && reg_re;
+  assign dio_pad_attr_17_re = addr_hit[312] & reg_re & !reg_error;
 
-  assign dio_pad_attr_18_we = addr_hit[313] & reg_we & ~wr_err;
+  assign dio_pad_attr_18_we = addr_hit[313] & reg_we & !reg_error;
   assign dio_pad_attr_18_wd = reg_wdata[9:0];
-  assign dio_pad_attr_18_re = addr_hit[313] && reg_re;
+  assign dio_pad_attr_18_re = addr_hit[313] & reg_re & !reg_error;
 
-  assign dio_pad_attr_19_we = addr_hit[314] & reg_we & ~wr_err;
+  assign dio_pad_attr_19_we = addr_hit[314] & reg_we & !reg_error;
   assign dio_pad_attr_19_wd = reg_wdata[9:0];
-  assign dio_pad_attr_19_re = addr_hit[314] && reg_re;
+  assign dio_pad_attr_19_re = addr_hit[314] & reg_re & !reg_error;
 
-  assign dio_pad_attr_20_we = addr_hit[315] & reg_we & ~wr_err;
+  assign dio_pad_attr_20_we = addr_hit[315] & reg_we & !reg_error;
   assign dio_pad_attr_20_wd = reg_wdata[9:0];
-  assign dio_pad_attr_20_re = addr_hit[315] && reg_re;
+  assign dio_pad_attr_20_re = addr_hit[315] & reg_re & !reg_error;
 
-  assign mio_pad_sleep_status_0_en_0_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_0_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_0_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_status_0_en_1_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_1_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_1_wd = reg_wdata[1];
 
-  assign mio_pad_sleep_status_0_en_2_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_2_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_2_wd = reg_wdata[2];
 
-  assign mio_pad_sleep_status_0_en_3_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_3_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_3_wd = reg_wdata[3];
 
-  assign mio_pad_sleep_status_0_en_4_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_4_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_4_wd = reg_wdata[4];
 
-  assign mio_pad_sleep_status_0_en_5_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_5_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_5_wd = reg_wdata[5];
 
-  assign mio_pad_sleep_status_0_en_6_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_6_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_6_wd = reg_wdata[6];
 
-  assign mio_pad_sleep_status_0_en_7_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_7_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_7_wd = reg_wdata[7];
 
-  assign mio_pad_sleep_status_0_en_8_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_8_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_8_wd = reg_wdata[8];
 
-  assign mio_pad_sleep_status_0_en_9_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_9_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_9_wd = reg_wdata[9];
 
-  assign mio_pad_sleep_status_0_en_10_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_10_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_10_wd = reg_wdata[10];
 
-  assign mio_pad_sleep_status_0_en_11_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_11_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_11_wd = reg_wdata[11];
 
-  assign mio_pad_sleep_status_0_en_12_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_12_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_12_wd = reg_wdata[12];
 
-  assign mio_pad_sleep_status_0_en_13_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_13_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_13_wd = reg_wdata[13];
 
-  assign mio_pad_sleep_status_0_en_14_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_14_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_14_wd = reg_wdata[14];
 
-  assign mio_pad_sleep_status_0_en_15_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_15_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_15_wd = reg_wdata[15];
 
-  assign mio_pad_sleep_status_0_en_16_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_16_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_16_wd = reg_wdata[16];
 
-  assign mio_pad_sleep_status_0_en_17_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_17_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_17_wd = reg_wdata[17];
 
-  assign mio_pad_sleep_status_0_en_18_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_18_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_18_wd = reg_wdata[18];
 
-  assign mio_pad_sleep_status_0_en_19_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_19_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_19_wd = reg_wdata[19];
 
-  assign mio_pad_sleep_status_0_en_20_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_20_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_20_wd = reg_wdata[20];
 
-  assign mio_pad_sleep_status_0_en_21_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_21_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_21_wd = reg_wdata[21];
 
-  assign mio_pad_sleep_status_0_en_22_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_22_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_22_wd = reg_wdata[22];
 
-  assign mio_pad_sleep_status_0_en_23_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_23_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_23_wd = reg_wdata[23];
 
-  assign mio_pad_sleep_status_0_en_24_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_24_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_24_wd = reg_wdata[24];
 
-  assign mio_pad_sleep_status_0_en_25_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_25_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_25_wd = reg_wdata[25];
 
-  assign mio_pad_sleep_status_0_en_26_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_26_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_26_wd = reg_wdata[26];
 
-  assign mio_pad_sleep_status_0_en_27_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_27_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_27_wd = reg_wdata[27];
 
-  assign mio_pad_sleep_status_0_en_28_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_28_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_28_wd = reg_wdata[28];
 
-  assign mio_pad_sleep_status_0_en_29_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_29_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_29_wd = reg_wdata[29];
 
-  assign mio_pad_sleep_status_0_en_30_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_30_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_30_wd = reg_wdata[30];
 
-  assign mio_pad_sleep_status_0_en_31_we = addr_hit[316] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_0_en_31_we = addr_hit[316] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_31_wd = reg_wdata[31];
 
-  assign mio_pad_sleep_status_1_en_32_we = addr_hit[317] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_1_en_32_we = addr_hit[317] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_32_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_status_1_en_33_we = addr_hit[317] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_1_en_33_we = addr_hit[317] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_33_wd = reg_wdata[1];
 
-  assign mio_pad_sleep_status_1_en_34_we = addr_hit[317] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_1_en_34_we = addr_hit[317] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_34_wd = reg_wdata[2];
 
-  assign mio_pad_sleep_status_1_en_35_we = addr_hit[317] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_1_en_35_we = addr_hit[317] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_35_wd = reg_wdata[3];
 
-  assign mio_pad_sleep_status_1_en_36_we = addr_hit[317] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_1_en_36_we = addr_hit[317] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_36_wd = reg_wdata[4];
 
-  assign mio_pad_sleep_status_1_en_37_we = addr_hit[317] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_1_en_37_we = addr_hit[317] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_37_wd = reg_wdata[5];
 
-  assign mio_pad_sleep_status_1_en_38_we = addr_hit[317] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_1_en_38_we = addr_hit[317] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_38_wd = reg_wdata[6];
 
-  assign mio_pad_sleep_status_1_en_39_we = addr_hit[317] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_1_en_39_we = addr_hit[317] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_39_wd = reg_wdata[7];
 
-  assign mio_pad_sleep_status_1_en_40_we = addr_hit[317] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_1_en_40_we = addr_hit[317] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_40_wd = reg_wdata[8];
 
-  assign mio_pad_sleep_status_1_en_41_we = addr_hit[317] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_1_en_41_we = addr_hit[317] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_41_wd = reg_wdata[9];
 
-  assign mio_pad_sleep_status_1_en_42_we = addr_hit[317] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_1_en_42_we = addr_hit[317] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_42_wd = reg_wdata[10];
 
-  assign mio_pad_sleep_status_1_en_43_we = addr_hit[317] & reg_we & ~wr_err;
+  assign mio_pad_sleep_status_1_en_43_we = addr_hit[317] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_43_wd = reg_wdata[11];
 
-  assign mio_pad_sleep_regwen_0_we = addr_hit[318] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_0_we = addr_hit[318] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_0_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_1_we = addr_hit[319] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_1_we = addr_hit[319] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_1_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_2_we = addr_hit[320] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_2_we = addr_hit[320] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_2_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_3_we = addr_hit[321] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_3_we = addr_hit[321] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_3_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_4_we = addr_hit[322] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_4_we = addr_hit[322] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_4_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_5_we = addr_hit[323] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_5_we = addr_hit[323] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_5_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_6_we = addr_hit[324] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_6_we = addr_hit[324] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_6_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_7_we = addr_hit[325] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_7_we = addr_hit[325] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_7_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_8_we = addr_hit[326] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_8_we = addr_hit[326] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_8_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_9_we = addr_hit[327] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_9_we = addr_hit[327] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_9_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_10_we = addr_hit[328] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_10_we = addr_hit[328] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_10_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_11_we = addr_hit[329] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_11_we = addr_hit[329] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_11_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_12_we = addr_hit[330] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_12_we = addr_hit[330] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_12_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_13_we = addr_hit[331] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_13_we = addr_hit[331] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_13_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_14_we = addr_hit[332] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_14_we = addr_hit[332] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_14_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_15_we = addr_hit[333] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_15_we = addr_hit[333] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_15_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_16_we = addr_hit[334] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_16_we = addr_hit[334] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_16_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_17_we = addr_hit[335] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_17_we = addr_hit[335] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_17_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_18_we = addr_hit[336] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_18_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_18_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_19_we = addr_hit[337] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_19_we = addr_hit[337] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_19_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_20_we = addr_hit[338] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_20_we = addr_hit[338] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_20_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_21_we = addr_hit[339] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_21_we = addr_hit[339] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_21_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_22_we = addr_hit[340] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_22_we = addr_hit[340] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_22_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_23_we = addr_hit[341] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_23_we = addr_hit[341] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_23_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_24_we = addr_hit[342] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_24_we = addr_hit[342] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_24_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_25_we = addr_hit[343] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_25_we = addr_hit[343] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_25_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_26_we = addr_hit[344] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_26_we = addr_hit[344] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_26_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_27_we = addr_hit[345] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_27_we = addr_hit[345] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_27_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_28_we = addr_hit[346] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_28_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_28_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_29_we = addr_hit[347] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_29_we = addr_hit[347] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_29_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_30_we = addr_hit[348] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_30_we = addr_hit[348] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_30_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_31_we = addr_hit[349] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_31_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_31_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_32_we = addr_hit[350] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_32_we = addr_hit[350] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_32_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_33_we = addr_hit[351] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_33_we = addr_hit[351] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_33_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_34_we = addr_hit[352] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_34_we = addr_hit[352] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_34_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_35_we = addr_hit[353] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_35_we = addr_hit[353] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_35_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_36_we = addr_hit[354] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_36_we = addr_hit[354] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_36_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_37_we = addr_hit[355] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_37_we = addr_hit[355] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_37_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_38_we = addr_hit[356] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_38_we = addr_hit[356] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_38_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_39_we = addr_hit[357] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_39_we = addr_hit[357] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_39_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_40_we = addr_hit[358] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_40_we = addr_hit[358] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_40_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_41_we = addr_hit[359] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_41_we = addr_hit[359] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_41_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_42_we = addr_hit[360] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_42_we = addr_hit[360] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_42_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_43_we = addr_hit[361] & reg_we & ~wr_err;
+  assign mio_pad_sleep_regwen_43_we = addr_hit[361] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_43_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_0_we = addr_hit[362] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_0_we = addr_hit[362] & reg_we & !reg_error;
   assign mio_pad_sleep_en_0_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_1_we = addr_hit[363] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_1_we = addr_hit[363] & reg_we & !reg_error;
   assign mio_pad_sleep_en_1_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_2_we = addr_hit[364] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_2_we = addr_hit[364] & reg_we & !reg_error;
   assign mio_pad_sleep_en_2_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_3_we = addr_hit[365] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_3_we = addr_hit[365] & reg_we & !reg_error;
   assign mio_pad_sleep_en_3_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_4_we = addr_hit[366] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_4_we = addr_hit[366] & reg_we & !reg_error;
   assign mio_pad_sleep_en_4_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_5_we = addr_hit[367] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_5_we = addr_hit[367] & reg_we & !reg_error;
   assign mio_pad_sleep_en_5_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_6_we = addr_hit[368] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_6_we = addr_hit[368] & reg_we & !reg_error;
   assign mio_pad_sleep_en_6_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_7_we = addr_hit[369] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_7_we = addr_hit[369] & reg_we & !reg_error;
   assign mio_pad_sleep_en_7_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_8_we = addr_hit[370] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_8_we = addr_hit[370] & reg_we & !reg_error;
   assign mio_pad_sleep_en_8_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_9_we = addr_hit[371] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_9_we = addr_hit[371] & reg_we & !reg_error;
   assign mio_pad_sleep_en_9_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_10_we = addr_hit[372] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_10_we = addr_hit[372] & reg_we & !reg_error;
   assign mio_pad_sleep_en_10_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_11_we = addr_hit[373] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_11_we = addr_hit[373] & reg_we & !reg_error;
   assign mio_pad_sleep_en_11_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_12_we = addr_hit[374] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_12_we = addr_hit[374] & reg_we & !reg_error;
   assign mio_pad_sleep_en_12_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_13_we = addr_hit[375] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_13_we = addr_hit[375] & reg_we & !reg_error;
   assign mio_pad_sleep_en_13_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_14_we = addr_hit[376] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_14_we = addr_hit[376] & reg_we & !reg_error;
   assign mio_pad_sleep_en_14_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_15_we = addr_hit[377] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_15_we = addr_hit[377] & reg_we & !reg_error;
   assign mio_pad_sleep_en_15_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_16_we = addr_hit[378] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_16_we = addr_hit[378] & reg_we & !reg_error;
   assign mio_pad_sleep_en_16_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_17_we = addr_hit[379] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_17_we = addr_hit[379] & reg_we & !reg_error;
   assign mio_pad_sleep_en_17_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_18_we = addr_hit[380] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_18_we = addr_hit[380] & reg_we & !reg_error;
   assign mio_pad_sleep_en_18_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_19_we = addr_hit[381] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_19_we = addr_hit[381] & reg_we & !reg_error;
   assign mio_pad_sleep_en_19_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_20_we = addr_hit[382] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_20_we = addr_hit[382] & reg_we & !reg_error;
   assign mio_pad_sleep_en_20_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_21_we = addr_hit[383] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_21_we = addr_hit[383] & reg_we & !reg_error;
   assign mio_pad_sleep_en_21_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_22_we = addr_hit[384] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_22_we = addr_hit[384] & reg_we & !reg_error;
   assign mio_pad_sleep_en_22_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_23_we = addr_hit[385] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_23_we = addr_hit[385] & reg_we & !reg_error;
   assign mio_pad_sleep_en_23_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_24_we = addr_hit[386] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_24_we = addr_hit[386] & reg_we & !reg_error;
   assign mio_pad_sleep_en_24_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_25_we = addr_hit[387] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_25_we = addr_hit[387] & reg_we & !reg_error;
   assign mio_pad_sleep_en_25_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_26_we = addr_hit[388] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_26_we = addr_hit[388] & reg_we & !reg_error;
   assign mio_pad_sleep_en_26_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_27_we = addr_hit[389] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_27_we = addr_hit[389] & reg_we & !reg_error;
   assign mio_pad_sleep_en_27_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_28_we = addr_hit[390] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_28_we = addr_hit[390] & reg_we & !reg_error;
   assign mio_pad_sleep_en_28_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_29_we = addr_hit[391] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_29_we = addr_hit[391] & reg_we & !reg_error;
   assign mio_pad_sleep_en_29_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_30_we = addr_hit[392] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_30_we = addr_hit[392] & reg_we & !reg_error;
   assign mio_pad_sleep_en_30_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_31_we = addr_hit[393] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_31_we = addr_hit[393] & reg_we & !reg_error;
   assign mio_pad_sleep_en_31_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_32_we = addr_hit[394] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_32_we = addr_hit[394] & reg_we & !reg_error;
   assign mio_pad_sleep_en_32_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_33_we = addr_hit[395] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_33_we = addr_hit[395] & reg_we & !reg_error;
   assign mio_pad_sleep_en_33_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_34_we = addr_hit[396] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_34_we = addr_hit[396] & reg_we & !reg_error;
   assign mio_pad_sleep_en_34_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_35_we = addr_hit[397] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_35_we = addr_hit[397] & reg_we & !reg_error;
   assign mio_pad_sleep_en_35_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_36_we = addr_hit[398] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_36_we = addr_hit[398] & reg_we & !reg_error;
   assign mio_pad_sleep_en_36_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_37_we = addr_hit[399] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_37_we = addr_hit[399] & reg_we & !reg_error;
   assign mio_pad_sleep_en_37_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_38_we = addr_hit[400] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_38_we = addr_hit[400] & reg_we & !reg_error;
   assign mio_pad_sleep_en_38_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_39_we = addr_hit[401] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_39_we = addr_hit[401] & reg_we & !reg_error;
   assign mio_pad_sleep_en_39_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_40_we = addr_hit[402] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_40_we = addr_hit[402] & reg_we & !reg_error;
   assign mio_pad_sleep_en_40_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_41_we = addr_hit[403] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_41_we = addr_hit[403] & reg_we & !reg_error;
   assign mio_pad_sleep_en_41_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_42_we = addr_hit[404] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_42_we = addr_hit[404] & reg_we & !reg_error;
   assign mio_pad_sleep_en_42_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_43_we = addr_hit[405] & reg_we & ~wr_err;
+  assign mio_pad_sleep_en_43_we = addr_hit[405] & reg_we & !reg_error;
   assign mio_pad_sleep_en_43_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_mode_0_we = addr_hit[406] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_0_we = addr_hit[406] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_0_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_1_we = addr_hit[407] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_1_we = addr_hit[407] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_1_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_2_we = addr_hit[408] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_2_we = addr_hit[408] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_2_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_3_we = addr_hit[409] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_3_we = addr_hit[409] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_3_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_4_we = addr_hit[410] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_4_we = addr_hit[410] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_4_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_5_we = addr_hit[411] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_5_we = addr_hit[411] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_5_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_6_we = addr_hit[412] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_6_we = addr_hit[412] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_6_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_7_we = addr_hit[413] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_7_we = addr_hit[413] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_7_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_8_we = addr_hit[414] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_8_we = addr_hit[414] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_8_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_9_we = addr_hit[415] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_9_we = addr_hit[415] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_9_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_10_we = addr_hit[416] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_10_we = addr_hit[416] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_10_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_11_we = addr_hit[417] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_11_we = addr_hit[417] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_11_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_12_we = addr_hit[418] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_12_we = addr_hit[418] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_12_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_13_we = addr_hit[419] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_13_we = addr_hit[419] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_13_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_14_we = addr_hit[420] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_14_we = addr_hit[420] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_14_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_15_we = addr_hit[421] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_15_we = addr_hit[421] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_15_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_16_we = addr_hit[422] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_16_we = addr_hit[422] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_16_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_17_we = addr_hit[423] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_17_we = addr_hit[423] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_17_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_18_we = addr_hit[424] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_18_we = addr_hit[424] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_18_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_19_we = addr_hit[425] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_19_we = addr_hit[425] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_19_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_20_we = addr_hit[426] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_20_we = addr_hit[426] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_20_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_21_we = addr_hit[427] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_21_we = addr_hit[427] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_21_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_22_we = addr_hit[428] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_22_we = addr_hit[428] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_22_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_23_we = addr_hit[429] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_23_we = addr_hit[429] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_23_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_24_we = addr_hit[430] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_24_we = addr_hit[430] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_24_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_25_we = addr_hit[431] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_25_we = addr_hit[431] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_25_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_26_we = addr_hit[432] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_26_we = addr_hit[432] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_26_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_27_we = addr_hit[433] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_27_we = addr_hit[433] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_27_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_28_we = addr_hit[434] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_28_we = addr_hit[434] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_28_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_29_we = addr_hit[435] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_29_we = addr_hit[435] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_29_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_30_we = addr_hit[436] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_30_we = addr_hit[436] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_30_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_31_we = addr_hit[437] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_31_we = addr_hit[437] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_31_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_32_we = addr_hit[438] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_32_we = addr_hit[438] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_32_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_33_we = addr_hit[439] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_33_we = addr_hit[439] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_33_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_34_we = addr_hit[440] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_34_we = addr_hit[440] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_34_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_35_we = addr_hit[441] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_35_we = addr_hit[441] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_35_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_36_we = addr_hit[442] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_36_we = addr_hit[442] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_36_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_37_we = addr_hit[443] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_37_we = addr_hit[443] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_37_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_38_we = addr_hit[444] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_38_we = addr_hit[444] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_38_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_39_we = addr_hit[445] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_39_we = addr_hit[445] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_39_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_40_we = addr_hit[446] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_40_we = addr_hit[446] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_40_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_41_we = addr_hit[447] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_41_we = addr_hit[447] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_41_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_42_we = addr_hit[448] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_42_we = addr_hit[448] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_42_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_43_we = addr_hit[449] & reg_we & ~wr_err;
+  assign mio_pad_sleep_mode_43_we = addr_hit[449] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_43_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_status_en_0_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_0_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_0_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_status_en_1_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_1_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_1_wd = reg_wdata[1];
 
-  assign dio_pad_sleep_status_en_2_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_2_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_2_wd = reg_wdata[2];
 
-  assign dio_pad_sleep_status_en_3_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_3_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_3_wd = reg_wdata[3];
 
-  assign dio_pad_sleep_status_en_4_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_4_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_4_wd = reg_wdata[4];
 
-  assign dio_pad_sleep_status_en_5_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_5_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_5_wd = reg_wdata[5];
 
-  assign dio_pad_sleep_status_en_6_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_6_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_6_wd = reg_wdata[6];
 
-  assign dio_pad_sleep_status_en_7_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_7_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_7_wd = reg_wdata[7];
 
-  assign dio_pad_sleep_status_en_8_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_8_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_8_wd = reg_wdata[8];
 
-  assign dio_pad_sleep_status_en_9_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_9_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_9_wd = reg_wdata[9];
 
-  assign dio_pad_sleep_status_en_10_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_10_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_10_wd = reg_wdata[10];
 
-  assign dio_pad_sleep_status_en_11_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_11_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_11_wd = reg_wdata[11];
 
-  assign dio_pad_sleep_status_en_12_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_12_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_12_wd = reg_wdata[12];
 
-  assign dio_pad_sleep_status_en_13_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_13_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_13_wd = reg_wdata[13];
 
-  assign dio_pad_sleep_status_en_14_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_14_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_14_wd = reg_wdata[14];
 
-  assign dio_pad_sleep_status_en_15_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_15_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_15_wd = reg_wdata[15];
 
-  assign dio_pad_sleep_status_en_16_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_16_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_16_wd = reg_wdata[16];
 
-  assign dio_pad_sleep_status_en_17_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_17_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_17_wd = reg_wdata[17];
 
-  assign dio_pad_sleep_status_en_18_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_18_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_18_wd = reg_wdata[18];
 
-  assign dio_pad_sleep_status_en_19_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_19_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_19_wd = reg_wdata[19];
 
-  assign dio_pad_sleep_status_en_20_we = addr_hit[450] & reg_we & ~wr_err;
+  assign dio_pad_sleep_status_en_20_we = addr_hit[450] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_20_wd = reg_wdata[20];
 
-  assign dio_pad_sleep_regwen_0_we = addr_hit[451] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_0_we = addr_hit[451] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_0_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_1_we = addr_hit[452] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_1_we = addr_hit[452] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_1_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_2_we = addr_hit[453] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_2_we = addr_hit[453] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_2_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_3_we = addr_hit[454] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_3_we = addr_hit[454] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_3_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_4_we = addr_hit[455] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_4_we = addr_hit[455] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_4_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_5_we = addr_hit[456] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_5_we = addr_hit[456] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_5_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_6_we = addr_hit[457] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_6_we = addr_hit[457] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_6_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_7_we = addr_hit[458] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_7_we = addr_hit[458] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_7_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_8_we = addr_hit[459] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_8_we = addr_hit[459] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_8_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_9_we = addr_hit[460] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_9_we = addr_hit[460] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_9_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_10_we = addr_hit[461] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_10_we = addr_hit[461] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_10_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_11_we = addr_hit[462] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_11_we = addr_hit[462] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_11_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_12_we = addr_hit[463] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_12_we = addr_hit[463] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_12_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_13_we = addr_hit[464] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_13_we = addr_hit[464] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_13_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_14_we = addr_hit[465] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_14_we = addr_hit[465] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_14_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_15_we = addr_hit[466] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_15_we = addr_hit[466] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_15_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_16_we = addr_hit[467] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_16_we = addr_hit[467] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_16_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_17_we = addr_hit[468] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_17_we = addr_hit[468] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_17_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_18_we = addr_hit[469] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_18_we = addr_hit[469] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_18_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_19_we = addr_hit[470] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_19_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_19_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_20_we = addr_hit[471] & reg_we & ~wr_err;
+  assign dio_pad_sleep_regwen_20_we = addr_hit[471] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_20_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_0_we = addr_hit[472] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_0_we = addr_hit[472] & reg_we & !reg_error;
   assign dio_pad_sleep_en_0_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_1_we = addr_hit[473] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_1_we = addr_hit[473] & reg_we & !reg_error;
   assign dio_pad_sleep_en_1_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_2_we = addr_hit[474] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_2_we = addr_hit[474] & reg_we & !reg_error;
   assign dio_pad_sleep_en_2_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_3_we = addr_hit[475] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_3_we = addr_hit[475] & reg_we & !reg_error;
   assign dio_pad_sleep_en_3_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_4_we = addr_hit[476] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_4_we = addr_hit[476] & reg_we & !reg_error;
   assign dio_pad_sleep_en_4_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_5_we = addr_hit[477] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_5_we = addr_hit[477] & reg_we & !reg_error;
   assign dio_pad_sleep_en_5_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_6_we = addr_hit[478] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_6_we = addr_hit[478] & reg_we & !reg_error;
   assign dio_pad_sleep_en_6_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_7_we = addr_hit[479] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_7_we = addr_hit[479] & reg_we & !reg_error;
   assign dio_pad_sleep_en_7_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_8_we = addr_hit[480] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_8_we = addr_hit[480] & reg_we & !reg_error;
   assign dio_pad_sleep_en_8_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_9_we = addr_hit[481] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_9_we = addr_hit[481] & reg_we & !reg_error;
   assign dio_pad_sleep_en_9_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_10_we = addr_hit[482] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_10_we = addr_hit[482] & reg_we & !reg_error;
   assign dio_pad_sleep_en_10_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_11_we = addr_hit[483] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_11_we = addr_hit[483] & reg_we & !reg_error;
   assign dio_pad_sleep_en_11_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_12_we = addr_hit[484] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_12_we = addr_hit[484] & reg_we & !reg_error;
   assign dio_pad_sleep_en_12_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_13_we = addr_hit[485] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_13_we = addr_hit[485] & reg_we & !reg_error;
   assign dio_pad_sleep_en_13_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_14_we = addr_hit[486] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_14_we = addr_hit[486] & reg_we & !reg_error;
   assign dio_pad_sleep_en_14_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_15_we = addr_hit[487] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_15_we = addr_hit[487] & reg_we & !reg_error;
   assign dio_pad_sleep_en_15_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_16_we = addr_hit[488] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_16_we = addr_hit[488] & reg_we & !reg_error;
   assign dio_pad_sleep_en_16_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_17_we = addr_hit[489] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_17_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_en_17_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_18_we = addr_hit[490] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_18_we = addr_hit[490] & reg_we & !reg_error;
   assign dio_pad_sleep_en_18_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_19_we = addr_hit[491] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_19_we = addr_hit[491] & reg_we & !reg_error;
   assign dio_pad_sleep_en_19_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_20_we = addr_hit[492] & reg_we & ~wr_err;
+  assign dio_pad_sleep_en_20_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_en_20_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_mode_0_we = addr_hit[493] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_0_we = addr_hit[493] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_0_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_1_we = addr_hit[494] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_1_we = addr_hit[494] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_1_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_2_we = addr_hit[495] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_2_we = addr_hit[495] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_2_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_3_we = addr_hit[496] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_3_we = addr_hit[496] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_3_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_4_we = addr_hit[497] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_4_we = addr_hit[497] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_4_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_5_we = addr_hit[498] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_5_we = addr_hit[498] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_5_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_6_we = addr_hit[499] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_6_we = addr_hit[499] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_6_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_7_we = addr_hit[500] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_7_we = addr_hit[500] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_7_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_8_we = addr_hit[501] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_8_we = addr_hit[501] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_8_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_9_we = addr_hit[502] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_9_we = addr_hit[502] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_9_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_10_we = addr_hit[503] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_10_we = addr_hit[503] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_10_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_11_we = addr_hit[504] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_11_we = addr_hit[504] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_11_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_12_we = addr_hit[505] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_12_we = addr_hit[505] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_12_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_13_we = addr_hit[506] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_13_we = addr_hit[506] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_13_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_14_we = addr_hit[507] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_14_we = addr_hit[507] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_14_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_15_we = addr_hit[508] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_15_we = addr_hit[508] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_15_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_16_we = addr_hit[509] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_16_we = addr_hit[509] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_16_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_17_we = addr_hit[510] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_17_we = addr_hit[510] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_17_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_18_we = addr_hit[511] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_18_we = addr_hit[511] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_18_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_19_we = addr_hit[512] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_19_we = addr_hit[512] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_19_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_20_we = addr_hit[513] & reg_we & ~wr_err;
+  assign dio_pad_sleep_mode_20_we = addr_hit[513] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_20_wd = reg_wdata[1:0];
 
-  assign wkup_detector_regwen_0_we = addr_hit[514] & reg_we & ~wr_err;
+  assign wkup_detector_regwen_0_we = addr_hit[514] & reg_we & !reg_error;
   assign wkup_detector_regwen_0_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_1_we = addr_hit[515] & reg_we & ~wr_err;
+  assign wkup_detector_regwen_1_we = addr_hit[515] & reg_we & !reg_error;
   assign wkup_detector_regwen_1_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_2_we = addr_hit[516] & reg_we & ~wr_err;
+  assign wkup_detector_regwen_2_we = addr_hit[516] & reg_we & !reg_error;
   assign wkup_detector_regwen_2_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_3_we = addr_hit[517] & reg_we & ~wr_err;
+  assign wkup_detector_regwen_3_we = addr_hit[517] & reg_we & !reg_error;
   assign wkup_detector_regwen_3_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_4_we = addr_hit[518] & reg_we & ~wr_err;
+  assign wkup_detector_regwen_4_we = addr_hit[518] & reg_we & !reg_error;
   assign wkup_detector_regwen_4_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_5_we = addr_hit[519] & reg_we & ~wr_err;
+  assign wkup_detector_regwen_5_we = addr_hit[519] & reg_we & !reg_error;
   assign wkup_detector_regwen_5_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_6_we = addr_hit[520] & reg_we & ~wr_err;
+  assign wkup_detector_regwen_6_we = addr_hit[520] & reg_we & !reg_error;
   assign wkup_detector_regwen_6_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_7_we = addr_hit[521] & reg_we & ~wr_err;
+  assign wkup_detector_regwen_7_we = addr_hit[521] & reg_we & !reg_error;
   assign wkup_detector_regwen_7_wd = reg_wdata[0];
 
-  assign wkup_detector_en_0_we = addr_hit[522] & reg_we & ~wr_err;
+  assign wkup_detector_en_0_we = addr_hit[522] & reg_we & !reg_error;
   assign wkup_detector_en_0_wd = reg_wdata[0];
 
-  assign wkup_detector_en_1_we = addr_hit[523] & reg_we & ~wr_err;
+  assign wkup_detector_en_1_we = addr_hit[523] & reg_we & !reg_error;
   assign wkup_detector_en_1_wd = reg_wdata[0];
 
-  assign wkup_detector_en_2_we = addr_hit[524] & reg_we & ~wr_err;
+  assign wkup_detector_en_2_we = addr_hit[524] & reg_we & !reg_error;
   assign wkup_detector_en_2_wd = reg_wdata[0];
 
-  assign wkup_detector_en_3_we = addr_hit[525] & reg_we & ~wr_err;
+  assign wkup_detector_en_3_we = addr_hit[525] & reg_we & !reg_error;
   assign wkup_detector_en_3_wd = reg_wdata[0];
 
-  assign wkup_detector_en_4_we = addr_hit[526] & reg_we & ~wr_err;
+  assign wkup_detector_en_4_we = addr_hit[526] & reg_we & !reg_error;
   assign wkup_detector_en_4_wd = reg_wdata[0];
 
-  assign wkup_detector_en_5_we = addr_hit[527] & reg_we & ~wr_err;
+  assign wkup_detector_en_5_we = addr_hit[527] & reg_we & !reg_error;
   assign wkup_detector_en_5_wd = reg_wdata[0];
 
-  assign wkup_detector_en_6_we = addr_hit[528] & reg_we & ~wr_err;
+  assign wkup_detector_en_6_we = addr_hit[528] & reg_we & !reg_error;
   assign wkup_detector_en_6_wd = reg_wdata[0];
 
-  assign wkup_detector_en_7_we = addr_hit[529] & reg_we & ~wr_err;
+  assign wkup_detector_en_7_we = addr_hit[529] & reg_we & !reg_error;
   assign wkup_detector_en_7_wd = reg_wdata[0];
 
-  assign wkup_detector_0_mode_0_we = addr_hit[530] & reg_we & ~wr_err;
+  assign wkup_detector_0_mode_0_we = addr_hit[530] & reg_we & !reg_error;
   assign wkup_detector_0_mode_0_wd = reg_wdata[2:0];
 
-  assign wkup_detector_0_filter_0_we = addr_hit[530] & reg_we & ~wr_err;
+  assign wkup_detector_0_filter_0_we = addr_hit[530] & reg_we & !reg_error;
   assign wkup_detector_0_filter_0_wd = reg_wdata[3];
 
-  assign wkup_detector_0_miodio_0_we = addr_hit[530] & reg_we & ~wr_err;
+  assign wkup_detector_0_miodio_0_we = addr_hit[530] & reg_we & !reg_error;
   assign wkup_detector_0_miodio_0_wd = reg_wdata[4];
 
-  assign wkup_detector_1_mode_1_we = addr_hit[531] & reg_we & ~wr_err;
+  assign wkup_detector_1_mode_1_we = addr_hit[531] & reg_we & !reg_error;
   assign wkup_detector_1_mode_1_wd = reg_wdata[2:0];
 
-  assign wkup_detector_1_filter_1_we = addr_hit[531] & reg_we & ~wr_err;
+  assign wkup_detector_1_filter_1_we = addr_hit[531] & reg_we & !reg_error;
   assign wkup_detector_1_filter_1_wd = reg_wdata[3];
 
-  assign wkup_detector_1_miodio_1_we = addr_hit[531] & reg_we & ~wr_err;
+  assign wkup_detector_1_miodio_1_we = addr_hit[531] & reg_we & !reg_error;
   assign wkup_detector_1_miodio_1_wd = reg_wdata[4];
 
-  assign wkup_detector_2_mode_2_we = addr_hit[532] & reg_we & ~wr_err;
+  assign wkup_detector_2_mode_2_we = addr_hit[532] & reg_we & !reg_error;
   assign wkup_detector_2_mode_2_wd = reg_wdata[2:0];
 
-  assign wkup_detector_2_filter_2_we = addr_hit[532] & reg_we & ~wr_err;
+  assign wkup_detector_2_filter_2_we = addr_hit[532] & reg_we & !reg_error;
   assign wkup_detector_2_filter_2_wd = reg_wdata[3];
 
-  assign wkup_detector_2_miodio_2_we = addr_hit[532] & reg_we & ~wr_err;
+  assign wkup_detector_2_miodio_2_we = addr_hit[532] & reg_we & !reg_error;
   assign wkup_detector_2_miodio_2_wd = reg_wdata[4];
 
-  assign wkup_detector_3_mode_3_we = addr_hit[533] & reg_we & ~wr_err;
+  assign wkup_detector_3_mode_3_we = addr_hit[533] & reg_we & !reg_error;
   assign wkup_detector_3_mode_3_wd = reg_wdata[2:0];
 
-  assign wkup_detector_3_filter_3_we = addr_hit[533] & reg_we & ~wr_err;
+  assign wkup_detector_3_filter_3_we = addr_hit[533] & reg_we & !reg_error;
   assign wkup_detector_3_filter_3_wd = reg_wdata[3];
 
-  assign wkup_detector_3_miodio_3_we = addr_hit[533] & reg_we & ~wr_err;
+  assign wkup_detector_3_miodio_3_we = addr_hit[533] & reg_we & !reg_error;
   assign wkup_detector_3_miodio_3_wd = reg_wdata[4];
 
-  assign wkup_detector_4_mode_4_we = addr_hit[534] & reg_we & ~wr_err;
+  assign wkup_detector_4_mode_4_we = addr_hit[534] & reg_we & !reg_error;
   assign wkup_detector_4_mode_4_wd = reg_wdata[2:0];
 
-  assign wkup_detector_4_filter_4_we = addr_hit[534] & reg_we & ~wr_err;
+  assign wkup_detector_4_filter_4_we = addr_hit[534] & reg_we & !reg_error;
   assign wkup_detector_4_filter_4_wd = reg_wdata[3];
 
-  assign wkup_detector_4_miodio_4_we = addr_hit[534] & reg_we & ~wr_err;
+  assign wkup_detector_4_miodio_4_we = addr_hit[534] & reg_we & !reg_error;
   assign wkup_detector_4_miodio_4_wd = reg_wdata[4];
 
-  assign wkup_detector_5_mode_5_we = addr_hit[535] & reg_we & ~wr_err;
+  assign wkup_detector_5_mode_5_we = addr_hit[535] & reg_we & !reg_error;
   assign wkup_detector_5_mode_5_wd = reg_wdata[2:0];
 
-  assign wkup_detector_5_filter_5_we = addr_hit[535] & reg_we & ~wr_err;
+  assign wkup_detector_5_filter_5_we = addr_hit[535] & reg_we & !reg_error;
   assign wkup_detector_5_filter_5_wd = reg_wdata[3];
 
-  assign wkup_detector_5_miodio_5_we = addr_hit[535] & reg_we & ~wr_err;
+  assign wkup_detector_5_miodio_5_we = addr_hit[535] & reg_we & !reg_error;
   assign wkup_detector_5_miodio_5_wd = reg_wdata[4];
 
-  assign wkup_detector_6_mode_6_we = addr_hit[536] & reg_we & ~wr_err;
+  assign wkup_detector_6_mode_6_we = addr_hit[536] & reg_we & !reg_error;
   assign wkup_detector_6_mode_6_wd = reg_wdata[2:0];
 
-  assign wkup_detector_6_filter_6_we = addr_hit[536] & reg_we & ~wr_err;
+  assign wkup_detector_6_filter_6_we = addr_hit[536] & reg_we & !reg_error;
   assign wkup_detector_6_filter_6_wd = reg_wdata[3];
 
-  assign wkup_detector_6_miodio_6_we = addr_hit[536] & reg_we & ~wr_err;
+  assign wkup_detector_6_miodio_6_we = addr_hit[536] & reg_we & !reg_error;
   assign wkup_detector_6_miodio_6_wd = reg_wdata[4];
 
-  assign wkup_detector_7_mode_7_we = addr_hit[537] & reg_we & ~wr_err;
+  assign wkup_detector_7_mode_7_we = addr_hit[537] & reg_we & !reg_error;
   assign wkup_detector_7_mode_7_wd = reg_wdata[2:0];
 
-  assign wkup_detector_7_filter_7_we = addr_hit[537] & reg_we & ~wr_err;
+  assign wkup_detector_7_filter_7_we = addr_hit[537] & reg_we & !reg_error;
   assign wkup_detector_7_filter_7_wd = reg_wdata[3];
 
-  assign wkup_detector_7_miodio_7_we = addr_hit[537] & reg_we & ~wr_err;
+  assign wkup_detector_7_miodio_7_we = addr_hit[537] & reg_we & !reg_error;
   assign wkup_detector_7_miodio_7_wd = reg_wdata[4];
 
-  assign wkup_detector_cnt_th_0_we = addr_hit[538] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th_0_we = addr_hit[538] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_0_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_1_we = addr_hit[539] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th_1_we = addr_hit[539] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_1_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_2_we = addr_hit[540] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th_2_we = addr_hit[540] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_2_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_3_we = addr_hit[541] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th_3_we = addr_hit[541] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_3_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_4_we = addr_hit[542] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th_4_we = addr_hit[542] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_4_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_5_we = addr_hit[543] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th_5_we = addr_hit[543] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_5_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_6_we = addr_hit[544] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th_6_we = addr_hit[544] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_6_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_7_we = addr_hit[545] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th_7_we = addr_hit[545] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_7_wd = reg_wdata[7:0];
 
-  assign wkup_detector_padsel_0_we = addr_hit[546] & reg_we & ~wr_err;
+  assign wkup_detector_padsel_0_we = addr_hit[546] & reg_we & !reg_error;
   assign wkup_detector_padsel_0_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_1_we = addr_hit[547] & reg_we & ~wr_err;
+  assign wkup_detector_padsel_1_we = addr_hit[547] & reg_we & !reg_error;
   assign wkup_detector_padsel_1_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_2_we = addr_hit[548] & reg_we & ~wr_err;
+  assign wkup_detector_padsel_2_we = addr_hit[548] & reg_we & !reg_error;
   assign wkup_detector_padsel_2_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_3_we = addr_hit[549] & reg_we & ~wr_err;
+  assign wkup_detector_padsel_3_we = addr_hit[549] & reg_we & !reg_error;
   assign wkup_detector_padsel_3_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_4_we = addr_hit[550] & reg_we & ~wr_err;
+  assign wkup_detector_padsel_4_we = addr_hit[550] & reg_we & !reg_error;
   assign wkup_detector_padsel_4_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_5_we = addr_hit[551] & reg_we & ~wr_err;
+  assign wkup_detector_padsel_5_we = addr_hit[551] & reg_we & !reg_error;
   assign wkup_detector_padsel_5_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_6_we = addr_hit[552] & reg_we & ~wr_err;
+  assign wkup_detector_padsel_6_we = addr_hit[552] & reg_we & !reg_error;
   assign wkup_detector_padsel_6_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_7_we = addr_hit[553] & reg_we & ~wr_err;
+  assign wkup_detector_padsel_7_we = addr_hit[553] & reg_we & !reg_error;
   assign wkup_detector_padsel_7_wd = reg_wdata[5:0];
 
-  assign wkup_cause_cause_0_we = addr_hit[554] & reg_we & ~wr_err;
+  assign wkup_cause_cause_0_we = addr_hit[554] & reg_we & !reg_error;
   assign wkup_cause_cause_0_wd = reg_wdata[0];
-  assign wkup_cause_cause_0_re = addr_hit[554] && reg_re;
+  assign wkup_cause_cause_0_re = addr_hit[554] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_1_we = addr_hit[554] & reg_we & ~wr_err;
+  assign wkup_cause_cause_1_we = addr_hit[554] & reg_we & !reg_error;
   assign wkup_cause_cause_1_wd = reg_wdata[1];
-  assign wkup_cause_cause_1_re = addr_hit[554] && reg_re;
+  assign wkup_cause_cause_1_re = addr_hit[554] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_2_we = addr_hit[554] & reg_we & ~wr_err;
+  assign wkup_cause_cause_2_we = addr_hit[554] & reg_we & !reg_error;
   assign wkup_cause_cause_2_wd = reg_wdata[2];
-  assign wkup_cause_cause_2_re = addr_hit[554] && reg_re;
+  assign wkup_cause_cause_2_re = addr_hit[554] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_3_we = addr_hit[554] & reg_we & ~wr_err;
+  assign wkup_cause_cause_3_we = addr_hit[554] & reg_we & !reg_error;
   assign wkup_cause_cause_3_wd = reg_wdata[3];
-  assign wkup_cause_cause_3_re = addr_hit[554] && reg_re;
+  assign wkup_cause_cause_3_re = addr_hit[554] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_4_we = addr_hit[554] & reg_we & ~wr_err;
+  assign wkup_cause_cause_4_we = addr_hit[554] & reg_we & !reg_error;
   assign wkup_cause_cause_4_wd = reg_wdata[4];
-  assign wkup_cause_cause_4_re = addr_hit[554] && reg_re;
+  assign wkup_cause_cause_4_re = addr_hit[554] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_5_we = addr_hit[554] & reg_we & ~wr_err;
+  assign wkup_cause_cause_5_we = addr_hit[554] & reg_we & !reg_error;
   assign wkup_cause_cause_5_wd = reg_wdata[5];
-  assign wkup_cause_cause_5_re = addr_hit[554] && reg_re;
+  assign wkup_cause_cause_5_re = addr_hit[554] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_6_we = addr_hit[554] & reg_we & ~wr_err;
+  assign wkup_cause_cause_6_we = addr_hit[554] & reg_we & !reg_error;
   assign wkup_cause_cause_6_wd = reg_wdata[6];
-  assign wkup_cause_cause_6_re = addr_hit[554] && reg_re;
+  assign wkup_cause_cause_6_re = addr_hit[554] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_7_we = addr_hit[554] & reg_we & ~wr_err;
+  assign wkup_cause_cause_7_we = addr_hit[554] & reg_we & !reg_error;
   assign wkup_cause_cause_7_wd = reg_wdata[7];
-  assign wkup_cause_cause_7_re = addr_hit[554] && reg_re;
+  assign wkup_cause_cause_7_re = addr_hit[554] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
@@ -845,75 +845,75 @@ module pwrmgr_reg_top (
     if (addr_hit[14] && reg_we && (PWRMGR_PERMIT[14] != (PWRMGR_PERMIT[14] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_wd = reg_wdata[0];
 
-  assign intr_enable_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_wd = reg_wdata[0];
 
-  assign intr_test_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_wd = reg_wdata[0];
 
-  assign ctrl_cfg_regwen_re = addr_hit[3] && reg_re;
+  assign ctrl_cfg_regwen_re = addr_hit[3] & reg_re & !reg_error;
 
-  assign control_low_power_hint_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_low_power_hint_we = addr_hit[4] & reg_we & !reg_error;
   assign control_low_power_hint_wd = reg_wdata[0];
 
-  assign control_core_clk_en_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_core_clk_en_we = addr_hit[4] & reg_we & !reg_error;
   assign control_core_clk_en_wd = reg_wdata[4];
 
-  assign control_io_clk_en_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_io_clk_en_we = addr_hit[4] & reg_we & !reg_error;
   assign control_io_clk_en_wd = reg_wdata[5];
 
-  assign control_usb_clk_en_lp_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_usb_clk_en_lp_we = addr_hit[4] & reg_we & !reg_error;
   assign control_usb_clk_en_lp_wd = reg_wdata[6];
 
-  assign control_usb_clk_en_active_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_usb_clk_en_active_we = addr_hit[4] & reg_we & !reg_error;
   assign control_usb_clk_en_active_wd = reg_wdata[7];
 
-  assign control_main_pd_n_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_main_pd_n_we = addr_hit[4] & reg_we & !reg_error;
   assign control_main_pd_n_wd = reg_wdata[8];
 
-  assign cfg_cdc_sync_we = addr_hit[5] & reg_we & ~wr_err;
+  assign cfg_cdc_sync_we = addr_hit[5] & reg_we & !reg_error;
   assign cfg_cdc_sync_wd = reg_wdata[0];
 
-  assign wakeup_en_regwen_we = addr_hit[6] & reg_we & ~wr_err;
+  assign wakeup_en_regwen_we = addr_hit[6] & reg_we & !reg_error;
   assign wakeup_en_regwen_wd = reg_wdata[0];
 
-  assign wakeup_en_en_0_we = addr_hit[7] & reg_we & ~wr_err;
+  assign wakeup_en_en_0_we = addr_hit[7] & reg_we & !reg_error;
   assign wakeup_en_en_0_wd = reg_wdata[0];
 
-  assign wakeup_en_en_1_we = addr_hit[7] & reg_we & ~wr_err;
+  assign wakeup_en_en_1_we = addr_hit[7] & reg_we & !reg_error;
   assign wakeup_en_en_1_wd = reg_wdata[1];
 
-  assign wakeup_en_en_2_we = addr_hit[7] & reg_we & ~wr_err;
+  assign wakeup_en_en_2_we = addr_hit[7] & reg_we & !reg_error;
   assign wakeup_en_en_2_wd = reg_wdata[2];
 
 
 
 
-  assign reset_en_regwen_we = addr_hit[9] & reg_we & ~wr_err;
+  assign reset_en_regwen_we = addr_hit[9] & reg_we & !reg_error;
   assign reset_en_regwen_wd = reg_wdata[0];
 
-  assign reset_en_we = addr_hit[10] & reg_we & ~wr_err;
+  assign reset_en_we = addr_hit[10] & reg_we & !reg_error;
   assign reset_en_wd = reg_wdata[0];
 
 
 
-  assign wake_info_capture_dis_we = addr_hit[13] & reg_we & ~wr_err;
+  assign wake_info_capture_dis_we = addr_hit[13] & reg_we & !reg_error;
   assign wake_info_capture_dis_wd = reg_wdata[0];
 
-  assign wake_info_reasons_we = addr_hit[14] & reg_we & ~wr_err;
+  assign wake_info_reasons_we = addr_hit[14] & reg_we & !reg_error;
   assign wake_info_reasons_wd = reg_wdata[2:0];
-  assign wake_info_reasons_re = addr_hit[14] && reg_re;
+  assign wake_info_reasons_re = addr_hit[14] & reg_re & !reg_error;
 
-  assign wake_info_fall_through_we = addr_hit[14] & reg_we & ~wr_err;
+  assign wake_info_fall_through_we = addr_hit[14] & reg_we & !reg_error;
   assign wake_info_fall_through_wd = reg_wdata[3];
-  assign wake_info_fall_through_re = addr_hit[14] && reg_re;
+  assign wake_info_fall_through_re = addr_hit[14] & reg_re & !reg_error;
 
-  assign wake_info_abort_we = addr_hit[14] & reg_we & ~wr_err;
+  assign wake_info_abort_we = addr_hit[14] & reg_we & !reg_error;
   assign wake_info_abort_wd = reg_wdata[4];
-  assign wake_info_abort_re = addr_hit[14] && reg_re;
+  assign wake_info_abort_re = addr_hit[14] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
@@ -775,86 +775,86 @@ module rstmgr_reg_top (
     if (addr_hit[8] && reg_we && (RSTMGR_PERMIT[8] != (RSTMGR_PERMIT[8] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign reset_info_por_we = addr_hit[0] & reg_we & ~wr_err;
+  assign reset_info_por_we = addr_hit[0] & reg_we & !reg_error;
   assign reset_info_por_wd = reg_wdata[0];
 
-  assign reset_info_low_power_exit_we = addr_hit[0] & reg_we & ~wr_err;
+  assign reset_info_low_power_exit_we = addr_hit[0] & reg_we & !reg_error;
   assign reset_info_low_power_exit_wd = reg_wdata[1];
 
-  assign reset_info_ndm_reset_we = addr_hit[0] & reg_we & ~wr_err;
+  assign reset_info_ndm_reset_we = addr_hit[0] & reg_we & !reg_error;
   assign reset_info_ndm_reset_wd = reg_wdata[2];
 
-  assign reset_info_hw_req_we = addr_hit[0] & reg_we & ~wr_err;
+  assign reset_info_hw_req_we = addr_hit[0] & reg_we & !reg_error;
   assign reset_info_hw_req_wd = reg_wdata[4:3];
 
-  assign alert_info_ctrl_en_we = addr_hit[1] & reg_we & ~wr_err;
+  assign alert_info_ctrl_en_we = addr_hit[1] & reg_we & !reg_error;
   assign alert_info_ctrl_en_wd = reg_wdata[0];
 
-  assign alert_info_ctrl_index_we = addr_hit[1] & reg_we & ~wr_err;
+  assign alert_info_ctrl_index_we = addr_hit[1] & reg_we & !reg_error;
   assign alert_info_ctrl_index_wd = reg_wdata[7:4];
 
-  assign alert_info_attr_re = addr_hit[2] && reg_re;
+  assign alert_info_attr_re = addr_hit[2] & reg_re & !reg_error;
 
-  assign alert_info_re = addr_hit[3] && reg_re;
+  assign alert_info_re = addr_hit[3] & reg_re & !reg_error;
 
-  assign cpu_info_ctrl_en_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cpu_info_ctrl_en_we = addr_hit[4] & reg_we & !reg_error;
   assign cpu_info_ctrl_en_wd = reg_wdata[0];
 
-  assign cpu_info_ctrl_index_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cpu_info_ctrl_index_we = addr_hit[4] & reg_we & !reg_error;
   assign cpu_info_ctrl_index_wd = reg_wdata[7:4];
 
-  assign cpu_info_attr_re = addr_hit[5] && reg_re;
+  assign cpu_info_attr_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign cpu_info_re = addr_hit[6] && reg_re;
+  assign cpu_info_re = addr_hit[6] & reg_re & !reg_error;
 
-  assign sw_rst_regen_en_0_we = addr_hit[7] & reg_we & ~wr_err;
+  assign sw_rst_regen_en_0_we = addr_hit[7] & reg_we & !reg_error;
   assign sw_rst_regen_en_0_wd = reg_wdata[0];
 
-  assign sw_rst_regen_en_1_we = addr_hit[7] & reg_we & ~wr_err;
+  assign sw_rst_regen_en_1_we = addr_hit[7] & reg_we & !reg_error;
   assign sw_rst_regen_en_1_wd = reg_wdata[1];
 
-  assign sw_rst_regen_en_2_we = addr_hit[7] & reg_we & ~wr_err;
+  assign sw_rst_regen_en_2_we = addr_hit[7] & reg_we & !reg_error;
   assign sw_rst_regen_en_2_wd = reg_wdata[2];
 
-  assign sw_rst_regen_en_3_we = addr_hit[7] & reg_we & ~wr_err;
+  assign sw_rst_regen_en_3_we = addr_hit[7] & reg_we & !reg_error;
   assign sw_rst_regen_en_3_wd = reg_wdata[3];
 
-  assign sw_rst_regen_en_4_we = addr_hit[7] & reg_we & ~wr_err;
+  assign sw_rst_regen_en_4_we = addr_hit[7] & reg_we & !reg_error;
   assign sw_rst_regen_en_4_wd = reg_wdata[4];
 
-  assign sw_rst_regen_en_5_we = addr_hit[7] & reg_we & ~wr_err;
+  assign sw_rst_regen_en_5_we = addr_hit[7] & reg_we & !reg_error;
   assign sw_rst_regen_en_5_wd = reg_wdata[5];
 
-  assign sw_rst_regen_en_6_we = addr_hit[7] & reg_we & ~wr_err;
+  assign sw_rst_regen_en_6_we = addr_hit[7] & reg_we & !reg_error;
   assign sw_rst_regen_en_6_wd = reg_wdata[6];
 
-  assign sw_rst_ctrl_n_val_0_we = addr_hit[8] & reg_we & ~wr_err;
+  assign sw_rst_ctrl_n_val_0_we = addr_hit[8] & reg_we & !reg_error;
   assign sw_rst_ctrl_n_val_0_wd = reg_wdata[0];
-  assign sw_rst_ctrl_n_val_0_re = addr_hit[8] && reg_re;
+  assign sw_rst_ctrl_n_val_0_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign sw_rst_ctrl_n_val_1_we = addr_hit[8] & reg_we & ~wr_err;
+  assign sw_rst_ctrl_n_val_1_we = addr_hit[8] & reg_we & !reg_error;
   assign sw_rst_ctrl_n_val_1_wd = reg_wdata[1];
-  assign sw_rst_ctrl_n_val_1_re = addr_hit[8] && reg_re;
+  assign sw_rst_ctrl_n_val_1_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign sw_rst_ctrl_n_val_2_we = addr_hit[8] & reg_we & ~wr_err;
+  assign sw_rst_ctrl_n_val_2_we = addr_hit[8] & reg_we & !reg_error;
   assign sw_rst_ctrl_n_val_2_wd = reg_wdata[2];
-  assign sw_rst_ctrl_n_val_2_re = addr_hit[8] && reg_re;
+  assign sw_rst_ctrl_n_val_2_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign sw_rst_ctrl_n_val_3_we = addr_hit[8] & reg_we & ~wr_err;
+  assign sw_rst_ctrl_n_val_3_we = addr_hit[8] & reg_we & !reg_error;
   assign sw_rst_ctrl_n_val_3_wd = reg_wdata[3];
-  assign sw_rst_ctrl_n_val_3_re = addr_hit[8] && reg_re;
+  assign sw_rst_ctrl_n_val_3_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign sw_rst_ctrl_n_val_4_we = addr_hit[8] & reg_we & ~wr_err;
+  assign sw_rst_ctrl_n_val_4_we = addr_hit[8] & reg_we & !reg_error;
   assign sw_rst_ctrl_n_val_4_wd = reg_wdata[4];
-  assign sw_rst_ctrl_n_val_4_re = addr_hit[8] && reg_re;
+  assign sw_rst_ctrl_n_val_4_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign sw_rst_ctrl_n_val_5_we = addr_hit[8] & reg_we & ~wr_err;
+  assign sw_rst_ctrl_n_val_5_we = addr_hit[8] & reg_we & !reg_error;
   assign sw_rst_ctrl_n_val_5_wd = reg_wdata[5];
-  assign sw_rst_ctrl_n_val_5_re = addr_hit[8] && reg_re;
+  assign sw_rst_ctrl_n_val_5_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign sw_rst_ctrl_n_val_6_we = addr_hit[8] & reg_we & ~wr_err;
+  assign sw_rst_ctrl_n_val_6_we = addr_hit[8] & reg_we & !reg_error;
   assign sw_rst_ctrl_n_val_6_wd = reg_wdata[6];
-  assign sw_rst_ctrl_n_val_6_re = addr_hit[8] && reg_re;
+  assign sw_rst_ctrl_n_val_6_re = addr_hit[8] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
@@ -20290,1553 +20290,1553 @@ module rv_plic_reg_top (
 
 
 
-  assign le_0_le_0_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_0_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_0_wd = reg_wdata[0];
 
-  assign le_0_le_1_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_1_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_1_wd = reg_wdata[1];
 
-  assign le_0_le_2_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_2_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_2_wd = reg_wdata[2];
 
-  assign le_0_le_3_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_3_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_3_wd = reg_wdata[3];
 
-  assign le_0_le_4_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_4_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_4_wd = reg_wdata[4];
 
-  assign le_0_le_5_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_5_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_5_wd = reg_wdata[5];
 
-  assign le_0_le_6_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_6_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_6_wd = reg_wdata[6];
 
-  assign le_0_le_7_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_7_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_7_wd = reg_wdata[7];
 
-  assign le_0_le_8_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_8_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_8_wd = reg_wdata[8];
 
-  assign le_0_le_9_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_9_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_9_wd = reg_wdata[9];
 
-  assign le_0_le_10_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_10_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_10_wd = reg_wdata[10];
 
-  assign le_0_le_11_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_11_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_11_wd = reg_wdata[11];
 
-  assign le_0_le_12_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_12_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_12_wd = reg_wdata[12];
 
-  assign le_0_le_13_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_13_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_13_wd = reg_wdata[13];
 
-  assign le_0_le_14_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_14_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_14_wd = reg_wdata[14];
 
-  assign le_0_le_15_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_15_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_15_wd = reg_wdata[15];
 
-  assign le_0_le_16_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_16_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_16_wd = reg_wdata[16];
 
-  assign le_0_le_17_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_17_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_17_wd = reg_wdata[17];
 
-  assign le_0_le_18_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_18_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_18_wd = reg_wdata[18];
 
-  assign le_0_le_19_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_19_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_19_wd = reg_wdata[19];
 
-  assign le_0_le_20_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_20_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_20_wd = reg_wdata[20];
 
-  assign le_0_le_21_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_21_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_21_wd = reg_wdata[21];
 
-  assign le_0_le_22_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_22_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_22_wd = reg_wdata[22];
 
-  assign le_0_le_23_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_23_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_23_wd = reg_wdata[23];
 
-  assign le_0_le_24_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_24_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_24_wd = reg_wdata[24];
 
-  assign le_0_le_25_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_25_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_25_wd = reg_wdata[25];
 
-  assign le_0_le_26_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_26_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_26_wd = reg_wdata[26];
 
-  assign le_0_le_27_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_27_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_27_wd = reg_wdata[27];
 
-  assign le_0_le_28_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_28_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_28_wd = reg_wdata[28];
 
-  assign le_0_le_29_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_29_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_29_wd = reg_wdata[29];
 
-  assign le_0_le_30_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_30_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_30_wd = reg_wdata[30];
 
-  assign le_0_le_31_we = addr_hit[6] & reg_we & ~wr_err;
+  assign le_0_le_31_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_31_wd = reg_wdata[31];
 
-  assign le_1_le_32_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_32_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_32_wd = reg_wdata[0];
 
-  assign le_1_le_33_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_33_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_33_wd = reg_wdata[1];
 
-  assign le_1_le_34_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_34_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_34_wd = reg_wdata[2];
 
-  assign le_1_le_35_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_35_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_35_wd = reg_wdata[3];
 
-  assign le_1_le_36_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_36_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_36_wd = reg_wdata[4];
 
-  assign le_1_le_37_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_37_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_37_wd = reg_wdata[5];
 
-  assign le_1_le_38_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_38_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_38_wd = reg_wdata[6];
 
-  assign le_1_le_39_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_39_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_39_wd = reg_wdata[7];
 
-  assign le_1_le_40_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_40_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_40_wd = reg_wdata[8];
 
-  assign le_1_le_41_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_41_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_41_wd = reg_wdata[9];
 
-  assign le_1_le_42_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_42_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_42_wd = reg_wdata[10];
 
-  assign le_1_le_43_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_43_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_43_wd = reg_wdata[11];
 
-  assign le_1_le_44_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_44_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_44_wd = reg_wdata[12];
 
-  assign le_1_le_45_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_45_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_45_wd = reg_wdata[13];
 
-  assign le_1_le_46_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_46_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_46_wd = reg_wdata[14];
 
-  assign le_1_le_47_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_47_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_47_wd = reg_wdata[15];
 
-  assign le_1_le_48_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_48_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_48_wd = reg_wdata[16];
 
-  assign le_1_le_49_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_49_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_49_wd = reg_wdata[17];
 
-  assign le_1_le_50_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_50_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_50_wd = reg_wdata[18];
 
-  assign le_1_le_51_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_51_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_51_wd = reg_wdata[19];
 
-  assign le_1_le_52_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_52_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_52_wd = reg_wdata[20];
 
-  assign le_1_le_53_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_53_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_53_wd = reg_wdata[21];
 
-  assign le_1_le_54_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_54_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_54_wd = reg_wdata[22];
 
-  assign le_1_le_55_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_55_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_55_wd = reg_wdata[23];
 
-  assign le_1_le_56_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_56_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_56_wd = reg_wdata[24];
 
-  assign le_1_le_57_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_57_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_57_wd = reg_wdata[25];
 
-  assign le_1_le_58_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_58_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_58_wd = reg_wdata[26];
 
-  assign le_1_le_59_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_59_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_59_wd = reg_wdata[27];
 
-  assign le_1_le_60_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_60_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_60_wd = reg_wdata[28];
 
-  assign le_1_le_61_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_61_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_61_wd = reg_wdata[29];
 
-  assign le_1_le_62_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_62_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_62_wd = reg_wdata[30];
 
-  assign le_1_le_63_we = addr_hit[7] & reg_we & ~wr_err;
+  assign le_1_le_63_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_63_wd = reg_wdata[31];
 
-  assign le_2_le_64_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_64_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_64_wd = reg_wdata[0];
 
-  assign le_2_le_65_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_65_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_65_wd = reg_wdata[1];
 
-  assign le_2_le_66_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_66_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_66_wd = reg_wdata[2];
 
-  assign le_2_le_67_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_67_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_67_wd = reg_wdata[3];
 
-  assign le_2_le_68_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_68_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_68_wd = reg_wdata[4];
 
-  assign le_2_le_69_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_69_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_69_wd = reg_wdata[5];
 
-  assign le_2_le_70_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_70_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_70_wd = reg_wdata[6];
 
-  assign le_2_le_71_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_71_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_71_wd = reg_wdata[7];
 
-  assign le_2_le_72_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_72_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_72_wd = reg_wdata[8];
 
-  assign le_2_le_73_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_73_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_73_wd = reg_wdata[9];
 
-  assign le_2_le_74_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_74_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_74_wd = reg_wdata[10];
 
-  assign le_2_le_75_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_75_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_75_wd = reg_wdata[11];
 
-  assign le_2_le_76_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_76_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_76_wd = reg_wdata[12];
 
-  assign le_2_le_77_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_77_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_77_wd = reg_wdata[13];
 
-  assign le_2_le_78_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_78_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_78_wd = reg_wdata[14];
 
-  assign le_2_le_79_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_79_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_79_wd = reg_wdata[15];
 
-  assign le_2_le_80_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_80_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_80_wd = reg_wdata[16];
 
-  assign le_2_le_81_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_81_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_81_wd = reg_wdata[17];
 
-  assign le_2_le_82_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_82_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_82_wd = reg_wdata[18];
 
-  assign le_2_le_83_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_83_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_83_wd = reg_wdata[19];
 
-  assign le_2_le_84_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_84_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_84_wd = reg_wdata[20];
 
-  assign le_2_le_85_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_85_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_85_wd = reg_wdata[21];
 
-  assign le_2_le_86_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_86_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_86_wd = reg_wdata[22];
 
-  assign le_2_le_87_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_87_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_87_wd = reg_wdata[23];
 
-  assign le_2_le_88_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_88_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_88_wd = reg_wdata[24];
 
-  assign le_2_le_89_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_89_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_89_wd = reg_wdata[25];
 
-  assign le_2_le_90_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_90_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_90_wd = reg_wdata[26];
 
-  assign le_2_le_91_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_91_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_91_wd = reg_wdata[27];
 
-  assign le_2_le_92_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_92_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_92_wd = reg_wdata[28];
 
-  assign le_2_le_93_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_93_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_93_wd = reg_wdata[29];
 
-  assign le_2_le_94_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_94_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_94_wd = reg_wdata[30];
 
-  assign le_2_le_95_we = addr_hit[8] & reg_we & ~wr_err;
+  assign le_2_le_95_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_95_wd = reg_wdata[31];
 
-  assign le_3_le_96_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_96_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_96_wd = reg_wdata[0];
 
-  assign le_3_le_97_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_97_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_97_wd = reg_wdata[1];
 
-  assign le_3_le_98_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_98_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_98_wd = reg_wdata[2];
 
-  assign le_3_le_99_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_99_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_99_wd = reg_wdata[3];
 
-  assign le_3_le_100_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_100_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_100_wd = reg_wdata[4];
 
-  assign le_3_le_101_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_101_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_101_wd = reg_wdata[5];
 
-  assign le_3_le_102_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_102_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_102_wd = reg_wdata[6];
 
-  assign le_3_le_103_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_103_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_103_wd = reg_wdata[7];
 
-  assign le_3_le_104_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_104_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_104_wd = reg_wdata[8];
 
-  assign le_3_le_105_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_105_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_105_wd = reg_wdata[9];
 
-  assign le_3_le_106_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_106_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_106_wd = reg_wdata[10];
 
-  assign le_3_le_107_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_107_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_107_wd = reg_wdata[11];
 
-  assign le_3_le_108_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_108_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_108_wd = reg_wdata[12];
 
-  assign le_3_le_109_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_109_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_109_wd = reg_wdata[13];
 
-  assign le_3_le_110_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_110_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_110_wd = reg_wdata[14];
 
-  assign le_3_le_111_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_111_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_111_wd = reg_wdata[15];
 
-  assign le_3_le_112_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_112_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_112_wd = reg_wdata[16];
 
-  assign le_3_le_113_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_113_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_113_wd = reg_wdata[17];
 
-  assign le_3_le_114_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_114_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_114_wd = reg_wdata[18];
 
-  assign le_3_le_115_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_115_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_115_wd = reg_wdata[19];
 
-  assign le_3_le_116_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_116_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_116_wd = reg_wdata[20];
 
-  assign le_3_le_117_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_117_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_117_wd = reg_wdata[21];
 
-  assign le_3_le_118_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_118_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_118_wd = reg_wdata[22];
 
-  assign le_3_le_119_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_119_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_119_wd = reg_wdata[23];
 
-  assign le_3_le_120_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_120_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_120_wd = reg_wdata[24];
 
-  assign le_3_le_121_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_121_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_121_wd = reg_wdata[25];
 
-  assign le_3_le_122_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_122_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_122_wd = reg_wdata[26];
 
-  assign le_3_le_123_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_123_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_123_wd = reg_wdata[27];
 
-  assign le_3_le_124_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_124_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_124_wd = reg_wdata[28];
 
-  assign le_3_le_125_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_125_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_125_wd = reg_wdata[29];
 
-  assign le_3_le_126_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_126_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_126_wd = reg_wdata[30];
 
-  assign le_3_le_127_we = addr_hit[9] & reg_we & ~wr_err;
+  assign le_3_le_127_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_127_wd = reg_wdata[31];
 
-  assign le_4_le_128_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_128_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_128_wd = reg_wdata[0];
 
-  assign le_4_le_129_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_129_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_129_wd = reg_wdata[1];
 
-  assign le_4_le_130_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_130_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_130_wd = reg_wdata[2];
 
-  assign le_4_le_131_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_131_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_131_wd = reg_wdata[3];
 
-  assign le_4_le_132_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_132_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_132_wd = reg_wdata[4];
 
-  assign le_4_le_133_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_133_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_133_wd = reg_wdata[5];
 
-  assign le_4_le_134_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_134_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_134_wd = reg_wdata[6];
 
-  assign le_4_le_135_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_135_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_135_wd = reg_wdata[7];
 
-  assign le_4_le_136_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_136_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_136_wd = reg_wdata[8];
 
-  assign le_4_le_137_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_137_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_137_wd = reg_wdata[9];
 
-  assign le_4_le_138_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_138_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_138_wd = reg_wdata[10];
 
-  assign le_4_le_139_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_139_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_139_wd = reg_wdata[11];
 
-  assign le_4_le_140_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_140_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_140_wd = reg_wdata[12];
 
-  assign le_4_le_141_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_141_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_141_wd = reg_wdata[13];
 
-  assign le_4_le_142_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_142_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_142_wd = reg_wdata[14];
 
-  assign le_4_le_143_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_143_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_143_wd = reg_wdata[15];
 
-  assign le_4_le_144_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_144_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_144_wd = reg_wdata[16];
 
-  assign le_4_le_145_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_145_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_145_wd = reg_wdata[17];
 
-  assign le_4_le_146_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_146_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_146_wd = reg_wdata[18];
 
-  assign le_4_le_147_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_147_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_147_wd = reg_wdata[19];
 
-  assign le_4_le_148_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_148_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_148_wd = reg_wdata[20];
 
-  assign le_4_le_149_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_149_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_149_wd = reg_wdata[21];
 
-  assign le_4_le_150_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_150_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_150_wd = reg_wdata[22];
 
-  assign le_4_le_151_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_151_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_151_wd = reg_wdata[23];
 
-  assign le_4_le_152_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_152_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_152_wd = reg_wdata[24];
 
-  assign le_4_le_153_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_153_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_153_wd = reg_wdata[25];
 
-  assign le_4_le_154_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_154_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_154_wd = reg_wdata[26];
 
-  assign le_4_le_155_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_155_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_155_wd = reg_wdata[27];
 
-  assign le_4_le_156_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_156_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_156_wd = reg_wdata[28];
 
-  assign le_4_le_157_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_157_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_157_wd = reg_wdata[29];
 
-  assign le_4_le_158_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_158_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_158_wd = reg_wdata[30];
 
-  assign le_4_le_159_we = addr_hit[10] & reg_we & ~wr_err;
+  assign le_4_le_159_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_159_wd = reg_wdata[31];
 
-  assign le_5_le_160_we = addr_hit[11] & reg_we & ~wr_err;
+  assign le_5_le_160_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_160_wd = reg_wdata[0];
 
-  assign le_5_le_161_we = addr_hit[11] & reg_we & ~wr_err;
+  assign le_5_le_161_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_161_wd = reg_wdata[1];
 
-  assign le_5_le_162_we = addr_hit[11] & reg_we & ~wr_err;
+  assign le_5_le_162_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_162_wd = reg_wdata[2];
 
-  assign le_5_le_163_we = addr_hit[11] & reg_we & ~wr_err;
+  assign le_5_le_163_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_163_wd = reg_wdata[3];
 
-  assign le_5_le_164_we = addr_hit[11] & reg_we & ~wr_err;
+  assign le_5_le_164_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_164_wd = reg_wdata[4];
 
-  assign le_5_le_165_we = addr_hit[11] & reg_we & ~wr_err;
+  assign le_5_le_165_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_165_wd = reg_wdata[5];
 
-  assign le_5_le_166_we = addr_hit[11] & reg_we & ~wr_err;
+  assign le_5_le_166_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_166_wd = reg_wdata[6];
 
-  assign le_5_le_167_we = addr_hit[11] & reg_we & ~wr_err;
+  assign le_5_le_167_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_167_wd = reg_wdata[7];
 
-  assign le_5_le_168_we = addr_hit[11] & reg_we & ~wr_err;
+  assign le_5_le_168_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_168_wd = reg_wdata[8];
 
-  assign le_5_le_169_we = addr_hit[11] & reg_we & ~wr_err;
+  assign le_5_le_169_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_169_wd = reg_wdata[9];
 
-  assign le_5_le_170_we = addr_hit[11] & reg_we & ~wr_err;
+  assign le_5_le_170_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_170_wd = reg_wdata[10];
 
-  assign prio0_we = addr_hit[12] & reg_we & ~wr_err;
+  assign prio0_we = addr_hit[12] & reg_we & !reg_error;
   assign prio0_wd = reg_wdata[1:0];
 
-  assign prio1_we = addr_hit[13] & reg_we & ~wr_err;
+  assign prio1_we = addr_hit[13] & reg_we & !reg_error;
   assign prio1_wd = reg_wdata[1:0];
 
-  assign prio2_we = addr_hit[14] & reg_we & ~wr_err;
+  assign prio2_we = addr_hit[14] & reg_we & !reg_error;
   assign prio2_wd = reg_wdata[1:0];
 
-  assign prio3_we = addr_hit[15] & reg_we & ~wr_err;
+  assign prio3_we = addr_hit[15] & reg_we & !reg_error;
   assign prio3_wd = reg_wdata[1:0];
 
-  assign prio4_we = addr_hit[16] & reg_we & ~wr_err;
+  assign prio4_we = addr_hit[16] & reg_we & !reg_error;
   assign prio4_wd = reg_wdata[1:0];
 
-  assign prio5_we = addr_hit[17] & reg_we & ~wr_err;
+  assign prio5_we = addr_hit[17] & reg_we & !reg_error;
   assign prio5_wd = reg_wdata[1:0];
 
-  assign prio6_we = addr_hit[18] & reg_we & ~wr_err;
+  assign prio6_we = addr_hit[18] & reg_we & !reg_error;
   assign prio6_wd = reg_wdata[1:0];
 
-  assign prio7_we = addr_hit[19] & reg_we & ~wr_err;
+  assign prio7_we = addr_hit[19] & reg_we & !reg_error;
   assign prio7_wd = reg_wdata[1:0];
 
-  assign prio8_we = addr_hit[20] & reg_we & ~wr_err;
+  assign prio8_we = addr_hit[20] & reg_we & !reg_error;
   assign prio8_wd = reg_wdata[1:0];
 
-  assign prio9_we = addr_hit[21] & reg_we & ~wr_err;
+  assign prio9_we = addr_hit[21] & reg_we & !reg_error;
   assign prio9_wd = reg_wdata[1:0];
 
-  assign prio10_we = addr_hit[22] & reg_we & ~wr_err;
+  assign prio10_we = addr_hit[22] & reg_we & !reg_error;
   assign prio10_wd = reg_wdata[1:0];
 
-  assign prio11_we = addr_hit[23] & reg_we & ~wr_err;
+  assign prio11_we = addr_hit[23] & reg_we & !reg_error;
   assign prio11_wd = reg_wdata[1:0];
 
-  assign prio12_we = addr_hit[24] & reg_we & ~wr_err;
+  assign prio12_we = addr_hit[24] & reg_we & !reg_error;
   assign prio12_wd = reg_wdata[1:0];
 
-  assign prio13_we = addr_hit[25] & reg_we & ~wr_err;
+  assign prio13_we = addr_hit[25] & reg_we & !reg_error;
   assign prio13_wd = reg_wdata[1:0];
 
-  assign prio14_we = addr_hit[26] & reg_we & ~wr_err;
+  assign prio14_we = addr_hit[26] & reg_we & !reg_error;
   assign prio14_wd = reg_wdata[1:0];
 
-  assign prio15_we = addr_hit[27] & reg_we & ~wr_err;
+  assign prio15_we = addr_hit[27] & reg_we & !reg_error;
   assign prio15_wd = reg_wdata[1:0];
 
-  assign prio16_we = addr_hit[28] & reg_we & ~wr_err;
+  assign prio16_we = addr_hit[28] & reg_we & !reg_error;
   assign prio16_wd = reg_wdata[1:0];
 
-  assign prio17_we = addr_hit[29] & reg_we & ~wr_err;
+  assign prio17_we = addr_hit[29] & reg_we & !reg_error;
   assign prio17_wd = reg_wdata[1:0];
 
-  assign prio18_we = addr_hit[30] & reg_we & ~wr_err;
+  assign prio18_we = addr_hit[30] & reg_we & !reg_error;
   assign prio18_wd = reg_wdata[1:0];
 
-  assign prio19_we = addr_hit[31] & reg_we & ~wr_err;
+  assign prio19_we = addr_hit[31] & reg_we & !reg_error;
   assign prio19_wd = reg_wdata[1:0];
 
-  assign prio20_we = addr_hit[32] & reg_we & ~wr_err;
+  assign prio20_we = addr_hit[32] & reg_we & !reg_error;
   assign prio20_wd = reg_wdata[1:0];
 
-  assign prio21_we = addr_hit[33] & reg_we & ~wr_err;
+  assign prio21_we = addr_hit[33] & reg_we & !reg_error;
   assign prio21_wd = reg_wdata[1:0];
 
-  assign prio22_we = addr_hit[34] & reg_we & ~wr_err;
+  assign prio22_we = addr_hit[34] & reg_we & !reg_error;
   assign prio22_wd = reg_wdata[1:0];
 
-  assign prio23_we = addr_hit[35] & reg_we & ~wr_err;
+  assign prio23_we = addr_hit[35] & reg_we & !reg_error;
   assign prio23_wd = reg_wdata[1:0];
 
-  assign prio24_we = addr_hit[36] & reg_we & ~wr_err;
+  assign prio24_we = addr_hit[36] & reg_we & !reg_error;
   assign prio24_wd = reg_wdata[1:0];
 
-  assign prio25_we = addr_hit[37] & reg_we & ~wr_err;
+  assign prio25_we = addr_hit[37] & reg_we & !reg_error;
   assign prio25_wd = reg_wdata[1:0];
 
-  assign prio26_we = addr_hit[38] & reg_we & ~wr_err;
+  assign prio26_we = addr_hit[38] & reg_we & !reg_error;
   assign prio26_wd = reg_wdata[1:0];
 
-  assign prio27_we = addr_hit[39] & reg_we & ~wr_err;
+  assign prio27_we = addr_hit[39] & reg_we & !reg_error;
   assign prio27_wd = reg_wdata[1:0];
 
-  assign prio28_we = addr_hit[40] & reg_we & ~wr_err;
+  assign prio28_we = addr_hit[40] & reg_we & !reg_error;
   assign prio28_wd = reg_wdata[1:0];
 
-  assign prio29_we = addr_hit[41] & reg_we & ~wr_err;
+  assign prio29_we = addr_hit[41] & reg_we & !reg_error;
   assign prio29_wd = reg_wdata[1:0];
 
-  assign prio30_we = addr_hit[42] & reg_we & ~wr_err;
+  assign prio30_we = addr_hit[42] & reg_we & !reg_error;
   assign prio30_wd = reg_wdata[1:0];
 
-  assign prio31_we = addr_hit[43] & reg_we & ~wr_err;
+  assign prio31_we = addr_hit[43] & reg_we & !reg_error;
   assign prio31_wd = reg_wdata[1:0];
 
-  assign prio32_we = addr_hit[44] & reg_we & ~wr_err;
+  assign prio32_we = addr_hit[44] & reg_we & !reg_error;
   assign prio32_wd = reg_wdata[1:0];
 
-  assign prio33_we = addr_hit[45] & reg_we & ~wr_err;
+  assign prio33_we = addr_hit[45] & reg_we & !reg_error;
   assign prio33_wd = reg_wdata[1:0];
 
-  assign prio34_we = addr_hit[46] & reg_we & ~wr_err;
+  assign prio34_we = addr_hit[46] & reg_we & !reg_error;
   assign prio34_wd = reg_wdata[1:0];
 
-  assign prio35_we = addr_hit[47] & reg_we & ~wr_err;
+  assign prio35_we = addr_hit[47] & reg_we & !reg_error;
   assign prio35_wd = reg_wdata[1:0];
 
-  assign prio36_we = addr_hit[48] & reg_we & ~wr_err;
+  assign prio36_we = addr_hit[48] & reg_we & !reg_error;
   assign prio36_wd = reg_wdata[1:0];
 
-  assign prio37_we = addr_hit[49] & reg_we & ~wr_err;
+  assign prio37_we = addr_hit[49] & reg_we & !reg_error;
   assign prio37_wd = reg_wdata[1:0];
 
-  assign prio38_we = addr_hit[50] & reg_we & ~wr_err;
+  assign prio38_we = addr_hit[50] & reg_we & !reg_error;
   assign prio38_wd = reg_wdata[1:0];
 
-  assign prio39_we = addr_hit[51] & reg_we & ~wr_err;
+  assign prio39_we = addr_hit[51] & reg_we & !reg_error;
   assign prio39_wd = reg_wdata[1:0];
 
-  assign prio40_we = addr_hit[52] & reg_we & ~wr_err;
+  assign prio40_we = addr_hit[52] & reg_we & !reg_error;
   assign prio40_wd = reg_wdata[1:0];
 
-  assign prio41_we = addr_hit[53] & reg_we & ~wr_err;
+  assign prio41_we = addr_hit[53] & reg_we & !reg_error;
   assign prio41_wd = reg_wdata[1:0];
 
-  assign prio42_we = addr_hit[54] & reg_we & ~wr_err;
+  assign prio42_we = addr_hit[54] & reg_we & !reg_error;
   assign prio42_wd = reg_wdata[1:0];
 
-  assign prio43_we = addr_hit[55] & reg_we & ~wr_err;
+  assign prio43_we = addr_hit[55] & reg_we & !reg_error;
   assign prio43_wd = reg_wdata[1:0];
 
-  assign prio44_we = addr_hit[56] & reg_we & ~wr_err;
+  assign prio44_we = addr_hit[56] & reg_we & !reg_error;
   assign prio44_wd = reg_wdata[1:0];
 
-  assign prio45_we = addr_hit[57] & reg_we & ~wr_err;
+  assign prio45_we = addr_hit[57] & reg_we & !reg_error;
   assign prio45_wd = reg_wdata[1:0];
 
-  assign prio46_we = addr_hit[58] & reg_we & ~wr_err;
+  assign prio46_we = addr_hit[58] & reg_we & !reg_error;
   assign prio46_wd = reg_wdata[1:0];
 
-  assign prio47_we = addr_hit[59] & reg_we & ~wr_err;
+  assign prio47_we = addr_hit[59] & reg_we & !reg_error;
   assign prio47_wd = reg_wdata[1:0];
 
-  assign prio48_we = addr_hit[60] & reg_we & ~wr_err;
+  assign prio48_we = addr_hit[60] & reg_we & !reg_error;
   assign prio48_wd = reg_wdata[1:0];
 
-  assign prio49_we = addr_hit[61] & reg_we & ~wr_err;
+  assign prio49_we = addr_hit[61] & reg_we & !reg_error;
   assign prio49_wd = reg_wdata[1:0];
 
-  assign prio50_we = addr_hit[62] & reg_we & ~wr_err;
+  assign prio50_we = addr_hit[62] & reg_we & !reg_error;
   assign prio50_wd = reg_wdata[1:0];
 
-  assign prio51_we = addr_hit[63] & reg_we & ~wr_err;
+  assign prio51_we = addr_hit[63] & reg_we & !reg_error;
   assign prio51_wd = reg_wdata[1:0];
 
-  assign prio52_we = addr_hit[64] & reg_we & ~wr_err;
+  assign prio52_we = addr_hit[64] & reg_we & !reg_error;
   assign prio52_wd = reg_wdata[1:0];
 
-  assign prio53_we = addr_hit[65] & reg_we & ~wr_err;
+  assign prio53_we = addr_hit[65] & reg_we & !reg_error;
   assign prio53_wd = reg_wdata[1:0];
 
-  assign prio54_we = addr_hit[66] & reg_we & ~wr_err;
+  assign prio54_we = addr_hit[66] & reg_we & !reg_error;
   assign prio54_wd = reg_wdata[1:0];
 
-  assign prio55_we = addr_hit[67] & reg_we & ~wr_err;
+  assign prio55_we = addr_hit[67] & reg_we & !reg_error;
   assign prio55_wd = reg_wdata[1:0];
 
-  assign prio56_we = addr_hit[68] & reg_we & ~wr_err;
+  assign prio56_we = addr_hit[68] & reg_we & !reg_error;
   assign prio56_wd = reg_wdata[1:0];
 
-  assign prio57_we = addr_hit[69] & reg_we & ~wr_err;
+  assign prio57_we = addr_hit[69] & reg_we & !reg_error;
   assign prio57_wd = reg_wdata[1:0];
 
-  assign prio58_we = addr_hit[70] & reg_we & ~wr_err;
+  assign prio58_we = addr_hit[70] & reg_we & !reg_error;
   assign prio58_wd = reg_wdata[1:0];
 
-  assign prio59_we = addr_hit[71] & reg_we & ~wr_err;
+  assign prio59_we = addr_hit[71] & reg_we & !reg_error;
   assign prio59_wd = reg_wdata[1:0];
 
-  assign prio60_we = addr_hit[72] & reg_we & ~wr_err;
+  assign prio60_we = addr_hit[72] & reg_we & !reg_error;
   assign prio60_wd = reg_wdata[1:0];
 
-  assign prio61_we = addr_hit[73] & reg_we & ~wr_err;
+  assign prio61_we = addr_hit[73] & reg_we & !reg_error;
   assign prio61_wd = reg_wdata[1:0];
 
-  assign prio62_we = addr_hit[74] & reg_we & ~wr_err;
+  assign prio62_we = addr_hit[74] & reg_we & !reg_error;
   assign prio62_wd = reg_wdata[1:0];
 
-  assign prio63_we = addr_hit[75] & reg_we & ~wr_err;
+  assign prio63_we = addr_hit[75] & reg_we & !reg_error;
   assign prio63_wd = reg_wdata[1:0];
 
-  assign prio64_we = addr_hit[76] & reg_we & ~wr_err;
+  assign prio64_we = addr_hit[76] & reg_we & !reg_error;
   assign prio64_wd = reg_wdata[1:0];
 
-  assign prio65_we = addr_hit[77] & reg_we & ~wr_err;
+  assign prio65_we = addr_hit[77] & reg_we & !reg_error;
   assign prio65_wd = reg_wdata[1:0];
 
-  assign prio66_we = addr_hit[78] & reg_we & ~wr_err;
+  assign prio66_we = addr_hit[78] & reg_we & !reg_error;
   assign prio66_wd = reg_wdata[1:0];
 
-  assign prio67_we = addr_hit[79] & reg_we & ~wr_err;
+  assign prio67_we = addr_hit[79] & reg_we & !reg_error;
   assign prio67_wd = reg_wdata[1:0];
 
-  assign prio68_we = addr_hit[80] & reg_we & ~wr_err;
+  assign prio68_we = addr_hit[80] & reg_we & !reg_error;
   assign prio68_wd = reg_wdata[1:0];
 
-  assign prio69_we = addr_hit[81] & reg_we & ~wr_err;
+  assign prio69_we = addr_hit[81] & reg_we & !reg_error;
   assign prio69_wd = reg_wdata[1:0];
 
-  assign prio70_we = addr_hit[82] & reg_we & ~wr_err;
+  assign prio70_we = addr_hit[82] & reg_we & !reg_error;
   assign prio70_wd = reg_wdata[1:0];
 
-  assign prio71_we = addr_hit[83] & reg_we & ~wr_err;
+  assign prio71_we = addr_hit[83] & reg_we & !reg_error;
   assign prio71_wd = reg_wdata[1:0];
 
-  assign prio72_we = addr_hit[84] & reg_we & ~wr_err;
+  assign prio72_we = addr_hit[84] & reg_we & !reg_error;
   assign prio72_wd = reg_wdata[1:0];
 
-  assign prio73_we = addr_hit[85] & reg_we & ~wr_err;
+  assign prio73_we = addr_hit[85] & reg_we & !reg_error;
   assign prio73_wd = reg_wdata[1:0];
 
-  assign prio74_we = addr_hit[86] & reg_we & ~wr_err;
+  assign prio74_we = addr_hit[86] & reg_we & !reg_error;
   assign prio74_wd = reg_wdata[1:0];
 
-  assign prio75_we = addr_hit[87] & reg_we & ~wr_err;
+  assign prio75_we = addr_hit[87] & reg_we & !reg_error;
   assign prio75_wd = reg_wdata[1:0];
 
-  assign prio76_we = addr_hit[88] & reg_we & ~wr_err;
+  assign prio76_we = addr_hit[88] & reg_we & !reg_error;
   assign prio76_wd = reg_wdata[1:0];
 
-  assign prio77_we = addr_hit[89] & reg_we & ~wr_err;
+  assign prio77_we = addr_hit[89] & reg_we & !reg_error;
   assign prio77_wd = reg_wdata[1:0];
 
-  assign prio78_we = addr_hit[90] & reg_we & ~wr_err;
+  assign prio78_we = addr_hit[90] & reg_we & !reg_error;
   assign prio78_wd = reg_wdata[1:0];
 
-  assign prio79_we = addr_hit[91] & reg_we & ~wr_err;
+  assign prio79_we = addr_hit[91] & reg_we & !reg_error;
   assign prio79_wd = reg_wdata[1:0];
 
-  assign prio80_we = addr_hit[92] & reg_we & ~wr_err;
+  assign prio80_we = addr_hit[92] & reg_we & !reg_error;
   assign prio80_wd = reg_wdata[1:0];
 
-  assign prio81_we = addr_hit[93] & reg_we & ~wr_err;
+  assign prio81_we = addr_hit[93] & reg_we & !reg_error;
   assign prio81_wd = reg_wdata[1:0];
 
-  assign prio82_we = addr_hit[94] & reg_we & ~wr_err;
+  assign prio82_we = addr_hit[94] & reg_we & !reg_error;
   assign prio82_wd = reg_wdata[1:0];
 
-  assign prio83_we = addr_hit[95] & reg_we & ~wr_err;
+  assign prio83_we = addr_hit[95] & reg_we & !reg_error;
   assign prio83_wd = reg_wdata[1:0];
 
-  assign prio84_we = addr_hit[96] & reg_we & ~wr_err;
+  assign prio84_we = addr_hit[96] & reg_we & !reg_error;
   assign prio84_wd = reg_wdata[1:0];
 
-  assign prio85_we = addr_hit[97] & reg_we & ~wr_err;
+  assign prio85_we = addr_hit[97] & reg_we & !reg_error;
   assign prio85_wd = reg_wdata[1:0];
 
-  assign prio86_we = addr_hit[98] & reg_we & ~wr_err;
+  assign prio86_we = addr_hit[98] & reg_we & !reg_error;
   assign prio86_wd = reg_wdata[1:0];
 
-  assign prio87_we = addr_hit[99] & reg_we & ~wr_err;
+  assign prio87_we = addr_hit[99] & reg_we & !reg_error;
   assign prio87_wd = reg_wdata[1:0];
 
-  assign prio88_we = addr_hit[100] & reg_we & ~wr_err;
+  assign prio88_we = addr_hit[100] & reg_we & !reg_error;
   assign prio88_wd = reg_wdata[1:0];
 
-  assign prio89_we = addr_hit[101] & reg_we & ~wr_err;
+  assign prio89_we = addr_hit[101] & reg_we & !reg_error;
   assign prio89_wd = reg_wdata[1:0];
 
-  assign prio90_we = addr_hit[102] & reg_we & ~wr_err;
+  assign prio90_we = addr_hit[102] & reg_we & !reg_error;
   assign prio90_wd = reg_wdata[1:0];
 
-  assign prio91_we = addr_hit[103] & reg_we & ~wr_err;
+  assign prio91_we = addr_hit[103] & reg_we & !reg_error;
   assign prio91_wd = reg_wdata[1:0];
 
-  assign prio92_we = addr_hit[104] & reg_we & ~wr_err;
+  assign prio92_we = addr_hit[104] & reg_we & !reg_error;
   assign prio92_wd = reg_wdata[1:0];
 
-  assign prio93_we = addr_hit[105] & reg_we & ~wr_err;
+  assign prio93_we = addr_hit[105] & reg_we & !reg_error;
   assign prio93_wd = reg_wdata[1:0];
 
-  assign prio94_we = addr_hit[106] & reg_we & ~wr_err;
+  assign prio94_we = addr_hit[106] & reg_we & !reg_error;
   assign prio94_wd = reg_wdata[1:0];
 
-  assign prio95_we = addr_hit[107] & reg_we & ~wr_err;
+  assign prio95_we = addr_hit[107] & reg_we & !reg_error;
   assign prio95_wd = reg_wdata[1:0];
 
-  assign prio96_we = addr_hit[108] & reg_we & ~wr_err;
+  assign prio96_we = addr_hit[108] & reg_we & !reg_error;
   assign prio96_wd = reg_wdata[1:0];
 
-  assign prio97_we = addr_hit[109] & reg_we & ~wr_err;
+  assign prio97_we = addr_hit[109] & reg_we & !reg_error;
   assign prio97_wd = reg_wdata[1:0];
 
-  assign prio98_we = addr_hit[110] & reg_we & ~wr_err;
+  assign prio98_we = addr_hit[110] & reg_we & !reg_error;
   assign prio98_wd = reg_wdata[1:0];
 
-  assign prio99_we = addr_hit[111] & reg_we & ~wr_err;
+  assign prio99_we = addr_hit[111] & reg_we & !reg_error;
   assign prio99_wd = reg_wdata[1:0];
 
-  assign prio100_we = addr_hit[112] & reg_we & ~wr_err;
+  assign prio100_we = addr_hit[112] & reg_we & !reg_error;
   assign prio100_wd = reg_wdata[1:0];
 
-  assign prio101_we = addr_hit[113] & reg_we & ~wr_err;
+  assign prio101_we = addr_hit[113] & reg_we & !reg_error;
   assign prio101_wd = reg_wdata[1:0];
 
-  assign prio102_we = addr_hit[114] & reg_we & ~wr_err;
+  assign prio102_we = addr_hit[114] & reg_we & !reg_error;
   assign prio102_wd = reg_wdata[1:0];
 
-  assign prio103_we = addr_hit[115] & reg_we & ~wr_err;
+  assign prio103_we = addr_hit[115] & reg_we & !reg_error;
   assign prio103_wd = reg_wdata[1:0];
 
-  assign prio104_we = addr_hit[116] & reg_we & ~wr_err;
+  assign prio104_we = addr_hit[116] & reg_we & !reg_error;
   assign prio104_wd = reg_wdata[1:0];
 
-  assign prio105_we = addr_hit[117] & reg_we & ~wr_err;
+  assign prio105_we = addr_hit[117] & reg_we & !reg_error;
   assign prio105_wd = reg_wdata[1:0];
 
-  assign prio106_we = addr_hit[118] & reg_we & ~wr_err;
+  assign prio106_we = addr_hit[118] & reg_we & !reg_error;
   assign prio106_wd = reg_wdata[1:0];
 
-  assign prio107_we = addr_hit[119] & reg_we & ~wr_err;
+  assign prio107_we = addr_hit[119] & reg_we & !reg_error;
   assign prio107_wd = reg_wdata[1:0];
 
-  assign prio108_we = addr_hit[120] & reg_we & ~wr_err;
+  assign prio108_we = addr_hit[120] & reg_we & !reg_error;
   assign prio108_wd = reg_wdata[1:0];
 
-  assign prio109_we = addr_hit[121] & reg_we & ~wr_err;
+  assign prio109_we = addr_hit[121] & reg_we & !reg_error;
   assign prio109_wd = reg_wdata[1:0];
 
-  assign prio110_we = addr_hit[122] & reg_we & ~wr_err;
+  assign prio110_we = addr_hit[122] & reg_we & !reg_error;
   assign prio110_wd = reg_wdata[1:0];
 
-  assign prio111_we = addr_hit[123] & reg_we & ~wr_err;
+  assign prio111_we = addr_hit[123] & reg_we & !reg_error;
   assign prio111_wd = reg_wdata[1:0];
 
-  assign prio112_we = addr_hit[124] & reg_we & ~wr_err;
+  assign prio112_we = addr_hit[124] & reg_we & !reg_error;
   assign prio112_wd = reg_wdata[1:0];
 
-  assign prio113_we = addr_hit[125] & reg_we & ~wr_err;
+  assign prio113_we = addr_hit[125] & reg_we & !reg_error;
   assign prio113_wd = reg_wdata[1:0];
 
-  assign prio114_we = addr_hit[126] & reg_we & ~wr_err;
+  assign prio114_we = addr_hit[126] & reg_we & !reg_error;
   assign prio114_wd = reg_wdata[1:0];
 
-  assign prio115_we = addr_hit[127] & reg_we & ~wr_err;
+  assign prio115_we = addr_hit[127] & reg_we & !reg_error;
   assign prio115_wd = reg_wdata[1:0];
 
-  assign prio116_we = addr_hit[128] & reg_we & ~wr_err;
+  assign prio116_we = addr_hit[128] & reg_we & !reg_error;
   assign prio116_wd = reg_wdata[1:0];
 
-  assign prio117_we = addr_hit[129] & reg_we & ~wr_err;
+  assign prio117_we = addr_hit[129] & reg_we & !reg_error;
   assign prio117_wd = reg_wdata[1:0];
 
-  assign prio118_we = addr_hit[130] & reg_we & ~wr_err;
+  assign prio118_we = addr_hit[130] & reg_we & !reg_error;
   assign prio118_wd = reg_wdata[1:0];
 
-  assign prio119_we = addr_hit[131] & reg_we & ~wr_err;
+  assign prio119_we = addr_hit[131] & reg_we & !reg_error;
   assign prio119_wd = reg_wdata[1:0];
 
-  assign prio120_we = addr_hit[132] & reg_we & ~wr_err;
+  assign prio120_we = addr_hit[132] & reg_we & !reg_error;
   assign prio120_wd = reg_wdata[1:0];
 
-  assign prio121_we = addr_hit[133] & reg_we & ~wr_err;
+  assign prio121_we = addr_hit[133] & reg_we & !reg_error;
   assign prio121_wd = reg_wdata[1:0];
 
-  assign prio122_we = addr_hit[134] & reg_we & ~wr_err;
+  assign prio122_we = addr_hit[134] & reg_we & !reg_error;
   assign prio122_wd = reg_wdata[1:0];
 
-  assign prio123_we = addr_hit[135] & reg_we & ~wr_err;
+  assign prio123_we = addr_hit[135] & reg_we & !reg_error;
   assign prio123_wd = reg_wdata[1:0];
 
-  assign prio124_we = addr_hit[136] & reg_we & ~wr_err;
+  assign prio124_we = addr_hit[136] & reg_we & !reg_error;
   assign prio124_wd = reg_wdata[1:0];
 
-  assign prio125_we = addr_hit[137] & reg_we & ~wr_err;
+  assign prio125_we = addr_hit[137] & reg_we & !reg_error;
   assign prio125_wd = reg_wdata[1:0];
 
-  assign prio126_we = addr_hit[138] & reg_we & ~wr_err;
+  assign prio126_we = addr_hit[138] & reg_we & !reg_error;
   assign prio126_wd = reg_wdata[1:0];
 
-  assign prio127_we = addr_hit[139] & reg_we & ~wr_err;
+  assign prio127_we = addr_hit[139] & reg_we & !reg_error;
   assign prio127_wd = reg_wdata[1:0];
 
-  assign prio128_we = addr_hit[140] & reg_we & ~wr_err;
+  assign prio128_we = addr_hit[140] & reg_we & !reg_error;
   assign prio128_wd = reg_wdata[1:0];
 
-  assign prio129_we = addr_hit[141] & reg_we & ~wr_err;
+  assign prio129_we = addr_hit[141] & reg_we & !reg_error;
   assign prio129_wd = reg_wdata[1:0];
 
-  assign prio130_we = addr_hit[142] & reg_we & ~wr_err;
+  assign prio130_we = addr_hit[142] & reg_we & !reg_error;
   assign prio130_wd = reg_wdata[1:0];
 
-  assign prio131_we = addr_hit[143] & reg_we & ~wr_err;
+  assign prio131_we = addr_hit[143] & reg_we & !reg_error;
   assign prio131_wd = reg_wdata[1:0];
 
-  assign prio132_we = addr_hit[144] & reg_we & ~wr_err;
+  assign prio132_we = addr_hit[144] & reg_we & !reg_error;
   assign prio132_wd = reg_wdata[1:0];
 
-  assign prio133_we = addr_hit[145] & reg_we & ~wr_err;
+  assign prio133_we = addr_hit[145] & reg_we & !reg_error;
   assign prio133_wd = reg_wdata[1:0];
 
-  assign prio134_we = addr_hit[146] & reg_we & ~wr_err;
+  assign prio134_we = addr_hit[146] & reg_we & !reg_error;
   assign prio134_wd = reg_wdata[1:0];
 
-  assign prio135_we = addr_hit[147] & reg_we & ~wr_err;
+  assign prio135_we = addr_hit[147] & reg_we & !reg_error;
   assign prio135_wd = reg_wdata[1:0];
 
-  assign prio136_we = addr_hit[148] & reg_we & ~wr_err;
+  assign prio136_we = addr_hit[148] & reg_we & !reg_error;
   assign prio136_wd = reg_wdata[1:0];
 
-  assign prio137_we = addr_hit[149] & reg_we & ~wr_err;
+  assign prio137_we = addr_hit[149] & reg_we & !reg_error;
   assign prio137_wd = reg_wdata[1:0];
 
-  assign prio138_we = addr_hit[150] & reg_we & ~wr_err;
+  assign prio138_we = addr_hit[150] & reg_we & !reg_error;
   assign prio138_wd = reg_wdata[1:0];
 
-  assign prio139_we = addr_hit[151] & reg_we & ~wr_err;
+  assign prio139_we = addr_hit[151] & reg_we & !reg_error;
   assign prio139_wd = reg_wdata[1:0];
 
-  assign prio140_we = addr_hit[152] & reg_we & ~wr_err;
+  assign prio140_we = addr_hit[152] & reg_we & !reg_error;
   assign prio140_wd = reg_wdata[1:0];
 
-  assign prio141_we = addr_hit[153] & reg_we & ~wr_err;
+  assign prio141_we = addr_hit[153] & reg_we & !reg_error;
   assign prio141_wd = reg_wdata[1:0];
 
-  assign prio142_we = addr_hit[154] & reg_we & ~wr_err;
+  assign prio142_we = addr_hit[154] & reg_we & !reg_error;
   assign prio142_wd = reg_wdata[1:0];
 
-  assign prio143_we = addr_hit[155] & reg_we & ~wr_err;
+  assign prio143_we = addr_hit[155] & reg_we & !reg_error;
   assign prio143_wd = reg_wdata[1:0];
 
-  assign prio144_we = addr_hit[156] & reg_we & ~wr_err;
+  assign prio144_we = addr_hit[156] & reg_we & !reg_error;
   assign prio144_wd = reg_wdata[1:0];
 
-  assign prio145_we = addr_hit[157] & reg_we & ~wr_err;
+  assign prio145_we = addr_hit[157] & reg_we & !reg_error;
   assign prio145_wd = reg_wdata[1:0];
 
-  assign prio146_we = addr_hit[158] & reg_we & ~wr_err;
+  assign prio146_we = addr_hit[158] & reg_we & !reg_error;
   assign prio146_wd = reg_wdata[1:0];
 
-  assign prio147_we = addr_hit[159] & reg_we & ~wr_err;
+  assign prio147_we = addr_hit[159] & reg_we & !reg_error;
   assign prio147_wd = reg_wdata[1:0];
 
-  assign prio148_we = addr_hit[160] & reg_we & ~wr_err;
+  assign prio148_we = addr_hit[160] & reg_we & !reg_error;
   assign prio148_wd = reg_wdata[1:0];
 
-  assign prio149_we = addr_hit[161] & reg_we & ~wr_err;
+  assign prio149_we = addr_hit[161] & reg_we & !reg_error;
   assign prio149_wd = reg_wdata[1:0];
 
-  assign prio150_we = addr_hit[162] & reg_we & ~wr_err;
+  assign prio150_we = addr_hit[162] & reg_we & !reg_error;
   assign prio150_wd = reg_wdata[1:0];
 
-  assign prio151_we = addr_hit[163] & reg_we & ~wr_err;
+  assign prio151_we = addr_hit[163] & reg_we & !reg_error;
   assign prio151_wd = reg_wdata[1:0];
 
-  assign prio152_we = addr_hit[164] & reg_we & ~wr_err;
+  assign prio152_we = addr_hit[164] & reg_we & !reg_error;
   assign prio152_wd = reg_wdata[1:0];
 
-  assign prio153_we = addr_hit[165] & reg_we & ~wr_err;
+  assign prio153_we = addr_hit[165] & reg_we & !reg_error;
   assign prio153_wd = reg_wdata[1:0];
 
-  assign prio154_we = addr_hit[166] & reg_we & ~wr_err;
+  assign prio154_we = addr_hit[166] & reg_we & !reg_error;
   assign prio154_wd = reg_wdata[1:0];
 
-  assign prio155_we = addr_hit[167] & reg_we & ~wr_err;
+  assign prio155_we = addr_hit[167] & reg_we & !reg_error;
   assign prio155_wd = reg_wdata[1:0];
 
-  assign prio156_we = addr_hit[168] & reg_we & ~wr_err;
+  assign prio156_we = addr_hit[168] & reg_we & !reg_error;
   assign prio156_wd = reg_wdata[1:0];
 
-  assign prio157_we = addr_hit[169] & reg_we & ~wr_err;
+  assign prio157_we = addr_hit[169] & reg_we & !reg_error;
   assign prio157_wd = reg_wdata[1:0];
 
-  assign prio158_we = addr_hit[170] & reg_we & ~wr_err;
+  assign prio158_we = addr_hit[170] & reg_we & !reg_error;
   assign prio158_wd = reg_wdata[1:0];
 
-  assign prio159_we = addr_hit[171] & reg_we & ~wr_err;
+  assign prio159_we = addr_hit[171] & reg_we & !reg_error;
   assign prio159_wd = reg_wdata[1:0];
 
-  assign prio160_we = addr_hit[172] & reg_we & ~wr_err;
+  assign prio160_we = addr_hit[172] & reg_we & !reg_error;
   assign prio160_wd = reg_wdata[1:0];
 
-  assign prio161_we = addr_hit[173] & reg_we & ~wr_err;
+  assign prio161_we = addr_hit[173] & reg_we & !reg_error;
   assign prio161_wd = reg_wdata[1:0];
 
-  assign prio162_we = addr_hit[174] & reg_we & ~wr_err;
+  assign prio162_we = addr_hit[174] & reg_we & !reg_error;
   assign prio162_wd = reg_wdata[1:0];
 
-  assign prio163_we = addr_hit[175] & reg_we & ~wr_err;
+  assign prio163_we = addr_hit[175] & reg_we & !reg_error;
   assign prio163_wd = reg_wdata[1:0];
 
-  assign prio164_we = addr_hit[176] & reg_we & ~wr_err;
+  assign prio164_we = addr_hit[176] & reg_we & !reg_error;
   assign prio164_wd = reg_wdata[1:0];
 
-  assign prio165_we = addr_hit[177] & reg_we & ~wr_err;
+  assign prio165_we = addr_hit[177] & reg_we & !reg_error;
   assign prio165_wd = reg_wdata[1:0];
 
-  assign prio166_we = addr_hit[178] & reg_we & ~wr_err;
+  assign prio166_we = addr_hit[178] & reg_we & !reg_error;
   assign prio166_wd = reg_wdata[1:0];
 
-  assign prio167_we = addr_hit[179] & reg_we & ~wr_err;
+  assign prio167_we = addr_hit[179] & reg_we & !reg_error;
   assign prio167_wd = reg_wdata[1:0];
 
-  assign prio168_we = addr_hit[180] & reg_we & ~wr_err;
+  assign prio168_we = addr_hit[180] & reg_we & !reg_error;
   assign prio168_wd = reg_wdata[1:0];
 
-  assign prio169_we = addr_hit[181] & reg_we & ~wr_err;
+  assign prio169_we = addr_hit[181] & reg_we & !reg_error;
   assign prio169_wd = reg_wdata[1:0];
 
-  assign prio170_we = addr_hit[182] & reg_we & ~wr_err;
+  assign prio170_we = addr_hit[182] & reg_we & !reg_error;
   assign prio170_wd = reg_wdata[1:0];
 
-  assign ie0_0_e_0_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_0_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_0_wd = reg_wdata[0];
 
-  assign ie0_0_e_1_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_1_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_1_wd = reg_wdata[1];
 
-  assign ie0_0_e_2_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_2_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_2_wd = reg_wdata[2];
 
-  assign ie0_0_e_3_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_3_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_3_wd = reg_wdata[3];
 
-  assign ie0_0_e_4_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_4_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_4_wd = reg_wdata[4];
 
-  assign ie0_0_e_5_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_5_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_5_wd = reg_wdata[5];
 
-  assign ie0_0_e_6_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_6_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_6_wd = reg_wdata[6];
 
-  assign ie0_0_e_7_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_7_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_7_wd = reg_wdata[7];
 
-  assign ie0_0_e_8_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_8_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_8_wd = reg_wdata[8];
 
-  assign ie0_0_e_9_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_9_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_9_wd = reg_wdata[9];
 
-  assign ie0_0_e_10_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_10_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_10_wd = reg_wdata[10];
 
-  assign ie0_0_e_11_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_11_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_11_wd = reg_wdata[11];
 
-  assign ie0_0_e_12_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_12_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_12_wd = reg_wdata[12];
 
-  assign ie0_0_e_13_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_13_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_13_wd = reg_wdata[13];
 
-  assign ie0_0_e_14_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_14_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_14_wd = reg_wdata[14];
 
-  assign ie0_0_e_15_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_15_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_15_wd = reg_wdata[15];
 
-  assign ie0_0_e_16_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_16_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_16_wd = reg_wdata[16];
 
-  assign ie0_0_e_17_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_17_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_17_wd = reg_wdata[17];
 
-  assign ie0_0_e_18_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_18_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_18_wd = reg_wdata[18];
 
-  assign ie0_0_e_19_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_19_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_19_wd = reg_wdata[19];
 
-  assign ie0_0_e_20_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_20_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_20_wd = reg_wdata[20];
 
-  assign ie0_0_e_21_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_21_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_21_wd = reg_wdata[21];
 
-  assign ie0_0_e_22_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_22_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_22_wd = reg_wdata[22];
 
-  assign ie0_0_e_23_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_23_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_23_wd = reg_wdata[23];
 
-  assign ie0_0_e_24_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_24_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_24_wd = reg_wdata[24];
 
-  assign ie0_0_e_25_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_25_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_25_wd = reg_wdata[25];
 
-  assign ie0_0_e_26_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_26_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_26_wd = reg_wdata[26];
 
-  assign ie0_0_e_27_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_27_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_27_wd = reg_wdata[27];
 
-  assign ie0_0_e_28_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_28_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_28_wd = reg_wdata[28];
 
-  assign ie0_0_e_29_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_29_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_29_wd = reg_wdata[29];
 
-  assign ie0_0_e_30_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_30_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_30_wd = reg_wdata[30];
 
-  assign ie0_0_e_31_we = addr_hit[183] & reg_we & ~wr_err;
+  assign ie0_0_e_31_we = addr_hit[183] & reg_we & !reg_error;
   assign ie0_0_e_31_wd = reg_wdata[31];
 
-  assign ie0_1_e_32_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_32_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_32_wd = reg_wdata[0];
 
-  assign ie0_1_e_33_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_33_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_33_wd = reg_wdata[1];
 
-  assign ie0_1_e_34_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_34_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_34_wd = reg_wdata[2];
 
-  assign ie0_1_e_35_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_35_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_35_wd = reg_wdata[3];
 
-  assign ie0_1_e_36_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_36_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_36_wd = reg_wdata[4];
 
-  assign ie0_1_e_37_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_37_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_37_wd = reg_wdata[5];
 
-  assign ie0_1_e_38_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_38_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_38_wd = reg_wdata[6];
 
-  assign ie0_1_e_39_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_39_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_39_wd = reg_wdata[7];
 
-  assign ie0_1_e_40_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_40_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_40_wd = reg_wdata[8];
 
-  assign ie0_1_e_41_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_41_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_41_wd = reg_wdata[9];
 
-  assign ie0_1_e_42_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_42_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_42_wd = reg_wdata[10];
 
-  assign ie0_1_e_43_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_43_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_43_wd = reg_wdata[11];
 
-  assign ie0_1_e_44_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_44_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_44_wd = reg_wdata[12];
 
-  assign ie0_1_e_45_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_45_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_45_wd = reg_wdata[13];
 
-  assign ie0_1_e_46_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_46_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_46_wd = reg_wdata[14];
 
-  assign ie0_1_e_47_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_47_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_47_wd = reg_wdata[15];
 
-  assign ie0_1_e_48_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_48_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_48_wd = reg_wdata[16];
 
-  assign ie0_1_e_49_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_49_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_49_wd = reg_wdata[17];
 
-  assign ie0_1_e_50_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_50_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_50_wd = reg_wdata[18];
 
-  assign ie0_1_e_51_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_51_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_51_wd = reg_wdata[19];
 
-  assign ie0_1_e_52_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_52_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_52_wd = reg_wdata[20];
 
-  assign ie0_1_e_53_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_53_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_53_wd = reg_wdata[21];
 
-  assign ie0_1_e_54_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_54_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_54_wd = reg_wdata[22];
 
-  assign ie0_1_e_55_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_55_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_55_wd = reg_wdata[23];
 
-  assign ie0_1_e_56_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_56_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_56_wd = reg_wdata[24];
 
-  assign ie0_1_e_57_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_57_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_57_wd = reg_wdata[25];
 
-  assign ie0_1_e_58_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_58_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_58_wd = reg_wdata[26];
 
-  assign ie0_1_e_59_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_59_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_59_wd = reg_wdata[27];
 
-  assign ie0_1_e_60_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_60_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_60_wd = reg_wdata[28];
 
-  assign ie0_1_e_61_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_61_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_61_wd = reg_wdata[29];
 
-  assign ie0_1_e_62_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_62_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_62_wd = reg_wdata[30];
 
-  assign ie0_1_e_63_we = addr_hit[184] & reg_we & ~wr_err;
+  assign ie0_1_e_63_we = addr_hit[184] & reg_we & !reg_error;
   assign ie0_1_e_63_wd = reg_wdata[31];
 
-  assign ie0_2_e_64_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_64_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_64_wd = reg_wdata[0];
 
-  assign ie0_2_e_65_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_65_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_65_wd = reg_wdata[1];
 
-  assign ie0_2_e_66_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_66_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_66_wd = reg_wdata[2];
 
-  assign ie0_2_e_67_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_67_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_67_wd = reg_wdata[3];
 
-  assign ie0_2_e_68_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_68_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_68_wd = reg_wdata[4];
 
-  assign ie0_2_e_69_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_69_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_69_wd = reg_wdata[5];
 
-  assign ie0_2_e_70_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_70_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_70_wd = reg_wdata[6];
 
-  assign ie0_2_e_71_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_71_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_71_wd = reg_wdata[7];
 
-  assign ie0_2_e_72_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_72_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_72_wd = reg_wdata[8];
 
-  assign ie0_2_e_73_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_73_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_73_wd = reg_wdata[9];
 
-  assign ie0_2_e_74_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_74_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_74_wd = reg_wdata[10];
 
-  assign ie0_2_e_75_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_75_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_75_wd = reg_wdata[11];
 
-  assign ie0_2_e_76_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_76_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_76_wd = reg_wdata[12];
 
-  assign ie0_2_e_77_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_77_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_77_wd = reg_wdata[13];
 
-  assign ie0_2_e_78_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_78_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_78_wd = reg_wdata[14];
 
-  assign ie0_2_e_79_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_79_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_79_wd = reg_wdata[15];
 
-  assign ie0_2_e_80_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_80_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_80_wd = reg_wdata[16];
 
-  assign ie0_2_e_81_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_81_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_81_wd = reg_wdata[17];
 
-  assign ie0_2_e_82_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_82_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_82_wd = reg_wdata[18];
 
-  assign ie0_2_e_83_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_83_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_83_wd = reg_wdata[19];
 
-  assign ie0_2_e_84_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_84_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_84_wd = reg_wdata[20];
 
-  assign ie0_2_e_85_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_85_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_85_wd = reg_wdata[21];
 
-  assign ie0_2_e_86_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_86_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_86_wd = reg_wdata[22];
 
-  assign ie0_2_e_87_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_87_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_87_wd = reg_wdata[23];
 
-  assign ie0_2_e_88_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_88_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_88_wd = reg_wdata[24];
 
-  assign ie0_2_e_89_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_89_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_89_wd = reg_wdata[25];
 
-  assign ie0_2_e_90_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_90_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_90_wd = reg_wdata[26];
 
-  assign ie0_2_e_91_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_91_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_91_wd = reg_wdata[27];
 
-  assign ie0_2_e_92_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_92_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_92_wd = reg_wdata[28];
 
-  assign ie0_2_e_93_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_93_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_93_wd = reg_wdata[29];
 
-  assign ie0_2_e_94_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_94_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_94_wd = reg_wdata[30];
 
-  assign ie0_2_e_95_we = addr_hit[185] & reg_we & ~wr_err;
+  assign ie0_2_e_95_we = addr_hit[185] & reg_we & !reg_error;
   assign ie0_2_e_95_wd = reg_wdata[31];
 
-  assign ie0_3_e_96_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_96_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_96_wd = reg_wdata[0];
 
-  assign ie0_3_e_97_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_97_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_97_wd = reg_wdata[1];
 
-  assign ie0_3_e_98_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_98_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_98_wd = reg_wdata[2];
 
-  assign ie0_3_e_99_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_99_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_99_wd = reg_wdata[3];
 
-  assign ie0_3_e_100_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_100_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_100_wd = reg_wdata[4];
 
-  assign ie0_3_e_101_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_101_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_101_wd = reg_wdata[5];
 
-  assign ie0_3_e_102_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_102_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_102_wd = reg_wdata[6];
 
-  assign ie0_3_e_103_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_103_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_103_wd = reg_wdata[7];
 
-  assign ie0_3_e_104_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_104_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_104_wd = reg_wdata[8];
 
-  assign ie0_3_e_105_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_105_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_105_wd = reg_wdata[9];
 
-  assign ie0_3_e_106_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_106_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_106_wd = reg_wdata[10];
 
-  assign ie0_3_e_107_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_107_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_107_wd = reg_wdata[11];
 
-  assign ie0_3_e_108_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_108_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_108_wd = reg_wdata[12];
 
-  assign ie0_3_e_109_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_109_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_109_wd = reg_wdata[13];
 
-  assign ie0_3_e_110_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_110_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_110_wd = reg_wdata[14];
 
-  assign ie0_3_e_111_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_111_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_111_wd = reg_wdata[15];
 
-  assign ie0_3_e_112_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_112_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_112_wd = reg_wdata[16];
 
-  assign ie0_3_e_113_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_113_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_113_wd = reg_wdata[17];
 
-  assign ie0_3_e_114_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_114_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_114_wd = reg_wdata[18];
 
-  assign ie0_3_e_115_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_115_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_115_wd = reg_wdata[19];
 
-  assign ie0_3_e_116_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_116_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_116_wd = reg_wdata[20];
 
-  assign ie0_3_e_117_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_117_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_117_wd = reg_wdata[21];
 
-  assign ie0_3_e_118_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_118_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_118_wd = reg_wdata[22];
 
-  assign ie0_3_e_119_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_119_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_119_wd = reg_wdata[23];
 
-  assign ie0_3_e_120_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_120_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_120_wd = reg_wdata[24];
 
-  assign ie0_3_e_121_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_121_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_121_wd = reg_wdata[25];
 
-  assign ie0_3_e_122_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_122_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_122_wd = reg_wdata[26];
 
-  assign ie0_3_e_123_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_123_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_123_wd = reg_wdata[27];
 
-  assign ie0_3_e_124_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_124_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_124_wd = reg_wdata[28];
 
-  assign ie0_3_e_125_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_125_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_125_wd = reg_wdata[29];
 
-  assign ie0_3_e_126_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_126_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_126_wd = reg_wdata[30];
 
-  assign ie0_3_e_127_we = addr_hit[186] & reg_we & ~wr_err;
+  assign ie0_3_e_127_we = addr_hit[186] & reg_we & !reg_error;
   assign ie0_3_e_127_wd = reg_wdata[31];
 
-  assign ie0_4_e_128_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_128_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_128_wd = reg_wdata[0];
 
-  assign ie0_4_e_129_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_129_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_129_wd = reg_wdata[1];
 
-  assign ie0_4_e_130_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_130_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_130_wd = reg_wdata[2];
 
-  assign ie0_4_e_131_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_131_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_131_wd = reg_wdata[3];
 
-  assign ie0_4_e_132_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_132_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_132_wd = reg_wdata[4];
 
-  assign ie0_4_e_133_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_133_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_133_wd = reg_wdata[5];
 
-  assign ie0_4_e_134_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_134_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_134_wd = reg_wdata[6];
 
-  assign ie0_4_e_135_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_135_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_135_wd = reg_wdata[7];
 
-  assign ie0_4_e_136_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_136_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_136_wd = reg_wdata[8];
 
-  assign ie0_4_e_137_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_137_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_137_wd = reg_wdata[9];
 
-  assign ie0_4_e_138_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_138_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_138_wd = reg_wdata[10];
 
-  assign ie0_4_e_139_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_139_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_139_wd = reg_wdata[11];
 
-  assign ie0_4_e_140_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_140_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_140_wd = reg_wdata[12];
 
-  assign ie0_4_e_141_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_141_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_141_wd = reg_wdata[13];
 
-  assign ie0_4_e_142_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_142_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_142_wd = reg_wdata[14];
 
-  assign ie0_4_e_143_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_143_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_143_wd = reg_wdata[15];
 
-  assign ie0_4_e_144_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_144_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_144_wd = reg_wdata[16];
 
-  assign ie0_4_e_145_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_145_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_145_wd = reg_wdata[17];
 
-  assign ie0_4_e_146_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_146_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_146_wd = reg_wdata[18];
 
-  assign ie0_4_e_147_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_147_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_147_wd = reg_wdata[19];
 
-  assign ie0_4_e_148_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_148_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_148_wd = reg_wdata[20];
 
-  assign ie0_4_e_149_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_149_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_149_wd = reg_wdata[21];
 
-  assign ie0_4_e_150_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_150_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_150_wd = reg_wdata[22];
 
-  assign ie0_4_e_151_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_151_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_151_wd = reg_wdata[23];
 
-  assign ie0_4_e_152_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_152_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_152_wd = reg_wdata[24];
 
-  assign ie0_4_e_153_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_153_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_153_wd = reg_wdata[25];
 
-  assign ie0_4_e_154_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_154_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_154_wd = reg_wdata[26];
 
-  assign ie0_4_e_155_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_155_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_155_wd = reg_wdata[27];
 
-  assign ie0_4_e_156_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_156_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_156_wd = reg_wdata[28];
 
-  assign ie0_4_e_157_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_157_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_157_wd = reg_wdata[29];
 
-  assign ie0_4_e_158_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_158_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_158_wd = reg_wdata[30];
 
-  assign ie0_4_e_159_we = addr_hit[187] & reg_we & ~wr_err;
+  assign ie0_4_e_159_we = addr_hit[187] & reg_we & !reg_error;
   assign ie0_4_e_159_wd = reg_wdata[31];
 
-  assign ie0_5_e_160_we = addr_hit[188] & reg_we & ~wr_err;
+  assign ie0_5_e_160_we = addr_hit[188] & reg_we & !reg_error;
   assign ie0_5_e_160_wd = reg_wdata[0];
 
-  assign ie0_5_e_161_we = addr_hit[188] & reg_we & ~wr_err;
+  assign ie0_5_e_161_we = addr_hit[188] & reg_we & !reg_error;
   assign ie0_5_e_161_wd = reg_wdata[1];
 
-  assign ie0_5_e_162_we = addr_hit[188] & reg_we & ~wr_err;
+  assign ie0_5_e_162_we = addr_hit[188] & reg_we & !reg_error;
   assign ie0_5_e_162_wd = reg_wdata[2];
 
-  assign ie0_5_e_163_we = addr_hit[188] & reg_we & ~wr_err;
+  assign ie0_5_e_163_we = addr_hit[188] & reg_we & !reg_error;
   assign ie0_5_e_163_wd = reg_wdata[3];
 
-  assign ie0_5_e_164_we = addr_hit[188] & reg_we & ~wr_err;
+  assign ie0_5_e_164_we = addr_hit[188] & reg_we & !reg_error;
   assign ie0_5_e_164_wd = reg_wdata[4];
 
-  assign ie0_5_e_165_we = addr_hit[188] & reg_we & ~wr_err;
+  assign ie0_5_e_165_we = addr_hit[188] & reg_we & !reg_error;
   assign ie0_5_e_165_wd = reg_wdata[5];
 
-  assign ie0_5_e_166_we = addr_hit[188] & reg_we & ~wr_err;
+  assign ie0_5_e_166_we = addr_hit[188] & reg_we & !reg_error;
   assign ie0_5_e_166_wd = reg_wdata[6];
 
-  assign ie0_5_e_167_we = addr_hit[188] & reg_we & ~wr_err;
+  assign ie0_5_e_167_we = addr_hit[188] & reg_we & !reg_error;
   assign ie0_5_e_167_wd = reg_wdata[7];
 
-  assign ie0_5_e_168_we = addr_hit[188] & reg_we & ~wr_err;
+  assign ie0_5_e_168_we = addr_hit[188] & reg_we & !reg_error;
   assign ie0_5_e_168_wd = reg_wdata[8];
 
-  assign ie0_5_e_169_we = addr_hit[188] & reg_we & ~wr_err;
+  assign ie0_5_e_169_we = addr_hit[188] & reg_we & !reg_error;
   assign ie0_5_e_169_wd = reg_wdata[9];
 
-  assign ie0_5_e_170_we = addr_hit[188] & reg_we & ~wr_err;
+  assign ie0_5_e_170_we = addr_hit[188] & reg_we & !reg_error;
   assign ie0_5_e_170_wd = reg_wdata[10];
 
-  assign threshold0_we = addr_hit[189] & reg_we & ~wr_err;
+  assign threshold0_we = addr_hit[189] & reg_we & !reg_error;
   assign threshold0_wd = reg_wdata[1:0];
 
-  assign cc0_we = addr_hit[190] & reg_we & ~wr_err;
+  assign cc0_we = addr_hit[190] & reg_we & !reg_error;
   assign cc0_wd = reg_wdata[7:0];
-  assign cc0_re = addr_hit[190] && reg_re;
+  assign cc0_re = addr_hit[190] & reg_re & !reg_error;
 
-  assign msip0_we = addr_hit[191] & reg_we & ~wr_err;
+  assign msip0_we = addr_hit[191] & reg_we & !reg_error;
   assign msip0_wd = reg_wdata[0];
 
   // Read data return

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
@@ -915,91 +915,91 @@ module sensor_ctrl_reg_top (
     if (addr_hit[5] && reg_we && (SENSOR_CTRL_PERMIT[5] != (SENSOR_CTRL_PERMIT[5] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign alert_test_recov_as_we = addr_hit[0] & reg_we & ~wr_err;
+  assign alert_test_recov_as_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_as_wd = reg_wdata[0];
 
-  assign alert_test_recov_cg_we = addr_hit[0] & reg_we & ~wr_err;
+  assign alert_test_recov_cg_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_cg_wd = reg_wdata[1];
 
-  assign alert_test_recov_gd_we = addr_hit[0] & reg_we & ~wr_err;
+  assign alert_test_recov_gd_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_gd_wd = reg_wdata[2];
 
-  assign alert_test_recov_ts_hi_we = addr_hit[0] & reg_we & ~wr_err;
+  assign alert_test_recov_ts_hi_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_ts_hi_wd = reg_wdata[3];
 
-  assign alert_test_recov_ts_lo_we = addr_hit[0] & reg_we & ~wr_err;
+  assign alert_test_recov_ts_lo_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_ts_lo_wd = reg_wdata[4];
 
-  assign alert_test_recov_ls_we = addr_hit[0] & reg_we & ~wr_err;
+  assign alert_test_recov_ls_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_ls_wd = reg_wdata[5];
 
-  assign alert_test_recov_ot_we = addr_hit[0] & reg_we & ~wr_err;
+  assign alert_test_recov_ot_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_ot_wd = reg_wdata[6];
 
-  assign cfg_regwen_we = addr_hit[1] & reg_we & ~wr_err;
+  assign cfg_regwen_we = addr_hit[1] & reg_we & !reg_error;
   assign cfg_regwen_wd = reg_wdata[0];
 
-  assign ack_mode_val_0_we = addr_hit[2] & reg_we & ~wr_err;
+  assign ack_mode_val_0_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_0_wd = reg_wdata[1:0];
 
-  assign ack_mode_val_1_we = addr_hit[2] & reg_we & ~wr_err;
+  assign ack_mode_val_1_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_1_wd = reg_wdata[3:2];
 
-  assign ack_mode_val_2_we = addr_hit[2] & reg_we & ~wr_err;
+  assign ack_mode_val_2_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_2_wd = reg_wdata[5:4];
 
-  assign ack_mode_val_3_we = addr_hit[2] & reg_we & ~wr_err;
+  assign ack_mode_val_3_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_3_wd = reg_wdata[7:6];
 
-  assign ack_mode_val_4_we = addr_hit[2] & reg_we & ~wr_err;
+  assign ack_mode_val_4_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_4_wd = reg_wdata[9:8];
 
-  assign ack_mode_val_5_we = addr_hit[2] & reg_we & ~wr_err;
+  assign ack_mode_val_5_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_5_wd = reg_wdata[11:10];
 
-  assign ack_mode_val_6_we = addr_hit[2] & reg_we & ~wr_err;
+  assign ack_mode_val_6_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_6_wd = reg_wdata[13:12];
 
-  assign alert_trig_val_0_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_trig_val_0_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_0_wd = reg_wdata[0];
 
-  assign alert_trig_val_1_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_trig_val_1_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_1_wd = reg_wdata[1];
 
-  assign alert_trig_val_2_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_trig_val_2_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_2_wd = reg_wdata[2];
 
-  assign alert_trig_val_3_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_trig_val_3_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_3_wd = reg_wdata[3];
 
-  assign alert_trig_val_4_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_trig_val_4_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_4_wd = reg_wdata[4];
 
-  assign alert_trig_val_5_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_trig_val_5_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_5_wd = reg_wdata[5];
 
-  assign alert_trig_val_6_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_trig_val_6_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_6_wd = reg_wdata[6];
 
-  assign alert_state_val_0_we = addr_hit[4] & reg_we & ~wr_err;
+  assign alert_state_val_0_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_0_wd = reg_wdata[0];
 
-  assign alert_state_val_1_we = addr_hit[4] & reg_we & ~wr_err;
+  assign alert_state_val_1_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_1_wd = reg_wdata[1];
 
-  assign alert_state_val_2_we = addr_hit[4] & reg_we & ~wr_err;
+  assign alert_state_val_2_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_2_wd = reg_wdata[2];
 
-  assign alert_state_val_3_we = addr_hit[4] & reg_we & ~wr_err;
+  assign alert_state_val_3_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_3_wd = reg_wdata[3];
 
-  assign alert_state_val_4_we = addr_hit[4] & reg_we & ~wr_err;
+  assign alert_state_val_4_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_4_wd = reg_wdata[4];
 
-  assign alert_state_val_5_we = addr_hit[4] & reg_we & ~wr_err;
+  assign alert_state_val_5_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_5_wd = reg_wdata[5];
 
-  assign alert_state_val_6_we = addr_hit[4] & reg_we & ~wr_err;
+  assign alert_state_val_6_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_6_wd = reg_wdata[6];
 
 

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -475,16 +475,16 @@ ${bits.msb}\
 
 % if field.swaccess.allows_write():
   % if field.swaccess.swrd() != SwRdAccess.RC:
-  assign ${sig_name}_we = addr_hit[${idx}] & reg_we & ~wr_err;
+  assign ${sig_name}_we = addr_hit[${idx}] & reg_we & !reg_error;
   assign ${sig_name}_wd = reg_wdata[${str_bits_sv(field.bits)}];
   % else:
   ## Generate WE based on read request, read should clear
-  assign ${sig_name}_we = addr_hit[${idx}] & reg_re;
+  assign ${sig_name}_we = addr_hit[${idx}] & reg_re & !reg_error;
   assign ${sig_name}_wd = '1;
   % endif
 % endif
 % if (field.swaccess.allows_read() and hwext) or shadowed:
-  assign ${sig_name}_re = addr_hit[${idx}] && reg_re;
+  assign ${sig_name}_re = addr_hit[${idx}] & reg_re & !reg_error;
 % endif
 </%def>\
 <%def name="rdata_gen(field, sig_name)">\


### PR DESCRIPTION
This PR qualifies `reg_we` and `reg_re` with `reg_error`.  This ensures that on any type of error (including integrity error), a transaction cannot happen. 

Please see #5434 