### PR TITLE
[flash_ctrl] Remove duplicated parameter from flash_mp.sv

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_mp.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_mp.sv
@@ -56,9 +56,6 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; (
   // Total number of regions including default region
   localparam int TotalRegions = MpRegions+1;
 
-  // Hardware interface permission table
-  localparam int HwInfoRules = 3;
-
   // bank + page address
   logic [AllPagesW-1:0] bank_page_addr;
   // bank address


### PR DESCRIPTION
This also appears in `flash_ctrl_pkg` (with the same value). Looking at
the history, I think that was added later and we just forgot to clean
it up from flash_mp.sv.
