### PR TITLE
[entropy_src] Remove duplicated parameters in entropy_src

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src.sv
@@ -11,8 +11,7 @@ module entropy_src
   import entropy_src_pkg::*;
   import entropy_src_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
-  parameter int EsFifoDepth = 2
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
 ) (
   input logic clk_i,
   input logic rst_ni,
@@ -65,9 +64,7 @@ module entropy_src
     .devmode_i(1'b1)
   );
 
-  entropy_src_core #(
-    .EsFifoDepth(EsFifoDepth)
-  ) u_entropy_src_core (
+  entropy_src_core u_entropy_src_core (
     .clk_i,
     .rst_ni,
     .reg2hw,

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -5,9 +5,8 @@
 // Description: entropy_src core module
 //
 
-module entropy_src_core import entropy_src_pkg::*; #(
-  parameter int EsFifoDepth = 4
-) (
+module entropy_src_core import entropy_src_pkg::*;
+(
   input logic clk_i,
   input logic rst_ni,
 


### PR DESCRIPTION
These shadow the equivalent parameters in `entropy_src_reg_pkg` (which
come from the hjson file), violating the SystemVerilog spec and being
generally confusing. Fortunately, they aren't needed :-)
