### PR TITLE
[aes] Use separate permutation for clearing second share of masked regs

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -95,6 +95,14 @@
       randcount: "64",
       randtype:  "perm"
     },
+    { name:    "RndCnstClearingSharePerm",
+      type:    "aes_pkg::clearing_lfsr_perm_t",
+      desc:    '''
+        Permutation applied to the clearing PRNG output for clearing the second share of registers.
+      '''
+      randcount: "64",
+      randtype:  "perm"
+    },
     { name:    "RndCnstMaskingLfsrSeed",
       type:    "aes_pkg::masking_lfsr_seed_t",
       desc:    '''

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -34,6 +34,7 @@ module aes
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
   parameter clearing_lfsr_seed_t   RndCnstClearingLfsrSeed  = RndCnstClearingLfsrSeedDefault,
   parameter clearing_lfsr_perm_t   RndCnstClearingLfsrPerm  = RndCnstClearingLfsrPermDefault,
+  parameter clearing_lfsr_perm_t   RndCnstClearingSharePerm = RndCnstClearingSharePermDefault,
   parameter masking_lfsr_seed_t    RndCnstMaskingLfsrSeed   = RndCnstMaskingLfsrSeedDefault,
   parameter mskg_chunk_lfsr_perm_t RndCnstMskgChunkLfsrPerm = RndCnstMskgChunkLfsrPermDefault
 ) (
@@ -150,6 +151,7 @@ module aes
     .EntropyWidth             ( EntropyWidth             ),
     .RndCnstClearingLfsrSeed  ( RndCnstClearingLfsrSeed  ),
     .RndCnstClearingLfsrPerm  ( RndCnstClearingLfsrPerm  ),
+    .RndCnstClearingSharePerm ( RndCnstClearingSharePerm ),
     .RndCnstMaskingLfsrSeed   ( RndCnstMaskingLfsrSeed   ),
     .RndCnstMskgChunkLfsrPerm ( RndCnstMskgChunkLfsrPerm )
   ) u_aes_core (

--- a/hw/ip/aes/rtl/aes_cipher_core.sv
+++ b/hw/ip/aes/rtl/aes_cipher_core.sv
@@ -225,12 +225,13 @@ module aes_cipher_core import aes_pkg::*;
   logic                               prd_masking_rsd_req;
   logic                               prd_masking_rsd_ack;
 
-  // Generate clearing signals of appropriate widths.
+  // Generate clearing signals of appropriate widths. If masking is enabled, the two shares of
+  // the registers must be cleared with different pseudo-random data.
   for (genvar s = 0; s < NumShares; s++) begin : gen_prd_clearing_shares
-    for (genvar c = 0; c < 2; c++) begin : gen_prd_clearing_128
+    for (genvar c = 0; c < NumChunksPRDClearing128; c++) begin : gen_prd_clearing_128
       assign prd_clearing_128[s][c * WidthPRDClearing +: WidthPRDClearing] = prd_clearing_i[s];
     end
-    for (genvar c = 0; c < 4; c++) begin : gen_prd_clearing_256
+    for (genvar c = 0; c < NumChunksPRDClearing256; c++) begin : gen_prd_clearing_256
       assign prd_clearing_256[s][c * WidthPRDClearing +: WidthPRDClearing] = prd_clearing_i[s];
     end
   end

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -34,7 +34,7 @@ module aes_control import aes_pkg::*;
   output logic                    alert_o,
 
   // I/O register read/write enables
-  input  logic [7:0]              key_init_qe_i [2],
+  input  logic [7:0]              key_init_qe_i [NumSharesKey],
   input  logic [3:0]              iv_qe_i,
   input  logic [3:0]              data_in_qe_i,
   input  logic [3:0]              data_out_re_i,
@@ -71,7 +71,7 @@ module aes_control import aes_pkg::*;
 
   // Initial key registers
   output key_init_sel_e           key_init_sel_o,
-  output sp2v_e [7:0]             key_init_we_o [2],
+  output sp2v_e [7:0]             key_init_we_o [NumSharesKey],
 
   // IV registers
   output iv_sel_e                 iv_sel_o,
@@ -347,7 +347,7 @@ module aes_control import aes_pkg::*;
 
         if (idle_o) begin
           // Initial key and IV updates are ignored if we are not idle.
-          for (int s = 0; s < 2; s++) begin
+          for (int s = 0; s < NumSharesKey; s++) begin
             for (int i = 0; i < 8; i++) begin
               key_init_we_o[s][i] = key_init_qe_i[s][i] ? SP2V_HIGH : SP2V_LOW;
             end
@@ -624,8 +624,8 @@ module aes_control import aes_pkg::*;
   // We only use clean initial keys. Either software/counter has updated
   // - all initial key registers, or
   // - none of the initial key registers but the registers were updated in the past.
-  logic [7:0] key_init_we [2];
-  for (genvar s = 0; s < 2; s++) begin : gen_status_key_init_we_shares
+  logic [7:0] key_init_we [NumSharesKey];
+  for (genvar s = 0; s < NumSharesKey; s++) begin : gen_status_key_init_we_shares
     for (genvar i = 0; i < 8; i++) begin : gen_status_key_init_we
       assign key_init_we[s][i] = (key_init_we_o[s][i] == SP2V_HIGH);
     end

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -208,7 +208,7 @@ module aes_core
   ////////////
 
   always_comb begin : key_init_get
-    for (int i = 0; i < 8; i++) begin
+    for (int i = 0; i < NumRegsKey; i++) begin
       key_init[0][i]    = reg2hw.key_share0[i].q;
       key_init_qe[0][i] = reg2hw.key_share0[i].qe;
       key_init[1][i]    = reg2hw.key_share1[i].q;
@@ -217,21 +217,21 @@ module aes_core
   end
 
   always_comb begin : iv_get
-    for (int i = 0; i < 4; i++) begin
+    for (int i = 0; i < NumRegsIv; i++) begin
       iv[i]    = reg2hw.iv[i].q;
       iv_qe[i] = reg2hw.iv[i].qe;
     end
   end
 
   always_comb begin : data_in_get
-    for (int i = 0; i < 4; i++) begin
+    for (int i = 0; i < NumRegsData; i++) begin
       data_in[i]    = reg2hw.data_in[i].q;
       data_in_qe[i] = reg2hw.data_in[i].qe;
     end
   end
 
   always_comb begin : data_out_get
-    for (int i = 0; i < 4; i++) begin
+    for (int i = 0; i < NumRegsData; i++) begin
       // data_out is actually hwo, but we need hrw for hwre
       unused_data_out_q[i] = reg2hw.data_out[i].q;
       data_out_re[i]       = reg2hw.data_out[i].re;
@@ -613,7 +613,7 @@ module aes_core
 
   // Input data register clear
   always_comb begin : data_in_reg_clear
-    for (int i = 0; i < 4; i++) begin
+    for (int i = 0; i < NumRegsData; i++) begin
       hw2reg.data_in[i].d  = prd_clearing_128[i*32 +: 32];
       hw2reg.data_in[i].de = data_in_we;
     end
@@ -798,20 +798,20 @@ module aes_core
   end
 
   always_comb begin : key_reg_put
-    for (int i = 0; i < 8; i++) begin
+    for (int i = 0; i < NumRegsKey; i++) begin
       hw2reg.key_share0[i].d = key_init_q[0][i];
       hw2reg.key_share1[i].d = key_init_q[1][i];
     end
   end
 
   always_comb begin : iv_reg_put
-    for (int i = 0; i < 4; i++) begin
+    for (int i = 0; i < NumRegsIv; i++) begin
       hw2reg.iv[i].d  = {iv_q[2*i+1], iv_q[2*i]};
     end
   end
 
   always_comb begin : data_out_put
-    for (int i = 0; i < 4; i++) begin
+    for (int i = 0; i < NumRegsData; i++) begin
       hw2reg.data_out[i].d = data_out_q[i];
     end
   end

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -6,8 +6,16 @@
 
 package aes_pkg;
 
-// Widths of signals carrying pseudo-random data for clearing and masking and purposes
+// The initial key is always provided in two shares, independently whether the cipher core is
+// masked or not.
+parameter int unsigned NumSharesKey = 2;
+
+// Widths of signals carrying pseudo-random data for clearing
 parameter int unsigned WidthPRDClearing = 64;
+parameter int unsigned NumChunksPRDClearing128 = 128/WidthPRDClearing;
+parameter int unsigned NumChunksPRDClearing256 = 256/WidthPRDClearing;
+
+// Widths of signals carrying pseudo-random data for masking
 parameter int unsigned WidthPRDSBox     = 8;  // Number PRD bits per S-Box. This includes the
                                               // 8 bits for the output mask when using any of the
                                               // masked Canright S-Box implementations.
@@ -196,7 +204,7 @@ typedef enum logic [Mux4SelWidth-1:0] {
 // Minimum Hamming distance: 3
 // Maximum Hamming distance: 5
 //
-localparam int Mux6SelWidth = 6;
+parameter int Mux6SelWidth = 6;
 typedef enum logic [Mux6SelWidth-1:0] {
   MUX6_SEL_0 = 6'b011101,
   MUX6_SEL_1 = 6'b110000,

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -28,6 +28,11 @@ parameter clearing_lfsr_perm_t RndCnstClearingLfsrPermDefault = {
   128'hb33fdfc81deb6292c21f8a3102585067,
   256'h9c2f4be1bbe937b4b7c9d7f4e57568d99c8ae291a899143e0d8459d31b143223
 };
+// A second permutation is needed for the second share.
+parameter clearing_lfsr_perm_t RndCnstClearingSharePermDefault = {
+  128'hf66fd61b27847edc2286706fb3a2e900,
+  256'h9736b95ac3f3b5205caf8dc536aad73605d393c8dd94476e830e97891d4828d0
+};
 
 // Masking PRNG default LFSR seed and permutation
 // We use a single seed that is split down into chunks internally. All LFSR chunks use the same

--- a/hw/ip/aes/rtl/aes_prng_clearing.sv
+++ b/hw/ip/aes/rtl/aes_prng_clearing.sv
@@ -29,7 +29,7 @@ module aes_prng_clearing import aes_pkg::*;
   // Connections to AES internals, PRNG consumers
   input  logic                    data_req_i,
   output logic                    data_ack_o,
-  output logic        [Width-1:0] data_o [2],
+  output logic        [Width-1:0] data_o [NumSharesKey],
   input  logic                    reseed_req_i,
   output logic                    reseed_ack_o,
 

--- a/hw/ip/csrng/rtl/csrng_block_encrypt.sv
+++ b/hw/ip/csrng/rtl/csrng_block_encrypt.sv
@@ -58,11 +58,15 @@ module csrng_block_encrypt #(
   logic [BlkLen-1:0]    cipher_data_out;
   logic                 aes_cipher_core_enable;
 
+  logic [aes_pkg::WidthPRDClearing-1:0] prd_clearing [NumShares];
+
   logic [3:0][3:0][7:0] state_init[NumShares];
 
   logic [7:0][31:0]     key_init[NumShares];
   logic [3:0][3:0][7:0] state_done[NumShares];
   logic [3:0][3:0][7:0] state_out;
+
+  assign     prd_clearing[0] = '0;
 
   assign     state_init[0] = block_encrypt_v_i;
 
@@ -108,7 +112,7 @@ module csrng_block_encrypt #(
     .key_clear_o        (                            ),
     .data_out_clear_i   ( 1'b0                       ), // Disable
     .data_out_clear_o   (                            ),
-    .prd_clearing_i     ( '0                         ),
+    .prd_clearing_i     ( prd_clearing               ),
     .force_zero_masks_i ( 1'b0                       ),
     .data_in_mask_o     (                            ),
     .entropy_req_o      (                            ),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3646,13 +3646,23 @@
           randwidth: 384
         }
         {
+          name: RndCnstClearingSharePerm
+          desc: Permutation applied to the clearing PRNG output for clearing the second share of registers.
+          type: aes_pkg::clearing_lfsr_perm_t
+          randcount: 64
+          randtype: perm
+          name_top: RndCnstAesClearingSharePerm
+          default: 0x7d9cf783c36c02e6cbd0c89a7299bac245b9fb80c85367bb5e53c511341509877fb72286f4e9e3047871a354afad126a
+          randwidth: 384
+        }
+        {
           name: RndCnstMaskingLfsrSeed
           desc: Default seed of the PRNG used for masking.
           type: aes_pkg::masking_lfsr_seed_t
           randcount: 160
           randtype: data
           name_top: RndCnstAesMaskingLfsrSeed
-          default: 0x46512073261cf96e55692b75e4024435ce910013
+          default: 0xd6e49c544ba9dcdff0245e84d6f5f03ecaef7217
           randwidth: 160
         }
         {
@@ -3662,7 +3672,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstAesMskgChunkLfsrPerm
-          default: 0x7b6c2c9ab7e757bfa48a0b1c5f20f388070c5352
+          default: 0x46fa4bd6dc82beb0a4e30305aa371e9c64e2bf26
           randwidth: 160
         }
       ]
@@ -3924,7 +3934,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstKeymgrLfsrSeed
-          default: 0xe2a9b121f6fd1b71
+          default: 0x8536e02c38ed5edf
           randwidth: 64
         }
         {
@@ -3934,7 +3944,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstKeymgrLfsrPerm
-          default: 0x25ac47e90b16aca159622bf4f3d00c09e515357736cd1b9da5ffb79436e6c0bd68060e7b10e193fd286a92322d3f8ca7
+          default: 0x6a27354364ad3bf532784c2725d903ee51f44fabb76f9fb3b2ff7145729959f821ae81803e317863c98b30854d042a6a
           randwidth: 384
         }
         {
@@ -3944,7 +3954,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstKeymgrRandPerm
-          default: 0xe2e014ba5846db4ae6cf1dcf1fe99e997a451802
+          default: 0x239b10b10987253b015a36f15153fe5dcf92f46f
           randwidth: 160
         }
         {
@@ -3954,7 +3964,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrRevisionSeed
-          default: 0xf085d06d98c25574d82449e1afa2201f312ea264f507a75d5b610152d8465246
+          default: 0xcb8bed0d3e48713de5986d0027d13a3a480b63b97279d8d378486795de27f2cf
           randwidth: 256
         }
         {
@@ -3964,7 +3974,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrCreatorIdentitySeed
-          default: 0xed2e99906a4afbd4dedb5cc59ef74e5ab14d5b983dd7598af12e48c599da1605
+          default: 0x8127b8ee31063c01e9be104c7777ecc6d68e333feddeac133f24dd2e11738ceb
           randwidth: 256
         }
         {
@@ -3974,7 +3984,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOwnerIntIdentitySeed
-          default: 0x198a2b804df44b9e44e1c905dcd81e3b8adcf2ea1eb87424e51caa14dbfbec75
+          default: 0xfcc7cc4ec8d98b59e767a253b29311c3e284411ee572a3934ffe951d3b79c1b3
           randwidth: 256
         }
         {
@@ -3984,7 +3994,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOwnerIdentitySeed
-          default: 0x710581e83789a7b90140c94645887a4457e74cd0c4cca056411c89563d15b47b
+          default: 0x18800440bd414d266de08fc479f858040892b0f3729f7ab9dafe7f2472fb41c8
           randwidth: 256
         }
         {
@@ -3994,7 +4004,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrSoftOutputSeed
-          default: 0xa2415e162f57f8aa2cce101e080c3a9db8ca70b49d1050c47fa9ce86f3443c8c
+          default: 0x653fadb4aee4626498a4c647603c2154be52121d214556318c84c8ec175dab2f
           randwidth: 256
         }
         {
@@ -4004,7 +4014,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrHardOutputSeed
-          default: 0xea8f46c61a39ebb93e4ef606d8cefa03d0ec61b1bdcbc0e305b5e826ef06ff71
+          default: 0xd5c72146d889aca6973a13272144f3eefeedd9d57e3f829a880463a023ca0c5e
           randwidth: 256
         }
         {
@@ -4014,7 +4024,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrAesSeed
-          default: 0x1d4967265f5be435bb86ec6ce55ef0383b7eff93cf28e950f9e20b072b46413f
+          default: 0x7663f6d1fbe7e4402c0329cac3b7d06751f2882df8f3259134067e7a112ffdb3
           randwidth: 256
         }
         {
@@ -4024,7 +4034,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrHmacSeed
-          default: 0xcde39c7f136f643dd889a82012723d99a28765b0f2275a007c6d3334cdf5f463
+          default: 0xbc5f1a8862845852761603352213b7a034816103a781d0a4f5a0a911c1bcafe
           randwidth: 256
         }
         {
@@ -4034,7 +4044,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrKmacSeed
-          default: 0x7d6a1dfc06309603ac5bdaa938cde8623691d2421c1380e95bb5ca2edd3d769f
+          default: 0x63dd2af7ca1c6ae78efcbdc6ada112f1235ee7dba5042c13061068c02cef00b7
           randwidth: 256
         }
         {
@@ -4044,7 +4054,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrNoneSeed
-          default: 0x31dc2b96a9ae6dddcd37c3e4506557f163afd8475e880d7228274b6f2922b53f
+          default: 0x56289223d7e05db35983fe5a262a6e3ab1655d42b3090ae475a2df4171fdfd7c
           randwidth: 256
         }
       ]
@@ -4564,7 +4574,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramKey
-          default: 0xde27f2cf29caab641654ac0a79a61ff5
+          default: 0x92e47f6e0845f450ead8f3095ff32c32
           randwidth: 128
         }
         {
@@ -4574,7 +4584,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramNonce
-          default: 0x27d13a3a480b63b97279d8d378486795
+          default: 0xe9d1b1f891dcab64f5a52883a710b72b
           randwidth: 128
         }
         {
@@ -4584,7 +4594,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstSramCtrlMainSramLfsrPerm
-          default: 0xa170a012778b2de5c91d1b7e1aed3c819da38b2f
+          default: 0x33d0bedd4d8c36cb029c0cfd5cb87f2170991f42
           randwidth: 160
         }
         {

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1912,6 +1912,7 @@ module top_earlgrey #(
     .SecSkipPRNGReseeding(SecAesSkipPRNGReseeding),
     .RndCnstClearingLfsrSeed(RndCnstAesClearingLfsrSeed),
     .RndCnstClearingLfsrPerm(RndCnstAesClearingLfsrPerm),
+    .RndCnstClearingSharePerm(RndCnstAesClearingSharePerm),
     .RndCnstMaskingLfsrSeed(RndCnstAesMaskingLfsrSeed),
     .RndCnstMskgChunkLfsrPerm(RndCnstAesMskgChunkLfsrPerm)
   ) u_aes (

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -111,14 +111,20 @@ package top_earlgrey_rnd_cnst_pkg;
     256'h7B029229DA078DF923F7D0F46154C34BA9D43C734AF2A1EAA8E0F3270944E4D9
   };
 
+  // Permutation applied to the clearing PRNG output for clearing the second share of registers.
+  parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingSharePerm = {
+    128'h7D9CF783C36C02E6CBD0C89A7299BAC2,
+    256'h45B9FB80C85367BB5E53C511341509877FB72286F4E9E3047871A354AFAD126A
+  };
+
   // Default seed of the PRNG used for masking.
   parameter aes_pkg::masking_lfsr_seed_t RndCnstAesMaskingLfsrSeed = {
-    160'h46512073261CF96E55692B75E4024435CE910013
+    160'hD6E49C544BA9DCDFF0245E84D6F5F03ECAEF7217
   };
 
   // Permutation applied to the LFSR chunks of the PRNG used for masking.
   parameter aes_pkg::mskg_chunk_lfsr_perm_t RndCnstAesMskgChunkLfsrPerm = {
-    160'h7B6C2C9AB7E757BFA48A0B1C5F20F388070C5352
+    160'h46FA4BD6DC82BEB0A4E30305AA371E9C64E2BF26
   };
 
   ////////////////////////////////////////////
@@ -126,68 +132,68 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter keymgr_pkg::lfsr_seed_t RndCnstKeymgrLfsrSeed = {
-    64'hE2A9B121F6FD1B71
+    64'h8536E02C38ED5EDF
   };
 
   // Compile-time random permutation for LFSR output
   parameter keymgr_pkg::lfsr_perm_t RndCnstKeymgrLfsrPerm = {
-    128'h25AC47E90B16ACA159622BF4F3D00C09,
-    256'hE515357736CD1B9DA5FFB79436E6C0BD68060E7B10E193FD286A92322D3F8CA7
+    128'h6A27354364AD3BF532784C2725D903EE,
+    256'h51F44FABB76F9FB3B2FF7145729959F821AE81803E317863C98B30854D042A6A
   };
 
   // Compile-time random permutation for entropy used in share overriding
   parameter keymgr_pkg::rand_perm_t RndCnstKeymgrRandPerm = {
-    160'hE2E014BA5846DB4AE6CF1DCF1FE99E997A451802
+    160'h239B10B10987253B015A36F15153FE5DCF92F46F
   };
 
   // Compile-time random bits for revision seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrRevisionSeed = {
-    256'hF085D06D98C25574D82449E1AFA2201F312EA264F507A75D5B610152D8465246
+    256'hCB8BED0D3E48713DE5986D0027D13A3A480B63B97279D8D378486795DE27F2CF
   };
 
   // Compile-time random bits for creator identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrCreatorIdentitySeed = {
-    256'hED2E99906A4AFBD4DEDB5CC59EF74E5AB14D5B983DD7598AF12E48C599DA1605
+    256'h8127B8EE31063C01E9BE104C7777ECC6D68E333FEDDEAC133F24DD2E11738CEB
   };
 
   // Compile-time random bits for owner intermediate identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrOwnerIntIdentitySeed = {
-    256'h198A2B804DF44B9E44E1C905DCD81E3B8ADCF2EA1EB87424E51CAA14DBFBEC75
+    256'hFCC7CC4EC8D98B59E767A253B29311C3E284411EE572A3934FFE951D3B79C1B3
   };
 
   // Compile-time random bits for owner identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrOwnerIdentitySeed = {
-    256'h710581E83789A7B90140C94645887A4457E74CD0C4CCA056411C89563D15B47B
+    256'h18800440BD414D266DE08FC479F858040892B0F3729F7AB9DAFE7F2472FB41C8
   };
 
   // Compile-time random bits for software generation seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrSoftOutputSeed = {
-    256'hA2415E162F57F8AA2CCE101E080C3A9DB8CA70B49D1050C47FA9CE86F3443C8C
+    256'h653FADB4AEE4626498A4C647603C2154BE52121D214556318C84C8EC175DAB2F
   };
 
   // Compile-time random bits for hardware generation seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrHardOutputSeed = {
-    256'hEA8F46C61A39EBB93E4EF606D8CEFA03D0EC61B1BDCBC0E305B5E826EF06FF71
+    256'hD5C72146D889ACA6973A13272144F3EEFEEDD9D57E3F829A880463A023CA0C5E
   };
 
   // Compile-time random bits for generation seed when aes destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrAesSeed = {
-    256'h1D4967265F5BE435BB86EC6CE55EF0383B7EFF93CF28E950F9E20B072B46413F
+    256'h7663F6D1FBE7E4402C0329CAC3B7D06751F2882DF8F3259134067E7A112FFDB3
   };
 
   // Compile-time random bits for generation seed when hmac destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrHmacSeed = {
-    256'hCDE39C7F136F643DD889A82012723D99A28765B0F2275A007C6D3334CDF5F463
+    256'hBC5F1A8862845852761603352213B7A034816103A781D0A4F5A0A911C1BCAFE
   };
 
   // Compile-time random bits for generation seed when kmac destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrKmacSeed = {
-    256'h7D6A1DFC06309603AC5BDAA938CDE8623691D2421C1380E95BB5CA2EDD3D769F
+    256'h63DD2AF7CA1C6AE78EFCBDC6ADA112F1235EE7DBA5042C13061068C02CEF00B7
   };
 
   // Compile-time random bits for generation seed when no destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrNoneSeed = {
-    256'h31DC2B96A9AE6DDDCD37C3E4506557F163AFD8475E880D7228274B6F2922B53F
+    256'h56289223D7E05DB35983FE5A262A6E3AB1655D42B3090AE475A2DF4171FDFD7C
   };
 
   ////////////////////////////////////////////
@@ -195,17 +201,17 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlMainSramKey = {
-    128'hDE27F2CF29CAAB641654AC0A79A61FF5
+    128'h92E47F6E0845F450EAD8F3095FF32C32
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlMainSramNonce = {
-    128'h27D13A3A480B63B97279D8D378486795
+    128'hE9D1B1F891DCAB64F5A52883A710B72B
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlMainSramLfsrPerm = {
-    160'hA170A012778B2DE5C91D1B7E1AED3C819DA38B2F
+    160'h33D0BEDD4D8C36CB029C0CFD5CB87F2170991F42
   };
 
 endpackage : top_earlgrey_rnd_cnst_pkg


### PR DESCRIPTION
Previously, both shares of masked registers (key, internal state) were cleared with the same pseudo-random data. As a result, the sum of the two shares was always 0 after clearing. This knowledge could potentially be exploited for SCA.

Therefore, this commit adds another, separate permutation that is applied to the output of the clearing PRNG for clearing the second share of masked registers. This new permutation is exposed as a compile-time random netlist constant.