### PR TITLE
[prim] Split out PRESENT and PRINCE support from prim:all

### DIFF
--- a/hw/ip/prim/lint/prim.waiver
+++ b/hw/ip/prim/lint/prim.waiver
@@ -24,7 +24,3 @@ waive -rules {HIER_BRANCH_NOT_READ} -location {tlul_fifo_sync.sv} -regexp {Conne
 #
 #waive -rules NOT_READ -location {prim_ram_*_wrapper*} -regexp {(a|b)_rdata_(q|d)\[38} \
 #      -comment "Syndrome is not going out to the interface"
-
-waive -rules {INTEGER} -location {prim_cipher_pkg.sv} -msg {'k' of type int used as a non-constant} \
-      -comment "We need to use the iterator value in the keyschedule function, hence this is ok."
-

--- a/hw/ip/prim/lint/prim_cipher_pkg.waiver
+++ b/hw/ip/prim/lint/prim_cipher_pkg.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_cipher_pkg
+
+waive -rules {INTEGER} -location {prim_cipher_pkg.sv} -msg {'k' of type int used as a non-constant} \
+      -comment "We need to use the iterator value in the keyschedule function, hence this is ok."

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -18,11 +18,11 @@ filesets:
       - lowrisc:prim:buf
       - lowrisc:prim:flop
       - lowrisc:prim:flop_2sync
-      - lowrisc:prim:cipher_pkg:0.1
       - lowrisc:prim:arbiter
       - lowrisc:prim:fifo
       - lowrisc:prim:alert
       - lowrisc:prim:subreg
+      - lowrisc:prim:cipher
     files:
       - rtl/prim_clock_gating_sync.sv
       - rtl/prim_esc_pkg.sv
@@ -36,9 +36,6 @@ filesets:
       - rtl/prim_keccak.sv
       - rtl/prim_packer.sv
       - rtl/prim_packer_fifo.sv
-      - rtl/prim_present.sv
-      - rtl/prim_prince.sv
-      - rtl/prim_subst_perm.sv
       - rtl/prim_gate_gen.sv
       - rtl/prim_pulse_sync.sv
       - rtl/prim_filter.sv

--- a/hw/ip/prim/prim_cipher.core
+++ b/hw/ip/prim/prim_cipher.core
@@ -3,12 +3,17 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: "lowrisc:prim:cipher_pkg:0.1"
-description: "PRINCE and PRESENT block cipher package"
+name: "lowrisc:prim:cipher"
+description: "Lightweight block ciphers (PRINCE and PRESENT)"
 filesets:
   files_rtl:
+    depend:
+      - lowrisc:prim:assert
+      - lowrisc:prim:cipher_pkg:0.1
     files:
-      - rtl/prim_cipher_pkg.sv
+      - rtl/prim_subst_perm.sv
+      - rtl/prim_present.sv
+      - rtl/prim_prince.sv
     file_type: systemVerilogSource
 
   files_verilator_waiver:
@@ -20,9 +25,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      - lint/prim_cipher_pkg.waiver
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:


### PR DESCRIPTION
Also move a waiver that applies to prim:cipher_pkg to the right
package (it was still in prim.waiver, which is only included by
prim:all).
