### PR TITLE
[dv/otp_ctrl] Support lc_escalate_en

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -24,17 +24,30 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
   logic                lc_prog_req, lc_prog_err;
   logic                lc_prog_err_dly1, lc_prog_no_sta_check;
 
+  // Signals to skip csr check during first two clock cycles after lc_escalate_en is set.
+  // Because lc_escalate_en might take one clock cycle to propogate to design.
+  logic                lc_esc_dly1, lc_esc_dly2;
+  bit                  skip_read_check;
+
   // Lc_err could trigger during LC program, so check intr and status after lc_req is finished.
   // Lc_err takes one clock cycle to propogate to intr signal. So avoid intr check if it happens
   // during the transition.
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       lc_prog_err_dly1 <= 0;
+      lc_esc_dly1      <= 0;
+      lc_esc_dly2      <= 0;
     end else begin
       lc_prog_err_dly1 <= lc_prog_err;
+      lc_esc_dly1      <= lc_escalate_en_i;
+      lc_esc_dly2      <= lc_esc_dly1;
     end
   end
-  assign lc_prog_no_sta_check = lc_prog_err | lc_prog_err_dly1 | lc_prog_req;
+
+  assign skip_read_check = (lc_escalate_en_i == lc_ctrl_pkg::On) &&
+                           (lc_esc_dly1 != lc_ctrl_pkg::On || lc_esc_dly2 != lc_ctrl_pkg::On);
+  assign lc_prog_no_sta_check = lc_prog_err | lc_prog_err_dly1 | lc_prog_req |
+                                lc_escalate_en_i == lc_ctrl_pkg::On;
 
   // TODO: for lc_tx, except esc_en signal, all value different from On is treated as Off,
   // technically we can randomize values here once scb supports
@@ -55,20 +68,33 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
     lc_dft_en_i = val;
   endtask
 
+  task automatic drive_lc_escalate_en(lc_ctrl_pkg::lc_tx_e val);
+    lc_escalate_en_i = val;
+  endtask
+
+  `define OTP_ASSERT_WO_LC_ESC(NAME, SEQ) \
+    `ASSERT(NAME, SEQ, clk_i, !rst_ni || lc_escalate_en_i == lc_ctrl_pkg::On)
+
   // If pwr_otp_idle is set only if pwr_otp init is done
-  `ASSERT(OtpPwrDoneWhenIdle_A, pwr_otp_idle_o |-> pwr_otp_done_o)
+  `OTP_ASSERT_WO_LC_ESC(OtpPwrDoneWhenIdle_A, pwr_otp_idle_o |-> pwr_otp_done_o)
 
   // Otp_hw_cfg_o is valid only when otp init is done
-  `ASSERT(OtpHwCfgValidOn_A, pwr_otp_done_o |-> otp_hw_cfg_o.valid == lc_ctrl_pkg::On)
+  `OTP_ASSERT_WO_LC_ESC(OtpHwCfgValidOn_A, pwr_otp_done_o |->
+                        otp_hw_cfg_o.valid == lc_ctrl_pkg::On)
   // If otp_hw_cfg is Off, then hw partition is not finished calculation, then otp init is not done
-  `ASSERT(OtpHwCfgValidOff_A, otp_hw_cfg_o.valid == lc_ctrl_pkg::Off |-> pwr_otp_done_o == 0)
+  `OTP_ASSERT_WO_LC_ESC(OtpHwCfgValidOff_A, otp_hw_cfg_o.valid == lc_ctrl_pkg::Off |->
+                        pwr_otp_done_o == 0)
   // Once OTP init is done, hw_cfg_o output value stays stable until next power cycle
-  `ASSERT(OtpHwCfgStable_A, otp_hw_cfg_o.valid == lc_ctrl_pkg::On |=> $stable(otp_hw_cfg_o))
+  `OTP_ASSERT_WO_LC_ESC(OtpHwCfgStable_A, otp_hw_cfg_o.valid == lc_ctrl_pkg::On |=>
+                        $stable(otp_hw_cfg_o))
 
   // Otp_keymgr valid is related to part_digest, should not be changed after otp_pwr_init
-  `ASSERT(OtpKeymgrValidStable_A, pwr_otp_done_o |-> $stable(keymgr_key_o.valid))
+  `OTP_ASSERT_WO_LC_ESC(OtpKeymgrValidStable_A, pwr_otp_done_o |-> $stable(keymgr_key_o.valid))
 
   // During lc_prog_req, either otp_idle will be reset or lc_error is set
-  `ASSERT(LcProgReq_A, $rose(lc_prog_req) |=>
+  `OTP_ASSERT_WO_LC_ESC(LcProgReq_A, $rose(lc_prog_req) |=>
                        (pwr_otp_idle_o == 0 || $rose(lc_prog_err)) within lc_prog_req[*1:$])
+
+  // TODO: add assertions when esc_en is On
+  `undef OTP_ASSERT_WO_LC_ESC
 endinterface

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -12,6 +12,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
   `uvm_object_new
 
   bit collect_used_addr = 1;
+  bit do_reset_in_seq = 1;
 
   rand bit                           do_req_keys, do_lc_trans, check_err_code;
   rand bit                           access_locked_parts;
@@ -62,6 +63,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
   constraint ecc_err_c {ecc_err_mask == 0;}
 
   virtual task dut_init(string reset_kind = "HARD");
+    if (!do_reset_in_seq) return;
     super.dut_init(reset_kind);
     csr_wr(ral.intr_enable, en_intr);
   endtask
@@ -82,7 +84,9 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
         if (i > 1) dut_init();
         // after otp-init done, check status
         cfg.clk_rst_vif.wait_clks(1);
-        csr_rd_check(.ptr(ral.status.dai_idle), .compare_value(1));
+        if ( cfg.otp_ctrl_vif.lc_escalate_en_i != lc_ctrl_pkg::On) begin
+          csr_rd_check(.ptr(ral.status.dai_idle), .compare_value(1));
+        end
       end
       do_otp_ctrl_init = 0;
 


### PR DESCRIPTION
This PR adds a sequence to support lc_esc_en.
This PR has basic sequence and scb support.

The following TODOs will be implemented in coming PRs:
1. Add assertions when lc_esc_en is On.
2. Add random input to lc_esc_en, not just On and Off
3. Support key request and lc_esc_en happened in parallel

Signed-off-by: Cindy Chen <chencindy@google.com>