### PR TITLE
[prim_prince] Annotate some arrays to avoid UNOPTFLAT warnings

### DIFF
--- a/hw/ip/prim/rtl/prim_prince.sv
+++ b/hw/ip/prim/rtl/prim_prince.sv
@@ -105,8 +105,15 @@ module prim_prince #(
   // datapath //
   //////////////
 
-  // state variable for holding the rounds
-  logic [NumRoundsHalf*2+1:0][DataWidth-1:0] data_state;
+  // State variable for holding the rounds
+  //
+  // The "split_var" hint that we pass to verilator here tells it to schedule the different parts of
+  // data_state separately. This avoids an UNOPTFLAT error where it would otherwise see a dependency
+  // chain
+  //
+  //    data_state -> data_state_round -> data_state_xor -> data_state
+  //
+  logic [NumRoundsHalf*2+1:0][DataWidth-1:0] data_state /* verilator split_var */;
 
   // pre-round XOR
   always_comb begin : p_pre_round_xor

--- a/hw/ip/prim/rtl/prim_subst_perm.sv
+++ b/hw/ip/prim/rtl/prim_subst_perm.sv
@@ -23,7 +23,13 @@ module prim_subst_perm #(
   // datapath //
   //////////////
 
-  logic [NumRounds:0][DataWidth-1:0] data_state;
+  // The "split_var" hint that we pass to verilator here tells it to schedule the different parts of
+  // data_state separately. This avoids an UNOPTFLAT error where it would otherwise see a dependency
+  // chain
+  //
+  //    data_state -> data_state_sbox -> data_state
+  //
+  logic [NumRounds:0][DataWidth-1:0] data_state /* verilator split_var */;
 
   // initialize
   assign data_state[0] = data_i;


### PR DESCRIPTION
Verilator's block scheduler isn't particularly clever, and it needs a
bit of hand-holding when you have an array which updates like this:

    foo[0] = 123;
    foo[1] = f(foo[0]);

Without the help, it sees foo depending on itself, which triggers an
UNOPTFLAT warning (and slow simulation!)
