### PR TITLE
[otbn] Qualify BignumRegIncReq assertion with insn_valid_o

### DIFF
--- a/hw/ip/otbn/rtl/otbn_decoder.sv
+++ b/hw/ip/otbn/rtl/otbn_decoder.sv
@@ -952,8 +952,10 @@ module otbn_decoder
     insn_valid_o |-> $onehot0({a_inc_bignum, a_wlen_word_inc_bignum, b_inc_bignum, d_inc_bignum}))
 
   // RfWdSelIncr requires active selection
-  `ASSERT(BignumRegIncReq, rf_wdata_sel_base == RfWdSelIncr
-      |-> $onehot({a_inc_bignum, a_wlen_word_inc_bignum, b_inc_bignum, d_inc_bignum}))
+  `ASSERT(BignumRegIncReq,
+          (insn_valid_o && (rf_wdata_sel_base == RfWdSelIncr))
+          |->
+          $onehot({a_inc_bignum, a_wlen_word_inc_bignum, b_inc_bignum, d_inc_bignum}))
 
   `ASSERT(BaseRenOnBignumIndirectA, insn_valid_o & rf_a_indirect_bignum |-> rf_ren_a_base)
   `ASSERT(BaseRenOnBignumIndirectB, insn_valid_o & rf_b_indirect_bignum |-> rf_ren_b_base)


### PR DESCRIPTION
This claim isn't actually always true: for example, if the instruction
data looks like a `BN.LID` (`insn[14:12] = 3'b100`) but both `insn[8]` and
`insn[7]` are set then both `a_wlen_word_inc_bignum` and `d_inc_bignum` will
be true.

Fixes #5492.