### PR TITLE
[doc] Prefer relative links and some cleanup

### DIFF
--- a/hw/ip/aes/doc/checklist.md
+++ b/hw/ip/aes/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "AES Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [AES peripheral.]({{<relref "hw/ip/aes/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [AES peripheral.]({{<relref "." >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist
@@ -11,7 +11,7 @@ All checklist items refer to the content in the [Checklist.]({{< relref "/doc/pr
 
 Type          | Item                           | Resolution  | Note/Collaterals
 --------------|-----------------------         |-------------|------------------
-Documentation | [SPEC_COMPLETE][]              | Done        | [AES Design Spec]({{<relref "hw/ip/aes/doc" >}})
+Documentation | [SPEC_COMPLETE][]              | Done        | [AES Design Spec]({{<relref "." >}})
 Documentation | [CSR_DEFINED][]                | Done        |
 RTL           | [CLKRST_CONNECTED][]           | Done        |
 RTL           | [IP_TOP][]                     | Done        |
@@ -110,8 +110,8 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [AES DV document]({{<relref "hw/ip/aes/doc/dv" >}})
-Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [AES DV plan]({{<relref "hw/ip/aes/doc/dv/index.md#dv_plan" >}})
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [AES DV document]({{<relref "dv" >}})
+Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [AES DV plan]({{<relref "dv/index.md#dv_plan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Done        |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |

--- a/hw/ip/aes/doc/dv/index.md
+++ b/hw/ip/aes/doc/dv/index.md
@@ -15,7 +15,7 @@ title: "AES DV document"
 * [Simulation results](https://reports.opentitan.org/hw/ip/aes/dv/latest/results.html)
 
 ## Design features
-For detailed information on AES design features, please see the [AES HWIP Technical Specification]({{< relref "hw/ip/aes/doc" >}}).
+For detailed information on AES design features, please see the [AES HWIP Technical Specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 AES testbench has been constructed based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).

--- a/hw/ip/alert_handler/doc/dv/index.md
+++ b/hw/ip/alert_handler/doc/dv/index.md
@@ -17,7 +17,7 @@ title: "ALERT_HANDLER DV document"
 * [Simulation results](https://reports.opentitan.org/hw/ip/alert_handler/dv/latest/results.html)
 
 ## Design features
-For detailed information on ALERT_HANDLER design features, please see the [ALERT_HANDLER HWIP technical specification]({{< relref "hw/ip/alert_handler/doc" >}}).
+For detailed information on ALERT_HANDLER design features, please see the [ALERT_HANDLER HWIP technical specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 ALERT_HANDLER testbench has been constructed based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).

--- a/hw/ip/aon_timer/doc/checklist.md
+++ b/hw/ip/aon_timer/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "AON Timer Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [AON Timer peripheral.]({{< relref "hw/ip/aon_timer/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [AON Timer peripheral.]({{< relref "." >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist
@@ -11,7 +11,7 @@ All checklist items refer to the content in the [Checklist.]({{< relref "/doc/pr
 
 Type          | Item                           | Resolution  | Note/Collaterals
 --------------|--------------------------------|-------------|------------------
-Documentation | [SPEC_COMPLETE][]              | Done        | [AON Timer Design Spec]({{<relref "hw/ip/aon_timer/doc" >}})
+Documentation | [SPEC_COMPLETE][]              | Done        | [AON Timer Design Spec]({{<relref "." >}})
 Documentation | [CSR_DEFINED][]                | Done        |
 RTL           | [CLKRST_CONNECTED][]           | Done        |
 RTL           | [IP_TOP][]                     | Done        |

--- a/hw/ip/aon_timer/doc/dv/index.md
+++ b/hw/ip/aon_timer/doc/dv/index.md
@@ -15,7 +15,7 @@ title: "AON_TIMER DV document"
 * [Simulation results](https://reports.opentitan.org/hw/ip/aon_timer/dv/latest/results.html)
 
 ## Design features
-For detailed information on AON_TIMER design features, please see the [AON_TIMER HWIP technical specification]({{< relref "hw/ip/aon_timer/doc" >}}).
+For detailed information on AON_TIMER design features, please see the [AON_TIMER HWIP technical specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 AON_TIMER testbench has been constructed based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).

--- a/hw/ip/clkmgr/doc/checklist.md
+++ b/hw/ip/clkmgr/doc/checklist.md
@@ -7,7 +7,7 @@ NOTE: This is a template checklist document that is required to be copied over t
 directory for a new design that transitions from L0 (Specification) to L1 (Development)
 stage, and updated as needed. Once done, please remove this comment before checking it in.
 -->
-This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [CLKMGR peripheral.]({{< relref "hw/ip/clkmgr/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [CLKMGR peripheral.]({{< relref "." >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist
@@ -16,7 +16,7 @@ All checklist items refer to the content in the [Checklist.]({{< relref "/doc/pr
 
 Type          | Item                           | Resolution  | Note/Collaterals
 --------------|--------------------------------|-------------|------------------
-Documentation | [SPEC_COMPLETE][]              | Done        | [CLKMGR Design Spec]({{<relref "hw/ip/clkmgr/doc" >}})
+Documentation | [SPEC_COMPLETE][]              | Done        | [CLKMGR Design Spec]({{<relref "." >}})
 Documentation | [CSR_DEFINED][]                | Done        |
 RTL           | [CLKRST_CONNECTED][]           | Done        |
 RTL           | [IP_TOP][]                     | Done        |

--- a/hw/ip/csrng/doc/checklist.md
+++ b/hw/ip/csrng/doc/checklist.md
@@ -7,7 +7,7 @@ NOTE: This is a template checklist document that is required to be copied over t
 directory for a new design that transitions from L0 (Specification) to L1 (Development)
 stage, and updated as needed. Once done, please remove this comment before checking it in.
 -->
-This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [CSRNG peripheral.]({{< relref "hw/ip/csrng/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [CSRNG peripheral.]({{< relref "." >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist
@@ -16,7 +16,7 @@ All checklist items refer to the content in the [Checklist.]({{< relref "/doc/pr
 
 Type          | Item                           | Resolution  | Note/Collaterals
 --------------|--------------------------------|-------------|------------------
-Documentation | [SPEC_COMPLETE][]              | Done        | [CSRNG Design Spec]({{<relref "hw/ip/csrng/doc" >}})
+Documentation | [SPEC_COMPLETE][]              | Done        | [CSRNG Design Spec]({{<relref "." >}})
 Documentation | [CSR_DEFINED][]                | Done        |
 RTL           | [CLKRST_CONNECTED][]           | Done        |
 RTL           | [IP_TOP][]                     | Done        |
@@ -115,8 +115,8 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [CSRNG DV document]({{<relref "hw/ip/csrng/doc/dv" >}})
-Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [CSRNG DV plan]({{<relref "hw/ip/csrng/doc/dv/index.md#dv_plan" >}})
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [CSRNG DV document]({{<relref "dv" >}})
+Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [CSRNG DV plan]({{<relref "dv/index.md#dv_plan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Done        |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |

--- a/hw/ip/csrng/doc/dv/index.md
+++ b/hw/ip/csrng/doc/dv/index.md
@@ -15,7 +15,7 @@ title: "CSRNG DV document"
 * [Simulation results](https://reports.opentitan.org/hw/ip/csrng/dv/latest/results.html)
 
 ## Design features
-For detailed information on CSRNG design features, please see the [CSRNG HWIP technical specification]({{< relref "hw/ip/csrng/doc" >}}).
+For detailed information on CSRNG design features, please see the [CSRNG HWIP technical specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 CSRNG testbench has been constructed based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).

--- a/hw/ip/dcd/doc/checklist.md
+++ b/hw/ip/dcd/doc/checklist.md
@@ -16,7 +16,7 @@ All checklist items refer to the content in the [Checklist.]({{< relref "/doc/pr
 
 Type          | Item                           | Resolution  | Note/Collaterals
 --------------|--------------------------------|-------------|------------------
-Documentation | [SPEC_COMPLETE][]              | Not Started | [DCD Design Spec]({{<relref "hw/ip/dcd/doc" >}})
+Documentation | [SPEC_COMPLETE][]              | Not Started | [DCD Design Spec]({{<relref "." >}})
 Documentation | [CSR_DEFINED][]                | Not Started |
 RTL           | [CLKRST_CONNECTED][]           | Not Started |
 RTL           | [IP_TOP][]                     | Not Started |
@@ -115,8 +115,8 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Not Started | [DCD DV document]({{<relref "hw/ip/dcd/doc/dv/index.md" >}})
-Documentation | [DV_PLAN_COMPLETED][]                 | Not Started | [DCD DV Plan]({{<relref "hw/ip/dcd/doc/dv/index.md#dv_plan" >}})
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Not Started | [DCD DV document]({{<relref "dv/index.md" >}})
+Documentation | [DV_PLAN_COMPLETED][]                 | Not Started | [DCD DV Plan]({{<relref "dv/index.md#dv_plan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Not Started |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Not Started |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Not Started |

--- a/hw/ip/dcd/doc/dv/index.md
+++ b/hw/ip/dcd/doc/dv/index.md
@@ -2,15 +2,6 @@
 title: "DCD DV document"
 ---
 
-<!-- Copy this file to hw/ip/dcd/doc/dv/index.md and make changes as needed.
-For convenience 'dcd' in the document can be searched and replaced easily with the
-desired IP (with case sensitivity!). Also, use the testbench block diagram
-located at OpenTitan team drive / 'design verification'
-as a starting point and modify it to reflect your dcd testbench and save it
-to hw/ip/dcd/doc/dv/tb.svg. It should get linked and rendered under the block
-diagram section below. Please update / modify / remove sections below as
-applicable. Once done, remove this comment before making a PR. -->
-
 ## Goals
 * **DV**
   * Verify all DCD IP features by running dynamic simulations with a SV/UVM based testbench

--- a/hw/ip/edn/doc/checklist.md
+++ b/hw/ip/edn/doc/checklist.md
@@ -7,7 +7,7 @@ NOTE: This is a template checklist document that is required to be copied over t
 directory for a new design that transitions from L0 (Specification) to L1 (Development)
 stage, and updated as needed. Once done, please remove this comment before checking it in.
 -->
-This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [EDN peripheral.]({{< relref "hw/ip/edn/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [EDN peripheral.]({{< relref "." >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist
@@ -16,7 +16,7 @@ All checklist items refer to the content in the [Checklist.]({{< relref "/doc/pr
 
 Type          | Item                           | Resolution  | Note/Collaterals
 --------------|--------------------------------|-------------|------------------
-Documentation | [SPEC_COMPLETE][]              | Done        | [EDN Design Spec]({{<relref "hw/ip/edn/doc" >}})
+Documentation | [SPEC_COMPLETE][]              | Done        | [EDN Design Spec]({{<relref "." >}})
 Documentation | [CSR_DEFINED][]                | Done        |
 RTL           | [CLKRST_CONNECTED][]           | Done        |
 RTL           | [IP_TOP][]                     | Done        |
@@ -113,8 +113,8 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [EDN DV document]({{<relref "hw/ip/edn/doc/dv" >}})
-Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [EDN DV plan]({{<relref "hw/ip/edn/doc/dv/index.md#dv_plan" >}})
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [EDN DV document]({{<relref "dv" >}})
+Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [EDN DV plan]({{<relref "dv/index.md#dv_plan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Done        |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |

--- a/hw/ip/edn/doc/dv/index.md
+++ b/hw/ip/edn/doc/dv/index.md
@@ -15,7 +15,7 @@ title: "EDN DV document"
 * [Simulation results](https://reports.opentitan.org/hw/ip/edn/dv/latest/results.html)
 
 ## Design features
-For detailed information on EDN design features, please see the [EDN HWIP technical specification]({{< relref "hw/ip/edn/doc" >}}).
+For detailed information on EDN design features, please see the [EDN HWIP technical specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 EDN testbench has been constructed based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).

--- a/hw/ip/entropy_src/doc/checklist.md
+++ b/hw/ip/entropy_src/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "ENTROPY_SRC Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [ENTROPY_SRC peripheral.]({{< relref "hw/ip/entropy_src/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [ENTROPY_SRC peripheral.]({{< relref "." >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist
@@ -11,7 +11,7 @@ All checklist items refer to the content in the [Checklist.]({{< relref "/doc/pr
 
 Type          | Item                           | Resolution  | Note/Collaterals
 --------------|--------------------------------|-------------|------------------
-Documentation | [SPEC_COMPLETE][]              | Done        | [ENTROPY_SRC Design Spec]({{<relref "hw/ip/entropy_src/doc" >}})
+Documentation | [SPEC_COMPLETE][]              | Done        | [ENTROPY_SRC Design Spec]({{<relref "." >}})
 Documentation | [CSR_DEFINED][]                | Done        |
 RTL           | [CLKRST_CONNECTED][]           | Done        |
 RTL           | [IP_TOP][]                     | Done        |
@@ -110,8 +110,8 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [ENTROPY_SRC DV document]({{<relref "hw/ip/entropy_src/doc/dv" >}})
-Documentation | [DV_PLAN_COMPLETED][]                 | In Progress | [ENTROPY_SRC DV plan]({{<relref "hw/ip/entropy_src/doc/dv/index.md#dv_plan" >}})
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [ENTROPY_SRC DV document]({{<relref "dv" >}})
+Documentation | [DV_PLAN_COMPLETED][]                 | In Progress | [ENTROPY_SRC DV plan]({{<relref "dv/index.md#dv_plan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Done        |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |

--- a/hw/ip/entropy_src/doc/dv/index.md
+++ b/hw/ip/entropy_src/doc/dv/index.md
@@ -15,7 +15,7 @@ title: "ENTROPY_SRC DV document"
 * [Simulation results](https://reports.opentitan.org/hw/ip/entropy_src/dv/latest/results.html)
 
 ## Design features
-For detailed information on ENTROPY_SRC design features, please see the [ENTROPY_SRC HWIP technical specification]({{< relref "hw/ip/entropy_src/doc" >}}).
+For detailed information on ENTROPY_SRC design features, please see the [ENTROPY_SRC HWIP technical specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 ENTROPY_SRC testbench has been constructed based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).

--- a/hw/ip/flash_ctrl/doc/dv/index.md
+++ b/hw/ip/flash_ctrl/doc/dv/index.md
@@ -15,7 +15,7 @@ title: "FLASH_CTRL DV document"
 * [Simulation results](https://reports.opentitan.org/hw/ip/flash_ctrl/dv/latest/results.html)
 
 ## Design features
-For detailed information on `flash_ctrl` design features, please see the [`flash_ctrl` HWIP technical specification]({{< relref "hw/ip/flash_ctrl/doc" >}}).
+For detailed information on `flash_ctrl` design features, please see the [`flash_ctrl` HWIP technical specification]({{< relref ".." >}}).
 The design-under-test (DUT) wraps the `flash_ctrl` IP, `flash_phy` and the TLUL SRAM adapter that converts the incoming TL accesses from the from host (CPU) interface into flash requests.
 These modules are instantiated and connected to each other and to the rest of the design at the top level.
 For the IP level DV, we replicate the instantiations and connections in `flash_ctrl_wrapper` module mainained in DV, located at `hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv`.

--- a/hw/ip/gpio/doc/checklist.md
+++ b/hw/ip/gpio/doc/checklist.md
@@ -137,7 +137,7 @@ Review        | [DV_PLAN_REVIEWED][]                  | Done            |
 Review        | [STD_TEST_CATEGORIES_PLANNED][]       | Done            | Exception (Security, Power, Debug)
 Review        | [V2_CHECKLIST_SCOPED][]               | Done            |
 
-[gpio_dv_doc]: {{<relref "/hw/ip/gpio/doc/dv/index.md">}}
+[gpio_dv_doc]: {{<relref "/dv/index.md">}}
 
 [DV_DOC_DRAFT_COMPLETED]:             {{<relref "/doc/project/checklist.md#dv_doc_draft_completed" >}}
 [DV_PLAN_COMPLETED]:                  {{<relref "/doc/project/checklist.md#dv_plan_completed" >}}

--- a/hw/ip/gpio/doc/checklist.md
+++ b/hw/ip/gpio/doc/checklist.md
@@ -137,7 +137,7 @@ Review        | [DV_PLAN_REVIEWED][]                  | Done            |
 Review        | [STD_TEST_CATEGORIES_PLANNED][]       | Done            | Exception (Security, Power, Debug)
 Review        | [V2_CHECKLIST_SCOPED][]               | Done            |
 
-[gpio_dv_doc]: {{<relref "/dv/index.md">}}
+[gpio_dv_doc]: {{<relref "dv/index.md">}}
 
 [DV_DOC_DRAFT_COMPLETED]:             {{<relref "/doc/project/checklist.md#dv_doc_draft_completed" >}}
 [DV_PLAN_COMPLETED]:                  {{<relref "/doc/project/checklist.md#dv_plan_completed" >}}

--- a/hw/ip/gpio/doc/dv/index.md
+++ b/hw/ip/gpio/doc/dv/index.md
@@ -15,7 +15,7 @@ title: "GPIO DV document"
 * [Simulation results](https://reports.opentitan.org/hw/ip/gpio/dv/latest/results.html)
 
 ## Design features
-For detailed information on GPIO design features, please see the [GPIO design specification]({{< relref "hw/ip/gpio/doc" >}}).
+For detailed information on GPIO design features, please see the [GPIO design specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 GPIO testbench has been constructed based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).

--- a/hw/ip/hmac/doc/checklist.md
+++ b/hw/ip/hmac/doc/checklist.md
@@ -21,7 +21,7 @@ RTL           | [FUNC_IMPLEMENTED][]           | Done        |
 RTL           | [ASSERT_KNOWN_ADDED][]         | Done        |
 Code Quality  | [LINT_SETUP][]                 | Done        |
 
-[HMAC Spec]: {{<relref "/hw/ip/hmac/doc">}}
+[HMAC Spec]: {{<relref "/.">}}
 
 [SPEC_COMPLETE]:              {{<relref "/doc/project/checklist.md#spec_complete" >}}
 [CSR_DEFINED]:                {{<relref "/doc/project/checklist.md#csr_defined" >}}

--- a/hw/ip/hmac/doc/checklist.md
+++ b/hw/ip/hmac/doc/checklist.md
@@ -21,7 +21,7 @@ RTL           | [FUNC_IMPLEMENTED][]           | Done        |
 RTL           | [ASSERT_KNOWN_ADDED][]         | Done        |
 Code Quality  | [LINT_SETUP][]                 | Done        |
 
-[HMAC Spec]: {{<relref "/.">}}
+[HMAC Spec]: {{<relref ".">}}
 
 [SPEC_COMPLETE]:              {{<relref "/doc/project/checklist.md#spec_complete" >}}
 [CSR_DEFINED]:                {{<relref "/doc/project/checklist.md#csr_defined" >}}

--- a/hw/ip/hmac/doc/dv/index.md
+++ b/hw/ip/hmac/doc/dv/index.md
@@ -16,7 +16,7 @@ title: "HMAC DV document"
 
 ## Design features
 For detailed information on HMAC design features, please see the
-[HMAC design specification]({{< relref "hw/ip/hmac/doc" >}}).
+[HMAC design specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 HMAC testbench has been constructed based on the

--- a/hw/ip/i2c/doc/checklist.md
+++ b/hw/ip/i2c/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "I2C Checklist"
 ---
 
-This checklist is for [Hardware Stage][] transitions for the [I2C peripheral.]({{<relref "hw/ip/i2c/doc" >}})
+This checklist is for [Hardware Stage][] transitions for the [I2C peripheral.]({{<relref "." >}})
 All checklist items refer to the content in the [Checklist.]({{<relref "/doc/project/checklist.md">}})
 
 [Hardware Stage]: {{<relref "/doc/project/development_stages.md" >}}
@@ -13,7 +13,7 @@ All checklist items refer to the content in the [Checklist.]({{<relref "/doc/pro
 
 Type          | Item                           | Resolution  | Note/Collaterals
 --------------|--------------------------------|-------------|------------------
-Documentation | [SPEC_COMPLETE][]              | Done        | [I2C Spec]({{<relref "hw/ip/i2c/doc" >}})
+Documentation | [SPEC_COMPLETE][]              | Done        | [I2C Spec]({{<relref "." >}})
 Documentation | [CSR_DEFINED][]                | Done        |
 RTL           | [CLKRST_CONNECTED][]           | Done        |
 RTL           | [IP_TOP][]                     | Done        |
@@ -112,8 +112,8 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [i2c_dv_doc]({{<relref "hw/ip/i2c/doc/dv" >}})
-Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [i2c_dv_plan]({{<relref "hw/ip/i2c/doc/dv/index.md#dv_plan" >}})
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [i2c_dv_doc]({{<relref "dv" >}})
+Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [i2c_dv_plan]({{<relref "dv/index.md#dv_plan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Done        |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |

--- a/hw/ip/i2c/doc/dv/index.md
+++ b/hw/ip/i2c/doc/dv/index.md
@@ -16,7 +16,7 @@ title: "I2C DV document"
 
 ## Design features
 For detailed information on I2C design features, please see the
-[I2C design specification]({{< relref "hw/ip/i2c/doc" >}}).
+[I2C design specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 I2C testbench has been constructed based on the

--- a/hw/ip/keymgr/doc/checklist.md
+++ b/hw/ip/keymgr/doc/checklist.md
@@ -115,8 +115,8 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [KEYMGR DV document]({{<relref "hw/ip/keymgr/doc/dv" >}})
-Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [KEYMGR DV plan]({{<relref "hw/ip/keymgr/doc/dv/index.md#dv_plan" >}})
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [KEYMGR DV document]({{<relref "dv" >}})
+Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [KEYMGR DV plan]({{<relref "dv/index.md#dv_plan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Done        |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |

--- a/hw/ip/keymgr/doc/dv/index.md
+++ b/hw/ip/keymgr/doc/dv/index.md
@@ -2,15 +2,6 @@
 title: "KEYMGR DV document"
 ---
 
-<!-- Copy this file to hw/ip/keymgr/doc/keymgr_dv_doc.md and make changes as needed.
-For convenience 'keymgr' in the document can be searched and replaced easily with the
-desired IP (with case sensitivity!). Also, use the testbench block diagram
-located at OpenTitan team drive / 'design verification'
-as a starting point and modify it to reflect your keymgr testbench and save it
-to hw/ip/keymgr/doc/tb.svg. It should get linked and rendered under the block
-diagram section below. Please update / modify / remove sections below as
-applicable. Once done, remove this comment before making a PR. -->
-
 ## Goals
 * **DV**
   * Verify all KEYMGR IP features by running dynamic simulations with a SV/UVM based testbench

--- a/hw/ip/kmac/doc/dv/index.md
+++ b/hw/ip/kmac/doc/dv/index.md
@@ -15,7 +15,7 @@ title: "KMAC DV document"
 * [Simulation results](https://reports.opentitan.org/hw/ip/kmac/dv/latest/results.html)
 
 ## Design features
-For detailed information on KMAC design features, please see the [KMAC HWIP technical specification]({{< relref "hw/ip/kmac/doc" >}}).
+For detailed information on KMAC design features, please see the [KMAC HWIP technical specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 KMAC testbench has been constructed based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).

--- a/hw/ip/kmac/doc/dv/index.md
+++ b/hw/ip/kmac/doc/dv/index.md
@@ -2,15 +2,6 @@
 title: "KMAC DV document"
 ---
 
-<!-- Copy this file to hw/ip/kmac/doc/kmac_dv_doc.md and make changes as needed.
-For convenience 'kmac' in the document can be searched and replaced easily with the
-desired IP (with case sensitivity!). Also, use the testbench block diagram
-located at OpenTitan team drive / 'design verification'
-as a starting point and modify it to reflect your kmac testbench and save it
-to hw/ip/kmac/doc/tb.svg. It should get linked and rendered under the block
-diagram section below. Please update / modify / remove sections below as
-applicable. Once done, remove this comment before making a PR. -->
-
 ## Goals
 * **DV**
   * Verify all KMAC IP features by running dynamic simulations with a SV/UVM based testbench

--- a/hw/ip/lc_ctrl/doc/_index.md
+++ b/hw/ip/lc_ctrl/doc/_index.md
@@ -153,7 +153,7 @@ They exist only after specific events, and are restored to normal once the devic
 
 The individual signals summarized in the table below are described in the following subsections.
 
-{{< snippet "hw/ip/lc_ctrl/doc/lc_ctrl_function_signals_table.md" >}}
+{{< snippet "lc_ctrl_function_signals_table.md" >}}
 
 Signals marked with an asterisk (Y\*) are only asserted under certain conditions as explained in detail below.
 
@@ -228,7 +228,7 @@ The CLK_BYP_REQ signal is only asserted when a transition command is issued.
 
 The individual signals summarized in the table below are described in the following subsections.
 
-{{< snippet "hw/ip/lc_ctrl/doc/lc_ctrl_access_signals_table.md" >}}
+{{< snippet "lc_ctrl_access_signals_table.md" >}}
 
 Signals marked with an asterisk (Y\*) are only asserted under certain conditions as explained in detail below.
 
@@ -263,7 +263,7 @@ The following is a list of all life cycle related collateral stored in OTP.
 Most collateral also contain associated metadata to indicate when the collateral is restricted from further software access, see [accessibility summary]({{< relref "#otp-accessibility-summary-and-impact-of-provision_en" >}}) for more details.
 Since not all collateral is consumed by the life cycle controller, the consuming agent is also shown.
 
-{{< snippet "hw/ip/lc_ctrl/doc/lc_ctrl_otp_collateral.md" >}}
+{{< snippet "lc_ctrl_otp_collateral.md" >}}
 
 The TOKENs and KEYS are considered secret data and are stored in [wrapped format]({{< relref "#conditional-transitions">}}).
 Before use, the secrets are unwrapped.
@@ -309,7 +309,7 @@ These are
 
 The table below summarizes the software accessibility of all life cycle collateral.
 
-{{< snippet "hw/ip/lc_ctrl/doc/lc_ctrl_otp_accessibility.md" >}}
+{{< snippet "lc_ctrl_otp_accessibility.md" >}}
 
 Note that CREATOR_SEED_SW_RW_EN is set to OFF if SECRET2_DIGEST has a nonzero value in PROD, PROD_END and DEV states.
 SEED_HW_RD_EN only becomes active if SECRET2_DIGEST has a nonzero value in DEV, PROD, PROD_END and RMA states.
@@ -321,11 +321,11 @@ As it pertains to life cycle, the flash contains three sets of important collate
 They are enumerated in the table below.
 Just as with OTP, the consumer and usage of each is also described.
 
-{{< snippet "hw/ip/lc_ctrl/doc/lc_ctrl_flash_collateral.md" >}}
+{{< snippet "lc_ctrl_flash_collateral.md" >}}
 
 Each collateral belongs to a separate flash partition, the table below enumerates the partition and whether the partition is memory mapped.
 
-{{< snippet "hw/ip/lc_ctrl/doc/lc_ctrl_flash_partitions.md" >}}
+{{< snippet "lc_ctrl_flash_partitions.md" >}}
 
 The general flash partition refers to any software managed storage in flash, and is not a specific carve out in the non-memory mapped area.
 
@@ -338,7 +338,7 @@ It is expected that ROM_ext during secure boot programs the protection correctly
 The CREATOR_DATA partitions however, are further qualified based on the personalization state of the device.
 Just as with OTP, the table below enumerates accessibility of flash collateral.
 
-{{< snippet "hw/ip/lc_ctrl/doc/lc_ctrl_flash_accessibility.md" >}}
+{{< snippet "lc_ctrl_flash_accessibility.md" >}}
 
 Note that CREATOR_SEED_SW_RW_EN is set to OFF if SECRET2_DIGEST has a nonzero value in PROD, PROD_END and DEV states.
 SEED_HW_RD_EN only becomes active if SECRET2_DIGEST has a nonzero value in DEV, PROD, PROD_END and RMA states.
@@ -490,7 +490,7 @@ The figure below provides more context about how the life cycle controller is in
 The encoding of the life-cycle state is used both for OTP storage and as part of the FSM state in the life cycle controller.
 In other words the state stored within OTP is not re-encoded before it is consumed as part of the life cycle controller FSM state.
 
-{{< snippet "hw/ip/lc_ctrl/doc/lc_ctrl_encoding_table.md" >}}
+{{< snippet "lc_ctrl_encoding_table.md" >}}
 
 Any decoding that does not fall into the table above is considered **INVALID**.
 
@@ -524,7 +524,7 @@ The second readout pass uses a linearly increasing address sequence, whereas the
 The life cycle transition counter has 16 strokes where each stroke maps to one 16bit OTP word.
 The strokes are similarly encoded as the life cycle state in the sense that upon the first transition attempt, all words are initialized with unique Cx values that can later be overwritten with unique Dx values without producing an ECC error.
 
-{{< snippet "hw/ip/lc_ctrl/doc/lc_ctrl_counter_table.md" >}}
+{{< snippet "lc_ctrl_counter_table.md" >}}
 
 Upon each life cycle transition attempt, the life cycle controller **FIRST** increments the transition counter before initiating any token hashing and comparison operations.
 

--- a/hw/ip/lc_ctrl/doc/checklist.md
+++ b/hw/ip/lc_ctrl/doc/checklist.md
@@ -7,7 +7,7 @@ NOTE: This is a template checklist document that is required to be copied over t
 directory for a new design that transitions from L0 (Specification) to L1 (Development)
 stage, and updated as needed. Once done, please remove this comment before checking it in.
 -->
-This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [LC_CTRL peripheral.]({{< relref "hw/ip/lc_ctrl/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [LC_CTRL peripheral.]({{< relref "." >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist
@@ -16,7 +16,7 @@ All checklist items refer to the content in the [Checklist.]({{< relref "/doc/pr
 
 Type          | Item                           | Resolution  | Note/Collaterals
 --------------|--------------------------------|-------------|------------------
-Documentation | [SPEC_COMPLETE][]              | Done        | [LC_CTRL Design Spec]({{<relref "hw/ip/lc_ctrl/doc" >}})
+Documentation | [SPEC_COMPLETE][]              | Done        | [LC_CTRL Design Spec]({{<relref "." >}})
 Documentation | [CSR_DEFINED][]                | Done        |
 RTL           | [CLKRST_CONNECTED][]           | Done        |
 RTL           | [IP_TOP][]                     | Done        |
@@ -115,8 +115,8 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [LC_CTRL DV document]({{<relref "hw/ip/lc_ctrl/doc/dv" >}})
-Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [LC_CTRL DV plan]({{<relref "hw/ip/lc_ctrl/doc/dv/index.md#dv_plan" >}})
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [LC_CTRL DV document]({{<relref "dv" >}})
+Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [LC_CTRL DV plan]({{<relref "dv/index.md#dv_plan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Done        |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |

--- a/hw/ip/lc_ctrl/doc/dv/index.md
+++ b/hw/ip/lc_ctrl/doc/dv/index.md
@@ -2,15 +2,6 @@
 title: "LC_CTRL DV document"
 ---
 
-<!-- Copy this file to hw/ip/lc_ctrl/doc/lc_ctrl_dv_doc.md and make changes as needed.
-For convenience 'lc_ctrl' in the document can be searched and replaced easily with the
-desired IP (with case sensitivity!). Also, use the testbench block diagram
-located at OpenTitan team drive / 'design verification'
-as a starting point and modify it to reflect your lc_ctrl testbench and save it
-to hw/ip/lc_ctrl/doc/tb.svg. It should get linked and rendered under the block
-diagram section below. Please update / modify / remove sections below as
-applicable. Once done, remove this comment before making a PR. -->
-
 ## Goals
 * **DV**
   * Verify all LC_CTRL IP features by running dynamic simulations with a SV/UVM based testbench

--- a/hw/ip/lc_ctrl/doc/dv/index.md
+++ b/hw/ip/lc_ctrl/doc/dv/index.md
@@ -15,7 +15,7 @@ title: "LC_CTRL DV document"
 * [Simulation results](https://reports.opentitan.org/hw/ip/lc_ctrl/dv/latest/results.html)
 
 ## Design features
-For detailed information on LC_CTRL design features, please see the [LC_CTRL HWIP technical specification]({{< relref "hw/ip/lc_ctrl/doc" >}}).
+For detailed information on LC_CTRL design features, please see the [LC_CTRL HWIP technical specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 LC_CTRL testbench has been constructed based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).

--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -48,7 +48,7 @@ which has been formally verified within the [Fiat Crypto project](http://adam.ch
 # Instruction Set
 
 OTBN is a processor with a custom instruction set.
-The full ISA description can be found in our [ISA manual]({{< relref "hw/ip/otbn/doc/isa" >}}).
+The full ISA description can be found in our [ISA manual]({{< relref "isa" >}}).
 The instruction set is split into two groups:
 
 * The **base instruction subset** operates on the 32b General Purpose Registers (GPRs).
@@ -94,7 +94,7 @@ For example, good choices for temporary registers are `x6`, `x7`, `x28`, `x29`, 
 
 OTBN has an in-built call stack which is accessed through the `x1` GPR.
 This is intended to be used as a return address stack, containing return addresses for the current stack of function calls.
-See the documentation for [`JAL`]({{< relref "hw/ip/otbn/doc/isa#jal" >}}) and [`JALR`]({{< relref "hw/ip/otbn/doc/isa#jalr" >}}) for a description of how to use it for this purpose.
+See the documentation for [`JAL`]({{< relref "isa#jal" >}}) and [`JALR`]({{< relref "isa#jalr" >}}) for a description of how to use it for this purpose.
 
 The call stack has a maximum depth of 8 elements.
 Each instruction that reads from `x1` pops a single element from the stack.
@@ -291,7 +291,7 @@ GPRs are accessible from the base instruction subset, and WDRs are accessible fr
 
 OTBN has 256b Wide Special purpose Registers (WSRs).
 These are analogous to the 32b CSRs, but are used by big number instructions.
-They can be accessed with the [`BN.WSRRS`]({{< relref "hw/ip/otbn/doc/isa#bnwsrrs" >}}) and [`BN.WSRRW`]({{< relref "hw/ip/otbn/doc/isa#bnwsrrw" >}}) instructions.
+They can be accessed with the [`BN.WSRRS`]({{< relref "isa#bnwsrrs" >}}) and [`BN.WSRRW`]({{< relref "isa#bnwsrrw" >}}) instructions.
 
 <table>
   <thead>
@@ -309,7 +309,7 @@ They can be accessed with the [`BN.WSRRS`]({{< relref "hw/ip/otbn/doc/isa#bnwsrr
       <td>RW</td>
 <td>
 
-The modulus used by the [`BN.ADDM`]({{< relref "hw/ip/otbn/doc/isa#bnaddm" >}}) and [`BN.SUBM`]({{< relref "hw/ip/otbn/doc/isa#bnsubm" >}}) instructions.
+The modulus used by the [`BN.ADDM`]({{< relref "isa#bnaddm" >}}) and [`BN.SUBM`]({{< relref "isa#bnsubm" >}}) instructions.
 This WSR is also visible as CSRs `MOD0` through to `MOD7`.
 
 </td>
@@ -356,7 +356,7 @@ The `M`, `L`, and `Z` flags are determined based on the result of the operation 
 
 ### Loop Stack
 
-OTBN has two instructions for hardware-assisted loops: [`LOOP`]({{< relref "hw/ip/otbn/doc/isa#loop" >}}) and [`LOOPI`]({{< relref "hw/ip/otbn/doc/isa#loopi" >}}).
+OTBN has two instructions for hardware-assisted loops: [`LOOP`]({{< relref "isa#loop" >}}) and [`LOOPI`]({{< relref "isa#loopi" >}}).
 Both use the same state for tracking control flow.
 This is a stack of tuples containing a loop count, start address and end address.
 The stack has a maximum depth of eight and the top of the stack is the current loop.
@@ -468,7 +468,7 @@ By design, OTBN is a simple processor and provides no error handling support to 
 
 Whenever OTBN observes an error, it will generate an alert.
 This gets sent to the alert manager.
-The alert will either be fatal or recoverable, depending on the class of error: see [Alerts]({{< relref "hw/ip/otbn/doc#alerts" >}}) and {{< regref "ERR_BITS" >}} below for details.
+The alert will either be fatal or recoverable, depending on the class of error: see [Alerts]({{< relref "#alerts" >}}) and {{< regref "ERR_BITS" >}} below for details.
 
 If OTBN was running when the alert occurred (this is true whenever {{< regref "STATUS.busy" >}} is high), it will also:
 - Immediately stop fetching and executing instructions.
@@ -480,7 +480,7 @@ One example of this is an error caused by an ECC failure when reading or program
 In this case, the {{< regref "ERR_BITS" >}} register will not change.
 This avoids race conditions with the host processor's error handling software.
 However, every error that OTBN detects when it isn't running causes a fatal alert.
-This means that the cause will be reflected in {{< regref "FATAL_ALERT_CAUSE" >}}, as described below in [Alerts]({{< relref "hw/ip/otbn/doc#alerts" >}}).
+This means that the cause will be reflected in {{< regref "FATAL_ALERT_CAUSE" >}}, as described below in [Alerts]({{< relref "#alerts" >}}).
 This way, no alert is generated without setting an error code somewhere.
 
 <div class="bd-callout bd-callout-warning">
@@ -556,7 +556,7 @@ A higher-level driver for the OTBN block is available at `sw/device/lib/runtime/
 # Writing OTBN applications {#writing-otbn-applications}
 
 OTBN applications are (small) pieces of software written in OTBN assembly.
-The full instruction set is described in the [ISA manual]({{< relref "hw/ip/otbn/doc/isa" >}}), and example software is available in the `sw/otbn` directory of the OpenTitan source tree.
+The full instruction set is described in the [ISA manual]({{< relref "isa" >}}), and example software is available in the `sw/otbn` directory of the OpenTitan source tree.
 
 A hands-on user guide to develop OTBN software can be found in the section [Writing and building software for OTBN]({{<relref "doc/ug/otbn_sw.md" >}}).
 
@@ -580,7 +580,7 @@ All data passing must be done when OTBN is not running, as indicated by the {{< 
 
 ## Returning from an application
 
-The software running on OTBN signals completion by executing the [`ECALL`]({{< relref "hw/ip/otbn/doc/isa#ecall" >}}) instruction.
+The software running on OTBN signals completion by executing the [`ECALL`]({{< relref "isa#ecall" >}}) instruction.
 
 When it executes this instruction, OTBN:
 - Stops fetching and executing instructions.

--- a/hw/ip/otbn/doc/checklist.md
+++ b/hw/ip/otbn/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "OTBN Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [OTBN peripheral.]({{< relref "hw/ip/otbn/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [OTBN peripheral.]({{< relref "." >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist
@@ -11,7 +11,7 @@ All checklist items refer to the content in the [Checklist.]({{< relref "/doc/pr
 
 Type          | Item                           | Resolution  | Note/Collaterals
 --------------|--------------------------------|-------------|------------------
-Documentation | [SPEC_COMPLETE][]              | Done        | [OTBN Design Spec]({{<relref "hw/ip/otbn/doc" >}}). The specification is feature-complete, we were able to successfully run larger chunks of crypto code with the described feature set. At the same time, the specification has (known and unknown) issues, such as incomplete or buggy descriptions of individual instructions. These issues are being worked on as they are discovered while the design is in the D1 stage.
+Documentation | [SPEC_COMPLETE][]              | Done        | [OTBN Design Spec]({{<relref "." >}}). The specification is feature-complete, we were able to successfully run larger chunks of crypto code with the described feature set. At the same time, the specification has (known and unknown) issues, such as incomplete or buggy descriptions of individual instructions. These issues are being worked on as they are discovered while the design is in the D1 stage.
 Documentation | [CSR_DEFINED][]                | Done        |
 RTL           | [CLKRST_CONNECTED][]           | Done        |
 RTL           | [IP_TOP][]                     | Done        |
@@ -110,8 +110,8 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [OTBN DV document]({{<relref "hw/ip/otbn/doc/dv" >}})
-Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [OTBN DV plan]({{<relref "hw/ip/otbn/doc/dv/index.md#dv_plan" >}})
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [OTBN DV document]({{<relref "dv" >}})
+Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [OTBN DV plan]({{<relref "dv/index.md#dv_plan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Done        |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |

--- a/hw/ip/otbn/doc/dv/index.md
+++ b/hw/ip/otbn/doc/dv/index.md
@@ -18,7 +18,7 @@ title: "OTBN DV document"
 ## Design features
 
 OTBN, the OpenTitan Big Number accelerator, is a cryptographic accelerator.
-For detailed information on OTBN design features, see the [OTBN HWIP technical specification]({{< relref "hw/ip/otbn/doc" >}}).
+For detailed information on OTBN design features, see the [OTBN HWIP technical specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 

--- a/hw/ip/otbn/doc/isa.md
+++ b/hw/ip/otbn/doc/isa.md
@@ -3,7 +3,7 @@ title: OpenTitan Big Number Accelerator (OTBN) Instruction Set Architecture
 ---
 
 This document describes the instruction set for OTBN.
-For more details about the processor itself, see the [OTBN Technical Specification]({{< relref "hw/ip/otbn/doc" >}}).
+For more details about the processor itself, see the [OTBN Technical Specification]({{< relref "." >}}).
 In particular, this document assumes knowledge of the *Processor State* section from that guide.
 
 The instruction set is split into *base* and *big number* subsets.

--- a/hw/ip/otp_ctrl/doc/_index.md
+++ b/hw/ip/otp_ctrl/doc/_index.md
@@ -105,7 +105,7 @@ Thus the security of both volatile (OTP controller) and non-volatile (OTP IP) st
 
 The OTP controller for OpenTitan contains the seven logical partitions shown below.
 
-{{< snippet "hw/ip/otp_ctrl/doc/otp_ctrl_partitions.md" >}}
+{{< snippet "otp_ctrl_partitions.md" >}}
 
 Generally speaking, the production life cycle of a device is split into 5 stages "Manufacturing" -> "Calibration and Testing" -> "Provisioning" -> "Mission" -> "RMA".
 OTP values are usually programmed during "Calibration and Testing", "Provisioning" and "RMA" stages, as explained below.
@@ -927,14 +927,14 @@ Hence, a read access to those windows will take in the order of 10-20 cycles unt
 
 Sizes below are specified in multiples of 32bit words.
 
-{{< snippet "hw/ip/otp_ctrl/doc/otp_ctrl_mmap.md" >}}
+{{< snippet "otp_ctrl_mmap.md" >}}
 
 Note that since the content in the SECRET* partitions are scrambled using a 64bit PRESENT cipher, read and write access through the DAI needs to occur at a 64bit granularity.
 Also, all digests (no matter whether they are SW or HW digests) have an access granule of 64bit.
 
 The table below lists digests locations, and the corresponding locked partitions.
 
-{{< snippet "hw/ip/otp_ctrl/doc/otp_ctrl_digests.md" >}}
+{{< snippet "otp_ctrl_digests.md" >}}
 
 Write access to the affected partition will be locked if the digest has a nonzero value.
 

--- a/hw/ip/otp_ctrl/doc/checklist.md
+++ b/hw/ip/otp_ctrl/doc/checklist.md
@@ -7,7 +7,7 @@ NOTE: This is a template checklist document that is required to be copied over t
 directory for a new design that transitions from L0 (Specification) to L1 (Development)
 stage, and updated as needed. Once done, please remove this comment before checking it in.
 -->
-This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [OTP_CTRL peripheral.]({{< relref "hw/ip/otp_ctrl/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [OTP_CTRL peripheral.]({{< relref "." >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist
@@ -16,7 +16,7 @@ All checklist items refer to the content in the [Checklist.]({{< relref "/doc/pr
 
 Type          | Item                           | Resolution  | Note/Collaterals
 --------------|--------------------------------|-------------|------------------
-Documentation | [SPEC_COMPLETE][]              | Done        | [OTP_CTRL Design Spec]({{<relref "hw/ip/otp_ctrl/doc" >}})
+Documentation | [SPEC_COMPLETE][]              | Done        | [OTP_CTRL Design Spec]({{<relref "." >}})
 Documentation | [CSR_DEFINED][]                | Done        |
 RTL           | [CLKRST_CONNECTED][]           | Done        |
 RTL           | [IP_TOP][]                     | Done        |
@@ -115,8 +115,8 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [OTP_CTRL DV document]({{<relref "hw/ip/otp_ctrl/doc/dv" >}})
-Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [OTP_CTRL DV plan]({{<relref "hw/ip/otp_ctrl/doc/dv/index.md#dv_plan" >}})
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [OTP_CTRL DV document]({{<relref "dv" >}})
+Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [OTP_CTRL DV plan]({{<relref "dv/index.md#dv_plan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Done        |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |

--- a/hw/ip/otp_ctrl/doc/dv/index.md
+++ b/hw/ip/otp_ctrl/doc/dv/index.md
@@ -15,7 +15,7 @@ title: "OTP_CTRL DV document"
 * [Simulation results](https://reports.opentitan.org/hw/ip/otp_ctrl/dv/latest/results.html)
 
 ## Design features
-For detailed information on OTP_CTRL design features, please see the [OTP_CTRL HWIP technical specification]({{< relref "hw/ip/otp_ctrl/doc" >}}).
+For detailed information on OTP_CTRL design features, please see the [OTP_CTRL HWIP technical specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 OTP_CTRL testbench has been constructed based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).

--- a/hw/ip/otp_ctrl/doc/dv/index.md
+++ b/hw/ip/otp_ctrl/doc/dv/index.md
@@ -2,15 +2,6 @@
 title: "OTP_CTRL DV document"
 ---
 
-<!-- Copy this file to hw/ip/otp_ctrl/doc/otp_ctrl_dv_doc.md and make changes as needed.
-For convenience 'otp_ctrl' in the document can be searched and replaced easily with the
-desired IP (with case sensitivity!). Also, use the testbench block diagram
-located at OpenTitan team drive / 'design verification'
-as a starting point and modify it to reflect your otp_ctrl testbench and save it
-to hw/ip/otp_ctrl/doc/tb.svg. It should get linked and rendered under the block
-diagram section below. Please update / modify / remove sections below as
-applicable. Once done, remove this comment before making a PR. -->
-
 ## Goals
 * **DV**
   * Verify all OTP_CTRL IP features by running dynamic simulations with a SV/UVM based testbench

--- a/hw/ip/pattgen/doc/checklist.md
+++ b/hw/ip/pattgen/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "Pattgen Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [Pattgen peripheral.]({{<relref "hw/ip/pattgen/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [Pattgen peripheral.]({{<relref "." >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist
@@ -11,7 +11,7 @@ All checklist items refer to the content in the [Checklist.]({{< relref "/doc/pr
 
 Type          | Item                           | Resolution  | Note/Collaterals
 --------------|-----------------------         |-------------|------------------
-Documentation | [SPEC_COMPLETE][]              | Done        | [Pattgen Design Spec]({{<relref "hw/ip/pattgen/doc" >}})
+Documentation | [SPEC_COMPLETE][]              | Done        | [Pattgen Design Spec]({{<relref "." >}})
 Documentation | [CSR_DEFINED][]                | Done        |
 RTL           | [CLKRST_CONNECTED][]           | Done        |
 RTL           | [IP_TOP][]                     | Done        |
@@ -112,8 +112,8 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Not Started | [pattgen_dv_doc]({{<relref "hw/ip/pattgen/doc/dv" >}})
-Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [pattgen_dv_plan]({{<relref "hw/ip/pattgen/doc/dv/index.md#dv_plan" >}})
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Not Started | [pattgen_dv_doc]({{<relref "dv" >}})
+Documentation | [DV_PLAN_COMPLETED][]                 | Done        | [pattgen_dv_plan]({{<relref "dv/index.md#dv_plan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Done        |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |

--- a/hw/ip/pattgen/doc/dv/index.md
+++ b/hw/ip/pattgen/doc/dv/index.md
@@ -16,7 +16,7 @@ title: "PATTGEN DV document"
 
 ## Design features
 For detailed information on PATTGEN design features, please see the
-[PATTGEN design specification]({{< relref "hw/ip/pattgen/doc" >}}).
+[PATTGEN design specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 PATTGEN testbench has been constructed based on the

--- a/hw/ip/pinmux/doc/dv/index.md
+++ b/hw/ip/pinmux/doc/dv/index.md
@@ -17,7 +17,7 @@ title: "PINMUX DV document"
 
 ## Design features
 For detailed information on PINMUX design features, please see the
-[PINMUX design specification]({{< relref "hw/ip/pinmux/doc" >}}).
+[PINMUX design specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 PINMUX FPV testbench has been constructed based on the [formal architecture]({{< relref "hw/formal/README.md" >}}).

--- a/hw/ip/pinmux/doc/padctrl.md
+++ b/hw/ip/pinmux/doc/padctrl.md
@@ -40,7 +40,7 @@ The top-level module `padctrl` contains the CSRs that are accessible via the TL-
 
 The chip level `padctrl` module provides two sets of parametric IO arrays prefixed with `mio*` and `dio*`.
 Both sets are functionally equivalent, but are meant to be used with either multiplexed or dedicated IOs as the naming suggests.
-I.e., the `mio*` pads can be connected to the `pinmux` module ([see spec]({{< relref "hw/ip/pinmux/doc" >}})) in order to provide as much IO flexibility as possible to the software running on the device.
+I.e., the `mio*` pads can be connected to the `pinmux` module ([see spec]({{< relref "." >}})) in order to provide as much IO flexibility as possible to the software running on the device.
 The `dio*` pads on the other hand are to be connected to peripherals that require dedicated ownership of the pads.
 Examples that fall into the latter category are a high-speed SPI peripherals or a UART device that should always be connected for debugging purposes.
 

--- a/hw/ip/pwrmgr/doc/checklist.md
+++ b/hw/ip/pwrmgr/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "PWRMGR Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [PWRMGR peripheral.]({{< relref "hw/ip/pwrmgr/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [PWRMGR peripheral.]({{< relref "." >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist
@@ -11,7 +11,7 @@ All checklist items refer to the content in the [Checklist.]({{< relref "/doc/pr
 
 Type          | Item                           | Resolution  | Note/Collaterals
 --------------|--------------------------------|-------------|------------------
-Documentation | [SPEC_COMPLETE][]              | Done        |[PWRMGR Design Spec]({{<relref "hw/ip/pwrmgr/doc" >}})
+Documentation | [SPEC_COMPLETE][]              | Done        |[PWRMGR Design Spec]({{<relref "." >}})
 Documentation | [CSR_DEFINED][]                | Done        |
 RTL           | [CLKRST_CONNECTED][]           | Done        |
 RTL           | [IP_TOP][]                     | Done        |

--- a/hw/ip/rstmgr/doc/checklist.md
+++ b/hw/ip/rstmgr/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "RSTMGR Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [RSTMGR peripheral.]({{< relref "hw/ip/rstmgr/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [RSTMGR peripheral.]({{< relref "." >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist
@@ -11,7 +11,7 @@ All checklist items refer to the content in the [Checklist.]({{< relref "/doc/pr
 
 Type          | Item                           | Resolution  | Note/Collaterals
 --------------|--------------------------------|-------------|------------------
-Documentation | [SPEC_COMPLETE][]              | Done        | [RSTMGR Design Spec]({{<relref "hw/ip/rstmgr/doc" >}})
+Documentation | [SPEC_COMPLETE][]              | Done        | [RSTMGR Design Spec]({{<relref "." >}})
 Documentation | [CSR_DEFINED][]                | Done        |
 RTL           | [CLKRST_CONNECTED][]           | Done        |
 RTL           | [IP_TOP][]                     | Done        |

--- a/hw/ip/rv_timer/doc/checklist.md
+++ b/hw/ip/rv_timer/doc/checklist.md
@@ -22,7 +22,7 @@ RTL           | [FUNC_IMPLEMENTED][]           | Done        |
 RTL           | [ASSERT_KNOWN_ADDED][]         | Done        |
 Code Quality  | [LINT_SETUP][]                 | Done        |
 
-[RV_TIMER Spec]:      {{<relref "/hw/ip/rv_timer/doc/_index.md">}}
+[RV_TIMER Spec]:      {{<relref "/_index.md">}}
 
 [SPEC_COMPLETE]:              {{<relref "/doc/project/checklist.md#spec_complete" >}}
 [CSR_DEFINED]:                {{<relref "/doc/project/checklist.md#csr_defined" >}}

--- a/hw/ip/rv_timer/doc/dv/index.md
+++ b/hw/ip/rv_timer/doc/dv/index.md
@@ -15,7 +15,7 @@ title: "RV_TIMER DV document"
 * [Simulation results](https://reports.opentitan.org/hw/ip/rv_timer/dv/latest/results.html)
 
 ## Design features
-For detailed information on RV_TIMER design features, please see the [RV_TIMER design specification]({{< relref "hw/ip/rv_timer/doc" >}}).
+For detailed information on RV_TIMER design features, please see the [RV_TIMER design specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 RV_TIMER testbench has been constructed based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).

--- a/hw/ip/spi_device/doc/dv/index.md
+++ b/hw/ip/spi_device/doc/dv/index.md
@@ -16,7 +16,7 @@ title: "SPI Device DV document"
 * [Simulation results](https://reports.opentitan.org/hw/ip/spi_device/dv/latest/results.html)
 
 ## Design features
-For detailed information on SPI Device design features, please see the [SPI_device design specification]({{< relref "hw/ip/spi_device/doc" >}}).
+For detailed information on SPI Device design features, please see the [SPI_device design specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 SPI Device testbench has been constructed based on the

--- a/hw/ip/sram_ctrl/doc/checklist.md
+++ b/hw/ip/sram_ctrl/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "SRAM_CTRL Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [SRAM_CTRL peripheral.]({{< relref "hw/ip/sram_ctrl/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [SRAM_CTRL peripheral.]({{< relref "." >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist
@@ -11,7 +11,7 @@ All checklist items refer to the content in the [Checklist.]({{< relref "/doc/pr
 
 Type          | Item                  | Resolution  | Note/Collaterals
 --------------|-----------------------|-------------|------------------
-Documentation | [SPEC_COMPLETE][]     | Done        | [SRAM_CTRL Design Spec]({{<relref "hw/ip/sram_ctrl/doc" >}})
+Documentation | [SPEC_COMPLETE][]     | Done        | [SRAM_CTRL Design Spec]({{<relref "." >}})
 Documentation | [CSR_DEFINED][]       | Done        |
 RTL           | [CLKRST_CONNECTED][]  | Done        |
 RTL           | [IP_TOP][]            | Done        |

--- a/hw/ip/sram_ctrl/doc/dv/index.md
+++ b/hw/ip/sram_ctrl/doc/dv/index.md
@@ -15,7 +15,7 @@ title: "SRAM_CTRL DV document"
 * [Simulation results](https://reports.opentitan.org/hw/ip/sram_ctrl/dv/latest/results.html)
 
 ## Design features
-For detailed information on SRAM_CTRL design features, please see the [SRAM_CTRL HWIP technical specification]({{< relref "hw/ip/sram_ctrl/doc" >}}).
+For detailed information on SRAM_CTRL design features, please see the [SRAM_CTRL HWIP technical specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 SRAM_CTRL testbench has been constructed based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).

--- a/hw/ip/tlul/doc/dv/index.md
+++ b/hw/ip/tlul/doc/dv/index.md
@@ -16,7 +16,7 @@ title: "TLUL XBAR DV document"
 * DV regression results dashboard (link TBD)
 
 ## Design features
-For detailed information on TLUL design features, please see the [TLUL design specification]({{< relref "hw/ip/tlul/doc" >}}).
+For detailed information on TLUL design features, please see the [TLUL design specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 XBAR testbench has been constructed based on the `hw/dv/sv/dv_lib`

--- a/hw/ip/uart/doc/dv/index.md
+++ b/hw/ip/uart/doc/dv/index.md
@@ -16,7 +16,7 @@ title: "UART DV document"
 * [Simulation results](https://reports.opentitan.org/hw/ip/uart/dv/latest/results.html)
 
 ## Design features
-For detailed information on UART design features, please see the [UART design specification]({{< relref "hw/ip/uart/doc" >}}).
+For detailed information on UART design features, please see the [UART design specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 UART testbench has been constructed based on the

--- a/hw/ip/usbdev/doc/checklist.md
+++ b/hw/ip/usbdev/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "USB Device Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [USB Device peripheral.]({{< relref "hw/ip/usbdev/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [USB Device peripheral.]({{< relref "." >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist
@@ -11,7 +11,7 @@ All checklist items refer to the content in the [Checklist.]({{< relref "/doc/pr
 
 Type          | Item                           | Resolution  | Note/Collaterals
 --------------|--------------------------------|-------------|------------------
-Documentation | [SPEC_COMPLETE][]              | Done        | [USB Device Design Spec]({{<relref "hw/ip/usbdev/doc" >}})
+Documentation | [SPEC_COMPLETE][]              | Done        | [USB Device Design Spec]({{<relref "." >}})
 Documentation | [CSR_DEFINED][]                | Done        |
 RTL           | [CLKRST_CONNECTED][]           | Done        |
 RTL           | [IP_TOP][]                     | Done        |
@@ -110,8 +110,8 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | In Progress | [USB Device DV document]({{<relref "hw/ip/usbdev/doc/dv" >}})
-Documentation | [DV_PLAN_COMPLETED][]                 | In Progress | [USB Device DV plan]({{<relref "hw/ip/usbdev/doc/dv/index.md#dv_plan" >}})
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | In Progress | [USB Device DV document]({{<relref "dv" >}})
+Documentation | [DV_PLAN_COMPLETED][]                 | In Progress | [USB Device DV plan]({{<relref "dv/index.md#dv_plan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Done        |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |

--- a/hw/ip/usbdev/doc/dv/index.md
+++ b/hw/ip/usbdev/doc/dv/index.md
@@ -17,7 +17,7 @@ title: "USBDEV DV document"
 * [Simulation results](https://reports.opentitan.org/hw/ip/usbdev/dv/latest/results.html)
 
 ## Design features
-For detailed information on USBDEV design features, please see the [USBDEV HWIP technical specification]({{< relref "hw/ip/usbdev/doc" >}}).
+For detailed information on USBDEV design features, please see the [USBDEV HWIP technical specification]({{< relref ".." >}}).
 
 ## Testbench architecture
 USBDEV testbench has been constructed based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).

--- a/site/docs/layouts/shortcodes/snippet.html
+++ b/site/docs/layouts/shortcodes/snippet.html
@@ -1,1 +1,1 @@
-{{ readFile (.Get 0) | markdownify }}
+{{ readFile (path.Join .Page.File.Dir (.Get 0)) | markdownify }}

--- a/util/uvmdvgen/checklist.md.tpl
+++ b/util/uvmdvgen/checklist.md.tpl
@@ -7,7 +7,7 @@ NOTE: This is a template checklist document that is required to be copied over t
 directory for a new design that transitions from L0 (Specification) to L1 (Development)
 stage, and updated as needed. Once done, please remove this comment before checking it in.
 -->
-This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [${name.upper()} peripheral.]({{< relref "hw/ip/${name}/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [${name.upper()} peripheral.]({{< relref "." >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 <%text>## Design Checklist</%text>
@@ -16,7 +16,7 @@ All checklist items refer to the content in the [Checklist.]({{< relref "/doc/pr
 
 Type          | Item                           | Resolution  | Note/Collaterals
 --------------|--------------------------------|-------------|------------------
-Documentation | [SPEC_COMPLETE][]              | Not Started | [${name.upper()} Design Spec]({{<relref "hw/ip/${name}/doc" >}})
+Documentation | [SPEC_COMPLETE][]              | Not Started | [${name.upper()} Design Spec]({{<relref "." >}})
 Documentation | [CSR_DEFINED][]                | Not Started |
 RTL           | [CLKRST_CONNECTED][]           | Not Started |
 RTL           | [IP_TOP][]                     | Not Started |
@@ -115,8 +115,8 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Not Started | [${name.upper()} DV Plan]({{<relref "hw/ip/${name}/doc/dv_plan" >}})
-Documentation | [DV_PLAN_COMPLETED][]                 | Not Started | [${name.upper()} Testplan]({{<relref "hw/ip/${name}/doc/dv_plan/index.md#testplan" >}})
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Not Started | [${name.upper()} DV Plan]({{<relref "dv" >}})
+Documentation | [DV_PLAN_COMPLETED][]                 | Not Started | [${name.upper()} Testplan]({{<relref "dv/index.md#testplan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Not Started |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Not Started |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Not Started |


### PR DESCRIPTION
To make IP blocks easier to relocate or rename, prefer relative links in the documentation.

No actual change to the output of documentation build process is expected.