### PR TITLE
[otbn] Add a "multi" vseq to run binaries back-to-back

### DIFF
--- a/hw/ip/otbn/data/otbn_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_testplan.hjson
@@ -61,14 +61,13 @@
       desc: '''
             Run sequences back-to-back
 
-            This runs several sequences back-to-back, sometimes resetting
-            between them. We don't expect to see much from these tests, because
-            OTBN doesn't keep internal state across runs, but it's another way
-            to catch bugs where we don't re-initialize properly.
+            This runs several sequences back-to-back, without resets between
+            them. This should catch initialisation problems where not all state
+            is cleared between programs when there's no reset.
 
             '''
       milestone: V2
-      tests: []
+      tests: ["otbn_multi"]
     }
   ]
 }

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -25,6 +25,7 @@ filesets:
       - seq_lib/otbn_vseq_list.sv: {is_include_file: true}
       - seq_lib/otbn_base_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_common_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_multi_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_single_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_smoke_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -117,4 +117,40 @@ class otbn_base_vseq extends cip_base_vseq #(
     `uvm_info(`gfn, $sformatf("\n\t ----| OTBN finished"), UVM_MEDIUM)
    endtask
 
+  virtual protected function string pick_elf_path();
+    chandle helper;
+    int     num_files;
+    string  elf_path;
+
+    // Check that cfg.otbn_elf_dir was set by the test
+    `DV_CHECK_FATAL(cfg.otbn_elf_dir.len() > 0);
+
+    // Pick an ELF file to use in the test. We have to do this via DPI (because you can't list a
+    // directory in pure SystemVerilog). To do so, we have to construct a helper object, which will
+    // look after memory allocation for the string holding the path.
+    helper = OtbnTestHelperMake(cfg.otbn_elf_dir);
+    `DV_CHECK_FATAL(helper != null)
+
+    // Ask the helper how many files there are. If it returns zero, the directory name is bogus or
+    // the directory is empty.
+    num_files = OtbnTestHelperCountFilesInDir(helper);
+    `DV_CHECK_FATAL(num_files > 0,
+                    $sformatf("No regular files found in directory `%0s'.", cfg.otbn_elf_dir))
+
+    // Pick a file, any file... Note that we pick an index on the SV side so that we use the right
+    // random seed. Then we convert back to a filename with another DPI call. If the result is the
+    // empty string, something went wrong.
+    elf_path = OtbnTestHelperGetFilePath(helper, $urandom_range(num_files - 1));
+    `DV_CHECK_FATAL(elf_path.len() > 0, "Bad index for ELF file")
+
+    // Use sformat in a trivial way to take a copy of the string, so we can safely free helper (and
+    // hence the old elf_path) afterwards.
+    elf_path = $sformatf("%0s", elf_path);
+
+    // Now that we've taken a copy of elf_path, we can safely free the test helper.
+    OtbnTestHelperFree(helper);
+
+    return elf_path;
+  endfunction
+
 endclass : otbn_base_vseq

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_multi_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_multi_vseq.sv
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence that runs multiple programs (or maybe the same program multiple times)
+
+class otbn_multi_vseq extends otbn_base_vseq;
+  `uvm_object_utils(otbn_multi_vseq)
+
+  // If we've already loaded a binary, we might decide to re-run it (this is going to be "more
+  // back-to-back" because then we don't wait for the front-door load between runs). Make this
+  // reasonably common.
+  rand int rerun_pct;
+  constraint rerun_pct_c {
+    rerun_pct dist {
+      0      :/ 1,
+      [1:99] :/ 1,
+      100    :/ 2
+    };
+  }
+
+  `uvm_object_new
+
+  task body();
+    string elf_path;
+
+    for (int i = 0; i < 10; i++) begin
+      bit rerun = (i == 0) ? 1'b0 : ($urandom_range(100) <= rerun_pct);
+
+      if (rerun) begin
+        `uvm_info(`gfn, $sformatf("Re-using OTBN binary at `%0s'", elf_path), UVM_LOW)
+      end else begin
+        `uvm_info(`gfn, $sformatf("Loading OTBN binary from `%0s'", elf_path), UVM_LOW)
+        elf_path = pick_elf_path();
+        load_elf(elf_path, 1'b0);
+      end
+
+      run_otbn();      
+    end
+  endtask
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_single_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_single_vseq.sv
@@ -28,40 +28,4 @@ class otbn_single_vseq extends otbn_base_vseq;
     run_otbn();
   endtask : body
 
-  virtual protected function string pick_elf_path();
-    chandle helper;
-    int     num_files;
-    string  elf_path;
-
-    // Check that cfg.otbn_elf_dir was set by the test
-    `DV_CHECK_FATAL(cfg.otbn_elf_dir.len() > 0);
-
-    // Pick an ELF file to use in the test. We have to do this via DPI (because you can't list a
-    // directory in pure SystemVerilog). To do so, we have to construct a helper object, which will
-    // look after memory allocation for the string holding the path.
-    helper = OtbnTestHelperMake(cfg.otbn_elf_dir);
-    `DV_CHECK_FATAL(helper != null)
-
-    // Ask the helper how many files there are. If it returns zero, the directory name is bogus or
-    // the directory is empty.
-    num_files = OtbnTestHelperCountFilesInDir(helper);
-    `DV_CHECK_FATAL(num_files > 0,
-                    $sformatf("No regular files found in directory `%0s'.", cfg.otbn_elf_dir))
-
-    // Pick a file, any file... Note that we pick an index on the SV side so that we use the right
-    // random seed. Then we convert back to a filename with another DPI call. If the result is the
-    // empty string, something went wrong.
-    elf_path = OtbnTestHelperGetFilePath(helper, $urandom_range(num_files - 1));
-    `DV_CHECK_FATAL(elf_path.len() > 0, "Bad index for ELF file")
-
-    // Use sformat in a trivial way to take a copy of the string, so we can safely free helper (and
-    // hence the old elf_path) afterwards.
-    elf_path = $sformatf("%0s", elf_path);
-
-    // Now that we've taken a copy of elf_path, we can safely free the test helper.
-    OtbnTestHelperFree(helper);
-
-    return elf_path;
-  endfunction
-
 endclass : otbn_single_vseq

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
@@ -4,5 +4,6 @@
 
 `include "otbn_base_vseq.sv"
 `include "otbn_common_vseq.sv"
+`include "otbn_multi_vseq.sv"
 `include "otbn_single_vseq.sv"
 `include "otbn_smoke_vseq.sv"

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -76,15 +76,15 @@ name:
     }
   ]
 
