### PR TITLE
[dv/otp_ctrl] test_access sequence

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -157,7 +157,7 @@
             - If error is unrecoverable, ensure that OTP entered terminal state
             '''
       milestone: V2
-      tests: []
+      tests: ["otp_ctrl_parallel_lc_esc", "otp_ctrl_check_fail"]
     }
     {
       name: test_access
@@ -167,7 +167,7 @@
             - Read out from the test access window and ensure no error occurs
             '''
       milestone: V2
-      tests: []
+      tests: ["otp_ctrl_test_access"]
     }
     {
       name: stress_all

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -34,6 +34,7 @@ filesets:
       - seq_lib/otp_ctrl_parallel_key_req_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_parallel_lc_req_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv: {is_include_file: true}
+      - seq_lib/otp_ctrl_test_access_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -182,7 +182,7 @@ package otp_ctrl_env_pkg;
 
   function automatic bit is_sw_part(bit [TL_DW-1:0] addr);
     int part_idx = get_part_index(addr);
-    if (part_idx inside {CreatorSwCfgDigestOffset, OwnerSwCfgDigestOffset}) return 1;
+    if (part_idx inside {CreatorSwCfgIdx, OwnerSwCfgIdx}) return 1;
     else return 0;
   endfunction
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -443,4 +443,20 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     `uvm_send(lc_token_pull_seq)
   endtask
 
+  // This test access OTP_CTRL's test_access memory. The open-sourced code only test if the access
+  // is valid. Please override this task in proprietary OTP.
+  virtual task otp_test_access();
+    repeat($urandom_range(1, 20)) begin
+      bit [TL_DW-1:0] addr = $urandom_range(TEST_ACCESS_BASE_ADDR,
+                                            TEST_ACCESS_BASE_ADDR + TEST_ACCESS_WINDOW_SIZE - 1);
+      bit [TL_DW-1:0] data = $urandom();
+      bit [TL_DW-1:0] rdata;
+
+      addr = cfg.ral.get_addr_from_offset(addr);
+      `uvm_info(`gfn, $sformatf("write test access %0h with data %0h", addr, data), UVM_HIGH)
+      tl_access(.addr(addr), .write(1), .data(data));
+      tl_access(.addr(addr), .write(0), .data(rdata), .check_exp_data(1), .exp_data(data));
+    end
+  endtask
+
 endclass : otp_ctrl_base_vseq

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -146,6 +146,9 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
         if (cfg.otp_ctrl_vif.lc_prog_req == 0) csr_rd(.ptr(ral.err_code), .value(tlul_val));
       end
 
+      // Read/write test access memory
+      if (cfg.otp_ctrl_vif.lc_dft_en_i == lc_ctrl_pkg::On) otp_test_access();
+
       // lock digests
       `uvm_info(`gfn, "Trigger HW digest calculation", UVM_HIGH)
       cal_hw_digests();

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_test_access_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_test_access_vseq.sv
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class otp_ctrl_test_access_vseq extends otp_ctrl_dai_errs_vseq;
+  `uvm_object_utils(otp_ctrl_test_access_vseq)
+
+  `uvm_object_new
+
+  virtual task dut_init(string reset_kind = "HARD");
+    super.dut_init(reset_kind);
+
+    // Drive dft_en pins to access the test_access memory.
+    cfg.otp_ctrl_vif.drive_lc_dft_en(lc_ctrl_pkg::On);
+
+    // Once turn on lc_dft_en regiser, will need some time to update the state register
+    // two clock cycles for lc_async mode, one clock cycle for driving dft_en.
+    cfg.clk_rst_vif.wait_clks(3);
+  endtask
+
+endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
@@ -16,3 +16,4 @@
 `include "otp_ctrl_parallel_lc_req_vseq.sv"
 `include "otp_ctrl_parallel_lc_esc_vseq.sv"
 `include "otp_ctrl_regwen_vseq.sv"
+`include "otp_ctrl_test_access_vseq.sv"

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -108,6 +108,10 @@
       run_opts: ["+zero_delays=1"]
     }
 
+    {
+      name: otp_ctrl_test_access
+      uvm_test_seq: otp_ctrl_test_access_vseq
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
This PR adds a test_access sequence to access otp_ctrl's test_access.
For open-sourced testbench, this is a dummy check to ensure the
connection is correct. The real output should be checked in
proprietary env.

Signed-off-by: Cindy Chen <chencindy@google.com>