### PR TITLE
[sw, mask_rom] Add accidentally removed dependency in 6c22addba

### DIFF
--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -41,6 +41,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
     name_suffix: 'elf',
     link_depends: rom_link_deps,
     dependencies: [
+      device_lib,
       mask_rom_lib,
     ],
   )


### PR DESCRIPTION
Accidentally removed this dependency, absence of this dependency does not break anything, but to avoid surprises I am adding it back.