### PR TITLE
Eliminate `#pragma once` in favor of include guards

### DIFF
--- a/hw/dv/verilator/cpp/dpi_memutil.h
+++ b/hw/dv/verilator/cpp/dpi_memutil.h
@@ -1,8 +1,8 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-
-#pragma once
+#ifndef OPENTITAN_HW_DV_VERILATOR_CPP_DPI_MEMUTIL_H_
+#define OPENTITAN_HW_DV_VERILATOR_CPP_DPI_MEMUTIL_H_
 
 #include <map>
 #include <string>
@@ -164,3 +164,5 @@ class DpiMemUtil {
   const MemArea &GetRegionForSegment(const std::string &path, int seg_idx,
                                      uint32_t lma, uint32_t mem_sz) const;
 };
+
+#endif  // OPENTITAN_HW_DV_VERILATOR_CPP_DPI_MEMUTIL_H_

--- a/hw/dv/verilator/cpp/ranged_map.h
+++ b/hw/dv/verilator/cpp/ranged_map.h
@@ -1,8 +1,8 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-
-#pragma once
+#ifndef OPENTITAN_HW_DV_VERILATOR_CPP_RANGED_MAP_H_
+#define OPENTITAN_HW_DV_VERILATOR_CPP_RANGED_MAP_H_
 
 // Utility class representing disjoint segments of memory
 
@@ -179,3 +179,5 @@ class RangedMap {
  private:
   std::map<rng_t, val_t> map_;
 };
+
+#endif  // OPENTITAN_HW_DV_VERILATOR_CPP_RANGED_MAP_H_

--- a/hw/dv/verilator/cpp/verilator_memutil.h
+++ b/hw/dv/verilator/cpp/verilator_memutil.h
@@ -1,8 +1,8 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-
-#pragma once
+#ifndef OPENTITAN_HW_DV_VERILATOR_CPP_VERILATOR_MEMUTIL_H_
+#define OPENTITAN_HW_DV_VERILATOR_CPP_VERILATOR_MEMUTIL_H_
 
 //
 // A wrapper class that converts a VerilatorMemutil into a SimCtrlExtension
@@ -40,3 +40,5 @@ class VerilatorMemUtil : public SimCtrlExtension {
   DpiMemUtil *mem_util_;
   std::unique_ptr<DpiMemUtil> allocation_;
 };
+
+#endif  // OPENTITAN_HW_DV_VERILATOR_CPP_VERILATOR_MEMUTIL_H_

--- a/hw/ip/otbn/dv/memutil/otbn_memutil.h
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil.h
@@ -1,8 +1,8 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-
-#pragma once
+#ifndef OPENTITAN_HW_IP_OTBN_DV_MEMUTIL_OTBN_MEMUTIL_H_
+#define OPENTITAN_HW_IP_OTBN_DV_MEMUTIL_OTBN_MEMUTIL_H_
 
 #include <svdpi.h>
 
@@ -58,3 +58,5 @@ svBit OtbnMemUtilGetSegInfo(OtbnMemUtil *mem_util, svBit is_imem, int seg_idx,
 svBit OtbnMemUtilGetSegData(OtbnMemUtil *mem_util, svBit is_imem, int word_off,
                             /* output bit[31:0] */ svBitVecVal *data_value);
 }
+
+#endif  // OPENTITAN_HW_IP_OTBN_DV_MEMUTIL_OTBN_MEMUTIL_H_

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -1,8 +1,8 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-
-#pragma once
+#ifndef OPENTITAN_HW_IP_OTBN_DV_MODEL_ISS_WRAPPER_H_
+#define OPENTITAN_HW_IP_OTBN_DV_MODEL_ISS_WRAPPER_H_
 
 #include <array>
 #include <cstdint>
@@ -71,3 +71,5 @@ struct ISSWrapper {
   // A temporary directory for communicating with the child process
   std::unique_ptr<TmpDir> tmpdir;
 };
+
+#endif  // OPENTITAN_HW_IP_OTBN_DV_MODEL_ISS_WRAPPER_H_

--- a/hw/ip/otbn/dv/model/otbn_trace_checker.h
+++ b/hw/ip/otbn/dv/model/otbn_trace_checker.h
@@ -1,8 +1,8 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-
-#pragma once
+#ifndef OPENTITAN_HW_IP_OTBN_DV_MODEL_OTBN_TRACE_CHECKER_H_
+#define OPENTITAN_HW_IP_OTBN_DV_MODEL_OTBN_TRACE_CHECKER_H_
 
 // A singleton class that listens to trace entries from the simulated core (as
 // an OtbnTraceListener) and compares them with the trace coming out of the
@@ -98,3 +98,5 @@ class OtbnTraceChecker : public OtbnTraceListener {
   bool done_;
   bool seen_err_;
 };
+
+#endif  // OPENTITAN_HW_IP_OTBN_DV_MODEL_OTBN_TRACE_CHECKER_H_

--- a/hw/ip/otbn/dv/tracer/cpp/otbn_trace_source.h
+++ b/hw/ip/otbn/dv/tracer/cpp/otbn_trace_source.h
@@ -1,8 +1,8 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-
-#pragma once
+#ifndef OPENTITAN_HW_IP_OTBN_DV_TRACER_CPP_OTBN_TRACE_SOURCE_H_
+#define OPENTITAN_HW_IP_OTBN_DV_TRACER_CPP_OTBN_TRACE_SOURCE_H_
 
 #include <vector>
 
@@ -34,3 +34,5 @@ class OtbnTraceSource {
  private:
   std::vector<OtbnTraceListener *> listeners_;
 };
+
+#endif  // OPENTITAN_HW_IP_OTBN_DV_TRACER_CPP_OTBN_TRACE_SOURCE_H_


### PR DESCRIPTION
The Google C/C++ Style Guide (referenced from the OpenTitan C/C++ guide)
requires #define guards in header files.

https://google.github.io/styleguide/cppguide.html#The__define_Guard