### PR TITLE
[top/lc_ctrl] connect CPU_EN and KEYMGR_EN signals

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -296,7 +296,7 @@
       swaccess: "ro",
       hwaccess: "hwo",
       hwext:    "true",
-      tags: [ // Life cycle internal HW will update status so could not auto-predict its value,
+      tags: [ // Life cycle internal HW will update status so can not auto-predict its value,
               // After reset, the field READY will be set to 1, so it is excluded from reset CSR test
               "excl:CsrAllTests:CsrExclCheck"],
       fields: [
@@ -465,7 +465,7 @@
         regwen:   "TRANSITION_REGWEN",
         cname:    "WORD",
         tags: [ // To update this register, SW needs to claim the associated hardware mutex via
-                // CLAIM_TRANSITION_IF, so could not auto predict its value.
+                // CLAIM_TRANSITION_IF, so can not auto predict its value.
                 "excl:CsrNonInitTests:CsrExclCheck"],
         fields: [
           { bits: "31:0"
@@ -489,7 +489,7 @@
                 hardware mutex via !!CLAIM_TRANSITION_IF.
                 '''
           tags: [ // To update this register, SW needs to claim the associated hardware mutex via
-                  // CLAIM_TRANSITION_IF, so could not auto predict its value.
+                  // CLAIM_TRANSITION_IF, so can not auto predict its value.
                   "excl:CsrNonInitTests:CsrExclCheck"],
           enum: [
             { value: "0",
@@ -558,6 +558,8 @@
       swaccess: "ro",
       hwaccess: "hwo",
       hwext:    "true",
+      tags: [ // Life cycle internal HW will update status so can not auto-predict its value.
+              "excl:CsrAllTests:CsrExclCheck"],
       fields: [
         { bits: "CsrLcStateWidth-1:0"
           name: "STATE"
@@ -634,8 +636,6 @@
           ]
         }
       ],
-      tags: [ // This value is driven by hardware.
-        "excl:CsrNonInitTests:CsrExclCheck"],
     }
 
     { name: "LC_TRANSITION_CNT",
@@ -643,6 +643,8 @@
       swaccess: "ro",
       hwaccess: "hwo",
       hwext:    "true",
+      tags: [ // Life cycle internal HW will update status so can not auto-predict its value.
+              "excl:CsrAllTests:CsrExclCheck"],
       fields: [
         { bits: "CsrLcCountWidth-1:0"
           name: "CNT"
@@ -657,8 +659,6 @@
           '''
         }
       ],
-      tags: [ // This value is driven by hardware.
-        "excl:CsrNonInitTests:CsrExclCheck"],
     }
 
     { name: "LC_ID_STATE",
@@ -666,6 +666,8 @@
       swaccess: "ro",
       hwaccess: "hwo",
       hwext:    "true",
+      tags: [ // Life cycle internal HW will update status so can not auto-predict its value.
+              "excl:CsrAllTests:CsrExclCheck"],
       fields: [
         { bits: "1:0"
           name: "STATE"
@@ -686,8 +688,6 @@
           ]
         }
       ],
-      tags: [ // This value is driven by hardware.
-        "excl:CsrNonInitTests:CsrExclCheck"],
     }
 
     ///////////////
@@ -705,8 +705,8 @@
         hwaccess: "hwo",
         hwext:    "true",
         cname:    "WORD",
