### PR TITLE
[sw/dif_keymgr] Key manager DIF library implementation + unit tests

### DIFF
--- a/sw/device/lib/dif/dif_keymgr.c
+++ b/sw/device/lib/dif/dif_keymgr.c
@@ -5,3 +5,721 @@
 #include "sw/device/lib/dif/dif_keymgr.h"
 
 #include "keymgr_regs.h"  // Generated.
+
+/**
+ * Address spaces of SW_BINDING_N, SALT_N, SW_SHARE0_OUTPUT_N, and
+ * SW_SHARE1_OUTPUT_N registers must be contiguous to be able to use
+ * `mmio_region_memcpy_to/from_mmio32()`.
+ */
+_Static_assert(KEYMGR_SW_BINDING_1_REG_OFFSET ==
+                   KEYMGR_SW_BINDING_0_REG_OFFSET + 4,
+               "SW_BINDING_N registers must be contiguous.");
+_Static_assert(KEYMGR_SW_BINDING_2_REG_OFFSET ==
+                   KEYMGR_SW_BINDING_0_REG_OFFSET + 8,
+               "SW_BINDING_N registers must be contiguous.");
+_Static_assert(KEYMGR_SW_BINDING_3_REG_OFFSET ==
+                   KEYMGR_SW_BINDING_0_REG_OFFSET + 12,
+               "SW_BINDING_N registers must be contiguous.");
+// TODO: Uncomment when lowRISC/opentitan#5194 is completed.
+// TODO: Consider defining a macro once all assertions are enabled.
+//_Static_assert(KEYMGR_SW_BINDING_4_REG_OFFSET ==
+//                   KEYMGR_SW_BINDING_0_REG_OFFSET + 16,
+//               "SW_BINDING_N registers must be contiguous.");
+//_Static_assert(KEYMGR_SW_BINDING_5_REG_OFFSET ==
+//                   KEYMGR_SW_BINDING_0_REG_OFFSET + 20,
+//               "SW_BINDING_N registers must be contiguous.");
+//_Static_assert(KEYMGR_SW_BINDING_6_REG_OFFSET ==
+//                   KEYMGR_SW_BINDING_0_REG_OFFSET + 24,
+//               "SW_BINDING_N registers must be contiguous.");
+//_Static_assert(KEYMGR_SW_BINDING_7_REG_OFFSET ==
+//                   KEYMGR_SW_BINDING_0_REG_OFFSET + 28,
+//               "SW_BINDING_N registers must be contiguous.");
+
+_Static_assert(KEYMGR_SALT_1_REG_OFFSET == KEYMGR_SALT_0_REG_OFFSET + 4,
+               "SALT_N registers must be contiguous.");
+_Static_assert(KEYMGR_SALT_2_REG_OFFSET == KEYMGR_SALT_0_REG_OFFSET + 8,
+               "SALT_N registers must be contiguous.");
+_Static_assert(KEYMGR_SALT_3_REG_OFFSET == KEYMGR_SALT_0_REG_OFFSET + 12,
+               "SALT_N registers must be contiguous.");
+// TODO: Uncomment when lowRISC/opentitan#5194 is completed.
+//_Static_assert(KEYMGR_SALT_4_REG_OFFSET ==
+//                   KEYMGR_SALT_0_REG_OFFSET + 16,
+//               "SALT_N registers must be contiguous.");
+//_Static_assert(KEYMGR_SALT_5_REG_OFFSET ==
+//                   KEYMGR_SALT_0_REG_OFFSET + 20,
+//               "SALT_N registers must be contiguous.");
+//_Static_assert(KEYMGR_SALT_6_REG_OFFSET ==
+//                   KEYMGR_SALT_0_REG_OFFSET + 24,
+//               "SALT_N registers must be contiguous.");
+//_Static_assert(KEYMGR_SALT_7_REG_OFFSET ==
+//                   KEYMGR_SALT_0_REG_OFFSET + 28,
+//               "SALT_N registers must be contiguous.");
+
+_Static_assert(KEYMGR_SW_SHARE0_OUTPUT_1_REG_OFFSET ==
+                   KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 4,
+               "SW_SHARE0_OUTPUT_N registers must be contiguous.");
+_Static_assert(KEYMGR_SW_SHARE0_OUTPUT_2_REG_OFFSET ==
+                   KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 8,
+               "SW_SHARE0_OUTPUT_N registers must be contiguous.");
+_Static_assert(KEYMGR_SW_SHARE0_OUTPUT_3_REG_OFFSET ==
+                   KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 12,
+               "SW_SHARE0_OUTPUT_N registers must be contiguous.");
+_Static_assert(KEYMGR_SW_SHARE0_OUTPUT_4_REG_OFFSET ==
+                   KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 16,
+               "SW_SHARE0_OUTPUT_N registers must be contiguous.");
+_Static_assert(KEYMGR_SW_SHARE0_OUTPUT_5_REG_OFFSET ==
+                   KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 20,
+               "SW_SHARE0_OUTPUT_N registers must be contiguous.");
+_Static_assert(KEYMGR_SW_SHARE0_OUTPUT_6_REG_OFFSET ==
+                   KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 24,
+               "SW_SHARE0_OUTPUT_N registers must be contiguous.");
+_Static_assert(KEYMGR_SW_SHARE0_OUTPUT_7_REG_OFFSET ==
+                   KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 28,
+               "SW_SHARE0_OUTPUT_N registers must be contiguous.");
+
+_Static_assert(KEYMGR_SW_SHARE1_OUTPUT_1_REG_OFFSET ==
+                   KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 4,
+               "SW_SHARE1_OUTPUT_N registers must be contiguous.");
+_Static_assert(KEYMGR_SW_SHARE1_OUTPUT_2_REG_OFFSET ==
+                   KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 8,
+               "SW_SHARE1_OUTPUT_N registers must be contiguous.");
+_Static_assert(KEYMGR_SW_SHARE1_OUTPUT_3_REG_OFFSET ==
+                   KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 12,
+               "SW_SHARE1_OUTPUT_N registers must be contiguous.");
+_Static_assert(KEYMGR_SW_SHARE1_OUTPUT_4_REG_OFFSET ==
+                   KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 16,
+               "SW_SHARE1_OUTPUT_N registers must be contiguous.");
+_Static_assert(KEYMGR_SW_SHARE1_OUTPUT_5_REG_OFFSET ==
+                   KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 20,
+               "SW_SHARE1_OUTPUT_N registers must be contiguous.");
+_Static_assert(KEYMGR_SW_SHARE1_OUTPUT_6_REG_OFFSET ==
+                   KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 24,
+               "SW_SHARE1_OUTPUT_N registers must be contiguous.");
+_Static_assert(KEYMGR_SW_SHARE1_OUTPUT_7_REG_OFFSET ==
+                   KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 28,
+               "SW_SHARE1_OUTPUT_N registers must be contiguous.");
+
+/**
+ * Error code constants of `dif_keymgr_status_code_t` are masks for the bits of
+ * ERR_CODE register shifted left by 1.
+ */
+_Static_assert(kDifKeymgrStatusCodeInvalidOperation >> 1 ==
+                   1 << KEYMGR_ERR_CODE_INVALID_OP_BIT,
+               "Layout of ERR_CODE register changed.");
+_Static_assert(kDifKeymgrStatusCodeInvalidKmacCommand >> 1 ==
+                   1 << KEYMGR_ERR_CODE_INVALID_CMD_BIT,
+               "Layout of ERR_CODE register changed.");
+_Static_assert(kDifKeymgrStatusCodeInvalidKmacInput >> 1 ==
+                   1 << KEYMGR_ERR_CODE_INVALID_KMAC_INPUT_BIT,
+               "Layout of ERR_CODE register changed.");
+_Static_assert(kDifKeymgrStatusCodeInvalidKmacOutput >> 1 ==
+                   1 << KEYMGR_ERR_CODE_INVALID_KMAC_DATA_BIT,
+               "Layout of ERR_CODE register changed.");
+
+/**
+ * Checks if the key manager is ready for a new operation, i.e. it is idle and
+ * the CONFIG register is unlocked.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool is_ready(const dif_keymgr_t *keymgr) {
+  // Keymgr must be idle and the CONTROL register must be writable.
+  uint32_t reg_op_status =
+      mmio_region_read32(keymgr->params.base_addr, KEYMGR_OP_STATUS_REG_OFFSET);
+  if (bitfield_field32_read(reg_op_status, KEYMGR_OP_STATUS_STATUS_FIELD) !=
+      KEYMGR_OP_STATUS_STATUS_VALUE_IDLE) {
+    return false;
+  }
+  uint32_t reg_cfg_regwen = mmio_region_read32(keymgr->params.base_addr,
+                                               KEYMGR_CFG_REGWEN_REG_OFFSET);
+  return bitfield_bit32_read(reg_cfg_regwen, KEYMGR_CFG_REGWEN_EN_BIT);
+}
+
+/**
+ * Max key version register information for a state transition.
+ */
+typedef struct max_key_version_reg_info {
+  /**
+   * Whether max key version must be set for this transition or not.
+   */
+  bool is_required;
+  /**
+   * Max key version register offset to use.
+   */
+  uint32_t reg_offset;
+  /**
+   * Write-enable register offset to use.
+   */
+  uint32_t wen_reg_offset;
+  /**
+   * Write-enable bit index.
+   */
+  bitfield_bit32_index_t wen_bit_index;
+} max_key_version_reg_info_t;
+
+/**
+ * Returns max key version register information for transitioning from a state.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool get_max_key_version_reg_info_for_next_state(
+    uint32_t cur_state, max_key_version_reg_info_t *reg_info) {
+  switch (cur_state) {
+    case KEYMGR_WORKING_STATE_STATE_VALUE_INIT:
+      *reg_info = (max_key_version_reg_info_t){
+          .is_required = true,
+          .reg_offset = KEYMGR_MAX_CREATOR_KEY_VER_REG_OFFSET,
+          .wen_reg_offset = KEYMGR_MAX_CREATOR_KEY_VER_REGWEN_REG_OFFSET,
+          .wen_bit_index = KEYMGR_MAX_CREATOR_KEY_VER_REGWEN_EN_BIT,
+      };
+      return true;
+    case KEYMGR_WORKING_STATE_STATE_VALUE_CREATOR_ROOT_KEY:
+      *reg_info = (max_key_version_reg_info_t){
+          .is_required = true,
+          .reg_offset = KEYMGR_MAX_OWNER_INT_KEY_VER_REG_OFFSET,
+          .wen_reg_offset = KEYMGR_MAX_OWNER_INT_KEY_VER_REGWEN_REG_OFFSET,
+          .wen_bit_index = KEYMGR_MAX_OWNER_INT_KEY_VER_REGWEN_EN_BIT,
+      };
+      return true;
+    case KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_INTERMEDIATE_KEY:
+      *reg_info = (max_key_version_reg_info_t){
+          .is_required = true,
+          .reg_offset = KEYMGR_MAX_OWNER_KEY_VER_REG_OFFSET,
+          .wen_reg_offset = KEYMGR_MAX_OWNER_KEY_VER_REGWEN_REG_OFFSET,
+          .wen_bit_index = KEYMGR_MAX_OWNER_KEY_VER_REGWEN_EN_BIT,
+      };
+      return true;
+    case KEYMGR_WORKING_STATE_STATE_VALUE_RESET:
+    case KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_KEY:
+    case KEYMGR_WORKING_STATE_STATE_VALUE_DISABLED:
+    case KEYMGR_WORKING_STATE_STATE_VALUE_INVALID:
+      *reg_info = (max_key_version_reg_info_t){
+          .is_required = false,
+      };
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Parameters for starting a key manager operation.
+ *
+ * Values of the members must be the actual values that will be written to the
+ * CONTROL register.
+ */
+typedef struct start_operation_params {
+  /**
+   * Destination for this operation.
+   */
+  uint32_t dest;
+  /**
+   * Operation to start.
+   */
+  uint32_t op;
+} start_operation_params_t;
+
+/**
+ * Starts a key manager operation.
+ */
+static void start_operation(const dif_keymgr_t *keymgr,
+                            start_operation_params_t params) {
+  uint32_t reg_control =
+      bitfield_field32_write(0, KEYMGR_CONTROL_DEST_SEL_FIELD, params.dest);
+  reg_control = bitfield_field32_write(
+      reg_control, KEYMGR_CONTROL_OPERATION_FIELD, params.op);
+  reg_control =
+      bitfield_bit32_write(reg_control, KEYMGR_CONTROL_START_BIT, true);
+  mmio_region_write32(keymgr->params.base_addr, KEYMGR_CONTROL_REG_OFFSET,
+                      reg_control);
+}
+
+/**
+ * Returns the bit index for a given IRQ.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool get_irq_bit_index(dif_keymgr_irq_t irq,
+                              bitfield_bit32_index_t *bit_index) {
+  switch (irq) {
+    case kDifKeymgrIrqDone:
+      *bit_index = KEYMGR_INTR_COMMON_OP_DONE_BIT;
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Checks if a value is a valid `dif_keymgr_toggle_t` and converts it to `bool`.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool toggle_to_bool(dif_keymgr_toggle_t val, bool *val_bool) {
+  switch (val) {
+    case kDifKeymgrToggleEnabled:
+      *val_bool = true;
+      break;
+    case kDifKeymgrToggleDisabled:
+      *val_bool = false;
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+
+/**
+ * Converts a `bool` to `dif_keymgr_toggle_t`.
+ */
+static dif_keymgr_toggle_t bool_to_toggle(bool val) {
+  return val ? kDifKeymgrToggleEnabled : kDifKeymgrToggleDisabled;
+}
+
+dif_keymgr_result_t dif_keymgr_init(dif_keymgr_params_t params,
+                                    dif_keymgr_t *keymgr) {
+  if (keymgr == NULL) {
+    return kDifKeymgrBadArg;
+  }
+
+  *keymgr = (dif_keymgr_t){.params = params};
+
+  return kDifKeymgrOk;
+}
+
+dif_keymgr_result_t dif_keymgr_configure(const dif_keymgr_t *keymgr,
+                                         dif_keymgr_config_t config) {
+  if (keymgr == NULL) {
+    return kDifKeymgrBadArg;
+  }
+
+  uint32_t reg_val = bitfield_field32_write(0, KEYMGR_RESEED_INTERVAL_VAL_FIELD,
+                                            config.entropy_reseed_interval);
+  mmio_region_write32(keymgr->params.base_addr,
+                      KEYMGR_RESEED_INTERVAL_REG_OFFSET, reg_val);
+
+  return kDifKeymgrOk;
+}
+
+dif_keymgr_lockable_result_t dif_keymgr_advance_state(
+    const dif_keymgr_t *keymgr, const dif_keymgr_state_params_t *params) {
+  if (keymgr == NULL) {
+    return kDifKeymgrLockableBadArg;
+  }
+
+  if (!is_ready(keymgr)) {
+    return kDifKeymgrLockableLocked;
+  }
+
+  // Get current state and determine if we need to set the max key version and
+  // sw binding value.
+  max_key_version_reg_info_t max_key_ver_reg_info;
+  uint32_t reg_working_state = mmio_region_read32(
+      keymgr->params.base_addr, KEYMGR_WORKING_STATE_REG_OFFSET);
+  if (!get_max_key_version_reg_info_for_next_state(
+          (bitfield_field32_read(reg_working_state,
+                                 KEYMGR_WORKING_STATE_STATE_FIELD)),
+          &max_key_ver_reg_info)) {
+    return kDifKeymgrLockableError;
+  }
+
+  // Set the binding value and max key version if keymgr is going to
+  // transition to an operational state.
+  if (max_key_ver_reg_info.is_required) {
+    if (params == NULL) {
+      return kDifKeymgrLockableBadArg;
+    }
+
+    // Check if SW_BINDING_N registers are locked
+    uint32_t reg_sw_binding_wen = mmio_region_read32(
+        keymgr->params.base_addr, KEYMGR_SW_BINDING_REGWEN_REG_OFFSET);
+    if (!bitfield_bit32_read(reg_sw_binding_wen,
+                             KEYMGR_SW_BINDING_REGWEN_EN_BIT)) {
+      return kDifKeymgrLockableLocked;
+    }
+
+    // Check if MAX_*_KEY_VER register is locked.
+    uint32_t reg_max_key_ver_wen = mmio_region_read32(
+        keymgr->params.base_addr, max_key_ver_reg_info.wen_reg_offset);
+    if (!bitfield_bit32_read(reg_max_key_ver_wen,
+                             max_key_ver_reg_info.wen_bit_index)) {
+      return kDifKeymgrLockableLocked;
+    }
+
+    // Write and lock (rw0c) the software binding value. This register is
+    // unlocked by hardware upon a successful state transition.
+    mmio_region_memcpy_to_mmio32(
+        keymgr->params.base_addr, KEYMGR_SW_BINDING_0_REG_OFFSET,
+        params->binding_value, sizeof(params->binding_value));
+    mmio_region_write32(keymgr->params.base_addr,
+                        KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 0);
+
+    // Write and lock (rw0c) the max key version.
+    mmio_region_write32(keymgr->params.base_addr,
+                        max_key_ver_reg_info.reg_offset,
+                        params->max_key_version);
+    mmio_region_write32(keymgr->params.base_addr,
+                        max_key_ver_reg_info.wen_reg_offset, 0);
+  } else if (params != NULL) {
+    return kDifKeymgrLockableBadArg;
+  }
+
+  // Advance state.
+  start_operation(keymgr, (start_operation_params_t){
+                              .dest = KEYMGR_CONTROL_DEST_SEL_VALUE_NONE,
+                              .op = KEYMGR_CONTROL_OPERATION_VALUE_ADVANCE,
+                          });
+
+  return kDifKeymgrLockableOk;
+}
+
+dif_keymgr_lockable_result_t dif_keymgr_disable(const dif_keymgr_t *keymgr) {
+  if (keymgr == NULL) {
+    return kDifKeymgrLockableBadArg;
+  }
+
+  if (!is_ready(keymgr)) {
+    return kDifKeymgrLockableLocked;
+  }
+
+  // Disable key manager.
+  start_operation(keymgr, (start_operation_params_t){
+                              .dest = KEYMGR_CONTROL_DEST_SEL_VALUE_NONE,
+                              .op = KEYMGR_CONTROL_OPERATION_VALUE_DISABLE,
+                          });
+
+  return kDifKeymgrLockableOk;
+}
+
+dif_keymgr_result_t dif_keymgr_get_status_codes(
+    const dif_keymgr_t *keymgr, dif_keymgr_status_codes_t *status_codes) {
+  if (keymgr == NULL || status_codes == NULL) {
+    return kDifKeymgrBadArg;
+  }
+
+  // Read and clear OP_STATUS register (rw1c).
+  uint32_t reg_op_status =
+      mmio_region_read32(keymgr->params.base_addr, KEYMGR_OP_STATUS_REG_OFFSET);
+  mmio_region_write32(keymgr->params.base_addr, KEYMGR_OP_STATUS_REG_OFFSET,
+                      reg_op_status);
+
+  bool is_idle = false;
+  bool has_error = false;
+  switch (reg_op_status) {
+    case KEYMGR_OP_STATUS_STATUS_VALUE_IDLE:
+      is_idle = true;
+      break;
+    case KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS:
+      is_idle = true;
+      break;
+    case KEYMGR_OP_STATUS_STATUS_VALUE_DONE_ERROR:
+      is_idle = true;
+      has_error = true;
+      break;
+    case KEYMGR_OP_STATUS_STATUS_VALUE_WIP:
+      break;
+    default:
+      return kDifKeymgrError;
+  }
+
+  // Bit 0 of `dif_keymgr_status_codes_t` indicates whether the key manager is
+  // idle or not.
+  *status_codes = bitfield_bit32_write(0, 0, is_idle);
+
+  if (has_error) {
+    // Read and clear ERR_CODE register (rw1c).
+    uint32_t reg_err_code = mmio_region_read32(keymgr->params.base_addr,
+                                               KEYMGR_ERR_CODE_REG_OFFSET);
+    mmio_region_write32(keymgr->params.base_addr, KEYMGR_ERR_CODE_REG_OFFSET,
+                        reg_err_code);
+    // Error bits start from bit 1 in `dif_keymgr_status_codes_t`.
+    // Note: The mask is hardcoded since it is not auto generated yet.
+    const bitfield_field32_t kErrorBitfield = (bitfield_field32_t){
+        .mask = 0xF,
+        .index = 1,
+    };
+    if (reg_err_code > kErrorBitfield.mask || reg_err_code == 0) {
+      return kDifKeymgrError;
+    }
+    *status_codes =
+        bitfield_field32_write(*status_codes, kErrorBitfield, reg_err_code);
+  }
+
+  return kDifKeymgrOk;
+}
+
+dif_keymgr_result_t dif_keymgr_get_state(const dif_keymgr_t *keymgr,
+                                         dif_keymgr_state_t *state) {
+  if (keymgr == NULL || state == NULL) {
+    return kDifKeymgrBadArg;
+  }
+
+  uint32_t reg_state = mmio_region_read32(keymgr->params.base_addr,
+                                          KEYMGR_WORKING_STATE_REG_OFFSET);
+
+  switch (bitfield_field32_read(reg_state, KEYMGR_WORKING_STATE_STATE_FIELD)) {
+    case KEYMGR_WORKING_STATE_STATE_VALUE_RESET:
+      *state = kDifKeymgrStateReset;
+      return kDifKeymgrOk;
+    case KEYMGR_WORKING_STATE_STATE_VALUE_INIT:
+      *state = kDifKeymgrStateInitialized;
+      return kDifKeymgrOk;
+    case KEYMGR_WORKING_STATE_STATE_VALUE_CREATOR_ROOT_KEY:
+      *state = kDifKeymgrStateCreatorRootKey;
+      return kDifKeymgrOk;
+    case KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_INTERMEDIATE_KEY:
+      *state = kDifKeymgrStateOwnerIntermediateKey;
+      return kDifKeymgrOk;
+    case KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_KEY:
+      *state = kDifKeymgrStateOwnerRootKey;
+      return kDifKeymgrOk;
+    case KEYMGR_WORKING_STATE_STATE_VALUE_DISABLED:
+      *state = kDifKeymgrStateDisabled;
+      return kDifKeymgrOk;
+    case KEYMGR_WORKING_STATE_STATE_VALUE_INVALID:
+      *state = kDifKeymgrStateInvalid;
+      return kDifKeymgrOk;
+    default:
+      return kDifKeymgrError;
+  }
+}
+
+dif_keymgr_lockable_result_t dif_keymgr_generate_identity_seed(
+    const dif_keymgr_t *keymgr) {
+  if (keymgr == NULL) {
+    return kDifKeymgrLockableBadArg;
+  }
+
+  if (!is_ready(keymgr)) {
+    return kDifKeymgrLockableLocked;
+  }
+
+  start_operation(keymgr, (start_operation_params_t){
+                              .dest = KEYMGR_CONTROL_DEST_SEL_VALUE_NONE,
+                              .op = KEYMGR_CONTROL_OPERATION_VALUE_GENERATE_ID,
+                          });
+
+  return kDifKeymgrLockableOk;
+}
+
+dif_keymgr_lockable_result_t dif_keymgr_generate_versioned_key(
+    const dif_keymgr_t *keymgr, dif_keymgr_versioned_key_params_t params) {
+  if (keymgr == NULL) {
+    return kDifKeymgrLockableBadArg;
+  }
+
+  start_operation_params_t hw_op_params;
+  switch (params.dest) {
+    case kDifKeymgrVersionedKeyDestSw:
+      hw_op_params = (start_operation_params_t){
+          .dest = KEYMGR_CONTROL_DEST_SEL_VALUE_NONE,
+          .op = KEYMGR_CONTROL_OPERATION_VALUE_GENERATE_SW_OUTPUT,
+      };
+      break;
+    case kDifKeymgrVersionedKeyDestAes:
+      hw_op_params = (start_operation_params_t){
+          .dest = KEYMGR_CONTROL_DEST_SEL_VALUE_AES,
+          .op = KEYMGR_CONTROL_OPERATION_VALUE_GENERATE_HW_OUTPUT,
+      };
+      break;
+    case kDifKeymgrVersionedKeyDestHmac:
+      hw_op_params = (start_operation_params_t){
+          .dest = KEYMGR_CONTROL_DEST_SEL_VALUE_HMAC,
+          .op = KEYMGR_CONTROL_OPERATION_VALUE_GENERATE_HW_OUTPUT,
+      };
+      break;
+    case kDifKeymgrVersionedKeyDestKmac:
+      hw_op_params = (start_operation_params_t){
+          .dest = KEYMGR_CONTROL_DEST_SEL_VALUE_KMAC,
+          .op = KEYMGR_CONTROL_OPERATION_VALUE_GENERATE_HW_OUTPUT,
+      };
+      break;
+    default:
+      return kDifKeymgrLockableBadArg;
+  }
+
+  if (!is_ready(keymgr)) {
+    return kDifKeymgrLockableLocked;
+  }
+
+  // Set salt and version
+  mmio_region_memcpy_to_mmio32(keymgr->params.base_addr,
+                               KEYMGR_SALT_0_REG_OFFSET, params.salt,
+                               sizeof(params.salt));
+  mmio_region_write32(keymgr->params.base_addr, KEYMGR_KEY_VERSION_REG_OFFSET,
+                      params.version);
+
+  start_operation(keymgr, hw_op_params);
+
+  return kDifKeymgrLockableOk;
+}
+
+dif_keymgr_result_t dif_keymgr_sideload_clear_set_enabled(
+    const dif_keymgr_t *keymgr, dif_keymgr_toggle_t state) {
+  bool enable = false;
+  if (keymgr == NULL || !toggle_to_bool(state, &enable)) {
+    return kDifKeymgrBadArg;
+  }
+
+  mmio_region_write32(
+      keymgr->params.base_addr, KEYMGR_SIDELOAD_CLEAR_REG_OFFSET,
+      bitfield_bit32_write(0, KEYMGR_SIDELOAD_CLEAR_VAL_BIT, enable));
+
+  return kDifKeymgrOk;
+}
+
+dif_keymgr_result_t dif_keymgr_sideload_clear_get_enabled(
+    const dif_keymgr_t *keymgr, dif_keymgr_toggle_t *state) {
+  if (keymgr == NULL || state == NULL) {
+    return kDifKeymgrBadArg;
+  }
+
+  uint32_t reg_val = mmio_region_read32(keymgr->params.base_addr,
+                                        KEYMGR_SIDELOAD_CLEAR_REG_OFFSET);
+  *state = bool_to_toggle(
+      bitfield_bit32_read(reg_val, KEYMGR_SIDELOAD_CLEAR_VAL_BIT));
+
+  return kDifKeymgrOk;
+}
+
+dif_keymgr_result_t dif_keymgr_read_output(const dif_keymgr_t *keymgr,
+                                           dif_keymgr_output_t *output) {
+  if (keymgr == NULL || output == NULL) {
+    return kDifKeymgrBadArg;
+  }
+
+  mmio_region_memcpy_from_mmio32(keymgr->params.base_addr,
+                                 KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET,
+                                 output->value[0], sizeof(output->value[0]));
+  mmio_region_memcpy_from_mmio32(keymgr->params.base_addr,
+                                 KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET,
+                                 output->value[1], sizeof(output->value[1]));
+
+  return kDifKeymgrOk;
+}
+
+dif_keymgr_result_t dif_keymgr_alert_force(const dif_keymgr_t *keymgr,
+                                           dif_keymgr_alert_t alert) {
+  if (keymgr == NULL) {
+    return kDifKeymgrBadArg;
+  }
+
+  bitfield_bit32_index_t bit_index;
+  switch (alert) {
+    case kDifKeymgrAlertHardware:
+      bit_index = KEYMGR_ALERT_TEST_FATAL_FAULT_ERR_BIT;
+      break;
+    case kDifKeymgrAlertSoftware:
+      bit_index = KEYMGR_ALERT_TEST_RECOV_OPERATION_ERR_BIT;
+      break;
+    default:
+      return kDifKeymgrBadArg;
+  }
+
+  mmio_region_write32(keymgr->params.base_addr, KEYMGR_ALERT_TEST_REG_OFFSET,
+                      bitfield_bit32_write(0, bit_index, true));
+
+  return kDifKeymgrOk;
+}
+
+dif_keymgr_result_t dif_keymgr_irq_is_pending(const dif_keymgr_t *keymgr,
+                                              dif_keymgr_irq_t irq,
+                                              bool *is_pending) {
+  bitfield_bit32_index_t bit_index;
+  if (keymgr == NULL || !get_irq_bit_index(irq, &bit_index) ||
+      is_pending == NULL) {
+    return kDifKeymgrBadArg;
+  }
+
+  uint32_t reg_val = mmio_region_read32(keymgr->params.base_addr,
+                                        KEYMGR_INTR_STATE_REG_OFFSET);
+  *is_pending = bitfield_bit32_read(reg_val, bit_index);
+
+  return kDifKeymgrOk;
+}
+
+dif_keymgr_result_t dif_keymgr_irq_acknowledge(const dif_keymgr_t *keymgr,
+                                               dif_keymgr_irq_t irq) {
+  bitfield_bit32_index_t bit_index;
+  if (keymgr == NULL || !get_irq_bit_index(irq, &bit_index)) {
+    return kDifKeymgrBadArg;
+  }
+
+  uint32_t reg_val = bitfield_bit32_write(0, bit_index, true);
+  mmio_region_write32(keymgr->params.base_addr, KEYMGR_INTR_STATE_REG_OFFSET,
+                      reg_val);
+
+  return kDifKeymgrOk;
+}
+
+dif_keymgr_result_t dif_keymgr_irq_get_enabled(const dif_keymgr_t *keymgr,
+                                               dif_keymgr_irq_t irq,
+                                               dif_keymgr_toggle_t *state) {
+  bitfield_bit32_index_t bit_index;
+  if (keymgr == NULL || !get_irq_bit_index(irq, &bit_index) || state == NULL) {
+    return kDifKeymgrBadArg;
+  }
+
+  uint32_t reg_val = mmio_region_read32(keymgr->params.base_addr,
+                                        KEYMGR_INTR_ENABLE_REG_OFFSET);
+  *state = bool_to_toggle(bitfield_bit32_read(reg_val, bit_index));
+
+  return kDifKeymgrOk;
+}
+
+dif_keymgr_result_t dif_keymgr_irq_set_enabled(const dif_keymgr_t *keymgr,
+                                               dif_keymgr_irq_t irq,
+                                               dif_keymgr_toggle_t state) {
+  bitfield_bit32_index_t bit_index;
+  bool enable = false;
+  if (keymgr == NULL || !get_irq_bit_index(irq, &bit_index) ||
+      !toggle_to_bool(state, &enable)) {
+    return kDifKeymgrBadArg;
+  }
+
+  uint32_t reg_val = mmio_region_read32(keymgr->params.base_addr,
+                                        KEYMGR_INTR_ENABLE_REG_OFFSET);
+  reg_val = bitfield_bit32_write(reg_val, bit_index, enable);
+  mmio_region_write32(keymgr->params.base_addr, KEYMGR_INTR_ENABLE_REG_OFFSET,
+                      reg_val);
+
+  return kDifKeymgrOk;
+}
+
+dif_keymgr_result_t dif_keymgr_irq_force(const dif_keymgr_t *keymgr,
+                                         dif_keymgr_irq_t irq) {
+  bitfield_bit32_index_t bit_index;
+  if (keymgr == NULL || !get_irq_bit_index(irq, &bit_index)) {
+    return kDifKeymgrBadArg;
+  }
+
+  uint32_t reg_val = bitfield_bit32_write(0, bit_index, true);
+  mmio_region_write32(keymgr->params.base_addr, KEYMGR_INTR_TEST_REG_OFFSET,
+                      reg_val);
+
+  return kDifKeymgrOk;
+}
+
+dif_keymgr_result_t dif_keymgr_irq_disable_all(
+    const dif_keymgr_t *keymgr, dif_keymgr_irq_snapshot_t *snapshot) {
+  if (keymgr == NULL) {
+    return kDifKeymgrBadArg;
+  }
+
+  if (snapshot != NULL) {
+    *snapshot = mmio_region_read32(keymgr->params.base_addr,
+                                   KEYMGR_INTR_ENABLE_REG_OFFSET);
+  }
+  mmio_region_write32(keymgr->params.base_addr, KEYMGR_INTR_ENABLE_REG_OFFSET,
+                      0);
+
+  return kDifKeymgrOk;
+}
+
+dif_keymgr_result_t dif_keymgr_irq_restore_all(
+    const dif_keymgr_t *keymgr, const dif_keymgr_irq_snapshot_t *snapshot) {
+  if (keymgr == NULL || snapshot == NULL) {
+    return kDifKeymgrBadArg;
+  }
+
+  mmio_region_write32(keymgr->params.base_addr, KEYMGR_INTR_ENABLE_REG_OFFSET,
+                      *snapshot);
+
+  return kDifKeymgrOk;
+}

