### PR TITLE
[sva] remove rtl core file dependency

### DIFF
--- a/hw/ip/aes/dv/sva/aes_bind.sv
+++ b/hw/ip/aes/dv/sva/aes_bind.sv
@@ -13,14 +13,11 @@ module aes_bind;
     .d2h  (tl_o)
   );
 
-  import aes_reg_pkg::*;
   bind aes aes_csr_assert_fpv aes_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/aes/dv/sva/aes_sva.core
+++ b/hw/ip/aes/dv/sva/aes_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/aes.hjson
-      depend: lowrisc:ip:aes
 
 targets:
   default: &default_target

--- a/hw/ip/alert_handler/dv/sva/alert_handler_bind.sv
+++ b/hw/ip/alert_handler/dv/sva/alert_handler_bind.sv
@@ -13,14 +13,11 @@ module alert_handler_bind;
     .d2h  (tl_o)
   );
 
-  import alert_handler_reg_pkg::*;
   bind alert_handler alert_handler_csr_assert_fpv alert_handler_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (i_reg_wrap.reg2hw),
-    .hw2reg (i_reg_wrap.hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/alert_handler/dv/sva/alert_handler_sva.core
+++ b/hw/ip/alert_handler/dv/sva/alert_handler_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/alert_handler.hjson
-      depend: lowrisc:ip:alert_handler_reg
 
 targets:
   default: &default_target

--- a/hw/ip/aon_timer/dv/sva/aon_timer_bind.sv
+++ b/hw/ip/aon_timer/dv/sva/aon_timer_bind.sv
@@ -13,14 +13,11 @@ module aon_timer_bind;
     .d2h  (tl_o)
   );
 
-  import aon_timer_reg_pkg::*;
   bind aon_timer aon_timer_csr_assert_fpv aon_timer_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/aon_timer/dv/sva/aon_timer_sva.core
+++ b/hw/ip/aon_timer/dv/sva/aon_timer_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/aon_timer.hjson
-      depend: lowrisc:ip:aon_timer
 
 targets:
   default: &default_target

--- a/hw/ip/csrng/dv/sva/csrng_bind.sv
+++ b/hw/ip/csrng/dv/sva/csrng_bind.sv
@@ -13,14 +13,11 @@ module csrng_bind;
     .d2h  (tl_o)
   );
 
-  import csrng_reg_pkg::*;
   bind csrng csrng_csr_assert_fpv csrng_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/csrng/dv/sva/csrng_sva.core
+++ b/hw/ip/csrng/dv/sva/csrng_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/csrng.hjson
-      depend: lowrisc:ip:csrng
 
 targets:
   default: &default_target

--- a/hw/ip/dcd/dv/sva/dcd_bind.sv
+++ b/hw/ip/dcd/dv/sva/dcd_bind.sv
@@ -13,14 +13,11 @@ module dcd_bind;
     .d2h  (tl_o)
   );
 
-  import dcd_reg_pkg::*;
   bind dcd dcd_csr_assert_fpv dcd_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/dcd/dv/sva/dcd_sva.core
+++ b/hw/ip/dcd/dv/sva/dcd_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/dcd.hjson
-      depend: lowrisc:ip:dcd
 
 targets:
   default: &default_target

--- a/hw/ip/edn/dv/sva/edn_bind.sv
+++ b/hw/ip/edn/dv/sva/edn_bind.sv
@@ -13,14 +13,11 @@ module edn_bind;
     .d2h  (tl_o)
   );
 
-  import edn_reg_pkg::*;
   bind edn edn_csr_assert_fpv edn_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/edn/dv/sva/edn_sva.core
+++ b/hw/ip/edn/dv/sva/edn_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/edn.hjson
-      depend: lowrisc:ip:edn
 
 targets:
   default: &default_target

--- a/hw/ip/entropy_src/dv/sva/entropy_src_bind.sv
+++ b/hw/ip/entropy_src/dv/sva/entropy_src_bind.sv
@@ -13,14 +13,11 @@ module entropy_src_bind;
     .d2h  (tl_o)
   );
 
-  import entropy_src_reg_pkg::*;
   bind entropy_src entropy_src_csr_assert_fpv entropy_src_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/entropy_src/dv/sva/entropy_src_sva.core