-        tags: [ // This value is driven by hardware.
-                "excl:CsrNonInitTests:CsrExclCheck"],
+        tags: [ // Life cycle internal HW will update status so can not auto-predict its value.
+                "excl:CsrAllTests:CsrExclCheck"],
         fields: [
           { bits: "31:0"
           }

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -1099,6 +1099,8 @@
         hwaccess:  "hwo",
         hwext:     "true",
         cname:     "WORD",
+        tags: [ // OTP internal HW will update status so can not auto-predict its value.
+                "excl:CsrAllTests:CsrExclCheck"],
         fields: [
           { bits: "31:0"
           }
@@ -1119,6 +1121,8 @@
         hwaccess:  "hwo",
         hwext:     "true",
         cname:     "WORD",
+        tags: [ // OTP internal HW will update status so can not auto-predict its value.
+                "excl:CsrAllTests:CsrExclCheck"],
         fields: [
           { bits: "31:0"
           }
@@ -1137,6 +1141,8 @@
         hwaccess:  "hwo",
         hwext:     "true",
         cname:     "WORD",
+        tags: [ // OTP internal HW will update status so can not auto-predict its value.
+                "excl:CsrAllTests:CsrExclCheck"],
         fields: [
           { bits: "31:0"
           }
@@ -1155,6 +1161,8 @@
         hwaccess:  "hwo",
         hwext:     "true",
         cname:     "WORD",
+        tags: [ // OTP internal HW will update status so can not auto-predict its value.
+                "excl:CsrAllTests:CsrExclCheck"],
         fields: [
           { bits: "31:0"
           }
@@ -1173,6 +1181,8 @@
         hwaccess:  "hwo",
         hwext:     "true",
         cname:     "WORD",
+        tags: [ // OTP internal HW will update status so can not auto-predict its value.
+                "excl:CsrAllTests:CsrExclCheck"],
         fields: [
           { bits: "31:0"
           }
@@ -1191,6 +1201,8 @@
         hwaccess:  "hwo",
         hwext:     "true",
         cname:     "WORD",
+        tags: [ // OTP internal HW will update status so can not auto-predict its value.
+                "excl:CsrAllTests:CsrExclCheck"],
         fields: [
           { bits: "31:0"
           }

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -762,6 +762,8 @@
         hwaccess:  "hwo",
         hwext:     "true",
         cname:     "WORD",
+        tags: [ // OTP internal HW will update status so can not auto-predict its value.
+                "excl:CsrAllTests:CsrExclCheck"],
         fields: [
           { bits: "31:0"
           }
@@ -781,6 +783,8 @@
         hwaccess:  "hwo",
         hwext:     "true",
         cname:     "WORD",
+        tags: [ // OTP internal HW will update status so can not auto-predict its value.
+                "excl:CsrAllTests:CsrExclCheck"],
         fields: [
           { bits: "31:0"
           }

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -101,12 +101,15 @@ package otp_ctrl_pkg;
     lc_ctrl_state_pkg::lc_id_state_e id_state;
   } otp_lc_data_t;
 
-  // Default for dangling connection
+  // Default for dangling connection.
+  // Note that we put the life cycle into
+  // TEST_UNLOCKED0 by default such that top levels without
+  // the OTP controller can still function.
   parameter otp_lc_data_t OTP_LC_DATA_DEFAULT = '{
     valid: 1'b1,
     error: 1'b0,
-    state: lc_ctrl_state_pkg::LcStRaw,
-    count: lc_ctrl_state_pkg::LcCnt0,
+    state: lc_ctrl_state_pkg::LcStTestUnlocked0,
+    count: lc_ctrl_state_pkg::LcCnt1,
     test_unlock_token: '0,
     test_exit_token: '0,
     rma_token: '0,

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -65,7 +65,7 @@ module rv_core_ibex import rv_core_ibex_pkg::*; #(
   output crashdump_t  crash_dump_o,
 
   // CPU Control Signals
-  input lc_ctrl_pkg::lc_tx_t fetch_enable_i,
+  input lc_ctrl_pkg::lc_tx_t lc_cpu_en_i,
   output logic        core_sleep_o
 );
 
@@ -164,12 +164,12 @@ module rv_core_ibex import rv_core_ibex_pkg::*; #(
   assign unused_alert_minor = alert_minor;
   assign unused_alert_major = alert_major;
 
-  lc_ctrl_pkg::lc_tx_t fetch_enable;
+  lc_ctrl_pkg::lc_tx_t [0:0] lc_cpu_en;
   prim_lc_sync u_lc_sync (
     .clk_i,
     .rst_ni,
-    .lc_en_i(fetch_enable_i),
-    .lc_en_o(fetch_enable)
+    .lc_en_i(lc_cpu_en_i),
+    .lc_en_o(lc_cpu_en)
   );
 
   ibex_core #(
@@ -251,7 +251,7 @@ module rv_core_ibex import rv_core_ibex_pkg::*; #(
     .rvfi_mem_wdata,
 `endif
 
-    .fetch_enable_i   (fetch_enable == lc_ctrl_pkg::On),
+    .fetch_enable_i   (lc_cpu_en[0] == lc_ctrl_pkg::On),
     .alert_minor_o    (alert_minor),
     .alert_major_o    (alert_major),
     .core_sleep_o

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -457,6 +457,18 @@
           top_signame: rv_core_ibex_crashdump
           index: -1
         }
+        {
+          struct: lc_tx_t
+          type: uni
+          name: lc_cpu_en
+          act: rcv
+          package: lc_ctrl_pkg
+          inst_name: rv_core_ibex
+          width: 1
+          default: ""
+          top_signame: lc_ctrl_lc_cpu_en
+          index: -1
+        }
       ]
     }
   ]
@@ -3455,6 +3467,10 @@
           default: lc_ctrl_pkg::Off
           package: lc_ctrl_pkg
           inst_name: lc_ctrl
+          width: 1
+          end_idx: -1
+          top_type: broadcast
+          top_signame: lc_ctrl_lc_keymgr_en
           index: -1
         }
         {
@@ -6439,6 +6455,8 @@
           package: lc_ctrl_pkg
           default: lc_ctrl_pkg::On
           inst_name: keymgr
+          width: 1
+          top_signame: lc_ctrl_lc_keymgr_en
           index: -1
         }
         {
@@ -7895,7 +7913,14 @@
         sram_ctrl_ret_aon.lc_hw_debug_en
         pinmux_aon.lc_hw_debug_en
       ]
-      lc_ctrl.lc_cpu_en: []
+      lc_ctrl.lc_cpu_en:
+      [
+        rv_core_ibex.lc_cpu_en
+      ]
+      lc_ctrl.lc_keymgr_en:
+      [
+        keymgr.lc_keymgr_en
+      ]
       lc_ctrl.lc_escalate_en:
       [
         aes.lc_escalate_en
@@ -13186,6 +13211,10 @@
         default: lc_ctrl_pkg::Off
         package: lc_ctrl_pkg
         inst_name: lc_ctrl
+        width: 1
+        end_idx: -1
+        top_type: broadcast
+        top_signame: lc_ctrl_lc_keymgr_en
         index: -1
       }
       {
@@ -14665,6 +14694,8 @@
         package: lc_ctrl_pkg
         default: lc_ctrl_pkg::On
         inst_name: keymgr
+        width: 1
+        top_signame: lc_ctrl_lc_keymgr_en
         index: -1
       }
       {
@@ -15824,6 +15855,18 @@
         index: -1
       }
       {
+        struct: lc_tx_t
+        type: uni
+        name: lc_cpu_en
+        act: rcv
+        package: lc_ctrl_pkg
+        inst_name: rv_core_ibex
+        width: 1
+        default: ""
+        top_signame: lc_ctrl_lc_cpu_en
+        index: -1
+      }
+      {
         struct: edn
         type: req_rsp
         name: edn
@@ -16847,6 +16890,17 @@
         package: lc_ctrl_pkg
         struct: lc_tx
         signame: lc_ctrl_lc_cpu_en
+        width: 1
+        type: uni
+        end_idx: -1
+        act: req
+        suffix: ""
+        default: lc_ctrl_pkg::Off
+      }
+      {
+        package: lc_ctrl_pkg
+        struct: lc_tx
+        signame: lc_ctrl_lc_keymgr_en
         width: 1
         type: uni
         end_idx: -1

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -195,6 +195,13 @@
           act:     "req",
           package: "rv_core_ibex_pkg",
         },
+
+        { struct:  "lc_tx_t",
+          type:    "uni",
+          name:    "lc_cpu_en",
+          act:     "rcv",
+          package: "lc_ctrl_pkg",
+        },
       ],
     }
 
@@ -806,8 +813,8 @@
       'lc_ctrl.lc_hw_debug_en'     : ['sram_ctrl_main.lc_hw_debug_en',
                                       'sram_ctrl_ret_aon.lc_hw_debug_en',
                                       'pinmux_aon.lc_hw_debug_en'],
-      'lc_ctrl.lc_cpu_en'          : [],
-      //'lc_ctrl.lc_keymgr_en'       : ['keymgr.lc_keymgr_en'],
+      'lc_ctrl.lc_cpu_en'          : ['rv_core_ibex.lc_cpu_en'],
+      'lc_ctrl.lc_keymgr_en'       : ['keymgr.lc_keymgr_en'],
       'lc_ctrl.lc_escalate_en'     : ['aes.lc_escalate_en',
                                       'otp_ctrl.lc_escalate_en',
                                       'sram_ctrl_main.lc_escalate_en',

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -293,8 +293,7 @@ module top_${top["name"]} #(
     // crash dump interface
     .crash_dump_o         (rv_core_ibex_crashdump),
     // CPU control signals
-    // TODO #5356
-    .fetch_enable_i       (lc_ctrl_pkg::On),
+    .lc_cpu_en_i          (lc_ctrl_lc_cpu_en),
     .core_sleep_o         (pwrmgr_aon_pwr_cpu.core_sleeping)
   );
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -50,8 +50,9 @@ class chip_base_vseq extends cip_base_vseq #(
     // Initialize flash seeds
     cfg.flash_info0_bkdr_vif.set_mem();
     cfg.flash_info1_bkdr_vif.set_mem();
+    // Backdoor load the OTP image.
+    cfg.otp_bkdr_vif.load_mem_from_file({cfg.sw_images[SwTypeOtp], ".vmem"});
     // Bring the chip out of reset.
-    cfg.otp_bkdr_vif.clear_mem();
     super.dut_init(reset_kind);
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -33,7 +33,8 @@ class chip_common_vseq extends chip_base_vseq;
 
   virtual task apply_reset(string kind = "HARD");
     super.apply_reset(kind);
-    cfg.otp_bkdr_vif.clear_mem();
+    // Backdoor load the OTP image.
+    cfg.otp_bkdr_vif.load_mem_from_file({cfg.sw_images[SwTypeOtp], ".vmem"});
     wait (cfg.rst_n_mon_vif.pins[0] === 1);
     cfg.clk_rst_vif.wait_clks(100);
   endtask

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -38,7 +38,6 @@ class chip_sw_base_vseq extends chip_base_vseq;
 
     // Backdoor load memories with sw images.
     cfg.rom_bkdr_vif.load_mem_from_file({cfg.sw_images[SwTypeRom], ".32.vmem"});
-    cfg.otp_bkdr_vif.load_mem_from_file({cfg.sw_images[SwTypeOtp], ".vmem"});
 
     // TODO: the location of the main execution image should be randomized for either bank in future
     if (cfg.use_spi_load_bootstrap) begin

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -17,7 +17,9 @@ class chip_base_test extends cip_base_test #(
   // the run_phase; as such, nothing more needs to be done.
 
   virtual function void build_phase(uvm_phase phase);
+    string sw_images_plusarg;
     super.build_phase(phase);
+
     // Knob to en/dis stubbing cpu (disabled by default).
     void'($value$plusargs("stub_cpu=%0b", cfg.stub_cpu));
     // Set tl_agent's is_active bit based on the retrieved stub_cpu value.
@@ -26,37 +28,34 @@ class chip_base_test extends cip_base_test #(
     // Knob to set the UART baud rate (set to 2M by default).
     void'($value$plusargs("uart_baud_rate=%0d", cfg.uart_baud_rate));
 
-    // The following plusargs are only valid for SW based tests.
-    if (!cfg.stub_cpu) begin
-      string sw_images_plusarg;
 
-      // Knob to configure writing sw logs to a separate file (enabled by default).
-      void'($value$plusargs("write_sw_logs_to_file=%0b", cfg.write_sw_logs_to_file));
+    // The following plusargs are only valid for SW based tests (i.e., no stubbed CPU).
+    // Knob to configure writing sw logs to a separate file (enabled by default).
+    void'($value$plusargs("write_sw_logs_to_file=%0b", cfg.write_sw_logs_to_file));
 
-      // Knob to enable logging over UART (disabled by default).
-      void'($value$plusargs("en_uart_logger=%0b", cfg.en_uart_logger));
-      cfg.m_uart_agent_cfg.en_logger = cfg.en_uart_logger;
-      cfg.m_uart_agent_cfg.write_logs_to_file = cfg.write_sw_logs_to_file;
+    // Knob to enable logging over UART (disabled by default).
+    void'($value$plusargs("en_uart_logger=%0b", cfg.en_uart_logger));
+    cfg.m_uart_agent_cfg.en_logger = cfg.en_uart_logger;
+    cfg.m_uart_agent_cfg.write_logs_to_file = cfg.write_sw_logs_to_file;
 
-      // Knob to set the sw_test_timeout_ns (set to 5ms by default).
-      void'($value$plusargs("sw_test_timeout_ns=%0d", cfg.sw_test_timeout_ns));
+    // Knob to set the sw_test_timeout_ns (set to 5ms by default).
+    void'($value$plusargs("sw_test_timeout_ns=%0d", cfg.sw_test_timeout_ns));
 
-      // Knob to pre-initialize RAM to 0s (disabled by default).
-      void'($value$plusargs("initialize_ram=%0b", cfg.initialize_ram));
+    // Knob to pre-initialize RAM to 0s (disabled by default).
+    void'($value$plusargs("initialize_ram=%0b", cfg.initialize_ram));
 
-      // Knob to use SPI to load image via ROM bootstrap.
-      void'($value$plusargs("use_spi_load_bootstrap=%0b", cfg.use_spi_load_bootstrap));
+    // Knob to use SPI to load image via ROM bootstrap.
+    void'($value$plusargs("use_spi_load_bootstrap=%0b", cfg.use_spi_load_bootstrap));
 
-      // Knob to indicate where to pick up the SW images from.
-      void'($value$plusargs("sw_build_bin_dir=%0s", cfg.sw_build_bin_dir));
+    // Knob to indicate where to pick up the SW images from.
+    void'($value$plusargs("sw_build_bin_dir=%0s", cfg.sw_build_bin_dir));
 
-      // Knob to indicate what build device to use (DV, Verilator or FPGA).
-      void'($value$plusargs("sw_build_device=%0s", cfg.sw_build_device));
+    // Knob to indicate what build device to use (DV, Verilator or FPGA).
+    void'($value$plusargs("sw_build_device=%0s", cfg.sw_build_device));
 
-      // Knob to set custom sw image names for rom and sw.
-      if ($value$plusargs("sw_images=%0s", sw_images_plusarg)) begin
-        cfg.parse_sw_images_string(sw_images_plusarg);
-      end
+    // Knob to set custom sw image names for rom and sw.
+    if ($value$plusargs("sw_images=%0s", sw_images_plusarg)) begin
+      cfg.parse_sw_images_string(sw_images_plusarg);
     end
   endfunction : build_phase
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -465,6 +465,7 @@ module top_earlgrey #(
   lc_ctrl_pkg::lc_tx_t       lc_ctrl_lc_nvm_debug_en;
   lc_ctrl_pkg::lc_tx_t       lc_ctrl_lc_hw_debug_en;
   lc_ctrl_pkg::lc_tx_t       lc_ctrl_lc_cpu_en;
+  lc_ctrl_pkg::lc_tx_t       lc_ctrl_lc_keymgr_en;
   lc_ctrl_pkg::lc_tx_t       lc_ctrl_lc_escalate_en;
   lc_ctrl_pkg::lc_tx_t       lc_ctrl_lc_check_byp_en;
   lc_ctrl_pkg::lc_tx_t       lc_ctrl_lc_clk_byp_ack;
@@ -673,8 +674,7 @@ module top_earlgrey #(
     // crash dump interface
     .crash_dump_o         (rv_core_ibex_crashdump),
     // CPU control signals
-    // TODO #5356
-    .fetch_enable_i       (lc_ctrl_pkg::On),
+    .lc_cpu_en_i          (lc_ctrl_lc_cpu_en),
     .core_sleep_o         (pwrmgr_aon_pwr_cpu.core_sleeping)
   );
 
@@ -1463,7 +1463,7 @@ module top_earlgrey #(
       .lc_nvm_debug_en_o(lc_ctrl_lc_nvm_debug_en),
       .lc_hw_debug_en_o(lc_ctrl_lc_hw_debug_en),
       .lc_cpu_en_o(lc_ctrl_lc_cpu_en),
-      .lc_keymgr_en_o(),
+      .lc_keymgr_en_o(lc_ctrl_lc_keymgr_en),
       .lc_escalate_en_o(lc_ctrl_lc_escalate_en),
       .lc_clk_byp_req_o(lc_clk_byp_req_o),
       .lc_clk_byp_ack_i(lc_ctrl_lc_clk_byp_ack),
@@ -1910,7 +1910,7 @@ module top_earlgrey #(
       .otp_key_i(otp_ctrl_otp_keymgr_key),
       .otp_hw_cfg_i(otp_ctrl_otp_hw_cfg),
       .flash_i(flash_ctrl_keymgr),
-      .lc_keymgr_en_i(lc_ctrl_pkg::On),
+      .lc_keymgr_en_i(lc_ctrl_lc_keymgr_en),
       .lc_keymgr_div_i(lc_ctrl_lc_keymgr_div),
       .tl_i(keymgr_tl_req),
       .tl_o(keymgr_tl_rsp),


### PR DESCRIPTION
Now that OTP/LC preloading is in place, we can go on and connect some of the more invasive LC enable signals.

Fix #5356

Signed-off-by: Michael Schaffner <msf@opentitan.org>