### PR TITLE
[sram] Add memory initialization

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
@@ -228,9 +228,10 @@ module otp_ctrl_kdi
   assign otbn_otp_key_o.nonce        = nonce_out_q;
   assign otbn_otp_key_o.seed_valid   = seed_valid_q;
 
+  localparam int NonceIdx = SramNonceWidth / ScrmblBlockWidth;
   for (genvar k = 0; k < NumSramKeyReqSlots; k++) begin : gen_out_assign
     assign sram_otp_key_o[k].key        = key_out_q;
-    assign sram_otp_key_o[k].nonce      = nonce_out_q[0];
+    assign sram_otp_key_o[k].nonce      = nonce_out_q[NonceIdx-1:0];
     assign sram_otp_key_o[k].seed_valid = seed_valid_q;
   end
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -147,7 +147,7 @@ package otp_ctrl_pkg;
   parameter int KeyMgrKeyWidth   = 256;
   parameter int FlashKeyWidth    = 128;
   parameter int SramKeyWidth     = 128;
-  parameter int SramNonceWidth   = 64;
+  parameter int SramNonceWidth   = 128;
   parameter int OtbnKeyWidth     = 128;
   parameter int OtbnNonceWidth   = 256;
 

--- a/hw/ip/prim/prim_ram_1p_scr.core
+++ b/hw/ip/prim/prim_ram_1p_scr.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:prim:util
       - lowrisc:prim:ram_1p_adv
+      - lowrisc:prim:lfsr
       - lowrisc:prim:all
     files:
       - rtl/prim_ram_1p_scr.sv

--- a/hw/ip/prim/rtl/prim_ram_1p_scr.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_scr.sv
@@ -46,7 +46,11 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
   // If set to 0, the cipher primitive is replicated, and together with a wider nonce input,
   // a unique keystream is generated for the full data width.
   parameter  bit ReplicateKeyStream  = 1'b0,
-
+  // Width of lfsr seed used for random init
+  parameter  int LfsrWidth           = 8,
+  parameter logic [LfsrWidth-1:0][$clog2(LfsrWidth)-1:0] StatePerm = {
+    24'h988eab
+  },
   // Derived parameters
   localparam int AddrWidth           = prim_util_pkg::vbits(Depth),
   // Depending on the data width, we need to instantiate multiple parallel cipher primitives to
@@ -66,6 +70,9 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
   input                             key_valid_i,
   input        [DataKeyWidth-1:0]   key_i,
   input        [NonceWidth-1:0]     nonce_i,
+  input        [LfsrWidth-1:0]      init_seed_i,
+  input                             init_req_i,
+  output logic                      init_ack_o,
 
   // Interface to TL-UL SRAM adapter
   input                             req_i,
@@ -116,6 +123,77 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
     .out_o(intg_error_o)
   );
 
