### PR TITLE
[dv/sram] access_during_key_req test

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_access_during_key_req_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_access_during_key_req_vseq.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence drives memory accesses during a request to OTP for a new scrambling key,
+// and verifies that accesses performed during this time are dropped (handled in scoreboard).
+class sram_ctrl_access_during_key_req_vseq extends sram_ctrl_multiple_keys_vseq;
+
+  `uvm_object_utils(sram_ctrl_access_during_key_req_vseq)
+  `uvm_object_new
+
+  virtual task pre_start();
+    access_during_key_req = 1;
+    super.pre_start();
+  endtask
+
+endclass

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_vseq_list.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_vseq_list.sv
@@ -10,3 +10,4 @@
 `include "sram_ctrl_stress_pipeline_vseq.sv"
 `include "sram_ctrl_lc_escalation_vseq.sv"
 `include "sram_ctrl_mem_tl_errors_vseq.sv"
+`include "sram_ctrl_access_during_key_req_vseq.sv"

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
@@ -27,6 +27,7 @@ filesets:
       - seq_lib/sram_ctrl_stress_pipeline_vseq.sv: {is_include_file: true}
       - seq_lib/sram_ctrl_lc_escalation_vseq.sv: {is_include_file: true}
       - seq_lib/sram_ctrl_mem_tl_errors_vseq.sv: {is_include_file: true}
+      - seq_lib/sram_ctrl_access_during_key_req_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -90,6 +90,10 @@
       uvm_test_seq: sram_ctrl_mem_tl_errors_vseq
       run_opts: ["+run_tl_errors"]
     }
+    {
+      name: "{variant}_access_during_key_req"
+      uvm_test_seq: sram_ctrl_access_during_key_req_vseq
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
this PR implements the `access_during_key_req` test as described in the
testplan.

in this test we drive a bunch of memory accesses during a request to OTP
for a new scrambling key, and verify that none of these requests are
  handled (similar to the lc_escalation test).

Signed-off-by: Udi Jonnalagadda <udij@google.com>