### PR TITLE
[otp] Minor width mismatch fixes when computing parameters

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_lci.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_lci.sv
@@ -54,7 +54,7 @@ module otp_ctrl_lci
 
   import prim_util_pkg::vbits;
 
-  localparam int NumLcOtpWords = Info.size >> OtpAddrShift;
+  localparam int NumLcOtpWords = int'(Info.size) >> OtpAddrShift;
   localparam int CntWidth = vbits(NumLcOtpWords);
 
   // This is required, since each native OTP word can only be programmed once.

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -73,8 +73,8 @@ module otp_ctrl_part_buf
 
   import prim_util_pkg::vbits;
 
-  localparam int DigestOffset = Info.offset + Info.size - ScrmblBlockWidth/8;
-  localparam int NumScrmblBlocks = Info.size / (ScrmblBlockWidth/8);
+  localparam int DigestOffset = int'(Info.offset) + int'(Info.size) - ScrmblBlockWidth/8;
+  localparam int NumScrmblBlocks = int'(Info.size) / (ScrmblBlockWidth/8);
   localparam int CntWidth = vbits(NumScrmblBlocks);
 
   // Integration checks for parameters.

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -59,7 +59,7 @@ module otp_ctrl_part_unbuf
 
   localparam logic [OtpByteAddrWidth:0] PartEnd = (OtpByteAddrWidth+1)'(Info.offset) +
                                                   (OtpByteAddrWidth+1)'(Info.size);
-  localparam int DigestOffset = (Info.offset + (Info.size - (ScrmblBlockWidth/8)));
+  localparam int DigestOffset = int'(PartEnd) - ScrmblBlockWidth/8;
 
   // Integration checks for parameters.
   `ASSERT_INIT(OffsetMustBeBlockAligned_A, (Info.offset % (ScrmblBlockWidth/8)) == 0)


### PR DESCRIPTION
These cause Verilator lint errors. The second patch in the PR is pretty trivial, but there's a bit of thought that went into the first one: I think it fixes a bug that was present in the previous code if size + offset is large.