### PR TITLE
[dv] Fix stress_all failure in i2c and pattgen

### DIFF
--- a/hw/ip/i2c/dv/env/seq_lib/i2c_stress_all_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_stress_all_vseq.sv
@@ -75,7 +75,7 @@ class i2c_stress_all_vseq extends i2c_rx_tx_vseq;
           i2c_common_vseq common_vseq;
           `downcast(common_vseq, i2c_vseq);
           common_vseq.common_seq_type = "intr_test";
-          cfg.en_scb = 1'b0;
+          cfg.en_scb = 1'b1;
         end
         "i2c_override_vseq": begin
           cfg.en_scb = 1'b0;

--- a/hw/ip/pattgen/dv/env/seq_lib/pattgen_stress_all_vseq.sv
+++ b/hw/ip/pattgen/dv/env/seq_lib/pattgen_stress_all_vseq.sv
@@ -53,17 +53,11 @@ class pattgen_stress_all_vseq extends pattgen_base_vseq;
 
       pattgen_vseq.set_sequencer(p_sequencer);
       `DV_CHECK_RANDOMIZE_FATAL(pattgen_vseq)
-      case (seq_name)
-        "pattgen_common_vseq": begin
-          pattgen_common_vseq common_vseq;
-          `downcast(common_vseq, pattgen_vseq);
-          common_vseq.common_seq_type = "intr_test";
-          cfg.en_scb = 1'b0;
-        end
-        default: begin
-          cfg.en_scb = 1'b1;
-        end
-      endcase
+      if (seq_name == "pattgen_common_vseq") begin
+        pattgen_common_vseq common_vseq;
+        `downcast(common_vseq, pattgen_vseq);
+        common_vseq.common_seq_type = "intr_test";
+      end
       // run vseq
       pattgen_vseq.start(p_sequencer);
       seq_run_hist[seq_name]++;


### PR DESCRIPTION
intr_test needs to have scb enabled
I have run a 20+ seeds and they're passing

Signed-off-by: Weicai Yang <weicai@google.com>