### PR TITLE
[top / tlul] Enable integrity checks in both hosts and device

### DIFF
--- a/hw/dv/sv/sim_sram/sim_sram.sv
+++ b/hw/dv/sv/sim_sram/sim_sram.sv
@@ -96,7 +96,9 @@ module sim_sram #(
       .SramAw     (SramAddrWidth),
       .SramDw     (Width),
       .ErrOnRead  (ErrOnRead),
-      .Outstanding(2)
+      .Outstanding(2),
+      .EnableRspIntgGen(1),
+      .EnableDataIntgGen(1)
     ) u_tl_adapter_sim_sram (
       .clk_i,
       .rst_ni,

--- a/hw/dv/sv/sim_sram/tlul_sink.sv
+++ b/hw/dv/sv/sim_sram/tlul_sink.sv
@@ -75,7 +75,8 @@ module tlul_sink import tlul_pkg::*; (
   //////////////////
   // Final Output //
   //////////////////
-  assign tl_o = '{
+  tlul_pkg::tl_d2h_t tl_o_pre;
+  assign tl_o_pre = '{
     a_ready:  ~pending,
     d_valid:  pending,
     d_opcode: d_opcode_q,
@@ -87,5 +88,10 @@ module tlul_sink import tlul_pkg::*; (
     d_user:   '0,
     d_error:  d_error_q
   };
+
+  tlul_rsp_intg_gen u_gen (
+    .tl_i(tl_o_pre),
+    .tl_o
+  );
 
 endmodule

--- a/hw/dv/sv/tl_agent/tl_agent.core
+++ b/hw/dv/sv/tl_agent/tl_agent.core
@@ -9,6 +9,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:tlul:headers:0.1
+      - lowrisc:prim:secded
       - lowrisc:dv:mem_model
       - lowrisc:dv:dv_lib
       - lowrisc:opentitan:bus_params_pkg

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -107,7 +107,7 @@ class tl_host_driver extends tl_base_driver;
         cfg.vif.host_cb.h2d_int.a_param   <= req.a_param;
         cfg.vif.host_cb.h2d_int.a_data    <= req.a_data;
         cfg.vif.host_cb.h2d_int.a_mask    <= req.a_mask;
-        cfg.vif.host_cb.h2d_int.a_user    <= tlul_pkg::TL_A_USER_DEFAULT;
+        cfg.vif.host_cb.h2d_int.a_user    <= req.get_a_user_val();
         cfg.vif.host_cb.h2d_int.a_source  <= req.a_source;
         cfg.vif.host_cb.h2d_int.a_valid   <= 1'b1;
       end else begin

--- a/hw/dv/sv/tl_agent/tl_seq_item.sv
+++ b/hw/dv/sv/tl_agent/tl_seq_item.sv
@@ -238,7 +238,55 @@ class tl_seq_item extends uvm_sequence_item;
 
   function bit get_error_size_over_max();
     return !(`chk_prot_max_size);
-  endfunction
+  endfunction // get_error_size_over_max
+
+  // Calling secded 64_57 directly does not seem great...
+  // Temporary solution to get dv going
+  virtual function tl_a_user_t get_a_user_val();
+    tl_a_user_t user;
+    tl_h2d_cmd_intg_t cmd_intg_payload;
+    logic [H2DCmdFullWidth - 1:0] payload_intg;
+    logic [D2HRspFullWidth - 1:0] data_intg;
+
+    // construct command integrity
+    cmd_intg_payload.tl_type = DataType;
+    cmd_intg_payload.addr = a_addr;
+    cmd_intg_payload.opcode = tl_a_op_e'(a_opcode);
+    cmd_intg_payload.mask = a_mask;
+    payload_intg = prim_secded_pkg::prim_secded_64_57_enc(H2DCmdMaxWidth'(cmd_intg_payload));
+
+    // construct data integrity
+    data_intg = prim_secded_pkg::prim_secded_64_57_enc(DataMaxWidth'(a_data));
+
+    user.rsvd = '0;
+    user.tl_type = DataType;
+    user.cmd_intg = payload_intg[H2DCmdFullWidth -1 -: H2DCmdIntgWidth];
+    user.data_intg = data_intg[DataFullWidth -1 -: DataIntgWidth];;
+    return user;
+  endfunction // get_a_user_val
+
+  // device facing version of the function above
+  virtual function tl_d_user_t get_d_user_val();
+    tl_d_user_t user;
+    tl_d2h_rsp_intg_t rsp_intg_payload;
+    logic [D2HRspFullWidth - 1:0] payload_intg;
+    logic [D2HRspFullWidth - 1:0] data_intg;
+
+    // construct response integrity
+    rsp_intg_payload.opcode = tl_d_op_e'(d_opcode);
+    rsp_intg_payload.size = d_size;
+    rsp_intg_payload.error = d_error;
+    payload_intg = prim_secded_pkg::prim_secded_64_57_enc(D2HRspMaxWidth'(rsp_intg_payload));
+
+    // construct data integrity
+    data_intg = prim_secded_pkg::prim_secded_64_57_enc(DataMaxWidth'(d_data));
+
+    user.rsp_intg = payload_intg[D2HRspFullWidth -1 -: D2HRspIntgWidth];
+    user.data_intg = data_intg[DataFullWidth -1 -: DataIntgWidth];
+    return user;
+  endfunction // get_d_user_val
+
+
 
   function void disable_a_chan_protocol_constraint();
     a_opcode_c.constraint_mode(0);

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -50,19 +50,21 @@ module aes_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_top.sv
@@ -50,19 +50,21 @@ module alert_handler_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
@@ -50,19 +50,21 @@ module aon_timer_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr_reg_top.sv
@@ -50,19 +50,21 @@ module clkmgr_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -50,19 +50,21 @@ module csrng_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -50,19 +50,21 @@ module edn_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -50,19 +50,21 @@ module entropy_src_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
@@ -55,19 +55,21 @@ module flash_ctrl_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/gpio/rtl/gpio_reg_top.sv
+++ b/hw/ip/gpio/rtl/gpio_reg_top.sv
@@ -50,19 +50,21 @@ module gpio_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -55,19 +55,21 @@ module hmac_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -50,19 +50,21 @@ module i2c_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -50,19 +50,21 @@ module keymgr_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -55,19 +55,21 @@ module kmac_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
@@ -50,19 +50,21 @@ module lc_ctrl_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/nmi_gen/rtl/nmi_gen_reg_top.sv
+++ b/hw/ip/nmi_gen/rtl/nmi_gen_reg_top.sv
@@ -50,19 +50,21 @@ module nmi_gen_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -55,19 +55,21 @@ module otbn_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
@@ -55,19 +55,21 @@ module otp_ctrl_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/pattgen/rtl/pattgen_reg_top.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_top.sv
@@ -50,19 +50,21 @@ module pattgen_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/ip/pinmux/rtl/pinmux_reg_top.sv
@@ -50,19 +50,21 @@ module pinmux_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -50,19 +50,21 @@ module pwrmgr_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_reg_top.sv
@@ -50,19 +50,21 @@ module rstmgr_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -337,7 +337,8 @@ module rv_dm #(
     .SramAw(AddressWidthWords),
     .SramDw(BusWidth),
     .Outstanding(1),
-    .ByteAccess(0)
+    .ByteAccess(0),
+    .EnableRspIntgGen(1)
   ) tl_adapter_device_mem (
     .clk_i,
     .rst_ni,

--- a/hw/ip/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic_reg_top.sv
@@ -50,19 +50,21 @@ module rv_plic_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
@@ -50,19 +50,21 @@ module rv_timer_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -55,19 +55,21 @@ module spi_device_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -55,19 +55,21 @@ module spi_host_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_top.sv
@@ -50,19 +50,21 @@ module sram_ctrl_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/tlul/rtl/tlul_cmd_intg_chk.sv
+++ b/hw/ip/tlul/rtl/tlul_cmd_intg_chk.sv
@@ -27,7 +27,9 @@ module tlul_cmd_intg_chk import tlul_pkg::*; (
     .err_o(err)
   );
 
-  assign err_o = |err;
+  // error output is transactional, it is up to the instantiating module
+  // to determine if a permanent latch is feasible
+  assign err_o = tl_i.a_valid & |err;
 
   logic unused_tl;
   assign unused_tl = |tl_i;

--- a/hw/ip/tlul/rtl/tlul_pkg.sv
+++ b/hw/ip/tlul/rtl/tlul_pkg.sv
@@ -39,10 +39,13 @@ package tlul_pkg;
 
   parameter int H2DCmdMaxWidth  = 57;
   parameter int H2DCmdIntgWidth = 7;
+  parameter int H2DCmdFullWidth = H2DCmdMaxWidth + H2DCmdIntgWidth;
   parameter int D2HRspMaxWidth  = 57;
   parameter int D2HRspIntgWidth = 7;
+  parameter int D2HRspFullWidth = D2HRspMaxWidth + D2HRspIntgWidth;
   parameter int DataMaxWidth    = 57;
   parameter int DataIntgWidth   = 7;
+  parameter int DataFullWidth   = DataMaxWidth + DataIntgWidth;
 
   typedef struct packed {
     logic [4:0]                 rsvd;
@@ -114,7 +117,11 @@ package tlul_pkg;
   typedef struct packed {
     tl_d_op_e                     opcode;
     logic  [top_pkg::TL_SZW-1:0]  size;
-    logic  [top_pkg::TL_AIW-1:0]  source;
+    // Temporarily removed because source changes throughout the fabric
+    // and thus cannot be used for end-to-end checking.
+    // A different PR will propose a work-around (a hoaky one) to see if
+    // it gets the job done.
+    //logic  [top_pkg::TL_AIW-1:0]  source;
     logic                         error;
   } tl_d2h_rsp_intg_t;
 
@@ -153,7 +160,7 @@ package tlul_pkg;
     unused_tlul = ^tl;
     payload.opcode = tl.d_opcode;
     payload.size   = tl.d_size;
-    payload.source = tl.d_source;
+    //payload.source = tl.d_source;
     payload.error  = tl.d_error;
     return payload;
   endfunction // extract_d2h_rsp_intg

--- a/hw/ip/tlul/rtl/tlul_rsp_intg_chk.sv
+++ b/hw/ip/tlul/rtl/tlul_rsp_intg_chk.sv
@@ -27,7 +27,12 @@ module tlul_rsp_intg_chk import tlul_pkg::*; (
     .err_o(err)
   );
 
-  assign err_o = |err;
+  // error is not permanently latched as rsp_intg_chk is typically
+  // used near the host.
+  // if the error is permanent, it would imply the host could forever
+  // receive bus errors and lose all ability to debug.
+  // It should be up to the host to determine the permanence of this error.
+  assign err_o = tl_i.d_valid & |err;
 
   logic unused_tl;
   assign unused_tl = |tl_i;

--- a/hw/ip/trial1/rtl/trial1_reg_top.sv
+++ b/hw/ip/trial1/rtl/trial1_reg_top.sv
@@ -50,19 +50,21 @@ module trial1_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -50,19 +50,21 @@ module uart_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -55,19 +55,21 @@ module usbdev_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/ip/usbuart/rtl/usbuart_reg_top.sv
+++ b/hw/ip/usbuart/rtl/usbuart_reg_top.sv
@@ -50,19 +50,21 @@ module usbuart_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
@@ -50,19 +50,21 @@ module alert_handler_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
@@ -50,19 +50,21 @@ module ast_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -50,19 +50,21 @@ module clkmgr_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_top.sv
@@ -55,19 +55,21 @@ module flash_ctrl_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
@@ -50,19 +50,21 @@ module pinmux_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
@@ -50,19 +50,21 @@ module pwrmgr_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
@@ -50,19 +50,21 @@ module rstmgr_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
@@ -50,19 +50,21 @@ module rv_plic_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
@@ -50,19 +50,21 @@ module sensor_ctrl_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -75,19 +75,21 @@ module ${lblock}_reg_top (
   logic intg_err;
   tlul_cmd_intg_chk u_chk (
     .tl_i,
-    // connect this to intg_err later when all DV / hosts are hooked up
-    .err_o()
+    .err_o(intg_err)
   );
-  assign intg_err = 1'b0;
 
-  // Once integrity error is detected, it does not let go until reset.
+  logic intg_err_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intg_err_o <= '0;
+      intg_err_q <= '0;
     end else if (intg_err) begin
-      intg_err_o <= 1'b1;
+      intg_err_q <= 1'b1;
     end
   end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = intg_err_q | intg_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;


### PR DESCRIPTION
This PR enables integrity checks throughout the system.
The integrity scheme is still not complete because data integrity still must be propagated through fully. This PR focuses on turning on the command and response integrity checks. 

Updates are made to DV components (these are expected to be enhanced more later) to allow block and top level environments to continue working. 

See #5450 for additional to do items. 

Sorry for the massive size of this PR.  But most files are generated, the actual changes are fairly small and should be easy to review. 