### PR TITLE
[nmi_gen] Ignore intg_err_o output from reg_top

### DIFF
--- a/hw/ip/nmi_gen/rtl/nmi_gen.sv
+++ b/hw/ip/nmi_gen/rtl/nmi_gen.sv
@@ -43,6 +43,7 @@ module nmi_gen
     .tl_o,
     .reg2hw,
     .hw2reg,
+    .intg_err_o(),
     .devmode_i(1'b1)
   );
 


### PR DESCRIPTION
This signal got added by commit 915df69, but we didn't wire it up
properly here (causing a Verilator lint error).
