### PR TITLE
[otbn] Fix bad_insn_addr ERR_BITS description

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -109,8 +109,7 @@
         { bits: "1",
           name: "bad_insn_addr"
           desc: '''
-            An IMEM read or write occurred with an out of bounds or unaligned
-            address.
+            An IMEM read occurred with an out of bounds or unaligned address.
           '''
         }
         { bits: "2",


### PR DESCRIPTION
Write to IMEM cannot occur from OTBN, so bad_insn_addr will only be
signalled on IMEM reads from OTBN.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>