### PR TITLE
[dv/otp_ctrl] Fix killing push-pull seq

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_req_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_req_vseq.sv
@@ -17,9 +17,12 @@ class otp_ctrl_parallel_lc_req_vseq extends otp_ctrl_parallel_base_vseq;
 
   constraint lc_trans_c {
     do_lc_trans == 0;
-    // TODO: support enable req_key while lc_escalate_en is set.
-    do_req_keys == 0;
   }
+
+  virtual task pre_start();
+    super.pre_start();
+    default_req_blocking = 0;
+  endtask
 
   virtual task run_parallel_seq(ref bit base_vseq_done);
     forever begin


### PR DESCRIPTION
When lc_escalate_en is On, it will turn all state machines to ErrorSt
and all output to defaults. Thus if pull request is sent, if won't get
any responses.

Previous code handle it by directly kill the sequence, but this is not
recommended, as it could casue some error in sequencer. Current method
set the push-pull sequence to non-blocking mode when lc_escalate_en is
On. Then scb will ensure the request never gets reponses. And eventually
we will issue reset to clear the push-pull sequence.

Signed-off-by: Cindy Chen <chencindy@google.com>