+  ///////////////////////////
+  // Lfsr for random init  //
+  ///////////////////////////
+
+  logic init_req_q, load_seed;
+  logic [AddrWidth-1:0] addr_cnt_q;
+  logic [LfsrWidth-1:0] lfsr_out;
+  logic init_sel;
+
+  // input muxed addr/data/mask
+  logic [AddrWidth-1:0] addr;
+  logic [Width-1:0] wdata;
+  logic [Width-1:0] wmask;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      init_req_q <= '0;
+    end else begin
+      init_req_q <= init_req_i;
+    end
+  end
+
+  assign load_seed = init_req_i & ~init_req_q;
+
+  prim_lfsr #(
+    .LfsrDw(LfsrWidth),
+    .StateOutDw(LfsrWidth),
+    .StatePermEn(1'b0),
+    .StatePerm(StatePerm)
+  ) u_lfsr (
+    .clk_i,
+    .rst_ni,
+    .lfsr_en_i(init_req_i),
+    .seed_en_i(load_seed),
+    .seed_i(init_seed_i),
+    .entropy_i('0),
+    .state_o(lfsr_out)
+  );
+
+  // TODO: Need to harden these counters long term
+  assign init_ack_o = init_req_q && addr_cnt_q == Depth - 1;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      addr_cnt_q <= '0;
+    end else if (init_ack_o) begin
+      addr_cnt_q <= '0;
+    end else if (init_req_q && addr_cnt_q < Depth - 1) begin
+      addr_cnt_q <= addr_cnt_q + AddrWidth'(1);
+    end
+  end
+
+  // The lfsr width and the width of the data may not be completely aligned
+  localparam int LfsrMult = (Width % LfsrWidth > 0) ? Width / LfsrWidth + 1 :
+                                                      Width / LfsrWidth;
+  localparam int FullRandWidth = LfsrMult * LfsrWidth;
+
+  // The random value may be larger than what is needed
+  logic [FullRandWidth-1:0] rand_val;
+  assign rand_val = {LfsrMult{lfsr_out}};
+
+  if (LfsrMult * LfsrWidth > Width) begin : gen_rand_tieoffs
+    logic unused_rand;
+    assign unused_rand = ^rand_val[FullRandWidth-1:Width];
+  end
+
+  assign init_sel = init_req_q;
+  assign addr = init_sel ? addr_cnt_q : addr_i;
+  assign wdata = init_sel ? rand_val[Width-1:0] : wdata_i;
+  assign wmask = init_sel ? '1 : wmask_i;
+
   /////////////////////////////////////////
   // Pending Write and Address Registers //
   /////////////////////////////////////////
@@ -130,15 +208,15 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
 
   // Read / write strobes
   logic read_en, write_en_d, write_en_q;
-  assign gnt_o = req_i & key_valid_i;
+  assign gnt_o = req_i & key_valid_i & ~init_sel;
 
   assign read_en = gnt_o & ~write_i;
-  assign write_en_d = gnt_o & write_i;
+  assign write_en_d = gnt_o & write_i | init_sel;
 
   logic write_pending_q;
   logic addr_collision_d, addr_collision_q;
   logic [AddrWidth-1:0] waddr_q;
-  assign addr_collision_d = read_en & (write_en_q | write_pending_q) & (addr_i == waddr_q);
+  assign addr_collision_d = read_en & (write_en_q | write_pending_q) & (addr == waddr_q);
 
   // Macro requests and write strobe
   // The macro operation is silenced if an integrity error is seen
@@ -162,7 +240,7 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
 
   // We only select the pending write address in case there is no incoming read transaction.
   logic [AddrWidth-1:0] addr_mux;
-  assign addr_mux = (read_en) ? addr_i : waddr_q;
+  assign addr_mux = (read_en) ? addr : waddr_q;
 
   // This creates a bijective address mapping using a substitution / permutation network.
   logic [AddrWidth-1:0] addr_scr;
@@ -189,7 +267,7 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
       .Decrypt   ( 0                )
     ) u_prim_subst_perm (
       .data_i ( addr_mux       ),
-      // Since the counter mode concatenates {nonce_i[NonceWidth-1-AddrWidth:0], addr_i} to form
+      // Since the counter mode concatenates {nonce_i[NonceWidth-1-AddrWidth:0], addr} to form
       // the IV, the upper AddrWidth bits of the nonce are not used and can be used for address
       // scrambling. In cases where N parallel PRINCE blocks are used due to a data
       // width > 64bit, N*AddrWidth nonce bits are left dangling.
@@ -243,8 +321,8 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
       .rst_ni,
       .valid_i ( gnt_o ),
       // The IV is composed of a nonce and the row address
-      //.data_i  ( {nonce_i[k * (64 - AddrWidth) +: (64 - AddrWidth)], addr_i} ),
-      .data_i  ( {data_scr_nonce[k], addr_i} ),
+      //.data_i  ( {nonce_i[k * (64 - AddrWidth) +: (64 - AddrWidth)], addr} ),
+      .data_i  ( {data_scr_nonce[k], addr} ),
       // All parallel scramblers use the same key
       .key_i,
       // Since we operate in counter mode, this can always be set to encryption mode
@@ -400,12 +478,12 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
       write_en_q          <= write_en_d;
 
       if (read_en) begin
-        raddr_q           <= addr_i;
+        raddr_q           <= addr;
       end
       if (write_en_d) begin
-        waddr_q <= addr_i;
-        wmask_q <= wmask_i;
-        wdata_q <= wdata_i;
+        waddr_q <= addr;
+        wmask_q <= wmask;
+        wdata_q <= wdata;
       end
       if (rw_collision) begin
         wdata_scr_q <= wdata_scr_d;

--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -41,8 +41,14 @@
     { name:      "RndCnstSramNonce",
       desc:      "Compile-time random reset value for SRAM scrambling nonce.",
       type:      "otp_ctrl_pkg::sram_nonce_t"
-      randcount: "64",
+      randcount: "128",
       randtype:  "data", // randomize randcount databits
+    },
+    { name:      "RndCnstSramLfsrPerm",
+      desc:      "Compile-time random permutation for LFSR output",
+      type:      "sram_ctrl_pkg::lfsr_perm_t"
+      randcount: "32",
+      randtype:  "perm",
     },
     { name:      "InstrExec",
       desc:      "Support execution from SRAM",
@@ -70,6 +76,14 @@
     { struct:  "sram_scr"
       type:    "req_rsp"
       name:    "sram_scr"
+      act:     "req"
+      default: "'0"
+      package: "sram_ctrl_pkg"
+    },
+    // Interface with SRAM scrambling wrapper init interface
+    { struct:  "sram_scr_init"
+      type:    "req_rsp"
+      name:    "sram_scr_init"
       act:     "req"
       default: "'0"
       package: "sram_ctrl_pkg"
@@ -204,8 +218,8 @@
     }
     { name: "CTRL",
       desc: "SRAM ctrl register.",
-      swaccess: "wo",
-      hwaccess: "hro",
+      swaccess: "rw",
+      hwaccess: "hrw",
       hwqe:     "true",
       hwext:    "true",
       regwen:   "CTRL_REGWEN"
@@ -221,6 +235,14 @@
                 can poll its status. Note that requesting a new scrambling key takes ~200 OTP cycles, which translates
                 to ~800 CPU cycles (OTP runs at 24MHz, CPU runs at 100MHz). Note that writing 1 to this register while
                 a key request is pending has no effect.
+                '''
+        },
+        { bits: "1",
+          name: "INIT",
+          desc: '''
+                Write 1 to request memory init.
+                The init process is seeded using the a nonce that is supplied during the init process.
+                The resulting memory is programmed with random data instead of deterministic values.
                 '''
         },
       ]

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
@@ -35,7 +35,18 @@ class sram_ctrl_base_vseq extends cip_base_vseq #(
 
   // setup basic sram_ctrl features
   virtual task sram_ctrl_init();
+    // TODO: Can this be removed? and rely on mem init below?
     cfg.mem_bkdr_vif.clear_mem();
+    req_scr_key();
+    req_mem_init();
+  endtask
+
+  // Request a memory init.
+  //
+  virtual task req_mem_init();
+    ral.ctrl.init.set(1'b1);
+    csr_update(.csr(ral.ctrl));
+    csr_spinwait(.ptr(ral.ctrl.init), .exp_data(0));
   endtask
 
   // Request a new scrambling key from the OTP interface.

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_common_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_common_vseq.sv
@@ -10,6 +10,11 @@ class sram_ctrl_common_vseq extends sram_ctrl_base_vseq;
   }
   `uvm_object_new
 
+  virtual task pre_start();
+    do_sram_ctrl_init = 1'b0;
+    super.pre_start();
+  endtask
+
   virtual task body();
     run_common_vseq_wrapper(num_trans);
   endtask : body

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -644,6 +644,9 @@ class sram_ctrl_scoreboard extends cip_base_scoreboard #(
         // do nothing
       end
       "ctrl": begin
+        // TODO: need to correctly handle init timing
+        do_read_check = 1'b0;
+
         // do nothing if 0 is written
         if (addr_phase_write && item.a_data) begin
           in_key_req = 1;

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_wrapper.sv
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_wrapper.sv
@@ -40,6 +40,9 @@ module sram_ctrl_wrapper
   // Scrambling key interface between sram_ctrl and scrambling RAM
   sram_scr_req_t scr_req;
   sram_scr_rsp_t scr_rsp;
+  sram_scr_init_req_t scr_init_req;
+  sram_scr_init_rsp_t scr_init_rsp;
+
 
   // SRAM interface between TLUL adapter and scrambling RAM
   wire                  req;
@@ -74,6 +77,8 @@ module sram_ctrl_wrapper
     // Interface with SRAM memory scrambling
     .sram_scr_o       (scr_req          ),
     .sram_scr_i       (scr_rsp          ),
+    .sram_scr_init_o  (scr_init_req     ),
+    .sram_scr_init_i  (scr_init_rsp     ),
     // Integrity error
     .intg_error_i     (intg_error)
   );
@@ -104,7 +109,8 @@ module sram_ctrl_wrapper
   // Scrambling memory
   prim_ram_1p_scr #(
     .Width(DataWidth),
-    .Depth(2 ** AddrWidth)
+    .Depth(2 ** AddrWidth),
+    .LfsrWidth(DataWidth)
   ) u_ram1p_sram (
     .clk_i        (clk_i          ),
     .rst_ni       (rst_ni         ),
@@ -112,6 +118,10 @@ module sram_ctrl_wrapper
     .key_valid_i  (scr_req.valid  ),
     .key_i        (scr_req.key    ),
     .nonce_i      (scr_req.nonce  ),
+    // Init interface
+    .init_req_i   (scr_init_req.req  ),
+    .init_seed_i  (scr_init_req.seed ),
+    .init_ack_o   (scr_init_rsp.ack  ),
     // SRAM response interface to TLUL adapter
     .req_i        (req            ),
     .gnt_o        (gnt            ),

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_pkg.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_pkg.sv
@@ -13,6 +13,9 @@ package sram_ctrl_pkg;
   parameter int Width = 32;
   // This is later on pruned to the correct width at the SRAM wrapper interface.
   parameter int AddrWidth = 32;
+  parameter int RandInitSeed = 32;
+  parameter int NonceWidth = 64;
+  typedef logic [RandInitSeed-1:0][$clog2(RandInitSeed)-1:0] lfsr_perm_t;
 
   /////////////
   // RndCnst //
@@ -21,7 +24,10 @@ package sram_ctrl_pkg;
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramKeyDefault =
       128'hbecda03b34bc0418a30a33861a610f71;
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramNonceDefault =
-      64'he73363ee4fedb75c;
+      128'h22f296f8f95efb84a75cd435a5541e9f;
+  parameter lfsr_perm_t RndCnstSramLfsrPermDefault = {
+      128'h1cf6cd183310ef2203bb344b679cdff1
+  };
 
   /////////////////////
   // Interface Types //
@@ -31,13 +37,22 @@ package sram_ctrl_pkg;
     // TL-UL transactions to the SRAM will not be granted if valid = 0.
     logic                                    valid;
     logic [otp_ctrl_pkg::SramKeyWidth-1:0]   key;
-    logic [otp_ctrl_pkg::SramNonceWidth-1:0] nonce;
+    logic [NonceWidth-1:0]                   nonce;
   } sram_scr_req_t;
+
+  typedef struct packed {
+    logic                                    req;
+    logic [RandInitSeed-1:0]                 seed;
+  } sram_scr_init_req_t;
 
   typedef struct packed {
     logic [1:0]           rerror; // Bit1: Uncorrectable, Bit0: Correctable
     logic [AddrWidth-1:0] raddr;  // Read address for error reporting.
   } sram_scr_rsp_t;
+
+  typedef struct packed {
+    logic                  ack;
+  } sram_scr_init_rsp_t;
 
   typedef enum logic [7:0] {
     EnSramIfetch  = 8'b10101010,

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
@@ -32,8 +32,14 @@ package sram_ctrl_reg_pkg;
   } sram_ctrl_reg2hw_exec_reg_t;
 
   typedef struct packed {
-    logic        q;
-    logic        qe;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } renew_scr_key;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } init;
   } sram_ctrl_reg2hw_ctrl_reg_t;
 
   typedef struct packed {
@@ -52,20 +58,30 @@ package sram_ctrl_reg_pkg;
   } sram_ctrl_hw2reg_status_reg_t;
 
   typedef struct packed {
+    struct packed {
+      logic        d;
+    } renew_scr_key;
+    struct packed {
+      logic        d;
+    } init;
+  } sram_ctrl_hw2reg_ctrl_reg_t;
+
+  typedef struct packed {
     logic [31:0] d;
     logic        de;
   } sram_ctrl_hw2reg_error_address_reg_t;
 
   // Register -> HW type
   typedef struct packed {
-    sram_ctrl_reg2hw_alert_test_reg_t alert_test; // [8:5]
-    sram_ctrl_reg2hw_exec_reg_t exec; // [4:2]
-    sram_ctrl_reg2hw_ctrl_reg_t ctrl; // [1:0]
+    sram_ctrl_reg2hw_alert_test_reg_t alert_test; // [10:7]
+    sram_ctrl_reg2hw_exec_reg_t exec; // [6:4]
+    sram_ctrl_reg2hw_ctrl_reg_t ctrl; // [3:0]
   } sram_ctrl_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    sram_ctrl_hw2reg_status_reg_t status; // [36:33]
+    sram_ctrl_hw2reg_status_reg_t status; // [38:35]
+    sram_ctrl_hw2reg_ctrl_reg_t ctrl; // [34:33]
     sram_ctrl_hw2reg_error_address_reg_t error_address; // [32:0]
   } sram_ctrl_hw2reg_t;
 
@@ -83,7 +99,7 @@ package sram_ctrl_reg_pkg;
   parameter logic [0:0] SRAM_CTRL_ALERT_TEST_FATAL_INTG_ERROR_RESVAL = 1'h 0;
   parameter logic [0:0] SRAM_CTRL_ALERT_TEST_FATAL_PARITY_ERROR_RESVAL = 1'h 0;
   parameter logic [3:0] SRAM_CTRL_STATUS_RESVAL = 4'h 0;
-  parameter logic [0:0] SRAM_CTRL_CTRL_RESVAL = 1'h 0;
+  parameter logic [1:0] SRAM_CTRL_CTRL_RESVAL = 2'h 0;
 
   // Register index
   typedef enum int {

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_top.sv
@@ -121,8 +121,14 @@ module sram_ctrl_reg_top (
   logic ctrl_regwen_qs;
   logic ctrl_regwen_wd;
   logic ctrl_regwen_we;
-  logic ctrl_wd;
-  logic ctrl_we;
+  logic ctrl_renew_scr_key_qs;
+  logic ctrl_renew_scr_key_wd;
+  logic ctrl_renew_scr_key_we;
+  logic ctrl_renew_scr_key_re;
+  logic ctrl_init_qs;
+  logic ctrl_init_wd;
+  logic ctrl_init_we;
+  logic ctrl_init_re;
   logic [31:0] error_address_qs;
 
   // Register instances
@@ -303,18 +309,35 @@ module sram_ctrl_reg_top (
 
   // R[ctrl]: V(True)
 
+  //   F[renew_scr_key]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_ctrl (
-    .re     (1'b0),
+  ) u_ctrl_renew_scr_key (
+    .re     (ctrl_renew_scr_key_re),
     // qualified with register enable
-    .we     (ctrl_we & ctrl_regwen_qs),
-    .wd     (ctrl_wd),
-    .d      ('0),
+    .we     (ctrl_renew_scr_key_we & ctrl_regwen_qs),
+    .wd     (ctrl_renew_scr_key_wd),
+    .d      (hw2reg.ctrl.renew_scr_key.d),
     .qre    (),
-    .qe     (reg2hw.ctrl.qe),
-    .q      (reg2hw.ctrl.q ),
-    .qs     ()
+    .qe     (reg2hw.ctrl.renew_scr_key.qe),
+    .q      (reg2hw.ctrl.renew_scr_key.q ),
+    .qs     (ctrl_renew_scr_key_qs)
+  );
+
+
+  //   F[init]: 1:1
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_ctrl_init (
+    .re     (ctrl_init_re),
+    // qualified with register enable
+    .we     (ctrl_init_we & ctrl_regwen_qs),
+    .wd     (ctrl_init_wd),
+    .d      (hw2reg.ctrl.init.d),
+    .qre    (),
+    .qe     (reg2hw.ctrl.init.qe),
+    .q      (reg2hw.ctrl.init.q ),
+    .qs     (ctrl_init_qs)
   );
 
 
@@ -395,8 +418,13 @@ module sram_ctrl_reg_top (
   assign ctrl_regwen_we = addr_hit[4] & reg_we & !reg_error;
   assign ctrl_regwen_wd = reg_wdata[0];
 
-  assign ctrl_we = addr_hit[5] & reg_we & !reg_error;
-  assign ctrl_wd = reg_wdata[0];
+  assign ctrl_renew_scr_key_we = addr_hit[5] & reg_we & !reg_error;
+  assign ctrl_renew_scr_key_wd = reg_wdata[0];
+  assign ctrl_renew_scr_key_re = addr_hit[5] & reg_re & !reg_error;
+
+  assign ctrl_init_we = addr_hit[5] & reg_we & !reg_error;
+  assign ctrl_init_wd = reg_wdata[1];
+  assign ctrl_init_re = addr_hit[5] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin
@@ -427,7 +455,8 @@ module sram_ctrl_reg_top (
       end
 
       addr_hit[5]: begin
-        reg_rdata_next[0] = '0;
+        reg_rdata_next[0] = ctrl_renew_scr_key_qs;
+        reg_rdata_next[1] = ctrl_init_qs;
       end
 
       addr_hit[6]: begin

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3112,11 +3112,21 @@
           name: RndCnstSramNonce
           desc: Compile-time random reset value for SRAM scrambling nonce.
           type: otp_ctrl_pkg::sram_nonce_t
-          randcount: 64
+          randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlRetAonSramNonce
-          default: 0x60c06703b494b3ff
-          randwidth: 64
+          default: 0x1d7d9d0ce1dd7d7c60c06703b494b3ff
+          randwidth: 128
+        }
+        {
+          name: RndCnstSramLfsrPerm
+          desc: Compile-time random permutation for LFSR output
+          type: sram_ctrl_pkg::lfsr_perm_t
+          randcount: 32
+          randtype: perm
+          name_top: RndCnstSramCtrlRetAonSramLfsrPerm
+          default: 0x8c24f71703eda8a2378916b6bf80c76651ebcea1
+          randwidth: 160
         }
         {
           name: InstrExec
@@ -3152,6 +3162,19 @@
           inst_name: sram_ctrl_ret_aon
           end_idx: -1
           top_signame: sram_ctrl_ret_aon_sram_scr
+          index: -1
+        }
+        {
+          name: sram_scr_init
+          struct: sram_scr_init
+          package: sram_ctrl_pkg
+          type: req_rsp
+          act: req
+          width: 1
+          default: "'0"
+          inst_name: sram_ctrl_ret_aon
+          end_idx: -1
+          top_signame: sram_ctrl_ret_aon_sram_scr_init
           index: -1
         }
         {
@@ -3265,7 +3288,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstFlashCtrlAddrKey
-          default: 0x738f30d9006289a1d7d9d0ce1dd7d7c
+          default: 0x48bae844c87b69111a24d5e4442bcfb7
           randwidth: 128
         }
         {
@@ -3275,7 +3298,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstFlashCtrlDataKey
-          default: 0xfe8f673fba39bb679d58aa91aeb2691c
+          default: 0xeec5e43d4b16446726a27b8f0b30ad50
           randwidth: 128
         }
         {
@@ -3285,7 +3308,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstFlashCtrlLfsrSeed
-          default: 0xae24af11
+          default: 0x369ae283
           randwidth: 32
         }
         {
@@ -3295,7 +3318,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstFlashCtrlLfsrPerm
-          default: 0x25da5869dc96fe354f1da55e9123cb082c63b331
+          default: 0xb0dd7870ffed25342f40f3d8926051da8b96d426
           randwidth: 160
         }
       ]
@@ -3609,7 +3632,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstAesClearingLfsrSeed
-          default: 0x4b16446726a27b8f
+          default: 0xed204633871cb178
           randwidth: 64
         }
         {
@@ -3619,7 +3642,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstAesClearingLfsrPerm
-          default: 0x725022afed8c3f0c64f132a9fc5d1745d64ec881fded0e5fe8d9f8dee8215810deb1848952d123d552f36aa086a2f99b
+          default: 0x99b01e35560f2eb97e3047685d6b7bd87b029229da078df923f7d0f46154c34ba9d43c734af2a1eaa8e0f3270944e4d9
           randwidth: 384
         }
         {
@@ -3629,7 +3652,7 @@
           randcount: 160
           randtype: data
           name_top: RndCnstAesMaskingLfsrSeed
-          default: 0xa77b61acd1356dc20cd7dd118e18edeb46b20763
+          default: 0x46512073261cf96e55692b75e4024435ce910013
           randwidth: 160
         }
         {
@@ -3639,7 +3662,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstAesMskgChunkLfsrPerm
-          default: 0x311a5ecd60ff1f145c3265abec8d303a85ac3b74
+          default: 0x7b6c2c9ab7e757bfa48a0b1c5f20f388070c5352
           randwidth: 160
         }
       ]
@@ -3901,7 +3924,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstKeymgrLfsrSeed
-          default: 0xa26d06fed461e43e
+          default: 0xe2a9b121f6fd1b71
           randwidth: 64
         }
         {
@@ -3911,7 +3934,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstKeymgrLfsrPerm
-          default: 0xedf8195a833eb78d252d435c8b301b7b2bc36b6270c52908ae9b07eb9f615ee3f51444e641509876adfc28647f9e304e
+          default: 0x25ac47e90b16aca159622bf4f3d00c09e515357736cd1b9da5ffb79436e6c0bd68060e7b10e193fd286a92322d3f8ca7
           randwidth: 384
         }
         {
@@ -3921,7 +3944,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstKeymgrRandPerm
-          default: 0x97cd1105dced6f9458f02a54bdf9ba9bc60a6184
+          default: 0xe2e014ba5846db4ae6cf1dcf1fe99e997a451802
           randwidth: 160
         }
         {
@@ -3931,7 +3954,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrRevisionSeed
-          default: 0x3c7a34558ccec99f160326db309c3ed8635b48d5dd14c50a053db7469bac5612
+          default: 0xf085d06d98c25574d82449e1afa2201f312ea264f507a75d5b610152d8465246
           randwidth: 256
         }
         {
@@ -3941,7 +3964,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrCreatorIdentitySeed
-          default: 0x81a3637187c027b6aca8e4ffc89a3209a1642741192e3979e50f4b7302bf908c
+          default: 0xed2e99906a4afbd4dedb5cc59ef74e5ab14d5b983dd7598af12e48c599da1605
           randwidth: 256
         }
         {
@@ -3951,7 +3974,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOwnerIntIdentitySeed
-          default: 0xdc165280c0509a5cbee310112a22e896651cdf06599bf6ffc17fff937de17023
+          default: 0x198a2b804df44b9e44e1c905dcd81e3b8adcf2ea1eb87424e51caa14dbfbec75
           randwidth: 256
         }
         {
@@ -3961,7 +3984,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOwnerIdentitySeed
-          default: 0x36c5b3d0a873f50b0e273058caa5291bd06f88a44b8243ca1a45b215cc7256c
+          default: 0x710581e83789a7b90140c94645887a4457e74cd0c4cca056411c89563d15b47b
           randwidth: 256
         }
         {
@@ -3971,7 +3994,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrSoftOutputSeed
-          default: 0x44af7c286396d54f33ceb281d957bf9ed89305d88d8d71c2ca6258cc000da006
+          default: 0xa2415e162f57f8aa2cce101e080c3a9db8ca70b49d1050c47fa9ce86f3443c8c
           randwidth: 256
         }
         {
@@ -3981,7 +4004,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrHardOutputSeed
-          default: 0xf085d06d98c25574d82449e1afa2201f312ea264f507a75d5b610152d8465246
+          default: 0xea8f46c61a39ebb93e4ef606d8cefa03d0ec61b1bdcbc0e305b5e826ef06ff71
           randwidth: 256
         }
         {
@@ -3991,7 +4014,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrAesSeed
-          default: 0xed2e99906a4afbd4dedb5cc59ef74e5ab14d5b983dd7598af12e48c599da1605
+          default: 0x1d4967265f5be435bb86ec6ce55ef0383b7eff93cf28e950f9e20b072b46413f
           randwidth: 256
         }
         {
@@ -4001,7 +4024,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrHmacSeed
-          default: 0x198a2b804df44b9e44e1c905dcd81e3b8adcf2ea1eb87424e51caa14dbfbec75
+          default: 0xcde39c7f136f643dd889a82012723d99a28765b0f2275a007c6d3334cdf5f463
           randwidth: 256
         }
         {
@@ -4011,7 +4034,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrKmacSeed
-          default: 0x710581e83789a7b90140c94645887a4457e74cd0c4cca056411c89563d15b47b
+          default: 0x7d6a1dfc06309603ac5bdaa938cde8623691d2421c1380e95bb5ca2edd3d769f
           randwidth: 256
         }
         {
@@ -4021,7 +4044,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrNoneSeed
-          default: 0xa2415e162f57f8aa2cce101e080c3a9db8ca70b49d1050c47fa9ce86f3443c8c
+          default: 0x31dc2b96a9ae6dddcd37c3e4506557f163afd8475e880d7228274b6f2922b53f
           randwidth: 256
         }
       ]
@@ -4538,18 +4561,28 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramKey
-          default: 0xd0ec61b1bdcbc0e305b5e826ef06ff71
+          default: 0xde27f2cf29caab641654ac0a79a61ff5
           randwidth: 128
         }
         {
           name: RndCnstSramNonce
           desc: Compile-time random reset value for SRAM scrambling nonce.
           type: otp_ctrl_pkg::sram_nonce_t
-          randcount: 64
+          randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramNonce
-          default: 0x3e4ef606d8cefa03
-          randwidth: 64
+          default: 0x27d13a3a480b63b97279d8d378486795
+          randwidth: 128
+        }
+        {
+          name: RndCnstSramLfsrPerm
+          desc: Compile-time random permutation for LFSR output
+          type: sram_ctrl_pkg::lfsr_perm_t
+          randcount: 32
+          randtype: perm
+          name_top: RndCnstSramCtrlMainSramLfsrPerm
+          default: 0xa170a012778b2de5c91d1b7e1aed3c819da38b2f
+          randwidth: 160
         }
         {
           name: InstrExec
@@ -4585,6 +4618,19 @@
           inst_name: sram_ctrl_main
           end_idx: -1
           top_signame: sram_ctrl_main_sram_scr
+          index: -1
+        }
+        {
+          name: sram_scr_init
+          struct: sram_scr_init
+          package: sram_ctrl_pkg
+          type: req_rsp
+          act: req
+          width: 1
+          default: "'0"
+          inst_name: sram_ctrl_main
+          end_idx: -1
+          top_signame: sram_ctrl_main_sram_scr_init
           index: -1
         }
         {
@@ -4866,6 +4912,18 @@
           index: -1
         }
         {
+          struct: sram_scr_init
+          package: sram_ctrl_pkg
+          type: req_rsp
+          name: sram_scr_init
+          act: rsp
+          inst_name: ram_main
+          width: 1
+          default: ""
+          top_signame: sram_ctrl_main_sram_scr_init
+          index: -1
+        }
+        {
           struct: tl_instr_en
           package: tlul_pkg
           type: uni
@@ -4953,6 +5011,18 @@
           width: 1
           default: ""
           top_signame: sram_ctrl_ret_aon_sram_scr
+          index: -1
+        }
+        {
+          struct: sram_scr_init
+          package: sram_ctrl_pkg
+          type: req_rsp
+          name: sram_scr_init
+          act: rsp
+          inst_name: ram_ret_aon
+          width: 1
+          default: ""
+          top_signame: sram_ctrl_ret_aon_sram_scr_init
           index: -1
         }
         {
@@ -5295,9 +5365,17 @@
       [
         ram_main.sram_scr
       ]
+      sram_ctrl_main.sram_scr_init:
+      [
+        ram_main.sram_scr_init
+      ]
       sram_ctrl_ret_aon.sram_scr:
       [
         ram_ret_aon.sram_scr
+      ]
+      sram_ctrl_ret_aon.sram_scr_init:
+      [
+        ram_ret_aon.sram_scr_init
       ]
       sram_ctrl_main.en_ifetch:
       [
@@ -10830,6 +10908,19 @@
         index: -1
       }
       {
+        name: sram_scr_init
+        struct: sram_scr_init
+        package: sram_ctrl_pkg
+        type: req_rsp
+        act: req
+        width: 1
+        default: "'0"
+        inst_name: sram_ctrl_ret_aon
+        end_idx: -1
+        top_signame: sram_ctrl_ret_aon_sram_scr_init
+        index: -1
+      }
+      {
         name: lc_escalate_en
         struct: lc_tx
         package: lc_ctrl_pkg
@@ -11599,6 +11690,19 @@
         index: -1
       }
       {
+        name: sram_scr_init
+        struct: sram_scr_init
+        package: sram_ctrl_pkg
+        type: req_rsp
+        act: req
+        width: 1
+        default: "'0"
+        inst_name: sram_ctrl_main
+        end_idx: -1
+        top_signame: sram_ctrl_main_sram_scr_init
+        index: -1
+      }
+      {
         name: lc_escalate_en
         struct: lc_tx
         package: lc_ctrl_pkg
@@ -11785,6 +11889,18 @@
         index: -1
       }
       {
+        struct: sram_scr_init
+        package: sram_ctrl_pkg
+        type: req_rsp
+        name: sram_scr_init
+        act: rsp
+        inst_name: ram_main
+        width: 1
+        default: ""
+        top_signame: sram_ctrl_main_sram_scr_init
+        index: -1
+      }
+      {
         struct: tl_instr_en
         package: tlul_pkg
         type: uni
@@ -11845,6 +11961,18 @@
         width: 1
         default: ""
         top_signame: sram_ctrl_ret_aon_sram_scr
+        index: -1
+      }
+      {
+        struct: sram_scr_init
+        package: sram_ctrl_pkg
+        type: req_rsp
+        name: sram_scr_init
+        act: rsp
+        inst_name: ram_ret_aon
+        width: 1
+        default: ""
+        top_signame: sram_ctrl_ret_aon_sram_scr_init
         index: -1
       }
       {
@@ -13394,6 +13522,28 @@
       }
       {
         package: sram_ctrl_pkg
+        struct: sram_scr_init_req
+        signame: sram_ctrl_main_sram_scr_init_req
+        width: 1
+        type: req_rsp
+        end_idx: -1
+        act: req
+        suffix: req
+        default: "'0"
+      }
+      {
+        package: sram_ctrl_pkg
+        struct: sram_scr_init_rsp
+        signame: sram_ctrl_main_sram_scr_init_rsp
+        width: 1
+        type: req_rsp
+        end_idx: -1
+        act: req
+        suffix: rsp
+        default: "'0"
+      }
+      {
+        package: sram_ctrl_pkg
         struct: sram_scr_req
         signame: sram_ctrl_ret_aon_sram_scr_req
         width: 1
@@ -13407,6 +13557,28 @@
         package: sram_ctrl_pkg
         struct: sram_scr_rsp
         signame: sram_ctrl_ret_aon_sram_scr_rsp
+        width: 1
+        type: req_rsp
+        end_idx: -1
+        act: req
+        suffix: rsp
+        default: "'0"
+      }
+      {
+        package: sram_ctrl_pkg
+        struct: sram_scr_init_req
+        signame: sram_ctrl_ret_aon_sram_scr_init_req
+        width: 1
+        type: req_rsp
+        end_idx: -1
+        act: req
+        suffix: req
+        default: "'0"
+      }
+      {
+        package: sram_ctrl_pkg
+        struct: sram_scr_init_rsp
+        signame: sram_ctrl_ret_aon_sram_scr_init_rsp
         width: 1
         type: req_rsp
         end_idx: -1

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -630,6 +630,12 @@
           name:    "sram_scr",
           act:     "rsp",
         },
+        { struct:  "sram_scr_init",
+          package: "sram_ctrl_pkg"
+          type:    "req_rsp",
+          name:    "sram_scr_init",
+          act:     "rsp",
+        },
         { struct:  "tl_instr_en",
           package: "tlul_pkg"
           type:    "uni",
@@ -675,6 +681,12 @@
           package: "sram_ctrl_pkg"
           type:    "req_rsp",
           name:    "sram_scr",
+          act:     "rsp",
+        },
+        { struct:  "sram_scr_init",
+          package: "sram_ctrl_pkg"
+          type:    "req_rsp",
+          name:    "sram_scr_init",
           act:     "rsp",
         },
         { struct:  "tl_instr_en",
@@ -845,7 +857,9 @@
       'flash_ctrl.rma_ack'      : ['lc_ctrl.lc_flash_rma_ack'],
       'flash_ctrl.rma_seed'     : ['lc_ctrl.lc_flash_rma_seed'],
       'sram_ctrl_main.sram_scr' : ['ram_main.sram_scr'],
-      'sram_ctrl_ret_aon.sram_scr'  : ['ram_ret_aon.sram_scr'],
+      'sram_ctrl_main.sram_scr_init' : ['ram_main.sram_scr_init'],
+      'sram_ctrl_ret_aon.sram_scr' : ['ram_ret_aon.sram_scr'],
+      'sram_ctrl_ret_aon.sram_scr_init' : ['ram_ret_aon.sram_scr_init'],
       'sram_ctrl_main.en_ifetch'    : ['ram_main.en_ifetch'],
       'sram_ctrl_ret_aon.en_ifetch' : ['ram_ret_aon.en_ifetch'],
       'ram_main.intg_error'     : ['sram_ctrl_main.intg_error'],

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -66,7 +66,12 @@ package top_earlgrey_rnd_cnst_pkg;
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlRetAonSramNonce = {
-    64'h60C06703B494B3FF
+    128'h1D7D9D0CE1DD7D7C60C06703B494B3FF
+  };
+
+  // Compile-time random permutation for LFSR output
+  parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlRetAonSramLfsrPerm = {
+    160'h8C24F71703EDA8A2378916B6BF80C76651EBCEA1
   };
 
   ////////////////////////////////////////////
@@ -74,22 +79,22 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for default address key
   parameter flash_ctrl_pkg::flash_key_t RndCnstFlashCtrlAddrKey = {
-    128'h738F30D9006289A1D7D9D0CE1DD7D7C
+    128'h48BAE844C87B69111A24D5E4442BCFB7
   };
 
   // Compile-time random bits for default data key
   parameter flash_ctrl_pkg::flash_key_t RndCnstFlashCtrlDataKey = {
-    128'hFE8F673FBA39BB679D58AA91AEB2691C
+    128'hEEC5E43D4B16446726A27B8F0B30AD50
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter flash_ctrl_pkg::lfsr_seed_t RndCnstFlashCtrlLfsrSeed = {
-    32'hAE24AF11
+    32'h369AE283
   };
 
   // Compile-time random permutation for LFSR output
   parameter flash_ctrl_pkg::lfsr_perm_t RndCnstFlashCtrlLfsrPerm = {
-    160'h25DA5869DC96FE354F1DA55E9123CB082C63B331
+    160'hB0DD7870FFED25342F40F3D8926051DA8B96D426
   };
 
   ////////////////////////////////////////////
@@ -97,23 +102,23 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for register clearing.
   parameter aes_pkg::clearing_lfsr_seed_t RndCnstAesClearingLfsrSeed = {
-    64'h4B16446726A27B8F
+    64'hED204633871CB178
   };
 
   // Permutation applied to the LFSR of the PRNG used for clearing.
   parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingLfsrPerm = {
-    128'h725022AFED8C3F0C64F132A9FC5D1745,
-    256'hD64EC881FDED0E5FE8D9F8DEE8215810DEB1848952D123D552F36AA086A2F99B
+    128'h99B01E35560F2EB97E3047685D6B7BD8,
+    256'h7B029229DA078DF923F7D0F46154C34BA9D43C734AF2A1EAA8E0F3270944E4D9
   };
 
   // Default seed of the PRNG used for masking.
   parameter aes_pkg::masking_lfsr_seed_t RndCnstAesMaskingLfsrSeed = {
-    160'hA77B61ACD1356DC20CD7DD118E18EDEB46B20763
+    160'h46512073261CF96E55692B75E4024435CE910013
   };
 
   // Permutation applied to the LFSR chunks of the PRNG used for masking.
   parameter aes_pkg::mskg_chunk_lfsr_perm_t RndCnstAesMskgChunkLfsrPerm = {
-    160'h311A5ECD60FF1F145C3265ABEC8D303A85AC3B74
+    160'h7B6C2C9AB7E757BFA48A0B1C5F20F388070C5352
   };
 
   ////////////////////////////////////////////
@@ -121,68 +126,68 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter keymgr_pkg::lfsr_seed_t RndCnstKeymgrLfsrSeed = {
-    64'hA26D06FED461E43E
+    64'hE2A9B121F6FD1B71
   };
 
   // Compile-time random permutation for LFSR output
   parameter keymgr_pkg::lfsr_perm_t RndCnstKeymgrLfsrPerm = {
-    128'hEDF8195A833EB78D252D435C8B301B7B,
-    256'h2BC36B6270C52908AE9B07EB9F615EE3F51444E641509876ADFC28647F9E304E
+    128'h25AC47E90B16ACA159622BF4F3D00C09,
+    256'hE515357736CD1B9DA5FFB79436E6C0BD68060E7B10E193FD286A92322D3F8CA7
   };
 
   // Compile-time random permutation for entropy used in share overriding
   parameter keymgr_pkg::rand_perm_t RndCnstKeymgrRandPerm = {
-    160'h97CD1105DCED6F9458F02A54BDF9BA9BC60A6184
+    160'hE2E014BA5846DB4AE6CF1DCF1FE99E997A451802
   };
 
   // Compile-time random bits for revision seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrRevisionSeed = {
-    256'h3C7A34558CCEC99F160326DB309C3ED8635B48D5DD14C50A053DB7469BAC5612
+    256'hF085D06D98C25574D82449E1AFA2201F312EA264F507A75D5B610152D8465246
   };
 
   // Compile-time random bits for creator identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrCreatorIdentitySeed = {
-    256'h81A3637187C027B6ACA8E4FFC89A3209A1642741192E3979E50F4B7302BF908C
+    256'hED2E99906A4AFBD4DEDB5CC59EF74E5AB14D5B983DD7598AF12E48C599DA1605
   };
 
   // Compile-time random bits for owner intermediate identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrOwnerIntIdentitySeed = {
-    256'hDC165280C0509A5CBEE310112A22E896651CDF06599BF6FFC17FFF937DE17023
+    256'h198A2B804DF44B9E44E1C905DCD81E3B8ADCF2EA1EB87424E51CAA14DBFBEC75
   };
 
   // Compile-time random bits for owner identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrOwnerIdentitySeed = {
-    256'h36C5B3D0A873F50B0E273058CAA5291BD06F88A44B8243CA1A45B215CC7256C
+    256'h710581E83789A7B90140C94645887A4457E74CD0C4CCA056411C89563D15B47B
   };
 
   // Compile-time random bits for software generation seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrSoftOutputSeed = {
-    256'h44AF7C286396D54F33CEB281D957BF9ED89305D88D8D71C2CA6258CC000DA006
+    256'hA2415E162F57F8AA2CCE101E080C3A9DB8CA70B49D1050C47FA9CE86F3443C8C
   };
 
   // Compile-time random bits for hardware generation seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrHardOutputSeed = {
-    256'hF085D06D98C25574D82449E1AFA2201F312EA264F507A75D5B610152D8465246
+    256'hEA8F46C61A39EBB93E4EF606D8CEFA03D0EC61B1BDCBC0E305B5E826EF06FF71
   };
 
   // Compile-time random bits for generation seed when aes destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrAesSeed = {
-    256'hED2E99906A4AFBD4DEDB5CC59EF74E5AB14D5B983DD7598AF12E48C599DA1605
+    256'h1D4967265F5BE435BB86EC6CE55EF0383B7EFF93CF28E950F9E20B072B46413F
   };
 
   // Compile-time random bits for generation seed when hmac destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrHmacSeed = {
-    256'h198A2B804DF44B9E44E1C905DCD81E3B8ADCF2EA1EB87424E51CAA14DBFBEC75
+    256'hCDE39C7F136F643DD889A82012723D99A28765B0F2275A007C6D3334CDF5F463
   };
 
   // Compile-time random bits for generation seed when kmac destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrKmacSeed = {
-    256'h710581E83789A7B90140C94645887A4457E74CD0C4CCA056411C89563D15B47B
+    256'h7D6A1DFC06309603AC5BDAA938CDE8623691D2421C1380E95BB5CA2EDD3D769F
   };
 
   // Compile-time random bits for generation seed when no destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrNoneSeed = {
-    256'hA2415E162F57F8AA2CCE101E080C3A9DB8CA70B49D1050C47FA9CE86F3443C8C
+    256'h31DC2B96A9AE6DDDCD37C3E4506557F163AFD8475E880D7228274B6F2922B53F
   };
 
   ////////////////////////////////////////////
@@ -190,12 +195,17 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlMainSramKey = {
-    128'hD0EC61B1BDCBC0E305B5E826EF06FF71
+    128'hDE27F2CF29CAAB641654AC0A79A61FF5
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlMainSramNonce = {
-    64'h3E4EF606D8CEFA03
+    128'h27D13A3A480B63B97279D8D378486795
+  };
+
+  // Compile-time random permutation for LFSR output
+  parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlMainSramLfsrPerm = {
+    160'hA170A012778B2DE5C91D1B7E1AED3C819DA38B2F
   };
 
 endpackage : top_earlgrey_rnd_cnst_pkg

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -447,6 +447,12 @@
           name:    "sram_scr",
           act:     "rsp",
         },
+        { struct:  "sram_scr_init",
+          package: "sram_ctrl_pkg"
+          type:    "req_rsp",
+          name:    "sram_scr_init",
+          act:     "rsp",
+        },
         { struct:  "tl_instr_en",
           package: "tlul_pkg"
           type:    "uni",
@@ -485,6 +491,12 @@
           package: "sram_ctrl_pkg"
           type:    "req_rsp",
           name:    "sram_scr",
+          act:     "rsp",
+        },
+        { struct:  "sram_scr_init",
+          package: "sram_ctrl_pkg"
+          type:    "req_rsp",
+          name:    "sram_scr_init",
           act:     "rsp",
         },
         { struct:  "tl_instr_en",
@@ -641,7 +653,9 @@
       'flash_ctrl.rma_ack'      : ['lc_ctrl.lc_flash_rma_ack'],
       'flash_ctrl.rma_seed'     : ['lc_ctrl.lc_flash_rma_seed'],
       'sram_ctrl_main.sram_scr' : ['ram_main.sram_scr'],
+      'sram_ctrl_main.sram_scr_init' : ['ram_main.sram_scr_init'],
       'sram_ctrl_ret_aon.sram_scr'  : ['ram_ret_aon.sram_scr'],
+      'sram_ctrl_ret_aon.sram_scr_init' : ['ram_ret_aon.sram_scr_init'],
       'sram_ctrl_main.en_ifetch'    : ['ram_main.en_ifetch'],
       'sram_ctrl_ret_aon.en_ifetch' : ['ram_ret_aon.en_ifetch'],
       'ram_main.intg_error'     : ['sram_ctrl_main.intg_error'],


### PR DESCRIPTION
- Software can request memory initialization
- Memory contents will be written with "random" values
- During the duration of initialization, front door memory accesses are blocked
- Software should poll on initialization completion before continuing

Signed-off-by: Timothy Chen <timothytim@google.com>