### PR TITLE
[doc] Use relative links in Hjson-related shortcodes

### DIFF
--- a/doc/rm/markdown_usage_style.md
+++ b/doc/rm/markdown_usage_style.md
@@ -290,7 +290,7 @@ See that document for integration overview within the broader top level system.
 
 ## Hardware Interfaces
 
-{{</* hwcfg "hw/ip/component/data/component.hjson" */>}}
+{{</* incGenFromIpDesc "../data/component.hjson" "hwcfg" */>}}
 
 ## Design Details
 
@@ -310,6 +310,6 @@ See that document for integration overview within the broader top level system.
 
 ## Register Table
 
-{{</* registers "hw/ip/component/data/component.hjson" */>}}
+{{</* incGenFromIpDesc "../data/component.hjson" "registers" */>}}
 
 ```

--- a/hw/ip/aes/doc/_index.md
+++ b/hw/ip/aes/doc/_index.md
@@ -116,7 +116,7 @@ The initialization vector (IV) register and the register to hold the previous in
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/ip/aes/data/aes.hjson" >}}
+{{< incGenFromIpDesc "../data/aes.hjson" "hwcfg" >}}
 
 The table below lists other signals of the AES unit.
 
@@ -488,4 +488,4 @@ Also, using a FIFO interface for something that is not actually FIFO (internally
 
 For a detailed overview of the register tool, please refer to the [Register Tool documentation.]({{< relref "doc/rm/register_tool" >}})
 
-{{< registers "hw/ip/aes/data/aes.hjson" >}}
+{{< incGenFromIpDesc "../data/aes.hjson" "registers" >}}

--- a/hw/ip/aes/doc/dv/index.md
+++ b/hw/ip/aes/doc/dv/index.md
@@ -115,4 +115,4 @@ Here's how to run a basic test without DPI calls:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/aes/dv/aes_sim_cfg.hjson -i aes_wakeup
 ```
 ## DV plan
-{{< testplan "hw/ip/aes/data/aes_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/aes_testplan.hjson" "testplan" >}}

--- a/hw/ip/alert_handler/doc/_index.md
+++ b/hw/ip/alert_handler/doc/_index.md
@@ -146,7 +146,7 @@ Parameter      | Default (Max)    | Description
 
 ### Signals
 
-{{< hwcfg "hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson" >}}
+{{< incGenFromIpDesc "/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson" "hwcfg" >}}
 
 The table below lists other alert handler module signals. The number of alert
 instances is parametric and hence alert and ping diff pairs are grouped together
@@ -935,7 +935,7 @@ In order to generate the register file for four alert sources, from
 $ ./reg_alert_handler.py alert_handler.hjson.tpl -n 4 > alert_handler.hjson
 ```
 
-{{< registers "hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson" >}}
+{{< incGenFromIpDesc "/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson" "registers" >}}
 
 
 # Additional Notes

--- a/hw/ip/alert_handler/doc/dv/index.md
+++ b/hw/ip/alert_handler/doc/dv/index.md
@@ -112,4 +112,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/$CHIP/ip/alert_handler/dv/alert_han
 In this run command, $CHIP can be top_earlgrey, etc.
 
 ## DV plan
-{{< testplan "hw/ip/alert_handler/data/alert_handler_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/alert_handler_testplan.hjson" "testplan" >}}

--- a/hw/ip/aon_timer/doc/_index.md
+++ b/hw/ip/aon_timer/doc/_index.md
@@ -70,7 +70,7 @@ This is used to stop the watchdog timer running when in debugging mode or when t
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/ip/aon_timer/data/aon_timer.hjson" >}}
+{{< incGenFromIpDesc "../data/aon_timer.hjson" "hwcfg" >}}
 
 ## Design Details
 
@@ -108,4 +108,4 @@ TODO
 
 ## Register Table
 
-{{< registers "hw/ip/aon_timer/data/aon_timer.hjson" >}}
+{{< incGenFromIpDesc "../data/aon_timer.hjson" "registers" >}}

--- a/hw/ip/aon_timer/doc/dv/index.md
+++ b/hw/ip/aon_timer/doc/dv/index.md
@@ -105,4 +105,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/aon_timer/dv/aon_timer_sim_cfg.h
 ```
 
 ## DV plan
-{{< testplan "hw/ip/aon_timer/data/aon_timer_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/aon_timer_testplan.hjson" "testplan" >}}

