### PR TITLE
Otbn rnd

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -20,7 +20,23 @@
       desc:    "Selection of the register file implementation. See otbn_pkg.sv."
       local:   "false",
       expose:  "true"
-    }
+    },
+    { name:    "RndCnstUrndLfsrSeed",
+      type:    "otbn_pkg::urnd_lfsr_seed_t",
+      desc:    '''
+        Default seed of the PRNG used for URND.
+      '''
+      randcount: "256",
+      randtype:  "data"
+    },
+    { name:    "RndCnstUrndChunkLfsrPerm",
+      type:    "otbn_pkg::urnd_chunk_lfsr_perm_t",
+      desc:    '''
+        Permutation applied to the LFSR chunks of the PRNG used for URND.
+      '''
+      randcount: "64",
+      randtype:  "perm"
+    },
   ]
   interrupt_list: [
     { name: "done"

--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -103,6 +103,7 @@ Providing the stack has at least one element, this is allowed, even if the stack
 Control and Status Registers (CSRs) are 32b wide registers used for "special" purposes, as detailed in their description;
 they are not related to the GPRs.
 CSRs can be accessed through dedicated instructions, `CSRRS` and `CSRRW`.
+Writes to read-only registers are ignored; they do not signal an error.
 All RW CSRs are set to 0 when OTBN starts (when 1 is written to {{< regref "CMD.start" >}}).
 
 <table>
@@ -286,6 +287,7 @@ GPRs are accessible from the base instruction subset, and WDRs are accessible fr
 OTBN has 256b Wide Special purpose Registers (WSRs).
 These are analogous to the 32b CSRs, but are used by big number instructions.
 They can be accessed with the [`BN.WSRRS`]({{< relref "isa#bnwsrrs" >}}) and [`BN.WSRRW`]({{< relref "isa#bnwsrrw" >}}) instructions.
+Writes to read-only registers are ignored; they do not signal an error.
 All RW WSRs are set to 0 when OTBN starts (when 1 is written to {{< regref "CMD.start" >}}).
 
 <table>

--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <fcntl.h>
 #include <ftw.h>
+#include <iomanip>
 #include <iostream>
 #include <memory>
 #include <regex>
@@ -218,6 +219,17 @@ static uint32_t read_ext_reg(const std::string &reg_name,
   return val;
 }
 
+static std::string wlen_val_to_hex_str(uint32_t val[8]) {
+  std::ostringstream oss;
+
+  oss << std::hex << "0x";
+  for (int i = 7; i >= 0; --i) {
+    oss << std::setfill('0') << std::setw(8) << val[i];
+  }
+
+  return oss.str();
+}
+
 ISSWrapper::ISSWrapper() : tmpdir(new TmpDir()) {
   std::string model_path(find_otbn_model());
 
@@ -320,6 +332,16 @@ void ISSWrapper::start(uint32_t addr) {
   std::ostringstream oss;
   oss << "start " << addr << "\n";
   run_command(oss.str(), nullptr);
+}
+
+void ISSWrapper::edn_rnd_data(uint32_t edn_rnd_data[8]) {
+  std::ostringstream oss;
+  oss << "edn_rnd_data " << wlen_val_to_hex_str(edn_rnd_data) << "\n";
+  run_command(oss.str(), nullptr);
+}
+
+void ISSWrapper::edn_urnd_reseed_complete() {
+  run_command("edn_urnd_reseed_complete\n", nullptr);
 }
 
 std::pair<int, uint32_t> ISSWrapper::step(bool gen_trace) {

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -36,6 +36,13 @@ struct ISSWrapper {
   // Jump to a new address and start running
   void start(uint32_t addr);
 
+  // Provide data for RND. ISS will stall when RND is read and RND data isn't
+  // available
+  void edn_rnd_data(uint32_t edn_rnd_data[8]);
+
+  // Signal URND reseed at beginning of execution is complete
+  void edn_urnd_reseed_complete();
+
   // Run simulation for a single cycle. Returns a pair (ret_code, err_bits).
   //
   // If gen_trace is true, pass trace data to the (singleton)

--- a/hw/ip/otbn/dv/otbnsim/sim/csr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/csr.py
@@ -43,6 +43,10 @@ class CSRFile:
             # RND register
             return wsrs.RND.read_u32()
 
+        if idx == 0xfc1:
+            # RND_PREFETCH register
+            return 0
+
         raise RuntimeError('Unknown CSR index: {:#x}'.format(idx))
 
     def write_unsigned(self, wsrs: WSRFile, idx: int, value: int) -> None:
@@ -67,8 +71,8 @@ class CSRFile:
             wsrs.MOD.write_unsigned(self._set_field(mod_n, 32, value, old))
             return
 
-        if idx == 0xfc0:
-            # RND register (writes are ignored)
+        if idx == 0xfc0 or idx == 0xfc1:
+            # RND/RND_PREFETCH register (writes are ignored)
             return
 
         raise RuntimeError('Unknown CSR index: {:#x}'.format(idx))

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -280,6 +280,14 @@ class CSRRS(OTBNInsn):
         self.csr = op_vals['csr']
         self.grs1 = op_vals['grs1']
 
+    def pre_execute(self, state: OTBNState) -> bool:
+        if self.csr == 0xfc0:
+            # Will return False if RND value not available, causing instruction
+            # to stall
+            return state.wsrs.RND.request_value()
+
+        return True
+
     def execute(self, state: OTBNState) -> None:
         old_val = state.read_csr(self.csr)
         bits_to_set = state.gprs.get_reg(self.grs1).read_unsigned()
@@ -297,6 +305,14 @@ class CSRRW(OTBNInsn):
         self.grd = op_vals['grd']
         self.csr = op_vals['csr']
         self.grs1 = op_vals['grs1']
+
+    def pre_execute(self, state: OTBNState) -> bool:
+        if self.csr == 0xfc0 and self.grd != 0:
+            # Will return False if RND value not available, causing instruction
+            # to stall
+            return state.wsrs.RND.request_value()
+
+        return True
 
     def execute(self, state: OTBNState) -> None:
         new_val = state.gprs.get_reg(self.grs1).read_unsigned()
@@ -976,6 +992,14 @@ class BNWSRR(OTBNInsn):
         super().__init__(raw, op_vals)
         self.wrd = op_vals['wrd']
         self.wsr = op_vals['wsr']
+
+    def pre_execute(self, state: OTBNState) -> bool:
+        if self.wsr == 0x1:
+            # Will return False if RND value not available, causing instruction
+            # to stall
+            return state.wsrs.RND.request_value()
+
+        return True
 
     def execute(self, state: OTBNState) -> None:
         val = state.wsrs.read_at_idx(self.wsr)

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -8,6 +8,9 @@ from .isa import OTBNInsn
 from .state import OTBNState
 from .trace import Trace
 
+_TEST_RND_DATA = \
+    0x99999999_99999999_99999999_99999999_99999999_99999999_99999999_99999999
+
 
 class OTBNSim:
     def __init__(self) -> None:
@@ -27,9 +30,17 @@ class OTBNSim:
 
         '''
         insn_count = 0
+        # ISS will stall at start until URND data is valid, immediately set it
+        # valid when in free running mode as nothing else will.
+        self.state.set_urnd_reseed_complete()
         while self.state.running:
             self.step(verbose)
             insn_count += 1
+
+            if self.state.wsrs.RND.pending_request:
+                # If an instruction requests RND data, make it available
+                # immediately.
+                self.state.wsrs.RND.set_unsigned(_TEST_RND_DATA)
 
         return insn_count
 

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -70,7 +70,11 @@ interface otbn_trace_if
   input otbn_pkg::alu_bignum_operation_t alu_bignum_operation,
   input logic                            mac_bignum_en,
 
-  input logic [otbn_pkg::WLEN-1:0] rnd
+  input logic [otbn_pkg::WLEN-1:0] rnd_data,
+  input logic                      rnd_req,
+  input logic                      rnd_valid,
+
+  input logic [otbn_pkg::WLEN-1:0] urnd_data
 );
   import otbn_pkg::*;
 
@@ -196,9 +200,14 @@ interface otbn_trace_if
 
   assign ispr_write[IsprRnd] = 1'b0;
   assign ispr_write_data[IsprRnd] = '0;
+  assign ispr_write[IsprUrnd] = 1'b0;
+  assign ispr_write_data[IsprUrnd] = '0;
 
-  assign ispr_read[IsprRnd] = any_ispr_read & (ispr_addr == IsprRnd);
-  assign ispr_read_data[IsprRnd] = rnd;
+  assign ispr_read[IsprRnd] = any_ispr_read & (ispr_addr == IsprRnd) & rnd_req & rnd_valid;
+  assign ispr_read_data[IsprRnd] = rnd_data;
+
+  assign ispr_read[IsprUrnd] = any_ispr_read & (ispr_addr == IsprUrnd);
+  assign ispr_read_data[IsprUrnd] = urnd_data;
 
   // Seperate per flag group tracking using the flags_t struct so tracer can cleanly present flag
   // accesses.

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
@@ -89,6 +89,7 @@ module otbn_tracer
       IsprAcc: return "ACC";
       IsprRnd: return "RND";
       IsprFlags: return "FLAGS";
+      IsprUrnd: return "URND";
       default: return "UNKNOWN_ISPR";
     endcase
   endfunction

--- a/hw/ip/otbn/dv/uvm/otbn_sim.core
+++ b/hw/ip/otbn/dv/uvm/otbn_sim.core
@@ -14,6 +14,7 @@ filesets:
     depend:
       - lowrisc:dv:otbn_test
       - lowrisc:dv:otbn_sva
+      - lowrisc:ip:edn_pkg
     files:
       - tb.sv
     file_type: systemVerilogSource

--- a/hw/ip/otbn/dv/verilator/otbn_mock_edn.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_mock_edn.sv
@@ -1,0 +1,50 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Mock EDN end point that returns a fixed value after a fixed delay used for
+ * OTBN simulation purposes.
+ */
+module otbn_mock_edn #(
+  parameter int Width = 256,
+  parameter logic [Width-1:0] FixedEdnVal = '0,
+  parameter int Delay = 16,
+
+  localparam int DelayWidth = $clog2(Delay)
+) (
+  input clk_i,
+  input rst_ni,
+
+  input              edn_req_i,
+  output             edn_ack_o,
+  output [Width-1:0] edn_data_o
+);
+  parameter int MaxDelay = Delay - 1;
+  logic [DelayWidth-1:0] edn_req_counter;
+  logic                  edn_req_active;
+  logic                  edn_req_complete;
+
+  assign edn_req_complete = edn_req_counter == MaxDelay[DelayWidth-1:0];
+  assign edn_ack_o        = edn_req_complete;
+  assign edn_data_o       = edn_req_complete ? FixedEdnVal : '0;
+
+  always @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      edn_req_counter <= 0;
+      edn_req_active  <= 0;
+    end else begin
+      if (edn_req_active) begin
+        edn_req_counter <= edn_req_counter + 4'b1;
+      end
+
+      if (edn_req_i & ~edn_req_active) begin
+        edn_req_active <= 1;
+      end
+
+      if (edn_req_complete) begin
+        edn_req_active <= 0;
+      end
+    end
+  end
+endmodule

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.core
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.core
@@ -19,6 +19,7 @@ filesets:
     files:
       - otbn_top_sim.cc: { file_type: cppSource }
       - otbn_top_sim.sv: { file_type: systemVerilogSource }
+      - otbn_mock_edn.sv: { file_type: systemVerilogSource }
   files_verilator_waiver:
     files:
       - otbn_top_sim_waivers.vlt

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -10,6 +10,9 @@ filesets:
     depend:
       - lowrisc:prim:assert
       - lowrisc:prim:util
+      - lowrisc:prim:lfsr
+      - lowrisc:prim:cipher_pkg
+      - lowrisc:ip:edn_pkg
       - lowrisc:ip:otbn_pkg
     files:
       - rtl/otbn_controller.sv
@@ -26,6 +29,8 @@ filesets:
       - rtl/otbn_mac_bignum.sv
       - rtl/otbn_loop_controller.sv
       - rtl/otbn_stack.sv
+      - rtl/otbn_rnd.sv
+      - rtl/otbn_start_stop_control.sv
       - rtl/otbn_core.sv
     file_type: systemVerilogSource
 

--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -88,7 +88,8 @@ module otbn_alu_bignum
   input  flags_t                      mac_operation_flags_i,
   input  flags_t                      mac_operation_flags_en_i,
 
-  input  logic [WLEN-1:0]             rnd_i
+  input  logic [WLEN-1:0]             rnd_data_i,
+  input  logic [WLEN-1:0]             urnd_data_i
 );
   ///////////
   // ISPRs //
@@ -195,7 +196,8 @@ module otbn_alu_bignum
 
     unique case (ispr_addr_i)
       IsprMod:   ispr_rdata_o = mod_q;
-      IsprRnd:   ispr_rdata_o = rnd_i;
+      IsprRnd:   ispr_rdata_o = rnd_data_i;
+      IsprUrnd:  ispr_rdata_o = urnd_data_i;
       IsprAcc:   ispr_rdata_o = ispr_acc_i;
       IsprFlags: ispr_rdata_o = {{(WLEN - (NFlagGroups * FlagsWidth)){1'b0}}, flags_flattened};
       default: ;

--- a/hw/ip/otbn/rtl/otbn_rnd.sv
+++ b/hw/ip/otbn/rtl/otbn_rnd.sv
@@ -1,0 +1,175 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+/**
+ * OTBN random number coordination
+ *
+ * This module implements the RND, RND_PREFETCH and URND CSRs/WSRs. The EDN (entropy distribution
+ * network) provides the bits for random numbers. RND gives direct access to EDN bits. URND provides
+ * bits from an LFSR that is seeded with bits from the EDN.
+ */
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// IMPORTANT NOTE:                                                                                //
+//                                   DO NOT USE THIS BLINDLY!                                     //
+//                                                                                                //
+// This is an initial prototype of the random number functionality in OTBN. Details are still     //
+// under discussion and subject to change. It has not yet been verified this provides the         //
+// necessary guarantees required for the various uses of random numbers in OTBN software.         //
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+module otbn_rnd import otbn_pkg::*;
+#(
+  parameter urnd_lfsr_seed_t       RndCnstUrndLfsrSeed      = RndCnstUrndLfsrSeedDefault,
+  parameter urnd_chunk_lfsr_perm_t RndCnstUrndChunkLfsrPerm = RndCnstUrndChunkLfsrPermDefault
+) (
+  input logic clk_i,
+  input logic rst_ni,
+
+  input  logic            rnd_req_i,
+  input  logic            rnd_prefetch_req_i,
+  output logic            rnd_valid_o,
+  output logic [WLEN-1:0] rnd_data_o,
+
+  // Request URND LFSR reseed from the EDN
+  input  logic            urnd_reseed_req_i,
+  // Remains asserted whilst reseed is in progress
+  output logic            urnd_reseed_busy_o,
+  // When asserted URND LFSR state advances. It is permissible to advance the state whilst
+  // reseeding.
+  input  logic            urnd_advance_i,
+  // URND data from LFSR
+  output logic [WLEN-1:0] urnd_data_o,
+
+  // Entropy distribution network (EDN)
+  output logic                    edn_rnd_req_o,
+  input  logic                    edn_rnd_ack_i,
+  input  logic [EdnDataWidth-1:0] edn_rnd_data_i,
+
+  output logic                    edn_urnd_req_o,
+  input  logic                    edn_urnd_ack_i,
+  input  logic [EdnDataWidth-1:0] edn_urnd_data_i
+);
+  // Determine how many LFSR chunks are required to fill a full WLEN register
+  localparam int LfsrChunksPerWLEN = WLEN / UrndChunkLfsrWidth;
+  localparam int BytesPerLfsrChunk = UrndChunkLfsrWidth / 8;
+
+  logic rnd_valid_q, rnd_valid_d;
+  logic [WLEN-1:0] rnd_data_q, rnd_data_d;
+  logic rnd_data_en;
+  logic rnd_req_complete;
+  logic edn_rnd_req_complete;
+  logic edn_rnd_req_start;
+
+  logic edn_rnd_req_q, edn_rnd_req_d;
+
+  ////////////////////////
+  // RND Implementation //
+  ////////////////////////
+
+  assign rnd_req_complete = rnd_req_i & rnd_valid_o;
+  assign edn_rnd_req_complete = edn_rnd_req_o & edn_rnd_ack_i;
+
+  assign rnd_data_en = edn_rnd_req_complete;
+  // RND becomes valid when EDN request completes and provides new bits. Valid is cleared when OTBN
+  // reads RND
+  assign rnd_valid_d = (rnd_valid_q & ~rnd_req_complete) | edn_rnd_req_complete;
+  assign rnd_data_d = edn_rnd_data_i;
+
+  // Start an EDN request when there is a prefetch or an attempt at reading RND when RND data is not
+  // available. Signalling `edn_rnd_req_start` whilst there is an outstanding request has no effect and
+  // is harmless.
+  assign edn_rnd_req_start = rnd_prefetch_req_i | (rnd_req_i & ~rnd_valid_q);
+
+  // Assert `edn_rnd_req_o` when a request is started and keep it asserted until the request is done
+  assign edn_rnd_req_d = (edn_rnd_req_q | edn_rnd_req_start) & ~edn_rnd_req_complete;
+
+  assign edn_rnd_req_o = edn_rnd_req_q;
+
+  always_ff @(posedge clk_i) begin
+    if (rnd_data_en) begin
+      rnd_data_q <= rnd_data_d;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rnd_valid_q   <= 1'b0;
+      edn_rnd_req_q <= 1'b0;
+    end else begin
+      rnd_valid_q   <= rnd_valid_d;
+      edn_rnd_req_q <= edn_rnd_req_d;
+    end
+  end
+
+  assign rnd_valid_o = rnd_valid_q;
+  assign rnd_data_o  = rnd_data_q;
+
+  /////////////////////////
+  // URND Implementation //
+  /////////////////////////
+
+  logic edn_urnd_req_complete;
+  logic edn_urnd_req_q, edn_urnd_req_d;
+
+  assign edn_urnd_req_complete = edn_urnd_req_o & edn_urnd_ack_i;
+  assign edn_urnd_req_d = (edn_urnd_req_q | urnd_reseed_req_i) & ~edn_urnd_req_complete;
+
+  assign edn_urnd_req_o = edn_urnd_req_q;
+  assign urnd_reseed_busy_o = edn_urnd_req_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      edn_urnd_req_q <= 1'b0;
+    end else begin
+      edn_urnd_req_q <= edn_urnd_req_d;
+    end
+  end
+
+  logic lfsr_seed_en;
+  logic [UrndChunkLfsrWidth-1:0] lfsr_seed  [LfsrChunksPerWLEN];
+  logic [UrndChunkLfsrWidth-1:0] lfsr_state [LfsrChunksPerWLEN];
+
+  assign lfsr_seed_en = edn_urnd_req_complete;
+
+  // We use multiple LFSR instances each having a width of ChunkSize.
+  // This is a functional prototype of the final URND functionality and is subject to change
+  // https://github.com/lowRISC/opentitan/issues/6083
+  for (genvar c = 0; c < LfsrChunksPerWLEN; c++) begin : gen_lfsr_chunks
+    localparam logic [UrndChunkLfsrWidth-1:0] LfsrChunkSeed =
+        RndCnstUrndLfsrSeed[c * UrndChunkLfsrWidth +: UrndChunkLfsrWidth];
+
+    assign lfsr_seed[c] = edn_urnd_data_i[c * UrndChunkLfsrWidth+: UrndChunkLfsrWidth];
+
+    prim_lfsr #(
+      .LfsrType    ( "GAL_XOR"                ),
+      .LfsrDw      ( UrndChunkLfsrWidth       ),
+      .StateOutDw  ( UrndChunkLfsrWidth       ),
+      .DefaultSeed ( LfsrChunkSeed            ),
+      .StatePermEn ( 1'b1                     ),
+      .StatePerm   ( RndCnstUrndChunkLfsrPerm )
+    ) u_lfsr_chunk (
+      .clk_i     ( clk_i          ),
+      .rst_ni    ( rst_ni         ),
+      .seed_en_i ( lfsr_seed_en   ),
+      .seed_i    ( lfsr_seed[c]   ),
+      .lfsr_en_i ( urnd_advance_i ),
+      .entropy_i ( '0             ),
+      .state_o   ( lfsr_state[c]  )
+    );
+  end
+
+  // Further "scramble" the LFSR state at the byte level to break linear shift patterns.
+  for (genvar c = 0; c < LfsrChunksPerWLEN; c++) begin : gen_lfsr_state_scramble_outer
+    for (genvar b = 0;b < BytesPerLfsrChunk; b++) begin : gen_lfsr_start_scramble_inner
+      assign urnd_data_o[b * 8 + c * UrndChunkLfsrWidth +: 8] =
+        prim_cipher_pkg::sbox4_8bit(lfsr_state[c][b*8 +: 8], prim_cipher_pkg::PRINCE_SBOX4);
+    end
+  end
+
+  `ASSERT(rnd_req_stable, rnd_req_i & ~rnd_valid_o |=> rnd_req_i)
+  `ASSERT(rnd_clear_on_req_complete, rnd_req_complete |=> ~rnd_valid_q)
+endmodule

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -1,0 +1,98 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * State machine to handle actions that occur around the start and stop of OTBN.
+ *
+ * This recieves the start signals from the top-level and passes them on to the
+ * controller to begin execution when pre-start actions have finished.
+ *
+ * pre-start actions:
+ *  - Seed LFSR for URND
+ */
+
+`include "prim_assert.sv"
+
+module otbn_start_stop_control
+  import otbn_pkg::*;
+#(
+  // Size of the instruction memory, in bytes
+  parameter int ImemSizeByte = 4096,
+  localparam int ImemAddrWidth = prim_util_pkg::vbits(ImemSizeByte)
+) (
+  input  logic  clk_i,
+  input  logic  rst_ni,
+
+  input  logic                     start_i,
+  input  logic [ImemAddrWidth-1:0] start_addr_i,
+
+  output logic                     controller_start_o,
+  output logic [ImemAddrWidth-1:0] controller_start_addr_o,
+
+  input  logic                     controller_done_i,
+
+  output logic urnd_reseed_req_o,
+  input  logic urnd_reseed_busy_i,
+  output logic urnd_advance_o,
+
+  output logic ispr_init_o
+);
+  otbn_start_stop_state_e state_q, state_d;
+
+  logic [ImemAddrWidth-1:0] start_addr_q;
+  logic start_addr_en;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      state_q <= OtbnStartStopStateHalt;
+    end else begin
+      state_q <= state_d;
+    end
+  end
+
+  always_ff @(posedge clk_i) begin
+    if (start_addr_en) begin
+      start_addr_q <= start_addr_i;
+    end
+  end
+
+  always_comb begin
+    urnd_reseed_req_o  = 1'b0;
+    urnd_advance_o     = 1'b0;
+    start_addr_en      = 1'b0;
+    state_d            = state_q;
+    ispr_init_o        = 1'b0;
+
+    unique case(state_q)
+      OtbnStartStopStateHalt: begin
+        if (start_i) begin
+          start_addr_en     = 1'b1;
+          urnd_reseed_req_o = 1'b1;
+          ispr_init_o       = 1'b1;
+          state_d           = OtbnStartStopStateUrndRefresh;
+        end
+      end
+      OtbnStartStopStateUrndRefresh: begin
+        if (!urnd_reseed_busy_i) begin
+          state_d     = OtbnStartStopStateRunning;
+        end
+      end
+      OtbnStartStopStateRunning: begin
+        urnd_advance_o = 1'b1;
+        if (controller_done_i) begin
+          state_d = OtbnStartStopStateHalt;
+        end
+      end
+      default: ;
+    endcase
+  end
+
+  // Logic seperate from main FSM code to avoid false combinational loop warning from verilator
+  assign controller_start_o = (state_q == OtbnStartStopStateUrndRefresh) & !urnd_reseed_busy_i;
+
+  `ASSERT(StartStopStateValid,
+      state_q inside {OtbnStartStopStateHalt, OtbnStartStopStateUrndRefresh, OtbnStartStopStateRunning})
+
+  assign controller_start_addr_o = start_addr_q;
+endmodule

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -4918,6 +4918,26 @@
           expose: "true"
           name_top: OtbnRegFile
         }
+        {
+          name: RndCnstUrndLfsrSeed
+          desc: Default seed of the PRNG used for URND.
+          type: otbn_pkg::urnd_lfsr_seed_t
+          randcount: 256
+          randtype: data
+          name_top: RndCnstOtbnUrndLfsrSeed
+          default: 0x1102be301eb1a8d04814ac33b45de425069e5959df06d42254a25afae52a5963
+          randwidth: 256
+        }
+        {
+          name: RndCnstUrndChunkLfsrPerm
+          desc: Permutation applied to the LFSR chunks of the PRNG used for URND.
+          type: otbn_pkg::urnd_chunk_lfsr_perm_t
+          randcount: 64
+          randtype: perm
+          name_top: RndCnstOtbnUrndChunkLfsrPerm
+          default: 0x96c27a70b8a45cfd2d3b52b1f040db79a46ed80e5942bc02513fbdfd5a98a66805bc17dded6ccd3271a3e37a08c92847
+          randwidth: 384
+        }
       ]
       inter_signal_list:
       [

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -2243,7 +2243,9 @@ module top_earlgrey #(
 
   otbn #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[29:28]),
-    .RegFile(OtbnRegFile)
+    .RegFile(OtbnRegFile),
+    .RndCnstUrndLfsrSeed(RndCnstOtbnUrndLfsrSeed),
+    .RndCnstUrndChunkLfsrPerm(RndCnstOtbnUrndChunkLfsrPerm)
   ) u_otbn (
 
       // Interrupt

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -214,4 +214,18 @@ package top_earlgrey_rnd_cnst_pkg;
     160'h33D0BEDD4D8C36CB029C0CFD5CB87F2170991F42
   };
 
+  ////////////////////////////////////////////
+  // otbn
+  ////////////////////////////////////////////
+  // Default seed of the PRNG used for URND.
+  parameter otbn_pkg::urnd_lfsr_seed_t RndCnstOtbnUrndLfsrSeed = {
+    256'h1102BE301EB1A8D04814AC33B45DE425069E5959DF06D42254A25AFAE52A5963
+  };
+
+  // Permutation applied to the LFSR chunks of the PRNG used for URND.
+  parameter otbn_pkg::urnd_chunk_lfsr_perm_t RndCnstOtbnUrndChunkLfsrPerm = {
+    128'h96C27A70B8A45CFD2D3B52B1F040DB79,
+    256'hA46ED80E5942BC02513FBDFD5A98A66805BC17DDED6CCD3271A3E37A08C92847
+  };
+
 endpackage : top_earlgrey_rnd_cnst_pkg

--- a/sw/device/tests/dif/dif_otbn_smoketest.c
+++ b/sw/device/tests/dif/dif_otbn_smoketest.c
@@ -11,6 +11,23 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+// Temporary solution to configue/enable the EDN and CSRNG to allow OTBN to run
+// before a DIF is available, https://github.com/lowRISC/opentitan/issues/6082
+static const uint32_t kEntropySrcConfRegOffset = 0x18;
+static const uint32_t kCsrngCtrlRegOffset = 0x14;
+static const uint32_t kEdnCtrlRegOffset = 0x14;
+
+static void setup_edn(void) {
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR),
+                      kEntropySrcConfRegOffset, 0x2);
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR),
+                      kCsrngCtrlRegOffset, 0x1);
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
+                      kEdnCtrlRegOffset, 0x9);
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR),
+                      kEdnCtrlRegOffset, 0x9);
+}
+
 OTBN_DECLARE_APP_SYMBOLS(barrett384);
 OTBN_DECLARE_PTR_SYMBOL(barrett384, wrap_barrett384);
 
@@ -129,6 +146,8 @@ static void test_err_test(otbn_t *otbn_ctx) {
 }
 
 bool test_main() {
+  setup_edn();
+
   dif_otbn_config_t otbn_config = {
       .base_addr = mmio_region_from_addr(TOP_EARLGREY_OTBN_BASE_ADDR),
   };

--- a/sw/device/tests/otbn/otbn_ecdsa_p256_test.c
+++ b/sw/device/tests/otbn/otbn_ecdsa_p256_test.c
@@ -11,6 +11,23 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+// Temporary solution to configue/enable the EDN and CSRNG to allow OTBN to run
+// before a DIF is available, https://github.com/lowRISC/opentitan/issues/6082
+static const uint32_t kEntropySrcConfRegOffset = 0x18;
+static const uint32_t kCsrngCtrlRegOffset = 0x14;
+static const uint32_t kEdnCtrlRegOffset = 0x14;
+
+static void setup_edn(void) {
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR),
+                      kEntropySrcConfRegOffset, 0x2);
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR),
+                      kCsrngCtrlRegOffset, 0x1);
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
+                      kEdnCtrlRegOffset, 0x9);
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR),
+                      kEdnCtrlRegOffset, 0x9);
+}
+
 /**
  * ECDSA sign and verify test with the NIST P-256 curve using OTBN.
  *
@@ -270,6 +287,8 @@ static void test_ecdsa_p256_roundtrip(void) {
 }
 
 bool test_main() {
+  setup_edn();
+
   test_ecdsa_p256_roundtrip();
 
   return true;

--- a/sw/device/tests/otbn/otbn_rsa_test.c
+++ b/sw/device/tests/otbn/otbn_rsa_test.c
@@ -11,6 +11,23 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+// Temporary solution to configue/enable the EDN and CSRNG to allow OTBN to run
+// before a DIF is available, https://github.com/lowRISC/opentitan/issues/6082
+static const uint32_t kEntropySrcConfRegOffset = 0x18;
+static const uint32_t kCsrngCtrlRegOffset = 0x14;
+static const uint32_t kEdnCtrlRegOffset = 0x14;
+
+static void setup_edn(void) {
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR),
+                      kEntropySrcConfRegOffset, 0x2);
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR),
+                      kCsrngCtrlRegOffset, 0x1);
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
+                      kEdnCtrlRegOffset, 0x9);
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR),
+                      kEdnCtrlRegOffset, 0x9);
+}
+
 /**
  * End-to-end RSA encryption and decryption test using OTBN.
  *
@@ -696,6 +713,8 @@ static void test_rsa4096_roundtrip(void) {
 }
 
 bool test_main() {
+  setup_edn();
+
   test_rsa512_roundtrip();
   test_rsa1024_roundtrip();
 


### PR DESCRIPTION
This is just a draft as it will break CI.

This introduces arbitrary stalls to OTBN which doesn't work with the ISS, it expects the RND read to complete in one cycle. Unlike a load we can't just specify a fixed number of cycles for the ISS to stall. It will either need to monitor the EDN interface/RND cache and use that to determine which cycle a RND read will complete or just observe the stall on an RND read and wait for the final unstalled cycle doing any checking then.

I've done some testing with the ISS disabled, the RND reads and prefetch all look to work, smoke test continues to pass.