+++ b/hw/ip/entropy_src/dv/sva/entropy_src_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/entropy_src.hjson
-      depend: lowrisc:ip:entropy_src
 
 targets:
   default: &default_target

--- a/hw/ip/flash_ctrl/dv/sva/flash_ctrl_bind.sv
+++ b/hw/ip/flash_ctrl/dv/sva/flash_ctrl_bind.sv
@@ -13,14 +13,11 @@ module flash_ctrl_bind;
     .d2h  (tl_o)
   );
 
-  import flash_ctrl_reg_pkg::*;
   bind flash_ctrl flash_ctrl_csr_assert_fpv flash_ctrl_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/flash_ctrl/dv/sva/flash_ctrl_sva.core
+++ b/hw/ip/flash_ctrl/dv/sva/flash_ctrl_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/flash_ctrl.hjson
-      depend: lowrisc:ip:flash_ctrl
 
 targets:
   default: &default_target

--- a/hw/ip/gpio/dv/sva/gpio_bind.sv
+++ b/hw/ip/gpio/dv/sva/gpio_bind.sv
@@ -13,14 +13,11 @@ module gpio_bind;
     .d2h  (tl_o)
   );
 
-  import gpio_reg_pkg::*;
   bind gpio gpio_csr_assert_fpv gpio_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/gpio/dv/sva/gpio_sva.core
+++ b/hw/ip/gpio/dv/sva/gpio_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/gpio.hjson
-      depend: lowrisc:ip:gpio
 
 targets:
   default: &default_target

--- a/hw/ip/hmac/dv/sva/hmac_bind.sv
+++ b/hw/ip/hmac/dv/sva/hmac_bind.sv
@@ -13,14 +13,11 @@ module hmac_bind;
     .d2h  (tl_o)
   );
 
-  import hmac_reg_pkg::*;
   bind hmac hmac_csr_assert_fpv hmac_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/hmac/dv/sva/hmac_sva.core
+++ b/hw/ip/hmac/dv/sva/hmac_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/hmac.hjson
-      depend: lowrisc:ip:hmac
 
 targets:
   default: &default_target

--- a/hw/ip/i2c/dv/sva/i2c_bind.sv
+++ b/hw/ip/i2c/dv/sva/i2c_bind.sv
@@ -13,14 +13,11 @@ module i2c_bind;
     .d2h  (tl_o)
   );
 
-  import i2c_reg_pkg::*;
   bind i2c i2c_csr_assert_fpv i2c_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/i2c/dv/sva/i2c_sva.core
+++ b/hw/ip/i2c/dv/sva/i2c_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/i2c.hjson
-      depend: lowrisc:ip:i2c
 
 targets:
   default: &default_target

--- a/hw/ip/keymgr/dv/sva/keymgr_bind.sv
+++ b/hw/ip/keymgr/dv/sva/keymgr_bind.sv
@@ -13,14 +13,11 @@ module keymgr_bind;
     .d2h  (tl_o)
   );
 
-  import keymgr_reg_pkg::*;
   bind keymgr keymgr_csr_assert_fpv keymgr_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/keymgr/dv/sva/keymgr_sva.core
+++ b/hw/ip/keymgr/dv/sva/keymgr_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/keymgr.hjson
-      depend: lowrisc:ip:keymgr
 
 targets:
   default: &default_target

--- a/hw/ip/kmac/dv/sva/kmac_bind.sv
+++ b/hw/ip/kmac/dv/sva/kmac_bind.sv
@@ -13,14 +13,11 @@ module kmac_bind;
     .d2h  (tl_o)
   );
 
-  import kmac_reg_pkg::*;
   bind kmac kmac_csr_assert_fpv kmac_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/kmac/dv/sva/kmac_sva.core
+++ b/hw/ip/kmac/dv/sva/kmac_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/kmac.hjson
-      depend: lowrisc:ip:kmac
 
 targets:
   default: &default_target

--- a/hw/ip/lc_ctrl/dv/sva/lc_ctrl_bind.sv
+++ b/hw/ip/lc_ctrl/dv/sva/lc_ctrl_bind.sv
@@ -13,14 +13,11 @@ module lc_ctrl_bind;
     .d2h  (tl_o)
   );
 
