### PR TITLE
[memutil] Factor out MemArea as a class and use it for otbn_model

### DIFF
--- a/hw/dv/verilator/cpp/dpi_memutil.cc
+++ b/hw/dv/verilator/cpp/dpi_memutil.cc
@@ -312,7 +312,9 @@ std::vector<uint8_t> StagedMem::GetFlat() const {
 }
 
 void DpiMemUtil::RegisterMemoryArea(const std::string &name, uint32_t base,
-                                    std::unique_ptr<MemArea> &&mem_area) {
+                                    const MemArea *mem_area) {
+  assert(mem_area);
+
   // Check that we don't overflow the address space.
   uint32_t size = mem_area->GetSizeBytes();
   uint32_t addr_top = base + (size - 1);
@@ -347,7 +349,7 @@ void DpiMemUtil::RegisterMemoryArea(const std::string &name, uint32_t base,
     throw std::runtime_error(oss.str());
   }
 
-  mem_areas_.emplace_back(std::move(mem_area));
+  mem_areas_.push_back(mem_area);
   base_addrs_.push_back(base);
   names_.push_back(name);
 }

--- a/hw/dv/verilator/cpp/dpi_memutil.h
+++ b/hw/dv/verilator/cpp/dpi_memutil.h
@@ -70,14 +70,15 @@ class DpiMemUtil {
    * with some other registered memory, the constructor throws a
    * std::runtime_error.
    *
-   * This function takes ownership of its |mem_area| argument, which
-   * must not be null.
+   * The |mem_area| argument describes the memory area to be registered and
+   * must not be null. This function does not take ownership of the object,
+   * which must survive at least as long as the DpiMemutil object.
    *
    * Memories must be registered before command arguments are parsed by
    * ParseCommandArgs() in order for them to be known.
    */
   void RegisterMemoryArea(const std::string &name, uint32_t base,
-                          std::unique_ptr<MemArea> &&mem_area);
+                          const MemArea *mem_area);
 
   /**
    * Guess the type of the file at |path|.
@@ -128,9 +129,10 @@ class DpiMemUtil {
   const StagedMem &GetMemoryData(const std::string &mem_name) const;
 
  private:
-  // Memory area registry. The maps give indices pointing into
-  // the vectors (which all have the same number of elements).
-  std::vector<std::unique_ptr<MemArea>> mem_areas_;
+  // Memory area registry. The maps give indices pointing into the vectors
+  // (which all have the same number of elements). Note that mem_areas_ does
+  // not own the objects that it points to.
+  std::vector<const MemArea *> mem_areas_;
   std::vector<uint32_t> base_addrs_;
   std::vector<std::string> names_;
 

--- a/hw/dv/verilator/cpp/mem_area.cc
+++ b/hw/dv/verilator/cpp/mem_area.cc
@@ -1,0 +1,113 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mem_area.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <sstream>
+
+#include "sv_scoped.h"
+
+// DPI exports, defined in prim_util_memload.svh
+extern "C" {
+void simutil_memload(const char *file);
+int simutil_set_mem(int index, const svBitVecVal *val);
+int simutil_get_mem(int index, svBitVecVal *val);
+}
+
+MemArea::MemArea(const std::string &scope, uint32_t num_words,
+                 uint32_t width_byte)
+    : scope_(scope), num_words_(num_words), width_byte_(width_byte) {
+  assert(0 < num_words);
+  assert(width_byte <= SV_MEM_WIDTH_BYTES);
+}
+
+void MemArea::Write(uint32_t word_offset,
+                    const std::vector<uint8_t> &data) const {
+  // If this fails to set scope, it will throw an error which should
+  // be caught at this function's callsite.
+  SVScoped scoped(scope_);
+
+  // This "mini buffer" is used to transfer each write to SystemVerilog.
+  // `simutil_set_mem` takes a fixed SV_MEM_WIDTH_BITS-bit vector but it will
+  // only use the bits required for the RAM width. As an example, for a 32-bit
+  // wide RAM only elements 3:0 of `minibuf` will be written to memory. Since
+  // the simulator may still read bits from minibuf it does not use, we must
+  // use a fixed allocation of the full bit vector size to avoid an out of
+  // bounds access.
+  uint8_t minibuf[SV_MEM_WIDTH_BYTES];
+  memset(minibuf, 0, sizeof minibuf);
+  assert(width_byte_ <= sizeof minibuf);
+
+  uint32_t data_words = (data.size() + width_byte_ - 1) / width_byte_;
+  assert(word_offset + data_words <= num_words_);
+
+  for (uint32_t i = 0; i < data_words; ++i) {
+    uint32_t dst_word = word_offset + i;
+    WriteBuffer(minibuf, data, i * width_byte_);
+    if (!simutil_set_mem(dst_word, (svBitVecVal *)minibuf)) {
+      std::ostringstream oss;
+      oss << "Could not set memory at byte offset 0x" << std::hex
+          << dst_word * width_byte_ << ".";
+      throw std::runtime_error(oss.str());
+    }
+  }
+}
+
+std::vector<uint8_t> MemArea::Read(uint32_t word_offset,
+                                   uint32_t num_words) const {
+  assert(word_offset + num_words <= num_words_);
+
+  uint32_t num_bytes = width_byte_ * num_words;
+  assert(num_words <= num_bytes);
+
+  SVScoped scoped(scope_);
+
+  // See Write for an explanation for this buffer.
+  uint8_t minibuf[SV_MEM_WIDTH_BYTES];
+  memset(minibuf, 0, sizeof minibuf);
+  assert(width_byte_ <= sizeof minibuf);
+
+  std::vector<uint8_t> ret;
+  ret.reserve(num_bytes);
+
+  for (uint32_t i = 0; i < num_words; ++i) {
+    uint32_t src_word = word_offset + i;
+    if (!simutil_get_mem(src_word, (svBitVecVal *)minibuf)) {
+      std::ostringstream oss;
+      oss << "Could not read memory at byte offset 0x" << std::hex
+          << src_word * width_byte_ << ".";
+      throw std::runtime_error(oss.str());
+    }
+    ReadBuffer(ret, minibuf);
+  }
+
+  return ret;
+}
+
+void MemArea::LoadVmem(const std::string &path) const {
+  SVScoped scoped(scope_.c_str());
+  // TODO: Add error handling.
+  simutil_memload(path.c_str());
+}
+
+void MemArea::WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
+                          const std::vector<uint8_t> &data,
+                          size_t start_idx) const {
+  size_t words_left = data.size() - start_idx;
+  size_t to_copy = std::min(words_left, (size_t)width_byte_);
+  if (to_copy < width_byte_) {
+    memset(buf, 0, SV_MEM_WIDTH_BYTES);
+  }
+  memcpy(buf, &data[start_idx], to_copy);
+}
+
+void MemArea::ReadBuffer(std::vector<uint8_t> &data,
+                         const uint8_t buf[SV_MEM_WIDTH_BYTES]) const {
+  // Append the first width_byte_ bytes of buf to data.
+  std::copy_n(reinterpret_cast<const char *>(buf), width_byte_,
+              std::back_inserter(data));
+}

--- a/hw/dv/verilator/cpp/mem_area.h
+++ b/hw/dv/verilator/cpp/mem_area.h
@@ -1,0 +1,116 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_HW_DV_VERILATOR_CPP_MEM_AREA_H_
+#define OPENTITAN_HW_DV_VERILATOR_CPP_MEM_AREA_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// This is the maximum width of a memory that's supported by the code in
+// prim_util_memload.svh
+#define SV_MEM_WIDTH_BITS 312
+#define SV_MEM_WIDTH_BYTES ((SV_MEM_WIDTH_BITS + 7) / 8)
+
+/**
+ * A "memory area", representing a memory in the simulated design.
+ */
+class MemArea {
+ public:
+  /** Constructor
+   *
+   * @param scope  The SystemVerilog scope where the instantiated memory can be
+   *               found. This needs to support the DPI-C interfaces \c
+   *               simutil_memload and \c simutil_set_mem (used for vmem and
+   *               ELF files, respectively).
+   *
+   * @param size   The size of the memory in bytes (must be positive and a
+   *               multiple of \p width_byte)
+   *
+   * @param size   The width of each entry in bytes (must be positive)
+   */
+  MemArea(const std::string &scope, uint32_t size, uint32_t width_byte);
+
+  virtual ~MemArea() {}
+
+  /** Write data to this memory area at the given word offset
+   *
+   * This assumes that the result will fit in the memory. If the scope cannot
+   * be set, this throws an SVScoped::Error. If a call to \c simutil_set_mem
+   * fails, this throws a \c std::runtime_error.
+   *
+   * @param word_offset The offset, in words, of the first word that should be
+   *                    written.
+   *
+   * @param data        The data that should be written. If the length is not a
+   *                    multiple of \p word_offset, the last word will be
+   *                    zero-extended.
+   */
+  virtual void Write(uint32_t word_offset,
+                     const std::vector<uint8_t> &data) const;
+
+  /** Read data from this memory area, starting at the given offset.
+   *
+   * This assumes that there are <tt>word_offset + num_words</tt> words in the
+   * memory. Returns a vector with <tt>num_words * width_byte_</tt> elements.
+   *
+   * If the scope cannot be set, this throws an SVScoped::Error. If a call to
+   * simutil_get_mem fails, this throws a std::runtime_error.
+   *
+   * @param word_offset The offset, in words, of the first word that should be
+   *                    written.
+   *
+   * @param num_words   The number of words to read.
+   */
+  virtual std::vector<uint8_t> Read(uint32_t word_offset,
+                                    uint32_t num_words) const;
+
+  /** Use \c simutil_memload to load a vmem file into the memory */
+  virtual void LoadVmem(const std::string &path) const;
+
+  const std::string &GetScope() const { return scope_; }
+  uint32_t GetSizeWords() const { return num_words_; }
+  uint32_t GetSizeBytes() const { return num_words_ * width_byte_; }
+  uint32_t GetWidthByte() const { return width_byte_; }
+  uint32_t GetWidth() const { return 8 * width_byte_; }
+
+ protected:
+  std::string scope_;    ///< Design scope (used for accesses over DPI)
+  uint32_t num_words_;   ///< Size of the memory area in words
+  uint32_t width_byte_;  ///< Size of each word in bytes
+
+  /** Write to buf with the data that should be copied to the physical memory
+   * for a single memory word.
+   *
+   * The default implementation just uses memcpy to copy the data across. Other
+   * implementations might add scrambling, ECC bits or similar. This must write
+   * every bit of buf that will be used by the memory, but needn't clear bits
+   * further up (this is done outside of the loop).
+   *
+   * @param buf       Destination buffer
+   * @param data      A large buffer that contains the data to be written
+   * @param start_idx An offset into \p data for the start of the memory word
+   */
+  virtual void WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
+                           const std::vector<uint8_t> &data,
+                           size_t start_idx) const;
+
+  /** Extract the logical memory contents corresponding to the physical
+   * memory contents in \p buf and append them to \p data.
+   *
+   * The default implementation just uses \c std::copy_n to copy the data
+   * across. Other implementations might undo scrambling, remove ECC bits or
+   * similar.
+   *
+   * @param data The target, onto which the extracted memory contents should be
+   *             appended.
+   *
+   * @param buf  Source buffer (physical memory bits)
+   */
+  virtual void ReadBuffer(std::vector<uint8_t> &data,
+                          const uint8_t buf[SV_MEM_WIDTH_BYTES]) const;
+};
+
+#endif  // OPENTITAN_HW_DV_VERILATOR_CPP_MEM_AREA_H_

