### PR TITLE
[sw, dif_aon_timer] DIF AON Timer to S1

### DIFF
--- a/hw/ip/aon_timer/data/aon_timer.prj.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.prj.hjson
@@ -12,5 +12,5 @@
     life_stage:         "L1",
     design_stage:       "D1",
     verification_stage: "V0",
-    dif_stage:          "S0",
+    dif_stage:          "S1",
 }

--- a/sw/device/lib/dif/dif_aon_timer.c
+++ b/sw/device/lib/dif/dif_aon_timer.c
@@ -4,7 +4,315 @@
 
 #include "sw/device/lib/dif/dif_aon_timer.h"
 
+#include <stddef.h>
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/mmio.h"
+
 #include "aon_timer_regs.h"  // Generated.
 
-// This just exists to check that the header compiles for now. The actual
-// implementation is work in progress.
+_Static_assert(AON_TIMER_INTR_STATE_WKUP_TIMER_EXPIRED_BIT ==
+                   AON_TIMER_INTR_TEST_WKUP_TIMER_EXPIRED_BIT,
+               "Wake-up IRQ have different indexes in different registers!");
+_Static_assert(AON_TIMER_INTR_STATE_WDOG_TIMER_EXPIRED_BIT ==
+                   AON_TIMER_INTR_TEST_WDOG_TIMER_EXPIRED_BIT,
+               "Watchdog IRQ have different indexes in different registers!");
+
+const size_t kAonTimerWakeupIrqIndex =
+    AON_TIMER_INTR_STATE_WKUP_TIMER_EXPIRED_BIT;
+
+const size_t kAonTimerWatchdogIrqIndex =
+    AON_TIMER_INTR_STATE_WDOG_TIMER_EXPIRED_BIT;
+
+static void aon_clear_wakeup_counter(const dif_aon_timer_t *aon) {
+  mmio_region_write32(aon->params.base_addr, AON_TIMER_WKUP_COUNT_REG_OFFSET,
+                      0);
+}
+
+static void aon_toggle_wakeup_timer(const dif_aon_timer_t *aon, bool enable) {
+  uint32_t reg =
+      mmio_region_read32(aon->params.base_addr, AON_TIMER_WKUP_CTRL_REG_OFFSET);
+  reg = bitfield_bit32_write(reg, AON_TIMER_WKUP_CTRL_ENABLE_BIT, enable);
+  mmio_region_write32(aon->params.base_addr, AON_TIMER_WKUP_CTRL_REG_OFFSET,
+                      reg);
+}
+
+static void aon_clear_watchdog_counter(const dif_aon_timer_t *aon) {
+  mmio_region_write32(aon->params.base_addr, AON_TIMER_WDOG_COUNT_REG_OFFSET,
+                      0);
+}
+
+static void aon_toggle_watchdog_timer(const dif_aon_timer_t *aon, bool enable) {
+  uint32_t reg =
+      mmio_region_read32(aon->params.base_addr, AON_TIMER_WDOG_CTRL_REG_OFFSET);
+  reg = bitfield_bit32_write(reg, AON_TIMER_WDOG_CTRL_ENABLE_BIT, enable);
+  mmio_region_write32(aon->params.base_addr, AON_TIMER_WDOG_CTRL_REG_OFFSET,
+                      reg);
+}
+
+static void aon_timer_watchdog_lock(const dif_aon_timer_t *aon) {
+  // Clear bit to lock the watchdog configuration register until the next reset.
+  // Write one to clear the bit.
+  mmio_region_write32(aon->params.base_addr, AON_TIMER_WDOG_REGWEN_REG_OFFSET,
+                      0x00000001);
+}
+
+static bool aon_watchdog_is_locked(const dif_aon_timer_t *aon) {
+  uint32_t reg = mmio_region_read32(aon->params.base_addr,
+                                    AON_TIMER_WDOG_REGWEN_REG_OFFSET);
+
+  // Locked when bit is cleared.
+  return !bitfield_bit32_read(reg, AON_TIMER_WDOG_REGWEN_REGWEN_BIT);
+}
+
+static bool aon_timer_get_irq_index(dif_aon_timer_irq_t irq, uint32_t *index) {
+  switch (irq) {
+    case kDifAonTimerIrqWakeupThreshold:
+      *index = kAonTimerWakeupIrqIndex;
+      break;
+    case kDifAonTimerIrqWatchdogBarkThreshold:
+      *index = kAonTimerWatchdogIrqIndex;
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+dif_aon_timer_result_t dif_aon_timer_init(dif_aon_timer_params_t params,
+                                          dif_aon_timer_t *aon) {
+  if (aon == NULL) {
+    return kDifAonTimerBadArg;
+  }
+
+  *aon = (dif_aon_timer_t){.params = params};
+
+  return kDifAonTimerOk;
+}
+
+dif_aon_timer_result_t dif_aon_timer_wakeup_start(const dif_aon_timer_t *aon,
+                                                  uint32_t threshold,
+                                                  uint32_t prescaler) {
+  if (aon == NULL || prescaler > AON_TIMER_WKUP_CTRL_PRESCALER_MASK) {
+    return kDifAonTimerBadArg;
+  }
+
+  // The timer should be stopped first, otherwise it will continue counting up.
+  aon_toggle_wakeup_timer(aon, false);
+  aon_clear_wakeup_counter(aon);
+
+  mmio_region_write32(aon->params.base_addr, AON_TIMER_WKUP_THOLD_REG_OFFSET,
+                      threshold);
+
+  uint32_t reg =
+      bitfield_field32_write(0, AON_TIMER_WKUP_CTRL_PRESCALER_FIELD, prescaler);
+  reg = bitfield_bit32_write(reg, AON_TIMER_WKUP_CTRL_ENABLE_BIT, true);
+  mmio_region_write32(aon->params.base_addr, AON_TIMER_WKUP_CTRL_REG_OFFSET,
+                      reg);
+
+  return kDifAonTimerOk;
+}
+
+dif_aon_timer_result_t dif_aon_timer_wakeup_stop(const dif_aon_timer_t *aon) {
+  if (aon == NULL) {
+    return kDifAonTimerBadArg;
+  }
+
+  aon_toggle_wakeup_timer(aon, false);
+
+  return kDifAonTimerOk;
+}
+
+dif_aon_timer_result_t dif_aon_timer_wakeup_restart(
+    const dif_aon_timer_t *aon) {
+  if (aon == NULL) {
+    return kDifAonTimerBadArg;
+  }
+
+  aon_clear_wakeup_counter(aon);
+  aon_toggle_wakeup_timer(aon, true);
+
+  return kDifAonTimerOk;
+}
+
+dif_aon_timer_result_t dif_aon_timer_wakeup_get_count(
+    const dif_aon_timer_t *aon, uint32_t *count) {
+  if (aon == NULL || count == NULL) {
+    return kDifAonTimerBadArg;
+  }
+
+  *count = mmio_region_read32(aon->params.base_addr,
+                              AON_TIMER_WKUP_COUNT_REG_OFFSET);
+
+  return kDifAonTimerOk;
+}
+
+dif_aon_timer_watchdog_result_t dif_aon_timer_watchdog_start(
+    const dif_aon_timer_t *aon, uint32_t bark_threshold,
+    uint32_t bite_threshold, bool pause_in_sleep, bool lock) {
+  if (aon == NULL) {
+    return kDifAonTimerWatchdogBadArg;
+  }
+
+  if (aon_watchdog_is_locked(aon)) {
+    return kDifAonTimerWatchdogLocked;
+  }
+
+  // The timer should be stopped first, otherwise it will continue counting up.
+  aon_toggle_watchdog_timer(aon, false);
+  aon_clear_watchdog_counter(aon);
+
+  mmio_region_write32(aon->params.base_addr,
+                      AON_TIMER_WDOG_BARK_THOLD_REG_OFFSET, bark_threshold);
+  mmio_region_write32(aon->params.base_addr,
+                      AON_TIMER_WDOG_BITE_THOLD_REG_OFFSET, bite_threshold);
+
+  uint32_t reg = bitfield_bit32_write(0, AON_TIMER_WDOG_CTRL_ENABLE_BIT, true);
+  if (pause_in_sleep) {
+    reg =
+        bitfield_bit32_write(reg, AON_TIMER_WDOG_CTRL_PAUSE_IN_SLEEP_BIT, true);
+  }
+  mmio_region_write32(aon->params.base_addr, AON_TIMER_WDOG_CTRL_REG_OFFSET,
+                      reg);
+
+  // Watchdog control register should only be locked after the last
+  // control register access.
+  if (lock) {
+    aon_timer_watchdog_lock(aon);
+  }
+
+  return kDifAonTimerWatchdogOk;
+}
+
+dif_aon_timer_watchdog_result_t dif_aon_timer_watchdog_stop(
+    const dif_aon_timer_t *aon) {
+  if (aon == NULL) {
+    return kDifAonTimerWatchdogBadArg;
+  }
+
+  if (aon_watchdog_is_locked(aon)) {
+    return kDifAonTimerWatchdogLocked;
+  }
+
+  aon_toggle_watchdog_timer(aon, false);
+
+  return kDifAonTimerWatchdogOk;
+}
+
+dif_aon_timer_watchdog_result_t dif_aon_timer_watchdog_restart(
+    const dif_aon_timer_t *aon) {
+  if (aon == NULL) {
+    return kDifAonTimerWatchdogBadArg;
+  }
+
+  if (aon_watchdog_is_locked(aon)) {
+    return kDifAonTimerWatchdogLocked;
+  }
+
+  aon_clear_watchdog_counter(aon);
+  aon_toggle_watchdog_timer(aon, true);
+
+  return kDifAonTimerWatchdogOk;
+}
+
+dif_aon_timer_result_t dif_aon_timer_watchdog_get_count(
+    const dif_aon_timer_t *aon, uint32_t *count) {
+  if (aon == NULL || count == NULL) {
+    return kDifAonTimerBadArg;
+  }
+
+  *count = mmio_region_read32(aon->params.base_addr,
+                              AON_TIMER_WDOG_COUNT_REG_OFFSET);
+
+  return kDifAonTimerOk;
+}
+
+dif_aon_timer_result_t dif_aon_timer_watchdog_pet(const dif_aon_timer_t *aon) {
+  if (aon == NULL) {
+    return kDifAonTimerBadArg;
+  }
+
+  aon_clear_watchdog_counter(aon);
+
+  return kDifAonTimerOk;
+}
+
+dif_aon_timer_watchdog_result_t dif_aon_timer_watchdog_lock(
+    const dif_aon_timer_t *aon) {
+  if (aon == NULL) {
+    return kDifAonTimerWatchdogBadArg;
+  }
+
+  aon_timer_watchdog_lock(aon);
+
+  return kDifAonTimerWatchdogOk;
+}
+
+dif_aon_timer_result_t dif_aon_timer_watchdog_is_locked(
+    const dif_aon_timer_t *aon, bool *is_locked) {
+  if (aon == NULL || is_locked == NULL) {
+    return kDifAonTimerBadArg;
+  }
+
+  *is_locked = aon_watchdog_is_locked(aon);
+
+  return kDifAonTimerOk;
+}
+
+dif_aon_timer_result_t dif_aon_timer_irq_is_pending(const dif_aon_timer_t *aon,
+                                                    dif_aon_timer_irq_t irq,
+                                                    bool *is_pending) {
+  if (aon == NULL || is_pending == NULL) {
+    return kDifAonTimerBadArg;
+  }
+
+  uint32_t index = 0;
+  if (!aon_timer_get_irq_index(irq, &index)) {
+    return kDifAonTimerError;
+  }
+
+  uint32_t reg = mmio_region_read32(aon->params.base_addr,
+                                    AON_TIMER_INTR_STATE_REG_OFFSET);
+  *is_pending = bitfield_bit32_read(reg, index);
+
+  return kDifAonTimerOk;
+}
+
+dif_aon_timer_result_t dif_aon_timer_irq_acknowledge(const dif_aon_timer_t *aon,
+                                                     dif_aon_timer_irq_t irq) {
+  if (aon == NULL) {
+    return kDifAonTimerBadArg;
+  }
+
+  uint32_t index = 0;
+  if (!aon_timer_get_irq_index(irq, &index)) {
+    return kDifAonTimerError;
+  }
+
+  // Write one to clear.
+  uint32_t reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(aon->params.base_addr, AON_TIMER_INTR_STATE_REG_OFFSET,
+                      reg);
+
+  return kDifAonTimerOk;
+}
+
+dif_aon_timer_result_t dif_aon_timer_irq_force(const dif_aon_timer_t *aon,
+                                               dif_aon_timer_irq_t irq) {
+  if (aon == NULL) {
+    return kDifAonTimerBadArg;
+  }
+
+  uint32_t index = 0;
+  if (!aon_timer_get_irq_index(irq, &index)) {
+    return kDifAonTimerError;
+  }
+
+  // Write only register.
+  uint32_t reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(aon->params.base_addr, AON_TIMER_INTR_TEST_REG_OFFSET,
+                      reg);
+
+  return kDifAonTimerOk;
+}

--- a/sw/device/lib/dif/dif_aon_timer.h
+++ b/sw/device/lib/dif/dif_aon_timer.h
@@ -118,7 +118,12 @@ DIF_WARN_UNUSED_RESULT
 dif_aon_timer_result_t dif_aon_timer_init(dif_aon_timer_params_t params,
                                           dif_aon_timer_t *aon);
 
-/** Starts Always-On Timer (wake-up timer).
+/**
+ * Starts Always-On Timer (wake-up timer).
+ *
+ * This operation starts the wake-up timer with the provided configuration.
+ * Note that the timer is stopped and counter cleared, before the timer is
+ * started with the new configuration.
  *
  * @param aon An Always-On Timer handle.
  * @param threshold Threshold in ticks.
@@ -163,6 +168,10 @@ dif_aon_timer_result_t dif_aon_timer_wakeup_get_count(
     const dif_aon_timer_t *aon, uint32_t *count);
 
 /** Starts Always-On Timer (watchdog timer).
+ *
+ * This operation starts the watchdog timer with the provided configuration.
+ * Note that the timer is stopped and counter cleared, before the timer is
+ * started with the new configuration.
  *
  * @param aon An Always-On Timer handle.
  * @param bark_threshold "Bark" threshold in ticks.
@@ -245,7 +254,7 @@ dif_aon_timer_watchdog_result_t dif_aon_timer_watchdog_lock(
  * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
-dif_aon_timer_watchdog_result_t dif_aon_timer_watchdog_is_locked(
+dif_aon_timer_result_t dif_aon_timer_watchdog_is_locked(
     const dif_aon_timer_t *aon, bool *is_locked);
 
 /**

--- a/sw/device/lib/dif/dif_aon_timer.md
+++ b/sw/device/lib/dif/dif_aon_timer.md
@@ -9,10 +9,10 @@ All checklist items refer to the content in the [Checklist]({{< relref "/doc/pro
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
-Implementation | [DIF_EXISTS][]       | Started     |
-Implementation | [DIF_USED_IN_TREE][] | Not Started |
-Tests          | [DIF_TEST_UNIT][]    | Not Started |
-Tests          | [DIF_TEST_SMOKE][]   | Not Started |
+Implementation | [DIF_EXISTS][]       | Done        |
+Implementation | [DIF_USED_IN_TREE][] | Done        |
+Tests          | [DIF_TEST_UNIT][]    | Done        |
+Tests          | [DIF_TEST_SMOKE][]   | Done        |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}

--- a/sw/device/tests/dif/dif_aon_timer_smoketest.c
+++ b/sw/device/tests/dif/dif_aon_timer_smoketest.c
@@ -1,0 +1,91 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_aon_timer.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/test_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+const test_config_t kTestConfig;
+
+static void aon_timer_test_wakeup_timer(dif_aon_timer_t *aon) {
+  // Make sure that wake-up timer is stopped.
+  CHECK(dif_aon_timer_wakeup_stop(aon) == kDifAonTimerOk);
+
+  // Make sure the wake-up IRQ is cleared to avoid false positive.
+  CHECK(dif_aon_timer_irq_acknowledge(aon, kDifAonTimerIrqWakeupThreshold) ==
+        kDifAonTimerOk);
+  bool is_pending;
+  CHECK(dif_aon_timer_irq_is_pending(aon, kDifAonTimerIrqWakeupThreshold,
+                                     &is_pending) == kDifAonTimerOk);
+  CHECK(!is_pending);
+
+  // Test the wake-up timer functionality by setting a single cycle counter.
+  // Delay to compensate for AON Timer 200kHz clock (less should suffice, but
+  // to be on a cautious side - lets keep it at 100 for now).
+  CHECK(dif_aon_timer_wakeup_start(aon, 1, 0) == kDifAonTimerOk);
+  usleep(100);
+
+  // Make sure that the timer has expired.
+  CHECK(dif_aon_timer_irq_is_pending(aon, kDifAonTimerIrqWakeupThreshold,
+                                     &is_pending) == kDifAonTimerOk);
+  CHECK(is_pending);
+
+  CHECK(dif_aon_timer_wakeup_stop(aon) == kDifAonTimerOk);
+
+  CHECK(dif_aon_timer_irq_acknowledge(aon, kDifAonTimerIrqWakeupThreshold) ==
+        kDifAonTimerOk);
+}
+
+static void aon_timer_test_watchdog_timer(dif_aon_timer_t *aon) {
+  // Make sure that watchdog timer is stopped.
+  CHECK(dif_aon_timer_watchdog_stop(aon) == kDifAonTimerWatchdogOk);
+
+  // Make sure the watchdog IRQ is cleared to avoid false positive.
+  CHECK(dif_aon_timer_irq_acknowledge(
+            aon, kDifAonTimerIrqWatchdogBarkThreshold) == kDifAonTimerOk);
+  bool is_pending;
+  CHECK(dif_aon_timer_irq_is_pending(aon, kDifAonTimerIrqWatchdogBarkThreshold,
+                                     &is_pending) == kDifAonTimerOk);
+  CHECK(!is_pending);
+
+  // Test the watchdog timer functionality by setting a single cycle "bark"
+  // counter. Delay to compensate for AON Timer 200kHz clock (less should
+  // suffice, but to be on a cautious side - lets keep it at 100 for now).
+  CHECK(dif_aon_timer_watchdog_start(aon, 1, 0xffffffff, false, false) ==
+        kDifAonTimerWatchdogOk);
+  usleep(100);
+
+  // Make sure that the timer has expired.
+  CHECK(dif_aon_timer_irq_is_pending(aon, kDifAonTimerIrqWatchdogBarkThreshold,
+                                     &is_pending) == kDifAonTimerOk);
+  CHECK(is_pending);
+
+  CHECK(dif_aon_timer_watchdog_stop(aon) == kDifAonTimerWatchdogOk);
+
+  CHECK(dif_aon_timer_irq_acknowledge(
+            aon, kDifAonTimerIrqWatchdogBarkThreshold) == kDifAonTimerOk);
+}
+
+bool test_main(void) {
+  dif_aon_timer_t aon;
+
+  LOG_INFO("Running AON timer test");
+
+  // Initialise AON Timer.
+  dif_aon_timer_params_t params = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR),
+  };
+  CHECK(dif_aon_timer_init(params, &aon) == kDifAonTimerOk);
+
+  aon_timer_test_wakeup_timer(&aon);
+  aon_timer_test_watchdog_timer(&aon);
+
+  return true;
+}

--- a/sw/device/tests/dif/dif_aon_timer_unittest.cc
+++ b/sw/device/tests/dif/dif_aon_timer_unittest.cc
@@ -1,0 +1,489 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_aon_timer.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/testing/mock_mmio.h"
+
+#include "aon_timer_regs.h"  // Generated.
+
+namespace dif_aon_timer_unittest {
+namespace {
+using mock_mmio::MmioTest;
+using mock_mmio::MockDevice;
+using testing::Each;
+using testing::Eq;
+using testing::Test;
+
+class AonTimerTest : public Test, public MmioTest {
+ protected:
+  dif_aon_timer_t aon_ = {
+      .params = {.base_addr = dev().region()},
+  };
+};
+
+class InitTest : public AonTimerTest {};
+
+TEST_F(InitTest, NullArgs) {
+  dif_aon_timer_params_t params = {.base_addr = dev().region()};
+  EXPECT_EQ(dif_aon_timer_init(params, nullptr), kDifAonTimerBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  dif_aon_timer_t aon;
+  dif_aon_timer_params_t params = {.base_addr = dev().region()};
+  EXPECT_EQ(dif_aon_timer_init(params, &aon), kDifAonTimerOk);
+}
+
+class WakeupStartTest : public AonTimerTest {};
+
+TEST_F(WakeupStartTest, NullArgs) {
+  EXPECT_EQ(dif_aon_timer_wakeup_start(nullptr, 1, 1), kDifAonTimerBadArg);
+}
+
+TEST_F(WakeupStartTest, BadPrescaler) {
+  EXPECT_EQ(dif_aon_timer_wakeup_start(&aon_, 1,
+                                       AON_TIMER_WKUP_CTRL_PRESCALER_MASK + 1),
+            kDifAonTimerBadArg);
+}
+
+TEST_F(WakeupStartTest, Success) {
+  EXPECT_READ32(AON_TIMER_WKUP_CTRL_REG_OFFSET, 0);
+  EXPECT_WRITE32(AON_TIMER_WKUP_CTRL_REG_OFFSET,
+                 {
+                     {AON_TIMER_WKUP_CTRL_ENABLE_BIT, false},
+                 });
+  EXPECT_WRITE32(AON_TIMER_WKUP_COUNT_REG_OFFSET, 0);
+  EXPECT_WRITE32(AON_TIMER_WKUP_THOLD_REG_OFFSET, 1);
+  EXPECT_WRITE32(AON_TIMER_WKUP_CTRL_REG_OFFSET,
+                 {
+                     {
+                         AON_TIMER_WKUP_CTRL_PRESCALER_OFFSET,
+                         AON_TIMER_WKUP_CTRL_PRESCALER_MASK,
+                     },
+                     {AON_TIMER_WKUP_CTRL_ENABLE_BIT, true},
+                 });
+
+  EXPECT_EQ(
+      dif_aon_timer_wakeup_start(&aon_, 1, AON_TIMER_WKUP_CTRL_PRESCALER_MASK),
+      kDifAonTimerOk);
+}
+
+class WakeupStopTest : public AonTimerTest {};
+
+TEST_F(WakeupStopTest, NullArgs) {
+  EXPECT_EQ(dif_aon_timer_wakeup_stop(nullptr), kDifAonTimerBadArg);
+}
+
+TEST_F(WakeupStopTest, Success) {
+  EXPECT_READ32(AON_TIMER_WKUP_CTRL_REG_OFFSET,
+                {
+                    {AON_TIMER_WKUP_CTRL_ENABLE_BIT, true},
+                });
+  EXPECT_WRITE32(AON_TIMER_WKUP_CTRL_REG_OFFSET,
+                 {
+                     {AON_TIMER_WKUP_CTRL_ENABLE_BIT, false},
+                 });
+
+  EXPECT_EQ(dif_aon_timer_wakeup_stop(&aon_), kDifAonTimerOk);
+}
+
+class WakeupRestartTest : public AonTimerTest {};
+
+TEST_F(WakeupRestartTest, NullArgs) {
+  EXPECT_EQ(dif_aon_timer_wakeup_restart(nullptr), kDifAonTimerBadArg);
+}
+
+TEST_F(WakeupRestartTest, Success) {
+  EXPECT_WRITE32(AON_TIMER_WKUP_COUNT_REG_OFFSET, 0);
+  EXPECT_READ32(AON_TIMER_WKUP_CTRL_REG_OFFSET, 0);
+  EXPECT_WRITE32(AON_TIMER_WKUP_CTRL_REG_OFFSET,
+                 {
+                     {AON_TIMER_WKUP_CTRL_ENABLE_BIT, true},
+                 });
+
+  EXPECT_EQ(dif_aon_timer_wakeup_restart(&aon_), kDifAonTimerOk);
+}
+
+class WakeupGetCountTest : public AonTimerTest {};
+
+TEST_F(WakeupGetCountTest, NullArgs) {
+  EXPECT_EQ(dif_aon_timer_wakeup_get_count(nullptr, nullptr),
+            kDifAonTimerBadArg);
+  EXPECT_EQ(dif_aon_timer_wakeup_get_count(&aon_, nullptr), kDifAonTimerBadArg);
+  uint32_t count;
+  EXPECT_EQ(dif_aon_timer_wakeup_get_count(nullptr, &count),
+            kDifAonTimerBadArg);
+}
+
+TEST_F(WakeupGetCountTest, Success) {
+  EXPECT_READ32(AON_TIMER_WKUP_COUNT_REG_OFFSET, 0xA5A5A5A5);
+
+  uint32_t count;
+  EXPECT_EQ(dif_aon_timer_wakeup_get_count(&aon_, &count), kDifAonTimerOk);
+  EXPECT_EQ(count, 0xA5A5A5A5);
+}
+
+class WatchdogStartTest : public AonTimerTest {
+ protected:
+  void SuccessCommon() {
+    EXPECT_READ32(AON_TIMER_WDOG_REGWEN_REG_OFFSET, 1);
+    EXPECT_READ32(AON_TIMER_WDOG_CTRL_REG_OFFSET, 0);
+    EXPECT_WRITE32(AON_TIMER_WDOG_CTRL_REG_OFFSET,
+                   {
+                       {AON_TIMER_WDOG_CTRL_ENABLE_BIT, false},
+                   });
+    EXPECT_WRITE32(AON_TIMER_WDOG_COUNT_REG_OFFSET, 0);
+    EXPECT_WRITE32(AON_TIMER_WDOG_BARK_THOLD_REG_OFFSET, 0xA5A5A5A5);
+    EXPECT_WRITE32(AON_TIMER_WDOG_BITE_THOLD_REG_OFFSET, 0x5A5A5A5A);
+  }
+};
+
+TEST_F(WatchdogStartTest, NullArgs) {
+  EXPECT_EQ(dif_aon_timer_watchdog_start(nullptr, 1, 1, false, false),
+            kDifAonTimerWatchdogBadArg);
+}
+
+TEST_F(WatchdogStartTest, Locked) {
+  EXPECT_READ32(AON_TIMER_WDOG_REGWEN_REG_OFFSET, 0);
+  EXPECT_EQ(dif_aon_timer_watchdog_start(&aon_, 1, 1, false, false),
+            kDifAonTimerWatchdogLocked);
+}
+
+TEST_F(WatchdogStartTest, Success) {
+  SuccessCommon();
+
+  EXPECT_WRITE32(AON_TIMER_WDOG_CTRL_REG_OFFSET,
+                 {
+                     {
+                         AON_TIMER_WDOG_CTRL_PAUSE_IN_SLEEP_BIT,
+                         false,
+                     },
+                     {AON_TIMER_WDOG_CTRL_ENABLE_BIT, true},
+                 });
+
+  EXPECT_EQ(
+      dif_aon_timer_watchdog_start(&aon_, 0xA5A5A5A5, 0x5A5A5A5A, false, false),
+      kDifAonTimerWatchdogOk);
+}
+
+TEST_F(WatchdogStartTest, SuccessPauseInSleep) {
+  SuccessCommon();
+
+  EXPECT_WRITE32(AON_TIMER_WDOG_CTRL_REG_OFFSET,
+                 {
+                     {
+                         AON_TIMER_WDOG_CTRL_PAUSE_IN_SLEEP_BIT,
+                         true,
+                     },
+                     {AON_TIMER_WDOG_CTRL_ENABLE_BIT, true},
+                 });
+
+  EXPECT_EQ(
+      dif_aon_timer_watchdog_start(&aon_, 0xA5A5A5A5, 0x5A5A5A5A, true, false),
+      kDifAonTimerWatchdogOk);
+}
+
+TEST_F(WatchdogStartTest, SuccessLock) {
+  SuccessCommon();
+
+  EXPECT_WRITE32(AON_TIMER_WDOG_CTRL_REG_OFFSET,
+                 {
+                     {
+                         AON_TIMER_WDOG_CTRL_PAUSE_IN_SLEEP_BIT,
+                         false,
+                     },
+                     {AON_TIMER_WDOG_CTRL_ENABLE_BIT, true},
+                 });
+
+  // Write one to clear.
+  EXPECT_WRITE32(AON_TIMER_WDOG_REGWEN_REG_OFFSET, 1);
+
+  EXPECT_EQ(
+      dif_aon_timer_watchdog_start(&aon_, 0xA5A5A5A5, 0x5A5A5A5A, false, true),
+      kDifAonTimerWatchdogOk);
+}
+
+TEST_F(WatchdogStartTest, SuccessPauseInSleepAndLock) {
+  SuccessCommon();
+
+  EXPECT_WRITE32(AON_TIMER_WDOG_CTRL_REG_OFFSET,
+                 {
+                     {
+                         AON_TIMER_WDOG_CTRL_PAUSE_IN_SLEEP_BIT,
+                         true,
+                     },
+                     {AON_TIMER_WDOG_CTRL_ENABLE_BIT, true},
+                 });
+
+  // Write one to clear.
+  EXPECT_WRITE32(AON_TIMER_WDOG_REGWEN_REG_OFFSET, 1);
+
+  EXPECT_EQ(
+      dif_aon_timer_watchdog_start(&aon_, 0xA5A5A5A5, 0x5A5A5A5A, true, true),
+      kDifAonTimerWatchdogOk);
+}
+
+class WatchdogStopTest : public AonTimerTest {};
+
+TEST_F(WatchdogStopTest, NullArgs) {
+  EXPECT_EQ(dif_aon_timer_watchdog_stop(nullptr), kDifAonTimerWatchdogBadArg);
+}
+
+TEST_F(WatchdogStopTest, Locked) {
+  EXPECT_READ32(AON_TIMER_WDOG_REGWEN_REG_OFFSET, 0);
+
+  EXPECT_EQ(dif_aon_timer_watchdog_stop(&aon_), kDifAonTimerWatchdogLocked);
+}
+
+TEST_F(WatchdogStopTest, Success) {
+  EXPECT_READ32(AON_TIMER_WDOG_REGWEN_REG_OFFSET, 1);
+  EXPECT_READ32(AON_TIMER_WDOG_CTRL_REG_OFFSET,
+                {
+                    {AON_TIMER_WDOG_CTRL_ENABLE_BIT, true},
+                });
+  EXPECT_WRITE32(AON_TIMER_WDOG_CTRL_REG_OFFSET,
+                 {
+                     {AON_TIMER_WDOG_CTRL_ENABLE_BIT, false},
+                 });
+
+  EXPECT_EQ(dif_aon_timer_watchdog_stop(&aon_), kDifAonTimerWatchdogOk);
+}
+
+class WatchdogRestartTest : public AonTimerTest {};
+
+TEST_F(WatchdogRestartTest, NullArgs) {
+  EXPECT_EQ(dif_aon_timer_watchdog_restart(nullptr),
+            kDifAonTimerWatchdogBadArg);
+}
+
+TEST_F(WatchdogRestartTest, Locked) {
+  EXPECT_READ32(AON_TIMER_WDOG_REGWEN_REG_OFFSET, 0);
+  EXPECT_EQ(dif_aon_timer_watchdog_restart(&aon_), kDifAonTimerWatchdogLocked);
+}
+
+TEST_F(WatchdogRestartTest, Success) {
+  EXPECT_READ32(AON_TIMER_WDOG_REGWEN_REG_OFFSET, 1);
+  EXPECT_WRITE32(AON_TIMER_WDOG_COUNT_REG_OFFSET, 0);
+  EXPECT_READ32(AON_TIMER_WDOG_CTRL_REG_OFFSET, 0);
+  EXPECT_WRITE32(AON_TIMER_WDOG_CTRL_REG_OFFSET,
+                 {
+                     {AON_TIMER_WDOG_CTRL_ENABLE_BIT, true},
+                 });
+
+  EXPECT_EQ(dif_aon_timer_watchdog_restart(&aon_), kDifAonTimerWatchdogOk);
+}
+
+class WatchdogGetCountTest : public AonTimerTest {};
+
+TEST_F(WatchdogGetCountTest, NullArgs) {
+  EXPECT_EQ(dif_aon_timer_watchdog_get_count(nullptr, nullptr),
+            kDifAonTimerWatchdogBadArg);
+  EXPECT_EQ(dif_aon_timer_watchdog_get_count(&aon_, nullptr),
+            kDifAonTimerWatchdogBadArg);
+  uint32_t count;
+  EXPECT_EQ(dif_aon_timer_watchdog_get_count(nullptr, &count),
+            kDifAonTimerWatchdogBadArg);
+}
+
+TEST_F(WatchdogGetCountTest, Success) {
+  EXPECT_READ32(AON_TIMER_WDOG_COUNT_REG_OFFSET, 0xA5A5A5A5);
+
+  uint32_t count;
+  EXPECT_EQ(dif_aon_timer_watchdog_get_count(&aon_, &count),
+            kDifAonTimerWatchdogOk);
+  EXPECT_EQ(count, 0xA5A5A5A5);
+}
+
+class WatchdogPetTest : public AonTimerTest {};
+
+TEST_F(WatchdogPetTest, NullArgs) {
+  EXPECT_EQ(dif_aon_timer_watchdog_pet(nullptr), kDifAonTimerBadArg);
+}
+
+TEST_F(WatchdogPetTest, Success) {
+  EXPECT_WRITE32(AON_TIMER_WDOG_COUNT_REG_OFFSET, 0);
+
+  EXPECT_EQ(dif_aon_timer_watchdog_pet(&aon_), kDifAonTimerOk);
+}
+
+class WatchdogLockTest : public AonTimerTest {};
+
+TEST_F(WatchdogLockTest, NullArgs) {
+  EXPECT_EQ(dif_aon_timer_watchdog_lock(nullptr), kDifAonTimerBadArg);
+}
+
+TEST_F(WatchdogLockTest, Success) {
+  // Write one to clear.
+  EXPECT_WRITE32(AON_TIMER_WDOG_REGWEN_REG_OFFSET, 1);
+
+  EXPECT_EQ(dif_aon_timer_watchdog_lock(&aon_), kDifAonTimerOk);
+}
+
+class WatchdogIsLockedTest : public AonTimerTest {};
+
+TEST_F(WatchdogIsLockedTest, NullArgs) {
+  EXPECT_EQ(dif_aon_timer_watchdog_is_locked(nullptr, nullptr),
+            kDifAonTimerBadArg);
+  EXPECT_EQ(dif_aon_timer_watchdog_is_locked(&aon_, nullptr),
+            kDifAonTimerBadArg);
+  bool is_locked;
+  EXPECT_EQ(dif_aon_timer_watchdog_is_locked(nullptr, &is_locked),
+            kDifAonTimerBadArg);
+}
+
+TEST_F(WatchdogIsLockedTest, Success) {
+  EXPECT_READ32(AON_TIMER_WDOG_REGWEN_REG_OFFSET, 1);
+
+  bool is_locked;
+  EXPECT_EQ(dif_aon_timer_watchdog_is_locked(&aon_, &is_locked),
+            kDifAonTimerOk);
+  EXPECT_EQ(is_locked, false);
+}
+
+TEST_F(WatchdogIsLockedTest, SuccessLocked) {
+  EXPECT_READ32(AON_TIMER_WDOG_REGWEN_REG_OFFSET, 0);
+
+  bool is_locked;
+  EXPECT_EQ(dif_aon_timer_watchdog_is_locked(&aon_, &is_locked),
+            kDifAonTimerOk);
+  EXPECT_EQ(is_locked, true);
+}
+
+class IrqIsPendingTest : public AonTimerTest {};
+
+TEST_F(IrqIsPendingTest, NullArgs) {
+  EXPECT_EQ(dif_aon_timer_irq_is_pending(
+                nullptr, kDifAonTimerIrqWakeupThreshold, nullptr),
+            kDifAonTimerBadArg);
+  EXPECT_EQ(dif_aon_timer_irq_is_pending(&aon_, kDifAonTimerIrqWakeupThreshold,
+                                         nullptr),
+            kDifAonTimerBadArg);
+  bool is_pending;
+  EXPECT_EQ(dif_aon_timer_irq_is_pending(
+                nullptr, kDifAonTimerIrqWakeupThreshold, &is_pending),
+            kDifAonTimerBadArg);
+}
+
+TEST_F(IrqIsPendingTest, BadInterrupt) {
+  bool is_pending;
+  int invalid = static_cast<int>(kDifAonTimerIrqWatchdogBarkThreshold) + 1;
+  EXPECT_EQ(dif_aon_timer_irq_is_pending(
+                &aon_, static_cast<dif_aon_timer_irq_t>(invalid), &is_pending),
+            kDifAonTimerError);
+}
+
+TEST_F(IrqIsPendingTest, Success) {
+  EXPECT_READ32(AON_TIMER_INTR_STATE_REG_OFFSET, 0);
+
+  bool is_pending = true;
+  EXPECT_EQ(dif_aon_timer_irq_is_pending(
+                &aon_, kDifAonTimerIrqWatchdogBarkThreshold, &is_pending),
+            kDifAonTimerOk);
+  EXPECT_EQ(is_pending, false);
+
+  EXPECT_READ32(AON_TIMER_INTR_STATE_REG_OFFSET, 0);
+
+  is_pending = true;
+  EXPECT_EQ(dif_aon_timer_irq_is_pending(&aon_, kDifAonTimerIrqWakeupThreshold,
+                                         &is_pending),
+            kDifAonTimerOk);
+  EXPECT_EQ(is_pending, false);
+}
+
+TEST_F(IrqIsPendingTest, SuccessPending) {
+  uint32_t reg = bitfield_bit32_write(
+      0, AON_TIMER_INTR_STATE_WKUP_TIMER_EXPIRED_BIT, true);
+  EXPECT_READ32(AON_TIMER_INTR_STATE_REG_OFFSET, reg);
+
+  bool is_pending = false;
+  EXPECT_EQ(dif_aon_timer_irq_is_pending(&aon_, kDifAonTimerIrqWakeupThreshold,
+                                         &is_pending),
+            kDifAonTimerOk);
+  EXPECT_EQ(is_pending, true);
+
+  reg = bitfield_bit32_write(0, AON_TIMER_INTR_STATE_WDOG_TIMER_EXPIRED_BIT,
+                             true);
+  EXPECT_READ32(AON_TIMER_INTR_STATE_REG_OFFSET, reg);
+
+  is_pending = false;
+  EXPECT_EQ(dif_aon_timer_irq_is_pending(
+                &aon_, kDifAonTimerIrqWatchdogBarkThreshold, &is_pending),
+            kDifAonTimerOk);
+  EXPECT_EQ(is_pending, true);
+}
+
+class IrqAcknowledgeTest : public AonTimerTest {};
+
+TEST_F(IrqAcknowledgeTest, NullArgs) {
+  EXPECT_EQ(
+      dif_aon_timer_irq_acknowledge(nullptr, kDifAonTimerIrqWakeupThreshold),
+      kDifAonTimerBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, BadInterrupt) {
+  int invalid = static_cast<int>(kDifAonTimerIrqWatchdogBarkThreshold) + 1;
+  EXPECT_EQ(dif_aon_timer_irq_acknowledge(
+                &aon_, static_cast<dif_aon_timer_irq_t>(invalid)),
+            kDifAonTimerError);
+}
+
+TEST_F(IrqAcknowledgeTest, Success) {
+  // Write one to clear.
+  uint32_t reg = bitfield_bit32_write(
+      0, AON_TIMER_INTR_STATE_WKUP_TIMER_EXPIRED_BIT, true);
+  EXPECT_WRITE32(AON_TIMER_INTR_STATE_REG_OFFSET, reg);
+
+  EXPECT_EQ(
+      dif_aon_timer_irq_acknowledge(&aon_, kDifAonTimerIrqWakeupThreshold),
+      kDifAonTimerOk);
+
+  // Write one to clear.
+  reg = bitfield_bit32_write(0, AON_TIMER_INTR_STATE_WDOG_TIMER_EXPIRED_BIT,
+                             true);
+  EXPECT_WRITE32(AON_TIMER_INTR_STATE_REG_OFFSET, reg);
+
+  EXPECT_EQ(dif_aon_timer_irq_acknowledge(&aon_,
+                                          kDifAonTimerIrqWatchdogBarkThreshold),
+            kDifAonTimerOk);
+}
+
+class IrqForceTest : public AonTimerTest {};
+
+TEST_F(IrqForceTest, NullArgs) {
+  EXPECT_EQ(dif_aon_timer_irq_force(nullptr, kDifAonTimerIrqWakeupThreshold),
+            kDifAonTimerBadArg);
+}
+
+TEST_F(IrqForceTest, BadInterrupt) {
+  int invalid = static_cast<int>(kDifAonTimerIrqWatchdogBarkThreshold) + 1;
+  EXPECT_EQ(
+      dif_aon_timer_irq_force(&aon_, static_cast<dif_aon_timer_irq_t>(invalid)),
+      kDifAonTimerError);
+}
+
+TEST_F(IrqForceTest, Success) {
+  // Write one to clear.
+  uint32_t reg =
+      bitfield_bit32_write(0, AON_TIMER_INTR_TEST_WKUP_TIMER_EXPIRED_BIT, true);
+  EXPECT_WRITE32(AON_TIMER_INTR_TEST_REG_OFFSET, reg);
+
+  EXPECT_EQ(dif_aon_timer_irq_force(&aon_, kDifAonTimerIrqWakeupThreshold),
+            kDifAonTimerOk);
+
+  // Write one to clear.
+  reg =
+      bitfield_bit32_write(0, AON_TIMER_INTR_TEST_WDOG_TIMER_EXPIRED_BIT, true);
+  EXPECT_WRITE32(AON_TIMER_INTR_TEST_REG_OFFSET, reg);
+
+  EXPECT_EQ(
+      dif_aon_timer_irq_force(&aon_, kDifAonTimerIrqWatchdogBarkThreshold),
+      kDifAonTimerOk);
+}
+
+}  // namespace
+}  // namespace dif_aon_timer_unittest

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -226,6 +226,22 @@ test('dif_clkmgr_unittest', executable(
   cpp_args: ['-DMOCK_MMIO'],
 ))
 
+test('dif_aon_timer_unittest', executable(
+  'dif_aon_timer_unittest',
+  sources: [
+    hw_ip_aon_timer_reg_h,
+    meson.source_root() / 'sw/device/lib/dif/dif_aon_timer.c',
+    'dif_aon_timer_unittest.cc',
+  ],
+  dependencies: [
+    sw_vendor_gtest,
+    sw_lib_testing_mock_mmio,
+  ],
+  native: true,
+  c_args: ['-DMOCK_MMIO'],
+  cpp_args: ['-DMOCK_MMIO'],
+))
+
 dif_plic_smoketest_lib = declare_dependency(
   link_with: static_library(
     'dif_plic_smoketest_lib',

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -428,3 +428,20 @@ sw_tests += {
     'library': dif_clkmgr_smoketest_lib,
   }
 }
+
+dif_aon_timer_smoketest_lib = declare_dependency(
+  link_with: static_library(
+    'dif_aon_timer_smoketest_lib',
+    sources: ['dif_aon_timer_smoketest.c'],
+    dependencies: [
+      sw_lib_dif_aon_timer,
+      sw_lib_mmio,
+      sw_lib_runtime_log,
+    ],
+  ),
+)
+sw_tests += {
+  'dif_aon_timer_smoketest': {
+    'library': dif_aon_timer_smoketest_lib,
+  }
+}

--- a/test/systemtest/config.py
+++ b/test/systemtest/config.py
@@ -49,6 +49,9 @@ TEST_APPS_SELFCHECKING = [
         "name": "dif_aes_smoketest",
     },
     {
+        "name": "dif_aon_timer_smoketest",
+    },
+    {
         "name": "dif_otp_ctrl_smoketest",
     },
     {


### PR DESCRIPTION
- It is not clear how `aon_timer.WKUP_CAUSE` is different to `aon_timer.INTR_STATE` from SW perspective - so there is no API to query the "cause" at this time.

**- AON wiring in hardware is broken, need to hook the smoketest into CI when fixed, see #5629**