### PR TITLE
[otbn] Integrate ECC check bits properly into the memory

### DIFF
--- a/hw/dv/verilator/cpp/ecc32_mem_area.cc
+++ b/hw/dv/verilator/cpp/ecc32_mem_area.cc
@@ -1,0 +1,124 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ecc32_mem_area.h"
+
+#include <cassert>
+#include <cstring>
+#include <stdexcept>
+
+Ecc32MemArea::Ecc32MemArea(const std::string &scope, uint32_t size,
+                           uint32_t width_32)
+    : MemArea(scope, size, 4 * width_32) {
+  // Check that multiplying by 4 didn't discard a bit
+  assert(4 * width_32 > width_32);
+
+  // No need to worry about ranges here: we've checked in the base class that
+  // width_byte isn't too big.
+  uint32_t phy_width_bits = 39 * width_32;
+
+  // This is a stronger check than the one in the base class (which
+  // makes sure there's enough space for the un-expanded memory width)
+  assert(phy_width_bits <= SV_MEM_WIDTH_BITS);
+}
+
+void Ecc32MemArea::LoadVmem(const std::string &path) const {
+  throw std::runtime_error(
+      "vmem files are not supported for memories with ECC bits");
+}
+
+void Ecc32MemArea::WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
+                               const std::vector<uint8_t> &data,
+                               size_t start_idx) const {
+  int log_width_32 = width_byte_ / 4;
+  int phy_width_bits = 39 * log_width_32;
+  int phy_width_bytes = (phy_width_bits + 7) / 8;
+
+  // Start by collecting our width_byte_ input bytes into (width_byte_ / 4)
+  // 32-bit groupings and adding check bits. (Eventually, we'll be adding
+  // proper ECC check bits here but, since we're not checking yet, let's
+  // zero-pad for now).
+  //
+  // TODO: Add proper ECC check bits here!
+  struct expanded_t {
+    uint8_t bytes[5];
+  };
+
+  std::vector<expanded_t> expanded(log_width_32);
+  for (int i = 0; i < log_width_32; ++i) {
+    // Store things little-endian, so the "real bits" go in bytes 0 to 3 and
+    // the check bits go in byte 4. Bytes 5 to 7 are zero.
+    expanded_t next;
+    memcpy(next.bytes, &data[start_idx + 4 * i], 4);
+    next.bytes[4] = 0;
+    expanded[i] = next;
+  }
+
+  // Now write to buf, pulling 39 bits from each element of in_64.
+  for (int i = 0; i < phy_width_bytes; ++i) {
+    uint8_t acc = 0;
+    int out_lsb = 0;
+
+    int in_word_idx = (8 * i) / 39;
+    int in_word_lsb = (8 * i) % 39;
+
+    int bits_left = 8;
+    while (bits_left) {
+      int in_byte_idx = in_word_lsb / 8;
+      int in_byte_lsb = in_word_lsb % 8;
+
+      int byte_width = (in_byte_idx == 4) ? 7 : 8;
+      int bits_at_byte = std::min(byte_width - in_byte_lsb, bits_left);
+
+      uint8_t in_data = expanded[in_word_idx].bytes[in_byte_idx] >> in_byte_lsb;
+      uint8_t in_mask = (((uint32_t)1 << bits_at_byte) - 1) & 0xff;
+
+      acc |= (in_data & in_mask) << out_lsb;
+
+      out_lsb += bits_at_byte;
+      if (in_byte_idx == 4) {
+        ++in_word_idx;
+        in_word_lsb = 0;
+      } else {
+        in_word_lsb += bits_at_byte;
+      }
+
+      bits_left -= bits_at_byte;
+    }
+    buf[i] = acc;
+  }
+}
+
+void Ecc32MemArea::ReadBuffer(std::vector<uint8_t> &data,
+                              const uint8_t buf[SV_MEM_WIDTH_BYTES]) const {
+  for (int i = 0; i < width_byte_; ++i) {
+    int in_word = i / 4;
+
+    int in_idx = (7 * in_word + 8 * i) / 8;
+    int in_lsb = (7 * in_word + 8 * i) % 8;
+
+    uint8_t acc = 0;
+
+    int bits_left = 8;
+    int out_lsb = 0;
+
+    while (bits_left) {
+      uint8_t in_data = buf[in_idx] >> in_lsb;
+
+      int bits_at_idx = std::min(8 - in_lsb, bits_left);
+
+      // The mask for the bits to take from in_data.
+      uint8_t in_mask = ((1u << bits_at_idx) - 1) & 0xff;
+
+      acc |= (in_data & in_mask) << out_lsb;
+
+      in_lsb = 0;
+      out_lsb += bits_at_idx;
+      bits_left -= bits_at_idx;
+      ++in_idx;
+    }
+
+    data.push_back(acc);
+  }
+}

