### PR TITLE
[otbn] Add a "reset" vseq that resets in the middle of operations

### DIFF
--- a/hw/ip/otbn/data/otbn_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_testplan.hjson
@@ -54,7 +54,7 @@
 
             '''
       milestone: V2
-      tests: []
+      tests: ["otbn_reset"]
     }
     {
       name: mem_integrity

--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -381,6 +381,11 @@ int ISSWrapper::step(bool gen_trace) {
   return mismatch ? -1 : (done ? 1 : 0);
 }
 
+void ISSWrapper::reset(bool gen_trace) {
+  if (gen_trace)
+    OtbnTraceChecker::get().Flush();
+}
+
 void ISSWrapper::get_regs(std::array<uint32_t, 32> *gprs,
                           std::array<u256_t, 32> *wdrs) {
   assert(gprs && wdrs);

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -57,6 +57,12 @@ struct ISSWrapper {
   // it's the value of the ERR_BITS register.
   int step(bool gen_trace);
 
+  // Reset simulation
+  //
+  // This doesn't actually send anything to the ISS, but instead tells
+  // the OtbnTraceChecker to clear out any partial instructions
+  void reset(bool gen_trace);
+
   // Get the current value of otbn.INSN_CNT. This should be called just after
   // step (but doesn't necessarily need to wait until the run has finished).
   uint32_t get_insn_cnt() const { return insn_cnt_; }

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -52,7 +52,7 @@ module otbn_core_model
                                                           string design_scope,
                                                           int unsigned imem_words,
                                                           int unsigned dmem_words);
-  import "DPI-C" function void otbn_model_destroy(chandle handle);
+  import "DPI-C" function void otbn_model_destroy(chandle model);
   import "DPI-C" context function
     int unsigned otbn_model_step(chandle          model,
                                  logic            start,
@@ -64,6 +64,7 @@ module otbn_core_model
                                  inout bit [31:0] insn_cnt,
                                  inout bit [31:0] err_bits,
                                  inout bit [31:0] stop_pc);
+  import "DPI-C" function void otbn_model_reset(chandle model);
 
 
   localparam int ImemSizeWords = ImemSizeByte / 4;
@@ -116,7 +117,9 @@ module otbn_core_model
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      // Clear status (stop running, and forget any errors and final PC)
+      if (status != 0) begin
+        otbn_model_reset(model_handle);
+      end
       status <= 0;
       raw_err_bits_q <= 0;
       stop_pc_q <= 0;

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -33,47 +33,90 @@ struct OtbnModel {
  public:
   OtbnModel(const std::string &mem_scope, const std::string &design_scope,
             unsigned imem_size_words, unsigned dmem_size_words)
-      : mem_util(mem_scope),
+      : mem_util_(mem_scope),
         design_scope_(design_scope),
         imem_size_words_(imem_size_words),
         dmem_size_words_(dmem_size_words) {}
 
-  // This class is a thin wrapper around ISSWrapper. The point is that we want
-  // to create the model in an initial block in the SystemVerilog simulation,
-  // but might not actually want to spawn the ISS. To handle that in a non-racy
-  // way, the most convenient thing is to spawn the ISS the first time it's
-  // actually needed.
-  //
-  // If ensure is true, this constructs an ISS wrapper if necessary. If
-  // something goes wrong, this function prints a message and then returns
-  // null. If ensure is true, it will never return null without printing a
-  // message, so error handling at the callsite can silently return a failure
-  // code.
-  ISSWrapper *get_wrapper(bool ensure) {
-    if (!iss) {
+  // True if this model is running in a simulation that has an RTL
+  // implementation too (which needs checking).
+  bool has_rtl() const { return !design_scope_.empty(); }
+
+  // Start a new run with the model, writing IMEM/DMEM and jumping to the given
+  // start address. Returns 0 on success; -1 on failure.
+  int start(unsigned start_addr);
+
+  // Step once in the model. Returns 1 if the model has finished, 0 if not and
+  // -1 on failure. If gen_trace is true, pass trace entries to the trace
+  // checker. If the model has finished, writes otbn.ERR_BITS to *err_bits.
+  int step(svLogic edn_rnd_data_valid,
+           svLogicVecVal *edn_rnd_data, /* logic [255:0] */
+           svLogic edn_urnd_data_valid, svBitVecVal *insn_cnt /* bit [31:0] */,
+           svBitVecVal *err_bits /* bit [31:0] */,
+           svBitVecVal *stop_pc /* bit [31:0] */);
+
+  // Check model against RTL (if there is any) when a run has finished. Prints
+  // messages to stderr on failure or mismatch. Returns 1 for a match, 0 for a
+  // mismatch, -1 for some other failure.
+  int check() const;
+
+  // Grab contents of dmem from the model and load it back into the RTL
+  // simulation. This is used when there's no RTL model of the design. Returns
+  // 0 on success; -1 on failure.
+  int load_dmem() const;
+
+  // Flush any information in the model
+  void reset();
+
+ private:
+  // Constructs an ISS wrapper if necessary. If something goes wrong, this
+  // function prints a message and then returns null. If ensure is true, it
+  // will never return null without printing a message, so error handling at
+  // the callsite can silently return a failure code.
+  ISSWrapper *ensure_wrapper() {
+    if (!iss_) {
       try {
-        iss.reset(new ISSWrapper());
+        iss_.reset(new ISSWrapper());
       } catch (const std::runtime_error &err) {
         std::cerr << "Error when constructing ISS wrapper: " << err.what()
                   << "\n";
         return nullptr;
       }
     }
-    assert(iss);
-    return iss.get();
+    assert(iss_);
+    return iss_.get();
   }
 
   std::vector<uint8_t> get_sim_memory(bool is_imem) const {
-    const MemArea &mem_area = mem_util.GetMemArea(is_imem);
+    const MemArea &mem_area = mem_util_.GetMemArea(is_imem);
     return mem_area.Read(0, mem_area.GetSizeWords());
   }
 
   void set_sim_memory(bool is_imem, const std::vector<uint8_t> &data) const {
-    mem_util.GetMemArea(is_imem).Write(0, data);
+    mem_util_.GetMemArea(is_imem).Write(0, data);
   }
 
-  std::unique_ptr<ISSWrapper> iss;
-  OtbnMemUtil mem_util;
+  // Grab contents of dmem from the model and compare them with the RTL. Prints
+  // messages to stderr on failure or mismatch. Returns true on success; false
+  // on mismatch. Throws a std::runtime_error on failure.
+  bool check_dmem(ISSWrapper &iss) const;
+
+  // Compare contents of ISS registers with those from the design. Prints
+  // messages to stderr on failure or mismatch. Returns true on success; false
+  // on mismatch. Throws a std::runtime_error on failure.
+  bool check_regs(ISSWrapper &iss) const;
+
+  // Compare contents of ISS call stack with those from the design. Prints
+  // messages to stderr on failure or mismatch. Returns true on success; false
+  // on mismatch. Throws a std::runtime_error on failure.
+  bool check_call_stack(ISSWrapper &iss) const;
+
+  // We want to create the model in an initial block in the SystemVerilog
+  // simulation, but might not actually want to spawn the ISS. To handle that
+  // in a non-racy way, the most convenient thing is to spawn the ISS the first
+  // time it's actually needed. Use ensure_iss() to create as needed.
+  std::unique_ptr<ISSWrapper> iss_;
+  OtbnMemUtil mem_util_;
   std::string design_scope_;
   unsigned imem_size_words_, dmem_size_words_;
 };
@@ -92,45 +135,6 @@ int otbn_stack_element_peek(int index, svBitVecVal *val) __attribute__((weak));
 #define CHECK_DUE_BIT (1U << 1)
 #define FAILED_STEP_BIT (1U << 2)
 #define FAILED_CMP_BIT (1U << 3)
-
-// The main entry point to the OTBN model, exported from here and used in
-// otbn_core_model.sv.
-//
-// This communicates state with otbn_core_model.sv through the status
-// parameter, which has the following bits:
-//
-//    Bit 0:      running       True if the model is currently running
-//    Bit 1:      check_due     True if the model finished running last cycle
-//    Bit 2:      failed_step   Something failed when trying to start/step ISS
-//    Bit 3:      failed_cmp    Consistency check at end of run failed
-//
-// The otbn_model_step function should only be called when either the model is
-// running (bit 0 of status), has a check due (bit 1 of status), or when start
-// is asserted. At other times, it will return immediately (but wastes a DPI
-// call).
-//
-// If the model is running and start is false, otbn_model_step steps the ISS by
-// a single cycle. If something goes wrong, it will set failed_step to true and
-// running to false. Otherwise, it writes the new value of otbn.INSN_CNT to
-// *insn_cnt.
-//
-// If nothing goes wrong and the ISS finishes its run, we set running to false,
-// write out err_bits and stop_pc and do the post-run task. If the model's
-// design_scope is non-empty, it should be the scope of an RTL implementation.
-// In that case, we compare register and memory contents with that
-// implementation, printing to stderr and setting the failed_cmp bit if there
-// are any mismatches. If the model's design_scope is the empty string, we grab
-// the contents of DMEM from the ISS and inject them into the simulation
-// memory.
-//
-// If start is true, we start the model at start_addr and then step once (as
-// described above).
-extern "C" unsigned otbn_model_step(
-    OtbnModel *model, svLogic start, unsigned start_addr, unsigned status,
-    svLogic edn_rnd_data_valid, svLogicVecVal *edn_rnd_data, /* logic [255:0] */
-    svLogic edn_urnd_data_valid, svBitVecVal *insn_cnt /* bit [31:0] */,
-    svBitVecVal *err_bits /* bit [31:0] */,
-    svBitVecVal *stop_pc /* bit [31:0] */);
 
 static std::vector<uint8_t> read_vector_from_file(const std::string &path,
                                                   size_t num_bytes) {
@@ -177,50 +181,6 @@ static void write_vector_to_file(const std::string &path,
   }
 }
 
-extern "C" OtbnModel *otbn_model_init(const char *mem_scope,
-                                      const char *design_scope,
-                                      unsigned imem_words,
-                                      unsigned dmem_words) {
-  assert(mem_scope && design_scope);
-  return new OtbnModel(mem_scope, design_scope, imem_words, dmem_words);
-}
-
-extern "C" void otbn_model_destroy(OtbnModel *model) { delete model; }
-
-// Start a new run with the model, writing IMEM/DMEM and jumping to the given
-// start address. Returns 0 on success; -1 on failure.
-static int start_model(OtbnModel &model, unsigned start_addr) {
-  const MemArea &imem = model.mem_util.GetMemArea(true);
-  assert(start_addr % 4 == 0);
-  assert(start_addr / 4 < imem.GetSizeWords());
-
-  ISSWrapper *iss = model.get_wrapper(true);
-  if (!iss)
-    return -1;
-
-  std::string dfname(iss->make_tmp_path("dmem"));
-  std::string ifname(iss->make_tmp_path("imem"));
-
-  try {
-    write_vector_to_file(dfname, model.get_sim_memory(false));
-    write_vector_to_file(ifname, model.get_sim_memory(true));
-  } catch (const std::exception &err) {
-    std::cerr << "Error when dumping memory contents: " << err.what() << "\n";
-    return -1;
-  }
-
-  try {
-    iss->load_d(dfname);
-    iss->load_i(ifname);
-    iss->start(start_addr);
-  } catch (const std::runtime_error &err) {
-    std::cerr << "Error when starting ISS: " << err.what() << "\n";
-    return -1;
-  }
-
-  return 0;
-}
-
 // Extract 256-bit RND EDN data from a 4 state logic value. RND data is placed
 // into 8 element uint32_t array dst.
 static void set_rnd_data(uint32_t dst[8], const svLogicVecVal src[8]) {
@@ -232,132 +192,6 @@ static void set_rnd_data(uint32_t dst[8], const svLogicVecVal src[8]) {
 }
 
 static bool is_xz(svLogic l) { return l == sv_x || l == sv_z; }
-
-// Step once in the model. Returns 1 if the model has finished, 0 if not and -1
-// on failure. If gen_trace is true, pass trace entries to the trace checker.
-// Writes the new value of otbn.INSN_CNT to *insn_cnt.
-//
-// If the model has finished, writes otbn.ERR_BITS to *err_bits and the final
-// PC to *stop_pc.
-static int step_model(OtbnModel &model, svLogic edn_rnd_data_valid,
-                      svLogicVecVal *edn_rnd_data, /* logic [255:0] */
-                      svLogic edn_urnd_data_valid, bool gen_trace,
-                      svBitVecVal *insn_cnt /* bit [31:0] */,
-                      svBitVecVal *err_bits /* bit [31:0] */,
-                      svBitVecVal *stop_pc /* bit [31:0] */) {
-  assert(err_bits);
-
-  ISSWrapper *iss = model.get_wrapper(true);
-  if (!iss)
-    return -1;
-
-  assert(!is_xz(edn_rnd_data_valid));
-  assert(!is_xz(edn_urnd_data_valid));
-
-  try {
-    if (edn_rnd_data_valid) {
-      uint32_t int_edn_rnd_data[8];
-      set_rnd_data(int_edn_rnd_data, edn_rnd_data);
-      iss->edn_rnd_data(int_edn_rnd_data);
-    }
-
-    if (edn_urnd_data_valid) {
-      iss->edn_urnd_reseed_complete();
-    }
-
-    switch (iss->step(gen_trace)) {
-      case -1:
-        // Something went wrong, such as a trace mismatch. We've already printed
-        // a message to stderr so can just return -1.
-        return -1;
-
-      case 1:
-        // The simulation has stopped. Fill in insn_cnt, err_bits and stop_pc.
-        set_sv_u32(insn_cnt, iss->get_insn_cnt());
-        set_sv_u32(err_bits, iss->get_err_bits());
-        set_sv_u32(stop_pc, iss->get_stop_pc());
-        return 1;
-
-      case 0:
-        // The simulation is still running. Update insn_cnt.
-        set_sv_u32(insn_cnt, iss->get_insn_cnt());
-        return 0;
-
-      default:
-        // This shouldn't happen
-        assert(0);
-    }
-  } catch (const std::runtime_error &err) {
-    std::cerr << "Error when stepping ISS: " << err.what() << "\n";
-    return -1;
-  }
-}
-
-// Grab contents of dmem from the model and load it back into the RTL. Returns
-// 0 on success; -1 on failure.
-static int load_dmem(OtbnModel &model) {
-  ISSWrapper *iss = model.get_wrapper(false);
-  if (!iss) {
-    std::cerr << "Cannot load dmem from OTBN model: ISS has not started.\n";
-    return -1;
-  }
-
-  const MemArea &dmem = model.mem_util.GetMemArea(false);
-
-  std::string dfname(iss->make_tmp_path("dmem_out"));
-  try {
-    iss->dump_d(dfname);
-    model.set_sim_memory(false,
-                         read_vector_from_file(dfname, dmem.GetSizeBytes()));
-  } catch (const std::exception &err) {
-    std::cerr << "Error when loading dmem from ISS: " << err.what() << "\n";
-    return -1;
-  }
-  return 0;
-}
-
-// Grab contents of dmem from the model and compare it with the RTL.
-// Prints messages to stderr on failure or mismatch. Returns true on
-// success; false on mismatch. Throws a std::runtime_error on failure.
-static bool check_dmem(OtbnModel &model, ISSWrapper &iss) {
-  const MemArea &dmem = model.mem_util.GetMemArea(false);
-  uint32_t dmem_bytes = dmem.GetSizeBytes();
-
-  std::string dfname(iss.make_tmp_path("dmem_out"));
-
-  iss.dump_d(dfname);
-  std::vector<uint8_t> iss_data = read_vector_from_file(dfname, dmem_bytes);
-  assert(iss_data.size() == dmem_bytes);
-
-  std::vector<uint8_t> rtl_data = model.get_sim_memory(false);
-  assert(rtl_data.size() == dmem_bytes);
-
-  // If the arrays match, we're done.
-  if (0 == memcmp(&iss_data[0], &rtl_data[0], dmem_bytes))
-    return true;
-
-  // If not, print out the first 10 mismatches
-  std::ios old_state(nullptr);
-  old_state.copyfmt(std::cerr);
-  std::cerr << "ERROR: Mismatches in dmem data:\n"
-            << std::hex << std::setfill('0');
-  int bad_count = 0;
-  for (size_t i = 0; i < dmem_bytes; ++i) {
-    if (iss_data[i] != rtl_data[i]) {
-      std::cerr << " @offset 0x" << std::setw(3) << i << ": rtl has 0x"
-                << std::setw(2) << (int)rtl_data[i] << "; iss has 0x"
-                << std::setw(2) << (int)iss_data[i] << "\n";
-      ++bad_count;
-
-      if (bad_count == 10) {
-        std::cerr << " (skipping further errors...)\n";
-        break;
-      }
-    }
-  }
-  std::cerr.copyfmt(old_state);
-  return false;
-}
 
 template <typename T>
 static std::array<T, 32> get_rtl_regs(const std::string &reg_scope) {
@@ -412,12 +246,20 @@ static std::vector<T> get_stack(const std::string &stack_scope) {
   while (1) {
     int peek_result = otbn_stack_element_peek(i, buf);
 
+    // otbn_stack_element_peek is defined in otbn_stack_snooper_if.sv. Possible
+    // return values are: 0 on success, if we've returned an element. 1 if the
+    // stack doesn't have an element at index i. 2 if something terrible has
+    // gone wrong (such as a completely bogus index).
+    assert(peek_result <= 2);
+
     if (peek_result == 2) {
       std::ostringstream oss;
       oss << "Failed to peek into RTL to get value of stack element " << i
           << " at scope `" << stack_scope << "'.";
       throw std::runtime_error(oss.str());
-    } else if (peek_result == 1) {
+    }
+
+    if (peek_result == 1) {
       // No more elements on stack
       break;
     }
@@ -432,15 +274,204 @@ static std::vector<T> get_stack(const std::string &stack_scope) {
   return ret;
 }
 
-// Compare contents of ISS registers with those from the design. Prints
-// messages to stderr on failure or mismatch. Returns true on success; false on
-// mismatch. Throws a std::runtime_error on failure.
-static bool check_regs(OtbnModel &model, ISSWrapper &iss) {
+int OtbnModel::start(unsigned start_addr) {
+  const MemArea &imem = mem_util_.GetMemArea(true);
+  assert(start_addr % 4 == 0);
+  assert(start_addr / 4 < imem.GetSizeWords());
+
+  ISSWrapper *iss = ensure_wrapper();
+  if (!iss)
+    return -1;
+
+  std::string dfname(iss->make_tmp_path("dmem"));
+  std::string ifname(iss->make_tmp_path("imem"));
+
+  try {
+    write_vector_to_file(dfname, get_sim_memory(false));
+    write_vector_to_file(ifname, get_sim_memory(true));
+  } catch (const std::exception &err) {
+    std::cerr << "Error when dumping memory contents: " << err.what() << "\n";
+    return -1;
+  }
+
+  try {
+    iss->load_d(dfname);
+    iss->load_i(ifname);
+    iss->start(start_addr);
+  } catch (const std::runtime_error &err) {
+    std::cerr << "Error when starting ISS: " << err.what() << "\n";
+    return -1;
+  }
+
+  return 0;
+}
+
+int OtbnModel::step(svLogic edn_rnd_data_valid,
+                    svLogicVecVal *edn_rnd_data, /* logic [255:0] */
+                    svLogic edn_urnd_data_valid,
+                    svBitVecVal *insn_cnt /* bit [31:0] */,
+                    svBitVecVal *err_bits /* bit [31:0] */,
+                    svBitVecVal *stop_pc /* bit [31:0] */) {
+  assert(err_bits);
+
+  ISSWrapper *iss = ensure_wrapper();
+  if (!iss)
+    return -1;
+
+  assert(!is_xz(edn_rnd_data_valid));
+  assert(!is_xz(edn_urnd_data_valid));
+
+  try {
+    if (edn_rnd_data_valid) {
+      uint32_t int_edn_rnd_data[8];
+      set_rnd_data(int_edn_rnd_data, edn_rnd_data);
+      iss->edn_rnd_data(int_edn_rnd_data);
+    }
+
+    if (edn_urnd_data_valid) {
+      iss->edn_urnd_reseed_complete();
+    }
+
+    switch (iss->step(has_rtl())) {
+      case -1:
+        // Something went wrong, such as a trace mismatch. We've already printed
+        // a message to stderr so can just return -1.
+        return -1;
+
+      case 1:
+        // The simulation has stopped. Fill in insn_cnt, err_bits and stop_pc.
+        set_sv_u32(insn_cnt, iss->get_insn_cnt());
+        set_sv_u32(err_bits, iss->get_err_bits());
+        set_sv_u32(stop_pc, iss->get_stop_pc());
+        return 1;
+
+      case 0:
+        // The simulation is still running. Update insn_cnt.
+        set_sv_u32(insn_cnt, iss->get_insn_cnt());
+        return 0;
+
+      default:
+        // This shouldn't happen
+        assert(0);
+    }
+  } catch (const std::runtime_error &err) {
+    std::cerr << "Error when stepping ISS: " << err.what() << "\n";
+    return -1;
+  }
+}
+
+int OtbnModel::check() const {
+  if (!has_rtl())
+    return 1;
+
+  ISSWrapper *iss = iss_.get();
+  if (!iss) {
+    std::cerr << "Cannot check OTBN model: ISS has not started.\n";
+    return -1;
+  }
+
+  bool good = true;
+
+  good &= OtbnTraceChecker::get().Finish();
+
+  try {
+    good &= check_dmem(*iss);
+  } catch (const std::exception &err) {
+    std::cerr << "Failed to check DMEM: " << err.what() << "\n";
+    return -1;
+  }
+
+  try {
+    good &= check_regs(*iss);
+  } catch (const std::exception &err) {
+    std::cerr << "Failed to check registers: " << err.what() << "\n";
+    return -1;
+  }
+
+  try {
+    good &= check_call_stack(*iss);
+  } catch (const std::exception &err) {
+    std::cerr << "Failed to check call stack: " << err.what() << "\n";
+    return -1;
+  }
+
+  return good ? 1 : 0;
+}
+
+int OtbnModel::load_dmem() const {
+  ISSWrapper *iss = iss_.get();
+  if (!iss) {
+    std::cerr << "Cannot load dmem from OTBN model: ISS has not started.\n";
+    return -1;
+  }
+
+  const MemArea &dmem = mem_util_.GetMemArea(false);
+
+  std::string dfname(iss->make_tmp_path("dmem_out"));
+  try {
+    iss->dump_d(dfname);
+    set_sim_memory(false, read_vector_from_file(dfname, dmem.GetSizeBytes()));
+  } catch (const std::exception &err) {
+    std::cerr << "Error when loading dmem from ISS: " << err.what() << "\n";
+    return -1;
+  }
+  return 0;
+}
+
+void OtbnModel::reset() {
+  ISSWrapper *iss = iss_.get();
+  if (iss)
+    iss->reset(has_rtl());
+}
+
+bool OtbnModel::check_dmem(ISSWrapper &iss) const {
+  const MemArea &dmem = mem_util_.GetMemArea(false);
+  uint32_t dmem_bytes = dmem.GetSizeBytes();
+
+  std::string dfname(iss.make_tmp_path("dmem_out"));
+
+  iss.dump_d(dfname);
+  std::vector<uint8_t> iss_data = read_vector_from_file(dfname, dmem_bytes);
+  assert(iss_data.size() == dmem_bytes);
+
+  std::vector<uint8_t> rtl_data = get_sim_memory(false);
+  assert(rtl_data.size() == dmem_bytes);
+
+  // If the arrays match, we're done.
+  if (0 == memcmp(&iss_data[0], &rtl_data[0], dmem_bytes))
+    return true;
+
+  // If not, print out the first 10 mismatches
+  std::ios old_state(nullptr);
+  old_state.copyfmt(std::cerr);
+  std::cerr << "ERROR: Mismatches in dmem data:\n"
+            << std::hex << std::setfill('0');
+  int bad_count = 0;
+  for (size_t i = 0; i < dmem_bytes; ++i) {
+    if (iss_data[i] != rtl_data[i]) {
+      std::cerr << " @offset 0x" << std::setw(3) << i << ": rtl has 0x"
+                << std::setw(2) << (int)rtl_data[i] << "; iss has 0x"
+                << std::setw(2) << (int)iss_data[i] << "\n";
+      ++bad_count;
+
+      if (bad_count == 10) {
+        std::cerr << " (skipping further errors...)\n";
+        break;
+      }
+    }
+  }
+  std::cerr.copyfmt(old_state);
+  return false;
+}
+
+bool OtbnModel::check_regs(ISSWrapper &iss) const {
+  assert(design_scope_.size());
+
   std::string base_scope =
-      model.design_scope_ +
+      design_scope_ +
       ".u_otbn_rf_base.gen_rf_base_ff.u_otbn_rf_base_inner.u_snooper";
   std::string wide_scope =
-      model.design_scope_ +
+      design_scope_ +
       ".u_otbn_rf_bignum.gen_rf_bignum_ff.u_otbn_rf_bignum_inner.u_snooper";
 
   auto rtl_gprs = get_rtl_regs<uint32_t>(base_scope);
@@ -494,12 +525,11 @@ static bool check_regs(OtbnModel &model, ISSWrapper &iss) {
   return good;
 }
 
-// Compare contents of ISS call stack with those from the design. Prints
-// messages to stderr on failure or mismatch. Returns true on success; false on
-// mismatch.  Throws a std::runtime_error on failure.
-static bool check_call_stack(OtbnModel &model, ISSWrapper &iss) {
+bool OtbnModel::check_call_stack(ISSWrapper &iss) const {
+  assert(design_scope_.size());
+
   std::string call_stack_snooper_scope =
-      model.design_scope_ + ".u_otbn_rf_base.u_call_stack_snooper";
+      design_scope_ + ".u_otbn_rf_base.u_call_stack_snooper";
 
   auto rtl_call_stack = get_stack<uint32_t>(call_stack_snooper_scope);
 
@@ -533,46 +563,48 @@ static bool check_call_stack(OtbnModel &model, ISSWrapper &iss) {
   return good;
 }
 
-// Check model against RTL when a run has finished. Prints messages to stderr
-// on failure or mismatch. Returns 1 for a match, 0 for a mismatch, -1 for some
-// other failure.
-int check_model(OtbnModel *model) {
-  assert(model);
-
-  ISSWrapper *iss = model->get_wrapper(false);
-  if (!iss) {
-    std::cerr << "Cannot check OTBN model: ISS has not started.\n";
-    return -1;
-  }
-
-  bool good = true;
-
-  good &= OtbnTraceChecker::get().Finish();
-
-  try {
-    good &= check_dmem(*model, *iss);
-  } catch (const std::exception &err) {
-    std::cerr << "Failed to check DMEM: " << err.what() << "\n";
-    return -1;
-  }
-
-  try {
-    good &= check_regs(*model, *iss);
-  } catch (const std::exception &err) {
-    std::cerr << "Failed to check registers: " << err.what() << "\n";
-    return -1;
-  }
-
-  try {
-    good &= check_call_stack(*model, *iss);
-  } catch (const std::exception &err) {
-    std::cerr << "Failed to check call stack: " << err.what() << "\n";
-    return -1;
-  }
-
-  return good ? 1 : 0;
+extern "C" OtbnModel *otbn_model_init(const char *mem_scope,
+                                      const char *design_scope,
+                                      unsigned imem_words,
+                                      unsigned dmem_words) {
+  assert(mem_scope && design_scope);
+  return new OtbnModel(mem_scope, design_scope, imem_words, dmem_words);
 }
 
+extern "C" void otbn_model_destroy(OtbnModel *model) { delete model; }
+
+// The main entry point to the OTBN model, exported from here and used in
+// otbn_core_model.sv.
+//
+// This communicates state with otbn_core_model.sv through the status
+// parameter, which has the following bits:
+//
+//    Bit 0:      running       True if the model is currently running
+//    Bit 1:      check_due     True if the model finished running last cycle
+//    Bit 2:      failed_step   Something failed when trying to start/step ISS
+//    Bit 3:      failed_cmp    Consistency check at end of run failed
+//
+// The otbn_model_step function should only be called when either the model is
+// running (bit 0 of status), has a check due (bit 1 of status), or when start
+// is asserted. At other times, it will return immediately (but wastes a DPI
+// call).
+//
+// If the model is running and start is false, otbn_model_step steps the ISS by
+// a single cycle. If something goes wrong, it will set failed_step to true and
+// running to false. Otherwise, it writes the new value of otbn.INSN_CNT to
+// *insn_cnt.
+//
+// If nothing goes wrong and the ISS finishes its run, we set running to false,
+// write out err_bits and stop_pc and do the post-run task. If the model's
+// design_scope is non-empty, it should be the scope of an RTL implementation.
+// In that case, we compare register and memory contents with that
+// implementation, printing to stderr and setting the failed_cmp bit if there
+// are any mismatches. If the model's design_scope is the empty string, we grab
+// the contents of DMEM from the ISS and inject them into the simulation
+// memory.
+//
+// If start is true, we start the model at start_addr and then step once (as
+// described above).
 extern "C" unsigned otbn_model_step(
     OtbnModel *model, svLogic start, unsigned start_addr, unsigned status,
     svLogic edn_rnd_data_valid, svLogicVecVal *edn_rnd_data, /* logic [255:0] */
@@ -583,9 +615,8 @@ extern "C" unsigned otbn_model_step(
 
   // Run model checks if needed. This usually happens just after an operation
   // has finished.
-  bool check_rtl = (model->design_scope_.size() > 0);
-  if (check_rtl && (status & CHECK_DUE_BIT)) {
-    switch (check_model(model)) {
+  if (model->has_rtl() && (status & CHECK_DUE_BIT)) {
+    switch (model->check()) {
       case 1:
         // Match (success)
         break;
@@ -606,7 +637,7 @@ extern "C" unsigned otbn_model_step(
 
   // Start the model if requested
   if (start) {
-    switch (start_model(*model, start_addr)) {
+    switch (model->start(start_addr)) {
       case 0:
         // All good
         status |= RUNNING_BIT;
@@ -623,9 +654,8 @@ extern "C" unsigned otbn_model_step(
     return status;
 
   // Step the model once
-  switch (step_model(*model, edn_rnd_data_valid, edn_rnd_data,
-                     edn_urnd_data_valid, check_rtl, insn_cnt, err_bits,
-                     stop_pc)) {
+  switch (model->step(edn_rnd_data_valid, edn_rnd_data, edn_urnd_data_valid,
+                      insn_cnt, err_bits, stop_pc)) {
     case 0:
       // Still running: no change
       break;
@@ -646,8 +676,8 @@ extern "C" unsigned otbn_model_step(
 
   // If we've just stopped running and there's no RTL, load the contents of
   // DMEM back from the ISS
-  if (!check_rtl) {
-    switch (load_dmem(*model)) {
+  if (!model->has_rtl()) {
+    switch (model->load_dmem()) {
       case 0:
         // Success
         break;
@@ -664,10 +694,5 @@ extern "C" unsigned otbn_model_step(
 // Flush any information in the model
 extern "C" void otbn_model_reset(OtbnModel *model) {
   assert(model);
-
-  ISSWrapper *iss = model->get_wrapper(false);
-  if (iss) {
-    bool check_rtl = (model->design_scope_.size() > 0);
-    iss->reset(check_rtl);
-  }
+  model->reset();
 }

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -660,3 +660,14 @@ extern "C" unsigned otbn_model_step(
 
   return status;
 }
+
+// Flush any information in the model
+extern "C" void otbn_model_reset(OtbnModel *model) {
+  assert(model);
+
+  ISSWrapper *iss = model->get_wrapper(false);
+  if (iss) {
+    bool check_rtl = (model->design_scope_.size() > 0);
+    iss->reset(check_rtl);
+  }
+}

--- a/hw/ip/otbn/dv/model/otbn_trace_checker.cc
+++ b/hw/ip/otbn/dv/model/otbn_trace_checker.cc
@@ -176,6 +176,12 @@ bool OtbnTraceChecker::OnIssTrace(const std::vector<std::string> &lines) {
   return MatchPair();
 }
 
+void OtbnTraceChecker::Flush() {
+  rtl_pending_ = false;
+  rtl_stall_ = false;
+  iss_pending_ = false;
+}
+
 bool OtbnTraceChecker::Finish() {
   assert(!(rtl_pending_ && iss_pending_));
   done_ = true;

--- a/hw/ip/otbn/dv/model/otbn_trace_checker.h
+++ b/hw/ip/otbn/dv/model/otbn_trace_checker.h
@@ -60,6 +60,10 @@ class OtbnTraceChecker : public OtbnTraceListener {
   // Prints an error message to stderr and returns false on mismatch.
   bool OnIssTrace(const std::vector<std::string> &lines);
 
+  // Flush any pending entries. We need to do this on reset, to handle
+  // the case where we reset the processor in the middle of a stall.
+  void Flush();
+
   // Call this when the ISS simulation completes an operation (on ECALL or
   // error).
   //

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -32,6 +32,7 @@ filesets:
       - seq_lib/otbn_base_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_common_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_multi_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_reset_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_single_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_smoke_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_reset_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_reset_vseq.sv
@@ -1,0 +1,63 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence that runs a program multiple times, resetting in the middle of runs
+
+class otbn_reset_vseq extends otbn_base_vseq;
+  `uvm_object_utils(otbn_reset_vseq)
+
+  int unsigned num_iters = 10;
+
+  `uvm_object_new
+
+  task body();
+    int max_cycles;
+    string elf_path;
+
+    elf_path = pick_elf_path();
+    `uvm_info(`gfn, $sformatf("Loading OTBN binary from `%0s'", elf_path), UVM_LOW)
+    load_elf(elf_path, 1'b1);
+
+    max_cycles = 1000;
+    for (int i = 0; i < num_iters; i++) begin
+      int cycle_counter;
+      int reset_wait;
+      bit timed_out = 1'b0;
+
+      // Guess the number of cycles until reset. The first time around, we pick any number between 1
+      // and 1,000. After that, we replace "1,000" with "75% of the longest we've seen the sequence
+      // run before terminating". This should avoid problems where we keep resetting after the
+      // sequence has finished.
+      reset_wait = $urandom_range(max_cycles * 3 / 4) + 1;
+
+      fork
+        run_otbn();
+        begin
+          repeat (reset_wait) begin
+            @(cfg.clk_rst_vif.cb);
+            cycle_counter++;
+          end
+          timed_out = 1'b1;
+        end
+      join_any
+
+      // When we get here, we know that either the OTBN sequence finished (in which case timed_out =
+      // 1'b0) or we timed out. If the OTBN sequence finished, kill the counter process. We don't
+      // kill the run_otbn task: it will spot a reset and terminate on its own.
+      if (!timed_out) begin
+        // If the OTBN sequence finished, update max_cycles. cycle_counter should always be less
+        // than max_cycles (because of how we calculate reset_wait).
+        `DV_CHECK_FATAL(cycle_counter < max_cycles);
+        max_cycles = cycle_counter;
+        disable fork;
+      end
+
+      // If this isn't the last iteration, or if we timed out, reset the DUT
+      if (timed_out || i + 1 < num_iters) begin
+        dut_init("HARD");
+      end
+    end
+  endtask
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
@@ -5,5 +5,6 @@
 `include "otbn_base_vseq.sv"
 `include "otbn_common_vseq.sv"
 `include "otbn_multi_vseq.sv"
+`include "otbn_reset_vseq.sv"
 `include "otbn_single_vseq.sv"
 `include "otbn_smoke_vseq.sv"

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -140,7 +140,12 @@ name:
       reseed: 5
     }
 
-    // TODO: add more tests here
+    {
+      name: "otbn_reset"
+      uvm_test_seq: "otbn_reset_vseq"
+      en_run_modes: ["build_otbn_rig_binary_mode"]
+      reseed: 5
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
The reset sequence itself is the third commit in the series. The first commit teaches the model wrapper to spot resets and tell our trace checker that something weird is going on. The second commit is a boring refactor (moving functions around, and stuffing code into class methods). If reviewers would prefer, I can split that out into a separate PR.