### PR TITLE
[dv] Update tl_agent and cip_lib for intg check

### DIFF
--- a/hw/dv/sv/bus_params_pkg/bus_params_pkg.sv
+++ b/hw/dv/sv/bus_params_pkg/bus_params_pkg.sv
@@ -46,11 +46,19 @@ package bus_params_pkg;
   parameter int BUS_DIW = top_pkg::TL_DIW;
 `endif
 
-// Set the bus data user width.
+// Set the bus a channel user width.
+`ifdef BUS_AUW
+  parameter int BUS_AUW = `BUS_AUW;
+`else
+  parameter int BUS_AUW = top_pkg::TL_AUW;
+`endif
+
+// Set the bus d channel user width.
 `ifdef BUS_DUW
   parameter int BUS_DUW = `BUS_DUW;
 `else
   parameter int BUS_DUW = top_pkg::TL_DUW;
 `endif
+
 
 endpackage

--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -11,7 +11,7 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
   `uvm_component_param_utils(cip_base_env #(CFG_T, VIRTUAL_SEQUENCER_T, SCOREBOARD_T, COV_T))
 
   tl_agent                                           m_tl_agent;
-  tl_reg_adapter                                     m_tl_reg_adapter;
+  tl_reg_adapter#(cip_tl_seq_item)                   m_tl_reg_adapter;
   alert_esc_agent                                    m_alert_agent[string];
   push_pull_agent#(.DeviceDataWidth(EDN_DATA_WIDTH)) m_edn_pull_agent;
 
@@ -32,7 +32,7 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
 
     // Create & configure the TL agent.
     m_tl_agent = tl_agent::type_id::create("m_tl_agent", this);
-    m_tl_reg_adapter = tl_reg_adapter#()::type_id::create("m_tl_reg_adapter");
+    m_tl_reg_adapter = tl_reg_adapter#(cip_tl_seq_item)::type_id::create("m_tl_reg_adapter");
     m_tl_reg_adapter.cfg = cfg.m_tl_agent_cfg;
     uvm_config_db#(tl_agent_cfg)::set(this, "m_tl_agent*", "cfg", cfg.m_tl_agent_cfg);
     cfg.m_tl_agent_cfg.en_cov = cfg.en_cov;

--- a/hw/dv/sv/cip_lib/cip_base_pkg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_pkg.sv
@@ -10,6 +10,7 @@ package cip_base_pkg;
   import csr_utils_pkg::*;
   import dv_lib_pkg::*;
   import dv_base_reg_pkg::*;
+  import tlul_pkg::*;
   import tl_agent_pkg::*;
   import alert_esc_agent_pkg::*;
   import push_pull_agent_pkg::*;
@@ -30,6 +31,8 @@ package cip_base_pkg;
     err_storage
   } shadow_reg_alert_e;
 
+  typedef class cip_tl_seq_item;
+
   // functions
   // package sources
   // base env
@@ -40,7 +43,7 @@ package cip_base_pkg;
   `include "cip_base_env.sv"
 
   // sequences
-  `include "cip_base_vseq.sv"
+  `include "cip_seq_list.sv"
 
   // tests
   `include "cip_base_test.sv"

--- a/hw/dv/sv/cip_lib/cip_lib.core
+++ b/hw/dv/sv/cip_lib/cip_lib.core
@@ -9,6 +9,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:dv:dv_lib
+      - lowrisc:tlul:headers
       - lowrisc:dv:tl_agent
       - lowrisc:dv:alert_esc_agent
       - lowrisc:dv:push_pull_agent
@@ -23,8 +24,10 @@ filesets:
       - cip_base_virtual_sequencer.sv: {is_include_file: true}
       - cip_base_scoreboard.sv: {is_include_file: true}
       - cip_base_env.sv: {is_include_file: true}
-      - cip_base_vseq.sv: {is_include_file: true}
-      - cip_base_vseq__tl_errors.svh: {is_include_file: true}
+      - seq_lib/cip_seq_list.sv: {is_include_file: true}
+      - seq_lib/cip_base_vseq.sv: {is_include_file: true}
+      - seq_lib/cip_base_vseq__tl_errors.svh: {is_include_file: true}
+      - seq_lib/cip_tl_seq_item.sv: {is_include_file: true}
       - cip_base_test.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -160,7 +160,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
                              tl_sequencer            tl_sequencer_h = p_sequencer.tl_sequencer_h);
     `DV_SPINWAIT(
         // thread to read/write tlul
-        tl_host_single_seq  tl_seq;
+        tl_host_single_seq #(cip_tl_seq_item) tl_seq;
         `uvm_create_on(tl_seq, tl_sequencer_h)
         if (cfg.zero_delays) begin
           tl_seq.min_req_delay = 0;

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -5,7 +5,8 @@
 // Shorthand to create and send a TL error seq
 // Set low priority (1) to send error item to TL agent, so when crossing error item with normal
 // seq, normal seq with default priority (100) has the priority to access TL driver