--- a/hw/dv/verilator/cpp/ecc32_mem_area.h
+++ b/hw/dv/verilator/cpp/ecc32_mem_area.h
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_HW_DV_VERILATOR_CPP_ECC32_MEM_AREA_H_
+#define OPENTITAN_HW_DV_VERILATOR_CPP_ECC32_MEM_AREA_H_
+
+#include "mem_area.h"
+
+/**
+ * A memory that implements 32-bit ECC, storing 39 = 32 + 7 bits of physical
+ * data for each 32 bits of logical data.
+ */
+class Ecc32MemArea : public MemArea {
+ public:
+  /**
+   * Constructor
+   *
+   * Create an Ecc32MemArea that will connect to a SystemVerilog memory at
+   * scope. It is size words long. Each memory word is 4 * width_32 bytes wide
+   * in the address space and 39 * width_32 bits wide in the physical memory.
+   */
+  Ecc32MemArea(const std::string &scope, uint32_t size, uint32_t width_32);
+
+  void LoadVmem(const std::string &path) const override;
+
+ private:
+  void WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
+                   const std::vector<uint8_t> &data,
+                   size_t start_idx) const override;
+
+  void ReadBuffer(std::vector<uint8_t> &data,
+                  const uint8_t buf[SV_MEM_WIDTH_BYTES]) const override;
+};
+
+#endif  // OPENTITAN_HW_DV_VERILATOR_CPP_ECC32_MEM_AREA_H_

--- a/hw/dv/verilator/memutil_dpi.core
+++ b/hw/dv/verilator/memutil_dpi.core
@@ -10,6 +10,8 @@ filesets:
     files:
       - cpp/dpi_memutil.cc
       - cpp/dpi_memutil.h: { is_include_file: true }
+      - cpp/ecc32_mem_area.cc
+      - cpp/ecc32_mem_area.h: { is_include_file: true }
       - cpp/mem_area.cc
       - cpp/mem_area.h: { is_include_file: true }
       - cpp/ranged_map.h: { is_include_file: true }

--- a/hw/ip/otbn/dv/memutil/otbn_memutil.cc
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil.cc
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "otbn_memutil.h"
+#include "ecc32_mem_area.h"
 
 #include <cassert>
 #include <cstring>
@@ -21,9 +22,9 @@ static std::string join_scopes(const std::string &a, const std::string &b) {
 
 OtbnMemUtil::OtbnMemUtil(const std::string &top_scope)
     : imem_(join_scopes(top_scope, "u_imem.u_mem.gen_generic.u_impl_generic"),
-            4096 / 4, 4),
+            4096 / 4, 4 / 4),
       dmem_(join_scopes(top_scope, "u_dmem.u_mem.gen_generic.u_impl_generic"),
-            4096 / 32, 32) {
+            4096 / 32, 32 / 4) {
   RegisterMemoryArea("imem", 0x4000, &imem_);
   RegisterMemoryArea("dmem", 0x8000, &dmem_);
 }

--- a/hw/ip/otbn/dv/memutil/otbn_memutil.h
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil.h
@@ -7,6 +7,7 @@
 #include <svdpi.h>
 
 #include "dpi_memutil.h"
