### PR TITLE
[sw, secure_boot] Introduce MaskROM + ROM_EXT on-device testing

### DIFF
--- a/sw/device/mask_rom/meson.build
+++ b/sw/device/mask_rom/meson.build
@@ -10,26 +10,38 @@ rom_linkfile = files(['mask_rom.ld'])
 rom_link_args = [
   '-Wl,-L,@0@'.format(meson.source_root()),
   '-Wl,-T,@0@/@1@'.format(meson.source_root(), rom_linkfile[0]),
-  embedded_target_extra_link_args
+  # Flatten the array, otherwise `mask_rom_lib` generation fails.
+  ''.join(embedded_target_extra_link_args),
 ]
 rom_link_deps = [rom_linkfile]
 
+# MaskROM library.
+mask_rom_lib = declare_dependency(
+  sources: [
+    'mask_rom_start.S',
+  ],
+    link_args: rom_link_args,
+    dependencies: [
+      freestanding_headers,
+      rom_ext_manifest_parser,
+      sw_lib_crt,
+      sw_lib_pinmux,
+    ],
+    link_with: static_library(
+      'mask_rom_lib',
+      sources: ['mask_rom.c'],
+      link_depends: [rom_linkfile],
+  )
+)
+
+# Production MaskROM images
 foreach device_name, device_lib : sw_lib_arch_core_devices
   mask_rom_elf = executable(
     'mask_rom_' + device_name,
-    sources: [
-      'mask_rom_start.S',
-      'mask_rom.c',
-    ],
     name_suffix: 'elf',
-    link_args: rom_link_args,
     link_depends: rom_link_deps,
     dependencies: [
-      chip_info_h,
-      device_lib,
-      rom_ext_manifest_parser,
-      sw_lib_pinmux,
-      sw_lib_crt,
+      mask_rom_lib,
     ],
   )
 

--- a/sw/device/rom_exts/dummy_main.c
+++ b/sw/device/rom_exts/dummy_main.c
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+int main(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+
+  return 0;
+}

