### PR TITLE
[dv] Add timeout for each TL error access

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/cip_base_vseq__tl_errors.svh
@@ -17,7 +17,7 @@
     tl_seq.req_abort_pct = $urandom_range(0, 100); \
     `DV_CHECK_RANDOMIZE_WITH_FATAL(tl_seq, with_c_) \
     csr_utils_pkg::increment_outstanding_access(); \
-    `uvm_send_pri(tl_seq, 1) \
+    `DV_SPINWAIT(`uvm_send_pri(tl_seq, 1), 10_000) \
     csr_utils_pkg::decrement_outstanding_access(); \
   end
 

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -32,9 +32,9 @@
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
-                // TODO #5484, comment this out because spi host memory is dummy
+                // TODO #5484, comment these 2 lines out because spi host memory is dummy
                 // "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
+                // "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 // xbar tests
                 "{proj_root}/hw/ip/tlul/generic_dv/xbar_tests.hjson",
                 // Config files to get the correct flags for otbn_memutil and otbn_tracer


### PR DESCRIPTION
Also comment out tl_err test in chip-level due to #5484, because
tl_err includes mem access and dummy spi_host mem may cause hang

Signed-off-by: Weicai Yang <weicai@google.com>