### PR TITLE
[tlul,prim] Do some splitting up in prim.core and avoid depending on prim:all in TLUL core files

### DIFF
--- a/hw/ip/prim/lint/prim.vlt
+++ b/hw/ip/prim/lint/prim.vlt
@@ -8,11 +8,6 @@
 // for RO wd is not used
 lint_off -rule UNUSED -file "*/rtl/prim_subreg.sv" -match "Signal is not used: 'wd'"
 
-// prim_fifo_sync
-// In passthrough mode, clk and reset are not read form within this module
-lint_off -rule UNUSED -file "*/rtl/prim_fifo_sync.sv" -match "*clk_i*"
-lint_off -rule UNUSED -file "*/rtl/prim_fifo_sync.sv" -match "*rst_ni*"
-
 // prim_lfsr
 // lfsr_perm_test is just used for an SVA
 lint_off -rule UNUSED -file "*/rtl/prim_lfsr.sv" -match "*lfsr_perm_test*"

--- a/hw/ip/prim/lint/prim.waiver
+++ b/hw/ip/prim/lint/prim.waiver
@@ -29,16 +29,6 @@ waive -rules INTEGER           -location {prim_packer.sv} -msg {'i' of type int 
 waive -rules INPUT_NOT_READ       -location {prim_subreg.sv} -regexp {Input port 'wd' is not read from} \
       -comment "for RO wd is not used"
 
-# primitives: prim_arbiter_*
-waive -rules PARTIAL_CONST_ASSIGN -location {prim_arbiter_*.sv} -regexp {'mask.0.' is conditionally assigned a constant} \
-      -comment "makes the code more readable"
-waive -rules CONST_FF -location {prim_arbiter_*.sv} -regexp {Flip-flop 'mask.0.' is driven by constant} \
-      -comment "makes the code more readable"
-
-# primitives: prim_sram_arbiter
-waive -rules CONST_OUTPUT -location {prim_sram_arbiter.sv} -regexp {rsp_error.* is driven by constant} \
-      -comment "SRAM protection is not yet implemented"
-
 # primitives: prim_fifos
 
 waive -rules VAR_INDEX_RANGE      -location {prim_fifo_*sync.sv} -regexp {maximum value .* may be too large for 'storage'} \
@@ -59,10 +49,6 @@ waive -rules {HIER_BRANCH_NOT_READ} -location {tlul_fifo_sync.sv} -regexp {Conne
 #
 #waive -rules NOT_READ -location {prim_ram_*_wrapper*} -regexp {(a|b)_rdata_(q|d)\[38} \
 #      -comment "Syndrome is not going out to the interface"
-
-# prim_arbiter_fixed
-waive -rules {HIER_BRANCH_NOT_READ INPUT_NOT_READ} -location {prim_arbiter_fixed.sv} -regexp {.*'(clk_i|rst_ni)' is not read from in module 'prim_arbiter_fixed'.*} \
-      -comment "clk_ and rst_ni are only used for assertions in this module."
 
 waive -rules {INTEGER} -location {prim_cipher_pkg.sv} -msg {'k' of type int used as a non-constant} \
       -comment "We need to use the iterator value in the keyschedule function, hence this is ok."

--- a/hw/ip/prim/lint/prim.waiver
+++ b/hw/ip/prim/lint/prim.waiver
@@ -4,15 +4,6 @@
 #
 # waiver file for prim
 
-# prim_fifo_sync
-waive -rules {ONE_BIT_MEM_WIDTH} -location {prim_fifo_sync.sv} -msg {Memory 'gen_normal_fifo.storage' has word width which is single bit wide} \
-      -comment "It is permissible that a FIFO has a wordwidth of 1bit"
-
-# prim_fifo_async
-waive -rules {ASSIGN_SIGN} -location {prim_fifo_async.sv} -msg {Signed target 'i' assigned unsigned value 'PTR_WIDTH - 3'} \
-      -comment "Parameter PTR_WIDTH is unsigned, but integer i is signed. This is fine. Changing the integer to unsigned might \
-                cause issues with the for loop never exiting, because an unsigned integer can never become < 0."
-
 # prim_assert
 waive -rules {UNDEF_MACRO_REF} -location {prim_assert.sv} -regexp {Macro definition for 'ASSERT_RPT' includes expansion of undefined macro '__(FILE|LINE)__'} \
       -comment "This is an UVM specific macro inside our assertion shortcuts"
@@ -28,18 +19,6 @@ waive -rules INTEGER           -location {prim_packer.sv} -msg {'i' of type int 
 # primitives: prim_subreg
 waive -rules INPUT_NOT_READ       -location {prim_subreg.sv} -regexp {Input port 'wd' is not read from} \
       -comment "for RO wd is not used"
-
-# primitives: prim_fifos
-
-waive -rules VAR_INDEX_RANGE      -location {prim_fifo_*sync.sv} -regexp {maximum value .* may be too large for 'storage'} \
-      -comment "index is protected by control logic"
-waive -rules EXPLICIT_BITLEN      -location {prim_fifo_*sync.sv} -regexp {Bit length not specified for constant '1'} \
-      -comment "index is protected by control logic"
-waive -rules NOT_READ             -location {prim_fifo_async.sv} -regexp {Signal 'nc_decval_msb' is not read} \
-      -comment "Store temporary values. Not used intentionally"
-
-waive -rules {INPUT_NOT_READ} -location {prim_fifo_sync.sv} -regexp {Input port '(clk_i|rst_ni)' is not read from, instance.*Depth=0\)} \
-      -comment "In passthrough mode, clk and reset are not read form within this module"
 
 # TL-UL fifo
 waive -rules {HIER_BRANCH_NOT_READ} -location {tlul_fifo_sync.sv} -regexp {Connected net '(clk_i|rst_ni)' at prim_fifo_sync.sv:.* is not read from in module 'prim_fifo_sync'} \

--- a/hw/ip/prim/lint/prim_arbiter.waiver
+++ b/hw/ip/prim/lint/prim_arbiter.waiver
@@ -1,0 +1,16 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_arbiter
+
+waive -rules PARTIAL_CONST_ASSIGN -location {prim_arbiter_*.sv} -regexp {'mask.0.' is conditionally assigned a constant} \
+      -comment "makes the code more readable"
+waive -rules CONST_FF -location {prim_arbiter_*.sv} -regexp {Flip-flop 'mask.0.' is driven by constant} \
+      -comment "makes the code more readable"
+
+waive -rules CONST_OUTPUT -location {prim_sram_arbiter.sv} -regexp {rsp_error.* is driven by constant} \
+      -comment "SRAM protection is not yet implemented"
+
+waive -rules {HIER_BRANCH_NOT_READ INPUT_NOT_READ} -location {prim_arbiter_fixed.sv} -regexp {.*'(clk_i|rst_ni)' is not read from in module 'prim_arbiter_fixed'.*} \
+      -comment "clk_ and rst_ni are only used for assertions in this module."

--- a/hw/ip/prim/lint/prim_fifo.vlt
+++ b/hw/ip/prim/lint/prim_fifo.vlt
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`verilator_config
+
+// prim_fifo_sync
+// In passthrough mode, clk and reset are not read form within this module
+lint_off -rule UNUSED -file "*/rtl/prim_fifo_sync.sv" -match "*clk_i*"
+lint_off -rule UNUSED -file "*/rtl/prim_fifo_sync.sv" -match "*rst_ni*"

--- a/hw/ip/prim/lint/prim_fifo.waiver
+++ b/hw/ip/prim/lint/prim_fifo.waiver
@@ -1,0 +1,26 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_fifo
+
+waive -rules {ONE_BIT_MEM_WIDTH} -location {prim_fifo_sync.sv} -msg {Memory 'gen_normal_fifo.storage' has word width which is single bit wide} \
+      -comment "It is permissible that a FIFO has a wordwidth of 1bit"
+
+waive -rules {INPUT_NOT_READ} -location {prim_fifo_sync.sv} -regexp {Input port '(clk_i|rst_ni)' is not read from, instance.*Depth=0\)} \
+      -comment "In passthrough mode, clk and reset are not read form within this module"
+
+
+waive -rules {ASSIGN_SIGN} -location {prim_fifo_async.sv} -msg {Signed target 'i' assigned unsigned value 'PTR_WIDTH - 3'} \
+      -comment "Parameter PTR_WIDTH is unsigned, but integer i is signed. This is fine. Changing the integer to unsigned might \
+                cause issues with the for loop never exiting, because an unsigned integer can never become < 0."
+
+waive -rules NOT_READ             -location {prim_fifo_async.sv} -regexp {Signal 'nc_decval_msb' is not read} \
+      -comment "Store temporary values. Not used intentionally"
+
+
+waive -rules VAR_INDEX_RANGE      -location {prim_fifo_*sync.sv} -regexp {maximum value .* may be too large for 'storage'} \
+      -comment "index is protected by control logic"
+
+waive -rules EXPLICIT_BITLEN      -location {prim_fifo_*sync.sv} -regexp {Bit length not specified for constant '1'} \
+      -comment "index is protected by control logic"

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -20,6 +20,7 @@ filesets:
       - lowrisc:prim:flop_2sync
       - lowrisc:prim:cipher_pkg:0.1
       - lowrisc:prim:arbiter
+      - lowrisc:prim:fifo
     files:
       - rtl/prim_clock_gating_sync.sv
       - rtl/prim_alert_pkg.sv
@@ -29,8 +30,6 @@ filesets:
       - rtl/prim_esc_receiver.sv
       - rtl/prim_esc_sender.sv
       - rtl/prim_sram_arbiter.sv
-      - rtl/prim_fifo_async.sv
-      - rtl/prim_fifo_sync.sv
       - rtl/prim_slicer.sv
       - rtl/prim_sync_reqack.sv
       - rtl/prim_sync_reqack_data.sv

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -19,14 +19,12 @@ filesets:
       - lowrisc:prim:flop
       - lowrisc:prim:flop_2sync
       - lowrisc:prim:cipher_pkg:0.1
+      - lowrisc:prim:arbiter
     files:
       - rtl/prim_clock_gating_sync.sv
       - rtl/prim_alert_pkg.sv
       - rtl/prim_alert_receiver.sv
       - rtl/prim_alert_sender.sv
-      - rtl/prim_arbiter_ppc.sv
-      - rtl/prim_arbiter_tree.sv
-      - rtl/prim_arbiter_fixed.sv
       - rtl/prim_esc_pkg.sv
       - rtl/prim_esc_receiver.sv
       - rtl/prim_esc_sender.sv

--- a/hw/ip/prim/prim_arbiter.core
+++ b/hw/ip/prim/prim_arbiter.core
@@ -1,0 +1,42 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:arbiter"
+description: "Generic arbiter"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+    files:
+      - rtl/prim_arbiter_ppc.sv
+      - rtl/prim_arbiter_tree.sv
+      - rtl/prim_arbiter_fixed.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_arbiter.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim/prim_fifo.core
+++ b/hw/ip/prim/prim_fifo.core
@@ -1,0 +1,45 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:fifo"
+description: "Synchronous and asynchronous fifos"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+      - lowrisc:prim:flop_2sync
+    files:
+      - rtl/prim_fifo_async.sv
+      - rtl/prim_fifo_sync.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_fifo.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_fifo.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim/prim_flop_2sync.core
+++ b/hw/ip/prim/prim_flop_2sync.core
@@ -10,6 +10,9 @@ filesets:
     depend:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
+      # Needed because the generic prim_generic_flop_2sync has a
+      # dependency on prim:flop.
+      - lowrisc:prim:flop
 
   files_verilator_waiver:
     depend:

--- a/hw/ip/tlul/adapter_reg.core
+++ b/hw/ip/tlul/adapter_reg.core
@@ -8,7 +8,8 @@ description: "TL-UL to Register interface adapter"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:prim:all
+      - lowrisc:prim:assert
+      - lowrisc:prim:secded
       - lowrisc:tlul:common
       - lowrisc:tlul:trans_intg
     files:

--- a/hw/ip/tlul/common.core
+++ b/hw/ip/tlul/common.core
@@ -9,7 +9,8 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:dv:pins_if
-      - lowrisc:prim:all
+      - lowrisc:prim:assert
+      - lowrisc:prim:fifo
       - lowrisc:tlul:headers
     files:
       - rtl/tlul_fifo_sync.sv

--- a/hw/ip/tlul/socket_1n.core
+++ b/hw/ip/tlul/socket_1n.core
@@ -8,7 +8,7 @@ description: "TL-UL socket 1:n"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:prim:all
+      - lowrisc:prim:assert
       - lowrisc:tlul:headers
       - lowrisc:tlul:common
     files:

--- a/hw/ip/tlul/socket_m1.core
+++ b/hw/ip/tlul/socket_m1.core
@@ -8,7 +8,8 @@ description: "TL-UL socket m:1"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:prim:all
+      - lowrisc:prim:assert
+      - lowrisc:prim:arbiter
       - lowrisc:tlul:common
       - lowrisc:tlul:headers
     files:

--- a/hw/ip/tlul/sram2tlul.core
+++ b/hw/ip/tlul/sram2tlul.core
@@ -8,7 +8,7 @@ description: "SRAM to TL-UL adapter (host)"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:prim:all
+      - lowrisc:prim:assert
       - lowrisc:tlul:common
     files:
       - rtl/sram2tlul.sv

--- a/hw/ip/tlul/trans_intg.core
+++ b/hw/ip/tlul/trans_intg.core
@@ -8,7 +8,7 @@ description: "Tlul transmission integrity"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:prim:all
+      - lowrisc:prim:assert
       - lowrisc:prim:secded
       - lowrisc:tlul:common
     files:


### PR DESCRIPTION
The main motivation for this is to cut down the dependency tree for my rom_ctrl work (I've been messing around trying to run Symbiyosys on it), but I think this should be a win in general.