--- a/sw/device/rom_exts/meson.build
+++ b/sw/device/rom_exts/meson.build
@@ -17,7 +17,10 @@ rom_ext_link_info = {
     [
       '-Wl,-L,@0@'.format(meson.source_root()),
       '-Wl,-T,@0@/@1@'.format(meson.source_root(), rom_ext_linkfile_slot_a[0]),
-      embedded_target_extra_link_args,
+      # Flatten the array, otherwise `rom_ext_base_for_testing` generation
+      # fails.
+      ''.join(embedded_target_extra_link_args),
+      '-Wl,--build-id=none',
     ],
     # Link dependency file for slot A.
     [
@@ -30,7 +33,9 @@ rom_ext_link_info = {
     [
       '-Wl,-L,@0@'.format(meson.source_root()),
       '-Wl,-T,@0@/@1@'.format(meson.source_root(), rom_ext_linkfile_slot_b[0]),
-      embedded_target_extra_link_args,
+      # Flatten the array, otherwise `rom_ext_slot_libs` generation fails.
+      ''.join(embedded_target_extra_link_args),
+      '-Wl,--build-id=none',
     ],
     # Link dependency file for slot B.
     [
@@ -38,6 +43,31 @@ rom_ext_link_info = {
     ],
   ],
 }
+
+rom_ext_slot_libs = {}
+foreach slot, slot_link_args : rom_ext_link_info
+  rom_ext_slot_libs += {
+    slot: declare_dependency(
+      sources: [
+        'rom_ext_manifest.S',
+        'rom_ext_start.S',
+      ],
+      link_args: slot_link_args[0],
+      dependencies: [
+        freestanding_headers,
+        sw_lib_crt,
+        sw_lib_dif_uart,
+        sw_lib_runtime_hart,
+        sw_lib_runtime_print,
+      ],
+      link_with: static_library(
+        slot + '_rom_ext_lib',
+        sources: ['rom_ext.c'],
+        link_depends: [slot_link_args[1]],
+    )
+  )
+}
+endforeach
 
 # ROM_EXT manifest generator.
 rom_exts_manifest_offsets_header = custom_target(
@@ -75,24 +105,20 @@ rom_ext_manifest_parser = declare_dependency(
 )
 
 foreach device_name, device_lib : sw_lib_arch_core_devices
-  foreach slot, slot_link_args : rom_ext_link_info
+  foreach slot, slot_lib : rom_ext_slot_libs
     rom_ext_elf = executable(
       slot + '_' + device_name,
-      sources: [
-        'rom_ext_manifest.S',
-        'rom_ext_start.S',
-        'rom_ext.c',
-      ],
       name_suffix: 'elf',
-      link_args: slot_link_args[0],
-      link_depends: slot_link_args[1],
       dependencies: [
         device_lib,
-        sw_lib_crt,
-        sw_lib_dif_uart,
-        sw_lib_runtime_hart,
-        sw_lib_runtime_print,
+        slot_lib,
       ],
+      # TODO: at the moment we are not looking past "Silicon Creator" code,
+      # however eventually there will be a transition to BL0 and/or kernel.
+      # At this point we are assuming that the entry point will be `main`.
+      sources: [
+        'dummy_main.c',
+      ]
     )
 
     rom_ext_embedded = custom_target(
@@ -115,3 +141,4 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
     )
   endforeach
 endforeach
+

--- a/sw/device/rom_exts/rom_ext.c
+++ b/sw/device/rom_exts/rom_ext.c
@@ -14,6 +14,8 @@
 
 static dif_uart_t uart;
 
+int main(int argc, char *argv[]);
+
 // TODO - need to decide what happens to the peripherals during the
 //        Mask ROM to ROM_EXT handover (for example, does UART need
 //        re-configuring, etc...). It is possible that the signature of
@@ -45,6 +47,9 @@ void rom_ext_boot(void) {
   base_uart_stdout(&uart);
 
   base_printf("Hello World!\n");
+
+  // TODO - there might be another level before jumping into main.
+  (void)main(0, NULL);
 
   // TODO - is this a correct way of handling the "return"?
   while (true) {

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -263,6 +263,11 @@ sw_tests += {
     'library': dif_uart_smoketest_lib,
   }
 }
+sw_rom_ext_tests += {
+  'dif_uart_smoketest': {
+    'library': dif_uart_smoketest_lib,
+  }
+}
 
 dif_rv_timer_smoketest_lib = declare_dependency(
   link_with: static_library(

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -13,6 +13,18 @@ sw_tests = {
   # },
 }
 
+# All tests added to this dictionary will result in build targets that have
+# names starting `sw/device/tests/<test_name>`. They will not contain the
+# subdirectory name, because the build targets are really declared at the bottom
+# of this file, rather than in the subdirectories.
+#
+# These tests will link against a ROM_EXT slot A image.
+sw_rom_ext_tests = {
+  #   'test_name': {
+  #   'library': test_lib,
+  # },
+}
+
 subdir('dif')
 subdir('rom_ext')
 subdir('runtime')
@@ -223,6 +235,35 @@ foreach sw_test_name, sw_test_info : sw_tests
         sw_test_sim_dv_logs,
       ],
       output: sw_test_name + '_export_' + device_name,
+      build_always_stale: true,
+      build_by_default: true,
+    )
+  endforeach
+endforeach
+
+foreach sw_test_name, sw_test_info : sw_rom_ext_tests
+  foreach device_name, device_lib : sw_lib_arch_core_devices
+    sw_test_elf = executable(
+      sw_test_name + '_rom_ext_' + device_name,
+      name_suffix: 'elf',
+      dependencies: [
+        # Only use ROM_EXT slot A for now.
+        rom_ext_slot_libs['rom_ext_slot_a'],
+        device_lib,
+        sw_test_info['library'],
+        sw_lib_irq_handlers,
+        sw_lib_testing_test_main,
+      ],
+    )
+
+    custom_target(
+      sw_test_name + '_rom_ext_export_' + device_name,
+      command: export_target_command,
+      depend_files: [export_target_depend_files,],
+      input: [
+        sw_test_elf,
+      ],
+      output: sw_test_name + '_rom_ext_export_' + device_name,
       build_always_stale: true,
       build_by_default: true,
     )

--- a/test/systemtest/silicon_creator_config.py
+++ b/test/systemtest/silicon_creator_config.py
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# List of self-checking test applications, which return PASS or FAIL after
+# completion.
+#
+# Each list entry is a dict with the following keys:
+#
+# name:
+#   Name of the test (required)
+# binary_name:
+#   Basename of the test binary. Default: name (optional)
+# verilator_extra_args:
+#   A list of additional command-line arguments passed to the Verilator
+#   simulation (optional).
+# targets:
+#   List of targets for which the test is executed. The test will be executed
+#   on all targets if not given (optional).
+TEST_SILICON_CREATOR_APPS_SELFCHECKING = [
+    {
+        "name": "dif_uart_smoketest",
+    },
+]


### PR DESCRIPTION
Please see #5353 for a background.

The relevant draft PR from which this change has spawned is #5352 .

- This change adds minimal testing for the Silicon Creator code.
- At the moment it is run via production Silicon Creator code, but a follow-up change is to add "null" version, which will have a reduced functionality.