### PR TITLE
[dv] Update driver to process item at active edge for 1st item

### DIFF
--- a/hw/dv/sv/push_pull_agent/push_pull_host_driver.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_host_driver.sv
@@ -29,6 +29,7 @@ class push_pull_host_driver #(parameter int HostDataWidth = 32,
   virtual task get_and_drive();
     // wait for the initial reset to pass
     @(posedge cfg.vif.rst_n);
+    cfg.vif.wait_clks(1);
     forever begin
       seq_item_port.try_next_item(req);
       if (req != null) begin

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -16,8 +16,8 @@ class tl_host_driver extends tl_base_driver;
 
   virtual task get_and_drive();
     // Wait for initial reset to pass.
-    wait(cfg.vif.rst_n === 1'b0);
     wait(cfg.vif.rst_n === 1'b1);
+    @(cfg.vif.host_cb);
     fork
       begin : process_seq_item
         forever begin


### PR DESCRIPTION
address #5713
Driver should process items at active edge. For 1st item, we didn't wait
for clock edge

Signed-off-by: Weicai Yang <weicai@google.com>