### PR TITLE
[otbn] Track the operation of the idle_o interface

### DIFF
--- a/hw/ip/otbn/doc/dv/index.md
+++ b/hw/ip/otbn/doc/dv/index.md
@@ -116,11 +116,7 @@ Core TLUL protocol assertions are checked by binding the [TL-UL protocol checker
 Outputs are also checked for `'X` values by assertions in the design RTL.
 The design RTL contains other assertions defined by the designers, which will be checked in simulation (and won't have been checked by the pre-DV Verilator simulations).
 
-<div class="bd-callout bd-callout-warning">
-
-**TODO**: Define other SVA checks. A protocol check for the alert interface? Are there any properties that should hold relating interrupt and idle signals?
-
-</div>
+Finally, the `otbn_idle_checker` checks that the `idle_o` output correctly matches the running state that you'd expect, based on writes to the `CMD` register and responses that will appear in the `DONE` interrupt.
 
 ## Building and running tests
 

--- a/hw/ip/otbn/dv/uvm/sva/otbn_bind.sv
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_bind.sv
@@ -13,7 +13,6 @@ module otbn_bind;
     .d2h    (tl_o)
   );
 
-  import otbn_reg_pkg::*;
   bind otbn otbn_csr_assert_fpv csr_checker (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),
@@ -21,6 +20,14 @@ module otbn_bind;
     .d2h    (tl_o),
     .reg2hw (reg2hw),
     .hw2reg (hw2reg)
+  );
+
+  bind otbn otbn_idle_checker idle_checker (
+    .clk_i    (clk_i),
+    .rst_ni   (rst_ni),
+    .reg2hw   (reg2hw),
+    .hw2reg   (hw2reg),
+    .idle_o_i (idle_o)
   );
 
 endmodule

--- a/hw/ip/otbn/dv/uvm/sva/otbn_idle_checker.sv
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_idle_checker.sv
@@ -1,0 +1,52 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+module otbn_idle_checker
+  import otbn_reg_pkg::*;
+(
+  input logic         clk_i,
+  input logic         rst_ni,
+
+  input otbn_reg2hw_t reg2hw,
+  input otbn_hw2reg_t hw2reg,
+
+  input logic         idle_o_i
+);
+
+  // Detect writes of 1 to CMD.START (the "start" bit has been eaten by reggen because the register
+  // only contains the one bit).
+  logic cmd_start;
+  assign cmd_start = reg2hw.cmd.qe & reg2hw.cmd.q;
+
+  // Detect the DONE signal. Note that snooping on intr_state.d and intr_state.de like this will
+  // pick it up irrespective of whether the interrupt is enabled and whether the previous state (in
+  // the 'q' part) was cleared.
+  logic done;
+  assign done = hw2reg.intr_state.de & hw2reg.intr_state.d;
+
+  // Our model of whether OTBN is running or not. We start on cmd_start if we're not already running
+  // and stop on done if we are. Note that the "running" signal includes the cycle that we see
+  // cmd_start
+  logic running_q, running_d;
+  always @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      running_q <= 1'b0;
+    end else begin
+      running_q <= running_d;
+    end
+  end
+  assign running_d = (cmd_start & ~running_q) | (running_q & ~done);
+
+  // We should never see done when we're not already running. (The converse assertion, that we never
+  // see cmd_start when we are running, need not be true: the host can do that if it likes and OTBN
+  // will ignore it).
+  `ASSERT(RunningIfDone_A, done |-> running_q)
+
+  // Check that we've modelled the running/not-running logic correctly. The idle_o pin from OTBN
+  // should be true iff running is false
+  `ASSERT(IdleIfNotRunning_A, idle_o_i ^ running_q)
+
+endmodule

--- a/hw/ip/otbn/dv/uvm/sva/otbn_sva.core
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_sva.core
@@ -7,10 +7,13 @@ description: "OTBN assertion modules and bind file."
 filesets:
   files_dv:
     depend:
-      - lowrisc:tlul:headers
       - lowrisc:fpv:csr_assert_gen
+      - lowrisc:ip:otbn
+      - lowrisc:prim:assert
+      - lowrisc:tlul:headers
     files:
       - otbn_bind.sv
+      - otbn_idle_checker.sv
     file_type: systemVerilogSource
 
   files_formal:

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -82,7 +82,7 @@ module otbn
 
   // TODO: Better define what "idle" means -- only the core, or also the
   // register interface?
-  assign idle_o = ~busy_q & ~start;
+  assign idle_o = ~busy_q;
 
 
   // Interrupts ================================================================


### PR DESCRIPTION
This is possible in the scoreboard, but it's probably easier to just
model with an FSM. Apart from anything else, getting the DONE signal
out with a proper monitor would be rather difficult.

Note that this commit slightly changes the behaviour of idle_o,
removing a combinatorial path from the TL input to idle_o. There
doesn't seem to be any need for it, and it makes the behaviour
slightly easier to describe.