### PR TITLE
[dv] Fix mem test hang

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/cip_base_vseq.sv
@@ -821,7 +821,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
     end
 
     num_accesses = num_accesses * num_times;
-    while (num_accesses) begin
+    while (num_accesses && !cfg.under_reset) begin
       fork
         begin
           bit [BUS_AW-1:0]  addr;


### PR DESCRIPTION
Recently I updated to count N access of read for mem test, but read only
occurs after at least a mem address is written. If reset occurs before any write,
it will forever sending read access, which creates a deadloop

This fixes the failure in hmac_csr_mem_rw_with_rand_reset 
Signed-off-by: Weicai Yang <weicai@google.com>