### PR TITLE
[flash_ctrl,lint] Fix width errors for parameters in flash_ctrl_pkg

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -8,9 +8,9 @@
 package flash_ctrl_pkg;
 
   // design parameters that can be altered through topgen
-  parameter int NumBanks        = flash_ctrl_reg_pkg::RegNumBanks;
-  parameter int PagesPerBank    = flash_ctrl_reg_pkg::RegPagesPerBank;
-  parameter int BusPgmResBytes  = flash_ctrl_reg_pkg::RegBusPgmResBytes;
+  parameter int unsigned NumBanks        = flash_ctrl_reg_pkg::RegNumBanks;
+  parameter int unsigned PagesPerBank    = flash_ctrl_reg_pkg::RegPagesPerBank;
+  parameter int unsigned BusPgmResBytes  = flash_ctrl_reg_pkg::RegBusPgmResBytes;
 
   // fixed parameters of flash derived from topgen parameters
   parameter int DataWidth       = ${cfg['data_width']};
@@ -64,7 +64,7 @@ package flash_ctrl_pkg;
   parameter int FifoDepthW      = prim_util_pkg::vbits(FifoDepth+1);
 
   // The end address in bus words for each kind of partition in each bank
-  parameter logic [PageW-1:0] DataPartitionEndAddr = PagesPerBank - 1;
+  parameter logic [PageW-1:0] DataPartitionEndAddr = PageW'(PagesPerBank - 1);
   //parameter logic [PageW-1:0] InfoPartitionEndAddr [InfoTypes] = '{
   % for type in range((cfg['info_types'])):
   //  ${cfg['infos_per_bank'][type]-1}${"," if not loop.last else ""}
@@ -72,7 +72,7 @@ package flash_ctrl_pkg;
   //};
   parameter logic [PageW-1:0] InfoPartitionEndAddr [InfoTypes] = '{
   % for type in range((cfg['info_types'])):
-    InfoTypeSize[${type}] - 1${"," if not loop.last else ""}
+    PageW'(InfoTypeSize[${type}] - 1)${"," if not loop.last else ""}
   % endfor
   };
 
@@ -136,13 +136,13 @@ package flash_ctrl_pkg;
   // One page for owner seeds
   // One page for isolated flash page
   parameter int NumSeeds = 2;
-  parameter int SeedBank = 0;
-  parameter int SeedInfoSel = 0;
-  parameter int CreatorSeedIdx = 0;
-  parameter int OwnerSeedIdx = 1;
-  parameter int CreatorInfoPage = 1;
-  parameter int OwnerInfoPage = 2;
-  parameter int IsolatedInfoPage = 3;
+  parameter bit [BankW-1:0] SeedBank = 0;
+  parameter bit [InfoTypesWidth-1:0] SeedInfoSel = 0;
+  parameter bit [0:0] CreatorSeedIdx = 0;
+  parameter bit [0:0] OwnerSeedIdx = 1;
+  parameter bit [PageW-1:0] CreatorInfoPage = 1;
+  parameter bit [PageW-1:0] OwnerInfoPage = 2;
+  parameter bit [PageW-1:0] IsolatedInfoPage = 3;
 
   // which page of which info type of which bank for seed selection
   parameter page_addr_t SeedInfoPageSel [NumSeeds] = '{
@@ -219,7 +219,7 @@ package flash_ctrl_pkg;
                  ecc_en:      1'b1,
                  he_en:       1'b1, // HW assumes high endurance
                  base:        '0,
-                 size:        {AllPagesW{1'b1}}
+                 size:        '1
                 }
      }
   };
@@ -385,7 +385,7 @@ package flash_ctrl_pkg;
        bank: SeedBank,
        part: FlashPartInfo,
        info_sel: SeedInfoSel,
-       start_page: OwnerInfoPage,
+       start_page: {1'b0, OwnerInfoPage},
        num_pages: 1
      },
 
@@ -394,7 +394,7 @@ package flash_ctrl_pkg;
        part: FlashPartData,
        info_sel: 0,
        start_page: 0,
-       num_pages: PagesPerBank
+       num_pages: (PageW + 1)'(PagesPerBank)
      },
 
     '{
@@ -402,7 +402,7 @@ package flash_ctrl_pkg;
        part: FlashPartData,
        info_sel: 0,
        start_page: 0,
-       num_pages: PagesPerBank
+       num_pages: (PageW + 1)'(PagesPerBank)
      }
   };
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -8,9 +8,9 @@
 package flash_ctrl_pkg;
 
   // design parameters that can be altered through topgen