-  gen_binaries: "{proj_root}/hw/ip/otbn/dv/uvm/gen-binaries.py"
   otbn_obj_dir: "{build_dir}/build-out"
-  gen_binary: "{gen_binaries} --count 1 --obj-dir {otbn_obj_dir}"
+  gen_binaries_py: "{proj_root}/hw/ip/otbn/dv/uvm/gen-binaries.py"
+  gen_binary: "{gen_binaries_py} --count 1 --obj-dir {otbn_obj_dir}"
+  gen_binaries: "{gen_binaries_py} --count 10 --obj-dir {otbn_obj_dir}"
 
   run_modes: [
-    // A run mode that runs the random instruction generator and builds the
-    // one resulting binary in {otbn_elf_dir}. If you override the otbn_elf_dir
-    // plusarg with --run-opts, we'll still build the binary (but will ignore
-    // it).
+    // Run the random instruction generator and builds the one resulting binary
+    // in {otbn_elf_dir}. If you override the otbn_elf_dir plusarg with
+    // --run-opts, we'll still build the binary (but will ignore it).
     {
       name: build_otbn_rig_binary_mode
       pre_run_cmds: [
@@ -92,11 +92,20 @@ name:
       ]
     }
 
-    // A run mode that builds the smoke test in {otbn_elf_dir}.
+    // Build the smoke test in {otbn_elf_dir}.
     {
       name: build_otbn_smoke_binary_mode
       pre_run_cmds: [
         "{gen_binary} {otbn_elf_dir}"
+      ]
+    }
+
+    // Run the random instruction generator several times and build the
+    // resulting binaries in {otbn_elf_dir}.
+    {
+      name: build_otbn_rig_binaries_mode
+      pre_run_cmds: [
+        "{gen_binaries} --no-smoke --seed {seed} {otbn_elf_dir}"
       ]
     }
   ]
@@ -112,10 +121,23 @@ name:
       // in running it loads of times.
       reseed: 1
     }
+
     {
       name: "otbn_single"
       uvm_test_seq: "otbn_single_vseq"
       en_run_modes: ["build_otbn_rig_binary_mode"]
+      reseed: 50
+    }
+
+    // This test runs 10 binaries each time, so we give it a reseed value
+    // that's about a tenth of the value for otbn_single: these tests should
+    // equally good at catching errors within a program, so there's no need to
+    // run it more.
+    {
+      name: "otbn_multi"
+      uvm_test_seq: "otbn_multi_vseq"
+      en_run_modes: ["build_otbn_rig_binaries_mode"]
+      reseed: 5
     }
 
     // TODO: add more tests here


### PR DESCRIPTION
This should catch errors where we don't re-initialise enough of the
design when starting a new operation. It intentionally doesn't do a
reset, which would hide that sort of thing.
