### PR TITLE
[dv/otp_ctrl] Fix tb issues related to mem

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -27,7 +27,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     cfg.backdoor_clear_mem = 0;
     // reset power init pin and lc pins
     cfg.otp_ctrl_vif.init();
-    if (do_otp_ctrl_init) otp_ctrl_init();
+    if (do_otp_ctrl_init && do_apply_reset) otp_ctrl_init();
     cfg.clk_rst_vif.wait_clks($urandom_range(0, 10));
     if (do_otp_pwr_init) otp_pwr_init();
   endtask


### PR DESCRIPTION
This PR fixes a few testbench issues with OTP TLUL mem.
1. If read lock is set, otp sw access memory partition will be locked.
So we override the cip_base_scb function.
2. Fix sequence issue that never lock the read partition (The lock is
reverted by reset)

Signed-off-by: Cindy Chen <chencindy@google.com>