### PR TITLE
[rtl/otp_ctrl] Report ECC correctable error in consistency check

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -354,6 +354,10 @@ module otp_ctrl_part_buf
                 error_d = CheckFailError;
               end
             end
+            // Signal ECC soft errors, but do not go into terminal error state.
+            if (otp_err_e'(otp_err_i) == MacroEccCorrError) begin
+              error_d = otp_err_e'(otp_err_i);
+            end
           end
         end
       end


### PR DESCRIPTION
This PR adds some logic to report ECC correctable error in consistency
check. Previous logic will silently fix the ecc correctable error
without reporting it to status and error bit.

Signed-off-by: Cindy Chen <chencindy@google.com>