### PR TITLE
[dv/sram] implement pipelining test and update scb

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
@@ -46,7 +46,7 @@ class sram_ctrl_smoke_vseq extends sram_ctrl_base_vseq;
     `uvm_info(`gfn,
               $sformatf("Performing %0d random memory accesses after reset!", num_ops_after_reset),
               UVM_LOW)
-    do_rand_ops(num_ops_after_reset, 1);
+    do_rand_ops(num_ops_after_reset);
 
     `uvm_info(`gfn, $sformatf("Starting %0d SRAM transactions", num_trans), UVM_LOW)
     for (int i = 0; i < num_trans; i++) begin
@@ -66,7 +66,13 @@ class sram_ctrl_smoke_vseq extends sram_ctrl_base_vseq;
       `uvm_info(`gfn,
                 $sformatf("Performing %0d random memory accesses!", num_ops),
                 UVM_LOW)
-      do_rand_ops(num_ops);
+      if (stress_pipeline) begin
+        for (int i = 0; i < num_ops; i++) begin
+          do_stress_ops($urandom(), $urandom_range(5, 20));
+        end
+      end else begin
+        do_rand_ops(num_ops);
+      end
     end
   endtask : body
 

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_stress_pipeline_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_stress_pipeline_vseq.sv
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class sram_ctrl_stress_pipeline_vseq extends sram_ctrl_multiple_keys_vseq;
+
+  `uvm_object_utils(sram_ctrl_stress_pipeline_vseq)
+  `uvm_object_new
+
+  // Since we now perform multiple accesses to each address, lower the total num_ops
+  // to prevent simulations taking forever
+  constraint num_ops_c {
+    num_ops dist {
+      [1 : 1000] :/ 1,
+      [1001 : 2500] :/ 6,
+      [2501 : 4000] :/ 2,
+      [4001 : 5000] :/ 1
+    };
+  }
+
+  virtual task pre_start();
+
+    stress_pipeline = 1'b1;
+
+    cfg.m_sram_cfg.a_valid_delay_min = 0;
+    cfg.m_sram_cfg.a_valid_delay_max = 0;
+
+    cfg.m_sram_cfg.a_ready_delay_min = 0;
+    cfg.m_sram_cfg.a_ready_delay_max = 0;
+
+    cfg.m_sram_cfg.d_ready_delay_min = 0;
+    cfg.m_sram_cfg.d_ready_delay_max = 0;
+
+    cfg.m_sram_cfg.d_valid_delay_min = 0;
+    cfg.m_sram_cfg.d_valid_delay_max = 0;
+
+    super.pre_start();
+
+  endtask
+
+endclass

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_vseq_list.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_vseq_list.sv
@@ -7,3 +7,4 @@
 `include "sram_ctrl_common_vseq.sv"
 `include "sram_ctrl_multiple_keys_vseq.sv"
 `include "sram_ctrl_bijection_vseq.sv"
+`include "sram_ctrl_stress_pipeline_vseq.sv"

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
@@ -24,6 +24,7 @@ filesets:
       - seq_lib/sram_ctrl_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/sram_ctrl_multiple_keys_vseq.sv: {is_include_file: true}
       - seq_lib/sram_ctrl_bijection_vseq.sv: {is_include_file: true}
+      - seq_lib/sram_ctrl_stress_pipeline_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -77,6 +77,10 @@
       name: "{variant}_bijection"
       uvm_test_seq: sram_ctrl_bijection_vseq
     }
+    {
+      name: "{variant}_stress_pipeline"
+      uvm_test_seq: sram_ctrl_stress_pipeline_vseq
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_wrapper.sv
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_wrapper.sv
@@ -81,7 +81,8 @@ module sram_ctrl_wrapper
   // TLUL Adapter SRAM
   tlul_adapter_sram #(
     .SramAw(AddrWidth),
-    .SramDw(DataWidth)
+    .SramDw(DataWidth),
+    .Outstanding(2)
   ) u_tl_adapter_sram (
     .clk_i    (clk_i          ),
     .rst_ni   (rst_ni         ),


### PR DESCRIPTION
this PR adds the SRAM pipelining test as laid out in the testplan.

in this test, we choose a random mem address and send a series of
back-to-back transactions to that address, to stress the internal
pipelining and forwarding logic.

this requires an overhaul of the scoreboard as the SRAM pipelining logic
means that while TL memory requests are handled in-order, the underlying
memory macro is updated in an out-of-order fashion, leading to several
tricky edge cases.

NOTE: this PR depends on #5530 to be merged first, as that contains a
      fix for an issue uncovered by this test.

Signed-off-by: Udi Jonnalagadda <udij@google.com>