### PR TITLE
[dv/otp_ctrl] Move lc_escalate to a separate sequence

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -116,7 +116,7 @@
             - Trigger escalation_en
             '''
       milestone: V2
-      tests: ["otp_ctrl_parallel_lc_req"]
+      tests: ["otp_ctrl_parallel_lc_req", "otp_ctrl_parallel_lc_esc"]
     }
     { name: otp_dai_errors
       desc: '''

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -33,6 +33,7 @@ filesets:
       - seq_lib/otp_ctrl_regwen_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_parallel_key_req_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_parallel_lc_req_vseq.sv: {is_include_file: true}
+      - seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -27,8 +27,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
 
   // Signals to skip csr check during first two clock cycles after lc_escalate_en is set.
   // Because lc_escalate_en might take one clock cycle to propogate to design.
-  logic                lc_esc_dly1, lc_esc_dly2;
-  bit                  skip_read_check;
+  lc_ctrl_pkg::lc_tx_e lc_esc_dly1, lc_esc_dly2;
 
   // Lc_err could trigger during LC program, so check intr and status after lc_req is finished.
   // Lc_err takes one clock cycle to propogate to intr signal. So avoid intr check if it happens
@@ -45,8 +44,6 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
     end
   end
 
-  assign skip_read_check = (lc_escalate_en_i == lc_ctrl_pkg::On) &&
-                           (lc_esc_dly1 != lc_ctrl_pkg::On || lc_esc_dly2 != lc_ctrl_pkg::On);
   assign lc_prog_no_sta_check = lc_prog_err | lc_prog_err_dly1 | lc_prog_req |
                                 lc_escalate_en_i == lc_ctrl_pkg::On;
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
@@ -1,0 +1,72 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence will randomly issue lc_escalate_en during or after partition is locked.
+// After lc_escalate_en is On, this sequence will continue run base sequence to check if all state
+// machines are locked to `ErrorSt`.
+
+class otp_ctrl_parallel_lc_esc_vseq extends otp_ctrl_dai_errs_vseq;
+  `uvm_object_utils(otp_ctrl_parallel_lc_esc_vseq)
+
+  `uvm_object_new
+
+  // This sequence will kill super.body sequence once lc_escalate_en is On. Disable these interface
+  // requests to avoid sequencer error.
+  constraint key_lc_reqs_c {
+    do_req_keys == 0;
+    do_lc_trans == 0;
+  }
+
+  virtual task body();
+    fork
+      begin : isolation_fork
+        fork
+          rand_wait_csr_no_outstanding();
+          super.body();
+        join_any;
+        disable fork;
+        set_lc_esc_and_check();
+      end
+    join
+  endtask
+
+  virtual task rand_wait_csr_no_outstanding();
+    wait(cfg.under_reset == 0);
+    cfg.clk_rst_vif.wait_clks($urandom_range(0, 10_000));
+    wait_no_outstanding_access();
+  endtask
+
+  virtual task set_lc_esc_and_check();
+    // TODO: random drive any values instead of just on and off
+    cfg.otp_ctrl_vif.drive_lc_escalate_en(lc_ctrl_pkg::On);
+
+    // TODO: in alert_esc_monitor, makes it auto-response like push-pull agent
+    if (en_auto_alerts_response && cfg.list_of_alerts.size()) run_alert_rsp_seq_nonblocking();
+
+    // Turn off reset because if issuing lc_escalation_en during otp program, scb cannot
+    // predict if the OTP memory is programmed or not.
+    // TODO: temp disable, support it in stress_all_with_rand_reset case
+    do_reset_in_seq = 0;
+
+    // Wait 5 clock cycles until async lc_escalate_en propogate to each state machine.
+    cfg.clk_rst_vif.wait_clks(5);
+
+    // After LC_escalate is On, we trigger the dai_errs_vseq to check interfaces will return
+    // default values and the design won't hang.
+    otp_ctrl_dai_errs_vseq::body();
+  endtask
+
+  virtual task post_start();
+    // Use reset to clear lc interrupt error
+    if (do_apply_reset) begin
+      apply_reset();
+      cfg.otp_ctrl_vif.drive_lc_escalate_en(lc_ctrl_pkg::Off);
+    end else wait(0); // wait until upper seq resets and kills this seq
+
+    // delay to avoid race condition when sending item and checking no item after reset occur
+    // at the same time
+    #1ps;
+    super.post_start();
+  endtask
+endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_req_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_req_vseq.sv
@@ -17,8 +17,6 @@ class otp_ctrl_parallel_lc_req_vseq extends otp_ctrl_parallel_base_vseq;
 
   constraint lc_trans_c {
     do_lc_trans == 0;
-    // TODO: support enable req_key while lc_escalate_en is set.
-    do_req_keys == 0;
   }
 
   virtual task run_parallel_seq(ref bit base_vseq_done);
@@ -37,19 +35,6 @@ class otp_ctrl_parallel_lc_req_vseq extends otp_ctrl_parallel_base_vseq;
           wait_clk_or_reset($urandom_range(0, 500));
           if (!base_vseq_done && !cfg.under_reset) req_lc_token();
         end
-      end
-      begin
-        // req lc token request
-        if ($urandom_range(0, 1)) begin
-          wait_clk_or_reset($urandom_range(0, 500));
-          if (!base_vseq_done && !cfg.under_reset) begin
-            // TODO: random drive any values instead of just on and off
-            cfg.otp_ctrl_vif.drive_lc_escalate_en(lc_ctrl_pkg::On);
-            // Turn off reset because if issuing lc_escalation_en during otp program, scb cannot
-            // predict if the OTP memory is programmed or not.
-            do_reset_in_seq = 0;
-          end
-        end
       end join
     end
   endtask
@@ -58,7 +43,6 @@ class otp_ctrl_parallel_lc_req_vseq extends otp_ctrl_parallel_base_vseq;
     // Use reset to clear lc interrupt error
     if (do_apply_reset) begin
       apply_reset();
-      cfg.otp_ctrl_vif.drive_lc_escalate_en(lc_ctrl_pkg::Off);
     end else wait(0); // wait until upper seq resets and kills this seq
 
     // delay to avoid race condition when sending item and checking no item after reset occur

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
@@ -14,4 +14,5 @@
 `include "otp_ctrl_parallel_base_vseq.sv"
 `include "otp_ctrl_parallel_key_req_vseq.sv"
 `include "otp_ctrl_parallel_lc_req_vseq.sv"
+`include "otp_ctrl_parallel_lc_esc_vseq.sv"
 `include "otp_ctrl_regwen_vseq.sv"

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -71,6 +71,11 @@
     }
 
     {
+      name: otp_ctrl_parallel_lc_esc
+      uvm_test_seq: otp_ctrl_parallel_lc_esc_vseq
+    }
+
+    {
       name: otp_ctrl_dai_lock
       uvm_test_seq: otp_ctrl_dai_lock_vseq
     }


### PR DESCRIPTION
This PR moves the logic to drive lc_escalate_en to a separate sequence.
The reason of doing this is mainly to simplify scb.

There are three cycles after lc_escalate_en is On that registers could
behavior different. Due to address cycle and data cycle delays, these
three cycles can be even longer. This makes SCB hard to predict the
correct values.

Signed-off-by: Cindy Chen <chencindy@google.com>