### PR TITLE
[tlul] Support data integrity passthrough

### DIFF
--- a/hw/ip/prim/rtl/prim_ram_1p_scr.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_scr.sv
@@ -38,7 +38,6 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
   parameter  int NumDiffRounds       = 2,
   // This parameter governs the block-width of additional diffusion layers.
   // For intra-byte diffusion, set this parameter to 8.
-  // Note that DataBitsPerMask must be a multiple of this parameter.
   parameter  int DiffWidth           = DataBitsPerMask,
   // Number of address scrambling rounds. Setting this to 0 disables address scrambling.
   parameter  int NumAddrScrRounds    = 2,
@@ -102,7 +101,7 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
 
   // The depth needs to be a power of 2 in case address scrambling is turned on
   `ASSERT_INIT(DepthPow2Check_A, NumAddrScrRounds <= '0 || 2**$clog2(Depth) == Depth)
-  `ASSERT_INIT(DiffWidthAligned_A, (DataBitsPerMask % DiffWidth) == 0)
+  `ASSERT_INIT(DiffWidthMinimum_A, DiffWidth >= 4)
   `ASSERT_INIT(DiffWidthWithParity_A, EnableParity && (DiffWidth == 8) || !EnableParity)
 
   //////////////////////////////

--- a/hw/ip/prim_generic/rtl/prim_generic_ram_1p.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_ram_1p.sv
@@ -25,6 +25,9 @@ module prim_generic_ram_1p import prim_ram_1p_pkg::*; #(
   input ram_1p_cfg_t       cfg_i
 );
 
