### PR TITLE
[fpga] Fix top_englishbreakfast on CW305 

### DIFF
--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -85,7 +85,7 @@
     // The proc group is not peripheral, and directly hardwired
 
     groups: [
-      // the powerup group is used exclusively by clk/pwr/rstmgr
+      // the powerup group is used exclusively by clk/pwr/rstmgr/pinmux
       { name: "powerup", src:"top", sw_cg: "no"                   }
       { name: "trans",   src:"top", sw_cg: "hint", unique: "yes", }
       { name: "infra",   src:"top", sw_cg: "no",                  }
@@ -151,7 +151,7 @@
       { name: "por_usb",     gen: true,  type: "top", domains: ["Aon",    ], parent: "por_aon", clk: "usb"     }
       { name: "lc",          gen: true,  type: "top", domains: [       "0"], parent: "lc_src",  clk: "main"    }
       { name: "lc_io_div4",  gen: true,  type: "top", domains: [       "0"], parent: "lc_src",  clk: "io_div4" }
-      { name: "sys",         gen: true,  type: "top", domains: ["Aon", "0"], parent: "sys_src", clk: "main"    }
+      { name: "sys",         gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "main"    }
       { name: "sys_io_div4", gen: true,  type: "top", domains: ["Aon", "0"], parent: "sys_src", clk: "io_div4" }
       { name: "sys_aon",     gen: true,  type: "top", domains: ["Aon", "0"], parent: "sys_src", clk: "aon"     }
       { name: "spi_device",  gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "io_div2", sw: 1 }
@@ -215,12 +215,13 @@
 
   // `module` defines the peripherals.
   // Details are coming from each modules' config file `ip.hjson`
+  // TODO: Define parameter here
   // attr: There are a few types of modules supported
      //   normal(default): Normal, non-templated modules that will be instantiated
-     //   templated: These modules are templated and must be run through topgen
-     //   reggen_top: These modules are not templated, but need to have reggen run
-     //              because they live exclusively in hw/top_* instead of hw/ip_*.
-     //              These modules are also instantiated as others.
+     //   templated:   These modules are templated and must be run through topgen
+     //   reggen_top:  These modules are not templated, but need to have reggen run
+     //                because they live exclusively in hw/top_* instead of hw/ip_*.
+     //                These modules are also instantiated in the top level.
      //   reggen_only: Similar to reggen_top, but are not instantiated in the top level.
   module: [
     { name: "uart0",    // instance name
@@ -287,7 +288,7 @@
       clock_group: "timers",
       reset_connections: {rst_ni: "sys_io_div4", rst_edn_ni: "sys"},
       base_addr: "0x40150000",
-      attr: "templated"         // Indicate this module is generated in the topgen
+      attr: "templated",
       localparam: {
         EscCntDw:  32,
         AccuCntDw: 16,
@@ -310,7 +311,7 @@
       reset_connections: {rst_ni: "por", rst_slow_ni: "por_aon"},
       domain: "Aon",
       base_addr: "0x40400000",
-      attr: "templated"         // Indicate this module is generated in the topgen
+      attr: "templated",
 
     },
     { name: "rstmgr_aon",
@@ -321,7 +322,7 @@
       reset_connections: {rst_ni: "rst_ni"},
       domain: "Aon",
       base_addr: "0x40410000",
-      attr: "templated"         // Indicate this module is generated in the topgen
+      attr: "templated",
     },
     { name: "clkmgr_aon",
       type: "clkmgr",
@@ -331,17 +332,16 @@
                           rst_io_div2_ni: "por_io_div2", rst_io_div4_ni: "por_io_div4"},
       domain: "Aon",
       base_addr: "0x40420000",
-      attr: "templated"
+      attr: "templated",
     },
     { name: "pinmux_aon",
       type: "pinmux",
-      clock: "main",
       clock_srcs: {clk_i: "io_div4", clk_aon_i: "aon"},
-      clock_group: "secure",
+      clock_group: "powerup",
       reset_connections: {rst_ni: "sys_io_div4", rst_aon_ni: "sys_aon"},
       domain: "Aon",
       base_addr: "0x40460000",
-      attr: "templated"
+      attr: "templated",
     },
     { name: "sensor_ctrl_aon",
       type: "sensor_ctrl",
@@ -350,7 +350,7 @@
       clock_reset_export: ["ast"],
       reset_connections: {rst_ni: "sys_io_div4"},
       domain: "Aon",
-      base_addr: "0x40500000",
+      base_addr: "0x40490000",
       attr: "reggen_top",
     },
     { name: "sram_ctrl_ret_aon",
@@ -359,7 +359,7 @@
       clock_group: "peri",
       reset_connections: {rst_ni: "sys_io_div4", rst_otp_ni: "lc_io_div4"},
       domain: "Aon",
-      base_addr: "0x40510000"
+      base_addr: "0x40500000"
     },
     { name: "flash_ctrl",
       type: "flash_ctrl",
@@ -367,7 +367,7 @@
       clock_group: "infra",
       reset_connections: {rst_ni: "lc", rst_otp_ni: "lc_io_div4"},
       base_addr: "0x41000000",
-      attr: "templated" // Indicate this module is generated in the topgen
+      attr: "templated",
     },
     { name: "rv_plic",
       type: "rv_plic",
@@ -375,7 +375,7 @@
       clock_group: "secure",
       reset_connections: {rst_ni: "sys"},
       base_addr: "0x41010000",
-      attr: "templated"         // Indicate this module is generated in the topgen
+      attr: "templated",
     },
     { name: "aes",
       type: "aes",
@@ -411,7 +411,8 @@
       base_addr: "0x00008000",
       swaccess: "ro",
       size: "0x4000",
-      integ_width: 7,
+      // data integrity width
+      integ_width: 8,
       inter_signal_list: [
         { struct: "tl"
           package: "tlul_pkg"
@@ -429,6 +430,7 @@
       base_addr: "0x10000000",
       size: "0x10000",
       byte_write: "true",
+      // data integrity width
       integ_width: 7,
       exec: "1",
       inter_signal_list: [
@@ -468,6 +470,7 @@
       base_addr: "0x40600000",
       size: "0x1000",
       byte_write: "true",
+      // data integrity width
       integ_width: 7,
       exec: "0",
       inter_signal_list: [
@@ -561,7 +564,10 @@
     },
   ],
 
-  // This is empty for top_englishbreakfast
+  // The port data structure is not something that should be used liberally.
+  // It is used specifically to assign special attributes to specific ports.
+  // For example, this allows us to designate a port as part of inter-module
+  // connections.
   port: [
     { name: "ast",
       inter_signal_list: [
@@ -635,15 +641,18 @@
       'flash_ctrl.rma_ack'      : ['lc_ctrl.lc_flash_rma_ack'],
       'flash_ctrl.rma_seed'     : ['lc_ctrl.lc_flash_rma_seed'],
       'sram_ctrl_main.sram_scr' : ['ram_main.sram_scr'],
-      'sram_ctrl_ret_aon.sram_scr' : ['ram_ret_aon.sram_scr'],
-      'sram_ctrl_main.en_ifetch' : ['ram_main.en_ifetch']
-      'sram_ctrl_ret_aon.en_ifetch' : ['ram_ret_aon.en_ifetch']
+      'sram_ctrl_ret_aon.sram_scr'  : ['ram_ret_aon.sram_scr'],
+      'sram_ctrl_main.en_ifetch'    : ['ram_main.en_ifetch'],
+      'sram_ctrl_ret_aon.en_ifetch' : ['ram_ret_aon.en_ifetch'],
       'ram_main.intg_error'     : ['sram_ctrl_main.intg_error'],
       'ram_ret_aon.intg_error'  : ['sram_ctrl_ret_aon.intg_error'],
       'pwrmgr_aon.pwr_flash'    : ['flash_ctrl.pwrmgr'],
       'pwrmgr_aon.pwr_rst'      : ['rstmgr_aon.pwr'],
       'pwrmgr_aon.pwr_clk'      : ['clkmgr_aon.pwr'],
       'pwrmgr_aon.pwr_lc'       : ['lc_ctrl.pwr_lc'],
+      'pwrmgr_aon.strap'        : ['pinmux_aon.strap_en'],
+      'pwrmgr_aon.low_power'    : ['pinmux_aon.sleep_en'],
+      'alert_handler.crashdump' : ['rstmgr_aon.alert_dump'],
       'rv_core_ibex.crash_dump'  : ['rstmgr_aon.cpu_dump'],
 
       // usbdev connection to pinmux
@@ -652,10 +661,6 @@
       'usbdev.usb_aon_wake_ack' : ['pinmux_aon.usb_aon_wake_ack'],
       'usbdev.usb_suspend'      : ['pinmux_aon.usb_suspend'],
       'pinmux_aon.usb_state_debug' : ['usbdev.usb_state_debug'],
-
-      // TODO see #4447
-      //'edn0.edn'              : ['keymgr.edn', 'otp_ctrl.edn', 'ast_edn.edn', 'kmac.entropy'],
-      //'edn1.edn'              : ['alert_handler.edn'],
 
       // The idle connection is automatically connected through topgen.
       // The user does not need to explicitly declare anything other than
@@ -679,7 +684,7 @@
       'lc_ctrl.lc_keymgr_en'       : [],
       'lc_ctrl.lc_escalate_en'     : ['aes.lc_escalate_en',
                                       'sram_ctrl_main.lc_escalate_en',
-                                      'sram_ctrl_ret_aon.lc_escalate_en'],      // TODO: OTP Clock bypass signal going from LC to AST/clkmgr
+                                      'sram_ctrl_ret_aon.lc_escalate_en'],
       'lc_ctrl.lc_clk_byp_ack'     : ['clkmgr_aon.lc_clk_bypass_ack'],
 
       // LC access control signal broadcast
@@ -710,18 +715,19 @@
         'clkmgr_aon.clk_usb'           : 'clk_usb',   // clock inputs
         'clkmgr_aon.clk_aon'           : 'clk_aon',   // clock inputs
         'clkmgr_aon.jitter_en'         : 'clk_main_jitter_en',
-        'pwrmgr_aon.pwr_ast'           : 'pwrmgr_ast',
-        'sensor_ctrl_aon.ast_alert'    : 'sensor_ctrl_ast_alert',
-        'sensor_ctrl_aon.ast_status'   : 'sensor_ctrl_ast_status',
-        'usbdev.usb_ref_val'           : '',
-        'usbdev.usb_ref_pulse'         : '',
+        'clkmgr_aon.ast_clk_bypass_ack': 'lc_clk_byp_ack',
         'eflash.flash_bist_enable'     : 'flash_bist_enable',
         'eflash.flash_power_down_h'    : 'flash_power_down_h',
         'eflash.flash_power_ready_h'   : 'flash_power_ready_h',
         'eflash.flash_test_mode_a'     : 'flash_test_mode_a',
         'eflash.flash_test_voltage_h'  : 'flash_test_voltage_h',
         'lc_ctrl.lc_clk_byp_req'       : 'lc_clk_byp_req',
-        'clkmgr_aon.ast_clk_bypass_ack': 'lc_clk_byp_ack',
+        'pinmux_aon.dft_strap_test'    : 'dft_strap_test'
+        'pwrmgr_aon.pwr_ast'           : 'pwrmgr_ast',
+        'sensor_ctrl_aon.ast_alert'    : 'sensor_ctrl_ast_alert',
+        'sensor_ctrl_aon.ast_status'   : 'sensor_ctrl_ast_status',
+        'usbdev.usb_ref_val'           : '',
+        'usbdev.usb_ref_pulse'         : '',
     },
   },
 
@@ -746,13 +752,10 @@
   ],
 
   // ===== INTERRUPT CTRL =====================================================
+
   // RV_PLIC has two searching algorithm internally to pick the most highest priority interrupt
   // source. "sequential" is smaller but slower, "matrix" is larger but faster.
   // Choose depends on the criteria. Currently it is set to "matrix" to meet FPGA timing @ 50MHz
-
-  // generated:
-  interrupt: [
-  ]
 
   // ===== ALERT HANDLER ======================================================
 

--- a/hw/top_englishbreakfast/rtl/top_englishbreakfast_cw305.sv
+++ b/hw/top_englishbreakfast/rtl/top_englishbreakfast_cw305.sv
@@ -63,9 +63,9 @@ module top_englishbreakfast_cw305 #(
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_out_core;
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_oe_core;
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_in_core;
-  logic [pinmux_reg_pkg::NDioPads-1:0] dio_out_core, dio_out_umux;
-  logic [pinmux_reg_pkg::NDioPads-1:0] dio_oe_core, dio_oe_umux;
-  logic [pinmux_reg_pkg::NDioPads-1:0] dio_in_core, dio_in_umux;
+  logic [pinmux_reg_pkg::NDioPads-1:0] dio_out_core;
+  logic [pinmux_reg_pkg::NDioPads-1:0] dio_oe_core;
+  logic [pinmux_reg_pkg::NDioPads-1:0] dio_in_core;
 
   padring #(
     // MIOs 43:34 and 31:20 are currently not
@@ -205,12 +205,12 @@ module top_englishbreakfast_cw305 #(
                              IO_USB_DN0 } ),
     // Muxed IOs
     .mio_in_o            ( mio_in_core   ),
-    .mio_out_i           ( mio_out_core  ),
+    .mio_out_i           ( mio_out       ),
     .mio_oe_i            ( mio_oe_core   ),
     // Dedicated IOs
-    .dio_in_o            ( dio_in_umux   ),
-    .dio_out_i           ( dio_out_umux  ),
-    .dio_oe_i            ( dio_oe_umux   ),
+    .dio_in_o            ( dio_in_core   ),
+    .dio_out_i           ( dio_out_core  ),
+    .dio_oe_i            ( dio_oe_core   ),
     // Pad Attributes
     .mio_attr_i          ( mio_attr      ),
     .dio_attr_i          ( dio_attr      )


### PR DESCRIPTION
This PR reconnects the DIO signals and the precise capture trigger that got accidentally disconnected when moving the JTAG mux into the pinmux IP. This re-enables SCA on the CW305 board. In addition, top_englishbreakfast is slightly realigned to top_earlgrey in order to ease future diffs.