### PR TITLE
[edn/rtl] increase boottime entropy req

### DIFF
--- a/hw/ip/edn/rtl/edn.sv
+++ b/hw/ip/edn/rtl/edn.sv
@@ -13,7 +13,7 @@ module edn
   parameter int NumEndPoints = 4,
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
   parameter int BootInsCmd = 32'h0000_0001,
-  parameter int BootGenCmd = 32'h0000_3003
+  parameter int BootGenCmd = 32'h00ff_f003
 ) (
   input logic clk_i,
   input logic rst_ni,


### PR DESCRIPTION
AES has need more entropy at boot time.
No reason not to increase the boot time generate cmd request.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>