### PR TITLE
[otbn] Add second EDN connection

### DIFF
--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -51,7 +51,7 @@
       type:    "req_rsp",
       name:    "edn",
       act:     "rsp",
-      width:   "6",
+      width:   "7",
       default: "'0",
       desc:    '''
                The collection of peripheral ports supported by edn. The width (4)

--- a/hw/ip/edn/rtl/edn.sv
+++ b/hw/ip/edn/rtl/edn.sv
@@ -10,7 +10,7 @@ module edn
   import edn_pkg::*;
   import edn_reg_pkg::*;
 #(
-  parameter int NumEndPoints = 6,
+  parameter int NumEndPoints = 7,
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
   parameter int BootInsCmd = 32'h0000_0001,
   parameter int BootGenCmd = 32'h00ff_f003

--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -36,13 +36,21 @@
   ]
 
   inter_signal_list: [
-    // EDN interface
+    // EDN interface for RND
     { struct:  "edn"
       type:    "req_rsp"
-      name:    "edn"
+      name:    "edn_rnd"
       act:     "req"
       package: "edn_pkg"
-    }
+    },
+
+    // EDN interface for URND
+    { struct:  "edn"
+      type:    "req_rsp"
+      name:    "edn_urnd"
+      act:     "req"
+      package: "edn_pkg"
+    },
 
     // OTBN is not performing any operation and can be clock/power-gated.
     { name:    "idle",

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -46,50 +46,57 @@ module otbn_top_sim (
   logic                     dmem_rerror;
 
   // Entropy Distribution Network (EDN)
-  logic                     edn_req;
-  logic                     edn_ack;
-  logic [EdnDataWidth-1:0]  edn_data;
+  logic                     edn_rnd_req, edn_urnd_req;
+  logic                     edn_rnd_ack, edn_urnd_ack;
+  logic [EdnDataWidth-1:0]  edn_rnd_data, edn_urnd_data;
 
   otbn_core #(
     .ImemSizeByte ( ImemSizeByte ),
     .DmemSizeByte ( DmemSizeByte )
   ) u_otbn_core (
-    .clk_i         ( IO_CLK          ),
-    .rst_ni        ( IO_RST_N        ),
+    .clk_i           ( IO_CLK          ),
+    .rst_ni          ( IO_RST_N        ),
 
-    .start_i       ( otbn_start      ),
-    .done_o        ( otbn_done_d     ),
+    .start_i         ( otbn_start      ),
+    .done_o          ( otbn_done_d     ),
 
-    .err_bits_o    ( otbn_err_bits_d ),
+    .err_bits_o      ( otbn_err_bits_d ),
 
-    .start_addr_i  ( ImemStartAddr   ),
+    .start_addr_i    ( ImemStartAddr   ),
 
-    .imem_req_o    ( imem_req        ),
-    .imem_addr_o   ( imem_addr       ),
-    .imem_wdata_o  (                 ),
-    .imem_rdata_i  ( imem_rdata      ),
-    .imem_rvalid_i ( imem_rvalid     ),
-    .imem_rerror_i ( imem_rerror     ),
+    .imem_req_o      ( imem_req        ),
+    .imem_addr_o     ( imem_addr       ),
+    .imem_wdata_o    (                 ),
+    .imem_rdata_i    ( imem_rdata      ),
+    .imem_rvalid_i   ( imem_rvalid     ),
+    .imem_rerror_i   ( imem_rerror     ),
 
-    .dmem_req_o    ( dmem_req        ),
-    .dmem_write_o  ( dmem_write      ),
-    .dmem_addr_o   ( dmem_addr       ),
-    .dmem_wdata_o  ( dmem_wdata      ),
-    .dmem_wmask_o  ( dmem_wmask      ),
-    .dmem_rdata_i  ( dmem_rdata      ),
-    .dmem_rvalid_i ( dmem_rvalid     ),
-    .dmem_rerror_i ( dmem_rerror     ),
+    .dmem_req_o      ( dmem_req        ),
+    .dmem_write_o    ( dmem_write      ),
+    .dmem_addr_o     ( dmem_addr       ),
+    .dmem_wdata_o    ( dmem_wdata      ),
+    .dmem_wmask_o    ( dmem_wmask      ),
+    .dmem_rdata_i    ( dmem_rdata      ),
+    .dmem_rvalid_i   ( dmem_rvalid     ),
+    .dmem_rerror_i   ( dmem_rerror     ),
 
-    .edn_req_o     ( edn_req         ),
-    .edn_ack_i     ( edn_ack         ),
-    .edn_data_i    ( edn_data        )
+    .edn_rnd_req_o   ( edn_rnd_req     ),
+    .edn_rnd_ack_i   ( edn_rnd_ack     ),
+    .edn_rnd_data_i  ( edn_rnd_data    ),
+
+    .edn_urnd_req_o  ( edn_urnd_req    ),
+    .edn_urnd_ack_i  ( edn_urnd_ack    ),
+    .edn_urnd_data_i ( edn_urnd_data   )
   );
 
   // Tie-off EDN signals, eventually simulation will provide something here for testing RND
-  logic unused_edn_req;
-  assign unused_edn_req = edn_req;
-  assign edn_ack = 1'b0;
-  assign edn_data = '0;
+  logic unused_edn_rnd_req, unused_edn_urnd_req;
+  assign unused_edn_rnd_req = edn_rnd_req;
+  assign unused_edn_urnd_req = edn_urnd_req;
+  assign edn_rnd_ack = 1'b0;
+  assign edn_rnd_data = '0;
+  assign edn_urnd_ack = 1'b0;
+  assign edn_urnd_data = '0;
 
   bind otbn_core otbn_trace_if #(.ImemAddrWidth, .DmemAddrWidth) i_otbn_trace_if (.*);
   bind otbn_core otbn_tracer u_otbn_tracer(.*, .otbn_trace(i_otbn_trace_if));

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -34,8 +34,11 @@ module otbn
   // EDN clock and interface
   input                                              clk_edn_i,
   input                                              rst_edn_ni,
-  output edn_pkg::edn_req_t                          edn_o,
-  input  edn_pkg::edn_rsp_t                          edn_i
+  output edn_pkg::edn_req_t                          edn_rnd_o,
+  input  edn_pkg::edn_rsp_t                          edn_rnd_i,
+
+  output edn_pkg::edn_req_t                          edn_urnd_o,
+  input  edn_pkg::edn_rsp_t                          edn_urnd_i
 );
 
   import prim_util_pkg::vbits;
@@ -443,25 +446,44 @@ module otbn
   end
 
 
-  // EDN Connection ============================================================
-  logic edn_req, edn_ack;
-  logic [EdnDataWidth-1:0] edn_data;
+  // EDN Connections ============================================================
+  logic edn_rnd_req, edn_rnd_ack;
+  logic [EdnDataWidth-1:0] edn_rnd_data;
 
-  // This synchronizes the data coming from EDN and stacks the
-  // 32bit EDN words to achieve an internal entropy width of 256 bit.
+  logic edn_urnd_req, edn_urnd_ack;
+  logic [EdnDataWidth-1:0] edn_urnd_data;
+
+  // These synchronize the data coming from EDN and stack the 32 bit EDN words to achieve an
+  // internal entropy width of 256 bit.
+
   prim_edn_req #(
     .OutWidth(EdnDataWidth)
-  ) u_prim_edn_req (
+  ) u_prim_edn_rnd_req (
     .clk_i,
     .rst_ni,
-    .req_i      ( edn_req  ),
-    .ack_o      ( edn_ack  ),
-    .data_o     ( edn_data ),
-    .fips_o     (          ), // unused
+    .req_i      ( edn_rnd_req  ),
+    .ack_o      ( edn_rnd_ack  ),
+    .data_o     ( edn_rnd_data ),
+    .fips_o     (              ), // unused
     .clk_edn_i,
     .rst_edn_ni,
-    .edn_o,
-    .edn_i
+    .edn_o      ( edn_rnd_o    ),
+    .edn_i      ( edn_rnd_i    )
+  );
+
+  prim_edn_req #(
+    .OutWidth(EdnDataWidth)
+  ) u_prim_edn_urnd_req (
+    .clk_i,
+    .rst_ni,
+    .req_i      ( edn_urnd_req  ),
+    .ack_o      ( edn_urnd_ack  ),
+    .data_o     ( edn_urnd_data ),
+    .fips_o     (               ), // unused
+    .clk_edn_i,
+    .rst_edn_ni,
+    .edn_o      ( edn_urnd_o    ),
+    .edn_i      ( edn_urnd_i    )
   );
 
 
@@ -561,32 +583,36 @@ module otbn
       .clk_i,
       .rst_ni,
 
-      .start_i (start),
-      .done_o  (done),
+      .start_i         (start),
+      .done_o          (done),
 
-      .err_bits_o (err_bits),
+      .err_bits_o      (err_bits),
 
-      .start_addr_i  (start_addr),
+      .start_addr_i    (start_addr),
 
-      .imem_req_o    (imem_req_core),
-      .imem_addr_o   (imem_addr_core),
-      .imem_wdata_o  (imem_wdata_core),
-      .imem_rdata_i  (imem_rdata_core),
-      .imem_rvalid_i (imem_rvalid_core),
-      .imem_rerror_i (imem_rerror_core),
+      .imem_req_o      (imem_req_core),
+      .imem_addr_o     (imem_addr_core),
+      .imem_wdata_o    (imem_wdata_core),
+      .imem_rdata_i    (imem_rdata_core),
+      .imem_rvalid_i   (imem_rvalid_core),
+      .imem_rerror_i   (imem_rerror_core),
 
-      .dmem_req_o    (dmem_req_core),
-      .dmem_write_o  (dmem_write_core),
-      .dmem_addr_o   (dmem_addr_core),
-      .dmem_wdata_o  (dmem_wdata_core),
-      .dmem_wmask_o  (dmem_wmask_core),
-      .dmem_rdata_i  (dmem_rdata_core),
-      .dmem_rvalid_i (dmem_rvalid_core),
-      .dmem_rerror_i (dmem_rerror_core),
+      .dmem_req_o      (dmem_req_core),
+      .dmem_write_o    (dmem_write_core),
+      .dmem_addr_o     (dmem_addr_core),
+      .dmem_wdata_o    (dmem_wdata_core),
+      .dmem_wmask_o    (dmem_wmask_core),
+      .dmem_rdata_i    (dmem_rdata_core),
+      .dmem_rvalid_i   (dmem_rvalid_core),
+      .dmem_rerror_i   (dmem_rerror_core),
 
-      .edn_req_o     (edn_req),
-      .edn_ack_i     (edn_ack),
-      .edn_data_i    (edn_data)
+      .edn_rnd_req_o   (edn_rnd_req),
+      .edn_rnd_ack_i   (edn_rnd_ack),
+      .edn_rnd_data_i  (edn_rnd_data),
+
+      .edn_urnd_req_o  (edn_urnd_req),
+      .edn_urnd_ack_i  (edn_urnd_ack),
+      .edn_urnd_data_i (edn_urnd_data)
     );
   `endif
 

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -51,10 +51,15 @@ module otbn_core
   input  logic                     dmem_rvalid_i,
   input  logic                     dmem_rerror_i,
 
-  // Entropy distribution network (EDN)
-  output logic                    edn_req_o,
-  input  logic                    edn_ack_i,
-  input  logic [EdnDataWidth-1:0] edn_data_i
+  // Entropy distribution network (EDN) connections
+  // One for RND, the other for URND
+  output logic                    edn_rnd_req_o,
+  input  logic                    edn_rnd_ack_i,
+  input  logic [EdnDataWidth-1:0] edn_rnd_data_i,
+
+  output logic                    edn_urnd_req_o,
+  input  logic                    edn_urnd_ack_i,
+  input  logic [EdnDataWidth-1:0] edn_urnd_data_i
 );
   // Random number
   // TODO: Hook up to RNG distribution network
@@ -417,11 +422,17 @@ module otbn_core
     .ispr_acc_wr_en_i   (ispr_acc_wr_en)
   );
 
-  logic                    unused_edn_ack;
-  logic [EdnDataWidth-1:0] unused_edn_data;
+  logic                    unused_edn_rnd_ack;
+  logic [EdnDataWidth-1:0] unused_edn_rnd_data;
+  logic                    unused_edn_urnd_ack;
+  logic [EdnDataWidth-1:0] unused_edn_urnd_data;
 
   // Tie-off EDN interface
-  assign unused_edn_ack  = edn_ack_i;
-  assign unused_edn_data = edn_data_i;
-  assign edn_req_o       = 1'b0;
+  assign unused_edn_rnd_ack  = edn_rnd_ack_i;
+  assign unused_edn_rnd_data = edn_rnd_data_i;
+  assign edn_rnd_req_o       = 1'b0;
+
+  assign unused_edn_urnd_ack  = edn_urnd_ack_i;
+  assign unused_edn_urnd_data = edn_urnd_data_i;
+  assign edn_urnd_req_o       = 1'b0;
 endmodule

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -4178,7 +4178,7 @@
           package: edn_pkg
           type: req_rsp
           act: rsp
-          width: 6
+          width: 7
           default: "'0"
           inst_name: edn0
           end_idx: -1
@@ -4250,7 +4250,7 @@
           package: edn_pkg
           type: req_rsp
           act: rsp
-          width: 6
+          width: 7
           default: "'0"
           inst_name: edn1
           end_idx: 1
@@ -4466,7 +4466,7 @@
       inter_signal_list:
       [
         {
-          name: edn
+          name: edn_rnd
           struct: edn
           package: edn_pkg
           type: req_rsp
@@ -4476,6 +4476,18 @@
           default: ""
           top_signame: edn1_edn
           index: 0
+        }
+        {
+          name: edn_urnd
+          struct: edn
+          package: edn_pkg
+          type: req_rsp
+          act: req
+          width: 1
+          inst_name: otbn
+          default: ""
+          top_signame: edn0_edn
+          index: 6
         }
         {
           name: idle
@@ -5007,10 +5019,11 @@
         kmac.entropy
         alert_handler.edn
         aes.edn
+        otbn.edn_urnd
       ]
       edn1.edn:
       [
-        otbn.edn
+        otbn.edn_rnd
       ]
       otp_ctrl.otp_keymgr_key:
       [
@@ -10912,7 +10925,7 @@
         package: edn_pkg
         type: req_rsp
         act: rsp
-        width: 6
+        width: 7
         default: "'0"
         inst_name: edn0
         end_idx: -1
@@ -10960,7 +10973,7 @@
         package: edn_pkg
         type: req_rsp
         act: rsp
-        width: 6
+        width: 7
         default: "'0"
         inst_name: edn1
         end_idx: 1
@@ -11082,7 +11095,7 @@
         index: -1
       }
       {
-        name: edn
+        name: edn_rnd
         struct: edn
         package: edn_pkg
         type: req_rsp
@@ -11092,6 +11105,18 @@
         default: ""
         top_signame: edn1_edn
         index: 0
+      }
+      {
+        name: edn_urnd
+        struct: edn
+        package: edn_pkg
+        type: req_rsp
+        act: req
+        width: 1
+        inst_name: otbn
+        default: ""
+        top_signame: edn0_edn
+        index: 6
       }
       {
         name: idle
@@ -12766,7 +12791,7 @@
         package: edn_pkg
         struct: edn_req
         signame: edn0_edn_req
-        width: 6
+        width: 7
         type: req_rsp
         end_idx: -1
         act: rsp
@@ -12777,7 +12802,7 @@
         package: edn_pkg
         struct: edn_rsp
         signame: edn0_edn_rsp
-        width: 6
+        width: 7
         type: req_rsp
         end_idx: -1
         act: rsp
@@ -12788,7 +12813,7 @@
         package: edn_pkg
         struct: edn_req
         signame: edn1_edn_req
-        width: 6
+        width: 7
         type: req_rsp
         end_idx: 1
         act: rsp
@@ -12799,7 +12824,7 @@
         package: edn_pkg
         struct: edn_rsp
         signame: edn1_edn_rsp
-        width: 6
+        width: 7
         type: req_rsp
         end_idx: 1
         act: rsp

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -787,8 +787,8 @@
 
       // Edn connections
       'edn0.edn'              : ['keymgr.edn', 'otp_ctrl.edn', 'ast_edn.edn', 'kmac.entropy',
-                                 'alert_handler.edn', 'aes.edn'],
-      'edn1.edn'              : ['otbn.edn'],
+                                 'alert_handler.edn', 'aes.edn', 'otbn.edn_urnd'],
+      'edn1.edn'              : ['otbn.edn_rnd'],
 
       // KeyMgr Sideload & KDF function
       'otp_ctrl.otp_keymgr_key' : ['keymgr.otp_key'],

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -446,10 +446,10 @@ module top_earlgrey #(
   logic       usbdev_usb_aon_wake_ack;
   logic       usbdev_usb_suspend;
   usbdev_pkg::awk_state_t       pinmux_aon_usb_state_debug;
-  edn_pkg::edn_req_t [5:0] edn0_edn_req;
-  edn_pkg::edn_rsp_t [5:0] edn0_edn_rsp;
-  edn_pkg::edn_req_t [5:0] edn1_edn_req;
-  edn_pkg::edn_rsp_t [5:0] edn1_edn_rsp;
+  edn_pkg::edn_req_t [6:0] edn0_edn_req;
+  edn_pkg::edn_rsp_t [6:0] edn0_edn_rsp;
+  edn_pkg::edn_req_t [6:0] edn1_edn_req;
+  edn_pkg::edn_rsp_t [6:0] edn1_edn_rsp;
   otp_ctrl_pkg::otp_keymgr_key_t       otp_ctrl_otp_keymgr_key;
   keymgr_pkg::hw_key_req_t       keymgr_kmac_key;
   keymgr_pkg::kmac_data_req_t       keymgr_kmac_data_req;
@@ -584,6 +584,7 @@ module top_earlgrey #(
   edn_pkg::edn_rsp_t unused_edn1_edn_rsp3;
   edn_pkg::edn_rsp_t unused_edn1_edn_rsp4;
   edn_pkg::edn_rsp_t unused_edn1_edn_rsp5;
+  edn_pkg::edn_rsp_t unused_edn1_edn_rsp6;
 
   // assign partial inter-module tie-off
   assign unused_edn1_edn_rsp1 = edn1_edn_rsp[1];
@@ -591,11 +592,13 @@ module top_earlgrey #(
   assign unused_edn1_edn_rsp3 = edn1_edn_rsp[3];
   assign unused_edn1_edn_rsp4 = edn1_edn_rsp[4];
   assign unused_edn1_edn_rsp5 = edn1_edn_rsp[5];
+  assign unused_edn1_edn_rsp6 = edn1_edn_rsp[6];
   assign edn1_edn_req[1] = '0;
   assign edn1_edn_req[2] = '0;
   assign edn1_edn_req[3] = '0;
   assign edn1_edn_req[4] = '0;
   assign edn1_edn_req[5] = '0;
+  assign edn1_edn_req[6] = '0;
 
 
   // Unused reset signals
@@ -2110,8 +2113,10 @@ module top_earlgrey #(
       .alert_rx_i  ( alert_rx[28:27] ),
 
       // Inter-module signals
-      .edn_o(edn1_edn_req[0]),
-      .edn_i(edn1_edn_rsp[0]),
+      .edn_rnd_o(edn1_edn_req[0]),
+      .edn_rnd_i(edn1_edn_rsp[0]),
+      .edn_urnd_o(edn0_edn_req[6]),
+      .edn_urnd_i(edn0_edn_rsp[6]),
       .idle_o(clkmgr_aon_idle[3]),
       .tl_i(otbn_tl_req),
       .tl_o(otbn_tl_rsp),


### PR DESCRIPTION
OTBN needs two connections, one for RND and URND. This purely adds the
second EDN connection, RND and URND are not yet implemented.

Fixes #5523

Signed-off-by: Greg Chadwick <gac@lowrisc.org>

Wasn't sure if I should switch edn0 from 6 to 7 connections or just use one of the spare ones on edn1 for now. I did this as it's the smaller change, happy to switch it around so one goes to edn0 and the other to edn1.