### PR TITLE
[fpv/otp_ctrl] fix assertion issue

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -421,7 +421,7 @@ module otp_ctrl_part_unbuf
   // If the partition is read locked, the TL-UL access must error out
   `ASSERT(TlulReadOnReadLock_A,
       tlul_req_i && tlul_gnt_o ##1 access_o.read_lock != Unlocked
-      |=>
+      |->
       tlul_rerror_o > '0 && tlul_rvalid_o)
   // ECC error in buffer regs.
   `ASSERT(EccErrorState_A,


### PR DESCRIPTION
This PR fixes an assertion error in DV regression. In property, it
already includes a one cycle delay. Using `=>` gives an extra cycle that
causes the failure.

Signed-off-by: Cindy Chen <chencindy@google.com>