### PR TITLE
[spi_host] Add missing connection to scanmode_i

### DIFF
--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -9,6 +9,7 @@
   bus_device: "tlul",
   bus_host: "none",
   regwidth: "32",
+  scan: "true",
   param_list: [
     { name: "ByteOrder",
       desc: '''Byte order to use when transmitting or receiving data.  If ByteOrder = 0,

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1161,6 +1161,7 @@ module top_earlgrey #(
       // Inter-module signals
       .tl_i(spi_host0_tl_req),
       .tl_o(spi_host0_tl_rsp),
+      .scanmode_i,
 
       // Clock and reset connections
       .clk_i (clkmgr_aon_clocks.clk_io_div4_peri),
@@ -1189,6 +1190,7 @@ module top_earlgrey #(
       // Inter-module signals
       .tl_i(spi_host1_tl_req),
       .tl_o(spi_host1_tl_rsp),
+      .scanmode_i,
 
       // Clock and reset connections
       .clk_i (clkmgr_aon_clocks.clk_io_div4_peri),


### PR DESCRIPTION
The module gained the port in dbd087ed00 but we forgot to add the flag
in the hjson to get topgen to wire it up for us. This causes Verilator
lint errors.
