### PR TITLE
[edn/rtl] remove TODOs and move to D2

### DIFF
--- a/hw/ip/edn/data/edn.prj.hjson
+++ b/hw/ip/edn/data/edn.prj.hjson
@@ -9,6 +9,6 @@
     hw_checklist:       "../doc/checklist",
     version:            "0.5",
     life_stage:         "L1",
-    design_stage:       "D1",
+    design_stage:       "D2",
     verification_stage: "V1",
 }

--- a/hw/ip/edn/doc/checklist.md
+++ b/hw/ip/edn/doc/checklist.md
@@ -49,15 +49,15 @@ RTL           | [FEATURE_COMPLETE][]    | Done        |
 RTL           | [AREA_SMOKE_CHECK][]    | Done        |
 RTL           | [PORT_FROZEN][]         | Done        |
 RTL           | [ARCHITECTURE_FROZEN][] | Done        |
-RTL           | [REVIEW_TODO][]         | Pending     |
+RTL           | [REVIEW_TODO][]         | Done        |
 RTL           | [STYLE_X][]             | Done        |
 Code Quality  | [LINT_PASS][]           | Done        |
 Code Quality  | [CDC_SETUP][]           | N/A         |
 Code Quality  | [FPGA_TIMING][]         | Done        |
 Code Quality  | [CDC_SYNCMACRO][]       | N/A         |
-Security      | [SEC_CM_IMPLEMENTED][]  | Not Started |
-Security      | [SEC_NON_RESET_FLOPS][] | Not Started |
-Security      | [SEC_SHADOW_REGS][]     | Not Started |
+Security      | [SEC_CM_IMPLEMENTED][]  | Deferred    |
+Security      | [SEC_NON_RESET_FLOPS][] | Deferred    |
+Security      | [SEC_SHADOW_REGS][]     | Deferred    |
 
 [NEW_FEATURES]:        {{<relref "/doc/project/checklist.md#new_features" >}}
 [BLOCK_DIAGRAM]:       {{<relref "/doc/project/checklist.md#block_diagram" >}}

--- a/hw/ip/edn/rtl/edn_ack_sm.sv
+++ b/hw/ip/edn/rtl/edn_ack_sm.sv
@@ -40,7 +40,7 @@ module edn_ack_sm (
   typedef enum logic [StateWidth-1:0] {
     Idle      = 6'b101101, // idle (hamming distance = 3)
     DataWait  = 6'b111010, // wait for data to return
-    AckPls    = 6'b010110, // signal ack to endpoint TODO: regen states
+    AckPls    = 6'b010110, // signal ack to endpoint
     Error     = 6'b001000  // illegal state reached and hang
   } state_e;
 


### PR DESCRIPTION
One commit removes a TODO from the RTL.
One commit updates the checklist and the project development level.