### PR TITLE
[aon_timer] Change escalate_en control to cpu_en

### DIFF
--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -51,7 +51,7 @@
     // Broadcast from LC
     { struct:  "lc_tx"
       type:    "uni"
-      name:    "lc_escalate_en"
+      name:    "lc_cpu_en"
       act:     "rcv"
       default: "lc_ctrl_pkg::Off"
       package: "lc_ctrl_pkg"

--- a/hw/ip/aon_timer/rtl/aon_timer.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer.sv
@@ -16,7 +16,7 @@ module aon_timer (
   output tlul_pkg::tl_d2h_t   tl_o,
 
   // clk_i domain
-  input  lc_ctrl_pkg::lc_tx_t lc_escalate_en_i,
+  input  lc_ctrl_pkg::lc_tx_t lc_cpu_en_i,
   output logic                intr_wkup_timer_expired_o,
   output logic                intr_wdog_timer_bark_o,
 
@@ -63,7 +63,7 @@ module aon_timer (
   logic                      wdog_count_reg_wr;
   logic [31:0]               wdog_count_wr_data;
   // Other sync signals
-  lc_ctrl_pkg::lc_tx_t [2:0] lc_escalate_en;
+  lc_ctrl_pkg::lc_tx_t [2:0] lc_cpu_en;
   // Wakeup signals
   logic                      aon_wkup_req_d, aon_wkup_req_q;
   logic                      wkup_ack, aon_wkup_ack;
@@ -252,11 +252,11 @@ module aon_timer (
   // Lifecycle sync
   prim_lc_sync #(
     .NumCopies(3)
-  ) u_lc_sync_escalate_en (
+  ) u_lc_sync_cpu_en (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
-    .lc_en_i (lc_escalate_en_i),
-    .lc_en_o (lc_escalate_en)
+    .lc_en_i (lc_cpu_en_i),
+    .lc_en_o (lc_cpu_en)
   );
 
   ////////////////
@@ -277,7 +277,7 @@ module aon_timer (
     .clk_aon_i,
     .rst_aon_ni,
     .sleep_mode_i              (sleep_mode),
-    .lc_escalate_en_i          (lc_escalate_en),
+    .lc_cpu_en_i               (lc_cpu_en),
     .wkup_enable_o             (wkup_enable),
     .wkup_prescaler_o          (wkup_prescaler),
     .wkup_thold_o              (wkup_thold),

--- a/hw/ip/aon_timer/rtl/aon_timer_core.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_core.sv
@@ -7,7 +7,7 @@ module aon_timer_core (
   input  logic                      clk_aon_i,
   input  logic                      rst_aon_ni,
 
-  input  lc_ctrl_pkg::lc_tx_t [2:0] lc_escalate_en_i,
+  input  lc_ctrl_pkg::lc_tx_t [2:0] lc_cpu_en_i,
   input  logic                      sleep_mode_i,
 
   // Register read outputs
@@ -94,7 +94,7 @@ module aon_timer_core (
 
   // Prescaler counter
   assign prescale_count_d = wkup_incr ? 12'h000 : (prescale_count_q + 12'h001);
-  assign prescale_en      = lc_escalate_en_i[0] == lc_ctrl_pkg::Off;
+  assign prescale_en      = lc_cpu_en_i[0] == lc_ctrl_pkg::Off;
 
   always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
     if (!rst_aon_ni) begin
@@ -105,7 +105,7 @@ module aon_timer_core (
   end
 
   // Wakeup timer count
-  assign wkup_incr     = (lc_escalate_en_i[1] == lc_ctrl_pkg::Off) & wkup_enable_q &
+  assign wkup_incr     = (lc_cpu_en_i[1] == lc_ctrl_pkg::Off) & wkup_enable_q &
                          (prescale_count_q == wkup_prescaler_q);
   assign wkup_count_d  = wkup_count_reg_wr_i ? wkup_count_wr_data_i :
                                                (wkup_count_q + 32'd1);
@@ -172,7 +172,7 @@ module aon_timer_core (
   assign wdog_bite_thold_o = wdog_bite_thold_q;
 
   // Watchdog timer count
-  assign wdog_incr     = wdog_enable_q & (lc_escalate_en_i[2] == lc_ctrl_pkg::Off) &
+  assign wdog_incr     = wdog_enable_q & (lc_cpu_en_i[2] == lc_ctrl_pkg::Off) &
                          ~(sleep_mode_i & wdog_pause_q);
   assign wdog_count_d  = wdog_count_reg_wr_i ? wdog_count_wr_data_i :
                                                (wdog_count_q + 32'd1);

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3875,7 +3875,7 @@
           index: -1
         }
         {
-          name: lc_escalate_en
+          name: lc_cpu_en
           struct: lc_tx
           package: lc_ctrl_pkg
           type: uni
@@ -3883,6 +3883,7 @@
           width: 1
           default: lc_ctrl_pkg::Off
           inst_name: aon_timer_aon
+          top_signame: lc_ctrl_lc_cpu_en
           index: -1
         }
         {
@@ -6731,6 +6732,7 @@
       lc_ctrl.lc_cpu_en:
       [
         rv_core_ibex.lc_cpu_en
+        aon_timer_aon.lc_cpu_en
       ]
       lc_ctrl.lc_keymgr_en:
       [
@@ -11790,7 +11792,7 @@
         index: -1
       }
       {
-        name: lc_escalate_en
+        name: lc_cpu_en
         struct: lc_tx
         package: lc_ctrl_pkg
         type: uni
@@ -11798,6 +11800,7 @@
         width: 1
         default: lc_ctrl_pkg::Off
         inst_name: aon_timer_aon
+        top_signame: lc_ctrl_lc_cpu_en
         index: -1
       }
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -827,7 +827,7 @@
       'lc_ctrl.lc_hw_debug_en'     : ['sram_ctrl_main.lc_hw_debug_en',
                                       'sram_ctrl_ret_aon.lc_hw_debug_en',
                                       'pinmux_aon.lc_hw_debug_en'],
-      'lc_ctrl.lc_cpu_en'          : ['rv_core_ibex.lc_cpu_en'],
+      'lc_ctrl.lc_cpu_en'          : ['rv_core_ibex.lc_cpu_en', 'aon_timer_aon.lc_cpu_en'],
       'lc_ctrl.lc_keymgr_en'       : ['keymgr.lc_keymgr_en'],
       'lc_ctrl.lc_escalate_en'     : ['aes.lc_escalate_en',
                                       'otp_ctrl.lc_escalate_en',

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1688,7 +1688,7 @@ module top_earlgrey #(
       // Inter-module signals
       .aon_timer_wkup_req_o(pwrmgr_aon_wakeups[2]),
       .aon_timer_rst_req_o(pwrmgr_aon_rstreqs),
-      .lc_escalate_en_i(lc_ctrl_pkg::Off),
+      .lc_cpu_en_i(lc_ctrl_lc_cpu_en),
       .sleep_mode_i(pwrmgr_aon_low_power),
       .tl_i(aon_timer_aon_tl_req),
       .tl_o(aon_timer_aon_tl_rsp),


### PR DESCRIPTION
* The issue with using escalate_en is that if the software configures
  the alert handling to skip from normal directly to scrap, we may not
  halt the watchdog timer.  There are also similar issues with other
  invalid states.
* By using cpu_en, we align the behavior of the aon_timer with that of
  the processing element (its main consumer) and thus is more consistent
  overall.  If the cpu is running, then the watchdog / wake timer should
  be in effect.  If the cpu is halted due to life cycle reasons, there
  would be no one to consume the output anyways.

Signed-off-by: Timothy Chen <timothytim@google.com>