### PR TITLE
[fpv] Move .core file generation into reggen

### DIFF
--- a/hw/formal/tools/csr_assert_gen/csr_assert_gen.py
+++ b/hw/formal/tools/csr_assert_gen/csr_assert_gen.py
@@ -36,15 +36,10 @@ def main():
     # Retrieve the parameters from the yml.
     files_root_dir = gapi['files_root']
     spec = gapi['parameters'].get('spec')
-    name = os.path.basename(spec).replace(".hjson", "")
-    depend = gapi['parameters'].get('depend') or "lowrisc:ip:{}".format(name)
 
-    if not name or not spec:
+    if not spec:
         print("Error: \"spec\" parameter missing or invalid: {}".format(spec))
         sys.exit(1)
-
-    # Generate the CSR assert file.
-    csr_assert_file = name + "_csr_assert_fpv.sv"
 
     # Convert spec (partial path relative to `files_root_dir`) into absolute
     # path so that we can pass it to `regtool.py`.
@@ -61,40 +56,6 @@ def main():
     except subprocess.CalledProcessError as e:
         print("Error: CSR assert gen failed:\n{}".format(str(e)))
         sys.exit(e.returncode)
-    print("CSR assert file written to {}".format(
-        os.path.abspath(csr_assert_file)))
-
-    # Generate the FuseSoc core file.
-    csr_assert_core_text = {
-        'name': "lowrisc:fpv:{}_csr_assert".format(name),
-        'filesets': {
-            'files_dv': {
-                'depend': [
-                    depend,
-                    "lowrisc:tlul:headers",
-                    "lowrisc:prim:assert",
-                ],
-                'files': [
-                    csr_assert_file,
-                ],
-                'file_type': 'systemVerilogSource'
-            },
-        },
-        'targets': {
-            'default': {
-                'filesets': [
-                    'files_dv',
-                ],
-            },
-        },
-    }
-    csr_assert_core_file = os.path.abspath(name + "_csr_assert_fpv.core")
-    with open(csr_assert_core_file, 'w') as f:
-        f.write("CAPI=2:\n")
-        yaml.dump(csr_assert_core_text,
-                  f,
-                  encoding="utf-8")
-    print("CSR assert core file written to {}".format(csr_assert_core_file))
 
 
 if __name__ == '__main__':

--- a/util/reggen/gen_fpv.py
+++ b/util/reggen/gen_fpv.py
@@ -7,7 +7,9 @@
 """
 
 import logging as log
+import os.path
 
+import yaml
 from mako import exceptions
 from mako.template import Template
 from pkg_resources import resource_filename
@@ -32,7 +34,10 @@ def gen_fpv(block: IpBlock, outdir):
         filename=resource_filename('reggen', 'fpv_csr.sv.tpl'))
 
     # Generate pkg.sv with block name
-    with open(outdir + "/" + block.name.lower() + "_csr_assert_fpv.sv", 'w') as fout:
+    lblock = block.name.lower()
+    mod_name = lblock + '_csr_assert_fpv'
+    file_name = mod_name + '.sv'
+    with open(os.path.join(outdir, file_name), 'w') as fout:
         try:
             fout.write(
                 fpv_csr_tpl.render(block=block,
@@ -42,5 +47,33 @@ def gen_fpv(block: IpBlock, outdir):
         except:  # noqa: 722
             log.error(exceptions.text_error_template().render())
             return 1
+
+    # Generate a fusesoc core file that points at the files we've just
+    # generated.
+    core_data = {
+        'name': "lowrisc:fpv:{}_csr_assert".format(lblock),
+        'filesets': {
+            'files_dv': {
+                'depend': [
+                    "lowrisc:ip:{}".format(lblock),
+                    "lowrisc:tlul:headers",
+                    "lowrisc:prim:assert",
+                ],
+                'files': [file_name],
+                'file_type': 'systemVerilogSource'
+            },
+        },
+        'targets': {
+            'default': {
+                'filesets': [
+                    'files_dv',
+                ],
+            },
+        },
+    }
+    core_file_path = os.path.join(outdir, lblock + '_csr_assert_fpv.core')
+    with open(core_file_path, 'w') as core_file:
+        core_file.write('CAPI=2:\n')
+        yaml.dump(core_data, core_file, encoding='utf-8')
 
     return 0


### PR DESCRIPTION
Once blocks may have multiple device interfaces, they might generate
more than one "`FOO_csr_assert_fpv.sv`", depending on their exact
interfaces. The .core file needs to list these files, which is a bit
difficult to do from `csr_assert_gen.py` (which doesn't have the reggen
data).

Rather than re-parse the reggen data (possible, but seems a bit
silly), move the .core file generation to reggen. Note: this assumes
that the core file for the block is always called
"`lowrisc:ip:<block>`". If this turns out not to be true in general, we
can either pass it through as another argument to regtool.py
or (perhaps better) call `gen_fpv` by loading up reggen directly.
