### PR TITLE
[dv] Update csr_wr to support field write

### DIFF
--- a/hw/dv/sv/csr_utils/csr_seq_lib.sv
+++ b/hw/dv/sv/csr_utils/csr_seq_lib.sv
@@ -200,7 +200,7 @@ class csr_write_seq extends csr_base_seq;
                                            backdoor dist {0 :/ 7, 1 :/ 3};)
       end
 
-      csr_wr(.csr(test_csrs[i]), .value(wdata), .blocking(0), .backdoor(backdoor));
+      csr_wr(.ptr(test_csrs[i]), .value(wdata), .blocking(0), .backdoor(backdoor));
     end
   endtask
 
@@ -243,7 +243,7 @@ class csr_rw_seq extends csr_base_seq;
       // might pick up stale mirrored value
       // the pre-predict also needs to happen after the register is being written, to make sure the
       // register is getting the updated access information.
-      csr_wr(.csr(test_csrs[i]), .value(wdata), .blocking(0), .predict(!external_checker));
+      csr_wr(.ptr(test_csrs[i]), .value(wdata), .blocking(0), .predict(!external_checker));
 
       do_check_csr_or_field_rd(.csr(test_csrs[i]),
                               .blocking(0),
@@ -364,7 +364,7 @@ class csr_bit_bash_seq extends csr_base_seq;
       val = rg.get();
       val[k]  = ~val[k];
       err_msg = $sformatf("Wrote %0s[%0d]: %0b", rg.get_full_name(), k, val[k]);
-      csr_wr(.csr(rg), .value(val), .blocking(1), .predict(!external_checker));
+      csr_wr(.ptr(rg), .value(val), .blocking(1), .predict(!external_checker));
 
       // TODO, outstanding access to same reg isn't supported in uvm_reg. Need to add another seq
       // uvm_reg waits until transaction is completed, before start another read/write in same reg
@@ -407,7 +407,7 @@ class csr_aliasing_seq extends csr_base_seq;
 
       `DV_CHECK_STD_RANDOMIZE_FATAL(wdata)
       wdata &= get_mask_excl_fields(test_csrs[i], CsrExclWrite, CsrAliasingTest, m_csr_excl_item);
-      csr_wr(.csr(test_csrs[i]), .value(wdata), .blocking(0), .predict(!external_checker));
+      csr_wr(.ptr(test_csrs[i]), .value(wdata), .blocking(0), .predict(!external_checker));
 
       all_csrs.shuffle();
       foreach (all_csrs[j]) begin

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -50,12 +50,12 @@ class aes_base_vseq extends cip_base_vseq #(
     aes_ctrl[0]    = 0;                  // set to encryption
     aes_ctrl[6:1]  = aes_pkg::AES_ECB;   // 6'b00_0001
     aes_ctrl[9:7]  = aes_pkg::AES_128;   // set to 128b key
-    csr_wr(.csr(ral.ctrl_shadowed), .value(aes_ctrl), .en_shadow_wr(1'b1), .blocking(1));
+    csr_wr(.ptr(ral.ctrl_shadowed), .value(aes_ctrl), .en_shadow_wr(1'b1), .blocking(1));
   endtask // aes_init
 
 
   virtual task trigger();
-      csr_wr(.csr(ral.trigger), .value(32'h00000001));
+      csr_wr(.ptr(ral.trigger), .value(32'h00000001));
   endtask // trigger
 
 
@@ -77,7 +77,7 @@ class aes_base_vseq extends cip_base_vseq #(
   virtual task prng_reseed();
     bit [TL_DW:0] reg_val = '0;
     reg_val[5] = 1'b1;
-    csr_wr(.csr(ral.trigger), .value(reg_val));
+    csr_wr(.ptr(ral.trigger), .value(reg_val));
   endtask // prng_reseed
 
 
@@ -116,31 +116,31 @@ class aes_base_vseq extends cip_base_vseq #(
   virtual task write_key(bit [7:0][31:0] key [2], bit do_b2b);
     `uvm_info(`gfn, $sformatf("\n\t --- back to back transactions : %b", do_b2b), UVM_MEDIUM)
     // Share 0 (the masked key share = key ^ mask)
-    csr_wr(.csr(ral.key_share0_0), .value(key[0][0]), .blocking(~do_b2b));
-    csr_wr(.csr(ral.key_share0_1), .value(key[0][1]), .blocking(~do_b2b));
-    csr_wr(.csr(ral.key_share0_2), .value(key[0][2]), .blocking(~do_b2b));
-    csr_wr(.csr(ral.key_share0_3), .value(key[0][3]), .blocking(~do_b2b));
-    csr_wr(.csr(ral.key_share0_4), .value(key[0][4]), .blocking(~do_b2b));
-    csr_wr(.csr(ral.key_share0_5), .value(key[0][5]), .blocking(~do_b2b));
-    csr_wr(.csr(ral.key_share0_6), .value(key[0][6]), .blocking(~do_b2b));
-    csr_wr(.csr(ral.key_share0_7), .value(key[0][7]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.key_share0_0), .value(key[0][0]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.key_share0_1), .value(key[0][1]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.key_share0_2), .value(key[0][2]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.key_share0_3), .value(key[0][3]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.key_share0_4), .value(key[0][4]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.key_share0_5), .value(key[0][5]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.key_share0_6), .value(key[0][6]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.key_share0_7), .value(key[0][7]), .blocking(~do_b2b));
     // Share 1 (the mask share)
-    csr_wr(.csr(ral.key_share1_0), .value(key[1][0]), .blocking(~do_b2b));
-    csr_wr(.csr(ral.key_share1_1), .value(key[1][1]), .blocking(~do_b2b));
-    csr_wr(.csr(ral.key_share1_2), .value(key[1][2]), .blocking(~do_b2b));
-    csr_wr(.csr(ral.key_share1_3), .value(key[1][3]), .blocking(~do_b2b));
-    csr_wr(.csr(ral.key_share1_4), .value(key[1][4]), .blocking(~do_b2b));
-    csr_wr(.csr(ral.key_share1_5), .value(key[1][5]), .blocking(~do_b2b));
-    csr_wr(.csr(ral.key_share1_6), .value(key[1][6]), .blocking(~do_b2b));
-    csr_wr(.csr(ral.key_share1_7), .value(key[1][7]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.key_share1_0), .value(key[1][0]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.key_share1_1), .value(key[1][1]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.key_share1_2), .value(key[1][2]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.key_share1_3), .value(key[1][3]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.key_share1_4), .value(key[1][4]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.key_share1_5), .value(key[1][5]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.key_share1_6), .value(key[1][6]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.key_share1_7), .value(key[1][7]), .blocking(~do_b2b));
   endtask // write_key
 
 
   virtual task write_iv(bit  [3:0][31:0] iv, bit do_b2b);
-    csr_wr(.csr(ral.iv_0), .value(iv[0]), .blocking(~do_b2b));
-    csr_wr(.csr(ral.iv_1), .value(iv[1]), .blocking(~do_b2b));
-    csr_wr(.csr(ral.iv_2), .value(iv[2]), .blocking(~do_b2b));
-    csr_wr(.csr(ral.iv_3), .value(iv[3]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.iv_0), .value(iv[0]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.iv_1), .value(iv[1]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.iv_2), .value(iv[2]), .blocking(~do_b2b));
+    csr_wr(.ptr(ral.iv_3), .value(iv[3]), .blocking(~do_b2b));
   endtask
 
 
@@ -156,10 +156,10 @@ class aes_base_vseq extends cip_base_vseq #(
     write_order.shuffle();
     foreach (write_order[i]) begin
       case (write_order[i])
-        0: csr_wr(.csr(ral.data_in_0), .value(data[0][31:0]), .blocking(~do_b2b));
-        1: csr_wr(.csr(ral.data_in_1), .value(data[1][31:0]), .blocking(~do_b2b));
-        2: csr_wr(.csr(ral.data_in_2), .value(data[2][31:0]), .blocking(~do_b2b));
-        3: csr_wr(.csr(ral.data_in_3), .value(data[3][31:0]), .blocking(~do_b2b));
+        0: csr_wr(.ptr(ral.data_in_0), .value(data[0][31:0]), .blocking(~do_b2b));
+        1: csr_wr(.ptr(ral.data_in_1), .value(data[1][31:0]), .blocking(~do_b2b));
+        2: csr_wr(.ptr(ral.data_in_2), .value(data[2][31:0]), .blocking(~do_b2b));
+        3: csr_wr(.ptr(ral.data_in_3), .value(data[3][31:0]), .blocking(~do_b2b));
       endcase
     end
   endtask
@@ -298,33 +298,33 @@ class aes_base_vseq extends cip_base_vseq #(
       txt = {txt, $sformatf("\n\t ----| \t %s", interleave_queue[i]) };
 
       case (interleave_queue[i])
-        "key_share0_0": csr_wr(.csr(ral.key_share0_0), .value(item.key[0][0]), .blocking(is_blocking));
-        "key_share0_1": csr_wr(.csr(ral.key_share0_1), .value(item.key[0][1]), .blocking(is_blocking));
-        "key_share0_2": csr_wr(.csr(ral.key_share0_2), .value(item.key[0][2]), .blocking(is_blocking));
-        "key_share0_3": csr_wr(.csr(ral.key_share0_3), .value(item.key[0][3]), .blocking(is_blocking));
-        "key_share0_4": csr_wr(.csr(ral.key_share0_4), .value(item.key[0][4]), .blocking(is_blocking));
-        "key_share0_5": csr_wr(.csr(ral.key_share0_5), .value(item.key[0][5]), .blocking(is_blocking));
-        "key_share0_6": csr_wr(.csr(ral.key_share0_6), .value(item.key[0][6]), .blocking(is_blocking));
-        "key_share0_7": csr_wr(.csr(ral.key_share0_7), .value(item.key[0][7]), .blocking(is_blocking));
+        "key_share0_0": csr_wr(.ptr(ral.key_share0_0), .value(item.key[0][0]), .blocking(is_blocking));
+        "key_share0_1": csr_wr(.ptr(ral.key_share0_1), .value(item.key[0][1]), .blocking(is_blocking));
+        "key_share0_2": csr_wr(.ptr(ral.key_share0_2), .value(item.key[0][2]), .blocking(is_blocking));
+        "key_share0_3": csr_wr(.ptr(ral.key_share0_3), .value(item.key[0][3]), .blocking(is_blocking));
+        "key_share0_4": csr_wr(.ptr(ral.key_share0_4), .value(item.key[0][4]), .blocking(is_blocking));
+        "key_share0_5": csr_wr(.ptr(ral.key_share0_5), .value(item.key[0][5]), .blocking(is_blocking));
+        "key_share0_6": csr_wr(.ptr(ral.key_share0_6), .value(item.key[0][6]), .blocking(is_blocking));
+        "key_share0_7": csr_wr(.ptr(ral.key_share0_7), .value(item.key[0][7]), .blocking(is_blocking));
 
-        "key_share1_0": csr_wr(.csr(ral.key_share1_0), .value(item.key[1][0]), .blocking(is_blocking));
-        "key_share1_1": csr_wr(.csr(ral.key_share1_1), .value(item.key[1][1]), .blocking(is_blocking));
-        "key_share1_2": csr_wr(.csr(ral.key_share1_2), .value(item.key[1][2]), .blocking(is_blocking));
-        "key_share1_3": csr_wr(.csr(ral.key_share1_3), .value(item.key[1][3]), .blocking(is_blocking));
-        "key_share1_4": csr_wr(.csr(ral.key_share1_4), .value(item.key[1][4]), .blocking(is_blocking));
-        "key_share1_5": csr_wr(.csr(ral.key_share1_5), .value(item.key[1][5]), .blocking(is_blocking));
-        "key_share1_6": csr_wr(.csr(ral.key_share1_6), .value(item.key[1][6]), .blocking(is_blocking));
-        "key_share1_7": csr_wr(.csr(ral.key_share1_7), .value(item.key[1][7]), .blocking(is_blocking));
+        "key_share1_0": csr_wr(.ptr(ral.key_share1_0), .value(item.key[1][0]), .blocking(is_blocking));
+        "key_share1_1": csr_wr(.ptr(ral.key_share1_1), .value(item.key[1][1]), .blocking(is_blocking));
+        "key_share1_2": csr_wr(.ptr(ral.key_share1_2), .value(item.key[1][2]), .blocking(is_blocking));
+        "key_share1_3": csr_wr(.ptr(ral.key_share1_3), .value(item.key[1][3]), .blocking(is_blocking));
+        "key_share1_4": csr_wr(.ptr(ral.key_share1_4), .value(item.key[1][4]), .blocking(is_blocking));
+        "key_share1_5": csr_wr(.ptr(ral.key_share1_5), .value(item.key[1][5]), .blocking(is_blocking));
+        "key_share1_6": csr_wr(.ptr(ral.key_share1_6), .value(item.key[1][6]), .blocking(is_blocking));
+        "key_share1_7": csr_wr(.ptr(ral.key_share1_7), .value(item.key[1][7]), .blocking(is_blocking));
 
-        "iv_0": csr_wr(.csr(ral.iv_0), .value(item.iv[0]), .blocking(is_blocking));
-        "iv_1": csr_wr(.csr(ral.iv_1), .value(item.iv[1]), .blocking(is_blocking));
-        "iv_2": csr_wr(.csr(ral.iv_2), .value(item.iv[2]), .blocking(is_blocking));
-        "iv_3": csr_wr(.csr(ral.iv_3), .value(item.iv[3]), .blocking(is_blocking));
+        "iv_0": csr_wr(.ptr(ral.iv_0), .value(item.iv[0]), .blocking(is_blocking));
+        "iv_1": csr_wr(.ptr(ral.iv_1), .value(item.iv[1]), .blocking(is_blocking));
+        "iv_2": csr_wr(.ptr(ral.iv_2), .value(item.iv[2]), .blocking(is_blocking));
+        "iv_3": csr_wr(.ptr(ral.iv_3), .value(item.iv[3]), .blocking(is_blocking));
 
-        "data_in_0": csr_wr(.csr(ral.data_in_0), .value(data[0][31:0]), .blocking(is_blocking));
-        "data_in_1": csr_wr(.csr(ral.data_in_1), .value(data[1][31:0]), .blocking(is_blocking));
-        "data_in_2": csr_wr(.csr(ral.data_in_2), .value(data[2][31:0]), .blocking(is_blocking));
-        "data_in_3": csr_wr(.csr(ral.data_in_3), .value(data[3][31:0]), .blocking(is_blocking));
+        "data_in_0": csr_wr(.ptr(ral.data_in_0), .value(data[0][31:0]), .blocking(is_blocking));
+        "data_in_1": csr_wr(.ptr(ral.data_in_1), .value(data[1][31:0]), .blocking(is_blocking));
+        "data_in_2": csr_wr(.ptr(ral.data_in_2), .value(data[2][31:0]), .blocking(is_blocking));
+        "data_in_3": csr_wr(.ptr(ral.data_in_3), .value(data[3][31:0]), .blocking(is_blocking));
 
         "clear_reg": begin
           clear_regs(item.clear_reg);

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -18,7 +18,7 @@
 
 `define RAND_WRITE_CLASS_CTRL(i, lock_bit) \
   `DV_CHECK_RANDOMIZE_WITH_FATAL(ral.class``i``_ctrl, lock.value == lock_bit;) \
-  csr_wr(.csr(ral.class``i``_ctrl), .value(ral.class``i``_ctrl.get()));
+  csr_wr(.ptr(ral.class``i``_ctrl), .value(ral.class``i``_ctrl.get()));
 
 class alert_handler_base_vseq extends cip_base_vseq #(
     .CFG_T               (alert_handler_env_cfg),
@@ -51,16 +51,16 @@ class alert_handler_base_vseq extends cip_base_vseq #(
                                   bit [TL_DW-1:0]                     alert_class = 'h0,
                                   bit [NUM_LOCAL_ALERT-1:0]           loc_alert_en = '1,
                                   bit [TL_DW-1:0]                     loc_alert_class = 'h0);
-    csr_wr(.csr(ral.intr_enable), .value(intr_en));
-    csr_wr(.csr(ral.alert_en), .value(alert_en));
-    csr_wr(.csr(ral.loc_alert_en), .value(loc_alert_en));
-    csr_wr(.csr(ral.loc_alert_class), .value(loc_alert_class));
+    csr_wr(.ptr(ral.intr_enable), .value(intr_en));
+    csr_wr(.ptr(ral.alert_en), .value(alert_en));
+    csr_wr(.ptr(ral.loc_alert_en), .value(loc_alert_en));
+    csr_wr(.ptr(ral.loc_alert_class), .value(loc_alert_class));
     for (int i = 0; i < $ceil(NUM_ALERTS * 2 / TL_DW); i++) begin
       string alert_name = (NUM_ALERTS <= TL_DW / 2) ? "alert_class" :
                                                       $sformatf("alert_class_%0d", i);
       uvm_reg alert_class_csr = ral.get_reg_by_name(alert_name);
       `DV_CHECK_NE_FATAL(alert_class_csr, null, alert_name)
-      csr_wr(.csr(alert_class_csr), .value(alert_class[i * TL_DW +: TL_DW]));
+      csr_wr(.ptr(alert_class_csr), .value(alert_class[i * TL_DW +: TL_DW]));
     end
 
   endtask
@@ -74,10 +74,10 @@ class alert_handler_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task alert_handler_wr_regwen_regs(bit [NUM_ALERT_HANDLER_CLASSES-1:0] regwen);
-    if (!regwen[0]) csr_wr(.csr(ral.classa_regwen), .value($urandom_range(0, 1)));
-    if (!regwen[1]) csr_wr(.csr(ral.classb_regwen), .value($urandom_range(0, 1)));
-    if (!regwen[2]) csr_wr(.csr(ral.classc_regwen), .value($urandom_range(0, 1)));
-    if (!regwen[3]) csr_wr(.csr(ral.classd_regwen), .value($urandom_range(0, 1)));
+    if (!regwen[0]) csr_wr(.ptr(ral.classa_regwen), .value($urandom_range(0, 1)));
+    if (!regwen[1]) csr_wr(.ptr(ral.classb_regwen), .value($urandom_range(0, 1)));
+    if (!regwen[2]) csr_wr(.ptr(ral.classc_regwen), .value($urandom_range(0, 1)));
+    if (!regwen[3]) csr_wr(.ptr(ral.classd_regwen), .value($urandom_range(0, 1)));
   endtask
 
   // If do_lock_config is set, write value 0 to rewgen register.
@@ -85,7 +85,7 @@ class alert_handler_base_vseq extends cip_base_vseq #(
   // Please note that writing 1 to regwen won't lock any lockable regs.
   virtual task lock_config(bit do_lock_config);
     if (do_lock_config || $urandom_range(0, 1)) begin
-      csr_wr(.csr(ral.regwen), .value(!do_lock_config));
+      csr_wr(.ptr(ral.regwen), .value(!do_lock_config));
     end
   endtask
 
@@ -139,14 +139,14 @@ class alert_handler_base_vseq extends cip_base_vseq #(
   virtual task check_alert_interrupts();
     bit [TL_DW-1:0] intr;
     csr_rd(.ptr(ral.intr_state), .value(intr));
-    csr_wr(.csr(ral.intr_state), .value('1));
+    csr_wr(.ptr(ral.intr_state), .value('1));
   endtask
 
   virtual task clear_esc();
-    csr_wr(.csr(ral.classa_clr), .value(1));
-    csr_wr(.csr(ral.classb_clr), .value(1));
-    csr_wr(.csr(ral.classc_clr), .value(1));
-    csr_wr(.csr(ral.classd_clr), .value(1));
+    csr_wr(.ptr(ral.classa_clr), .value(1));
+    csr_wr(.ptr(ral.classb_clr), .value(1));
+    csr_wr(.ptr(ral.classc_clr), .value(1));
+    csr_wr(.ptr(ral.classd_clr), .value(1));
   endtask
 
   // checking for csr_rd is done in scb
@@ -239,21 +239,21 @@ class alert_handler_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task wr_intr_timeout_cycle(bit[TL_DW-1:0] intr_timeout_cyc[NUM_ALERT_HANDLER_CLASSES]);
-    csr_wr(.csr(ral.classa_timeout_cyc), .value(intr_timeout_cyc[0]));
-    csr_wr(.csr(ral.classb_timeout_cyc), .value(intr_timeout_cyc[1]));
-    csr_wr(.csr(ral.classc_timeout_cyc), .value(intr_timeout_cyc[2]));
-    csr_wr(.csr(ral.classd_timeout_cyc), .value(intr_timeout_cyc[3]));
+    csr_wr(.ptr(ral.classa_timeout_cyc), .value(intr_timeout_cyc[0]));
+    csr_wr(.ptr(ral.classb_timeout_cyc), .value(intr_timeout_cyc[1]));
+    csr_wr(.ptr(ral.classc_timeout_cyc), .value(intr_timeout_cyc[2]));
+    csr_wr(.ptr(ral.classd_timeout_cyc), .value(intr_timeout_cyc[3]));
   endtask
 
   virtual task wr_class_accum_threshold(bit[TL_DW-1:0] accum_thresh[NUM_ALERT_HANDLER_CLASSES]);
-    csr_wr(.csr(ral.classa_accum_thresh), .value(accum_thresh[0]));
-    csr_wr(.csr(ral.classb_accum_thresh), .value(accum_thresh[1]));
-    csr_wr(.csr(ral.classc_accum_thresh), .value(accum_thresh[2]));
-    csr_wr(.csr(ral.classd_accum_thresh), .value(accum_thresh[3]));
+    csr_wr(.ptr(ral.classa_accum_thresh), .value(accum_thresh[0]));
+    csr_wr(.ptr(ral.classb_accum_thresh), .value(accum_thresh[1]));
+    csr_wr(.ptr(ral.classc_accum_thresh), .value(accum_thresh[2]));
+    csr_wr(.ptr(ral.classd_accum_thresh), .value(accum_thresh[3]));
   endtask
 
   virtual task wr_ping_timeout_cycle(bit[TL_DW-1:0] timeout_val);
-    csr_wr(.csr(ral.ping_timeout_cyc), .value(timeout_val));
+    csr_wr(.ptr(ral.ping_timeout_cyc), .value(timeout_val));
     if (!config_locked) begin
       if (timeout_val == 0) timeout_val = 1;
       foreach (cfg.alert_host_cfg[i]) cfg.alert_host_cfg[i].ping_timeout_cycle = timeout_val;

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
@@ -34,7 +34,7 @@ class csrng_base_vseq extends cip_base_vseq #(
 
   // write csrng command request register
   virtual task wr_cmd_req(bit[3:0] acmd, bit[3:0] clen, bit[3:0] flags, bit[18:0] glen);
-    csr_wr(.csr(ral.cmd_req), .value({1'b0, glen, flags, clen, acmd}));
+    csr_wr(.ptr(ral.cmd_req), .value({1'b0, glen, flags, clen, acmd}));
   endtask
 
 endclass : csrng_base_vseq

--- a/hw/ip/edn/dv/env/seq_lib/edn_smoke_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_smoke_vseq.sv
@@ -13,7 +13,7 @@ class edn_smoke_vseq extends edn_base_vseq;
     super.body();
 
     // Enable edn
-    csr_wr(.csr(ral.ctrl), .value(1'b1));
+    csr_wr(.ptr(ral.ctrl), .value(1'b1));
 
     m_endpoint_pull_seq = push_pull_host_seq#(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH)::type_id::
         create("m_endpoint_pull_seq");

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -11,12 +11,12 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
   task body();
     // TODO: Temporary for developing rng_agent
     // Enable/Disable rng
-    csr_wr(.csr(ral.conf), .value(5'h10));
-    csr_wr(.csr(ral.conf), .value(5'h00));
-    csr_wr(.csr(ral.conf), .value(5'h10));
-    csr_wr(.csr(ral.conf), .value(5'h00));
-    csr_wr(.csr(ral.conf), .value(5'h10));
-    csr_wr(.csr(ral.conf), .value(5'h00));
+    csr_wr(.ptr(ral.conf), .value(5'h10));
+    csr_wr(.ptr(ral.conf), .value(5'h00));
+    csr_wr(.ptr(ral.conf), .value(5'h10));
+    csr_wr(.ptr(ral.conf), .value(5'h00));
+    csr_wr(.ptr(ral.conf), .value(5'h10));
+    csr_wr(.ptr(ral.conf), .value(5'h00));
   endtask : body
 
 endclass : entropy_src_rng_vseq

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_smoke_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_smoke_vseq.sv
@@ -12,13 +12,13 @@ class entropy_src_smoke_vseq extends entropy_src_base_vseq;
     csr_rd_check(.ptr(ral.entropy_data), .compare_value(1'b0));
 
     // Change entropy rate
-    csr_wr(.csr(ral.rate), .value('h8));
+    csr_wr(.ptr(ral.rate), .value('h8));
 
     // Route to ENTROPY_DATA register
-    csr_wr(.csr(ral.entropy_control), .value(1'b1));
+    csr_wr(.ptr(ral.entropy_control), .value(1'b1));
 
     // Enable entropy_src - lfsr mode
-    csr_wr(.csr(ral.conf), .value(2'b10));
+    csr_wr(.ptr(ral.conf), .value(2'b10));
 
     // Wait for entropy_valid interrupt
     csr_spinwait(.ptr(ral.intr_state.es_entropy_valid), .exp_data(1'b1));
@@ -32,7 +32,7 @@ class entropy_src_smoke_vseq extends entropy_src_base_vseq;
     csr_rd_check(.ptr(ral.intr_state), .compare_value(1'b1));
 
     // Clear entropy_valid interrupt bit
-    csr_wr(.csr(ral.intr_state), .value(1'b1));
+    csr_wr(.ptr(ral.intr_state), .value(1'b1));
 
     // Ensure entropy_valid interrupt bit cleared
     csr_rd_check(.ptr(ral.intr_state), .compare_value(1'b0));

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -50,7 +50,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
         get_csr_val_with_updated_field(ral.mp_region_cfg_0.base_0, data, region_cfg.start_page) |
         get_csr_val_with_updated_field(ral.mp_region_cfg_0.size_0, data, region_cfg.num_pages);
     csr = ral.get_reg_by_name($sformatf("mp_region_cfg_%0d", index));
-    csr_wr(.csr(csr), .value(data));
+    csr_wr(.ptr(csr), .value(data));
   endtask
 
   // Configure the protection for the "default" region (all pages that do not fall into one
@@ -61,12 +61,12 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     data = get_csr_val_with_updated_field(ral.default_region.rd_en, data, read_en) |
            get_csr_val_with_updated_field(ral.default_region.prog_en, data, program_en) |
            get_csr_val_with_updated_field(ral.default_region.erase_en, data, erase_en);
-    csr_wr(.csr(ral.default_region), .value(data));
+    csr_wr(.ptr(ral.default_region), .value(data));
   endtask
 
   // Configure bank erasability.
   virtual task flash_ctrl_bank_erase_cfg(bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en);
-    csr_wr(.csr(ral.mp_bank_cfg), .value(bank_erase_en));
+    csr_wr(.ptr(ral.mp_bank_cfg), .value(bank_erase_en));
   endtask
 
   // Configure read and program fifo levels for interrupt.
@@ -76,12 +76,12 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
     data = get_csr_val_with_updated_field(ral.fifo_lvl.prog, data, program_fifo_intr_level) |
            get_csr_val_with_updated_field(ral.fifo_lvl.rd, data, read_fifo_intr_level);
-    csr_wr(.csr(ral.fifo_lvl), .value(data));
+    csr_wr(.ptr(ral.fifo_lvl), .value(data));
   endtask
 
   // Reset the program and read fifos.
   virtual task flash_ctrl_fifo_reset(bit reset = 1'b1);
-    csr_wr(.csr(ral.fifo_rst), .value(reset));
+    csr_wr(.ptr(ral.fifo_rst), .value(reset));
   endtask
 
   // Wait for flash_ctrl op to finish.
@@ -99,7 +99,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     )
     if (clear_op_status) begin
       data = get_csr_val_with_updated_field(ral.op_status.done, data, 0);
-      csr_wr(.csr(ral.op_status), .value(data));
+      csr_wr(.ptr(ral.op_status), .value(data));
     end
   endtask
 
@@ -116,7 +116,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     )
     if (clear_op_status) begin
       data = get_csr_val_with_updated_field(ral.op_status.err, data, 0);
-      csr_wr(.csr(ral.op_status), .value(data));
+      csr_wr(.ptr(ral.op_status), .value(data));
     end
   endtask
 
@@ -150,7 +150,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     bit [InfoTypesWidth-1:0] info_sel;
 
 
-    csr_wr(.csr(ral.addr), .value(flash_op.addr));
+    csr_wr(.ptr(ral.addr), .value(flash_op.addr));
 
     // flash_op.partition -> partition_sel  ,    info_sel         |
     //  (flash_dv_part_e) | (flash_part_e)  | bit[InfoTypesWidth] |
@@ -169,7 +169,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
         get_csr_val_with_updated_field(ral.control.partition_sel, data, partition_sel) |
         get_csr_val_with_updated_field(ral.control.info_sel, data, info_sel) |
         get_csr_val_with_updated_field(ral.control.num, data, flash_op.num_words - 1);
-    csr_wr(.csr(ral.control), .value(data));
+    csr_wr(.ptr(ral.control), .value(data));
   endtask
 
   // Program data into flash, stopping whenever full.

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_dout_din_regs_random_rw_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_dout_din_regs_random_rw_vseq.sv
@@ -55,14 +55,14 @@ class gpio_dout_din_regs_random_rw_vseq extends gpio_base_vseq;
               cfg.clk_rst_vif.wait_clks(1);
               // DATA_IN register is RO, but writing random value to it
               // should have no impact on gpio functionality
-              csr_wr(.csr(ral.data_in), .value(csr_val));
+              csr_wr(.ptr(ral.data_in), .value(csr_val));
             end
-            1: csr_wr(.csr(ral.direct_out      ), .value(csr_val));
-            1: csr_wr(.csr(ral.direct_oe       ), .value(csr_val));
-            1: csr_wr(.csr(ral.masked_out_lower), .value(csr_val));
-            1: csr_wr(.csr(ral.masked_oe_lower ), .value(csr_val));
-            1: csr_wr(.csr(ral.masked_out_upper), .value(csr_val));
-            1: csr_wr(.csr(ral.masked_oe_upper ), .value(csr_val));
+            1: csr_wr(.ptr(ral.direct_out      ), .value(csr_val));
+            1: csr_wr(.ptr(ral.direct_oe       ), .value(csr_val));
+            1: csr_wr(.ptr(ral.masked_out_lower), .value(csr_val));
+            1: csr_wr(.ptr(ral.masked_oe_lower ), .value(csr_val));
+            1: csr_wr(.ptr(ral.masked_out_upper), .value(csr_val));
+            1: csr_wr(.ptr(ral.masked_oe_upper ), .value(csr_val));
           endcase
         end
         // read any one of the gpio data registers

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_full_random_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_full_random_vseq.sv
@@ -119,7 +119,7 @@ class gpio_full_random_vseq extends gpio_random_long_reg_writes_reg_reads_vseq;
           csr_wr_value[pin] = gpio_if_pins_o_val[pin];
         end
       end
-      csr_wr(.csr(ral.direct_out), .value(csr_wr_value));
+      csr_wr(.ptr(ral.direct_out), .value(csr_wr_value));
       // Update value of data_out
       data_out = csr_wr_value;
       `uvm_info(`gfn, $sformatf("data_out updated to value %0h", data_out), UVM_HIGH)
@@ -142,7 +142,7 @@ class gpio_full_random_vseq extends gpio_random_long_reg_writes_reg_reads_vseq;
       end
       // updated csr_wr_value
       csr_wr_value = {mask, data};
-      csr_wr(.csr(ral.masked_out_lower), .value(csr_wr_value));
+      csr_wr(.ptr(ral.masked_out_lower), .value(csr_wr_value));
       // Update data_out value
       for (uint pin = 0; pin < ral.masked_out_lower.mask.get_n_bits(); pin++) begin
         if (mask[pin] == 1'b1) begin
@@ -171,7 +171,7 @@ class gpio_full_random_vseq extends gpio_random_long_reg_writes_reg_reads_vseq;
       end
       // updated csr_wr_value
       csr_wr_value = {mask, data};
-      csr_wr(.csr(ral.masked_out_upper), .value(csr_wr_value));
+      csr_wr(.ptr(ral.masked_out_upper), .value(csr_wr_value));
       // Update value of data_out
       for (uint pin = 0; pin < ral.masked_out_upper.mask.get_n_bits(); pin++) begin
         if (mask[pin] == 1'b1) begin
@@ -191,7 +191,7 @@ class gpio_full_random_vseq extends gpio_random_long_reg_writes_reg_reads_vseq;
           csr_wr_value[pin] = 1'b0;
         end
       end
-      csr_wr(.csr(ral.direct_oe), .value(csr_wr_value));
+      csr_wr(.ptr(ral.direct_oe), .value(csr_wr_value));
       // Update data_oe value
       data_oe = csr_wr_value;
       `uvm_info(`gfn, $sformatf("data_oe updated to value %0h", data_oe), UVM_HIGH)
@@ -214,7 +214,7 @@ class gpio_full_random_vseq extends gpio_random_long_reg_writes_reg_reads_vseq;
       end
       // updated csr_wr_value
       csr_wr_value = {mask, data};
-      csr_wr(.csr(ral.masked_oe_lower), .value(csr_wr_value));
+      csr_wr(.ptr(ral.masked_oe_lower), .value(csr_wr_value));
       // Update data_oe value
       for (uint pin = 0; pin < ral.masked_oe_lower.mask.get_n_bits(); pin++) begin
         if (mask[pin] == 1'b1) begin
@@ -242,7 +242,7 @@ class gpio_full_random_vseq extends gpio_random_long_reg_writes_reg_reads_vseq;
       end
       // updated csr_wr_value
       csr_wr_value = {mask, data};
-      csr_wr(.csr(ral.masked_oe_upper), .value(csr_wr_value));
+      csr_wr(.ptr(ral.masked_oe_upper), .value(csr_wr_value));
       // Update data_oe value
       for (uint pin = 0; pin < ral.masked_oe_upper.mask.get_n_bits(); pin++) begin
         if (mask[pin] == 1'b1) begin

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_random_long_reg_writes_reg_reads_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_random_long_reg_writes_reg_reads_vseq.sv
@@ -66,48 +66,48 @@ class gpio_random_long_reg_writes_reg_reads_vseq extends gpio_base_vseq;
     randcase
       1: begin
         // Writing to DATA_IN reg
-        csr_wr(.csr(ral.data_in), .value(csr_wr_value));
+        csr_wr(.ptr(ral.data_in), .value(csr_wr_value));
       end
       1: begin
-        csr_wr(.csr(ral.direct_out), .value(csr_wr_value));
+        csr_wr(.ptr(ral.direct_out), .value(csr_wr_value));
       end
       1: begin
-        csr_wr(.csr(ral.masked_out_lower), .value(csr_wr_value));
+        csr_wr(.ptr(ral.masked_out_lower), .value(csr_wr_value));
       end
       1: begin
-        csr_wr(.csr(ral.masked_out_upper), .value(csr_wr_value));
+        csr_wr(.ptr(ral.masked_out_upper), .value(csr_wr_value));
       end
       1: begin
         undrive_gpio_in();
-        csr_wr(.csr(ral.direct_oe), .value(csr_wr_value));
+        csr_wr(.ptr(ral.direct_oe), .value(csr_wr_value));
       end
       1: begin
-        csr_wr(.csr(ral.masked_oe_lower), .value(csr_wr_value));
+        csr_wr(.ptr(ral.masked_oe_lower), .value(csr_wr_value));
       end
       1: begin
-        csr_wr(.csr(ral.masked_oe_upper), .value(csr_wr_value));
+        csr_wr(.ptr(ral.masked_oe_upper), .value(csr_wr_value));
       end
       1: begin
-        csr_wr(.csr(ral.intr_enable), .value(csr_wr_value));
+        csr_wr(.ptr(ral.intr_enable), .value(csr_wr_value));
       end
       1: begin
-        csr_wr(.csr(ral.intr_test), .value(csr_wr_value));
+        csr_wr(.ptr(ral.intr_test), .value(csr_wr_value));
         `uvm_info(`gfn, "Writing to intr_test", UVM_NONE)
       end
       1: begin
-        csr_wr(.csr(ral.intr_state), .value(csr_wr_value));
+        csr_wr(.ptr(ral.intr_state), .value(csr_wr_value));
       end
       1: begin
-        csr_wr(.csr(ral.intr_ctrl_en_falling), .value(csr_wr_value));
+        csr_wr(.ptr(ral.intr_ctrl_en_falling), .value(csr_wr_value));
       end
       1: begin
-        csr_wr(.csr(ral.intr_ctrl_en_rising), .value(csr_wr_value));
+        csr_wr(.ptr(ral.intr_ctrl_en_rising), .value(csr_wr_value));
       end
       1: begin
-        csr_wr(.csr(ral.intr_ctrl_en_lvllow), .value(csr_wr_value));
+        csr_wr(.ptr(ral.intr_ctrl_en_lvllow), .value(csr_wr_value));
       end
       1: begin
-        csr_wr(.csr(ral.intr_ctrl_en_lvlhigh), .value(csr_wr_value));
+        csr_wr(.ptr(ral.intr_ctrl_en_lvlhigh), .value(csr_wr_value));
       end
     endcase
   endtask : gpio_reg_wr

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -98,13 +98,13 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
 
   // trigger hash computation to start
   virtual task trigger_hash();
-    csr_wr(.csr(ral.cmd), .value(1'b1 << HashStart));
+    csr_wr(.ptr(ral.cmd), .value(1'b1 << HashStart));
     // if sha is not enabled, assert error interrupt and check error code
     if (!ral.cfg.sha_en.get_mirrored_value()) check_error_code();
   endtask
 
   virtual task trigger_process();
-    csr_wr(.csr(ral.cmd), .value(1'b1 << HashProcess));
+    csr_wr(.ptr(ral.cmd), .value(1'b1 << HashProcess));
   endtask
 
   virtual task trigger_hash_when_active();
@@ -241,7 +241,7 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
     csr_utils_pkg::wait_no_outstanding_access();
     csr_rd(ral.status, rdata);
     csr_rd(ral.intr_state, rdata);
-    csr_wr(.csr(ral.intr_state), .value(rdata));
+    csr_wr(.ptr(ral.intr_state), .value(rdata));
   endtask
 
   // this task is called when sha_en=0 and sequence set hash_start, or streamed in msg
@@ -256,11 +256,11 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
         check_interrupts(.interrupts((1 << HmacErr)), .check_set(1'b1));
       end else begin
         csr_rd_check(.ptr(ral.intr_state), .compare_value(1 << HmacErr));
-        csr_wr(.csr(ral.intr_state), .value(1 << HmacErr));
+        csr_wr(.ptr(ral.intr_state), .value(1 << HmacErr));
       end
     end else begin
       csr_rd(.ptr(ral.intr_state), .value(error_code));
-      csr_wr(.csr(ral.intr_state), .value(error_code));
+      csr_wr(.ptr(ral.intr_state), .value(error_code));
     end
     csr_rd(ral.err_code, error_code);
   endtask

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_smoke_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_smoke_vseq.sv
@@ -129,7 +129,7 @@ class hmac_smoke_vseq extends hmac_base_vseq;
           end
         end
         csr_rd(.ptr(ral.intr_state), .value(intr_state_val));
-        csr_wr(.csr(ral.intr_state), .value(intr_state_val));
+        csr_wr(.ptr(ral.intr_state), .value(intr_state_val));
       end
 
       // if disable sha, digest should be cleared

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_test_vectors_sha_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_test_vectors_sha_vseq.sv
@@ -62,7 +62,7 @@ class hmac_test_vectors_sha_vseq extends hmac_base_vseq;
 
         wait(cfg.intr_vif.pins[HmacDone] === 1'b1);
         csr_rd(.ptr(ral.intr_state), .value(intr_state_val));
-        csr_wr(.csr(ral.intr_state), .value(intr_state_val));
+        csr_wr(.ptr(ral.intr_state), .value(intr_state_val));
         // read digest and compare with the expected result, scb will calculate and check too
         compare_digest(parsed_vectors[j].exp_digest);
       end

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -224,7 +224,7 @@ class i2c_base_vseq extends cip_base_vseq #(
     csr_update(ral.fifo_ctrl);
 
     //enable then clear interrupts
-    csr_wr(.csr(ral.intr_enable), .value({TL_DW{1'b1}}));
+    csr_wr(.ptr(ral.intr_enable), .value({TL_DW{1'b1}}));
     process_interrupts();
   endtask : host_init
 
@@ -373,11 +373,11 @@ class i2c_base_vseq extends cip_base_vseq #(
 
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(clear_intr_dly)
     cfg.clk_rst_vif.wait_clks(clear_intr_dly);
-    csr_wr(.csr(ral.intr_state), .value(intr_clear));
+    csr_wr(.ptr(ral.intr_state), .value(intr_clear));
   endtask : process_interrupts
 
   virtual task clear_interrupt(i2c_intr_e intr, bit verify_clear = 1'b1);
-    csr_wr(.csr(ral.intr_state), .value(1 << intr));
+    csr_wr(.ptr(ral.intr_state), .value(1 << intr));
     if (verify_clear) wait(!cfg.intr_vif.pins[intr]);
   endtask : clear_interrupt
 

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -175,7 +175,7 @@ class keymgr_base_vseq extends cip_base_vseq #(
     // check for chech in scb and clear err_code
     csr_rd(.ptr(ral.err_code), .value(rd_val));
     if (rd_val != 0) begin
-      csr_wr(.csr(ral.err_code), .value(rd_val));
+      csr_wr(.ptr(ral.err_code), .value(rd_val));
     end
   endtask : wait_op_done
 

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
@@ -234,7 +234,7 @@ class kmac_base_vseq extends cip_base_vseq #(
     csr_update(.csr(ral.cfg));
 
     // setup KEY_LEN csr
-    csr_wr(.csr(ral.key_len), .value(key_len));
+    csr_wr(.ptr(ral.key_len), .value(key_len));
 
     // print debug info
     `uvm_info(`gfn, $sformatf("KMAC INITIALIZATION INFO:\n%0s", convert2string()), UVM_HIGH)
@@ -364,13 +364,13 @@ class kmac_base_vseq extends cip_base_vseq #(
     foreach (prefix_arr[i]) begin
       string csr_name = $sformatf("prefix_%0d", i);
       uvm_reg csr = ral.get_reg_by_name(csr_name);
-      csr_wr(.csr(csr), .value(prefix_arr[i]));
+      csr_wr(.ptr(csr), .value(prefix_arr[i]));
     end
   endtask
 
   // This task writes the given command to the CMD csr
   virtual task issue_cmd(kmac_cmd_e cmd);
-    csr_wr(.csr(ral.cmd), .value(cmd));
+    csr_wr(.ptr(ral.cmd), .value(cmd));
   endtask
 
   // This task commands KMAC to manually squeeze more output data,
@@ -387,7 +387,7 @@ class kmac_base_vseq extends cip_base_vseq #(
       for (int j = 0; j < KMAC_NUM_KEYS_PER_SHARE; j++) begin
         string csr_name = $sformatf("key_share%0d_%0d", i, j);
         uvm_reg csr = ral.get_reg_by_name(csr_name);
-        csr_wr(.csr(csr), .value(key_share[i][j]));
+        csr_wr(.ptr(csr), .value(key_share[i][j]));
       end
     end
 
@@ -400,8 +400,8 @@ class kmac_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task provide_sw_entropy();
-    csr_wr(.csr(ral.entropy_seed_lower), .value($urandom()));
-    csr_wr(.csr(ral.entropy_seed_upper), .value($urandom()));
+    csr_wr(.ptr(ral.entropy_seed_lower), .value($urandom()));
+    csr_wr(.ptr(ral.entropy_seed_upper), .value($urandom()));
   endtask
 
   // Call this task to initiate a KDF hashing operation
@@ -585,7 +585,7 @@ class kmac_base_vseq extends cip_base_vseq #(
     //
     // TODO: might need a way to determine when to check fifo-related state in the scoreboard
     csr_rd(.ptr(ral.intr_state), .value(irq_data));
-    csr_wr(.csr(ral.intr_state), .value(irq_data));
+    csr_wr(.ptr(ral.intr_state), .value(irq_data));
 
     csr_spinwait(.ptr(ral.status.fifo_full), .exp_data(1'b0));
   endtask
@@ -603,7 +603,7 @@ class kmac_base_vseq extends cip_base_vseq #(
     end
     // read and clear intr_state
     csr_rd(.ptr(ral.intr_state), .value(intr_state));
-    csr_wr(.csr(ral.intr_state), .value(intr_state));
+    csr_wr(.ptr(ral.intr_state), .value(intr_state));
   endtask
 
   // This task reads a chunk of data from the STATE window and appends it to the `digest`

--- a/hw/ip/pattgen/dv/env/seq_lib/pattgen_base_vseq.sv
+++ b/hw/ip/pattgen/dv/env/seq_lib/pattgen_base_vseq.sv
@@ -73,7 +73,7 @@ class pattgen_base_vseq extends cip_base_vseq #(
 
   // setup basic pattgen features
   virtual task initialize_dut();
-    csr_wr(.csr(ral.intr_enable), .value({TL_DW{1'b1}}));
+    csr_wr(.ptr(ral.intr_enable), .value({TL_DW{1'b1}}));
     `uvm_info(`gfn, "\n  call pattgen_init", UVM_DEBUG)
   endtask : initialize_dut
 
@@ -109,9 +109,9 @@ class pattgen_base_vseq extends cip_base_vseq #(
       ral.size.len_ch0.set(channel_cfg[0].len);
       ral.size.reps_ch0.set(channel_cfg[0].reps);
       csr_update(ral.size);
-      csr_wr(.csr(ral.prediv_ch0), .value(channel_cfg[0].prediv));
-      csr_wr(.csr(ral.data_ch0_0), .value(channel_cfg[0].data[31:0]));
-      csr_wr(.csr(ral.data_ch0_1), .value(channel_cfg[0].data[63:32]));
+      csr_wr(.ptr(ral.prediv_ch0), .value(channel_cfg[0].prediv));
+      csr_wr(.ptr(ral.data_ch0_0), .value(channel_cfg[0].data[31:0]));
+      csr_wr(.ptr(ral.data_ch0_1), .value(channel_cfg[0].data[63:32]));
       ral.ctrl.polarity_ch0.set(channel_cfg[0].polarity);
       update_pattgen_agent_cfg(.channel(0));
       csr_update(ral.ctrl);
@@ -131,9 +131,9 @@ class pattgen_base_vseq extends cip_base_vseq #(
       ral.size.len_ch1.set(channel_cfg[1].len);
       ral.size.reps_ch1.set(channel_cfg[1].reps);
       csr_update(ral.size);
-      csr_wr(.csr(ral.prediv_ch1), .value(channel_cfg[1].prediv));
-      csr_wr(.csr(ral.data_ch1_0), .value(channel_cfg[1].data[31:0]));
-      csr_wr(.csr(ral.data_ch1_1), .value(channel_cfg[1].data[63:32]));
+      csr_wr(.ptr(ral.prediv_ch1), .value(channel_cfg[1].prediv));
+      csr_wr(.ptr(ral.data_ch1_0), .value(channel_cfg[1].data[31:0]));
+      csr_wr(.ptr(ral.data_ch1_1), .value(channel_cfg[1].data[63:32]));
       ral.ctrl.polarity_ch1.set(channel_cfg[1].polarity);
       update_pattgen_agent_cfg(.channel(1));
       csr_update(ral.ctrl);
@@ -329,7 +329,7 @@ class pattgen_base_vseq extends cip_base_vseq #(
       endcase
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(clear_intr_dly)
       cfg.clk_rst_vif.wait_clks(clear_intr_dly);
-      csr_wr(.csr(ral.intr_state), .value(intr_clear));
+      csr_wr(.ptr(ral.intr_state), .value(intr_clear));
     end else begin
       `uvm_info(`gfn, $sformatf("\n  channel error, no clear interrupts %b", intr_clear), UVM_DEBUG)
     end

--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_base_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_base_vseq.sv
@@ -148,7 +148,7 @@ class rv_timer_base_vseq extends cip_base_vseq #(
 
     if ($urandom_range(0, 1)) begin
       wr_value = 1 << timer;
-      csr_wr(.csr(intr_state_rg), .value(wr_value));
+      csr_wr(.ptr(intr_state_rg), .value(wr_value));
     end else begin
       wr_value = $urandom();
       set_compare_val(hart, timer, wr_value);

--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_cfg_update_on_fly_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_cfg_update_on_fly_vseq.sv
@@ -40,7 +40,7 @@ class rv_timer_cfg_update_on_fly_vseq extends rv_timer_random_vseq;
       `uvm_info(`gfn, $sformatf("Running test iteration %0d/%0d", trans, num_trans), UVM_LOW)
 
       // disable timers
-      csr_wr(.csr(ral.ctrl), .value(ral.ctrl.get_reset()));
+      csr_wr(.ptr(ral.ctrl), .value(ral.ctrl.get_reset()));
 
       for (int hart = 0; hart < NUM_HARTS; hart++) begin
         for (int timer = 0; timer < NUM_TIMERS; timer++) begin

--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_disabled_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_disabled_vseq.sv
@@ -17,7 +17,7 @@ class rv_timer_disabled_vseq extends rv_timer_random_vseq;
       `DV_CHECK_RANDOMIZE_FATAL(this)
 
       // disable timers
-      csr_wr(.csr(ral.ctrl), .value(ral.ctrl.get_reset()));
+      csr_wr(.ptr(ral.ctrl), .value(ral.ctrl.get_reset()));
 
       // configure the timers and harts based on rand fields
       cfg_all_timers();

--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_random_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_random_vseq.sv
@@ -107,7 +107,7 @@ class rv_timer_random_vseq extends rv_timer_base_vseq;
       if (trans > 1) `DV_CHECK_RANDOMIZE_FATAL(this)
 
       // disable timers first
-      csr_wr(.csr(ral.ctrl), .value(ral.ctrl.get_reset()));
+      csr_wr(.ptr(ral.ctrl), .value(ral.ctrl.get_reset()));
 
       // configure the timers and harts based on rand fields
       cfg_all_timers();
@@ -151,7 +151,7 @@ class rv_timer_random_vseq extends rv_timer_base_vseq;
       join
 
       // Disable timers.
-      csr_wr(.csr(ral.ctrl), .value(ral.ctrl.get_reset()));
+      csr_wr(.ptr(ral.ctrl), .value(ral.ctrl.get_reset()));
 
       // Write one to clear the interrupt status.
       for (int i = 0; i < NUM_HARTS; i++) begin

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -237,7 +237,7 @@ class spi_device_base_vseq extends cip_base_vseq #(
 
     // update txf_ptr.wptr
     tx_wptr = get_csr_val_with_updated_field(ral.txf_ptr.wptr, ral.txf_ptr.get(), tx_wptr);
-    csr_wr(.csr(ral.txf_ptr), .value(tx_wptr));
+    csr_wr(.ptr(ral.txf_ptr), .value(tx_wptr));
   endtask
 
   // read spi host data received from the host
@@ -267,7 +267,7 @@ class spi_device_base_vseq extends cip_base_vseq #(
     end
 
     // update rxf_ptr.rptr
-    csr_wr(.csr(ral.rxf_ptr), .value(rx_rptr));
+    csr_wr(.ptr(ral.rxf_ptr), .value(rx_rptr));
   endtask
 
   virtual task read_tx_avail_bytes(sram_avail_type_e avail_type, ref uint avail_bytes);

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_intr_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_intr_vseq.sv
@@ -26,7 +26,7 @@ class spi_device_intr_vseq extends spi_device_txrx_vseq;
         // clean up rx fifo
         process_rx_read(ASYNC_FIFO_SIZE);
         // clean interrupts
-        csr_wr(.csr(ral.intr_state), .value('1));
+        csr_wr(.ptr(ral.intr_state), .value('1));
       end
 
       repeat (NumSpiDevIntr) begin
@@ -35,7 +35,7 @@ class spi_device_intr_vseq extends spi_device_txrx_vseq;
         `uvm_info(`gfn, $sformatf("\nTesting %0s", spi_dev_intr.name), UVM_LOW)
         drive_and_check_one_intr(spi_dev_intr);
 
-        csr_wr(.csr(ral.intr_state), .value('1));
+        csr_wr(.ptr(ral.intr_state), .value('1));
         check_for_tx_rx_idle();
       end
       `uvm_info(`gfn, $sformatf("finished run %0d/%0d", i, num_trans), UVM_LOW)
@@ -93,7 +93,7 @@ class spi_device_intr_vseq extends spi_device_txrx_vseq;
 
           // clean interrupts and test it's edge triggered
           filled_bytes = aligned_watermark + SRAM_WORD_SIZE;
-          csr_wr(.csr(ral.intr_state), .value('1));
+          csr_wr(.ptr(ral.intr_state), .value('1));
           spi_host_xfer_bytes(SRAM_WORD_SIZE, device_bytes_q);
           wait_for_rx_avail_bytes(filled_bytes, SramDataAvail, avail_bytes);
           check_interrupts(.interrupts(1 << RxFifoGeLevel), .check_set(0));

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
@@ -42,7 +42,7 @@ class sram_ctrl_base_vseq extends cip_base_vseq #(
   //
   // Will trigger a request to the KDI push_pull agent.
   virtual task req_scr_key();
-    csr_wr(.csr(ral.ctrl), .value(1'b1));
+    csr_wr(.ptr(ral.ctrl), .value(1'b1));
   endtask
 
   // Task to perform a single SRAM read at the specified location

--- a/hw/ip/uart/dv/env/seq_lib/uart_base_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_base_vseq.sv
@@ -145,7 +145,7 @@ class uart_base_vseq extends cip_base_vseq #(.CFG_T               (uart_env_cfg)
 
   // task to send a byte of data out of dut
   virtual task send_tx_byte(byte data);
-    csr_wr(.csr(ral.wdata), .value(data));
+    csr_wr(.ptr(ral.wdata), .value(data));
   endtask
 
   // task to send a byte of data into dut, can override it to test error cases

--- a/hw/ip/uart/dv/env/seq_lib/uart_intr_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_intr_vseq.sv
@@ -37,7 +37,7 @@ class uart_intr_vseq extends uart_base_vseq;
         // tx may have unfinished transaction
         spinwait_txidle();
         dut_shutdown();
-        csr_wr(.csr(ral.intr_state), .value('hff));
+        csr_wr(.ptr(ral.intr_state), .value('hff));
       end
       `uvm_info(`gfn, $sformatf("finished run %0d/%0d", i, num_trans), UVM_LOW)
     end
@@ -68,7 +68,7 @@ class uart_intr_vseq extends uart_base_vseq;
         check_one_intr(.uart_intr(uart_intr), .exp(1));
         cfg.m_uart_agent_cfg.vif.wait_for_tx_idle();
         // check interrupt is non-sticky
-        csr_wr(.csr(ral.intr_state), .value(1 << uart_intr));
+        csr_wr(.ptr(ral.intr_state), .value(1 << uart_intr));
         drive_tx_bytes(.num_bytes(watermark_bytes - 1));
         check_one_intr(.uart_intr(uart_intr), .exp(0));
         cfg.m_uart_agent_cfg.vif.wait_for_tx_idle();
@@ -82,7 +82,7 @@ class uart_intr_vseq extends uart_base_vseq;
         drive_rx_bytes(.num_bytes(1));
         check_one_intr(.uart_intr(uart_intr), .exp(en_rx));
         // check interrupt is non-sticky
-        csr_wr(.csr(ral.intr_state), .value(1 << uart_intr));
+        csr_wr(.ptr(ral.intr_state), .value(1 << uart_intr));
         drive_rx_bytes(.num_bytes(1));
         check_one_intr(.uart_intr(uart_intr), .exp(0));
       end
@@ -95,7 +95,7 @@ class uart_intr_vseq extends uart_base_vseq;
           spinwait_txidle();
           check_one_intr(.uart_intr(uart_intr), .exp(1));
           // check interrupt is non-sticky
-          csr_wr(.csr(ral.intr_state), .value(1 << uart_intr));
+          csr_wr(.ptr(ral.intr_state), .value(1 << uart_intr));
           check_one_intr(.uart_intr(uart_intr), .exp(0));
         end
       end
@@ -130,7 +130,7 @@ class uart_intr_vseq extends uart_base_vseq;
         drive_rx_bytes(.num_bytes(1));
         // clear rx fifo and interrupts triggered by above driving
         clear_fifos(.clear_tx_fifo(0), .clear_rx_fifo(1));
-        csr_wr(.csr(ral.intr_state), .value('hff));
+        csr_wr(.ptr(ral.intr_state), .value('hff));
 
         fork
           begin
@@ -192,11 +192,11 @@ class uart_intr_vseq extends uart_base_vseq;
         check_one_intr(.uart_intr(uart_intr), .exp(0));
         wait_for_baud_clock_cycles(2);
         check_one_intr(.uart_intr(uart_intr), .exp(en_rx & en_timeout));
-        csr_wr(.csr(ral.intr_state), .value('hff));
+        csr_wr(.ptr(ral.intr_state), .value('hff));
         // expect timeout again since no fifo activity
         wait_for_baud_clock_cycles(timeout_val);
         check_one_intr(.uart_intr(uart_intr), .exp(en_rx & en_timeout));
-        csr_wr(.csr(ral.intr_state), .value('hff));
+        csr_wr(.ptr(ral.intr_state), .value('hff));
 
         if (!en_rx) return;
         // reset timeout timer by issuing a rdata read
@@ -267,7 +267,7 @@ class uart_intr_vseq extends uart_base_vseq;
         "uart_intr val: %0h, en_intr: %0h", exp, en_intr))
 
     if (do_clear) begin
-      csr_wr(.csr(ral.intr_state), .value(exp));
+      csr_wr(.ptr(ral.intr_state), .value(exp));
     end
   endtask : check_all_intr
 

--- a/hw/ip/uart/dv/env/seq_lib/uart_loopback_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_loopback_vseq.sv
@@ -49,7 +49,7 @@ class uart_loopback_vseq extends uart_tx_rx_vseq;
     spinwait_rxidle();
     csr_rd_check(.ptr(ral.rdata), .compare_value(tx_byte));
     // clear TxEmpty interrupt
-    csr_wr(.csr(ral.intr_state), .value(1 << TxEmpty));
+    csr_wr(.ptr(ral.intr_state), .value(1 << TxEmpty));
     // check status is default value
     csr_rd_check(.ptr(ral.status), .compare_value(ral.status.get_reset()));
 

--- a/hw/ip/uart/dv/env/seq_lib/uart_rx_oversample_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_rx_oversample_vseq.sv
@@ -45,7 +45,7 @@ class uart_rx_oversample_vseq extends uart_tx_rx_vseq;
     clear_fifos(.clear_rx_fifo(1), .clear_tx_fifo(0));
     // clear all interrupts as the driving of rx value in seq may trigger interrupt that scb
     // doesn't expect
-    csr_wr(.csr(ral.intr_state), .value('1));
+    csr_wr(.ptr(ral.intr_state), .value('1));
   endtask : body
 
   // find the center of oversampled clk

--- a/hw/ip/uart/dv/env/seq_lib/uart_tx_ovrd_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_tx_ovrd_vseq.sv
@@ -26,13 +26,13 @@ class uart_tx_ovrd_vseq extends uart_smoke_vseq;
 
       if (en_ovrd) exp = txval;
       else         exp = 1;
-      csr_wr(.csr(ral.ovrd), .value({txval, en_ovrd}));
+      csr_wr(.ptr(ral.ovrd), .value({txval, en_ovrd}));
       cfg.clk_rst_vif.wait_clks(1);
       if (!cfg.under_reset) `DV_CHECK_EQ(cfg.m_uart_agent_cfg.vif.uart_tx, exp)
       cfg.clk_rst_vif.wait_clks(dly_to_next_trans);
     end
     // disable ovrd
-    csr_wr(.csr(ral.ovrd), .value(0));
+    csr_wr(.ptr(ral.ovrd), .value(0));
     cfg.clk_rst_vif.wait_clks(1);
     cfg.m_uart_agent_cfg.en_tx_monitor = 1;
 

--- a/hw/ip/uart/dv/env/seq_lib/uart_tx_rx_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_tx_rx_vseq.sv
@@ -158,7 +158,7 @@ class uart_tx_rx_vseq extends uart_base_vseq;
     clear_rx_intr = clear_intr[RxWatermark] | clear_intr[RxOverflow] | clear_intr[RxFrameErr] |
                     clear_intr[RxParityErr];
     wait_when_in_ignored_period(clear_tx_intr, clear_rx_intr);
-    csr_wr(.csr(ral.intr_state), .value(clear_intr));
+    csr_wr(.ptr(ral.intr_state), .value(clear_intr));
   endtask
 
   virtual task process_tx();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_shadow_reg_errors_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_shadow_reg_errors_vseq.sv
@@ -42,14 +42,14 @@ class chip_shadow_reg_errors_vseq extends chip_common_vseq;
                                          {BkdrRegPathRtlCommitted, BkdrRegPathRtlShadow};)
       csr_peek(.ptr(shadowed_csrs[i]), .value(origin_val), .kind(kind));
       poke_val = gen_storage_err_val(shadowed_csrs[i], origin_val, 0);
-      csr_poke(.csr(shadowed_csrs[i]), .value(poke_val), .kind(kind), .predict(1));
+      csr_poke(.ptr(shadowed_csrs[i]), .value(poke_val), .kind(kind), .predict(1));
 
       // Check storage error alerts
       alert_name = shadowed_csrs[i].get_storage_err_alert_name();
       `DV_SPINWAIT(while (!cfg.m_alert_agent_cfg[alert_name].vif.get_alert())
                    cfg.clk_rst_vif.wait_clks(1);,
                    $sformatf("%0s storage_err alert not detected", shadowed_csrs[i].get_name()));
-      csr_poke(.csr(shadowed_csrs[i]), .value(origin_val), .kind(kind), .predict(1));
+      csr_poke(.ptr(shadowed_csrs[i]), .value(origin_val), .kind(kind), .predict(1));
       `DV_SPINWAIT(cfg.m_alert_agent_cfg[alert_name].vif.wait_ack_complete();,
                    $sformatf("timeout for alert:%0s", alert_name))
     end
@@ -59,7 +59,7 @@ class chip_shadow_reg_errors_vseq extends chip_common_vseq;
   // and the second write is 'haaaa_aaaa
   // If any shadow reg does not follow this, can add additional requirements to this task
   virtual task wr_shadowed_reg_update_err(dv_base_reg csr, output bit alert_triggered);
-    csr_wr(.csr(csr), .value('h5555_5555), .en_shadow_wr(0), .predict(1));
+    csr_wr(.ptr(csr), .value('h5555_5555), .en_shadow_wr(0), .predict(1));
     shadow_reg_wr(.csr(csr), .wdata('haaaa_aaaa), .alert_triggered(alert_triggered));
   endtask : wr_shadowed_reg_update_err
 


### PR DESCRIPTION
for field write, use `csr_wr(.ptr(ral.csr.fld), ...)`, 
similar update is added for `csr_poke`
Using `csr_wr(.csr(...)) will have compile error, it's now `ptr`, 
which can be `csr` or a `field` of CSR

Signed-off-by: Weicai Yang <weicai@google.com>