### PR TITLE
[dv/common] Fix xcelium compile error

### DIFF
--- a/hw/dv/sv/mem_bkdr_if/mem_bkdr_if.sv
+++ b/hw/dv/sv/mem_bkdr_if/mem_bkdr_if.sv
@@ -636,7 +636,13 @@ interface mem_bkdr_if #(parameter bit MEM_PARITY = 0,
     end
     // TODO - temporary workaround until ECC encoding is implemented
     if (MEM_ECC) begin
-      foreach (`MEM_ARR_PATH_SLICE[i]) `DV_CHECK_STD_RANDOMIZE_FATAL(`MEM_ARR_PATH_SLICE[i], , path)
+      foreach (`MEM_ARR_PATH_SLICE[i]) begin
+        // Workaround to avoid Xcelium compile error:
+        // `DV_CHECK_STD_RANDOMIZE_FATAL(`MEM_ARR_PATH_SLICE[i], , path)
+        bit [MAX_MEM_WIDTH-1:0] val = `MEM_ARR_PATH_SLICE[i];
+        `DV_CHECK_STD_RANDOMIZE_FATAL(val, , path)
+        for (int j = 0; j < mem_width; j++)  `MEM_ARR_PATH_SLICE[i][j] = val[j];
+      end
     end
   endfunction
 

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -133,12 +133,17 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
           // Otp_keymgr outputs creator root key shares from the secret2 partition.
           // Depends on lc_seed_hw_rd_en_i, it will output the real keys or a constant
           exp_keymgr_data.valid = digests[Secret2Idx] != 0;
-          exp_keymgr_data.key_share0 = (cfg.otp_ctrl_vif.lc_seed_hw_rd_en_i == lc_ctrl_pkg::On) ?
-              {<<32 {otp_a[CreatorRootKeyShare0Offset/4 +: CreatorRootKeyShare0Size/4]}} :
-              PartInvDefault[CreatorRootKeyShare0Offset*8 +: CreatorRootKeyShare0Size*8];
-          exp_keymgr_data.key_share1 = (cfg.otp_ctrl_vif.lc_seed_hw_rd_en_i == lc_ctrl_pkg::On) ?
-              {<<32 {otp_a[CreatorRootKeyShare1Offset/4 +: CreatorRootKeyShare1Size/4]}} :
-              PartInvDefault[CreatorRootKeyShare1Offset*8 +: CreatorRootKeyShare1Size*8];
+          if (cfg.otp_ctrl_vif.lc_seed_hw_rd_en_i == lc_ctrl_pkg::On) begin
+            exp_keymgr_data.key_share0 =
+                {<<32 {otp_a[CreatorRootKeyShare0Offset/4 +: CreatorRootKeyShare0Size/4]}};
+            exp_keymgr_data.key_share1 =
+                {<<32 {otp_a[CreatorRootKeyShare1Offset/4 +: CreatorRootKeyShare1Size/4]}};
+          end else begin
+            exp_keymgr_data.key_share0 =
+                PartInvDefault[CreatorRootKeyShare0Offset*8 +: CreatorRootKeyShare0Size*8];
+            exp_keymgr_data.key_share1 =
+                PartInvDefault[CreatorRootKeyShare1Offset*8 +: CreatorRootKeyShare1Size*8];
+          end
           `DV_CHECK_EQ(cfg.otp_ctrl_vif.keymgr_key_o, exp_keymgr_data)
         end
       end


### PR DESCRIPTION
Fix two xcelium compile error:
1. In mem_bkdr_if, for standarized randomization function, xcelium
throws error for using mem index. But it passed the compilation once we
create a variable.
2. In otp_ctrl scb, xcelium throw compile error for streaming and
concatenation, saying it violates LRM 11.4.14.
Fix it by using a if else instead.

Signed-off-by: Cindy Chen <chencindy@google.com>