### PR TITLE
[entropy_src/rtl] add ast rng fips signal

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -40,6 +40,13 @@
       width:   1
       package: ""
     }
+    { struct:  "logic"
+      type:    "uni"
+      name:    "rng_fips"
+      act:     "req"
+      width:   1
+      package: ""
+    }
   ],
   alert_list: [
     { name: "recov_alert",

--- a/hw/ip/entropy_src/rtl/entropy_src.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src.sv
@@ -24,6 +24,9 @@ module entropy_src
   // Efuse Interface
   input logic efuse_es_sw_reg_en_i,
 
+  // RNG Interface
+  output logic rng_fips_o,
+
   // Entropy Interface
   input  entropy_src_hw_if_req_t entropy_src_hw_if_i,
   output entropy_src_hw_if_rsp_t entropy_src_hw_if_o,
@@ -74,6 +77,7 @@ module entropy_src
     .hw2reg,
 
     .efuse_es_sw_reg_en_i,
+    .rng_fips_o,
 
     .entropy_src_hw_if_o,
     .entropy_src_hw_if_i,

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -17,6 +17,9 @@ module entropy_src_core import entropy_src_pkg::*; #(
   // Efuse Interface
   input logic efuse_es_sw_reg_en_i,
 
+  // RNG Interface
+  output logic rng_fips_o,
+
 
   // Entropy Interface
   input  entropy_src_hw_if_req_t entropy_src_hw_if_i,
@@ -974,6 +977,9 @@ module entropy_src_core import entropy_src_pkg::*; #(
          boot_bypass_q;
 
   assign es_bypass_mode = boot_bypass_q || es_bypass_to_sw;
+
+  // send off to AST RNG for possibly faster entropy generation
+  assign rng_fips_o = es_bypass_mode;
 
   //--------------------------------------------
   // common health test window counter

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -4255,6 +4255,15 @@
           index: -1
         }
         {
+          name: rng_fips
+          struct: logic
+          type: uni
+          act: req
+          width: 1
+          inst_name: entropy_src
+          index: -1
+        }
+        {
           name: tl
           struct: tl
           package: tlul_pkg
@@ -11269,6 +11278,15 @@
         struct: logic
         type: uni
         act: rcv
+        width: 1
+        inst_name: entropy_src
+        index: -1
+      }
+      {
+        name: rng_fips
+        struct: logic
+        type: uni
+        act: req
         width: 1
         inst_name: entropy_src
         index: -1

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -2028,6 +2028,7 @@ module top_earlgrey #(
       .entropy_src_xht_o(),
       .entropy_src_xht_i(entropy_src_pkg::ENTROPY_SRC_XHT_RSP_DEFAULT),
       .efuse_es_sw_reg_en_i('0),
+      .rng_fips_o(),
       .tl_i(entropy_src_tl_req),
       .tl_o(entropy_src_tl_rsp),
 


### PR DESCRIPTION
Added an entropy_src to ast signal to indicate fips mode.
Fips mode is where ast rng can generate lower quality entropy.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>