-`define create_tl_access_error_case(task_name_, with_c_, seq_t_ = tl_host_custom_seq,
+`define create_tl_access_error_case(task_name_, with_c_,
+                                    seq_t_ = tl_host_custom_seq #(cip_tl_seq_item),
                                     seqr_t = p_sequencer.tl_sequencer_h) \
   begin \
     seq_t_ tl_seq; \
@@ -94,7 +95,7 @@ virtual task tl_protocol_err(tl_sequencer tl_sequencer_h = p_sequencer.tl_sequen
   repeat ($urandom_range(10, 100)) begin
     if (cfg.under_reset) return;
     `create_tl_access_error_case(
-        tl_protocol_err, , tl_host_protocol_err_seq, tl_sequencer_h
+        tl_protocol_err, , tl_host_protocol_err_seq #(cip_tl_seq_item), tl_sequencer_h
         )
   end
 endtask

--- a/hw/dv/sv/cip_lib/seq_lib/cip_seq_list.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_seq_list.sv
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// customized tl seq for CIP
+`include "cip_tl_seq_item.sv"
+
+// vseqs
+`include "cip_base_vseq.sv"

--- a/hw/dv/sv/cip_lib/seq_lib/cip_tl_seq_item.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_tl_seq_item.sv
@@ -1,0 +1,63 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// extend tl_seq_item to return a|d_user data with ECC value
+class cip_tl_seq_item extends tl_seq_item;
+
+  `uvm_object_utils_begin(cip_tl_seq_item)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+  function void post_randomize();
+    a_user = get_a_user_val();
+    d_user = get_d_user_val();
+  endfunction
+
+  // calculate ecc value for a_user
+  virtual function tl_a_user_t get_a_user_val();
+    tl_a_user_t user;
+    tl_h2d_cmd_intg_t cmd_intg_payload;
+    logic [H2DCmdFullWidth - 1 : 0] payload_intg;
+    logic [D2HRspFullWidth - 1 : 0] data_intg;
+
+    // construct command integrity
+    cmd_intg_payload.tl_type = DataType;
+    cmd_intg_payload.addr = a_addr;
+    cmd_intg_payload.opcode = tl_a_op_e'(a_opcode);
+    cmd_intg_payload.mask = a_mask;
+    payload_intg = prim_secded_pkg::prim_secded_64_57_enc(H2DCmdMaxWidth'(cmd_intg_payload));
+
+    // construct data integrity
+    data_intg = prim_secded_pkg::prim_secded_64_57_enc(DataMaxWidth'(a_data));
+
+    user.rsvd = '0;
+    user.tl_type = DataType;
+    user.cmd_intg = payload_intg[H2DCmdFullWidth -1 -: H2DCmdIntgWidth];
+    user.data_intg = data_intg[DataFullWidth -1 -: DataIntgWidth];;
+    return user;
+  endfunction // get_a_user_val
+
+  // device facing version of the function above
+  virtual function tl_d_user_t get_d_user_val();
+    tl_d_user_t user;
+    tl_d2h_rsp_intg_t rsp_intg_payload;
+    logic [D2HRspFullWidth - 1:0] payload_intg;
+    logic [D2HRspFullWidth - 1:0] data_intg;
+
+    // construct response integrity
+    rsp_intg_payload.opcode = tl_d_op_e'(d_opcode);
+    rsp_intg_payload.size = d_size;
+    rsp_intg_payload.error = d_error;
+    payload_intg = prim_secded_pkg::prim_secded_64_57_enc(D2HRspMaxWidth'(rsp_intg_payload));
+
+    // construct data integrity
+    data_intg = prim_secded_pkg::prim_secded_64_57_enc(DataMaxWidth'(d_data));
+
+    user.rsp_intg = payload_intg[D2HRspFullWidth -1 -: D2HRspIntgWidth];
+    user.data_intg = data_intg[DataFullWidth -1 -: DataIntgWidth];
+    return user;
+  endfunction // get_d_user_val
+
+endclass

--- a/hw/dv/sv/tl_agent/seq_lib/tl_host_base_seq.sv
+++ b/hw/dv/sv/tl_agent/seq_lib/tl_host_base_seq.sv
@@ -30,9 +30,10 @@
 // 3. Provide ability to override and "fix" the a_source to a particular value.
 // This is done to satisfy the use case where the TL host sends ALL requests with the same source
 // ID.
-class tl_host_base_seq extends dv_base_seq #(.REQ        (tl_seq_item),
-                                             .CFG_T      (tl_agent_cfg),
-                                             .SEQUENCER_T(tl_sequencer));
+class tl_host_base_seq #(type REQ_T = tl_seq_item) extends dv_base_seq #(
+    .REQ        (REQ_T),
+    .CFG_T      (tl_agent_cfg),
+    .SEQUENCER_T(tl_sequencer));
 
   // The knob below allows the user to fix a_source in the reqs from a higher level sequence. It is
   // the responsibility of the higher level sequence to ensure that the overridden_a_source_val is
@@ -41,7 +42,7 @@ class tl_host_base_seq extends dv_base_seq #(.REQ        (tl_seq_item),
   bit override_a_source_val = 0;
   bit [SourceWidth-1:0] overridden_a_source_val;
 
-  `uvm_object_utils_begin(tl_host_base_seq)
+  `uvm_object_param_utils_begin(tl_host_base_seq #(REQ_T))
     `uvm_field_int(override_a_source_val, UVM_DEFAULT | UVM_NOCOMPARE | UVM_NOPACK)
     `uvm_field_int(overridden_a_source_val, UVM_DEFAULT | UVM_NOCOMPARE | UVM_NOPACK)
   `uvm_object_utils_end
@@ -60,7 +61,7 @@ class tl_host_base_seq extends dv_base_seq #(.REQ        (tl_seq_item),
 
   // Overrides the base class implementation to late randomize / set a_source.
   virtual task finish_item(uvm_sequence_item item, int set_priority = -1);
-    tl_seq_item req;
+    REQ req;
 
     `downcast(req, item)
     if (cfg == null) get_cfg(req);
@@ -76,7 +77,7 @@ class tl_host_base_seq extends dv_base_seq #(.REQ        (tl_seq_item),
 
   // Called after the rsp is received.
   virtual task get_base_response(output uvm_sequence_item response, input int transaction_id = -1);
-    tl_seq_item rsp;
+    REQ rsp;
     super.get_base_response(response, transaction_id);
     `downcast(rsp, response)
     if (cfg == null) get_cfg(rsp);

--- a/hw/dv/sv/tl_agent/seq_lib/tl_host_custom_seq.sv
+++ b/hw/dv/sv/tl_agent/seq_lib/tl_host_custom_seq.sv
@@ -4,9 +4,9 @@
 
 // Disable TL protocol related constraint on a_chan to create a fully customized tl_item for error
 // cases
-class tl_host_custom_seq extends tl_host_single_seq;
+class tl_host_custom_seq #(type REQ_T = tl_seq_item) extends tl_host_single_seq #(REQ_T);
 
-  `uvm_object_utils(tl_host_custom_seq)
+  `uvm_object_param_utils(tl_host_custom_seq #(REQ_T))
   `uvm_object_new
 
   virtual function void randomize_req(REQ req, int idx);

--- a/hw/dv/sv/tl_agent/seq_lib/tl_host_protocol_err_seq.sv
+++ b/hw/dv/sv/tl_agent/seq_lib/tl_host_protocol_err_seq.sv
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // This seq will send an item that triggers d_error due to protocol violation
-class tl_host_protocol_err_seq extends tl_host_single_seq;
+class tl_host_protocol_err_seq #(type REQ_T = tl_seq_item) extends tl_host_single_seq #(REQ_T);
 
-  `uvm_object_utils(tl_host_protocol_err_seq)
+  `uvm_object_param_utils(tl_host_protocol_err_seq #(REQ_T))
   `uvm_object_new
 
   // forever randomize the item until we find one that violates the TL protocol

--- a/hw/dv/sv/tl_agent/seq_lib/tl_host_single_seq.sv
+++ b/hw/dv/sv/tl_agent/seq_lib/tl_host_single_seq.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Extend host seq to send single specific item constructed by the caller
-class tl_host_single_seq extends tl_host_seq;
+class tl_host_single_seq #(type REQ_T = tl_seq_item) extends tl_host_seq #(REQ_T);
     rand bit                    write;
     rand bit [AddrWidth-1:0]    addr;
     rand bit [OpcodeWidth-1:0]  opcode;
@@ -19,12 +19,12 @@ class tl_host_single_seq extends tl_host_seq;
     bit control_rand_source    = 0;
     bit control_rand_opcode    = 0;
 
-  `uvm_object_utils(tl_host_single_seq)
+  `uvm_object_param_utils(tl_host_single_seq #(REQ_T))
   `uvm_object_new
 
   constraint req_cnt_eq_1_c { req_cnt == 1; }
 
-  virtual function void randomize_req(tl_seq_item req, int idx);
+  virtual function void randomize_req(REQ req, int idx);
     if (!(req.randomize() with {
         a_valid_delay inside {[min_req_delay:max_req_delay]};
         a_data == data;

--- a/hw/dv/sv/tl_agent/tl_agent_pkg.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_pkg.sv
@@ -21,6 +21,7 @@ package tl_agent_pkg;
   parameter int SizeWidth   = bus_params_pkg::BUS_SZW;
   parameter int MaskWidth   = bus_params_pkg::BUS_DBW;
   parameter int SourceWidth = bus_params_pkg::BUS_AIW;
+  parameter int AUserWidth  = bus_params_pkg::BUS_AUW;
   parameter int DUserWidth  = bus_params_pkg::BUS_DUW;
   parameter int OpcodeWidth = 3;
 

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -107,7 +107,7 @@ class tl_host_driver extends tl_base_driver;
         cfg.vif.host_cb.h2d_int.a_param   <= req.a_param;
         cfg.vif.host_cb.h2d_int.a_data    <= req.a_data;
         cfg.vif.host_cb.h2d_int.a_mask    <= req.a_mask;
-        cfg.vif.host_cb.h2d_int.a_user    <= req.get_a_user_val();
+        cfg.vif.host_cb.h2d_int.a_user    <= req.a_user;
         cfg.vif.host_cb.h2d_int.a_source  <= req.a_source;
         cfg.vif.host_cb.h2d_int.a_valid   <= 1'b1;
       end else begin

--- a/hw/dv/sv/tl_agent/tl_reg_adapter.sv
+++ b/hw/dv/sv/tl_agent/tl_reg_adapter.sv
@@ -18,7 +18,7 @@ class tl_reg_adapter #(type ITEM_T = tl_seq_item) extends uvm_reg_adapter;
   function new(string name = "tl_reg_adapter");
     super.new(name);
     // Force the uvm_reg_map to use this sequence to sync with the driver instead.
-    parent_sequence = tl_host_base_seq::type_id::create("m_tl_host_base_seq");
+    parent_sequence = tl_host_base_seq#(ITEM_T)::type_id::create("m_tl_host_base_seq");
     supports_byte_enable = 1;
     provides_responses = 1;
   endfunction : new

--- a/hw/ip/tlul/generic_dv/env/seq_lib/xbar_base_vseq.sv
+++ b/hw/ip/tlul/generic_dv/env/seq_lib/xbar_base_vseq.sv
@@ -60,7 +60,7 @@ class xbar_base_vseq extends dv_base_vseq #(.CFG_T               (xbar_env_cfg),
       end
     end
     foreach (device_seq[i]) begin
-      device_seq[i] = tl_device_seq::type_id::create(
+      device_seq[i] = tl_device_seq#()::type_id::create(
                       $sformatf("%0s_seq", xbar_devices[i].device_name));
       device_seq[i].d_error_pct = $urandom_range(0, 70);
     end

--- a/hw/top_earlgrey/rtl/top_pkg.sv
+++ b/hw/top_earlgrey/rtl/top_pkg.sv
@@ -9,7 +9,8 @@ localparam int TL_AW=32;
 localparam int TL_DW=32;    // = TL_DBW * 8; TL_DBW must be a power-of-two
 localparam int TL_AIW=8;    // a_source, d_source
 localparam int TL_DIW=1;    // d_sink
-localparam int TL_DUW=16;   // d_user
+localparam int TL_AUW=21;   // a_user
+localparam int TL_DUW=14;   // d_user
 localparam int TL_DBW=(TL_DW>>3);
 localparam int TL_SZW=$clog2($clog2(TL_DBW)+1);
 localparam int NUM_AST_ALERTS=7;


### PR DESCRIPTION
1. update tl seq to be able to parameterize seq item
2. add cip_tl_seq_item which generates a/d_user with ecc
3. update cip_lib to use cip_tl_seq_item

In next PR, will add error ECC support. In this PR, it only generates correct ECC

Signed-off-by: Weicai Yang <weicai@google.com>