### PR TITLE
[otbn] Properly reset CSRs, WSRs and loop stack in ISS when starting

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from shared.mem_layout import get_memory_layout
 
@@ -137,14 +137,21 @@ class OTBNState:
         self.csrs.flags.abort()
         self.wdrs.abort()
 
-    def start(self) -> None:
-        '''Set the running flag and the ext_reg busy flag'''
+    def start(self, addr: int) -> None:
+        '''Set the running flag and the ext_reg busy flag; perform state init'''
         self.ext_regs.set_bits('STATUS', 1 << 0)
         self.running = True
         self._start_stall = True
         self.stalled = True
         self.pending_halt = False
         self._err_bits = 0
+
+        self.pc = addr
+
+        # Reset CSRs, WSRs and loop stack
+        self.csrs = CSRFile()
+        self.wsrs = WSRFile()
+        self.loop_stack = LoopStack()
 
     def stop(self) -> None:
         '''Set flags to stop the processor and abort the instruction'''

--- a/hw/ip/otbn/dv/otbnsim/standalone.py
+++ b/hw/ip/otbn/dv/otbnsim/standalone.py
@@ -33,8 +33,7 @@ def main() -> int:
     sim = OTBNSim()
     load_elf(sim, args.elf)
 
-    sim.state.pc = 0
-    sim.state.start()
+    sim.state.start(0)
     sim.run(verbose=args.verbose)
 
     if args.dump_dmem is not None:

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -77,8 +77,7 @@ def on_start(sim: OTBNSim, args: List[str]) -> None:
                          .format(addr))
 
     print('START {:#08x}'.format(addr))
-    sim.state.pc = addr
-    sim.state.start()
+    sim.state.start(addr)
 
 
 def on_step(sim: OTBNSim, args: List[str]) -> None:


### PR DESCRIPTION
This has no effect if you just run a single binary (because then we
set them in the `__init__` method), but is important if you run several
back-to-back.
