### PR TITLE
[otbn] Expand OTBN DMem/IMem width

### DIFF
--- a/hw/dv/verilator/cpp/dpi_memutil.cc
+++ b/hw/dv/verilator/cpp/dpi_memutil.cc
@@ -245,12 +245,13 @@ static void WriteSegment(const MemArea &m, uint32_t offset,
   // be caught at this function's callsite.
   SVScoped scoped(m.location.data());
 
-  // This "mini buffer" is used to transfer each write to SystemVerilog. It's
-  // not massively efficient, but doing so ensures that we pass 256 bits (32
-  // bytes) of initialised data each time. This is for simutil_set_mem (defined
-  // in prim_util_memload.svh), whose "val" argument has SystemVerilog type bit
-  // [255:0].
-  uint8_t minibuf[32];
+  // This "mini buffer" is used to transfer each write to SystemVerilog.
+  // `simutil_set_mem` takes a fixed 312 bit vector but it will only use the
+  // bits required for the RAM width. For example for a 32-bit wide RAM only
+  // elements 3 - 0 of `minibuf` will be written to memory. The simulator may
+  // still read bits from minibuf it does not use so we must use a fixed
+  // allocation of the full bit vector size to avoid out of bounds access.
+  uint8_t minibuf[39];
   memset(minibuf, 0, sizeof minibuf);
   assert(m.width_byte <= sizeof minibuf);
 

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -104,10 +104,10 @@ static std::vector<uint8_t> get_sim_memory(const char *scope, size_t num_words,
   SVScoped scoped(scope);
 
   // simutil_get_mem passes data as a packed array of svBitVecVal words. It
-  // only works for memories of size at most 256 bits, so we can just allocate
-  // 256/8 = 32 bytes as 32/sizeof(svBitVecVal) words on the stack.
-  assert(word_size <= 256 / 8);
-  svBitVecVal buf[256 / 8 / sizeof(svBitVecVal)];
+  // only works for memories of size at most 312 bits, so we can just allocate
+  // 312/8 = 39 bytes as 39/sizeof(svBitVecVal) words on the stack.
+  assert(word_size <= 312 / 8);
+  svBitVecVal buf[312 / 8 / sizeof(svBitVecVal)];
 
   std::vector<uint8_t> ret;
 
@@ -135,8 +135,8 @@ static void set_sim_memory(const std::vector<uint8_t> &data, const char *scope,
   assert(num_words * word_size == data.size());
 
   // See get_sim_memory for why this array is sized like this.
-  assert(word_size <= 256 / 8);
-  svBitVecVal buf[256 / 8 / sizeof(svBitVecVal)];
+  assert(word_size <= 312 / 8);
+  svBitVecVal buf[312 / 8 / sizeof(svBitVecVal)];
 
   for (size_t w = 0; w < num_words; w++) {
     const uint8_t *p = &data[w * word_size];

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -109,7 +109,7 @@ module otbn
   logic [ImemIndexWidth-1:0] imem_index;
   logic [31:0] imem_wdata;
   logic [31:0] imem_wmask;
-  logic [31:0] imem_rdata;
+  logic [38:0] imem_rdata;
   logic imem_rvalid;
   logic [1:0] imem_rerror_vec;
   logic imem_rerror;
@@ -138,7 +138,7 @@ module otbn
   assign unused_imem_addr_core_wordbits = imem_addr_core[1:0];
 
   prim_ram_1p_adv #(
-    .Width           (32),
+    .Width           (39),
     .Depth           (ImemSizeWords),
     .DataBitsPerMask (32), // Write masks are not supported.
     .CfgW            (8)
@@ -148,8 +148,8 @@ module otbn
     .req_i    (imem_req),
     .write_i  (imem_write),
     .addr_i   (imem_index),
-    .wdata_i  (imem_wdata),
-    .wmask_i  (imem_wmask),
+    .wdata_i  (39'(imem_wdata)),
+    .wmask_i  (39'(imem_wmask)),
     .rdata_o  (imem_rdata),
     .rvalid_o (imem_rvalid),
     .rerror_o (imem_rerror_vec),
@@ -212,8 +212,8 @@ module otbn
   // Explicitly tie off bus interface during core operation to avoid leaking
   // the currently executed instruction from IMEM through the bus
   // unintentionally.
-  assign imem_rdata_bus  = !imem_access_core ? imem_rdata : 32'b0;
-  assign imem_rdata_core = imem_rdata;
+  assign imem_rdata_bus  = !imem_access_core ? imem_rdata[31:0] : 32'b0;
+  assign imem_rdata_core = imem_rdata[31:0];
 
   assign imem_rvalid_bus  = !imem_access_core ? imem_rvalid : 1'b0;
   assign imem_rvalid_core = imem_access_core ? imem_rvalid : 1'b0;
@@ -243,7 +243,7 @@ module otbn
   logic [DmemIndexWidth-1:0] dmem_index;
   logic [WLEN-1:0] dmem_wdata;
   logic [WLEN-1:0] dmem_wmask;
-  logic [WLEN-1:0] dmem_rdata;
+  logic [(WLEN+7*8)-1:0] dmem_rdata;
   logic dmem_rvalid;
   logic [1:0] dmem_rerror_vec;
   logic dmem_rerror;
@@ -273,7 +273,7 @@ module otbn
   assign unused_dmem_addr_core_wordbits = ^dmem_addr_core[DmemAddrWidth-DmemIndexWidth-1:0];
 
   prim_ram_1p_adv #(
-    .Width           (WLEN),
+    .Width           (WLEN+7*8),
     .Depth           (DmemSizeWords),
     .DataBitsPerMask (32), // 32b write masks for 32b word writes from bus
     .CfgW            (8)
@@ -283,8 +283,8 @@ module otbn
     .req_i    (dmem_req),
     .write_i  (dmem_write),
     .addr_i   (dmem_index),
-    .wdata_i  (dmem_wdata),
-    .wmask_i  (dmem_wmask),
+    .wdata_i  (312'(dmem_wdata)),
+    .wmask_i  (312'(dmem_wmask)),
     .rdata_o  (dmem_rdata),
     .rvalid_o (dmem_rvalid),
     .rerror_o (dmem_rerror_vec),
@@ -335,8 +335,8 @@ module otbn
 
   // Explicitly tie off bus interface during core operation to avoid leaking
   // DMEM data through the bus unintentionally.
-  assign dmem_rdata_bus  = !dmem_access_core ? dmem_rdata : '0;
-  assign dmem_rdata_core = dmem_rdata;
+  assign dmem_rdata_bus  = !dmem_access_core ? dmem_rdata[WLEN-1:0] : '0;
+  assign dmem_rdata_core = dmem_rdata[WLEN-1:0];
 
   assign dmem_rvalid_bus  = !dmem_access_core ? dmem_rvalid : 1'b0;
   assign dmem_rvalid_core = dmem_access_core  ? dmem_rvalid : 1'b0;

--- a/hw/ip/prim/rtl/prim_util_memload.svh
+++ b/hw/ip/prim/rtl/prim_util_memload.svh
@@ -13,7 +13,11 @@
  * - A parameter `Width` giving the memory width (word size) in bit.
  * - A parameter `Depth` giving the memory depth in words.
  * - A parameter `MemInitFile` with a file path of a VMEM file to be loaded into
-*    the memory if not empty.
+ *   the memory if not empty.
+ *
+ * Note this works with memories up to a maximum width of 312 bits. Should this maximum width be
+ * increased all of the `simutil_set_mem` and `simutil_get_mem` call sites must be found (e.g. using
+ * git grep) and adjusted appropriately.
  */
 
 `ifndef SYNTHESIS
@@ -29,10 +33,10 @@
   // Returns 1 (true) for success, 0 (false) for errors.
   export "DPI-C" function simutil_set_mem;
 
-  function int simutil_set_mem(input int index, input bit [255:0] val);
+  function int simutil_set_mem(input int index, input bit [311:0] val);
 
-    // Function will only work for memories <= 256 bits
-    if (Width > 256) begin
+    // Function will only work for memories <= 312 bits
+    if (Width > 312) begin
       return 0;
     end
 
@@ -47,10 +51,10 @@
   // Function for getting a specific element in |mem|
   export "DPI-C" function simutil_get_mem;
 
-  function int simutil_get_mem(input int index, output bit [255:0] val);
+  function int simutil_get_mem(input int index, output bit [311:0] val);
 
-    // Function will only work for memories <= 256 bits
-    if (Width > 256) begin
+    // Function will only work for memories <= 312 bits
+    if (Width > 312) begin
       return 0;
     end
 


### PR DESCRIPTION
Extra upper bits are ignored. This increase is required to aid area
estimations for an OTBN design including integrity features.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>