### PR TITLE
[dv/uvmdvgen] Add comment for testplan

### DIFF
--- a/util/uvmdvgen/index.md.tpl
+++ b/util/uvmdvgen/index.md.tpl
@@ -123,5 +123,6 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/${name}/dv/${name}_sim_cfg.hjson
 ```
 
 ${'##'} DV plan
-<!-- TODO: uncomment the line below after adding the testplan -->
+<!-- TODO: uncomment the line below after adding the testplan.
+Please make sure the testplan is added to `/util/build_docs.py`. -->
 {{</* incGenFromIpDesc "hw/ip/${name}/data/${name}_testplan.hjson" "testplan" */>}


### PR DESCRIPTION
This PR adds a comment to remind user to add testplan to the
`util/build_docs.py` to avoid doc generation error.

Signed-off-by: Cindy Chen <chencindy@google.com>