+  // Width must be fully divisible by DataBitsPerMask
+  `ASSERT_INIT(DataBitsPerMaskCheck_A, (Width % DataBitsPerMask) == 0)
+
   logic unused_cfg;
   assign unused_cfg = ^cfg_i;
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -804,7 +804,9 @@ module top_earlgrey #(
     .Depth(32768),
     .EnableParity(0),
     .LfsrWidth(32),
-    .StatePerm(RndCnstSramCtrlMainSramLfsrPerm)
+    .StatePerm(RndCnstSramCtrlMainSramLfsrPerm),
+    .DataBitsPerMask(1), // TODO: Temporary change to ensure byte updates can still be done
+    .DiffWidth(8)
   ) u_ram1p_ram_main (
     .clk_i   (clkmgr_aon_clocks.clk_main_infra),
     .rst_ni   (rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
@@ -875,7 +877,9 @@ module top_earlgrey #(
     .Depth(1024),
     .EnableParity(0),
     .LfsrWidth(32),
-    .StatePerm(RndCnstSramCtrlRetAonSramLfsrPerm)
+    .StatePerm(RndCnstSramCtrlRetAonSramLfsrPerm),
+    .DataBitsPerMask(1), // TODO: Temporary change to ensure byte updates can still be done
+    .DiffWidth(8)
   ) u_ram1p_ram_ret_aon (
     .clk_i   (clkmgr_aon_clocks.clk_io_div4_infra),
     .rst_ni   (rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -768,8 +768,8 @@ module top_earlgrey #(
   logic        ram_main_we;
   logic        ram_main_intg_err;
   logic [14:0] ram_main_addr;
-  logic [31:0] ram_main_wdata;
-  logic [31:0] ram_main_wmask;
+  logic [38:0] ram_main_wdata;
+  logic [38:0] ram_main_wmask;
   logic [38:0] ram_main_rdata;
   logic        ram_main_rvalid;
   logic [1:0]  ram_main_rerror;
@@ -780,7 +780,8 @@ module top_earlgrey #(
     .Outstanding(2),
     .CmdIntgCheck(1),
     .EnableRspIntgGen(1),
-    .EnableDataIntgGen(1)  // TODO: Needs to be updated for integrity passthrough
+    .EnableDataIntgGen(0),
+    .EnableDataIntgPt(1)
   ) u_tl_adapter_ram_main (
     .clk_i   (clkmgr_aon_clocks.clk_main_infra),
     .rst_ni   (rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
@@ -794,7 +795,7 @@ module top_earlgrey #(
     .wdata_o     (ram_main_wdata),
     .wmask_o     (ram_main_wmask),
     .intg_error_o(ram_main_intg_err),
-    .rdata_i     (ram_main_rdata[31:0]),
+    .rdata_i     (ram_main_rdata),
     .rvalid_i    (ram_main_rvalid),
     .rerror_i    (ram_main_rerror)
   );
@@ -823,8 +824,8 @@ module top_earlgrey #(
     .gnt_o       (ram_main_gnt),
     .write_i     (ram_main_we),
     .addr_i      (ram_main_addr),
-    .wdata_i     (39'(ram_main_wdata)),
-    .wmask_i     (39'(ram_main_wmask)),
+    .wdata_i     (ram_main_wdata),
+    .wmask_i     (ram_main_wmask),
     .rdata_o     (ram_main_rdata),
     .rvalid_o    (ram_main_rvalid),
     .rerror_o    (ram_main_rerror),
@@ -841,8 +842,8 @@ module top_earlgrey #(
   logic        ram_ret_aon_we;
   logic        ram_ret_aon_intg_err;
   logic [9:0] ram_ret_aon_addr;
-  logic [31:0] ram_ret_aon_wdata;
-  logic [31:0] ram_ret_aon_wmask;
+  logic [38:0] ram_ret_aon_wdata;
+  logic [38:0] ram_ret_aon_wmask;
   logic [38:0] ram_ret_aon_rdata;
   logic        ram_ret_aon_rvalid;
   logic [1:0]  ram_ret_aon_rerror;
@@ -853,7 +854,8 @@ module top_earlgrey #(
     .Outstanding(2),
     .CmdIntgCheck(1),
     .EnableRspIntgGen(1),
-    .EnableDataIntgGen(1)  // TODO: Needs to be updated for integrity passthrough
+    .EnableDataIntgGen(0),
+    .EnableDataIntgPt(1)
   ) u_tl_adapter_ram_ret_aon (
     .clk_i   (clkmgr_aon_clocks.clk_io_div4_infra),
     .rst_ni   (rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]),
@@ -867,7 +869,7 @@ module top_earlgrey #(
     .wdata_o     (ram_ret_aon_wdata),
     .wmask_o     (ram_ret_aon_wmask),
     .intg_error_o(ram_ret_aon_intg_err),
-    .rdata_i     (ram_ret_aon_rdata[31:0]),
+    .rdata_i     (ram_ret_aon_rdata),
     .rvalid_i    (ram_ret_aon_rvalid),
     .rerror_i    (ram_ret_aon_rerror)
   );
@@ -896,8 +898,8 @@ module top_earlgrey #(
     .gnt_o       (ram_ret_aon_gnt),
     .write_i     (ram_ret_aon_we),
     .addr_i      (ram_ret_aon_addr),
-    .wdata_i     (39'(ram_ret_aon_wdata)),
-    .wmask_i     (39'(ram_ret_aon_wmask)),
+    .wdata_i     (ram_ret_aon_wdata),
+    .wmask_i     (ram_ret_aon_wmask),
     .rdata_o     (ram_ret_aon_rdata),
     .rvalid_o    (ram_ret_aon_rvalid),
     .rerror_o    (ram_ret_aon_rerror),

--- a/hw/top_earlgrey/top_earlgrey_verilator.core
+++ b/hw/top_earlgrey/top_earlgrey_verilator.core
@@ -107,6 +107,7 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
+          - '--unroll-count 512'
           - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DVL_USER_STOP -DTOPLEVEL_NAME=top_earlgrey_verilator -g"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - '-Wall'

--- a/hw/top_englishbreakfast/top_englishbreakfast_verilator.core
+++ b/hw/top_englishbreakfast/top_englishbreakfast_verilator.core
@@ -97,6 +97,7 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
+          - '--unroll-count 512'
           - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DVL_USER_STOP -DTOPLEVEL_NAME=top_englishbreakfast_verilator -g"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - '-Wall'

--- a/util/topgen/templates/toplevel.sv.tpl
+++ b/util/topgen/templates/toplevel.sv.tpl
@@ -403,7 +403,9 @@ mem_name = Name(mem_name[1:])
     .Depth(${sram_depth}),
     .EnableParity(0),
     .LfsrWidth(${data_width}),
-    .StatePerm(RndCnstSramCtrl${mem_name.as_camel_case()}SramLfsrPerm)
+    .StatePerm(RndCnstSramCtrl${mem_name.as_camel_case()}SramLfsrPerm),
+    .DataBitsPerMask(1), // TODO: Temporary change to ensure byte updates can still be done
+    .DiffWidth(8)
   ) u_ram1p_${m["name"]} (
     % for key in clocks:
     .${key}   (${clocks[key]}),

--- a/util/topgen/templates/toplevel.sv.tpl
+++ b/util/topgen/templates/toplevel.sv.tpl
@@ -359,8 +359,8 @@ module top_${top["name"]} #(
   logic ${lib.bitarray(1,          max_char)} ${m["name"]}_we;
   logic ${lib.bitarray(1,          max_char)} ${m["name"]}_intg_err;
   logic ${lib.bitarray(addr_width, max_char)} ${m["name"]}_addr;
-  logic ${lib.bitarray(data_width, max_char)} ${m["name"]}_wdata;
-  logic ${lib.bitarray(data_width, max_char)} ${m["name"]}_wmask;
+  logic ${lib.bitarray(full_data_width, max_char)} ${m["name"]}_wdata;
+  logic ${lib.bitarray(full_data_width, max_char)} ${m["name"]}_wmask;
   logic ${lib.bitarray(full_data_width, max_char)} ${m["name"]}_rdata;
   logic ${lib.bitarray(1,          max_char)} ${m["name"]}_rvalid;
   logic ${lib.bitarray(2,          max_char)} ${m["name"]}_rerror;
@@ -371,7 +371,8 @@ module top_${top["name"]} #(
     .Outstanding(2),
     .CmdIntgCheck(1),
     .EnableRspIntgGen(1),
-    .EnableDataIntgGen(1)  // TODO: Needs to be updated for integrity passthrough
+    .EnableDataIntgGen(0),
+    .EnableDataIntgPt(1)
   ) u_tl_adapter_${m["name"]} (
     % for key in clocks:
     .${key}   (${clocks[key]}),
@@ -389,7 +390,7 @@ module top_${top["name"]} #(
     .wdata_o     (${m["name"]}_wdata),
     .wmask_o     (${m["name"]}_wmask),
     .intg_error_o(${m["name"]}_intg_err),
-    .rdata_i     (${m["name"]}_rdata[${data_width-1}:0]),
+    .rdata_i     (${m["name"]}_rdata),
     .rvalid_i    (${m["name"]}_rvalid),
     .rerror_i    (${m["name"]}_rerror)
   );
@@ -426,8 +427,8 @@ mem_name = Name(mem_name[1:])
     .gnt_o       (${m["name"]}_gnt),
     .write_i     (${m["name"]}_we),
     .addr_i      (${m["name"]}_addr),
-    .wdata_i     (${full_data_width}'(${m["name"]}_wdata)),
-    .wmask_i     (${full_data_width}'(${m["name"]}_wmask)),
+    .wdata_i     (${m["name"]}_wdata),
+    .wmask_i     (${m["name"]}_wmask),
     .rdata_o     (${m["name"]}_rdata),
     .rvalid_o    (${m["name"]}_rvalid),
     .rerror_o    (${m["name"]}_rerror),


### PR DESCRIPTION
- Add tlul_adapter_sram option to directly passthrough data integrity. 
- This needs to be followed by a change in regfile to recognize integrity can be passed through
- This needs to be followed by a change that properly handles byte accesses with word-level integrity.

Only last 2 commits are valid, others will be rebased away. 