-  import lc_ctrl_reg_pkg::*;
   bind lc_ctrl lc_ctrl_csr_assert_fpv lc_ctrl_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/lc_ctrl/dv/sva/lc_ctrl_sva.core
+++ b/hw/ip/lc_ctrl/dv/sva/lc_ctrl_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/lc_ctrl.hjson
-      depend: lowrisc:ip:lc_ctrl
 
 targets:
   default: &default_target

--- a/hw/ip/otbn/dv/uvm/sva/otbn_bind.sv
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_bind.sv
@@ -13,14 +13,11 @@ module otbn_bind;
     .d2h    (tl_o)
   );
 
-  import otbn_reg_pkg::*;
   bind otbn otbn_csr_assert_fpv csr_checker (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/otbn/dv/uvm/sva/otbn_sva.core
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../../data/otbn.hjson
-      depend: lowrisc:ip:otbn
 
 targets:
   default: &default_target

--- a/hw/ip/otp_ctrl/dv/sva/otp_ctrl_bind.sv
+++ b/hw/ip/otp_ctrl/dv/sva/otp_ctrl_bind.sv
@@ -13,14 +13,11 @@ module otp_ctrl_bind;
     .d2h  (tl_o)
   );
 
-  import otp_ctrl_reg_pkg::*;
   bind otp_ctrl otp_ctrl_csr_assert_fpv otp_ctrl_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/otp_ctrl/dv/sva/otp_ctrl_sva.core
+++ b/hw/ip/otp_ctrl/dv/sva/otp_ctrl_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/otp_ctrl.hjson
-      depend: lowrisc:ip:otp_ctrl_pkg
 
 targets:
   default: &default_target

--- a/hw/ip/pattgen/dv/sva/pattgen_bind.sv
+++ b/hw/ip/pattgen/dv/sva/pattgen_bind.sv
@@ -13,14 +13,11 @@ module pattgen_bind;
     .d2h  (tl_o)
   );
 
-  import pattgen_reg_pkg::*;
   bind pattgen pattgen_csr_assert_fpv pattgen_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/pattgen/dv/sva/pattgen_sva.core
+++ b/hw/ip/pattgen/dv/sva/pattgen_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/pattgen.hjson
-      depend: lowrisc:ip:pattgen
 
 targets:
   default: &default_target

--- a/hw/ip/pinmux/fpv/pinmux_fpv.core
+++ b/hw/ip/pinmux/fpv/pinmux_fpv.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../data/pinmux.hjson
-      depend: lowrisc:ip:pinmux_reg
 
 targets:
   default: &default_target

--- a/hw/ip/pinmux/fpv/tb/pinmux_bind_fpv.sv
+++ b/hw/ip/pinmux/fpv/tb/pinmux_bind_fpv.sv
@@ -33,9 +33,7 @@ module pinmux_bind_fpv;
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule : pinmux_bind_fpv

--- a/hw/ip/pwm/dv/sva/pwm_bind.sv
+++ b/hw/ip/pwm/dv/sva/pwm_bind.sv
@@ -13,4 +13,10 @@ module pwm_bind;
     .d2h  (tl_o)
   );
 
+  bind pwm pwm_csr_assert_fpv pwm_csr_assert (
+    .clk_i,
+    .rst_ni,
+    .h2d    (tl_i),
+    .d2h    (tl_o)
+  );
 endmodule

--- a/hw/ip/pwm/dv/sva/pwm_sva.core
+++ b/hw/ip/pwm/dv/sva/pwm_sva.core
@@ -15,6 +15,11 @@ filesets:
   files_formal:
     depend:
       - lowrisc:ip:pwm
+generate:
+  csr_assert_gen:
+    generator: csr_assert_gen
+    parameters:
+      spec: ../../data/pwm.hjson
 
 targets:
   default: &default_target

--- a/hw/ip/rv_plic/data/rv_plic.hjson
+++ b/hw/ip/rv_plic/data/rv_plic.hjson
@@ -10,7 +10,6 @@
 #  - prio:   Max value of interrupt priorities
 {
   name: "RV_PLIC",
-  fusesoc_core_name: "lowrisc:ip:rv_plic_example"
   clock_primary: "clk_i",
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }

