### PR TITLE
[top] Expand rom to 40b for slightly improved security properties

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -7381,7 +7381,7 @@
       base_addr: 0x00008000
       swaccess: ro
       size: 0x4000
-      integ_width: 7
+      integ_width: 8
       inter_signal_list:
       [
         {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -555,7 +555,7 @@
       swaccess: "ro",
       size: "0x4000",
       // data integrity width
-      integ_width: 7,
+      integ_width: 8,
       inter_signal_list: [
         { struct: "tl"
           package: "tlul_pkg"

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -726,7 +726,7 @@ module top_earlgrey #(
   // ROM device
   logic        rom_req;
   logic [11:0] rom_addr;
-  logic [38:0] rom_rdata;
+  logic [39:0] rom_rdata;
   logic        rom_rvalid;
 
   tlul_adapter_sram #(
@@ -753,7 +753,7 @@ module top_earlgrey #(
   );
 
   prim_rom_adv #(
-    .Width(39),
+    .Width(40),
     .Depth(4096),
     .MemInitFile(BootRomInitFile)
   ) u_rom_rom (


### PR DESCRIPTION
- Now all Rom nibbles will be fed through the 4-bit sbox, even if
  only 1 round of permutation is done for scrambling

Signed-off-by: Timothy Chen <timothytim@google.com>