### PR TITLE
[sw,dv] Update headers to pass fix_include_guards.py

### DIFF
--- a/hw/dv/dpi/common/tcp_server/tcp_server.h
+++ b/hw/dv/dpi/common/tcp_server/tcp_server.h
@@ -2,15 +2,15 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#ifndef OPENTITAN_HW_DV_DPI_COMMON_TCP_SERVER_TCP_SERVER_H_
+#define OPENTITAN_HW_DV_DPI_COMMON_TCP_SERVER_TCP_SERVER_H_
+
 /**
  * Functions to create and interact with a threaded TCP server
  *
  * This is intended to be used by simulation add-on DPI modules to provide
  * basic TCP socket communication between a host and simulated peripherals.
  */
-
-#ifndef TCP_SERVER_H_
-#define TCP_SERVER_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,4 +66,4 @@ void tcp_server_client_close(struct tcp_server_ctx *ctx);
 #ifdef __cplusplus
 }  // extern "C"
 #endif
-#endif  // TCP_SERVER_H_
+#endif  // OPENTITAN_HW_DV_DPI_COMMON_TCP_SERVER_TCP_SERVER_H_

--- a/hw/dv/dpi/dmidpi/dmidpi.h
+++ b/hw/dv/dpi/dmidpi/dmidpi.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef DMIDPI_H_
-#define DMIDPI_H_
+#ifndef OPENTITAN_HW_DV_DPI_DMIDPI_DMIDPI_H_
+#define OPENTITAN_HW_DV_DPI_DMIDPI_DMIDPI_H_
 
 #include <svdpi.h>
 
@@ -49,4 +49,4 @@ void dmidpi_tick(void *ctx_void, svBit *dmi_req_valid,
 #ifdef __cplusplus
 }  // extern "C"
 #endif
-#endif  // DMIDPI_H_
+#endif  // OPENTITAN_HW_DV_DPI_DMIDPI_DMIDPI_H_

--- a/hw/dv/dpi/gpiodpi/gpiodpi.h
+++ b/hw/dv/dpi/gpiodpi/gpiodpi.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef GPIODPI_H_
-#define GPIODPI_H_
+#ifndef OPENTITAN_HW_DV_DPI_GPIODPI_GPIODPI_H_
+#define OPENTITAN_HW_DV_DPI_GPIODPI_GPIODPI_H_
 
 #include <svdpi.h>
 
@@ -46,4 +46,4 @@ uint32_t gpiodpi_host_to_device_tick(void *ctx_void, svBitVecVal *gpio_oe);
 void gpiodpi_close(void *ctx_void);
 
 }  // extern "C"
-#endif  // GPIODPI_H_
+#endif  // OPENTITAN_HW_DV_DPI_GPIODPI_GPIODPI_H_

--- a/hw/dv/dpi/jtagdpi/jtagdpi.h
+++ b/hw/dv/dpi/jtagdpi/jtagdpi.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef JTAGDPI_H_
-#define JTAGDPI_H_
+#ifndef OPENTITAN_HW_DV_DPI_JTAGDPI_JTAGDPI_H_
+#define OPENTITAN_HW_DV_DPI_JTAGDPI_JTAGDPI_H_
 
 #include <svdpi.h>
 
@@ -53,4 +53,4 @@ void jtagdpi_tick(void *ctx_void, svBit *tck, svBit *tms, svBit *tdi,
 #ifdef __cplusplus
 }  // extern "C"
 #endif
-#endif  // JTAGDPI_H_
+#endif  // OPENTITAN_HW_DV_DPI_JTAGDPI_JTAGDPI_H_

