### PR TITLE
[ibex] Just take the bottom 32 bits of dm::FooAddress

### DIFF
--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -259,8 +259,8 @@ module top_${top["name"]} #(
     .BranchPredictor          (0),
     .DbgTriggerEn             (1),
     .SecureIbex               (0),
-    .DmHaltAddr               (ADDR_SPACE_DEBUG_MEM + dm::HaltAddress),
-    .DmExceptionAddr          (ADDR_SPACE_DEBUG_MEM + dm::ExceptionAddress),
+    .DmHaltAddr               (ADDR_SPACE_DEBUG_MEM + dm::HaltAddress[31:0]),
+    .DmExceptionAddr          (ADDR_SPACE_DEBUG_MEM + dm::ExceptionAddress[31:0]),
     .PipeLine                 (IbexPipeLine)
   ) u_rv_core_ibex (
     // clock and reset

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -656,8 +656,8 @@ module top_earlgrey #(
     .BranchPredictor          (0),
     .DbgTriggerEn             (1),
     .SecureIbex               (0),
-    .DmHaltAddr               (ADDR_SPACE_DEBUG_MEM + dm::HaltAddress),
-    .DmExceptionAddr          (ADDR_SPACE_DEBUG_MEM + dm::ExceptionAddress),
+    .DmHaltAddr               (ADDR_SPACE_DEBUG_MEM + dm::HaltAddress[31:0]),
+    .DmExceptionAddr          (ADDR_SPACE_DEBUG_MEM + dm::ExceptionAddress[31:0]),
     .PipeLine                 (IbexPipeLine)
   ) u_rv_core_ibex (
     // clock and reset


### PR DESCRIPTION
The pulp_riscv_dbg module is presumably designed to support 64-bit
systems, so its addresses are 64 bits wide. Slice out the bottom 32
bits explicitly, avoiding width mismatch warnings for the addition and
then for setting a 32-bit parameter with the 64-bit result.