--- a/hw/ip/rv_plic/data/rv_plic.hjson.tpl
+++ b/hw/ip/rv_plic/data/rv_plic.hjson.tpl
@@ -11,7 +11,6 @@
 #  - prio:   Max value of interrupt priorities
 {
   name: "RV_PLIC",
-  fusesoc_core_name: "lowrisc:ip:rv_plic_example"
   clock_primary: "clk_i",
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }

--- a/hw/ip/rv_plic/fpv/tb/rv_plic_bind_fpv.sv
+++ b/hw/ip/rv_plic/fpv/tb/rv_plic_bind_fpv.sv
@@ -39,9 +39,7 @@ module rv_plic_bind_fpv;
     .clk_i,
     .rst_ni,
     .h2d  (tl_i),
-    .d2h  (tl_o),
-    .reg2hw,
-    .hw2reg
+    .d2h  (tl_o)
   );
 
 endmodule : rv_plic_bind_fpv

--- a/hw/ip/rv_timer/dv/sva/rv_timer_bind.sv
+++ b/hw/ip/rv_timer/dv/sva/rv_timer_bind.sv
@@ -13,14 +13,11 @@ module rv_timer_bind;
     .d2h  (tl_o)
   );
 
-  import rv_timer_reg_pkg::*;
   bind rv_timer rv_timer_csr_assert_fpv rv_timer_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/rv_timer/dv/sva/rv_timer_sva.core
+++ b/hw/ip/rv_timer/dv/sva/rv_timer_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/rv_timer.hjson
-      depend: lowrisc:ip:rv_timer
 
 targets:
   default: &default_target

--- a/hw/ip/spi_device/dv/sva/spi_device_bind.sv
+++ b/hw/ip/spi_device/dv/sva/spi_device_bind.sv
@@ -13,14 +13,11 @@ module spi_device_bind;
     .d2h  (tl_o)
   );
 
-  import spi_device_reg_pkg::*;
   bind spi_device spi_device_csr_assert_fpv spi_device_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/spi_device/dv/sva/spi_device_sva.core
+++ b/hw/ip/spi_device/dv/sva/spi_device_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/spi_device.hjson
-      depend: lowrisc:ip:spi_device
 
 targets:
   default: &default_target

--- a/hw/ip/sram_ctrl/dv/sva/sram_ctrl_bind.sv
+++ b/hw/ip/sram_ctrl/dv/sva/sram_ctrl_bind.sv
@@ -13,14 +13,11 @@ module sram_ctrl_bind;
     .d2h  (tl_o)
   );
 
-  import sram_ctrl_reg_pkg::*;
   bind sram_ctrl sram_ctrl_csr_assert_fpv sram_ctrl_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/sram_ctrl/dv/sva/sram_ctrl_sva.core
+++ b/hw/ip/sram_ctrl/dv/sva/sram_ctrl_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/sram_ctrl.hjson
-      depend: lowrisc:ip:sram_ctrl
 
 targets:
   default: &default_target

--- a/hw/ip/uart/dv/sva/uart_bind.sv
+++ b/hw/ip/uart/dv/sva/uart_bind.sv
@@ -13,14 +13,11 @@ module uart_bind;
     .d2h  (tl_o)
   );
 
-  import uart_reg_pkg::*;
   bind uart uart_csr_assert_fpv uart_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
 );
 
 endmodule

--- a/hw/ip/uart/dv/sva/uart_sva.core
+++ b/hw/ip/uart/dv/sva/uart_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/uart.hjson
-      depend: lowrisc:ip:uart
 
 targets:
   default: &default_target

--- a/hw/ip/usbdev/dv/sva/usbdev_bind.sv
+++ b/hw/ip/usbdev/dv/sva/usbdev_bind.sv
@@ -13,14 +13,11 @@ module usbdev_bind;
     .d2h  (tl_o)
   );
 
-  import usbdev_reg_pkg::*;
   bind usbdev usbdev_csr_assert_fpv usbdev_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/usbdev/dv/sva/usbdev_sva.core
+++ b/hw/ip/usbdev/dv/sva/usbdev_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/usbdev.hjson
-      depend: lowrisc:ip:usbdev
 
 targets:
   default: &default_target

--- a/hw/ip/usbuart/dv/sva/usbuart_bind.sv
+++ b/hw/ip/usbuart/dv/sva/usbuart_bind.sv
@@ -13,14 +13,11 @@ module usbuart_bind;
     .d2h  (tl_o)
   );
 
