### PR TITLE
[sw, rom_ext_signer] use mundane exponent and modulus getters instead of dummies

### DIFF
--- a/sw/host/rom_ext_image_tools/signer/Cargo.lock
+++ b/sw/host/rom_ext_image_tools/signer/Cargo.lock
@@ -71,9 +71,9 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "mundane"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e675fddc3f33a2926843ec693a65848755d1cf0e3f299c6afd3a7fc0048700"
+checksum = "9e0fa854bb6ab697baa4b14bf0ea911a9eeb95b2f3dc98192df9ea4fc79d097c"
 dependencies = [
  "goblin",
 ]

--- a/sw/host/rom_ext_image_tools/signer/Cargo.toml
+++ b/sw/host/rom_ext_image_tools/signer/Cargo.toml
@@ -29,5 +29,5 @@ rom_ext_config = { path = "config" }
 rom_ext_image = { path = "image" }
 
 [dependencies.mundane]
-version = "0.4.3"
+version = "0.4.4"
 features = ["rsa-pkcs1v15"]

--- a/sw/host/rom_ext_image_tools/signer/README.md
+++ b/sw/host/rom_ext_image_tools/signer/README.md
@@ -8,9 +8,9 @@ particular to allow for a manufacturer specific configuration and facilities to
 deliver security updates - OpenTitan design provisions the Extension ROM
 (ROM_EXT) that lives in the flash memory.
 
-ROM_EXT consists of a [manifest][rom-ext-manifest] and the image itself. When
+ROM_EXT consists of a [manifest][1] and the image itself. When
 the image is generated - the manifest data is "blank". The responsibility of
-ROM_EXT signer is to update the manifest, sign the image and add the
+the ROM_EXT signer is to update the manifest, sign the image and add the
 signature to it.
 
 ## Tooling
@@ -24,7 +24,12 @@ well as incredible and versatile infrastructure. Rust's Cargo (build/packaging
 system) and mature community driven database (crates.io), makes it easy and
 cheap (in terms of effort) to find, integrate and use relevant functionality.
 
-** This makes rust great for host side tooling **
+**This makes rust great for host side tooling**
+
+# Current state
+
+**Please note that this change is work in progress, and can be tracked via:
+https://github.com/lowRISC/opentitan/issues/5232**
 
 # Design
 
@@ -44,30 +49,41 @@ The configuration file is in `.hjson` format, which is deserialised (turned
 into Rust structures) using `hjson_serde` and `serde` crates.
 
 Configuration file contains data for all of the fields that need updating in
-the manifest before signing.
+the manifest before signing. Some manifest fields are unfeasible to specify
+in the configuration file - these are binary blobs such as a private key in DER
+format. Instead the file paths to these are specified.
 
-Please note that signature key modulus and signature key public exponent are
-extracted separately. The configuration file has a link to the private key,
-and public key is extracted from it via `ring` library.
+Please note that some field values are known upfront, however other must be
+obtained at runtime. Fields like (but not limited to) signature public modulus
+and signature key public exponent are extracted separately.
 
-Generic (u32 or u64) integers are defines as an array. This is done to make
-updating the manifest easier. Complex fields such as "Peripheral Lockdown
-Info" have a separate data structure, and are spliced into the image separately.
+Complex fields such as "Peripheral Lockdown Info" have a separate data
+structure.
 
 ## Image manipulation (updating the manifest)
 
-Reads the binary image of the disk. It uses the parsed configuration to
-update the manifest before signing, and is responsible for generating the signed
-file.
+The manifest fields must be updated prior to signing, and then the signature
+itself has to be written into the respective manifest field.
+
+- Reads the binary image of the disk
+- Reads and parses the configuration of the disk
+- Reads the files specified in the configuration of the disk
+- Updates the manifest fields
+- Signs the updated image
+- Updated the manifest signature field with the generated signature
+- Writes the updated image to disk
 
 ## Image signing
 
-TODO
+Signing is done via mundane cryptographic library:
+https://crates.io/crates/mundane
+
+For signing details such as signing scheme, please see [manifest][1]
+documentation.
 
 ## "Receipt" production
 
-TODO
+TBD
 
-<!-- Links -->
-[csm-secure-boot]: {{< relref "doc/security/specs/secure_boot" >}}
-[rom-ext-manifest]: {{< relref "sw/device/rom_exts/docs/manifest" >}}
+
+[1]: /sw/device/rom_exts/docs/manifest.md


### PR DESCRIPTION
This change also updates the documentation.