### PR TITLE
[dv/jtag_agent] Support DMI access

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_agent.core
+++ b/hw/dv/sv/jtag_agent/jtag_agent.core
@@ -18,7 +18,8 @@ filesets:
       - jtag_driver.sv: {is_include_file: true}
       - jtag_monitor.sv: {is_include_file: true}
       - jtag_agent.sv: {is_include_file: true}
-      - seq_lib/jtag_base_seq.sv: {is_include_file: true}
+      - seq_lib/jtag_ir_seq.sv: {is_include_file: true}
+      - seq_lib/jtag_dr_seq.sv: {is_include_file: true}
       - seq_lib/jtag_seq_list.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/dv/sv/jtag_agent/jtag_agent_pkg.sv
+++ b/hw/dv/sv/jtag_agent/jtag_agent_pkg.sv
@@ -16,7 +16,6 @@ package jtag_agent_pkg;
   parameter uint JTAG_IRW = 32; // max IR width
   parameter uint JTAG_DRW = 64; // max DR width
 
-  // local types
   // forward declare classes to allow typedefs below
   typedef class jtag_item;
   typedef class jtag_agent_cfg;
@@ -24,8 +23,6 @@ package jtag_agent_pkg;
   // reuse dv_base_seqeuencer as is with the right parameter set
   typedef dv_base_sequencer #(.ITEM_T     (jtag_item),
                               .CFG_T      (jtag_agent_cfg)) jtag_sequencer;
-
-  // functions
 
   // package sources
   `include "jtag_item.sv"

--- a/hw/dv/sv/jtag_agent/jtag_item.sv
+++ b/hw/dv/sv/jtag_agent/jtag_item.sv
@@ -5,27 +5,29 @@
 class jtag_item extends uvm_sequence_item;
 
   // random variables
-  rand uint addr_len;
-  rand uint data_len;
+  rand uint ir_len;
+  rand uint dr_len;
 
-  rand logic [JTAG_IRW-1:0] addr;   // address
-  rand logic [JTAG_DRW-1:0] data;   // data written or read
-  rand logic                write;  // write signal
+  rand logic [JTAG_IRW-1:0] ir;
+  rand logic [JTAG_DRW-1:0] dr;
+  rand logic [JTAG_DRW-1:0] dout;
+  rand bit                  select_ir;
 
-  constraint addr_len_c {
-    addr_len <= JTAG_IRW;
+  constraint ir_len_c {
+    ir_len <= JTAG_IRW;
   }
 
-  constraint data_len_c {
-    data_len <= JTAG_DRW;
+  constraint dr_len_c {
+    dr_len <= JTAG_DRW;
   }
 
   `uvm_object_utils_begin(jtag_item)
-    `uvm_field_int(addr_len,  UVM_DEFAULT)
-    `uvm_field_int(data_len,  UVM_DEFAULT)
-    `uvm_field_int(addr,      UVM_DEFAULT)
-    `uvm_field_int(data,      UVM_DEFAULT)
-    `uvm_field_int(write,     UVM_DEFAULT)
+    `uvm_field_int(ir_len, UVM_DEFAULT)
+    `uvm_field_int(dr_len, UVM_DEFAULT)
+    `uvm_field_int(ir,     UVM_DEFAULT)
+    `uvm_field_int(dr,     UVM_DEFAULT)
+    `uvm_field_int(dout,   UVM_DEFAULT)
+    `uvm_field_int(select_ir,   UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/hw/dv/sv/jtag_agent/seq_lib/jtag_base_seq.sv
+++ b/hw/dv/sv/jtag_agent/seq_lib/jtag_base_seq.sv
@@ -2,16 +2,32 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class jtag_base_seq extends dv_base_seq #(
+class jtag_ir_seq extends dv_base_seq #(
+    .REQ         (jtag_item),
     .CFG_T       (jtag_agent_cfg),
     .SEQUENCER_T (jtag_sequencer)
   );
-  `uvm_object_utils(jtag_base_seq)
 
+  rand logic [JTAG_IRW-1:0] ir;
+
+  `uvm_object_utils(jtag_ir_seq)
   `uvm_object_new
 
   virtual task body();
-    `uvm_fatal(`gtn, "Need to override this when you extend from this class!")
+    req = jtag_item::type_id::create("req");
+    start_item(req);
+    randomize_req(req);
+    finish_item(req);
+    get_response(rsp);
+    `uvm_info(`gfn, $sformatf("rcvd response:\n%0s", rsp.sprint()), UVM_HIGH)
   endtask
 