--- a/sw/device/lib/dif/dif_keymgr.md
+++ b/sw/device/lib/dif/dif_keymgr.md
@@ -11,17 +11,15 @@ All checklist items refer to the content in the [Checklist]({{< relref "/doc/pro
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
-Implementation | [DIF_EXISTS][]       | Not Started |
-Implementation | [DIF_USED_IN_TREE][] | Not Started |
-Tests          | [DIF_TEST_UNIT][]    | Not Started |
+Implementation | [DIF_EXISTS][]       | Done        |
+Implementation | [DIF_USED_IN_TREE][] | Done        | Not used prior to DIF implementation.
+Tests          | [DIF_TEST_UNIT][]    | Done        |
 Tests          | [DIF_TEST_SMOKE][]   | Not Started |
-Review         | Reviewer(s)          | Not Started |
-Review         | Signoff date         | Not Started |
 
-[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif-exists" >}}
-[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif-used-in-tree" >}}
-[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif-test-unit" >}}
-[DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif-test-smoke" >}}
+[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
+[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
+[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
+[DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
 
 ### S2
 
@@ -37,18 +35,16 @@ Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
 Coordination   | [DIF_DV_TESTS][]            | Not Started |
 Implementation | [DIF_USED_TOCK][]           | Not Started |
 Review         | HW IP Usage Reviewer(s)     | Not Started |
-Review         | Reviewer(s)                 | Not Started |
-Review         | Signoff date                | Not Started |
 
-[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif-features" >}}
-[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif-hw-usage-reviewed" >}}
-[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-feature-complete" >}}
-[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif-hw-params" >}}
-[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif-doc-hw" >}}
-[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif-doc-api" >}}
-[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif-code-style" >}}
-[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif-dv-tests" >}}
-[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif-used-tock" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
+[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif_hw_usage_reviewed" >}}
+[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
+[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif_hw_params" >}}
+[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif_doc_api" >}}
+[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
+[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif_used_tock" >}}
 
 ### S3
 
@@ -63,9 +59,9 @@ Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |
 
-[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-hw-design-complete" >}}
-[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-verification-complete" >}}
-[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif-review-c-stable" >}}
-[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-test-unit-complete" >}}
-[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif-todo-complete" >}}
-[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif-review-tock-stable" >}}
+[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
+[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
+[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif_review_c_stable" >}}
+[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_test_unit_complete" >}}
+[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}
+[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif_review_tock_stable" >}}

--- a/sw/device/lib/testing/mock_mmio.h
+++ b/sw/device/lib/testing/mock_mmio.h
@@ -5,12 +5,11 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_MOCK_MMIO_H_
 #define OPENTITAN_SW_DEVICE_LIB_TESTING_MOCK_MMIO_H_
 
-#include <stdint.h>
-#include <string.h>
-
 #include <initializer_list>
 #include <memory>
 #include <random>
+#include <stdint.h>
+#include <string.h>
 #include <vector>
 
 #include "gmock/gmock.h"
@@ -112,12 +111,14 @@ Int ToInt(LittleEndianBytes str) {
  * `BitField`'s documentation for details one what this means. This overload
  * enables bitfield EXPECT_* macros:
  *   EXPECT_READ32(offset, {{A_OFFSET, 0x55}, {B_OFFSET, 0xaa}});
+ *   EXPECT_READ32(offset, fields);
+ * where `fields` is an `std::vector<BitField>`.
  *
  * @param fields a list of bit field entries.
  * @return a value of type `Int` built out of `fields`.
  */
 template <typename Int>
-Int ToInt(std::initializer_list<BitField> fields) {
+Int ToInt(std::vector<BitField> fields) {
   Int val = 0;
   for (auto field : fields) {
     // Due to the way that gtest ASSERT_* works, and the fact that this must be

--- a/sw/device/tests/dif/dif_keymgr_unittest.cc
+++ b/sw/device/tests/dif/dif_keymgr_unittest.cc
@@ -1,0 +1,1114 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_keymgr.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/testing/mock_mmio.h"
+
+#include "keymgr_regs.h"  // Generated
+
+namespace dif_keymgr_unittest {
+namespace {
+
+/**
+ * Returns a `uint32_t` with a single zero bit.
+ */
+uint32_t AllOnesExcept(uint32_t index) { return ~(1u << index); }
+
+/**
+ * Returns a vector of values for a given enum type.
+ *
+ * Assumes that the values are sequential and the first value is 0. `last` must
+ * be the last valid value for the given enum and is included in the returned
+ * vector.
+ */
+template <typename T>
+std::vector<T> CreateEnumVector(T last) {
+  using TT = typename std::underlying_type<T>::type;
+  std::vector<T> res;
+  for (TT i = 0; i <= static_cast<TT>(last); ++i) {
+    res.push_back(static_cast<T>(i));
+  }
+  return res;
+}
+
+/**
+ * Returns a seemingly valid, i.e. nonzero, pointer for the given type or a
+ * `nullptr`.
+ */
+template <typename T>
+T *GetGoodBadPtrArg(bool is_good) {
+  if (is_good) {
+    return reinterpret_cast<T *>(alignof(T));
+  } else {
+    return nullptr;
+  }
+}
+
+/**
+ * Returns a valid or invalid value for the given enum type.
+ *
+ * `last` must be the last valid value of the given enum type and `last+1` must
+ * be an invalid value.
+ */
+template <typename T>
+T GetGoodBadEnumArg(bool is_good, T last) {
+  if (is_good) {
+    return last;
+  } else {
+    return static_cast<T>(last + 1);
+  }
+}
+
+/**
+ * Constants used in tests.
+ */
+static constexpr std::array<uint32_t, 3> kStatesWithOperationalNextStates{
+    KEYMGR_WORKING_STATE_STATE_VALUE_INIT,
+    KEYMGR_WORKING_STATE_STATE_VALUE_CREATOR_ROOT_KEY,
+    KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_INTERMEDIATE_KEY,
+};
+static constexpr std::array<uint32_t, 4> kStatesWithNonOperationalNextStates{
+    KEYMGR_WORKING_STATE_STATE_VALUE_RESET,
+    KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_KEY,
+    KEYMGR_WORKING_STATE_STATE_VALUE_DISABLED,
+    KEYMGR_WORKING_STATE_STATE_VALUE_INVALID,
+};
+
+class DifKeymgrTest : public testing::Test, public mock_mmio::MmioTest {
+ protected:
+  /**
+   * Parameters for initializing a `dif_keymgr_t`.
+   */
+  const dif_keymgr_params_t params_ = {.base_addr = dev().region()};
+};
+
+/**
+ * Class for parameterizing bad argument tests for functions with two arguments.
+ */
+class BadArgsTwo : public DifKeymgrTest,
+                   public testing::WithParamInterface<std::tuple<bool, bool>> {
+ protected:
+  bool AllParamsGood() {
+    return std::get<0>(GetParam()) && std::get<1>(GetParam());
+  }
+
+  void SetUp() override {
+    if (AllParamsGood()) {
+      // Only test negative cases.
+      GTEST_SKIP();
+    }
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    BadArgsTwo, BadArgsTwo, testing::Combine(testing::Bool(), testing::Bool()),
+    [&](testing::TestParamInfo<std::tuple<bool, bool>> info) {
+      auto stringify = [](bool foo) { return foo ? "Good" : "Bad"; };
+      std::stringstream ss;
+      ss << stringify(std::get<0>(info.param))
+         << stringify(std::get<1>(info.param));
+      return ss.str();
+    });
+
+/**
+ * Class for parameterizing bad argument tests for functions with three
+ * arguments.
+ */
+class BadArgsThree
+    : public DifKeymgrTest,
+      public testing::WithParamInterface<std::tuple<bool, bool, bool>> {
+ protected:
+  bool AllParamsGood() {
+    return std::get<0>(GetParam()) && std::get<1>(GetParam()) &&
+           std::get<2>(GetParam());
+  }
+
+  void SetUp() override {
+    if (AllParamsGood()) {
+      // Only test negative cases.
+      GTEST_SKIP();
+    }
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    BadArgsThree, BadArgsThree,
+    testing::Combine(testing::Bool(), testing::Bool(), testing::Bool()),
+    [&](testing::TestParamInfo<std::tuple<bool, bool, bool>> info) {
+      auto stringify = [](bool foo) { return foo ? "Good" : "Bad"; };
+      std::stringstream ss;
+      ss << stringify(std::get<0>(info.param))
+         << stringify(std::get<1>(info.param))
+         << stringify(std::get<2>(info.param));
+      return ss.str();
+    });
+
+class InitTest : public DifKeymgrTest {};
+
+TEST_F(InitTest, BadArgs) {
+  EXPECT_EQ(dif_keymgr_init(params_, nullptr), kDifKeymgrBadArg);
+}
+
+TEST_F(InitTest, Init) {
+  dif_keymgr_t keymgr;
+  EXPECT_EQ(dif_keymgr_init(params_, &keymgr), kDifKeymgrOk);
+}
+
+/**
+ * Base class for the rest of the tests in this file, provides a
+ * `dif_keymgr_t` instance and some methods for common expectations.
+ */
+class DifKeymgrInitialized : public DifKeymgrTest {
+ protected:
+  /**
+   * Expectations for an idle key manager.
+   */
+  void ExpectIdle() {
+    EXPECT_READ32(KEYMGR_OP_STATUS_REG_OFFSET,
+                  {{
+                      .offset = KEYMGR_OP_STATUS_STATUS_OFFSET,
+                      .value = KEYMGR_OP_STATUS_STATUS_VALUE_IDLE,
+                  }});
+    EXPECT_READ32(KEYMGR_CFG_REGWEN_REG_OFFSET,
+                  {{
+                      .offset = KEYMGR_CFG_REGWEN_EN_BIT,
+                      .value = 1,
+                  }});
+  }
+
+  /**
+   * Expectations for an idle key manager at a given state.
+   */
+  void ExpectIdleAtState(uint32_t state) {
+    ExpectIdle();
+    EXPECT_READ32(KEYMGR_WORKING_STATE_REG_OFFSET,
+                  {{
+                      .offset = KEYMGR_WORKING_STATE_STATE_OFFSET,
+                      .value = state,
+                  }});
+  }
+
+  /**
+   * Expectations for a busy key manager.
+   */
+  void ExpectBusy() {
+    EXPECT_READ32(KEYMGR_OP_STATUS_REG_OFFSET,
+                  {{
+                      .offset = KEYMGR_OP_STATUS_STATUS_OFFSET,
+                      .value = KEYMGR_OP_STATUS_STATUS_VALUE_WIP,
+                  }});
+  }
+
+  /**
+   * Expectations for a locked CONFIG register.
+   */
+  void ExpectLockedConfig() {
+    EXPECT_READ32(KEYMGR_OP_STATUS_REG_OFFSET,
+                  {{
+                      .offset = KEYMGR_OP_STATUS_STATUS_OFFSET,
+                      .value = KEYMGR_OP_STATUS_STATUS_VALUE_IDLE,
+                  }});
+    EXPECT_READ32(KEYMGR_CFG_REGWEN_REG_OFFSET,
+                  AllOnesExcept(KEYMGR_CFG_REGWEN_EN_BIT));
+  }
+
+  struct OperationStartParams {
+    uint32_t dest_sel;
+    uint32_t operation;
+  };
+
+  /**
+   * Expectations for starting an operation.
+   */
+  void ExpectOperationStart(const OperationStartParams &params) {
+    EXPECT_WRITE32(KEYMGR_CONTROL_REG_OFFSET,
+                   {{
+                        .offset = KEYMGR_CONTROL_DEST_SEL_OFFSET,
+                        .value = params.dest_sel,
+                    },
+                    {
+                        .offset = KEYMGR_CONTROL_OPERATION_OFFSET,
+                        .value = params.operation,
+                    },
+                    {
+                        .offset = KEYMGR_CONTROL_START_BIT,
+                        .value = 1,
+                    }});
+  }
+
+  /**
+   * Initialized `dif_keymgr_t` used in tests.
+   */
+  const dif_keymgr_t keymgr_ = {.params = params_};
+};
+
+class ConfigureTest : public DifKeymgrInitialized {};
+
+TEST_F(ConfigureTest, BadArgs) {
+  EXPECT_EQ(dif_keymgr_configure(nullptr, {}), kDifKeymgrBadArg);
+}
+
+TEST_F(ConfigureTest, Configure) {
+  constexpr dif_keymgr_config_t kConfig = {.entropy_reseed_interval = 0xA5A5};
+
+  EXPECT_WRITE32(KEYMGR_RESEED_INTERVAL_REG_OFFSET,
+                 kConfig.entropy_reseed_interval);
+
+  EXPECT_EQ(dif_keymgr_configure(&keymgr_, kConfig), kDifKeymgrOk);
+}
+
+class AdvanceStateTest : public DifKeymgrInitialized {
+ protected:
+  dif_keymgr_state_params_t kStateParams{
+      .binding_value = {0xFF, 0xC3, 0xB9, 0xA5, 0x00, 0x3C, 0x46, 0x5A},
+      .max_key_version = 0xA5A5A5A5,
+  };
+
+  struct MaxKeyVersionRegInfo {
+    uint32_t offset;
+    uint32_t wen_offset;
+    uint32_t wen_bit_index;
+  };
+
+  /**
+   * Returns max key version register information for the given state.
+   */
+  MaxKeyVersionRegInfo GetMaxKeyVersionRegInfo(uint32_t state) {
+    switch (state) {
+      case KEYMGR_WORKING_STATE_STATE_VALUE_INIT:
+        return {
+            .offset = KEYMGR_MAX_CREATOR_KEY_VER_REG_OFFSET,
+            .wen_offset = KEYMGR_MAX_CREATOR_KEY_VER_REGWEN_REG_OFFSET,
+            .wen_bit_index = KEYMGR_MAX_CREATOR_KEY_VER_REGWEN_EN_BIT,
+        };
+      case KEYMGR_WORKING_STATE_STATE_VALUE_CREATOR_ROOT_KEY:
+        return {
+            .offset = KEYMGR_MAX_OWNER_INT_KEY_VER_REG_OFFSET,
+            .wen_offset = KEYMGR_MAX_OWNER_INT_KEY_VER_REGWEN_REG_OFFSET,
+            .wen_bit_index = KEYMGR_MAX_OWNER_INT_KEY_VER_REGWEN_EN_BIT,
+        };
+      case KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_INTERMEDIATE_KEY:
+        return {
+            .offset = KEYMGR_MAX_OWNER_KEY_VER_REG_OFFSET,
+            .wen_offset = KEYMGR_MAX_OWNER_KEY_VER_REGWEN_REG_OFFSET,
+            .wen_bit_index = KEYMGR_MAX_OWNER_KEY_VER_REGWEN_EN_BIT,
+        };
+      default:
+        ADD_FAILURE();
+        abort();
+        break;
+    }
+  }
+};
+
+TEST_F(AdvanceStateTest, BadArgsNoKeymgr) {
+  EXPECT_EQ(dif_keymgr_advance_state(nullptr, &kStateParams),
+            kDifKeymgrLockableBadArg);
+  EXPECT_EQ(dif_keymgr_advance_state(nullptr, nullptr),
+            kDifKeymgrLockableBadArg);
+}
+
+class AdvanceToOperational : public AdvanceStateTest,
+                             public testing::WithParamInterface<uint32_t> {};
+
+TEST_P(AdvanceToOperational, BadArgsToOperationalWithoutParams) {
+  ExpectIdleAtState(GetParam());
+
+  EXPECT_EQ(dif_keymgr_advance_state(&keymgr_, nullptr),
+            kDifKeymgrLockableBadArg);
+}
+
+INSTANTIATE_TEST_SUITE_P(AdvanceToOperational, AdvanceToOperational,
+                         testing::ValuesIn(kStatesWithOperationalNextStates));
+
+class AdvanceToNonOperational : public AdvanceStateTest,
+                                public testing::WithParamInterface<uint32_t> {};
+
+TEST_P(AdvanceToNonOperational, BadArgsToNonOperationalWithParams) {
+  ExpectIdleAtState(GetParam());
+
+  EXPECT_EQ(dif_keymgr_advance_state(&keymgr_, &kStateParams),
+            kDifKeymgrLockableBadArg);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AdvanceToNonOperational, AdvanceToNonOperational,
+    testing::ValuesIn(kStatesWithNonOperationalNextStates));
+
+TEST_F(AdvanceStateTest, LockedBusy) {
+  ExpectBusy();
+
+  EXPECT_EQ(dif_keymgr_advance_state(&keymgr_, &kStateParams),
+            kDifKeymgrLockableLocked);
+}
+
+TEST_F(AdvanceStateTest, LockedConfig) {
+  ExpectLockedConfig();
+
+  EXPECT_EQ(dif_keymgr_advance_state(&keymgr_, &kStateParams),
+            kDifKeymgrLockableLocked);
+}
+
+TEST_P(AdvanceToOperational, LockedBinding) {
+  ExpectIdleAtState(GetParam());
+  EXPECT_READ32(KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 0);
+
+  EXPECT_EQ(dif_keymgr_advance_state(&keymgr_, &kStateParams),
+            kDifKeymgrLockableLocked);
+}
+
+TEST_P(AdvanceToOperational, LockedMaxKeyVersion) {
+  ExpectIdleAtState(GetParam());
+  EXPECT_READ32(KEYMGR_SW_BINDING_REGWEN_REG_OFFSET,
+                {{
+                    .offset = KEYMGR_SW_BINDING_REGWEN_EN_BIT,
+                    .value = 1,
+                }});
+  EXPECT_READ32(GetMaxKeyVersionRegInfo(GetParam()).wen_offset, 0);
+
+  EXPECT_EQ(dif_keymgr_advance_state(&keymgr_, &kStateParams),
+            kDifKeymgrLockableLocked);
+}
+
+TEST_P(AdvanceToOperational, Success) {
+  ExpectIdleAtState(GetParam());
+  EXPECT_READ32(KEYMGR_SW_BINDING_REGWEN_REG_OFFSET,
+                {{
+                    .offset = KEYMGR_SW_BINDING_REGWEN_EN_BIT,
+                    .value = 1,
+                }});
+  auto reg_info = GetMaxKeyVersionRegInfo(GetParam());
+  EXPECT_READ32(reg_info.wen_offset, {{
+                                         .offset = reg_info.wen_bit_index,
+                                         .value = 1,
+                                     }});
+  size_t binding_len = sizeof(kStateParams.binding_value) /
+                       sizeof(kStateParams.binding_value[0]);
+  for (size_t i = 0; i < binding_len; ++i) {
+    EXPECT_WRITE32(KEYMGR_SW_BINDING_0_REG_OFFSET + i * 4,
+                   kStateParams.binding_value[i]);
+  }
+  EXPECT_WRITE32(KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 0);
+  EXPECT_WRITE32(reg_info.offset, kStateParams.max_key_version);
+  EXPECT_WRITE32(reg_info.wen_offset, 0);
+  ExpectOperationStart({
+      .dest_sel = KEYMGR_CONTROL_DEST_SEL_VALUE_NONE,
+      .operation = KEYMGR_CONTROL_OPERATION_VALUE_ADVANCE,
+  });
+
+  EXPECT_EQ(dif_keymgr_advance_state(&keymgr_, &kStateParams),
+            kDifKeymgrLockableOk);
+}
+
+TEST_P(AdvanceToNonOperational, Success) {
+  ExpectIdleAtState(GetParam());
+  ExpectOperationStart({
+      .dest_sel = KEYMGR_CONTROL_DEST_SEL_VALUE_NONE,
+      .operation = KEYMGR_CONTROL_OPERATION_VALUE_ADVANCE,
+  });
+
+  EXPECT_EQ(dif_keymgr_advance_state(&keymgr_, nullptr), kDifKeymgrLockableOk);
+}
+
+class DisableTest : public DifKeymgrInitialized {};
+
+TEST_F(DisableTest, BadArgs) {
+  EXPECT_EQ(dif_keymgr_disable(nullptr), kDifKeymgrLockableBadArg);
+}
+
+TEST_F(DisableTest, LockedBusy) {
+  ExpectBusy();
+  EXPECT_EQ(dif_keymgr_disable(&keymgr_), kDifKeymgrLockableLocked);
+}
+
+TEST_F(DisableTest, LockedConfig) {
+  ExpectLockedConfig();
+
+  EXPECT_EQ(dif_keymgr_disable(&keymgr_), kDifKeymgrLockableLocked);
+}
+
+TEST_F(DisableTest, Disable) {
+  ExpectIdle();
+  ExpectOperationStart({
+      .dest_sel = KEYMGR_CONTROL_DEST_SEL_VALUE_NONE,
+      .operation = KEYMGR_CONTROL_OPERATION_VALUE_DISABLE,
+  });
+
+  EXPECT_EQ(dif_keymgr_disable(&keymgr_), kDifKeymgrLockableOk);
+}
+
+TEST_P(BadArgsTwo, GetStatusCodes) {
+  auto keymgr = GetGoodBadPtrArg<dif_keymgr_t>(std::get<0>(GetParam()));
+  auto status_codes =
+      GetGoodBadPtrArg<dif_keymgr_status_codes_t>(std::get<1>(GetParam()));
+
+  EXPECT_EQ(dif_keymgr_get_status_codes(keymgr, status_codes),
+            kDifKeymgrBadArg);
+}
+
+struct GetStatusCodesTestCase {
+  /**
+   * Values of OP_STATUS or ERR_CODE registers.
+   */
+  std::vector<mock_mmio::BitField> reg_val;
+  /**
+   * Expected output of `dif_keymgr_get_status_codes()`.
+   */
+  dif_keymgr_status_codes_t exp_val;
+};
+
+class GetStatusCodesNoError
+    : public DifKeymgrInitialized,
+      public testing::WithParamInterface<GetStatusCodesTestCase> {};
+
+TEST_P(GetStatusCodesNoError, Success) {
+  EXPECT_READ32(KEYMGR_OP_STATUS_REG_OFFSET, GetParam().reg_val);
+  EXPECT_WRITE32(KEYMGR_OP_STATUS_REG_OFFSET, GetParam().reg_val);
+
+  dif_keymgr_status_codes_t act_val;
+  EXPECT_EQ(dif_keymgr_get_status_codes(&keymgr_, &act_val), kDifKeymgrOk);
+  EXPECT_EQ(GetParam().exp_val, act_val);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GetStatusCodesNoError, GetStatusCodesNoError,
+    testing::Values(
+        GetStatusCodesTestCase{
+            .reg_val = {{
+                .offset = KEYMGR_OP_STATUS_STATUS_OFFSET,
+                .value = KEYMGR_OP_STATUS_STATUS_VALUE_IDLE,
+            }},
+            .exp_val = kDifKeymgrStatusCodeIdle,
+        },
+        GetStatusCodesTestCase{
+            .reg_val = {{
+                .offset = KEYMGR_OP_STATUS_STATUS_OFFSET,
+                .value = KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS,
+            }},
+            .exp_val = kDifKeymgrStatusCodeIdle,
+        },
+        GetStatusCodesTestCase{
+            .reg_val = {{
+                .offset = KEYMGR_OP_STATUS_STATUS_OFFSET,
+                .value = KEYMGR_OP_STATUS_STATUS_VALUE_WIP,
+            }},
+            .exp_val = 0,
+        }));
+
+class GetStatusCodesWithError
+    : public DifKeymgrInitialized,
+      public testing::WithParamInterface<GetStatusCodesTestCase> {};
+
+TEST_P(GetStatusCodesWithError, Success) {
+  EXPECT_READ32(KEYMGR_OP_STATUS_REG_OFFSET,
+                KEYMGR_OP_STATUS_STATUS_VALUE_DONE_ERROR);
+  EXPECT_WRITE32(KEYMGR_OP_STATUS_REG_OFFSET,
+                 KEYMGR_OP_STATUS_STATUS_VALUE_DONE_ERROR);
+  EXPECT_READ32(KEYMGR_ERR_CODE_REG_OFFSET, GetParam().reg_val);
+  EXPECT_WRITE32(KEYMGR_ERR_CODE_REG_OFFSET, GetParam().reg_val);
+
+  dif_keymgr_status_codes_t act_val;
+  EXPECT_EQ(dif_keymgr_get_status_codes(&keymgr_, &act_val), kDifKeymgrOk);
+  EXPECT_EQ(GetParam().exp_val, act_val);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GetStatusCodesWithError, GetStatusCodesWithError,
+    testing::Values(
+        GetStatusCodesTestCase{
+            .reg_val = {{
+                .offset = KEYMGR_ERR_CODE_INVALID_OP_BIT,
+                .value = 1,
+            }},
+            .exp_val = kDifKeymgrStatusCodeIdle |
+                       kDifKeymgrStatusCodeInvalidOperation,
+        },
+        GetStatusCodesTestCase{
+            .reg_val = {{
+                .offset = KEYMGR_ERR_CODE_INVALID_CMD_BIT,
+                .value = 1,
+            }},
+            .exp_val = kDifKeymgrStatusCodeIdle |
+                       kDifKeymgrStatusCodeInvalidKmacCommand,
+        },
+        GetStatusCodesTestCase{
+            .reg_val = {{
+                .offset = KEYMGR_ERR_CODE_INVALID_KMAC_INPUT_BIT,
+                .value = 1,
+            }},
+            .exp_val = kDifKeymgrStatusCodeIdle |
+                       kDifKeymgrStatusCodeInvalidKmacInput,
+        },
+        GetStatusCodesTestCase{
+            .reg_val = {{
+                .offset = KEYMGR_ERR_CODE_INVALID_KMAC_DATA_BIT,
+                .value = 1,
+            }},
+            .exp_val = kDifKeymgrStatusCodeIdle |
+                       kDifKeymgrStatusCodeInvalidKmacOutput,
+        },
+        GetStatusCodesTestCase{
+            .reg_val = {{
+                            .offset = KEYMGR_ERR_CODE_INVALID_OP_BIT,
+                            .value = 1,
+                        },
+                        {
+                            .offset = KEYMGR_ERR_CODE_INVALID_KMAC_INPUT_BIT,
+                            .value = 1,
+                        }},
+            .exp_val = kDifKeymgrStatusCodeIdle |
+                       kDifKeymgrStatusCodeInvalidOperation |
+                       kDifKeymgrStatusCodeInvalidKmacInput,
+        },
+        GetStatusCodesTestCase{
+            .reg_val = {{
+                            .offset = KEYMGR_ERR_CODE_INVALID_CMD_BIT,
+                            .value = 1,
+                        },
+                        {
+                            .offset = KEYMGR_ERR_CODE_INVALID_KMAC_DATA_BIT,
+                            .value = 1,
+                        }},
+            .exp_val = kDifKeymgrStatusCodeIdle |
+                       kDifKeymgrStatusCodeInvalidKmacCommand |
+                       kDifKeymgrStatusCodeInvalidKmacOutput,
+        }));
+
+class GetStateTest : public DifKeymgrInitialized {};
+
+TEST_P(BadArgsTwo, GetState) {
+  auto keymgr = GetGoodBadPtrArg<dif_keymgr_t>(std::get<0>(GetParam()));
+  auto state = GetGoodBadPtrArg<dif_keymgr_state_t>(std::get<1>(GetParam()));
+
+  EXPECT_EQ(dif_keymgr_get_state(keymgr, state), kDifKeymgrBadArg);
+}
+
+struct GetStateTestCase {
+  /**
+   * Value of the WORKING_STATE register.
+   */
+  std::vector<mock_mmio::BitField> reg_val;
+  /**
+   * Expected output of `dif_keymgr_get_state()`.
+   */
+  dif_keymgr_state_t exp_output;
+};
+
+class GetState : public GetStateTest,
+                 public testing::WithParamInterface<GetStateTestCase> {};
+
+TEST_P(GetState, Success) {
+  EXPECT_READ32(KEYMGR_WORKING_STATE_REG_OFFSET, GetParam().reg_val);
+
+  dif_keymgr_state_t state;
+  EXPECT_EQ(dif_keymgr_get_state(&keymgr_, &state), kDifKeymgrOk);
+  EXPECT_EQ(state, GetParam().exp_output);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllValidStates, GetState,
+    testing::Values(
+        GetStateTestCase{
+            .reg_val = {{
+                .offset = KEYMGR_WORKING_STATE_STATE_OFFSET,
+                .value = KEYMGR_WORKING_STATE_STATE_VALUE_RESET,
+            }},
+            .exp_output = kDifKeymgrStateReset,
+        },
+        GetStateTestCase{
+            .reg_val = {{
+                .offset = KEYMGR_WORKING_STATE_STATE_OFFSET,
+                .value = KEYMGR_WORKING_STATE_STATE_VALUE_INIT,
+            }},
+            .exp_output = kDifKeymgrStateInitialized,
+        },
+        GetStateTestCase{
+            .reg_val = {{
+                .offset = KEYMGR_WORKING_STATE_STATE_OFFSET,
+                .value = KEYMGR_WORKING_STATE_STATE_VALUE_CREATOR_ROOT_KEY,
+            }},
+            .exp_output = kDifKeymgrStateCreatorRootKey,
+        },
+        GetStateTestCase{
+            .reg_val = {{
+                .offset = KEYMGR_WORKING_STATE_STATE_OFFSET,
+                .value =
+                    KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_INTERMEDIATE_KEY,
+            }},
+            .exp_output = kDifKeymgrStateOwnerIntermediateKey,
+        },
+        GetStateTestCase{
+            .reg_val = {{
+                .offset = KEYMGR_WORKING_STATE_STATE_OFFSET,
+                .value = KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_KEY,
+            }},
+            .exp_output = kDifKeymgrStateOwnerRootKey,
+        },
+        GetStateTestCase{
+            .reg_val = {{
+                .offset = KEYMGR_WORKING_STATE_STATE_OFFSET,
+                .value = KEYMGR_WORKING_STATE_STATE_VALUE_DISABLED,
+            }},
+            .exp_output = kDifKeymgrStateDisabled,
+        },
+        GetStateTestCase{
+            .reg_val = {{
+                .offset = KEYMGR_WORKING_STATE_STATE_OFFSET,
+                .value = KEYMGR_WORKING_STATE_STATE_VALUE_INVALID,
+            }},
+            .exp_output = kDifKeymgrStateInvalid,
+        }));
+
+TEST_F(GetStateTest, UnexpectedState) {
+  EXPECT_READ32(KEYMGR_WORKING_STATE_REG_OFFSET,
+                KEYMGR_WORKING_STATE_STATE_MASK);
+
+  dif_keymgr_state_t state;
+  EXPECT_EQ(dif_keymgr_get_state(&keymgr_, &state), kDifKeymgrError);
+}
+
+class GenerateIdentityTest : public DifKeymgrInitialized {};
+
+TEST_F(GenerateIdentityTest, BadArgs) {
+  EXPECT_EQ(dif_keymgr_generate_identity_seed(nullptr),
+            kDifKeymgrLockableBadArg);
+}
+
+TEST_F(GenerateIdentityTest, LockedBusy) {
+  ExpectBusy();
+
+  EXPECT_EQ(dif_keymgr_generate_identity_seed(&keymgr_),
+            kDifKeymgrLockableLocked);
+}
+
+TEST_F(GenerateIdentityTest, LockedConfig) {
+  ExpectLockedConfig();
+
+  EXPECT_EQ(dif_keymgr_generate_identity_seed(&keymgr_),
+            kDifKeymgrLockableLocked);
+}
+
+TEST_F(GenerateIdentityTest, Generate) {
+  ExpectIdle();
+  ExpectOperationStart({
+      .dest_sel = KEYMGR_CONTROL_DEST_SEL_VALUE_NONE,
+      .operation = KEYMGR_CONTROL_OPERATION_VALUE_GENERATE_ID,
+  });
+
+  EXPECT_EQ(dif_keymgr_generate_identity_seed(&keymgr_), kDifKeymgrLockableOk);
+}
+
+class GenerateVersionedKeyTest : public DifKeymgrInitialized {};
+
+TEST_P(BadArgsTwo, GenerateVersionedKey) {
+  auto keymgr = GetGoodBadPtrArg<dif_keymgr_t>(std::get<0>(GetParam()));
+  auto dest = GetGoodBadEnumArg<dif_keymgr_versioned_key_dest_t>(
+      std::get<1>(GetParam()), kDifKeymgrVersionedKeyDestLast);
+
+  EXPECT_EQ(dif_keymgr_generate_versioned_key(keymgr, {.dest = dest}),
+            kDifKeymgrLockableBadArg);
+}
+
+TEST_F(GenerateVersionedKeyTest, LockedBusy) {
+  ExpectBusy();
+
+  EXPECT_EQ(dif_keymgr_generate_versioned_key(&keymgr_, {}),
+            kDifKeymgrLockableLocked);
+}
+
+TEST_F(GenerateVersionedKeyTest, LockedConfig) {
+  ExpectLockedConfig();
+
+  EXPECT_EQ(dif_keymgr_generate_versioned_key(&keymgr_, {}),
+            kDifKeymgrLockableLocked);
+}
+
+struct GenerateVersionedKeyTestCase {
+  /**
+   * Destination of the generated key.
+   */
+  dif_keymgr_versioned_key_dest_t dest;
+  /**
+   * Expected DEST_SEL value to be written to the CONTROL register.
+   */
+  uint32_t exp_dest_sel;
+  /**
+   * Expected OPERATION values to be written to the CONTROL register.
+   */
+  uint32_t exp_operation;
+};
+
+class GenerateVersionedKey
+    : public GenerateVersionedKeyTest,
+      public testing::WithParamInterface<GenerateVersionedKeyTestCase> {};
+
+TEST_P(GenerateVersionedKey, Success) {
+  dif_keymgr_versioned_key_params_t params{
+      .dest = GetParam().dest,
+      .salt = {0x5A, 0x46, 0x3C, 0x00, 0xA5, 0xB9, 0xC3, 0xFF},
+      .version = 0xA5A5A5A5,
+  };
+
+  ExpectIdle();
+  size_t salt_len = sizeof(params.salt) / sizeof(params.salt[0]);
+  for (size_t i = 0; i < salt_len; ++i) {
+    EXPECT_WRITE32(KEYMGR_SALT_0_REG_OFFSET + i * 4, params.salt[i]);
+  }
+  EXPECT_WRITE32(KEYMGR_KEY_VERSION_REG_OFFSET, params.version);
+  ExpectOperationStart({
+      .dest_sel = GetParam().exp_dest_sel,
+      .operation = GetParam().exp_operation,
+  });
+
+  EXPECT_EQ(dif_keymgr_generate_versioned_key(&keymgr_, params),
+            kDifKeymgrLockableOk);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GenerateVersionedKeyAllDests, GenerateVersionedKey,
+    testing::Values(
+        GenerateVersionedKeyTestCase{
+            .dest = kDifKeymgrVersionedKeyDestSw,
+            .exp_dest_sel = KEYMGR_CONTROL_DEST_SEL_VALUE_NONE,
+            .exp_operation = KEYMGR_CONTROL_OPERATION_VALUE_GENERATE_SW_OUTPUT,
+        },
+        GenerateVersionedKeyTestCase{
+            .dest = kDifKeymgrVersionedKeyDestAes,
+            .exp_dest_sel = KEYMGR_CONTROL_DEST_SEL_VALUE_AES,
+            .exp_operation = KEYMGR_CONTROL_OPERATION_VALUE_GENERATE_HW_OUTPUT,
+        },
+        GenerateVersionedKeyTestCase{
+            .dest = kDifKeymgrVersionedKeyDestHmac,
+            .exp_dest_sel = KEYMGR_CONTROL_DEST_SEL_VALUE_HMAC,
+            .exp_operation = KEYMGR_CONTROL_OPERATION_VALUE_GENERATE_HW_OUTPUT,
+        },
+        GenerateVersionedKeyTestCase{
+            .dest = kDifKeymgrVersionedKeyDestKmac,
+            .exp_dest_sel = KEYMGR_CONTROL_DEST_SEL_VALUE_KMAC,
+            .exp_operation = KEYMGR_CONTROL_OPERATION_VALUE_GENERATE_HW_OUTPUT,
+        }));
+
+class SideloadClearTest : public DifKeymgrInitialized {};
+
+TEST_P(BadArgsTwo, GetBadArg) {
+  auto keymgr = GetGoodBadPtrArg<dif_keymgr_t>(std::get<0>(GetParam()));
+  auto state = GetGoodBadPtrArg<dif_keymgr_toggle_t>(std::get<1>(GetParam()));
+
+  EXPECT_EQ(dif_keymgr_sideload_clear_get_enabled(keymgr, state),
+            kDifKeymgrBadArg);
+}
+
+TEST_P(BadArgsTwo, SetBadArg) {
+  auto keymgr = GetGoodBadPtrArg<dif_keymgr_t>(std::get<0>(GetParam()));
+  auto state = GetGoodBadEnumArg<dif_keymgr_toggle_t>(std::get<1>(GetParam()),
+                                                      kDifKeymgrToggleDisabled);
+
+  EXPECT_EQ(dif_keymgr_sideload_clear_set_enabled(keymgr, state),
+            kDifKeymgrBadArg);
+}
+
+TEST_F(SideloadClearTest, Set) {
+  EXPECT_WRITE32(KEYMGR_SIDELOAD_CLEAR_REG_OFFSET,
+                 {{
+                     .offset = KEYMGR_SIDELOAD_CLEAR_VAL_BIT,
+                     .value = 1,
+                 }});
+  EXPECT_EQ(
+      dif_keymgr_sideload_clear_set_enabled(&keymgr_, kDifKeymgrToggleEnabled),
+      kDifKeymgrOk);
+
+  EXPECT_WRITE32(KEYMGR_SIDELOAD_CLEAR_REG_OFFSET,
+                 {{
+                     .offset = KEYMGR_SIDELOAD_CLEAR_VAL_BIT,
+                     .value = 0,
+                 }});
+  EXPECT_EQ(
+      dif_keymgr_sideload_clear_set_enabled(&keymgr_, kDifKeymgrToggleDisabled),
+      kDifKeymgrOk);
+}
+
+TEST_F(SideloadClearTest, Get) {
+  EXPECT_READ32(KEYMGR_SIDELOAD_CLEAR_REG_OFFSET,
+                {{
+                    .offset = KEYMGR_SIDELOAD_CLEAR_VAL_BIT,
+                    .value = 1,
+                }});
+  dif_keymgr_toggle_t state = kDifKeymgrToggleDisabled;
+  EXPECT_EQ(dif_keymgr_sideload_clear_get_enabled(&keymgr_, &state),
+            kDifKeymgrOk);
+  EXPECT_EQ(state, kDifKeymgrToggleEnabled);
+
+  EXPECT_READ32(KEYMGR_SIDELOAD_CLEAR_REG_OFFSET,
+                {{
+                    .offset = KEYMGR_SIDELOAD_CLEAR_VAL_BIT,
+                    .value = 0,
+                }});
+  state = kDifKeymgrToggleEnabled;
+  EXPECT_EQ(dif_keymgr_sideload_clear_get_enabled(&keymgr_, &state),
+            kDifKeymgrOk);
+  EXPECT_EQ(state, kDifKeymgrToggleDisabled);
+}
+
+class ReadOutputTest : public DifKeymgrInitialized {};
+
+TEST_P(BadArgsTwo, ReadOutput) {
+  auto keymgr = GetGoodBadPtrArg<dif_keymgr_t>(std::get<0>(GetParam()));
+  auto output = GetGoodBadPtrArg<dif_keymgr_output_t>(std::get<1>(GetParam()));
+
+  EXPECT_EQ(dif_keymgr_read_output(keymgr, output), kDifKeymgrBadArg);
+}
+
+TEST_F(ReadOutputTest, Read) {
+  constexpr size_t kNumShares = 2;
+  constexpr size_t kNumShareWords = 8;
+  constexpr std::array<std::array<uint32_t, kNumShareWords>, kNumShares>
+      kExpected{{{0x8D, 0x25, 0x44, 0x0A, 0xEC, 0x1C, 0xAC, 0x0E},
+                 {0x44, 0x5B, 0x90, 0x39, 0x24, 0x72, 0xA7, 0xCB}}};
+  constexpr std::array<uint32_t, kNumShares> kShareRegOffsets{
+      {KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET,
+       KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET}};
+
+  for (size_t i = 0; i < kNumShares; ++i) {
+    for (size_t j = 0; j < kNumShareWords; ++j) {
+      EXPECT_READ32(kShareRegOffsets[i] + j * 4, kExpected[i][j]);
+    }
+  }
+
+  dif_keymgr_output_t output;
+  EXPECT_EQ(dif_keymgr_read_output(&keymgr_, &output), kDifKeymgrOk);
+  for (size_t i = 0; i < kNumShares; ++i) {
+    EXPECT_THAT(kExpected[i], ::testing::ElementsAreArray(output.value[i]));
+  }
+}
+
+TEST_P(BadArgsTwo, AlertForce) {
+  auto keymgr = GetGoodBadPtrArg<dif_keymgr_t>(std::get<0>(GetParam()));
+  auto alert = GetGoodBadEnumArg<dif_keymgr_alert_t>(std::get<1>(GetParam()),
+                                                     kDifKeymgrAlertLast);
+
+  EXPECT_EQ(dif_keymgr_alert_force(keymgr, alert), kDifKeymgrBadArg);
+}
+
+struct AlertTestCase {
+  dif_keymgr_alert_t alert;
+  bitfield_bit32_index_t bit_index;
+};
+
+class AlertForce : public DifKeymgrInitialized,
+                   public testing::WithParamInterface<AlertTestCase> {};
+
+TEST_P(AlertForce, Success) {
+  EXPECT_WRITE32(KEYMGR_ALERT_TEST_REG_OFFSET,
+                 {{
+                     .offset = GetParam().bit_index,
+                     .value = 1,
+                 }});
+
+  EXPECT_EQ(dif_keymgr_alert_force(&keymgr_, GetParam().alert), kDifKeymgrOk);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AlertForceAll, AlertForce,
+    testing::Values(
+        AlertTestCase{
+            .alert = kDifKeymgrAlertHardware,
+            .bit_index = KEYMGR_ALERT_TEST_FATAL_FAULT_ERR_BIT,
+        },
+        AlertTestCase{
+            .alert = kDifKeymgrAlertSoftware,
+            .bit_index = KEYMGR_ALERT_TEST_RECOV_OPERATION_ERR_BIT,
+        }));
+
+class IrqTest : public DifKeymgrInitialized {};
+
+TEST_P(BadArgsThree, IrqIsPending) {
+  auto keymgr = GetGoodBadPtrArg<dif_keymgr_t>(std::get<0>(GetParam()));
+  auto irq = GetGoodBadEnumArg<dif_keymgr_irq_t>(std::get<1>(GetParam()),
+                                                 kDifKeymgrIrqLast);
+  auto is_pending = GetGoodBadPtrArg<bool>(std::get<2>(GetParam()));
+
+  EXPECT_EQ(dif_keymgr_irq_is_pending(keymgr, irq, is_pending),
+            kDifKeymgrBadArg);
+}
+
+class IrqIsPending
+    : public IrqTest,
+      public testing::WithParamInterface<std::tuple<dif_keymgr_irq_t, bool>> {};
+
+TEST_P(IrqIsPending, IsPending) {
+  auto irq = std::get<0>(GetParam());
+  bool exp_val = std::get<1>(GetParam());
+
+  EXPECT_READ32(KEYMGR_INTR_STATE_REG_OFFSET, {{
+                                                  .offset = irq,
+                                                  .value = exp_val,
+                                              }});
+  bool is_pending = !exp_val;
+  EXPECT_EQ(dif_keymgr_irq_is_pending(&keymgr_, irq, &is_pending),
+            kDifKeymgrOk);
+  EXPECT_EQ(is_pending, exp_val);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IsPendingAllIrqs, IrqIsPending,
+    testing::Combine(testing::ValuesIn(
+                         CreateEnumVector<dif_keymgr_irq_t>(kDifKeymgrIrqLast)),
+                     testing::Bool()));
+
+TEST_P(BadArgsTwo, IrqAck) {
+  auto keymgr = GetGoodBadPtrArg<dif_keymgr_t>(std::get<0>(GetParam()));
+  auto irq = GetGoodBadEnumArg<dif_keymgr_irq_t>(std::get<1>(GetParam()),
+                                                 kDifKeymgrIrqLast);
+
+  EXPECT_EQ(dif_keymgr_irq_acknowledge(keymgr, irq), kDifKeymgrBadArg);
+}
+
+class Irq : public IrqTest,
+            public testing::WithParamInterface<dif_keymgr_irq_t> {};
+
+TEST_P(Irq, Ack) {
+  EXPECT_WRITE32(KEYMGR_INTR_STATE_REG_OFFSET, {{
+                                                   .offset = GetParam(),
+                                                   .value = 1,
+                                               }});
+
+  EXPECT_EQ(dif_keymgr_irq_acknowledge(&keymgr_, GetParam()), kDifKeymgrOk);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllIrqs, Irq,
+    testing::ValuesIn(CreateEnumVector<dif_keymgr_irq_t>(kDifKeymgrIrqLast)));
+
+TEST_P(BadArgsThree, GetEnabled) {
+  auto keymgr = GetGoodBadPtrArg<dif_keymgr_t>(std::get<0>(GetParam()));
+  auto irq = GetGoodBadEnumArg<dif_keymgr_irq_t>(std::get<1>(GetParam()),
+                                                 kDifKeymgrIrqLast);
+  auto is_enabled =
+      GetGoodBadPtrArg<dif_keymgr_toggle_t>(std::get<2>(GetParam()));
+
+  EXPECT_EQ(dif_keymgr_irq_get_enabled(keymgr, irq, is_enabled),
+            kDifKeymgrBadArg);
+}
+
+class IrqGetSetEnabled
+    : public IrqTest,
+      public testing::WithParamInterface<
+          std::tuple<dif_keymgr_irq_t, dif_keymgr_toggle_t>> {};
+
+TEST_P(IrqGetSetEnabled, GetEnabled) {
+  auto irq = std::get<0>(GetParam());
+  auto exp_val = std::get<1>(GetParam());
+
+  EXPECT_READ32(KEYMGR_INTR_ENABLE_REG_OFFSET,
+                {{
+                    .offset = irq,
+                    .value = (exp_val == kDifKeymgrToggleEnabled),
+                }});
+
+  dif_keymgr_toggle_t is_enabled = (exp_val == kDifKeymgrToggleEnabled)
+                                       ? kDifKeymgrToggleDisabled
+                                       : kDifKeymgrToggleEnabled;
+  EXPECT_EQ(dif_keymgr_irq_get_enabled(&keymgr_, irq, &is_enabled),
+            kDifKeymgrOk);
+  EXPECT_EQ(is_enabled, exp_val);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllIrqsAndToggles, IrqGetSetEnabled,
+    testing::Combine(testing::ValuesIn(
+                         CreateEnumVector<dif_keymgr_irq_t>(kDifKeymgrIrqLast)),
+                     testing::ValuesIn(CreateEnumVector<dif_keymgr_toggle_t>(
+                         kDifKeymgrToggleDisabled))));
+
+TEST_P(BadArgsThree, SetEnabled) {
+  auto keymgr = GetGoodBadPtrArg<dif_keymgr_t>(std::get<0>(GetParam()));
+  auto irq = GetGoodBadEnumArg<dif_keymgr_irq_t>(std::get<1>(GetParam()),
+                                                 kDifKeymgrIrqLast);
+  auto state = GetGoodBadEnumArg<dif_keymgr_toggle_t>(std::get<2>(GetParam()),
+                                                      kDifKeymgrToggleDisabled);
+
+  EXPECT_EQ(dif_keymgr_irq_set_enabled(keymgr, irq, state), kDifKeymgrBadArg);
+}
+
+TEST_P(IrqGetSetEnabled, SetEnabled) {
+  auto irq = std::get<0>(GetParam());
+  auto new_state = std::get<1>(GetParam());
+  EXPECT_MASK32(KEYMGR_INTR_ENABLE_REG_OFFSET,
+                {{
+                    .offset = irq,
+                    .mask = 1,
+                    .value = (new_state == kDifKeymgrToggleEnabled),
+                }});
+
+  EXPECT_EQ(dif_keymgr_irq_set_enabled(&keymgr_, irq, new_state), kDifKeymgrOk);
+}
+
+TEST_P(BadArgsTwo, IrqForce) {
+  auto keymgr = GetGoodBadPtrArg<dif_keymgr_t>(std::get<0>(GetParam()));
+  auto irq = GetGoodBadEnumArg<dif_keymgr_irq_t>(std::get<1>(GetParam()),
+                                                 kDifKeymgrIrqLast);
+
+  EXPECT_EQ(dif_keymgr_irq_force(keymgr, irq), kDifKeymgrBadArg);
+}
+
+TEST_P(Irq, Force) {
+  EXPECT_WRITE32(KEYMGR_INTR_TEST_REG_OFFSET, {{
+                                                  .offset = GetParam(),
+                                                  .value = 1,
+                                              }});
+
+  EXPECT_EQ(dif_keymgr_irq_force(&keymgr_, GetParam()), kDifKeymgrOk);
+}
+
+TEST_P(BadArgsTwo, DisableAll) {
+  // `snapshot` (second argument) is optional, skip if `keymgr` (first argument)
+  // is good.
+  if (std::get<0>(GetParam())) {
+    GTEST_SKIP();
+  }
+
+  auto keymgr = GetGoodBadPtrArg<dif_keymgr_t>(std::get<0>(GetParam()));
+  auto snapshot =
+      GetGoodBadPtrArg<dif_keymgr_irq_snapshot_t>(std::get<1>(GetParam()));
+
+  EXPECT_EQ(dif_keymgr_irq_disable_all(keymgr, snapshot), kDifKeymgrBadArg);
+}
+
+TEST_F(IrqTest, DisableAll) {
+  constexpr uint32_t kExpVal = 0xA5A5A5A5;
+
+  // With `snapshot`.
+  EXPECT_READ32(KEYMGR_INTR_ENABLE_REG_OFFSET, kExpVal);
+  EXPECT_WRITE32(KEYMGR_INTR_ENABLE_REG_OFFSET, 0);
+
+  dif_keymgr_irq_snapshot_t snapshot = 0;
+  EXPECT_EQ(dif_keymgr_irq_disable_all(&keymgr_, &snapshot), kDifKeymgrOk);
+  EXPECT_EQ(snapshot, kExpVal);
+
+  // Without `snapshot`.
+  EXPECT_WRITE32(KEYMGR_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_keymgr_irq_disable_all(&keymgr_, nullptr), kDifKeymgrOk);
+}
+
+TEST_P(BadArgsTwo, IrqRestore) {
+  auto keymgr = GetGoodBadPtrArg<dif_keymgr_t>(std::get<0>(GetParam()));
+  auto snapshot =
+      GetGoodBadPtrArg<dif_keymgr_irq_snapshot_t>(std::get<1>(GetParam()));
+
+  EXPECT_EQ(dif_keymgr_irq_restore_all(keymgr, snapshot), kDifKeymgrBadArg);
+}
+
+TEST_F(IrqTest, RestoreAll) {
+  dif_keymgr_irq_snapshot_t snapshot = 0xA5A5A5A5;
+
+  EXPECT_WRITE32(KEYMGR_INTR_ENABLE_REG_OFFSET, snapshot);
+
+  EXPECT_EQ(dif_keymgr_irq_restore_all(&keymgr_, &snapshot), kDifKeymgrOk);
+}
+
+}  // namespace
+}  // namespace dif_keymgr_unittest

--- a/sw/device/tests/dif/dif_pwrmgr_unittest.cc
+++ b/sw/device/tests/dif/dif_pwrmgr_unittest.cc
@@ -55,7 +55,7 @@ TEST_F(InitTest, Init) {
 }
 
 // Base class for the rest of the tests in this file, provides a
-// `dif_gpio_t` instance.
+// `dif_pwrmgr_t` instance.
 class DifPwrmgrInitialized : public DifPwrmgrTest {
  protected:
   /**

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -130,6 +130,22 @@ test('dif_pwrmgr_unittest', executable(
   cpp_args: ['-DMOCK_MMIO'],
 ))
 
+test('dif_keymgr_unittest', executable(
+  'dif_keymgr_unittest',
+  sources: [
+    hw_ip_keymgr_reg_h,
+    meson.source_root() / 'sw/device/lib/dif/dif_keymgr.c',
+    'dif_keymgr_unittest.cc',
+  ],
+  dependencies: [
+    sw_vendor_gtest,
+    sw_lib_testing_mock_mmio,
+  ],
+  native: true,
+  c_args: ['-DMOCK_MMIO'],
+  cpp_args: ['-DMOCK_MMIO'],
+))
+
 test('dif_rstmgr_unittest', executable(
   'dif_rstmgr_unittest',
   sources: [


### PR DESCRIPTION
This PR adds the implementation of key manager DIF library along with unit tests and includes the following commits:
- [sw/dif_pwrmgr] Fix a typo in dif_pwrmgr_unittest.cc
- [sw/dif_keymgr] Minor fixes and updates in dif_keymgr.h
- [sw/dif_keymgr] Implement Key Manager DIF Library
- Update ToInt overload in mock_mmio.h
- [sw/dif_keymgr] Add unit tests for key manager DIF library

----

(Initial description for the draft version.)

@tjaychen and @moidx, I created this as a draft because I would like to hear what you think about `dif_keymgr_advance_state()`. It basically enforces that max key version is set before transitioning to an operational state, i.e. CreatorRootKey, OwnerIntermediateKey, and OwnerRootKey, as described [here](https://docs.opentitan.org/doc/security/specs/identities_and_root_keys/). Do you think this is a good idea or should we break it up and provide set/get/lock/is_locked for max key version registers? If we decide to keep it as is, do we need a getter for max key version registers?

@tjaychen, I also have some questions regarding the peripheral:
* For `CONTROL.DEST_SEL` the spec says:
> This field should be programmed for both hw / sw generation, as this helps diverisifies the output.

Can you please clarify? This field is already required for HW generation and the DIF writes `NONE` for SW generation. Should it write something else? Also, would it make sense to move "Generate SW Output" from `CONTROL.OPERATION` to `CONTROL.DEST_SEL` (it looks like this could slightly simplify this interface)?
* I noticed that entropy reseed interval doesn't have a WEN register. Is it OK to change this value even if the key manager is busy?
* `dif_keymgr_clear_sideload_keys()` writes `0` immediately after writing `1`. Please let me know if we need to wait in-between. Callers can also loop over this function if that also works.
* It would be nice to have an auto-generated mask for the bits of the `ERR_CODE` register. The mask is hardcoded for now.