### PR TITLE
[dv/alert_handler] remove logic to auto-generate alert parameters in alert_handler testbenches 

### DIFF
--- a/hw/ip/alert_handler/data/alert_handler_env_pkg__params.sv.tpl
+++ b/hw/ip/alert_handler/data/alert_handler_env_pkg__params.sv.tpl
@@ -1,6 +1,0 @@
-// Copyright lowRISC contributors.
-// Licensed under the Apache License, Version 2.0, see LICENSE for details.
-// SPDX-License-Identifier: Apache-2.0
-
-parameter uint NUM_ALERTS = ${n_alerts};
-parameter bit [NUM_ALERTS-1:0] ASYNC_ON = ${async_on};

--- a/hw/ip/alert_handler/doc/dv/index.md
+++ b/hw/ip/alert_handler/doc/dv/index.md
@@ -34,7 +34,7 @@ In addition, it instantiates the following interfaces, connects them to the DUT 
 * Interrupts ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}}))
 * Devmode ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}}))
 
-In chip level testing, alert_handler testbench environment can be reused with a chip-level paramter package located at `hw/$CHIP/ip/alert_handler/dv/alert_handler_env_pkg__params.sv`
+The alert_handler testbench environment can be reused in chip level testing.
 
 ### Common DV utility components
 The following utilities provide generic helper tasks and functions to perform activities that are common across the project:

--- a/hw/ip/alert_handler/dv/alert_handler_generic_sim.core
+++ b/hw/ip/alert_handler/dv/alert_handler_generic_sim.core
@@ -14,8 +14,6 @@ filesets:
     depend:
       - lowrisc:dv:alert_handler_tb
       - lowrisc:dv:alert_handler_sva
-    files:
-      - tb/alert_handler_env_pkg__params.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/alert_handler/dv/env/alert_handler_env_pkg.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_env_pkg.sv
@@ -18,11 +18,8 @@ package alert_handler_env_pkg;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
-  // this file could be auto-generated for top_earlgrey alert_handler
-  // the path to this file should be provided in alert_handler*_sim.core
-  `include "alert_handler_env_pkg__params.sv"
-
   // parameters
+  parameter uint NUM_ALERTS                  = alert_handler_reg_pkg::NAlerts;
   parameter uint NUM_ESCS                    = 4;
   parameter uint NUM_MAX_ESC_SEV             = 8;
   parameter uint NUM_ESC_SIGNALS             = 4;
@@ -31,6 +28,7 @@ package alert_handler_env_pkg;
   parameter uint NUM_ALERT_HANDLER_CLASS_MSB = $clog2(NUM_ALERT_HANDLER_CLASSES) - 1;
   parameter uint MIN_CYCLE_PER_PHASE         = 2;
   parameter uint NUM_LOCAL_ALERT             = 4;
+  parameter bit  [NUM_ALERTS-1:0] ASYNC_ON   = alert_handler_reg_pkg::AsyncOn;
   // ignore esc signal cycle count after ping occurs - as ping response might ended up adding one
   // extra cycle to the calculated cnt, or even combine two signals into one.
   parameter uint IGNORE_CNT_CHECK_NS         = 100_000_000;

--- a/hw/ip/alert_handler/dv/tb/alert_handler_env_pkg__params.sv
+++ b/hw/ip/alert_handler/dv/tb/alert_handler_env_pkg__params.sv
@@ -1,6 +1,0 @@
-// Copyright lowRISC contributors.
-// Licensed under the Apache License, Version 2.0, see LICENSE for details.
-// SPDX-License-Identifier: Apache-2.0
-
-parameter uint NUM_ALERTS = 4;
-parameter bit [NUM_ALERTS-1:0] ASYNC_ON = 0;

--- a/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_sim.core
+++ b/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_sim.core
@@ -14,8 +14,6 @@ filesets:
     depend:
       - lowrisc:dv:alert_handler_tb
       - lowrisc:top_earlgrey:alert_handler_sva
-    files:
-      - alert_handler_env_pkg__params.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/top_englishbreakfast/util/remove_autogen_files.sh
+++ b/hw/top_englishbreakfast/util/remove_autogen_files.sh
@@ -15,7 +15,6 @@ top_path=$(dirname $(realpath $0))/../
 find ${top_path} -depth -type d -name "autogen" -exec rm -rf {} \;
 
 # Some autogen files are not in autogen folders.
-rm -rf ${top_path}/ip/alert_handler/dv/alert_handler_env_pkg__params.sv
 rm -rf ${top_path}/ip/sensor_ctrl/rtl/*
 rm -rf ${top_path}/ip/xbar_main/xbar_main.core
 rm -rf ${top_path}/ip/xbar_peri/xbar_peri.core

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -155,14 +155,11 @@ def generate_alert_handler(top, out_path):
     rtl_path.mkdir(parents=True, exist_ok=True)
     doc_path = out_path / 'ip/alert_handler/data/autogen'
     doc_path.mkdir(parents=True, exist_ok=True)
-    dv_path = out_path / 'ip/alert_handler/dv'
-    dv_path.mkdir(parents=True, exist_ok=True)
 
     # Generating IP top module script is not generalized yet.
     # So, topgen reads template files from alert_handler directory directly.
     tpl_path = Path(__file__).resolve().parent / '../hw/ip/alert_handler/data'
     hjson_tpl_path = tpl_path / 'alert_handler.hjson.tpl'
-    dv_tpl_path = tpl_path / 'alert_handler_env_pkg__params.sv.tpl'
 
     # Generate Register Package and RTLs
     out = StringIO()
@@ -196,22 +193,6 @@ def generate_alert_handler(top, out_path):
                             object_pairs_hook=validate.checking_dict)
     validate.validate(hjson_obj)
     gen_rtl.gen_rtl(hjson_obj, str(rtl_path))
-
-    # generate testbench for alert_handler
-    with dv_tpl_path.open(mode='r', encoding='UTF-8') as fin:
-        dv_tpl = Template(fin.read())
-        try:
-            out = dv_tpl.render(n_alerts=n_alerts, async_on=async_on)
-        except:  # noqa : E722
-            log.error(exceptions.text_error_template().render())
-        log.info("ALERT_HANDLER DV: %s" % out)
-        if out == "":
-            log.error("Cannot generate dv alert_handler parameter file")
-            return
-
-        dv_gen_path = dv_path / 'alert_handler_env_pkg__params.sv'
-        with dv_gen_path.open(mode='w', encoding='UTF-8') as fout:
-            fout.write(genhdr + gencmd + out)
 
 
 def generate_plic(top, out_path):


### PR DESCRIPTION
In previous logic, DV will auto-generate parameters from hjson file,
which includes `NUM_ALERTS` and `ASYNC_ON` in alert_handler testbenches
for both IP and top_level. (Note this is still alert_handler testbench, not top_level DV).

However, in design, these parameters are auto-generated from hjson as
well. There is no need to generate again in DV, and it is easier to just
reuse the parameter from design.

thanks Philipp for pointing out the confusion. 

Signed-off-by: Cindy Chen <chencindy@google.com>