### PR TITLE
[top / ast] Continued ast integration

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -60,6 +60,14 @@
       width:   "1",
       act:     "req",
     },
+
+    // ram configuration
+    { struct:  "ram_1p_cfg",
+      package: "prim_ram_1p_pkg",
+      type:    "uni",
+      name:    "ram_cfg",
+      act:     "rcv"
+    }
   ],
 
   regwidth: "32"

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -134,8 +134,7 @@ module otbn_top_sim (
   prim_ram_1p_adv #(
     .Width           ( WLEN          ),
     .Depth           ( DmemSizeWords ),
-    .DataBitsPerMask ( 32            ),
-    .CfgW            ( 8             )
+    .DataBitsPerMask ( 32            )
   ) u_dmem (
     .clk_i    ( IO_CLK          ),
     .rst_ni   ( IO_RST_N        ),
@@ -165,8 +164,7 @@ module otbn_top_sim (
   prim_ram_1p_adv #(
     .Width           ( 32            ),
     .Depth           ( ImemSizeWords ),
-    .DataBitsPerMask ( 32            ),
-    .CfgW            ( 8             )
+    .DataBitsPerMask ( 32            )
   ) u_imem (
     .clk_i    ( IO_CLK          ),
     .rst_ni   ( IO_RST_N        ),

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -31,6 +31,9 @@ module otbn
   input  prim_alert_pkg::alert_rx_t [NumAlerts-1:0] alert_rx_i,
   output prim_alert_pkg::alert_tx_t [NumAlerts-1:0] alert_tx_o,
 
+  // Memory configuration
+  input prim_ram_1p_pkg::ram_1p_cfg_t ram_cfg_i,
+
   // EDN clock and interface
   input                                              clk_edn_i,
   input                                              rst_edn_ni,
@@ -143,8 +146,7 @@ module otbn
   prim_ram_1p_adv #(
     .Width           (39),
     .Depth           (ImemSizeWords),
-    .DataBitsPerMask (32), // Write masks are not supported.
-    .CfgW            (8)
+    .DataBitsPerMask (32) // Write masks are not supported.
   ) u_imem (
     .clk_i,
     .rst_ni,
@@ -156,7 +158,7 @@ module otbn
     .rdata_o  (imem_rdata),
     .rvalid_o (imem_rvalid),
     .rerror_o (imem_rerror_vec),
-    .cfg_i    ('0)
+    .cfg_i    (ram_cfg_i)
   );
 
   // imem_rerror_vec is 2 bits wide and is used to report ECC errors. Bit 1 is set if there's an
@@ -278,8 +280,7 @@ module otbn
   prim_ram_1p_adv #(
     .Width           (WLEN+7*8),
     .Depth           (DmemSizeWords),
-    .DataBitsPerMask (32), // 32b write masks for 32b word writes from bus
-    .CfgW            (8)
+    .DataBitsPerMask (32) // 32b write masks for 32b word writes from bus
   ) u_dmem (
     .clk_i,
     .rst_ni,
@@ -291,7 +292,7 @@ module otbn
     .rdata_o  (dmem_rdata),
     .rvalid_o (dmem_rvalid),
     .rerror_o (dmem_rerror_vec),
-    .cfg_i    ('0)
+    .cfg_i    (ram_cfg_i)
   );
 
   // Combine uncorrectable / correctable errors. See note above definition of imem_rerror for

--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -75,7 +75,7 @@
       package: "jtag_pkg"
     }
     // Testmode signals to AST
-    { struct:  "dft_strap_test",
+    { struct:  "dft_strap_test_req",
       type:    "uni",
       name:    "dft_strap_test",
       act:     "req",

--- a/hw/ip/prim/prim_ram_1p.core
+++ b/hw/ip/prim/prim_ram_1p.core
@@ -9,6 +9,7 @@ filesets:
   primgen_dep:
     depend:
       - lowrisc:prim:prim_pkg
+      - lowrisc:prim:ram_1p_pkg
       - lowrisc:prim:primgen
 
 

--- a/hw/ip/prim/prim_ram_1p_pkg.core
+++ b/hw/ip/prim/prim_ram_1p_pkg.core
@@ -1,0 +1,18 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:ram_1p_pkg"
+description: "Ram 1p package"
+filesets:
+  files_rtl:
+    depend:
+    files:
+      - rtl/prim_ram_1p_pkg.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/ip/prim/prim_ram_2p.core
+++ b/hw/ip/prim/prim_ram_2p.core
@@ -9,6 +9,7 @@ filesets:
   primgen_dep:
     depend:
       - lowrisc:prim:prim_pkg
+      - lowrisc:prim:ram_2p_pkg
       - lowrisc:prim:primgen
 
 

--- a/hw/ip/prim/prim_ram_2p_pkg.core
+++ b/hw/ip/prim/prim_ram_2p_pkg.core
@@ -1,0 +1,18 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:ram_2p_pkg"
+description: "Ram 2p package"
+filesets:
+  files_rtl:
+    depend:
+    files:
+      - rtl/prim_ram_2p_pkg.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/ip/prim/prim_rom.core
+++ b/hw/ip/prim/prim_rom.core
@@ -9,6 +9,7 @@ filesets:
   primgen_dep:
     depend:
       - lowrisc:prim:prim_pkg
+      - lowrisc:prim:rom_pkg
       - lowrisc:prim:primgen
 
 

--- a/hw/ip/prim/prim_rom_pkg.core
+++ b/hw/ip/prim/prim_rom_pkg.core
@@ -1,0 +1,18 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:rom_pkg"
+description: "Rom package"
+filesets:
+  files_rtl:
+    depend:
+    files:
+      - rtl/prim_rom_pkg.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/ip/prim/rtl/prim_ram_1p_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_adv.sv
@@ -15,11 +15,10 @@
 
 `include "prim_assert.sv"
 
-module prim_ram_1p_adv #(
+module prim_ram_1p_adv import prim_ram_1p_pkg::*; #(
   parameter  int Depth                = 512,
   parameter  int Width                = 32,
   parameter  int DataBitsPerMask      = 1,  // Number of data bits per bit of write mask
-  parameter  int CfgW                 = 8,  // WTC, RTC, etc
   parameter      MemInitFile          = "", // VMEM file to initialize the memory with
 
   // Configurations
@@ -48,11 +47,9 @@ module prim_ram_1p_adv #(
   output logic [1:0]         rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
 
   // config
-  input [CfgW-1:0] cfg_i
+  input ram_1p_cfg_t         cfg_i
 );
 
-  logic [CfgW-1:0] unused_cfg;
-  assign unused_cfg = cfg_i;
 
   `ASSERT_INIT(CannotHaveEccAndParity_A, !(EnableParity && EnableECC))
 
@@ -101,7 +98,8 @@ module prim_ram_1p_adv #(
     .addr_i   (addr_q),
     .wdata_i  (wdata_q),
     .wmask_i  (wmask_q),
-    .rdata_o  (rdata_sram)
+    .rdata_o  (rdata_sram),
+    .cfg_i
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin

--- a/hw/ip/prim/rtl/prim_ram_1p_pkg.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_pkg.sv
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package prim_ram_1p_pkg;
+
+  typedef struct packed {
+    logic       cfg_en;
+    logic [3:0] cfg;
+  } cfg_t;
+
+  typedef struct packed {
+    cfg_t ram_cfg;  // configuration for ram
+    cfg_t rf_cfg;   // configuration for regfile
+  } ram_1p_cfg_t;
+
+  parameter ram_1p_cfg_t RAM_1P_CFG_DEFAULT = '0;
+
+endpackage // prim_ram_1p_pkg

--- a/hw/ip/prim/rtl/prim_ram_1p_scr.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_scr.sv
@@ -23,12 +23,11 @@
 
 `include "prim_assert.sv"
 
-module prim_ram_1p_scr #(
+module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
   parameter  int Depth               = 16*1024, // Needs to be a power of 2 if NumAddrScrRounds > 0.
   parameter  int Width               = 32, // Needs to be byte aligned if byte parity is enabled.
   parameter  int DataBitsPerMask     = 8, // Needs to be set to 8 in case of byte parity.
   parameter  bit EnableParity        = 1, // Enable byte parity.
-  parameter  int CfgWidth            = 8, // WTC, RTC, etc
 
   // Scrambling parameters. Note that this needs to be low-latency, hence we have to keep the
   // amount of cipher rounds low. PRINCE has 5 half rounds in its original form, which corresponds
@@ -87,7 +86,7 @@ module prim_ram_1p_scr #(
   output logic                      intg_error_o,
 
   // config
-  input [CfgWidth-1:0]              cfg_i
+  input ram_1p_cfg_t                cfg_i
 );
 
   //////////////////////
@@ -422,7 +421,6 @@ module prim_ram_1p_scr #(
     .Depth(Depth),
     .Width(Width),
     .DataBitsPerMask(DataBitsPerMask),
-    .CfgW(CfgWidth),
     .EnableECC(1'b0),
     .EnableParity(EnableParity),
     .EnableInputPipeline(1'b0),

--- a/hw/ip/prim/rtl/prim_ram_2p_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_2p_adv.sv
@@ -15,11 +15,10 @@
 
 `include "prim_assert.sv"
 
-module prim_ram_2p_adv #(
+module prim_ram_2p_adv import prim_ram_2p_pkg::*; #(
   parameter  int Depth                = 512,
   parameter  int Width                = 32,
   parameter  int DataBitsPerMask      = 1,  // Number of data bits per bit of write mask
-  parameter  int CfgW                 = 8,  // WTC, RTC, etc
   parameter      MemInitFile          = "", // VMEM file to initialize the memory with
 
   // Configurations
@@ -56,14 +55,13 @@ module prim_ram_2p_adv #(
   output logic             b_rvalid_o, // read response (b_rdata_o) is valid
   output logic [1:0]       b_rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
 
-  input        [CfgW-1:0]  cfg_i
+  input ram_2p_cfg_t       cfg_i
 );
 
   prim_ram_2p_async_adv #(
     .Depth               (Depth),
     .Width               (Width),
     .DataBitsPerMask     (DataBitsPerMask),
-    .CfgW                (CfgW),
     .MemInitFile         (MemInitFile),
     .EnableECC           (EnableECC),
     .EnableParity        (EnableParity),

--- a/hw/ip/prim/rtl/prim_ram_2p_async_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_2p_async_adv.sv
@@ -15,11 +15,10 @@
 
 `include "prim_assert.sv"
 
-module prim_ram_2p_async_adv #(
+module prim_ram_2p_async_adv import prim_ram_2p_pkg::*; #(
   parameter  int Depth                = 512,
   parameter  int Width                = 32,
   parameter  int DataBitsPerMask      = 1,  // Number of data bits per bit of write mask
-  parameter  int CfgW                 = 8,  // WTC, RTC, etc
   parameter      MemInitFile          = "", // VMEM file to initialize the memory with
 
   // Configurations
@@ -59,11 +58,9 @@ module prim_ram_2p_async_adv #(
   output logic [1:0]       b_rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
 
   // config
-  input [CfgW-1:0] cfg_i
+  input ram_2p_cfg_t       cfg_i
 );
 
-  logic [CfgW-1:0] unused_cfg;
-  assign unused_cfg = cfg_i;
 
   `ASSERT_INIT(CannotHaveEccAndParity_A, !(EnableParity && EnableECC))
 
@@ -130,7 +127,9 @@ module prim_ram_2p_async_adv #(
     .b_addr_i   (b_addr_q),
     .b_wdata_i  (b_wdata_q),
     .b_wmask_i  (b_wmask_q),
-    .b_rdata_o  (b_rdata_sram)
+    .b_rdata_o  (b_rdata_sram),
+
+    .cfg_i
   );
 
   always_ff @(posedge clk_a_i or negedge rst_a_ni) begin

--- a/hw/ip/prim/rtl/prim_ram_2p_pkg.sv
+++ b/hw/ip/prim/rtl/prim_ram_2p_pkg.sv
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package prim_ram_2p_pkg;
+
+  typedef struct packed {
+    logic       cfg_en;
+    logic [3:0] cfg;
+  } cfg_t;
+
+  typedef struct packed {
+    cfg_t a_ram_fcfg;  // configuration for a port
+    cfg_t a_ram_lcfg;  // configuration for a port
+    cfg_t b_ram_fcfg;  // configuration for b port
+    cfg_t b_ram_lcfg;  // configuration for b port
+  } ram_2p_cfg_t;
+
+  parameter ram_2p_cfg_t RAM_2P_CFG_DEFAULT = '0;
+
+endpackage // prim_ram_2p_pkg

--- a/hw/ip/prim/rtl/prim_rom_adv.sv
+++ b/hw/ip/prim/rtl/prim_rom_adv.sv
@@ -6,13 +6,11 @@
 
 `include "prim_assert.sv"
 
-module prim_rom_adv #(
+module prim_rom_adv import prim_rom_pkg::*; #(
   // Parameters passed on the the ROM primitive.
   parameter  int Width       = 32,
   parameter  int Depth       = 2048, // 8kB default
   parameter      MemInitFile = "", // VMEM file to initialize the memory with
-
-  parameter  int CfgW        = 8,     // WTC, RTC, etc
 
   localparam int Aw          = $clog2(Depth)
 ) (
@@ -23,12 +21,8 @@ module prim_rom_adv #(
   output logic             rvalid_o,
   output logic [Width-1:0] rdata_o,
 
-  input        [CfgW-1:0]  cfg_i
+  input rom_cfg_t          cfg_i
 );
-
-  // We will eventually use cfg_i for RTC/WTC or other memory parameters.
-  logic [CfgW-1:0] unused_cfg;
-  assign unused_cfg = cfg_i;
 
   prim_rom #(
     .Width(Width),
@@ -38,7 +32,8 @@ module prim_rom_adv #(
     .clk_i,
     .req_i,
     .addr_i,
-    .rdata_o
+    .rdata_o,
+    .cfg_i
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin

--- a/hw/ip/prim/rtl/prim_rom_pkg.sv
+++ b/hw/ip/prim/rtl/prim_rom_pkg.sv
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package prim_rom_pkg;
+
+  typedef struct packed {
+    logic       cfg_en;
+    logic [3:0] cfg;
+  } rom_cfg_t;
+
+endpackage // prim_rom_pkg

--- a/hw/ip/prim_generic/prim_generic_ram_1p.core
+++ b/hw/ip/prim_generic/prim_generic_ram_1p.core
@@ -9,6 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
+      - lowrisc:prim:ram_1p_pkg
       - lowrisc:prim:util_memload
     files:
       - rtl/prim_generic_ram_1p.sv

--- a/hw/ip/prim_generic/prim_generic_ram_2p.core
+++ b/hw/ip/prim_generic/prim_generic_ram_2p.core
@@ -9,6 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
+      - lowrisc:prim:ram_2p_pkg
       - lowrisc:prim:util_memload
     files:
       - rtl/prim_generic_ram_2p.sv

--- a/hw/ip/prim_generic/prim_generic_rom.core
+++ b/hw/ip/prim_generic/prim_generic_rom.core
@@ -9,6 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
+      - lowrisc:prim:rom_pkg
       - lowrisc:prim:util_memload
     files:
       - rtl/prim_generic_rom.sv

--- a/hw/ip/prim_generic/rtl/prim_generic_flash.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash.sv
@@ -167,7 +167,8 @@ module prim_generic_flash #(
     .addr_i(cfg_addr),
     .wdata_i(cfg_wdata),
     .wmask_i({32{1'b1}}),
-    .rdata_o(cfg_rdata)
+    .rdata_o(cfg_rdata),
+    .cfg_i('0)
   );
 
   lc_ctrl_pkg::lc_tx_t unused_bist_enable;

--- a/hw/ip/prim_generic/rtl/prim_generic_flash_bank.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash_bank.sv
@@ -381,7 +381,8 @@ module prim_generic_flash_bank #(
     .addr_i   (mem_addr),
     .wdata_i  (mem_wdata[MemWidth-1:0]),
     .wmask_i  ({MemWidth{1'b1}}),
-    .rdata_o  (rd_nom_data_main)
+    .rdata_o  (rd_nom_data_main),
+    .cfg_i    ('0)
   );
 
   prim_ram_1p #(
@@ -395,7 +396,8 @@ module prim_generic_flash_bank #(
     .addr_i   (mem_addr),
     .wdata_i  (mem_wdata[MemWidth +: MetaDataWidth]),
     .wmask_i  ({MetaDataWidth{1'b1}}),
-    .rdata_o  (rd_meta_data_main)
+    .rdata_o  (rd_meta_data_main),
+    .cfg_i    ('0)
   );
 
   for (genvar info_type = 0; info_type < InfoTypes; info_type++) begin : gen_info_types
@@ -416,7 +418,8 @@ module prim_generic_flash_bank #(
       .addr_i   (mem_addr[0 +: InfoAddrW]),
       .wdata_i  (mem_wdata[MemWidth-1:0]),
       .wmask_i  ({MemWidth{1'b1}}),
-      .rdata_o  (rd_nom_data_info[info_type])
+      .rdata_o  (rd_nom_data_info[info_type]),
+      .cfg_i    ('0)
     );
 
     prim_ram_1p #(
@@ -430,7 +433,8 @@ module prim_generic_flash_bank #(
       .addr_i   (mem_addr[0 +: InfoAddrW]),
       .wdata_i  (mem_wdata[MemWidth +: MetaDataWidth]),
       .wmask_i  ({MetaDataWidth{1'b1}}),
-      .rdata_o  (rd_meta_data_info[info_type])
+      .rdata_o  (rd_meta_data_info[info_type]),
+      .cfg_i    ('0)
     );
   end
 

--- a/hw/ip/prim_generic/rtl/prim_generic_ram_1p.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_ram_1p.sv
@@ -6,7 +6,7 @@
 
 `include "prim_assert.sv"
 
-module prim_generic_ram_1p #(
+module prim_generic_ram_1p import prim_ram_1p_pkg::*; #(
   parameter  int Width           = 32, // bit
   parameter  int Depth           = 128,
   parameter  int DataBitsPerMask = 1, // Number of data bits per bit of write mask
@@ -21,8 +21,12 @@ module prim_generic_ram_1p #(
   input  logic [Aw-1:0]    addr_i,
   input  logic [Width-1:0] wdata_i,
   input  logic [Width-1:0] wmask_i,
-  output logic [Width-1:0] rdata_o // Read data. Data is returned one cycle after req_i is high.
+  output logic [Width-1:0] rdata_o, // Read data. Data is returned one cycle after req_i is high.
+  input ram_1p_cfg_t       cfg_i
 );
+
+  logic unused_cfg;
+  assign unused_cfg = ^cfg_i;
 
   // Width of internal write mask. Note wmask_i input into the module is always assumed
   // to be the full bit mask

--- a/hw/ip/prim_generic/rtl/prim_generic_ram_2p.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_ram_2p.sv
@@ -6,7 +6,7 @@
 //   This module is for simulation and small size SRAM.
 //   Implementing ECC should be done inside wrapper not this model.
 `include "prim_assert.sv"
-module prim_generic_ram_2p #(
+module prim_generic_ram_2p import prim_ram_2p_pkg::*; #(
   parameter  int Width           = 32, // bit
   parameter  int Depth           = 128,
   parameter  int DataBitsPerMask = 1, // Number of data bits per bit of write mask
@@ -30,8 +30,14 @@ module prim_generic_ram_2p #(
   input        [Aw-1:0]    b_addr_i,
   input        [Width-1:0] b_wdata_i,
   input  logic [Width-1:0] b_wmask_i,
-  output logic [Width-1:0] b_rdata_o
+  output logic [Width-1:0] b_rdata_o,
+
+  input ram_2p_cfg_t       cfg_i
 );
+
+  logic unused_cfg;
+  assign unused_cfg = ^cfg_i;
+
   // Width of internal write mask. Note *_wmask_i input into the module is always assumed
   // to be the full bit mask.
   localparam int MaskWidth = Width / DataBitsPerMask;

--- a/hw/ip/prim_generic/rtl/prim_generic_rom.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_rom.sv
@@ -4,7 +4,7 @@
 
 `include "prim_assert.sv"
 
-module prim_generic_rom #(
+module prim_generic_rom import prim_rom_pkg::*; #(
   parameter  int Width       = 32,
   parameter  int Depth       = 2048, // 8kB default
   parameter      MemInitFile = "", // VMEM file to initialize the memory with
@@ -14,8 +14,12 @@ module prim_generic_rom #(
   input  logic             clk_i,
   input  logic             req_i,
   input  logic [Aw-1:0]    addr_i,
-  output logic [Width-1:0] rdata_o
+  output logic [Width-1:0] rdata_o,
+  input rom_cfg_t          cfg_i
 );
+
+  logic unused_cfg;
+  assign unused_cfg = ^cfg_i;
 
   logic [Width-1:0] mem [Depth];
 

--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -38,7 +38,15 @@
       default: "1024"
       local:   "true"
     }
-  ]
+  ],
+  inter_signal_list: [
+    { struct:  "ram_2p_cfg",
+      package: "prim_ram_2p_pkg",
+      type:    "uni",
+      name:    "ram_cfg",
+      act:     "rcv"
+    }
+  ],
   regwidth: "32",
   registers: [
     { name: "CONTROL",

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -30,6 +30,9 @@ module spi_device (
   output logic intr_rxoverflow_o,  // RX Async FIFO Overflow
   output logic intr_txunderflow_o, // TX Async FIFO Underflow
 
+  // Memory configuration
+  input prim_ram_2p_pkg::ram_2p_cfg_t ram_cfg_i,
+
   // DFT related controls
   input scan_clk_i,
   input scan_rst_ni,
@@ -629,7 +632,6 @@ module spi_device (
     .Depth (SramDepth),
     .Width (SramDw),    // 32 x 512 --> 2kB
     .DataBitsPerMask (8),
-    .CfgW  (8),
 
     .EnableECC           (0),
     .EnableParity        (1),
@@ -660,7 +662,7 @@ module spi_device (
     .b_rdata_o  (mem_b_rdata),
     .b_rerror_o (mem_b_rerror),
 
-    .cfg_i      ('0)
+    .cfg_i      (ram_cfg_i)
   );
 
   // Register module

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -73,6 +73,12 @@
       package: "usbdev_pkg",
       struct:  "awk_state",
     },
+    { struct:  "ram_2p_cfg",
+      package: "prim_ram_2p_pkg",
+      type:    "uni",
+      name:    "ram_cfg",
+      act:     "rcv"
+    }
   ]
   param_list: [
     { name:    "NEndpoints",

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -58,6 +58,9 @@ module usbdev import usbdev_pkg::*; (
   output logic       usb_ref_val_o,
   output logic       usb_ref_pulse_o,
 
+  // memory configuration
+  input prim_ram_2p_pkg::ram_2p_cfg_t ram_cfg_i,
+
   // Interrupts
   output logic       intr_pkt_received_o, // Packet received
   output logic       intr_pkt_sent_o, // Packet sent
@@ -688,7 +691,6 @@ module usbdev import usbdev_pkg::*; (
     .Depth (SramDepth),
     .Width (SramDw),    // 32 x 512 --> 2kB
     .DataBitsPerMask(SramDw),
-    .CfgW  (8),
 
     .EnableECC           (0), // No Protection
     .EnableParity        (0),
@@ -716,8 +718,7 @@ module usbdev import usbdev_pkg::*; (
     .b_rvalid_o (),
     .b_rdata_o  (usb_mem_b_rdata),
     .b_rerror_o (),
-
-    .cfg_i      (8'h0)
+    .cfg_i      (ram_cfg_i)
   );
 
   // Register module

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -711,6 +711,18 @@
       inter_signal_list:
       [
         {
+          name: ram_cfg
+          struct: ram_2p_cfg
+          package: prim_ram_2p_pkg
+          type: uni
+          act: rcv
+          width: 1
+          inst_name: spi_device
+          default: ""
+          top_signame: ast_ram_2p_cfg
+          index: -1
+        }
+        {
           name: tl
           struct: tl
           package: tlul_pkg
@@ -1124,6 +1136,18 @@
           inst_name: usbdev
           default: ""
           top_signame: pinmux_aon_usb_state_debug
+          index: -1
+        }
+        {
+          name: ram_cfg
+          struct: ram_2p_cfg
+          package: prim_ram_2p_pkg
+          type: uni
+          act: rcv
+          width: 1
+          inst_name: usbdev
+          default: ""
+          top_signame: ast_ram_2p_cfg
           index: -1
         }
         {
@@ -2603,13 +2627,15 @@
         }
         {
           name: dft_strap_test
-          struct: dft_strap_test
+          struct: dft_strap_test_req
           package: pinmux_pkg
           type: uni
           act: req
           width: 1
           default: "'0"
           inst_name: pinmux_aon
+          external: true
+          top_signame: dft_strap_test
           index: -1
         }
         {
@@ -2922,6 +2948,30 @@
           default: ""
           external: true
           top_signame: sensor_ctrl_ast_status
+          index: -1
+        }
+        {
+          name: ast2pinmux
+          struct: logic
+          type: uni
+          act: rcv
+          width: 10
+          inst_name: sensor_ctrl_aon
+          default: ""
+          external: true
+          top_signame: ast2pinmux
+          index: -1
+        }
+        {
+          name: pinmux2ast
+          struct: logic
+          type: uni
+          act: req
+          width: 10
+          inst_name: sensor_ctrl_aon
+          default: ""
+          external: true
+          top_signame: pinmux2ast
           index: -1
         }
         {
@@ -4604,6 +4654,18 @@
           index: 3
         }
         {
+          name: ram_cfg
+          struct: ram_1p_cfg
+          package: prim_ram_1p_pkg
+          type: uni
+          act: rcv
+          width: 1
+          inst_name: otbn
+          default: ""
+          top_signame: ast_ram_1p_cfg
+          index: -1
+        }
+        {
           name: tl
           struct: tl
           package: tlul_pkg
@@ -4654,6 +4716,18 @@
           default: ""
           end_idx: -1
           top_signame: rom_tl
+          index: -1
+        }
+        {
+          struct: rom_cfg
+          package: prim_rom_pkg
+          type: uni
+          name: cfg
+          act: rcv
+          inst_name: rom
+          width: 1
+          default: ""
+          top_signame: ast_rom_cfg
           index: -1
         }
       ]
@@ -4733,6 +4807,18 @@
           top_signame: ram_main_intg_error
           index: -1
         }
+        {
+          struct: ram_1p_cfg
+          package: prim_ram_1p_pkg
+          type: uni
+          name: cfg
+          act: rcv
+          inst_name: ram_main
+          width: 1
+          default: ""
+          top_signame: ast_ram_1p_cfg
+          index: -1
+        }
       ]
       clock_connections:
       {
@@ -4809,6 +4895,18 @@
           end_idx: -1
           top_type: broadcast
           top_signame: ram_ret_aon_intg_error
+          index: -1
+        }
+        {
+          struct: ram_1p_cfg
+          package: prim_ram_1p_pkg
+          type: uni
+          name: cfg
+          act: rcv
+          inst_name: ram_ret_aon
+          width: 1
+          default: ""
+          top_signame: ast_ram_1p_cfg
           index: -1
         }
       ]
@@ -4961,7 +5059,7 @@
   port:
   [
     {
-      name: ast_edn
+      name: ast
       inter_signal_list:
       [
         {
@@ -4970,11 +5068,69 @@
           name: edn
           act: rsp
           package: edn_pkg
-          inst_name: ast_edn
+          inst_name: ast
           width: 1
           default: ""
           top_signame: edn0_edn
           index: 2
+          external: true
+        }
+        {
+          struct: lc_tx
+          type: uni
+          name: lc_dft_en
+          act: req
+          package: lc_ctrl_pkg
+          inst_name: ast
+          width: 1
+          default: ""
+          top_signame: lc_ctrl_lc_dft_en
+          index: -1
+          external: true
+        }
+        {
+          struct: ram_1p_cfg
+          package: prim_ram_1p_pkg
+          type: uni
+          name: ram_1p_cfg
+          act: rcv
+          inst_name: ast
+          width: 1
+          default: ""
+          end_idx: -1
+          top_type: broadcast
+          top_signame: ast_ram_1p_cfg
+          index: -1
+          external: true
+        }
+        {
+          struct: ram_2p_cfg
+          package: prim_ram_2p_pkg
+          type: uni
+          name: ram_2p_cfg
+          act: rcv
+          inst_name: ast
+          width: 1
+          default: ""
+          end_idx: -1
+          top_type: broadcast
+          top_signame: ast_ram_2p_cfg
+          index: -1
+          external: true
+        }
+        {
+          struct: rom_cfg
+          package: prim_rom_pkg
+          type: uni
+          name: rom_cfg
+          act: rcv
+          inst_name: ast
+          width: 1
+          default: ""
+          end_idx: -1
+          top_type: broadcast
+          top_signame: ast_rom_cfg
+          index: -1
           external: true
         }
       ]
@@ -4984,6 +5140,21 @@
   {
     connect:
     {
+      ast.ram_1p_cfg:
+      [
+        otbn.ram_cfg
+        ram_main.cfg
+        ram_ret_aon.cfg
+      ]
+      ast.ram_2p_cfg:
+      [
+        spi_device.ram_cfg
+        usbdev.ram_cfg
+      ]
+      ast.rom_cfg:
+      [
+        rom.cfg
+      ]
       alert_handler.crashdump:
       [
         rstmgr_aon.alert_dump
@@ -5121,7 +5292,7 @@
       [
         keymgr.edn
         otp_ctrl.edn
-        ast_edn.edn
+        ast.edn
         kmac.entropy
         alert_handler.edn
         aes.edn
@@ -5185,6 +5356,7 @@
       [
         otp_ctrl.lc_dft_en
         pinmux_aon.lc_dft_en
+        ast.lc_dft_en
       ]
       lc_ctrl.lc_nvm_debug_en:
       [
@@ -5430,19 +5602,17 @@
     ]
     external:
     {
+      ast.edn: ""
+      ast.lc_dft_en: ""
+      ast.ram_1p_cfg: ram_1p_cfg
+      ast.ram_2p_cfg: ram_2p_cfg
+      ast.rom_cfg: rom_cfg
       clkmgr_aon.clk_main: clk_main
       clkmgr_aon.clk_io: clk_io
       clkmgr_aon.clk_usb: clk_usb
       clkmgr_aon.clk_aon: clk_aon
       clkmgr_aon.jitter_en: clk_main_jitter_en
-      pwrmgr_aon.pwr_ast: pwrmgr_ast
-      sensor_ctrl_aon.ast_alert: sensor_ctrl_ast_alert
-      sensor_ctrl_aon.ast_status: sensor_ctrl_ast_status
-      usbdev.usb_ref_val: ""
-      usbdev.usb_ref_pulse: ""
-      peri.tl_ast: ast_tl
-      otp_ctrl.otp_ast_pwr_seq: ""
-      otp_ctrl.otp_ast_pwr_seq_h: ""
+      clkmgr_aon.ast_clk_bypass_ack: lc_clk_byp_ack
       eflash.flash_bist_enable: flash_bist_enable
       eflash.flash_power_down_h: flash_power_down_h
       eflash.flash_power_ready_h: flash_power_ready_h
@@ -5450,8 +5620,17 @@
       eflash.flash_test_voltage_h: flash_test_voltage_h
       entropy_src.entropy_src_rng: es_rng
       lc_ctrl.lc_clk_byp_req: lc_clk_byp_req
-      clkmgr_aon.ast_clk_bypass_ack: lc_clk_byp_ack
-      ast_edn.edn: ""
+      peri.tl_ast: ast_tl
+      pinmux_aon.dft_strap_test: dft_strap_test
+      pwrmgr_aon.pwr_ast: pwrmgr_ast
+      otp_ctrl.otp_ast_pwr_seq: ""
+      otp_ctrl.otp_ast_pwr_seq_h: ""
+      sensor_ctrl_aon.ast_alert: sensor_ctrl_ast_alert
+      sensor_ctrl_aon.ast_status: sensor_ctrl_ast_status
+      sensor_ctrl_aon.pinmux2ast: pinmux2ast
+      sensor_ctrl_aon.ast2pinmux: ast2pinmux
+      usbdev.usb_ref_val: ""
+      usbdev.usb_ref_pulse: ""
       clkmgr_aon.clocks_ast: clks_ast
       rstmgr_aon.resets_ast: rsts_ast
     }
@@ -7017,6 +7196,7 @@
       pattgen
       spi_host1
       flash_ctrl
+      sensor_ctrl_aon
     ]
     nc_modules:
     [
@@ -7339,6 +7519,12 @@
         type: input
         module_name: flash_ctrl
       }
+      {
+        name: sensor_ctrl_aon_ast_debug_in
+        width: 10
+        type: input
+        module_name: sensor_ctrl_aon
+      }
     ]
     outputs:
     [
@@ -7455,6 +7641,12 @@
         width: 1
         type: output
         module_name: flash_ctrl
+      }
+      {
+        name: sensor_ctrl_aon_ast_debug_out
+        width: 10
+        type: output
+        module_name: sensor_ctrl_aon
       }
     ]
   }
@@ -8786,6 +8978,18 @@
         index: -1
       }
       {
+        name: ram_cfg
+        struct: ram_2p_cfg
+        package: prim_ram_2p_pkg
+        type: uni
+        act: rcv
+        width: 1
+        inst_name: spi_device
+        default: ""
+        top_signame: ast_ram_2p_cfg
+        index: -1
+      }
+      {
         name: tl
         struct: tl
         package: tlul_pkg
@@ -8975,6 +9179,18 @@
         inst_name: usbdev
         default: ""
         top_signame: pinmux_aon_usb_state_debug
+        index: -1
+      }
+      {
+        name: ram_cfg
+        struct: ram_2p_cfg
+        package: prim_ram_2p_pkg
+        type: uni
+        act: rcv
+        width: 1
+        inst_name: usbdev
+        default: ""
+        top_signame: ast_ram_2p_cfg
         index: -1
       }
       {
@@ -10138,13 +10354,15 @@
       }
       {
         name: dft_strap_test
-        struct: dft_strap_test
+        struct: dft_strap_test_req
         package: pinmux_pkg
         type: uni
         act: req
         width: 1
         default: "'0"
         inst_name: pinmux_aon
+        external: true
+        top_signame: dft_strap_test
         index: -1
       }
       {
@@ -10365,6 +10583,30 @@
         default: ""
         external: true
         top_signame: sensor_ctrl_ast_status
+        index: -1
+      }
+      {
+        name: ast2pinmux
+        struct: logic
+        type: uni
+        act: rcv
+        width: 10
+        inst_name: sensor_ctrl_aon
+        default: ""
+        external: true
+        top_signame: ast2pinmux
+        index: -1
+      }
+      {
+        name: pinmux2ast
+        struct: logic
+        type: uni
+        act: req
+        width: 10
+        inst_name: sensor_ctrl_aon
+        default: ""
+        external: true
+        top_signame: pinmux2ast
         index: -1
       }
       {
@@ -11277,6 +11519,18 @@
         index: 3
       }
       {
+        name: ram_cfg
+        struct: ram_1p_cfg
+        package: prim_ram_1p_pkg
+        type: uni
+        act: rcv
+        width: 1
+        inst_name: otbn
+        default: ""
+        top_signame: ast_ram_1p_cfg
+        index: -1
+      }
+      {
         name: tl
         struct: tl
         package: tlul_pkg
@@ -11300,6 +11554,18 @@
         default: ""
         end_idx: -1
         top_signame: rom_tl
+        index: -1
+      }
+      {
+        struct: rom_cfg
+        package: prim_rom_pkg
+        type: uni
+        name: cfg
+        act: rcv
+        inst_name: rom
+        width: 1
+        default: ""
+        top_signame: ast_rom_cfg
         index: -1
       }
       {
@@ -11354,6 +11620,18 @@
         index: -1
       }
       {
+        struct: ram_1p_cfg
+        package: prim_ram_1p_pkg
+        type: uni
+        name: cfg
+        act: rcv
+        inst_name: ram_main
+        width: 1
+        default: ""
+        top_signame: ast_ram_1p_cfg
+        index: -1
+      }
+      {
         struct: tl
         package: tlul_pkg
         type: req_rsp
@@ -11402,6 +11680,18 @@
         end_idx: -1
         top_type: broadcast
         top_signame: ram_ret_aon_intg_error
+        index: -1
+      }
+      {
+        struct: ram_1p_cfg
+        package: prim_ram_1p_pkg
+        type: uni
+        name: cfg
+        act: rcv
+        inst_name: ram_ret_aon
+        width: 1
+        default: ""
+        top_signame: ast_ram_1p_cfg
         index: -1
       }
       {
@@ -12140,16 +12430,146 @@
         name: edn
         act: rsp
         package: edn_pkg
-        inst_name: ast_edn
+        inst_name: ast
         width: 1
         default: ""
         top_signame: edn0_edn
         index: 2
         external: true
       }
+      {
+        struct: lc_tx
+        type: uni
+        name: lc_dft_en
+        act: req
+        package: lc_ctrl_pkg
+        inst_name: ast
+        width: 1
+        default: ""
+        top_signame: lc_ctrl_lc_dft_en
+        index: -1
+        external: true
+      }
+      {
+        struct: ram_1p_cfg
+        package: prim_ram_1p_pkg
+        type: uni
+        name: ram_1p_cfg
+        act: rcv
+        inst_name: ast
+        width: 1
+        default: ""
+        end_idx: -1
+        top_type: broadcast
+        top_signame: ast_ram_1p_cfg
+        index: -1
+        external: true
+      }
+      {
+        struct: ram_2p_cfg
+        package: prim_ram_2p_pkg
+        type: uni
+        name: ram_2p_cfg
+        act: rcv
+        inst_name: ast
+        width: 1
+        default: ""
+        end_idx: -1
+        top_type: broadcast
+        top_signame: ast_ram_2p_cfg
+        index: -1
+        external: true
+      }
+      {
+        struct: rom_cfg
+        package: prim_rom_pkg
+        type: uni
+        name: rom_cfg
+        act: rcv
+        inst_name: ast
+        width: 1
+        default: ""
+        end_idx: -1
+        top_type: broadcast
+        top_signame: ast_rom_cfg
+        index: -1
+        external: true
+      }
     ]
     external:
     [
+      {
+        package: edn_pkg
+        struct: edn_req
+        signame: ast_edn_req_i
+        width: 1
+        type: req_rsp
+        default: ""
+        direction: in
+        conn_type: true
+        index: 2
+        netname: edn0_edn_req
+      }
+      {
+        package: edn_pkg
+        struct: edn_rsp
+        signame: ast_edn_rsp_o
+        width: 1
+        type: req_rsp
+        default: ""
+        direction: out
+        conn_type: true
+        index: 2
+        netname: edn0_edn_rsp
+      }
+      {
+        package: lc_ctrl_pkg
+        struct: lc_tx
+        signame: ast_lc_dft_en_o
+        width: 1
+        type: uni
+        default: ""
+        direction: out
+        conn_type: true
+        index: -1
+        netname: lc_ctrl_lc_dft_en
+      }
+      {
+        package: prim_ram_1p_pkg
+        struct: ram_1p_cfg
+        signame: ram_1p_cfg_i
+        width: 1
+        type: uni
+        default: ""
+        direction: in
+        conn_type: true
+        index: -1
+        netname: ast_ram_1p_cfg
+      }
+      {
+        package: prim_ram_2p_pkg
+        struct: ram_2p_cfg
+        signame: ram_2p_cfg_i
+        width: 1
+        type: uni
+        default: ""
+        direction: in
+        conn_type: true
+        index: -1
+        netname: ast_ram_2p_cfg
+      }
+      {
+        package: prim_rom_pkg
+        struct: rom_cfg
+        signame: rom_cfg_i
+        width: 1
+        type: uni
+        default: ""
+        direction: in
+        conn_type: true
+        index: -1
+        netname: ast_rom_cfg
+      }
       {
         package: ""
         struct: logic
@@ -12158,6 +12578,7 @@
         type: uni
         default: ""
         direction: in
+        conn_type: false
         index: -1
         netname: clk_main
       }
@@ -12169,6 +12590,7 @@
         type: uni
         default: ""
         direction: in
+        conn_type: false
         index: -1
         netname: clk_io
       }
@@ -12180,6 +12602,7 @@
         type: uni
         default: ""
         direction: in
+        conn_type: false
         index: -1
         netname: clk_usb
       }
@@ -12191,6 +12614,7 @@
         type: uni
         default: ""
         direction: in
+        conn_type: false
         index: -1
         netname: clk_aon
       }
@@ -12202,129 +12626,21 @@
         type: uni
         default: ""
         direction: out
+        conn_type: false
         index: -1
         netname: clk_main_jitter_en
       }
       {
-        package: pwrmgr_pkg
-        struct: pwr_ast_req
-        signame: pwrmgr_ast_req_o
-        width: 1
-        type: req_rsp
-        default: ""
-        direction: out
-        index: -1
-        netname: pwrmgr_ast_req
-      }
-      {
-        package: pwrmgr_pkg
-        struct: pwr_ast_rsp
-        signame: pwrmgr_ast_rsp_i
-        width: 1
-        type: req_rsp
-        default: ""
-        direction: in
-        index: -1
-        netname: pwrmgr_ast_rsp
-      }
-      {
-        package: ast_pkg
-        struct: ast_alert_req
-        signame: sensor_ctrl_ast_alert_req_i
-        width: 1
-        type: req_rsp
-        default: ""
-        direction: in
-        index: -1
-        netname: sensor_ctrl_ast_alert_req
-      }
-      {
-        package: ast_pkg
-        struct: ast_alert_rsp
-        signame: sensor_ctrl_ast_alert_rsp_o
-        width: 1
-        type: req_rsp
-        default: ""
-        direction: out
-        index: -1
-        netname: sensor_ctrl_ast_alert_rsp
-      }
-      {
-        package: ast_pkg
-        struct: ast_status
-        signame: sensor_ctrl_ast_status_i
+        package: lc_ctrl_pkg
+        struct: lc_tx
+        signame: lc_clk_byp_ack_i
         width: 1
         type: uni
         default: ""
         direction: in
+        conn_type: false
         index: -1
-        netname: sensor_ctrl_ast_status
-      }
-      {
-        package: ""
-        struct: logic
-        signame: usbdev_usb_ref_val_o
-        width: 1
-        type: uni
-        default: ""
-        direction: out
-        index: -1
-        netname: usbdev_usb_ref_val
-      }
-      {
-        package: ""
-        struct: logic
-        signame: usbdev_usb_ref_pulse_o
-        width: 1
-        type: uni
-        default: ""
-        direction: out
-        index: -1
-        netname: usbdev_usb_ref_pulse
-      }
-      {
-        package: tlul_pkg
-        struct: tl_h2d
-        signame: ast_tl_req_o
-        width: 1
-        type: req_rsp
-        default: ""
-        direction: out
-        index: -1
-        netname: ast_tl_h2d
-      }
-      {
-        package: tlul_pkg
-        struct: tl_d2h
-        signame: ast_tl_rsp_i
-        width: 1
-        type: req_rsp
-        default: ""
-        direction: in
-        index: -1
-        netname: ast_tl_d2h
-      }
-      {
-        package: otp_ctrl_pkg
-        struct: otp_ast_req
-        signame: otp_ctrl_otp_ast_pwr_seq_o
-        width: 1
-        type: uni
-        default: "'0"
-        direction: out
-        index: -1
-        netname: otp_ctrl_otp_ast_pwr_seq
-      }
-      {
-        package: otp_ctrl_pkg
-        struct: otp_ast_rsp
-        signame: otp_ctrl_otp_ast_pwr_seq_h_i
-        width: 1
-        type: uni
-        default: "'0"
-        direction: in
-        index: -1
-        netname: otp_ctrl_otp_ast_pwr_seq_h
+        netname: lc_clk_byp_ack
       }
       {
         package: lc_ctrl_pkg
@@ -12334,6 +12650,7 @@
         type: uni
         default: ""
         direction: in
+        conn_type: false
         index: -1
         netname: flash_bist_enable
       }
@@ -12345,6 +12662,7 @@
         type: uni
         default: ""
         direction: in
+        conn_type: false
         index: -1
         netname: flash_power_down_h
       }
@@ -12356,6 +12674,7 @@
         type: uni
         default: ""
         direction: in
+        conn_type: false
         index: -1
         netname: flash_power_ready_h
       }
@@ -12367,6 +12686,7 @@
         type: uni
         default: ""
         direction: in
+        conn_type: false
         index: -1
         netname: flash_test_mode_a
       }
@@ -12378,6 +12698,7 @@
         type: uni
         default: ""
         direction: in
+        conn_type: false
         index: -1
         netname: flash_test_voltage_h
       }
@@ -12389,6 +12710,7 @@
         type: req_rsp
         default: ""
         direction: out
+        conn_type: false
         index: -1
         netname: es_rng_req
       }
@@ -12400,6 +12722,7 @@
         type: req_rsp
         default: ""
         direction: in
+        conn_type: false
         index: -1
         netname: es_rng_rsp
       }
@@ -12411,41 +12734,177 @@
         type: uni
         default: lc_ctrl_pkg::Off
         direction: out
+        conn_type: false
         index: -1
         netname: lc_clk_byp_req
       }
       {
-        package: lc_ctrl_pkg
-        struct: lc_tx
-        signame: lc_clk_byp_ack_i
-        width: 1
-        type: uni
-        default: ""
-        direction: in
-        index: -1
-        netname: lc_clk_byp_ack
-      }
-      {
-        package: edn_pkg
-        struct: edn_req
-        signame: ast_edn_edn_req_i
-        width: 1
-        type: req_rsp
-        default: ""
-        direction: in
-        index: 2
-        netname: edn0_edn_req
-      }
-      {
-        package: edn_pkg
-        struct: edn_rsp
-        signame: ast_edn_edn_rsp_o
+        package: tlul_pkg
+        struct: tl_h2d
+        signame: ast_tl_req_o
         width: 1
         type: req_rsp
         default: ""
         direction: out
-        index: 2
-        netname: edn0_edn_rsp
+        conn_type: false
+        index: -1
+        netname: ast_tl_h2d
+      }
+      {
+        package: tlul_pkg
+        struct: tl_d2h
+        signame: ast_tl_rsp_i
+        width: 1
+        type: req_rsp
+        default: ""
+        direction: in
+        conn_type: false
+        index: -1
+        netname: ast_tl_d2h
+      }
+      {
+        package: pinmux_pkg
+        struct: dft_strap_test_req
+        signame: dft_strap_test_o
+        width: 1
+        type: uni
+        default: "'0"
+        direction: out
+        conn_type: false
+        index: -1
+        netname: dft_strap_test
+      }
+      {
+        package: pwrmgr_pkg
+        struct: pwr_ast_req
+        signame: pwrmgr_ast_req_o
+        width: 1
+        type: req_rsp
+        default: ""
+        direction: out
+        conn_type: false
+        index: -1
+        netname: pwrmgr_ast_req
+      }
+      {
+        package: pwrmgr_pkg
+        struct: pwr_ast_rsp
+        signame: pwrmgr_ast_rsp_i
+        width: 1
+        type: req_rsp
+        default: ""
+        direction: in
+        conn_type: false
+        index: -1
+        netname: pwrmgr_ast_rsp
+      }
+      {
+        package: otp_ctrl_pkg
+        struct: otp_ast_req
+        signame: otp_ctrl_otp_ast_pwr_seq_o
+        width: 1
+        type: uni
+        default: "'0"
+        direction: out
+        conn_type: false
+        index: -1
+        netname: otp_ctrl_otp_ast_pwr_seq
+      }
+      {
+        package: otp_ctrl_pkg
+        struct: otp_ast_rsp
+        signame: otp_ctrl_otp_ast_pwr_seq_h_i
+        width: 1
+        type: uni
+        default: "'0"
+        direction: in
+        conn_type: false
+        index: -1
+        netname: otp_ctrl_otp_ast_pwr_seq_h
+      }
+      {
+        package: ast_pkg
+        struct: ast_alert_req
+        signame: sensor_ctrl_ast_alert_req_i
+        width: 1
+        type: req_rsp
+        default: ""
+        direction: in
+        conn_type: false
+        index: -1
+        netname: sensor_ctrl_ast_alert_req
+      }
+      {
+        package: ast_pkg
+        struct: ast_alert_rsp
+        signame: sensor_ctrl_ast_alert_rsp_o
+        width: 1
+        type: req_rsp
+        default: ""
+        direction: out
+        conn_type: false
+        index: -1
+        netname: sensor_ctrl_ast_alert_rsp
+      }
+      {
+        package: ast_pkg
+        struct: ast_status
+        signame: sensor_ctrl_ast_status_i
+        width: 1
+        type: uni
+        default: ""
+        direction: in
+        conn_type: false
+        index: -1
+        netname: sensor_ctrl_ast_status
+      }
+      {
+        package: ""
+        struct: logic
+        signame: pinmux2ast_o
+        width: 10
+        type: uni
+        default: ""
+        direction: out
+        conn_type: false
+        index: -1
+        netname: pinmux2ast
+      }
+      {
+        package: ""
+        struct: logic
+        signame: ast2pinmux_i
+        width: 10
+        type: uni
+        default: ""
+        direction: in
+        conn_type: false
+        index: -1
+        netname: ast2pinmux
+      }
+      {
+        package: ""
+        struct: logic
+        signame: usbdev_usb_ref_val_o
+        width: 1
+        type: uni
+        default: ""
+        direction: out
+        conn_type: false
+        index: -1
+        netname: usbdev_usb_ref_val
+      }
+      {
+        package: ""
+        struct: logic
+        signame: usbdev_usb_ref_pulse_o
+        width: 1
+        type: uni
+        default: ""
+        direction: out
+        conn_type: false
+        index: -1
+        netname: usbdev_usb_ref_pulse
       }
       {
         package: clkmgr_pkg
@@ -12455,6 +12914,7 @@
         type: uni
         default: ""
         direction: out
+        conn_type: false
         index: -1
         netname: clks_ast
       }
@@ -12466,12 +12926,46 @@
         type: uni
         default: ""
         direction: out
+        conn_type: false
         index: -1
         netname: rsts_ast
       }
     ]
     definitions:
     [
+      {
+        package: prim_ram_1p_pkg
+        struct: ram_1p_cfg
+        signame: ast_ram_1p_cfg
+        width: 1
+        type: uni
+        end_idx: -1
+        act: rcv
+        suffix: ""
+        default: ""
+      }
+      {
+        package: prim_ram_2p_pkg
+        struct: ram_2p_cfg
+        signame: ast_ram_2p_cfg
+        width: 1
+        type: uni
+        end_idx: -1
+        act: rcv
+        suffix: ""
+        default: ""
+      }
+      {
+        package: prim_rom_pkg
+        struct: rom_cfg
+        signame: ast_rom_cfg
+        width: 1
+        type: uni
+        end_idx: -1
+        act: rcv
+        suffix: ""
+        default: ""
+      }
       {
         package: alert_pkg
         struct: alert_crashdump

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -579,6 +579,13 @@
           type: "req_rsp"
           act: "rsp"
           name: "tl"
+        },
+        // Interface to memory configuration
+        { struct:  "rom_cfg",
+          package: "prim_rom_pkg",
+          type:    "uni",
+          name:    "cfg",
+          act:     "rcv"
         }
       ]
     },
@@ -619,6 +626,13 @@
           name:    "intg_error",
           act:     "req",
         },
+        // Interface to memory configuration
+        { struct:  "ram_1p_cfg",
+          package: "prim_ram_1p_pkg",
+          type:    "uni",
+          name:    "cfg",
+          act:     "rcv"
+        }
       ]
     },
     { name: "ram_ret_aon",
@@ -659,6 +673,13 @@
           name:    "intg_error",
           act:     "req",
         },
+        // Interface to memory configuration
+        { struct:  "ram_1p_cfg",
+          package: "prim_ram_1p_pkg",
+          type:    "uni",
+          name:    "cfg",
+          act:     "rcv"
+        }
       ]
     },
     { name: "eflash",
@@ -729,7 +750,7 @@
   // For example, this allows us to designate a port as part of inter-module
   // connections.
   port: [
-    { name: "ast_edn",
+    { name: "ast",
       inter_signal_list: [
         { struct: "edn",
           type: "req_rsp",
@@ -739,6 +760,42 @@
           act:  "rsp",
           package: "edn_pkg",
         },
+
+        { struct: "lc_tx",
+          type: "uni",
+          name: "lc_dft_en",
+          // The activity direction for a port inter-signal is "opposite" of
+          // what the external module actually needs.
+          act:  "req",
+          package: "lc_ctrl_pkg",
+        },
+
+        { struct:  "ram_1p_cfg",
+          package: "prim_ram_1p_pkg",
+          type:    "uni",
+          name:    "ram_1p_cfg",
+          // The activity direction for a port inter-signal is "opposite" of
+          // what the external module actually needs.
+          act:     "rcv"
+        },
+
+        { struct:  "ram_2p_cfg",
+          package: "prim_ram_2p_pkg",
+          type:    "uni",
+          name:    "ram_2p_cfg",
+          // The activity direction for a port inter-signal is "opposite" of
+          // what the external module actually needs.
+          act:     "rcv"
+        },
+
+        { struct:  "rom_cfg",
+          package: "prim_rom_pkg",
+          type:    "uni",
+          name:    "rom_cfg",
+          // The activity direction for a port inter-signal is "opposite" of
+          // what the external module actually needs.
+          act:     "rcv"
+        }
       ]
     },
   ]
@@ -751,6 +808,9 @@
   //  e.g flash_ctrl0.flash: [flash_phy0.flash_ctrl]
   inter_module: {
     'connect': {
+      'ast.ram_1p_cfg'          : ['otbn.ram_cfg', 'ram_main.cfg', 'ram_ret_aon.cfg'],
+      'ast.ram_2p_cfg'          : ['spi_device.ram_cfg', 'usbdev.ram_cfg'],
+      'ast.rom_cfg'             : ['rom.cfg'],
       'alert_handler.crashdump' : ['rstmgr_aon.alert_dump'],
       'alert_handler.esc_rx'    : ['rv_core_ibex.esc_nmi_rx',
                                    'lc_ctrl.esc_wipe_secrets_rx',
@@ -796,7 +856,7 @@
       'pinmux_aon.usb_state_debug' : ['usbdev.usb_state_debug'],
 
       // Edn connections
-      'edn0.edn'              : ['keymgr.edn', 'otp_ctrl.edn', 'ast_edn.edn', 'kmac.entropy',
+      'edn0.edn'              : ['keymgr.edn', 'otp_ctrl.edn', 'ast.edn', 'kmac.entropy',
                                  'alert_handler.edn', 'aes.edn', 'otbn.edn_urnd'],
       'edn1.edn'              : ['otbn.edn_rnd'],
 
@@ -830,7 +890,9 @@
 
       // LC function control signal broadcast
       'lc_ctrl.lc_dft_en'          : ['otp_ctrl.lc_dft_en',
-                                      'pinmux_aon.lc_dft_en'],
+                                      'pinmux_aon.lc_dft_en',
+                                      'ast.lc_dft_en'
+                                     ],
       'lc_ctrl.lc_nvm_debug_en'    : ['eflash.lc_nvm_debug_en'],
       'lc_ctrl.lc_hw_debug_en'     : ['sram_ctrl_main.lc_hw_debug_en',
                                       'sram_ctrl_ret_aon.lc_hw_debug_en',
@@ -868,19 +930,17 @@
 
     // ext is to create port in the top.
     'external': {
-       'clkmgr_aon.clk_main'           : 'clk_main',  // clock inputs
+        'ast.edn'                      : '',
+        'ast.lc_dft_en'                : '',
+        'ast.ram_1p_cfg'               : 'ram_1p_cfg',
+        'ast.ram_2p_cfg'               : 'ram_2p_cfg',
+        'ast.rom_cfg'                  : 'rom_cfg',
+        'clkmgr_aon.clk_main'          : 'clk_main',  // clock inputs
         'clkmgr_aon.clk_io'            : 'clk_io',    // clock inputs
         'clkmgr_aon.clk_usb'           : 'clk_usb',   // clock inputs
         'clkmgr_aon.clk_aon'           : 'clk_aon',   // clock inputs
         'clkmgr_aon.jitter_en'         : 'clk_main_jitter_en',
-        'pwrmgr_aon.pwr_ast'           : 'pwrmgr_ast',
-        'sensor_ctrl_aon.ast_alert'    : 'sensor_ctrl_ast_alert',
-        'sensor_ctrl_aon.ast_status'   : 'sensor_ctrl_ast_status',
-        'usbdev.usb_ref_val'           : '',
-        'usbdev.usb_ref_pulse'         : '',
-        'peri.tl_ast'                  : 'ast_tl',
-        'otp_ctrl.otp_ast_pwr_seq'     : '',
-        'otp_ctrl.otp_ast_pwr_seq_h'   : '',
+        'clkmgr_aon.ast_clk_bypass_ack': 'lc_clk_byp_ack',
         'eflash.flash_bist_enable'     : 'flash_bist_enable',
         'eflash.flash_power_down_h'    : 'flash_power_down_h',
         'eflash.flash_power_ready_h'   : 'flash_power_ready_h',
@@ -888,8 +948,17 @@
         'eflash.flash_test_voltage_h'  : 'flash_test_voltage_h',
         'entropy_src.entropy_src_rng'  : 'es_rng',
         'lc_ctrl.lc_clk_byp_req'       : 'lc_clk_byp_req',
-        'clkmgr_aon.ast_clk_bypass_ack': 'lc_clk_byp_ack',
-        'ast_edn.edn'                  : ''
+        'peri.tl_ast'                  : 'ast_tl',
+        'pinmux_aon.dft_strap_test'    : 'dft_strap_test'
+        'pwrmgr_aon.pwr_ast'           : 'pwrmgr_ast',
+        'otp_ctrl.otp_ast_pwr_seq'     : '',
+        'otp_ctrl.otp_ast_pwr_seq_h'   : '',
+        'sensor_ctrl_aon.ast_alert'    : 'sensor_ctrl_ast_alert',
+        'sensor_ctrl_aon.ast_status'   : 'sensor_ctrl_ast_status',
+        'sensor_ctrl_aon.pinmux2ast'   : 'pinmux2ast',
+        'sensor_ctrl_aon.ast2pinmux'   : 'ast2pinmux',
+        'usbdev.usb_ref_val'           : '',
+        'usbdev.usb_ref_pulse'         : '',
     },
   },
 
@@ -944,7 +1013,7 @@
     //  module list except defined in `dio_modules`.
     mio_modules: ["gpio", "uart0", "uart1", "uart2", "uart3",
                   "i2c0", "i2c1", "i2c2", "pattgen", "spi_host1",
-                  "flash_ctrl"]
+                  "flash_ctrl", "sensor_ctrl_aon"]
 
     // If any module isn't defined in above two lists, its inputs will be tied
     //  to 0, and the output/OE signals will be floating (or connected to

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -189,11 +189,17 @@ module top_${top["name"]} #(
 ## whereas an index of 0 means a port is directly driven by a module
   // define mixed connection to port
 % for port in top['inter_signal']['external']:
-  % if port['index'] > 0:
+  % if port['conn_type'] and port['index'] > 0:
     % if port['direction'] == 'in':
   assign ${port['netname']}[${port['index']}] = ${port['signame']};
     % else:
   assign ${port['signame']} = ${port['netname']}[${port['index']}];
+    % endif
+  % elif port['conn_type']:
+    % if port['direction'] == 'in':
+  assign ${port['netname']} = ${port['signame']};
+    % else:
+  assign ${port['signame']} = ${port['netname']};
     % endif
   % endif
 % endfor
@@ -377,8 +383,7 @@ module top_${top["name"]} #(
   prim_ram_1p_scr #(
     .Width(${full_data_width}),
     .Depth(${sram_depth}),
-    .EnableParity(0),
-    .CfgWidth(8)
+    .EnableParity(0)
   ) u_ram1p_${m["name"]} (
     % for key in clocks:
     .${key}   (${clocks[key]}),
@@ -403,7 +408,7 @@ module top_${top["name"]} #(
     .rerror_o    (${m["name"]}_rerror),
     .raddr_o     (${m["inter_signal_list"][1]["top_signame"]}_rsp.raddr),
     .intg_error_o(${m["inter_signal_list"][3]["top_signame"]}),
-    .cfg_i       ( '0 )
+    .cfg_i       (ram_1p_cfg_i)
   );
 
   assign ${m["inter_signal_list"][1]["top_signame"]}_rsp.rerror = ${m["name"]}_rerror;
@@ -469,7 +474,7 @@ module top_${top["name"]} #(
     .addr_i   (${m["name"]}_addr),
     .rdata_o  (${m["name"]}_rdata),
     .rvalid_o (${m["name"]}_rvalid),
-    .cfg_i    ('0) // tied off for now
+    .cfg_i    (rom_cfg_i)
   );
 
   % elif m["type"] == "eflash":

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -71,7 +71,7 @@
       package: "jtag_pkg"
     }
     // Testmode signals to AST
-    { struct:  "dft_strap_test",
+    { struct:  "dft_strap_test_req",
       type:    "uni",
       name:    "dft_strap_test",
       act:     "req",
@@ -153,13 +153,13 @@
     { name: "NMioPeriphIn",
       desc: "Number of muxed peripheral inputs",
       type: "int",
-      default: "49",
+      default: "59",
       local: "true"
     },
     { name: "NMioPeriphOut",
       desc: "Number of muxed peripheral outputs",
       type: "int",
-      default: "53",
+      default: "63",
       local: "true"
     },
     { name: "NMioPads",
@@ -313,7 +313,7 @@
                   regwen_multi: "true",
                   cname:        "OUT",
                   fields: [
-                    { bits: "5:0",
+                    { bits: "6:0",
                       name: "OUT",
                       desc: '''
                       0: tie constantly to zero, 1: tie constantly to 1, 2: high-Z,

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
@@ -8,8 +8,8 @@ package pinmux_reg_pkg;
 
   // Param list
   parameter int AttrDw = 10;
-  parameter int NMioPeriphIn = 49;
-  parameter int NMioPeriphOut = 53;
+  parameter int NMioPeriphIn = 59;
+  parameter int NMioPeriphOut = 63;
   parameter int NMioPads = 44;
   parameter int NDioPads = 21;
   parameter int NWkupDetect = 8;
@@ -33,7 +33,7 @@ package pinmux_reg_pkg;
   } pinmux_reg2hw_mio_periph_insel_mreg_t;
 
   typedef struct packed {
-    logic [5:0]  q;
+    logic [6:0]  q;
   } pinmux_reg2hw_mio_outsel_mreg_t;
 
   typedef struct packed {
@@ -123,8 +123,8 @@ package pinmux_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    pinmux_reg2hw_mio_periph_insel_mreg_t [48:0] mio_periph_insel; // [1708:1415]
-    pinmux_reg2hw_mio_outsel_mreg_t [43:0] mio_outsel; // [1414:1151]
+    pinmux_reg2hw_mio_periph_insel_mreg_t [58:0] mio_periph_insel; // [1812:1459]
+    pinmux_reg2hw_mio_outsel_mreg_t [43:0] mio_outsel; // [1458:1151]
     pinmux_reg2hw_mio_pad_attr_mreg_t [43:0] mio_pad_attr; // [1150:667]
     pinmux_reg2hw_dio_pad_attr_mreg_t [20:0] dio_pad_attr; // [666:436]
     pinmux_reg2hw_mio_pad_sleep_status_mreg_t [43:0] mio_pad_sleep_status; // [435:392]
@@ -199,512 +199,532 @@ package pinmux_reg_pkg;
   parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_REGWEN_46_OFFSET = 12'h b8;
   parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_REGWEN_47_OFFSET = 12'h bc;
   parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_REGWEN_48_OFFSET = 12'h c0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_0_OFFSET = 12'h c4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_1_OFFSET = 12'h c8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_2_OFFSET = 12'h cc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_3_OFFSET = 12'h d0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_4_OFFSET = 12'h d4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_5_OFFSET = 12'h d8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_6_OFFSET = 12'h dc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_7_OFFSET = 12'h e0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_8_OFFSET = 12'h e4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_9_OFFSET = 12'h e8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_10_OFFSET = 12'h ec;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_11_OFFSET = 12'h f0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_12_OFFSET = 12'h f4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_13_OFFSET = 12'h f8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_14_OFFSET = 12'h fc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_15_OFFSET = 12'h 100;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_16_OFFSET = 12'h 104;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_17_OFFSET = 12'h 108;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_18_OFFSET = 12'h 10c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_19_OFFSET = 12'h 110;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_20_OFFSET = 12'h 114;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_21_OFFSET = 12'h 118;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_22_OFFSET = 12'h 11c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_23_OFFSET = 12'h 120;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_24_OFFSET = 12'h 124;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_25_OFFSET = 12'h 128;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_26_OFFSET = 12'h 12c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_27_OFFSET = 12'h 130;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_28_OFFSET = 12'h 134;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_29_OFFSET = 12'h 138;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_30_OFFSET = 12'h 13c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_31_OFFSET = 12'h 140;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_32_OFFSET = 12'h 144;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_33_OFFSET = 12'h 148;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_34_OFFSET = 12'h 14c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_35_OFFSET = 12'h 150;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_36_OFFSET = 12'h 154;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_37_OFFSET = 12'h 158;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_38_OFFSET = 12'h 15c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_39_OFFSET = 12'h 160;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_40_OFFSET = 12'h 164;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_41_OFFSET = 12'h 168;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_42_OFFSET = 12'h 16c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_43_OFFSET = 12'h 170;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_44_OFFSET = 12'h 174;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_45_OFFSET = 12'h 178;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_46_OFFSET = 12'h 17c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_47_OFFSET = 12'h 180;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_48_OFFSET = 12'h 184;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_0_OFFSET = 12'h 188;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_1_OFFSET = 12'h 18c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_2_OFFSET = 12'h 190;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_3_OFFSET = 12'h 194;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_4_OFFSET = 12'h 198;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_5_OFFSET = 12'h 19c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_6_OFFSET = 12'h 1a0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_7_OFFSET = 12'h 1a4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_8_OFFSET = 12'h 1a8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_9_OFFSET = 12'h 1ac;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_10_OFFSET = 12'h 1b0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_11_OFFSET = 12'h 1b4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_12_OFFSET = 12'h 1b8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_13_OFFSET = 12'h 1bc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_14_OFFSET = 12'h 1c0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_15_OFFSET = 12'h 1c4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_16_OFFSET = 12'h 1c8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_17_OFFSET = 12'h 1cc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_18_OFFSET = 12'h 1d0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_19_OFFSET = 12'h 1d4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_20_OFFSET = 12'h 1d8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_21_OFFSET = 12'h 1dc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_22_OFFSET = 12'h 1e0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_23_OFFSET = 12'h 1e4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_24_OFFSET = 12'h 1e8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_25_OFFSET = 12'h 1ec;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_26_OFFSET = 12'h 1f0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_27_OFFSET = 12'h 1f4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_28_OFFSET = 12'h 1f8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_29_OFFSET = 12'h 1fc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_30_OFFSET = 12'h 200;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_31_OFFSET = 12'h 204;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_32_OFFSET = 12'h 208;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_33_OFFSET = 12'h 20c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_34_OFFSET = 12'h 210;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_35_OFFSET = 12'h 214;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_36_OFFSET = 12'h 218;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_37_OFFSET = 12'h 21c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_38_OFFSET = 12'h 220;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_39_OFFSET = 12'h 224;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_40_OFFSET = 12'h 228;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_41_OFFSET = 12'h 22c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_42_OFFSET = 12'h 230;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_43_OFFSET = 12'h 234;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_0_OFFSET = 12'h 238;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_1_OFFSET = 12'h 23c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_2_OFFSET = 12'h 240;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_3_OFFSET = 12'h 244;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_4_OFFSET = 12'h 248;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_5_OFFSET = 12'h 24c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_6_OFFSET = 12'h 250;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_7_OFFSET = 12'h 254;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_8_OFFSET = 12'h 258;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_9_OFFSET = 12'h 25c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_10_OFFSET = 12'h 260;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_11_OFFSET = 12'h 264;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_12_OFFSET = 12'h 268;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_13_OFFSET = 12'h 26c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_14_OFFSET = 12'h 270;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_15_OFFSET = 12'h 274;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_16_OFFSET = 12'h 278;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_17_OFFSET = 12'h 27c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_18_OFFSET = 12'h 280;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_19_OFFSET = 12'h 284;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_20_OFFSET = 12'h 288;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_21_OFFSET = 12'h 28c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_22_OFFSET = 12'h 290;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_23_OFFSET = 12'h 294;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_24_OFFSET = 12'h 298;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_25_OFFSET = 12'h 29c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_26_OFFSET = 12'h 2a0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_27_OFFSET = 12'h 2a4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_28_OFFSET = 12'h 2a8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_29_OFFSET = 12'h 2ac;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_30_OFFSET = 12'h 2b0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_31_OFFSET = 12'h 2b4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_32_OFFSET = 12'h 2b8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_33_OFFSET = 12'h 2bc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_34_OFFSET = 12'h 2c0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_35_OFFSET = 12'h 2c4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_36_OFFSET = 12'h 2c8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_37_OFFSET = 12'h 2cc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_38_OFFSET = 12'h 2d0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_39_OFFSET = 12'h 2d4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_40_OFFSET = 12'h 2d8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_41_OFFSET = 12'h 2dc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_42_OFFSET = 12'h 2e0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_43_OFFSET = 12'h 2e4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_0_OFFSET = 12'h 2e8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_1_OFFSET = 12'h 2ec;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_2_OFFSET = 12'h 2f0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_3_OFFSET = 12'h 2f4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_4_OFFSET = 12'h 2f8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_5_OFFSET = 12'h 2fc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_6_OFFSET = 12'h 300;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_7_OFFSET = 12'h 304;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_8_OFFSET = 12'h 308;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_9_OFFSET = 12'h 30c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_10_OFFSET = 12'h 310;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_11_OFFSET = 12'h 314;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_12_OFFSET = 12'h 318;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_13_OFFSET = 12'h 31c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_14_OFFSET = 12'h 320;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_15_OFFSET = 12'h 324;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_16_OFFSET = 12'h 328;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_17_OFFSET = 12'h 32c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_18_OFFSET = 12'h 330;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_19_OFFSET = 12'h 334;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_20_OFFSET = 12'h 338;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_21_OFFSET = 12'h 33c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_22_OFFSET = 12'h 340;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_23_OFFSET = 12'h 344;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_24_OFFSET = 12'h 348;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_25_OFFSET = 12'h 34c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_26_OFFSET = 12'h 350;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_27_OFFSET = 12'h 354;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_28_OFFSET = 12'h 358;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_29_OFFSET = 12'h 35c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_30_OFFSET = 12'h 360;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_31_OFFSET = 12'h 364;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_32_OFFSET = 12'h 368;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_33_OFFSET = 12'h 36c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_34_OFFSET = 12'h 370;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_35_OFFSET = 12'h 374;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_36_OFFSET = 12'h 378;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_37_OFFSET = 12'h 37c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_38_OFFSET = 12'h 380;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_39_OFFSET = 12'h 384;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_40_OFFSET = 12'h 388;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_41_OFFSET = 12'h 38c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_42_OFFSET = 12'h 390;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_43_OFFSET = 12'h 394;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_0_OFFSET = 12'h 398;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_1_OFFSET = 12'h 39c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_2_OFFSET = 12'h 3a0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_3_OFFSET = 12'h 3a4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_4_OFFSET = 12'h 3a8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_5_OFFSET = 12'h 3ac;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_6_OFFSET = 12'h 3b0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_7_OFFSET = 12'h 3b4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_8_OFFSET = 12'h 3b8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_9_OFFSET = 12'h 3bc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_10_OFFSET = 12'h 3c0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_11_OFFSET = 12'h 3c4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_12_OFFSET = 12'h 3c8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_13_OFFSET = 12'h 3cc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_14_OFFSET = 12'h 3d0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_15_OFFSET = 12'h 3d4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_16_OFFSET = 12'h 3d8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_17_OFFSET = 12'h 3dc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_18_OFFSET = 12'h 3e0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_19_OFFSET = 12'h 3e4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_20_OFFSET = 12'h 3e8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_21_OFFSET = 12'h 3ec;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_22_OFFSET = 12'h 3f0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_23_OFFSET = 12'h 3f4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_24_OFFSET = 12'h 3f8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_25_OFFSET = 12'h 3fc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_26_OFFSET = 12'h 400;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_27_OFFSET = 12'h 404;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_28_OFFSET = 12'h 408;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_29_OFFSET = 12'h 40c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_30_OFFSET = 12'h 410;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_31_OFFSET = 12'h 414;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_32_OFFSET = 12'h 418;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_33_OFFSET = 12'h 41c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_34_OFFSET = 12'h 420;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_35_OFFSET = 12'h 424;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_36_OFFSET = 12'h 428;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_37_OFFSET = 12'h 42c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_38_OFFSET = 12'h 430;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_39_OFFSET = 12'h 434;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_40_OFFSET = 12'h 438;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_41_OFFSET = 12'h 43c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_42_OFFSET = 12'h 440;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_43_OFFSET = 12'h 444;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_0_OFFSET = 12'h 448;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_1_OFFSET = 12'h 44c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_2_OFFSET = 12'h 450;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_3_OFFSET = 12'h 454;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_4_OFFSET = 12'h 458;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_5_OFFSET = 12'h 45c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_6_OFFSET = 12'h 460;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_7_OFFSET = 12'h 464;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_8_OFFSET = 12'h 468;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_9_OFFSET = 12'h 46c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_10_OFFSET = 12'h 470;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_11_OFFSET = 12'h 474;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_12_OFFSET = 12'h 478;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_13_OFFSET = 12'h 47c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_14_OFFSET = 12'h 480;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_15_OFFSET = 12'h 484;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_16_OFFSET = 12'h 488;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_17_OFFSET = 12'h 48c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_18_OFFSET = 12'h 490;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_19_OFFSET = 12'h 494;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_20_OFFSET = 12'h 498;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_0_OFFSET = 12'h 49c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_1_OFFSET = 12'h 4a0;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_2_OFFSET = 12'h 4a4;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_3_OFFSET = 12'h 4a8;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_4_OFFSET = 12'h 4ac;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_5_OFFSET = 12'h 4b0;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_6_OFFSET = 12'h 4b4;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_7_OFFSET = 12'h 4b8;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_8_OFFSET = 12'h 4bc;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_9_OFFSET = 12'h 4c0;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_10_OFFSET = 12'h 4c4;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_11_OFFSET = 12'h 4c8;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_12_OFFSET = 12'h 4cc;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_13_OFFSET = 12'h 4d0;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_14_OFFSET = 12'h 4d4;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_15_OFFSET = 12'h 4d8;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_16_OFFSET = 12'h 4dc;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_17_OFFSET = 12'h 4e0;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_18_OFFSET = 12'h 4e4;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_19_OFFSET = 12'h 4e8;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_20_OFFSET = 12'h 4ec;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_STATUS_0_OFFSET = 12'h 4f0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_STATUS_1_OFFSET = 12'h 4f4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_0_OFFSET = 12'h 4f8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_1_OFFSET = 12'h 4fc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_2_OFFSET = 12'h 500;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_3_OFFSET = 12'h 504;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_4_OFFSET = 12'h 508;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_5_OFFSET = 12'h 50c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_6_OFFSET = 12'h 510;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_7_OFFSET = 12'h 514;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_8_OFFSET = 12'h 518;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_9_OFFSET = 12'h 51c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_10_OFFSET = 12'h 520;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_11_OFFSET = 12'h 524;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_12_OFFSET = 12'h 528;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_13_OFFSET = 12'h 52c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_14_OFFSET = 12'h 530;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_15_OFFSET = 12'h 534;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_16_OFFSET = 12'h 538;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_17_OFFSET = 12'h 53c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_18_OFFSET = 12'h 540;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_19_OFFSET = 12'h 544;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_20_OFFSET = 12'h 548;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_21_OFFSET = 12'h 54c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_22_OFFSET = 12'h 550;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_23_OFFSET = 12'h 554;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_24_OFFSET = 12'h 558;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_25_OFFSET = 12'h 55c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_26_OFFSET = 12'h 560;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_27_OFFSET = 12'h 564;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_28_OFFSET = 12'h 568;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_29_OFFSET = 12'h 56c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_30_OFFSET = 12'h 570;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_31_OFFSET = 12'h 574;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_32_OFFSET = 12'h 578;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_33_OFFSET = 12'h 57c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_34_OFFSET = 12'h 580;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_35_OFFSET = 12'h 584;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_36_OFFSET = 12'h 588;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_37_OFFSET = 12'h 58c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_38_OFFSET = 12'h 590;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_39_OFFSET = 12'h 594;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_40_OFFSET = 12'h 598;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_41_OFFSET = 12'h 59c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_42_OFFSET = 12'h 5a0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_43_OFFSET = 12'h 5a4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_0_OFFSET = 12'h 5a8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_1_OFFSET = 12'h 5ac;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_2_OFFSET = 12'h 5b0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_3_OFFSET = 12'h 5b4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_4_OFFSET = 12'h 5b8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_5_OFFSET = 12'h 5bc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_6_OFFSET = 12'h 5c0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_7_OFFSET = 12'h 5c4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_8_OFFSET = 12'h 5c8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_9_OFFSET = 12'h 5cc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_10_OFFSET = 12'h 5d0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_11_OFFSET = 12'h 5d4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_12_OFFSET = 12'h 5d8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_13_OFFSET = 12'h 5dc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_14_OFFSET = 12'h 5e0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_15_OFFSET = 12'h 5e4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_16_OFFSET = 12'h 5e8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_17_OFFSET = 12'h 5ec;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_18_OFFSET = 12'h 5f0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_19_OFFSET = 12'h 5f4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_20_OFFSET = 12'h 5f8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_21_OFFSET = 12'h 5fc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_22_OFFSET = 12'h 600;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_23_OFFSET = 12'h 604;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_24_OFFSET = 12'h 608;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_25_OFFSET = 12'h 60c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_26_OFFSET = 12'h 610;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_27_OFFSET = 12'h 614;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_28_OFFSET = 12'h 618;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_29_OFFSET = 12'h 61c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_30_OFFSET = 12'h 620;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_31_OFFSET = 12'h 624;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_32_OFFSET = 12'h 628;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_33_OFFSET = 12'h 62c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_34_OFFSET = 12'h 630;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_35_OFFSET = 12'h 634;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_36_OFFSET = 12'h 638;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_37_OFFSET = 12'h 63c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_38_OFFSET = 12'h 640;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_39_OFFSET = 12'h 644;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_40_OFFSET = 12'h 648;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_41_OFFSET = 12'h 64c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_42_OFFSET = 12'h 650;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_43_OFFSET = 12'h 654;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_0_OFFSET = 12'h 658;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_1_OFFSET = 12'h 65c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_2_OFFSET = 12'h 660;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_3_OFFSET = 12'h 664;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_4_OFFSET = 12'h 668;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_5_OFFSET = 12'h 66c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_6_OFFSET = 12'h 670;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_7_OFFSET = 12'h 674;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_8_OFFSET = 12'h 678;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_9_OFFSET = 12'h 67c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_10_OFFSET = 12'h 680;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_11_OFFSET = 12'h 684;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_12_OFFSET = 12'h 688;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_13_OFFSET = 12'h 68c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_14_OFFSET = 12'h 690;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_15_OFFSET = 12'h 694;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_16_OFFSET = 12'h 698;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_17_OFFSET = 12'h 69c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_18_OFFSET = 12'h 6a0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_19_OFFSET = 12'h 6a4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_20_OFFSET = 12'h 6a8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_21_OFFSET = 12'h 6ac;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_22_OFFSET = 12'h 6b0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_23_OFFSET = 12'h 6b4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_24_OFFSET = 12'h 6b8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_25_OFFSET = 12'h 6bc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_26_OFFSET = 12'h 6c0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_27_OFFSET = 12'h 6c4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_28_OFFSET = 12'h 6c8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_29_OFFSET = 12'h 6cc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_30_OFFSET = 12'h 6d0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_31_OFFSET = 12'h 6d4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_32_OFFSET = 12'h 6d8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_33_OFFSET = 12'h 6dc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_34_OFFSET = 12'h 6e0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_35_OFFSET = 12'h 6e4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_36_OFFSET = 12'h 6e8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_37_OFFSET = 12'h 6ec;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_38_OFFSET = 12'h 6f0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_39_OFFSET = 12'h 6f4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_40_OFFSET = 12'h 6f8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_41_OFFSET = 12'h 6fc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_42_OFFSET = 12'h 700;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_43_OFFSET = 12'h 704;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_STATUS_OFFSET = 12'h 708;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_0_OFFSET = 12'h 70c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_1_OFFSET = 12'h 710;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_2_OFFSET = 12'h 714;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_3_OFFSET = 12'h 718;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_4_OFFSET = 12'h 71c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_5_OFFSET = 12'h 720;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_6_OFFSET = 12'h 724;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_7_OFFSET = 12'h 728;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_8_OFFSET = 12'h 72c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_9_OFFSET = 12'h 730;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_10_OFFSET = 12'h 734;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_11_OFFSET = 12'h 738;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_12_OFFSET = 12'h 73c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_13_OFFSET = 12'h 740;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_14_OFFSET = 12'h 744;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_15_OFFSET = 12'h 748;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_16_OFFSET = 12'h 74c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_17_OFFSET = 12'h 750;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_18_OFFSET = 12'h 754;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_19_OFFSET = 12'h 758;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_20_OFFSET = 12'h 75c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_0_OFFSET = 12'h 760;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_1_OFFSET = 12'h 764;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_2_OFFSET = 12'h 768;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_3_OFFSET = 12'h 76c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_4_OFFSET = 12'h 770;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_5_OFFSET = 12'h 774;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_6_OFFSET = 12'h 778;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_7_OFFSET = 12'h 77c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_8_OFFSET = 12'h 780;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_9_OFFSET = 12'h 784;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_10_OFFSET = 12'h 788;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_11_OFFSET = 12'h 78c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_12_OFFSET = 12'h 790;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_13_OFFSET = 12'h 794;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_14_OFFSET = 12'h 798;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_15_OFFSET = 12'h 79c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_16_OFFSET = 12'h 7a0;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_17_OFFSET = 12'h 7a4;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_18_OFFSET = 12'h 7a8;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_19_OFFSET = 12'h 7ac;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_20_OFFSET = 12'h 7b0;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_0_OFFSET = 12'h 7b4;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_1_OFFSET = 12'h 7b8;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_2_OFFSET = 12'h 7bc;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_3_OFFSET = 12'h 7c0;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_4_OFFSET = 12'h 7c4;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_5_OFFSET = 12'h 7c8;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_6_OFFSET = 12'h 7cc;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_7_OFFSET = 12'h 7d0;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_8_OFFSET = 12'h 7d4;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_9_OFFSET = 12'h 7d8;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_10_OFFSET = 12'h 7dc;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_11_OFFSET = 12'h 7e0;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_12_OFFSET = 12'h 7e4;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_13_OFFSET = 12'h 7e8;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_14_OFFSET = 12'h 7ec;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_15_OFFSET = 12'h 7f0;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_16_OFFSET = 12'h 7f4;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_17_OFFSET = 12'h 7f8;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_18_OFFSET = 12'h 7fc;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_19_OFFSET = 12'h 800;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_20_OFFSET = 12'h 804;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_0_OFFSET = 12'h 808;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_1_OFFSET = 12'h 80c;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_2_OFFSET = 12'h 810;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_3_OFFSET = 12'h 814;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_4_OFFSET = 12'h 818;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_5_OFFSET = 12'h 81c;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_6_OFFSET = 12'h 820;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_7_OFFSET = 12'h 824;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_0_OFFSET = 12'h 828;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_1_OFFSET = 12'h 82c;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_2_OFFSET = 12'h 830;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_3_OFFSET = 12'h 834;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_4_OFFSET = 12'h 838;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_5_OFFSET = 12'h 83c;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_6_OFFSET = 12'h 840;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_7_OFFSET = 12'h 844;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_0_OFFSET = 12'h 848;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_1_OFFSET = 12'h 84c;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_2_OFFSET = 12'h 850;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_3_OFFSET = 12'h 854;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_4_OFFSET = 12'h 858;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_5_OFFSET = 12'h 85c;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_6_OFFSET = 12'h 860;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_7_OFFSET = 12'h 864;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_0_OFFSET = 12'h 868;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_1_OFFSET = 12'h 86c;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_2_OFFSET = 12'h 870;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_3_OFFSET = 12'h 874;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_4_OFFSET = 12'h 878;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_5_OFFSET = 12'h 87c;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_6_OFFSET = 12'h 880;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_7_OFFSET = 12'h 884;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_0_OFFSET = 12'h 888;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_1_OFFSET = 12'h 88c;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_2_OFFSET = 12'h 890;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_3_OFFSET = 12'h 894;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_4_OFFSET = 12'h 898;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_5_OFFSET = 12'h 89c;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_6_OFFSET = 12'h 8a0;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_7_OFFSET = 12'h 8a4;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_CAUSE_OFFSET = 12'h 8a8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_REGWEN_49_OFFSET = 12'h c4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_REGWEN_50_OFFSET = 12'h c8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_REGWEN_51_OFFSET = 12'h cc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_REGWEN_52_OFFSET = 12'h d0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_REGWEN_53_OFFSET = 12'h d4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_REGWEN_54_OFFSET = 12'h d8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_REGWEN_55_OFFSET = 12'h dc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_REGWEN_56_OFFSET = 12'h e0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_REGWEN_57_OFFSET = 12'h e4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_REGWEN_58_OFFSET = 12'h e8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_0_OFFSET = 12'h ec;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_1_OFFSET = 12'h f0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_2_OFFSET = 12'h f4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_3_OFFSET = 12'h f8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_4_OFFSET = 12'h fc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_5_OFFSET = 12'h 100;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_6_OFFSET = 12'h 104;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_7_OFFSET = 12'h 108;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_8_OFFSET = 12'h 10c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_9_OFFSET = 12'h 110;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_10_OFFSET = 12'h 114;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_11_OFFSET = 12'h 118;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_12_OFFSET = 12'h 11c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_13_OFFSET = 12'h 120;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_14_OFFSET = 12'h 124;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_15_OFFSET = 12'h 128;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_16_OFFSET = 12'h 12c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_17_OFFSET = 12'h 130;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_18_OFFSET = 12'h 134;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_19_OFFSET = 12'h 138;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_20_OFFSET = 12'h 13c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_21_OFFSET = 12'h 140;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_22_OFFSET = 12'h 144;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_23_OFFSET = 12'h 148;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_24_OFFSET = 12'h 14c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_25_OFFSET = 12'h 150;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_26_OFFSET = 12'h 154;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_27_OFFSET = 12'h 158;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_28_OFFSET = 12'h 15c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_29_OFFSET = 12'h 160;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_30_OFFSET = 12'h 164;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_31_OFFSET = 12'h 168;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_32_OFFSET = 12'h 16c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_33_OFFSET = 12'h 170;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_34_OFFSET = 12'h 174;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_35_OFFSET = 12'h 178;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_36_OFFSET = 12'h 17c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_37_OFFSET = 12'h 180;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_38_OFFSET = 12'h 184;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_39_OFFSET = 12'h 188;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_40_OFFSET = 12'h 18c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_41_OFFSET = 12'h 190;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_42_OFFSET = 12'h 194;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_43_OFFSET = 12'h 198;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_44_OFFSET = 12'h 19c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_45_OFFSET = 12'h 1a0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_46_OFFSET = 12'h 1a4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_47_OFFSET = 12'h 1a8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_48_OFFSET = 12'h 1ac;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_49_OFFSET = 12'h 1b0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_50_OFFSET = 12'h 1b4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_51_OFFSET = 12'h 1b8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_52_OFFSET = 12'h 1bc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_53_OFFSET = 12'h 1c0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_54_OFFSET = 12'h 1c4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_55_OFFSET = 12'h 1c8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_56_OFFSET = 12'h 1cc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_57_OFFSET = 12'h 1d0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PERIPH_INSEL_58_OFFSET = 12'h 1d4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_0_OFFSET = 12'h 1d8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_1_OFFSET = 12'h 1dc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_2_OFFSET = 12'h 1e0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_3_OFFSET = 12'h 1e4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_4_OFFSET = 12'h 1e8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_5_OFFSET = 12'h 1ec;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_6_OFFSET = 12'h 1f0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_7_OFFSET = 12'h 1f4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_8_OFFSET = 12'h 1f8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_9_OFFSET = 12'h 1fc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_10_OFFSET = 12'h 200;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_11_OFFSET = 12'h 204;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_12_OFFSET = 12'h 208;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_13_OFFSET = 12'h 20c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_14_OFFSET = 12'h 210;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_15_OFFSET = 12'h 214;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_16_OFFSET = 12'h 218;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_17_OFFSET = 12'h 21c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_18_OFFSET = 12'h 220;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_19_OFFSET = 12'h 224;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_20_OFFSET = 12'h 228;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_21_OFFSET = 12'h 22c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_22_OFFSET = 12'h 230;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_23_OFFSET = 12'h 234;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_24_OFFSET = 12'h 238;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_25_OFFSET = 12'h 23c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_26_OFFSET = 12'h 240;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_27_OFFSET = 12'h 244;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_28_OFFSET = 12'h 248;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_29_OFFSET = 12'h 24c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_30_OFFSET = 12'h 250;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_31_OFFSET = 12'h 254;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_32_OFFSET = 12'h 258;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_33_OFFSET = 12'h 25c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_34_OFFSET = 12'h 260;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_35_OFFSET = 12'h 264;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_36_OFFSET = 12'h 268;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_37_OFFSET = 12'h 26c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_38_OFFSET = 12'h 270;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_39_OFFSET = 12'h 274;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_40_OFFSET = 12'h 278;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_41_OFFSET = 12'h 27c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_42_OFFSET = 12'h 280;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_REGWEN_43_OFFSET = 12'h 284;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_0_OFFSET = 12'h 288;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_1_OFFSET = 12'h 28c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_2_OFFSET = 12'h 290;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_3_OFFSET = 12'h 294;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_4_OFFSET = 12'h 298;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_5_OFFSET = 12'h 29c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_6_OFFSET = 12'h 2a0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_7_OFFSET = 12'h 2a4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_8_OFFSET = 12'h 2a8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_9_OFFSET = 12'h 2ac;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_10_OFFSET = 12'h 2b0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_11_OFFSET = 12'h 2b4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_12_OFFSET = 12'h 2b8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_13_OFFSET = 12'h 2bc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_14_OFFSET = 12'h 2c0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_15_OFFSET = 12'h 2c4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_16_OFFSET = 12'h 2c8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_17_OFFSET = 12'h 2cc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_18_OFFSET = 12'h 2d0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_19_OFFSET = 12'h 2d4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_20_OFFSET = 12'h 2d8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_21_OFFSET = 12'h 2dc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_22_OFFSET = 12'h 2e0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_23_OFFSET = 12'h 2e4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_24_OFFSET = 12'h 2e8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_25_OFFSET = 12'h 2ec;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_26_OFFSET = 12'h 2f0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_27_OFFSET = 12'h 2f4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_28_OFFSET = 12'h 2f8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_29_OFFSET = 12'h 2fc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_30_OFFSET = 12'h 300;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_31_OFFSET = 12'h 304;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_32_OFFSET = 12'h 308;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_33_OFFSET = 12'h 30c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_34_OFFSET = 12'h 310;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_35_OFFSET = 12'h 314;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_36_OFFSET = 12'h 318;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_37_OFFSET = 12'h 31c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_38_OFFSET = 12'h 320;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_39_OFFSET = 12'h 324;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_40_OFFSET = 12'h 328;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_41_OFFSET = 12'h 32c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_42_OFFSET = 12'h 330;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_OUTSEL_43_OFFSET = 12'h 334;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_0_OFFSET = 12'h 338;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_1_OFFSET = 12'h 33c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_2_OFFSET = 12'h 340;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_3_OFFSET = 12'h 344;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_4_OFFSET = 12'h 348;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_5_OFFSET = 12'h 34c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_6_OFFSET = 12'h 350;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_7_OFFSET = 12'h 354;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_8_OFFSET = 12'h 358;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_9_OFFSET = 12'h 35c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_10_OFFSET = 12'h 360;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_11_OFFSET = 12'h 364;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_12_OFFSET = 12'h 368;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_13_OFFSET = 12'h 36c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_14_OFFSET = 12'h 370;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_15_OFFSET = 12'h 374;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_16_OFFSET = 12'h 378;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_17_OFFSET = 12'h 37c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_18_OFFSET = 12'h 380;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_19_OFFSET = 12'h 384;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_20_OFFSET = 12'h 388;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_21_OFFSET = 12'h 38c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_22_OFFSET = 12'h 390;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_23_OFFSET = 12'h 394;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_24_OFFSET = 12'h 398;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_25_OFFSET = 12'h 39c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_26_OFFSET = 12'h 3a0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_27_OFFSET = 12'h 3a4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_28_OFFSET = 12'h 3a8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_29_OFFSET = 12'h 3ac;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_30_OFFSET = 12'h 3b0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_31_OFFSET = 12'h 3b4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_32_OFFSET = 12'h 3b8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_33_OFFSET = 12'h 3bc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_34_OFFSET = 12'h 3c0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_35_OFFSET = 12'h 3c4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_36_OFFSET = 12'h 3c8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_37_OFFSET = 12'h 3cc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_38_OFFSET = 12'h 3d0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_39_OFFSET = 12'h 3d4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_40_OFFSET = 12'h 3d8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_41_OFFSET = 12'h 3dc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_42_OFFSET = 12'h 3e0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_REGWEN_43_OFFSET = 12'h 3e4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_0_OFFSET = 12'h 3e8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_1_OFFSET = 12'h 3ec;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_2_OFFSET = 12'h 3f0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_3_OFFSET = 12'h 3f4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_4_OFFSET = 12'h 3f8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_5_OFFSET = 12'h 3fc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_6_OFFSET = 12'h 400;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_7_OFFSET = 12'h 404;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_8_OFFSET = 12'h 408;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_9_OFFSET = 12'h 40c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_10_OFFSET = 12'h 410;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_11_OFFSET = 12'h 414;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_12_OFFSET = 12'h 418;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_13_OFFSET = 12'h 41c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_14_OFFSET = 12'h 420;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_15_OFFSET = 12'h 424;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_16_OFFSET = 12'h 428;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_17_OFFSET = 12'h 42c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_18_OFFSET = 12'h 430;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_19_OFFSET = 12'h 434;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_20_OFFSET = 12'h 438;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_21_OFFSET = 12'h 43c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_22_OFFSET = 12'h 440;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_23_OFFSET = 12'h 444;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_24_OFFSET = 12'h 448;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_25_OFFSET = 12'h 44c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_26_OFFSET = 12'h 450;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_27_OFFSET = 12'h 454;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_28_OFFSET = 12'h 458;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_29_OFFSET = 12'h 45c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_30_OFFSET = 12'h 460;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_31_OFFSET = 12'h 464;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_32_OFFSET = 12'h 468;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_33_OFFSET = 12'h 46c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_34_OFFSET = 12'h 470;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_35_OFFSET = 12'h 474;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_36_OFFSET = 12'h 478;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_37_OFFSET = 12'h 47c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_38_OFFSET = 12'h 480;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_39_OFFSET = 12'h 484;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_40_OFFSET = 12'h 488;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_41_OFFSET = 12'h 48c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_42_OFFSET = 12'h 490;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_ATTR_43_OFFSET = 12'h 494;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_0_OFFSET = 12'h 498;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_1_OFFSET = 12'h 49c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_2_OFFSET = 12'h 4a0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_3_OFFSET = 12'h 4a4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_4_OFFSET = 12'h 4a8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_5_OFFSET = 12'h 4ac;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_6_OFFSET = 12'h 4b0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_7_OFFSET = 12'h 4b4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_8_OFFSET = 12'h 4b8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_9_OFFSET = 12'h 4bc;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_10_OFFSET = 12'h 4c0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_11_OFFSET = 12'h 4c4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_12_OFFSET = 12'h 4c8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_13_OFFSET = 12'h 4cc;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_14_OFFSET = 12'h 4d0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_15_OFFSET = 12'h 4d4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_16_OFFSET = 12'h 4d8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_17_OFFSET = 12'h 4dc;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_18_OFFSET = 12'h 4e0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_19_OFFSET = 12'h 4e4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_20_OFFSET = 12'h 4e8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_0_OFFSET = 12'h 4ec;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_1_OFFSET = 12'h 4f0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_2_OFFSET = 12'h 4f4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_3_OFFSET = 12'h 4f8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_4_OFFSET = 12'h 4fc;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_5_OFFSET = 12'h 500;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_6_OFFSET = 12'h 504;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_7_OFFSET = 12'h 508;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_8_OFFSET = 12'h 50c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_9_OFFSET = 12'h 510;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_10_OFFSET = 12'h 514;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_11_OFFSET = 12'h 518;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_12_OFFSET = 12'h 51c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_13_OFFSET = 12'h 520;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_14_OFFSET = 12'h 524;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_15_OFFSET = 12'h 528;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_16_OFFSET = 12'h 52c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_17_OFFSET = 12'h 530;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_18_OFFSET = 12'h 534;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_19_OFFSET = 12'h 538;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_20_OFFSET = 12'h 53c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_STATUS_0_OFFSET = 12'h 540;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_STATUS_1_OFFSET = 12'h 544;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_0_OFFSET = 12'h 548;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_1_OFFSET = 12'h 54c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_2_OFFSET = 12'h 550;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_3_OFFSET = 12'h 554;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_4_OFFSET = 12'h 558;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_5_OFFSET = 12'h 55c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_6_OFFSET = 12'h 560;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_7_OFFSET = 12'h 564;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_8_OFFSET = 12'h 568;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_9_OFFSET = 12'h 56c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_10_OFFSET = 12'h 570;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_11_OFFSET = 12'h 574;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_12_OFFSET = 12'h 578;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_13_OFFSET = 12'h 57c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_14_OFFSET = 12'h 580;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_15_OFFSET = 12'h 584;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_16_OFFSET = 12'h 588;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_17_OFFSET = 12'h 58c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_18_OFFSET = 12'h 590;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_19_OFFSET = 12'h 594;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_20_OFFSET = 12'h 598;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_21_OFFSET = 12'h 59c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_22_OFFSET = 12'h 5a0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_23_OFFSET = 12'h 5a4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_24_OFFSET = 12'h 5a8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_25_OFFSET = 12'h 5ac;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_26_OFFSET = 12'h 5b0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_27_OFFSET = 12'h 5b4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_28_OFFSET = 12'h 5b8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_29_OFFSET = 12'h 5bc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_30_OFFSET = 12'h 5c0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_31_OFFSET = 12'h 5c4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_32_OFFSET = 12'h 5c8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_33_OFFSET = 12'h 5cc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_34_OFFSET = 12'h 5d0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_35_OFFSET = 12'h 5d4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_36_OFFSET = 12'h 5d8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_37_OFFSET = 12'h 5dc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_38_OFFSET = 12'h 5e0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_39_OFFSET = 12'h 5e4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_40_OFFSET = 12'h 5e8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_41_OFFSET = 12'h 5ec;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_42_OFFSET = 12'h 5f0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_43_OFFSET = 12'h 5f4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_0_OFFSET = 12'h 5f8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_1_OFFSET = 12'h 5fc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_2_OFFSET = 12'h 600;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_3_OFFSET = 12'h 604;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_4_OFFSET = 12'h 608;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_5_OFFSET = 12'h 60c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_6_OFFSET = 12'h 610;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_7_OFFSET = 12'h 614;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_8_OFFSET = 12'h 618;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_9_OFFSET = 12'h 61c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_10_OFFSET = 12'h 620;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_11_OFFSET = 12'h 624;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_12_OFFSET = 12'h 628;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_13_OFFSET = 12'h 62c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_14_OFFSET = 12'h 630;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_15_OFFSET = 12'h 634;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_16_OFFSET = 12'h 638;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_17_OFFSET = 12'h 63c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_18_OFFSET = 12'h 640;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_19_OFFSET = 12'h 644;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_20_OFFSET = 12'h 648;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_21_OFFSET = 12'h 64c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_22_OFFSET = 12'h 650;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_23_OFFSET = 12'h 654;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_24_OFFSET = 12'h 658;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_25_OFFSET = 12'h 65c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_26_OFFSET = 12'h 660;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_27_OFFSET = 12'h 664;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_28_OFFSET = 12'h 668;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_29_OFFSET = 12'h 66c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_30_OFFSET = 12'h 670;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_31_OFFSET = 12'h 674;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_32_OFFSET = 12'h 678;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_33_OFFSET = 12'h 67c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_34_OFFSET = 12'h 680;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_35_OFFSET = 12'h 684;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_36_OFFSET = 12'h 688;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_37_OFFSET = 12'h 68c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_38_OFFSET = 12'h 690;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_39_OFFSET = 12'h 694;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_40_OFFSET = 12'h 698;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_41_OFFSET = 12'h 69c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_42_OFFSET = 12'h 6a0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_43_OFFSET = 12'h 6a4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_0_OFFSET = 12'h 6a8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_1_OFFSET = 12'h 6ac;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_2_OFFSET = 12'h 6b0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_3_OFFSET = 12'h 6b4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_4_OFFSET = 12'h 6b8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_5_OFFSET = 12'h 6bc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_6_OFFSET = 12'h 6c0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_7_OFFSET = 12'h 6c4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_8_OFFSET = 12'h 6c8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_9_OFFSET = 12'h 6cc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_10_OFFSET = 12'h 6d0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_11_OFFSET = 12'h 6d4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_12_OFFSET = 12'h 6d8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_13_OFFSET = 12'h 6dc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_14_OFFSET = 12'h 6e0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_15_OFFSET = 12'h 6e4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_16_OFFSET = 12'h 6e8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_17_OFFSET = 12'h 6ec;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_18_OFFSET = 12'h 6f0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_19_OFFSET = 12'h 6f4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_20_OFFSET = 12'h 6f8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_21_OFFSET = 12'h 6fc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_22_OFFSET = 12'h 700;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_23_OFFSET = 12'h 704;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_24_OFFSET = 12'h 708;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_25_OFFSET = 12'h 70c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_26_OFFSET = 12'h 710;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_27_OFFSET = 12'h 714;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_28_OFFSET = 12'h 718;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_29_OFFSET = 12'h 71c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_30_OFFSET = 12'h 720;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_31_OFFSET = 12'h 724;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_32_OFFSET = 12'h 728;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_33_OFFSET = 12'h 72c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_34_OFFSET = 12'h 730;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_35_OFFSET = 12'h 734;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_36_OFFSET = 12'h 738;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_37_OFFSET = 12'h 73c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_38_OFFSET = 12'h 740;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_39_OFFSET = 12'h 744;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_40_OFFSET = 12'h 748;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_41_OFFSET = 12'h 74c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_42_OFFSET = 12'h 750;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_43_OFFSET = 12'h 754;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_STATUS_OFFSET = 12'h 758;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_0_OFFSET = 12'h 75c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_1_OFFSET = 12'h 760;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_2_OFFSET = 12'h 764;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_3_OFFSET = 12'h 768;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_4_OFFSET = 12'h 76c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_5_OFFSET = 12'h 770;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_6_OFFSET = 12'h 774;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_7_OFFSET = 12'h 778;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_8_OFFSET = 12'h 77c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_9_OFFSET = 12'h 780;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_10_OFFSET = 12'h 784;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_11_OFFSET = 12'h 788;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_12_OFFSET = 12'h 78c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_13_OFFSET = 12'h 790;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_14_OFFSET = 12'h 794;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_15_OFFSET = 12'h 798;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_16_OFFSET = 12'h 79c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_17_OFFSET = 12'h 7a0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_18_OFFSET = 12'h 7a4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_19_OFFSET = 12'h 7a8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_20_OFFSET = 12'h 7ac;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_0_OFFSET = 12'h 7b0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_1_OFFSET = 12'h 7b4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_2_OFFSET = 12'h 7b8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_3_OFFSET = 12'h 7bc;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_4_OFFSET = 12'h 7c0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_5_OFFSET = 12'h 7c4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_6_OFFSET = 12'h 7c8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_7_OFFSET = 12'h 7cc;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_8_OFFSET = 12'h 7d0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_9_OFFSET = 12'h 7d4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_10_OFFSET = 12'h 7d8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_11_OFFSET = 12'h 7dc;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_12_OFFSET = 12'h 7e0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_13_OFFSET = 12'h 7e4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_14_OFFSET = 12'h 7e8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_15_OFFSET = 12'h 7ec;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_16_OFFSET = 12'h 7f0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_17_OFFSET = 12'h 7f4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_18_OFFSET = 12'h 7f8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_19_OFFSET = 12'h 7fc;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_20_OFFSET = 12'h 800;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_0_OFFSET = 12'h 804;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_1_OFFSET = 12'h 808;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_2_OFFSET = 12'h 80c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_3_OFFSET = 12'h 810;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_4_OFFSET = 12'h 814;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_5_OFFSET = 12'h 818;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_6_OFFSET = 12'h 81c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_7_OFFSET = 12'h 820;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_8_OFFSET = 12'h 824;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_9_OFFSET = 12'h 828;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_10_OFFSET = 12'h 82c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_11_OFFSET = 12'h 830;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_12_OFFSET = 12'h 834;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_13_OFFSET = 12'h 838;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_14_OFFSET = 12'h 83c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_15_OFFSET = 12'h 840;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_16_OFFSET = 12'h 844;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_17_OFFSET = 12'h 848;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_18_OFFSET = 12'h 84c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_19_OFFSET = 12'h 850;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_20_OFFSET = 12'h 854;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_0_OFFSET = 12'h 858;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_1_OFFSET = 12'h 85c;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_2_OFFSET = 12'h 860;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_3_OFFSET = 12'h 864;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_4_OFFSET = 12'h 868;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_5_OFFSET = 12'h 86c;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_6_OFFSET = 12'h 870;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_7_OFFSET = 12'h 874;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_0_OFFSET = 12'h 878;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_1_OFFSET = 12'h 87c;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_2_OFFSET = 12'h 880;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_3_OFFSET = 12'h 884;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_4_OFFSET = 12'h 888;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_5_OFFSET = 12'h 88c;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_6_OFFSET = 12'h 890;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_7_OFFSET = 12'h 894;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_0_OFFSET = 12'h 898;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_1_OFFSET = 12'h 89c;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_2_OFFSET = 12'h 8a0;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_3_OFFSET = 12'h 8a4;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_4_OFFSET = 12'h 8a8;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_5_OFFSET = 12'h 8ac;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_6_OFFSET = 12'h 8b0;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_7_OFFSET = 12'h 8b4;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_0_OFFSET = 12'h 8b8;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_1_OFFSET = 12'h 8bc;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_2_OFFSET = 12'h 8c0;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_3_OFFSET = 12'h 8c4;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_4_OFFSET = 12'h 8c8;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_5_OFFSET = 12'h 8cc;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_6_OFFSET = 12'h 8d0;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_7_OFFSET = 12'h 8d4;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_0_OFFSET = 12'h 8d8;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_1_OFFSET = 12'h 8dc;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_2_OFFSET = 12'h 8e0;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_3_OFFSET = 12'h 8e4;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_4_OFFSET = 12'h 8e8;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_5_OFFSET = 12'h 8ec;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_6_OFFSET = 12'h 8f0;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_7_OFFSET = 12'h 8f4;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_CAUSE_OFFSET = 12'h 8f8;
 
   // Reset values for hwext registers and their fields
   parameter logic [9:0] PINMUX_MIO_PAD_ATTR_0_RESVAL = 10'h 0;
@@ -898,6 +918,16 @@ package pinmux_reg_pkg;
     PINMUX_MIO_PERIPH_INSEL_REGWEN_46,
     PINMUX_MIO_PERIPH_INSEL_REGWEN_47,
     PINMUX_MIO_PERIPH_INSEL_REGWEN_48,
+    PINMUX_MIO_PERIPH_INSEL_REGWEN_49,
+    PINMUX_MIO_PERIPH_INSEL_REGWEN_50,
+    PINMUX_MIO_PERIPH_INSEL_REGWEN_51,
+    PINMUX_MIO_PERIPH_INSEL_REGWEN_52,
+    PINMUX_MIO_PERIPH_INSEL_REGWEN_53,
+    PINMUX_MIO_PERIPH_INSEL_REGWEN_54,
+    PINMUX_MIO_PERIPH_INSEL_REGWEN_55,
+    PINMUX_MIO_PERIPH_INSEL_REGWEN_56,
+    PINMUX_MIO_PERIPH_INSEL_REGWEN_57,
+    PINMUX_MIO_PERIPH_INSEL_REGWEN_58,
     PINMUX_MIO_PERIPH_INSEL_0,
     PINMUX_MIO_PERIPH_INSEL_1,
     PINMUX_MIO_PERIPH_INSEL_2,
@@ -947,6 +977,16 @@ package pinmux_reg_pkg;
     PINMUX_MIO_PERIPH_INSEL_46,
     PINMUX_MIO_PERIPH_INSEL_47,
     PINMUX_MIO_PERIPH_INSEL_48,
+    PINMUX_MIO_PERIPH_INSEL_49,
+    PINMUX_MIO_PERIPH_INSEL_50,
+    PINMUX_MIO_PERIPH_INSEL_51,
+    PINMUX_MIO_PERIPH_INSEL_52,
+    PINMUX_MIO_PERIPH_INSEL_53,
+    PINMUX_MIO_PERIPH_INSEL_54,
+    PINMUX_MIO_PERIPH_INSEL_55,
+    PINMUX_MIO_PERIPH_INSEL_56,
+    PINMUX_MIO_PERIPH_INSEL_57,
+    PINMUX_MIO_PERIPH_INSEL_58,
     PINMUX_MIO_OUTSEL_REGWEN_0,
     PINMUX_MIO_OUTSEL_REGWEN_1,
     PINMUX_MIO_OUTSEL_REGWEN_2,
@@ -1407,7 +1447,7 @@ package pinmux_reg_pkg;
   } pinmux_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] PINMUX_PERMIT [555] = '{
+  parameter logic [3:0] PINMUX_PERMIT [575] = '{
     4'b 0001, // index[  0] PINMUX_MIO_PERIPH_INSEL_REGWEN_0
     4'b 0001, // index[  1] PINMUX_MIO_PERIPH_INSEL_REGWEN_1
     4'b 0001, // index[  2] PINMUX_MIO_PERIPH_INSEL_REGWEN_2
@@ -1457,512 +1497,532 @@ package pinmux_reg_pkg;
     4'b 0001, // index[ 46] PINMUX_MIO_PERIPH_INSEL_REGWEN_46
     4'b 0001, // index[ 47] PINMUX_MIO_PERIPH_INSEL_REGWEN_47
     4'b 0001, // index[ 48] PINMUX_MIO_PERIPH_INSEL_REGWEN_48
-    4'b 0001, // index[ 49] PINMUX_MIO_PERIPH_INSEL_0
-    4'b 0001, // index[ 50] PINMUX_MIO_PERIPH_INSEL_1
-    4'b 0001, // index[ 51] PINMUX_MIO_PERIPH_INSEL_2
-    4'b 0001, // index[ 52] PINMUX_MIO_PERIPH_INSEL_3
-    4'b 0001, // index[ 53] PINMUX_MIO_PERIPH_INSEL_4
-    4'b 0001, // index[ 54] PINMUX_MIO_PERIPH_INSEL_5
-    4'b 0001, // index[ 55] PINMUX_MIO_PERIPH_INSEL_6
-    4'b 0001, // index[ 56] PINMUX_MIO_PERIPH_INSEL_7
-    4'b 0001, // index[ 57] PINMUX_MIO_PERIPH_INSEL_8
-    4'b 0001, // index[ 58] PINMUX_MIO_PERIPH_INSEL_9
-    4'b 0001, // index[ 59] PINMUX_MIO_PERIPH_INSEL_10
-    4'b 0001, // index[ 60] PINMUX_MIO_PERIPH_INSEL_11
-    4'b 0001, // index[ 61] PINMUX_MIO_PERIPH_INSEL_12
-    4'b 0001, // index[ 62] PINMUX_MIO_PERIPH_INSEL_13
-    4'b 0001, // index[ 63] PINMUX_MIO_PERIPH_INSEL_14
-    4'b 0001, // index[ 64] PINMUX_MIO_PERIPH_INSEL_15
-    4'b 0001, // index[ 65] PINMUX_MIO_PERIPH_INSEL_16
-    4'b 0001, // index[ 66] PINMUX_MIO_PERIPH_INSEL_17
-    4'b 0001, // index[ 67] PINMUX_MIO_PERIPH_INSEL_18
-    4'b 0001, // index[ 68] PINMUX_MIO_PERIPH_INSEL_19
-    4'b 0001, // index[ 69] PINMUX_MIO_PERIPH_INSEL_20
-    4'b 0001, // index[ 70] PINMUX_MIO_PERIPH_INSEL_21
-    4'b 0001, // index[ 71] PINMUX_MIO_PERIPH_INSEL_22
-    4'b 0001, // index[ 72] PINMUX_MIO_PERIPH_INSEL_23
-    4'b 0001, // index[ 73] PINMUX_MIO_PERIPH_INSEL_24
-    4'b 0001, // index[ 74] PINMUX_MIO_PERIPH_INSEL_25
-    4'b 0001, // index[ 75] PINMUX_MIO_PERIPH_INSEL_26
-    4'b 0001, // index[ 76] PINMUX_MIO_PERIPH_INSEL_27
-    4'b 0001, // index[ 77] PINMUX_MIO_PERIPH_INSEL_28
-    4'b 0001, // index[ 78] PINMUX_MIO_PERIPH_INSEL_29
-    4'b 0001, // index[ 79] PINMUX_MIO_PERIPH_INSEL_30
-    4'b 0001, // index[ 80] PINMUX_MIO_PERIPH_INSEL_31
-    4'b 0001, // index[ 81] PINMUX_MIO_PERIPH_INSEL_32
-    4'b 0001, // index[ 82] PINMUX_MIO_PERIPH_INSEL_33
-    4'b 0001, // index[ 83] PINMUX_MIO_PERIPH_INSEL_34
-    4'b 0001, // index[ 84] PINMUX_MIO_PERIPH_INSEL_35
-    4'b 0001, // index[ 85] PINMUX_MIO_PERIPH_INSEL_36
-    4'b 0001, // index[ 86] PINMUX_MIO_PERIPH_INSEL_37
-    4'b 0001, // index[ 87] PINMUX_MIO_PERIPH_INSEL_38
-    4'b 0001, // index[ 88] PINMUX_MIO_PERIPH_INSEL_39
-    4'b 0001, // index[ 89] PINMUX_MIO_PERIPH_INSEL_40
-    4'b 0001, // index[ 90] PINMUX_MIO_PERIPH_INSEL_41
-    4'b 0001, // index[ 91] PINMUX_MIO_PERIPH_INSEL_42
-    4'b 0001, // index[ 92] PINMUX_MIO_PERIPH_INSEL_43
-    4'b 0001, // index[ 93] PINMUX_MIO_PERIPH_INSEL_44
-    4'b 0001, // index[ 94] PINMUX_MIO_PERIPH_INSEL_45
-    4'b 0001, // index[ 95] PINMUX_MIO_PERIPH_INSEL_46
-    4'b 0001, // index[ 96] PINMUX_MIO_PERIPH_INSEL_47
-    4'b 0001, // index[ 97] PINMUX_MIO_PERIPH_INSEL_48
-    4'b 0001, // index[ 98] PINMUX_MIO_OUTSEL_REGWEN_0
-    4'b 0001, // index[ 99] PINMUX_MIO_OUTSEL_REGWEN_1
-    4'b 0001, // index[100] PINMUX_MIO_OUTSEL_REGWEN_2
-    4'b 0001, // index[101] PINMUX_MIO_OUTSEL_REGWEN_3
-    4'b 0001, // index[102] PINMUX_MIO_OUTSEL_REGWEN_4
-    4'b 0001, // index[103] PINMUX_MIO_OUTSEL_REGWEN_5
-    4'b 0001, // index[104] PINMUX_MIO_OUTSEL_REGWEN_6
-    4'b 0001, // index[105] PINMUX_MIO_OUTSEL_REGWEN_7
-    4'b 0001, // index[106] PINMUX_MIO_OUTSEL_REGWEN_8
-    4'b 0001, // index[107] PINMUX_MIO_OUTSEL_REGWEN_9
-    4'b 0001, // index[108] PINMUX_MIO_OUTSEL_REGWEN_10
-    4'b 0001, // index[109] PINMUX_MIO_OUTSEL_REGWEN_11
-    4'b 0001, // index[110] PINMUX_MIO_OUTSEL_REGWEN_12
-    4'b 0001, // index[111] PINMUX_MIO_OUTSEL_REGWEN_13
-    4'b 0001, // index[112] PINMUX_MIO_OUTSEL_REGWEN_14
-    4'b 0001, // index[113] PINMUX_MIO_OUTSEL_REGWEN_15
-    4'b 0001, // index[114] PINMUX_MIO_OUTSEL_REGWEN_16
-    4'b 0001, // index[115] PINMUX_MIO_OUTSEL_REGWEN_17
-    4'b 0001, // index[116] PINMUX_MIO_OUTSEL_REGWEN_18
-    4'b 0001, // index[117] PINMUX_MIO_OUTSEL_REGWEN_19
-    4'b 0001, // index[118] PINMUX_MIO_OUTSEL_REGWEN_20
-    4'b 0001, // index[119] PINMUX_MIO_OUTSEL_REGWEN_21
-    4'b 0001, // index[120] PINMUX_MIO_OUTSEL_REGWEN_22
-    4'b 0001, // index[121] PINMUX_MIO_OUTSEL_REGWEN_23
-    4'b 0001, // index[122] PINMUX_MIO_OUTSEL_REGWEN_24
-    4'b 0001, // index[123] PINMUX_MIO_OUTSEL_REGWEN_25
-    4'b 0001, // index[124] PINMUX_MIO_OUTSEL_REGWEN_26
-    4'b 0001, // index[125] PINMUX_MIO_OUTSEL_REGWEN_27
-    4'b 0001, // index[126] PINMUX_MIO_OUTSEL_REGWEN_28
-    4'b 0001, // index[127] PINMUX_MIO_OUTSEL_REGWEN_29
-    4'b 0001, // index[128] PINMUX_MIO_OUTSEL_REGWEN_30
-    4'b 0001, // index[129] PINMUX_MIO_OUTSEL_REGWEN_31
-    4'b 0001, // index[130] PINMUX_MIO_OUTSEL_REGWEN_32
-    4'b 0001, // index[131] PINMUX_MIO_OUTSEL_REGWEN_33
-    4'b 0001, // index[132] PINMUX_MIO_OUTSEL_REGWEN_34
-    4'b 0001, // index[133] PINMUX_MIO_OUTSEL_REGWEN_35
-    4'b 0001, // index[134] PINMUX_MIO_OUTSEL_REGWEN_36
-    4'b 0001, // index[135] PINMUX_MIO_OUTSEL_REGWEN_37
-    4'b 0001, // index[136] PINMUX_MIO_OUTSEL_REGWEN_38
-    4'b 0001, // index[137] PINMUX_MIO_OUTSEL_REGWEN_39
-    4'b 0001, // index[138] PINMUX_MIO_OUTSEL_REGWEN_40
-    4'b 0001, // index[139] PINMUX_MIO_OUTSEL_REGWEN_41
-    4'b 0001, // index[140] PINMUX_MIO_OUTSEL_REGWEN_42
-    4'b 0001, // index[141] PINMUX_MIO_OUTSEL_REGWEN_43
-    4'b 0001, // index[142] PINMUX_MIO_OUTSEL_0
-    4'b 0001, // index[143] PINMUX_MIO_OUTSEL_1
-    4'b 0001, // index[144] PINMUX_MIO_OUTSEL_2
-    4'b 0001, // index[145] PINMUX_MIO_OUTSEL_3
-    4'b 0001, // index[146] PINMUX_MIO_OUTSEL_4
-    4'b 0001, // index[147] PINMUX_MIO_OUTSEL_5
-    4'b 0001, // index[148] PINMUX_MIO_OUTSEL_6
-    4'b 0001, // index[149] PINMUX_MIO_OUTSEL_7
-    4'b 0001, // index[150] PINMUX_MIO_OUTSEL_8
-    4'b 0001, // index[151] PINMUX_MIO_OUTSEL_9
-    4'b 0001, // index[152] PINMUX_MIO_OUTSEL_10
-    4'b 0001, // index[153] PINMUX_MIO_OUTSEL_11
-    4'b 0001, // index[154] PINMUX_MIO_OUTSEL_12
-    4'b 0001, // index[155] PINMUX_MIO_OUTSEL_13
-    4'b 0001, // index[156] PINMUX_MIO_OUTSEL_14
-    4'b 0001, // index[157] PINMUX_MIO_OUTSEL_15
-    4'b 0001, // index[158] PINMUX_MIO_OUTSEL_16
-    4'b 0001, // index[159] PINMUX_MIO_OUTSEL_17
-    4'b 0001, // index[160] PINMUX_MIO_OUTSEL_18
-    4'b 0001, // index[161] PINMUX_MIO_OUTSEL_19
-    4'b 0001, // index[162] PINMUX_MIO_OUTSEL_20
-    4'b 0001, // index[163] PINMUX_MIO_OUTSEL_21
-    4'b 0001, // index[164] PINMUX_MIO_OUTSEL_22
-    4'b 0001, // index[165] PINMUX_MIO_OUTSEL_23
-    4'b 0001, // index[166] PINMUX_MIO_OUTSEL_24
-    4'b 0001, // index[167] PINMUX_MIO_OUTSEL_25
-    4'b 0001, // index[168] PINMUX_MIO_OUTSEL_26
-    4'b 0001, // index[169] PINMUX_MIO_OUTSEL_27
-    4'b 0001, // index[170] PINMUX_MIO_OUTSEL_28
-    4'b 0001, // index[171] PINMUX_MIO_OUTSEL_29
-    4'b 0001, // index[172] PINMUX_MIO_OUTSEL_30
-    4'b 0001, // index[173] PINMUX_MIO_OUTSEL_31
-    4'b 0001, // index[174] PINMUX_MIO_OUTSEL_32
-    4'b 0001, // index[175] PINMUX_MIO_OUTSEL_33
-    4'b 0001, // index[176] PINMUX_MIO_OUTSEL_34
-    4'b 0001, // index[177] PINMUX_MIO_OUTSEL_35
-    4'b 0001, // index[178] PINMUX_MIO_OUTSEL_36
-    4'b 0001, // index[179] PINMUX_MIO_OUTSEL_37
-    4'b 0001, // index[180] PINMUX_MIO_OUTSEL_38
-    4'b 0001, // index[181] PINMUX_MIO_OUTSEL_39
-    4'b 0001, // index[182] PINMUX_MIO_OUTSEL_40
-    4'b 0001, // index[183] PINMUX_MIO_OUTSEL_41
-    4'b 0001, // index[184] PINMUX_MIO_OUTSEL_42
-    4'b 0001, // index[185] PINMUX_MIO_OUTSEL_43
-    4'b 0001, // index[186] PINMUX_MIO_PAD_ATTR_REGWEN_0
-    4'b 0001, // index[187] PINMUX_MIO_PAD_ATTR_REGWEN_1
-    4'b 0001, // index[188] PINMUX_MIO_PAD_ATTR_REGWEN_2
-    4'b 0001, // index[189] PINMUX_MIO_PAD_ATTR_REGWEN_3
-    4'b 0001, // index[190] PINMUX_MIO_PAD_ATTR_REGWEN_4
-    4'b 0001, // index[191] PINMUX_MIO_PAD_ATTR_REGWEN_5
-    4'b 0001, // index[192] PINMUX_MIO_PAD_ATTR_REGWEN_6
-    4'b 0001, // index[193] PINMUX_MIO_PAD_ATTR_REGWEN_7
-    4'b 0001, // index[194] PINMUX_MIO_PAD_ATTR_REGWEN_8
-    4'b 0001, // index[195] PINMUX_MIO_PAD_ATTR_REGWEN_9
-    4'b 0001, // index[196] PINMUX_MIO_PAD_ATTR_REGWEN_10
-    4'b 0001, // index[197] PINMUX_MIO_PAD_ATTR_REGWEN_11
-    4'b 0001, // index[198] PINMUX_MIO_PAD_ATTR_REGWEN_12
-    4'b 0001, // index[199] PINMUX_MIO_PAD_ATTR_REGWEN_13
-    4'b 0001, // index[200] PINMUX_MIO_PAD_ATTR_REGWEN_14
-    4'b 0001, // index[201] PINMUX_MIO_PAD_ATTR_REGWEN_15
-    4'b 0001, // index[202] PINMUX_MIO_PAD_ATTR_REGWEN_16
-    4'b 0001, // index[203] PINMUX_MIO_PAD_ATTR_REGWEN_17
-    4'b 0001, // index[204] PINMUX_MIO_PAD_ATTR_REGWEN_18
-    4'b 0001, // index[205] PINMUX_MIO_PAD_ATTR_REGWEN_19
-    4'b 0001, // index[206] PINMUX_MIO_PAD_ATTR_REGWEN_20
-    4'b 0001, // index[207] PINMUX_MIO_PAD_ATTR_REGWEN_21
-    4'b 0001, // index[208] PINMUX_MIO_PAD_ATTR_REGWEN_22
-    4'b 0001, // index[209] PINMUX_MIO_PAD_ATTR_REGWEN_23
-    4'b 0001, // index[210] PINMUX_MIO_PAD_ATTR_REGWEN_24
-    4'b 0001, // index[211] PINMUX_MIO_PAD_ATTR_REGWEN_25
-    4'b 0001, // index[212] PINMUX_MIO_PAD_ATTR_REGWEN_26
-    4'b 0001, // index[213] PINMUX_MIO_PAD_ATTR_REGWEN_27
-    4'b 0001, // index[214] PINMUX_MIO_PAD_ATTR_REGWEN_28
-    4'b 0001, // index[215] PINMUX_MIO_PAD_ATTR_REGWEN_29
-    4'b 0001, // index[216] PINMUX_MIO_PAD_ATTR_REGWEN_30
-    4'b 0001, // index[217] PINMUX_MIO_PAD_ATTR_REGWEN_31
-    4'b 0001, // index[218] PINMUX_MIO_PAD_ATTR_REGWEN_32
-    4'b 0001, // index[219] PINMUX_MIO_PAD_ATTR_REGWEN_33
-    4'b 0001, // index[220] PINMUX_MIO_PAD_ATTR_REGWEN_34
-    4'b 0001, // index[221] PINMUX_MIO_PAD_ATTR_REGWEN_35
-    4'b 0001, // index[222] PINMUX_MIO_PAD_ATTR_REGWEN_36
-    4'b 0001, // index[223] PINMUX_MIO_PAD_ATTR_REGWEN_37
-    4'b 0001, // index[224] PINMUX_MIO_PAD_ATTR_REGWEN_38
-    4'b 0001, // index[225] PINMUX_MIO_PAD_ATTR_REGWEN_39
-    4'b 0001, // index[226] PINMUX_MIO_PAD_ATTR_REGWEN_40
-    4'b 0001, // index[227] PINMUX_MIO_PAD_ATTR_REGWEN_41
-    4'b 0001, // index[228] PINMUX_MIO_PAD_ATTR_REGWEN_42
-    4'b 0001, // index[229] PINMUX_MIO_PAD_ATTR_REGWEN_43
-    4'b 0011, // index[230] PINMUX_MIO_PAD_ATTR_0
-    4'b 0011, // index[231] PINMUX_MIO_PAD_ATTR_1
-    4'b 0011, // index[232] PINMUX_MIO_PAD_ATTR_2
-    4'b 0011, // index[233] PINMUX_MIO_PAD_ATTR_3
-    4'b 0011, // index[234] PINMUX_MIO_PAD_ATTR_4
-    4'b 0011, // index[235] PINMUX_MIO_PAD_ATTR_5
-    4'b 0011, // index[236] PINMUX_MIO_PAD_ATTR_6
-    4'b 0011, // index[237] PINMUX_MIO_PAD_ATTR_7
-    4'b 0011, // index[238] PINMUX_MIO_PAD_ATTR_8
-    4'b 0011, // index[239] PINMUX_MIO_PAD_ATTR_9
-    4'b 0011, // index[240] PINMUX_MIO_PAD_ATTR_10
-    4'b 0011, // index[241] PINMUX_MIO_PAD_ATTR_11
-    4'b 0011, // index[242] PINMUX_MIO_PAD_ATTR_12
-    4'b 0011, // index[243] PINMUX_MIO_PAD_ATTR_13
-    4'b 0011, // index[244] PINMUX_MIO_PAD_ATTR_14
-    4'b 0011, // index[245] PINMUX_MIO_PAD_ATTR_15
-    4'b 0011, // index[246] PINMUX_MIO_PAD_ATTR_16
-    4'b 0011, // index[247] PINMUX_MIO_PAD_ATTR_17
-    4'b 0011, // index[248] PINMUX_MIO_PAD_ATTR_18
-    4'b 0011, // index[249] PINMUX_MIO_PAD_ATTR_19
-    4'b 0011, // index[250] PINMUX_MIO_PAD_ATTR_20
-    4'b 0011, // index[251] PINMUX_MIO_PAD_ATTR_21
-    4'b 0011, // index[252] PINMUX_MIO_PAD_ATTR_22
-    4'b 0011, // index[253] PINMUX_MIO_PAD_ATTR_23
-    4'b 0011, // index[254] PINMUX_MIO_PAD_ATTR_24
-    4'b 0011, // index[255] PINMUX_MIO_PAD_ATTR_25
-    4'b 0011, // index[256] PINMUX_MIO_PAD_ATTR_26
-    4'b 0011, // index[257] PINMUX_MIO_PAD_ATTR_27
-    4'b 0011, // index[258] PINMUX_MIO_PAD_ATTR_28
-    4'b 0011, // index[259] PINMUX_MIO_PAD_ATTR_29
-    4'b 0011, // index[260] PINMUX_MIO_PAD_ATTR_30
-    4'b 0011, // index[261] PINMUX_MIO_PAD_ATTR_31
-    4'b 0011, // index[262] PINMUX_MIO_PAD_ATTR_32
-    4'b 0011, // index[263] PINMUX_MIO_PAD_ATTR_33
-    4'b 0011, // index[264] PINMUX_MIO_PAD_ATTR_34
-    4'b 0011, // index[265] PINMUX_MIO_PAD_ATTR_35
-    4'b 0011, // index[266] PINMUX_MIO_PAD_ATTR_36
-    4'b 0011, // index[267] PINMUX_MIO_PAD_ATTR_37
-    4'b 0011, // index[268] PINMUX_MIO_PAD_ATTR_38
-    4'b 0011, // index[269] PINMUX_MIO_PAD_ATTR_39
-    4'b 0011, // index[270] PINMUX_MIO_PAD_ATTR_40
-    4'b 0011, // index[271] PINMUX_MIO_PAD_ATTR_41
-    4'b 0011, // index[272] PINMUX_MIO_PAD_ATTR_42
-    4'b 0011, // index[273] PINMUX_MIO_PAD_ATTR_43
-    4'b 0001, // index[274] PINMUX_DIO_PAD_ATTR_REGWEN_0
-    4'b 0001, // index[275] PINMUX_DIO_PAD_ATTR_REGWEN_1
-    4'b 0001, // index[276] PINMUX_DIO_PAD_ATTR_REGWEN_2
-    4'b 0001, // index[277] PINMUX_DIO_PAD_ATTR_REGWEN_3
-    4'b 0001, // index[278] PINMUX_DIO_PAD_ATTR_REGWEN_4
-    4'b 0001, // index[279] PINMUX_DIO_PAD_ATTR_REGWEN_5
-    4'b 0001, // index[280] PINMUX_DIO_PAD_ATTR_REGWEN_6
-    4'b 0001, // index[281] PINMUX_DIO_PAD_ATTR_REGWEN_7
-    4'b 0001, // index[282] PINMUX_DIO_PAD_ATTR_REGWEN_8
-    4'b 0001, // index[283] PINMUX_DIO_PAD_ATTR_REGWEN_9
-    4'b 0001, // index[284] PINMUX_DIO_PAD_ATTR_REGWEN_10
-    4'b 0001, // index[285] PINMUX_DIO_PAD_ATTR_REGWEN_11
-    4'b 0001, // index[286] PINMUX_DIO_PAD_ATTR_REGWEN_12
-    4'b 0001, // index[287] PINMUX_DIO_PAD_ATTR_REGWEN_13
-    4'b 0001, // index[288] PINMUX_DIO_PAD_ATTR_REGWEN_14
-    4'b 0001, // index[289] PINMUX_DIO_PAD_ATTR_REGWEN_15
-    4'b 0001, // index[290] PINMUX_DIO_PAD_ATTR_REGWEN_16
-    4'b 0001, // index[291] PINMUX_DIO_PAD_ATTR_REGWEN_17
-    4'b 0001, // index[292] PINMUX_DIO_PAD_ATTR_REGWEN_18
-    4'b 0001, // index[293] PINMUX_DIO_PAD_ATTR_REGWEN_19
-    4'b 0001, // index[294] PINMUX_DIO_PAD_ATTR_REGWEN_20
-    4'b 0011, // index[295] PINMUX_DIO_PAD_ATTR_0
-    4'b 0011, // index[296] PINMUX_DIO_PAD_ATTR_1
-    4'b 0011, // index[297] PINMUX_DIO_PAD_ATTR_2
-    4'b 0011, // index[298] PINMUX_DIO_PAD_ATTR_3
-    4'b 0011, // index[299] PINMUX_DIO_PAD_ATTR_4
-    4'b 0011, // index[300] PINMUX_DIO_PAD_ATTR_5
-    4'b 0011, // index[301] PINMUX_DIO_PAD_ATTR_6
-    4'b 0011, // index[302] PINMUX_DIO_PAD_ATTR_7
-    4'b 0011, // index[303] PINMUX_DIO_PAD_ATTR_8
-    4'b 0011, // index[304] PINMUX_DIO_PAD_ATTR_9
-    4'b 0011, // index[305] PINMUX_DIO_PAD_ATTR_10
-    4'b 0011, // index[306] PINMUX_DIO_PAD_ATTR_11
-    4'b 0011, // index[307] PINMUX_DIO_PAD_ATTR_12
-    4'b 0011, // index[308] PINMUX_DIO_PAD_ATTR_13
-    4'b 0011, // index[309] PINMUX_DIO_PAD_ATTR_14
-    4'b 0011, // index[310] PINMUX_DIO_PAD_ATTR_15
-    4'b 0011, // index[311] PINMUX_DIO_PAD_ATTR_16
-    4'b 0011, // index[312] PINMUX_DIO_PAD_ATTR_17
-    4'b 0011, // index[313] PINMUX_DIO_PAD_ATTR_18
-    4'b 0011, // index[314] PINMUX_DIO_PAD_ATTR_19
-    4'b 0011, // index[315] PINMUX_DIO_PAD_ATTR_20
-    4'b 1111, // index[316] PINMUX_MIO_PAD_SLEEP_STATUS_0
-    4'b 0011, // index[317] PINMUX_MIO_PAD_SLEEP_STATUS_1
-    4'b 0001, // index[318] PINMUX_MIO_PAD_SLEEP_REGWEN_0
-    4'b 0001, // index[319] PINMUX_MIO_PAD_SLEEP_REGWEN_1
-    4'b 0001, // index[320] PINMUX_MIO_PAD_SLEEP_REGWEN_2
-    4'b 0001, // index[321] PINMUX_MIO_PAD_SLEEP_REGWEN_3
-    4'b 0001, // index[322] PINMUX_MIO_PAD_SLEEP_REGWEN_4
-    4'b 0001, // index[323] PINMUX_MIO_PAD_SLEEP_REGWEN_5
-    4'b 0001, // index[324] PINMUX_MIO_PAD_SLEEP_REGWEN_6
-    4'b 0001, // index[325] PINMUX_MIO_PAD_SLEEP_REGWEN_7
-    4'b 0001, // index[326] PINMUX_MIO_PAD_SLEEP_REGWEN_8
-    4'b 0001, // index[327] PINMUX_MIO_PAD_SLEEP_REGWEN_9
-    4'b 0001, // index[328] PINMUX_MIO_PAD_SLEEP_REGWEN_10
-    4'b 0001, // index[329] PINMUX_MIO_PAD_SLEEP_REGWEN_11
-    4'b 0001, // index[330] PINMUX_MIO_PAD_SLEEP_REGWEN_12
-    4'b 0001, // index[331] PINMUX_MIO_PAD_SLEEP_REGWEN_13
-    4'b 0001, // index[332] PINMUX_MIO_PAD_SLEEP_REGWEN_14
-    4'b 0001, // index[333] PINMUX_MIO_PAD_SLEEP_REGWEN_15
-    4'b 0001, // index[334] PINMUX_MIO_PAD_SLEEP_REGWEN_16
-    4'b 0001, // index[335] PINMUX_MIO_PAD_SLEEP_REGWEN_17
-    4'b 0001, // index[336] PINMUX_MIO_PAD_SLEEP_REGWEN_18
-    4'b 0001, // index[337] PINMUX_MIO_PAD_SLEEP_REGWEN_19
-    4'b 0001, // index[338] PINMUX_MIO_PAD_SLEEP_REGWEN_20
-    4'b 0001, // index[339] PINMUX_MIO_PAD_SLEEP_REGWEN_21
-    4'b 0001, // index[340] PINMUX_MIO_PAD_SLEEP_REGWEN_22
-    4'b 0001, // index[341] PINMUX_MIO_PAD_SLEEP_REGWEN_23
-    4'b 0001, // index[342] PINMUX_MIO_PAD_SLEEP_REGWEN_24
-    4'b 0001, // index[343] PINMUX_MIO_PAD_SLEEP_REGWEN_25
-    4'b 0001, // index[344] PINMUX_MIO_PAD_SLEEP_REGWEN_26
-    4'b 0001, // index[345] PINMUX_MIO_PAD_SLEEP_REGWEN_27
-    4'b 0001, // index[346] PINMUX_MIO_PAD_SLEEP_REGWEN_28
-    4'b 0001, // index[347] PINMUX_MIO_PAD_SLEEP_REGWEN_29
-    4'b 0001, // index[348] PINMUX_MIO_PAD_SLEEP_REGWEN_30
-    4'b 0001, // index[349] PINMUX_MIO_PAD_SLEEP_REGWEN_31
-    4'b 0001, // index[350] PINMUX_MIO_PAD_SLEEP_REGWEN_32
-    4'b 0001, // index[351] PINMUX_MIO_PAD_SLEEP_REGWEN_33
-    4'b 0001, // index[352] PINMUX_MIO_PAD_SLEEP_REGWEN_34
-    4'b 0001, // index[353] PINMUX_MIO_PAD_SLEEP_REGWEN_35
-    4'b 0001, // index[354] PINMUX_MIO_PAD_SLEEP_REGWEN_36
-    4'b 0001, // index[355] PINMUX_MIO_PAD_SLEEP_REGWEN_37
-    4'b 0001, // index[356] PINMUX_MIO_PAD_SLEEP_REGWEN_38
-    4'b 0001, // index[357] PINMUX_MIO_PAD_SLEEP_REGWEN_39
-    4'b 0001, // index[358] PINMUX_MIO_PAD_SLEEP_REGWEN_40
-    4'b 0001, // index[359] PINMUX_MIO_PAD_SLEEP_REGWEN_41
-    4'b 0001, // index[360] PINMUX_MIO_PAD_SLEEP_REGWEN_42
-    4'b 0001, // index[361] PINMUX_MIO_PAD_SLEEP_REGWEN_43
-    4'b 0001, // index[362] PINMUX_MIO_PAD_SLEEP_EN_0
-    4'b 0001, // index[363] PINMUX_MIO_PAD_SLEEP_EN_1
-    4'b 0001, // index[364] PINMUX_MIO_PAD_SLEEP_EN_2
-    4'b 0001, // index[365] PINMUX_MIO_PAD_SLEEP_EN_3
-    4'b 0001, // index[366] PINMUX_MIO_PAD_SLEEP_EN_4
-    4'b 0001, // index[367] PINMUX_MIO_PAD_SLEEP_EN_5
-    4'b 0001, // index[368] PINMUX_MIO_PAD_SLEEP_EN_6
-    4'b 0001, // index[369] PINMUX_MIO_PAD_SLEEP_EN_7
-    4'b 0001, // index[370] PINMUX_MIO_PAD_SLEEP_EN_8
-    4'b 0001, // index[371] PINMUX_MIO_PAD_SLEEP_EN_9
-    4'b 0001, // index[372] PINMUX_MIO_PAD_SLEEP_EN_10
-    4'b 0001, // index[373] PINMUX_MIO_PAD_SLEEP_EN_11
-    4'b 0001, // index[374] PINMUX_MIO_PAD_SLEEP_EN_12
-    4'b 0001, // index[375] PINMUX_MIO_PAD_SLEEP_EN_13
-    4'b 0001, // index[376] PINMUX_MIO_PAD_SLEEP_EN_14
-    4'b 0001, // index[377] PINMUX_MIO_PAD_SLEEP_EN_15
-    4'b 0001, // index[378] PINMUX_MIO_PAD_SLEEP_EN_16
-    4'b 0001, // index[379] PINMUX_MIO_PAD_SLEEP_EN_17
-    4'b 0001, // index[380] PINMUX_MIO_PAD_SLEEP_EN_18
-    4'b 0001, // index[381] PINMUX_MIO_PAD_SLEEP_EN_19
-    4'b 0001, // index[382] PINMUX_MIO_PAD_SLEEP_EN_20
-    4'b 0001, // index[383] PINMUX_MIO_PAD_SLEEP_EN_21
-    4'b 0001, // index[384] PINMUX_MIO_PAD_SLEEP_EN_22
-    4'b 0001, // index[385] PINMUX_MIO_PAD_SLEEP_EN_23
-    4'b 0001, // index[386] PINMUX_MIO_PAD_SLEEP_EN_24
-    4'b 0001, // index[387] PINMUX_MIO_PAD_SLEEP_EN_25
-    4'b 0001, // index[388] PINMUX_MIO_PAD_SLEEP_EN_26
-    4'b 0001, // index[389] PINMUX_MIO_PAD_SLEEP_EN_27
-    4'b 0001, // index[390] PINMUX_MIO_PAD_SLEEP_EN_28
-    4'b 0001, // index[391] PINMUX_MIO_PAD_SLEEP_EN_29
-    4'b 0001, // index[392] PINMUX_MIO_PAD_SLEEP_EN_30
-    4'b 0001, // index[393] PINMUX_MIO_PAD_SLEEP_EN_31
-    4'b 0001, // index[394] PINMUX_MIO_PAD_SLEEP_EN_32
-    4'b 0001, // index[395] PINMUX_MIO_PAD_SLEEP_EN_33
-    4'b 0001, // index[396] PINMUX_MIO_PAD_SLEEP_EN_34
-    4'b 0001, // index[397] PINMUX_MIO_PAD_SLEEP_EN_35
-    4'b 0001, // index[398] PINMUX_MIO_PAD_SLEEP_EN_36
-    4'b 0001, // index[399] PINMUX_MIO_PAD_SLEEP_EN_37
-    4'b 0001, // index[400] PINMUX_MIO_PAD_SLEEP_EN_38
-    4'b 0001, // index[401] PINMUX_MIO_PAD_SLEEP_EN_39
-    4'b 0001, // index[402] PINMUX_MIO_PAD_SLEEP_EN_40
-    4'b 0001, // index[403] PINMUX_MIO_PAD_SLEEP_EN_41
-    4'b 0001, // index[404] PINMUX_MIO_PAD_SLEEP_EN_42
-    4'b 0001, // index[405] PINMUX_MIO_PAD_SLEEP_EN_43
-    4'b 0001, // index[406] PINMUX_MIO_PAD_SLEEP_MODE_0
-    4'b 0001, // index[407] PINMUX_MIO_PAD_SLEEP_MODE_1
-    4'b 0001, // index[408] PINMUX_MIO_PAD_SLEEP_MODE_2
-    4'b 0001, // index[409] PINMUX_MIO_PAD_SLEEP_MODE_3
-    4'b 0001, // index[410] PINMUX_MIO_PAD_SLEEP_MODE_4
-    4'b 0001, // index[411] PINMUX_MIO_PAD_SLEEP_MODE_5
-    4'b 0001, // index[412] PINMUX_MIO_PAD_SLEEP_MODE_6
-    4'b 0001, // index[413] PINMUX_MIO_PAD_SLEEP_MODE_7
-    4'b 0001, // index[414] PINMUX_MIO_PAD_SLEEP_MODE_8
-    4'b 0001, // index[415] PINMUX_MIO_PAD_SLEEP_MODE_9
-    4'b 0001, // index[416] PINMUX_MIO_PAD_SLEEP_MODE_10
-    4'b 0001, // index[417] PINMUX_MIO_PAD_SLEEP_MODE_11
-    4'b 0001, // index[418] PINMUX_MIO_PAD_SLEEP_MODE_12
-    4'b 0001, // index[419] PINMUX_MIO_PAD_SLEEP_MODE_13
-    4'b 0001, // index[420] PINMUX_MIO_PAD_SLEEP_MODE_14
-    4'b 0001, // index[421] PINMUX_MIO_PAD_SLEEP_MODE_15
-    4'b 0001, // index[422] PINMUX_MIO_PAD_SLEEP_MODE_16
-    4'b 0001, // index[423] PINMUX_MIO_PAD_SLEEP_MODE_17
-    4'b 0001, // index[424] PINMUX_MIO_PAD_SLEEP_MODE_18
-    4'b 0001, // index[425] PINMUX_MIO_PAD_SLEEP_MODE_19
-    4'b 0001, // index[426] PINMUX_MIO_PAD_SLEEP_MODE_20
-    4'b 0001, // index[427] PINMUX_MIO_PAD_SLEEP_MODE_21
-    4'b 0001, // index[428] PINMUX_MIO_PAD_SLEEP_MODE_22
-    4'b 0001, // index[429] PINMUX_MIO_PAD_SLEEP_MODE_23
-    4'b 0001, // index[430] PINMUX_MIO_PAD_SLEEP_MODE_24
-    4'b 0001, // index[431] PINMUX_MIO_PAD_SLEEP_MODE_25
-    4'b 0001, // index[432] PINMUX_MIO_PAD_SLEEP_MODE_26
-    4'b 0001, // index[433] PINMUX_MIO_PAD_SLEEP_MODE_27
-    4'b 0001, // index[434] PINMUX_MIO_PAD_SLEEP_MODE_28
-    4'b 0001, // index[435] PINMUX_MIO_PAD_SLEEP_MODE_29
-    4'b 0001, // index[436] PINMUX_MIO_PAD_SLEEP_MODE_30
-    4'b 0001, // index[437] PINMUX_MIO_PAD_SLEEP_MODE_31
-    4'b 0001, // index[438] PINMUX_MIO_PAD_SLEEP_MODE_32
-    4'b 0001, // index[439] PINMUX_MIO_PAD_SLEEP_MODE_33
-    4'b 0001, // index[440] PINMUX_MIO_PAD_SLEEP_MODE_34
-    4'b 0001, // index[441] PINMUX_MIO_PAD_SLEEP_MODE_35
-    4'b 0001, // index[442] PINMUX_MIO_PAD_SLEEP_MODE_36
-    4'b 0001, // index[443] PINMUX_MIO_PAD_SLEEP_MODE_37
-    4'b 0001, // index[444] PINMUX_MIO_PAD_SLEEP_MODE_38
-    4'b 0001, // index[445] PINMUX_MIO_PAD_SLEEP_MODE_39
-    4'b 0001, // index[446] PINMUX_MIO_PAD_SLEEP_MODE_40
-    4'b 0001, // index[447] PINMUX_MIO_PAD_SLEEP_MODE_41
-    4'b 0001, // index[448] PINMUX_MIO_PAD_SLEEP_MODE_42
-    4'b 0001, // index[449] PINMUX_MIO_PAD_SLEEP_MODE_43
-    4'b 0111, // index[450] PINMUX_DIO_PAD_SLEEP_STATUS
-    4'b 0001, // index[451] PINMUX_DIO_PAD_SLEEP_REGWEN_0
-    4'b 0001, // index[452] PINMUX_DIO_PAD_SLEEP_REGWEN_1
-    4'b 0001, // index[453] PINMUX_DIO_PAD_SLEEP_REGWEN_2
-    4'b 0001, // index[454] PINMUX_DIO_PAD_SLEEP_REGWEN_3
-    4'b 0001, // index[455] PINMUX_DIO_PAD_SLEEP_REGWEN_4
-    4'b 0001, // index[456] PINMUX_DIO_PAD_SLEEP_REGWEN_5
-    4'b 0001, // index[457] PINMUX_DIO_PAD_SLEEP_REGWEN_6
-    4'b 0001, // index[458] PINMUX_DIO_PAD_SLEEP_REGWEN_7
-    4'b 0001, // index[459] PINMUX_DIO_PAD_SLEEP_REGWEN_8
-    4'b 0001, // index[460] PINMUX_DIO_PAD_SLEEP_REGWEN_9
-    4'b 0001, // index[461] PINMUX_DIO_PAD_SLEEP_REGWEN_10
-    4'b 0001, // index[462] PINMUX_DIO_PAD_SLEEP_REGWEN_11
-    4'b 0001, // index[463] PINMUX_DIO_PAD_SLEEP_REGWEN_12
-    4'b 0001, // index[464] PINMUX_DIO_PAD_SLEEP_REGWEN_13
-    4'b 0001, // index[465] PINMUX_DIO_PAD_SLEEP_REGWEN_14
-    4'b 0001, // index[466] PINMUX_DIO_PAD_SLEEP_REGWEN_15
-    4'b 0001, // index[467] PINMUX_DIO_PAD_SLEEP_REGWEN_16
-    4'b 0001, // index[468] PINMUX_DIO_PAD_SLEEP_REGWEN_17
-    4'b 0001, // index[469] PINMUX_DIO_PAD_SLEEP_REGWEN_18
-    4'b 0001, // index[470] PINMUX_DIO_PAD_SLEEP_REGWEN_19
-    4'b 0001, // index[471] PINMUX_DIO_PAD_SLEEP_REGWEN_20
-    4'b 0001, // index[472] PINMUX_DIO_PAD_SLEEP_EN_0
-    4'b 0001, // index[473] PINMUX_DIO_PAD_SLEEP_EN_1
-    4'b 0001, // index[474] PINMUX_DIO_PAD_SLEEP_EN_2
-    4'b 0001, // index[475] PINMUX_DIO_PAD_SLEEP_EN_3
-    4'b 0001, // index[476] PINMUX_DIO_PAD_SLEEP_EN_4
-    4'b 0001, // index[477] PINMUX_DIO_PAD_SLEEP_EN_5
-    4'b 0001, // index[478] PINMUX_DIO_PAD_SLEEP_EN_6
-    4'b 0001, // index[479] PINMUX_DIO_PAD_SLEEP_EN_7
-    4'b 0001, // index[480] PINMUX_DIO_PAD_SLEEP_EN_8
-    4'b 0001, // index[481] PINMUX_DIO_PAD_SLEEP_EN_9
-    4'b 0001, // index[482] PINMUX_DIO_PAD_SLEEP_EN_10
-    4'b 0001, // index[483] PINMUX_DIO_PAD_SLEEP_EN_11
-    4'b 0001, // index[484] PINMUX_DIO_PAD_SLEEP_EN_12
-    4'b 0001, // index[485] PINMUX_DIO_PAD_SLEEP_EN_13
-    4'b 0001, // index[486] PINMUX_DIO_PAD_SLEEP_EN_14
-    4'b 0001, // index[487] PINMUX_DIO_PAD_SLEEP_EN_15
-    4'b 0001, // index[488] PINMUX_DIO_PAD_SLEEP_EN_16
-    4'b 0001, // index[489] PINMUX_DIO_PAD_SLEEP_EN_17
-    4'b 0001, // index[490] PINMUX_DIO_PAD_SLEEP_EN_18
-    4'b 0001, // index[491] PINMUX_DIO_PAD_SLEEP_EN_19
-    4'b 0001, // index[492] PINMUX_DIO_PAD_SLEEP_EN_20
-    4'b 0001, // index[493] PINMUX_DIO_PAD_SLEEP_MODE_0
-    4'b 0001, // index[494] PINMUX_DIO_PAD_SLEEP_MODE_1
-    4'b 0001, // index[495] PINMUX_DIO_PAD_SLEEP_MODE_2
-    4'b 0001, // index[496] PINMUX_DIO_PAD_SLEEP_MODE_3
-    4'b 0001, // index[497] PINMUX_DIO_PAD_SLEEP_MODE_4
-    4'b 0001, // index[498] PINMUX_DIO_PAD_SLEEP_MODE_5
-    4'b 0001, // index[499] PINMUX_DIO_PAD_SLEEP_MODE_6
-    4'b 0001, // index[500] PINMUX_DIO_PAD_SLEEP_MODE_7
-    4'b 0001, // index[501] PINMUX_DIO_PAD_SLEEP_MODE_8
-    4'b 0001, // index[502] PINMUX_DIO_PAD_SLEEP_MODE_9
-    4'b 0001, // index[503] PINMUX_DIO_PAD_SLEEP_MODE_10
-    4'b 0001, // index[504] PINMUX_DIO_PAD_SLEEP_MODE_11
-    4'b 0001, // index[505] PINMUX_DIO_PAD_SLEEP_MODE_12
-    4'b 0001, // index[506] PINMUX_DIO_PAD_SLEEP_MODE_13
-    4'b 0001, // index[507] PINMUX_DIO_PAD_SLEEP_MODE_14
-    4'b 0001, // index[508] PINMUX_DIO_PAD_SLEEP_MODE_15
-    4'b 0001, // index[509] PINMUX_DIO_PAD_SLEEP_MODE_16
-    4'b 0001, // index[510] PINMUX_DIO_PAD_SLEEP_MODE_17
-    4'b 0001, // index[511] PINMUX_DIO_PAD_SLEEP_MODE_18
-    4'b 0001, // index[512] PINMUX_DIO_PAD_SLEEP_MODE_19
-    4'b 0001, // index[513] PINMUX_DIO_PAD_SLEEP_MODE_20
-    4'b 0001, // index[514] PINMUX_WKUP_DETECTOR_REGWEN_0
-    4'b 0001, // index[515] PINMUX_WKUP_DETECTOR_REGWEN_1
-    4'b 0001, // index[516] PINMUX_WKUP_DETECTOR_REGWEN_2
-    4'b 0001, // index[517] PINMUX_WKUP_DETECTOR_REGWEN_3
-    4'b 0001, // index[518] PINMUX_WKUP_DETECTOR_REGWEN_4
-    4'b 0001, // index[519] PINMUX_WKUP_DETECTOR_REGWEN_5
-    4'b 0001, // index[520] PINMUX_WKUP_DETECTOR_REGWEN_6
-    4'b 0001, // index[521] PINMUX_WKUP_DETECTOR_REGWEN_7
-    4'b 0001, // index[522] PINMUX_WKUP_DETECTOR_EN_0
-    4'b 0001, // index[523] PINMUX_WKUP_DETECTOR_EN_1
-    4'b 0001, // index[524] PINMUX_WKUP_DETECTOR_EN_2
-    4'b 0001, // index[525] PINMUX_WKUP_DETECTOR_EN_3
-    4'b 0001, // index[526] PINMUX_WKUP_DETECTOR_EN_4
-    4'b 0001, // index[527] PINMUX_WKUP_DETECTOR_EN_5
-    4'b 0001, // index[528] PINMUX_WKUP_DETECTOR_EN_6
-    4'b 0001, // index[529] PINMUX_WKUP_DETECTOR_EN_7
-    4'b 0001, // index[530] PINMUX_WKUP_DETECTOR_0
-    4'b 0001, // index[531] PINMUX_WKUP_DETECTOR_1
-    4'b 0001, // index[532] PINMUX_WKUP_DETECTOR_2
-    4'b 0001, // index[533] PINMUX_WKUP_DETECTOR_3
-    4'b 0001, // index[534] PINMUX_WKUP_DETECTOR_4
-    4'b 0001, // index[535] PINMUX_WKUP_DETECTOR_5
-    4'b 0001, // index[536] PINMUX_WKUP_DETECTOR_6
-    4'b 0001, // index[537] PINMUX_WKUP_DETECTOR_7
-    4'b 0001, // index[538] PINMUX_WKUP_DETECTOR_CNT_TH_0
-    4'b 0001, // index[539] PINMUX_WKUP_DETECTOR_CNT_TH_1
-    4'b 0001, // index[540] PINMUX_WKUP_DETECTOR_CNT_TH_2
-    4'b 0001, // index[541] PINMUX_WKUP_DETECTOR_CNT_TH_3
-    4'b 0001, // index[542] PINMUX_WKUP_DETECTOR_CNT_TH_4
-    4'b 0001, // index[543] PINMUX_WKUP_DETECTOR_CNT_TH_5
-    4'b 0001, // index[544] PINMUX_WKUP_DETECTOR_CNT_TH_6
-    4'b 0001, // index[545] PINMUX_WKUP_DETECTOR_CNT_TH_7
-    4'b 0001, // index[546] PINMUX_WKUP_DETECTOR_PADSEL_0
-    4'b 0001, // index[547] PINMUX_WKUP_DETECTOR_PADSEL_1
-    4'b 0001, // index[548] PINMUX_WKUP_DETECTOR_PADSEL_2
-    4'b 0001, // index[549] PINMUX_WKUP_DETECTOR_PADSEL_3
-    4'b 0001, // index[550] PINMUX_WKUP_DETECTOR_PADSEL_4
-    4'b 0001, // index[551] PINMUX_WKUP_DETECTOR_PADSEL_5
-    4'b 0001, // index[552] PINMUX_WKUP_DETECTOR_PADSEL_6
-    4'b 0001, // index[553] PINMUX_WKUP_DETECTOR_PADSEL_7
-    4'b 0001  // index[554] PINMUX_WKUP_CAUSE
+    4'b 0001, // index[ 49] PINMUX_MIO_PERIPH_INSEL_REGWEN_49
+    4'b 0001, // index[ 50] PINMUX_MIO_PERIPH_INSEL_REGWEN_50
+    4'b 0001, // index[ 51] PINMUX_MIO_PERIPH_INSEL_REGWEN_51
+    4'b 0001, // index[ 52] PINMUX_MIO_PERIPH_INSEL_REGWEN_52
+    4'b 0001, // index[ 53] PINMUX_MIO_PERIPH_INSEL_REGWEN_53
+    4'b 0001, // index[ 54] PINMUX_MIO_PERIPH_INSEL_REGWEN_54
+    4'b 0001, // index[ 55] PINMUX_MIO_PERIPH_INSEL_REGWEN_55
+    4'b 0001, // index[ 56] PINMUX_MIO_PERIPH_INSEL_REGWEN_56
+    4'b 0001, // index[ 57] PINMUX_MIO_PERIPH_INSEL_REGWEN_57
+    4'b 0001, // index[ 58] PINMUX_MIO_PERIPH_INSEL_REGWEN_58
+    4'b 0001, // index[ 59] PINMUX_MIO_PERIPH_INSEL_0
+    4'b 0001, // index[ 60] PINMUX_MIO_PERIPH_INSEL_1
+    4'b 0001, // index[ 61] PINMUX_MIO_PERIPH_INSEL_2
+    4'b 0001, // index[ 62] PINMUX_MIO_PERIPH_INSEL_3
+    4'b 0001, // index[ 63] PINMUX_MIO_PERIPH_INSEL_4
+    4'b 0001, // index[ 64] PINMUX_MIO_PERIPH_INSEL_5
+    4'b 0001, // index[ 65] PINMUX_MIO_PERIPH_INSEL_6
+    4'b 0001, // index[ 66] PINMUX_MIO_PERIPH_INSEL_7
+    4'b 0001, // index[ 67] PINMUX_MIO_PERIPH_INSEL_8
+    4'b 0001, // index[ 68] PINMUX_MIO_PERIPH_INSEL_9
+    4'b 0001, // index[ 69] PINMUX_MIO_PERIPH_INSEL_10
+    4'b 0001, // index[ 70] PINMUX_MIO_PERIPH_INSEL_11
+    4'b 0001, // index[ 71] PINMUX_MIO_PERIPH_INSEL_12
+    4'b 0001, // index[ 72] PINMUX_MIO_PERIPH_INSEL_13
+    4'b 0001, // index[ 73] PINMUX_MIO_PERIPH_INSEL_14
+    4'b 0001, // index[ 74] PINMUX_MIO_PERIPH_INSEL_15
+    4'b 0001, // index[ 75] PINMUX_MIO_PERIPH_INSEL_16
+    4'b 0001, // index[ 76] PINMUX_MIO_PERIPH_INSEL_17
+    4'b 0001, // index[ 77] PINMUX_MIO_PERIPH_INSEL_18
+    4'b 0001, // index[ 78] PINMUX_MIO_PERIPH_INSEL_19
+    4'b 0001, // index[ 79] PINMUX_MIO_PERIPH_INSEL_20
+    4'b 0001, // index[ 80] PINMUX_MIO_PERIPH_INSEL_21
+    4'b 0001, // index[ 81] PINMUX_MIO_PERIPH_INSEL_22
+    4'b 0001, // index[ 82] PINMUX_MIO_PERIPH_INSEL_23
+    4'b 0001, // index[ 83] PINMUX_MIO_PERIPH_INSEL_24
+    4'b 0001, // index[ 84] PINMUX_MIO_PERIPH_INSEL_25
+    4'b 0001, // index[ 85] PINMUX_MIO_PERIPH_INSEL_26
+    4'b 0001, // index[ 86] PINMUX_MIO_PERIPH_INSEL_27
+    4'b 0001, // index[ 87] PINMUX_MIO_PERIPH_INSEL_28
+    4'b 0001, // index[ 88] PINMUX_MIO_PERIPH_INSEL_29
+    4'b 0001, // index[ 89] PINMUX_MIO_PERIPH_INSEL_30
+    4'b 0001, // index[ 90] PINMUX_MIO_PERIPH_INSEL_31
+    4'b 0001, // index[ 91] PINMUX_MIO_PERIPH_INSEL_32
+    4'b 0001, // index[ 92] PINMUX_MIO_PERIPH_INSEL_33
+    4'b 0001, // index[ 93] PINMUX_MIO_PERIPH_INSEL_34
+    4'b 0001, // index[ 94] PINMUX_MIO_PERIPH_INSEL_35
+    4'b 0001, // index[ 95] PINMUX_MIO_PERIPH_INSEL_36
+    4'b 0001, // index[ 96] PINMUX_MIO_PERIPH_INSEL_37
+    4'b 0001, // index[ 97] PINMUX_MIO_PERIPH_INSEL_38
+    4'b 0001, // index[ 98] PINMUX_MIO_PERIPH_INSEL_39
+    4'b 0001, // index[ 99] PINMUX_MIO_PERIPH_INSEL_40
+    4'b 0001, // index[100] PINMUX_MIO_PERIPH_INSEL_41
+    4'b 0001, // index[101] PINMUX_MIO_PERIPH_INSEL_42
+    4'b 0001, // index[102] PINMUX_MIO_PERIPH_INSEL_43
+    4'b 0001, // index[103] PINMUX_MIO_PERIPH_INSEL_44
+    4'b 0001, // index[104] PINMUX_MIO_PERIPH_INSEL_45
+    4'b 0001, // index[105] PINMUX_MIO_PERIPH_INSEL_46
+    4'b 0001, // index[106] PINMUX_MIO_PERIPH_INSEL_47
+    4'b 0001, // index[107] PINMUX_MIO_PERIPH_INSEL_48
+    4'b 0001, // index[108] PINMUX_MIO_PERIPH_INSEL_49
+    4'b 0001, // index[109] PINMUX_MIO_PERIPH_INSEL_50
+    4'b 0001, // index[110] PINMUX_MIO_PERIPH_INSEL_51
+    4'b 0001, // index[111] PINMUX_MIO_PERIPH_INSEL_52
+    4'b 0001, // index[112] PINMUX_MIO_PERIPH_INSEL_53
+    4'b 0001, // index[113] PINMUX_MIO_PERIPH_INSEL_54
+    4'b 0001, // index[114] PINMUX_MIO_PERIPH_INSEL_55
+    4'b 0001, // index[115] PINMUX_MIO_PERIPH_INSEL_56
+    4'b 0001, // index[116] PINMUX_MIO_PERIPH_INSEL_57
+    4'b 0001, // index[117] PINMUX_MIO_PERIPH_INSEL_58
+    4'b 0001, // index[118] PINMUX_MIO_OUTSEL_REGWEN_0
+    4'b 0001, // index[119] PINMUX_MIO_OUTSEL_REGWEN_1
+    4'b 0001, // index[120] PINMUX_MIO_OUTSEL_REGWEN_2
+    4'b 0001, // index[121] PINMUX_MIO_OUTSEL_REGWEN_3
+    4'b 0001, // index[122] PINMUX_MIO_OUTSEL_REGWEN_4
+    4'b 0001, // index[123] PINMUX_MIO_OUTSEL_REGWEN_5
+    4'b 0001, // index[124] PINMUX_MIO_OUTSEL_REGWEN_6
+    4'b 0001, // index[125] PINMUX_MIO_OUTSEL_REGWEN_7
+    4'b 0001, // index[126] PINMUX_MIO_OUTSEL_REGWEN_8
+    4'b 0001, // index[127] PINMUX_MIO_OUTSEL_REGWEN_9
+    4'b 0001, // index[128] PINMUX_MIO_OUTSEL_REGWEN_10
+    4'b 0001, // index[129] PINMUX_MIO_OUTSEL_REGWEN_11
+    4'b 0001, // index[130] PINMUX_MIO_OUTSEL_REGWEN_12
+    4'b 0001, // index[131] PINMUX_MIO_OUTSEL_REGWEN_13
+    4'b 0001, // index[132] PINMUX_MIO_OUTSEL_REGWEN_14
+    4'b 0001, // index[133] PINMUX_MIO_OUTSEL_REGWEN_15
+    4'b 0001, // index[134] PINMUX_MIO_OUTSEL_REGWEN_16
+    4'b 0001, // index[135] PINMUX_MIO_OUTSEL_REGWEN_17
+    4'b 0001, // index[136] PINMUX_MIO_OUTSEL_REGWEN_18
+    4'b 0001, // index[137] PINMUX_MIO_OUTSEL_REGWEN_19
+    4'b 0001, // index[138] PINMUX_MIO_OUTSEL_REGWEN_20
+    4'b 0001, // index[139] PINMUX_MIO_OUTSEL_REGWEN_21
+    4'b 0001, // index[140] PINMUX_MIO_OUTSEL_REGWEN_22
+    4'b 0001, // index[141] PINMUX_MIO_OUTSEL_REGWEN_23
+    4'b 0001, // index[142] PINMUX_MIO_OUTSEL_REGWEN_24
+    4'b 0001, // index[143] PINMUX_MIO_OUTSEL_REGWEN_25
+    4'b 0001, // index[144] PINMUX_MIO_OUTSEL_REGWEN_26
+    4'b 0001, // index[145] PINMUX_MIO_OUTSEL_REGWEN_27
+    4'b 0001, // index[146] PINMUX_MIO_OUTSEL_REGWEN_28
+    4'b 0001, // index[147] PINMUX_MIO_OUTSEL_REGWEN_29
+    4'b 0001, // index[148] PINMUX_MIO_OUTSEL_REGWEN_30
+    4'b 0001, // index[149] PINMUX_MIO_OUTSEL_REGWEN_31
+    4'b 0001, // index[150] PINMUX_MIO_OUTSEL_REGWEN_32
+    4'b 0001, // index[151] PINMUX_MIO_OUTSEL_REGWEN_33
+    4'b 0001, // index[152] PINMUX_MIO_OUTSEL_REGWEN_34
+    4'b 0001, // index[153] PINMUX_MIO_OUTSEL_REGWEN_35
+    4'b 0001, // index[154] PINMUX_MIO_OUTSEL_REGWEN_36
+    4'b 0001, // index[155] PINMUX_MIO_OUTSEL_REGWEN_37
+    4'b 0001, // index[156] PINMUX_MIO_OUTSEL_REGWEN_38
+    4'b 0001, // index[157] PINMUX_MIO_OUTSEL_REGWEN_39
+    4'b 0001, // index[158] PINMUX_MIO_OUTSEL_REGWEN_40
+    4'b 0001, // index[159] PINMUX_MIO_OUTSEL_REGWEN_41
+    4'b 0001, // index[160] PINMUX_MIO_OUTSEL_REGWEN_42
+    4'b 0001, // index[161] PINMUX_MIO_OUTSEL_REGWEN_43
+    4'b 0001, // index[162] PINMUX_MIO_OUTSEL_0
+    4'b 0001, // index[163] PINMUX_MIO_OUTSEL_1
+    4'b 0001, // index[164] PINMUX_MIO_OUTSEL_2
+    4'b 0001, // index[165] PINMUX_MIO_OUTSEL_3
+    4'b 0001, // index[166] PINMUX_MIO_OUTSEL_4
+    4'b 0001, // index[167] PINMUX_MIO_OUTSEL_5
+    4'b 0001, // index[168] PINMUX_MIO_OUTSEL_6
+    4'b 0001, // index[169] PINMUX_MIO_OUTSEL_7
+    4'b 0001, // index[170] PINMUX_MIO_OUTSEL_8
+    4'b 0001, // index[171] PINMUX_MIO_OUTSEL_9
+    4'b 0001, // index[172] PINMUX_MIO_OUTSEL_10
+    4'b 0001, // index[173] PINMUX_MIO_OUTSEL_11
+    4'b 0001, // index[174] PINMUX_MIO_OUTSEL_12
+    4'b 0001, // index[175] PINMUX_MIO_OUTSEL_13
+    4'b 0001, // index[176] PINMUX_MIO_OUTSEL_14
+    4'b 0001, // index[177] PINMUX_MIO_OUTSEL_15
+    4'b 0001, // index[178] PINMUX_MIO_OUTSEL_16
+    4'b 0001, // index[179] PINMUX_MIO_OUTSEL_17
+    4'b 0001, // index[180] PINMUX_MIO_OUTSEL_18
+    4'b 0001, // index[181] PINMUX_MIO_OUTSEL_19
+    4'b 0001, // index[182] PINMUX_MIO_OUTSEL_20
+    4'b 0001, // index[183] PINMUX_MIO_OUTSEL_21
+    4'b 0001, // index[184] PINMUX_MIO_OUTSEL_22
+    4'b 0001, // index[185] PINMUX_MIO_OUTSEL_23
+    4'b 0001, // index[186] PINMUX_MIO_OUTSEL_24
+    4'b 0001, // index[187] PINMUX_MIO_OUTSEL_25
+    4'b 0001, // index[188] PINMUX_MIO_OUTSEL_26
+    4'b 0001, // index[189] PINMUX_MIO_OUTSEL_27
+    4'b 0001, // index[190] PINMUX_MIO_OUTSEL_28
+    4'b 0001, // index[191] PINMUX_MIO_OUTSEL_29
+    4'b 0001, // index[192] PINMUX_MIO_OUTSEL_30
+    4'b 0001, // index[193] PINMUX_MIO_OUTSEL_31
+    4'b 0001, // index[194] PINMUX_MIO_OUTSEL_32
+    4'b 0001, // index[195] PINMUX_MIO_OUTSEL_33
+    4'b 0001, // index[196] PINMUX_MIO_OUTSEL_34
+    4'b 0001, // index[197] PINMUX_MIO_OUTSEL_35
+    4'b 0001, // index[198] PINMUX_MIO_OUTSEL_36
+    4'b 0001, // index[199] PINMUX_MIO_OUTSEL_37
+    4'b 0001, // index[200] PINMUX_MIO_OUTSEL_38
+    4'b 0001, // index[201] PINMUX_MIO_OUTSEL_39
+    4'b 0001, // index[202] PINMUX_MIO_OUTSEL_40
+    4'b 0001, // index[203] PINMUX_MIO_OUTSEL_41
+    4'b 0001, // index[204] PINMUX_MIO_OUTSEL_42
+    4'b 0001, // index[205] PINMUX_MIO_OUTSEL_43
+    4'b 0001, // index[206] PINMUX_MIO_PAD_ATTR_REGWEN_0
+    4'b 0001, // index[207] PINMUX_MIO_PAD_ATTR_REGWEN_1
+    4'b 0001, // index[208] PINMUX_MIO_PAD_ATTR_REGWEN_2
+    4'b 0001, // index[209] PINMUX_MIO_PAD_ATTR_REGWEN_3
+    4'b 0001, // index[210] PINMUX_MIO_PAD_ATTR_REGWEN_4
+    4'b 0001, // index[211] PINMUX_MIO_PAD_ATTR_REGWEN_5
+    4'b 0001, // index[212] PINMUX_MIO_PAD_ATTR_REGWEN_6
+    4'b 0001, // index[213] PINMUX_MIO_PAD_ATTR_REGWEN_7
+    4'b 0001, // index[214] PINMUX_MIO_PAD_ATTR_REGWEN_8
+    4'b 0001, // index[215] PINMUX_MIO_PAD_ATTR_REGWEN_9
+    4'b 0001, // index[216] PINMUX_MIO_PAD_ATTR_REGWEN_10
+    4'b 0001, // index[217] PINMUX_MIO_PAD_ATTR_REGWEN_11
+    4'b 0001, // index[218] PINMUX_MIO_PAD_ATTR_REGWEN_12
+    4'b 0001, // index[219] PINMUX_MIO_PAD_ATTR_REGWEN_13
+    4'b 0001, // index[220] PINMUX_MIO_PAD_ATTR_REGWEN_14
+    4'b 0001, // index[221] PINMUX_MIO_PAD_ATTR_REGWEN_15
+    4'b 0001, // index[222] PINMUX_MIO_PAD_ATTR_REGWEN_16
+    4'b 0001, // index[223] PINMUX_MIO_PAD_ATTR_REGWEN_17
+    4'b 0001, // index[224] PINMUX_MIO_PAD_ATTR_REGWEN_18
+    4'b 0001, // index[225] PINMUX_MIO_PAD_ATTR_REGWEN_19
+    4'b 0001, // index[226] PINMUX_MIO_PAD_ATTR_REGWEN_20
+    4'b 0001, // index[227] PINMUX_MIO_PAD_ATTR_REGWEN_21
+    4'b 0001, // index[228] PINMUX_MIO_PAD_ATTR_REGWEN_22
+    4'b 0001, // index[229] PINMUX_MIO_PAD_ATTR_REGWEN_23
+    4'b 0001, // index[230] PINMUX_MIO_PAD_ATTR_REGWEN_24
+    4'b 0001, // index[231] PINMUX_MIO_PAD_ATTR_REGWEN_25
+    4'b 0001, // index[232] PINMUX_MIO_PAD_ATTR_REGWEN_26
+    4'b 0001, // index[233] PINMUX_MIO_PAD_ATTR_REGWEN_27
+    4'b 0001, // index[234] PINMUX_MIO_PAD_ATTR_REGWEN_28
+    4'b 0001, // index[235] PINMUX_MIO_PAD_ATTR_REGWEN_29
+    4'b 0001, // index[236] PINMUX_MIO_PAD_ATTR_REGWEN_30
+    4'b 0001, // index[237] PINMUX_MIO_PAD_ATTR_REGWEN_31
+    4'b 0001, // index[238] PINMUX_MIO_PAD_ATTR_REGWEN_32
+    4'b 0001, // index[239] PINMUX_MIO_PAD_ATTR_REGWEN_33
+    4'b 0001, // index[240] PINMUX_MIO_PAD_ATTR_REGWEN_34
+    4'b 0001, // index[241] PINMUX_MIO_PAD_ATTR_REGWEN_35
+    4'b 0001, // index[242] PINMUX_MIO_PAD_ATTR_REGWEN_36
+    4'b 0001, // index[243] PINMUX_MIO_PAD_ATTR_REGWEN_37
+    4'b 0001, // index[244] PINMUX_MIO_PAD_ATTR_REGWEN_38
+    4'b 0001, // index[245] PINMUX_MIO_PAD_ATTR_REGWEN_39
+    4'b 0001, // index[246] PINMUX_MIO_PAD_ATTR_REGWEN_40
+    4'b 0001, // index[247] PINMUX_MIO_PAD_ATTR_REGWEN_41
+    4'b 0001, // index[248] PINMUX_MIO_PAD_ATTR_REGWEN_42
+    4'b 0001, // index[249] PINMUX_MIO_PAD_ATTR_REGWEN_43
+    4'b 0011, // index[250] PINMUX_MIO_PAD_ATTR_0
+    4'b 0011, // index[251] PINMUX_MIO_PAD_ATTR_1
+    4'b 0011, // index[252] PINMUX_MIO_PAD_ATTR_2
+    4'b 0011, // index[253] PINMUX_MIO_PAD_ATTR_3
+    4'b 0011, // index[254] PINMUX_MIO_PAD_ATTR_4
+    4'b 0011, // index[255] PINMUX_MIO_PAD_ATTR_5
+    4'b 0011, // index[256] PINMUX_MIO_PAD_ATTR_6
+    4'b 0011, // index[257] PINMUX_MIO_PAD_ATTR_7
+    4'b 0011, // index[258] PINMUX_MIO_PAD_ATTR_8
+    4'b 0011, // index[259] PINMUX_MIO_PAD_ATTR_9
+    4'b 0011, // index[260] PINMUX_MIO_PAD_ATTR_10
+    4'b 0011, // index[261] PINMUX_MIO_PAD_ATTR_11
+    4'b 0011, // index[262] PINMUX_MIO_PAD_ATTR_12
+    4'b 0011, // index[263] PINMUX_MIO_PAD_ATTR_13
+    4'b 0011, // index[264] PINMUX_MIO_PAD_ATTR_14
+    4'b 0011, // index[265] PINMUX_MIO_PAD_ATTR_15
+    4'b 0011, // index[266] PINMUX_MIO_PAD_ATTR_16
+    4'b 0011, // index[267] PINMUX_MIO_PAD_ATTR_17
+    4'b 0011, // index[268] PINMUX_MIO_PAD_ATTR_18
+    4'b 0011, // index[269] PINMUX_MIO_PAD_ATTR_19
+    4'b 0011, // index[270] PINMUX_MIO_PAD_ATTR_20
+    4'b 0011, // index[271] PINMUX_MIO_PAD_ATTR_21
+    4'b 0011, // index[272] PINMUX_MIO_PAD_ATTR_22
+    4'b 0011, // index[273] PINMUX_MIO_PAD_ATTR_23
+    4'b 0011, // index[274] PINMUX_MIO_PAD_ATTR_24
+    4'b 0011, // index[275] PINMUX_MIO_PAD_ATTR_25
+    4'b 0011, // index[276] PINMUX_MIO_PAD_ATTR_26
+    4'b 0011, // index[277] PINMUX_MIO_PAD_ATTR_27
+    4'b 0011, // index[278] PINMUX_MIO_PAD_ATTR_28
+    4'b 0011, // index[279] PINMUX_MIO_PAD_ATTR_29
+    4'b 0011, // index[280] PINMUX_MIO_PAD_ATTR_30
+    4'b 0011, // index[281] PINMUX_MIO_PAD_ATTR_31
+    4'b 0011, // index[282] PINMUX_MIO_PAD_ATTR_32
+    4'b 0011, // index[283] PINMUX_MIO_PAD_ATTR_33
+    4'b 0011, // index[284] PINMUX_MIO_PAD_ATTR_34
+    4'b 0011, // index[285] PINMUX_MIO_PAD_ATTR_35
+    4'b 0011, // index[286] PINMUX_MIO_PAD_ATTR_36
+    4'b 0011, // index[287] PINMUX_MIO_PAD_ATTR_37
+    4'b 0011, // index[288] PINMUX_MIO_PAD_ATTR_38
+    4'b 0011, // index[289] PINMUX_MIO_PAD_ATTR_39
+    4'b 0011, // index[290] PINMUX_MIO_PAD_ATTR_40
+    4'b 0011, // index[291] PINMUX_MIO_PAD_ATTR_41
+    4'b 0011, // index[292] PINMUX_MIO_PAD_ATTR_42
+    4'b 0011, // index[293] PINMUX_MIO_PAD_ATTR_43
+    4'b 0001, // index[294] PINMUX_DIO_PAD_ATTR_REGWEN_0
+    4'b 0001, // index[295] PINMUX_DIO_PAD_ATTR_REGWEN_1
+    4'b 0001, // index[296] PINMUX_DIO_PAD_ATTR_REGWEN_2
+    4'b 0001, // index[297] PINMUX_DIO_PAD_ATTR_REGWEN_3
+    4'b 0001, // index[298] PINMUX_DIO_PAD_ATTR_REGWEN_4
+    4'b 0001, // index[299] PINMUX_DIO_PAD_ATTR_REGWEN_5
+    4'b 0001, // index[300] PINMUX_DIO_PAD_ATTR_REGWEN_6
+    4'b 0001, // index[301] PINMUX_DIO_PAD_ATTR_REGWEN_7
+    4'b 0001, // index[302] PINMUX_DIO_PAD_ATTR_REGWEN_8
+    4'b 0001, // index[303] PINMUX_DIO_PAD_ATTR_REGWEN_9
+    4'b 0001, // index[304] PINMUX_DIO_PAD_ATTR_REGWEN_10
+    4'b 0001, // index[305] PINMUX_DIO_PAD_ATTR_REGWEN_11
+    4'b 0001, // index[306] PINMUX_DIO_PAD_ATTR_REGWEN_12
+    4'b 0001, // index[307] PINMUX_DIO_PAD_ATTR_REGWEN_13
+    4'b 0001, // index[308] PINMUX_DIO_PAD_ATTR_REGWEN_14
+    4'b 0001, // index[309] PINMUX_DIO_PAD_ATTR_REGWEN_15
+    4'b 0001, // index[310] PINMUX_DIO_PAD_ATTR_REGWEN_16
+    4'b 0001, // index[311] PINMUX_DIO_PAD_ATTR_REGWEN_17
+    4'b 0001, // index[312] PINMUX_DIO_PAD_ATTR_REGWEN_18
+    4'b 0001, // index[313] PINMUX_DIO_PAD_ATTR_REGWEN_19
+    4'b 0001, // index[314] PINMUX_DIO_PAD_ATTR_REGWEN_20
+    4'b 0011, // index[315] PINMUX_DIO_PAD_ATTR_0
+    4'b 0011, // index[316] PINMUX_DIO_PAD_ATTR_1
+    4'b 0011, // index[317] PINMUX_DIO_PAD_ATTR_2
+    4'b 0011, // index[318] PINMUX_DIO_PAD_ATTR_3
+    4'b 0011, // index[319] PINMUX_DIO_PAD_ATTR_4
+    4'b 0011, // index[320] PINMUX_DIO_PAD_ATTR_5
+    4'b 0011, // index[321] PINMUX_DIO_PAD_ATTR_6
+    4'b 0011, // index[322] PINMUX_DIO_PAD_ATTR_7
+    4'b 0011, // index[323] PINMUX_DIO_PAD_ATTR_8
+    4'b 0011, // index[324] PINMUX_DIO_PAD_ATTR_9
+    4'b 0011, // index[325] PINMUX_DIO_PAD_ATTR_10
+    4'b 0011, // index[326] PINMUX_DIO_PAD_ATTR_11
+    4'b 0011, // index[327] PINMUX_DIO_PAD_ATTR_12
+    4'b 0011, // index[328] PINMUX_DIO_PAD_ATTR_13
+    4'b 0011, // index[329] PINMUX_DIO_PAD_ATTR_14
+    4'b 0011, // index[330] PINMUX_DIO_PAD_ATTR_15
+    4'b 0011, // index[331] PINMUX_DIO_PAD_ATTR_16
+    4'b 0011, // index[332] PINMUX_DIO_PAD_ATTR_17
+    4'b 0011, // index[333] PINMUX_DIO_PAD_ATTR_18
+    4'b 0011, // index[334] PINMUX_DIO_PAD_ATTR_19
+    4'b 0011, // index[335] PINMUX_DIO_PAD_ATTR_20
+    4'b 1111, // index[336] PINMUX_MIO_PAD_SLEEP_STATUS_0
+    4'b 0011, // index[337] PINMUX_MIO_PAD_SLEEP_STATUS_1
+    4'b 0001, // index[338] PINMUX_MIO_PAD_SLEEP_REGWEN_0
+    4'b 0001, // index[339] PINMUX_MIO_PAD_SLEEP_REGWEN_1
+    4'b 0001, // index[340] PINMUX_MIO_PAD_SLEEP_REGWEN_2
+    4'b 0001, // index[341] PINMUX_MIO_PAD_SLEEP_REGWEN_3
+    4'b 0001, // index[342] PINMUX_MIO_PAD_SLEEP_REGWEN_4
+    4'b 0001, // index[343] PINMUX_MIO_PAD_SLEEP_REGWEN_5
+    4'b 0001, // index[344] PINMUX_MIO_PAD_SLEEP_REGWEN_6
+    4'b 0001, // index[345] PINMUX_MIO_PAD_SLEEP_REGWEN_7
+    4'b 0001, // index[346] PINMUX_MIO_PAD_SLEEP_REGWEN_8
+    4'b 0001, // index[347] PINMUX_MIO_PAD_SLEEP_REGWEN_9
+    4'b 0001, // index[348] PINMUX_MIO_PAD_SLEEP_REGWEN_10
+    4'b 0001, // index[349] PINMUX_MIO_PAD_SLEEP_REGWEN_11
+    4'b 0001, // index[350] PINMUX_MIO_PAD_SLEEP_REGWEN_12
+    4'b 0001, // index[351] PINMUX_MIO_PAD_SLEEP_REGWEN_13
+    4'b 0001, // index[352] PINMUX_MIO_PAD_SLEEP_REGWEN_14
+    4'b 0001, // index[353] PINMUX_MIO_PAD_SLEEP_REGWEN_15
+    4'b 0001, // index[354] PINMUX_MIO_PAD_SLEEP_REGWEN_16
+    4'b 0001, // index[355] PINMUX_MIO_PAD_SLEEP_REGWEN_17
+    4'b 0001, // index[356] PINMUX_MIO_PAD_SLEEP_REGWEN_18
+    4'b 0001, // index[357] PINMUX_MIO_PAD_SLEEP_REGWEN_19
+    4'b 0001, // index[358] PINMUX_MIO_PAD_SLEEP_REGWEN_20
+    4'b 0001, // index[359] PINMUX_MIO_PAD_SLEEP_REGWEN_21
+    4'b 0001, // index[360] PINMUX_MIO_PAD_SLEEP_REGWEN_22
+    4'b 0001, // index[361] PINMUX_MIO_PAD_SLEEP_REGWEN_23
+    4'b 0001, // index[362] PINMUX_MIO_PAD_SLEEP_REGWEN_24
+    4'b 0001, // index[363] PINMUX_MIO_PAD_SLEEP_REGWEN_25
+    4'b 0001, // index[364] PINMUX_MIO_PAD_SLEEP_REGWEN_26
+    4'b 0001, // index[365] PINMUX_MIO_PAD_SLEEP_REGWEN_27
+    4'b 0001, // index[366] PINMUX_MIO_PAD_SLEEP_REGWEN_28
+    4'b 0001, // index[367] PINMUX_MIO_PAD_SLEEP_REGWEN_29
+    4'b 0001, // index[368] PINMUX_MIO_PAD_SLEEP_REGWEN_30
+    4'b 0001, // index[369] PINMUX_MIO_PAD_SLEEP_REGWEN_31
+    4'b 0001, // index[370] PINMUX_MIO_PAD_SLEEP_REGWEN_32
+    4'b 0001, // index[371] PINMUX_MIO_PAD_SLEEP_REGWEN_33
+    4'b 0001, // index[372] PINMUX_MIO_PAD_SLEEP_REGWEN_34
+    4'b 0001, // index[373] PINMUX_MIO_PAD_SLEEP_REGWEN_35
+    4'b 0001, // index[374] PINMUX_MIO_PAD_SLEEP_REGWEN_36
+    4'b 0001, // index[375] PINMUX_MIO_PAD_SLEEP_REGWEN_37
+    4'b 0001, // index[376] PINMUX_MIO_PAD_SLEEP_REGWEN_38
+    4'b 0001, // index[377] PINMUX_MIO_PAD_SLEEP_REGWEN_39
+    4'b 0001, // index[378] PINMUX_MIO_PAD_SLEEP_REGWEN_40
+    4'b 0001, // index[379] PINMUX_MIO_PAD_SLEEP_REGWEN_41
+    4'b 0001, // index[380] PINMUX_MIO_PAD_SLEEP_REGWEN_42
+    4'b 0001, // index[381] PINMUX_MIO_PAD_SLEEP_REGWEN_43
+    4'b 0001, // index[382] PINMUX_MIO_PAD_SLEEP_EN_0
+    4'b 0001, // index[383] PINMUX_MIO_PAD_SLEEP_EN_1
+    4'b 0001, // index[384] PINMUX_MIO_PAD_SLEEP_EN_2
+    4'b 0001, // index[385] PINMUX_MIO_PAD_SLEEP_EN_3
+    4'b 0001, // index[386] PINMUX_MIO_PAD_SLEEP_EN_4
+    4'b 0001, // index[387] PINMUX_MIO_PAD_SLEEP_EN_5
+    4'b 0001, // index[388] PINMUX_MIO_PAD_SLEEP_EN_6
+    4'b 0001, // index[389] PINMUX_MIO_PAD_SLEEP_EN_7
+    4'b 0001, // index[390] PINMUX_MIO_PAD_SLEEP_EN_8
+    4'b 0001, // index[391] PINMUX_MIO_PAD_SLEEP_EN_9
+    4'b 0001, // index[392] PINMUX_MIO_PAD_SLEEP_EN_10
+    4'b 0001, // index[393] PINMUX_MIO_PAD_SLEEP_EN_11
+    4'b 0001, // index[394] PINMUX_MIO_PAD_SLEEP_EN_12
+    4'b 0001, // index[395] PINMUX_MIO_PAD_SLEEP_EN_13
+    4'b 0001, // index[396] PINMUX_MIO_PAD_SLEEP_EN_14
+    4'b 0001, // index[397] PINMUX_MIO_PAD_SLEEP_EN_15
+    4'b 0001, // index[398] PINMUX_MIO_PAD_SLEEP_EN_16
+    4'b 0001, // index[399] PINMUX_MIO_PAD_SLEEP_EN_17
+    4'b 0001, // index[400] PINMUX_MIO_PAD_SLEEP_EN_18
+    4'b 0001, // index[401] PINMUX_MIO_PAD_SLEEP_EN_19
+    4'b 0001, // index[402] PINMUX_MIO_PAD_SLEEP_EN_20
+    4'b 0001, // index[403] PINMUX_MIO_PAD_SLEEP_EN_21
+    4'b 0001, // index[404] PINMUX_MIO_PAD_SLEEP_EN_22
+    4'b 0001, // index[405] PINMUX_MIO_PAD_SLEEP_EN_23
+    4'b 0001, // index[406] PINMUX_MIO_PAD_SLEEP_EN_24
+    4'b 0001, // index[407] PINMUX_MIO_PAD_SLEEP_EN_25
+    4'b 0001, // index[408] PINMUX_MIO_PAD_SLEEP_EN_26
+    4'b 0001, // index[409] PINMUX_MIO_PAD_SLEEP_EN_27
+    4'b 0001, // index[410] PINMUX_MIO_PAD_SLEEP_EN_28
+    4'b 0001, // index[411] PINMUX_MIO_PAD_SLEEP_EN_29
+    4'b 0001, // index[412] PINMUX_MIO_PAD_SLEEP_EN_30
+    4'b 0001, // index[413] PINMUX_MIO_PAD_SLEEP_EN_31
+    4'b 0001, // index[414] PINMUX_MIO_PAD_SLEEP_EN_32
+    4'b 0001, // index[415] PINMUX_MIO_PAD_SLEEP_EN_33
+    4'b 0001, // index[416] PINMUX_MIO_PAD_SLEEP_EN_34
+    4'b 0001, // index[417] PINMUX_MIO_PAD_SLEEP_EN_35
+    4'b 0001, // index[418] PINMUX_MIO_PAD_SLEEP_EN_36
+    4'b 0001, // index[419] PINMUX_MIO_PAD_SLEEP_EN_37
+    4'b 0001, // index[420] PINMUX_MIO_PAD_SLEEP_EN_38
+    4'b 0001, // index[421] PINMUX_MIO_PAD_SLEEP_EN_39
+    4'b 0001, // index[422] PINMUX_MIO_PAD_SLEEP_EN_40
+    4'b 0001, // index[423] PINMUX_MIO_PAD_SLEEP_EN_41
+    4'b 0001, // index[424] PINMUX_MIO_PAD_SLEEP_EN_42
+    4'b 0001, // index[425] PINMUX_MIO_PAD_SLEEP_EN_43
+    4'b 0001, // index[426] PINMUX_MIO_PAD_SLEEP_MODE_0
+    4'b 0001, // index[427] PINMUX_MIO_PAD_SLEEP_MODE_1
+    4'b 0001, // index[428] PINMUX_MIO_PAD_SLEEP_MODE_2
+    4'b 0001, // index[429] PINMUX_MIO_PAD_SLEEP_MODE_3
+    4'b 0001, // index[430] PINMUX_MIO_PAD_SLEEP_MODE_4
+    4'b 0001, // index[431] PINMUX_MIO_PAD_SLEEP_MODE_5
+    4'b 0001, // index[432] PINMUX_MIO_PAD_SLEEP_MODE_6
+    4'b 0001, // index[433] PINMUX_MIO_PAD_SLEEP_MODE_7
+    4'b 0001, // index[434] PINMUX_MIO_PAD_SLEEP_MODE_8
+    4'b 0001, // index[435] PINMUX_MIO_PAD_SLEEP_MODE_9
+    4'b 0001, // index[436] PINMUX_MIO_PAD_SLEEP_MODE_10
+    4'b 0001, // index[437] PINMUX_MIO_PAD_SLEEP_MODE_11
+    4'b 0001, // index[438] PINMUX_MIO_PAD_SLEEP_MODE_12
+    4'b 0001, // index[439] PINMUX_MIO_PAD_SLEEP_MODE_13
+    4'b 0001, // index[440] PINMUX_MIO_PAD_SLEEP_MODE_14
+    4'b 0001, // index[441] PINMUX_MIO_PAD_SLEEP_MODE_15
+    4'b 0001, // index[442] PINMUX_MIO_PAD_SLEEP_MODE_16
+    4'b 0001, // index[443] PINMUX_MIO_PAD_SLEEP_MODE_17
+    4'b 0001, // index[444] PINMUX_MIO_PAD_SLEEP_MODE_18
+    4'b 0001, // index[445] PINMUX_MIO_PAD_SLEEP_MODE_19
+    4'b 0001, // index[446] PINMUX_MIO_PAD_SLEEP_MODE_20
+    4'b 0001, // index[447] PINMUX_MIO_PAD_SLEEP_MODE_21
+    4'b 0001, // index[448] PINMUX_MIO_PAD_SLEEP_MODE_22
+    4'b 0001, // index[449] PINMUX_MIO_PAD_SLEEP_MODE_23
+    4'b 0001, // index[450] PINMUX_MIO_PAD_SLEEP_MODE_24
+    4'b 0001, // index[451] PINMUX_MIO_PAD_SLEEP_MODE_25
+    4'b 0001, // index[452] PINMUX_MIO_PAD_SLEEP_MODE_26
+    4'b 0001, // index[453] PINMUX_MIO_PAD_SLEEP_MODE_27
+    4'b 0001, // index[454] PINMUX_MIO_PAD_SLEEP_MODE_28
+    4'b 0001, // index[455] PINMUX_MIO_PAD_SLEEP_MODE_29
+    4'b 0001, // index[456] PINMUX_MIO_PAD_SLEEP_MODE_30
+    4'b 0001, // index[457] PINMUX_MIO_PAD_SLEEP_MODE_31
+    4'b 0001, // index[458] PINMUX_MIO_PAD_SLEEP_MODE_32
+    4'b 0001, // index[459] PINMUX_MIO_PAD_SLEEP_MODE_33
+    4'b 0001, // index[460] PINMUX_MIO_PAD_SLEEP_MODE_34
+    4'b 0001, // index[461] PINMUX_MIO_PAD_SLEEP_MODE_35
+    4'b 0001, // index[462] PINMUX_MIO_PAD_SLEEP_MODE_36
+    4'b 0001, // index[463] PINMUX_MIO_PAD_SLEEP_MODE_37
+    4'b 0001, // index[464] PINMUX_MIO_PAD_SLEEP_MODE_38
+    4'b 0001, // index[465] PINMUX_MIO_PAD_SLEEP_MODE_39
+    4'b 0001, // index[466] PINMUX_MIO_PAD_SLEEP_MODE_40
+    4'b 0001, // index[467] PINMUX_MIO_PAD_SLEEP_MODE_41
+    4'b 0001, // index[468] PINMUX_MIO_PAD_SLEEP_MODE_42
+    4'b 0001, // index[469] PINMUX_MIO_PAD_SLEEP_MODE_43
+    4'b 0111, // index[470] PINMUX_DIO_PAD_SLEEP_STATUS
+    4'b 0001, // index[471] PINMUX_DIO_PAD_SLEEP_REGWEN_0
+    4'b 0001, // index[472] PINMUX_DIO_PAD_SLEEP_REGWEN_1
+    4'b 0001, // index[473] PINMUX_DIO_PAD_SLEEP_REGWEN_2
+    4'b 0001, // index[474] PINMUX_DIO_PAD_SLEEP_REGWEN_3
+    4'b 0001, // index[475] PINMUX_DIO_PAD_SLEEP_REGWEN_4
+    4'b 0001, // index[476] PINMUX_DIO_PAD_SLEEP_REGWEN_5
+    4'b 0001, // index[477] PINMUX_DIO_PAD_SLEEP_REGWEN_6
+    4'b 0001, // index[478] PINMUX_DIO_PAD_SLEEP_REGWEN_7
+    4'b 0001, // index[479] PINMUX_DIO_PAD_SLEEP_REGWEN_8
+    4'b 0001, // index[480] PINMUX_DIO_PAD_SLEEP_REGWEN_9
+    4'b 0001, // index[481] PINMUX_DIO_PAD_SLEEP_REGWEN_10
+    4'b 0001, // index[482] PINMUX_DIO_PAD_SLEEP_REGWEN_11
+    4'b 0001, // index[483] PINMUX_DIO_PAD_SLEEP_REGWEN_12
+    4'b 0001, // index[484] PINMUX_DIO_PAD_SLEEP_REGWEN_13
+    4'b 0001, // index[485] PINMUX_DIO_PAD_SLEEP_REGWEN_14
+    4'b 0001, // index[486] PINMUX_DIO_PAD_SLEEP_REGWEN_15
+    4'b 0001, // index[487] PINMUX_DIO_PAD_SLEEP_REGWEN_16
+    4'b 0001, // index[488] PINMUX_DIO_PAD_SLEEP_REGWEN_17
+    4'b 0001, // index[489] PINMUX_DIO_PAD_SLEEP_REGWEN_18
+    4'b 0001, // index[490] PINMUX_DIO_PAD_SLEEP_REGWEN_19
+    4'b 0001, // index[491] PINMUX_DIO_PAD_SLEEP_REGWEN_20
+    4'b 0001, // index[492] PINMUX_DIO_PAD_SLEEP_EN_0
+    4'b 0001, // index[493] PINMUX_DIO_PAD_SLEEP_EN_1
+    4'b 0001, // index[494] PINMUX_DIO_PAD_SLEEP_EN_2
+    4'b 0001, // index[495] PINMUX_DIO_PAD_SLEEP_EN_3
+    4'b 0001, // index[496] PINMUX_DIO_PAD_SLEEP_EN_4
+    4'b 0001, // index[497] PINMUX_DIO_PAD_SLEEP_EN_5
+    4'b 0001, // index[498] PINMUX_DIO_PAD_SLEEP_EN_6
+    4'b 0001, // index[499] PINMUX_DIO_PAD_SLEEP_EN_7
+    4'b 0001, // index[500] PINMUX_DIO_PAD_SLEEP_EN_8
+    4'b 0001, // index[501] PINMUX_DIO_PAD_SLEEP_EN_9
+    4'b 0001, // index[502] PINMUX_DIO_PAD_SLEEP_EN_10
+    4'b 0001, // index[503] PINMUX_DIO_PAD_SLEEP_EN_11
+    4'b 0001, // index[504] PINMUX_DIO_PAD_SLEEP_EN_12
+    4'b 0001, // index[505] PINMUX_DIO_PAD_SLEEP_EN_13
+    4'b 0001, // index[506] PINMUX_DIO_PAD_SLEEP_EN_14
+    4'b 0001, // index[507] PINMUX_DIO_PAD_SLEEP_EN_15
+    4'b 0001, // index[508] PINMUX_DIO_PAD_SLEEP_EN_16
+    4'b 0001, // index[509] PINMUX_DIO_PAD_SLEEP_EN_17
+    4'b 0001, // index[510] PINMUX_DIO_PAD_SLEEP_EN_18
+    4'b 0001, // index[511] PINMUX_DIO_PAD_SLEEP_EN_19
+    4'b 0001, // index[512] PINMUX_DIO_PAD_SLEEP_EN_20
+    4'b 0001, // index[513] PINMUX_DIO_PAD_SLEEP_MODE_0
+    4'b 0001, // index[514] PINMUX_DIO_PAD_SLEEP_MODE_1
+    4'b 0001, // index[515] PINMUX_DIO_PAD_SLEEP_MODE_2
+    4'b 0001, // index[516] PINMUX_DIO_PAD_SLEEP_MODE_3
+    4'b 0001, // index[517] PINMUX_DIO_PAD_SLEEP_MODE_4
+    4'b 0001, // index[518] PINMUX_DIO_PAD_SLEEP_MODE_5
+    4'b 0001, // index[519] PINMUX_DIO_PAD_SLEEP_MODE_6
+    4'b 0001, // index[520] PINMUX_DIO_PAD_SLEEP_MODE_7
+    4'b 0001, // index[521] PINMUX_DIO_PAD_SLEEP_MODE_8
+    4'b 0001, // index[522] PINMUX_DIO_PAD_SLEEP_MODE_9
+    4'b 0001, // index[523] PINMUX_DIO_PAD_SLEEP_MODE_10
+    4'b 0001, // index[524] PINMUX_DIO_PAD_SLEEP_MODE_11
+    4'b 0001, // index[525] PINMUX_DIO_PAD_SLEEP_MODE_12
+    4'b 0001, // index[526] PINMUX_DIO_PAD_SLEEP_MODE_13
+    4'b 0001, // index[527] PINMUX_DIO_PAD_SLEEP_MODE_14
+    4'b 0001, // index[528] PINMUX_DIO_PAD_SLEEP_MODE_15
+    4'b 0001, // index[529] PINMUX_DIO_PAD_SLEEP_MODE_16
+    4'b 0001, // index[530] PINMUX_DIO_PAD_SLEEP_MODE_17
+    4'b 0001, // index[531] PINMUX_DIO_PAD_SLEEP_MODE_18
+    4'b 0001, // index[532] PINMUX_DIO_PAD_SLEEP_MODE_19
+    4'b 0001, // index[533] PINMUX_DIO_PAD_SLEEP_MODE_20
+    4'b 0001, // index[534] PINMUX_WKUP_DETECTOR_REGWEN_0
+    4'b 0001, // index[535] PINMUX_WKUP_DETECTOR_REGWEN_1
+    4'b 0001, // index[536] PINMUX_WKUP_DETECTOR_REGWEN_2
+    4'b 0001, // index[537] PINMUX_WKUP_DETECTOR_REGWEN_3
+    4'b 0001, // index[538] PINMUX_WKUP_DETECTOR_REGWEN_4
+    4'b 0001, // index[539] PINMUX_WKUP_DETECTOR_REGWEN_5
+    4'b 0001, // index[540] PINMUX_WKUP_DETECTOR_REGWEN_6
+    4'b 0001, // index[541] PINMUX_WKUP_DETECTOR_REGWEN_7
+    4'b 0001, // index[542] PINMUX_WKUP_DETECTOR_EN_0
+    4'b 0001, // index[543] PINMUX_WKUP_DETECTOR_EN_1
+    4'b 0001, // index[544] PINMUX_WKUP_DETECTOR_EN_2
+    4'b 0001, // index[545] PINMUX_WKUP_DETECTOR_EN_3
+    4'b 0001, // index[546] PINMUX_WKUP_DETECTOR_EN_4
+    4'b 0001, // index[547] PINMUX_WKUP_DETECTOR_EN_5
+    4'b 0001, // index[548] PINMUX_WKUP_DETECTOR_EN_6
+    4'b 0001, // index[549] PINMUX_WKUP_DETECTOR_EN_7
+    4'b 0001, // index[550] PINMUX_WKUP_DETECTOR_0
+    4'b 0001, // index[551] PINMUX_WKUP_DETECTOR_1
+    4'b 0001, // index[552] PINMUX_WKUP_DETECTOR_2
+    4'b 0001, // index[553] PINMUX_WKUP_DETECTOR_3
+    4'b 0001, // index[554] PINMUX_WKUP_DETECTOR_4
+    4'b 0001, // index[555] PINMUX_WKUP_DETECTOR_5
+    4'b 0001, // index[556] PINMUX_WKUP_DETECTOR_6
+    4'b 0001, // index[557] PINMUX_WKUP_DETECTOR_7
+    4'b 0001, // index[558] PINMUX_WKUP_DETECTOR_CNT_TH_0
+    4'b 0001, // index[559] PINMUX_WKUP_DETECTOR_CNT_TH_1
+    4'b 0001, // index[560] PINMUX_WKUP_DETECTOR_CNT_TH_2
+    4'b 0001, // index[561] PINMUX_WKUP_DETECTOR_CNT_TH_3
+    4'b 0001, // index[562] PINMUX_WKUP_DETECTOR_CNT_TH_4
+    4'b 0001, // index[563] PINMUX_WKUP_DETECTOR_CNT_TH_5
+    4'b 0001, // index[564] PINMUX_WKUP_DETECTOR_CNT_TH_6
+    4'b 0001, // index[565] PINMUX_WKUP_DETECTOR_CNT_TH_7
+    4'b 0001, // index[566] PINMUX_WKUP_DETECTOR_PADSEL_0
+    4'b 0001, // index[567] PINMUX_WKUP_DETECTOR_PADSEL_1
+    4'b 0001, // index[568] PINMUX_WKUP_DETECTOR_PADSEL_2
+    4'b 0001, // index[569] PINMUX_WKUP_DETECTOR_PADSEL_3
+    4'b 0001, // index[570] PINMUX_WKUP_DETECTOR_PADSEL_4
+    4'b 0001, // index[571] PINMUX_WKUP_DETECTOR_PADSEL_5
+    4'b 0001, // index[572] PINMUX_WKUP_DETECTOR_PADSEL_6
+    4'b 0001, // index[573] PINMUX_WKUP_DETECTOR_PADSEL_7
+    4'b 0001  // index[574] PINMUX_WKUP_CAUSE
   };
 
 endpackage

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
@@ -247,6 +247,36 @@ module pinmux_reg_top (
   logic mio_periph_insel_regwen_48_qs;
   logic mio_periph_insel_regwen_48_wd;
   logic mio_periph_insel_regwen_48_we;
+  logic mio_periph_insel_regwen_49_qs;
+  logic mio_periph_insel_regwen_49_wd;
+  logic mio_periph_insel_regwen_49_we;
+  logic mio_periph_insel_regwen_50_qs;
+  logic mio_periph_insel_regwen_50_wd;
+  logic mio_periph_insel_regwen_50_we;
+  logic mio_periph_insel_regwen_51_qs;
+  logic mio_periph_insel_regwen_51_wd;
+  logic mio_periph_insel_regwen_51_we;
+  logic mio_periph_insel_regwen_52_qs;
+  logic mio_periph_insel_regwen_52_wd;
+  logic mio_periph_insel_regwen_52_we;
+  logic mio_periph_insel_regwen_53_qs;
+  logic mio_periph_insel_regwen_53_wd;
+  logic mio_periph_insel_regwen_53_we;
+  logic mio_periph_insel_regwen_54_qs;
+  logic mio_periph_insel_regwen_54_wd;
+  logic mio_periph_insel_regwen_54_we;
+  logic mio_periph_insel_regwen_55_qs;
+  logic mio_periph_insel_regwen_55_wd;
+  logic mio_periph_insel_regwen_55_we;
+  logic mio_periph_insel_regwen_56_qs;
+  logic mio_periph_insel_regwen_56_wd;
+  logic mio_periph_insel_regwen_56_we;
+  logic mio_periph_insel_regwen_57_qs;
+  logic mio_periph_insel_regwen_57_wd;
+  logic mio_periph_insel_regwen_57_we;
+  logic mio_periph_insel_regwen_58_qs;
+  logic mio_periph_insel_regwen_58_wd;
+  logic mio_periph_insel_regwen_58_we;
   logic [5:0] mio_periph_insel_0_qs;
   logic [5:0] mio_periph_insel_0_wd;
   logic mio_periph_insel_0_we;
@@ -394,6 +424,36 @@ module pinmux_reg_top (
   logic [5:0] mio_periph_insel_48_qs;
   logic [5:0] mio_periph_insel_48_wd;
   logic mio_periph_insel_48_we;
+  logic [5:0] mio_periph_insel_49_qs;
+  logic [5:0] mio_periph_insel_49_wd;
+  logic mio_periph_insel_49_we;
+  logic [5:0] mio_periph_insel_50_qs;
+  logic [5:0] mio_periph_insel_50_wd;
+  logic mio_periph_insel_50_we;
+  logic [5:0] mio_periph_insel_51_qs;
+  logic [5:0] mio_periph_insel_51_wd;
+  logic mio_periph_insel_51_we;
+  logic [5:0] mio_periph_insel_52_qs;
+  logic [5:0] mio_periph_insel_52_wd;
+  logic mio_periph_insel_52_we;
+  logic [5:0] mio_periph_insel_53_qs;
+  logic [5:0] mio_periph_insel_53_wd;
+  logic mio_periph_insel_53_we;
+  logic [5:0] mio_periph_insel_54_qs;
+  logic [5:0] mio_periph_insel_54_wd;
+  logic mio_periph_insel_54_we;
+  logic [5:0] mio_periph_insel_55_qs;
+  logic [5:0] mio_periph_insel_55_wd;
+  logic mio_periph_insel_55_we;
+  logic [5:0] mio_periph_insel_56_qs;
+  logic [5:0] mio_periph_insel_56_wd;
+  logic mio_periph_insel_56_we;
+  logic [5:0] mio_periph_insel_57_qs;
+  logic [5:0] mio_periph_insel_57_wd;
+  logic mio_periph_insel_57_we;
+  logic [5:0] mio_periph_insel_58_qs;
+  logic [5:0] mio_periph_insel_58_wd;
+  logic mio_periph_insel_58_we;
   logic mio_outsel_regwen_0_qs;
   logic mio_outsel_regwen_0_wd;
   logic mio_outsel_regwen_0_we;
@@ -526,137 +586,137 @@ module pinmux_reg_top (
   logic mio_outsel_regwen_43_qs;
   logic mio_outsel_regwen_43_wd;
   logic mio_outsel_regwen_43_we;
-  logic [5:0] mio_outsel_0_qs;
-  logic [5:0] mio_outsel_0_wd;
+  logic [6:0] mio_outsel_0_qs;
+  logic [6:0] mio_outsel_0_wd;
   logic mio_outsel_0_we;
-  logic [5:0] mio_outsel_1_qs;
-  logic [5:0] mio_outsel_1_wd;
+  logic [6:0] mio_outsel_1_qs;
+  logic [6:0] mio_outsel_1_wd;
   logic mio_outsel_1_we;
-  logic [5:0] mio_outsel_2_qs;
-  logic [5:0] mio_outsel_2_wd;
+  logic [6:0] mio_outsel_2_qs;
+  logic [6:0] mio_outsel_2_wd;
   logic mio_outsel_2_we;
-  logic [5:0] mio_outsel_3_qs;
-  logic [5:0] mio_outsel_3_wd;
+  logic [6:0] mio_outsel_3_qs;
+  logic [6:0] mio_outsel_3_wd;
   logic mio_outsel_3_we;
-  logic [5:0] mio_outsel_4_qs;
-  logic [5:0] mio_outsel_4_wd;
+  logic [6:0] mio_outsel_4_qs;
+  logic [6:0] mio_outsel_4_wd;
   logic mio_outsel_4_we;
-  logic [5:0] mio_outsel_5_qs;
-  logic [5:0] mio_outsel_5_wd;
+  logic [6:0] mio_outsel_5_qs;
+  logic [6:0] mio_outsel_5_wd;
   logic mio_outsel_5_we;
-  logic [5:0] mio_outsel_6_qs;
-  logic [5:0] mio_outsel_6_wd;
+  logic [6:0] mio_outsel_6_qs;
+  logic [6:0] mio_outsel_6_wd;
   logic mio_outsel_6_we;
-  logic [5:0] mio_outsel_7_qs;
-  logic [5:0] mio_outsel_7_wd;
+  logic [6:0] mio_outsel_7_qs;
+  logic [6:0] mio_outsel_7_wd;
   logic mio_outsel_7_we;
-  logic [5:0] mio_outsel_8_qs;
-  logic [5:0] mio_outsel_8_wd;
+  logic [6:0] mio_outsel_8_qs;
+  logic [6:0] mio_outsel_8_wd;
   logic mio_outsel_8_we;
-  logic [5:0] mio_outsel_9_qs;
-  logic [5:0] mio_outsel_9_wd;
+  logic [6:0] mio_outsel_9_qs;
+  logic [6:0] mio_outsel_9_wd;
   logic mio_outsel_9_we;
-  logic [5:0] mio_outsel_10_qs;
-  logic [5:0] mio_outsel_10_wd;
+  logic [6:0] mio_outsel_10_qs;
+  logic [6:0] mio_outsel_10_wd;
   logic mio_outsel_10_we;
-  logic [5:0] mio_outsel_11_qs;
-  logic [5:0] mio_outsel_11_wd;
+  logic [6:0] mio_outsel_11_qs;
+  logic [6:0] mio_outsel_11_wd;
   logic mio_outsel_11_we;
-  logic [5:0] mio_outsel_12_qs;
-  logic [5:0] mio_outsel_12_wd;
+  logic [6:0] mio_outsel_12_qs;
+  logic [6:0] mio_outsel_12_wd;
   logic mio_outsel_12_we;
-  logic [5:0] mio_outsel_13_qs;
-  logic [5:0] mio_outsel_13_wd;
+  logic [6:0] mio_outsel_13_qs;
+  logic [6:0] mio_outsel_13_wd;
   logic mio_outsel_13_we;
-  logic [5:0] mio_outsel_14_qs;
-  logic [5:0] mio_outsel_14_wd;
+  logic [6:0] mio_outsel_14_qs;
+  logic [6:0] mio_outsel_14_wd;
   logic mio_outsel_14_we;
-  logic [5:0] mio_outsel_15_qs;
-  logic [5:0] mio_outsel_15_wd;
+  logic [6:0] mio_outsel_15_qs;
+  logic [6:0] mio_outsel_15_wd;
   logic mio_outsel_15_we;
-  logic [5:0] mio_outsel_16_qs;
-  logic [5:0] mio_outsel_16_wd;
+  logic [6:0] mio_outsel_16_qs;
+  logic [6:0] mio_outsel_16_wd;
   logic mio_outsel_16_we;
-  logic [5:0] mio_outsel_17_qs;
-  logic [5:0] mio_outsel_17_wd;
+  logic [6:0] mio_outsel_17_qs;
+  logic [6:0] mio_outsel_17_wd;
   logic mio_outsel_17_we;
-  logic [5:0] mio_outsel_18_qs;
-  logic [5:0] mio_outsel_18_wd;
+  logic [6:0] mio_outsel_18_qs;
+  logic [6:0] mio_outsel_18_wd;
   logic mio_outsel_18_we;
-  logic [5:0] mio_outsel_19_qs;
-  logic [5:0] mio_outsel_19_wd;
+  logic [6:0] mio_outsel_19_qs;
+  logic [6:0] mio_outsel_19_wd;
   logic mio_outsel_19_we;
-  logic [5:0] mio_outsel_20_qs;
-  logic [5:0] mio_outsel_20_wd;
+  logic [6:0] mio_outsel_20_qs;
+  logic [6:0] mio_outsel_20_wd;
   logic mio_outsel_20_we;
-  logic [5:0] mio_outsel_21_qs;
-  logic [5:0] mio_outsel_21_wd;
+  logic [6:0] mio_outsel_21_qs;
+  logic [6:0] mio_outsel_21_wd;
   logic mio_outsel_21_we;
-  logic [5:0] mio_outsel_22_qs;
-  logic [5:0] mio_outsel_22_wd;
+  logic [6:0] mio_outsel_22_qs;
+  logic [6:0] mio_outsel_22_wd;
   logic mio_outsel_22_we;
-  logic [5:0] mio_outsel_23_qs;
-  logic [5:0] mio_outsel_23_wd;
+  logic [6:0] mio_outsel_23_qs;
+  logic [6:0] mio_outsel_23_wd;
   logic mio_outsel_23_we;
-  logic [5:0] mio_outsel_24_qs;
-  logic [5:0] mio_outsel_24_wd;
+  logic [6:0] mio_outsel_24_qs;
+  logic [6:0] mio_outsel_24_wd;
   logic mio_outsel_24_we;
-  logic [5:0] mio_outsel_25_qs;
-  logic [5:0] mio_outsel_25_wd;
+  logic [6:0] mio_outsel_25_qs;
+  logic [6:0] mio_outsel_25_wd;
   logic mio_outsel_25_we;
-  logic [5:0] mio_outsel_26_qs;
-  logic [5:0] mio_outsel_26_wd;
+  logic [6:0] mio_outsel_26_qs;
+  logic [6:0] mio_outsel_26_wd;
   logic mio_outsel_26_we;
-  logic [5:0] mio_outsel_27_qs;
-  logic [5:0] mio_outsel_27_wd;
+  logic [6:0] mio_outsel_27_qs;
+  logic [6:0] mio_outsel_27_wd;
   logic mio_outsel_27_we;
-  logic [5:0] mio_outsel_28_qs;
-  logic [5:0] mio_outsel_28_wd;
+  logic [6:0] mio_outsel_28_qs;
+  logic [6:0] mio_outsel_28_wd;
   logic mio_outsel_28_we;
-  logic [5:0] mio_outsel_29_qs;
-  logic [5:0] mio_outsel_29_wd;
+  logic [6:0] mio_outsel_29_qs;
+  logic [6:0] mio_outsel_29_wd;
   logic mio_outsel_29_we;
-  logic [5:0] mio_outsel_30_qs;
-  logic [5:0] mio_outsel_30_wd;
+  logic [6:0] mio_outsel_30_qs;
+  logic [6:0] mio_outsel_30_wd;
   logic mio_outsel_30_we;
-  logic [5:0] mio_outsel_31_qs;
-  logic [5:0] mio_outsel_31_wd;
+  logic [6:0] mio_outsel_31_qs;
+  logic [6:0] mio_outsel_31_wd;
   logic mio_outsel_31_we;
-  logic [5:0] mio_outsel_32_qs;
-  logic [5:0] mio_outsel_32_wd;
+  logic [6:0] mio_outsel_32_qs;
+  logic [6:0] mio_outsel_32_wd;
   logic mio_outsel_32_we;
-  logic [5:0] mio_outsel_33_qs;
-  logic [5:0] mio_outsel_33_wd;
+  logic [6:0] mio_outsel_33_qs;
+  logic [6:0] mio_outsel_33_wd;
   logic mio_outsel_33_we;
-  logic [5:0] mio_outsel_34_qs;
-  logic [5:0] mio_outsel_34_wd;
+  logic [6:0] mio_outsel_34_qs;
+  logic [6:0] mio_outsel_34_wd;
   logic mio_outsel_34_we;
-  logic [5:0] mio_outsel_35_qs;
-  logic [5:0] mio_outsel_35_wd;
+  logic [6:0] mio_outsel_35_qs;
+  logic [6:0] mio_outsel_35_wd;
   logic mio_outsel_35_we;
-  logic [5:0] mio_outsel_36_qs;
-  logic [5:0] mio_outsel_36_wd;
+  logic [6:0] mio_outsel_36_qs;
+  logic [6:0] mio_outsel_36_wd;
   logic mio_outsel_36_we;
-  logic [5:0] mio_outsel_37_qs;
-  logic [5:0] mio_outsel_37_wd;
+  logic [6:0] mio_outsel_37_qs;
+  logic [6:0] mio_outsel_37_wd;
   logic mio_outsel_37_we;
-  logic [5:0] mio_outsel_38_qs;
-  logic [5:0] mio_outsel_38_wd;
+  logic [6:0] mio_outsel_38_qs;
+  logic [6:0] mio_outsel_38_wd;
   logic mio_outsel_38_we;
-  logic [5:0] mio_outsel_39_qs;
-  logic [5:0] mio_outsel_39_wd;
+  logic [6:0] mio_outsel_39_qs;
+  logic [6:0] mio_outsel_39_wd;
   logic mio_outsel_39_we;
-  logic [5:0] mio_outsel_40_qs;
-  logic [5:0] mio_outsel_40_wd;
+  logic [6:0] mio_outsel_40_qs;
+  logic [6:0] mio_outsel_40_wd;
   logic mio_outsel_40_we;
-  logic [5:0] mio_outsel_41_qs;
-  logic [5:0] mio_outsel_41_wd;
+  logic [6:0] mio_outsel_41_qs;
+  logic [6:0] mio_outsel_41_wd;
   logic mio_outsel_41_we;
-  logic [5:0] mio_outsel_42_qs;
-  logic [5:0] mio_outsel_42_wd;
+  logic [6:0] mio_outsel_42_qs;
+  logic [6:0] mio_outsel_42_wd;
   logic mio_outsel_42_we;
-  logic [5:0] mio_outsel_43_qs;
-  logic [5:0] mio_outsel_43_wd;
+  logic [6:0] mio_outsel_43_qs;
+  logic [6:0] mio_outsel_43_wd;
   logic mio_outsel_43_we;
   logic mio_pad_attr_regwen_0_qs;
   logic mio_pad_attr_regwen_0_wd;
@@ -3419,6 +3479,276 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_48_qs)
   );
 
+  // Subregister 49 of Multireg mio_periph_insel_regwen
+  // R[mio_periph_insel_regwen_49]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W0C"),
+    .RESVAL  (1'h1)
+  ) u_mio_periph_insel_regwen_49 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (mio_periph_insel_regwen_49_we),
+    .wd     (mio_periph_insel_regwen_49_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_regwen_49_qs)
+  );
+
+  // Subregister 50 of Multireg mio_periph_insel_regwen
+  // R[mio_periph_insel_regwen_50]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W0C"),
+    .RESVAL  (1'h1)
+  ) u_mio_periph_insel_regwen_50 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (mio_periph_insel_regwen_50_we),
+    .wd     (mio_periph_insel_regwen_50_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_regwen_50_qs)
+  );
+
+  // Subregister 51 of Multireg mio_periph_insel_regwen
+  // R[mio_periph_insel_regwen_51]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W0C"),
+    .RESVAL  (1'h1)
+  ) u_mio_periph_insel_regwen_51 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (mio_periph_insel_regwen_51_we),
+    .wd     (mio_periph_insel_regwen_51_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_regwen_51_qs)
+  );
+
+  // Subregister 52 of Multireg mio_periph_insel_regwen
+  // R[mio_periph_insel_regwen_52]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W0C"),
+    .RESVAL  (1'h1)
+  ) u_mio_periph_insel_regwen_52 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (mio_periph_insel_regwen_52_we),
+    .wd     (mio_periph_insel_regwen_52_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_regwen_52_qs)
+  );
+
+  // Subregister 53 of Multireg mio_periph_insel_regwen
+  // R[mio_periph_insel_regwen_53]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W0C"),
+    .RESVAL  (1'h1)
+  ) u_mio_periph_insel_regwen_53 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (mio_periph_insel_regwen_53_we),
+    .wd     (mio_periph_insel_regwen_53_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_regwen_53_qs)
+  );
+
+  // Subregister 54 of Multireg mio_periph_insel_regwen
+  // R[mio_periph_insel_regwen_54]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W0C"),
+    .RESVAL  (1'h1)
+  ) u_mio_periph_insel_regwen_54 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (mio_periph_insel_regwen_54_we),
+    .wd     (mio_periph_insel_regwen_54_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_regwen_54_qs)
+  );
+
+  // Subregister 55 of Multireg mio_periph_insel_regwen
+  // R[mio_periph_insel_regwen_55]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W0C"),
+    .RESVAL  (1'h1)
+  ) u_mio_periph_insel_regwen_55 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (mio_periph_insel_regwen_55_we),
+    .wd     (mio_periph_insel_regwen_55_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_regwen_55_qs)
+  );
+
+  // Subregister 56 of Multireg mio_periph_insel_regwen
+  // R[mio_periph_insel_regwen_56]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W0C"),
+    .RESVAL  (1'h1)
+  ) u_mio_periph_insel_regwen_56 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (mio_periph_insel_regwen_56_we),
+    .wd     (mio_periph_insel_regwen_56_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_regwen_56_qs)
+  );
+
+  // Subregister 57 of Multireg mio_periph_insel_regwen
+  // R[mio_periph_insel_regwen_57]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W0C"),
+    .RESVAL  (1'h1)
+  ) u_mio_periph_insel_regwen_57 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (mio_periph_insel_regwen_57_we),
+    .wd     (mio_periph_insel_regwen_57_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_regwen_57_qs)
+  );
+
+  // Subregister 58 of Multireg mio_periph_insel_regwen
+  // R[mio_periph_insel_regwen_58]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W0C"),
+    .RESVAL  (1'h1)
+  ) u_mio_periph_insel_regwen_58 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (mio_periph_insel_regwen_58_we),
+    .wd     (mio_periph_insel_regwen_58_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_regwen_58_qs)
+  );
+
 
 
   // Subregister 0 of Multireg mio_periph_insel
@@ -4744,6 +5074,276 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_48_qs)
   );
 
+  // Subregister 49 of Multireg mio_periph_insel
+  // R[mio_periph_insel_49]: V(False)
+
+  prim_subreg #(
+    .DW      (6),
+    .SWACCESS("RW"),
+    .RESVAL  (6'h0)
+  ) u_mio_periph_insel_49 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mio_periph_insel_49_we & mio_periph_insel_regwen_49_qs),
+    .wd     (mio_periph_insel_49_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mio_periph_insel[49].q ),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_49_qs)
+  );
+
+  // Subregister 50 of Multireg mio_periph_insel
+  // R[mio_periph_insel_50]: V(False)
+
+  prim_subreg #(
+    .DW      (6),
+    .SWACCESS("RW"),
+    .RESVAL  (6'h0)
+  ) u_mio_periph_insel_50 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mio_periph_insel_50_we & mio_periph_insel_regwen_50_qs),
+    .wd     (mio_periph_insel_50_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mio_periph_insel[50].q ),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_50_qs)
+  );
+
+  // Subregister 51 of Multireg mio_periph_insel
+  // R[mio_periph_insel_51]: V(False)
+
+  prim_subreg #(
+    .DW      (6),
+    .SWACCESS("RW"),
+    .RESVAL  (6'h0)
+  ) u_mio_periph_insel_51 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mio_periph_insel_51_we & mio_periph_insel_regwen_51_qs),
+    .wd     (mio_periph_insel_51_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mio_periph_insel[51].q ),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_51_qs)
+  );
+
+  // Subregister 52 of Multireg mio_periph_insel
+  // R[mio_periph_insel_52]: V(False)
+
+  prim_subreg #(
+    .DW      (6),
+    .SWACCESS("RW"),
+    .RESVAL  (6'h0)
+  ) u_mio_periph_insel_52 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mio_periph_insel_52_we & mio_periph_insel_regwen_52_qs),
+    .wd     (mio_periph_insel_52_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mio_periph_insel[52].q ),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_52_qs)
+  );
+
+  // Subregister 53 of Multireg mio_periph_insel
+  // R[mio_periph_insel_53]: V(False)
+
+  prim_subreg #(
+    .DW      (6),
+    .SWACCESS("RW"),
+    .RESVAL  (6'h0)
+  ) u_mio_periph_insel_53 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mio_periph_insel_53_we & mio_periph_insel_regwen_53_qs),
+    .wd     (mio_periph_insel_53_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mio_periph_insel[53].q ),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_53_qs)
+  );
+
+  // Subregister 54 of Multireg mio_periph_insel
+  // R[mio_periph_insel_54]: V(False)
+
+  prim_subreg #(
+    .DW      (6),
+    .SWACCESS("RW"),
+    .RESVAL  (6'h0)
+  ) u_mio_periph_insel_54 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mio_periph_insel_54_we & mio_periph_insel_regwen_54_qs),
+    .wd     (mio_periph_insel_54_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mio_periph_insel[54].q ),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_54_qs)
+  );
+
+  // Subregister 55 of Multireg mio_periph_insel
+  // R[mio_periph_insel_55]: V(False)
+
+  prim_subreg #(
+    .DW      (6),
+    .SWACCESS("RW"),
+    .RESVAL  (6'h0)
+  ) u_mio_periph_insel_55 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mio_periph_insel_55_we & mio_periph_insel_regwen_55_qs),
+    .wd     (mio_periph_insel_55_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mio_periph_insel[55].q ),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_55_qs)
+  );
+
+  // Subregister 56 of Multireg mio_periph_insel
+  // R[mio_periph_insel_56]: V(False)
+
+  prim_subreg #(
+    .DW      (6),
+    .SWACCESS("RW"),
+    .RESVAL  (6'h0)
+  ) u_mio_periph_insel_56 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mio_periph_insel_56_we & mio_periph_insel_regwen_56_qs),
+    .wd     (mio_periph_insel_56_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mio_periph_insel[56].q ),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_56_qs)
+  );
+
+  // Subregister 57 of Multireg mio_periph_insel
+  // R[mio_periph_insel_57]: V(False)
+
+  prim_subreg #(
+    .DW      (6),
+    .SWACCESS("RW"),
+    .RESVAL  (6'h0)
+  ) u_mio_periph_insel_57 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mio_periph_insel_57_we & mio_periph_insel_regwen_57_qs),
+    .wd     (mio_periph_insel_57_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mio_periph_insel[57].q ),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_57_qs)
+  );
+
+  // Subregister 58 of Multireg mio_periph_insel
+  // R[mio_periph_insel_58]: V(False)
+
+  prim_subreg #(
+    .DW      (6),
+    .SWACCESS("RW"),
+    .RESVAL  (6'h0)
+  ) u_mio_periph_insel_58 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mio_periph_insel_58_we & mio_periph_insel_regwen_58_qs),
+    .wd     (mio_periph_insel_58_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mio_periph_insel[58].q ),
+
+    // to register interface (read)
+    .qs     (mio_periph_insel_58_qs)
+  );
+
 
 
   // Subregister 0 of Multireg mio_outsel_regwen
@@ -5940,9 +6540,9 @@ module pinmux_reg_top (
   // R[mio_outsel_0]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -5967,9 +6567,9 @@ module pinmux_reg_top (
   // R[mio_outsel_1]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_1 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -5994,9 +6594,9 @@ module pinmux_reg_top (
   // R[mio_outsel_2]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_2 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6021,9 +6621,9 @@ module pinmux_reg_top (
   // R[mio_outsel_3]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_3 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6048,9 +6648,9 @@ module pinmux_reg_top (
   // R[mio_outsel_4]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_4 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6075,9 +6675,9 @@ module pinmux_reg_top (
   // R[mio_outsel_5]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_5 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6102,9 +6702,9 @@ module pinmux_reg_top (
   // R[mio_outsel_6]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_6 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6129,9 +6729,9 @@ module pinmux_reg_top (
   // R[mio_outsel_7]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_7 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6156,9 +6756,9 @@ module pinmux_reg_top (
   // R[mio_outsel_8]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_8 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6183,9 +6783,9 @@ module pinmux_reg_top (
   // R[mio_outsel_9]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_9 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6210,9 +6810,9 @@ module pinmux_reg_top (
   // R[mio_outsel_10]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_10 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6237,9 +6837,9 @@ module pinmux_reg_top (
   // R[mio_outsel_11]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_11 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6264,9 +6864,9 @@ module pinmux_reg_top (
   // R[mio_outsel_12]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_12 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6291,9 +6891,9 @@ module pinmux_reg_top (
   // R[mio_outsel_13]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_13 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6318,9 +6918,9 @@ module pinmux_reg_top (
   // R[mio_outsel_14]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_14 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6345,9 +6945,9 @@ module pinmux_reg_top (
   // R[mio_outsel_15]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_15 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6372,9 +6972,9 @@ module pinmux_reg_top (
   // R[mio_outsel_16]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_16 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6399,9 +6999,9 @@ module pinmux_reg_top (
   // R[mio_outsel_17]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_17 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6426,9 +7026,9 @@ module pinmux_reg_top (
   // R[mio_outsel_18]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_18 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6453,9 +7053,9 @@ module pinmux_reg_top (
   // R[mio_outsel_19]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_19 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6480,9 +7080,9 @@ module pinmux_reg_top (
   // R[mio_outsel_20]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_20 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6507,9 +7107,9 @@ module pinmux_reg_top (
   // R[mio_outsel_21]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_21 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6534,9 +7134,9 @@ module pinmux_reg_top (
   // R[mio_outsel_22]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_22 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6561,9 +7161,9 @@ module pinmux_reg_top (
   // R[mio_outsel_23]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_23 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6588,9 +7188,9 @@ module pinmux_reg_top (
   // R[mio_outsel_24]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_24 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6615,9 +7215,9 @@ module pinmux_reg_top (
   // R[mio_outsel_25]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_25 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6642,9 +7242,9 @@ module pinmux_reg_top (
   // R[mio_outsel_26]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_26 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6669,9 +7269,9 @@ module pinmux_reg_top (
   // R[mio_outsel_27]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_27 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6696,9 +7296,9 @@ module pinmux_reg_top (
   // R[mio_outsel_28]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_28 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6723,9 +7323,9 @@ module pinmux_reg_top (
   // R[mio_outsel_29]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_29 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6750,9 +7350,9 @@ module pinmux_reg_top (
   // R[mio_outsel_30]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_30 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6777,9 +7377,9 @@ module pinmux_reg_top (
   // R[mio_outsel_31]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_31 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6804,9 +7404,9 @@ module pinmux_reg_top (
   // R[mio_outsel_32]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_32 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6831,9 +7431,9 @@ module pinmux_reg_top (
   // R[mio_outsel_33]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_33 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6858,9 +7458,9 @@ module pinmux_reg_top (
   // R[mio_outsel_34]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_34 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6885,9 +7485,9 @@ module pinmux_reg_top (
   // R[mio_outsel_35]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_35 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6912,9 +7512,9 @@ module pinmux_reg_top (
   // R[mio_outsel_36]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_36 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6939,9 +7539,9 @@ module pinmux_reg_top (
   // R[mio_outsel_37]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_37 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6966,9 +7566,9 @@ module pinmux_reg_top (
   // R[mio_outsel_38]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_38 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -6993,9 +7593,9 @@ module pinmux_reg_top (
   // R[mio_outsel_39]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_39 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -7020,9 +7620,9 @@ module pinmux_reg_top (
   // R[mio_outsel_40]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_40 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -7047,9 +7647,9 @@ module pinmux_reg_top (
   // R[mio_outsel_41]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_41 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -7074,9 +7674,9 @@ module pinmux_reg_top (
   // R[mio_outsel_42]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_42 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -7101,9 +7701,9 @@ module pinmux_reg_top (
   // R[mio_outsel_43]: V(False)
 
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SWACCESS("RW"),
-    .RESVAL  (6'h2)
+    .RESVAL  (7'h2)
   ) u_mio_outsel_43 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -18622,7 +19222,7 @@ module pinmux_reg_top (
 
 
 
-  logic [554:0] addr_hit;
+  logic [574:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[  0] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_0_OFFSET);
@@ -18674,512 +19274,532 @@ module pinmux_reg_top (
     addr_hit[ 46] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_46_OFFSET);
     addr_hit[ 47] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_47_OFFSET);
     addr_hit[ 48] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_48_OFFSET);
-    addr_hit[ 49] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_0_OFFSET);
-    addr_hit[ 50] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_1_OFFSET);
-    addr_hit[ 51] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_2_OFFSET);
-    addr_hit[ 52] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_3_OFFSET);
-    addr_hit[ 53] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_4_OFFSET);
-    addr_hit[ 54] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_5_OFFSET);
-    addr_hit[ 55] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_6_OFFSET);
-    addr_hit[ 56] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_7_OFFSET);
-    addr_hit[ 57] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_8_OFFSET);
-    addr_hit[ 58] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_9_OFFSET);
-    addr_hit[ 59] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_10_OFFSET);
-    addr_hit[ 60] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_11_OFFSET);
-    addr_hit[ 61] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_12_OFFSET);
-    addr_hit[ 62] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_13_OFFSET);
-    addr_hit[ 63] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_14_OFFSET);
-    addr_hit[ 64] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_15_OFFSET);
-    addr_hit[ 65] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_16_OFFSET);
-    addr_hit[ 66] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_17_OFFSET);
-    addr_hit[ 67] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_18_OFFSET);
-    addr_hit[ 68] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_19_OFFSET);
-    addr_hit[ 69] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_20_OFFSET);
-    addr_hit[ 70] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_21_OFFSET);
-    addr_hit[ 71] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_22_OFFSET);
-    addr_hit[ 72] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_23_OFFSET);
-    addr_hit[ 73] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_24_OFFSET);
-    addr_hit[ 74] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_25_OFFSET);
-    addr_hit[ 75] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_26_OFFSET);
-    addr_hit[ 76] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_27_OFFSET);
-    addr_hit[ 77] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_28_OFFSET);
-    addr_hit[ 78] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_29_OFFSET);
-    addr_hit[ 79] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_30_OFFSET);
-    addr_hit[ 80] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_31_OFFSET);
-    addr_hit[ 81] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_32_OFFSET);
-    addr_hit[ 82] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_33_OFFSET);
-    addr_hit[ 83] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_34_OFFSET);
-    addr_hit[ 84] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_35_OFFSET);
-    addr_hit[ 85] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_36_OFFSET);
-    addr_hit[ 86] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_37_OFFSET);
-    addr_hit[ 87] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_38_OFFSET);
-    addr_hit[ 88] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_39_OFFSET);
-    addr_hit[ 89] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_40_OFFSET);
-    addr_hit[ 90] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_41_OFFSET);
-    addr_hit[ 91] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_42_OFFSET);
-    addr_hit[ 92] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_43_OFFSET);
-    addr_hit[ 93] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_44_OFFSET);
-    addr_hit[ 94] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_45_OFFSET);
-    addr_hit[ 95] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_46_OFFSET);
-    addr_hit[ 96] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_47_OFFSET);
-    addr_hit[ 97] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_48_OFFSET);
-    addr_hit[ 98] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_0_OFFSET);
-    addr_hit[ 99] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_1_OFFSET);
-    addr_hit[100] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_2_OFFSET);
-    addr_hit[101] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_3_OFFSET);
-    addr_hit[102] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_4_OFFSET);
-    addr_hit[103] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_5_OFFSET);
-    addr_hit[104] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_6_OFFSET);
-    addr_hit[105] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_7_OFFSET);
-    addr_hit[106] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_8_OFFSET);
-    addr_hit[107] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_9_OFFSET);
-    addr_hit[108] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_10_OFFSET);
-    addr_hit[109] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_11_OFFSET);
-    addr_hit[110] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_12_OFFSET);
-    addr_hit[111] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_13_OFFSET);
-    addr_hit[112] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_14_OFFSET);
-    addr_hit[113] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_15_OFFSET);
-    addr_hit[114] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_16_OFFSET);
-    addr_hit[115] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_17_OFFSET);
-    addr_hit[116] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_18_OFFSET);
-    addr_hit[117] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_19_OFFSET);
-    addr_hit[118] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_20_OFFSET);
-    addr_hit[119] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_21_OFFSET);
-    addr_hit[120] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_22_OFFSET);
-    addr_hit[121] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_23_OFFSET);
-    addr_hit[122] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_24_OFFSET);
-    addr_hit[123] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_25_OFFSET);
-    addr_hit[124] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_26_OFFSET);
-    addr_hit[125] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_27_OFFSET);
-    addr_hit[126] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_28_OFFSET);
-    addr_hit[127] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_29_OFFSET);
-    addr_hit[128] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_30_OFFSET);
-    addr_hit[129] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_31_OFFSET);
-    addr_hit[130] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_32_OFFSET);
-    addr_hit[131] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_33_OFFSET);
-    addr_hit[132] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_34_OFFSET);
-    addr_hit[133] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_35_OFFSET);
-    addr_hit[134] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_36_OFFSET);
-    addr_hit[135] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_37_OFFSET);
-    addr_hit[136] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_38_OFFSET);
-    addr_hit[137] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_39_OFFSET);
-    addr_hit[138] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_40_OFFSET);
-    addr_hit[139] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_41_OFFSET);
-    addr_hit[140] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_42_OFFSET);
-    addr_hit[141] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_43_OFFSET);
-    addr_hit[142] = (reg_addr == PINMUX_MIO_OUTSEL_0_OFFSET);
-    addr_hit[143] = (reg_addr == PINMUX_MIO_OUTSEL_1_OFFSET);
-    addr_hit[144] = (reg_addr == PINMUX_MIO_OUTSEL_2_OFFSET);
-    addr_hit[145] = (reg_addr == PINMUX_MIO_OUTSEL_3_OFFSET);
-    addr_hit[146] = (reg_addr == PINMUX_MIO_OUTSEL_4_OFFSET);
-    addr_hit[147] = (reg_addr == PINMUX_MIO_OUTSEL_5_OFFSET);
-    addr_hit[148] = (reg_addr == PINMUX_MIO_OUTSEL_6_OFFSET);
-    addr_hit[149] = (reg_addr == PINMUX_MIO_OUTSEL_7_OFFSET);
-    addr_hit[150] = (reg_addr == PINMUX_MIO_OUTSEL_8_OFFSET);
-    addr_hit[151] = (reg_addr == PINMUX_MIO_OUTSEL_9_OFFSET);
-    addr_hit[152] = (reg_addr == PINMUX_MIO_OUTSEL_10_OFFSET);
-    addr_hit[153] = (reg_addr == PINMUX_MIO_OUTSEL_11_OFFSET);
-    addr_hit[154] = (reg_addr == PINMUX_MIO_OUTSEL_12_OFFSET);
-    addr_hit[155] = (reg_addr == PINMUX_MIO_OUTSEL_13_OFFSET);
-    addr_hit[156] = (reg_addr == PINMUX_MIO_OUTSEL_14_OFFSET);
-    addr_hit[157] = (reg_addr == PINMUX_MIO_OUTSEL_15_OFFSET);
-    addr_hit[158] = (reg_addr == PINMUX_MIO_OUTSEL_16_OFFSET);
-    addr_hit[159] = (reg_addr == PINMUX_MIO_OUTSEL_17_OFFSET);
-    addr_hit[160] = (reg_addr == PINMUX_MIO_OUTSEL_18_OFFSET);
-    addr_hit[161] = (reg_addr == PINMUX_MIO_OUTSEL_19_OFFSET);
-    addr_hit[162] = (reg_addr == PINMUX_MIO_OUTSEL_20_OFFSET);
-    addr_hit[163] = (reg_addr == PINMUX_MIO_OUTSEL_21_OFFSET);
-    addr_hit[164] = (reg_addr == PINMUX_MIO_OUTSEL_22_OFFSET);
-    addr_hit[165] = (reg_addr == PINMUX_MIO_OUTSEL_23_OFFSET);
-    addr_hit[166] = (reg_addr == PINMUX_MIO_OUTSEL_24_OFFSET);
-    addr_hit[167] = (reg_addr == PINMUX_MIO_OUTSEL_25_OFFSET);
-    addr_hit[168] = (reg_addr == PINMUX_MIO_OUTSEL_26_OFFSET);
-    addr_hit[169] = (reg_addr == PINMUX_MIO_OUTSEL_27_OFFSET);
-    addr_hit[170] = (reg_addr == PINMUX_MIO_OUTSEL_28_OFFSET);
-    addr_hit[171] = (reg_addr == PINMUX_MIO_OUTSEL_29_OFFSET);
-    addr_hit[172] = (reg_addr == PINMUX_MIO_OUTSEL_30_OFFSET);
-    addr_hit[173] = (reg_addr == PINMUX_MIO_OUTSEL_31_OFFSET);
-    addr_hit[174] = (reg_addr == PINMUX_MIO_OUTSEL_32_OFFSET);
-    addr_hit[175] = (reg_addr == PINMUX_MIO_OUTSEL_33_OFFSET);
-    addr_hit[176] = (reg_addr == PINMUX_MIO_OUTSEL_34_OFFSET);
-    addr_hit[177] = (reg_addr == PINMUX_MIO_OUTSEL_35_OFFSET);
-    addr_hit[178] = (reg_addr == PINMUX_MIO_OUTSEL_36_OFFSET);
-    addr_hit[179] = (reg_addr == PINMUX_MIO_OUTSEL_37_OFFSET);
-    addr_hit[180] = (reg_addr == PINMUX_MIO_OUTSEL_38_OFFSET);
-    addr_hit[181] = (reg_addr == PINMUX_MIO_OUTSEL_39_OFFSET);
-    addr_hit[182] = (reg_addr == PINMUX_MIO_OUTSEL_40_OFFSET);
-    addr_hit[183] = (reg_addr == PINMUX_MIO_OUTSEL_41_OFFSET);
-    addr_hit[184] = (reg_addr == PINMUX_MIO_OUTSEL_42_OFFSET);
-    addr_hit[185] = (reg_addr == PINMUX_MIO_OUTSEL_43_OFFSET);
-    addr_hit[186] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_0_OFFSET);
-    addr_hit[187] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_1_OFFSET);
-    addr_hit[188] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_2_OFFSET);
-    addr_hit[189] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_3_OFFSET);
-    addr_hit[190] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_4_OFFSET);
-    addr_hit[191] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_5_OFFSET);
-    addr_hit[192] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_6_OFFSET);
-    addr_hit[193] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_7_OFFSET);
-    addr_hit[194] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_8_OFFSET);
-    addr_hit[195] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_9_OFFSET);
-    addr_hit[196] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_10_OFFSET);
-    addr_hit[197] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_11_OFFSET);
-    addr_hit[198] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_12_OFFSET);
-    addr_hit[199] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_13_OFFSET);
-    addr_hit[200] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_14_OFFSET);
-    addr_hit[201] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_15_OFFSET);
-    addr_hit[202] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_16_OFFSET);
-    addr_hit[203] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_17_OFFSET);
-    addr_hit[204] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_18_OFFSET);
-    addr_hit[205] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_19_OFFSET);
-    addr_hit[206] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_20_OFFSET);
-    addr_hit[207] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_21_OFFSET);
-    addr_hit[208] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_22_OFFSET);
-    addr_hit[209] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_23_OFFSET);
-    addr_hit[210] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_24_OFFSET);
-    addr_hit[211] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_25_OFFSET);
-    addr_hit[212] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_26_OFFSET);
-    addr_hit[213] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_27_OFFSET);
-    addr_hit[214] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_28_OFFSET);
-    addr_hit[215] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_29_OFFSET);
-    addr_hit[216] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_30_OFFSET);
-    addr_hit[217] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_31_OFFSET);
-    addr_hit[218] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_32_OFFSET);
-    addr_hit[219] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_33_OFFSET);
-    addr_hit[220] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_34_OFFSET);
-    addr_hit[221] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_35_OFFSET);
-    addr_hit[222] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_36_OFFSET);
-    addr_hit[223] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_37_OFFSET);
-    addr_hit[224] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_38_OFFSET);
-    addr_hit[225] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_39_OFFSET);
-    addr_hit[226] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_40_OFFSET);
-    addr_hit[227] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_41_OFFSET);
-    addr_hit[228] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_42_OFFSET);
-    addr_hit[229] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_43_OFFSET);
-    addr_hit[230] = (reg_addr == PINMUX_MIO_PAD_ATTR_0_OFFSET);
-    addr_hit[231] = (reg_addr == PINMUX_MIO_PAD_ATTR_1_OFFSET);
-    addr_hit[232] = (reg_addr == PINMUX_MIO_PAD_ATTR_2_OFFSET);
-    addr_hit[233] = (reg_addr == PINMUX_MIO_PAD_ATTR_3_OFFSET);
-    addr_hit[234] = (reg_addr == PINMUX_MIO_PAD_ATTR_4_OFFSET);
-    addr_hit[235] = (reg_addr == PINMUX_MIO_PAD_ATTR_5_OFFSET);
-    addr_hit[236] = (reg_addr == PINMUX_MIO_PAD_ATTR_6_OFFSET);
-    addr_hit[237] = (reg_addr == PINMUX_MIO_PAD_ATTR_7_OFFSET);
-    addr_hit[238] = (reg_addr == PINMUX_MIO_PAD_ATTR_8_OFFSET);
-    addr_hit[239] = (reg_addr == PINMUX_MIO_PAD_ATTR_9_OFFSET);
-    addr_hit[240] = (reg_addr == PINMUX_MIO_PAD_ATTR_10_OFFSET);
-    addr_hit[241] = (reg_addr == PINMUX_MIO_PAD_ATTR_11_OFFSET);
-    addr_hit[242] = (reg_addr == PINMUX_MIO_PAD_ATTR_12_OFFSET);
-    addr_hit[243] = (reg_addr == PINMUX_MIO_PAD_ATTR_13_OFFSET);
-    addr_hit[244] = (reg_addr == PINMUX_MIO_PAD_ATTR_14_OFFSET);
-    addr_hit[245] = (reg_addr == PINMUX_MIO_PAD_ATTR_15_OFFSET);
-    addr_hit[246] = (reg_addr == PINMUX_MIO_PAD_ATTR_16_OFFSET);
-    addr_hit[247] = (reg_addr == PINMUX_MIO_PAD_ATTR_17_OFFSET);
-    addr_hit[248] = (reg_addr == PINMUX_MIO_PAD_ATTR_18_OFFSET);
-    addr_hit[249] = (reg_addr == PINMUX_MIO_PAD_ATTR_19_OFFSET);
-    addr_hit[250] = (reg_addr == PINMUX_MIO_PAD_ATTR_20_OFFSET);
-    addr_hit[251] = (reg_addr == PINMUX_MIO_PAD_ATTR_21_OFFSET);
-    addr_hit[252] = (reg_addr == PINMUX_MIO_PAD_ATTR_22_OFFSET);
-    addr_hit[253] = (reg_addr == PINMUX_MIO_PAD_ATTR_23_OFFSET);
-    addr_hit[254] = (reg_addr == PINMUX_MIO_PAD_ATTR_24_OFFSET);
-    addr_hit[255] = (reg_addr == PINMUX_MIO_PAD_ATTR_25_OFFSET);
-    addr_hit[256] = (reg_addr == PINMUX_MIO_PAD_ATTR_26_OFFSET);
-    addr_hit[257] = (reg_addr == PINMUX_MIO_PAD_ATTR_27_OFFSET);
-    addr_hit[258] = (reg_addr == PINMUX_MIO_PAD_ATTR_28_OFFSET);
-    addr_hit[259] = (reg_addr == PINMUX_MIO_PAD_ATTR_29_OFFSET);
-    addr_hit[260] = (reg_addr == PINMUX_MIO_PAD_ATTR_30_OFFSET);
-    addr_hit[261] = (reg_addr == PINMUX_MIO_PAD_ATTR_31_OFFSET);
-    addr_hit[262] = (reg_addr == PINMUX_MIO_PAD_ATTR_32_OFFSET);
-    addr_hit[263] = (reg_addr == PINMUX_MIO_PAD_ATTR_33_OFFSET);
-    addr_hit[264] = (reg_addr == PINMUX_MIO_PAD_ATTR_34_OFFSET);
-    addr_hit[265] = (reg_addr == PINMUX_MIO_PAD_ATTR_35_OFFSET);
-    addr_hit[266] = (reg_addr == PINMUX_MIO_PAD_ATTR_36_OFFSET);
-    addr_hit[267] = (reg_addr == PINMUX_MIO_PAD_ATTR_37_OFFSET);
-    addr_hit[268] = (reg_addr == PINMUX_MIO_PAD_ATTR_38_OFFSET);
-    addr_hit[269] = (reg_addr == PINMUX_MIO_PAD_ATTR_39_OFFSET);
-    addr_hit[270] = (reg_addr == PINMUX_MIO_PAD_ATTR_40_OFFSET);
-    addr_hit[271] = (reg_addr == PINMUX_MIO_PAD_ATTR_41_OFFSET);
-    addr_hit[272] = (reg_addr == PINMUX_MIO_PAD_ATTR_42_OFFSET);
-    addr_hit[273] = (reg_addr == PINMUX_MIO_PAD_ATTR_43_OFFSET);
-    addr_hit[274] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_0_OFFSET);
-    addr_hit[275] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_1_OFFSET);
-    addr_hit[276] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_2_OFFSET);
-    addr_hit[277] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_3_OFFSET);
-    addr_hit[278] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_4_OFFSET);
-    addr_hit[279] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_5_OFFSET);
-    addr_hit[280] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_6_OFFSET);
-    addr_hit[281] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_7_OFFSET);
-    addr_hit[282] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_8_OFFSET);
-    addr_hit[283] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_9_OFFSET);
-    addr_hit[284] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_10_OFFSET);
-    addr_hit[285] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_11_OFFSET);
-    addr_hit[286] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_12_OFFSET);
-    addr_hit[287] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_13_OFFSET);
-    addr_hit[288] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_14_OFFSET);
-    addr_hit[289] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_15_OFFSET);
-    addr_hit[290] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_16_OFFSET);
-    addr_hit[291] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_17_OFFSET);
-    addr_hit[292] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_18_OFFSET);
-    addr_hit[293] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_19_OFFSET);
-    addr_hit[294] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_20_OFFSET);
-    addr_hit[295] = (reg_addr == PINMUX_DIO_PAD_ATTR_0_OFFSET);
-    addr_hit[296] = (reg_addr == PINMUX_DIO_PAD_ATTR_1_OFFSET);
-    addr_hit[297] = (reg_addr == PINMUX_DIO_PAD_ATTR_2_OFFSET);
-    addr_hit[298] = (reg_addr == PINMUX_DIO_PAD_ATTR_3_OFFSET);
-    addr_hit[299] = (reg_addr == PINMUX_DIO_PAD_ATTR_4_OFFSET);
-    addr_hit[300] = (reg_addr == PINMUX_DIO_PAD_ATTR_5_OFFSET);
-    addr_hit[301] = (reg_addr == PINMUX_DIO_PAD_ATTR_6_OFFSET);
-    addr_hit[302] = (reg_addr == PINMUX_DIO_PAD_ATTR_7_OFFSET);
-    addr_hit[303] = (reg_addr == PINMUX_DIO_PAD_ATTR_8_OFFSET);
-    addr_hit[304] = (reg_addr == PINMUX_DIO_PAD_ATTR_9_OFFSET);
-    addr_hit[305] = (reg_addr == PINMUX_DIO_PAD_ATTR_10_OFFSET);
-    addr_hit[306] = (reg_addr == PINMUX_DIO_PAD_ATTR_11_OFFSET);
-    addr_hit[307] = (reg_addr == PINMUX_DIO_PAD_ATTR_12_OFFSET);
-    addr_hit[308] = (reg_addr == PINMUX_DIO_PAD_ATTR_13_OFFSET);
-    addr_hit[309] = (reg_addr == PINMUX_DIO_PAD_ATTR_14_OFFSET);
-    addr_hit[310] = (reg_addr == PINMUX_DIO_PAD_ATTR_15_OFFSET);
-    addr_hit[311] = (reg_addr == PINMUX_DIO_PAD_ATTR_16_OFFSET);
-    addr_hit[312] = (reg_addr == PINMUX_DIO_PAD_ATTR_17_OFFSET);
-    addr_hit[313] = (reg_addr == PINMUX_DIO_PAD_ATTR_18_OFFSET);
-    addr_hit[314] = (reg_addr == PINMUX_DIO_PAD_ATTR_19_OFFSET);
-    addr_hit[315] = (reg_addr == PINMUX_DIO_PAD_ATTR_20_OFFSET);
-    addr_hit[316] = (reg_addr == PINMUX_MIO_PAD_SLEEP_STATUS_0_OFFSET);
-    addr_hit[317] = (reg_addr == PINMUX_MIO_PAD_SLEEP_STATUS_1_OFFSET);
-    addr_hit[318] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_0_OFFSET);
-    addr_hit[319] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_1_OFFSET);
-    addr_hit[320] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_2_OFFSET);
-    addr_hit[321] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_3_OFFSET);
-    addr_hit[322] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_4_OFFSET);
-    addr_hit[323] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_5_OFFSET);
-    addr_hit[324] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_6_OFFSET);
-    addr_hit[325] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_7_OFFSET);
-    addr_hit[326] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_8_OFFSET);
-    addr_hit[327] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_9_OFFSET);
-    addr_hit[328] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_10_OFFSET);
-    addr_hit[329] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_11_OFFSET);
-    addr_hit[330] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_12_OFFSET);
-    addr_hit[331] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_13_OFFSET);
-    addr_hit[332] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_14_OFFSET);
-    addr_hit[333] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_15_OFFSET);
-    addr_hit[334] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_16_OFFSET);
-    addr_hit[335] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_17_OFFSET);
-    addr_hit[336] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_18_OFFSET);
-    addr_hit[337] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_19_OFFSET);
-    addr_hit[338] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_20_OFFSET);
-    addr_hit[339] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_21_OFFSET);
-    addr_hit[340] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_22_OFFSET);
-    addr_hit[341] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_23_OFFSET);
-    addr_hit[342] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_24_OFFSET);
-    addr_hit[343] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_25_OFFSET);
-    addr_hit[344] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_26_OFFSET);
-    addr_hit[345] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_27_OFFSET);
-    addr_hit[346] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_28_OFFSET);
-    addr_hit[347] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_29_OFFSET);
-    addr_hit[348] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_30_OFFSET);
-    addr_hit[349] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_31_OFFSET);
-    addr_hit[350] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_32_OFFSET);
-    addr_hit[351] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_33_OFFSET);
-    addr_hit[352] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_34_OFFSET);
-    addr_hit[353] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_35_OFFSET);
-    addr_hit[354] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_36_OFFSET);
-    addr_hit[355] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_37_OFFSET);
-    addr_hit[356] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_38_OFFSET);
-    addr_hit[357] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_39_OFFSET);
-    addr_hit[358] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_40_OFFSET);
-    addr_hit[359] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_41_OFFSET);
-    addr_hit[360] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_42_OFFSET);
-    addr_hit[361] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_43_OFFSET);
-    addr_hit[362] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_0_OFFSET);
-    addr_hit[363] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_1_OFFSET);
-    addr_hit[364] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_2_OFFSET);
-    addr_hit[365] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_3_OFFSET);
-    addr_hit[366] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_4_OFFSET);
-    addr_hit[367] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_5_OFFSET);
-    addr_hit[368] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_6_OFFSET);
-    addr_hit[369] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_7_OFFSET);
-    addr_hit[370] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_8_OFFSET);
-    addr_hit[371] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_9_OFFSET);
-    addr_hit[372] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_10_OFFSET);
-    addr_hit[373] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_11_OFFSET);
-    addr_hit[374] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_12_OFFSET);
-    addr_hit[375] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_13_OFFSET);
-    addr_hit[376] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_14_OFFSET);
-    addr_hit[377] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_15_OFFSET);
-    addr_hit[378] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_16_OFFSET);
-    addr_hit[379] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_17_OFFSET);
-    addr_hit[380] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_18_OFFSET);
-    addr_hit[381] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_19_OFFSET);
-    addr_hit[382] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_20_OFFSET);
-    addr_hit[383] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_21_OFFSET);
-    addr_hit[384] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_22_OFFSET);
-    addr_hit[385] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_23_OFFSET);
-    addr_hit[386] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_24_OFFSET);
-    addr_hit[387] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_25_OFFSET);
-    addr_hit[388] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_26_OFFSET);
-    addr_hit[389] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_27_OFFSET);
-    addr_hit[390] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_28_OFFSET);
-    addr_hit[391] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_29_OFFSET);
-    addr_hit[392] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_30_OFFSET);
-    addr_hit[393] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_31_OFFSET);
-    addr_hit[394] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_32_OFFSET);
-    addr_hit[395] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_33_OFFSET);
-    addr_hit[396] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_34_OFFSET);
-    addr_hit[397] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_35_OFFSET);
-    addr_hit[398] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_36_OFFSET);
-    addr_hit[399] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_37_OFFSET);
-    addr_hit[400] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_38_OFFSET);
-    addr_hit[401] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_39_OFFSET);
-    addr_hit[402] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_40_OFFSET);
-    addr_hit[403] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_41_OFFSET);
-    addr_hit[404] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_42_OFFSET);
-    addr_hit[405] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_43_OFFSET);
-    addr_hit[406] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_0_OFFSET);
-    addr_hit[407] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_1_OFFSET);
-    addr_hit[408] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_2_OFFSET);
-    addr_hit[409] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_3_OFFSET);
-    addr_hit[410] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_4_OFFSET);
-    addr_hit[411] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_5_OFFSET);
-    addr_hit[412] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_6_OFFSET);
-    addr_hit[413] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_7_OFFSET);
-    addr_hit[414] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_8_OFFSET);
-    addr_hit[415] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_9_OFFSET);
-    addr_hit[416] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_10_OFFSET);
-    addr_hit[417] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_11_OFFSET);
-    addr_hit[418] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_12_OFFSET);
-    addr_hit[419] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_13_OFFSET);
-    addr_hit[420] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_14_OFFSET);
-    addr_hit[421] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_15_OFFSET);
-    addr_hit[422] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_16_OFFSET);
-    addr_hit[423] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_17_OFFSET);
-    addr_hit[424] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_18_OFFSET);
-    addr_hit[425] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_19_OFFSET);
-    addr_hit[426] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_20_OFFSET);
-    addr_hit[427] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_21_OFFSET);
-    addr_hit[428] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_22_OFFSET);
-    addr_hit[429] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_23_OFFSET);
-    addr_hit[430] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_24_OFFSET);
-    addr_hit[431] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_25_OFFSET);
-    addr_hit[432] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_26_OFFSET);
-    addr_hit[433] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_27_OFFSET);
-    addr_hit[434] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_28_OFFSET);
-    addr_hit[435] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_29_OFFSET);
-    addr_hit[436] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_30_OFFSET);
-    addr_hit[437] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_31_OFFSET);
-    addr_hit[438] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_32_OFFSET);
-    addr_hit[439] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_33_OFFSET);
-    addr_hit[440] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_34_OFFSET);
-    addr_hit[441] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_35_OFFSET);
-    addr_hit[442] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_36_OFFSET);
-    addr_hit[443] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_37_OFFSET);
-    addr_hit[444] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_38_OFFSET);
-    addr_hit[445] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_39_OFFSET);
-    addr_hit[446] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_40_OFFSET);
-    addr_hit[447] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_41_OFFSET);
-    addr_hit[448] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_42_OFFSET);
-    addr_hit[449] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_43_OFFSET);
-    addr_hit[450] = (reg_addr == PINMUX_DIO_PAD_SLEEP_STATUS_OFFSET);
-    addr_hit[451] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_0_OFFSET);
-    addr_hit[452] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_1_OFFSET);
-    addr_hit[453] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_2_OFFSET);
-    addr_hit[454] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_3_OFFSET);
-    addr_hit[455] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_4_OFFSET);
-    addr_hit[456] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_5_OFFSET);
-    addr_hit[457] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_6_OFFSET);
-    addr_hit[458] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_7_OFFSET);
-    addr_hit[459] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_8_OFFSET);
-    addr_hit[460] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_9_OFFSET);
-    addr_hit[461] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_10_OFFSET);
-    addr_hit[462] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_11_OFFSET);
-    addr_hit[463] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_12_OFFSET);
-    addr_hit[464] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_13_OFFSET);
-    addr_hit[465] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_14_OFFSET);
-    addr_hit[466] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_15_OFFSET);
-    addr_hit[467] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_16_OFFSET);
-    addr_hit[468] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_17_OFFSET);
-    addr_hit[469] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_18_OFFSET);
-    addr_hit[470] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_19_OFFSET);
-    addr_hit[471] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_20_OFFSET);
-    addr_hit[472] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_0_OFFSET);
-    addr_hit[473] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_1_OFFSET);
-    addr_hit[474] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_2_OFFSET);
-    addr_hit[475] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_3_OFFSET);
-    addr_hit[476] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_4_OFFSET);
-    addr_hit[477] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_5_OFFSET);
-    addr_hit[478] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_6_OFFSET);
-    addr_hit[479] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_7_OFFSET);
-    addr_hit[480] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_8_OFFSET);
-    addr_hit[481] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_9_OFFSET);
-    addr_hit[482] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_10_OFFSET);
-    addr_hit[483] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_11_OFFSET);
-    addr_hit[484] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_12_OFFSET);
-    addr_hit[485] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_13_OFFSET);
-    addr_hit[486] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_14_OFFSET);
-    addr_hit[487] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_15_OFFSET);
-    addr_hit[488] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_16_OFFSET);
-    addr_hit[489] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_17_OFFSET);
-    addr_hit[490] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_18_OFFSET);
-    addr_hit[491] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_19_OFFSET);
-    addr_hit[492] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_20_OFFSET);
-    addr_hit[493] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_0_OFFSET);
-    addr_hit[494] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_1_OFFSET);
-    addr_hit[495] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_2_OFFSET);
-    addr_hit[496] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_3_OFFSET);
-    addr_hit[497] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_4_OFFSET);
-    addr_hit[498] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_5_OFFSET);
-    addr_hit[499] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_6_OFFSET);
-    addr_hit[500] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_7_OFFSET);
-    addr_hit[501] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_8_OFFSET);
-    addr_hit[502] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_9_OFFSET);
-    addr_hit[503] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_10_OFFSET);
-    addr_hit[504] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_11_OFFSET);
-    addr_hit[505] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_12_OFFSET);
-    addr_hit[506] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_13_OFFSET);
-    addr_hit[507] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_14_OFFSET);
-    addr_hit[508] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_15_OFFSET);
-    addr_hit[509] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_16_OFFSET);
-    addr_hit[510] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_17_OFFSET);
-    addr_hit[511] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_18_OFFSET);
-    addr_hit[512] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_19_OFFSET);
-    addr_hit[513] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_20_OFFSET);
-    addr_hit[514] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_0_OFFSET);
-    addr_hit[515] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_1_OFFSET);
-    addr_hit[516] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_2_OFFSET);
-    addr_hit[517] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_3_OFFSET);
-    addr_hit[518] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_4_OFFSET);
-    addr_hit[519] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_5_OFFSET);
-    addr_hit[520] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_6_OFFSET);
-    addr_hit[521] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_7_OFFSET);
-    addr_hit[522] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_0_OFFSET);
-    addr_hit[523] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_1_OFFSET);
-    addr_hit[524] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_2_OFFSET);
-    addr_hit[525] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_3_OFFSET);
-    addr_hit[526] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_4_OFFSET);
-    addr_hit[527] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_5_OFFSET);
-    addr_hit[528] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_6_OFFSET);
-    addr_hit[529] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_7_OFFSET);
-    addr_hit[530] = (reg_addr == PINMUX_WKUP_DETECTOR_0_OFFSET);
-    addr_hit[531] = (reg_addr == PINMUX_WKUP_DETECTOR_1_OFFSET);
-    addr_hit[532] = (reg_addr == PINMUX_WKUP_DETECTOR_2_OFFSET);
-    addr_hit[533] = (reg_addr == PINMUX_WKUP_DETECTOR_3_OFFSET);
-    addr_hit[534] = (reg_addr == PINMUX_WKUP_DETECTOR_4_OFFSET);
-    addr_hit[535] = (reg_addr == PINMUX_WKUP_DETECTOR_5_OFFSET);
-    addr_hit[536] = (reg_addr == PINMUX_WKUP_DETECTOR_6_OFFSET);
-    addr_hit[537] = (reg_addr == PINMUX_WKUP_DETECTOR_7_OFFSET);
-    addr_hit[538] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_0_OFFSET);
-    addr_hit[539] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_1_OFFSET);
-    addr_hit[540] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_2_OFFSET);
-    addr_hit[541] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_3_OFFSET);
-    addr_hit[542] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_4_OFFSET);
-    addr_hit[543] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_5_OFFSET);
-    addr_hit[544] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_6_OFFSET);
-    addr_hit[545] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_7_OFFSET);
-    addr_hit[546] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_0_OFFSET);
-    addr_hit[547] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_1_OFFSET);
-    addr_hit[548] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_2_OFFSET);
-    addr_hit[549] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_3_OFFSET);
-    addr_hit[550] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_4_OFFSET);
-    addr_hit[551] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_5_OFFSET);
-    addr_hit[552] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_6_OFFSET);
-    addr_hit[553] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_7_OFFSET);
-    addr_hit[554] = (reg_addr == PINMUX_WKUP_CAUSE_OFFSET);
+    addr_hit[ 49] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_49_OFFSET);
+    addr_hit[ 50] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_50_OFFSET);
+    addr_hit[ 51] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_51_OFFSET);
+    addr_hit[ 52] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_52_OFFSET);
+    addr_hit[ 53] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_53_OFFSET);
+    addr_hit[ 54] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_54_OFFSET);
+    addr_hit[ 55] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_55_OFFSET);
+    addr_hit[ 56] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_56_OFFSET);
+    addr_hit[ 57] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_57_OFFSET);
+    addr_hit[ 58] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_58_OFFSET);
+    addr_hit[ 59] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_0_OFFSET);
+    addr_hit[ 60] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_1_OFFSET);
+    addr_hit[ 61] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_2_OFFSET);
+    addr_hit[ 62] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_3_OFFSET);
+    addr_hit[ 63] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_4_OFFSET);
+    addr_hit[ 64] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_5_OFFSET);
+    addr_hit[ 65] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_6_OFFSET);
+    addr_hit[ 66] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_7_OFFSET);
+    addr_hit[ 67] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_8_OFFSET);
+    addr_hit[ 68] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_9_OFFSET);
+    addr_hit[ 69] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_10_OFFSET);
+    addr_hit[ 70] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_11_OFFSET);
+    addr_hit[ 71] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_12_OFFSET);
+    addr_hit[ 72] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_13_OFFSET);
+    addr_hit[ 73] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_14_OFFSET);
+    addr_hit[ 74] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_15_OFFSET);
+    addr_hit[ 75] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_16_OFFSET);
+    addr_hit[ 76] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_17_OFFSET);
+    addr_hit[ 77] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_18_OFFSET);
+    addr_hit[ 78] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_19_OFFSET);
+    addr_hit[ 79] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_20_OFFSET);
+    addr_hit[ 80] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_21_OFFSET);
+    addr_hit[ 81] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_22_OFFSET);
+    addr_hit[ 82] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_23_OFFSET);
+    addr_hit[ 83] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_24_OFFSET);
+    addr_hit[ 84] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_25_OFFSET);
+    addr_hit[ 85] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_26_OFFSET);
+    addr_hit[ 86] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_27_OFFSET);
+    addr_hit[ 87] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_28_OFFSET);
+    addr_hit[ 88] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_29_OFFSET);
+    addr_hit[ 89] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_30_OFFSET);
+    addr_hit[ 90] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_31_OFFSET);
+    addr_hit[ 91] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_32_OFFSET);
+    addr_hit[ 92] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_33_OFFSET);
+    addr_hit[ 93] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_34_OFFSET);
+    addr_hit[ 94] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_35_OFFSET);
+    addr_hit[ 95] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_36_OFFSET);
+    addr_hit[ 96] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_37_OFFSET);
+    addr_hit[ 97] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_38_OFFSET);
+    addr_hit[ 98] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_39_OFFSET);
+    addr_hit[ 99] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_40_OFFSET);
+    addr_hit[100] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_41_OFFSET);
+    addr_hit[101] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_42_OFFSET);
+    addr_hit[102] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_43_OFFSET);
+    addr_hit[103] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_44_OFFSET);
+    addr_hit[104] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_45_OFFSET);
+    addr_hit[105] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_46_OFFSET);
+    addr_hit[106] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_47_OFFSET);
+    addr_hit[107] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_48_OFFSET);
+    addr_hit[108] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_49_OFFSET);
+    addr_hit[109] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_50_OFFSET);
+    addr_hit[110] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_51_OFFSET);
+    addr_hit[111] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_52_OFFSET);
+    addr_hit[112] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_53_OFFSET);
+    addr_hit[113] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_54_OFFSET);
+    addr_hit[114] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_55_OFFSET);
+    addr_hit[115] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_56_OFFSET);
+    addr_hit[116] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_57_OFFSET);
+    addr_hit[117] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_58_OFFSET);
+    addr_hit[118] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_0_OFFSET);
+    addr_hit[119] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_1_OFFSET);
+    addr_hit[120] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_2_OFFSET);
+    addr_hit[121] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_3_OFFSET);
+    addr_hit[122] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_4_OFFSET);
+    addr_hit[123] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_5_OFFSET);
+    addr_hit[124] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_6_OFFSET);
+    addr_hit[125] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_7_OFFSET);
+    addr_hit[126] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_8_OFFSET);
+    addr_hit[127] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_9_OFFSET);
+    addr_hit[128] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_10_OFFSET);
+    addr_hit[129] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_11_OFFSET);
+    addr_hit[130] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_12_OFFSET);
+    addr_hit[131] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_13_OFFSET);
+    addr_hit[132] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_14_OFFSET);
+    addr_hit[133] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_15_OFFSET);
+    addr_hit[134] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_16_OFFSET);
+    addr_hit[135] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_17_OFFSET);
+    addr_hit[136] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_18_OFFSET);
+    addr_hit[137] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_19_OFFSET);
+    addr_hit[138] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_20_OFFSET);
+    addr_hit[139] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_21_OFFSET);
+    addr_hit[140] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_22_OFFSET);
+    addr_hit[141] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_23_OFFSET);
+    addr_hit[142] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_24_OFFSET);
+    addr_hit[143] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_25_OFFSET);
+    addr_hit[144] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_26_OFFSET);
+    addr_hit[145] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_27_OFFSET);
+    addr_hit[146] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_28_OFFSET);
+    addr_hit[147] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_29_OFFSET);
+    addr_hit[148] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_30_OFFSET);
+    addr_hit[149] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_31_OFFSET);
+    addr_hit[150] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_32_OFFSET);
+    addr_hit[151] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_33_OFFSET);
+    addr_hit[152] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_34_OFFSET);
+    addr_hit[153] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_35_OFFSET);
+    addr_hit[154] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_36_OFFSET);
+    addr_hit[155] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_37_OFFSET);
+    addr_hit[156] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_38_OFFSET);
+    addr_hit[157] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_39_OFFSET);
+    addr_hit[158] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_40_OFFSET);
+    addr_hit[159] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_41_OFFSET);
+    addr_hit[160] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_42_OFFSET);
+    addr_hit[161] = (reg_addr == PINMUX_MIO_OUTSEL_REGWEN_43_OFFSET);
+    addr_hit[162] = (reg_addr == PINMUX_MIO_OUTSEL_0_OFFSET);
+    addr_hit[163] = (reg_addr == PINMUX_MIO_OUTSEL_1_OFFSET);
+    addr_hit[164] = (reg_addr == PINMUX_MIO_OUTSEL_2_OFFSET);
+    addr_hit[165] = (reg_addr == PINMUX_MIO_OUTSEL_3_OFFSET);
+    addr_hit[166] = (reg_addr == PINMUX_MIO_OUTSEL_4_OFFSET);
+    addr_hit[167] = (reg_addr == PINMUX_MIO_OUTSEL_5_OFFSET);
+    addr_hit[168] = (reg_addr == PINMUX_MIO_OUTSEL_6_OFFSET);
+    addr_hit[169] = (reg_addr == PINMUX_MIO_OUTSEL_7_OFFSET);
+    addr_hit[170] = (reg_addr == PINMUX_MIO_OUTSEL_8_OFFSET);
+    addr_hit[171] = (reg_addr == PINMUX_MIO_OUTSEL_9_OFFSET);
+    addr_hit[172] = (reg_addr == PINMUX_MIO_OUTSEL_10_OFFSET);
+    addr_hit[173] = (reg_addr == PINMUX_MIO_OUTSEL_11_OFFSET);
+    addr_hit[174] = (reg_addr == PINMUX_MIO_OUTSEL_12_OFFSET);
+    addr_hit[175] = (reg_addr == PINMUX_MIO_OUTSEL_13_OFFSET);
+    addr_hit[176] = (reg_addr == PINMUX_MIO_OUTSEL_14_OFFSET);
+    addr_hit[177] = (reg_addr == PINMUX_MIO_OUTSEL_15_OFFSET);
+    addr_hit[178] = (reg_addr == PINMUX_MIO_OUTSEL_16_OFFSET);
+    addr_hit[179] = (reg_addr == PINMUX_MIO_OUTSEL_17_OFFSET);
+    addr_hit[180] = (reg_addr == PINMUX_MIO_OUTSEL_18_OFFSET);
+    addr_hit[181] = (reg_addr == PINMUX_MIO_OUTSEL_19_OFFSET);
+    addr_hit[182] = (reg_addr == PINMUX_MIO_OUTSEL_20_OFFSET);
+    addr_hit[183] = (reg_addr == PINMUX_MIO_OUTSEL_21_OFFSET);
+    addr_hit[184] = (reg_addr == PINMUX_MIO_OUTSEL_22_OFFSET);
+    addr_hit[185] = (reg_addr == PINMUX_MIO_OUTSEL_23_OFFSET);
+    addr_hit[186] = (reg_addr == PINMUX_MIO_OUTSEL_24_OFFSET);
+    addr_hit[187] = (reg_addr == PINMUX_MIO_OUTSEL_25_OFFSET);
+    addr_hit[188] = (reg_addr == PINMUX_MIO_OUTSEL_26_OFFSET);
+    addr_hit[189] = (reg_addr == PINMUX_MIO_OUTSEL_27_OFFSET);
+    addr_hit[190] = (reg_addr == PINMUX_MIO_OUTSEL_28_OFFSET);
+    addr_hit[191] = (reg_addr == PINMUX_MIO_OUTSEL_29_OFFSET);
+    addr_hit[192] = (reg_addr == PINMUX_MIO_OUTSEL_30_OFFSET);
+    addr_hit[193] = (reg_addr == PINMUX_MIO_OUTSEL_31_OFFSET);
+    addr_hit[194] = (reg_addr == PINMUX_MIO_OUTSEL_32_OFFSET);
+    addr_hit[195] = (reg_addr == PINMUX_MIO_OUTSEL_33_OFFSET);
+    addr_hit[196] = (reg_addr == PINMUX_MIO_OUTSEL_34_OFFSET);
+    addr_hit[197] = (reg_addr == PINMUX_MIO_OUTSEL_35_OFFSET);
+    addr_hit[198] = (reg_addr == PINMUX_MIO_OUTSEL_36_OFFSET);
+    addr_hit[199] = (reg_addr == PINMUX_MIO_OUTSEL_37_OFFSET);
+    addr_hit[200] = (reg_addr == PINMUX_MIO_OUTSEL_38_OFFSET);
+    addr_hit[201] = (reg_addr == PINMUX_MIO_OUTSEL_39_OFFSET);
+    addr_hit[202] = (reg_addr == PINMUX_MIO_OUTSEL_40_OFFSET);
+    addr_hit[203] = (reg_addr == PINMUX_MIO_OUTSEL_41_OFFSET);
+    addr_hit[204] = (reg_addr == PINMUX_MIO_OUTSEL_42_OFFSET);
+    addr_hit[205] = (reg_addr == PINMUX_MIO_OUTSEL_43_OFFSET);
+    addr_hit[206] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_0_OFFSET);
+    addr_hit[207] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_1_OFFSET);
+    addr_hit[208] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_2_OFFSET);
+    addr_hit[209] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_3_OFFSET);
+    addr_hit[210] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_4_OFFSET);
+    addr_hit[211] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_5_OFFSET);
+    addr_hit[212] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_6_OFFSET);
+    addr_hit[213] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_7_OFFSET);
+    addr_hit[214] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_8_OFFSET);
+    addr_hit[215] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_9_OFFSET);
+    addr_hit[216] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_10_OFFSET);
+    addr_hit[217] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_11_OFFSET);
+    addr_hit[218] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_12_OFFSET);
+    addr_hit[219] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_13_OFFSET);
+    addr_hit[220] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_14_OFFSET);
+    addr_hit[221] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_15_OFFSET);
+    addr_hit[222] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_16_OFFSET);
+    addr_hit[223] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_17_OFFSET);
+    addr_hit[224] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_18_OFFSET);
+    addr_hit[225] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_19_OFFSET);
+    addr_hit[226] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_20_OFFSET);
+    addr_hit[227] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_21_OFFSET);
+    addr_hit[228] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_22_OFFSET);
+    addr_hit[229] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_23_OFFSET);
+    addr_hit[230] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_24_OFFSET);
+    addr_hit[231] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_25_OFFSET);
+    addr_hit[232] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_26_OFFSET);
+    addr_hit[233] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_27_OFFSET);
+    addr_hit[234] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_28_OFFSET);
+    addr_hit[235] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_29_OFFSET);
+    addr_hit[236] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_30_OFFSET);
+    addr_hit[237] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_31_OFFSET);
+    addr_hit[238] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_32_OFFSET);
+    addr_hit[239] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_33_OFFSET);
+    addr_hit[240] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_34_OFFSET);
+    addr_hit[241] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_35_OFFSET);
+    addr_hit[242] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_36_OFFSET);
+    addr_hit[243] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_37_OFFSET);
+    addr_hit[244] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_38_OFFSET);
+    addr_hit[245] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_39_OFFSET);
+    addr_hit[246] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_40_OFFSET);
+    addr_hit[247] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_41_OFFSET);
+    addr_hit[248] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_42_OFFSET);
+    addr_hit[249] = (reg_addr == PINMUX_MIO_PAD_ATTR_REGWEN_43_OFFSET);
+    addr_hit[250] = (reg_addr == PINMUX_MIO_PAD_ATTR_0_OFFSET);
+    addr_hit[251] = (reg_addr == PINMUX_MIO_PAD_ATTR_1_OFFSET);
+    addr_hit[252] = (reg_addr == PINMUX_MIO_PAD_ATTR_2_OFFSET);
+    addr_hit[253] = (reg_addr == PINMUX_MIO_PAD_ATTR_3_OFFSET);
+    addr_hit[254] = (reg_addr == PINMUX_MIO_PAD_ATTR_4_OFFSET);
+    addr_hit[255] = (reg_addr == PINMUX_MIO_PAD_ATTR_5_OFFSET);
+    addr_hit[256] = (reg_addr == PINMUX_MIO_PAD_ATTR_6_OFFSET);
+    addr_hit[257] = (reg_addr == PINMUX_MIO_PAD_ATTR_7_OFFSET);
+    addr_hit[258] = (reg_addr == PINMUX_MIO_PAD_ATTR_8_OFFSET);
+    addr_hit[259] = (reg_addr == PINMUX_MIO_PAD_ATTR_9_OFFSET);
+    addr_hit[260] = (reg_addr == PINMUX_MIO_PAD_ATTR_10_OFFSET);
+    addr_hit[261] = (reg_addr == PINMUX_MIO_PAD_ATTR_11_OFFSET);
+    addr_hit[262] = (reg_addr == PINMUX_MIO_PAD_ATTR_12_OFFSET);
+    addr_hit[263] = (reg_addr == PINMUX_MIO_PAD_ATTR_13_OFFSET);
+    addr_hit[264] = (reg_addr == PINMUX_MIO_PAD_ATTR_14_OFFSET);
+    addr_hit[265] = (reg_addr == PINMUX_MIO_PAD_ATTR_15_OFFSET);
+    addr_hit[266] = (reg_addr == PINMUX_MIO_PAD_ATTR_16_OFFSET);
+    addr_hit[267] = (reg_addr == PINMUX_MIO_PAD_ATTR_17_OFFSET);
+    addr_hit[268] = (reg_addr == PINMUX_MIO_PAD_ATTR_18_OFFSET);
+    addr_hit[269] = (reg_addr == PINMUX_MIO_PAD_ATTR_19_OFFSET);
+    addr_hit[270] = (reg_addr == PINMUX_MIO_PAD_ATTR_20_OFFSET);
+    addr_hit[271] = (reg_addr == PINMUX_MIO_PAD_ATTR_21_OFFSET);
+    addr_hit[272] = (reg_addr == PINMUX_MIO_PAD_ATTR_22_OFFSET);
+    addr_hit[273] = (reg_addr == PINMUX_MIO_PAD_ATTR_23_OFFSET);
+    addr_hit[274] = (reg_addr == PINMUX_MIO_PAD_ATTR_24_OFFSET);
+    addr_hit[275] = (reg_addr == PINMUX_MIO_PAD_ATTR_25_OFFSET);
+    addr_hit[276] = (reg_addr == PINMUX_MIO_PAD_ATTR_26_OFFSET);
+    addr_hit[277] = (reg_addr == PINMUX_MIO_PAD_ATTR_27_OFFSET);
+    addr_hit[278] = (reg_addr == PINMUX_MIO_PAD_ATTR_28_OFFSET);
+    addr_hit[279] = (reg_addr == PINMUX_MIO_PAD_ATTR_29_OFFSET);
+    addr_hit[280] = (reg_addr == PINMUX_MIO_PAD_ATTR_30_OFFSET);
+    addr_hit[281] = (reg_addr == PINMUX_MIO_PAD_ATTR_31_OFFSET);
+    addr_hit[282] = (reg_addr == PINMUX_MIO_PAD_ATTR_32_OFFSET);
+    addr_hit[283] = (reg_addr == PINMUX_MIO_PAD_ATTR_33_OFFSET);
+    addr_hit[284] = (reg_addr == PINMUX_MIO_PAD_ATTR_34_OFFSET);
+    addr_hit[285] = (reg_addr == PINMUX_MIO_PAD_ATTR_35_OFFSET);
+    addr_hit[286] = (reg_addr == PINMUX_MIO_PAD_ATTR_36_OFFSET);
+    addr_hit[287] = (reg_addr == PINMUX_MIO_PAD_ATTR_37_OFFSET);
+    addr_hit[288] = (reg_addr == PINMUX_MIO_PAD_ATTR_38_OFFSET);
+    addr_hit[289] = (reg_addr == PINMUX_MIO_PAD_ATTR_39_OFFSET);
+    addr_hit[290] = (reg_addr == PINMUX_MIO_PAD_ATTR_40_OFFSET);
+    addr_hit[291] = (reg_addr == PINMUX_MIO_PAD_ATTR_41_OFFSET);
+    addr_hit[292] = (reg_addr == PINMUX_MIO_PAD_ATTR_42_OFFSET);
+    addr_hit[293] = (reg_addr == PINMUX_MIO_PAD_ATTR_43_OFFSET);
+    addr_hit[294] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_0_OFFSET);
+    addr_hit[295] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_1_OFFSET);
+    addr_hit[296] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_2_OFFSET);
+    addr_hit[297] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_3_OFFSET);
+    addr_hit[298] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_4_OFFSET);
+    addr_hit[299] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_5_OFFSET);
+    addr_hit[300] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_6_OFFSET);
+    addr_hit[301] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_7_OFFSET);
+    addr_hit[302] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_8_OFFSET);
+    addr_hit[303] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_9_OFFSET);
+    addr_hit[304] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_10_OFFSET);
+    addr_hit[305] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_11_OFFSET);
+    addr_hit[306] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_12_OFFSET);
+    addr_hit[307] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_13_OFFSET);
+    addr_hit[308] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_14_OFFSET);
+    addr_hit[309] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_15_OFFSET);
+    addr_hit[310] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_16_OFFSET);
+    addr_hit[311] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_17_OFFSET);
+    addr_hit[312] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_18_OFFSET);
+    addr_hit[313] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_19_OFFSET);
+    addr_hit[314] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_20_OFFSET);
+    addr_hit[315] = (reg_addr == PINMUX_DIO_PAD_ATTR_0_OFFSET);
+    addr_hit[316] = (reg_addr == PINMUX_DIO_PAD_ATTR_1_OFFSET);
+    addr_hit[317] = (reg_addr == PINMUX_DIO_PAD_ATTR_2_OFFSET);
+    addr_hit[318] = (reg_addr == PINMUX_DIO_PAD_ATTR_3_OFFSET);
+    addr_hit[319] = (reg_addr == PINMUX_DIO_PAD_ATTR_4_OFFSET);
+    addr_hit[320] = (reg_addr == PINMUX_DIO_PAD_ATTR_5_OFFSET);
+    addr_hit[321] = (reg_addr == PINMUX_DIO_PAD_ATTR_6_OFFSET);
+    addr_hit[322] = (reg_addr == PINMUX_DIO_PAD_ATTR_7_OFFSET);
+    addr_hit[323] = (reg_addr == PINMUX_DIO_PAD_ATTR_8_OFFSET);
+    addr_hit[324] = (reg_addr == PINMUX_DIO_PAD_ATTR_9_OFFSET);
+    addr_hit[325] = (reg_addr == PINMUX_DIO_PAD_ATTR_10_OFFSET);
+    addr_hit[326] = (reg_addr == PINMUX_DIO_PAD_ATTR_11_OFFSET);
+    addr_hit[327] = (reg_addr == PINMUX_DIO_PAD_ATTR_12_OFFSET);
+    addr_hit[328] = (reg_addr == PINMUX_DIO_PAD_ATTR_13_OFFSET);
+    addr_hit[329] = (reg_addr == PINMUX_DIO_PAD_ATTR_14_OFFSET);
+    addr_hit[330] = (reg_addr == PINMUX_DIO_PAD_ATTR_15_OFFSET);
+    addr_hit[331] = (reg_addr == PINMUX_DIO_PAD_ATTR_16_OFFSET);
+    addr_hit[332] = (reg_addr == PINMUX_DIO_PAD_ATTR_17_OFFSET);
+    addr_hit[333] = (reg_addr == PINMUX_DIO_PAD_ATTR_18_OFFSET);
+    addr_hit[334] = (reg_addr == PINMUX_DIO_PAD_ATTR_19_OFFSET);
+    addr_hit[335] = (reg_addr == PINMUX_DIO_PAD_ATTR_20_OFFSET);
+    addr_hit[336] = (reg_addr == PINMUX_MIO_PAD_SLEEP_STATUS_0_OFFSET);
+    addr_hit[337] = (reg_addr == PINMUX_MIO_PAD_SLEEP_STATUS_1_OFFSET);
+    addr_hit[338] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_0_OFFSET);
+    addr_hit[339] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_1_OFFSET);
+    addr_hit[340] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_2_OFFSET);
+    addr_hit[341] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_3_OFFSET);
+    addr_hit[342] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_4_OFFSET);
+    addr_hit[343] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_5_OFFSET);
+    addr_hit[344] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_6_OFFSET);
+    addr_hit[345] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_7_OFFSET);
+    addr_hit[346] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_8_OFFSET);
+    addr_hit[347] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_9_OFFSET);
+    addr_hit[348] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_10_OFFSET);
+    addr_hit[349] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_11_OFFSET);
+    addr_hit[350] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_12_OFFSET);
+    addr_hit[351] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_13_OFFSET);
+    addr_hit[352] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_14_OFFSET);
+    addr_hit[353] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_15_OFFSET);
+    addr_hit[354] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_16_OFFSET);
+    addr_hit[355] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_17_OFFSET);
+    addr_hit[356] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_18_OFFSET);
+    addr_hit[357] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_19_OFFSET);
+    addr_hit[358] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_20_OFFSET);
+    addr_hit[359] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_21_OFFSET);
+    addr_hit[360] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_22_OFFSET);
+    addr_hit[361] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_23_OFFSET);
+    addr_hit[362] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_24_OFFSET);
+    addr_hit[363] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_25_OFFSET);
+    addr_hit[364] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_26_OFFSET);
+    addr_hit[365] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_27_OFFSET);
+    addr_hit[366] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_28_OFFSET);
+    addr_hit[367] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_29_OFFSET);
+    addr_hit[368] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_30_OFFSET);
+    addr_hit[369] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_31_OFFSET);
+    addr_hit[370] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_32_OFFSET);
+    addr_hit[371] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_33_OFFSET);
+    addr_hit[372] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_34_OFFSET);
+    addr_hit[373] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_35_OFFSET);
+    addr_hit[374] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_36_OFFSET);
+    addr_hit[375] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_37_OFFSET);
+    addr_hit[376] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_38_OFFSET);
+    addr_hit[377] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_39_OFFSET);
+    addr_hit[378] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_40_OFFSET);
+    addr_hit[379] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_41_OFFSET);
+    addr_hit[380] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_42_OFFSET);
+    addr_hit[381] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_43_OFFSET);
+    addr_hit[382] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_0_OFFSET);
+    addr_hit[383] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_1_OFFSET);
+    addr_hit[384] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_2_OFFSET);
+    addr_hit[385] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_3_OFFSET);
+    addr_hit[386] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_4_OFFSET);
+    addr_hit[387] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_5_OFFSET);
+    addr_hit[388] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_6_OFFSET);
+    addr_hit[389] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_7_OFFSET);
+    addr_hit[390] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_8_OFFSET);
+    addr_hit[391] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_9_OFFSET);
+    addr_hit[392] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_10_OFFSET);
+    addr_hit[393] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_11_OFFSET);
+    addr_hit[394] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_12_OFFSET);
+    addr_hit[395] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_13_OFFSET);
+    addr_hit[396] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_14_OFFSET);
+    addr_hit[397] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_15_OFFSET);
+    addr_hit[398] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_16_OFFSET);
+    addr_hit[399] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_17_OFFSET);
+    addr_hit[400] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_18_OFFSET);
+    addr_hit[401] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_19_OFFSET);
+    addr_hit[402] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_20_OFFSET);
+    addr_hit[403] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_21_OFFSET);
+    addr_hit[404] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_22_OFFSET);
+    addr_hit[405] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_23_OFFSET);
+    addr_hit[406] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_24_OFFSET);
+    addr_hit[407] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_25_OFFSET);
+    addr_hit[408] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_26_OFFSET);
+    addr_hit[409] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_27_OFFSET);
+    addr_hit[410] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_28_OFFSET);
+    addr_hit[411] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_29_OFFSET);
+    addr_hit[412] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_30_OFFSET);
+    addr_hit[413] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_31_OFFSET);
+    addr_hit[414] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_32_OFFSET);
+    addr_hit[415] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_33_OFFSET);
+    addr_hit[416] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_34_OFFSET);
+    addr_hit[417] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_35_OFFSET);
+    addr_hit[418] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_36_OFFSET);
+    addr_hit[419] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_37_OFFSET);
+    addr_hit[420] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_38_OFFSET);
+    addr_hit[421] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_39_OFFSET);
+    addr_hit[422] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_40_OFFSET);
+    addr_hit[423] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_41_OFFSET);
+    addr_hit[424] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_42_OFFSET);
+    addr_hit[425] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_43_OFFSET);
+    addr_hit[426] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_0_OFFSET);
+    addr_hit[427] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_1_OFFSET);
+    addr_hit[428] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_2_OFFSET);
+    addr_hit[429] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_3_OFFSET);
+    addr_hit[430] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_4_OFFSET);
+    addr_hit[431] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_5_OFFSET);
+    addr_hit[432] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_6_OFFSET);
+    addr_hit[433] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_7_OFFSET);
+    addr_hit[434] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_8_OFFSET);
+    addr_hit[435] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_9_OFFSET);
+    addr_hit[436] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_10_OFFSET);
+    addr_hit[437] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_11_OFFSET);
+    addr_hit[438] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_12_OFFSET);
+    addr_hit[439] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_13_OFFSET);
+    addr_hit[440] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_14_OFFSET);
+    addr_hit[441] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_15_OFFSET);
+    addr_hit[442] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_16_OFFSET);
+    addr_hit[443] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_17_OFFSET);
+    addr_hit[444] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_18_OFFSET);
+    addr_hit[445] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_19_OFFSET);
+    addr_hit[446] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_20_OFFSET);
+    addr_hit[447] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_21_OFFSET);
+    addr_hit[448] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_22_OFFSET);
+    addr_hit[449] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_23_OFFSET);
+    addr_hit[450] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_24_OFFSET);
+    addr_hit[451] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_25_OFFSET);
+    addr_hit[452] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_26_OFFSET);
+    addr_hit[453] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_27_OFFSET);
+    addr_hit[454] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_28_OFFSET);
+    addr_hit[455] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_29_OFFSET);
+    addr_hit[456] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_30_OFFSET);
+    addr_hit[457] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_31_OFFSET);
+    addr_hit[458] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_32_OFFSET);
+    addr_hit[459] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_33_OFFSET);
+    addr_hit[460] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_34_OFFSET);
+    addr_hit[461] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_35_OFFSET);
+    addr_hit[462] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_36_OFFSET);
+    addr_hit[463] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_37_OFFSET);
+    addr_hit[464] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_38_OFFSET);
+    addr_hit[465] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_39_OFFSET);
+    addr_hit[466] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_40_OFFSET);
+    addr_hit[467] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_41_OFFSET);
+    addr_hit[468] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_42_OFFSET);
+    addr_hit[469] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_43_OFFSET);
+    addr_hit[470] = (reg_addr == PINMUX_DIO_PAD_SLEEP_STATUS_OFFSET);
+    addr_hit[471] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_0_OFFSET);
+    addr_hit[472] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_1_OFFSET);
+    addr_hit[473] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_2_OFFSET);
+    addr_hit[474] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_3_OFFSET);
+    addr_hit[475] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_4_OFFSET);
+    addr_hit[476] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_5_OFFSET);
+    addr_hit[477] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_6_OFFSET);
+    addr_hit[478] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_7_OFFSET);
+    addr_hit[479] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_8_OFFSET);
+    addr_hit[480] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_9_OFFSET);
+    addr_hit[481] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_10_OFFSET);
+    addr_hit[482] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_11_OFFSET);
+    addr_hit[483] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_12_OFFSET);
+    addr_hit[484] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_13_OFFSET);
+    addr_hit[485] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_14_OFFSET);
+    addr_hit[486] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_15_OFFSET);
+    addr_hit[487] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_16_OFFSET);
+    addr_hit[488] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_17_OFFSET);
+    addr_hit[489] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_18_OFFSET);
+    addr_hit[490] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_19_OFFSET);
+    addr_hit[491] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_20_OFFSET);
+    addr_hit[492] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_0_OFFSET);
+    addr_hit[493] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_1_OFFSET);
+    addr_hit[494] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_2_OFFSET);
+    addr_hit[495] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_3_OFFSET);
+    addr_hit[496] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_4_OFFSET);
+    addr_hit[497] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_5_OFFSET);
+    addr_hit[498] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_6_OFFSET);
+    addr_hit[499] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_7_OFFSET);
+    addr_hit[500] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_8_OFFSET);
+    addr_hit[501] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_9_OFFSET);
+    addr_hit[502] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_10_OFFSET);
+    addr_hit[503] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_11_OFFSET);
+    addr_hit[504] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_12_OFFSET);
+    addr_hit[505] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_13_OFFSET);
+    addr_hit[506] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_14_OFFSET);
+    addr_hit[507] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_15_OFFSET);
+    addr_hit[508] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_16_OFFSET);
+    addr_hit[509] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_17_OFFSET);
+    addr_hit[510] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_18_OFFSET);
+    addr_hit[511] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_19_OFFSET);
+    addr_hit[512] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_20_OFFSET);
+    addr_hit[513] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_0_OFFSET);
+    addr_hit[514] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_1_OFFSET);
+    addr_hit[515] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_2_OFFSET);
+    addr_hit[516] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_3_OFFSET);
+    addr_hit[517] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_4_OFFSET);
+    addr_hit[518] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_5_OFFSET);
+    addr_hit[519] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_6_OFFSET);
+    addr_hit[520] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_7_OFFSET);
+    addr_hit[521] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_8_OFFSET);
+    addr_hit[522] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_9_OFFSET);
+    addr_hit[523] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_10_OFFSET);
+    addr_hit[524] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_11_OFFSET);
+    addr_hit[525] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_12_OFFSET);
+    addr_hit[526] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_13_OFFSET);
+    addr_hit[527] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_14_OFFSET);
+    addr_hit[528] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_15_OFFSET);
+    addr_hit[529] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_16_OFFSET);
+    addr_hit[530] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_17_OFFSET);
+    addr_hit[531] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_18_OFFSET);
+    addr_hit[532] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_19_OFFSET);
+    addr_hit[533] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_20_OFFSET);
+    addr_hit[534] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_0_OFFSET);
+    addr_hit[535] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_1_OFFSET);
+    addr_hit[536] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_2_OFFSET);
+    addr_hit[537] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_3_OFFSET);
+    addr_hit[538] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_4_OFFSET);
+    addr_hit[539] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_5_OFFSET);
+    addr_hit[540] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_6_OFFSET);
+    addr_hit[541] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_7_OFFSET);
+    addr_hit[542] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_0_OFFSET);
+    addr_hit[543] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_1_OFFSET);
+    addr_hit[544] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_2_OFFSET);
+    addr_hit[545] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_3_OFFSET);
+    addr_hit[546] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_4_OFFSET);
+    addr_hit[547] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_5_OFFSET);
+    addr_hit[548] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_6_OFFSET);
+    addr_hit[549] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_7_OFFSET);
+    addr_hit[550] = (reg_addr == PINMUX_WKUP_DETECTOR_0_OFFSET);
+    addr_hit[551] = (reg_addr == PINMUX_WKUP_DETECTOR_1_OFFSET);
+    addr_hit[552] = (reg_addr == PINMUX_WKUP_DETECTOR_2_OFFSET);
+    addr_hit[553] = (reg_addr == PINMUX_WKUP_DETECTOR_3_OFFSET);
+    addr_hit[554] = (reg_addr == PINMUX_WKUP_DETECTOR_4_OFFSET);
+    addr_hit[555] = (reg_addr == PINMUX_WKUP_DETECTOR_5_OFFSET);
+    addr_hit[556] = (reg_addr == PINMUX_WKUP_DETECTOR_6_OFFSET);
+    addr_hit[557] = (reg_addr == PINMUX_WKUP_DETECTOR_7_OFFSET);
+    addr_hit[558] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_0_OFFSET);
+    addr_hit[559] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_1_OFFSET);
+    addr_hit[560] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_2_OFFSET);
+    addr_hit[561] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_3_OFFSET);
+    addr_hit[562] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_4_OFFSET);
+    addr_hit[563] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_5_OFFSET);
+    addr_hit[564] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_6_OFFSET);
+    addr_hit[565] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_7_OFFSET);
+    addr_hit[566] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_0_OFFSET);
+    addr_hit[567] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_1_OFFSET);
+    addr_hit[568] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_2_OFFSET);
+    addr_hit[569] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_3_OFFSET);
+    addr_hit[570] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_4_OFFSET);
+    addr_hit[571] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_5_OFFSET);
+    addr_hit[572] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_6_OFFSET);
+    addr_hit[573] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_7_OFFSET);
+    addr_hit[574] = (reg_addr == PINMUX_WKUP_CAUSE_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -19742,6 +20362,26 @@ module pinmux_reg_top (
     if (addr_hit[552] && reg_we && (PINMUX_PERMIT[552] != (PINMUX_PERMIT[552] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[553] && reg_we && (PINMUX_PERMIT[553] != (PINMUX_PERMIT[553] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[554] && reg_we && (PINMUX_PERMIT[554] != (PINMUX_PERMIT[554] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[555] && reg_we && (PINMUX_PERMIT[555] != (PINMUX_PERMIT[555] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[556] && reg_we && (PINMUX_PERMIT[556] != (PINMUX_PERMIT[556] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[557] && reg_we && (PINMUX_PERMIT[557] != (PINMUX_PERMIT[557] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[558] && reg_we && (PINMUX_PERMIT[558] != (PINMUX_PERMIT[558] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[559] && reg_we && (PINMUX_PERMIT[559] != (PINMUX_PERMIT[559] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[560] && reg_we && (PINMUX_PERMIT[560] != (PINMUX_PERMIT[560] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[561] && reg_we && (PINMUX_PERMIT[561] != (PINMUX_PERMIT[561] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[562] && reg_we && (PINMUX_PERMIT[562] != (PINMUX_PERMIT[562] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[563] && reg_we && (PINMUX_PERMIT[563] != (PINMUX_PERMIT[563] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[564] && reg_we && (PINMUX_PERMIT[564] != (PINMUX_PERMIT[564] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[565] && reg_we && (PINMUX_PERMIT[565] != (PINMUX_PERMIT[565] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[566] && reg_we && (PINMUX_PERMIT[566] != (PINMUX_PERMIT[566] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[567] && reg_we && (PINMUX_PERMIT[567] != (PINMUX_PERMIT[567] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[568] && reg_we && (PINMUX_PERMIT[568] != (PINMUX_PERMIT[568] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[569] && reg_we && (PINMUX_PERMIT[569] != (PINMUX_PERMIT[569] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[570] && reg_we && (PINMUX_PERMIT[570] != (PINMUX_PERMIT[570] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[571] && reg_we && (PINMUX_PERMIT[571] != (PINMUX_PERMIT[571] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[572] && reg_we && (PINMUX_PERMIT[572] != (PINMUX_PERMIT[572] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[573] && reg_we && (PINMUX_PERMIT[573] != (PINMUX_PERMIT[573] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[574] && reg_we && (PINMUX_PERMIT[574] != (PINMUX_PERMIT[574] & reg_be))) wr_err = 1'b1 ;
   end
 
   assign mio_periph_insel_regwen_0_we = addr_hit[0] & reg_we & !reg_error;
@@ -19891,1851 +20531,1911 @@ module pinmux_reg_top (
   assign mio_periph_insel_regwen_48_we = addr_hit[48] & reg_we & !reg_error;
   assign mio_periph_insel_regwen_48_wd = reg_wdata[0];
 
-  assign mio_periph_insel_0_we = addr_hit[49] & reg_we & !reg_error;
+  assign mio_periph_insel_regwen_49_we = addr_hit[49] & reg_we & !reg_error;
+  assign mio_periph_insel_regwen_49_wd = reg_wdata[0];
+
+  assign mio_periph_insel_regwen_50_we = addr_hit[50] & reg_we & !reg_error;
+  assign mio_periph_insel_regwen_50_wd = reg_wdata[0];
+
+  assign mio_periph_insel_regwen_51_we = addr_hit[51] & reg_we & !reg_error;
+  assign mio_periph_insel_regwen_51_wd = reg_wdata[0];
+
+  assign mio_periph_insel_regwen_52_we = addr_hit[52] & reg_we & !reg_error;
+  assign mio_periph_insel_regwen_52_wd = reg_wdata[0];
+
+  assign mio_periph_insel_regwen_53_we = addr_hit[53] & reg_we & !reg_error;
+  assign mio_periph_insel_regwen_53_wd = reg_wdata[0];
+
+  assign mio_periph_insel_regwen_54_we = addr_hit[54] & reg_we & !reg_error;
+  assign mio_periph_insel_regwen_54_wd = reg_wdata[0];
+
+  assign mio_periph_insel_regwen_55_we = addr_hit[55] & reg_we & !reg_error;
+  assign mio_periph_insel_regwen_55_wd = reg_wdata[0];
+
+  assign mio_periph_insel_regwen_56_we = addr_hit[56] & reg_we & !reg_error;
+  assign mio_periph_insel_regwen_56_wd = reg_wdata[0];
+
+  assign mio_periph_insel_regwen_57_we = addr_hit[57] & reg_we & !reg_error;
+  assign mio_periph_insel_regwen_57_wd = reg_wdata[0];
+
+  assign mio_periph_insel_regwen_58_we = addr_hit[58] & reg_we & !reg_error;
+  assign mio_periph_insel_regwen_58_wd = reg_wdata[0];
+
+  assign mio_periph_insel_0_we = addr_hit[59] & reg_we & !reg_error;
   assign mio_periph_insel_0_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_1_we = addr_hit[50] & reg_we & !reg_error;
+  assign mio_periph_insel_1_we = addr_hit[60] & reg_we & !reg_error;
   assign mio_periph_insel_1_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_2_we = addr_hit[51] & reg_we & !reg_error;
+  assign mio_periph_insel_2_we = addr_hit[61] & reg_we & !reg_error;
   assign mio_periph_insel_2_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_3_we = addr_hit[52] & reg_we & !reg_error;
+  assign mio_periph_insel_3_we = addr_hit[62] & reg_we & !reg_error;
   assign mio_periph_insel_3_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_4_we = addr_hit[53] & reg_we & !reg_error;
+  assign mio_periph_insel_4_we = addr_hit[63] & reg_we & !reg_error;
   assign mio_periph_insel_4_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_5_we = addr_hit[54] & reg_we & !reg_error;
+  assign mio_periph_insel_5_we = addr_hit[64] & reg_we & !reg_error;
   assign mio_periph_insel_5_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_6_we = addr_hit[55] & reg_we & !reg_error;
+  assign mio_periph_insel_6_we = addr_hit[65] & reg_we & !reg_error;
   assign mio_periph_insel_6_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_7_we = addr_hit[56] & reg_we & !reg_error;
+  assign mio_periph_insel_7_we = addr_hit[66] & reg_we & !reg_error;
   assign mio_periph_insel_7_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_8_we = addr_hit[57] & reg_we & !reg_error;
+  assign mio_periph_insel_8_we = addr_hit[67] & reg_we & !reg_error;
   assign mio_periph_insel_8_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_9_we = addr_hit[58] & reg_we & !reg_error;
+  assign mio_periph_insel_9_we = addr_hit[68] & reg_we & !reg_error;
   assign mio_periph_insel_9_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_10_we = addr_hit[59] & reg_we & !reg_error;
+  assign mio_periph_insel_10_we = addr_hit[69] & reg_we & !reg_error;
   assign mio_periph_insel_10_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_11_we = addr_hit[60] & reg_we & !reg_error;
+  assign mio_periph_insel_11_we = addr_hit[70] & reg_we & !reg_error;
   assign mio_periph_insel_11_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_12_we = addr_hit[61] & reg_we & !reg_error;
+  assign mio_periph_insel_12_we = addr_hit[71] & reg_we & !reg_error;
   assign mio_periph_insel_12_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_13_we = addr_hit[62] & reg_we & !reg_error;
+  assign mio_periph_insel_13_we = addr_hit[72] & reg_we & !reg_error;
   assign mio_periph_insel_13_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_14_we = addr_hit[63] & reg_we & !reg_error;
+  assign mio_periph_insel_14_we = addr_hit[73] & reg_we & !reg_error;
   assign mio_periph_insel_14_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_15_we = addr_hit[64] & reg_we & !reg_error;
+  assign mio_periph_insel_15_we = addr_hit[74] & reg_we & !reg_error;
   assign mio_periph_insel_15_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_16_we = addr_hit[65] & reg_we & !reg_error;
+  assign mio_periph_insel_16_we = addr_hit[75] & reg_we & !reg_error;
   assign mio_periph_insel_16_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_17_we = addr_hit[66] & reg_we & !reg_error;
+  assign mio_periph_insel_17_we = addr_hit[76] & reg_we & !reg_error;
   assign mio_periph_insel_17_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_18_we = addr_hit[67] & reg_we & !reg_error;
+  assign mio_periph_insel_18_we = addr_hit[77] & reg_we & !reg_error;
   assign mio_periph_insel_18_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_19_we = addr_hit[68] & reg_we & !reg_error;
+  assign mio_periph_insel_19_we = addr_hit[78] & reg_we & !reg_error;
   assign mio_periph_insel_19_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_20_we = addr_hit[69] & reg_we & !reg_error;
+  assign mio_periph_insel_20_we = addr_hit[79] & reg_we & !reg_error;
   assign mio_periph_insel_20_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_21_we = addr_hit[70] & reg_we & !reg_error;
+  assign mio_periph_insel_21_we = addr_hit[80] & reg_we & !reg_error;
   assign mio_periph_insel_21_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_22_we = addr_hit[71] & reg_we & !reg_error;
+  assign mio_periph_insel_22_we = addr_hit[81] & reg_we & !reg_error;
   assign mio_periph_insel_22_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_23_we = addr_hit[72] & reg_we & !reg_error;
+  assign mio_periph_insel_23_we = addr_hit[82] & reg_we & !reg_error;
   assign mio_periph_insel_23_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_24_we = addr_hit[73] & reg_we & !reg_error;
+  assign mio_periph_insel_24_we = addr_hit[83] & reg_we & !reg_error;
   assign mio_periph_insel_24_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_25_we = addr_hit[74] & reg_we & !reg_error;
+  assign mio_periph_insel_25_we = addr_hit[84] & reg_we & !reg_error;
   assign mio_periph_insel_25_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_26_we = addr_hit[75] & reg_we & !reg_error;
+  assign mio_periph_insel_26_we = addr_hit[85] & reg_we & !reg_error;
   assign mio_periph_insel_26_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_27_we = addr_hit[76] & reg_we & !reg_error;
+  assign mio_periph_insel_27_we = addr_hit[86] & reg_we & !reg_error;
   assign mio_periph_insel_27_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_28_we = addr_hit[77] & reg_we & !reg_error;
+  assign mio_periph_insel_28_we = addr_hit[87] & reg_we & !reg_error;
   assign mio_periph_insel_28_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_29_we = addr_hit[78] & reg_we & !reg_error;
+  assign mio_periph_insel_29_we = addr_hit[88] & reg_we & !reg_error;
   assign mio_periph_insel_29_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_30_we = addr_hit[79] & reg_we & !reg_error;
+  assign mio_periph_insel_30_we = addr_hit[89] & reg_we & !reg_error;
   assign mio_periph_insel_30_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_31_we = addr_hit[80] & reg_we & !reg_error;
+  assign mio_periph_insel_31_we = addr_hit[90] & reg_we & !reg_error;
   assign mio_periph_insel_31_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_32_we = addr_hit[81] & reg_we & !reg_error;
+  assign mio_periph_insel_32_we = addr_hit[91] & reg_we & !reg_error;
   assign mio_periph_insel_32_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_33_we = addr_hit[82] & reg_we & !reg_error;
+  assign mio_periph_insel_33_we = addr_hit[92] & reg_we & !reg_error;
   assign mio_periph_insel_33_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_34_we = addr_hit[83] & reg_we & !reg_error;
+  assign mio_periph_insel_34_we = addr_hit[93] & reg_we & !reg_error;
   assign mio_periph_insel_34_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_35_we = addr_hit[84] & reg_we & !reg_error;
+  assign mio_periph_insel_35_we = addr_hit[94] & reg_we & !reg_error;
   assign mio_periph_insel_35_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_36_we = addr_hit[85] & reg_we & !reg_error;
+  assign mio_periph_insel_36_we = addr_hit[95] & reg_we & !reg_error;
   assign mio_periph_insel_36_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_37_we = addr_hit[86] & reg_we & !reg_error;
+  assign mio_periph_insel_37_we = addr_hit[96] & reg_we & !reg_error;
   assign mio_periph_insel_37_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_38_we = addr_hit[87] & reg_we & !reg_error;
+  assign mio_periph_insel_38_we = addr_hit[97] & reg_we & !reg_error;
   assign mio_periph_insel_38_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_39_we = addr_hit[88] & reg_we & !reg_error;
+  assign mio_periph_insel_39_we = addr_hit[98] & reg_we & !reg_error;
   assign mio_periph_insel_39_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_40_we = addr_hit[89] & reg_we & !reg_error;
+  assign mio_periph_insel_40_we = addr_hit[99] & reg_we & !reg_error;
   assign mio_periph_insel_40_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_41_we = addr_hit[90] & reg_we & !reg_error;
+  assign mio_periph_insel_41_we = addr_hit[100] & reg_we & !reg_error;
   assign mio_periph_insel_41_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_42_we = addr_hit[91] & reg_we & !reg_error;
+  assign mio_periph_insel_42_we = addr_hit[101] & reg_we & !reg_error;
   assign mio_periph_insel_42_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_43_we = addr_hit[92] & reg_we & !reg_error;
+  assign mio_periph_insel_43_we = addr_hit[102] & reg_we & !reg_error;
   assign mio_periph_insel_43_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_44_we = addr_hit[93] & reg_we & !reg_error;
+  assign mio_periph_insel_44_we = addr_hit[103] & reg_we & !reg_error;
   assign mio_periph_insel_44_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_45_we = addr_hit[94] & reg_we & !reg_error;
+  assign mio_periph_insel_45_we = addr_hit[104] & reg_we & !reg_error;
   assign mio_periph_insel_45_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_46_we = addr_hit[95] & reg_we & !reg_error;
+  assign mio_periph_insel_46_we = addr_hit[105] & reg_we & !reg_error;
   assign mio_periph_insel_46_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_47_we = addr_hit[96] & reg_we & !reg_error;
+  assign mio_periph_insel_47_we = addr_hit[106] & reg_we & !reg_error;
   assign mio_periph_insel_47_wd = reg_wdata[5:0];
 
-  assign mio_periph_insel_48_we = addr_hit[97] & reg_we & !reg_error;
+  assign mio_periph_insel_48_we = addr_hit[107] & reg_we & !reg_error;
   assign mio_periph_insel_48_wd = reg_wdata[5:0];
 
-  assign mio_outsel_regwen_0_we = addr_hit[98] & reg_we & !reg_error;
+  assign mio_periph_insel_49_we = addr_hit[108] & reg_we & !reg_error;
+  assign mio_periph_insel_49_wd = reg_wdata[5:0];
+
+  assign mio_periph_insel_50_we = addr_hit[109] & reg_we & !reg_error;
+  assign mio_periph_insel_50_wd = reg_wdata[5:0];
+
+  assign mio_periph_insel_51_we = addr_hit[110] & reg_we & !reg_error;
+  assign mio_periph_insel_51_wd = reg_wdata[5:0];
+
+  assign mio_periph_insel_52_we = addr_hit[111] & reg_we & !reg_error;
+  assign mio_periph_insel_52_wd = reg_wdata[5:0];
+
+  assign mio_periph_insel_53_we = addr_hit[112] & reg_we & !reg_error;
+  assign mio_periph_insel_53_wd = reg_wdata[5:0];
+
+  assign mio_periph_insel_54_we = addr_hit[113] & reg_we & !reg_error;
+  assign mio_periph_insel_54_wd = reg_wdata[5:0];
+
+  assign mio_periph_insel_55_we = addr_hit[114] & reg_we & !reg_error;
+  assign mio_periph_insel_55_wd = reg_wdata[5:0];
+
+  assign mio_periph_insel_56_we = addr_hit[115] & reg_we & !reg_error;
+  assign mio_periph_insel_56_wd = reg_wdata[5:0];
+
+  assign mio_periph_insel_57_we = addr_hit[116] & reg_we & !reg_error;
+  assign mio_periph_insel_57_wd = reg_wdata[5:0];
+
+  assign mio_periph_insel_58_we = addr_hit[117] & reg_we & !reg_error;
+  assign mio_periph_insel_58_wd = reg_wdata[5:0];
+
+  assign mio_outsel_regwen_0_we = addr_hit[118] & reg_we & !reg_error;
   assign mio_outsel_regwen_0_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_1_we = addr_hit[99] & reg_we & !reg_error;
+  assign mio_outsel_regwen_1_we = addr_hit[119] & reg_we & !reg_error;
   assign mio_outsel_regwen_1_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_2_we = addr_hit[100] & reg_we & !reg_error;
+  assign mio_outsel_regwen_2_we = addr_hit[120] & reg_we & !reg_error;
   assign mio_outsel_regwen_2_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_3_we = addr_hit[101] & reg_we & !reg_error;
+  assign mio_outsel_regwen_3_we = addr_hit[121] & reg_we & !reg_error;
   assign mio_outsel_regwen_3_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_4_we = addr_hit[102] & reg_we & !reg_error;
+  assign mio_outsel_regwen_4_we = addr_hit[122] & reg_we & !reg_error;
   assign mio_outsel_regwen_4_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_5_we = addr_hit[103] & reg_we & !reg_error;
+  assign mio_outsel_regwen_5_we = addr_hit[123] & reg_we & !reg_error;
   assign mio_outsel_regwen_5_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_6_we = addr_hit[104] & reg_we & !reg_error;
+  assign mio_outsel_regwen_6_we = addr_hit[124] & reg_we & !reg_error;
   assign mio_outsel_regwen_6_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_7_we = addr_hit[105] & reg_we & !reg_error;
+  assign mio_outsel_regwen_7_we = addr_hit[125] & reg_we & !reg_error;
   assign mio_outsel_regwen_7_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_8_we = addr_hit[106] & reg_we & !reg_error;
+  assign mio_outsel_regwen_8_we = addr_hit[126] & reg_we & !reg_error;
   assign mio_outsel_regwen_8_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_9_we = addr_hit[107] & reg_we & !reg_error;
+  assign mio_outsel_regwen_9_we = addr_hit[127] & reg_we & !reg_error;
   assign mio_outsel_regwen_9_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_10_we = addr_hit[108] & reg_we & !reg_error;
+  assign mio_outsel_regwen_10_we = addr_hit[128] & reg_we & !reg_error;
   assign mio_outsel_regwen_10_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_11_we = addr_hit[109] & reg_we & !reg_error;
+  assign mio_outsel_regwen_11_we = addr_hit[129] & reg_we & !reg_error;
   assign mio_outsel_regwen_11_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_12_we = addr_hit[110] & reg_we & !reg_error;
+  assign mio_outsel_regwen_12_we = addr_hit[130] & reg_we & !reg_error;
   assign mio_outsel_regwen_12_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_13_we = addr_hit[111] & reg_we & !reg_error;
+  assign mio_outsel_regwen_13_we = addr_hit[131] & reg_we & !reg_error;
   assign mio_outsel_regwen_13_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_14_we = addr_hit[112] & reg_we & !reg_error;
+  assign mio_outsel_regwen_14_we = addr_hit[132] & reg_we & !reg_error;
   assign mio_outsel_regwen_14_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_15_we = addr_hit[113] & reg_we & !reg_error;
+  assign mio_outsel_regwen_15_we = addr_hit[133] & reg_we & !reg_error;
   assign mio_outsel_regwen_15_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_16_we = addr_hit[114] & reg_we & !reg_error;
+  assign mio_outsel_regwen_16_we = addr_hit[134] & reg_we & !reg_error;
   assign mio_outsel_regwen_16_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_17_we = addr_hit[115] & reg_we & !reg_error;
+  assign mio_outsel_regwen_17_we = addr_hit[135] & reg_we & !reg_error;
   assign mio_outsel_regwen_17_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_18_we = addr_hit[116] & reg_we & !reg_error;
+  assign mio_outsel_regwen_18_we = addr_hit[136] & reg_we & !reg_error;
   assign mio_outsel_regwen_18_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_19_we = addr_hit[117] & reg_we & !reg_error;
+  assign mio_outsel_regwen_19_we = addr_hit[137] & reg_we & !reg_error;
   assign mio_outsel_regwen_19_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_20_we = addr_hit[118] & reg_we & !reg_error;
+  assign mio_outsel_regwen_20_we = addr_hit[138] & reg_we & !reg_error;
   assign mio_outsel_regwen_20_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_21_we = addr_hit[119] & reg_we & !reg_error;
+  assign mio_outsel_regwen_21_we = addr_hit[139] & reg_we & !reg_error;
   assign mio_outsel_regwen_21_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_22_we = addr_hit[120] & reg_we & !reg_error;
+  assign mio_outsel_regwen_22_we = addr_hit[140] & reg_we & !reg_error;
   assign mio_outsel_regwen_22_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_23_we = addr_hit[121] & reg_we & !reg_error;
+  assign mio_outsel_regwen_23_we = addr_hit[141] & reg_we & !reg_error;
   assign mio_outsel_regwen_23_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_24_we = addr_hit[122] & reg_we & !reg_error;
+  assign mio_outsel_regwen_24_we = addr_hit[142] & reg_we & !reg_error;
   assign mio_outsel_regwen_24_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_25_we = addr_hit[123] & reg_we & !reg_error;
+  assign mio_outsel_regwen_25_we = addr_hit[143] & reg_we & !reg_error;
   assign mio_outsel_regwen_25_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_26_we = addr_hit[124] & reg_we & !reg_error;
+  assign mio_outsel_regwen_26_we = addr_hit[144] & reg_we & !reg_error;
   assign mio_outsel_regwen_26_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_27_we = addr_hit[125] & reg_we & !reg_error;
+  assign mio_outsel_regwen_27_we = addr_hit[145] & reg_we & !reg_error;
   assign mio_outsel_regwen_27_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_28_we = addr_hit[126] & reg_we & !reg_error;
+  assign mio_outsel_regwen_28_we = addr_hit[146] & reg_we & !reg_error;
   assign mio_outsel_regwen_28_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_29_we = addr_hit[127] & reg_we & !reg_error;
+  assign mio_outsel_regwen_29_we = addr_hit[147] & reg_we & !reg_error;
   assign mio_outsel_regwen_29_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_30_we = addr_hit[128] & reg_we & !reg_error;
+  assign mio_outsel_regwen_30_we = addr_hit[148] & reg_we & !reg_error;
   assign mio_outsel_regwen_30_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_31_we = addr_hit[129] & reg_we & !reg_error;
+  assign mio_outsel_regwen_31_we = addr_hit[149] & reg_we & !reg_error;
   assign mio_outsel_regwen_31_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_32_we = addr_hit[130] & reg_we & !reg_error;
+  assign mio_outsel_regwen_32_we = addr_hit[150] & reg_we & !reg_error;
   assign mio_outsel_regwen_32_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_33_we = addr_hit[131] & reg_we & !reg_error;
+  assign mio_outsel_regwen_33_we = addr_hit[151] & reg_we & !reg_error;
   assign mio_outsel_regwen_33_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_34_we = addr_hit[132] & reg_we & !reg_error;
+  assign mio_outsel_regwen_34_we = addr_hit[152] & reg_we & !reg_error;
   assign mio_outsel_regwen_34_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_35_we = addr_hit[133] & reg_we & !reg_error;
+  assign mio_outsel_regwen_35_we = addr_hit[153] & reg_we & !reg_error;
   assign mio_outsel_regwen_35_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_36_we = addr_hit[134] & reg_we & !reg_error;
+  assign mio_outsel_regwen_36_we = addr_hit[154] & reg_we & !reg_error;
   assign mio_outsel_regwen_36_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_37_we = addr_hit[135] & reg_we & !reg_error;
+  assign mio_outsel_regwen_37_we = addr_hit[155] & reg_we & !reg_error;
   assign mio_outsel_regwen_37_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_38_we = addr_hit[136] & reg_we & !reg_error;
+  assign mio_outsel_regwen_38_we = addr_hit[156] & reg_we & !reg_error;
   assign mio_outsel_regwen_38_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_39_we = addr_hit[137] & reg_we & !reg_error;
+  assign mio_outsel_regwen_39_we = addr_hit[157] & reg_we & !reg_error;
   assign mio_outsel_regwen_39_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_40_we = addr_hit[138] & reg_we & !reg_error;
+  assign mio_outsel_regwen_40_we = addr_hit[158] & reg_we & !reg_error;
   assign mio_outsel_regwen_40_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_41_we = addr_hit[139] & reg_we & !reg_error;
+  assign mio_outsel_regwen_41_we = addr_hit[159] & reg_we & !reg_error;
   assign mio_outsel_regwen_41_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_42_we = addr_hit[140] & reg_we & !reg_error;
+  assign mio_outsel_regwen_42_we = addr_hit[160] & reg_we & !reg_error;
   assign mio_outsel_regwen_42_wd = reg_wdata[0];
 
-  assign mio_outsel_regwen_43_we = addr_hit[141] & reg_we & !reg_error;
+  assign mio_outsel_regwen_43_we = addr_hit[161] & reg_we & !reg_error;
   assign mio_outsel_regwen_43_wd = reg_wdata[0];
 
-  assign mio_outsel_0_we = addr_hit[142] & reg_we & !reg_error;
-  assign mio_outsel_0_wd = reg_wdata[5:0];
+  assign mio_outsel_0_we = addr_hit[162] & reg_we & !reg_error;
+  assign mio_outsel_0_wd = reg_wdata[6:0];
 
-  assign mio_outsel_1_we = addr_hit[143] & reg_we & !reg_error;
-  assign mio_outsel_1_wd = reg_wdata[5:0];
+  assign mio_outsel_1_we = addr_hit[163] & reg_we & !reg_error;
+  assign mio_outsel_1_wd = reg_wdata[6:0];
 
-  assign mio_outsel_2_we = addr_hit[144] & reg_we & !reg_error;
-  assign mio_outsel_2_wd = reg_wdata[5:0];
+  assign mio_outsel_2_we = addr_hit[164] & reg_we & !reg_error;
+  assign mio_outsel_2_wd = reg_wdata[6:0];
 
-  assign mio_outsel_3_we = addr_hit[145] & reg_we & !reg_error;
-  assign mio_outsel_3_wd = reg_wdata[5:0];
+  assign mio_outsel_3_we = addr_hit[165] & reg_we & !reg_error;
+  assign mio_outsel_3_wd = reg_wdata[6:0];
 
-  assign mio_outsel_4_we = addr_hit[146] & reg_we & !reg_error;
-  assign mio_outsel_4_wd = reg_wdata[5:0];
+  assign mio_outsel_4_we = addr_hit[166] & reg_we & !reg_error;
+  assign mio_outsel_4_wd = reg_wdata[6:0];
 
-  assign mio_outsel_5_we = addr_hit[147] & reg_we & !reg_error;
-  assign mio_outsel_5_wd = reg_wdata[5:0];
+  assign mio_outsel_5_we = addr_hit[167] & reg_we & !reg_error;
+  assign mio_outsel_5_wd = reg_wdata[6:0];
 
-  assign mio_outsel_6_we = addr_hit[148] & reg_we & !reg_error;
-  assign mio_outsel_6_wd = reg_wdata[5:0];
+  assign mio_outsel_6_we = addr_hit[168] & reg_we & !reg_error;
+  assign mio_outsel_6_wd = reg_wdata[6:0];
 
-  assign mio_outsel_7_we = addr_hit[149] & reg_we & !reg_error;
-  assign mio_outsel_7_wd = reg_wdata[5:0];
+  assign mio_outsel_7_we = addr_hit[169] & reg_we & !reg_error;
+  assign mio_outsel_7_wd = reg_wdata[6:0];
 
-  assign mio_outsel_8_we = addr_hit[150] & reg_we & !reg_error;
-  assign mio_outsel_8_wd = reg_wdata[5:0];
+  assign mio_outsel_8_we = addr_hit[170] & reg_we & !reg_error;
+  assign mio_outsel_8_wd = reg_wdata[6:0];
 
-  assign mio_outsel_9_we = addr_hit[151] & reg_we & !reg_error;
-  assign mio_outsel_9_wd = reg_wdata[5:0];
+  assign mio_outsel_9_we = addr_hit[171] & reg_we & !reg_error;
+  assign mio_outsel_9_wd = reg_wdata[6:0];
 
-  assign mio_outsel_10_we = addr_hit[152] & reg_we & !reg_error;
-  assign mio_outsel_10_wd = reg_wdata[5:0];
+  assign mio_outsel_10_we = addr_hit[172] & reg_we & !reg_error;
+  assign mio_outsel_10_wd = reg_wdata[6:0];
 
-  assign mio_outsel_11_we = addr_hit[153] & reg_we & !reg_error;
-  assign mio_outsel_11_wd = reg_wdata[5:0];
+  assign mio_outsel_11_we = addr_hit[173] & reg_we & !reg_error;
+  assign mio_outsel_11_wd = reg_wdata[6:0];
 
-  assign mio_outsel_12_we = addr_hit[154] & reg_we & !reg_error;
-  assign mio_outsel_12_wd = reg_wdata[5:0];
+  assign mio_outsel_12_we = addr_hit[174] & reg_we & !reg_error;
+  assign mio_outsel_12_wd = reg_wdata[6:0];
 
-  assign mio_outsel_13_we = addr_hit[155] & reg_we & !reg_error;
-  assign mio_outsel_13_wd = reg_wdata[5:0];
+  assign mio_outsel_13_we = addr_hit[175] & reg_we & !reg_error;
+  assign mio_outsel_13_wd = reg_wdata[6:0];
 
-  assign mio_outsel_14_we = addr_hit[156] & reg_we & !reg_error;
-  assign mio_outsel_14_wd = reg_wdata[5:0];
+  assign mio_outsel_14_we = addr_hit[176] & reg_we & !reg_error;
+  assign mio_outsel_14_wd = reg_wdata[6:0];
 
-  assign mio_outsel_15_we = addr_hit[157] & reg_we & !reg_error;
-  assign mio_outsel_15_wd = reg_wdata[5:0];
+  assign mio_outsel_15_we = addr_hit[177] & reg_we & !reg_error;
+  assign mio_outsel_15_wd = reg_wdata[6:0];
 
-  assign mio_outsel_16_we = addr_hit[158] & reg_we & !reg_error;
-  assign mio_outsel_16_wd = reg_wdata[5:0];
+  assign mio_outsel_16_we = addr_hit[178] & reg_we & !reg_error;
+  assign mio_outsel_16_wd = reg_wdata[6:0];
 
-  assign mio_outsel_17_we = addr_hit[159] & reg_we & !reg_error;
-  assign mio_outsel_17_wd = reg_wdata[5:0];
+  assign mio_outsel_17_we = addr_hit[179] & reg_we & !reg_error;
+  assign mio_outsel_17_wd = reg_wdata[6:0];
 
-  assign mio_outsel_18_we = addr_hit[160] & reg_we & !reg_error;
-  assign mio_outsel_18_wd = reg_wdata[5:0];
+  assign mio_outsel_18_we = addr_hit[180] & reg_we & !reg_error;
+  assign mio_outsel_18_wd = reg_wdata[6:0];
 
-  assign mio_outsel_19_we = addr_hit[161] & reg_we & !reg_error;
-  assign mio_outsel_19_wd = reg_wdata[5:0];
+  assign mio_outsel_19_we = addr_hit[181] & reg_we & !reg_error;
+  assign mio_outsel_19_wd = reg_wdata[6:0];
 
-  assign mio_outsel_20_we = addr_hit[162] & reg_we & !reg_error;
-  assign mio_outsel_20_wd = reg_wdata[5:0];
+  assign mio_outsel_20_we = addr_hit[182] & reg_we & !reg_error;
+  assign mio_outsel_20_wd = reg_wdata[6:0];
 
-  assign mio_outsel_21_we = addr_hit[163] & reg_we & !reg_error;
-  assign mio_outsel_21_wd = reg_wdata[5:0];
+  assign mio_outsel_21_we = addr_hit[183] & reg_we & !reg_error;
+  assign mio_outsel_21_wd = reg_wdata[6:0];
 
-  assign mio_outsel_22_we = addr_hit[164] & reg_we & !reg_error;
-  assign mio_outsel_22_wd = reg_wdata[5:0];
+  assign mio_outsel_22_we = addr_hit[184] & reg_we & !reg_error;
+  assign mio_outsel_22_wd = reg_wdata[6:0];
 
-  assign mio_outsel_23_we = addr_hit[165] & reg_we & !reg_error;
-  assign mio_outsel_23_wd = reg_wdata[5:0];
+  assign mio_outsel_23_we = addr_hit[185] & reg_we & !reg_error;
+  assign mio_outsel_23_wd = reg_wdata[6:0];
 
-  assign mio_outsel_24_we = addr_hit[166] & reg_we & !reg_error;
-  assign mio_outsel_24_wd = reg_wdata[5:0];
+  assign mio_outsel_24_we = addr_hit[186] & reg_we & !reg_error;
+  assign mio_outsel_24_wd = reg_wdata[6:0];
 
-  assign mio_outsel_25_we = addr_hit[167] & reg_we & !reg_error;
-  assign mio_outsel_25_wd = reg_wdata[5:0];
+  assign mio_outsel_25_we = addr_hit[187] & reg_we & !reg_error;
+  assign mio_outsel_25_wd = reg_wdata[6:0];
 
-  assign mio_outsel_26_we = addr_hit[168] & reg_we & !reg_error;
-  assign mio_outsel_26_wd = reg_wdata[5:0];
+  assign mio_outsel_26_we = addr_hit[188] & reg_we & !reg_error;
+  assign mio_outsel_26_wd = reg_wdata[6:0];
 
-  assign mio_outsel_27_we = addr_hit[169] & reg_we & !reg_error;
-  assign mio_outsel_27_wd = reg_wdata[5:0];
+  assign mio_outsel_27_we = addr_hit[189] & reg_we & !reg_error;
+  assign mio_outsel_27_wd = reg_wdata[6:0];
 
-  assign mio_outsel_28_we = addr_hit[170] & reg_we & !reg_error;
-  assign mio_outsel_28_wd = reg_wdata[5:0];
+  assign mio_outsel_28_we = addr_hit[190] & reg_we & !reg_error;
+  assign mio_outsel_28_wd = reg_wdata[6:0];
 
-  assign mio_outsel_29_we = addr_hit[171] & reg_we & !reg_error;
-  assign mio_outsel_29_wd = reg_wdata[5:0];
+  assign mio_outsel_29_we = addr_hit[191] & reg_we & !reg_error;
+  assign mio_outsel_29_wd = reg_wdata[6:0];
 
-  assign mio_outsel_30_we = addr_hit[172] & reg_we & !reg_error;
-  assign mio_outsel_30_wd = reg_wdata[5:0];
+  assign mio_outsel_30_we = addr_hit[192] & reg_we & !reg_error;
+  assign mio_outsel_30_wd = reg_wdata[6:0];
 
-  assign mio_outsel_31_we = addr_hit[173] & reg_we & !reg_error;
-  assign mio_outsel_31_wd = reg_wdata[5:0];
+  assign mio_outsel_31_we = addr_hit[193] & reg_we & !reg_error;
+  assign mio_outsel_31_wd = reg_wdata[6:0];
 
-  assign mio_outsel_32_we = addr_hit[174] & reg_we & !reg_error;
-  assign mio_outsel_32_wd = reg_wdata[5:0];
+  assign mio_outsel_32_we = addr_hit[194] & reg_we & !reg_error;
+  assign mio_outsel_32_wd = reg_wdata[6:0];
 
-  assign mio_outsel_33_we = addr_hit[175] & reg_we & !reg_error;
-  assign mio_outsel_33_wd = reg_wdata[5:0];
+  assign mio_outsel_33_we = addr_hit[195] & reg_we & !reg_error;
+  assign mio_outsel_33_wd = reg_wdata[6:0];
 
-  assign mio_outsel_34_we = addr_hit[176] & reg_we & !reg_error;
-  assign mio_outsel_34_wd = reg_wdata[5:0];
+  assign mio_outsel_34_we = addr_hit[196] & reg_we & !reg_error;
+  assign mio_outsel_34_wd = reg_wdata[6:0];
 
-  assign mio_outsel_35_we = addr_hit[177] & reg_we & !reg_error;
-  assign mio_outsel_35_wd = reg_wdata[5:0];
+  assign mio_outsel_35_we = addr_hit[197] & reg_we & !reg_error;
+  assign mio_outsel_35_wd = reg_wdata[6:0];
 
-  assign mio_outsel_36_we = addr_hit[178] & reg_we & !reg_error;
-  assign mio_outsel_36_wd = reg_wdata[5:0];
+  assign mio_outsel_36_we = addr_hit[198] & reg_we & !reg_error;
+  assign mio_outsel_36_wd = reg_wdata[6:0];
 
-  assign mio_outsel_37_we = addr_hit[179] & reg_we & !reg_error;
-  assign mio_outsel_37_wd = reg_wdata[5:0];
+  assign mio_outsel_37_we = addr_hit[199] & reg_we & !reg_error;
+  assign mio_outsel_37_wd = reg_wdata[6:0];
 
-  assign mio_outsel_38_we = addr_hit[180] & reg_we & !reg_error;
-  assign mio_outsel_38_wd = reg_wdata[5:0];
+  assign mio_outsel_38_we = addr_hit[200] & reg_we & !reg_error;
+  assign mio_outsel_38_wd = reg_wdata[6:0];
 
-  assign mio_outsel_39_we = addr_hit[181] & reg_we & !reg_error;
-  assign mio_outsel_39_wd = reg_wdata[5:0];
+  assign mio_outsel_39_we = addr_hit[201] & reg_we & !reg_error;
+  assign mio_outsel_39_wd = reg_wdata[6:0];
 
-  assign mio_outsel_40_we = addr_hit[182] & reg_we & !reg_error;
-  assign mio_outsel_40_wd = reg_wdata[5:0];
+  assign mio_outsel_40_we = addr_hit[202] & reg_we & !reg_error;
+  assign mio_outsel_40_wd = reg_wdata[6:0];
 
-  assign mio_outsel_41_we = addr_hit[183] & reg_we & !reg_error;
-  assign mio_outsel_41_wd = reg_wdata[5:0];
+  assign mio_outsel_41_we = addr_hit[203] & reg_we & !reg_error;
+  assign mio_outsel_41_wd = reg_wdata[6:0];
 
-  assign mio_outsel_42_we = addr_hit[184] & reg_we & !reg_error;
-  assign mio_outsel_42_wd = reg_wdata[5:0];
+  assign mio_outsel_42_we = addr_hit[204] & reg_we & !reg_error;
+  assign mio_outsel_42_wd = reg_wdata[6:0];
 
-  assign mio_outsel_43_we = addr_hit[185] & reg_we & !reg_error;
-  assign mio_outsel_43_wd = reg_wdata[5:0];
+  assign mio_outsel_43_we = addr_hit[205] & reg_we & !reg_error;
+  assign mio_outsel_43_wd = reg_wdata[6:0];
 
-  assign mio_pad_attr_regwen_0_we = addr_hit[186] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_0_we = addr_hit[206] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_0_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_1_we = addr_hit[187] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_1_we = addr_hit[207] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_1_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_2_we = addr_hit[188] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_2_we = addr_hit[208] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_2_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_3_we = addr_hit[189] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_3_we = addr_hit[209] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_3_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_4_we = addr_hit[190] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_4_we = addr_hit[210] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_4_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_5_we = addr_hit[191] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_5_we = addr_hit[211] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_5_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_6_we = addr_hit[192] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_6_we = addr_hit[212] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_6_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_7_we = addr_hit[193] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_7_we = addr_hit[213] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_7_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_8_we = addr_hit[194] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_8_we = addr_hit[214] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_8_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_9_we = addr_hit[195] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_9_we = addr_hit[215] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_9_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_10_we = addr_hit[196] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_10_we = addr_hit[216] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_10_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_11_we = addr_hit[197] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_11_we = addr_hit[217] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_11_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_12_we = addr_hit[198] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_12_we = addr_hit[218] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_12_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_13_we = addr_hit[199] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_13_we = addr_hit[219] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_13_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_14_we = addr_hit[200] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_14_we = addr_hit[220] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_14_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_15_we = addr_hit[201] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_15_we = addr_hit[221] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_15_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_16_we = addr_hit[202] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_16_we = addr_hit[222] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_16_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_17_we = addr_hit[203] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_17_we = addr_hit[223] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_17_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_18_we = addr_hit[204] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_18_we = addr_hit[224] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_18_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_19_we = addr_hit[205] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_19_we = addr_hit[225] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_19_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_20_we = addr_hit[206] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_20_we = addr_hit[226] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_20_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_21_we = addr_hit[207] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_21_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_21_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_22_we = addr_hit[208] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_22_we = addr_hit[228] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_22_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_23_we = addr_hit[209] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_23_we = addr_hit[229] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_23_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_24_we = addr_hit[210] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_24_we = addr_hit[230] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_24_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_25_we = addr_hit[211] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_25_we = addr_hit[231] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_25_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_26_we = addr_hit[212] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_26_we = addr_hit[232] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_26_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_27_we = addr_hit[213] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_27_we = addr_hit[233] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_27_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_28_we = addr_hit[214] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_28_we = addr_hit[234] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_28_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_29_we = addr_hit[215] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_29_we = addr_hit[235] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_29_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_30_we = addr_hit[216] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_30_we = addr_hit[236] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_30_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_31_we = addr_hit[217] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_31_we = addr_hit[237] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_31_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_32_we = addr_hit[218] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_32_we = addr_hit[238] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_32_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_33_we = addr_hit[219] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_33_we = addr_hit[239] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_33_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_34_we = addr_hit[220] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_34_we = addr_hit[240] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_34_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_35_we = addr_hit[221] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_35_we = addr_hit[241] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_35_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_36_we = addr_hit[222] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_36_we = addr_hit[242] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_36_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_37_we = addr_hit[223] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_37_we = addr_hit[243] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_37_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_38_we = addr_hit[224] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_38_we = addr_hit[244] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_38_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_39_we = addr_hit[225] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_39_we = addr_hit[245] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_39_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_40_we = addr_hit[226] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_40_we = addr_hit[246] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_40_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_41_we = addr_hit[227] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_41_we = addr_hit[247] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_41_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_42_we = addr_hit[228] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_42_we = addr_hit[248] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_42_wd = reg_wdata[0];
 
-  assign mio_pad_attr_regwen_43_we = addr_hit[229] & reg_we & !reg_error;
+  assign mio_pad_attr_regwen_43_we = addr_hit[249] & reg_we & !reg_error;
   assign mio_pad_attr_regwen_43_wd = reg_wdata[0];
 
-  assign mio_pad_attr_0_we = addr_hit[230] & reg_we & !reg_error;
+  assign mio_pad_attr_0_we = addr_hit[250] & reg_we & !reg_error;
   assign mio_pad_attr_0_wd = reg_wdata[9:0];
-  assign mio_pad_attr_0_re = addr_hit[230] & reg_re & !reg_error;
+  assign mio_pad_attr_0_re = addr_hit[250] & reg_re & !reg_error;
 
-  assign mio_pad_attr_1_we = addr_hit[231] & reg_we & !reg_error;
+  assign mio_pad_attr_1_we = addr_hit[251] & reg_we & !reg_error;
   assign mio_pad_attr_1_wd = reg_wdata[9:0];
-  assign mio_pad_attr_1_re = addr_hit[231] & reg_re & !reg_error;
+  assign mio_pad_attr_1_re = addr_hit[251] & reg_re & !reg_error;
 
-  assign mio_pad_attr_2_we = addr_hit[232] & reg_we & !reg_error;
+  assign mio_pad_attr_2_we = addr_hit[252] & reg_we & !reg_error;
   assign mio_pad_attr_2_wd = reg_wdata[9:0];
-  assign mio_pad_attr_2_re = addr_hit[232] & reg_re & !reg_error;
+  assign mio_pad_attr_2_re = addr_hit[252] & reg_re & !reg_error;
 
-  assign mio_pad_attr_3_we = addr_hit[233] & reg_we & !reg_error;
+  assign mio_pad_attr_3_we = addr_hit[253] & reg_we & !reg_error;
   assign mio_pad_attr_3_wd = reg_wdata[9:0];
-  assign mio_pad_attr_3_re = addr_hit[233] & reg_re & !reg_error;
+  assign mio_pad_attr_3_re = addr_hit[253] & reg_re & !reg_error;
 
-  assign mio_pad_attr_4_we = addr_hit[234] & reg_we & !reg_error;
+  assign mio_pad_attr_4_we = addr_hit[254] & reg_we & !reg_error;
   assign mio_pad_attr_4_wd = reg_wdata[9:0];
-  assign mio_pad_attr_4_re = addr_hit[234] & reg_re & !reg_error;
+  assign mio_pad_attr_4_re = addr_hit[254] & reg_re & !reg_error;
 
-  assign mio_pad_attr_5_we = addr_hit[235] & reg_we & !reg_error;
+  assign mio_pad_attr_5_we = addr_hit[255] & reg_we & !reg_error;
   assign mio_pad_attr_5_wd = reg_wdata[9:0];
-  assign mio_pad_attr_5_re = addr_hit[235] & reg_re & !reg_error;
+  assign mio_pad_attr_5_re = addr_hit[255] & reg_re & !reg_error;
 
-  assign mio_pad_attr_6_we = addr_hit[236] & reg_we & !reg_error;
+  assign mio_pad_attr_6_we = addr_hit[256] & reg_we & !reg_error;
   assign mio_pad_attr_6_wd = reg_wdata[9:0];
-  assign mio_pad_attr_6_re = addr_hit[236] & reg_re & !reg_error;
+  assign mio_pad_attr_6_re = addr_hit[256] & reg_re & !reg_error;
 
-  assign mio_pad_attr_7_we = addr_hit[237] & reg_we & !reg_error;
+  assign mio_pad_attr_7_we = addr_hit[257] & reg_we & !reg_error;
   assign mio_pad_attr_7_wd = reg_wdata[9:0];
-  assign mio_pad_attr_7_re = addr_hit[237] & reg_re & !reg_error;
+  assign mio_pad_attr_7_re = addr_hit[257] & reg_re & !reg_error;
 
-  assign mio_pad_attr_8_we = addr_hit[238] & reg_we & !reg_error;
+  assign mio_pad_attr_8_we = addr_hit[258] & reg_we & !reg_error;
   assign mio_pad_attr_8_wd = reg_wdata[9:0];
-  assign mio_pad_attr_8_re = addr_hit[238] & reg_re & !reg_error;
+  assign mio_pad_attr_8_re = addr_hit[258] & reg_re & !reg_error;
 
-  assign mio_pad_attr_9_we = addr_hit[239] & reg_we & !reg_error;
+  assign mio_pad_attr_9_we = addr_hit[259] & reg_we & !reg_error;
   assign mio_pad_attr_9_wd = reg_wdata[9:0];
-  assign mio_pad_attr_9_re = addr_hit[239] & reg_re & !reg_error;
+  assign mio_pad_attr_9_re = addr_hit[259] & reg_re & !reg_error;
 
-  assign mio_pad_attr_10_we = addr_hit[240] & reg_we & !reg_error;
+  assign mio_pad_attr_10_we = addr_hit[260] & reg_we & !reg_error;
   assign mio_pad_attr_10_wd = reg_wdata[9:0];
-  assign mio_pad_attr_10_re = addr_hit[240] & reg_re & !reg_error;
+  assign mio_pad_attr_10_re = addr_hit[260] & reg_re & !reg_error;
 
-  assign mio_pad_attr_11_we = addr_hit[241] & reg_we & !reg_error;
+  assign mio_pad_attr_11_we = addr_hit[261] & reg_we & !reg_error;
   assign mio_pad_attr_11_wd = reg_wdata[9:0];
-  assign mio_pad_attr_11_re = addr_hit[241] & reg_re & !reg_error;
+  assign mio_pad_attr_11_re = addr_hit[261] & reg_re & !reg_error;
 
-  assign mio_pad_attr_12_we = addr_hit[242] & reg_we & !reg_error;
+  assign mio_pad_attr_12_we = addr_hit[262] & reg_we & !reg_error;
   assign mio_pad_attr_12_wd = reg_wdata[9:0];
-  assign mio_pad_attr_12_re = addr_hit[242] & reg_re & !reg_error;
+  assign mio_pad_attr_12_re = addr_hit[262] & reg_re & !reg_error;
 
-  assign mio_pad_attr_13_we = addr_hit[243] & reg_we & !reg_error;
+  assign mio_pad_attr_13_we = addr_hit[263] & reg_we & !reg_error;
   assign mio_pad_attr_13_wd = reg_wdata[9:0];
-  assign mio_pad_attr_13_re = addr_hit[243] & reg_re & !reg_error;
+  assign mio_pad_attr_13_re = addr_hit[263] & reg_re & !reg_error;
 
-  assign mio_pad_attr_14_we = addr_hit[244] & reg_we & !reg_error;
+  assign mio_pad_attr_14_we = addr_hit[264] & reg_we & !reg_error;
   assign mio_pad_attr_14_wd = reg_wdata[9:0];
-  assign mio_pad_attr_14_re = addr_hit[244] & reg_re & !reg_error;
+  assign mio_pad_attr_14_re = addr_hit[264] & reg_re & !reg_error;
 
-  assign mio_pad_attr_15_we = addr_hit[245] & reg_we & !reg_error;
+  assign mio_pad_attr_15_we = addr_hit[265] & reg_we & !reg_error;
   assign mio_pad_attr_15_wd = reg_wdata[9:0];
-  assign mio_pad_attr_15_re = addr_hit[245] & reg_re & !reg_error;
+  assign mio_pad_attr_15_re = addr_hit[265] & reg_re & !reg_error;
 
-  assign mio_pad_attr_16_we = addr_hit[246] & reg_we & !reg_error;
+  assign mio_pad_attr_16_we = addr_hit[266] & reg_we & !reg_error;
   assign mio_pad_attr_16_wd = reg_wdata[9:0];
-  assign mio_pad_attr_16_re = addr_hit[246] & reg_re & !reg_error;
+  assign mio_pad_attr_16_re = addr_hit[266] & reg_re & !reg_error;
 
-  assign mio_pad_attr_17_we = addr_hit[247] & reg_we & !reg_error;
+  assign mio_pad_attr_17_we = addr_hit[267] & reg_we & !reg_error;
   assign mio_pad_attr_17_wd = reg_wdata[9:0];
-  assign mio_pad_attr_17_re = addr_hit[247] & reg_re & !reg_error;
+  assign mio_pad_attr_17_re = addr_hit[267] & reg_re & !reg_error;
 
-  assign mio_pad_attr_18_we = addr_hit[248] & reg_we & !reg_error;
+  assign mio_pad_attr_18_we = addr_hit[268] & reg_we & !reg_error;
   assign mio_pad_attr_18_wd = reg_wdata[9:0];
-  assign mio_pad_attr_18_re = addr_hit[248] & reg_re & !reg_error;
+  assign mio_pad_attr_18_re = addr_hit[268] & reg_re & !reg_error;
 
-  assign mio_pad_attr_19_we = addr_hit[249] & reg_we & !reg_error;
+  assign mio_pad_attr_19_we = addr_hit[269] & reg_we & !reg_error;
   assign mio_pad_attr_19_wd = reg_wdata[9:0];
-  assign mio_pad_attr_19_re = addr_hit[249] & reg_re & !reg_error;
+  assign mio_pad_attr_19_re = addr_hit[269] & reg_re & !reg_error;
 
-  assign mio_pad_attr_20_we = addr_hit[250] & reg_we & !reg_error;
+  assign mio_pad_attr_20_we = addr_hit[270] & reg_we & !reg_error;
   assign mio_pad_attr_20_wd = reg_wdata[9:0];
-  assign mio_pad_attr_20_re = addr_hit[250] & reg_re & !reg_error;
+  assign mio_pad_attr_20_re = addr_hit[270] & reg_re & !reg_error;
 
-  assign mio_pad_attr_21_we = addr_hit[251] & reg_we & !reg_error;
+  assign mio_pad_attr_21_we = addr_hit[271] & reg_we & !reg_error;
   assign mio_pad_attr_21_wd = reg_wdata[9:0];
-  assign mio_pad_attr_21_re = addr_hit[251] & reg_re & !reg_error;
+  assign mio_pad_attr_21_re = addr_hit[271] & reg_re & !reg_error;
 
-  assign mio_pad_attr_22_we = addr_hit[252] & reg_we & !reg_error;
+  assign mio_pad_attr_22_we = addr_hit[272] & reg_we & !reg_error;
   assign mio_pad_attr_22_wd = reg_wdata[9:0];
-  assign mio_pad_attr_22_re = addr_hit[252] & reg_re & !reg_error;
+  assign mio_pad_attr_22_re = addr_hit[272] & reg_re & !reg_error;
 
-  assign mio_pad_attr_23_we = addr_hit[253] & reg_we & !reg_error;
+  assign mio_pad_attr_23_we = addr_hit[273] & reg_we & !reg_error;
   assign mio_pad_attr_23_wd = reg_wdata[9:0];
-  assign mio_pad_attr_23_re = addr_hit[253] & reg_re & !reg_error;
+  assign mio_pad_attr_23_re = addr_hit[273] & reg_re & !reg_error;
 
-  assign mio_pad_attr_24_we = addr_hit[254] & reg_we & !reg_error;
+  assign mio_pad_attr_24_we = addr_hit[274] & reg_we & !reg_error;
   assign mio_pad_attr_24_wd = reg_wdata[9:0];
-  assign mio_pad_attr_24_re = addr_hit[254] & reg_re & !reg_error;
+  assign mio_pad_attr_24_re = addr_hit[274] & reg_re & !reg_error;
 
-  assign mio_pad_attr_25_we = addr_hit[255] & reg_we & !reg_error;
+  assign mio_pad_attr_25_we = addr_hit[275] & reg_we & !reg_error;
   assign mio_pad_attr_25_wd = reg_wdata[9:0];
-  assign mio_pad_attr_25_re = addr_hit[255] & reg_re & !reg_error;
+  assign mio_pad_attr_25_re = addr_hit[275] & reg_re & !reg_error;
 
-  assign mio_pad_attr_26_we = addr_hit[256] & reg_we & !reg_error;
+  assign mio_pad_attr_26_we = addr_hit[276] & reg_we & !reg_error;
   assign mio_pad_attr_26_wd = reg_wdata[9:0];
-  assign mio_pad_attr_26_re = addr_hit[256] & reg_re & !reg_error;
+  assign mio_pad_attr_26_re = addr_hit[276] & reg_re & !reg_error;
 
-  assign mio_pad_attr_27_we = addr_hit[257] & reg_we & !reg_error;
+  assign mio_pad_attr_27_we = addr_hit[277] & reg_we & !reg_error;
   assign mio_pad_attr_27_wd = reg_wdata[9:0];
-  assign mio_pad_attr_27_re = addr_hit[257] & reg_re & !reg_error;
+  assign mio_pad_attr_27_re = addr_hit[277] & reg_re & !reg_error;
 
-  assign mio_pad_attr_28_we = addr_hit[258] & reg_we & !reg_error;
+  assign mio_pad_attr_28_we = addr_hit[278] & reg_we & !reg_error;
   assign mio_pad_attr_28_wd = reg_wdata[9:0];
-  assign mio_pad_attr_28_re = addr_hit[258] & reg_re & !reg_error;
+  assign mio_pad_attr_28_re = addr_hit[278] & reg_re & !reg_error;
 
-  assign mio_pad_attr_29_we = addr_hit[259] & reg_we & !reg_error;
+  assign mio_pad_attr_29_we = addr_hit[279] & reg_we & !reg_error;
   assign mio_pad_attr_29_wd = reg_wdata[9:0];
-  assign mio_pad_attr_29_re = addr_hit[259] & reg_re & !reg_error;
+  assign mio_pad_attr_29_re = addr_hit[279] & reg_re & !reg_error;
 
-  assign mio_pad_attr_30_we = addr_hit[260] & reg_we & !reg_error;
+  assign mio_pad_attr_30_we = addr_hit[280] & reg_we & !reg_error;
   assign mio_pad_attr_30_wd = reg_wdata[9:0];
-  assign mio_pad_attr_30_re = addr_hit[260] & reg_re & !reg_error;
+  assign mio_pad_attr_30_re = addr_hit[280] & reg_re & !reg_error;
 
-  assign mio_pad_attr_31_we = addr_hit[261] & reg_we & !reg_error;
+  assign mio_pad_attr_31_we = addr_hit[281] & reg_we & !reg_error;
   assign mio_pad_attr_31_wd = reg_wdata[9:0];
-  assign mio_pad_attr_31_re = addr_hit[261] & reg_re & !reg_error;
+  assign mio_pad_attr_31_re = addr_hit[281] & reg_re & !reg_error;
 
-  assign mio_pad_attr_32_we = addr_hit[262] & reg_we & !reg_error;
+  assign mio_pad_attr_32_we = addr_hit[282] & reg_we & !reg_error;
   assign mio_pad_attr_32_wd = reg_wdata[9:0];
-  assign mio_pad_attr_32_re = addr_hit[262] & reg_re & !reg_error;
+  assign mio_pad_attr_32_re = addr_hit[282] & reg_re & !reg_error;
 
-  assign mio_pad_attr_33_we = addr_hit[263] & reg_we & !reg_error;
+  assign mio_pad_attr_33_we = addr_hit[283] & reg_we & !reg_error;
   assign mio_pad_attr_33_wd = reg_wdata[9:0];
-  assign mio_pad_attr_33_re = addr_hit[263] & reg_re & !reg_error;
+  assign mio_pad_attr_33_re = addr_hit[283] & reg_re & !reg_error;
 
-  assign mio_pad_attr_34_we = addr_hit[264] & reg_we & !reg_error;
+  assign mio_pad_attr_34_we = addr_hit[284] & reg_we & !reg_error;
   assign mio_pad_attr_34_wd = reg_wdata[9:0];
-  assign mio_pad_attr_34_re = addr_hit[264] & reg_re & !reg_error;
+  assign mio_pad_attr_34_re = addr_hit[284] & reg_re & !reg_error;
 
-  assign mio_pad_attr_35_we = addr_hit[265] & reg_we & !reg_error;
+  assign mio_pad_attr_35_we = addr_hit[285] & reg_we & !reg_error;
   assign mio_pad_attr_35_wd = reg_wdata[9:0];
-  assign mio_pad_attr_35_re = addr_hit[265] & reg_re & !reg_error;
+  assign mio_pad_attr_35_re = addr_hit[285] & reg_re & !reg_error;
 
-  assign mio_pad_attr_36_we = addr_hit[266] & reg_we & !reg_error;
+  assign mio_pad_attr_36_we = addr_hit[286] & reg_we & !reg_error;
   assign mio_pad_attr_36_wd = reg_wdata[9:0];
-  assign mio_pad_attr_36_re = addr_hit[266] & reg_re & !reg_error;
+  assign mio_pad_attr_36_re = addr_hit[286] & reg_re & !reg_error;
 
-  assign mio_pad_attr_37_we = addr_hit[267] & reg_we & !reg_error;
+  assign mio_pad_attr_37_we = addr_hit[287] & reg_we & !reg_error;
   assign mio_pad_attr_37_wd = reg_wdata[9:0];
-  assign mio_pad_attr_37_re = addr_hit[267] & reg_re & !reg_error;
+  assign mio_pad_attr_37_re = addr_hit[287] & reg_re & !reg_error;
 
-  assign mio_pad_attr_38_we = addr_hit[268] & reg_we & !reg_error;
+  assign mio_pad_attr_38_we = addr_hit[288] & reg_we & !reg_error;
   assign mio_pad_attr_38_wd = reg_wdata[9:0];
-  assign mio_pad_attr_38_re = addr_hit[268] & reg_re & !reg_error;
+  assign mio_pad_attr_38_re = addr_hit[288] & reg_re & !reg_error;
 
-  assign mio_pad_attr_39_we = addr_hit[269] & reg_we & !reg_error;
+  assign mio_pad_attr_39_we = addr_hit[289] & reg_we & !reg_error;
   assign mio_pad_attr_39_wd = reg_wdata[9:0];
-  assign mio_pad_attr_39_re = addr_hit[269] & reg_re & !reg_error;
+  assign mio_pad_attr_39_re = addr_hit[289] & reg_re & !reg_error;
 
-  assign mio_pad_attr_40_we = addr_hit[270] & reg_we & !reg_error;
+  assign mio_pad_attr_40_we = addr_hit[290] & reg_we & !reg_error;
   assign mio_pad_attr_40_wd = reg_wdata[9:0];
-  assign mio_pad_attr_40_re = addr_hit[270] & reg_re & !reg_error;
+  assign mio_pad_attr_40_re = addr_hit[290] & reg_re & !reg_error;
 
-  assign mio_pad_attr_41_we = addr_hit[271] & reg_we & !reg_error;
+  assign mio_pad_attr_41_we = addr_hit[291] & reg_we & !reg_error;
   assign mio_pad_attr_41_wd = reg_wdata[9:0];
-  assign mio_pad_attr_41_re = addr_hit[271] & reg_re & !reg_error;
+  assign mio_pad_attr_41_re = addr_hit[291] & reg_re & !reg_error;
 
-  assign mio_pad_attr_42_we = addr_hit[272] & reg_we & !reg_error;
+  assign mio_pad_attr_42_we = addr_hit[292] & reg_we & !reg_error;
   assign mio_pad_attr_42_wd = reg_wdata[9:0];
-  assign mio_pad_attr_42_re = addr_hit[272] & reg_re & !reg_error;
+  assign mio_pad_attr_42_re = addr_hit[292] & reg_re & !reg_error;
 
-  assign mio_pad_attr_43_we = addr_hit[273] & reg_we & !reg_error;
+  assign mio_pad_attr_43_we = addr_hit[293] & reg_we & !reg_error;
   assign mio_pad_attr_43_wd = reg_wdata[9:0];
-  assign mio_pad_attr_43_re = addr_hit[273] & reg_re & !reg_error;
+  assign mio_pad_attr_43_re = addr_hit[293] & reg_re & !reg_error;
 
-  assign dio_pad_attr_regwen_0_we = addr_hit[274] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_0_we = addr_hit[294] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_0_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_1_we = addr_hit[275] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_1_we = addr_hit[295] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_1_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_2_we = addr_hit[276] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_2_we = addr_hit[296] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_2_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_3_we = addr_hit[277] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_3_we = addr_hit[297] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_3_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_4_we = addr_hit[278] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_4_we = addr_hit[298] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_4_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_5_we = addr_hit[279] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_5_we = addr_hit[299] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_5_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_6_we = addr_hit[280] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_6_we = addr_hit[300] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_6_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_7_we = addr_hit[281] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_7_we = addr_hit[301] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_7_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_8_we = addr_hit[282] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_8_we = addr_hit[302] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_8_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_9_we = addr_hit[283] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_9_we = addr_hit[303] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_9_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_10_we = addr_hit[284] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_10_we = addr_hit[304] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_10_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_11_we = addr_hit[285] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_11_we = addr_hit[305] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_11_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_12_we = addr_hit[286] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_12_we = addr_hit[306] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_12_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_13_we = addr_hit[287] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_13_we = addr_hit[307] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_13_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_14_we = addr_hit[288] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_14_we = addr_hit[308] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_14_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_15_we = addr_hit[289] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_15_we = addr_hit[309] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_15_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_16_we = addr_hit[290] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_16_we = addr_hit[310] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_16_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_17_we = addr_hit[291] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_17_we = addr_hit[311] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_17_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_18_we = addr_hit[292] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_18_we = addr_hit[312] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_18_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_19_we = addr_hit[293] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_19_we = addr_hit[313] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_19_wd = reg_wdata[0];
 
-  assign dio_pad_attr_regwen_20_we = addr_hit[294] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_20_we = addr_hit[314] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_20_wd = reg_wdata[0];
 
-  assign dio_pad_attr_0_we = addr_hit[295] & reg_we & !reg_error;
+  assign dio_pad_attr_0_we = addr_hit[315] & reg_we & !reg_error;
   assign dio_pad_attr_0_wd = reg_wdata[9:0];
-  assign dio_pad_attr_0_re = addr_hit[295] & reg_re & !reg_error;
+  assign dio_pad_attr_0_re = addr_hit[315] & reg_re & !reg_error;
 
-  assign dio_pad_attr_1_we = addr_hit[296] & reg_we & !reg_error;
+  assign dio_pad_attr_1_we = addr_hit[316] & reg_we & !reg_error;
   assign dio_pad_attr_1_wd = reg_wdata[9:0];
-  assign dio_pad_attr_1_re = addr_hit[296] & reg_re & !reg_error;
+  assign dio_pad_attr_1_re = addr_hit[316] & reg_re & !reg_error;
 
-  assign dio_pad_attr_2_we = addr_hit[297] & reg_we & !reg_error;
+  assign dio_pad_attr_2_we = addr_hit[317] & reg_we & !reg_error;
   assign dio_pad_attr_2_wd = reg_wdata[9:0];
-  assign dio_pad_attr_2_re = addr_hit[297] & reg_re & !reg_error;
+  assign dio_pad_attr_2_re = addr_hit[317] & reg_re & !reg_error;
 
-  assign dio_pad_attr_3_we = addr_hit[298] & reg_we & !reg_error;
+  assign dio_pad_attr_3_we = addr_hit[318] & reg_we & !reg_error;
   assign dio_pad_attr_3_wd = reg_wdata[9:0];
-  assign dio_pad_attr_3_re = addr_hit[298] & reg_re & !reg_error;
+  assign dio_pad_attr_3_re = addr_hit[318] & reg_re & !reg_error;
 
-  assign dio_pad_attr_4_we = addr_hit[299] & reg_we & !reg_error;
+  assign dio_pad_attr_4_we = addr_hit[319] & reg_we & !reg_error;
   assign dio_pad_attr_4_wd = reg_wdata[9:0];
-  assign dio_pad_attr_4_re = addr_hit[299] & reg_re & !reg_error;
+  assign dio_pad_attr_4_re = addr_hit[319] & reg_re & !reg_error;
 
-  assign dio_pad_attr_5_we = addr_hit[300] & reg_we & !reg_error;
+  assign dio_pad_attr_5_we = addr_hit[320] & reg_we & !reg_error;
   assign dio_pad_attr_5_wd = reg_wdata[9:0];
-  assign dio_pad_attr_5_re = addr_hit[300] & reg_re & !reg_error;
+  assign dio_pad_attr_5_re = addr_hit[320] & reg_re & !reg_error;
 
-  assign dio_pad_attr_6_we = addr_hit[301] & reg_we & !reg_error;
+  assign dio_pad_attr_6_we = addr_hit[321] & reg_we & !reg_error;
   assign dio_pad_attr_6_wd = reg_wdata[9:0];
-  assign dio_pad_attr_6_re = addr_hit[301] & reg_re & !reg_error;
+  assign dio_pad_attr_6_re = addr_hit[321] & reg_re & !reg_error;
 
-  assign dio_pad_attr_7_we = addr_hit[302] & reg_we & !reg_error;
+  assign dio_pad_attr_7_we = addr_hit[322] & reg_we & !reg_error;
   assign dio_pad_attr_7_wd = reg_wdata[9:0];
-  assign dio_pad_attr_7_re = addr_hit[302] & reg_re & !reg_error;
+  assign dio_pad_attr_7_re = addr_hit[322] & reg_re & !reg_error;
 
-  assign dio_pad_attr_8_we = addr_hit[303] & reg_we & !reg_error;
+  assign dio_pad_attr_8_we = addr_hit[323] & reg_we & !reg_error;
   assign dio_pad_attr_8_wd = reg_wdata[9:0];
-  assign dio_pad_attr_8_re = addr_hit[303] & reg_re & !reg_error;
+  assign dio_pad_attr_8_re = addr_hit[323] & reg_re & !reg_error;
 
-  assign dio_pad_attr_9_we = addr_hit[304] & reg_we & !reg_error;
+  assign dio_pad_attr_9_we = addr_hit[324] & reg_we & !reg_error;
   assign dio_pad_attr_9_wd = reg_wdata[9:0];
-  assign dio_pad_attr_9_re = addr_hit[304] & reg_re & !reg_error;
+  assign dio_pad_attr_9_re = addr_hit[324] & reg_re & !reg_error;
 
-  assign dio_pad_attr_10_we = addr_hit[305] & reg_we & !reg_error;
+  assign dio_pad_attr_10_we = addr_hit[325] & reg_we & !reg_error;
   assign dio_pad_attr_10_wd = reg_wdata[9:0];
-  assign dio_pad_attr_10_re = addr_hit[305] & reg_re & !reg_error;
+  assign dio_pad_attr_10_re = addr_hit[325] & reg_re & !reg_error;
 
-  assign dio_pad_attr_11_we = addr_hit[306] & reg_we & !reg_error;
+  assign dio_pad_attr_11_we = addr_hit[326] & reg_we & !reg_error;
   assign dio_pad_attr_11_wd = reg_wdata[9:0];
-  assign dio_pad_attr_11_re = addr_hit[306] & reg_re & !reg_error;
+  assign dio_pad_attr_11_re = addr_hit[326] & reg_re & !reg_error;
 
-  assign dio_pad_attr_12_we = addr_hit[307] & reg_we & !reg_error;
+  assign dio_pad_attr_12_we = addr_hit[327] & reg_we & !reg_error;
   assign dio_pad_attr_12_wd = reg_wdata[9:0];
-  assign dio_pad_attr_12_re = addr_hit[307] & reg_re & !reg_error;
+  assign dio_pad_attr_12_re = addr_hit[327] & reg_re & !reg_error;
 
-  assign dio_pad_attr_13_we = addr_hit[308] & reg_we & !reg_error;
+  assign dio_pad_attr_13_we = addr_hit[328] & reg_we & !reg_error;
   assign dio_pad_attr_13_wd = reg_wdata[9:0];
-  assign dio_pad_attr_13_re = addr_hit[308] & reg_re & !reg_error;
+  assign dio_pad_attr_13_re = addr_hit[328] & reg_re & !reg_error;
 
-  assign dio_pad_attr_14_we = addr_hit[309] & reg_we & !reg_error;
+  assign dio_pad_attr_14_we = addr_hit[329] & reg_we & !reg_error;
   assign dio_pad_attr_14_wd = reg_wdata[9:0];
-  assign dio_pad_attr_14_re = addr_hit[309] & reg_re & !reg_error;
+  assign dio_pad_attr_14_re = addr_hit[329] & reg_re & !reg_error;
 
-  assign dio_pad_attr_15_we = addr_hit[310] & reg_we & !reg_error;
+  assign dio_pad_attr_15_we = addr_hit[330] & reg_we & !reg_error;
   assign dio_pad_attr_15_wd = reg_wdata[9:0];
-  assign dio_pad_attr_15_re = addr_hit[310] & reg_re & !reg_error;
+  assign dio_pad_attr_15_re = addr_hit[330] & reg_re & !reg_error;
 
-  assign dio_pad_attr_16_we = addr_hit[311] & reg_we & !reg_error;
+  assign dio_pad_attr_16_we = addr_hit[331] & reg_we & !reg_error;
   assign dio_pad_attr_16_wd = reg_wdata[9:0];
-  assign dio_pad_attr_16_re = addr_hit[311] & reg_re & !reg_error;
+  assign dio_pad_attr_16_re = addr_hit[331] & reg_re & !reg_error;
 
-  assign dio_pad_attr_17_we = addr_hit[312] & reg_we & !reg_error;
+  assign dio_pad_attr_17_we = addr_hit[332] & reg_we & !reg_error;
   assign dio_pad_attr_17_wd = reg_wdata[9:0];
-  assign dio_pad_attr_17_re = addr_hit[312] & reg_re & !reg_error;
+  assign dio_pad_attr_17_re = addr_hit[332] & reg_re & !reg_error;
 
-  assign dio_pad_attr_18_we = addr_hit[313] & reg_we & !reg_error;
+  assign dio_pad_attr_18_we = addr_hit[333] & reg_we & !reg_error;
   assign dio_pad_attr_18_wd = reg_wdata[9:0];
-  assign dio_pad_attr_18_re = addr_hit[313] & reg_re & !reg_error;
+  assign dio_pad_attr_18_re = addr_hit[333] & reg_re & !reg_error;
 
-  assign dio_pad_attr_19_we = addr_hit[314] & reg_we & !reg_error;
+  assign dio_pad_attr_19_we = addr_hit[334] & reg_we & !reg_error;
   assign dio_pad_attr_19_wd = reg_wdata[9:0];
-  assign dio_pad_attr_19_re = addr_hit[314] & reg_re & !reg_error;
+  assign dio_pad_attr_19_re = addr_hit[334] & reg_re & !reg_error;
 
-  assign dio_pad_attr_20_we = addr_hit[315] & reg_we & !reg_error;
+  assign dio_pad_attr_20_we = addr_hit[335] & reg_we & !reg_error;
   assign dio_pad_attr_20_wd = reg_wdata[9:0];
-  assign dio_pad_attr_20_re = addr_hit[315] & reg_re & !reg_error;
+  assign dio_pad_attr_20_re = addr_hit[335] & reg_re & !reg_error;
 
-  assign mio_pad_sleep_status_0_en_0_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_0_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_0_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_status_0_en_1_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_1_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_1_wd = reg_wdata[1];
 
-  assign mio_pad_sleep_status_0_en_2_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_2_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_2_wd = reg_wdata[2];
 
-  assign mio_pad_sleep_status_0_en_3_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_3_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_3_wd = reg_wdata[3];
 
-  assign mio_pad_sleep_status_0_en_4_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_4_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_4_wd = reg_wdata[4];
 
-  assign mio_pad_sleep_status_0_en_5_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_5_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_5_wd = reg_wdata[5];
 
-  assign mio_pad_sleep_status_0_en_6_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_6_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_6_wd = reg_wdata[6];
 
-  assign mio_pad_sleep_status_0_en_7_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_7_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_7_wd = reg_wdata[7];
 
-  assign mio_pad_sleep_status_0_en_8_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_8_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_8_wd = reg_wdata[8];
 
-  assign mio_pad_sleep_status_0_en_9_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_9_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_9_wd = reg_wdata[9];
 
-  assign mio_pad_sleep_status_0_en_10_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_10_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_10_wd = reg_wdata[10];
 
-  assign mio_pad_sleep_status_0_en_11_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_11_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_11_wd = reg_wdata[11];
 
-  assign mio_pad_sleep_status_0_en_12_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_12_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_12_wd = reg_wdata[12];
 
-  assign mio_pad_sleep_status_0_en_13_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_13_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_13_wd = reg_wdata[13];
 
-  assign mio_pad_sleep_status_0_en_14_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_14_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_14_wd = reg_wdata[14];
 
-  assign mio_pad_sleep_status_0_en_15_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_15_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_15_wd = reg_wdata[15];
 
-  assign mio_pad_sleep_status_0_en_16_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_16_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_16_wd = reg_wdata[16];
 
-  assign mio_pad_sleep_status_0_en_17_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_17_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_17_wd = reg_wdata[17];
 
-  assign mio_pad_sleep_status_0_en_18_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_18_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_18_wd = reg_wdata[18];
 
-  assign mio_pad_sleep_status_0_en_19_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_19_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_19_wd = reg_wdata[19];
 
-  assign mio_pad_sleep_status_0_en_20_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_20_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_20_wd = reg_wdata[20];
 
-  assign mio_pad_sleep_status_0_en_21_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_21_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_21_wd = reg_wdata[21];
 
-  assign mio_pad_sleep_status_0_en_22_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_22_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_22_wd = reg_wdata[22];
 
-  assign mio_pad_sleep_status_0_en_23_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_23_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_23_wd = reg_wdata[23];
 
-  assign mio_pad_sleep_status_0_en_24_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_24_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_24_wd = reg_wdata[24];
 
-  assign mio_pad_sleep_status_0_en_25_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_25_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_25_wd = reg_wdata[25];
 
-  assign mio_pad_sleep_status_0_en_26_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_26_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_26_wd = reg_wdata[26];
 
-  assign mio_pad_sleep_status_0_en_27_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_27_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_27_wd = reg_wdata[27];
 
-  assign mio_pad_sleep_status_0_en_28_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_28_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_28_wd = reg_wdata[28];
 
-  assign mio_pad_sleep_status_0_en_29_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_29_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_29_wd = reg_wdata[29];
 
-  assign mio_pad_sleep_status_0_en_30_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_30_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_30_wd = reg_wdata[30];
 
-  assign mio_pad_sleep_status_0_en_31_we = addr_hit[316] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_31_we = addr_hit[336] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_31_wd = reg_wdata[31];
 
-  assign mio_pad_sleep_status_1_en_32_we = addr_hit[317] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_32_we = addr_hit[337] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_32_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_status_1_en_33_we = addr_hit[317] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_33_we = addr_hit[337] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_33_wd = reg_wdata[1];
 
-  assign mio_pad_sleep_status_1_en_34_we = addr_hit[317] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_34_we = addr_hit[337] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_34_wd = reg_wdata[2];
 
-  assign mio_pad_sleep_status_1_en_35_we = addr_hit[317] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_35_we = addr_hit[337] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_35_wd = reg_wdata[3];
 
-  assign mio_pad_sleep_status_1_en_36_we = addr_hit[317] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_36_we = addr_hit[337] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_36_wd = reg_wdata[4];
 
-  assign mio_pad_sleep_status_1_en_37_we = addr_hit[317] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_37_we = addr_hit[337] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_37_wd = reg_wdata[5];
 
-  assign mio_pad_sleep_status_1_en_38_we = addr_hit[317] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_38_we = addr_hit[337] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_38_wd = reg_wdata[6];
 
-  assign mio_pad_sleep_status_1_en_39_we = addr_hit[317] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_39_we = addr_hit[337] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_39_wd = reg_wdata[7];
 
-  assign mio_pad_sleep_status_1_en_40_we = addr_hit[317] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_40_we = addr_hit[337] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_40_wd = reg_wdata[8];
 
-  assign mio_pad_sleep_status_1_en_41_we = addr_hit[317] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_41_we = addr_hit[337] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_41_wd = reg_wdata[9];
 
-  assign mio_pad_sleep_status_1_en_42_we = addr_hit[317] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_42_we = addr_hit[337] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_42_wd = reg_wdata[10];
 
-  assign mio_pad_sleep_status_1_en_43_we = addr_hit[317] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_43_we = addr_hit[337] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_43_wd = reg_wdata[11];
 
-  assign mio_pad_sleep_regwen_0_we = addr_hit[318] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_0_we = addr_hit[338] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_0_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_1_we = addr_hit[319] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_1_we = addr_hit[339] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_1_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_2_we = addr_hit[320] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_2_we = addr_hit[340] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_2_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_3_we = addr_hit[321] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_3_we = addr_hit[341] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_3_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_4_we = addr_hit[322] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_4_we = addr_hit[342] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_4_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_5_we = addr_hit[323] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_5_we = addr_hit[343] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_5_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_6_we = addr_hit[324] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_6_we = addr_hit[344] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_6_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_7_we = addr_hit[325] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_7_we = addr_hit[345] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_7_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_8_we = addr_hit[326] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_8_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_8_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_9_we = addr_hit[327] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_9_we = addr_hit[347] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_9_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_10_we = addr_hit[328] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_10_we = addr_hit[348] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_10_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_11_we = addr_hit[329] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_11_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_11_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_12_we = addr_hit[330] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_12_we = addr_hit[350] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_12_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_13_we = addr_hit[331] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_13_we = addr_hit[351] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_13_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_14_we = addr_hit[332] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_14_we = addr_hit[352] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_14_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_15_we = addr_hit[333] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_15_we = addr_hit[353] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_15_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_16_we = addr_hit[334] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_16_we = addr_hit[354] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_16_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_17_we = addr_hit[335] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_17_we = addr_hit[355] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_17_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_18_we = addr_hit[336] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_18_we = addr_hit[356] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_18_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_19_we = addr_hit[337] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_19_we = addr_hit[357] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_19_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_20_we = addr_hit[338] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_20_we = addr_hit[358] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_20_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_21_we = addr_hit[339] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_21_we = addr_hit[359] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_21_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_22_we = addr_hit[340] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_22_we = addr_hit[360] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_22_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_23_we = addr_hit[341] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_23_we = addr_hit[361] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_23_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_24_we = addr_hit[342] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_24_we = addr_hit[362] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_24_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_25_we = addr_hit[343] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_25_we = addr_hit[363] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_25_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_26_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_26_we = addr_hit[364] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_26_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_27_we = addr_hit[345] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_27_we = addr_hit[365] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_27_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_28_we = addr_hit[346] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_28_we = addr_hit[366] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_28_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_29_we = addr_hit[347] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_29_we = addr_hit[367] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_29_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_30_we = addr_hit[348] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_30_we = addr_hit[368] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_30_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_31_we = addr_hit[349] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_31_we = addr_hit[369] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_31_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_32_we = addr_hit[350] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_32_we = addr_hit[370] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_32_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_33_we = addr_hit[351] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_33_we = addr_hit[371] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_33_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_34_we = addr_hit[352] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_34_we = addr_hit[372] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_34_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_35_we = addr_hit[353] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_35_we = addr_hit[373] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_35_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_36_we = addr_hit[354] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_36_we = addr_hit[374] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_36_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_37_we = addr_hit[355] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_37_we = addr_hit[375] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_37_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_38_we = addr_hit[356] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_38_we = addr_hit[376] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_38_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_39_we = addr_hit[357] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_39_we = addr_hit[377] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_39_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_40_we = addr_hit[358] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_40_we = addr_hit[378] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_40_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_41_we = addr_hit[359] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_41_we = addr_hit[379] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_41_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_42_we = addr_hit[360] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_42_we = addr_hit[380] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_42_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_43_we = addr_hit[361] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_43_we = addr_hit[381] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_43_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_0_we = addr_hit[362] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_0_we = addr_hit[382] & reg_we & !reg_error;
   assign mio_pad_sleep_en_0_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_1_we = addr_hit[363] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_1_we = addr_hit[383] & reg_we & !reg_error;
   assign mio_pad_sleep_en_1_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_2_we = addr_hit[364] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_2_we = addr_hit[384] & reg_we & !reg_error;
   assign mio_pad_sleep_en_2_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_3_we = addr_hit[365] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_3_we = addr_hit[385] & reg_we & !reg_error;
   assign mio_pad_sleep_en_3_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_4_we = addr_hit[366] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_4_we = addr_hit[386] & reg_we & !reg_error;
   assign mio_pad_sleep_en_4_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_5_we = addr_hit[367] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_5_we = addr_hit[387] & reg_we & !reg_error;
   assign mio_pad_sleep_en_5_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_6_we = addr_hit[368] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_6_we = addr_hit[388] & reg_we & !reg_error;
   assign mio_pad_sleep_en_6_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_7_we = addr_hit[369] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_7_we = addr_hit[389] & reg_we & !reg_error;
   assign mio_pad_sleep_en_7_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_8_we = addr_hit[370] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_8_we = addr_hit[390] & reg_we & !reg_error;
   assign mio_pad_sleep_en_8_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_9_we = addr_hit[371] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_9_we = addr_hit[391] & reg_we & !reg_error;
   assign mio_pad_sleep_en_9_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_10_we = addr_hit[372] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_10_we = addr_hit[392] & reg_we & !reg_error;
   assign mio_pad_sleep_en_10_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_11_we = addr_hit[373] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_11_we = addr_hit[393] & reg_we & !reg_error;
   assign mio_pad_sleep_en_11_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_12_we = addr_hit[374] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_12_we = addr_hit[394] & reg_we & !reg_error;
   assign mio_pad_sleep_en_12_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_13_we = addr_hit[375] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_13_we = addr_hit[395] & reg_we & !reg_error;
   assign mio_pad_sleep_en_13_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_14_we = addr_hit[376] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_14_we = addr_hit[396] & reg_we & !reg_error;
   assign mio_pad_sleep_en_14_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_15_we = addr_hit[377] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_15_we = addr_hit[397] & reg_we & !reg_error;
   assign mio_pad_sleep_en_15_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_16_we = addr_hit[378] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_16_we = addr_hit[398] & reg_we & !reg_error;
   assign mio_pad_sleep_en_16_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_17_we = addr_hit[379] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_17_we = addr_hit[399] & reg_we & !reg_error;
   assign mio_pad_sleep_en_17_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_18_we = addr_hit[380] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_18_we = addr_hit[400] & reg_we & !reg_error;
   assign mio_pad_sleep_en_18_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_19_we = addr_hit[381] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_19_we = addr_hit[401] & reg_we & !reg_error;
   assign mio_pad_sleep_en_19_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_20_we = addr_hit[382] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_20_we = addr_hit[402] & reg_we & !reg_error;
   assign mio_pad_sleep_en_20_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_21_we = addr_hit[383] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_21_we = addr_hit[403] & reg_we & !reg_error;
   assign mio_pad_sleep_en_21_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_22_we = addr_hit[384] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_22_we = addr_hit[404] & reg_we & !reg_error;
   assign mio_pad_sleep_en_22_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_23_we = addr_hit[385] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_23_we = addr_hit[405] & reg_we & !reg_error;
   assign mio_pad_sleep_en_23_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_24_we = addr_hit[386] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_24_we = addr_hit[406] & reg_we & !reg_error;
   assign mio_pad_sleep_en_24_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_25_we = addr_hit[387] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_25_we = addr_hit[407] & reg_we & !reg_error;
   assign mio_pad_sleep_en_25_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_26_we = addr_hit[388] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_26_we = addr_hit[408] & reg_we & !reg_error;
   assign mio_pad_sleep_en_26_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_27_we = addr_hit[389] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_27_we = addr_hit[409] & reg_we & !reg_error;
   assign mio_pad_sleep_en_27_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_28_we = addr_hit[390] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_28_we = addr_hit[410] & reg_we & !reg_error;
   assign mio_pad_sleep_en_28_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_29_we = addr_hit[391] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_29_we = addr_hit[411] & reg_we & !reg_error;
   assign mio_pad_sleep_en_29_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_30_we = addr_hit[392] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_30_we = addr_hit[412] & reg_we & !reg_error;
   assign mio_pad_sleep_en_30_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_31_we = addr_hit[393] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_31_we = addr_hit[413] & reg_we & !reg_error;
   assign mio_pad_sleep_en_31_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_32_we = addr_hit[394] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_32_we = addr_hit[414] & reg_we & !reg_error;
   assign mio_pad_sleep_en_32_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_33_we = addr_hit[395] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_33_we = addr_hit[415] & reg_we & !reg_error;
   assign mio_pad_sleep_en_33_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_34_we = addr_hit[396] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_34_we = addr_hit[416] & reg_we & !reg_error;
   assign mio_pad_sleep_en_34_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_35_we = addr_hit[397] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_35_we = addr_hit[417] & reg_we & !reg_error;
   assign mio_pad_sleep_en_35_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_36_we = addr_hit[398] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_36_we = addr_hit[418] & reg_we & !reg_error;
   assign mio_pad_sleep_en_36_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_37_we = addr_hit[399] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_37_we = addr_hit[419] & reg_we & !reg_error;
   assign mio_pad_sleep_en_37_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_38_we = addr_hit[400] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_38_we = addr_hit[420] & reg_we & !reg_error;
   assign mio_pad_sleep_en_38_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_39_we = addr_hit[401] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_39_we = addr_hit[421] & reg_we & !reg_error;
   assign mio_pad_sleep_en_39_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_40_we = addr_hit[402] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_40_we = addr_hit[422] & reg_we & !reg_error;
   assign mio_pad_sleep_en_40_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_41_we = addr_hit[403] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_41_we = addr_hit[423] & reg_we & !reg_error;
   assign mio_pad_sleep_en_41_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_42_we = addr_hit[404] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_42_we = addr_hit[424] & reg_we & !reg_error;
   assign mio_pad_sleep_en_42_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_43_we = addr_hit[405] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_43_we = addr_hit[425] & reg_we & !reg_error;
   assign mio_pad_sleep_en_43_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_mode_0_we = addr_hit[406] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_0_we = addr_hit[426] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_0_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_1_we = addr_hit[407] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_1_we = addr_hit[427] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_1_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_2_we = addr_hit[408] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_2_we = addr_hit[428] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_2_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_3_we = addr_hit[409] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_3_we = addr_hit[429] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_3_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_4_we = addr_hit[410] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_4_we = addr_hit[430] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_4_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_5_we = addr_hit[411] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_5_we = addr_hit[431] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_5_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_6_we = addr_hit[412] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_6_we = addr_hit[432] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_6_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_7_we = addr_hit[413] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_7_we = addr_hit[433] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_7_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_8_we = addr_hit[414] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_8_we = addr_hit[434] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_8_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_9_we = addr_hit[415] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_9_we = addr_hit[435] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_9_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_10_we = addr_hit[416] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_10_we = addr_hit[436] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_10_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_11_we = addr_hit[417] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_11_we = addr_hit[437] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_11_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_12_we = addr_hit[418] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_12_we = addr_hit[438] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_12_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_13_we = addr_hit[419] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_13_we = addr_hit[439] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_13_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_14_we = addr_hit[420] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_14_we = addr_hit[440] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_14_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_15_we = addr_hit[421] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_15_we = addr_hit[441] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_15_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_16_we = addr_hit[422] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_16_we = addr_hit[442] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_16_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_17_we = addr_hit[423] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_17_we = addr_hit[443] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_17_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_18_we = addr_hit[424] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_18_we = addr_hit[444] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_18_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_19_we = addr_hit[425] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_19_we = addr_hit[445] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_19_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_20_we = addr_hit[426] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_20_we = addr_hit[446] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_20_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_21_we = addr_hit[427] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_21_we = addr_hit[447] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_21_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_22_we = addr_hit[428] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_22_we = addr_hit[448] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_22_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_23_we = addr_hit[429] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_23_we = addr_hit[449] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_23_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_24_we = addr_hit[430] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_24_we = addr_hit[450] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_24_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_25_we = addr_hit[431] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_25_we = addr_hit[451] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_25_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_26_we = addr_hit[432] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_26_we = addr_hit[452] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_26_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_27_we = addr_hit[433] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_27_we = addr_hit[453] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_27_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_28_we = addr_hit[434] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_28_we = addr_hit[454] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_28_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_29_we = addr_hit[435] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_29_we = addr_hit[455] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_29_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_30_we = addr_hit[436] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_30_we = addr_hit[456] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_30_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_31_we = addr_hit[437] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_31_we = addr_hit[457] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_31_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_32_we = addr_hit[438] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_32_we = addr_hit[458] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_32_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_33_we = addr_hit[439] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_33_we = addr_hit[459] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_33_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_34_we = addr_hit[440] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_34_we = addr_hit[460] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_34_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_35_we = addr_hit[441] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_35_we = addr_hit[461] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_35_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_36_we = addr_hit[442] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_36_we = addr_hit[462] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_36_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_37_we = addr_hit[443] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_37_we = addr_hit[463] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_37_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_38_we = addr_hit[444] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_38_we = addr_hit[464] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_38_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_39_we = addr_hit[445] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_39_we = addr_hit[465] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_39_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_40_we = addr_hit[446] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_40_we = addr_hit[466] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_40_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_41_we = addr_hit[447] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_41_we = addr_hit[467] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_41_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_42_we = addr_hit[448] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_42_we = addr_hit[468] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_42_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_43_we = addr_hit[449] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_43_we = addr_hit[469] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_43_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_status_en_0_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_0_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_0_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_status_en_1_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_1_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_1_wd = reg_wdata[1];
 
-  assign dio_pad_sleep_status_en_2_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_2_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_2_wd = reg_wdata[2];
 
-  assign dio_pad_sleep_status_en_3_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_3_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_3_wd = reg_wdata[3];
 
-  assign dio_pad_sleep_status_en_4_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_4_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_4_wd = reg_wdata[4];
 
-  assign dio_pad_sleep_status_en_5_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_5_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_5_wd = reg_wdata[5];
 
-  assign dio_pad_sleep_status_en_6_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_6_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_6_wd = reg_wdata[6];
 
-  assign dio_pad_sleep_status_en_7_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_7_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_7_wd = reg_wdata[7];
 
-  assign dio_pad_sleep_status_en_8_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_8_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_8_wd = reg_wdata[8];
 
-  assign dio_pad_sleep_status_en_9_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_9_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_9_wd = reg_wdata[9];
 
-  assign dio_pad_sleep_status_en_10_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_10_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_10_wd = reg_wdata[10];
 
-  assign dio_pad_sleep_status_en_11_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_11_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_11_wd = reg_wdata[11];
 
-  assign dio_pad_sleep_status_en_12_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_12_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_12_wd = reg_wdata[12];
 
-  assign dio_pad_sleep_status_en_13_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_13_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_13_wd = reg_wdata[13];
 
-  assign dio_pad_sleep_status_en_14_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_14_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_14_wd = reg_wdata[14];
 
-  assign dio_pad_sleep_status_en_15_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_15_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_15_wd = reg_wdata[15];
 
-  assign dio_pad_sleep_status_en_16_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_16_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_16_wd = reg_wdata[16];
 
-  assign dio_pad_sleep_status_en_17_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_17_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_17_wd = reg_wdata[17];
 
-  assign dio_pad_sleep_status_en_18_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_18_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_18_wd = reg_wdata[18];
 
-  assign dio_pad_sleep_status_en_19_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_19_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_19_wd = reg_wdata[19];
 
-  assign dio_pad_sleep_status_en_20_we = addr_hit[450] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_20_we = addr_hit[470] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_20_wd = reg_wdata[20];
 
-  assign dio_pad_sleep_regwen_0_we = addr_hit[451] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_0_we = addr_hit[471] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_0_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_1_we = addr_hit[452] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_1_we = addr_hit[472] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_1_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_2_we = addr_hit[453] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_2_we = addr_hit[473] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_2_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_3_we = addr_hit[454] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_3_we = addr_hit[474] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_3_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_4_we = addr_hit[455] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_4_we = addr_hit[475] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_4_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_5_we = addr_hit[456] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_5_we = addr_hit[476] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_5_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_6_we = addr_hit[457] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_6_we = addr_hit[477] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_6_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_7_we = addr_hit[458] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_7_we = addr_hit[478] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_7_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_8_we = addr_hit[459] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_8_we = addr_hit[479] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_8_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_9_we = addr_hit[460] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_9_we = addr_hit[480] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_9_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_10_we = addr_hit[461] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_10_we = addr_hit[481] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_10_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_11_we = addr_hit[462] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_11_we = addr_hit[482] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_11_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_12_we = addr_hit[463] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_12_we = addr_hit[483] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_12_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_13_we = addr_hit[464] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_13_we = addr_hit[484] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_13_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_14_we = addr_hit[465] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_14_we = addr_hit[485] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_14_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_15_we = addr_hit[466] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_15_we = addr_hit[486] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_15_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_16_we = addr_hit[467] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_16_we = addr_hit[487] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_16_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_17_we = addr_hit[468] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_17_we = addr_hit[488] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_17_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_18_we = addr_hit[469] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_18_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_18_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_19_we = addr_hit[470] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_19_we = addr_hit[490] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_19_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_20_we = addr_hit[471] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_20_we = addr_hit[491] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_20_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_0_we = addr_hit[472] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_0_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_en_0_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_1_we = addr_hit[473] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_1_we = addr_hit[493] & reg_we & !reg_error;
   assign dio_pad_sleep_en_1_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_2_we = addr_hit[474] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_2_we = addr_hit[494] & reg_we & !reg_error;
   assign dio_pad_sleep_en_2_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_3_we = addr_hit[475] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_3_we = addr_hit[495] & reg_we & !reg_error;
   assign dio_pad_sleep_en_3_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_4_we = addr_hit[476] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_4_we = addr_hit[496] & reg_we & !reg_error;
   assign dio_pad_sleep_en_4_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_5_we = addr_hit[477] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_5_we = addr_hit[497] & reg_we & !reg_error;
   assign dio_pad_sleep_en_5_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_6_we = addr_hit[478] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_6_we = addr_hit[498] & reg_we & !reg_error;
   assign dio_pad_sleep_en_6_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_7_we = addr_hit[479] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_7_we = addr_hit[499] & reg_we & !reg_error;
   assign dio_pad_sleep_en_7_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_8_we = addr_hit[480] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_8_we = addr_hit[500] & reg_we & !reg_error;
   assign dio_pad_sleep_en_8_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_9_we = addr_hit[481] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_9_we = addr_hit[501] & reg_we & !reg_error;
   assign dio_pad_sleep_en_9_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_10_we = addr_hit[482] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_10_we = addr_hit[502] & reg_we & !reg_error;
   assign dio_pad_sleep_en_10_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_11_we = addr_hit[483] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_11_we = addr_hit[503] & reg_we & !reg_error;
   assign dio_pad_sleep_en_11_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_12_we = addr_hit[484] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_12_we = addr_hit[504] & reg_we & !reg_error;
   assign dio_pad_sleep_en_12_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_13_we = addr_hit[485] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_13_we = addr_hit[505] & reg_we & !reg_error;
   assign dio_pad_sleep_en_13_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_14_we = addr_hit[486] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_14_we = addr_hit[506] & reg_we & !reg_error;
   assign dio_pad_sleep_en_14_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_15_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_15_we = addr_hit[507] & reg_we & !reg_error;
   assign dio_pad_sleep_en_15_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_16_we = addr_hit[488] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_16_we = addr_hit[508] & reg_we & !reg_error;
   assign dio_pad_sleep_en_16_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_17_we = addr_hit[489] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_17_we = addr_hit[509] & reg_we & !reg_error;
   assign dio_pad_sleep_en_17_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_18_we = addr_hit[490] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_18_we = addr_hit[510] & reg_we & !reg_error;
   assign dio_pad_sleep_en_18_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_19_we = addr_hit[491] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_19_we = addr_hit[511] & reg_we & !reg_error;
   assign dio_pad_sleep_en_19_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_20_we = addr_hit[492] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_20_we = addr_hit[512] & reg_we & !reg_error;
   assign dio_pad_sleep_en_20_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_mode_0_we = addr_hit[493] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_0_we = addr_hit[513] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_0_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_1_we = addr_hit[494] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_1_we = addr_hit[514] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_1_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_2_we = addr_hit[495] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_2_we = addr_hit[515] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_2_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_3_we = addr_hit[496] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_3_we = addr_hit[516] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_3_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_4_we = addr_hit[497] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_4_we = addr_hit[517] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_4_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_5_we = addr_hit[498] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_5_we = addr_hit[518] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_5_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_6_we = addr_hit[499] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_6_we = addr_hit[519] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_6_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_7_we = addr_hit[500] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_7_we = addr_hit[520] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_7_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_8_we = addr_hit[501] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_8_we = addr_hit[521] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_8_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_9_we = addr_hit[502] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_9_we = addr_hit[522] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_9_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_10_we = addr_hit[503] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_10_we = addr_hit[523] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_10_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_11_we = addr_hit[504] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_11_we = addr_hit[524] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_11_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_12_we = addr_hit[505] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_12_we = addr_hit[525] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_12_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_13_we = addr_hit[506] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_13_we = addr_hit[526] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_13_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_14_we = addr_hit[507] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_14_we = addr_hit[527] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_14_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_15_we = addr_hit[508] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_15_we = addr_hit[528] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_15_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_16_we = addr_hit[509] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_16_we = addr_hit[529] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_16_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_17_we = addr_hit[510] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_17_we = addr_hit[530] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_17_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_18_we = addr_hit[511] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_18_we = addr_hit[531] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_18_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_19_we = addr_hit[512] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_19_we = addr_hit[532] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_19_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_20_we = addr_hit[513] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_20_we = addr_hit[533] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_20_wd = reg_wdata[1:0];
 
-  assign wkup_detector_regwen_0_we = addr_hit[514] & reg_we & !reg_error;
+  assign wkup_detector_regwen_0_we = addr_hit[534] & reg_we & !reg_error;
   assign wkup_detector_regwen_0_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_1_we = addr_hit[515] & reg_we & !reg_error;
+  assign wkup_detector_regwen_1_we = addr_hit[535] & reg_we & !reg_error;
   assign wkup_detector_regwen_1_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_2_we = addr_hit[516] & reg_we & !reg_error;
+  assign wkup_detector_regwen_2_we = addr_hit[536] & reg_we & !reg_error;
   assign wkup_detector_regwen_2_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_3_we = addr_hit[517] & reg_we & !reg_error;
+  assign wkup_detector_regwen_3_we = addr_hit[537] & reg_we & !reg_error;
   assign wkup_detector_regwen_3_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_4_we = addr_hit[518] & reg_we & !reg_error;
+  assign wkup_detector_regwen_4_we = addr_hit[538] & reg_we & !reg_error;
   assign wkup_detector_regwen_4_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_5_we = addr_hit[519] & reg_we & !reg_error;
+  assign wkup_detector_regwen_5_we = addr_hit[539] & reg_we & !reg_error;
   assign wkup_detector_regwen_5_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_6_we = addr_hit[520] & reg_we & !reg_error;
+  assign wkup_detector_regwen_6_we = addr_hit[540] & reg_we & !reg_error;
   assign wkup_detector_regwen_6_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_7_we = addr_hit[521] & reg_we & !reg_error;
+  assign wkup_detector_regwen_7_we = addr_hit[541] & reg_we & !reg_error;
   assign wkup_detector_regwen_7_wd = reg_wdata[0];
 
-  assign wkup_detector_en_0_we = addr_hit[522] & reg_we & !reg_error;
+  assign wkup_detector_en_0_we = addr_hit[542] & reg_we & !reg_error;
   assign wkup_detector_en_0_wd = reg_wdata[0];
 
-  assign wkup_detector_en_1_we = addr_hit[523] & reg_we & !reg_error;
+  assign wkup_detector_en_1_we = addr_hit[543] & reg_we & !reg_error;
   assign wkup_detector_en_1_wd = reg_wdata[0];
 
-  assign wkup_detector_en_2_we = addr_hit[524] & reg_we & !reg_error;
+  assign wkup_detector_en_2_we = addr_hit[544] & reg_we & !reg_error;
   assign wkup_detector_en_2_wd = reg_wdata[0];
 
-  assign wkup_detector_en_3_we = addr_hit[525] & reg_we & !reg_error;
+  assign wkup_detector_en_3_we = addr_hit[545] & reg_we & !reg_error;
   assign wkup_detector_en_3_wd = reg_wdata[0];
 
-  assign wkup_detector_en_4_we = addr_hit[526] & reg_we & !reg_error;
+  assign wkup_detector_en_4_we = addr_hit[546] & reg_we & !reg_error;
   assign wkup_detector_en_4_wd = reg_wdata[0];
 
-  assign wkup_detector_en_5_we = addr_hit[527] & reg_we & !reg_error;
+  assign wkup_detector_en_5_we = addr_hit[547] & reg_we & !reg_error;
   assign wkup_detector_en_5_wd = reg_wdata[0];
 
-  assign wkup_detector_en_6_we = addr_hit[528] & reg_we & !reg_error;
+  assign wkup_detector_en_6_we = addr_hit[548] & reg_we & !reg_error;
   assign wkup_detector_en_6_wd = reg_wdata[0];
 
-  assign wkup_detector_en_7_we = addr_hit[529] & reg_we & !reg_error;
+  assign wkup_detector_en_7_we = addr_hit[549] & reg_we & !reg_error;
   assign wkup_detector_en_7_wd = reg_wdata[0];
 
-  assign wkup_detector_0_mode_0_we = addr_hit[530] & reg_we & !reg_error;
+  assign wkup_detector_0_mode_0_we = addr_hit[550] & reg_we & !reg_error;
   assign wkup_detector_0_mode_0_wd = reg_wdata[2:0];
 
-  assign wkup_detector_0_filter_0_we = addr_hit[530] & reg_we & !reg_error;
+  assign wkup_detector_0_filter_0_we = addr_hit[550] & reg_we & !reg_error;
   assign wkup_detector_0_filter_0_wd = reg_wdata[3];
 
-  assign wkup_detector_0_miodio_0_we = addr_hit[530] & reg_we & !reg_error;
+  assign wkup_detector_0_miodio_0_we = addr_hit[550] & reg_we & !reg_error;
   assign wkup_detector_0_miodio_0_wd = reg_wdata[4];
 
-  assign wkup_detector_1_mode_1_we = addr_hit[531] & reg_we & !reg_error;
+  assign wkup_detector_1_mode_1_we = addr_hit[551] & reg_we & !reg_error;
   assign wkup_detector_1_mode_1_wd = reg_wdata[2:0];
 
-  assign wkup_detector_1_filter_1_we = addr_hit[531] & reg_we & !reg_error;
+  assign wkup_detector_1_filter_1_we = addr_hit[551] & reg_we & !reg_error;
   assign wkup_detector_1_filter_1_wd = reg_wdata[3];
 
-  assign wkup_detector_1_miodio_1_we = addr_hit[531] & reg_we & !reg_error;
+  assign wkup_detector_1_miodio_1_we = addr_hit[551] & reg_we & !reg_error;
   assign wkup_detector_1_miodio_1_wd = reg_wdata[4];
 
-  assign wkup_detector_2_mode_2_we = addr_hit[532] & reg_we & !reg_error;
+  assign wkup_detector_2_mode_2_we = addr_hit[552] & reg_we & !reg_error;
   assign wkup_detector_2_mode_2_wd = reg_wdata[2:0];
 
-  assign wkup_detector_2_filter_2_we = addr_hit[532] & reg_we & !reg_error;
+  assign wkup_detector_2_filter_2_we = addr_hit[552] & reg_we & !reg_error;
   assign wkup_detector_2_filter_2_wd = reg_wdata[3];
 
-  assign wkup_detector_2_miodio_2_we = addr_hit[532] & reg_we & !reg_error;
+  assign wkup_detector_2_miodio_2_we = addr_hit[552] & reg_we & !reg_error;
   assign wkup_detector_2_miodio_2_wd = reg_wdata[4];
 
-  assign wkup_detector_3_mode_3_we = addr_hit[533] & reg_we & !reg_error;
+  assign wkup_detector_3_mode_3_we = addr_hit[553] & reg_we & !reg_error;
   assign wkup_detector_3_mode_3_wd = reg_wdata[2:0];
 
-  assign wkup_detector_3_filter_3_we = addr_hit[533] & reg_we & !reg_error;
+  assign wkup_detector_3_filter_3_we = addr_hit[553] & reg_we & !reg_error;
   assign wkup_detector_3_filter_3_wd = reg_wdata[3];
 
-  assign wkup_detector_3_miodio_3_we = addr_hit[533] & reg_we & !reg_error;
+  assign wkup_detector_3_miodio_3_we = addr_hit[553] & reg_we & !reg_error;
   assign wkup_detector_3_miodio_3_wd = reg_wdata[4];
 
-  assign wkup_detector_4_mode_4_we = addr_hit[534] & reg_we & !reg_error;
+  assign wkup_detector_4_mode_4_we = addr_hit[554] & reg_we & !reg_error;
   assign wkup_detector_4_mode_4_wd = reg_wdata[2:0];
 
-  assign wkup_detector_4_filter_4_we = addr_hit[534] & reg_we & !reg_error;
+  assign wkup_detector_4_filter_4_we = addr_hit[554] & reg_we & !reg_error;
   assign wkup_detector_4_filter_4_wd = reg_wdata[3];
 
-  assign wkup_detector_4_miodio_4_we = addr_hit[534] & reg_we & !reg_error;
+  assign wkup_detector_4_miodio_4_we = addr_hit[554] & reg_we & !reg_error;
   assign wkup_detector_4_miodio_4_wd = reg_wdata[4];
 
-  assign wkup_detector_5_mode_5_we = addr_hit[535] & reg_we & !reg_error;
+  assign wkup_detector_5_mode_5_we = addr_hit[555] & reg_we & !reg_error;
   assign wkup_detector_5_mode_5_wd = reg_wdata[2:0];
 
-  assign wkup_detector_5_filter_5_we = addr_hit[535] & reg_we & !reg_error;
+  assign wkup_detector_5_filter_5_we = addr_hit[555] & reg_we & !reg_error;
   assign wkup_detector_5_filter_5_wd = reg_wdata[3];
 
-  assign wkup_detector_5_miodio_5_we = addr_hit[535] & reg_we & !reg_error;
+  assign wkup_detector_5_miodio_5_we = addr_hit[555] & reg_we & !reg_error;
   assign wkup_detector_5_miodio_5_wd = reg_wdata[4];
 
-  assign wkup_detector_6_mode_6_we = addr_hit[536] & reg_we & !reg_error;
+  assign wkup_detector_6_mode_6_we = addr_hit[556] & reg_we & !reg_error;
   assign wkup_detector_6_mode_6_wd = reg_wdata[2:0];
 
-  assign wkup_detector_6_filter_6_we = addr_hit[536] & reg_we & !reg_error;
+  assign wkup_detector_6_filter_6_we = addr_hit[556] & reg_we & !reg_error;
   assign wkup_detector_6_filter_6_wd = reg_wdata[3];
 
-  assign wkup_detector_6_miodio_6_we = addr_hit[536] & reg_we & !reg_error;
+  assign wkup_detector_6_miodio_6_we = addr_hit[556] & reg_we & !reg_error;
   assign wkup_detector_6_miodio_6_wd = reg_wdata[4];
 
-  assign wkup_detector_7_mode_7_we = addr_hit[537] & reg_we & !reg_error;
+  assign wkup_detector_7_mode_7_we = addr_hit[557] & reg_we & !reg_error;
   assign wkup_detector_7_mode_7_wd = reg_wdata[2:0];
 
-  assign wkup_detector_7_filter_7_we = addr_hit[537] & reg_we & !reg_error;
+  assign wkup_detector_7_filter_7_we = addr_hit[557] & reg_we & !reg_error;
   assign wkup_detector_7_filter_7_wd = reg_wdata[3];
 
-  assign wkup_detector_7_miodio_7_we = addr_hit[537] & reg_we & !reg_error;
+  assign wkup_detector_7_miodio_7_we = addr_hit[557] & reg_we & !reg_error;
   assign wkup_detector_7_miodio_7_wd = reg_wdata[4];
 
-  assign wkup_detector_cnt_th_0_we = addr_hit[538] & reg_we & !reg_error;
+  assign wkup_detector_cnt_th_0_we = addr_hit[558] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_0_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_1_we = addr_hit[539] & reg_we & !reg_error;
+  assign wkup_detector_cnt_th_1_we = addr_hit[559] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_1_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_2_we = addr_hit[540] & reg_we & !reg_error;
+  assign wkup_detector_cnt_th_2_we = addr_hit[560] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_2_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_3_we = addr_hit[541] & reg_we & !reg_error;
+  assign wkup_detector_cnt_th_3_we = addr_hit[561] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_3_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_4_we = addr_hit[542] & reg_we & !reg_error;
+  assign wkup_detector_cnt_th_4_we = addr_hit[562] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_4_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_5_we = addr_hit[543] & reg_we & !reg_error;
+  assign wkup_detector_cnt_th_5_we = addr_hit[563] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_5_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_6_we = addr_hit[544] & reg_we & !reg_error;
+  assign wkup_detector_cnt_th_6_we = addr_hit[564] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_6_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_7_we = addr_hit[545] & reg_we & !reg_error;
+  assign wkup_detector_cnt_th_7_we = addr_hit[565] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_7_wd = reg_wdata[7:0];
 
-  assign wkup_detector_padsel_0_we = addr_hit[546] & reg_we & !reg_error;
+  assign wkup_detector_padsel_0_we = addr_hit[566] & reg_we & !reg_error;
   assign wkup_detector_padsel_0_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_1_we = addr_hit[547] & reg_we & !reg_error;
+  assign wkup_detector_padsel_1_we = addr_hit[567] & reg_we & !reg_error;
   assign wkup_detector_padsel_1_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_2_we = addr_hit[548] & reg_we & !reg_error;
+  assign wkup_detector_padsel_2_we = addr_hit[568] & reg_we & !reg_error;
   assign wkup_detector_padsel_2_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_3_we = addr_hit[549] & reg_we & !reg_error;
+  assign wkup_detector_padsel_3_we = addr_hit[569] & reg_we & !reg_error;
   assign wkup_detector_padsel_3_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_4_we = addr_hit[550] & reg_we & !reg_error;
+  assign wkup_detector_padsel_4_we = addr_hit[570] & reg_we & !reg_error;
   assign wkup_detector_padsel_4_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_5_we = addr_hit[551] & reg_we & !reg_error;
+  assign wkup_detector_padsel_5_we = addr_hit[571] & reg_we & !reg_error;
   assign wkup_detector_padsel_5_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_6_we = addr_hit[552] & reg_we & !reg_error;
+  assign wkup_detector_padsel_6_we = addr_hit[572] & reg_we & !reg_error;
   assign wkup_detector_padsel_6_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_7_we = addr_hit[553] & reg_we & !reg_error;
+  assign wkup_detector_padsel_7_we = addr_hit[573] & reg_we & !reg_error;
   assign wkup_detector_padsel_7_wd = reg_wdata[5:0];
 
-  assign wkup_cause_cause_0_we = addr_hit[554] & reg_we & !reg_error;
+  assign wkup_cause_cause_0_we = addr_hit[574] & reg_we & !reg_error;
   assign wkup_cause_cause_0_wd = reg_wdata[0];
-  assign wkup_cause_cause_0_re = addr_hit[554] & reg_re & !reg_error;
+  assign wkup_cause_cause_0_re = addr_hit[574] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_1_we = addr_hit[554] & reg_we & !reg_error;
+  assign wkup_cause_cause_1_we = addr_hit[574] & reg_we & !reg_error;
   assign wkup_cause_cause_1_wd = reg_wdata[1];
-  assign wkup_cause_cause_1_re = addr_hit[554] & reg_re & !reg_error;
+  assign wkup_cause_cause_1_re = addr_hit[574] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_2_we = addr_hit[554] & reg_we & !reg_error;
+  assign wkup_cause_cause_2_we = addr_hit[574] & reg_we & !reg_error;
   assign wkup_cause_cause_2_wd = reg_wdata[2];
-  assign wkup_cause_cause_2_re = addr_hit[554] & reg_re & !reg_error;
+  assign wkup_cause_cause_2_re = addr_hit[574] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_3_we = addr_hit[554] & reg_we & !reg_error;
+  assign wkup_cause_cause_3_we = addr_hit[574] & reg_we & !reg_error;
   assign wkup_cause_cause_3_wd = reg_wdata[3];
-  assign wkup_cause_cause_3_re = addr_hit[554] & reg_re & !reg_error;
+  assign wkup_cause_cause_3_re = addr_hit[574] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_4_we = addr_hit[554] & reg_we & !reg_error;
+  assign wkup_cause_cause_4_we = addr_hit[574] & reg_we & !reg_error;
   assign wkup_cause_cause_4_wd = reg_wdata[4];
-  assign wkup_cause_cause_4_re = addr_hit[554] & reg_re & !reg_error;
+  assign wkup_cause_cause_4_re = addr_hit[574] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_5_we = addr_hit[554] & reg_we & !reg_error;
+  assign wkup_cause_cause_5_we = addr_hit[574] & reg_we & !reg_error;
   assign wkup_cause_cause_5_wd = reg_wdata[5];
-  assign wkup_cause_cause_5_re = addr_hit[554] & reg_re & !reg_error;
+  assign wkup_cause_cause_5_re = addr_hit[574] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_6_we = addr_hit[554] & reg_we & !reg_error;
+  assign wkup_cause_cause_6_we = addr_hit[574] & reg_we & !reg_error;
   assign wkup_cause_cause_6_wd = reg_wdata[6];
-  assign wkup_cause_cause_6_re = addr_hit[554] & reg_re & !reg_error;
+  assign wkup_cause_cause_6_re = addr_hit[574] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_7_we = addr_hit[554] & reg_we & !reg_error;
+  assign wkup_cause_cause_7_we = addr_hit[574] & reg_we & !reg_error;
   assign wkup_cause_cause_7_wd = reg_wdata[7];
-  assign wkup_cause_cause_7_re = addr_hit[554] & reg_re & !reg_error;
+  assign wkup_cause_cause_7_re = addr_hit[574] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin
@@ -21938,1074 +22638,1154 @@ module pinmux_reg_top (
       end
 
       addr_hit[49]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_0_qs;
+        reg_rdata_next[0] = mio_periph_insel_regwen_49_qs;
       end
 
       addr_hit[50]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_1_qs;
+        reg_rdata_next[0] = mio_periph_insel_regwen_50_qs;
       end
 
       addr_hit[51]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_2_qs;
+        reg_rdata_next[0] = mio_periph_insel_regwen_51_qs;
       end
 
       addr_hit[52]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_3_qs;
+        reg_rdata_next[0] = mio_periph_insel_regwen_52_qs;
       end
 
       addr_hit[53]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_4_qs;
+        reg_rdata_next[0] = mio_periph_insel_regwen_53_qs;
       end
 
       addr_hit[54]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_5_qs;
+        reg_rdata_next[0] = mio_periph_insel_regwen_54_qs;
       end
 
       addr_hit[55]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_6_qs;
+        reg_rdata_next[0] = mio_periph_insel_regwen_55_qs;
       end
 
       addr_hit[56]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_7_qs;
+        reg_rdata_next[0] = mio_periph_insel_regwen_56_qs;
       end
 
       addr_hit[57]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_8_qs;
+        reg_rdata_next[0] = mio_periph_insel_regwen_57_qs;
       end
 
       addr_hit[58]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_9_qs;
+        reg_rdata_next[0] = mio_periph_insel_regwen_58_qs;
       end
 
       addr_hit[59]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_10_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_0_qs;
       end
 
       addr_hit[60]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_11_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_1_qs;
       end
 
       addr_hit[61]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_12_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_2_qs;
       end
 
       addr_hit[62]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_13_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_3_qs;
       end
 
       addr_hit[63]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_14_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_4_qs;
       end
 
       addr_hit[64]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_15_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_5_qs;
       end
 
       addr_hit[65]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_16_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_6_qs;
       end
 
       addr_hit[66]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_17_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_7_qs;
       end
 
       addr_hit[67]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_18_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_8_qs;
       end
 
       addr_hit[68]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_19_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_9_qs;
       end
 
       addr_hit[69]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_20_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_10_qs;
       end
 
       addr_hit[70]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_21_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_11_qs;
       end
 
       addr_hit[71]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_22_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_12_qs;
       end
 
       addr_hit[72]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_23_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_13_qs;
       end
 
       addr_hit[73]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_24_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_14_qs;
       end
 
       addr_hit[74]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_25_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_15_qs;
       end
 
       addr_hit[75]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_26_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_16_qs;
       end
 
       addr_hit[76]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_27_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_17_qs;
       end
 
       addr_hit[77]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_28_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_18_qs;
       end
 
       addr_hit[78]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_29_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_19_qs;
       end
 
       addr_hit[79]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_30_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_20_qs;
       end
 
       addr_hit[80]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_31_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_21_qs;
       end
 
       addr_hit[81]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_32_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_22_qs;
       end
 
       addr_hit[82]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_33_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_23_qs;
       end
 
       addr_hit[83]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_34_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_24_qs;
       end
 
       addr_hit[84]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_35_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_25_qs;
       end
 
       addr_hit[85]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_36_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_26_qs;
       end
 
       addr_hit[86]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_37_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_27_qs;
       end
 
       addr_hit[87]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_38_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_28_qs;
       end
 
       addr_hit[88]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_39_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_29_qs;
       end
 
       addr_hit[89]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_40_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_30_qs;
       end
 
       addr_hit[90]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_41_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_31_qs;
       end
 
       addr_hit[91]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_42_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_32_qs;
       end
 
       addr_hit[92]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_43_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_33_qs;
       end
 
       addr_hit[93]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_44_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_34_qs;
       end
 
       addr_hit[94]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_45_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_35_qs;
       end
 
       addr_hit[95]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_46_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_36_qs;
       end
 
       addr_hit[96]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_47_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_37_qs;
       end
 
       addr_hit[97]: begin
-        reg_rdata_next[5:0] = mio_periph_insel_48_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_38_qs;
       end
 
       addr_hit[98]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_0_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_39_qs;
       end
 
       addr_hit[99]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_1_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_40_qs;
       end
 
       addr_hit[100]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_2_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_41_qs;
       end
 
       addr_hit[101]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_3_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_42_qs;
       end
 
       addr_hit[102]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_4_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_43_qs;
       end
 
       addr_hit[103]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_5_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_44_qs;
       end
 
       addr_hit[104]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_6_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_45_qs;
       end
 
       addr_hit[105]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_7_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_46_qs;
       end
 
       addr_hit[106]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_8_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_47_qs;
       end
 
       addr_hit[107]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_9_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_48_qs;
       end
 
       addr_hit[108]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_10_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_49_qs;
       end
 
       addr_hit[109]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_11_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_50_qs;
       end
 
       addr_hit[110]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_12_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_51_qs;
       end
 
       addr_hit[111]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_13_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_52_qs;
       end
 
       addr_hit[112]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_14_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_53_qs;
       end
 
       addr_hit[113]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_15_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_54_qs;
       end
 
       addr_hit[114]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_16_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_55_qs;
       end
 
       addr_hit[115]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_17_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_56_qs;
       end
 
       addr_hit[116]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_18_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_57_qs;
       end
 
       addr_hit[117]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_19_qs;
+        reg_rdata_next[5:0] = mio_periph_insel_58_qs;
       end
 
       addr_hit[118]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_20_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_0_qs;
       end
 
       addr_hit[119]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_21_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_1_qs;
       end
 
       addr_hit[120]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_22_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_2_qs;
       end
 
       addr_hit[121]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_23_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_3_qs;
       end
 
       addr_hit[122]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_24_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_4_qs;
       end
 
       addr_hit[123]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_25_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_5_qs;
       end
 
       addr_hit[124]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_26_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_6_qs;
       end
 
       addr_hit[125]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_27_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_7_qs;
       end
 
       addr_hit[126]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_28_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_8_qs;
       end
 
       addr_hit[127]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_29_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_9_qs;
       end
 
       addr_hit[128]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_30_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_10_qs;
       end
 
       addr_hit[129]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_31_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_11_qs;
       end
 
       addr_hit[130]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_32_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_12_qs;
       end
 
       addr_hit[131]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_33_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_13_qs;
       end
 
       addr_hit[132]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_34_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_14_qs;
       end
 
       addr_hit[133]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_35_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_15_qs;
       end
 
       addr_hit[134]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_36_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_16_qs;
       end
 
       addr_hit[135]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_37_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_17_qs;
       end
 
       addr_hit[136]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_38_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_18_qs;
       end
 
       addr_hit[137]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_39_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_19_qs;
       end
 
       addr_hit[138]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_40_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_20_qs;
       end
 
       addr_hit[139]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_41_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_21_qs;
       end
 
       addr_hit[140]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_42_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_22_qs;
       end
 
       addr_hit[141]: begin
-        reg_rdata_next[0] = mio_outsel_regwen_43_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_23_qs;
       end
 
       addr_hit[142]: begin
-        reg_rdata_next[5:0] = mio_outsel_0_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_24_qs;
       end
 
       addr_hit[143]: begin
-        reg_rdata_next[5:0] = mio_outsel_1_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_25_qs;
       end
 
       addr_hit[144]: begin
-        reg_rdata_next[5:0] = mio_outsel_2_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_26_qs;
       end
 
       addr_hit[145]: begin
-        reg_rdata_next[5:0] = mio_outsel_3_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_27_qs;
       end
 
       addr_hit[146]: begin
-        reg_rdata_next[5:0] = mio_outsel_4_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_28_qs;
       end
 
       addr_hit[147]: begin
-        reg_rdata_next[5:0] = mio_outsel_5_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_29_qs;
       end
 
       addr_hit[148]: begin
-        reg_rdata_next[5:0] = mio_outsel_6_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_30_qs;
       end
 
       addr_hit[149]: begin
-        reg_rdata_next[5:0] = mio_outsel_7_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_31_qs;
       end
 
       addr_hit[150]: begin
-        reg_rdata_next[5:0] = mio_outsel_8_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_32_qs;
       end
 
       addr_hit[151]: begin
-        reg_rdata_next[5:0] = mio_outsel_9_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_33_qs;
       end
 
       addr_hit[152]: begin
-        reg_rdata_next[5:0] = mio_outsel_10_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_34_qs;
       end
 
       addr_hit[153]: begin
-        reg_rdata_next[5:0] = mio_outsel_11_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_35_qs;
       end
 
       addr_hit[154]: begin
-        reg_rdata_next[5:0] = mio_outsel_12_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_36_qs;
       end
 
       addr_hit[155]: begin
-        reg_rdata_next[5:0] = mio_outsel_13_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_37_qs;
       end
 
       addr_hit[156]: begin
-        reg_rdata_next[5:0] = mio_outsel_14_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_38_qs;
       end
 
       addr_hit[157]: begin
-        reg_rdata_next[5:0] = mio_outsel_15_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_39_qs;
       end
 
       addr_hit[158]: begin
-        reg_rdata_next[5:0] = mio_outsel_16_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_40_qs;
       end
 
       addr_hit[159]: begin
-        reg_rdata_next[5:0] = mio_outsel_17_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_41_qs;
       end
 
       addr_hit[160]: begin
-        reg_rdata_next[5:0] = mio_outsel_18_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_42_qs;
       end
 
       addr_hit[161]: begin
-        reg_rdata_next[5:0] = mio_outsel_19_qs;
+        reg_rdata_next[0] = mio_outsel_regwen_43_qs;
       end
 
       addr_hit[162]: begin
-        reg_rdata_next[5:0] = mio_outsel_20_qs;
+        reg_rdata_next[6:0] = mio_outsel_0_qs;
       end
 
       addr_hit[163]: begin
-        reg_rdata_next[5:0] = mio_outsel_21_qs;
+        reg_rdata_next[6:0] = mio_outsel_1_qs;
       end
 
       addr_hit[164]: begin
-        reg_rdata_next[5:0] = mio_outsel_22_qs;
+        reg_rdata_next[6:0] = mio_outsel_2_qs;
       end
 
       addr_hit[165]: begin
-        reg_rdata_next[5:0] = mio_outsel_23_qs;
+        reg_rdata_next[6:0] = mio_outsel_3_qs;
       end
 
       addr_hit[166]: begin
-        reg_rdata_next[5:0] = mio_outsel_24_qs;
+        reg_rdata_next[6:0] = mio_outsel_4_qs;
       end
 
       addr_hit[167]: begin
-        reg_rdata_next[5:0] = mio_outsel_25_qs;
+        reg_rdata_next[6:0] = mio_outsel_5_qs;
       end
 
       addr_hit[168]: begin
-        reg_rdata_next[5:0] = mio_outsel_26_qs;
+        reg_rdata_next[6:0] = mio_outsel_6_qs;
       end
 
       addr_hit[169]: begin
-        reg_rdata_next[5:0] = mio_outsel_27_qs;
+        reg_rdata_next[6:0] = mio_outsel_7_qs;
       end
 
       addr_hit[170]: begin
-        reg_rdata_next[5:0] = mio_outsel_28_qs;
+        reg_rdata_next[6:0] = mio_outsel_8_qs;
       end
 
       addr_hit[171]: begin
-        reg_rdata_next[5:0] = mio_outsel_29_qs;
+        reg_rdata_next[6:0] = mio_outsel_9_qs;
       end
 
       addr_hit[172]: begin
-        reg_rdata_next[5:0] = mio_outsel_30_qs;
+        reg_rdata_next[6:0] = mio_outsel_10_qs;
       end
 
       addr_hit[173]: begin
-        reg_rdata_next[5:0] = mio_outsel_31_qs;
+        reg_rdata_next[6:0] = mio_outsel_11_qs;
       end
 
       addr_hit[174]: begin
-        reg_rdata_next[5:0] = mio_outsel_32_qs;
+        reg_rdata_next[6:0] = mio_outsel_12_qs;
       end
 
       addr_hit[175]: begin
-        reg_rdata_next[5:0] = mio_outsel_33_qs;
+        reg_rdata_next[6:0] = mio_outsel_13_qs;
       end
 
       addr_hit[176]: begin
-        reg_rdata_next[5:0] = mio_outsel_34_qs;
+        reg_rdata_next[6:0] = mio_outsel_14_qs;
       end
 
       addr_hit[177]: begin
-        reg_rdata_next[5:0] = mio_outsel_35_qs;
+        reg_rdata_next[6:0] = mio_outsel_15_qs;
       end
 
       addr_hit[178]: begin
-        reg_rdata_next[5:0] = mio_outsel_36_qs;
+        reg_rdata_next[6:0] = mio_outsel_16_qs;
       end
 
       addr_hit[179]: begin
-        reg_rdata_next[5:0] = mio_outsel_37_qs;
+        reg_rdata_next[6:0] = mio_outsel_17_qs;
       end
 
       addr_hit[180]: begin
-        reg_rdata_next[5:0] = mio_outsel_38_qs;
+        reg_rdata_next[6:0] = mio_outsel_18_qs;
       end
 
       addr_hit[181]: begin
-        reg_rdata_next[5:0] = mio_outsel_39_qs;
+        reg_rdata_next[6:0] = mio_outsel_19_qs;
       end
 
       addr_hit[182]: begin
-        reg_rdata_next[5:0] = mio_outsel_40_qs;
+        reg_rdata_next[6:0] = mio_outsel_20_qs;
       end
 
       addr_hit[183]: begin
-        reg_rdata_next[5:0] = mio_outsel_41_qs;
+        reg_rdata_next[6:0] = mio_outsel_21_qs;
       end
 
       addr_hit[184]: begin
-        reg_rdata_next[5:0] = mio_outsel_42_qs;
+        reg_rdata_next[6:0] = mio_outsel_22_qs;
       end
 
       addr_hit[185]: begin
-        reg_rdata_next[5:0] = mio_outsel_43_qs;
+        reg_rdata_next[6:0] = mio_outsel_23_qs;
       end
 
       addr_hit[186]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_0_qs;
+        reg_rdata_next[6:0] = mio_outsel_24_qs;
       end
 
       addr_hit[187]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_1_qs;
+        reg_rdata_next[6:0] = mio_outsel_25_qs;
       end
 
       addr_hit[188]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_2_qs;
+        reg_rdata_next[6:0] = mio_outsel_26_qs;
       end
 
       addr_hit[189]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_3_qs;
+        reg_rdata_next[6:0] = mio_outsel_27_qs;
       end
 
       addr_hit[190]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_4_qs;
+        reg_rdata_next[6:0] = mio_outsel_28_qs;
       end
 
       addr_hit[191]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_5_qs;
+        reg_rdata_next[6:0] = mio_outsel_29_qs;
       end
 
       addr_hit[192]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_6_qs;
+        reg_rdata_next[6:0] = mio_outsel_30_qs;
       end
 
       addr_hit[193]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_7_qs;
+        reg_rdata_next[6:0] = mio_outsel_31_qs;
       end
 
       addr_hit[194]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_8_qs;
+        reg_rdata_next[6:0] = mio_outsel_32_qs;
       end
 
       addr_hit[195]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_9_qs;
+        reg_rdata_next[6:0] = mio_outsel_33_qs;
       end
 
       addr_hit[196]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_10_qs;
+        reg_rdata_next[6:0] = mio_outsel_34_qs;
       end
 
       addr_hit[197]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_11_qs;
+        reg_rdata_next[6:0] = mio_outsel_35_qs;
       end
 
       addr_hit[198]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_12_qs;
+        reg_rdata_next[6:0] = mio_outsel_36_qs;
       end
 
       addr_hit[199]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_13_qs;
+        reg_rdata_next[6:0] = mio_outsel_37_qs;
       end
 
       addr_hit[200]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_14_qs;
+        reg_rdata_next[6:0] = mio_outsel_38_qs;
       end
 
       addr_hit[201]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_15_qs;
+        reg_rdata_next[6:0] = mio_outsel_39_qs;
       end
 
       addr_hit[202]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_16_qs;
+        reg_rdata_next[6:0] = mio_outsel_40_qs;
       end
 
       addr_hit[203]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_17_qs;
+        reg_rdata_next[6:0] = mio_outsel_41_qs;
       end
 
       addr_hit[204]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_18_qs;
+        reg_rdata_next[6:0] = mio_outsel_42_qs;
       end
 
       addr_hit[205]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_19_qs;
+        reg_rdata_next[6:0] = mio_outsel_43_qs;
       end
 
       addr_hit[206]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_20_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_0_qs;
       end
 
       addr_hit[207]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_21_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_1_qs;
       end
 
       addr_hit[208]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_22_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_2_qs;
       end
 
       addr_hit[209]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_23_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_3_qs;
       end
 
       addr_hit[210]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_24_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_4_qs;
       end
 
       addr_hit[211]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_25_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_5_qs;
       end
 
       addr_hit[212]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_26_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_6_qs;
       end
 
       addr_hit[213]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_27_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_7_qs;
       end
 
       addr_hit[214]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_28_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_8_qs;
       end
 
       addr_hit[215]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_29_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_9_qs;
       end
 
       addr_hit[216]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_30_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_10_qs;
       end
 
       addr_hit[217]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_31_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_11_qs;
       end
 
       addr_hit[218]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_32_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_12_qs;
       end
 
       addr_hit[219]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_33_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_13_qs;
       end
 
       addr_hit[220]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_34_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_14_qs;
       end
 
       addr_hit[221]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_35_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_15_qs;
       end
 
       addr_hit[222]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_36_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_16_qs;
       end
 
       addr_hit[223]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_37_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_17_qs;
       end
 
       addr_hit[224]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_38_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_18_qs;
       end
 
       addr_hit[225]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_39_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_19_qs;
       end
 
       addr_hit[226]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_40_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_20_qs;
       end
 
       addr_hit[227]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_41_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_21_qs;
       end
 
       addr_hit[228]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_42_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_22_qs;
       end
 
       addr_hit[229]: begin
-        reg_rdata_next[0] = mio_pad_attr_regwen_43_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_23_qs;
       end
 
       addr_hit[230]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_0_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_24_qs;
       end
 
       addr_hit[231]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_1_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_25_qs;
       end
 
       addr_hit[232]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_2_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_26_qs;
       end
 
       addr_hit[233]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_3_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_27_qs;
       end
 
       addr_hit[234]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_4_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_28_qs;
       end
 
       addr_hit[235]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_5_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_29_qs;
       end
 
       addr_hit[236]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_6_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_30_qs;
       end
 
       addr_hit[237]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_7_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_31_qs;
       end
 
       addr_hit[238]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_8_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_32_qs;
       end
 
       addr_hit[239]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_9_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_33_qs;
       end
 
       addr_hit[240]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_10_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_34_qs;
       end
 
       addr_hit[241]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_11_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_35_qs;
       end
 
       addr_hit[242]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_12_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_36_qs;
       end
 
       addr_hit[243]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_13_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_37_qs;
       end
 
       addr_hit[244]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_14_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_38_qs;
       end
 
       addr_hit[245]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_15_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_39_qs;
       end
 
       addr_hit[246]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_16_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_40_qs;
       end
 
       addr_hit[247]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_17_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_41_qs;
       end
 
       addr_hit[248]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_18_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_42_qs;
       end
 
       addr_hit[249]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_19_qs;
+        reg_rdata_next[0] = mio_pad_attr_regwen_43_qs;
       end
 
       addr_hit[250]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_20_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_0_qs;
       end
 
       addr_hit[251]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_21_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_1_qs;
       end
 
       addr_hit[252]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_22_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_2_qs;
       end
 
       addr_hit[253]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_23_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_3_qs;
       end
 
       addr_hit[254]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_24_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_4_qs;
       end
 
       addr_hit[255]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_25_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_5_qs;
       end
 
       addr_hit[256]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_26_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_6_qs;
       end
 
       addr_hit[257]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_27_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_7_qs;
       end
 
       addr_hit[258]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_28_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_8_qs;
       end
 
       addr_hit[259]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_29_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_9_qs;
       end
 
       addr_hit[260]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_30_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_10_qs;
       end
 
       addr_hit[261]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_31_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_11_qs;
       end
 
       addr_hit[262]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_32_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_12_qs;
       end
 
       addr_hit[263]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_33_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_13_qs;
       end
 
       addr_hit[264]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_34_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_14_qs;
       end
 
       addr_hit[265]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_35_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_15_qs;
       end
 
       addr_hit[266]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_36_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_16_qs;
       end
 
       addr_hit[267]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_37_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_17_qs;
       end
 
       addr_hit[268]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_38_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_18_qs;
       end
 
       addr_hit[269]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_39_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_19_qs;
       end
 
       addr_hit[270]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_40_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_20_qs;
       end
 
       addr_hit[271]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_41_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_21_qs;
       end
 
       addr_hit[272]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_42_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_22_qs;
       end
 
       addr_hit[273]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_43_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_23_qs;
       end
 
       addr_hit[274]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_0_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_24_qs;
       end
 
       addr_hit[275]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_1_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_25_qs;
       end
 
       addr_hit[276]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_2_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_26_qs;
       end
 
       addr_hit[277]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_3_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_27_qs;
       end
 
       addr_hit[278]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_4_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_28_qs;
       end
 
       addr_hit[279]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_5_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_29_qs;
       end
 
       addr_hit[280]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_6_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_30_qs;
       end
 
       addr_hit[281]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_7_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_31_qs;
       end
 
       addr_hit[282]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_8_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_32_qs;
       end
 
       addr_hit[283]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_9_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_33_qs;
       end
 
       addr_hit[284]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_10_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_34_qs;
       end
 
       addr_hit[285]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_11_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_35_qs;
       end
 
       addr_hit[286]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_12_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_36_qs;
       end
 
       addr_hit[287]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_13_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_37_qs;
       end
 
       addr_hit[288]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_14_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_38_qs;
       end
 
       addr_hit[289]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_15_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_39_qs;
       end
 
       addr_hit[290]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_16_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_40_qs;
       end
 
       addr_hit[291]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_17_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_41_qs;
       end
 
       addr_hit[292]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_18_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_42_qs;
       end
 
       addr_hit[293]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_19_qs;
+        reg_rdata_next[9:0] = mio_pad_attr_43_qs;
       end
 
       addr_hit[294]: begin
-        reg_rdata_next[0] = dio_pad_attr_regwen_20_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_0_qs;
       end
 
       addr_hit[295]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_0_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_1_qs;
       end
 
       addr_hit[296]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_1_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_2_qs;
       end
 
       addr_hit[297]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_2_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_3_qs;
       end
 
       addr_hit[298]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_3_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_4_qs;
       end
 
       addr_hit[299]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_4_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_5_qs;
       end
 
       addr_hit[300]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_5_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_6_qs;
       end
 
       addr_hit[301]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_6_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_7_qs;
       end
 
       addr_hit[302]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_7_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_8_qs;
       end
 
       addr_hit[303]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_8_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_9_qs;
       end
 
       addr_hit[304]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_9_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_10_qs;
       end
 
       addr_hit[305]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_10_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_11_qs;
       end
 
       addr_hit[306]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_11_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_12_qs;
       end
 
       addr_hit[307]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_12_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_13_qs;
       end
 
       addr_hit[308]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_13_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_14_qs;
       end
 
       addr_hit[309]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_14_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_15_qs;
       end
 
       addr_hit[310]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_15_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_16_qs;
       end
 
       addr_hit[311]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_16_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_17_qs;
       end
 
       addr_hit[312]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_17_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_18_qs;
       end
 
       addr_hit[313]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_18_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_19_qs;
       end
 
       addr_hit[314]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_19_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_20_qs;
       end
 
       addr_hit[315]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_20_qs;
+        reg_rdata_next[9:0] = dio_pad_attr_0_qs;
       end
 
       addr_hit[316]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_1_qs;
+      end
+
+      addr_hit[317]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_2_qs;
+      end
+
+      addr_hit[318]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_3_qs;
+      end
+
+      addr_hit[319]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_4_qs;
+      end
+
+      addr_hit[320]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_5_qs;
+      end
+
+      addr_hit[321]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_6_qs;
+      end
+
+      addr_hit[322]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_7_qs;
+      end
+
+      addr_hit[323]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_8_qs;
+      end
+
+      addr_hit[324]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_9_qs;
+      end
+
+      addr_hit[325]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_10_qs;
+      end
+
+      addr_hit[326]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_11_qs;
+      end
+
+      addr_hit[327]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_12_qs;
+      end
+
+      addr_hit[328]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_13_qs;
+      end
+
+      addr_hit[329]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_14_qs;
+      end
+
+      addr_hit[330]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_15_qs;
+      end
+
+      addr_hit[331]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_16_qs;
+      end
+
+      addr_hit[332]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_17_qs;
+      end
+
+      addr_hit[333]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_18_qs;
+      end
+
+      addr_hit[334]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_19_qs;
+      end
+
+      addr_hit[335]: begin
+        reg_rdata_next[9:0] = dio_pad_attr_20_qs;
+      end
+
+      addr_hit[336]: begin
         reg_rdata_next[0] = mio_pad_sleep_status_0_en_0_qs;
         reg_rdata_next[1] = mio_pad_sleep_status_0_en_1_qs;
         reg_rdata_next[2] = mio_pad_sleep_status_0_en_2_qs;
@@ -23040,7 +23820,7 @@ module pinmux_reg_top (
         reg_rdata_next[31] = mio_pad_sleep_status_0_en_31_qs;
       end
 
-      addr_hit[317]: begin
+      addr_hit[337]: begin
         reg_rdata_next[0] = mio_pad_sleep_status_1_en_32_qs;
         reg_rdata_next[1] = mio_pad_sleep_status_1_en_33_qs;
         reg_rdata_next[2] = mio_pad_sleep_status_1_en_34_qs;
@@ -23055,535 +23835,535 @@ module pinmux_reg_top (
         reg_rdata_next[11] = mio_pad_sleep_status_1_en_43_qs;
       end
 
-      addr_hit[318]: begin
+      addr_hit[338]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_0_qs;
       end
 
-      addr_hit[319]: begin
+      addr_hit[339]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_1_qs;
       end
 
-      addr_hit[320]: begin
+      addr_hit[340]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_2_qs;
       end
 
-      addr_hit[321]: begin
+      addr_hit[341]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_3_qs;
       end
 
-      addr_hit[322]: begin
+      addr_hit[342]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_4_qs;
       end
 
-      addr_hit[323]: begin
+      addr_hit[343]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_5_qs;
       end
 
-      addr_hit[324]: begin
+      addr_hit[344]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_6_qs;
       end
 
-      addr_hit[325]: begin
+      addr_hit[345]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_7_qs;
       end
 
-      addr_hit[326]: begin
+      addr_hit[346]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_8_qs;
       end
 
-      addr_hit[327]: begin
+      addr_hit[347]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_9_qs;
       end
 
-      addr_hit[328]: begin
+      addr_hit[348]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_10_qs;
       end
 
-      addr_hit[329]: begin
+      addr_hit[349]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_11_qs;
       end
 
-      addr_hit[330]: begin
+      addr_hit[350]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_12_qs;
       end
 
-      addr_hit[331]: begin
+      addr_hit[351]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_13_qs;
       end
 
-      addr_hit[332]: begin
+      addr_hit[352]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_14_qs;
       end
 
-      addr_hit[333]: begin
+      addr_hit[353]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_15_qs;
       end
 
-      addr_hit[334]: begin
+      addr_hit[354]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_16_qs;
       end
 
-      addr_hit[335]: begin
+      addr_hit[355]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_17_qs;
       end
 
-      addr_hit[336]: begin
+      addr_hit[356]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_18_qs;
       end
 
-      addr_hit[337]: begin
+      addr_hit[357]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_19_qs;
       end
 
-      addr_hit[338]: begin
+      addr_hit[358]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_20_qs;
       end
 
-      addr_hit[339]: begin
+      addr_hit[359]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_21_qs;
       end
 
-      addr_hit[340]: begin
+      addr_hit[360]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_22_qs;
       end
 
-      addr_hit[341]: begin
+      addr_hit[361]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_23_qs;
       end
 
-      addr_hit[342]: begin
+      addr_hit[362]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_24_qs;
       end
 
-      addr_hit[343]: begin
+      addr_hit[363]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_25_qs;
       end
 
-      addr_hit[344]: begin
+      addr_hit[364]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_26_qs;
       end
 
-      addr_hit[345]: begin
+      addr_hit[365]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_27_qs;
       end
 
-      addr_hit[346]: begin
+      addr_hit[366]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_28_qs;
       end
 
-      addr_hit[347]: begin
+      addr_hit[367]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_29_qs;
       end
 
-      addr_hit[348]: begin
+      addr_hit[368]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_30_qs;
       end
 
-      addr_hit[349]: begin
+      addr_hit[369]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_31_qs;
       end
 
-      addr_hit[350]: begin
+      addr_hit[370]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_32_qs;
       end
 
-      addr_hit[351]: begin
+      addr_hit[371]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_33_qs;
       end
 
-      addr_hit[352]: begin
+      addr_hit[372]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_34_qs;
       end
 
-      addr_hit[353]: begin
+      addr_hit[373]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_35_qs;
       end
 
-      addr_hit[354]: begin
+      addr_hit[374]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_36_qs;
       end
 
-      addr_hit[355]: begin
+      addr_hit[375]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_37_qs;
       end
 
-      addr_hit[356]: begin
+      addr_hit[376]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_38_qs;
       end
 
-      addr_hit[357]: begin
+      addr_hit[377]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_39_qs;
       end
 
-      addr_hit[358]: begin
+      addr_hit[378]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_40_qs;
       end
 
-      addr_hit[359]: begin
+      addr_hit[379]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_41_qs;
       end
 
-      addr_hit[360]: begin
+      addr_hit[380]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_42_qs;
       end
 
-      addr_hit[361]: begin
+      addr_hit[381]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_43_qs;
       end
 
-      addr_hit[362]: begin
+      addr_hit[382]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_0_qs;
       end
 
-      addr_hit[363]: begin
+      addr_hit[383]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_1_qs;
       end
 
-      addr_hit[364]: begin
+      addr_hit[384]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_2_qs;
       end
 
-      addr_hit[365]: begin
+      addr_hit[385]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_3_qs;
       end
 
-      addr_hit[366]: begin
+      addr_hit[386]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_4_qs;
       end
 
-      addr_hit[367]: begin
+      addr_hit[387]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_5_qs;
       end
 
-      addr_hit[368]: begin
+      addr_hit[388]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_6_qs;
       end
 
-      addr_hit[369]: begin
+      addr_hit[389]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_7_qs;
       end
 
-      addr_hit[370]: begin
+      addr_hit[390]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_8_qs;
       end
 
-      addr_hit[371]: begin
+      addr_hit[391]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_9_qs;
       end
 
-      addr_hit[372]: begin
+      addr_hit[392]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_10_qs;
       end
 
-      addr_hit[373]: begin
+      addr_hit[393]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_11_qs;
       end
 
-      addr_hit[374]: begin
+      addr_hit[394]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_12_qs;
       end
 
-      addr_hit[375]: begin
+      addr_hit[395]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_13_qs;
       end
 
-      addr_hit[376]: begin
+      addr_hit[396]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_14_qs;
       end
 
-      addr_hit[377]: begin
+      addr_hit[397]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_15_qs;
       end
 
-      addr_hit[378]: begin
+      addr_hit[398]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_16_qs;
       end
 
-      addr_hit[379]: begin
+      addr_hit[399]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_17_qs;
       end
 
-      addr_hit[380]: begin
+      addr_hit[400]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_18_qs;
       end
 
-      addr_hit[381]: begin
+      addr_hit[401]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_19_qs;
       end
 
-      addr_hit[382]: begin
+      addr_hit[402]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_20_qs;
       end
 
-      addr_hit[383]: begin
+      addr_hit[403]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_21_qs;
       end
 
-      addr_hit[384]: begin
+      addr_hit[404]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_22_qs;
       end
 
-      addr_hit[385]: begin
+      addr_hit[405]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_23_qs;
       end
 
-      addr_hit[386]: begin
+      addr_hit[406]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_24_qs;
       end
 
-      addr_hit[387]: begin
+      addr_hit[407]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_25_qs;
       end
 
-      addr_hit[388]: begin
+      addr_hit[408]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_26_qs;
       end
 
-      addr_hit[389]: begin
+      addr_hit[409]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_27_qs;
       end
 
-      addr_hit[390]: begin
+      addr_hit[410]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_28_qs;
       end
 
-      addr_hit[391]: begin
+      addr_hit[411]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_29_qs;
       end
 
-      addr_hit[392]: begin
+      addr_hit[412]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_30_qs;
       end
 
-      addr_hit[393]: begin
+      addr_hit[413]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_31_qs;
       end
 
-      addr_hit[394]: begin
+      addr_hit[414]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_32_qs;
       end
 
-      addr_hit[395]: begin
+      addr_hit[415]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_33_qs;
       end
 
-      addr_hit[396]: begin
+      addr_hit[416]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_34_qs;
       end
 
-      addr_hit[397]: begin
+      addr_hit[417]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_35_qs;
       end
 
-      addr_hit[398]: begin
+      addr_hit[418]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_36_qs;
       end
 
-      addr_hit[399]: begin
+      addr_hit[419]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_37_qs;
       end
 
-      addr_hit[400]: begin
+      addr_hit[420]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_38_qs;
       end
 
-      addr_hit[401]: begin
+      addr_hit[421]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_39_qs;
       end
 
-      addr_hit[402]: begin
+      addr_hit[422]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_40_qs;
       end
 
-      addr_hit[403]: begin
+      addr_hit[423]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_41_qs;
       end
 
-      addr_hit[404]: begin
+      addr_hit[424]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_42_qs;
       end
 
-      addr_hit[405]: begin
+      addr_hit[425]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_43_qs;
       end
 
-      addr_hit[406]: begin
+      addr_hit[426]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_0_qs;
       end
 
-      addr_hit[407]: begin
+      addr_hit[427]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_1_qs;
       end
 
-      addr_hit[408]: begin
+      addr_hit[428]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_2_qs;
       end
 
-      addr_hit[409]: begin
+      addr_hit[429]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_3_qs;
       end
 
-      addr_hit[410]: begin
+      addr_hit[430]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_4_qs;
       end
 
-      addr_hit[411]: begin
+      addr_hit[431]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_5_qs;
       end
 
-      addr_hit[412]: begin
+      addr_hit[432]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_6_qs;
       end
 
-      addr_hit[413]: begin
+      addr_hit[433]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_7_qs;
       end
 
-      addr_hit[414]: begin
+      addr_hit[434]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_8_qs;
       end
 
-      addr_hit[415]: begin
+      addr_hit[435]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_9_qs;
       end
 
-      addr_hit[416]: begin
+      addr_hit[436]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_10_qs;
       end
 
-      addr_hit[417]: begin
+      addr_hit[437]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_11_qs;
       end
 
-      addr_hit[418]: begin
+      addr_hit[438]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_12_qs;
       end
 
-      addr_hit[419]: begin
+      addr_hit[439]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_13_qs;
       end
 
-      addr_hit[420]: begin
+      addr_hit[440]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_14_qs;
       end
 
-      addr_hit[421]: begin
+      addr_hit[441]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_15_qs;
       end
 
-      addr_hit[422]: begin
+      addr_hit[442]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_16_qs;
       end
 
-      addr_hit[423]: begin
+      addr_hit[443]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_17_qs;
       end
 
-      addr_hit[424]: begin
+      addr_hit[444]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_18_qs;
       end
 
-      addr_hit[425]: begin
+      addr_hit[445]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_19_qs;
       end
 
-      addr_hit[426]: begin
+      addr_hit[446]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_20_qs;
       end
 
-      addr_hit[427]: begin
+      addr_hit[447]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_21_qs;
       end
 
-      addr_hit[428]: begin
+      addr_hit[448]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_22_qs;
       end
 
-      addr_hit[429]: begin
+      addr_hit[449]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_23_qs;
       end
 
-      addr_hit[430]: begin
+      addr_hit[450]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_24_qs;
       end
 
-      addr_hit[431]: begin
+      addr_hit[451]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_25_qs;
       end
 
-      addr_hit[432]: begin
+      addr_hit[452]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_26_qs;
       end
 
-      addr_hit[433]: begin
+      addr_hit[453]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_27_qs;
       end
 
-      addr_hit[434]: begin
+      addr_hit[454]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_28_qs;
       end
 
-      addr_hit[435]: begin
+      addr_hit[455]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_29_qs;
       end
 
-      addr_hit[436]: begin
+      addr_hit[456]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_30_qs;
       end
 
-      addr_hit[437]: begin
+      addr_hit[457]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_31_qs;
       end
 
-      addr_hit[438]: begin
+      addr_hit[458]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_32_qs;
       end
 
-      addr_hit[439]: begin
+      addr_hit[459]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_33_qs;
       end
 
-      addr_hit[440]: begin
+      addr_hit[460]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_34_qs;
       end
 
-      addr_hit[441]: begin
+      addr_hit[461]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_35_qs;
       end
 
-      addr_hit[442]: begin
+      addr_hit[462]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_36_qs;
       end
 
-      addr_hit[443]: begin
+      addr_hit[463]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_37_qs;
       end
 
-      addr_hit[444]: begin
+      addr_hit[464]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_38_qs;
       end
 
-      addr_hit[445]: begin
+      addr_hit[465]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_39_qs;
       end
 
-      addr_hit[446]: begin
+      addr_hit[466]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_40_qs;
       end
 
-      addr_hit[447]: begin
+      addr_hit[467]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_41_qs;
       end
 
-      addr_hit[448]: begin
+      addr_hit[468]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_42_qs;
       end
 
-      addr_hit[449]: begin
+      addr_hit[469]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_43_qs;
       end
 
-      addr_hit[450]: begin
+      addr_hit[470]: begin
         reg_rdata_next[0] = dio_pad_sleep_status_en_0_qs;
         reg_rdata_next[1] = dio_pad_sleep_status_en_1_qs;
         reg_rdata_next[2] = dio_pad_sleep_status_en_2_qs;
@@ -23607,435 +24387,435 @@ module pinmux_reg_top (
         reg_rdata_next[20] = dio_pad_sleep_status_en_20_qs;
       end
 
-      addr_hit[451]: begin
+      addr_hit[471]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_0_qs;
       end
 
-      addr_hit[452]: begin
+      addr_hit[472]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_1_qs;
       end
 
-      addr_hit[453]: begin
+      addr_hit[473]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_2_qs;
       end
 
-      addr_hit[454]: begin
+      addr_hit[474]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_3_qs;
       end
 
-      addr_hit[455]: begin
+      addr_hit[475]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_4_qs;
       end
 
-      addr_hit[456]: begin
+      addr_hit[476]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_5_qs;
       end
 
-      addr_hit[457]: begin
+      addr_hit[477]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_6_qs;
       end
 
-      addr_hit[458]: begin
+      addr_hit[478]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_7_qs;
       end
 
-      addr_hit[459]: begin
+      addr_hit[479]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_8_qs;
       end
 
-      addr_hit[460]: begin
+      addr_hit[480]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_9_qs;
       end
 
-      addr_hit[461]: begin
+      addr_hit[481]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_10_qs;
       end
 
-      addr_hit[462]: begin
+      addr_hit[482]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_11_qs;
       end
 
-      addr_hit[463]: begin
+      addr_hit[483]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_12_qs;
       end
 
-      addr_hit[464]: begin
+      addr_hit[484]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_13_qs;
       end
 
-      addr_hit[465]: begin
+      addr_hit[485]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_14_qs;
       end
 
-      addr_hit[466]: begin
+      addr_hit[486]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_15_qs;
       end
 
-      addr_hit[467]: begin
+      addr_hit[487]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_16_qs;
       end
 
-      addr_hit[468]: begin
+      addr_hit[488]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_17_qs;
       end
 
-      addr_hit[469]: begin
+      addr_hit[489]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_18_qs;
       end
 
-      addr_hit[470]: begin
+      addr_hit[490]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_19_qs;
       end
 
-      addr_hit[471]: begin
+      addr_hit[491]: begin
         reg_rdata_next[0] = dio_pad_sleep_regwen_20_qs;
       end
 
-      addr_hit[472]: begin
+      addr_hit[492]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_0_qs;
       end
 
-      addr_hit[473]: begin
+      addr_hit[493]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_1_qs;
       end
 
-      addr_hit[474]: begin
+      addr_hit[494]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_2_qs;
       end
 
-      addr_hit[475]: begin
+      addr_hit[495]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_3_qs;
       end
 
-      addr_hit[476]: begin
+      addr_hit[496]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_4_qs;
       end
 
-      addr_hit[477]: begin
+      addr_hit[497]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_5_qs;
       end
 
-      addr_hit[478]: begin
+      addr_hit[498]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_6_qs;
       end
 
-      addr_hit[479]: begin
+      addr_hit[499]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_7_qs;
       end
 
-      addr_hit[480]: begin
+      addr_hit[500]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_8_qs;
       end
 
-      addr_hit[481]: begin
+      addr_hit[501]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_9_qs;
       end
 
-      addr_hit[482]: begin
+      addr_hit[502]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_10_qs;
       end
 
-      addr_hit[483]: begin
+      addr_hit[503]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_11_qs;
       end
 
-      addr_hit[484]: begin
+      addr_hit[504]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_12_qs;
       end
 
-      addr_hit[485]: begin
+      addr_hit[505]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_13_qs;
       end
 
-      addr_hit[486]: begin
+      addr_hit[506]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_14_qs;
       end
 
-      addr_hit[487]: begin
+      addr_hit[507]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_15_qs;
       end
 
-      addr_hit[488]: begin
+      addr_hit[508]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_16_qs;
       end
 
-      addr_hit[489]: begin
+      addr_hit[509]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_17_qs;
       end
 
-      addr_hit[490]: begin
+      addr_hit[510]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_18_qs;
       end
 
-      addr_hit[491]: begin
+      addr_hit[511]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_19_qs;
       end
 
-      addr_hit[492]: begin
+      addr_hit[512]: begin
         reg_rdata_next[0] = dio_pad_sleep_en_20_qs;
       end
 
-      addr_hit[493]: begin
+      addr_hit[513]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_0_qs;
       end
 
-      addr_hit[494]: begin
+      addr_hit[514]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_1_qs;
       end
 
-      addr_hit[495]: begin
+      addr_hit[515]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_2_qs;
       end
 
-      addr_hit[496]: begin
+      addr_hit[516]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_3_qs;
       end
 
-      addr_hit[497]: begin
+      addr_hit[517]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_4_qs;
       end
 
-      addr_hit[498]: begin
+      addr_hit[518]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_5_qs;
       end
 
-      addr_hit[499]: begin
+      addr_hit[519]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_6_qs;
       end
 
-      addr_hit[500]: begin
+      addr_hit[520]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_7_qs;
       end
 
-      addr_hit[501]: begin
+      addr_hit[521]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_8_qs;
       end
 
-      addr_hit[502]: begin
+      addr_hit[522]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_9_qs;
       end
 
-      addr_hit[503]: begin
+      addr_hit[523]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_10_qs;
       end
 
-      addr_hit[504]: begin
+      addr_hit[524]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_11_qs;
       end
 
-      addr_hit[505]: begin
+      addr_hit[525]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_12_qs;
       end
 
-      addr_hit[506]: begin
+      addr_hit[526]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_13_qs;
       end
 
-      addr_hit[507]: begin
+      addr_hit[527]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_14_qs;
       end
 
-      addr_hit[508]: begin
+      addr_hit[528]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_15_qs;
       end
 
-      addr_hit[509]: begin
+      addr_hit[529]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_16_qs;
       end
 
-      addr_hit[510]: begin
+      addr_hit[530]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_17_qs;
       end
 
-      addr_hit[511]: begin
+      addr_hit[531]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_18_qs;
       end
 
-      addr_hit[512]: begin
+      addr_hit[532]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_19_qs;
       end
 
-      addr_hit[513]: begin
+      addr_hit[533]: begin
         reg_rdata_next[1:0] = dio_pad_sleep_mode_20_qs;
       end
 
-      addr_hit[514]: begin
+      addr_hit[534]: begin
         reg_rdata_next[0] = wkup_detector_regwen_0_qs;
       end
 
-      addr_hit[515]: begin
+      addr_hit[535]: begin
         reg_rdata_next[0] = wkup_detector_regwen_1_qs;
       end
 
-      addr_hit[516]: begin
+      addr_hit[536]: begin
         reg_rdata_next[0] = wkup_detector_regwen_2_qs;
       end
 
-      addr_hit[517]: begin
+      addr_hit[537]: begin
         reg_rdata_next[0] = wkup_detector_regwen_3_qs;
       end
 
-      addr_hit[518]: begin
+      addr_hit[538]: begin
         reg_rdata_next[0] = wkup_detector_regwen_4_qs;
       end
 
-      addr_hit[519]: begin
+      addr_hit[539]: begin
         reg_rdata_next[0] = wkup_detector_regwen_5_qs;
       end
 
-      addr_hit[520]: begin
+      addr_hit[540]: begin
         reg_rdata_next[0] = wkup_detector_regwen_6_qs;
       end
 
-      addr_hit[521]: begin
+      addr_hit[541]: begin
         reg_rdata_next[0] = wkup_detector_regwen_7_qs;
       end
 
-      addr_hit[522]: begin
+      addr_hit[542]: begin
         reg_rdata_next[0] = wkup_detector_en_0_qs;
       end
 
-      addr_hit[523]: begin
+      addr_hit[543]: begin
         reg_rdata_next[0] = wkup_detector_en_1_qs;
       end
 
-      addr_hit[524]: begin
+      addr_hit[544]: begin
         reg_rdata_next[0] = wkup_detector_en_2_qs;
       end
 
-      addr_hit[525]: begin
+      addr_hit[545]: begin
         reg_rdata_next[0] = wkup_detector_en_3_qs;
       end
 
-      addr_hit[526]: begin
+      addr_hit[546]: begin
         reg_rdata_next[0] = wkup_detector_en_4_qs;
       end
 
-      addr_hit[527]: begin
+      addr_hit[547]: begin
         reg_rdata_next[0] = wkup_detector_en_5_qs;
       end
 
-      addr_hit[528]: begin
+      addr_hit[548]: begin
         reg_rdata_next[0] = wkup_detector_en_6_qs;
       end
 
-      addr_hit[529]: begin
+      addr_hit[549]: begin
         reg_rdata_next[0] = wkup_detector_en_7_qs;
       end
 
-      addr_hit[530]: begin
+      addr_hit[550]: begin
         reg_rdata_next[2:0] = wkup_detector_0_mode_0_qs;
         reg_rdata_next[3] = wkup_detector_0_filter_0_qs;
         reg_rdata_next[4] = wkup_detector_0_miodio_0_qs;
       end
 
-      addr_hit[531]: begin
+      addr_hit[551]: begin
         reg_rdata_next[2:0] = wkup_detector_1_mode_1_qs;
         reg_rdata_next[3] = wkup_detector_1_filter_1_qs;
         reg_rdata_next[4] = wkup_detector_1_miodio_1_qs;
       end
 
-      addr_hit[532]: begin
+      addr_hit[552]: begin
         reg_rdata_next[2:0] = wkup_detector_2_mode_2_qs;
         reg_rdata_next[3] = wkup_detector_2_filter_2_qs;
         reg_rdata_next[4] = wkup_detector_2_miodio_2_qs;
       end
 
-      addr_hit[533]: begin
+      addr_hit[553]: begin
         reg_rdata_next[2:0] = wkup_detector_3_mode_3_qs;
         reg_rdata_next[3] = wkup_detector_3_filter_3_qs;
         reg_rdata_next[4] = wkup_detector_3_miodio_3_qs;
       end
 
-      addr_hit[534]: begin
+      addr_hit[554]: begin
         reg_rdata_next[2:0] = wkup_detector_4_mode_4_qs;
         reg_rdata_next[3] = wkup_detector_4_filter_4_qs;
         reg_rdata_next[4] = wkup_detector_4_miodio_4_qs;
       end
 
-      addr_hit[535]: begin
+      addr_hit[555]: begin
         reg_rdata_next[2:0] = wkup_detector_5_mode_5_qs;
         reg_rdata_next[3] = wkup_detector_5_filter_5_qs;
         reg_rdata_next[4] = wkup_detector_5_miodio_5_qs;
       end
 
-      addr_hit[536]: begin
+      addr_hit[556]: begin
         reg_rdata_next[2:0] = wkup_detector_6_mode_6_qs;
         reg_rdata_next[3] = wkup_detector_6_filter_6_qs;
         reg_rdata_next[4] = wkup_detector_6_miodio_6_qs;
       end
 
-      addr_hit[537]: begin
+      addr_hit[557]: begin
         reg_rdata_next[2:0] = wkup_detector_7_mode_7_qs;
         reg_rdata_next[3] = wkup_detector_7_filter_7_qs;
         reg_rdata_next[4] = wkup_detector_7_miodio_7_qs;
       end
 
-      addr_hit[538]: begin
+      addr_hit[558]: begin
         reg_rdata_next[7:0] = wkup_detector_cnt_th_0_qs;
       end
 
-      addr_hit[539]: begin
+      addr_hit[559]: begin
         reg_rdata_next[7:0] = wkup_detector_cnt_th_1_qs;
       end
 
-      addr_hit[540]: begin
+      addr_hit[560]: begin
         reg_rdata_next[7:0] = wkup_detector_cnt_th_2_qs;
       end
 
-      addr_hit[541]: begin
+      addr_hit[561]: begin
         reg_rdata_next[7:0] = wkup_detector_cnt_th_3_qs;
       end
 
-      addr_hit[542]: begin
+      addr_hit[562]: begin
         reg_rdata_next[7:0] = wkup_detector_cnt_th_4_qs;
       end
 
-      addr_hit[543]: begin
+      addr_hit[563]: begin
         reg_rdata_next[7:0] = wkup_detector_cnt_th_5_qs;
       end
 
-      addr_hit[544]: begin
+      addr_hit[564]: begin
         reg_rdata_next[7:0] = wkup_detector_cnt_th_6_qs;
       end
 
-      addr_hit[545]: begin
+      addr_hit[565]: begin
         reg_rdata_next[7:0] = wkup_detector_cnt_th_7_qs;
       end
 
-      addr_hit[546]: begin
+      addr_hit[566]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel_0_qs;
       end
 
-      addr_hit[547]: begin
+      addr_hit[567]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel_1_qs;
       end
 
-      addr_hit[548]: begin
+      addr_hit[568]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel_2_qs;
       end
 
-      addr_hit[549]: begin
+      addr_hit[569]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel_3_qs;
       end
 
-      addr_hit[550]: begin
+      addr_hit[570]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel_4_qs;
       end
 
-      addr_hit[551]: begin
+      addr_hit[571]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel_5_qs;
       end
 
-      addr_hit[552]: begin
+      addr_hit[572]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel_6_qs;
       end
 
-      addr_hit[553]: begin
+      addr_hit[573]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel_7_qs;
       end
 
-      addr_hit[554]: begin
+      addr_hit[574]: begin
         reg_rdata_next[0] = wkup_cause_cause_0_qs;
         reg_rdata_next[1] = wkup_cause_cause_1_qs;
         reg_rdata_next[2] = wkup_cause_cause_2_qs;

--- a/hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.hjson
+++ b/hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.hjson
@@ -13,6 +13,18 @@
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }
   ],
+  available_input_list: [
+    { name: "ast_debug_in",
+      desc: "ast debug inputs from pinmux",
+      width: "10"
+    },
+  ],
+  available_output_list: [
+    { name: "ast_debug_out",
+      desc: "ast debug outputs to pinmux",
+      width: "10"
+    }
+  ],
   regwidth: "32",
   param_list: [
     { name:    "NumAlerts",
@@ -98,8 +110,6 @@
 
   // Define ast_struct package
   inter_signal_list: [
-
-    // should be defined by ast wrapper later
     { struct:  "ast_alert",
       type:    "req_rsp",
       name:    "ast_alert",
@@ -107,13 +117,29 @@
       package: "ast_pkg",
     },
 
-    // should be defined by ast wrapper later
     { struct:  "ast_status",
       type:    "uni",
       name:    "ast_status",
       act:     "rcv",
       package: "ast_pkg",
     },
+
+    { struct:  "logic",
+      type:    "uni",
+      name:    "ast2pinmux",
+      act:     "rcv",
+      width:   10,
+      package: ""
+    },
+
+    { struct:  "logic",
+      type:    "uni",
+      name:    "pinmux2ast",
+      act:     "req",
+      width:   10,
+      package: ""
+    },
+
   ],
 
 registers: [

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl.sv
@@ -21,6 +21,13 @@ module sensor_ctrl import sensor_ctrl_pkg::*; #(
   input ast_pkg::ast_alert_req_t ast_alert_i,
   output ast_pkg::ast_alert_rsp_t ast_alert_o,
   input ast_pkg::ast_status_t ast_status_i,
+  input [ast_pkg::Ast2PadOutWidth-1:0] ast2pinmux_i,
+  output logic [ast_pkg::Pad2AstInWidth-1:0] pinmux2ast_o,
+
+  // Interface to pinmux
+  input [ast_pkg::Pad2AstInWidth-1:0] cio_ast_debug_in_i,
+  output logic [ast_pkg::Ast2PadOutWidth-1:0] cio_ast_debug_out_o,
+  output logic [ast_pkg::Ast2PadOutWidth-1:0] cio_ast_debug_out_en_o,
 
   // Alerts
   input  prim_alert_pkg::alert_rx_t [NumAlerts-1:0] alert_rx_i,
@@ -145,6 +152,14 @@ module sensor_ctrl import sensor_ctrl_pkg::*; #(
       ast_alert_o.alerts_trig[i].n = ~reg2hw.alert_trig[i];
     end
   end
+
+  ///////////////////////////
+  // pinmux feedthrough to ast
+  ///////////////////////////
+
+  assign cio_ast_debug_out_o = ast2pinmux_i;
+  assign cio_ast_debug_out_en_o = '1;
+  assign pinmux2ast_o = cio_ast_debug_in_i;
 
 
 endmodule // sensor_ctrl

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -474,8 +474,8 @@ module top_earlgrey_nexysvideo #(
     .usbdev_usb_ref_pulse_o       (                 ),
     .ast_tl_req_o                 (                 ),
     .ast_tl_rsp_i                 ( '0              ),
-    .ast_edn_edn_req_i            ( '0              ),
-    .ast_edn_edn_rsp_o            (                 ),
+    .ast_edn_req_i                ( '0              ),
+    .ast_edn_rsp_o                (                 ),
     .otp_ctrl_otp_ast_pwr_seq_o   (                 ),
     .otp_ctrl_otp_ast_pwr_seq_h_i ( '0              ),
     .flash_bist_enable_i          ( 1'b0            ),
@@ -503,6 +503,11 @@ module top_earlgrey_nexysvideo #(
     // Pad attributes
     .mio_attr_o      ( mio_attr      ),
     .dio_attr_o      ( dio_attr      ),
+
+    // Memory attributes
+    .ram_1p_cfg_i    ( '0 ),
+    .ram_2p_cfg_i    ( '0 ),
+    .rom_cfg_i       ( '0 ),
 
     // DFT signals
     .scan_rst_ni     ( 1'b1          ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
@@ -171,8 +171,8 @@ module top_earlgrey_verilator (
     .usbdev_usb_ref_pulse_o       (                  ),
     .ast_tl_req_o                 (                  ),
     .ast_tl_rsp_i                 ( '0               ),
-    .ast_edn_edn_req_i            ( '0               ),
-    .ast_edn_edn_rsp_o            (                  ),
+    .ast_edn_req_i                ( '0               ),
+    .ast_edn_rsp_o                (                  ),
     .otp_ctrl_otp_ast_pwr_seq_o   (                  ),
     .otp_ctrl_otp_ast_pwr_seq_h_i ( '0               ),
     .flash_bist_enable_i          ( lc_ctrl_pkg::Off ),
@@ -200,6 +200,11 @@ module top_earlgrey_verilator (
     // Pad attributes
     .mio_attr_o                   ( ),
     .dio_attr_o                   ( ),
+
+    // Memory attributes
+    .ram_1p_cfg_i                 ('0),
+    .ram_2p_cfg_i                 ('0),
+    .rom_cfg_i                    ('0),
 
     // DFT signals
     .scan_rst_ni                  (1'b1),

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -1110,7 +1110,17 @@ typedef enum top_earlgrey_pinmux_peripheral_in {
   kTopEarlgreyPinmuxPeripheralInFlashCtrlTck = 46, /**< flash_ctrl_tck */
   kTopEarlgreyPinmuxPeripheralInFlashCtrlTms = 47, /**< flash_ctrl_tms */
   kTopEarlgreyPinmuxPeripheralInFlashCtrlTdi = 48, /**< flash_ctrl_tdi */
-  kTopEarlgreyPinmuxPeripheralInLast = 48, /**< \internal Last valid peripheral input */
+  kTopEarlgreyPinmuxPeripheralInSensorCtrlAonAstDebugIn0 = 49, /**< sensor_ctrl_aon_ast_debug_in 0 */
+  kTopEarlgreyPinmuxPeripheralInSensorCtrlAonAstDebugIn1 = 50, /**< sensor_ctrl_aon_ast_debug_in 1 */
+  kTopEarlgreyPinmuxPeripheralInSensorCtrlAonAstDebugIn2 = 51, /**< sensor_ctrl_aon_ast_debug_in 2 */
+  kTopEarlgreyPinmuxPeripheralInSensorCtrlAonAstDebugIn3 = 52, /**< sensor_ctrl_aon_ast_debug_in 3 */
+  kTopEarlgreyPinmuxPeripheralInSensorCtrlAonAstDebugIn4 = 53, /**< sensor_ctrl_aon_ast_debug_in 4 */
+  kTopEarlgreyPinmuxPeripheralInSensorCtrlAonAstDebugIn5 = 54, /**< sensor_ctrl_aon_ast_debug_in 5 */
+  kTopEarlgreyPinmuxPeripheralInSensorCtrlAonAstDebugIn6 = 55, /**< sensor_ctrl_aon_ast_debug_in 6 */
+  kTopEarlgreyPinmuxPeripheralInSensorCtrlAonAstDebugIn7 = 56, /**< sensor_ctrl_aon_ast_debug_in 7 */
+  kTopEarlgreyPinmuxPeripheralInSensorCtrlAonAstDebugIn8 = 57, /**< sensor_ctrl_aon_ast_debug_in 8 */
+  kTopEarlgreyPinmuxPeripheralInSensorCtrlAonAstDebugIn9 = 58, /**< sensor_ctrl_aon_ast_debug_in 9 */
+  kTopEarlgreyPinmuxPeripheralInLast = 58, /**< \internal Last valid peripheral input */
 } top_earlgrey_pinmux_peripheral_in_t;
 
 /**
@@ -1277,7 +1287,17 @@ typedef enum top_earlgrey_pinmux_outsel {
   kTopEarlgreyPinmuxOutselSpiHost1Sck = 53, /**< spi_host1_sck */
   kTopEarlgreyPinmuxOutselSpiHost1Csb = 54, /**< spi_host1_csb */
   kTopEarlgreyPinmuxOutselFlashCtrlTdo = 55, /**< flash_ctrl_tdo */
-  kTopEarlgreyPinmuxOutselLast = 55, /**< \internal Last valid outsel value */
+  kTopEarlgreyPinmuxOutselSensorCtrlAonAstDebugOut0 = 56, /**< sensor_ctrl_aon_ast_debug_out 0 */
+  kTopEarlgreyPinmuxOutselSensorCtrlAonAstDebugOut1 = 57, /**< sensor_ctrl_aon_ast_debug_out 1 */
+  kTopEarlgreyPinmuxOutselSensorCtrlAonAstDebugOut2 = 58, /**< sensor_ctrl_aon_ast_debug_out 2 */
+  kTopEarlgreyPinmuxOutselSensorCtrlAonAstDebugOut3 = 59, /**< sensor_ctrl_aon_ast_debug_out 3 */
+  kTopEarlgreyPinmuxOutselSensorCtrlAonAstDebugOut4 = 60, /**< sensor_ctrl_aon_ast_debug_out 4 */
+  kTopEarlgreyPinmuxOutselSensorCtrlAonAstDebugOut5 = 61, /**< sensor_ctrl_aon_ast_debug_out 5 */
+  kTopEarlgreyPinmuxOutselSensorCtrlAonAstDebugOut6 = 62, /**< sensor_ctrl_aon_ast_debug_out 6 */
+  kTopEarlgreyPinmuxOutselSensorCtrlAonAstDebugOut7 = 63, /**< sensor_ctrl_aon_ast_debug_out 7 */
+  kTopEarlgreyPinmuxOutselSensorCtrlAonAstDebugOut8 = 64, /**< sensor_ctrl_aon_ast_debug_out 8 */
+  kTopEarlgreyPinmuxOutselSensorCtrlAonAstDebugOut9 = 65, /**< sensor_ctrl_aon_ast_debug_out 9 */
+  kTopEarlgreyPinmuxOutselLast = 65, /**< \internal Last valid outsel value */
 } top_earlgrey_pinmux_outsel_t;
 
 /**

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -562,7 +562,56 @@
   ],
 
   // This is empty for top_englishbreakfast
-  port: []
+  port: [
+    { name: "ast",
+      inter_signal_list: [
+        { struct: "edn",
+          type: "req_rsp",
+          name: "edn",
+          // The activity direction for a port inter-signal is "opposite" of
+          // what the external module actually needs.
+          act:  "rsp",
+          package: "edn_pkg",
+        },
+
+        { struct: "lc_tx",
+          type: "uni",
+          name: "lc_dft_en",
+          // The activity direction for a port inter-signal is "opposite" of
+          // what the external module actually needs.
+          act:  "req",
+          package: "lc_ctrl_pkg",
+        },
+
+        { struct:  "ram_1p_cfg",
+          package: "prim_ram_1p_pkg",
+          type:    "uni",
+          name:    "ram_1p_cfg",
+          // The activity direction for a port inter-signal is "opposite" of
+          // what the external module actually needs.
+          act:     "rcv"
+        },
+
+        { struct:  "ram_2p_cfg",
+          package: "prim_ram_2p_pkg",
+          type:    "uni",
+          name:    "ram_2p_cfg",
+          // The activity direction for a port inter-signal is "opposite" of
+          // what the external module actually needs.
+          act:     "rcv"
+        },
+
+        { struct:  "rom_cfg",
+          package: "prim_rom_pkg",
+          type:    "uni",
+          name:    "rom_cfg",
+          // The activity direction for a port inter-signal is "opposite" of
+          // what the external module actually needs.
+          act:     "rcv"
+        }
+      ]
+    },
+  ]
 
   // Inter-module Connection.
   // format:
@@ -653,7 +702,10 @@
 
     // ext is to create port in the top.
     'external': {
-       'clkmgr_aon.clk_main'           : 'clk_main',  // clock inputs
+        'ast.ram_1p_cfg'               : 'ram_1p_cfg',
+        'ast.ram_2p_cfg'               : 'ram_2p_cfg',
+        'ast.rom_cfg'                  : 'rom_cfg',
+        'clkmgr_aon.clk_main'          : 'clk_main',  // clock inputs
         'clkmgr_aon.clk_io'            : 'clk_io',    // clock inputs
         'clkmgr_aon.clk_usb'           : 'clk_usb',   // clock inputs
         'clkmgr_aon.clk_aon'           : 'clk_aon',   // clock inputs

--- a/hw/top_englishbreakfast/rtl/top_englishbreakfast_cw305.sv
+++ b/hw/top_englishbreakfast/rtl/top_englishbreakfast_cw305.sv
@@ -337,6 +337,11 @@ module top_englishbreakfast_cw305 #(
     .mio_attr_o      ( mio_attr      ),
     .dio_attr_o      ( dio_attr      ),
 
+    // Memory attributes
+    .ram_1p_cfg_i    ( '0 ),
+    .ram_2p_cfg_i    ( '0 ),
+    .rom_cfg_i       ( '0 ),
+
     // DFT signals
     .scan_rst_ni     ( 1'b1             ),
     .scan_en_i       ( 1'b0             ),

--- a/hw/top_englishbreakfast/rtl/top_englishbreakfast_verilator.sv
+++ b/hw/top_englishbreakfast/rtl/top_englishbreakfast_verilator.sv
@@ -190,6 +190,11 @@ module top_englishbreakfast_verilator (
     .mio_attr_o                 ( ),
     .dio_attr_o                 ( ),
 
+    // Memory attributes
+    .ram_1p_cfg_i               ('0),
+    .ram_2p_cfg_i               ('0),
+    .rom_cfg_i                  ('0),
+
     // DFT signals
     .scan_rst_ni                (1'b1),
     .scanmode_i                 (lc_ctrl_pkg::Off)

--- a/util/topgen/intermodule.py
+++ b/util/topgen/intermodule.py
@@ -456,8 +456,11 @@ def elab_intermodule(topcfg: OrderedDict):
         # if top signame already defined, then a previous connection category
         # is already connected to external pin.  Sig name is only used for
         # port definition
+        conn_type = False
         if "top_signame" not in sig:
             sig["top_signame"] = sig_name
+        else:
+            conn_type = True
 
         if "index" not in sig:
             sig["index"] = -1
@@ -481,6 +484,7 @@ def elab_intermodule(topcfg: OrderedDict):
                              ('default', sig["default"]),
                              ('direction',
                               'out' if sig['act'] == "req" else 'in'),
+                             ('conn_type', conn_type),
                              ('index', index),
                              ('netname', netname + req_suffix)]))
             topcfg["inter_signal"]["external"].append(
@@ -491,6 +495,7 @@ def elab_intermodule(topcfg: OrderedDict):
                              ('default', sig["default"]),
                              ('direction',
                               'in' if sig['act'] == "req" else 'out'),
+                             ('conn_type', conn_type),
                              ('index', index),
                              ('netname', netname + rsp_suffix)]))
         else:  # uni
@@ -506,6 +511,7 @@ def elab_intermodule(topcfg: OrderedDict):
                              ('default', sig["default"]),
                              ('direction',
                               'out' if sig['act'] == "req" else 'in'),
+                             ('conn_type', conn_type),
                              ('index', index),
                              ('netname', netname)]))
 
@@ -814,6 +820,7 @@ def check_intermodule(topcfg: Dict, prefix: str) -> int:
         if sig_i != -1:
             log.error("{item} cannot have index".format(item=item))
             total_error += 1
+
         sig_struct = find_intermodule_signal(topcfg["inter_signal"]["signals"],
                                              sig_m, sig_s)
         err, sig_struct = check_intermodule_field(sig_struct)


### PR DESCRIPTION
- wire up memory configuration
- wire up digital test inputs / outputs
- wire up dft_en

Minor updates to intermodule script required for memory configuration.
Added prim_ram*_pkg and prim_rom*_pkg to represent configuration information.

In the future, it would be ideal for ast to directly re-use these declarations.