### PR TITLE
[spi_host] Remove the ByteOrder and MaxCS parameters from the module

### DIFF
--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -10,10 +10,7 @@
 
 module spi_host
   import spi_host_reg_pkg::*;
-#(
-  parameter int ByteOrder = 0,
-  parameter int MaxCS = 1
-) (
+ (
   input              clk_i,
   input              rst_ni,
   input              clk_core_i,


### PR DESCRIPTION
These didn't do anything except to shadow the parameters that are set
by reggen (to hopefully the correct values) in spi_host_reg_pkg.

(With my "standards compliance hat" on, this is a proper bug: you ain't allowed to shadow parameters like this in SystemVerilog. Verilator complains, and it appeared in an overnight lint report, which is why I noticed it).