### PR TITLE
[fpv/rv_plic] Fix compile error from auto-gen csr_fpv_assert core file

### DIFF
--- a/hw/ip/rv_plic/data/rv_plic.hjson
+++ b/hw/ip/rv_plic/data/rv_plic.hjson
@@ -10,6 +10,7 @@
 #  - prio:   Max value of interrupt priorities
 {
   name: "RV_PLIC",
+  fusesoc_core_name: "lowrisc:ip:rv_plic_example"
   clock_primary: "clk_i",
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }

--- a/hw/ip/rv_plic/data/rv_plic.hjson.tpl
+++ b/hw/ip/rv_plic/data/rv_plic.hjson.tpl
@@ -11,6 +11,7 @@
 #  - prio:   Max value of interrupt priorities
 {
   name: "RV_PLIC",
+  fusesoc_core_name: "lowrisc:ip:rv_plic_example"
   clock_primary: "clk_i",
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }

--- a/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
+++ b/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
@@ -18,6 +18,7 @@
 #  - prio:   Max value of interrupt priorities
 {
   name: "RV_PLIC",
+  fusesoc_core_name: "lowrisc:ip:rv_plic_example"
   clock_primary: "clk_i",
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }


### PR DESCRIPTION
This PR fixes a fusesoc dependency error from auto-generated
csr_fpv_assertion core file.
In `ip_block.py` we assume all IP core file names are
`lowrisc:ip:{block_name}`. However, for rv_plic, it is called
`lowrisc:ip:rv_plic_example`. So in hjson file, I added the core name to
avoid fusesoc compile error.

Signed-off-by: Cindy Chen <chencindy@google.com>