### PR TITLE
[xbar/dv] Fix assertion error due to short reset

### DIFF
--- a/hw/dv/sv/common_ifs/clk_rst_if.sv
+++ b/hw/dv/sv/common_ifs/clk_rst_if.sv
@@ -191,7 +191,7 @@ interface clk_rst_if #(
                              int post_reset_dly_clks  = 0,
                              int rst_n_scheme         = 1);
     int dly_ps;
-    if ($isunknown(reset_width_clks)) reset_width_clks = $urandom_range(4, 20);
+    if ($isunknown(reset_width_clks)) reset_width_clks = $urandom_range(50, 100);
     dly_ps = $urandom_range(0, clk_period_ps);
     wait_clks(pre_reset_dly_clks);
     case (rst_n_scheme)


### PR DESCRIPTION
xbar has 2 clock domains. reset needs to last for at least one clock to
avoid false alarm from SVA as assertion checks reset at the active clock
edge.
increase reset to 50-100 TL clock periods, which should be long enough
for most of IPs. (default faster clock / slowest clock < 10)

Signed-off-by: Weicai Yang <weicai@google.com>