### PR TITLE
[dv/otp_ctrl] Fix typo in otp_ctrl_env_pkg

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -182,7 +182,7 @@ package otp_ctrl_env_pkg;
 
   function automatic bit is_sw_part(bit [TL_DW-1:0] addr);
     int part_idx = get_part_index(addr);
-    if (part_idx inside {CreatorSwCfgDigestOffset, OwnerSwCfgDigestOffset}) return 1;
+    if (part_idx inside {CreatorSwCfgIdx, OwnerSwCfgIdx}) return 1;
     else return 0;
   endfunction
 


### PR DESCRIPTION
Cov shows otp_ctrl did not access memory blocks, the reason was due to a
typo in env_pkg file.
The variable `part_idx` already converted address to partition index, so
we should use index here instead of actual address offset.

Signed-off-by: Cindy Chen <chencindy@google.com>