### PR TITLE
[dv/common] Fix regression warnings

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg_field.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_field.sv
@@ -50,7 +50,7 @@ class dv_base_reg_field extends uvm_reg_field;
     if (is_intr_test_fld) begin
       uvm_reg_field intr_state_fld = get_intr_state_field();
       // use UVM_PREDICT_READ to avoid uvm_warning due to UVM_PREDICT_DIRECT
-      intr_state_fld.predict(field_val | `gmv(intr_state_fld), .kind(UVM_PREDICT_READ));
+      void'(intr_state_fld.predict(field_val | `gmv(intr_state_fld), .kind(UVM_PREDICT_READ)));
     end
 
     super.do_predict(rw, kind, be);

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -31,8 +31,8 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   endtask
 
   // Cfg errors are cleared after reset
-  virtual task apply_reset(string reset_kind = "HARD");
-    super.apply_reset(reset_kind);
+  virtual task apply_reset(string kind = "HARD");
+    super.apply_reset(kind);
     cfg.ecc_err = OtpNoEccErr;
   endtask
 


### PR DESCRIPTION
This PR fixes two warnings in regression:
1. Add a void cast when using predict function
2. Correct apply_reset input name in otp_ctrl dv

Signed-off-by: Cindy Chen <chencindy@google.com>