### PR TITLE
[csrng] Remove duplicated parameter

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -13,12 +13,6 @@
       local: "false",
       expose: "true"
     },
-    { name: "NHwApps",
-      type: "int",
-      default: "2",
-      desc: "Number of CSRNG hardware applications",
-      local: "true"
-    }
   ],
   interrupt_list: [
     { name: "cs_cmd_req_done"

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -7,7 +7,6 @@
 package csrng_reg_pkg;
 
   // Param list
-  parameter int NHwApps = 2;
   parameter int NumAlerts = 1;
 
   // Address width within the block


### PR DESCRIPTION
*EDIT: I've changed this to work the other way around from the original PR. New commit message below.*

The existing code defined the `NHwApps` parameter in `csrng.hjson` (which
flows into `csrng_reg_pkg.sv`) and also defined it as a parameter in the
`csrng` and `csrng_core` modules.

This causes a namespace conflict, violating the SystemVerilog spec. We
can't remove the parameter from the `csrng` module because it's used in
DV to allow the testbench to test different configurations from what
ends up in the chip. Fortunately, `NHwApps` doesn't alter the top-level
port list so isn't needed by the reggen/topgen machinery, meaning that
we can just remove it from the hjson file.
