### PR TITLE
[fpv] compile issue fix

### DIFF
--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -50,7 +50,7 @@ if {$env(FPV_TOP) == "rv_dm"} {
   clock clk_i -both_edges
   clock cio_sck_i
   clock -rate {scanmode_i, tl_i} clk_i
-  clock -rate {cio_csb_i, cio_sdi_i} cio_sck_i
+  clock -rate {cio_csb_i, cio_sd_i} cio_sck_i
   reset -expr {!rst_ni cio_csb_i}
 
 } elseif {$env(FPV_TOP) == "usbuart"} {

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -163,7 +163,7 @@ module aes
     .entropy_masking_ack_i  ( entropy_masking_ack  ),
     .entropy_masking_i      ( edn_data             ),
 
-    .lc_escalate_en_i       ( lc_escalate_en       ),
+    .lc_escalate_en_i       ( lc_escalate_en[0]    ),
 
     .alert_recov_o          ( alert[0]             ),
     .alert_fatal_o          ( alert[1]             ),


### PR DESCRIPTION
This PR fixes two compile issue:
1. SPI_DEVICE the fpv.tcl script has a signal name mismatch
2. AES has an issue where input is recogized as an array

Signed-off-by: Cindy Chen <chencindy@google.com>