### PR TITLE
[pattgen] Add missing variable declaration

### DIFF
--- a/hw/ip/pattgen/rtl/pattgen_chan.sv
+++ b/hw/ip/pattgen/rtl/pattgen_chan.sv
@@ -34,6 +34,7 @@ module pattgen_chan
   logic [9:0]  rep_cnt_d;
   logic [9:0]  rep_cnt_q;
 
+  logic        complete_en;
   logic        complete_d;
   logic        complete_q;
   logic        complete_q2;


### PR DESCRIPTION
There is an assignment to `complete_en`, but the variable isn't
declared (causing a Verilator warning).