+#include "ecc32_mem_area.h"
 
 class OtbnMemUtil : public DpiMemUtil {
  public:
@@ -29,7 +30,7 @@ class OtbnMemUtil : public DpiMemUtil {
   }
 
  private:
-  MemArea imem_, dmem_;
+  Ecc32MemArea imem_, dmem_;
 };
 
 // DPI-accessible wrappers

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -29,7 +29,7 @@ module otbn_top_sim (
   // Instruction memory (IMEM) signals
   logic                     imem_req;
   logic [ImemAddrWidth-1:0] imem_addr;
-  logic [31:0]              imem_rdata;
+  logic [38:0]              imem_rdata;
   logic                     imem_rvalid;
   logic [1:0]               imem_rerror_vec;
   logic                     imem_rerror;
@@ -38,9 +38,12 @@ module otbn_top_sim (
   logic                     dmem_req;
   logic                     dmem_write;
   logic [DmemAddrWidth-1:0] dmem_addr;
-  logic [WLEN-1:0]          dmem_wdata;
-  logic [WLEN-1:0]          dmem_wmask;
-  logic [WLEN-1:0]          dmem_rdata;
+  logic [WLEN-1:0]          dmem_wdata_nointeg;
+  logic [WLEN-1:0]          dmem_wmask_nointeg;
+  logic [WLEN-1:0]          dmem_rdata_nointeg;
+  logic [ExtWLEN-1:0]       dmem_wdata;
+  logic [ExtWLEN-1:0]       dmem_wmask;
+  logic [ExtWLEN-1:0]       dmem_rdata;
   logic                     dmem_rvalid;
   logic [1:0]               dmem_rerror_vec;
   logic                     dmem_rerror;
@@ -54,40 +57,55 @@ module otbn_top_sim (
     .ImemSizeByte ( ImemSizeByte ),
     .DmemSizeByte ( DmemSizeByte )
   ) u_otbn_core (
-    .clk_i           ( IO_CLK          ),
-    .rst_ni          ( IO_RST_N        ),
+    .clk_i           ( IO_CLK             ),
+    .rst_ni          ( IO_RST_N           ),
 
-    .start_i         ( otbn_start      ),
-    .done_o          ( otbn_done_d     ),
+    .start_i         ( otbn_start         ),
+    .done_o          ( otbn_done_d        ),
 
-    .err_bits_o      ( otbn_err_bits_d ),
+    .err_bits_o      ( otbn_err_bits_d    ),
 
-    .start_addr_i    ( ImemStartAddr   ),
+    .start_addr_i    ( ImemStartAddr      ),
 
-    .imem_req_o      ( imem_req        ),
-    .imem_addr_o     ( imem_addr       ),
-    .imem_wdata_o    (                 ),
-    .imem_rdata_i    ( imem_rdata      ),
-    .imem_rvalid_i   ( imem_rvalid     ),
-    .imem_rerror_i   ( imem_rerror     ),
+    .imem_req_o      ( imem_req           ),
+    .imem_addr_o     ( imem_addr          ),
+    .imem_wdata_o    (                    ),
+    .imem_rdata_i    ( imem_rdata[31:0]   ),
+    .imem_rvalid_i   ( imem_rvalid        ),
+    .imem_rerror_i   ( imem_rerror        ),
 
-    .dmem_req_o      ( dmem_req        ),
-    .dmem_write_o    ( dmem_write      ),
-    .dmem_addr_o     ( dmem_addr       ),
-    .dmem_wdata_o    ( dmem_wdata      ),
-    .dmem_wmask_o    ( dmem_wmask      ),
-    .dmem_rdata_i    ( dmem_rdata      ),
-    .dmem_rvalid_i   ( dmem_rvalid     ),
-    .dmem_rerror_i   ( dmem_rerror     ),
+    .dmem_req_o      ( dmem_req           ),
+    .dmem_write_o    ( dmem_write         ),
+    .dmem_addr_o     ( dmem_addr          ),
+    .dmem_wdata_o    ( dmem_wdata_nointeg ),
+    .dmem_wmask_o    ( dmem_wmask_nointeg ),
+    .dmem_rdata_i    ( dmem_rdata_nointeg ),
+    .dmem_rvalid_i   ( dmem_rvalid        ),
+    .dmem_rerror_i   ( dmem_rerror        ),
 
-    .edn_rnd_req_o   ( edn_rnd_req     ),
-    .edn_rnd_ack_i   ( edn_rnd_ack     ),
-    .edn_rnd_data_i  ( edn_rnd_data    ),
+    .edn_rnd_req_o   ( edn_rnd_req        ),
+    .edn_rnd_ack_i   ( edn_rnd_ack        ),
+    .edn_rnd_data_i  ( edn_rnd_data       ),
 
-    .edn_urnd_req_o  ( edn_urnd_req    ),
-    .edn_urnd_ack_i  ( edn_urnd_ack    ),
-    .edn_urnd_data_i ( edn_urnd_data   )
+    .edn_urnd_req_o  ( edn_urnd_req       ),
+    .edn_urnd_ack_i  ( edn_urnd_ack       ),
+    .edn_urnd_data_i ( edn_urnd_data      )
   );
+
+  // The core doesn't currently handle the integrity bits that we will insert into the memory.
+  // Convert between its view and that of the actual SRAM macro here.
+  logic [BaseWordsPerWLEN-1:0] unused_rdata_integrity;
+  for (genvar i = 0; i < BaseWordsPerWLEN; i++) begin: gen_dmem_adapter
+    assign dmem_wdata[i*39 +: 39] = {7'd0, dmem_wdata_nointeg[i*32 +: 32]};
+    assign dmem_wmask[i*39 +: 39] = {{7{dmem_wmask_nointeg[i*32]}}, dmem_wmask_nointeg[i*32 +: 32]};
+    assign dmem_rdata_nointeg[i*32 +: 32] = dmem_rdata[i*39 +: 32];
+    assign unused_rdata_integrity[i] = &{dmem_rdata[i*39 + 32 +: 7]};
+  end
+
+  // The top bits of IMEM rdata aren't currently used (they will eventually be used for integrity
+  // checks both on the bus and within the core)
+  logic unused_imem_top_rdata;
+  assign unused_imem_top_rdata = &{1'b0, imem_rdata[38:32]};
 
   // Tie-off EDN signals, eventually simulation will provide something here for testing RND
   logic unused_edn_rnd_req, unused_edn_urnd_req;
@@ -132,9 +150,9 @@ module otbn_top_sim (
   assign unused_dmem_addr = dmem_addr[DmemAddrWidth-DmemIndexWidth-1:0];
 
   prim_ram_1p_adv #(
-    .Width           ( WLEN          ),
+    .Width           ( ExtWLEN       ),
     .Depth           ( DmemSizeWords ),
-    .DataBitsPerMask ( 32            )
+    .DataBitsPerMask ( 39            )
   ) u_dmem (
     .clk_i    ( IO_CLK          ),
     .rst_ni   ( IO_RST_N        ),
@@ -162,9 +180,9 @@ module otbn_top_sim (
   assign unused_imem_addr = imem_addr[1:0];
 
   prim_ram_1p_adv #(
-    .Width           ( 32            ),
+    .Width           ( 39            ),
     .Depth           ( ImemSizeWords ),
-    .DataBitsPerMask ( 32            )
+    .DataBitsPerMask ( 39            )
   ) u_imem (
     .clk_i    ( IO_CLK          ),
     .rst_ni   ( IO_RST_N        ),

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -11,6 +11,9 @@ package otbn_pkg;
   // Data path width for BN (wide) instructions, in bits.
   parameter int WLEN = 256;
 
+  // "Extended" WLEN: the size of the datapath with added parity bits
+  parameter int ExtWLEN = WLEN * 39 / 32;
+
   // Number of 32-bit words per WLEN
   parameter int BaseWordsPerWLEN = WLEN / 32;
 


### PR DESCRIPTION
These extra bits will be used for ECC-based integrity checks. We're
not doing that as yet, but want correctly sized memories for area
estimation.

We'd already expanded the memories, using the top bits as check bits.
Unfortunately, that causes (correctly) Verilator lint errors. Most are
easy enough to waive with `unused_foo` signals, but our choice of a
write mask doesn't divide into the memory size which causes warnings
in the SRAM primitive.

Rather than hack around further, this patch integrates things more
properly, putting 7 (ignored) "check bits" after each 32-bit word in
the data memory. For now, otbn.sv converts between the expanded
312-bit words and the narrow 256-bit words that the SRAM adapter, the
core and the model expect. Once we start generating/consuming
integrity properly, this conversion will essentially move to the Ibex
and OTBN ALUs.

As well as the narrowing/widening conversions in otbn.sv (repeated in
otbn_top_sim.sv), we also have to teach the backdoor memory setter and
getter to handle things properly.
