### PR TITLE
[dif] Add missing `extern "C"` declarations.

### DIFF
--- a/sw/device/lib/dif/dif_hmac.h
+++ b/sw/device/lib/dif/dif_hmac.h
@@ -14,6 +14,10 @@
 #include <stdint.h>
 #include "sw/device/lib/base/mmio.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
 /**
  * HMAC interrupt configuration.
  *
@@ -379,5 +383,9 @@ dif_hmac_digest_result_t dif_hmac_digest_read(const dif_hmac_t *hmac,
  */
 dif_hmac_result_t dif_hmac_wipe_secret(const dif_hmac_t *hmac,
                                        uint32_t entropy);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_HMAC_H_

--- a/sw/device/lib/dif/dif_usbdev.h
+++ b/sw/device/lib/dif/dif_usbdev.h
@@ -15,6 +15,10 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_warn_unused_result.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
 /**
  * Hardware constants.
  */
@@ -911,5 +915,9 @@ dif_usbdev_result_t dif_usbdev_irq_restore(dif_usbdev_t *usbdev,
 DIF_WARN_UNUSED_RESULT
 dif_usbdev_result_t dif_usbdev_irq_test(dif_usbdev_t *usbdev,
                                         dif_usbdev_irq_t irq);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_USBDEV_H_


### PR DESCRIPTION
DIFs are implemented in C and so the API requires C linkage in C++.
The current template includes the necessary `extern "C"`
declaration but the hmac and usbdev header files did not have it.

Signed-off-by: Michael Munday <mike.munday@lowrisc.org>