### PR TITLE
[reggen] Promote FOO_SIZE to an int unsigned in *_reg_pkg.sv

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -643,11 +643,11 @@ package flash_ctrl_reg_pkg;
 
   // Window parameter
   parameter logic [BlockAw-1:0] FLASH_CTRL_PROG_FIFO_OFFSET = 9'h 16c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_PROG_FIFO_SIZE   = 9'h 4;
+  parameter int unsigned        FLASH_CTRL_PROG_FIFO_SIZE   = 'h 4;
   parameter logic [BlockAw-1:0] FLASH_CTRL_RD_FIFO_OFFSET = 9'h 170;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_RD_FIFO_SIZE   = 9'h 4;
+  parameter int unsigned        FLASH_CTRL_RD_FIFO_SIZE   = 'h 4;
   parameter logic [BlockAw-1:0] FLASH_CTRL_PRIM_FLASH_CFG_OFFSET = 9'h 180;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_PRIM_FLASH_CFG_SIZE   = 9'h 54;
+  parameter int unsigned        FLASH_CTRL_PRIM_FLASH_CFG_SIZE   = 'h 54;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/hmac/rtl/hmac_reg_pkg.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_pkg.sv
@@ -247,7 +247,7 @@ package hmac_reg_pkg;
 
   // Window parameter
   parameter logic [BlockAw-1:0] HMAC_MSG_FIFO_OFFSET = 12'h 800;
-  parameter logic [BlockAw-1:0] HMAC_MSG_FIFO_SIZE   = 12'h 800;
+  parameter int unsigned        HMAC_MSG_FIFO_SIZE   = 'h 800;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -320,9 +320,9 @@ package kmac_reg_pkg;
 
   // Window parameter
   parameter logic [BlockAw-1:0] KMAC_STATE_OFFSET = 12'h 400;
-  parameter logic [BlockAw-1:0] KMAC_STATE_SIZE   = 12'h 200;
+  parameter int unsigned        KMAC_STATE_SIZE   = 'h 200;
   parameter logic [BlockAw-1:0] KMAC_MSG_FIFO_OFFSET = 12'h 800;
-  parameter logic [BlockAw-1:0] KMAC_MSG_FIFO_SIZE   = 12'h 800;
+  parameter int unsigned        KMAC_MSG_FIFO_SIZE   = 'h 800;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -60,7 +60,7 @@ class otbn_base_vseq extends cip_base_vseq #(
   protected function automatic void
   get_queue_entries(bit for_imem, ref otbn_loaded_word entries[$]);
     // Get the size of this memory (to make sure the number of loaded words makes sense)
-    logic [21:0] mem_size = for_imem ? OTBN_IMEM_SIZE   : OTBN_DMEM_SIZE;
+    int unsigned mem_size = for_imem ? OTBN_IMEM_SIZE : OTBN_DMEM_SIZE;
 
     // Iterate over the segments for this memory
     int seg_count = OtbnMemUtilGetSegCount(cfg.mem_util, for_imem);
@@ -89,7 +89,7 @@ class otbn_base_vseq extends cip_base_vseq #(
 
         // OtbnMemUtil should have checked that this address was valid for the given memory, but it
         // can't hurt to check again.