+  virtual function randomize_req(jtag_item req);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
+        ir_len    == DMI_IRW;
+        dr_len    == DMI_DRW;
+        ir        == local::ir;
+        select_ir == 1;
+    )
+  endfunction
 endclass

--- a/hw/dv/sv/jtag_agent/seq_lib/jtag_dr_seq.sv
+++ b/hw/dv/sv/jtag_agent/seq_lib/jtag_dr_seq.sv
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A dmi access sequence to drive a single CSR read or write
+class jtag_dr_seq extends jtag_ir_seq;
+
+  rand logic [JTAG_IRW-1:0] dr;
+
+  `uvm_object_utils(jtag_dr_seq)
+  `uvm_object_new
+
+  virtual function randomize_req(jtag_item req);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
+        ir_len == DMI_IRW;
+        dr_len == DMI_DRW;
+        dr        == local::dr;
+        select_dr == 1;
+    )
+  endfunction
+endclass

--- a/hw/dv/sv/jtag_riscv_agent/README.md
+++ b/hw/dv/sv/jtag_riscv_agent/README.md
@@ -1,0 +1,5 @@
+---
+title: "JTAG DV UVM Agent"
+---
+
+JTAG UVM Agent is extended from DV library agent classes.

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent.core
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent.core
@@ -1,0 +1,28 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:jtag_riscv_agent:0.1"
+description: "JTAG RISCV DV UVM agent"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:dv_utils
+      - lowrisc:dv:dv_lib
+      - lowrisc:dv:jtag_agent
+    files:
+      - jtag_riscv_if.sv
+      - jtag_riscv_agent_pkg.sv
+      - jtag_riscv_agent_cfg.sv: {is_include_file: true}
+      - jtag_riscv_agent_cov.sv: {is_include_file: true}
+      - jtag_riscv_item.sv: {is_include_file: true}
+      - jtag_riscv_monitor.sv: {is_include_file: true}
+      - jtag_riscv_agent.sv: {is_include_file: true}
+      - seq_lib/jtag_riscv_dmi_access_seq.sv: {is_include_file: true}
+      - seq_lib/jtag_riscv_seq_list.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class jtag_riscv_agent extends dv_base_agent #(
+      .CFG_T          (jtag_riscv_agent_cfg),
+      .SEQUENCER_T    (jtag_riscv_sequencer),
+      .MONITOR_T      (jtag_riscv_monitor),
+      .COV_T          (jtag_riscv_agent_cov)
+  );
+
+  `uvm_component_utils(jtag_riscv_agent)
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    // get jtag_riscv_if handle
+    if (!uvm_config_db#(virtual jtag_riscv_if)::get(this, "", "vif", cfg.vif))
+      `uvm_fatal(`gfn, "failed to get jtag_riscv_if handle from uvm_config_db")
+
+    cfg.has_driver = 0;
+  endfunction
+
+endclass

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_cfg.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_cfg.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class jtag_riscv_agent_cfg extends dv_base_agent_cfg;
+
+// interface handle used by driver, monitor & the sequencer, via cfg handle
+  virtual jtag_riscv_if vif;
+
+  `uvm_object_utils_begin(jtag_riscv_agent_cfg)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+  // control tck
+  function void set_tck_en(bit en);
+    vif.tck_en = en;
+  endfunction
+
+  // assert trst_n for a number of cycles
+  task do_trst_n(int cycles = $urandom_range(5, 20));
+    vif.do_trst_n(cycles);
+  endtask
+
+endclass

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_cov.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_cov.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class jtag_riscv_agent_cov extends dv_base_agent_cov #(jtag_riscv_agent_cfg);
+  `uvm_component_utils(jtag_riscv_agent_cov)
+
+  // the base class provides the following handles for use:
+  // jtag_agent_cfg: cfg
+
+  // covergroups
+
+  function new(string name, uvm_component parent);
+    super.new(name, parent);
+    // instantiate all covergroups here
+  endfunction : new
+
+endclass

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_pkg.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_pkg.sv
@@ -1,0 +1,58 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package jtag_riscv_agent_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import dv_utils_pkg::*;
+  import dv_lib_pkg::*;
+  import jtag_agent_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  // parameters
+
+  // JTAG TAP for DMI according to debug spec 0.13
+  parameter uint DMI_OPW   = 2;
+  parameter uint DMI_DATAW = 32;
+  parameter uint DMI_ADDRW = 7;
+  parameter uint DMI_IRW   = 5;
+  parameter uint DMI_DRW   = DMI_OPW + DMI_DATAW + DMI_ADDRW;
+
+  // local types
+  typedef enum bit [DMI_IRW-1:0] {
+    JtagBypass0   = 'h0,
+    JtagIdcode    = 'h1,
+    JtagDtmCsr    = 'h10,
+    JtagDmiAccess = 'h11,
+    JtagBypass1   = 'h1f
+  } jtag_ir_e;
+
+  typedef enum bit [DMI_OPW-1:0] {
+    DmiNoErr      = 'h0,
+    DmiFail       = 'h2,
+    DmiInProgress = 'h3
+  } jtag_op_status_e;
+
+  typedef enum bit [DMI_OPW-1:0] {
+    DmiStatus = 'h0,
+    DmiRead   = 'h1,
+    DmiWrite  = 'h2
+  } jtag_op_e;
+
+  // forward declare classes to allow typedefs below
+  typedef class jtag_riscv_item;
+  typedef class jtag_riscv_agent_cfg;
+
+  // package sources
+  `include "jtag_riscv_item.sv"
+  `include "jtag_riscv_agent_cfg.sv"
+  `include "jtag_riscv_agent_cov.sv"
+  `include "jtag_riscv_monitor.sv"
+  `include "jtag_riscv_agent.sv"
+  `include "jtag_riscv_seq_list.sv"
+
+  endpackage: jtag_riscv_agent_pkg

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_if.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_if.sv
@@ -1,0 +1,72 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// jtag interface with default 50MHz tck
+interface jtag_if #(time JtagDefaultTckPeriodNs = 20ns) ();
+
+  // interface pins
+  logic tck;
+  logic trst_n;
+  wire  tms;
+  wire  tdi;
+  wire  tdo;
+
+  // generate local tck
+  bit   tck_en;
+  time  tck_period_ns = JtagDefaultTckPeriodNs;
+
+  clocking host_cb @(posedge tck);
+    output  tms;
+    output  tdi;
+    input   tdo;
+  endclocking
+  modport host_mp(clocking host_cb, output trst_n);
+
+  clocking device_cb @(posedge tck);
+    input  tms;
+    input  tdi;
+    output tdo;
+  endclocking
+  modport device_mp(clocking device_cb, input trst_n);
+
+  modport mon_mp (
+    input tck,
+    input trst_n,
+    input tms,
+    input tdi,
+    input tdo
+  );
+
+  // debug signals
+
+  // task to wait for tck cycles
+  task automatic wait_tck(int cycles);
+    repeat (cycles) @(posedge tck);
+  endtask
+
+  // task to issue trst_n
+  task automatic do_trst_n(int cycles);
+    trst_n <= 1'b0;
+    if (tck_en) wait_tck(cycles);
+    else        #(tck_period_ns * cycles * 1ns);
+    trst_n <= 1'b1;
+  endtask
+
+  // Generate the tck, with UartDefaultClkPeriodNs period as default
+  initial begin
+    tck = 1'b1;
+    do_trst_n($urandom_range(1, 10));
+    forever begin
+      if (tck_en) begin
+        #(tck_period_ns / 2);
+        tck = ~tck;
+        #(tck_period_ns / 2);
+        tck = ~tck;
+      end else begin
+        @(tck_en);
+      end
+    end
+  end
+
+endinterface

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_item.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_item.sv
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class jtag_riscv_item extends uvm_sequence_item;
+
+  // random variables
+  rand uint ir_len;
+  rand uint dr_len;
+
+  rand logic [JTAG_IRW-1:0] ir;    // instruction
+  rand logic [JTAG_DRW-1:0] dr;    // data written or read
+  rand logic                write; // write signal
+
+  // DMI variables
+  rand logic [DMI_OPW-1:0]   op;
+  rand logic [DMI_DATAW-1:0] data;
+  rand logic [DMI_ADDRW-1:0] addr; // word address
+
+  constraint ir_len_c {
+    ir_len <= JTAG_IRW;
+  }
+
+  constraint dr_len_c {
+    dr_len <= JTAG_DRW;
+  }
+
+  `uvm_object_utils_begin(jtag_riscv_item)
+    `uvm_field_int(ir_len, UVM_DEFAULT)
+    `uvm_field_int(dr_len, UVM_DEFAULT)
+    `uvm_field_int(ir,     UVM_DEFAULT)
+    `uvm_field_int(dr,     UVM_DEFAULT)
+    `uvm_field_int(write,  UVM_DEFAULT)
+    `uvm_field_int(op,     UVM_DEFAULT)
+    `uvm_field_int(data,   UVM_DEFAULT)
+    `uvm_field_int(addr,   UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+endclass

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_monitor.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_monitor.sv
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class jtag_monitor extends dv_base_monitor #(
+    .ITEM_T (jtag_item),
+    .CFG_T  (jtag_agent_cfg),
+    .COV_T  (jtag_agent_cov)
+  );
+  `uvm_component_utils(jtag_monitor)
+
+  // the base class provides the following handles for use:
+  // jtag_agent_cfg: cfg
+  // jtag_agent_cov: cov
+  // uvm_analysis_port #(jtag_item): analysis_port
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+  endfunction
+
+  task run_phase(uvm_phase phase);
+    super.run_phase(phase);
+  endtask
+
+  // collect transactions forever - already forked in dv_base_moditor::run_phase
+  virtual protected task collect_trans(uvm_phase phase);
+    forever begin
+      // TODO: detect event
+
+      // TODO: sample the interface
+
+      // TODO: sample the covergroups
+
+      // TODO: write trans to analysis_port
+
+      // TODO: remove the line below: it is added to prevent zero delay loop in template code
+      #1us;
+    end
+  endtask
+
+endclass

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_virtual_sequencer.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_virtual_sequencer.sv
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class jtag_riscv_virtual_sequencer extends cip_base_virtual_sequencer #(
+    .ITEM_T (jtag_riscv_item),
+    .CFG_T  (jtag_riscv_agent_cfg)
+);
+  `uvm_component_utils(jtag_riscv_virtual_sequencer)
+
+  `uvm_component_new
+
+  jtag_sequencer#(.DeviceDataWidth(SRAM_DATA_SIZE)) jtag_sequencer_h;
+endclass

--- a/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_base_seq.sv
+++ b/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_base_seq.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class jtag_base_seq extends dv_base_seq #(
+    .REQ         (jtag_item),
+    .CFG_T       (jtag_agent_cfg),
+    .SEQUENCER_T (jtag_sequencer)
+  );
+  `uvm_object_utils(jtag_base_seq)
+
+  `uvm_object_new
+
+  virtual task body();
+    `uvm_fatal(`gtn, "Need to override this when you extend from this class!")
+  endtask
+
+endclass

--- a/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_dmi_access_seq.sv
+++ b/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_dmi_access_seq.sv
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A dmi access sequence to drive a single CSR read or write
+class jtag_dmi_access_seq extends jtag_base_seq;
+
+  rand bit [DMI_OPW-1:0]   op;
+  rand bit [DMI_DATAW-1:0] data;
+  rand bit [DMI_ADDRW-1:0] addr;
+
+  `uvm_object_utils(jtag_dmi_access_seq)
+  `uvm_object_new
+
+  virtual task body();
+    req = jtag_item::type_id::create("req");
+    start_item(req);
+    randomize_req(req);
+    finish_item(req);
+    get_response(rsp);
+    `uvm_info(`gfn, $sformatf("rcvd response:\n%0s", rsp.sprint()), UVM_HIGH)
+  endtask
+
+  virtual function randomize_req(jtag_item req);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
+        ir_len == DMI_IRW;
+        dr_len == DMI_DRW;
+        op     == local::op;
+        data   == local::data;
+        addr   == local::addr;
+        write  == (local::op == DmiWrite) ? 1 : 0;
+        dr     == {local::addr, local::data, local::op};
+        ir     == JtagDmiAccess;
+    )
+  endfunction
+endclass

--- a/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_seq_list.sv
+++ b/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_seq_list.sv
@@ -2,5 +2,5 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-`include "jtag_ir_seq.sv"
-`include "jtag_dr_seq.sv"
+`include "jtag_base_seq.sv"
+`include "jtag_dmi_access_seq.sv"


### PR DESCRIPTION
This PR implemented the following changes to support DMI access:
1. Update the data/addr naming to ir/dr
2. Add more parameters for DMI access
3. Update read sequence in jtag_driver
4. Add a dmi simple sequence to drive individual csr access

Signed-off-by: Cindy Chen <chencindy@google.com>