### PR TITLE
Update lowrisc_ibex to lowRISC/ibex@42827fc9

### DIFF
--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -37,6 +37,7 @@ module rv_core_ibex #(
   input  logic        rst_esc_ni,
 
   input  logic        test_en_i,     // enable all clock gates for testing
+  input  prim_ram_1p_pkg::ram_1p_cfg_t ram_cfg_i,
 
   input  logic [31:0] hart_id_i,
   input  logic [31:0] boot_addr_i,
@@ -196,6 +197,7 @@ module rv_core_ibex #(
     .rst_ni,
 
     .test_en_i,
+    .ram_cfg_i,
 
     .hart_id_i,
     .boot_addr_i,

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -268,6 +268,7 @@ module top_${top["name"]} #(
     .clk_esc_i            (${esc_clk}),
     .rst_esc_ni           (${esc_rst}[rstmgr_pkg::Domain0Sel]),
     .test_en_i            (1'b0),
+    .ram_cfg_i            (ast_ram_1p_cfg),
     // static pinning
     .hart_id_i            (32'b0),
     .boot_addr_i          (ADDR_SPACE_ROM),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -682,6 +682,7 @@ module top_earlgrey #(
     .clk_esc_i            (clkmgr_aon_clocks.clk_io_div4_timers),
     .rst_esc_ni           (rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]),
     .test_en_i            (1'b0),
+    .ram_cfg_i            (ast_ram_1p_cfg),
     // static pinning
     .hart_id_i            (32'b0),
     .boot_addr_i          (ADDR_SPACE_ROM),

--- a/hw/vendor/lowrisc_ibex.lock.hjson
+++ b/hw/vendor/lowrisc_ibex.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/ibex.git
-    rev: 6d9e1aca8ad7cf09d4effcde97e471d6c213ead1
+    rev: 42827fc9cd0b2043d5d179cae46b0238a55d3652
   }
 }

--- a/hw/vendor/lowrisc_ibex/doc/02_user/integration.rst
+++ b/hw/vendor/lowrisc_ibex/doc/02_user/integration.rst
@@ -33,6 +33,7 @@ Instantiation Template
       .clk_i          (),
       .rst_ni         (),
       .test_en_i      (),
+      .ram_cfg_i      (),
 
       // Configuration
       .hart_id_i      (),
@@ -157,6 +158,9 @@ Interfaces
 | ``rst_ni``              | 1                       | in  | Active-low asynchronous reset          |
 +-------------------------+-------------------------+-----+----------------------------------------+
 | ``test_en_i``           | 1                       | in  | Test input, enables clock              |
++-------------------------+-------------------------+-----+----------------------------------------+
+| ``ram_cfg_i``           | 10                      | in  | RAM configuration inputs, routed to    |
+|                         |                         |     | the icache RAMs                        |
 +-------------------------+-------------------------+-----+----------------------------------------+
 | ``hart_id_i``           | 32                      | in  | Hart ID, usually static, can be read   |
 |                         |                         |     | from :ref:`csr-mhartid` CSR            |

--- a/hw/vendor/lowrisc_ibex/examples/fpga/artya7/rtl/top_artya7.sv
+++ b/hw/vendor/lowrisc_ibex/examples/fpga/artya7/rtl/top_artya7.sv
@@ -51,6 +51,7 @@ module top_artya7 (
      .rst_ni                (rst_sys_n),
 
      .test_en_i             ('b0),
+     .ram_cfg_i             ('b0),
 
      .hart_id_i             (32'b0),
      // First instruction executed is at 0x0 + 0x80

--- a/hw/vendor/lowrisc_ibex/examples/simple_system/rtl/ibex_simple_system.sv
+++ b/hw/vendor/lowrisc_ibex/examples/simple_system/rtl/ibex_simple_system.sv
@@ -183,6 +183,7 @@ module ibex_simple_system (
       .rst_ni                (rst_sys_n),
 
       .test_en_i             ('b0),
+      .ram_cfg_i             ('b0),
 
       .hart_id_i             (32'b0),
       // First instruction executed is at 0x0 + 0x80

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv
@@ -34,78 +34,79 @@ module ibex_core #(
     parameter int unsigned        DmExceptionAddr  = 32'h1A110808
 ) (
     // Clock and Reset
-    input  logic                  clk_i,
-    input  logic                  rst_ni,
+    input  logic                         clk_i,
+    input  logic                         rst_ni,
 
-    input  logic                  test_en_i,     // enable all clock gates for testing
+    input  logic                         test_en_i,     // enable all clock gates for testing
+    input  prim_ram_1p_pkg::ram_1p_cfg_t ram_cfg_i,
 
-    input  logic [31:0]           hart_id_i,
-    input  logic [31:0]           boot_addr_i,
+    input  logic [31:0]                  hart_id_i,
+    input  logic [31:0]                  boot_addr_i,
 
     // Instruction memory interface
-    output logic                  instr_req_o,
-    input  logic                  instr_gnt_i,
-    input  logic                  instr_rvalid_i,
-    output logic [31:0]           instr_addr_o,
-    input  logic [31:0]           instr_rdata_i,
-    input  logic                  instr_err_i,
+    output logic                         instr_req_o,
+    input  logic                         instr_gnt_i,
+    input  logic                         instr_rvalid_i,
+    output logic [31:0]                  instr_addr_o,
+    input  logic [31:0]                  instr_rdata_i,
+    input  logic                         instr_err_i,
 
     // Data memory interface
-    output logic                  data_req_o,
-    input  logic                  data_gnt_i,
-    input  logic                  data_rvalid_i,
-    output logic                  data_we_o,
-    output logic [3:0]            data_be_o,
-    output logic [31:0]           data_addr_o,
-    output logic [31:0]           data_wdata_o,
-    input  logic [31:0]           data_rdata_i,
-    input  logic                  data_err_i,
+    output logic                         data_req_o,
+    input  logic                         data_gnt_i,
+    input  logic                         data_rvalid_i,
+    output logic                         data_we_o,
+    output logic [3:0]                   data_be_o,
+    output logic [31:0]                  data_addr_o,
+    output logic [31:0]                  data_wdata_o,
+    input  logic [31:0]                  data_rdata_i,
+    input  logic                         data_err_i,
 
     // Interrupt inputs
-    input  logic                  irq_software_i,
-    input  logic                  irq_timer_i,
-    input  logic                  irq_external_i,
-    input  logic [14:0]           irq_fast_i,
-    input  logic                  irq_nm_i,       // non-maskeable interrupt
+    input  logic                         irq_software_i,
+    input  logic                         irq_timer_i,
+    input  logic                         irq_external_i,
+    input  logic [14:0]                  irq_fast_i,
+    input  logic                         irq_nm_i,       // non-maskeable interrupt
 
     // Debug Interface
-    input  logic                  debug_req_i,
-    output ibex_pkg::crash_dump_t crash_dump_o,
+    input  logic                         debug_req_i,
+    output ibex_pkg::crash_dump_t        crash_dump_o,
 
     // RISC-V Formal Interface
     // Does not comply with the coding standards of _i/_o suffixes, but follows
     // the convention of RISC-V Formal Interface Specification.
 `ifdef RVFI
-    output logic                  rvfi_valid,
-    output logic [63:0]           rvfi_order,
-    output logic [31:0]           rvfi_insn,
-    output logic                  rvfi_trap,
-    output logic                  rvfi_halt,
-    output logic                  rvfi_intr,
-    output logic [ 1:0]           rvfi_mode,
-    output logic [ 1:0]           rvfi_ixl,
-    output logic [ 4:0]           rvfi_rs1_addr,
-    output logic [ 4:0]           rvfi_rs2_addr,
-    output logic [ 4:0]           rvfi_rs3_addr,
-    output logic [31:0]           rvfi_rs1_rdata,
-    output logic [31:0]           rvfi_rs2_rdata,
-    output logic [31:0]           rvfi_rs3_rdata,
-    output logic [ 4:0]           rvfi_rd_addr,
-    output logic [31:0]           rvfi_rd_wdata,
-    output logic [31:0]           rvfi_pc_rdata,
-    output logic [31:0]           rvfi_pc_wdata,
-    output logic [31:0]           rvfi_mem_addr,
-    output logic [ 3:0]           rvfi_mem_rmask,
-    output logic [ 3:0]           rvfi_mem_wmask,
-    output logic [31:0]           rvfi_mem_rdata,
-    output logic [31:0]           rvfi_mem_wdata,
+    output logic                         rvfi_valid,
+    output logic [63:0]                  rvfi_order,
+    output logic [31:0]                  rvfi_insn,
+    output logic                         rvfi_trap,
+    output logic                         rvfi_halt,
+    output logic                         rvfi_intr,
+    output logic [ 1:0]                  rvfi_mode,
+    output logic [ 1:0]                  rvfi_ixl,
+    output logic [ 4:0]                  rvfi_rs1_addr,
+    output logic [ 4:0]                  rvfi_rs2_addr,
+    output logic [ 4:0]                  rvfi_rs3_addr,
+    output logic [31:0]                  rvfi_rs1_rdata,
+    output logic [31:0]                  rvfi_rs2_rdata,
+    output logic [31:0]                  rvfi_rs3_rdata,
+    output logic [ 4:0]                  rvfi_rd_addr,
+    output logic [31:0]                  rvfi_rd_wdata,
+    output logic [31:0]                  rvfi_pc_rdata,
+    output logic [31:0]                  rvfi_pc_wdata,
+    output logic [31:0]                  rvfi_mem_addr,
+    output logic [ 3:0]                  rvfi_mem_rmask,
+    output logic [ 3:0]                  rvfi_mem_wmask,
+    output logic [31:0]                  rvfi_mem_rdata,
+    output logic [31:0]                  rvfi_mem_wdata,
 `endif
 
     // CPU Control Signals
-    input  logic                  fetch_enable_i,
-    output logic                  alert_minor_o,
-    output logic                  alert_major_o,
-    output logic                  core_sleep_o
+    input  logic                         fetch_enable_i,
+    output logic                         alert_minor_o,
+    output logic                         alert_major_o,
+    output logic                         core_sleep_o
 );
 
   import ibex_pkg::*;
@@ -411,6 +412,7 @@ module ibex_core #(
       .clk_i                    ( clk                    ),
       .rst_ni                   ( rst_ni                 ),
 
+      .ram_cfg_i                ( ram_cfg_i              ),
       .boot_addr_i              ( boot_addr_i            ),
       .req_i                    ( instr_req_int          ), // instruction request control
 

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_core_tracing.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_core_tracing.sv
@@ -28,49 +28,51 @@ module ibex_core_tracing #(
     parameter int unsigned        DmExceptionAddr  = 32'h1A110808
 ) (
     // Clock and Reset
-    input  logic                  clk_i,
-    input  logic                  rst_ni,
+    input  logic                         clk_i,
+    input  logic                         rst_ni,
 
-    input  logic                  test_en_i,     // enable all clock gates for testing
+    input  logic                         test_en_i,     // enable all clock gates for testing
+    input  prim_ram_1p_pkg::ram_1p_cfg_t ram_cfg_i,
 
-    input  logic [31:0]           hart_id_i,
-    input  logic [31:0]           boot_addr_i,
+
+    input  logic [31:0]                  hart_id_i,
+    input  logic [31:0]                  boot_addr_i,
 
     // Instruction memory interface
-    output logic                  instr_req_o,
-    input  logic                  instr_gnt_i,
-    input  logic                  instr_rvalid_i,
-    output logic [31:0]           instr_addr_o,
-    input  logic [31:0]           instr_rdata_i,
-    input  logic                  instr_err_i,
+    output logic                         instr_req_o,
+    input  logic                         instr_gnt_i,
+    input  logic                         instr_rvalid_i,
+    output logic [31:0]                  instr_addr_o,
+    input  logic [31:0]                  instr_rdata_i,
+    input  logic                         instr_err_i,
 
     // Data memory interface
-    output logic                  data_req_o,
-    input  logic                  data_gnt_i,
-    input  logic                  data_rvalid_i,
-    output logic                  data_we_o,
-    output logic [3:0]            data_be_o,
-    output logic [31:0]           data_addr_o,
-    output logic [31:0]           data_wdata_o,
-    input  logic [31:0]           data_rdata_i,
-    input  logic                  data_err_i,
+    output logic                         data_req_o,
+    input  logic                         data_gnt_i,
+    input  logic                         data_rvalid_i,
+    output logic                         data_we_o,
+    output logic [3:0]                   data_be_o,
+    output logic [31:0]                  data_addr_o,
+    output logic [31:0]                  data_wdata_o,
+    input  logic [31:0]                  data_rdata_i,
+    input  logic                         data_err_i,
 
     // Interrupt inputs
-    input  logic                  irq_software_i,
-    input  logic                  irq_timer_i,
-    input  logic                  irq_external_i,
-    input  logic [14:0]           irq_fast_i,
-    input  logic                  irq_nm_i,       // non-maskeable interrupt
+    input  logic                         irq_software_i,
+    input  logic                         irq_timer_i,
+    input  logic                         irq_external_i,
+    input  logic [14:0]                  irq_fast_i,
+    input  logic                         irq_nm_i,       // non-maskeable interrupt
 
     // Debug Interface
-    input  logic                  debug_req_i,
-    output ibex_pkg::crash_dump_t crash_dump_o,
+    input  logic                         debug_req_i,
+    output ibex_pkg::crash_dump_t        crash_dump_o,
 
     // CPU Control Signals
-    input  logic                  fetch_enable_i,
-    output logic                  alert_minor_o,
-    output logic                  alert_major_o,
-    output logic                  core_sleep_o
+    input  logic                         fetch_enable_i,
+    output logic                         alert_minor_o,
+    output logic                         alert_major_o,
+    output logic                         core_sleep_o
 
 );
 
@@ -130,6 +132,7 @@ module ibex_core_tracing #(
     .rst_ni,
 
     .test_en_i,
+    .ram_cfg_i,
 
     .hart_id_i,
     .boot_addr_i,

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
@@ -1282,7 +1282,7 @@ module ibex_cs_registers #(
 
   if (DbgTriggerEn) begin : gen_trigger_regs
     localparam int unsigned DbgHwNumLen = DbgHwBreakNum > 1 ? $clog2(DbgHwBreakNum) : 1;
-    localparam int MaxTselect = DbgHwBreakNum - 1;
+    localparam int unsigned MaxTselect = DbgHwBreakNum - 1;
 
     // Register values
     logic [DbgHwNumLen-1:0]   tselect_d, tselect_q;
@@ -1313,6 +1313,7 @@ module ibex_cs_registers #(
     // select register. Only allow changes to the register if it is within the supported region.
     assign tselect_d = (csr_wdata_int < DbgHwBreakNum) ? csr_wdata_int[DbgHwNumLen-1:0] :
                                                          MaxTselect[DbgHwNumLen-1:0];
+
     // tmatch_control is enabled when the execute bit is set
     assign tmatch_control_d = csr_wdata_int[2];
     assign tmatch_value_d   = csr_wdata_int[31:0];

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_id_stage.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_id_stage.sv
@@ -671,9 +671,12 @@ module ibex_id_stage #(
     // Branches always take two cycles in fixed time execution mode, with or without the branch
     // target ALU (to avoid a path from the branch decision into the branch target ALU operand
     // muxing).
-    assign branch_set_raw      = (BranchTargetALU && !data_ind_timing_i) ? branch_set_raw_d : branch_set_raw_q;
+    assign branch_set_raw      = (BranchTargetALU && !data_ind_timing_i) ? branch_set_raw_d :
+                                                                           branch_set_raw_q;
+
     // Use the speculative branch signal when BTALU is enabled
-    assign branch_set_raw_spec = (BranchTargetALU && !data_ind_timing_i) ? branch_spec : branch_set_raw_q;
+    assign branch_set_raw_spec = (BranchTargetALU && !data_ind_timing_i) ? branch_spec :
+                                                                           branch_set_raw_q;
   end
 
   // Track whether the current instruction in ID/EX has done a branch or jump set.
@@ -691,10 +694,10 @@ module ibex_id_stage #(
   // the _raw signals from the state machine may be asserted for multiple cycles when
   // instr_executing_spec is asserted and instr_executing is not asserted. This may occur where
   // a memory error is seen or a there are outstanding memory accesses (indicate a load or store is
-  // in the WB stage). The branch or jump speculatively begins the fetch but is held back from completing
-  // until it is certain the outstanding access hasn't seen a memory error. This logic ensures only
-  // the first cycle of a branch or jump set is sent to the controller to prevent needless extra IF
-  // flushes and fetches.
+  // in the WB stage). The branch or jump speculatively begins the fetch but is held back from
+  // completing until it is certain the outstanding access hasn't seen a memory error. This logic
+  // ensures only the first cycle of a branch or jump set is sent to the controller to prevent
+  // needless extra IF flushes and fetches.
   assign jump_set        = jump_set_raw        & ~branch_jump_set_done_q;
   assign branch_set      = branch_set_raw      & ~branch_jump_set_done_q;
   assign branch_set_spec = branch_set_raw_spec & ~branch_jump_set_done_q;
@@ -716,7 +719,8 @@ module ibex_id_stage #(
 
   end else begin : g_nosec_branch_taken
 
-    // Signal unused without fixed time execution mode - only taken branches will trigger branch_set_raw
+    // Signal unused without fixed time execution mode - only taken branches will trigger
+    // branch_set_raw
     assign branch_taken = 1'b1;
 
   end

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_if_stage.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_if_stage.sv
@@ -21,76 +21,77 @@ module ibex_if_stage #(
     parameter bit          PCIncrCheck       = 1'b0,
     parameter bit          BranchPredictor   = 1'b0
 ) (
-    input  logic                   clk_i,
-    input  logic                   rst_ni,
+    input  logic                         clk_i,
+    input  logic                         rst_ni,
 
-    input  logic [31:0]            boot_addr_i,              // also used for mtvec
-    input  logic                   req_i,                    // instruction request control
+    input  prim_ram_1p_pkg::ram_1p_cfg_t ram_cfg_i,
+    input  logic [31:0]                  boot_addr_i,              // also used for mtvec
+    input  logic                         req_i,                    // instruction request control
 
     // instruction cache interface
-    output logic                  instr_req_o,
-    output logic [31:0]           instr_addr_o,
-    input  logic                  instr_gnt_i,
-    input  logic                  instr_rvalid_i,
-    input  logic [31:0]           instr_rdata_i,
-    input  logic                  instr_err_i,
-    input  logic                  instr_pmp_err_i,
+    output logic                        instr_req_o,
+    output logic [31:0]                 instr_addr_o,
+    input  logic                        instr_gnt_i,
+    input  logic                        instr_rvalid_i,
+    input  logic [31:0]                 instr_rdata_i,
+    input  logic                        instr_err_i,
+    input  logic                        instr_pmp_err_i,
 
     // output of ID stage
-    output logic                  instr_valid_id_o,         // instr in IF-ID is valid
-    output logic                  instr_new_id_o,           // instr in IF-ID is new
-    output logic [31:0]           instr_rdata_id_o,         // instr for ID stage
-    output logic [31:0]           instr_rdata_alu_id_o,     // replicated instr for ID stage
-                                                            // to reduce fan-out
-    output logic [15:0]           instr_rdata_c_id_o,       // compressed instr for ID stage
-                                                            // (mtval), meaningful only if
-                                                            // instr_is_compressed_id_o = 1'b1
-    output logic                  instr_is_compressed_id_o, // compressed decoder thinks this
-                                                            // is a compressed instr
-    output logic                  instr_bp_taken_o,         // instruction was predicted to be
-                                                            // a taken branch
-    output logic                  instr_fetch_err_o,        // bus error on fetch
-    output logic                  instr_fetch_err_plus2_o,  // bus error misaligned
-    output logic                  illegal_c_insn_id_o,      // compressed decoder thinks this
-                                                            // is an invalid instr
-    output logic                  dummy_instr_id_o,         // Instruction is a dummy
-    output logic [31:0]           pc_if_o,
-    output logic [31:0]           pc_id_o,
+    output logic                        instr_valid_id_o,         // instr in IF-ID is valid
+    output logic                        instr_new_id_o,           // instr in IF-ID is new
+    output logic [31:0]                 instr_rdata_id_o,         // instr for ID stage
+    output logic [31:0]                 instr_rdata_alu_id_o,     // replicated instr for ID stage
+                                                                  // to reduce fan-out
+    output logic [15:0]                 instr_rdata_c_id_o,       // compressed instr for ID stage
+                                                                  // (mtval), meaningful only if
+                                                                 // instr_is_compressed_id_o = 1'b1
+    output logic                        instr_is_compressed_id_o, // compressed decoder thinks this
+                                                                  // is a compressed instr
+    output logic                        instr_bp_taken_o,         // instruction was predicted to be
+                                                                  // a taken branch
+    output logic                        instr_fetch_err_o,        // bus error on fetch
+    output logic                        instr_fetch_err_plus2_o,  // bus error misaligned
+    output logic                        illegal_c_insn_id_o,      // compressed decoder thinks this
+                                                                  // is an invalid instr
+    output logic                        dummy_instr_id_o,         // Instruction is a dummy
+    output logic [31:0]                 pc_if_o,
+    output logic [31:0]                 pc_id_o,
 
     // control signals
-    input  logic                  instr_valid_clear_i,      // clear instr valid bit in IF-ID
-    input  logic                  pc_set_i,                 // set the PC to a new value
-    input  logic                  pc_set_spec_i,
-    input  ibex_pkg::pc_sel_e     pc_mux_i,                 // selector for PC multiplexer
-    input  logic                  nt_branch_mispredict_i,   // Not-taken branch in ID/EX was
-                                                            // mispredicted (predicted taken)
-    input  ibex_pkg::exc_pc_sel_e exc_pc_mux_i,             // selects ISR address
-    input  ibex_pkg::exc_cause_e  exc_cause,                // selects ISR address for
-                                                            // vectorized interrupt lines
-    input logic                   dummy_instr_en_i,
-    input logic [2:0]             dummy_instr_mask_i,
-    input logic                   dummy_instr_seed_en_i,
-    input logic [31:0]            dummy_instr_seed_i,
-    input logic                   icache_enable_i,
-    input logic                   icache_inval_i,
+    input  logic                        instr_valid_clear_i,      // clear instr valid bit in IF-ID
+    input  logic                        pc_set_i,                 // set the PC to a new value
+    input  logic                        pc_set_spec_i,
+    input  ibex_pkg::pc_sel_e           pc_mux_i,                 // selector for PC multiplexer
+    input  logic                        nt_branch_mispredict_i,   // Not-taken branch in ID/EX was
+                                                                  // mispredicted (predicted taken)
+    input  ibex_pkg::exc_pc_sel_e       exc_pc_mux_i,             // selects ISR address
+    input  ibex_pkg::exc_cause_e        exc_cause,                // selects ISR address for
+                                                                  // vectorized interrupt lines
+    input logic                         dummy_instr_en_i,
+    input logic [2:0]                   dummy_instr_mask_i,
+    input logic                         dummy_instr_seed_en_i,
+    input logic [31:0]                  dummy_instr_seed_i,
+    input logic                         icache_enable_i,
+    input logic                         icache_inval_i,
 
     // jump and branch target
-    input  logic [31:0]           branch_target_ex_i,       // branch/jump target address
+    input  logic [31:0]                 branch_target_ex_i,       // branch/jump target address
 
     // CSRs
-    input  logic [31:0]           csr_mepc_i,               // PC to restore after handling
-                                                            // the interrupt/exception
-    input  logic [31:0]           csr_depc_i,               // PC to restore after handling
-                                                            // the debug request
-    input  logic [31:0]           csr_mtvec_i,              // base PC to jump to on exception
-    output logic                  csr_mtvec_init_o,         // tell CS regfile to init mtvec
+    input  logic [31:0]                 csr_mepc_i,               // PC to restore after handling
+                                                                  // the interrupt/exception
+    input  logic [31:0]                 csr_depc_i,               // PC to restore after handling
+                                                                  // the debug request
+    input  logic [31:0]                 csr_mtvec_i,              // base PC to jump to on exception
+    output logic                        csr_mtvec_init_o,         // tell CS regfile to init mtvec
 
     // pipeline stall
-    input  logic                  id_in_ready_i,            // ID stage is ready for new instr
+    input  logic                        id_in_ready_i,            // ID stage is ready for new instr
 
     // misc signals
-    output logic                  pc_mismatch_alert_o,
-    output logic                  if_busy_o                 // IF stage is busy fetching instr
+    output logic                        pc_mismatch_alert_o,
+    output logic                        if_busy_o                 // IF stage is busy fetching instr
 );
 
   import ibex_pkg::*;
@@ -213,6 +214,7 @@ module ibex_if_stage #(
         .instr_err_i         ( instr_err_i                ),
         .instr_pmp_err_i     ( instr_pmp_err_i            ),
 
+        .ram_cfg_i           ( ram_cfg_i                  ),
         .icache_enable_i     ( icache_enable_i            ),
         .icache_inval_i      ( icache_inval_i             ),
         .busy_o              ( prefetch_busy              )
@@ -252,8 +254,10 @@ module ibex_if_stage #(
     );
     // ICache tieoffs
     logic unused_icen, unused_icinv;
-    assign unused_icen  = icache_enable_i;
-    assign unused_icinv = icache_inval_i;
+    prim_ram_1p_pkg::ram_1p_cfg_t unused_ram_cfg;
+    assign unused_icen    = icache_enable_i;
+    assign unused_icinv   = icache_inval_i;
+    assign unused_ram_cfg = ram_cfg_i;
   end
 
   assign unused_fetch_addr_n0 = fetch_addr_n[0];

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_multdiv_fast.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_multdiv_fast.sv
@@ -224,7 +224,7 @@ module ibex_multdiv_fast #(
 
           summand1 = '0;
           summand2 = accum;
-          summand3 = mult3_res;
+          summand3 = $unsigned(mult3_res);
 
           mult_state_d = MULL;
           mult_valid = 1'b1;


### PR DESCRIPTION
Update code from upstream repository
https://github.com/lowRISC/ibex.git to revision
42827fc9cd0b2043d5d179cae46b0238a55d3652

* [rtl/icache] Switch ECC granularity to 32bits (Tom Roberts)
* Update lowrisc_ip to lowRISC/opentitan@1ae03937f (Tom Roberts)
* [rtl] Fix lint issues (Greg Chadwick)
* [dv/ibex] filter out tests on a per-config basis (Udi Jonnalagadda)

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>