--- a/hw/ip/aes/model/aes.h
+++ b/hw/ip/aes/model/aes.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef AES_H_
-#define AES_H_
+#ifndef OPENTITAN_HW_IP_AES_MODEL_AES_H_
+#define OPENTITAN_HW_IP_AES_MODEL_AES_H_
 
 /**
  * Encrypt one data block (16 Bytes) in ECB mode.
@@ -235,4 +235,4 @@ static const unsigned char inv_sbox[256] = {
     0x17, 0x2b, 0x04, 0x7e, 0xba, 0x77, 0xd6, 0x26,
     0xe1, 0x69, 0x14, 0x63, 0x55, 0x21, 0x0c, 0x7d};
 
-#endif  // AES_H_
+#endif  // OPENTITAN_HW_IP_AES_MODEL_AES_H_

--- a/hw/ip/aes/model/aes_example.h
+++ b/hw/ip/aes/model/aes_example.h
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#ifndef OPENTITAN_HW_IP_AES_MODEL_AES_EXAMPLE_H_
+#define OPENTITAN_HW_IP_AES_MODEL_AES_EXAMPLE_H_
+
 // The examples below are extracted from
 // the Advanced Encryption Standard (AES) FIPS Publication 197 available at
 // https://www.nist.gov/publications/advanced-encryption-standard-aes.
@@ -63,3 +66,5 @@ static const unsigned char cipher_text_gold_32_0[16] = {
 static const unsigned char cipher_text_gold_32_1[16] = {
     0x8e, 0xa2, 0xb7, 0xca, 0x51, 0x67, 0x45, 0xbf,
     0xea, 0xfc, 0x49, 0x90, 0x4b, 0x49, 0x60, 0x89};
+
+#endif  // OPENTITAN_HW_IP_AES_MODEL_AES_EXAMPLE_H_

--- a/hw/ip/aes/model/aes_modes.h
+++ b/hw/ip/aes/model/aes_modes.h
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#ifndef OPENTITAN_HW_IP_AES_MODEL_AES_MODES_H_
+#define OPENTITAN_HW_IP_AES_MODEL_AES_MODES_H_
+
 // The examples below are extracted from the NIST Publication SP 800-38A
 // "Recommendation for Block Cipher Modes of Operation: Methods and Techniques"
 // available at https://csrc.nist.gov/publications/detail/sp/800-38a/final .
@@ -171,3 +174,5 @@ static const unsigned char kAesModesCipherTextCtr256[64] = {
     0x09, 0x30, 0xda, 0xa2, 0x3d, 0xe9, 0x4c, 0xe8, 0x70, 0x17, 0xba,
     0x2d, 0x84, 0x98, 0x8d, 0xdf, 0xc9, 0xc5, 0x8d, 0xb6, 0x7a, 0xad,
     0xa6, 0x13, 0xc2, 0xdd, 0x08, 0x45, 0x79, 0x41, 0xa6};
+
+#endif  // OPENTITAN_HW_IP_AES_MODEL_AES_MODES_H_

--- a/hw/ip/hmac/dv/cryptoc_dpi/hash-internal.h
+++ b/hw/ip/hmac/dv/cryptoc_dpi/hash-internal.h
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef SECURITY_UTIL_LITE_HASH_INTERNAL_H__
-#define SECURITY_UTIL_LITE_HASH_INTERNAL_H__
+#ifndef OPENTITAN_HW_IP_HMAC_DV_CRYPTOC_DPI_HASH_INTERNAL_H_
+#define OPENTITAN_HW_IP_HMAC_DV_CRYPTOC_DPI_HASH_INTERNAL_H_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -53,4 +53,4 @@ typedef struct HASH_CTX {
 }
 #endif  // __cplusplus
 
-#endif  // SECURITY_UTIL_LITE_HASH_INTERNAL_H__
+#endif  // OPENTITAN_HW_IP_HMAC_DV_CRYPTOC_DPI_HASH_INTERNAL_H_

--- a/hw/ip/hmac/dv/cryptoc_dpi/hmac.h
+++ b/hw/ip/hmac/dv/cryptoc_dpi/hmac.h
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef SECURITY_UTIL_LITE_HMAC_H__
-#define SECURITY_UTIL_LITE_HMAC_H__
+#ifndef OPENTITAN_HW_IP_HMAC_DV_CRYPTOC_DPI_HMAC_H_
+#define OPENTITAN_HW_IP_HMAC_DV_CRYPTOC_DPI_HMAC_H_
 
 #include <stdint.h>
 
@@ -39,4 +39,4 @@ const uint8_t *HMAC_final(LITE_HMAC_CTX *ctx);
 }
 #endif
 
-#endif  // SECURITY_UTIL_LITE_HMAC_H__
+#endif  // OPENTITAN_HW_IP_HMAC_DV_CRYPTOC_DPI_HMAC_H_

--- a/hw/ip/hmac/dv/cryptoc_dpi/hmac_wrap.h
+++ b/hw/ip/hmac/dv/cryptoc_dpi/hmac_wrap.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef HMAC_WRAP_H__
-#define HMAC_WRAP_H__
+#ifndef OPENTITAN_HW_IP_HMAC_DV_CRYPTOC_DPI_HMAC_WRAP_H_
+#define OPENTITAN_HW_IP_HMAC_DV_CRYPTOC_DPI_HMAC_WRAP_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -23,4 +23,4 @@ const uint8_t *HMAC_SHA256(const void *key, size_t key_len, const void *msg,
 }
 #endif
 
-#endif
+#endif  // OPENTITAN_HW_IP_HMAC_DV_CRYPTOC_DPI_HMAC_WRAP_H_

--- a/hw/ip/hmac/dv/cryptoc_dpi/sha.h
+++ b/hw/ip/hmac/dv/cryptoc_dpi/sha.h
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef SECURITY_UTIL_LITE_SHA_H_
-#define SECURITY_UTIL_LITE_SHA_H_
+#ifndef OPENTITAN_HW_IP_HMAC_DV_CRYPTOC_DPI_SHA_H_
+#define OPENTITAN_HW_IP_HMAC_DV_CRYPTOC_DPI_SHA_H_
 
 #include <stdint.h>
 
@@ -40,4 +40,4 @@ const uint8_t *SHA_hash(const void *data, size_t len, uint8_t *digest);
 }
 #endif  // __cplusplus
 
-#endif  // SECURITY_UTIL_LITE_SHA_H_
+#endif  // OPENTITAN_HW_IP_HMAC_DV_CRYPTOC_DPI_SHA_H_

--- a/hw/ip/hmac/dv/cryptoc_dpi/sha256.h
+++ b/hw/ip/hmac/dv/cryptoc_dpi/sha256.h
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef SECURITY_UTIL_LITE_SHA256_H__
-#define SECURITY_UTIL_LITE_SHA256_H__
+#ifndef OPENTITAN_HW_IP_HMAC_DV_CRYPTOC_DPI_SHA256_H_
+#define OPENTITAN_HW_IP_HMAC_DV_CRYPTOC_DPI_SHA256_H_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -38,4 +38,4 @@ const uint8_t *SHA256_hash(const void *data, size_t len, uint8_t *digest);
 }
 #endif  // __cplusplus
 
-#endif  // SECURITY_UTIL_LITE_SHA256_H__
+#endif  // OPENTITAN_HW_IP_HMAC_DV_CRYPTOC_DPI_SHA256_H_

--- a/hw/ip/hmac/dv/cryptoc_dpi/util.h
+++ b/hw/ip/hmac/dv/cryptoc_dpi/util.h
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef SECURITY_UTIL_LITE_UTIL_H_
-#define SECURITY_UTIL_LITE_UTIL_H_
+#ifndef OPENTITAN_HW_IP_HMAC_DV_CRYPTOC_DPI_UTIL_H_
+#define OPENTITAN_HW_IP_HMAC_DV_CRYPTOC_DPI_UTIL_H_
 
 #include <stddef.h>
 
@@ -20,4 +20,4 @@
  * useful for scrubbing security sensitive buffers. */
 void *always_memset(void *s, int c, size_t n);
 