-  parameter int NumBanks        = flash_ctrl_reg_pkg::RegNumBanks;
-  parameter int PagesPerBank    = flash_ctrl_reg_pkg::RegPagesPerBank;
-  parameter int BusPgmResBytes  = flash_ctrl_reg_pkg::RegBusPgmResBytes;
+  parameter int unsigned NumBanks        = flash_ctrl_reg_pkg::RegNumBanks;
+  parameter int unsigned PagesPerBank    = flash_ctrl_reg_pkg::RegPagesPerBank;
+  parameter int unsigned BusPgmResBytes  = flash_ctrl_reg_pkg::RegBusPgmResBytes;
 
   // fixed parameters of flash derived from topgen parameters
   parameter int DataWidth       = 64;
@@ -64,16 +64,16 @@ package flash_ctrl_pkg;
   parameter int FifoDepthW      = prim_util_pkg::vbits(FifoDepth+1);
 
   // The end address in bus words for each kind of partition in each bank
-  parameter logic [PageW-1:0] DataPartitionEndAddr = PagesPerBank - 1;
+  parameter logic [PageW-1:0] DataPartitionEndAddr = PageW'(PagesPerBank - 1);
   //parameter logic [PageW-1:0] InfoPartitionEndAddr [InfoTypes] = '{
   //  9,
   //  0,
   //  1
   //};
   parameter logic [PageW-1:0] InfoPartitionEndAddr [InfoTypes] = '{
-    InfoTypeSize[0] - 1,
-    InfoTypeSize[1] - 1,
-    InfoTypeSize[2] - 1
+    PageW'(InfoTypeSize[0] - 1),
+    PageW'(InfoTypeSize[1] - 1),
+    PageW'(InfoTypeSize[2] - 1)
   };
 
   ////////////////////////////
@@ -136,13 +136,13 @@ package flash_ctrl_pkg;
   // One page for owner seeds
   // One page for isolated flash page
   parameter int NumSeeds = 2;
-  parameter int SeedBank = 0;
-  parameter int SeedInfoSel = 0;
-  parameter int CreatorSeedIdx = 0;
-  parameter int OwnerSeedIdx = 1;
-  parameter int CreatorInfoPage = 1;
-  parameter int OwnerInfoPage = 2;
-  parameter int IsolatedInfoPage = 3;
+  parameter bit [BankW-1:0] SeedBank = 0;
+  parameter bit [InfoTypesWidth-1:0] SeedInfoSel = 0;
+  parameter bit [0:0] CreatorSeedIdx = 0;
+  parameter bit [0:0] OwnerSeedIdx = 1;
+  parameter bit [PageW-1:0] CreatorInfoPage = 1;
+  parameter bit [PageW-1:0] OwnerInfoPage = 2;
+  parameter bit [PageW-1:0] IsolatedInfoPage = 3;
 
   // which page of which info type of which bank for seed selection
   parameter page_addr_t SeedInfoPageSel [NumSeeds] = '{
@@ -219,7 +219,7 @@ package flash_ctrl_pkg;
                  ecc_en:      1'b1,
                  he_en:       1'b1, // HW assumes high endurance
                  base:        '0,
-                 size:        {AllPagesW{1'b1}}
+                 size:        '1
                 }
      }
   };
@@ -385,7 +385,7 @@ package flash_ctrl_pkg;
        bank: SeedBank,
        part: FlashPartInfo,
        info_sel: SeedInfoSel,
-       start_page: OwnerInfoPage,
+       start_page: {1'b0, OwnerInfoPage},
        num_pages: 1
      },
 
@@ -394,7 +394,7 @@ package flash_ctrl_pkg;
        part: FlashPartData,
        info_sel: 0,
        start_page: 0,
-       num_pages: PagesPerBank
+       num_pages: (PageW + 1)'(PagesPerBank)
      },
 
     '{
@@ -402,7 +402,7 @@ package flash_ctrl_pkg;
        part: FlashPartData,
        info_sel: 0,
        start_page: 0,
-       num_pages: PagesPerBank
+       num_pages: (PageW + 1)'(PagesPerBank)
      }
   };
 

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
@@ -14,9 +14,9 @@
 package flash_ctrl_pkg;
 
   // design parameters that can be altered through topgen
