### PR TITLE
[fpv/otp_ctrl] Disable assertions due to lc_esc_en

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -540,7 +540,9 @@ module otp_ctrl
   logic key_edn_req, key_edn_ack;
   prim_arbiter_tree #(
     .N(2),
-    .EnDataPort(0)
+    .EnDataPort(0),
+    // Disable req stable assertion check due to lc_escalate_en_i
+    .EnReqStabA(0)
   ) u_edn_arb (
     .clk_i,
     .rst_ni,
@@ -556,7 +558,9 @@ module otp_ctrl
   // This synchronizes the data coming from EDN and stacks the
   // 32bit EDN words to achieve an internal entropy width of 64bit.
   prim_edn_req #(
-    .OutWidth(EdnDataWidth)
+    .OutWidth(EdnDataWidth),
+    // Disable req stable assertion check due to lc_escalate_en_i
+    .EnReqStabA(0)
   ) u_prim_edn_req (
     .clk_i,
     .rst_ni,
@@ -592,6 +596,7 @@ module otp_ctrl
   prim_arbiter_tree #(
     .N(NumAgents),
     .DW($bits(otp_bundle_t)),
+    // Disable req stable assertion check due to lc_escalate_en_i
     .EnReqStabA(0)
   ) u_otp_arb (
     .clk_i,

--- a/hw/ip/prim/rtl/prim_edn_req.sv
+++ b/hw/ip/prim/rtl/prim_edn_req.sv
@@ -16,7 +16,11 @@
 module prim_edn_req
   import prim_alert_pkg::*;
 #(
-  parameter int OutWidth = 32
+  parameter int OutWidth = 32,
+
+  // Non-functional parameter to switch on the request stability assertion.
+  // Used in submodule `prim_sync_reqack`.
+  parameter bit EnReqStabA = 1
 ) (
   // Design side
   input                       clk_i,
@@ -42,7 +46,8 @@ module prim_edn_req
   prim_sync_reqack_data #(
     .Width(SyncWidth),
     .DataSrc2Dst(1'b0),
-    .DataReg(1'b0)
+    .DataReg(1'b0),
+    .EnReqStabA(EnReqStabA)
   ) u_prim_sync_reqack_data (
     .clk_src_i  ( clk_i                           ),
     .rst_src_ni ( rst_ni                          ),

--- a/hw/ip/prim/rtl/prim_sync_reqack.sv
+++ b/hw/ip/prim/rtl/prim_sync_reqack.sv
@@ -23,7 +23,10 @@
 
 `include "prim_assert.sv"
 
-module prim_sync_reqack (
+module prim_sync_reqack #(
+  // Non-functional parameter to switch on the request stability assertion
+  parameter bit EnReqStabA = 1
+) (
   input  clk_src_i,       // REQ side, SRC domain
   input  rst_src_ni,      // REQ side, SRC domain
   input  clk_dst_i,       // ACK side, DST domain
@@ -164,8 +167,10 @@ module prim_sync_reqack (
     end
   end
 
-  // SRC domain can only de-assert REQ after receiving ACK.
-  `ASSERT(SyncReqAckHoldReq, $fell(src_req_i) |-> $fell(src_ack_o), clk_src_i, !rst_src_ni)
+  if (EnReqStabA) begin : gen_lock_assertion
+    // SRC domain can only de-assert REQ after receiving ACK.
+    `ASSERT(SyncReqAckHoldReq, $fell(src_req_i) |-> $fell(src_ack_o), clk_src_i, !rst_src_ni)
+  end
 
   // DST domain cannot assert ACK without REQ.
   `ASSERT(SyncReqAckAckNeedsReq, dst_ack_i |-> dst_req_o, clk_dst_i, !rst_dst_ni)

--- a/hw/ip/prim/rtl/prim_sync_reqack_data.sv
+++ b/hw/ip/prim/rtl/prim_sync_reqack_data.sv
@@ -20,8 +20,9 @@ module prim_sync_reqack_data #(
   parameter int unsigned Width       = 1,
   parameter bit          DataSrc2Dst = 1'b1, // Direction of data flow: 1'b1 = SRC to DST,
                                              //                         1'b0 = DST to SRC
-  parameter bit          DataReg     = 1'b0  // Enable optional register stage for data,
+  parameter bit          DataReg     = 1'b0, // Enable optional register stage for data,
                                              // only usable with DataSrc2Dst == 1'b0.
+  parameter bit EnReqStabA = 1               // Used in submodule `prim_sync_reqack`.
 ) (
   input  clk_src_i,       // REQ side, SRC domain
   input  rst_src_ni,      // REQ side, SRC domain
@@ -40,7 +41,9 @@ module prim_sync_reqack_data #(
   ////////////////////////////////////
   // REQ/ACK synchronizer primitive //
   ////////////////////////////////////
-  prim_sync_reqack u_prim_sync_reqack (
+  prim_sync_reqack #(
+    .EnReqStabA(EnReqStabA)
+  ) u_prim_sync_reqack (
     .clk_src_i,
     .rst_src_ni,
     .clk_dst_i,


### PR DESCRIPTION
This PR disable `prim_sync_reqack` assertion that checks request has to
stay high until ack. This scenario won't work if `lc_escalate_en` is
issue. Then the req will reset to default even though ack is still low.

Signed-off-by: Cindy Chen <chencindy@google.com>