### PR TITLE
[pattgen, dv] Update pattgen dv

### DIFF
--- a/hw/ip/pattgen/data/pattgen_testplan.hjson
+++ b/hw/ip/pattgen/data/pattgen_testplan.hjson
@@ -5,7 +5,7 @@
   name: "pattgen"
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
-"hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"],
   entries: [
     {

--- a/hw/ip/pattgen/dv/cov/pattgen_cov.core
+++ b/hw/ip/pattgen/dv/cov/pattgen_cov.core
@@ -1,0 +1,20 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:pattgen_cov:0.1"
+description: "PATTGEN functional coverage interface & bind."
+
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:dv_utils
+    files:
+      - pattgen_cov_if.sv
+      - pattgen_cov_bind.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/pattgen/dv/cov/pattgen_cov_bind.sv
+++ b/hw/ip/pattgen/dv/cov/pattgen_cov_bind.sv
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Binds PATTGEN functional coverage interaface to the top level PATTGEN module.
+module pattgen_cov_bind;
+
+  bind pattgen pattgen_cov_if u_pattgen_cov_if (.*);
+
+endmodule

--- a/hw/ip/pattgen/dv/cov/pattgen_cov_if.sv
+++ b/hw/ip/pattgen/dv/cov/pattgen_cov_if.sv
@@ -1,0 +1,82 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Implements functional coverage for PATTGEN.
+interface pattgen_cov_if (
+  input logic clk_i
+);
+
+  import uvm_pkg::*;
+  import dv_utils_pkg::*;
+  `include "dv_fcov_macros.svh"
+
+  bit en_full_cov = 1'b1;
+  bit en_intg_cov = 1'b1;
+
+  // If en_full_cov is set, then en_intg_cov must also be set since it is a subset.
+  bit en_intg_cov_loc;
+  assign en_intg_cov_loc = en_full_cov | en_intg_cov;
+
+  bit ch0_perf, ch1_perf;
+  assign ch0_perf = {u_pattgen_core.ch0_ctrl.len, 
+                     u_pattgen_core.ch0_ctrl.reps, 
+                     u_pattgen_core.ch0_ctrl.prediv} == 'h0;
+  assign ch1_perf = {u_pattgen_core.ch1_ctrl.len,
+                     u_pattgen_core.ch1_ctrl.reps,
+                     u_pattgen_core.ch1_ctrl.prediv} == 'h0;
+
+  covergroup pattgen_op_cg @(u_pattgen_core.ch0_ctrl.enable or u_pattgen_core.ch1_ctrl.enable);
+    option.name         = "pattgen_op_cg";
+    option.comment      = "PATTGEN CH0 and CH1 operation";
+    option.per_instance = 1;
+
+    // Channel 0 coverpoints
+    cp_enable: coverpoint {u_pattgen_core.ch1_ctrl.enable, u_pattgen_core.ch0_ctrl.enable} {
+      bins CH0_ENABLE  = (2'b00 => 2'b01);
+      bins CH0_DISABLE = (2'b01 => 2'b00);
+      bins CH1_ENABLE  = (2'b00 => 2'b10);
+      bins CH1_DISABLE = (2'b10 => 2'b00);
+      bins CHX_ENABLE  = (2'b00 => 2'b11);  // CHX: dual channels
+      bins CHX_DISABLE = (2'b11 => 2'b00);
+      bins CHX_OTHERS  = default;
+    }
+    // Channel 0 coverpoints
+    cp_ch0_perf: coverpoint {ch0_perf} {
+      bins LOW_PERF = {'h0};
+      bins TYP_PERF = {!'h0};
+    }
+    cp_ch0_polarity: coverpoint {u_pattgen_core.ch0_ctrl.polarity} {
+      bins TX_CLK_FALL = {1'b0};
+      bins TX_CLK_RISE = {1'b1};
+    }
+
+    // Channel 1 coverpoints
+    cp_ch1_perf: coverpoint {ch1_perf} {
+      bins LOW_PERF = {'h0};
+      bins TYP_PERF = {!'h0};
+    }
+    cp_ch1_polarity: coverpoint {u_pattgen_core.ch1_ctrl.polarity} {
+      bins TX_CLK_FALL = {1'b0};
+      bins TX_CLK_RISE = {1'b1};
+    }
+
+    // Cross coverpoints
+    cr_ch0_op: cross cp_enable, cp_ch0_polarity, cp_ch0_perf {
+      bins CH0_OP_ENABLE  = binsof(cp_enable.CH0_ENABLE);
+      bins CH0_OP_DISABLE = binsof(cp_enable.CH0_DISABLE);
+    }
+    cr_ch1_op: cross cp_enable, cp_ch1_polarity, cp_ch1_perf {
+      bins CH1_OP_ENABLE  = binsof(cp_enable.CH1_ENABLE);
+      bins CH1_OP_DISABLE = binsof(cp_enable.CH1_DISABLE);
+    }
+    cr_chx_op: cross cp_enable, cp_ch0_polarity, cp_ch0_perf, cp_ch1_polarity, cp_ch1_perf {
+      bins CHX_OP_ENABLE  = binsof(cp_enable.CHX_ENABLE);
+      bins CHX_OP_DISABLE = binsof(cp_enable.CHX_DISABLE);
+    }
+
+  endgroup : pattgen_op_cg
+
+  `DV_FCOV_INSTANTIATE_CG(pattgen_op_cg, en_full_cov)
+
+endinterface : pattgen_cov_if

--- a/hw/ip/pattgen/dv/env/seq_lib/pattgen_perf_vseq.sv
+++ b/hw/ip/pattgen/dv/env/seq_lib/pattgen_perf_vseq.sv
@@ -23,7 +23,7 @@ class pattgen_perf_vseq extends pattgen_base_vseq;
         1'b0 :/ cfg.seq_cfg.pattgen_low_polarity_pct,
         1'b1 :/ (100 - cfg.seq_cfg.pattgen_low_polarity_pct)
       };
-      ch_cfg.prediv dist {0 :/ 1, 1024 :/ 2};
+      ch_cfg.prediv dist {0 :/ 1, 1024 :/ 1};
       ch_cfg.len    dist {0 :/ 1, 1023 :/ 1};
       ch_cfg.reps   dist {0 :/ 1,   63 :/ 1};
       // dependent constraints

--- a/hw/ip/pattgen/dv/pattgen_sim.core
+++ b/hw/ip/pattgen/dv/pattgen_sim.core
@@ -13,6 +13,7 @@ filesets:
     depend:
       - lowrisc:dv:pattgen_test
       - lowrisc:dv:pattgen_sva
+      - lowrisc:dv:pattgen_cov
     files:
       - tb.sv
     file_type: systemVerilogSource

--- a/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson
+++ b/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson
@@ -41,7 +41,13 @@
 
   // Default UVM test and seq class name.
   uvm_test: pattgen_base_test
-  uvm_test_seq: pattgen_base_vseq
+  uvm_test_seq: pattgen_base_vseq,
+
+  // additional top for coverage
+  sim_tops: [ "pattgen_bind", "pattgen_cov_bind"]
+  
+  // Pattgen functional coverage
+  xcelium_cov_refine_files: ["{proj_root}/hw/ip/pattgen/dv/cov/pattgen_cov.vRefine"]
 
   // List of test specifications.
   tests: [


### PR DESCRIPTION
Update pattgen dv

  - Add functional coverage dv/cov
  - Update scoreboard for coverage
  - Fix stress_all_with_rand_reset test 

Note: pattgen_cov.vRefine is WiP

Signed-off-by: Hoang Tung <Hoang.Tung@wdc.com>