--- a/hw/dv/verilator/cpp/verilator_memutil.h
+++ b/hw/dv/verilator/cpp/verilator_memutil.h
@@ -28,8 +28,8 @@ class VerilatorMemUtil : public SimCtrlExtension {
 
   // Pass-thru function to underlying object
   void RegisterMemoryArea(const std::string &name, uint32_t base,
-                          std::unique_ptr<MemArea> &&mem_area) {
-    return mem_util_->RegisterMemoryArea(name, base, std::move(mem_area));
+                          const MemArea *mem_area) {
+    return mem_util_->RegisterMemoryArea(name, base, mem_area);
   }
 
  private:

--- a/hw/dv/verilator/cpp/verilator_memutil.h
+++ b/hw/dv/verilator/cpp/verilator_memutil.h
@@ -5,7 +5,7 @@
 #define OPENTITAN_HW_DV_VERILATOR_CPP_VERILATOR_MEMUTIL_H_
 
 //
-// A wrapper class that converts a VerilatorMemutil into a SimCtrlExtension
+// A wrapper class that converts a DpiMemutil into a SimCtrlExtension
 //
 
 #include <memory>
@@ -26,14 +26,10 @@ class VerilatorMemUtil : public SimCtrlExtension {
   // Get underlying DpiMemUtil object
   DpiMemUtil *GetUnderlying() { return mem_util_; }
 
-  // Pass-thru functions to underlying object
-  bool RegisterMemoryArea(const std::string name, const std::string location,
-                          size_t width_bit, const MemAreaLoc *addr_loc) {
-    return mem_util_->RegisterMemoryArea(name, location, width_bit, addr_loc);
-  }
-
-  bool RegisterMemoryArea(const std::string name, const std::string location) {
-    return mem_util_->RegisterMemoryArea(name, location);
+  // Pass-thru function to underlying object
+  void RegisterMemoryArea(const std::string &name, uint32_t base,
+                          std::unique_ptr<MemArea> &&mem_area) {
+    return mem_util_->RegisterMemoryArea(name, base, std::move(mem_area));
   }
 
  private:

--- a/hw/dv/verilator/memutil_dpi.core
+++ b/hw/dv/verilator/memutil_dpi.core
@@ -8,9 +8,11 @@ description: "DPI memory utilities"
 filesets:
   files_cpp:
     files:
-      - cpp/ranged_map.h: { is_include_file: true }
       - cpp/dpi_memutil.cc
       - cpp/dpi_memutil.h: { is_include_file: true }
+      - cpp/mem_area.cc
+      - cpp/mem_area.h: { is_include_file: true }
+      - cpp/ranged_map.h: { is_include_file: true }
       - cpp/sv_scoped.cc
       - cpp/sv_scoped.h: { is_include_file: true }
     file_type: cppSource

--- a/hw/ip/otbn/dv/memutil/otbn_memutil.cc
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil.cc
@@ -10,11 +10,20 @@
 #include <limits>
 #include <stdexcept>
 
+// join two, possibly relative, scopes correctly.
+static std::string join_scopes(const std::string &a, const std::string &b) {
+  assert(a.size() && b.size());
+  // If a = ".." and b = "foo.bar", we want "..foo.bar". Otherwise, a
+  // = "..foo" and b = "bar.baz", so we want "..foo.bar.baz"
+  // (inserting a "." between the two)
+  return (a.back() == '.') ? a + b : a + "." + b;
+}
+
 OtbnMemUtil::OtbnMemUtil(const std::string &top_scope)
-    : imem_(top_scope + ".u_imem.u_mem.gen_generic.u_impl_generic", 4096 / 4,
-            4),
-      dmem_(top_scope + ".u_dmem.u_mem.gen_generic.u_impl_generic", 4096 / 32,
-            32) {
+    : imem_(join_scopes(top_scope, "u_imem.u_mem.gen_generic.u_impl_generic"),
+            4096 / 4, 4),
+      dmem_(join_scopes(top_scope, "u_dmem.u_mem.gen_generic.u_impl_generic"),
+            4096 / 32, 32) {
   RegisterMemoryArea("imem", 0x4000, &imem_);
   RegisterMemoryArea("dmem", 0x8000, &dmem_);
 }

--- a/hw/ip/otbn/dv/memutil/otbn_memutil.cc
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil.cc
@@ -10,14 +10,13 @@
 #include <limits>
 #include <stdexcept>
 
-OtbnMemUtil::OtbnMemUtil(const std::string &top_scope) {
-  std::unique_ptr<MemArea> imem(new MemArea(
-      top_scope + ".u_imem.u_mem.gen_generic.u_impl_generic", 4096 / 4, 4));
-  std::unique_ptr<MemArea> dmem(new MemArea(
-      top_scope + ".u_dmem.u_mem.gen_generic.u_impl_generic", 4096 / 32, 32));
-
-  RegisterMemoryArea("imem", 0x4000, std::move(imem));
-  RegisterMemoryArea("dmem", 0x8000, std::move(dmem));
+OtbnMemUtil::OtbnMemUtil(const std::string &top_scope)
+    : imem_(top_scope + ".u_imem.u_mem.gen_generic.u_impl_generic", 4096 / 4,
+            4),
+      dmem_(top_scope + ".u_dmem.u_mem.gen_generic.u_impl_generic", 4096 / 32,
+            32) {
+  RegisterMemoryArea("imem", 0x4000, &imem_);
+  RegisterMemoryArea("dmem", 0x8000, &dmem_);
 }
 
 void OtbnMemUtil::LoadElf(const std::string &elf_path) {

--- a/hw/ip/otbn/dv/memutil/otbn_memutil.cc
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil.cc
@@ -11,19 +11,13 @@
 #include <stdexcept>
 
 OtbnMemUtil::OtbnMemUtil(const std::string &top_scope) {
-  MemAreaLoc imem_loc = {.base = 0x4000, .size = 4096};
-  std::string imem_scope =
-      top_scope + ".u_imem.u_mem.gen_generic.u_impl_generic";
-  if (!RegisterMemoryArea("imem", imem_scope, 32, &imem_loc)) {
-    throw std::runtime_error("Failed to register IMEM OTBN memory area.");
-  }
+  std::unique_ptr<MemArea> imem(new MemArea(
+      top_scope + ".u_imem.u_mem.gen_generic.u_impl_generic", 4096 / 4, 4));
+  std::unique_ptr<MemArea> dmem(new MemArea(
+      top_scope + ".u_dmem.u_mem.gen_generic.u_impl_generic", 4096 / 32, 32));
 
-  MemAreaLoc dmem_loc = {.base = 0x8000, .size = 4096};
-  std::string dmem_scope =
-      top_scope + ".u_dmem.u_mem.gen_generic.u_impl_generic";
-  if (!RegisterMemoryArea("dmem", dmem_scope, 256, &dmem_loc)) {
-    throw std::runtime_error("Failed to register DMEM OTBN memory area.");
-  }
+  RegisterMemoryArea("imem", 0x4000, std::move(imem));
+  RegisterMemoryArea("dmem", 0x8000, std::move(dmem));
 }
 
 void OtbnMemUtil::LoadElf(const std::string &elf_path) {

--- a/hw/ip/otbn/dv/memutil/otbn_memutil.h
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil.h
@@ -23,6 +23,11 @@ class OtbnMemUtil : public DpiMemUtil {
   // Get access to the segments currently staged for imem/dmem
   const StagedMem::SegMap &GetSegs(bool is_imem) const;
 
+  // Get access to a memory area
+  const MemArea &GetMemArea(bool is_imem) const {
+    return is_imem ? imem_ : dmem_;
+  }
+
  private:
   MemArea imem_, dmem_;
 };

--- a/hw/ip/otbn/dv/memutil/otbn_memutil.h
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil.h
@@ -22,6 +22,9 @@ class OtbnMemUtil : public DpiMemUtil {
 
   // Get access to the segments currently staged for imem/dmem
   const StagedMem::SegMap &GetSegs(bool is_imem) const;
+
+ private:
+  MemArea imem_, dmem_;
 };
 
 // DPI-accessible wrappers

--- a/hw/ip/otbn/dv/memutil/otbn_memutil_sim_opts.hjson
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil_sim_opts.hjson
@@ -8,16 +8,21 @@
   memutil_dpi_core: "lowrisc:dv_verilator:memutil_dpi:0"
   memutil_dpi_src_dir: "{eval_cmd} echo \"{memutil_dpi_core}\" | tr ':' '_'"
 
+  otbn_memutil_core: "lowrisc:dv:otbn_memutil:0"
+  otbn_memutil_src_dir: "{eval_cmd} echo \"{otbn_memutil_core}\" | tr ':' '_'"
+
   build_modes: [
     {
       name: vcs_otbn_memutil_build_opts
       build_opts: ["-CFLAGS -I{build_dir}/src/{memutil_dpi_src_dir}/cpp",
+                   "-CFLAGS -I{build_dir}/src/{otbn_memutil_src_dir}",
                    "-lelf"]
     }
 
     {
       name: xcelium_otbn_memutil_build_opts
       build_opts: ["-I{build_dir}/src/{memutil_dpi_src_dir}/cpp",
+                   "-I{build_dir}/src/{otbn_memutil_src_dir}",
                    "-lelf"]
     }
   ]

--- a/hw/ip/otbn/dv/model/otbn_model.core
+++ b/hw/ip/otbn/dv/model/otbn_model.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:otbn_pkg
       - lowrisc:dv_verilator:memutil_dpi
+      - lowrisc:dv:otbn_memutil
       - lowrisc:ip:otbn_tracer
     files:
       - otbn_model.cc: { file_type: cppSource }

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -68,16 +68,11 @@ module tb;
   // decoding errors).
   assign model_if.start = dut.start;
 
-  localparam ImemScope = "..dut.u_imem.u_mem.gen_generic.u_impl_generic";
-  localparam DmemScope = "..dut.u_dmem.u_mem.gen_generic.u_impl_generic";
-  localparam DesignScope = "..dut.u_otbn_core";
-
   otbn_core_model #(
     .DmemSizeByte (otbn_reg_pkg::OTBN_DMEM_SIZE),
     .ImemSizeByte (otbn_reg_pkg::OTBN_IMEM_SIZE),
-    .DmemScope    (DmemScope),
-    .ImemScope    (ImemScope),
-    .DesignScope  (DesignScope)
+    .MemScope     ("..dut"),
+    .DesignScope  ("..dut.u_otbn_core")
   ) u_model (
     .clk_i        (model_if.clk_i),
     .rst_ni       (model_if.rst_ni),

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -205,11 +205,8 @@ module otbn_top_sim (
 
   // The model
   //
-  // This runs in parallel with the real core above. Eventually, we'll have strong consistency
-  // checks between the two. For now, we just check that they have the same "done" signals.
+  // This runs in parallel with the real core above, with consistency checks between the two.
 
-  localparam string ImemScope = "..u_imem.u_mem.gen_generic.u_impl_generic";
-  localparam string DmemScope = "..u_dmem.u_mem.gen_generic.u_impl_generic";
   localparam string DesignScope = "..u_otbn_core";
 
   logic      otbn_model_done;
@@ -219,8 +216,7 @@ module otbn_top_sim (
   otbn_core_model #(
     .DmemSizeByte    ( DmemSizeByte ),
     .ImemSizeByte    ( ImemSizeByte ),
-    .DmemScope       ( DmemScope ),
-    .ImemScope       ( ImemScope ),
+    .MemScope        ( ".." ),
     .DesignScope     ( DesignScope )
   ) u_otbn_core_model (
     .clk_i        ( IO_CLK ),

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -519,15 +519,11 @@ module otbn
     assign start_model = start & otbn_use_model;
     assign start_rtl = start & ~otbn_use_model;
 
-    // Model (Instruction Set Simulation)
-    localparam string ImemScope = "..u_imem.u_mem.gen_generic.u_impl_generic";
-    localparam string DmemScope = "..u_dmem.u_mem.gen_generic.u_impl_generic";
-
+    // Model (Instruction Set Simulator)
     otbn_core_model #(
       .DmemSizeByte(DmemSizeByte),
       .ImemSizeByte(ImemSizeByte),
-      .DmemScope(DmemScope),
-      .ImemScope(ImemScope),
+      .MemScope(".."),
       .DesignScope("")
     ) u_otbn_core_model (
       .clk_i,

--- a/hw/top_earlgrey/top_earlgrey_verilator.cc
+++ b/hw/top_earlgrey/top_earlgrey_verilator.cc
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <iostream>
+#include <string>
 
 #include "verilated_toplevel.h"
 #include "verilator_memutil.h"
@@ -15,27 +16,36 @@ int main(int argc, char **argv) {
   simctrl.SetTop(&top, &top.clk_i, &top.rst_ni,
                  VerilatorSimCtrlFlags::ResetPolarityNegative);
 
-  memutil.RegisterMemoryArea(
-      "rom",
-      "TOP.top_earlgrey_verilator.top_earlgrey.u_rom_rom.u_prim_rom."
+  std::string top_scope("TOP.top_earlgrey_verilator.top_earlgrey");
+  std::string ram1p_adv_scope(
+      "u_prim_ram_1p_adv.u_mem."
       "gen_generic.u_impl_generic");
-  memutil.RegisterMemoryArea(
-      "ram",
-      "TOP.top_earlgrey_verilator.top_earlgrey.u_ram1p_ram_main."
-      "u_prim_ram_1p_adv.u_mem.gen_generic.u_impl_generic");
-  memutil.RegisterMemoryArea(
-      "flash",
-      ("TOP.top_earlgrey_verilator.top_earlgrey.u_flash_eflash.u_flash."
-       "gen_generic.u_impl_generic.gen_prim_flash_banks[0].u_prim_flash_bank.u_"
-       "mem.gen_"
-       "generic.u_impl_generic"),
-      64, nullptr);
-  memutil.RegisterMemoryArea(
-      "otp",
-      "TOP.top_earlgrey_verilator.top_earlgrey.u_otp_ctrl.u_otp."
-      "gen_generic.u_impl_generic.u_prim_ram_1p_adv.u_mem.gen_generic."
-      "u_impl_generic");
+
+  std::string rom_scope(top_scope +
+                        ".u_rom_rom.u_prim_rom.gen_generic.u_impl_generic");
+  std::string ram_scope(top_scope + ".u_ram1p_ram_main." + ram1p_adv_scope);
+  std::string flash_scope(top_scope +
+                          ".u_flash_eflash.u_flash."
+                          "gen_generic.u_impl_generic."
+                          "gen_prim_flash_banks[0]."
+                          "u_prim_flash_bank.u_mem."
+                          "gen_generic.u_impl_generic");
+  std::string otp_scope(top_scope +
+                        ".u_otp_ctrl.u_otp.gen_generic.u_impl_generic." +
+                        ram1p_adv_scope);
+
+  std::unique_ptr<MemArea> rom(new MemArea(rom_scope, 0x4000 / 4, 4)),
+      ram(new MemArea(ram_scope, 0x20000 / 4, 4)),
+      flash(new MemArea(flash_scope, 0x100000 / 8, 8)),
+      otp(new MemArea(otp_scope, 0x4000 / 4, 4));
+
+  memutil.RegisterMemoryArea("rom", 0x8000, std::move(rom));
+  memutil.RegisterMemoryArea("ram", 0x10000000u, std::move(ram));
+  memutil.RegisterMemoryArea("flash", 0x20000000u, std::move(flash));
+  memutil.RegisterMemoryArea("otp", 0x40000000u /* (bogus LMA) */,
+                             std::move(otp));
   simctrl.RegisterExtension(&memutil);
+
   // The initial reset delay must be long enough such that pwr/rst/clkmgr will
   // release clocks to the entire design.  This allows for synchronous resets
   // to appropriately propagate.

--- a/hw/top_earlgrey/top_earlgrey_verilator.cc
+++ b/hw/top_earlgrey/top_earlgrey_verilator.cc
@@ -21,29 +21,23 @@ int main(int argc, char **argv) {
       "u_prim_ram_1p_adv.u_mem."
       "gen_generic.u_impl_generic");
 
-  std::string rom_scope(top_scope +
-                        ".u_rom_rom.u_prim_rom.gen_generic.u_impl_generic");
-  std::string ram_scope(top_scope + ".u_ram1p_ram_main." + ram1p_adv_scope);
-  std::string flash_scope(top_scope +
-                          ".u_flash_eflash.u_flash."
-                          "gen_generic.u_impl_generic."
-                          "gen_prim_flash_banks[0]."
-                          "u_prim_flash_bank.u_mem."
-                          "gen_generic.u_impl_generic");
-  std::string otp_scope(top_scope +
-                        ".u_otp_ctrl.u_otp.gen_generic.u_impl_generic." +
-                        ram1p_adv_scope);
+  MemArea rom(top_scope + ".u_rom_rom.u_prim_rom.gen_generic.u_impl_generic",
+              0x4000 / 4, 4);
+  MemArea ram(top_scope + ".u_ram1p_ram_main." + ram1p_adv_scope, 0x20000 / 4,
+              4);
+  MemArea flash(top_scope +
+                    ".u_flash_eflash.u_flash.gen_generic.u_impl_generic."
+                    "gen_prim_flash_banks[0].u_prim_flash_bank.u_mem."
+                    "gen_generic.u_impl_generic",
+                0x100000 / 8, 8);
+  MemArea otp(top_scope + ".u_otp_ctrl.u_otp.gen_generic.u_impl_generic." +
+                  ram1p_adv_scope,
+              0x4000 / 4, 4);
 
-  std::unique_ptr<MemArea> rom(new MemArea(rom_scope, 0x4000 / 4, 4)),
-      ram(new MemArea(ram_scope, 0x20000 / 4, 4)),
-      flash(new MemArea(flash_scope, 0x100000 / 8, 8)),
-      otp(new MemArea(otp_scope, 0x4000 / 4, 4));
-
-  memutil.RegisterMemoryArea("rom", 0x8000, std::move(rom));
-  memutil.RegisterMemoryArea("ram", 0x10000000u, std::move(ram));
-  memutil.RegisterMemoryArea("flash", 0x20000000u, std::move(flash));
-  memutil.RegisterMemoryArea("otp", 0x40000000u /* (bogus LMA) */,
-                             std::move(otp));
+  memutil.RegisterMemoryArea("rom", 0x8000, &rom);
+  memutil.RegisterMemoryArea("ram", 0x10000000u, &ram);
+  memutil.RegisterMemoryArea("flash", 0x20000000u, &flash);
+  memutil.RegisterMemoryArea("otp", 0x40000000u /* (bogus LMA) */, &otp);
   simctrl.RegisterExtension(&memutil);
 
   // The initial reset delay must be long enough such that pwr/rst/clkmgr will

--- a/hw/top_englishbreakfast/top_englishbreakfast_verilator.cc
+++ b/hw/top_englishbreakfast/top_englishbreakfast_verilator.cc
@@ -22,23 +22,19 @@ int main(int argc, char **argv) {
       "u_prim_ram_1p_adv.u_mem."
       "gen_generic.u_impl_generic");
 
-  std::string rom_scope(top_scope +
-                        ".u_rom_rom.u_prim_rom.gen_generic.u_impl_generic");
-  std::string ram_scope(top_scope + ".u_ram1p_ram_main." + ram1p_adv_scope);
-  std::string flash_scope(top_scope +
-                          ".u_flash_eflash.u_flash."
-                          "gen_generic.u_impl_generic."
-                          "gen_prim_flash_banks[0]."
-                          "u_prim_flash_bank.u_mem."
-                          "gen_generic.u_impl_generic");
+  MemArea rom(top_scope + ".u_rom_rom.u_prim_rom.gen_generic.u_impl_generic",
+              0x4000 / 4, 4);
+  MemArea ram(top_scope + ".u_ram1p_ram_main." + ram1p_adv_scope, 0x20000 / 4,
+              4);
+  MemArea flash(top_scope +
+                    ".u_flash_eflash.u_flash.gen_generic.u_impl_generic."
+                    "gen_prim_flash_banks[0].u_prim_flash_bank.u_mem."
+                    "gen_generic.u_impl_generic",
+                0x100000 / 8, 8);
 
-  std::unique_ptr<MemArea> rom(new MemArea(rom_scope, 0x4000 / 4, 4)),
-      ram(new MemArea(ram_scope, 0x20000 / 4, 4)),
-      flash(new MemArea(flash_scope, 0x100000 / 8, 8));
-
-  memutil.RegisterMemoryArea("rom", 0x8000, std::move(rom));
-  memutil.RegisterMemoryArea("ram", 0x10000000u, std::move(ram));
-  memutil.RegisterMemoryArea("flash", 0x20000000u, std::move(flash));
+  memutil.RegisterMemoryArea("rom", 0x8000, &rom);
+  memutil.RegisterMemoryArea("ram", 0x10000000u, &ram);
+  memutil.RegisterMemoryArea("flash", 0x20000000u, &flash);
   simctrl.RegisterExtension(&memutil);
 
   // see top_earlgrey_verilator.cc for justification and explanation

--- a/hw/top_englishbreakfast/top_englishbreakfast_verilator.cc
+++ b/hw/top_englishbreakfast/top_englishbreakfast_verilator.cc
@@ -15,23 +15,32 @@ int main(int argc, char **argv) {
   simctrl.SetTop(&top, &top.clk_i, &top.rst_ni,
                  VerilatorSimCtrlFlags::ResetPolarityNegative);
 
-  memutil.RegisterMemoryArea("rom",
-                             "TOP.top_englishbreakfast_verilator.top_"
-                             "englishbreakfast.u_rom_rom.u_prim_rom."
-                             "gen_generic.u_impl_generic");
-  memutil.RegisterMemoryArea("ram",
-                             "TOP.top_englishbreakfast_verilator.top_"
-                             "englishbreakfast.u_ram1p_ram_main.u_mem."
-                             "gen_generic.u_impl_generic");
-  memutil.RegisterMemoryArea(
-      "flash",
-      ("TOP.top_englishbreakfast_verilator.top_englishbreakfast.u_flash_eflash."
-       "u_flash."
-       "gen_generic.u_impl_generic.gen_prim_flash_banks[0].u_prim_flash_bank.u_"
-       "mem.gen_"
-       "generic.u_impl_generic"),
-      64, nullptr);
+  std::string top_scope(
+      "TOP.top_englishbreakfast_verilator."
+      "top_englishbreakfast");
+  std::string ram1p_adv_scope(
+      "u_prim_ram_1p_adv.u_mem."
+      "gen_generic.u_impl_generic");
+
+  std::string rom_scope(top_scope +
+                        ".u_rom_rom.u_prim_rom.gen_generic.u_impl_generic");
+  std::string ram_scope(top_scope + ".u_ram1p_ram_main." + ram1p_adv_scope);
+  std::string flash_scope(top_scope +
+                          ".u_flash_eflash.u_flash."
+                          "gen_generic.u_impl_generic."
+                          "gen_prim_flash_banks[0]."
+                          "u_prim_flash_bank.u_mem."
+                          "gen_generic.u_impl_generic");
+
+  std::unique_ptr<MemArea> rom(new MemArea(rom_scope, 0x4000 / 4, 4)),
+      ram(new MemArea(ram_scope, 0x20000 / 4, 4)),
+      flash(new MemArea(flash_scope, 0x100000 / 8, 8));
+
+  memutil.RegisterMemoryArea("rom", 0x8000, std::move(rom));
+  memutil.RegisterMemoryArea("ram", 0x10000000u, std::move(ram));
+  memutil.RegisterMemoryArea("flash", 0x20000000u, std::move(flash));
   simctrl.RegisterExtension(&memutil);
+
   // see top_earlgrey_verilator.cc for justification and explanation
   simctrl.SetInitialResetDelay(500);
   simctrl.SetResetDuration(10);


### PR DESCRIPTION
The idea is that blocks that define MemAreas with special
properties (like ECC bits or scrambling) can use a subclass of MemArea
that will do the required conversions as part of wrapping the raw
simutil_set_mem calls.

This PR doesn't add the subclasses for "special" memories, but it restructures things a little bit and then teaches the code in `otbn_model.cc` (which needs to read and write memory over DPI) to use the new MemArea classes, removing quite a bit of duplication.

This is a staging post for a follow-up PR, which will rewire OTBN's DMEM ECC bits to be laid out properly: I originally worked on that first, but realised that all the "expand from 32 to 39" and "take 32 from 39" logic was going to be duplicated.