-#endif  // SECURITY_UTIL_LITE_UTIL_H_
+#endif  // OPENTITAN_HW_IP_HMAC_DV_CRYPTOC_DPI_UTIL_H_

--- a/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/prince_ref.h
+++ b/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/prince_ref.h
@@ -3,6 +3,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#ifndef OPENTITAN_HW_IP_PRIM_DV_PRIM_PRINCE_CRYPTO_DPI_PRINCE_PRINCE_REF_H_
+#define OPENTITAN_HW_IP_PRIM_DV_PRIM_PRINCE_CRYPTO_DPI_PRINCE_PRINCE_REF_H_
+
 /*! \file prince_ref.h
     \brief Reference implementation of the Prince block cipher, complient to
    C99. 'Reference' here means straightforward, unoptimized, and checked against
@@ -31,9 +34,6 @@
  *    - Modification of `prince_core(...)` to handle the new key schedule and
  *      user-specified number of half-rounds.
  */
-
-#ifndef OPENTITAN_HW_IP_PRIM_DV_PRIM_PRINCE_CRYPTO_DPI_PRINCE_PRINCE_REF_H_
-#define OPENTITAN_HW_IP_PRIM_DV_PRIM_PRINCE_CRYPTO_DPI_PRINCE_PRINCE_REF_H_
 
 #include <stdint.h>
 #include <string.h>

