### PR TITLE
[dv/otp_ctrl] Fix lc sequence mismatch

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -22,8 +22,9 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
 
   // connect with lc_prog push-pull interface
   logic                lc_prog_req, lc_prog_err;
-  logic                lc_prog_err_dly1, lc_prog_no_intr_check;
+  logic                lc_prog_err_dly1, lc_prog_no_sta_check;
 
+  // Lc_err could trigger during LC program, so check intr and status after lc_req is finished.
   // Lc_err takes one clock cycle to propogate to intr signal. So avoid intr check if it happens
   // during the transition.
   always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -33,7 +34,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
       lc_prog_err_dly1 <= lc_prog_err;
     end
   end
-  assign lc_prog_no_intr_check = lc_prog_err | lc_prog_err_dly1;
+  assign lc_prog_no_sta_check = lc_prog_err | lc_prog_err_dly1 | lc_prog_req;
 
   // TODO: for lc_tx, except esc_en signal, all value different from On is treated as Off,
   // technically we can randomize values here once scb supports

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -238,9 +238,10 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
 
   virtual task rd_and_clear_intrs();
     bit [TL_DW-1:0] val;
-    wait(cfg.otp_ctrl_vif.lc_prog_no_intr_check == 0);
-    csr_rd(ral.intr_state, val);
-    csr_wr(ral.intr_state, val);
+    if (cfg.otp_ctrl_vif.lc_prog_no_sta_check == 0) begin
+      csr_rd(ral.intr_state, val);
+      csr_wr(ral.intr_state, val);
+    end
   endtask
 
   virtual task req_sram_key(int index);


### PR DESCRIPTION
This PR fixed nightly regression lc sequence mismatch to align with
design behavior in PR #5433

Signed-off-by: Cindy Chen <chencindy@google.com>