### PR TITLE
[top] Latest ast integration

### DIFF
--- a/hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv
+++ b/hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv
@@ -143,8 +143,8 @@ module flash_ctrl_wrapper (
     .flash_power_ready_h_i,
     .flash_power_down_h_i,
     .flash_bist_enable_i,
-    .flash_test_mode_a_i    (1'b0),
-    .flash_test_voltage_h_i (1'b0),
+    .flash_test_mode_a_io   (),
+    .flash_test_voltage_h_io(),
     .lc_nvm_debug_en_i
   );
 

--- a/hw/ip/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy.sv
@@ -26,8 +26,8 @@ module flash_phy import flash_ctrl_pkg::*; (
   input scan_rst_ni,
   input flash_power_ready_h_i,
   input flash_power_down_h_i,
-  input [3:0] flash_test_mode_a_i,
-  input flash_test_voltage_h_i,
+  inout [3:0] flash_test_mode_a_io,
+  inout flash_test_voltage_h_io,
   input lc_ctrl_pkg::lc_tx_t flash_bist_enable_i,
   input lc_ctrl_pkg::lc_tx_t lc_nvm_debug_en_i
 );
@@ -272,8 +272,8 @@ module flash_phy import flash_ctrl_pkg::*; (
     .scan_rst_ni,
     .flash_power_ready_h_i,
     .flash_power_down_h_i,
-    .flash_test_mode_a_i,
-    .flash_test_voltage_h_i,
+    .flash_test_mode_a_io,
+    .flash_test_voltage_h_io,
     .flash_err_o(flash_ctrl_o.flash_err),
     .flash_alert_po(flash_ctrl_o.flash_alert_p),
     .flash_alert_no(flash_ctrl_o.flash_alert_n),

--- a/hw/ip/prim_generic/rtl/prim_generic_flash.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash.sv
@@ -32,8 +32,8 @@ module prim_generic_flash #(
   input scan_rst_ni,
   input flash_power_ready_h_i,
   input flash_power_down_h_i,
-  input [TestModeWidth-1:0] flash_test_mode_a_i,
-  input flash_test_voltage_h_i,
+  inout [TestModeWidth-1:0] flash_test_mode_a_io,
+  inout flash_test_voltage_h_io,
   output logic flash_err_o,
   output logic flash_alert_po,
   output logic flash_alert_no,
@@ -111,8 +111,8 @@ module prim_generic_flash #(
   assign unused_scanmode = scanmode_i;
   assign unused_scan_en = scan_en_i;
   assign unused_scan_rst_n = scan_rst_ni;
-  assign unused_flash_test_mode = flash_test_mode_a_i;
-  assign unused_flash_test_voltage = flash_test_voltage_h_i;
+  assign unused_flash_test_mode = flash_test_mode_a_io;
+  assign unused_flash_test_voltage = flash_test_voltage_h_io;
   assign unused_tck = tck_i;
   assign unused_tdi = tdi_i;
   assign unused_tms = tms_i;

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -4336,6 +4336,9 @@
           act: req
           width: 1
           inst_name: entropy_src
+          default: ""
+          external: true
+          top_signame: es_rng_fips
           index: -1
         }
         {
@@ -5097,14 +5100,11 @@
         {
           struct: logic
           package: ""
-          width: 4
+          width: "4"
           type: uni
           act: rcv
           name: flash_test_mode_a
           inst_name: eflash
-          default: ""
-          external: true
-          top_signame: flash_test_mode_a
           index: -1
         }
         {
@@ -5114,10 +5114,6 @@
           act: rcv
           name: flash_test_voltage_h
           inst_name: eflash
-          width: 1
-          default: ""
-          external: true
-          top_signame: flash_test_voltage_h
           index: -1
         }
       ]
@@ -5707,9 +5703,8 @@
       eflash.flash_bist_enable: flash_bist_enable
       eflash.flash_power_down_h: flash_power_down_h
       eflash.flash_power_ready_h: flash_power_ready_h
-      eflash.flash_test_mode_a: flash_test_mode_a
-      eflash.flash_test_voltage_h: flash_test_voltage_h
       entropy_src.entropy_src_rng: es_rng
+      entropy_src.rng_fips: es_rng_fips
       lc_ctrl.lc_clk_byp_req: lc_clk_byp_req
       peri.tl_ast: ast_tl
       pinmux_aon.dft_strap_test: dft_strap_test
@@ -11462,6 +11457,9 @@
         act: req
         width: 1
         inst_name: entropy_src
+        default: ""
+        external: true
+        top_signame: es_rng_fips
         index: -1
       }
       {
@@ -11964,14 +11962,11 @@
       {
         struct: logic
         package: ""
-        width: 4
+        width: "4"
         type: uni
         act: rcv
         name: flash_test_mode_a
         inst_name: eflash
-        default: ""
-        external: true
-        top_signame: flash_test_mode_a
         index: -1
       }
       {
@@ -11981,10 +11976,6 @@
         act: rcv
         name: flash_test_voltage_h
         inst_name: eflash
-        width: 1
-        default: ""
-        external: true
-        top_signame: flash_test_voltage_h
         index: -1
       }
       {
@@ -12918,30 +12909,6 @@
         netname: flash_power_ready_h
       }
       {
-        package: ""
-        struct: logic
-        signame: flash_test_mode_a_i
-        width: 4
-        type: uni
-        default: ""
-        direction: in
-        conn_type: false
-        index: -1
-        netname: flash_test_mode_a
-      }
-      {
-        package: ""
-        struct: logic
-        signame: flash_test_voltage_h_i
-        width: 1
-        type: uni
-        default: ""
-        direction: in
-        conn_type: false
-        index: -1
-        netname: flash_test_voltage_h
-      }
-      {
         package: entropy_src_pkg
         struct: entropy_src_rng_req
         signame: es_rng_req_o
@@ -12964,6 +12931,18 @@
         conn_type: false
         index: -1
         netname: es_rng_rsp
+      }
+      {
+        package: ""
+        struct: logic
+        signame: es_rng_fips_o
+        width: 1
+        type: uni
+        default: ""
+        direction: out
+        conn_type: false
+        index: -1
+        netname: es_rng_fips
       }
       {
         package: lc_ctrl_pkg

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -961,9 +961,8 @@
         'eflash.flash_bist_enable'     : 'flash_bist_enable',
         'eflash.flash_power_down_h'    : 'flash_power_down_h',
         'eflash.flash_power_ready_h'   : 'flash_power_ready_h',
-        'eflash.flash_test_mode_a'     : 'flash_test_mode_a',
-        'eflash.flash_test_voltage_h'  : 'flash_test_voltage_h',
         'entropy_src.entropy_src_rng'  : 'es_rng',
+        'entropy_src.rng_fips'         : 'es_rng_fips',
         'lc_ctrl.lc_clk_byp_req'       : 'lc_clk_byp_req',
         'peri.tl_ast'                  : 'ast_tl',
         'pinmux_aon.dft_strap_test'    : 'dft_strap_test'

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -68,10 +68,9 @@ module top_earlgrey #(
   input  lc_ctrl_pkg::lc_tx_t       flash_bist_enable_i,
   input  logic       flash_power_down_h_i,
   input  logic       flash_power_ready_h_i,
-  input  logic [3:0] flash_test_mode_a_i,
-  input  logic       flash_test_voltage_h_i,
   output entropy_src_pkg::entropy_src_rng_req_t       es_rng_req_o,
   input  entropy_src_pkg::entropy_src_rng_rsp_t       es_rng_rsp_i,
+  output logic       es_rng_fips_o,
   output lc_ctrl_pkg::lc_tx_t       lc_clk_byp_req_o,
   output tlul_pkg::tl_h2d_t       ast_tl_req_o,
   input  tlul_pkg::tl_d2h_t       ast_tl_rsp_i,
@@ -89,6 +88,11 @@ module top_earlgrey #(
   output logic       usbdev_usb_ref_pulse_o,
   output clkmgr_pkg::clkmgr_ast_out_t       clks_ast_o,
   output rstmgr_pkg::rstmgr_ast_out_t       rsts_ast_o,
+
+  // Flash specific voltages
+  inout [3:0] flash_test_mode_a_io,
+  inout flash_test_voltage_h_io,
+
   input                      scan_rst_ni, // reset used for test mode
   input                      scan_en_i,
   input lc_ctrl_pkg::lc_tx_t scanmode_i   // lc_ctrl_pkg::On for Scan
@@ -975,8 +979,8 @@ module top_earlgrey #(
     .flash_bist_enable_i,
     .flash_power_down_h_i,
     .flash_power_ready_h_i,
-    .flash_test_mode_a_i,
-    .flash_test_voltage_h_i,
+    .flash_test_mode_a_io,
+    .flash_test_voltage_h_io,
     .scanmode_i,
     .scan_en_i,
     .scan_rst_ni
@@ -2054,7 +2058,7 @@ module top_earlgrey #(
       .entropy_src_xht_o(),
       .entropy_src_xht_i(entropy_src_pkg::ENTROPY_SRC_XHT_RSP_DEFAULT),
       .efuse_es_sw_reg_en_i('0),
-      .rng_fips_o(),
+      .rng_fips_o(es_rng_fips_o),
       .tl_i(entropy_src_tl_req),
       .tl_o(entropy_src_tl_rsp),
 

--- a/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
@@ -296,10 +296,10 @@ module top_earlgrey_asic (
   logic usb_diff_input;
   logic [ast_pkg::UsbCalibWidth-1:0] usb_io_pu_cal;
 
-  assign usb_pullup_p_en_o = dio_out_core[top_earlgrey_pkg::TopEarlgreyDioPinUsbdevDpPullup] &
-                             dio_oe_core[top_earlgrey_pkg::TopEarlgreyDioPinUsbdevDpPullup];
-  assign usb_pullup_n_en_o = dio_out_core[top_earlgrey_pkg::TopEarlgreyDioPinUsbdevDnPullup] &
-                             dio_oe_core[top_earlgrey_pkg::TopEarlgreyDioPinUsbdevDnPullup];
+  assign usb_pullup_p_en = dio_out_core[top_earlgrey_pkg::TopEarlgreyDioPinUsbdevDpPullup] &
+                           dio_oe_core[top_earlgrey_pkg::TopEarlgreyDioPinUsbdevDpPullup];
+  assign usb_pullup_n_en = dio_out_core[top_earlgrey_pkg::TopEarlgreyDioPinUsbdevDnPullup] &
+                           dio_oe_core[top_earlgrey_pkg::TopEarlgreyDioPinUsbdevDnPullup];
 
   // Input tie-off muxes
   for (genvar k = 0; k < pinmux_reg_pkg::NDioPads; k++) begin : gen_input_tie_off
@@ -353,6 +353,7 @@ module top_earlgrey_asic (
   // The entropy source pacakge definition should eventually be moved to es
   entropy_src_pkg::entropy_src_rng_req_t es_rng_req;
   entropy_src_pkg::entropy_src_rng_rsp_t es_rng_rsp;
+  logic es_rng_fips;
 
   // entropy distribution network
   edn_pkg::edn_req_t ast_edn_edn_req;
@@ -560,7 +561,7 @@ module top_earlgrey_asic (
     .adc_d_val_o           ( adc_rsp.data_valid ),
     // rng
     .rng_en_i              ( es_rng_req.rng_enable ),
-    .rng_fips_i            ( '0 ),
+    .rng_fips_i            ( es_rng_fips ),
     .rng_val_o             ( es_rng_rsp.rng_valid ),
     .rng_b_o               ( es_rng_rsp.rng_b ),
     // entropy
@@ -594,15 +595,15 @@ module top_earlgrey_asic (
     // pinmux related
     .padmux2ast_i          ( pinmux2ast ),
     .ast2padmux_o          ( ast2pinmux ),
-    //TODO: Connect to PAD
-    .pad2ast_t0_ai         ( '0 ),
-    .pad2ast_t1_ai         ( '0 ),
-    .ast2pad_t0_ao         ( ),
-    .ast2pad_t1_ao         ( ),
+    // Direct short to PAD
+    .pad2ast_t0_ai         ( IOA4 ),
+    .pad2ast_t1_ai         ( IOA5 ),
+    .ast2pad_t0_ao         ( IOA2 ),
+    .ast2pad_t1_ao         ( IOA3 ),
     .lc_clk_byp_req_i      ( lc_ast_clk_byp_req ),
     .lc_clk_byp_ack_o      ( lc_ast_clk_byp_ack ),
     .flash_bist_en_o       ( flash_bist_enable  ),
-    //TODO: Connect to memories
+    // Memory configuration connections
     .dpram_rmf_o           ( ast_ram_2p_fcfg ),
     .dpram_rml_o           ( ast_ram_2p_lcfg ),
     .spram_rm_o            ( ast_ram_1p_cfg  ),
@@ -705,13 +706,15 @@ module top_earlgrey_asic (
     .flash_power_ready_h_i        ( flash_power_ready_h        ),
     .es_rng_req_o                 ( es_rng_req                 ),
     .es_rng_rsp_i                 ( es_rng_rsp                 ),
+    .es_rng_fips_o                ( es_rng_fips                ),
     .lc_clk_byp_req_o             ( lc_ast_clk_byp_req         ),
     .lc_clk_byp_ack_i             ( lc_ast_clk_byp_ack         ),
     .pinmux2ast_o                 ( pinmux2ast                 ),
     .ast2pinmux_i                 ( ast2pinmux                 ),
-    // TODO: connect these
-    .flash_test_mode_a_i          ('0                          ),
-    .flash_test_voltage_h_i       ('0                          ),
+
+    // Flash test mode voltages
+    .flash_test_mode_a_io         ( FLASH_TEST_MODE            ),
+    .flash_test_voltage_h_io      ( FLASH_TEST_VOLT            ),
 
     // Multiplexed I/O
     .mio_in_i                     ( mio_in_core                ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -487,8 +487,6 @@ module top_earlgrey_nexysvideo #(
     .es_rng_rsp_i                 ( '0              ),
     .lc_clk_byp_req_o             ( lc_clk_bypass   ),
     .lc_clk_byp_ack_i             ( lc_clk_bypass   ),
-    .flash_test_mode_a_i          ('0               ),
-    .flash_test_voltage_h_i       ('0               ),
 
     // Multiplexed I/O
     .mio_in_i        ( mio_in_core   ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
@@ -184,8 +184,6 @@ module top_earlgrey_verilator (
     .es_rng_rsp_i                 ( '0               ),
     .lc_clk_byp_req_o             ( lc_clk_bypass    ),
     .lc_clk_byp_ack_i             ( lc_clk_bypass    ),
-    .flash_test_mode_a_i          ('0),
-    .flash_test_voltage_h_i       ('0),
 
     // Multiplexed I/O
     .mio_in_i                     (mio_in),

--- a/hw/top_englishbreakfast/rtl/top_englishbreakfast_cw305.sv
+++ b/hw/top_englishbreakfast/rtl/top_englishbreakfast_cw305.sv
@@ -316,8 +316,6 @@ module top_englishbreakfast_cw305 #(
     .flash_bist_enable_i          ( 1'b0            ),
     .flash_power_down_h_i         ( 1'b0            ),
     .flash_power_ready_h_i        ( 1'b1            ),
-    .flash_test_mode_a_i          ('0),
-    .flash_test_voltage_h_i       ('0),
     .lc_clk_byp_req_o             ( lc_clk_bypass   ),
     .lc_clk_byp_ack_i             ( lc_clk_bypass   ),
     .clks_ast_o                   (                 ),

--- a/util/topgen/templates/toplevel.sv.tpl
+++ b/util/topgen/templates/toplevel.sv.tpl
@@ -81,6 +81,11 @@ module top_${top["name"]} #(
   % for sig in top["inter_signal"]["external"]:
   ${"input " if sig["direction"] == "in" else "output"} ${lib.im_defname(sig)} ${lib.bitarray(sig["width"],1)} ${sig["signame"]},
   % endfor
+
+  // Flash specific voltages
+  inout [3:0] flash_test_mode_a_io,
+  inout flash_test_voltage_h_io,
+
 % endif
   input                      scan_rst_ni, // reset used for test mode
   input                      scan_en_i,
@@ -539,8 +544,8 @@ module top_${top["name"]} #(
     .flash_bist_enable_i,
     .flash_power_down_h_i,
     .flash_power_ready_h_i,
-    .flash_test_mode_a_i,
-    .flash_test_voltage_h_i,
+    .flash_test_mode_a_io,
+    .flash_test_voltage_h_io,
     .scanmode_i,
     .scan_en_i,
     .scan_rst_ni


### PR DESCRIPTION
- hookup rng_fips to entropy_src
- properly name test_voltage/test_mode ports and hook them up
- hookup analog test connections to the pad

Signed-off-by: Timothy Chen <timothytim@google.com>