### PR TITLE
[edn/rtl] fixes #5525

### DIFF
--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -6,26 +6,6 @@
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }
   ],
-  param_list: [
-    { name: "NumEndPoints",
-      desc: "The number of endpoint ports supported by this EDN instance",
-      type: "int",
-      default: "64",
-      local: "true"
-    },
-    { name: "BootInsCmd",
-      desc: "Default boot-time CSRNG application interface instantiate command",
-      type: "int",
-      default: "1",
-      local: "true"
-    },
-    { name: "BootGenCmd",
-      desc: "Default boot-time CSRNG application interface generate command",
-      type: "int",
-      default: "12291",
-      local: "true"
-    },
-  ],
   interrupt_list: [
     { name: "edn_cmd_req_done"
       desc: "Asserted when a software CSRNG request has completed."}

--- a/hw/ip/edn/rtl/edn_reg_pkg.sv
+++ b/hw/ip/edn/rtl/edn_reg_pkg.sv
@@ -7,9 +7,6 @@
 package edn_reg_pkg;
 
   // Param list
-  parameter int NumEndPoints = 64;
-  parameter int BootInsCmd = 1;
-  parameter int BootGenCmd = 12291;
   parameter int NumAlerts = 1;
 
   // Address widths within the block


### PR DESCRIPTION
Removing copy of parameters in the hjson file.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>