--- a/sw/device/benchmarks/coremark/top_earlgrey/core_portme.h
+++ b/sw/device/benchmarks/coremark/top_earlgrey/core_portme.h
@@ -1,5 +1,8 @@
 /* File : core_portme.h */
 
+#ifndef OPENTITAN_SW_DEVICE_BENCHMARKS_COREMARK_TOP_EARLGREY_CORE_PORTME_H_
+#define OPENTITAN_SW_DEVICE_BENCHMARKS_COREMARK_TOP_EARLGREY_CORE_PORTME_H_
+
 /*
         Author : Shay Gal-On, EEMBC
         Legal : TODO!
@@ -8,9 +11,6 @@
         This file contains configuration constants required to execute on
    different platforms
 */
-
-#ifndef OPENTITAN_SW_DEVICE_BENCHMARKS_COREMARK_TOP_EARLGREY_CORE_PORTME_H_
-#define OPENTITAN_SW_DEVICE_BENCHMARKS_COREMARK_TOP_EARLGREY_CORE_PORTME_H_
 
 #include <stddef.h>
 

--- a/sw/device/lib/testing/test_coverage.h
+++ b/sw/device/lib/testing/test_coverage.h
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_COVERAGE_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_COVERAGE_H_
+
 /**
  * Sends the LLVM profile buffer along with its length and CRC32.
  *
@@ -10,3 +13,5 @@
  * reports.
  */
 void test_coverage_send_buffer(void);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_COVERAGE_H_

--- a/sw/device/riscv_compliance_support/support.h
+++ b/sw/device/riscv_compliance_support/support.h
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#ifndef OPENTITAN_SW_DEVICE_RISCV_COMPLIANCE_SUPPORT_SUPPORT_H_
+#define OPENTITAN_SW_DEVICE_RISCV_COMPLIANCE_SUPPORT_SUPPORT_H_
+
 /**
  * @brief OpenTitan-specific wrapper for RISC-V Compliance
  *
@@ -17,3 +20,5 @@
  * Main function for RISC-V Compliance, provided as an out-of-band.
  */
 int opentitan_compliance_main(int argc, char **argv);
+
+#endif  // OPENTITAN_SW_DEVICE_RISCV_COMPLIANCE_SUPPORT_SUPPORT_H_


### PR DESCRIPTION
See also #5693 which fixes headers using #pragma once.

As fix_include_guard.py is run in CI, any future variance from the expected include guard style should be caught prior to commit.