### PR TITLE
[otbn] Tidy up how we call gen-binaries.py from UVM

### DIFF
--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -48,11 +48,7 @@ name:
   sim_tops: ["otbn_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  //
-  // TODO: This is set to one at the moment so things run quickly while we're
-  //       bringing stuff up. It will need a more sensible value when we start
-  //       testing seriously.
-  reseed: 1
+  reseed: 50
 
   // Default UVM test and seq class name.
   uvm_test: otbn_base_test
@@ -82,15 +78,25 @@ name:
 
   gen_binaries: "{proj_root}/hw/ip/otbn/dv/uvm/gen-binaries.py"
   otbn_obj_dir: "{build_dir}/build-out"
+  gen_binary: "{gen_binaries} --count 1 --obj-dir {otbn_obj_dir}"
+
   run_modes: [
     // A run mode that runs the random instruction generator and builds the
-    // resulting binaries in {otbn_elf_dir}. If you override the otbn_elf_dir
-    // plusarg with --run-opts, we'll still build the binaries (but will ignore
-    // them).
+    // one resulting binary in {otbn_elf_dir}. If you override the otbn_elf_dir
+    // plusarg with --run-opts, we'll still build the binary (but will ignore
+    // it).
     {
-      name: build_otbn_rig_binaries_mode
+      name: build_otbn_rig_binary_mode
       pre_run_cmds: [
-        "{gen_binaries} --seed {seed} --obj-dir {otbn_obj_dir} {otbn_elf_dir}"
+        "{gen_binary} --no-smoke --seed {seed} {otbn_elf_dir}"
+      ]
+    }
+
+    // A run mode that builds the smoke test in {otbn_elf_dir}.
+    {
+      name: build_otbn_smoke_binary_mode
+      pre_run_cmds: [
+        "{gen_binary} {otbn_elf_dir}"
       ]
     }
   ]
@@ -100,12 +106,16 @@ name:
     {
       name: "otbn_smoke"
       uvm_test_seq: "otbn_smoke_vseq"
-      en_run_modes: ["build_otbn_rig_binaries_mode"]
+      en_run_modes: ["build_otbn_smoke_binary_mode"]
+      // Run just one smoke test: it's a fixed binary and there's not much
+      // interaction with the environment so there's probably not much point
+      // in running it loads of times.
+      reseed: 1
     }
     {
       name: "otbn_single"
       uvm_test_seq: "otbn_single_vseq"
-      en_run_modes: ["build_otbn_rig_binaries_mode"]
+      en_run_modes: ["build_otbn_rig_binary_mode"]
     }
 
     // TODO: add more tests here


### PR DESCRIPTION
Now we just generate one binary for each test (rather than generating
20 and only using one of them!). Also, we bump up the default reseed
count for otbn_single so that the nightly test has more chance of
seeing things going wrong.

Fixes #5330.