-  import usbuart_reg_pkg::*;
   bind usbuart usbuart_csr_assert_fpv usbuart_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule

--- a/hw/ip/usbuart/dv/sva/usbuart_sva.core
+++ b/hw/ip/usbuart/dv/sva/usbuart_sva.core
@@ -22,7 +22,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/usbuart.hjson
-      depend: lowrisc:ip:usbuart
 
 targets:
   default: &default_target

--- a/hw/top_earlgrey/ip/alert_handler/dv/sva/alert_handler_sva.core
+++ b/hw/top_earlgrey/ip/alert_handler/dv/sva/alert_handler_sva.core
@@ -19,7 +19,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/autogen/alert_handler.hjson
-      depend: lowrisc:ip:alert_handler_reg
 
 targets:
   default:

--- a/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
+++ b/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
@@ -18,7 +18,6 @@
 #  - prio:   Max value of interrupt priorities
 {
   name: "RV_PLIC",
-  fusesoc_core_name: "lowrisc:ip:rv_plic_example"
   clock_primary: "clk_i",
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }

--- a/hw/top_earlgrey/ip/rv_plic/fpv/rv_plic_bind_fpv.sv
+++ b/hw/top_earlgrey/ip/rv_plic/fpv/rv_plic_bind_fpv.sv
@@ -39,9 +39,7 @@ module rv_plic_bind_fpv;
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 
 endmodule : rv_plic_bind_fpv

--- a/hw/top_earlgrey/ip/rv_plic/fpv/rv_plic_fpv.core
+++ b/hw/top_earlgrey/ip/rv_plic/fpv/rv_plic_fpv.core
@@ -21,7 +21,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../data/autogen/rv_plic.hjson
-      depend: lowrisc:top_earlgrey:rv_plic
 
 targets:
   default: &default_target

--- a/util/fpvgen/bind_fpv.sv.tpl
+++ b/util/fpvgen/bind_fpv.sv.tpl
@@ -36,9 +36,7 @@ module ${dut.name}_bind_fpv;
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 % endif
 

--- a/util/reggen/fpv_csr.sv.tpl
+++ b/util/reggen/fpv_csr.sv.tpl
@@ -26,18 +26,14 @@
 `endif
 
 // Block: ${lblock}
-module ${mod_base}_csr_assert_fpv import tlul_pkg::*; import ${lblock}_reg_pkg::*;
+module ${mod_base}_csr_assert_fpv import tlul_pkg::*;
     import top_pkg::*;(
   input clk_i,
   input rst_ni,
 
   // tile link ports
   input tl_h2d_t h2d,
-  input tl_d2h_t d2h,
-
-  // reg and hw ports
-  input ${mod_base}_reg2hw_t reg2hw,
-  input ${mod_base}_hw2reg_t hw2reg
+  input tl_d2h_t d2h
 );
 
 `ifndef VERILATOR

