### PR TITLE
[rtl/lc_ctrl] Fix jtag d_error

### DIFF
--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -190,7 +190,7 @@ module lc_ctrl
   // Unused
   assign tap_tl_h2d.a_param   = '0;
   assign tap_tl_h2d.a_source  = '0;
-  assign tap_tl_h2d.a_user    = '0;
+  assign tap_tl_h2d.a_user    = tlul_pkg::TL_A_USER_DEFAULT;
 
   // TL-UL to DMI transducing
   assign tap_tl_h2d.d_ready  = dmi_resp_ready;


### PR DESCRIPTION
When I try to use DMI to access LC_CTRL CSR, I always get a `d_error`.
The error is coming from this check: https://github.com/lowRISC/opentitan/blob/master/hw/ip/tlul/rtl/tlul_pkg.sv#L142
I believe it is related to default value for tap's tl_i.a_user.

Signed-off-by: Cindy Chen <chencindy@google.com>