### PR TITLE
[spi_device/dv] Fix regression timeout

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_fifo_underflow_overflow_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_fifo_underflow_overflow_vseq.sv
@@ -8,6 +8,10 @@ class spi_device_fifo_underflow_overflow_vseq extends spi_device_txrx_vseq;
   `uvm_object_utils(spi_device_fifo_underflow_overflow_vseq)
   `uvm_object_new
 
+  constraint num_trans_c {
+    num_trans inside {[2:3]};
+  }
+
   virtual task body();
     allow_underflow_overflow = 1;
     // when underflow, sio may be unknown, disable checking it

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_txrx_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_txrx_vseq.sv
@@ -64,7 +64,7 @@ class spi_device_txrx_vseq extends spi_device_base_vseq;
   }
 
   constraint num_trans_c {
-    num_trans == 5;
+    num_trans inside {[2:5]};
   }
 
   constraint en_dummy_host_xfer_c {

--- a/hw/ip/spi_device/dv/tests/spi_device_base_test.sv
+++ b/hw/ip/spi_device/dv/tests/spi_device_base_test.sv
@@ -9,7 +9,7 @@ class spi_device_base_test extends cip_base_test #(.ENV_T(spi_device_env),
 
   virtual function void build_phase(uvm_phase phase);
     max_quit_count  = 50;
-    test_timeout_ns = 1000_000_000; // 1s
+    test_timeout_ns = 1500_000_000; // 1.5s
     super.build_phase(phase);
     // configure the spi agent to be in Host mode
     cfg.m_spi_agent_cfg.if_mode = Host;


### PR DESCRIPTION
mem size is increased recently, made these changes to avoid timeout
1. increase max timeout timer to 1.5s, 1s takes a bit over 1hr
2. reduce num_trans in spi_device_fifo_underflow_overflow_vseq
Signed-off-by: Weicai Yang <weicai@google.com>