### PR TITLE
[tlul] Yet more messing around to silence lint warnings

### DIFF
--- a/hw/ip/tlul/rtl/tlul_err_resp.sv
+++ b/hw/ip/tlul/rtl/tlul_err_resp.sv
@@ -57,8 +57,9 @@ module tlul_err_resp (
   end
 
   // Waive unused bits of tl_h_i
-  logic unused_tl_h = &{1'b0,
-                        tl_h_i.a_param, tl_h_i.a_address, tl_h_i.a_mask,
-                        tl_h_i.a_data, tl_h_i.a_user, tl_h_i.d_ready};
+  logic unused_tl_h;
+  assign unused_tl_h = &{1'b0,
+                         tl_h_i.a_param, tl_h_i.a_address, tl_h_i.a_mask,
+                         tl_h_i.a_data, tl_h_i.a_user, tl_h_i.d_ready};
 
 endmodule


### PR DESCRIPTION
AscentLint quite reasonably warns that the code that was there is an
initial assignment that will be ignored in synthesis.

It seems that I'm trying to game my GitHub stats by pushing a plausible, but subtly broken, lint fix every morning. Sadly, I think my run has come to an end. With a bit of luck, this version of the code will avoid lint errors from both AscentLint and Verilator...