### PR TITLE
[lint] Waive Verilator warnings about unused parameters in packages

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -28,8 +28,7 @@ module otbn_core_model
   // real implementation running alongside and we check DMEM contents on completion.
   parameter string DesignScope = "",
 
-  localparam int ImemAddrWidth = prim_util_pkg::vbits(ImemSizeByte),
-  localparam int DmemAddrWidth = prim_util_pkg::vbits(DmemSizeByte)
+  localparam int ImemAddrWidth = prim_util_pkg::vbits(ImemSizeByte)
 )(
   input  logic  clk_i,
   input  logic  rst_ni,

--- a/hw/lint/tools/verilator/common.vlt
+++ b/hw/lint/tools/verilator/common.vlt
@@ -13,3 +13,8 @@ lint_off -rule PINCONNECTEMPTY
 // This warning gives wrong results with blackboxed embedded modules, see
 // https://github.com/verilator/verilator/issues/2430
 lint_off -rule DECLFILENAME -file "*" -match "Filename '*' does not match NOTFOUNDMODULE name:*"
+
+// Don't generate lint errors for unused parameters in packages. The point is
+// that a user of a package might not want to use all of the parameters it
+// defines.
+lint_off -rule UNUSED -file "*_pkg.sv" -match "*Parameter is not used*"


### PR DESCRIPTION
There's also a (genuine) OTBN cleanup that got caught by the same Verilator check, but the interesting patch is the first one, with the following commit message:

By default, recent versions of Verilator complain if not every
parameter that was defined in a package gets used somewhere. This
might be reasonable if there's a single top-level, but it doesn't work
at all if you have lots of different top-levels (several chip
top-levels, then each IP block), all of whom use different
combinations of the parameters.
