### PR TITLE
[spi_device] Remove cmdparse until read command path implemented

### DIFF
--- a/hw/ip/spi_device/rtl/spi_cmdparse.sv
+++ b/hw/ip/spi_device/rtl/spi_cmdparse.sv
@@ -123,7 +123,7 @@ module spi_cmdparse
   end
 
   always_comb begin
-    st = st_d;
+    st_d = st;
 
     sel_dp = DpNone;
 

--- a/hw/ip/spi_device/spi_device.core
+++ b/hw/ip/spi_device/spi_device.core
@@ -23,7 +23,6 @@ filesets:
       - rtl/spi_fwm_rxf_ctrl.sv
       - rtl/spi_fwm_txf_ctrl.sv
       - rtl/spi_fwmode.sv
-      - rtl/spi_cmdparse.sv
       - rtl/spi_s2p.sv
       - rtl/spi_p2s.sv
       - rtl/spi_device.sv


### PR DESCRIPTION
Removing cmdparse temporary until readcmd path is implemented and
checked in the synthesis tool.