### PR TITLE
[dv/otp_ctrl] Drive lc_escalate_en with rand values

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
@@ -10,6 +10,9 @@ class otp_ctrl_parallel_lc_esc_vseq extends otp_ctrl_dai_errs_vseq;
   `uvm_object_utils(otp_ctrl_parallel_lc_esc_vseq)
 
   `uvm_object_new
+  bit [lc_ctrl_pkg::TxWidth-1:0] lc_esc_on_val;
+
+  constraint lc_esc_on_c {lc_esc_on_val != lc_ctrl_pkg::Off;}
 
   // This sequence will kill super.body sequence once lc_escalate_en is On. Disable these interface
   // requests to avoid sequencer error.

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -84,7 +84,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
         if (i > 1) dut_init();
         // after otp-init done, check status
         cfg.clk_rst_vif.wait_clks(1);
-        if ( cfg.otp_ctrl_vif.lc_escalate_en_i != lc_ctrl_pkg::On) begin
+        if (!cfg.otp_ctrl_vif.lc_esc_on) begin
           csr_rd_check(.ptr(ral.status.dai_idle), .compare_value(1));
         end
       end

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -136,6 +136,12 @@ module tb;
   bind `OTP_CTRL_MEM_HIER mem_bkdr_if #(.MEM_ECC(1)) mem_bkdr_if();
 
   initial begin
+    // these SVA checks the lc_escalate_en is either Off or On, we will use more than these 2 values.
+    // If it's not Off, it should be On
+    $assertoff(0, tb.dut.u_prim_lc_sync_escalate_en.CheckTransients_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_escalate_en.CheckTransients0_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_escalate_en.CheckTransients1_A);
+
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);


### PR DESCRIPTION
This PR drives random value to lc_escalate_en instead of just
lc_ctrl_pkg::On/Off. Note that different from other ports, for this one,
any value that is not a Off is On.

Signed-off-by: Cindy Chen <chencindy@google.com>