### PR TITLE
[rstmgr] Remove duplicated parameters from rstmgr_ctrl

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.sv.tpl
@@ -144,9 +144,7 @@ module rstmgr import rstmgr_pkg::*; (
 
 
   // lc reset sources
-  rstmgr_ctrl #(
-    .PowerDomains(PowerDomains)
-  ) u_lc_src (
+  rstmgr_ctrl u_lc_src (
     .clk_i,
     .rst_ni(local_rst_n),
     .rst_req_i(pwr_i.rst_lc_req),
@@ -155,9 +153,7 @@ module rstmgr import rstmgr_pkg::*; (
   );
 
   // sys reset sources
-  rstmgr_ctrl #(
-    .PowerDomains(PowerDomains)
-  ) u_sys_src (
+  rstmgr_ctrl u_sys_src (
     .clk_i,
     .rst_ni(local_rst_n),
     .rst_req_i(pwr_i.rst_sys_req | {PowerDomains{ndm_req_valid}}),

--- a/hw/ip/rstmgr/rtl/rstmgr.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr.sv
@@ -134,9 +134,7 @@ module rstmgr import rstmgr_pkg::*; (
 
 
   // lc reset sources
-  rstmgr_ctrl #(
-    .PowerDomains(PowerDomains)
-  ) u_lc_src (
+  rstmgr_ctrl u_lc_src (
     .clk_i,
     .rst_ni(local_rst_n),
     .rst_req_i(pwr_i.rst_lc_req),
@@ -145,9 +143,7 @@ module rstmgr import rstmgr_pkg::*; (
   );
 
   // sys reset sources
-  rstmgr_ctrl #(
-    .PowerDomains(PowerDomains)
-  ) u_sys_src (
+  rstmgr_ctrl u_sys_src (
     .clk_i,
     .rst_ni(local_rst_n),
     .rst_req_i(pwr_i.rst_sys_req | {PowerDomains{ndm_req_valid}}),

--- a/hw/ip/rstmgr/rtl/rstmgr_ctrl.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_ctrl.sv
@@ -7,10 +7,10 @@
 
 `include "prim_assert.sv"
 
-module rstmgr_ctrl import rstmgr_pkg::*; #(
-  parameter int PowerDomains = 2,
-  localparam int OffDomains = PowerDomains - 1
-) (
+module rstmgr_ctrl
+  import rstmgr_pkg::*;
+  import rstmgr_reg_pkg::*;
+(
   input clk_i,
   input rst_ni,
   input [PowerDomains-1:0] rst_req_i,

--- a/hw/ip/rstmgr/rtl/rstmgr_pkg.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_pkg.sv
@@ -14,7 +14,7 @@ package rstmgr_pkg;
   parameter int Domain0Sel = 1;
 
   // Number of non-always-on domains
-  parameter int OffDomains = PowerDomains-1;
+  parameter int OffDomains = PowerDomains - 1;
 
   // positions of software controllable reset bits
   parameter int SPI_DEVICE = 0;

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -151,9 +151,7 @@ module rstmgr import rstmgr_pkg::*; (
 
 
   // lc reset sources
-  rstmgr_ctrl #(
-    .PowerDomains(PowerDomains)
-  ) u_lc_src (
+  rstmgr_ctrl u_lc_src (
     .clk_i,
     .rst_ni(local_rst_n),
     .rst_req_i(pwr_i.rst_lc_req),
@@ -162,9 +160,7 @@ module rstmgr import rstmgr_pkg::*; (
   );
 
   // sys reset sources
-  rstmgr_ctrl #(
-    .PowerDomains(PowerDomains)
-  ) u_sys_src (
+  rstmgr_ctrl u_sys_src (
     .clk_i,
     .rst_ni(local_rst_n),
     .rst_req_i(pwr_i.rst_sys_req | {PowerDomains{ndm_req_valid}}),


### PR DESCRIPTION
These are also defined in rstmgr_pkg.sv with the same values, causing
a namespace clash. I think we probably just forgot to remove them from
rstmgr_ctrl.sv when we added them to the package.
