### PR TITLE
[dv/top_earlgrey] chip csr_aliasing timeout

### DIFF
--- a/hw/dv/sv/csr_utils/csr_seq_lib.sv
+++ b/hw/dv/sv/csr_utils/csr_seq_lib.sv
@@ -410,6 +410,11 @@ class csr_aliasing_seq extends csr_base_seq;
       csr_wr(.csr(test_csrs[i]), .value(wdata), .blocking(0), .predict(!external_checker));
 
       all_csrs.shuffle();
+
+      // If all_csrs queue size is larger than 100, randomly pick 100 CSRs to avoid chip level test
+      // runtime too long.
+      if (all_csrs.size() > 100) all_csrs = all_csrs[0 : 99];
+
       foreach (all_csrs[j]) begin
         uvm_reg_data_t compare_mask;
 


### PR DESCRIPTION
Current chip csr_aliasing automation test timeout because chip level
totally has 1510 csrs in csr_aliasing test. So totally there are around
1510 * 1510 csr access in one iteration.
To reduce the runtime, For each CSR in top-level, we only randomly pick
100 CSRs, so the totally csr access is 1510 * 100.
For two iterations, this fix reduce the runtime to 38 mins.

Signed-off-by: Cindy Chen <chencindy@google.com>