### PR TITLE
[otp_ctrl] Disable assertion due to esc_en failure

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -591,7 +591,8 @@ module otp_ctrl
   // transactions can be completely independent.
   prim_arbiter_tree #(
     .N(NumAgents),
-    .DW($bits(otp_bundle_t))
+    .DW($bits(otp_bundle_t)),
+    .EnReqStabA(0)
   ) u_otp_arb (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
This PR disables an assertion from `prim_arbiter_tree`. The assertion
tries to check if req should stay high until grant signal is set.
However, it does not work if `lc_escalate_en` signal is set.
Michael please feel free to discard this PR if you prefer some other ways to fix
it.

Signed-off-by: Cindy Chen <chencindy@google.com>