### PR TITLE
[lint] Waive Verilator warning about filename for dm package

### DIFF
--- a/hw/vendor/lint/pulp_risv_dbg.vlt
+++ b/hw/vendor/lint/pulp_risv_dbg.vlt
@@ -1,0 +1,8 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`verilator_config
+
+// Waive the warning that the debug module's package (dm) is in a file called dm_pkg.sv
+lint_off -rule DECLFILENAME -file "*/src/dm_pkg.sv" -match "Filename 'dm_pkg' does not match PACKAGE name: 'dm'"

--- a/hw/vendor/pulp_riscv_dbg.core
+++ b/hw/vendor/pulp_riscv_dbg.core
@@ -22,7 +22,13 @@ filesets:
       - pulp_riscv_dbg/src/dmi_jtag_tap.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    files:
+      - lint/pulp_risv_dbg.vlt
+    file_type: vlt
+
 targets:
   default:
     filesets:
+      - tool_verilator ? (files_verilator_waiver)
       - files_src


### PR DESCRIPTION
This file is vendored, so we don't really want to change it. Waive the
warning instead.
