### PR TITLE
[entropy_src/rtl] sha3 block added as conditioner

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -172,7 +172,7 @@
                    The number in this register represents how many clocks there are between
                    each newLFSR value generation.
                 '''
-          resval: "0x00000008"
+          resval: "0x00000004"
         }
       ]
     },
@@ -221,9 +221,9 @@
           name: "FIPS_WINDOW",
           desc: '''This is the window size for all health tests. This value is used in normal mode
                    when entropy is being tested in FIPS/CC compliance mode.
-                   The default value is (1024 bits * 1 clock/4 bits);
+                   The default value is (2048 bits * 1 clock/4 bits);
                 '''
-          resval: "0x0100"
+          resval: "0x0200"
         }
         { bits: "31:16",
           name: "BYPASS_WINDOW",
@@ -979,6 +979,26 @@
         { bits: "2:0",
           name: "ENTROPY_FIFO_DEPTH",
           desc: "This is the depth of the entropy source FIFO."
+        }
+        { bits: "5:3",
+          name: "SHA3_FSM",
+          desc: "This is the SHA3 finite state machine current state."
+        }
+        { bits: "6",
+          name: "SHA3_BLOCK_PR",
+          desc: "This is the SHA3 block processed signal current state."
+        }
+        { bits: "7",
+          name: "SHA3_SQUEEZING",
+          desc: "This is the SHA3 squeezing signal current state."
+        }
+        { bits: "8",
+          name: "SHA3_ABSORBED",
+          desc: "This is the SHA3 absorbed signal current state."
+        }
+        { bits: "9",
+          name: "SHA3_ERR",
+          desc: "This is a logic-or of all of the SHA3 error signals."
         }
         { bits: "31",
           name: "DIAG",

--- a/hw/ip/entropy_src/doc/_index.md
+++ b/hw/ip/entropy_src/doc/_index.md
@@ -47,7 +47,7 @@ These tests include:
 - Optional Vendor Specific tests, which allow silicon creators to extend the health checks by adding a top-level block external to this IP.
 
 The Repetition Count and Adaptive Proportion test are specifically recommended by SP 800-90B, and are implemented in accordance with those recommendations.
-In FIPS/CC-compliance mode, all checks except the Repetition Count test are performed on fixed window of data, typically consisting of 1024 bits each.
+In FIPS/CC-compliance mode, all checks except the Repetition Count test are performed on fixed window of data, typically consisting of 2048 bits each.
 Per the definition in SP 800-90B, the Repetition Count test does not operate on a fixed window.
 The repetition count test fails if any sequence of bits continuously asserts the same value for too many samples, as determined by the programmable threshold, regardless of whether that sequence crosses any window boundaries.
 The thresholds for these tests should be chosen to achieve a low false-positive rate (&alpha;) given a conservative estimate of the manufacturing tolerances of the PTRNG noise source.
@@ -55,7 +55,7 @@ The combined choice of threshold and window size then determine the false-negati
 
 When the IP is disabled by clearing the `ENABLE` bit in {{< regref "CONF" >}}, all heath checks are disabled and all counters internal to the health checks are reset.
 
-In order to compensate for the fact our tests (like *all* realistic statistical tests) have finite resolution for detecting defects, we conservatively use 1024 bits of PTRNG noise source to construct each 384 bit conditioned entropy sample.
+In order to compensate for the fact our tests (like *all* realistic statistical tests) have finite resolution for detecting defects, we conservatively use 2048 bits of PTRNG noise source to construct each 384 bit conditioned entropy sample.
 When passed through the conditioning block, the resultant entropy stream will be full entropy unless the PTRNG noise source has encountered some statistical defect serious enough to reduce the raw min-entropy to a level below 0.375 bits of entropy per output bit.
 We choose this level as our definition of "non-tolerable statistical defects" for the purposes of evaluating this system under AIS31.
 Given this definition of "non-tolerable defects", the health-checks as implemented for this block will almost certainly detect any of the previously mentioned defects in a single iteration of the health checks (i.e. such serious defects will be detected with very low &beta;).
@@ -106,14 +106,14 @@ After the block is enabled and initialized, entropy bits will be collected up in
 
 After a reset, the ENTROPY_SRC block will start up in boot-time mode by default.
 This feature is designed to provide an initial seed's worth of entropy with lower latency than the normal FIPS/CC compliant health check process.
-Health testing will still be performed on boot-time mode entropy, but the window of checking is, by default, 384 bits instead of 1024 bits.
+Health testing will still be performed on boot-time mode entropy, but the window of checking is, by default, 384 bits instead of 2048 bits.
 When entropy is delivered to the downstream hardware block, a signal will indicate what type of entropy it is - FIPS compliant or not.
 Boot-time mode can be completely disabled in the {{< regref "CONF" >}} register.
 
 Once the initial boot-time mode phase has completed, the ENTROPY_SRC block will switch to FIPS compliant mode.
 In this mode, once the raw entropy has been health checked, it will be passed into a conditioner block.
 This block will compress the bits such that the entropy bits/physical bits, or min-entropy value, should be improved over the raw data source min-entropy value.
-The compression operation, by default, will compress every 1024 tested bits into 384 full-entropy bits.
+The compression operation, by default, will compress every 2048 tested bits into 384 full-entropy bits.
 
 The hardware conditioning can also be bypassed and replaced in normal operation with a firmware-defined conditioning algorithm.
 This firmware conditioning algorithm, can be disabled on boot for security purposes.

--- a/hw/ip/entropy_src/entropy_src.core
+++ b/hw/ip/entropy_src/entropy_src.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:prim:lfsr
       - lowrisc:ip:tlul
+      - lowrisc:ip:sha3
       - lowrisc:ip:entropy_src_pkg
     files:
       - rtl/entropy_src_reg_pkg.sv

--- a/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
@@ -13,48 +13,53 @@ module entropy_src_main_sm (
   input logic                enable_i,
   input logic                ht_done_pulse_i,
   input logic                ht_fail_pulse_i,
-  input logic                postht_not_empty_i,
   output logic               rst_alert_cntr_o,
   input logic                bypass_mode_i,
   output logic               rst_bypass_mode_o,
   input logic                main_stage_rdy_i,
   input logic                bypass_stage_rdy_i,
+  input logic                sha3_state_vld_i,
   output logic               main_stage_pop_o,
   output logic               bypass_stage_pop_o,
+  output logic               sha3_start_o,
+  output logic               sha3_process_o,
+  output logic               sha3_done_o,
   output logic               main_sm_err_o
 );
 
 // Encoding generated with:
-// $ ./util/design/sparse-fsm-encode.py -d 3 -m 7 -n 8 \
-//      -s 373118154 --language=sv
+// $ ./util/design/sparse-fsm-encode.py -d 3 -m 9 -n 8 \
+//      -s 3744885553 --language=sv
 //
 // Hamming distance histogram:
 //
 //  0: --
 //  1: --
 //  2: --
-//  3: |||||||||||||||||||| (42.86%)
-//  4: ||||||||||||||| (33.33%)
-//  5: |||| (9.52%)
-//  6: |||| (9.52%)
-//  7: || (4.76%)
+//  3: |||||||||||||||||| (25.00%)
+//  4: |||||||||||||||||||| (27.78%)
+//  5: |||||||||||||||||||| (27.78%)
+//  6: |||||||||||| (16.67%)
+//  7: || (2.78%)
 //  8: --
 //
 // Minimum Hamming distance: 3
 // Maximum Hamming distance: 7
-// Minimum Hamming weight: 2
+// Minimum Hamming weight: 3
 // Maximum Hamming weight: 6
 //
 
   localparam int StateWidth = 8;
   typedef enum logic [StateWidth-1:0] {
-    Idle              = 8'b01100010, // idle
-    HealthTestDone    = 8'b00011101, // wait for health test done pulse
-    PostHealthTestChk = 8'b01001100, // wait for post health test packer not empty state
-    FlowModeChk       = 8'b01110111, // determine what mode the flow is in
-    BypassMode        = 8'b11011001, // in bypass mode
-    NormalMode        = 8'b00000111, // in normal mode
-    Error             = 8'b01000001  // illegal state reached and hang
+    Idle              = 8'b10111100, // idle
+    BootHTRunning     = 8'b11100101, // boot mode, wait for health test done pulse
+    BootPostHTChk     = 8'b10011010, // boot mode, wait for post health test packer not empty state
+    NormHTStart       = 8'b00010011, // normal mode, pulse the sha3 start input
+    NormHTRunning     = 8'b11001001, // normal mode, wait for health test done pulse
+    NormSha3Process   = 8'b11010100, // normal mode, pulse the sha3 process input
+    NormSha3Valid     = 8'b00101101, // normal mode, wait for sha3 valid indication
+    NormSha3Done      = 8'b01111011, // normal mode, capture sha3 result, pulse done input
+    Error             = 8'b01000110  // illegal state reached and hang
   } state_e;
 
   state_e state_d, state_q;
@@ -81,44 +86,65 @@ module entropy_src_main_sm (
     rst_alert_cntr_o = 1'b0;
     main_stage_pop_o = 1'b0;
     bypass_stage_pop_o = 1'b0;
+    sha3_start_o = 1'b0;
+    sha3_process_o = 1'b0;
+    sha3_done_o = 1'b0;
     main_sm_err_o = 1'b0;
     unique case (state_q)
       Idle: begin
         if (enable_i) begin
-          state_d = HealthTestDone;
+          if (bypass_mode_i) begin
+            state_d = BootHTRunning;
+          end else begin
+            state_d = NormHTStart;
+          end
         end
       end
-      HealthTestDone: begin
+      BootHTRunning: begin
         if (ht_done_pulse_i) begin
           if (ht_fail_pulse_i) begin
             state_d = Idle;
           end else begin
-            state_d = PostHealthTestChk;
+            state_d = BootPostHTChk;
           end
         end
       end
-      PostHealthTestChk: begin
-        rst_alert_cntr_o = 1'b1;
-        if (postht_not_empty_i) begin
-          state_d = FlowModeChk;
-        end
-      end
-      FlowModeChk: begin
-        if (bypass_mode_i) begin
-          state_d = BypassMode;
+      BootPostHTChk: begin
+        if (!bypass_stage_rdy_i) begin
         end else begin
-          state_d = NormalMode;
-        end
-      end
-      BypassMode: begin
-        if (bypass_stage_rdy_i) begin
+          rst_alert_cntr_o = 1'b1;
           rst_bypass_mode_o = 1'b1;
           bypass_stage_pop_o = 1'b1;
           state_d = Idle;
         end
       end
-      NormalMode: begin
+      NormHTStart: begin
+        sha3_start_o = 1'b1;
+        state_d = NormHTRunning;
+      end
+      NormHTRunning: begin
+        if (ht_done_pulse_i) begin
+          if (ht_fail_pulse_i) begin
+            sha3_done_o = 1'b1;
+            state_d = Idle;
+          end else begin
+            state_d = NormSha3Process;
+          end
+        end
+      end
+      NormSha3Process: begin
+        rst_alert_cntr_o = 1'b1;
+        sha3_process_o = 1'b1;
+        state_d = NormSha3Valid;
+      end
+      NormSha3Valid: begin
+        if (sha3_state_vld_i) begin
+          state_d = NormSha3Done;
+        end
+      end
+      NormSha3Done: begin
         if (main_stage_rdy_i) begin
+          sha3_done_o = 1'b1;
           main_stage_pop_o = 1'b1;
           state_d = Idle;
         end

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -498,6 +498,21 @@ package entropy_src_reg_pkg;
       logic [2:0]  d;
     } entropy_fifo_depth;
     struct packed {
+      logic [2:0]  d;
+    } sha3_fsm;
+    struct packed {
+      logic        d;
+    } sha3_block_pr;
+    struct packed {
+      logic        d;
+    } sha3_squeezing;
+    struct packed {
+      logic        d;
+    } sha3_absorbed;
+    struct packed {
+      logic        d;
+    } sha3_err;
+    struct packed {
       logic        d;
     } diag;
   } entropy_src_hw2reg_debug_status_reg_t;
@@ -568,37 +583,37 @@ package entropy_src_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    entropy_src_hw2reg_intr_state_reg_t intr_state; // [900:895]
-    entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [894:863]
-    entropy_src_hw2reg_repcnt_thresholds_reg_t repcnt_thresholds; // [862:831]
-    entropy_src_hw2reg_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [830:799]
-    entropy_src_hw2reg_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [798:767]
-    entropy_src_hw2reg_bucket_thresholds_reg_t bucket_thresholds; // [766:735]
-    entropy_src_hw2reg_markov_hi_thresholds_reg_t markov_hi_thresholds; // [734:703]
-    entropy_src_hw2reg_markov_lo_thresholds_reg_t markov_lo_thresholds; // [702:671]
-    entropy_src_hw2reg_extht_hi_thresholds_reg_t extht_hi_thresholds; // [670:639]
-    entropy_src_hw2reg_extht_lo_thresholds_reg_t extht_lo_thresholds; // [638:607]
-    entropy_src_hw2reg_repcnt_hi_watermarks_reg_t repcnt_hi_watermarks; // [606:575]
-    entropy_src_hw2reg_adaptp_hi_watermarks_reg_t adaptp_hi_watermarks; // [574:543]
-    entropy_src_hw2reg_adaptp_lo_watermarks_reg_t adaptp_lo_watermarks; // [542:511]
-    entropy_src_hw2reg_extht_hi_watermarks_reg_t extht_hi_watermarks; // [510:479]
-    entropy_src_hw2reg_extht_lo_watermarks_reg_t extht_lo_watermarks; // [478:447]
-    entropy_src_hw2reg_bucket_hi_watermarks_reg_t bucket_hi_watermarks; // [446:415]
-    entropy_src_hw2reg_markov_hi_watermarks_reg_t markov_hi_watermarks; // [414:383]
-    entropy_src_hw2reg_markov_lo_watermarks_reg_t markov_lo_watermarks; // [382:351]
-    entropy_src_hw2reg_repcnt_total_fails_reg_t repcnt_total_fails; // [350:319]
-    entropy_src_hw2reg_adaptp_hi_total_fails_reg_t adaptp_hi_total_fails; // [318:287]
-    entropy_src_hw2reg_adaptp_lo_total_fails_reg_t adaptp_lo_total_fails; // [286:255]
-    entropy_src_hw2reg_bucket_total_fails_reg_t bucket_total_fails; // [254:223]
-    entropy_src_hw2reg_markov_hi_total_fails_reg_t markov_hi_total_fails; // [222:191]
-    entropy_src_hw2reg_markov_lo_total_fails_reg_t markov_lo_total_fails; // [190:159]
-    entropy_src_hw2reg_extht_hi_total_fails_reg_t extht_hi_total_fails; // [158:127]
-    entropy_src_hw2reg_extht_lo_total_fails_reg_t extht_lo_total_fails; // [126:95]
-    entropy_src_hw2reg_alert_fail_counts_reg_t alert_fail_counts; // [94:67]
-    entropy_src_hw2reg_extht_fail_counts_reg_t extht_fail_counts; // [66:59]
-    entropy_src_hw2reg_fw_ov_rd_data_reg_t fw_ov_rd_data; // [58:27]
-    entropy_src_hw2reg_fw_ov_fifo_sts_reg_t fw_ov_fifo_sts; // [26:20]
-    entropy_src_hw2reg_debug_status_reg_t debug_status; // [19:16]
+    entropy_src_hw2reg_intr_state_reg_t intr_state; // [907:902]
+    entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [901:870]
+    entropy_src_hw2reg_repcnt_thresholds_reg_t repcnt_thresholds; // [869:838]
+    entropy_src_hw2reg_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [837:806]
+    entropy_src_hw2reg_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [805:774]
+    entropy_src_hw2reg_bucket_thresholds_reg_t bucket_thresholds; // [773:742]
+    entropy_src_hw2reg_markov_hi_thresholds_reg_t markov_hi_thresholds; // [741:710]
+    entropy_src_hw2reg_markov_lo_thresholds_reg_t markov_lo_thresholds; // [709:678]
+    entropy_src_hw2reg_extht_hi_thresholds_reg_t extht_hi_thresholds; // [677:646]
+    entropy_src_hw2reg_extht_lo_thresholds_reg_t extht_lo_thresholds; // [645:614]
+    entropy_src_hw2reg_repcnt_hi_watermarks_reg_t repcnt_hi_watermarks; // [613:582]
+    entropy_src_hw2reg_adaptp_hi_watermarks_reg_t adaptp_hi_watermarks; // [581:550]
+    entropy_src_hw2reg_adaptp_lo_watermarks_reg_t adaptp_lo_watermarks; // [549:518]
+    entropy_src_hw2reg_extht_hi_watermarks_reg_t extht_hi_watermarks; // [517:486]
+    entropy_src_hw2reg_extht_lo_watermarks_reg_t extht_lo_watermarks; // [485:454]
+    entropy_src_hw2reg_bucket_hi_watermarks_reg_t bucket_hi_watermarks; // [453:422]
+    entropy_src_hw2reg_markov_hi_watermarks_reg_t markov_hi_watermarks; // [421:390]
+    entropy_src_hw2reg_markov_lo_watermarks_reg_t markov_lo_watermarks; // [389:358]
+    entropy_src_hw2reg_repcnt_total_fails_reg_t repcnt_total_fails; // [357:326]
+    entropy_src_hw2reg_adaptp_hi_total_fails_reg_t adaptp_hi_total_fails; // [325:294]
+    entropy_src_hw2reg_adaptp_lo_total_fails_reg_t adaptp_lo_total_fails; // [293:262]
+    entropy_src_hw2reg_bucket_total_fails_reg_t bucket_total_fails; // [261:230]
+    entropy_src_hw2reg_markov_hi_total_fails_reg_t markov_hi_total_fails; // [229:198]
+    entropy_src_hw2reg_markov_lo_total_fails_reg_t markov_lo_total_fails; // [197:166]
+    entropy_src_hw2reg_extht_hi_total_fails_reg_t extht_hi_total_fails; // [165:134]
+    entropy_src_hw2reg_extht_lo_total_fails_reg_t extht_lo_total_fails; // [133:102]
+    entropy_src_hw2reg_alert_fail_counts_reg_t alert_fail_counts; // [101:74]
+    entropy_src_hw2reg_extht_fail_counts_reg_t extht_fail_counts; // [73:66]
+    entropy_src_hw2reg_fw_ov_rd_data_reg_t fw_ov_rd_data; // [65:34]
+    entropy_src_hw2reg_fw_ov_fifo_sts_reg_t fw_ov_fifo_sts; // [33:27]
+    entropy_src_hw2reg_debug_status_reg_t debug_status; // [26:16]
     entropy_src_hw2reg_err_code_reg_t err_code; // [15:0]
   } entropy_src_hw2reg_t;
 

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -334,6 +334,16 @@ module entropy_src_reg_top (
   logic pre_cond_fifo_depth_we;
   logic [2:0] debug_status_entropy_fifo_depth_qs;
   logic debug_status_entropy_fifo_depth_re;
+  logic [2:0] debug_status_sha3_fsm_qs;
+  logic debug_status_sha3_fsm_re;
+  logic debug_status_sha3_block_pr_qs;
+  logic debug_status_sha3_block_pr_re;
+  logic debug_status_sha3_squeezing_qs;
+  logic debug_status_sha3_squeezing_re;
+  logic debug_status_sha3_absorbed_qs;
+  logic debug_status_sha3_absorbed_re;
+  logic debug_status_sha3_err_qs;
+  logic debug_status_sha3_err_re;
   logic debug_status_diag_qs;
   logic debug_status_diag_re;
   logic [3:0] seed_qs;
@@ -902,7 +912,7 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h8)
+    .RESVAL  (16'h4)
   ) u_rate (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -1000,7 +1010,7 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h100)
+    .RESVAL  (16'h200)
   ) u_health_test_windows_fips_window (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -2042,6 +2052,81 @@ module entropy_src_reg_top (
   );
 
 
+  //   F[sha3_fsm]: 5:3
+  prim_subreg_ext #(
+    .DW    (3)
+  ) u_debug_status_sha3_fsm (
+    .re     (debug_status_sha3_fsm_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.debug_status.sha3_fsm.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (debug_status_sha3_fsm_qs)
+  );
+
+
+  //   F[sha3_block_pr]: 6:6
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_debug_status_sha3_block_pr (
+    .re     (debug_status_sha3_block_pr_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.debug_status.sha3_block_pr.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (debug_status_sha3_block_pr_qs)
+  );
+
+
+  //   F[sha3_squeezing]: 7:7
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_debug_status_sha3_squeezing (
+    .re     (debug_status_sha3_squeezing_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.debug_status.sha3_squeezing.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (debug_status_sha3_squeezing_qs)
+  );
+
+
+  //   F[sha3_absorbed]: 8:8
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_debug_status_sha3_absorbed (
+    .re     (debug_status_sha3_absorbed_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.debug_status.sha3_absorbed.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (debug_status_sha3_absorbed_qs)
+  );
+
+
+  //   F[sha3_err]: 9:9
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_debug_status_sha3_err (
+    .re     (debug_status_sha3_err_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.debug_status.sha3_err.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (debug_status_sha3_err_qs)
+  );
+
+
   //   F[diag]: 31:31
   prim_subreg_ext #(
     .DW    (1)
@@ -2658,6 +2743,16 @@ module entropy_src_reg_top (
 
   assign debug_status_entropy_fifo_depth_re = addr_hit[43] & reg_re & !reg_error;
 
+  assign debug_status_sha3_fsm_re = addr_hit[43] & reg_re & !reg_error;
+
+  assign debug_status_sha3_block_pr_re = addr_hit[43] & reg_re & !reg_error;
+
+  assign debug_status_sha3_squeezing_re = addr_hit[43] & reg_re & !reg_error;
+
+  assign debug_status_sha3_absorbed_re = addr_hit[43] & reg_re & !reg_error;
+
+  assign debug_status_sha3_err_re = addr_hit[43] & reg_re & !reg_error;
+
   assign debug_status_diag_re = addr_hit[43] & reg_re & !reg_error;
 
   assign seed_we = addr_hit[44] & reg_we & !reg_error;
@@ -2889,6 +2984,11 @@ module entropy_src_reg_top (
 
       addr_hit[43]: begin
         reg_rdata_next[2:0] = debug_status_entropy_fifo_depth_qs;
+        reg_rdata_next[5:3] = debug_status_sha3_fsm_qs;
+        reg_rdata_next[6] = debug_status_sha3_block_pr_qs;
+        reg_rdata_next[7] = debug_status_sha3_squeezing_qs;
+        reg_rdata_next[8] = debug_status_sha3_absorbed_qs;
+        reg_rdata_next[9] = debug_status_sha3_err_qs;
         reg_rdata_next[31] = debug_status_diag_qs;
       end
 


### PR DESCRIPTION
Replacing the placeholder FIFO with the kmac sha3 module.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>

[entropy_src/rtl] sha3 block conditioner

