### PR TITLE
[dv] force life cycle input for mem test

### DIFF
--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -326,7 +326,7 @@ module tb;
     string common_seq_type, csr_seq_type;
     void'($value$plusargs("run_%0s", common_seq_type));
     void'($value$plusargs("csr_%0s", csr_seq_type));
-    if (common_seq_type inside {"mem_partial_access", "tl_errors"} ||
+    if (common_seq_type inside {"mem_partial_access", "csr_mem_rw_with_rand_reset", "tl_errors"} ||
         csr_seq_type == "mem_walk") begin
       force tb.dut.top_earlgrey.u_otp_ctrl.lc_dft_en_i = 4'b1010;
     end


### PR DESCRIPTION
The force was added before. Need to add it for
csr_mem_rw_with_rand_reset as well

Signed-off-by: Weicai Yang <weicai@google.com>