### PR TITLE
[lint] Add waivers for Ibex lint

### DIFF
--- a/hw/ip/rv_core_ibex/lint/rv_core_ibex.waiver
+++ b/hw/ip/rv_core_ibex/lint/rv_core_ibex.waiver
@@ -88,8 +88,16 @@ waive -rules INPUT_NOT_READ -location {ibex_decoder.sv ibex_compressed_decoder.s
       -comment "These signals are only used for assertions inside these two modules"
 waive -rules IFDEF_CODE -location {ibex_core.sv} -regexp {Assignment to 'unused_instr_new_id' contained within `else block} \
       -comment "Declaration of signal and assignment to it are in same `else block"
+waive -rules IFDEF_CODE -location {ibex_core.sv} -regexp {Assignment to 'unused_instr_id_done' contained within `else block} \
+      -comment "Declaration of signal and assignment to it are in same `else block"
+waive -rules IFDEF_CODE -location {ibex_core.sv} -regexp {Assignment to 'unused_instr_done_wb' contained within `else block} \
+      -comment "Declaration of signal and assignment to it are in same `else block"
 waive -rules IFDEF_CODE -location {rv_core_ibex.sv} -regexp {Assignment to 'tl_d_o' contained within `else block} \
       -comment "DV environment will drive things when `else block isn't used so assignment only occurs in `else block"
+waive -rules CLOCK_USE -location {ibex_id_stage.sv} -regexp {'clk_i' is connected to 'ibex_decoder' port 'clk_i'} \
+      -comment "clk_i is unused in ibex_decoder configurations without RV32B and isn't connected to logic"
+waive -rules RESET_USE -location {ibex_id_stage.sv} -regexp {'rst_ni' is connected to 'ibex_decoder' port 'rst_ni'} \
+      -comment "rst_ni is unused in ibex_decoder configurations without RV32B and isn't connected to logic"
 
 # Highlighting my main concerns here, documenting areas to review in next dive
 #


### PR DESCRIPTION
Signed-off-by: Greg Chadwick <gac@lowrisc.org>

Still seeing some ascent lint failures https://reports.opentitan.org/hw/ip/rv_core_ibex/lint/ascentlint/latest/results.html

Some require Ibex fixes (https://github.com/lowRISC/ibex/pull/1301) the others are dealt with the waivers here.

The 'CLOCK_USE' and 'RESET_USE' lint could be considered tool issues. I presume these are to warn if you use clock or reset signals in plain logic. Here they're getting assigned to unused_X signals for the auto unused signal waiver. So they're being used in plain logic, but it's logic that has no relevance to the design.