### PR TITLE
[tools/dv] added UNR flow for xcelium

### DIFF
--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -142,6 +142,7 @@
   // Project defaults for Xcelium
   xcelium_cov_cfg_file: "{dv_root}/tools/xcelium/xcelium.ccf"
   xcelium_cov_refine_files: []
+  xcelium_unr_cfg_file:  "{dv_root}/tools/xcelium/unr.cfg"
   xcelium_common_excl_file: ["{dv_root}/tools/xcelium/exclude.tcl"]
 
   // Build-specific coverage cfg files for Xcelium.

--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -119,6 +119,34 @@
                      "-init {xcelium_common_excl_file}",
                      " {eval_cmd} echo {xcelium_cov_refine_files} | sed -E 's/(\\S+)/-load_refinement \\1/g' "]
 
+  cov_unr_dir:     "{scratch_path}/cov_unr"
+
+  // not needed we can reuse the last build snapshot
+  cov_unr_build_opts:[]
+  cov_unr_build_cmd:[]
+  
+  cov_unr_run_cmd: "{job_prefix} xrun"
+
+               
+  cov_unr_run_opts: [// use xrun in UNR mode
+                     "-unr",
+                     // jason gold switch (use formal)
+                     "-jg",
+                     // use the same snapshot as used for regression
+                     "-r {tb}",
+                     // pointer to the merged coverage data from the regression
+                     "-covdb {cov_merge_db_dir}",
+                     // what metrics to use
+                     "-jg_coverage {cov_metrics}",
+                     "-64bit",
+                     "-xmlibdirname {build_dir}/xcelium.d",
+                     // overwrite previous results 
+                     "-covoverwrite",
+                     "-inst_top {dut_instance}",
+                     // UNR Configurations
+                     "-input {xcelium_unr_cfg_file} "]
+
+
   // pass and fail patterns
   build_fail_patterns: ["\\*E.*$"]
   run_fail_patterns:   ["\\*E.*$"] // Null pointer error

--- a/hw/dv/tools/xcelium/unr.cfg
+++ b/hw/dv/tools/xcelium/unr.cfg
@@ -1,0 +1,16 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+check_unr -setup 
+
+#Setup the clock and reset the design 
+clock -infer
+reset rst_n
+get_reset_info
+
+set_prove_time_limit 5m
+
+check_unr -prove
+check_unr -list -type unreachable
+database -export_unicov
+report -detailed

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -547,8 +547,8 @@ class SimCfg(FlowCfg):
         coverage exclusions.
         '''
         # TODO, Only support VCS
-        if self.tool != 'vcs':
-            log.error("Currently only support VCS for coverage UNR")
+        if self.tool not in ['vcs', 'xcelium']:
+            log.error("Currently only support VCS and Xcelium for coverage UNR")    
             sys.exit(1)
         # Create initial set of directories, such as dispatched, passed etc.
         self._create_dirs()


### PR DESCRIPTION
@sriyerg  as agreed 
This adds the supporting structure for running UNR with Jason Gold using xcelium.
Still to be done is updating the dvsim.py with the correct flow.

The steps to running UNR with xcelium is.

1. run a coverage regression
2. merge the results (cov_merge)
3. run UNR with the latest build snapshot - and the merged coverage results -> this will produce a UNR database
4. merge the UNR database with the (cov_merge)
5. view the results in IMC

the double merge was a puzzle to me - but I talked to Cadence and this is needed to make sure that UNR is not taking too much time to complete. so that is the recommended way.

I think I have setup all the parameters and the "include files" in the hjson flow ready to be picked up by dvsim.

all the options needed are under unr_run_cmd_opts and unr_run_cmd (the build command is not needed as the snapshot from the regression should be used)

I have commented out the VCS only in the dv_sim script to check that the hjson works. but other than that I have not done any attempt to update the actual flow as agreed.