-  parameter int NumBanks        = flash_ctrl_reg_pkg::RegNumBanks;
-  parameter int PagesPerBank    = flash_ctrl_reg_pkg::RegPagesPerBank;
-  parameter int BusPgmResBytes  = flash_ctrl_reg_pkg::RegBusPgmResBytes;
+  parameter int unsigned NumBanks        = flash_ctrl_reg_pkg::RegNumBanks;
+  parameter int unsigned PagesPerBank    = flash_ctrl_reg_pkg::RegPagesPerBank;
+  parameter int unsigned BusPgmResBytes  = flash_ctrl_reg_pkg::RegBusPgmResBytes;
 
   // fixed parameters of flash derived from topgen parameters
   parameter int DataWidth       = 64;
@@ -70,16 +70,16 @@ package flash_ctrl_pkg;
   parameter int FifoDepthW      = prim_util_pkg::vbits(FifoDepth+1);
 
   // The end address in bus words for each kind of partition in each bank
-  parameter logic [PageW-1:0] DataPartitionEndAddr = PagesPerBank - 1;
+  parameter logic [PageW-1:0] DataPartitionEndAddr = PageW'(PagesPerBank - 1);
   //parameter logic [PageW-1:0] InfoPartitionEndAddr [InfoTypes] = '{
   //  9,
   //  0,
   //  1
   //};
   parameter logic [PageW-1:0] InfoPartitionEndAddr [InfoTypes] = '{
-    InfoTypeSize[0] - 1,
-    InfoTypeSize[1] - 1,
-    InfoTypeSize[2] - 1
+    PageW'(InfoTypeSize[0] - 1),
+    PageW'(InfoTypeSize[1] - 1),
+    PageW'(InfoTypeSize[2] - 1)
   };
 
   ////////////////////////////
@@ -142,13 +142,13 @@ package flash_ctrl_pkg;
   // One page for owner seeds
   // One page for isolated flash page
   parameter int NumSeeds = 2;
-  parameter int SeedBank = 0;
-  parameter int SeedInfoSel = 0;
-  parameter int CreatorSeedIdx = 0;
-  parameter int OwnerSeedIdx = 1;
-  parameter int CreatorInfoPage = 1;
-  parameter int OwnerInfoPage = 2;
-  parameter int IsolatedInfoPage = 3;
+  parameter bit [BankW-1:0] SeedBank = 0;
+  parameter bit [InfoTypesWidth-1:0] SeedInfoSel = 0;
+  parameter bit [0:0] CreatorSeedIdx = 0;
+  parameter bit [0:0] OwnerSeedIdx = 1;
+  parameter bit [PageW-1:0] CreatorInfoPage = 1;
+  parameter bit [PageW-1:0] OwnerInfoPage = 2;
+  parameter bit [PageW-1:0] IsolatedInfoPage = 3;
 
   // which page of which info type of which bank for seed selection
   parameter page_addr_t SeedInfoPageSel [NumSeeds] = '{
@@ -225,7 +225,7 @@ package flash_ctrl_pkg;
                  ecc_en:      1'b1,
                  he_en:       1'b1, // HW assumes high endurance
                  base:        '0,
-                 size:        {AllPagesW{1'b1}}
+                 size:        '1
                 }
      }
   };
@@ -391,7 +391,7 @@ package flash_ctrl_pkg;
        bank: SeedBank,
        part: FlashPartInfo,
        info_sel: SeedInfoSel,
-       start_page: OwnerInfoPage,
+       start_page: {1'b0, OwnerInfoPage},
        num_pages: 1
      },
 
@@ -400,7 +400,7 @@ package flash_ctrl_pkg;
        part: FlashPartData,
        info_sel: 0,
        start_page: 0,
-       num_pages: PagesPerBank
+       num_pages: (PageW + 1)'(PagesPerBank)
      },
 
     '{
@@ -408,7 +408,7 @@ package flash_ctrl_pkg;
        part: FlashPartData,
        info_sel: 0,
        start_page: 0,
-       num_pages: PagesPerBank
+       num_pages: (PageW + 1)'(PagesPerBank)
      }
   };
 


### PR DESCRIPTION
Most of these changes are pretty mechanical, silencing Verilator
warnings by making casts explicit.

The only non-trivial change is in flash_ctrl_info_cfg.sv, where a
page_addr_t structure (normally used for addressing pages within a
data partition) is used to address pages in an info partition. This
means that the "CurPage" index needs expanding from InfoPageW to
PageW. In practice, Info partitions are no bigger than data
partitions, so this should be fine, but we also add a comment and an
ASSERT_INIT to make sure this holds.

I'm a little confused about this last change because these types really are different sizes, so I would have thought `CurAddr` would get the wrong value whenever `flash_ctrl_info_pkg` was instantiated with a bank other than zero. But we haven't seen horrible bugs: am I missing something?