### PR TITLE
[otbn] Fix read/write enables in tracer

### DIFF
--- a/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
@@ -114,7 +114,8 @@ module otbn_tracer
                                             otbn_trace.rf_base_rd_data_b));
     end
 
-    if (otbn_trace.rf_base_wr_en && otbn_trace.rf_base_wr_addr != 0) begin
+    if (otbn_trace.rf_base_wr_en && otbn_trace.rf_base_wr_commit &&
+        otbn_trace.rf_base_wr_addr != '0) begin
       output_trace(RegWritePrefix, $sformatf("x%02d: 0x%08x", otbn_trace.rf_base_wr_addr,
                                              otbn_trace.rf_base_wr_data));
     end


### PR DESCRIPTION
* `insn_valid` must be factored in with the read enable for the bignum
  register file as it uses the raw decoder signal.
* `rf_base_wr_commit` must be combined with the write enable for the
  base register file to determine if the write occurred.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>