--- a/util/reggen/gen_fpv.py
+++ b/util/reggen/gen_fpv.py
@@ -58,7 +58,6 @@ def gen_fpv(block: IpBlock, outdir):
         'filesets': {
             'files_dv': {
                 'depend': [
-                    block.fusesoc_core_name,
                     "lowrisc:tlul:headers",
                     "lowrisc:prim:assert",
                 ],

--- a/util/reggen/ip_block.py
+++ b/util/reggen/ip_block.py
@@ -34,10 +34,6 @@ OPTIONAL_FIELDS = {
     'available_inout_list': ['lnw', "list of available peripheral inouts"],
     'available_input_list': ['lnw', "list of available peripheral inputs"],
     'available_output_list': ['lnw', "list of available peripheral outputs"],
-    'fusesoc_core_name': [
-        's',
-        "name of the FuseSoC core. Defaults to 'lowrisc:ip:<name>'."
-    ],
     'hier_path': [
         None,
         'additional hierarchy path before the reg block instance'
@@ -87,7 +83,6 @@ class IpBlock:
                  scan: bool,
                  inter_signals: List[InterSignal],
                  bus_interfaces: BusInterfaces,
-                 fusesoc_core_name: str,
                  hier_path: Optional[str],
                  clock_signals: List[str],
                  reset_signals: List[str],
@@ -120,7 +115,6 @@ class IpBlock:
         self.scan = scan
         self.inter_signals = inter_signals
         self.bus_interfaces = bus_interfaces
-        self.fusesoc_core_name = fusesoc_core_name
         self.hier_path = hier_path
         self.clock_signals = clock_signals
         self.reset_signals = reset_signals
@@ -224,10 +218,6 @@ class IpBlock:
                                    'bus_interfaces field of ' + where))
         inter_signals += bus_interfaces.inter_signals()
 
-        fusesoc_core_name = check_str(
-            rd.get('fusesoc_core_name', 'lowrisc:ip:' + name.lower()),
-            'fusesoc_core_name field of ' + what)
-
         hier_path = check_optional_str(rd.get('hier_path', None),
                                        'hier_path field of ' + what)
 
@@ -275,8 +265,8 @@ class IpBlock:
         return IpBlock(name, regwidth, params, reg_blocks,
                        interrupts, no_auto_intr, alerts, no_auto_alert,
                        scan, inter_signals, bus_interfaces,
-                       fusesoc_core_name, hier_path, clock_signals,
-                       reset_signals, xputs, wakeups, rst_reqs, scan_reset)
+                       hier_path, clock_signals, reset_signals, xputs,
+                       wakeups, rst_reqs, scan_reset)
 
     @staticmethod
     def from_text(txt: str,
@@ -314,7 +304,6 @@ class IpBlock:
         ret['scan'] = self.scan
         ret['inter_signal_list'] = self.inter_signals
         ret['bus_interfaces'] = self.bus_interfaces.as_dicts()
-        ret['fusesoc_core_name'] = self.fusesoc_core_name
 
         if self.hier_path is not None:
             ret['hier_path'] = self.hier_path

--- a/util/uvmdvgen/bind.sv.tpl
+++ b/util/uvmdvgen/bind.sv.tpl
@@ -16,14 +16,11 @@ module ${name}_bind;
 % endif
 % if has_ral:
 
-  import ${name}_reg_pkg::*;
   bind ${name} ${name}_csr_assert_fpv ${name}_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 % endif
 

--- a/util/uvmdvgen/sva.core.tpl
+++ b/util/uvmdvgen/sva.core.tpl
@@ -25,7 +25,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/${name}.hjson
-      depend: lowrisc:ip:${name}
 % endif
 
 targets:


### PR DESCRIPTION
Backgound:
The original FPV csr auto-generated assertions need to find hdl path for registers that can be updated by HW.
This creates an hierarchy issue when we bind the auto-generated CSR assertions to DV. Because FPV and DV has slightly different hierarchy path.
At that time, my solution was to directly bind the `hw2reg` and `reg2hw` signals. However, these two signals were created by `{ip_name}_reg_pkg.sv` enum types. Thus I need to import the `{ip_name}_reg_pkg.sv` to generate the CSR assertions.

However, this starts to create issues when:
1. Modules like `clkmgr` that has ip and top_level instances, thus the dependency is not simply `lowrisc:ip:clkmgr`.
2. Modules that does not have `reg2hw` or `hw2reg` (e.g. pwm thanks @tunghoang290780 for reporting that)

The simplified CSR assertions do not need the `reg2hw` and `hw2reg` because it only generate assertions for CSRs that is HW RO. When next stage, we need to support other regs, I plan to follow what DV did: add the `hdl` path in hjson (potentially here we can reuse the DV `hdl`).

This PR is created to remove RTL dependency for FPV csr assertion.  Please refer to the *first two* commits for the actual  script change. The rest commits are changes from each IP. 

@rswarbrick thank you for all your hard work on re-organizing the reggen. I think the variable `fusesoc_core_file` is specifically developed for this FPV use case. I removed the variable as FPV is going to pursue a different method. Would you mind helping me confirm the commit "[reggen] remove fusesoc_core_name", and confirm it is not used elsewhere?

@tunghoang290780 @matutem sorry for the inconvenience. I think both of you have new IPs coming. If this PR landed, you might have to change two files:
"dv/sva/{ip_name}_bind.sv"
"dv/sva/{ip_name}_sva.core"
Hope not too much trouble for you :)

Definitely a lesson learned from this PR :) and will not using RTL dependency that much :')