### PR TITLE
[spi_device] Clock and Reset mux for DPSRAM B port

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -93,6 +93,25 @@
             '''
           resval: "0",
         },
+        { bits: "31"
+          name: "sram_clk_en",
+          desc: '''SRAM Clock Enable.
+
+            This controls the clock gating cell lying on DP SRAM clock. As the
+            nature of absent of SPI_CLK in idle state, the clock mux for SRAM
+            B port cannot be glitch-free MUX. So, it is up to SW to change the
+            clock safely.
+
+            Programming sequence:
+
+              1. Check if SPI line is idle
+              2. Clear sram_clk_en to 0.
+              3. Change mode to FwMode for peri clk, FlashMode or PassThrough
+                 for SPI_CLK.
+              4. Set sram_clk_en to 1.
+          '''
+          resval: "1"
+        }
       ]
     },
     { name: "CFG",

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -58,6 +58,7 @@ module spi_device (
   logic              sram_clk;
   logic              sram_clk_en;
   logic              sram_clk_ungated;
+  logic              sram_clk_muxed;
   logic              sram_rst_n;
   logic              sram_rst_n_noscan;
 
@@ -435,8 +436,17 @@ module spi_device (
     .clk_o  (sram_clk_ungated)
   );
 
+  prim_clock_mux2 #(
+    .NoFpgaBufG(1'b1)
+  ) u_sram_clk_scan (
+    .clk0_i (sram_clk_ungated),
+    .clk1_i (scan_clk_i),
+    .sel_i  (scanmode[ClkSramSel] == lc_ctrl_pkg::On),
+    .clk_o  (sram_clk_muxed)
+  );
+
   prim_clock_gating u_sram_clk_cg (
-    .clk_i  (sram_clk_ungated),
+    .clk_i  (sram_clk_muxed),
     .en_i   (sram_clk_en),
     .test_en_i (scanmode[ClkSramSel] == lc_ctrl_pkg::On),
     .clk_o  (sram_clk)

--- a/hw/ip/spi_device/rtl/spi_device_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_pkg.sv
@@ -102,6 +102,8 @@ package spi_device_pkg;
     TxRstMuxSel,
     RxRstMuxSel,
     ClkMuxSel,
+    ClkSramSel,
+    RstSramSel,
     ScanModeUseLast
   } scan_mode_e;
 

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -97,6 +97,9 @@ package spi_device_reg_pkg;
     struct packed {
       logic        q;
     } rst_rxfifo;
+    struct packed {
+      logic        q;
+    } sram_clk_en;
   } spi_device_reg2hw_control_reg_t;
 
   typedef struct packed {
@@ -233,10 +236,10 @@ package spi_device_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    spi_device_reg2hw_intr_state_reg_t intr_state; // [168:163]
-    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [162:157]
-    spi_device_reg2hw_intr_test_reg_t intr_test; // [156:145]
-    spi_device_reg2hw_control_reg_t control; // [144:140]
+    spi_device_reg2hw_intr_state_reg_t intr_state; // [169:164]
+    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [163:158]
+    spi_device_reg2hw_intr_test_reg_t intr_test; // [157:146]
+    spi_device_reg2hw_control_reg_t control; // [145:140]
     spi_device_reg2hw_cfg_reg_t cfg; // [139:128]
     spi_device_reg2hw_fifo_level_reg_t fifo_level; // [127:96]
     spi_device_reg2hw_rxf_ptr_reg_t rxf_ptr; // [95:80]
@@ -310,7 +313,7 @@ package spi_device_reg_pkg;
     4'b 0001, // index[ 0] SPI_DEVICE_INTR_STATE
     4'b 0001, // index[ 1] SPI_DEVICE_INTR_ENABLE
     4'b 0001, // index[ 2] SPI_DEVICE_INTR_TEST
-    4'b 0111, // index[ 3] SPI_DEVICE_CONTROL
+    4'b 1111, // index[ 3] SPI_DEVICE_CONTROL
     4'b 0011, // index[ 4] SPI_DEVICE_CFG
     4'b 1111, // index[ 5] SPI_DEVICE_FIFO_LEVEL
     4'b 0111, // index[ 6] SPI_DEVICE_ASYNC_FIFO_LEVEL

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -210,6 +210,9 @@ module spi_device_reg_top (
   logic control_rst_rxfifo_qs;
   logic control_rst_rxfifo_wd;
   logic control_rst_rxfifo_we;
+  logic control_sram_clk_en_qs;
+  logic control_sram_clk_en_wd;
+  logic control_sram_clk_en_we;
   logic cfg_cpol_qs;
   logic cfg_cpol_wd;
   logic cfg_cpol_we;
@@ -780,6 +783,32 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (control_rst_rxfifo_qs)
+  );
+
+
+  //   F[sram_clk_en]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h1)
+  ) u_control_sram_clk_en (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (control_sram_clk_en_we),
+    .wd     (control_sram_clk_en_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.control.sram_clk_en.q ),
+
+    // to register interface (read)
+    .qs     (control_sram_clk_en_qs)
   );
 
 
@@ -1411,6 +1440,9 @@ module spi_device_reg_top (
   assign control_rst_rxfifo_we = addr_hit[3] & reg_we & !reg_error;
   assign control_rst_rxfifo_wd = reg_wdata[17];
 
+  assign control_sram_clk_en_we = addr_hit[3] & reg_we & !reg_error;
+  assign control_sram_clk_en_wd = reg_wdata[31];
+
   assign cfg_cpol_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_cpol_wd = reg_wdata[0];
 
@@ -1504,6 +1536,7 @@ module spi_device_reg_top (
         reg_rdata_next[5:4] = control_mode_qs;
         reg_rdata_next[16] = control_rst_txfifo_qs;
         reg_rdata_next[17] = control_rst_rxfifo_qs;
+        reg_rdata_next[31] = control_sram_clk_en_qs;
       end
 
       addr_hit[4]: begin


### PR DESCRIPTION
This PR is to add clock and reset mux for SRAM inside SPI_DEVICE.

In FlashMode and PassThrough mode, the B port of DPSRAM uses SPI_CLK in contrast to the peri clk in FwMode.
It now as glitch mux. glitch-free mux cannot be added as SPI_CLK does not toggle when Idle.

SW should follow suggested programming sequence in `sram_clk_en` field to not introduce any glitch when switching the clock.