### PR TITLE
[ipgen] Implement tool to produce IP blocks from IP templates

### DIFF
--- a/doc/rm/_index.md
+++ b/doc/rm/_index.md
@@ -7,6 +7,7 @@ title: "Reference Manuals"
 * Tool Guides
    * [Topgen Tool]({{< relref "topgen_tool" >}}): Describes `topgen.py` and its Hjson format source. Used to generate rtl and validation files for top specific modules such as PLIC, Pinmux and crossbar.
    * [Register Tool]({{< relref "register_tool" >}}): Describes `regtool.py` and its Hjson format source. Used to generate documentation, rtl, header files and validation files for IP Registers and toplevel.
+   * [Ipgen Tool]({{< relref "ipgen_tool" >}}): Describes `ipgen.py` and its Hjson control file. Used to generate IP blocks from IP templates.
    * [Crossbar Tool]({{< relref "crossbar_tool" >}}): Describes `tlgen.py` and its Hjson format source. Used to generate self-documentation, rtl files of the crossbars at the toplevel.
    * [Vendor-In Tool]({{< relref "vendor_in_tool" >}}): Describes `util/vendor.py` and its Hjson control file. Used to pull a local copy of code maintained in other upstream repositories and apply local patch sets.
 * Coding Style Guides

--- a/doc/rm/ipgen_tool.md
+++ b/doc/rm/ipgen_tool.md
@@ -1,0 +1,230 @@
+---
+title: "Ipgen: Generate IP blocks from IP templates"
+---
+
+Ipgen is a tool to produce IP blocks from IP templates.
+
+IP templates are highly customizable IP blocks which need to be pre-processed before they can be used in a hardware design.
+In the pre-processing ("rendering"), which is performed by the ipgen tool, templates of source files, written in the Mako templating language, are converted into "real" source files.
+The templates can be customized through template parameters, which are available within the templates.
+
+Ipgen is a command-line tool and a library.
+Users wishing to instantiate an IP template or query it for template parameters will find the command-line application useful.
+For use in higher-level scripting, e.g. within [topgen](topgen_tool.md) using ipgen as Python library is recommended.
+
+
+## Anatomy of an IP template
+
+An IP template is a directory with a well-defined directory layout, which mostly mirrors the standard layout of IP blocks.
+
+An IP template directory has a well-defined structure:
+
+* The IP template name (`<templatename>`) equals the directory name.
+* The directory contains a file `data/<templatename>.tpldesc.hjson` containing all configuration information related to the template.
+* The directory also contains zero or more files ending in `.tpl`.
+  These files are Mako templates and rendered into an file in the same location without the `.tpl` file extension.
+
+### The template description file
+
+Each IP template comes with a description itself.
+This description is contained in the `data/<templatename>.tpldesc.hjson` file in the template directory.
+The file is written in Hjson.
+
+It contains a top-level dictionary, the keys of which are documented next.
+
+#### List of template parameters: `template_param_list`
+
+Keys within `template_param_list`:
+
+* `name` (string): Name of the template parameter.
+* `desc` (string): Human-readable description of the template parameter.
+* `type` (string): Data type of the parameter. Valid values: `int`, `str`
+* `default` (string|int): The default value of the parameter. The data type should match the `type` argument. As convenience, strings are converted into integers on demand (if possible).
+
+#### Example template description file
+
+An exemplary template description file with two parameters, `src` and `target` is shown below.
+
+```hjson
+// data/<templatename>.tpldesc.hjson
+{
+  "template_param_list": [
+    {
+      "name": "src",
+      "desc": "Number of Interrupt Source",
+      "type": "int",
+      "default": "32"
+    },
+    {
+      "name": "target",
+      "desc": "Number of Interrupt Targets",
+      "type": "int",
+      "default": "32"
+    },
+  ],
+}
+```
+
+### Source file templates (`.tpl` files)
+
+Templates are written in the [Mako templating language](https://www.makotemplates.org/).
+All template parameters are available in the rendering context.
+For example, a template parameter `src` can be used in the template as `{{ src }}`.
+
+Furthermore, the following functions are available:
+
+* `instance_vlnv(vlnv)`: Transform a FuseSoC core name, expressed as VLNV string, into an instance-specific name.
+  The `vendor` is set to `lowrisc`, the `library` is set to `opentitan`, and the `name` is prefixed with the instance name.
+  Use this function on the `name` of all FuseSoC cores which contain sources generated from templates and which export symbols into the global namespace.
+
+### Templating FuseSoC core files
+
+FuseSoC core files can be templated just like any other file.
+Especially handy is the `instance_vlnv()` template function, which transforms a placeholder VLNV (a string in the form `vendor:library:name:version`) into a instance-specific one.
+
+For example, a `rv_plic.core.tpl` file could look like this:
+
+```yaml
+CAPI=2:
+name: ${instance_vlnv("lowrisc:ip:rv_plic")}
+```
+
+After processing, the `name` key is set to e.g. `lowrisc:opentitan:top_earlgrey_rv_plic`.
+
+The following rules should be applied when creating IP templates:
+
+* Template and use an instance-specific name for all FuseSoC cores which reference templated source files (e.g. SystemVerilog files).
+* Template and use an instance-specific name at least the top-level FuseSoC core.
+* If a FuseSoC core with an instance-specific name exposes a well-defined public interface (see below) add a `provides: lowrisc:ip_interfaces:<name>` line to the core file to allow other cores to refer to it without knowning the actual core name.
+
+#### Templating core files to uphold the "same name, same interface" principle
+
+FuseSoC core files should be written in a way that upholds the principle "same name, same public interface", i.e. if a FuseSoC core has the same name as another one, it must also provide the same public interface.
+
+Since SystemVerilog does not provide no strong control over which symbols become part of the public API developers must be carefully evaluate their source code.
+At least, the public interface is comprised of
+- module header(s), e.g. parameter names, ports (names, data types),
+- package names, and all identifiers within it, including enum values (but not the values assigned to them),
+- defines
+
+If any of those aspects of a source file are templated, the core name referencing the files must be made instance-specific.
+
+## Library usage
+
+Ipgen can be used as Python library by importing from the `ipgen` package.
+Refer to the comments within the source code for usage information.
+
+The following example shows how to produce an IP block from an IP template.
+
+```python
+from pathlib import Path
+from ipgen import IpConfig, IpTemplate, IpBlockRenderer
+
+# Load the template
+ip_template = IpTemplate.from_template_path(Path('a/ip/template/directory'))
+
+# Prepare the IP template configuration
+params = {}
+params['src'] = 17
+ip_config = IpConfig("my_instance", params)
+
+# Produce an IP block
+renderer = IpBlockRenderer(ip_template, ip_config)
+renderer.render(Path("path/to/the/output/directory"))
+```
+
+The output produced by ipgen is determined by the chosen renderer.
+For most use cases the `IpBlockRenderer` is the right choice, as it produces a full IP block directory.
+Refer to the `ipgen.renderer` module for more renderers available with ipgen.
+
+## Command-line usage
+
+The ipgen command-line tool lives in `util/ipgen.py`.
+The first argument is typically the action to be executed.
+
+```console
+$ cd $REPO_TOP
+$ util/ipgen.py --help
+usage: ipgen.py [-h] ACTION ...
+
+optional arguments:
+  -h, --help  show this help message and exit
+
+actions:
+  Use 'ipgen.py ACTION --help' to learn more about the individual actions.
+
+  ACTION
+    describe  Show details about an IP template
+    generate  Generate an IP block from an IP template
+```
+
+## `ipgen generate`
+
+```console
+$ cd $REPO_TOP
+$ util/ipgen.py generate --help
+usage: ipgen.py generate [-h] [--verbose] -C TEMPLATE_DIR -o OUTDIR [--force] [--config-file CONFIG_FILE]
+
+Generate an IP block from an IP template
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --verbose             More info messages
+  -C TEMPLATE_DIR, --template-dir TEMPLATE_DIR
+                        IP template directory
+  -o OUTDIR, --outdir OUTDIR
+                        output directory for the resulting IP block
+  --force, -f           overwrite the output directory, if it exists
+  --config-file CONFIG_FILE, -c CONFIG_FILE
+                        path to a configuration file
+```
+
+## `ipgen describe`
+
+```console
+$ cd $REPO_TOP
+$ util/ipgen.py generate --help
+usage: ipgen.py describe [-h] [--verbose] -C TEMPLATE_DIR
+
+Show all information available for the IP template.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --verbose             More info messages
+  -C TEMPLATE_DIR, --template-dir TEMPLATE_DIR
+                        IP template directory
+```
+
+
+## Limitations
+
+### Changing the IP block name is not supported
+
+Every IP block has a name, which is reflected in many places: in the name of the directory containing the block, in the base name of various files (e.g. the Hjson files in the `data` directory), in the `name` key of the IP description file in `data/<ipname>.hjson`, and many more.
+
+To "rename" an IP block, the content of multiple files, and multiple file names, have to be adjusted to reflect the name of the IP block, while keeping cross-references intact.
+Doing that is possible but a non-trivial amount of work, which is currently not implemented.
+This limitation is of lesser importance, as each template may be used only once in every toplevel design (see below).
+
+What is supported and required for most IP templates is the modification of the FuseSoC core name, which can be achieved by templating relevant `.core` files (see above).
+
+
+### Each template may be used only once per (top-level) design
+
+Each template may be used to generate only once IP block for each top-level design.
+The generated IP block can still be instantiated multiple times from SystemVerilog, including with different SystemVerilog parameters passed to it.
+It is not possible, however, to, for example, use one IP block template to produce two different flash controllers with different template parameters.
+
+IP templates generally contain code which exports symbols into the global namespace of the design: names of SystemVerilog modules and packages, defines, names of FuseSoC cores, etc.
+Such names need to be unique for each design, i.e. we cannot have multiple SystemVerilog modules with the same name in one design.
+To produce multiple IP blocks from the same IP template within a top-level design, exported symbols in generated IP blocks must be made "unique" within the design.
+Making symbols unique can be either done manually by the author of the template or automatically.
+
+In the manual approach, the template author writes all global identifiers in templates in a unique way, e.g. `module {prefix}_flash_ctrl` in SystemVerilog code, and with similar approaches wherever the name of the IP block is used (e.g. in cross-references in `top_<toplevelname>.hjson`).
+This is easy to implement in ipgen, but harder on the IP template authors, as it is easy to miss identifiers.
+
+In the automated approach, a tool that understands the source code transforms all identifiers.
+C++ name mangling uses a similar approach.
+The challenge is, however, to create a tool which can reliably do such source code transformations on a complex language like SystemVerilog.
+
+Finally, a third approach could be a combination of less frequently used/supported SystemVerilog language features like libraries, configs, and compilation units.

--- a/util/ipgen.py
+++ b/util/ipgen.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+r"""IP Generator: Produce IP blocks from IP templates
+"""
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from ipgen import (IpBlockRenderer, IpConfig, IpTemplate, TemplateParseError,
+                   TemplateRenderError)
+
+
+def init_logging(verbose: bool) -> None:
+    """ Initialize the logging system """
+    if verbose:
+        logging.basicConfig(format="%(levelname)s: %(message)s",
+                            level=logging.DEBUG)
+    else:
+        logging.basicConfig(format="%(levelname)s: %(message)s")
+
+
+def action_generate(ip_template: IpTemplate, args: argparse.Namespace) -> None:
+    """ Handle the 'generate' action/subcommand. """
+    overwrite_output_dir = args.force
+    output_path = args.outdir
+
+    # Read the IP configuration file.
+    config_fp = args.config_file
+    config_text = config_fp.read()
+    config_fp.close()
+    ip_config = IpConfig.from_text(config_text, "the file passed to --config")
+
+    # Render the IP template into an IP block.
+    renderer = IpBlockRenderer(ip_template, ip_config)
+    renderer.render(output_path, overwrite_output_dir)
+
+    print(
+        f"Wrote IP block {ip_config.instance_name!r} from template {ip_template.name!r} to '{output_path}'."
+    )
+
+
+def action_describe(ip_template: IpTemplate, args: argparse.Namespace) -> None:
+    """ Handle the 'describe' action/subcommand. """
+    headline = f"IP template {ip_template.name!r}"
+    print(headline)
+    print('=' * len(headline))
+    print()
+    print(f"The template is stored in '{ip_template.template_path}'.")
+    print()
+    print("Template parameters")
+    print("-------------------")
+    print()
+    for param in ip_template.params.values():
+        print(f"{param.name}:")
+        print(f"  Description: {param.desc}")
+        print(f"  Type: {param.param_type}")
+        print(f"  Default value: {param.default}")
+        print()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+
+    # Shared arguments across all actions
+    parent_parser = argparse.ArgumentParser(add_help=False)
+    parent_parser.add_argument(
+        "--verbose",
+        help="More info messages",
+        action="store_true",
+    )
+    parent_parser.add_argument(
+        '-C',
+        '--template-dir',
+        type=Path,
+        required=True,
+        help='IP template directory',
+    )
+
+    subparsers = parser.add_subparsers(
+        metavar='ACTION',
+        title="actions",
+        description=("Use 'ipgen.py ACTION --help' to learn more about the "
+                     "individual actions."))
+    subparsers.required = True
+
+    # 'describe' subparser
+    parser_generate = subparsers.add_parser(
+        "describe",
+        description="Show all information available for the IP template.",
+        help="Show details about an IP template",
+        parents=[parent_parser],
+    )
+    parser_generate.set_defaults(func=action_describe)
+
+    # 'generate' subparser
+    parser_generate = subparsers.add_parser(
+        "generate",
+        description="Generate an IP block from an IP template",
+        help="Generate an IP block from an IP template",
+        parents=[parent_parser],
+    )
+    parser_generate.add_argument(
+        "-o",
+        "--outdir",
+        required=True,
+        type=Path,
+        help="output directory for the resulting IP block",
+    )
+    parser_generate.add_argument(
+        "--force",
+        "-f",
+        required=False,
+        default=False,
+        action="store_true",
+        help="overwrite the output directory, if it exists",
+    )
+    parser_generate.add_argument(
+        "--config-file",
+        "-c",
+        required=False,
+        type=argparse.FileType('r'),
+        help="path to a configuration file",
+    )
+    parser_generate.set_defaults(func=action_generate)
+
+    # Parse command line arguments, parse IP template, and invoke subparsers
+    args = parser.parse_args()
+    init_logging(args.verbose)
+
+    try:
+        ip_template = IpTemplate.from_template_path(args.template_dir)
+        args.func(ip_template, args)
+    except (TemplateParseError, TemplateRenderError) as e:
+        if args.verbose:
+            # Show the full backtrace if operating in verbose mode.
+            logging.exception(e)
+        else:
+            # Otherwise just log the problem itself in a more user-friendly way.
+            logging.error(str(e))
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/util/ipgen/__init__.py
+++ b/util/ipgen/__init__.py
@@ -1,0 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from .lib import IpConfig, IpTemplate, TemplateParseError  # noqa: F401
+from .renderer import (IpBlockRenderer, IpDescriptionOnlyRenderer,
+                       TemplateRenderError)  # noqa: F401

--- a/util/ipgen/lib.py
+++ b/util/ipgen/lib.py
@@ -1,0 +1,209 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from typing import Dict, Optional, Union, cast
+
+import hjson  # type: ignore
+from reggen.lib import check_int, check_keys, check_list, check_name, check_str
+from reggen.params import BaseParam, Params
+
+
+class TemplateParseError(Exception):
+    pass
+
+
+class TemplateParameter(BaseParam):
+    """ A template parameter. """
+    def __init__(self, name: str, desc: Optional[str], param_type: str,
+                 default: str):
+        super().__init__(name, desc, param_type)
+        self.default = default
+        self.value = None
+
+    def as_dict(self) -> Dict[str, object]:
+        rd = super().as_dict()
+        rd['default'] = self.default
+        return rd
+
+
+def _parse_template_parameter(where: str, raw: object) -> TemplateParameter:
+    rd = check_keys(raw, where, ['name', 'desc', 'type'], ['default'])
+
+    name = check_str(rd['name'], 'name field of ' + where)
+
+    r_desc = rd.get('desc')
+    if r_desc is None:
+        desc = None
+    else:
+        desc = check_str(r_desc, 'desc field of ' + where)
+
+    r_type = rd.get('type')
+    param_type = check_str(r_type, 'type field of ' + where)
+    if not param_type in ('string', 'int'):
+        raise ValueError('At {}, the {} param has an invalid type field {!r}. '
+                         'Allowed values are: string, int.'.format(
+                             where, name, param_type))
+
+    r_default = rd.get('default')
+    default = check_str(r_default, 'default field of ' + where)
+    if param_type[:3] == 'int':
+        check_int(default,
+                  'default field of {}, (an integer parameter)'.format(name))
+
+    return TemplateParameter(name, desc, param_type, default)
+
+
+class TemplateParams(Params):
+    """ A group of template parameters. """
+    @classmethod
+    def from_raw(cls, where: str, raw: object) -> 'TemplateParams':
+        """ Produce a TemplateParams instance from an object as it is in Hjson.
+        """
+        ret = cls()
+        rl = check_list(raw, where)
+        for idx, r_param in enumerate(rl):
+            entry_where = 'entry {} in {}'.format(idx + 1, where)
+            param = _parse_template_parameter(entry_where, r_param)
+            if param.name in ret:
+                raise ValueError('At {}, found a duplicate parameter with '
+                                 'name {}.'.format(entry_where, param.name))
+            ret.add(param)
+        return ret
+
+
+class IpTemplate:
+    """ An IP template.
+
+    An IP template is an IP block which needs to be parametrized before it
+    can be transformed into an actual IP block (which can then be instantiated
+    in a hardware design).
+    """
+
+    name: str
+    params: Params
+    template_path: Path
+
+    def __init__(self, name: str, params: Params, template_path: Path):
+        self.name = name
+        self.params = params
+        self.template_path = template_path
+
+    @classmethod
+    def from_template_path(cls, template_path: Path) -> 'IpTemplate':
+        """ Create an IpTemplate from a template directory.
+
+        An IP template directory has a well-defined structure:
+
+        - The IP template name (TEMPLATE_NAME) is equal to the directory name.
+        - It contains a file 'data/TEMPLATE_NAME.tpldesc.hjson' containing all
+          configuration information related to the template.
+        - It contains zero or more files ending in '.tpl'. These files are
+          Mako templates and rendered into an file in the same location without
+          the '.tpl' file extension.
+        """
+
+        # Check if the directory structure matches expectations.
+        if not template_path.is_dir():
+            raise TemplateParseError(
+                "Template path {!r} is not a directory.".format(
+                    str(template_path)))
+        if not (template_path / 'data').is_dir():
+            raise TemplateParseError(
+                "Template path {!r} does not contain the required 'data' directory."
+                .format(str(template_path)))
+
+        # The template name equals the name of the template directory.
+        template_name = template_path.stem
+
+        # Find the template description file.
+        tpldesc_file = template_path / 'data/{}.tpldesc.hjson'.format(
+            template_name)
+
+        # Read the template description from file.
+        try:
+            tpldesc_obj = hjson.load(open(tpldesc_file, 'r'), use_decimal=True)
+        except (OSError, FileNotFoundError) as e:
+            raise TemplateParseError(
+                "Unable to read template description file {!r}: {}".format(
+                    str(tpldesc_file), str(e)))
+
+        # Parse the template description file.
+        where = 'template description file {!r}'.format(str(tpldesc_file))
+        if 'template_param_list' not in tpldesc_obj:
+            raise TemplateParseError(
+                f"Required key 'variables' not found in {where}")
+
+        try:
+            params = TemplateParams.from_raw(
+                f"list of parameters in {where}",
+                tpldesc_obj['template_param_list'])
+        except ValueError as e:
+            raise TemplateParseError(e) from None
+
+        return cls(template_name, params, template_path)
+
+
+def check_param_dict(obj: object, what: str) -> Dict[str, Union[int, str]]:
+    """ Check that obj is a dict with str keys and int or str values. """
+    if not isinstance(obj, dict):
+        raise ValueError(
+            "{} is expected to be a dict, but was actually a {}.".format(
+                what,
+                type(obj).__name__))
+
+    for key, value in obj.items():
+        if not isinstance(key, str):
+            raise ValueError(
+                '{} has a key {!r}, which is not a string.'.format(what, key))
+
+        if not (isinstance(value, str) or isinstance(value, int)):
+            raise ValueError(f"key {key} of {what} has a value {value!r}, "
+                             "which is neither a str, nor an int.")
+
+    return cast(Dict[str, Union[int, str]], obj)
+
+
+class IpConfig:
+    def __init__(self,
+                 instance_name: str,
+                 param_values: Dict[str, Union[str, int]] = {}):
+        self.instance_name = instance_name
+        self.param_values = param_values
+
+    @classmethod
+    def from_raw(cls, raw: object, where: str) -> 'IpConfig':
+        """ Load an IpConfig from a raw object """
+
+        rd = check_keys(raw, 'configuration file ' + where, ['instance_name'],
+                        ['param_values'])
+        instance_name = check_name(rd.get('instance_name'),
+                                   "the key 'instance_name' of " + where)
+
+        param_values = check_param_dict(rd.get('param_values', []),
+                                        f"the key 'param_values' of {where}")
+
+        return cls(instance_name, param_values)
+
+    @classmethod
+    def from_text(cls, txt: str, where: str) -> 'IpConfig':
+        """Load an IpConfig from an Hjson description in txt"""
+        return cls.from_raw(hjson.loads(txt, use_decimal=True), where)
+
+    def to_file(self, file_path: Path, header: Optional[str] = ""):
+        obj = {}
+        obj['instance_name'] = self.instance_name
+        obj['param_values'] = str(self.param_values)
+
+        with open(file_path, 'w') as fp:
+            if header:
+                fp.write(header)
+            hjson.dump(obj,
+                       fp,
+                       ensure_ascii=False,
+                       use_decimal=True,
+                       for_json=True,
+                       encoding='UTF-8',
+                       indent=2)
+            fp.write("\n")

--- a/util/ipgen/renderer.py
+++ b/util/ipgen/renderer.py
@@ -1,0 +1,286 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import shutil
+import time
+from pathlib import Path
+from typing import Dict, Optional, Union
+
+import reggen.gen_rtl
+from mako import exceptions as mako_exceptions  # type: ignore
+from mako.lookup import TemplateLookup as MakoTemplateLookup  # type: ignore
+from reggen.ip_block import IpBlock
+
+from .lib import IpConfig, IpTemplate
+
+_HJSON_LICENSE_HEADER = ("""// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+""")
+
+
+class TemplateRenderError(Exception):
+    pass
+
+
+class IpTemplateRendererBase:
+    """ Render an IpTemplate into an IP block. """
+
+    ip_template: IpTemplate
+    ip_config: IpConfig
+
+    _lookup: Optional[MakoTemplateLookup] = None
+
+    def __init__(self, ip_template: IpTemplate, ip_config: IpConfig) -> None:
+        self.ip_template = ip_template
+        self.ip_config = ip_config
+        self._check_param_values()
+
+    def _check_param_values(self) -> None:
+        """ Check if all parameters in IpConfig are defined in the template. """
+
+        for name in self.ip_config.param_values:
+            if name not in self.ip_template.params:
+                raise KeyError("No parameter named {!r} exists.".format(name))
+
+    def get_template_parameter_values(self) -> Dict[str, Union[str, int]]:
+        """ Get a typed mapping of all template parameters and their values.
+        """
+        ret = {}
+
+        for name, template_param in self.ip_template.params.items():
+            if name in self.ip_config.param_values:
+                val = self.ip_config.param_values[name]
+            else:
+                val = template_param.default
+
+            assert template_param.param_type in ('string', 'int')
+            try:
+                if template_param.param_type == 'string':
+                    val_typed = str(val)  # type: Union[int, str]
+                elif template_param.param_type == 'int':
+                    if not isinstance(val, int):
+                        val_typed = int(val, 0)
+                    else:
+                        val_typed = val
+            except (ValueError, TypeError):
+                raise TemplateRenderError(
+                    "For parameter {} cannot convert value {!r} "
+                    "to {}.".format(name, val,
+                                    template_param.param_type)) from None
+
+            ret[name] = val_typed
+
+        return ret
+
+    def _get_mako_template_lookup(self) -> MakoTemplateLookup:
+        """ Get a Mako TemplateLookup object """
+
+        if self._lookup is None:
+            # Define the directory containing the IP template as "base"
+            # directory, allowing templates to include other templates within
+            # this directory using relative paths.
+            # Use strict_undefined to throw a NameError if undefined variables
+            # are used within a template.
+            self._lookup = MakoTemplateLookup(
+                directories=[str(self.ip_template.template_path)],
+                strict_undefined=True)
+        return self._lookup
+
+    def _tplfunc_instance_vlnv(self, template_vlnv_str: str):
+        template_vlnv = template_vlnv_str.split(':', 3)
+        if len(template_vlnv) < 3:
+            raise TemplateRenderError(
+                f"{template_vlnv_str} isn't a valid FuseSoC VLNV. "
+                "Required format: 'vendor:library:name:version'")
+        template_core_name = template_vlnv[2]
+
+        # Remove the template name from the start of the core name.
+        # For example, a core name `rv_plic_component` will result in an
+        # instance name 'my_instance_component' (instead of
+        # 'my_instance_rv_plic_component').
+        if template_core_name.startswith(self.ip_template.name):
+            template_core_name = template_core_name[len(self.ip_template.name):]
+
+        instance_core_name = self.ip_config.instance_name + template_core_name
+        instance_vlnv = 'lowrisc:opentitan:' + instance_core_name
+        return instance_vlnv
+
+    def _render_mako_template_to_str(self, template_filepath: Path) -> str:
+        """ Render a template and return the rendered text. """
+
+        lookup = self._get_mako_template_lookup()
+        template_filepath_rel = template_filepath.relative_to(
+            self.ip_template.template_path)
+        template = lookup.get_template(str(template_filepath_rel))
+
+        helper_funcs = {}
+        helper_funcs['instance_vlnv'] = self._tplfunc_instance_vlnv
+
+        # TODO: Introduce namespacing for the template parameters and other
+        # parameters, and/or pass the IpConfig instance to the template after
+        # we have converted more IP blocks to ipgen.
+        tpl_args = {
+            "instance_name": self.ip_config.instance_name,  # type: ignore
+            **helper_funcs,  # type: ignore
+            **self.get_template_parameter_values()  # type: ignore
+        }
+        try:
+            return template.render(**tpl_args)
+        except:
+            raise TemplateRenderError(
+                "Unable to render template: " +
+                mako_exceptions.text_error_template().render()) from None
+
+    def _render_mako_template_to_file(self, template_filepath: Path,
+                                      outdir_path: Path) -> None:
+        """ Render a file template into a file in outdir_path.
+
+        The name of the output file matches the file name of the template file,
+        without the '.tpl' suffix.
+        """
+
+        assert outdir_path.is_dir()
+
+        outfile_name = self._filename_without_tpl_suffix(template_filepath)
+
+        with open(outdir_path / outfile_name, 'w') as f:
+            f.write(self._render_mako_template_to_str(template_filepath))
+
+    def _filename_without_tpl_suffix(self, filepath: Path) -> str:
+        """ Get the name of the file without a '.tpl' suffix. """
+        assert filepath.suffix == '.tpl'
+        return filepath.stem
+
+
+class IpDescriptionOnlyRenderer(IpTemplateRendererBase):
+    """ Generate the IP description only.
+
+    The IP description is the content of what is typically stored
+    data/ip_name.hjson.
+    """
+    def render(self) -> str:
+        template_path = self.ip_template.template_path
+
+        # Look for a data/ip_name.hjson.tpl template file and render it.
+        hjson_tpl_path = template_path / 'data' / (self.ip_template.name +
+                                                   '.hjson.tpl')
+        if hjson_tpl_path.is_file():
+            return self._render_mako_template_to_str(hjson_tpl_path)
+
+        # Otherwise, if a data/ip_name.hjson file exists, use that.
+        hjson_path = template_path / 'data' / (self.ip_template.name +
+                                               '.hjson')
+        try:
+            with open(hjson_path, 'r') as f:
+                return f.read()
+        except FileNotFoundError:
+            raise FileNotFoundError(
+                "Neither a IP description template at {}, "
+                "nor an IP description at {} exist!".format(
+                    hjson_tpl_path, hjson_path))
+
+
+class IpBlockRenderer(IpTemplateRendererBase):
+    """ Produce a full IP block directory from a template.
+
+    - Copy everything but Mako templates (files ending with '.tpl') into the
+      destination directory.
+    - Process all Mako templates and write the results to the output directory.
+      A template at <PATH>.tpl will write results to <PATH> in the output
+      directory.
+    - Run reggen to generate the register interface.
+    """
+    def render(self, output_dir: Path, overwrite_output_dir: bool) -> None:
+        """ Render the IP template into output_dir. """
+
+        # Ensure that we operate on an absolute path for output_dir.
+        output_dir = output_dir.resolve()
+
+        if not overwrite_output_dir and output_dir.exists():
+            raise TemplateRenderError(
+                "Output directory '{}' exists and should not be overwritten.".
+                format(output_dir))
+
+        # Prepare the IP directory in a staging area to later atomically move it
+        # to the final destination.
+        output_dir_staging = output_dir.parent / f".~{output_dir.stem}.staging"
+        if output_dir_staging.is_dir():
+            raise TemplateRenderError(
+                "Output staging directory '{}' already exists. Remove it and "
+                "try again.".format(output_dir_staging))
+
+        template_path = self.ip_template.template_path
+
+        try:
+            # Copy everything but the templates.
+            shutil.copytree(template_path,
+                            output_dir_staging,
+                            ignore=shutil.ignore_patterns('*.tpl'))
+
+            # Render templates.
+            for template_filepath in template_path.glob('**/*.tpl'):
+                template_filepath_rel = template_filepath.relative_to(
+                    template_path)
+
+                # Put the output file into the same relative directory as the
+                # template. The output file will also have the same name as the
+                # template, just without the '.tpl' suffix.
+                outdir_path = output_dir_staging / template_filepath_rel.parent
+
+                self._render_mako_template_to_file(template_filepath,
+                                                   outdir_path)
+
+            # Generate register interface through reggen.
+            hjson_path = (output_dir_staging / 'data' /
+                          (self.ip_template.name + '.hjson'))
+            rtl_path = output_dir_staging / 'rtl'
+            # TODO: Pass on template parameters to reggen? Or enable the user
+            # to set a different set of parameters in the renderer?
+            reggen.gen_rtl.gen_rtl(IpBlock.from_path(str(hjson_path), []),
+                                   str(rtl_path))
+
+            # Write IP configuration (to reproduce the generation process).
+            # TODO: Should the ipconfig file be written to the instance name,
+            # or the template name?
+            self.ip_config.to_file(
+                output_dir_staging /
+                'data/{}.ipconfig.hjson'.format(self.ip_config.instance_name),
+                header=_HJSON_LICENSE_HEADER)
+
+            # Safely overwrite the existing directory if necessary:
+            #
+            # - First move the existing directory out of the way.
+            # - Then move the staging directory with the new content in place.
+            # - Finally remove the old directory.
+            #
+            # If anything goes wrong in the meantime we are left with either
+            # the old or the new directory, and potentially some backups of
+            # outdated files.
+            do_overwrite = overwrite_output_dir and output_dir.exists()
+            output_dir_existing_bak = output_dir.with_suffix(
+                '.bak~' + str(int(time.time())))
+            if do_overwrite:
+                os.rename(output_dir, output_dir_existing_bak)
+
+            # Move the staging directory to the final destination.
+            os.rename(output_dir_staging, output_dir)
+
+            # Remove the old/"overwritten" data.
+            if do_overwrite:
+                try:
+                    shutil.rmtree(output_dir_existing_bak)
+                except Exception as e:
+                    msg = (
+                        f'Unable to delete the backup directory '
+                        '{output_dir_existing_bak} of the overwritten data. '
+                        'Please remove it manually.')
+                    raise TemplateRenderError(msg).with_traceback(
+                        e.__traceback__)
+
+        finally:
+            # Ensure that the staging directory is removed at the end. Ignore
+            # errors as the directory should not exist at this point actually.
+            shutil.rmtree(output_dir_staging, ignore_errors=True)


### PR DESCRIPTION
Ipgen is a tool to produce IP blocks from IP templates.

IP templates are highly customizable IP blocks which need to be pre-processed before they can be used in a hardware design.
In the pre-processing ("rendering"), which is performed by the ipgen tool, templates of source files, written in the Mako templating language, are converted into "real" source files.
The templates can be customized through template parameters, which are available within the templates.

This PR adds the ipgen tool mostly as it was designed by Eunchan and discussed more widely in https://docs.google.com/document/d/1jimqHdR1x8on3jwzsi8SHTdhXFvujHj-EFk-eGU9mX4/edit
Some deviations from the original proposal exist, the documentation also included in this PR discusses the implemented design in detail.

*For reviewers*: This PR contains multiple commits.
* ~Ignore all commits starting with `[reggen]`. (They are being reviewed in #5635 and will be removed before landing.)~ (Edit: They are gone now.)
* The tool is described in `doc/rm/ipgen_tool.md`, which is part of this PR. I recommend starting with this file.

Further notes:
* The implementation tries to mostly follow the style of reggen and uses code from it to avoid re-inventing the wheel. Ultimaely, I hope we can form a common base library to work with Hjson files out of tools like reggen, topgen, and ipgen.
* Ipgen isn't used anywhere yet in this PR. This will come in a follow-up.
* Currently OpenTitan contains the following IP templates within `hw/ip`: alert_handler, clkmgr, flash_ctrl, pinmux, pwrmgr, rstmgr, rv_plic

Fixes #4345