### PR TITLE
[dv/dpi] Fix assignment to SystemVerilog chandle

### DIFF
--- a/hw/dv/dpi/dmidpi/dmidpi.sv
+++ b/hw/dv/dpi/dmidpi/dmidpi.sv
@@ -43,7 +43,7 @@ module dmidpi #(
 
   final begin
     dmidpi_close(ctx);
-    ctx = 0;
+    ctx = null;
   end
 
   always_ff @(posedge clk_i, negedge rst_ni) begin

--- a/hw/dv/dpi/jtagdpi/jtagdpi.sv
+++ b/hw/dv/dpi/jtagdpi/jtagdpi.sv
@@ -36,7 +36,7 @@ module jtagdpi #(
 
   final begin
     jtagdpi_close(ctx);
-    ctx = 0;
+    ctx = null;
   end
 
   always_ff @(posedge clk_i, negedge rst_ni) begin

--- a/hw/dv/dpi/uartdpi/uartdpi.sv
+++ b/hw/dv/dpi/uartdpi/uartdpi.sv
@@ -44,7 +44,7 @@ module uartdpi #(
 
   final begin
     uartdpi_close(ctx);
-    ctx = 0;
+    ctx = null;
   end
 
   // TX


### PR DESCRIPTION
Section 6.14 of the standard states that assignment to chandle can only
be made from `null` or an other chandle, not from an integer literal.

This patch allows the compilation of the simulation models with modelsim