### PR TITLE
[dv/regr] update result paths for sram/kmac

### DIFF
--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -46,6 +46,10 @@
       name: scratch_path
       value: "{scratch_base_path}/{variant}-{flow}-{tool}"
     }
+    {
+      name: rel_path
+      value: "hw/ip/{variant}/dv"
+    }
   ]
 
   build_modes: [

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -46,6 +46,10 @@
       name: scratch_path
       value: "{scratch_base_path}/{variant}-{flow}-{tool}"
     }
+    {
+      name: rel_path
+      value: "hw/ip/{variant}/dv"
+    }
   ]
 
   build_modes: [


### PR DESCRIPTION
this PR updates the result paths for both the KMAC and SRAM IPs, as both
have two variants that are tested.

currently, the regression results are published to:
`reports.opentitan.org/hw/ip/kmac/dv/latest/results.html`,
where the segment of `hw/ip/kmac/dv` is set to a variable called
`{rel_path}` inside of `common_project_cfg.hjson`.

having both variants write regression results to the same link
will result in something breaking, so this `rel_path` variable is now
overridden in the `base_sim_cfg.hjson` for both IPs so that the variant
name is now factored into the results link to "uniquify" things.

Signed-off-by: Udi Jonnalagadda <udij@google.com>