### PR TITLE
[dv/sram] refactor sram_zero_delays

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_mem_tl_errors_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_mem_tl_errors_vseq.sv
@@ -22,23 +22,6 @@ class sram_ctrl_mem_tl_errors_vseq extends sram_ctrl_multiple_keys_vseq;
     for (int i = 0; i < num_times; i++) begin
       `uvm_info(`gfn, $sformatf("Running run_tl_errors_vseq %0d/%0d", i, num_times), UVM_LOW)
 
-      // randomly enable zero delays
-      //
-      // TODO: Move this into the env build_phase and control with zero_delays knob
-      if ($urandom_range(0, 1)) begin
-        cfg.m_sram_cfg.a_valid_delay_min = 0;
-        cfg.m_sram_cfg.a_valid_delay_max = 0;
-
-        cfg.m_sram_cfg.a_ready_delay_min = 0;
-        cfg.m_sram_cfg.a_ready_delay_max = 0;
-
-        cfg.m_sram_cfg.d_valid_delay_min = 0;
-        cfg.m_sram_cfg.d_valid_delay_max = 0;
-
-        cfg.m_sram_cfg.d_ready_delay_min = 0;
-        cfg.m_sram_cfg.d_ready_delay_max = 0;
-      end
-
       // spawn various threads to interleave TLUL protocol error accesses and valid memory accesses
       fork
         begin: isolation

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_stress_pipeline_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_stress_pipeline_vseq.sv
@@ -22,8 +22,6 @@ class sram_ctrl_stress_pipeline_vseq extends sram_ctrl_multiple_keys_vseq;
 
     stress_pipeline = 1'b1;
 
-    cfg.set_sram_zero_delays();
-
     super.pre_start();
 
   endtask

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.sv
@@ -49,6 +49,10 @@ class sram_ctrl_env extends cip_base_env #(
     uvm_config_db#(push_pull_agent_cfg#(.DeviceDataWidth(KDI_DATA_SIZE)))::set(
       this, "m_kdi_agent", "cfg", cfg.m_kdi_cfg);
     cfg.m_kdi_cfg.en_cov = cfg.en_cov;
+
+    if (cfg.zero_delays) begin
+      cfg.set_sram_zero_delays();
+    end
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -80,6 +80,7 @@
     {
       name: "{variant}_stress_pipeline"
       uvm_test_seq: sram_ctrl_stress_pipeline_vseq
+      run_opts: ["+zero_delays=1"]
     }
     {
       name: "{variant}_lc_escalation"


### PR DESCRIPTION
this PR refactors how zero delays are set in the SRAM TL agent,
tying it to the main zero_delays knob in the CSR TL agent.

Signed-off-by: Udi Jonnalagadda <udij@google.com>