### PR TITLE
[rv_plic] Small cleanups

### DIFF
--- a/hw/ip/rv_plic/doc/checklist.md
+++ b/hw/ip/rv_plic/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "RV_PLIC Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{<relref "/doc/project/development_stages.md" >}}) transitions for the [RV_PLIC peripheral](../).
+This checklist is for [Hardware Stage]({{<relref "/doc/project/development_stages.md" >}}) transitions for the [RV_PLIC peripheral](..).
 All checklist items refer to the content in the [Checklist.]({{<relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist
@@ -21,7 +21,7 @@ RTL           | [FUNC_IMPLEMENTED][]           | Done        |
 RTL           | [ASSERT_KNOWN_ADDED][]         | Done        |
 Code Quality  | [LINT_SETUP][]                 | Done        |
 
-[RV_PLIC Spec]: {{<relref "/hw/ip/rv_plic/doc">}}
+[RV_PLIC Spec]: {{<relref ".">}}
 
 [SPEC_COMPLETE]:              {{<relref "/doc/project/checklist.md#spec_complete" >}}
 [CSR_DEFINED]:                {{<relref "/doc/project/checklist.md#csr_defined" >}}

--- a/hw/ip/rv_plic/doc/dv/index.md
+++ b/hw/ip/rv_plic/doc/dv/index.md
@@ -13,22 +13,22 @@ title: "RV_PLIC DV document"
 
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
-  * [HW development stages]({{< relref "doc/project/development_stages" >}})
+  * [HW development stages]({{< relref "/doc/project/development_stages" >}})
 * FPV dashboard (link TBD)
 
 ## Design features
 For detailed information on RV_PLIC design features, please see the
-[RV_PLIC design specification]({{< relref "hw/ip/rv_plic/doc" >}}).
+[RV_PLIC design specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 RV_PLIC FPV testbench has been constructed based on the [formal
-architecture]({{< relref "hw/formal/README.md" >}}).
+architecture]({{< relref "/hw/formal/README.md" >}}).
 
 ### Block diagram
 ![Block diagram](fpv.svg)
 
 #### TLUL assertions
-* The `hw/rv_plic/fpv/tb/rv_plic_bind.sv` binds the `tlul_assert` [assertions]({{< relref "hw/ip/tlul/doc/TlulProtocolChecker.md" >}})
+* The `hw/rv_plic/fpv/tb/rv_plic_bind.sv` binds the `tlul_assert` [assertions]({{< relref "/hw/ip/tlul/doc/TlulProtocolChecker.md" >}})
   to rv_plic to ensure TileLink interface protocol compliance.
 * The `hw/rv_plic/fpv/tb/rv_plic_bind.sv` also binds the `rv_plic_csr_assert_fpv`
   under `hw/rv_plic/fpv/vip/` to check if TileLink writes and reads correct
@@ -45,7 +45,7 @@ is used to reduce the number of repeated assertions code. In RV_PLIC, we
 declared two symbolic variables `src_sel` and `tgt_sel` to represent the index for
 interrupt source and interrupt target.
 Detailed explanation is listed in the
-[Symbolic Variables]({{< relref "hw/formal/README.md#symbolic-variables" >}}) section.
+[Symbolic Variables]({{< relref "/hw/formal/README.md#symbolic-variables" >}}) section.
 
 ## DV plan
 {{< incGenFromIpDesc "../../data/rv_plic_fpv_testplan.hjson" "testplan" >}}

--- a/hw/ip/rv_plic/rv_plic.core
+++ b/hw/ip/rv_plic/rv_plic.core
@@ -3,24 +3,24 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:ip:rv_plic_example:0.1"
-description: "RISC-V PLIC"
+description: "RISC-V Platform Interrupt Controller (PLIC)"
 
 filesets:
   files_rtl:
     depend:
       - lowrisc:ip:rv_plic_component
+      - lowrisc:ip:tlul
+      - lowrisc:prim:subreg
     files:
       - rtl/rv_plic_reg_pkg.sv
       - rtl/rv_plic_reg_top.sv
       - rtl/rv_plic.sv
     file_type: systemVerilogSource
 
-
 parameters:
   SYNTHESIS:
     datatype: bool
     paramtype: vlogdefine
-
 
 targets:
   default: &default_target
@@ -38,6 +38,3 @@ targets:
         mode: lint-only
         verilator_options:
           - "-Wall"
-
-
-

--- a/hw/ip/rv_plic/rv_plic_component.core
+++ b/hw/ip/rv_plic/rv_plic_component.core
@@ -3,13 +3,12 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:ip:rv_plic_component:0.1"
-description: "RISC-V PLIC component without the CSRs"
+description: "RISC-V Platform Interrupt Controller (PLIC)"
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:ip:tlul
-      - lowrisc:prim:all
+      - lowrisc:prim:assert
     files:
       - rtl/rv_plic_gateway.sv
       - rtl/rv_plic_target.sv
@@ -46,4 +45,3 @@ targets:
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
       - files_rtl
-


### PR DESCRIPTION
* Clean up core files
* Use relative links in documentation, making the block relocateable.