-        `DV_CHECK_FATAL({word_off, 2'b00} < {12'b0, mem_size})
+        `DV_CHECK_FATAL({word_off, 2'b00} < {2'b00, mem_size})
 
         entry.for_imem = for_imem;
         entry.offset   = word_off[21:0];

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim_waivers.vlt
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim_waivers.vlt
@@ -4,7 +4,5 @@
 
 `verilator_config
 
-lint_off -rule WIDTH -file "*/otbn_top_sim.sv" -match "*'OTBN_IMEM_SIZE' generates * bits*"
-lint_off -rule WIDTH -file "*/otbn_top_sim.sv" -match "*'OTBN_DMEM_SIZE' generates * bits*"
 lint_off -rule WIDTH -file "*/otbn_top_sim.sv" -match "*'ImemStartAddr' generates 32 bits*"
 lint_off -rule WIDTH -file "*/otbn_top_sim.sv" -match "*'stack_wr_ptr_q' generates 4 bits*"

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -153,9 +153,9 @@ package otbn_reg_pkg;
 
   // Window parameter
   parameter logic [BlockAw-1:0] OTBN_IMEM_OFFSET = 16'h 4000;
-  parameter logic [BlockAw-1:0] OTBN_IMEM_SIZE   = 16'h 1000;
+  parameter int unsigned        OTBN_IMEM_SIZE   = 'h 1000;
   parameter logic [BlockAw-1:0] OTBN_DMEM_OFFSET = 16'h 8000;
-  parameter logic [BlockAw-1:0] OTBN_DMEM_SIZE   = 16'h 1000;
+  parameter int unsigned        OTBN_DMEM_SIZE   = 'h 1000;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -369,9 +369,9 @@ package otp_ctrl_reg_pkg;
 
   // Window parameter
   parameter logic [BlockAw-1:0] OTP_CTRL_SW_CFG_WINDOW_OFFSET = 14'h 1000;
-  parameter logic [BlockAw-1:0] OTP_CTRL_SW_CFG_WINDOW_SIZE   = 14'h 800;
+  parameter int unsigned        OTP_CTRL_SW_CFG_WINDOW_SIZE   = 'h 800;
   parameter logic [BlockAw-1:0] OTP_CTRL_TEST_ACCESS_OFFSET = 14'h 2000;
-  parameter logic [BlockAw-1:0] OTP_CTRL_TEST_ACCESS_SIZE   = 14'h 40;
+  parameter int unsigned        OTP_CTRL_TEST_ACCESS_SIZE   = 'h 40;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -287,7 +287,7 @@ package spi_device_reg_pkg;
 
   // Window parameter
   parameter logic [BlockAw-1:0] SPI_DEVICE_BUFFER_OFFSET = 13'h 1000;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_BUFFER_SIZE   = 13'h 1000;
+  parameter int unsigned        SPI_DEVICE_BUFFER_SIZE   = 'h 1000;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
@@ -311,7 +311,7 @@ package spi_host_reg_pkg;
 
   // Window parameter
   parameter logic [BlockAw-1:0] SPI_HOST_TXDATA_OFFSET = 6'h 1c;
-  parameter logic [BlockAw-1:0] SPI_HOST_TXDATA_SIZE   = 6'h 4;
+  parameter int unsigned        SPI_HOST_TXDATA_SIZE   = 'h 4;
 
   // Register Index
   typedef enum int {

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -607,7 +607,7 @@ package usbdev_reg_pkg;
 
   // Window parameter
   parameter logic [BlockAw-1:0] USBDEV_BUFFER_OFFSET = 12'h 800;
-  parameter logic [BlockAw-1:0] USBDEV_BUFFER_SIZE   = 12'h 800;
+  parameter int unsigned        USBDEV_BUFFER_SIZE   = 'h 800;
 
   // Register Index
   typedef enum int {

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
@@ -643,11 +643,11 @@ package flash_ctrl_reg_pkg;
 
   // Window parameter
   parameter logic [BlockAw-1:0] FLASH_CTRL_PROG_FIFO_OFFSET = 9'h 16c;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_PROG_FIFO_SIZE   = 9'h 4;
+  parameter int unsigned        FLASH_CTRL_PROG_FIFO_SIZE   = 'h 4;
   parameter logic [BlockAw-1:0] FLASH_CTRL_RD_FIFO_OFFSET = 9'h 170;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_RD_FIFO_SIZE   = 9'h 4;
+  parameter int unsigned        FLASH_CTRL_RD_FIFO_SIZE   = 'h 4;
   parameter logic [BlockAw-1:0] FLASH_CTRL_PRIM_FLASH_CFG_OFFSET = 9'h 180;
-  parameter logic [BlockAw-1:0] FLASH_CTRL_PRIM_FLASH_CFG_SIZE   = 9'h 54;
+  parameter int unsigned        FLASH_CTRL_PRIM_FLASH_CFG_SIZE   = 'h 54;
 
   // Register Index
   typedef enum int {

--- a/util/reggen/reg_pkg.sv.tpl
+++ b/util/reggen/reg_pkg.sv.tpl
@@ -271,10 +271,10 @@ def field_resname(reg, field):
 <%
     win_pfx = '{}_{}'.format(ublock, w.name.upper())
     base_txt_val = "{}'h {:x}".format(addr_width, w.offset)
-    size_txt_val = "{}'h {:x}".format(addr_width, w.size_in_bytes)
+    size_txt_val = "'h {:x}".format(w.size_in_bytes)
 %>\
   parameter logic [BlockAw-1:0] ${win_pfx}_OFFSET = ${base_txt_val};
-  parameter logic [BlockAw-1:0] ${win_pfx}_SIZE   = ${size_txt_val};
+  parameter int unsigned        ${win_pfx}_SIZE   = ${size_txt_val};
 % endfor
 
 % endif


### PR DESCRIPTION
*EDIT: This PR originally did something rather different; I've updated this message to match the new code*

With the previous version of the code, there was a problem if the last
window happened to finish on the same power of 2 boundary as the
block's address space. In that case, we ended up with something like

    parameter logic [9:0] BLOCK_FOO_SIZE = 10'd1024;

which is, of course, zero.

It turns out that the only code in the tree that uses these `_SIZE`
parameters is using them to compute `int` parameters (rather than
something involving the address width). As such, we can just promote
the parameter to an `int unsigned`, fixing various width mismatches as a
bonus!
