### PR TITLE
Update lowrisc_ibex to lowRISC/ibex@4b43afa5

### DIFF
--- a/hw/vendor/lowrisc_ibex.lock.hjson
+++ b/hw/vendor/lowrisc_ibex.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/ibex.git
-    rev: 42827fc9cd0b2043d5d179cae46b0238a55d3652
+    rev: 4b43afa53315d00784d5c3b714583276127eddcc
   }
 }

--- a/hw/vendor/lowrisc_ibex/doc/03_reference/cs_registers.rst
+++ b/hw/vendor/lowrisc_ibex/doc/03_reference/cs_registers.rst
@@ -36,6 +36,8 @@ Ibex implements all the Control and Status Registers (CSRs) listed in the follow
 +---------+--------------------+--------+-----------------------------------------------+
 |  0x390  | ``mseccfg``        | WARL   | Machine Security Configuration                |
 +---------+--------------------+--------+-----------------------------------------------+
+|  0x391  | ``mseccfgh``       | WARL   | Upper 32 bits of ``mseccfg``                  |
++---------+--------------------+--------+-----------------------------------------------+
 |  0x3A0  | ``pmpcfg0``        | WARL   | PMP Configuration Register                    |
 +---------+--------------------+--------+-----------------------------------------------+
 |     .             .               .                    .                              |
@@ -248,12 +250,12 @@ A particular bit in the register reads as one if the corresponding interrupt inp
 | 3     | **Machine Software Interrupt Pending (MSIP):** if set, ``irq_software_i`` is pending. |
 +-------+---------------------------------------------------------------------------------------+
 
-Machine Security Configuration (mseccfg)
+Machine Security Configuration (mseccfg/mseccfgh)
 ----------------------------------------
 
-CSR Address: ``0x390``
+CSR Address: ``0x390 - 0x391``
 
-Reset Value: ``0x0000_0000``
+Reset Value: ``0x0000_0000_0000_0000``
 
 +------+-----------------------------------------------------------------------------------------------------------------------------------+
 | Bit# | Definition                                                                                                                        |
@@ -262,12 +264,14 @@ Reset Value: ``0x0000_0000``
 +------+-----------------------------------------------------------------------------------------------------------------------------------+
 | 1    | **Machine Mode Whitelist Policy (MMWP):** If set default policy for PMP is deny for M-Mode accesses that don't match a PMP region |
 +------+-----------------------------------------------------------------------------------------------------------------------------------+
-| 0    | **Machine Mode Lockdown (MML):** Alters behaviour of ``pmpcfgX`` bits                                                               |
+| 0    | **Machine Mode Lockdown (MML):** Alters behaviour of ``pmpcfgX`` bits                                                             |
 +------+-----------------------------------------------------------------------------------------------------------------------------------+
 
 ``mseccfg`` is specified in the Trusted Execution Environment (TEE) working group proposal :download:`PMP Enhancements for memory access and execution prevention on Machine mode <../03_reference/pdfs/riscv-epmp.pdf>`, which gives the full details of it's functionality including the new PMP behaviour when ``mseccfg.MML`` is set.
 Note that the reset value means PMP behavior out of reset matches the RISC-V Privileged Architecture.
 A write to ``mseccfg`` is required to change it.
+Note ``mseccfgh`` reads as all 0s and ignores all writes.
+Any access to ``mseccfg`` or ``mseccfgh`` when using an Ibex configuration without PMP (``PMPEnable`` is 0) will trigger an illegal instruction exception.
 
 PMP Configuration Register (pmpcfgx)
 ------------------------------------

--- a/hw/vendor/lowrisc_ibex/doc/03_reference/security.rst
+++ b/hw/vendor/lowrisc_ibex/doc/03_reference/security.rst
@@ -21,6 +21,7 @@ This makes it more difficult for an external observer to infer secret data by ob
 
 In Ibex, most instructions already execute independent of their input operands.
 When data-independent timing is enabled:
+
 * Branches execute identically regardless of their taken/not-taken status
 * Early completion of multiplication by zero/one is removed
 * Early completion of divide by zero is removed

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
@@ -349,10 +349,22 @@ module ibex_cs_registers #(
       end
 
       CSR_MSECCFG: begin
-        csr_rdata_int                       = '0;
-        csr_rdata_int[CSR_MSECCFG_MML_BIT]  = pmp_mseccfg.mml;
-        csr_rdata_int[CSR_MSECCFG_MMWP_BIT] = pmp_mseccfg.mmwp;
-        csr_rdata_int[CSR_MSECCFG_RLB_BIT]  = pmp_mseccfg.rlb;
+        if (PMPEnable) begin
+          csr_rdata_int                       = '0;
+          csr_rdata_int[CSR_MSECCFG_MML_BIT]  = pmp_mseccfg.mml;
+          csr_rdata_int[CSR_MSECCFG_MMWP_BIT] = pmp_mseccfg.mmwp;
+          csr_rdata_int[CSR_MSECCFG_RLB_BIT]  = pmp_mseccfg.rlb;
+        end else begin
+          illegal_csr = 1'b1;
+        end
+      end
+
+      CSR_MSECCFGH: begin
+        if (PMPEnable) begin
+          csr_rdata_int = '0;
+        end else begin
+          illegal_csr = 1'b1;
+        end
       end
 
       // PMP registers
@@ -563,6 +575,9 @@ module ibex_cs_registers #(
 
           // Read-only for SW
           dcsr_d.cause = dcsr_q.cause;
+
+          // Interrupts always disabled during single stepping
+          dcsr_d.stepie = 1'b0;
 
           // currently not supported:
           dcsr_d.nmip = 1'b0;

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_pkg.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_pkg.sv
@@ -368,6 +368,7 @@ typedef enum logic[11:0] {
   CSR_MIP       = 12'h344,
 
   CSR_MSECCFG   = 12'h390,
+  CSR_MSECCFGH  = 12'h391,
 
   // Physical memory protection
   CSR_PMPCFG0   = 12'h3A0,


### PR DESCRIPTION
Vendoring to bring across the debug changes, plus the MSECCFGH fix. Neither are major issues but better to get them into OT sooner rather than later.

Update code from upstream repository
https://github.com/lowRISC/ibex.git to revision
4b43afa53315d00784d5c3b714583276127eddcc

* [doc] Fix table rendering for `mseccfg` (Greg Chadwick)
* [rtl] Add MSECCFGH CSR (Greg Chadwick)
* [rtl] Hard wire dcsr.stepie to 0 (Greg Chadwick)
* [rtl] Fix hardware breakpoints and exceptions interaction (Greg
  Chadwick)
* Fix spacing for bullet points to appear (Yusef Karim)
* [ci/ibex] temporarily remove pmp_full_random_test (Udi Jonnalagadda)

Signed-off-by: Greg Chadwick <gac@lowrisc.org>