--- a/hw/ip/clkmgr/doc/_index.md
+++ b/hw/ip/clkmgr/doc/_index.md
@@ -188,4 +188,4 @@ To control peripheral clocks, directly change the bits in {{< regref "CLK_ENABLE
 
 ## Register Table
 
-{{< registers "hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson" >}}
+{{< incGenFromIpDesc "/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson" "registers" >}}

--- a/hw/ip/csrng/doc/_index.md
+++ b/hw/ip/csrng/doc/_index.md
@@ -135,7 +135,7 @@ Finally, an `ack` response and status will be returned to the application interf
 
 ## Hardware Interfaces
 
- {{< hwcfg "hw/ip/csrng/data/csrng.hjson" >}}
+ {{< incGenFromIpDesc "../data/csrng.hjson" "hwcfg" >}}
 
 ## Design Details
 
@@ -510,4 +510,4 @@ void csrng_init(unsigned int enable) {
 
 ## Register Table
 
-{{< registers "hw/ip/csrng/data/csrng.hjson" >}}
+{{< incGenFromIpDesc "../data/csrng.hjson" "registers" >}}

--- a/hw/ip/csrng/doc/dv/index.md
+++ b/hw/ip/csrng/doc/dv/index.md
@@ -101,4 +101,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/csrng/dv/csrng_sim_cfg.hjson -i 
 ```
 
 ## DV plan
-{{< testplan "hw/ip/csrng/data/csrng_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/csrng_testplan.hjson" "testplan" >}}

--- a/hw/ip/dcd/doc/_index.md
+++ b/hw/ip/dcd/doc/_index.md
@@ -21,7 +21,7 @@ title: "ADC_CTRL HWIP Technical Specification"
 
 ## Hardware Interface
 
-{{< hwcfg "hw/ip/dcd/data/dcd.hjson" >}}
+{{< incGenFromIpDesc "../data/dcd.hjson" "hwcfg" >}}
 
 ## Design Details
 
@@ -32,4 +32,4 @@ title: "ADC_CTRL HWIP Technical Specification"
 
 ## Registers
 
-{{< registers "hw/ip/dcd/data/dcd.hjson" >}}
+{{< incGenFromIpDesc "../data/dcd.hjson" "registers" >}}

--- a/hw/ip/dcd/doc/dv/index.md
+++ b/hw/ip/dcd/doc/dv/index.md
@@ -114,4 +114,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/dcd/dv/dcd_sim_cfg.hjson -i dcd_
 ```
 
 ## DV plan
-{{< testplan "hw/ip/dcd/data/dcd_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/dcd_testplan.hjson" "testplan" >}}

--- a/hw/ip/edn/doc/_index.md
+++ b/hw/ip/edn/doc/_index.md
@@ -172,7 +172,7 @@ If the `fips` signal is deasserted, it means the associated CSRNG instance has b
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/ip/edn/data/edn.hjson" >}}
+{{< incGenFromIpDesc "../data/edn.hjson" "hwcfg" >}}
 
 ## Design Details
 
@@ -238,4 +238,4 @@ Need to alert the system of a FIFO overflow condition.
 
 ## Register Table
 
-{{< registers "hw/ip/edn/data/edn.hjson" >}}
+{{< incGenFromIpDesc "../data/edn.hjson" "registers" >}}

--- a/hw/ip/edn/doc/dv/index.md
+++ b/hw/ip/edn/doc/dv/index.md
@@ -103,4 +103,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/edn/dv/edn_sim_cfg.hjson -i edn_
 ```
 
 ## DV plan
-{{< testplan "hw/ip/edn/data/edn_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/edn_testplan.hjson" "testplan" >}}

--- a/hw/ip/entropy_src/doc/_index.md
+++ b/hw/ip/entropy_src/doc/_index.md
@@ -181,7 +181,7 @@ At any time, the `ENABLE` field can be cleared to halt the entropy generation (a
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/ip/entropy_src/data/entropy_src.hjson" >}}
+{{< incGenFromIpDesc "../data/entropy_src.hjson" "hwcfg" >}}
 
 ## Design Details
 
@@ -407,4 +407,4 @@ Need to alert the system of a FIFO overflow condition.
 
 ## Register Table
 
-{{< registers "hw/ip/entropy_src/data/entropy_src.hjson" >}}
+{{< incGenFromIpDesc "../data/entropy_src.hjson" "registers" >}}

--- a/hw/ip/entropy_src/doc/dv/index.md
+++ b/hw/ip/entropy_src/doc/dv/index.md
@@ -100,4 +100,4 @@ $ make TEST_NAME=entropy_src_smoke
 ```
 
 ## DV plan
-{{< testplan "hw/ip/entropy_src/data/entropy_src_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/entropy_src_testplan.hjson" "testplan" >}}

--- a/hw/ip/flash_ctrl/doc/_index.md
+++ b/hw/ip/flash_ctrl/doc/_index.md
@@ -293,7 +293,7 @@ For these pages, scramble shall be permanently disabled as the manufacturer shou
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/ip/flash_ctrl/data/flash_ctrl.hjson" >}}
+{{< incGenFromIpDesc "../data/flash_ctrl.hjson" "hwcfg" >}}
 
 ### Signals
 
@@ -457,4 +457,4 @@ When all desired words have been programmed, the controller will post OP_DONE in
 The flash protocol controller maintains two separate access windows for the FIFO.
 It is implemented this way because the access window supports transaction back-pressure should the FIFO become full (in case of write) or empty (in case of read).
 
-{{< registers "hw/ip/flash_ctrl/data/flash_ctrl.hjson" >}}
+{{< incGenFromIpDesc "../data/flash_ctrl.hjson" "registers" >}}

--- a/hw/ip/flash_ctrl/doc/dv/index.md
+++ b/hw/ip/flash_ctrl/doc/dv/index.md
@@ -128,4 +128,4 @@ $ ./util/dvsim/dvsim.py hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson -i flash_ct
 ```
 
 ## DV plan
-{{< testplan "hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/flash_ctrl_testplan.hjson" "testplan" >}}

--- a/hw/ip/gpio/doc/_index.md
+++ b/hw/ip/gpio/doc/_index.md
@@ -63,7 +63,7 @@ the top level netlist.
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/ip/gpio/data/gpio.hjson" >}}
+{{< incGenFromIpDesc "../data/gpio.hjson" "hwcfg" >}}
 
 ## Design Details
 
@@ -281,4 +281,4 @@ printf("0b%b", *GPIO_INTR_STATE);       // 0b00001100
 
 ## Register Table
 
-{{< registers "hw/ip/gpio/data/gpio.hjson" >}}
+{{< incGenFromIpDesc "../data/gpio.hjson" "registers" >}}

--- a/hw/ip/gpio/doc/dv/index.md
+++ b/hw/ip/gpio/doc/dv/index.md
@@ -113,4 +113,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/gpio/dv/gpio_sim_cfg.hjson -i gp
 ```
 
 ## DV plan
-{{< testplan "hw/ip/gpio/data/gpio_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/gpio_testplan.hjson" "testplan" >}}

--- a/hw/ip/hmac/doc/_index.md
+++ b/hw/ip/hmac/doc/_index.md
@@ -83,7 +83,7 @@ hash result and the previous digest registers.
 
 ## Hardware Interface
 
-{{< hwcfg "hw/ip/hmac/data/hmac.hjson" >}}
+{{< incGenFromIpDesc "../data/hmac.hjson" "hwcfg" >}}
 
 ## Design Details
 
@@ -302,4 +302,4 @@ interconnect.
 
 ## Register Table
 
-{{< registers "hw/ip/hmac/data/hmac.hjson" >}}
+{{< incGenFromIpDesc "../data/hmac.hjson" "registers" >}}

--- a/hw/ip/hmac/doc/dv/index.md
+++ b/hw/ip/hmac/doc/dv/index.md
@@ -143,4 +143,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/hmac/dv/hmac_sim_cfg.hjson -i hm
 ```
 
 ## DV plan
-{{< testplan "hw/ip/hmac/data/hmac_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/hmac_testplan.hjson" "testplan" >}}

--- a/hw/ip/i2c/doc/_index.md
+++ b/hw/ip/i2c/doc/_index.md
@@ -83,7 +83,7 @@ This IP also supports clock-stretching, should that be required by target device
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/ip/i2c/data/i2c.hjson" >}}
+{{< incGenFromIpDesc "../data/i2c.hjson" "hwcfg" >}}
 
 ## Design Details
 
@@ -509,4 +509,4 @@ All other parameters in registers `TIMING2`, `TIMING3`, `TIMING4` are unchanged 
 
 ## Register Table
 
-{{<registers "hw/ip/i2c/data/i2c.hjson" >}}
+{{< incGenFromIpDesc "../data/i2c.hjson" "registers" >}}

--- a/hw/ip/i2c/doc/dv/index.md
+++ b/hw/ip/i2c/doc/dv/index.md
@@ -98,4 +98,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/i2c/dv/i2c_sim_cfg.hjson -i i2c_
 ```
 
 ## DV plan
-{{< testplan "hw/ip/i2c/data/i2c_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/i2c_testplan.hjson" "testplan" >}}

--- a/hw/ip/keymgr/doc/_index.md
+++ b/hw/ip/keymgr/doc/_index.md
@@ -376,7 +376,7 @@ An unsuccessful advance call (errors) does not unlock the binding.
 This allows the next stage of software to re-use the binding registers.
 
 ## Hardware Interfaces
-{{< hwcfg "hw/ip/keymgr/data/keymgr.hjson" >}}
+{{< incGenFromIpDesc "../data/keymgr.hjson" "hwcfg" >}}
 
 # Programmers Guide
 
@@ -399,4 +399,4 @@ More details to come.
 
 ## Register Table
 
-{{< registers "hw/ip/keymgr/data/keymgr.hjson" >}}
+{{< incGenFromIpDesc "../data/keymgr.hjson" "registers" >}}

--- a/hw/ip/keymgr/doc/dv/index.md
+++ b/hw/ip/keymgr/doc/dv/index.md
@@ -114,4 +114,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson -
 ```
 
 ## DV plan
-{{< testplan "hw/ip/keymgr/data/keymgr_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/keymgr_testplan.hjson" "testplan" >}}

--- a/hw/ip/kmac/doc/_index.md
+++ b/hw/ip/kmac/doc/_index.md
@@ -75,7 +75,7 @@ If desired, the masking can be disabled and the internal state width can be redu
 
 ## Hardware Interface
 
-{{< hwcfg "hw/ip/kmac/data/kmac.hjson" >}}
+{{< incGenFromIpDesc "../data/kmac.hjson" "hwcfg" >}}
 
 ## Design Details
 
@@ -330,7 +330,7 @@ It could restore the previous hashing state later and continue the operation.
 
 ## Registers
 
-{{< registers "hw/ip/kmac/data/kmac.hjson" >}}
+{{< incGenFromIpDesc "../data/kmac.hjson" "registers" >}}
 
 
 

--- a/hw/ip/lc_ctrl/doc/_index.md
+++ b/hw/ip/lc_ctrl/doc/_index.md
@@ -363,7 +363,7 @@ Parameter                      | Default (Max)         | Top Earlgrey   | Descri
 
 ### Signals
 
-{{< hwcfg "hw/ip/lc_ctrl/data/lc_ctrl.hjson" >}}
+{{< incGenFromIpDesc "../data/lc_ctrl.hjson" "hwcfg" >}}
 
 Signal                       | Direction        | Type                                 | Description
 -----------------------------|------------------|--------------------------------------|---------------
@@ -648,5 +648,5 @@ It is expected that the JTAG TAP interface is used to access the life cycle tran
 
 ## Register Table
 
-{{< registers "hw/ip/lc_ctrl/data/lc_ctrl.hjson" >}}
+{{< incGenFromIpDesc "../data/lc_ctrl.hjson" "registers" >}}
 

--- a/hw/ip/lc_ctrl/doc/dv/index.md
+++ b/hw/ip/lc_ctrl/doc/dv/index.md
@@ -114,4 +114,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
 ```
 
 ## DV plan
-{{< testplan "hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/lc_ctrl_testplan.hjson" "testplan" >}}

--- a/hw/ip/nmi_gen/doc/index.md
+++ b/hw/ip/nmi_gen/doc/index.md
@@ -32,7 +32,7 @@ N_ESC_SEV      | 4 (-)                 | Number of escalation receivers (should 
 
 ## Signals
 
-{{< hwcfg "hw/ip/nmi_gen/data/nmi_gen.hjson" >}}
+{{< incGenFromIpDesc "../data/nmi_gen.hjson" "hwcfg" >}}
 
 The table below lists other `nmi_gen` signals.
 
@@ -44,4 +44,4 @@ Signal                               | Direction        | Type                  
 
 ## Register Table
 
-{{< registers "hw/ip/nmi_gen/data/nmi_gen.hjson" >}}
+{{< incGenFromIpDesc "../data/nmi_gen.hjson" "registers" >}}

--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -435,7 +435,7 @@ outer_body:
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/ip/otbn/data/otbn.hjson" >}}
+{{< incGenFromIpDesc "../data/otbn.hjson" "hwcfg" >}}
 
 ## Design Details
 
@@ -551,7 +551,7 @@ A higher-level driver for the OTBN block is available at `sw/device/lib/runtime/
 
 ## Register Table
 
-{{< registers "hw/ip/otbn/data/otbn.hjson" >}}
+{{< incGenFromIpDesc "../data/otbn.hjson" "registers" >}}
 
 # Writing OTBN applications {#writing-otbn-applications}
 

--- a/hw/ip/otp_ctrl/doc/_index.md
+++ b/hw/ip/otp_ctrl/doc/_index.md
@@ -305,7 +305,7 @@ Parameter                   | Default (Max) | Top Earlgrey | Description
 
 ### Signals
 
-{{< hwcfg "hw/ip/otp_ctrl/data/otp_ctrl.hjson" >}}
+{{< incGenFromIpDesc "../data/otp_ctrl.hjson" "hwcfg" >}}
 
 The table below lists other OTP controller signals.
 
@@ -984,7 +984,7 @@ This is however rare and should not happen after fabrication testing.
 
 ## Register Table
 
-{{< registers "hw/ip/otp_ctrl/data/otp_ctrl.hjson" >}}
+{{< incGenFromIpDesc "../data/otp_ctrl.hjson" "registers" >}}
 
 
 # Additional Notes

--- a/hw/ip/otp_ctrl/doc/dv/index.md
+++ b/hw/ip/otp_ctrl/doc/dv/index.md
@@ -114,4 +114,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjs
 ```
 
 ## DV plan
-{{< testplan "hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/otp_ctrl_testplan.hjson" "testplan" >}}

--- a/hw/ip/pattgen/doc/_index.md
+++ b/hw/ip/pattgen/doc/_index.md
@@ -47,7 +47,7 @@ Changes to the configuration registers only take effect once the channel has bee
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/ip/pattgen/data/pattgen.hjson" >}}
+{{< incGenFromIpDesc "../data/pattgen.hjson" "hwcfg" >}}
 
 ## Design Details
 
@@ -138,4 +138,4 @@ To start both channel patterns at the same time, configure both channels then si
 
 ## Register Table
 
-{{< registers "hw/ip/pattgen/data/pattgen.hjson" >}}
+{{< incGenFromIpDesc "../data/pattgen.hjson" "registers" >}}

--- a/hw/ip/pattgen/doc/dv/index.md
+++ b/hw/ip/pattgen/doc/dv/index.md
@@ -99,4 +99,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson
 ```
 
 ## DV plan
-{{< testplan "hw/ip/pattgen/data/pattgen_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/pattgen_testplan.hjson" "testplan" >}}

--- a/hw/ip/pinmux/doc/_index.md
+++ b/hw/ip/pinmux/doc/_index.md
@@ -70,7 +70,7 @@ Additional details about the signal names and parameters are given in the sectio
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson" >}}
+{{< incGenFromIpDesc "/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson" "hwcfg" >}}
 
 ## Parameters
 
@@ -130,4 +130,4 @@ design]({{< relref "hw/top_earlgrey/doc" >}}).
 
 Similar register descriptions can be generated with different parameterizations.
 
-{{< registers "hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson" >}}
+{{< incGenFromIpDesc "/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson" "registers" >}}

--- a/hw/ip/pinmux/doc/dv/index.md
+++ b/hw/ip/pinmux/doc/dv/index.md
@@ -39,4 +39,4 @@ In the pinmux_assert_fpv module, we declared two symbolic variables `mio_sel_i` 
 Detailed explanation is listed in the [Symbolic Variables]({{< relref "hw/formal/README.md#symbolic-variables" >}}) section.
 
 ## DV plan
-{{< testplan "hw/ip/pinmux/data/pinmux_fpv_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/pinmux_fpv_testplan.hjson" "testplan" >}}

--- a/hw/ip/pwm/doc/_index.md
+++ b/hw/ip/pwm/doc/_index.md
@@ -77,7 +77,7 @@ Once the internal duty cycle reaches the target value, the internal duty cycle b
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/ip/pwm/data/pwm.hjson" >}}
+{{< incGenFromIpDesc "../data/pwm.hjson" "hwcfg" >}}
 
 ## Design Details
 
@@ -314,4 +314,4 @@ This step is necessary for changing the blink timing parameters
 
 ## Register Table
 
-{{< registers "hw/ip/pwm/data/pwm.hjson" >}}
+{{< incGenFromIpDesc "../data/pwm.hjson" "registers" >}}

--- a/hw/ip/pwrmgr/doc/_index.md
+++ b/hw/ip/pwrmgr/doc/_index.md
@@ -255,4 +255,4 @@ Please see [power management programmers model](https://docs.google.com/document
 
 ## Register Table
 
-{{< registers "hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson" >}}
+{{< incGenFromIpDesc "/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson" "registers" >}}

--- a/hw/ip/rstmgr/doc/_index.md
+++ b/hw/ip/rstmgr/doc/_index.md
@@ -147,7 +147,7 @@ Shadow resets have not been implemented yet.
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson" >}}
+{{< incGenFromIpDesc "/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson" "hwcfg" >}}
 
 ### Signals
 
@@ -308,4 +308,4 @@ Set {{< regref "ALERT_INFO_CTRL.INDEX" >}} to the desired segment, and then read
 
 ## Register Table
 
-{{< registers "hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson" >}}
+{{< incGenFromIpDesc "/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson" "registers" >}}

--- a/hw/ip/rv_plic/doc/_index.md
+++ b/hw/ip/rv_plic/doc/_index.md
@@ -35,7 +35,7 @@ The RV_PLIC is compatible with any RISC-V core implementing the RISC-V privilege
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson" >}}
+{{< incGenFromIpDesc "/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson" "hwcfg" >}}
 
 ## Design Details
 
@@ -261,4 +261,4 @@ interrupt sources may be different.
 -   CC: N_TARGET
     Claim by read, complete by write
 
-{{< registers "hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson" >}}
+{{< incGenFromIpDesc "/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson" "registers" >}}

--- a/hw/ip/rv_plic/doc/dv/index.md
+++ b/hw/ip/rv_plic/doc/dv/index.md
@@ -48,4 +48,4 @@ Detailed explanation is listed in the
 [Symbolic Variables]({{< relref "hw/formal/README.md#symbolic-variables" >}}) section.
 
 ## DV plan
-{{< testplan "hw/ip/rv_plic/data/rv_plic_fpv_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/rv_plic_fpv_testplan.hjson" "testplan" >}}

--- a/hw/ip/rv_timer/doc/_index.md
+++ b/hw/ip/rv_timer/doc/_index.md
@@ -49,7 +49,7 @@ value. The 64-bit `mtime` value is compared with the 64-bit `mtimecmp`. If
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/ip/rv_timer/data/rv_timer.hjson" >}}
+{{< incGenFromIpDesc "../data/rv_timer.hjson" "hwcfg" >}}
 
 ## Design Details
 
@@ -246,4 +246,4 @@ In this case both {{<regref "COMPARE_LOWER0_0">}} and {{<regref "COMPARE_UPPER0_
 
 ## Register Table
 
-{{< registers "hw/ip/rv_timer/data/rv_timer.hjson" >}}
+{{< incGenFromIpDesc "../data/rv_timer.hjson" "registers" >}}

--- a/hw/ip/rv_timer/doc/dv/index.md
+++ b/hw/ip/rv_timer/doc/dv/index.md
@@ -102,4 +102,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjs
 ```
 
 ## DV plan
-{{< testplan "hw/ip/rv_timer/data/rv_timer_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/rv_timer_testplan.hjson" "testplan" >}}

--- a/hw/ip/spi_device/doc/_index.md
+++ b/hw/ip/spi_device/doc/_index.md
@@ -69,7 +69,7 @@ signal when the SPI interface is idle.
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/ip/spi_device/data/spi_device.hjson" >}}
+{{< incGenFromIpDesc "../data/spi_device.hjson" "hwcfg" >}}
 
 ## General Data Transfer on Pins
 
@@ -418,4 +418,4 @@ the phase bit, bit 11).
 
 ## Register Table
 
-{{< registers "hw/ip/spi_device/data/spi_device.hjson" >}}
+{{< incGenFromIpDesc "../data/spi_device.hjson" "registers" >}}

--- a/hw/ip/spi_device/doc/dv/index.md
+++ b/hw/ip/spi_device/doc/dv/index.md
@@ -103,4 +103,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/spi_device/dv/spi_device_sim_cfg
 ```
 
 ## DV plan
-{{< testplan "hw/ip/spi_device/data/spi_device_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/spi_device_testplan.hjson" "testplan" >}}

--- a/hw/ip/spi_host/doc/_index.md
+++ b/hw/ip/spi_host/doc/_index.md
@@ -365,7 +365,7 @@ This can be used to cancel a previous command.
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/ip/spi_host/data/spi_host.hjson" >}}
+{{< incGenFromIpDesc "../data/spi_host.hjson" "hwcfg" >}}
 
 ## Design Details
 
@@ -549,4 +549,4 @@ The Byte Select, or `bytesel`, unit is responsible for unpacking data from the F
 
 ## Register Table
 
-{{< registers "hw/ip/spi_host/data/spi_host.hjson" >}}
+{{< incGenFromIpDesc "../data/spi_host.hjson" "registers" >}}

--- a/hw/ip/sram_ctrl/doc/_index.md
+++ b/hw/ip/sram_ctrl/doc/_index.md
@@ -47,7 +47,7 @@ Parameter                   | Default (Max)         | Top Earlgrey | Description
 
 ### Signals
 
-{{< hwcfg "hw/ip/sram_ctrl/data/sram_ctrl.hjson" >}}
+{{< incGenFromIpDesc "../data/sram_ctrl.hjson" "hwcfg" >}}
 
 The table below lists other SRAM controller signals.
 
@@ -283,4 +283,4 @@ Optionally, SW can read the {{< regref "ERROR_ADDRESS" >}} register, which expos
 
 ## Register Table
 
-{{< registers "hw/ip/sram_ctrl/data/sram_ctrl.hjson" >}}
+{{< incGenFromIpDesc "../data/sram_ctrl.hjson" "registers" >}}

--- a/hw/ip/sram_ctrl/doc/dv/index.md
+++ b/hw/ip/sram_ctrl/doc/dv/index.md
@@ -105,4 +105,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/sram_ctrl/dv/sram_ctrl_sim_cfg.h
 ```
 
 ## DV plan
-{{< testplan "hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/sram_ctrl_base_testplan.hjson" "testplan" >}}

--- a/hw/ip/tlul/doc/dv/index.md
+++ b/hw/ip/tlul/doc/dv/index.md
@@ -113,4 +113,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/$CHIP/ip/$XBAR_IP/dv/autogen/${XBAR
 In this run command, $XBAR_IP can be xbar_main, xbar_peri, etc. $CHIP can be top_earlgrey, etc.
 
 ## DV plan
-{{< testplan "hw/ip/tlul/data/tlul_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/tlul_testplan.hjson" "testplan" >}}

--- a/hw/ip/uart/doc/_index.md
+++ b/hw/ip/uart/doc/_index.md
@@ -44,7 +44,7 @@ Additional features such as parity have been added.
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/ip/uart/data/uart.hjson" >}}
+{{< incGenFromIpDesc "../data/uart.hjson" "hwcfg" >}}
 
 ## Design Details
 
@@ -485,4 +485,4 @@ case the host will eventually get a watermark interrupt, this will happen
 
 ## Register Table
 
-{{< registers "hw/ip/uart/data/uart.hjson" >}}
+{{< incGenFromIpDesc "../data/uart.hjson" "registers" >}}

--- a/hw/ip/uart/doc/dv/index.md
+++ b/hw/ip/uart/doc/dv/index.md
@@ -100,4 +100,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/uart/dv/uart_sim_cfg.hjson -i ua
 ```
 
 ## DV plan
-{{< testplan "hw/ip/uart/data/uart_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/uart_testplan.hjson" "testplan" >}}

--- a/hw/ip/usbdev/doc/_index.md
+++ b/hw/ip/usbdev/doc/_index.md
@@ -182,7 +182,7 @@ The BOM can be filled by parts from Digikey.
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/ip/usbdev/data/usbdev.hjson" >}}
+{{< incGenFromIpDesc "../data/usbdev.hjson" "hwcfg" >}}
 
 
 ## USB Link State
@@ -362,4 +362,4 @@ The hardware then sends NACKs to any IN/OUT requests until the software has deci
 
 ## Register Table
 
-{{< registers "hw/ip/usbdev/data/usbdev.hjson" >}}
+{{< incGenFromIpDesc "../data/usbdev.hjson" "registers" >}}

--- a/hw/ip/usbdev/doc/dv/index.md
+++ b/hw/ip/usbdev/doc/dv/index.md
@@ -98,4 +98,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson -
 ```
 
 ## DV plan
-{{< testplan "hw/ip/usbdev/data/usbdev_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/usbdev_testplan.hjson" "testplan" >}}

--- a/hw/ip/usbuart/doc/_index.md
+++ b/hw/ip/usbuart/doc/_index.md
@@ -54,7 +54,7 @@ the requested Baud rate and parity may be read.
 
 ## Hardware Interfaces
 
-{{< hwcfg "hw/ip/usbuart/data/usbuart.hjson" >}}
+{{< incGenFromIpDesc "../data/usbuart.hjson" "hwcfg" >}}
 
 ## Design Details
 
@@ -223,4 +223,4 @@ void uart_interrupt_routine() {
 
 ## Register Table
 
-{{< registers "hw/ip/usbuart/data/usbuart.hjson" >}}
+{{< incGenFromIpDesc "../data/usbuart.hjson" "registers" >}}

--- a/hw/top_earlgrey/doc/dv/index.md
+++ b/hw/top_earlgrey/doc/dv/index.md
@@ -141,4 +141,4 @@ For a list of available tests  to run, please see the 'Tests' column in the [DV 
 ### Nightly
 
 ## DV plan
-{{< testplan "hw/top_earlgrey/data/chip_testplan.hjson" >}}
+{{< incGenFromIpDesc "../../data/chip_testplan.hjson" "testplan" >}}

--- a/site/docs/layouts/shortcodes/hwcfg.html
+++ b/site/docs/layouts/shortcodes/hwcfg.html
@@ -1,6 +1,0 @@
-{{ $baseName := .Get 0 }}
-{{ $path := path.Join .Site.Params.generatedRoot (printf "%s.hwcfg" $baseName) }}
-{{ if not (fileExists $path) }}
-  {{ errorf "hwcfg has not been generated for %s" $baseName }}
-{{ end }}
-{{ readFile $path | safeHTML }}

--- a/site/docs/layouts/shortcodes/incGenFromIpDesc.html
+++ b/site/docs/layouts/shortcodes/incGenFromIpDesc.html
@@ -1,0 +1,30 @@
+{{/*
+A Hugo shortcode to include the content generated from the IP description Hjson
+
+Usage: {{< incGenFromIpDesc hjsonPath contentType >}}
+
+hjsonPath: Path to an IP description file in Hjson (ip_name.hjson)
+  Relative paths are resolved relative to the directory using the shortcode.
+  Absolute paths are resolved relative to REPO_TOP.
+
+contentType: Type of generated content to include.
+  Valid options: testplan, hwcfg, registers
+
+The actual content is rendered as HTML by the util/build_docs.py script and only
+included by the shortcode here.
+*/}}
+
+{{ $hjsonPath := .Get 0 }}
+{{ $contentType := .Get 1 }}
+{{ $ipDescFile := (printf "%s.%s" $hjsonPath $contentType) }}
+
+{{ $path := "UNDEF" }}
+{{ if (hasPrefix $hjsonPath "/") }}
+  {{ $path = path.Join .Site.Params.generatedRoot $ipDescFile }}
+{{ else }}
+  {{ $path = path.Join .Site.Params.generatedRoot .Page.File.Dir $ipDescFile }}
+{{ end }}
+{{ if not (fileExists $path) }}
+  {{ errorf "HTML for %s has not been generated for %s (looked at %s)" $contentType $hjsonPath $path }}
+{{ end }}
+{{ readFile $path | safeHTML }}

--- a/site/docs/layouts/shortcodes/registers.html
+++ b/site/docs/layouts/shortcodes/registers.html
@@ -1,6 +1,0 @@
-{{ $baseName := .Get 0 }}
-{{ $path := path.Join .Site.Params.generatedRoot (printf "%s.registers" $baseName) }}
-{{ if not (fileExists $path) }}
-  {{ errorf "Registers have not been generated for %s" $baseName }}
-{{ end }}
-{{ readFile $path | safeHTML }}

--- a/site/docs/layouts/shortcodes/testplan.html
+++ b/site/docs/layouts/shortcodes/testplan.html
@@ -1,6 +1,0 @@
-{{ $baseName := .Get 0 }}
-{{ $path := path.Join .Site.Params.generatedRoot (printf "%s.testplan" $baseName) }}
-{{ if not (fileExists $path) }}
-  {{ errorf "Testplan has not been generated for %s" $baseName }}
-{{ end }}
-{{ readFile $path | safeHTML }}

--- a/sw/device/tests/README.md
+++ b/sw/device/tests/README.md
@@ -29,4 +29,4 @@ Based on the captured value, the testbench monitor invokes UVM methods to pass o
 
 # List of Tests
 
-{{< testplan "hw/top_earlgrey/data/standalone_sw_testplan.hjson" >}}
+{{< incGenFromIpDesc "/hw/top_earlgrey/data/standalone_sw_testplan.hjson" "testplan" >}}

--- a/util/dvsim/testplanner/examples/foo_dv_plan.md
+++ b/util/dvsim/testplanner/examples/foo_dv_plan.md
@@ -4,4 +4,4 @@ title: "FOO DV document"
 
 # testplan
 
-{{< testplan "util/dvsim/testplanner/examples/foo_testplan.hjson" >}}
+{{< incGenFromIpDesc "foo_testplan.hjson" "testplan" >}}

--- a/util/uvmdvgen/index.md.tpl
+++ b/util/uvmdvgen/index.md.tpl
@@ -124,4 +124,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/${name}/dv/${name}_sim_cfg.hjson
 
 ${'##'} DV plan
 <!-- TODO: uncomment the line below after adding the testplan -->
-{{</* testplan "hw/ip/${name}/data/${name}_testplan.hjson" */>}}
+{{</* incGenFromIpDesc "hw/ip/${name}/data/${name}_testplan.hjson" "testplan" */>}


### PR DESCRIPTION
The testplan, hwcfg, and registers shortcodes currently take a single
argument referring to the IP description file in Hjson format.

Before this commit, the Hjson file path was relative to $REPO_TOP.
After this commit, the path is relative to the file using the
shortcode. The previous behavior can be achieved by using absolute
paths, which are rooted in $REPO_TOP.

With this change users of the short codes do not need knowledge
about the overall file structure, making the IP directory "relocatable."

To avoid doing the same change three times in the testplan, hwcfg, and
registers shortcodes, this commit unifies them into a single shortcode.
(Unfortunately "inheritance"/"nesting" isn't really easy with Hugo
shortcodes.)