### PR TITLE
[kmac, lint] Minor lint fixes in KMAC

### DIFF
--- a/hw/ip/kmac/rtl/keccak_round.sv
+++ b/hw/ip/kmac/rtl/keccak_round.sv
@@ -22,14 +22,14 @@ module keccak_round #(
   localparam int DInAddr  = $clog2(DInEntry),
 
   // Control parameters
-  parameter  bit EnMasking = 0,  // Enable secure hardening
+  parameter  bit EnMasking = 1'b0,  // Enable secure hardening
   localparam int Share     = EnMasking ? 2 : 1,
 
   // If ReuseShare is not 0, the logic will use unused sheet as an entropy
   // at Chi stage. It still needs small portion of the fresh entropy from
   // rand_data_i but the amount required are significantly small.
   // TODO: Implement the feature inside keccak_2share
-  parameter  int ReuseShare = 0  // Re-use adjacent share for entropy
+  parameter  bit ReuseShare = 1'b0  // Re-use adjacent share for entropy
 ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -660,8 +660,8 @@ module kmac
     assign sw_msg_data  = tlram_wdata_endian ;
     assign sw_msg_mask  = tlram_wmask_endian ;
   end else begin : gen_sw_msg_diff
-    assign sw_msg_data = {(MsgWidth-MsgWindowWidth)'(0), tlram_wdata_endian};
-    assign sw_msg_mask = {(MsgWidth-MsgWindowWidth)'(0), tlram_wmask_endian};
+    assign sw_msg_data = {{MsgWidth-MsgWindowWidth{1'b0}}, tlram_wdata_endian};
+    assign sw_msg_mask = {{MsgWidth-MsgWindowWidth{1'b0}}, tlram_wmask_endian};
   end
   assign tlram_gnt    = sw_msg_ready ;
 

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -665,6 +665,9 @@ module kmac
   end
   assign tlram_gnt    = sw_msg_ready ;
 
+  logic unused_tlram_addr;
+  assign unused_tlram_addr = &{1'b0, tlram_addr};
+
   // KeyMgr Mux/Demux
   kmac_keymgr #(
     .EnMasking(EnMasking)

--- a/hw/ip/kmac/rtl/kmac_keymgr.sv
+++ b/hw/ip/kmac/rtl/kmac_keymgr.sv
@@ -9,7 +9,7 @@
 module kmac_keymgr
   import kmac_pkg::*;
 #(
-  parameter  int EnMasking = 0,
+  parameter  bit EnMasking = 1'b0,
   localparam int Share = (EnMasking) ? 2 : 1 // derived parameter
 ) (
   input clk_i,

--- a/hw/ip/kmac/rtl/kmac_staterd.sv
+++ b/hw/ip/kmac/rtl/kmac_staterd.sv
@@ -114,13 +114,6 @@ module kmac_staterd
   logic [SelAddrW-1:0] addr_sel;
   assign addr_sel = tlram_addr[StateAddrW+:SelAddrW];
 
-  always_comb begin
-    tlram_rdata_endian = '0;
-    for (int i = 0 ; i < Share ; i++) begin
-      if ($unsigned(i) == addr_sel) begin
-        tlram_rdata_endian = muxed_state[i];
-      end
-    end
-  end
+  assign tlram_rdata_endian = int'(addr_sel) < Share ? muxed_state[addr_sel] : 0;
 
 endmodule

--- a/hw/ip/kmac/rtl/kmac_staterd.sv
+++ b/hw/ip/kmac/rtl/kmac_staterd.sv
@@ -15,7 +15,7 @@ module kmac_staterd
 
   // EnMasking: Enable masking security hardening inside keccak_round
   // If it is enabled, the result digest will be two set of 1600bit.
-  parameter  int EnMasking = 0,
+  parameter  bit EnMasking = 1'b0,
   localparam int Share = (EnMasking) ? 2 : 1  // derived parameter
 ) (
   input clk_i,


### PR DESCRIPTION
These fix Verilator warnings which appear in the overnight lint runs. Most changes are pretty trivial, but the second patch (which simplifies the definition of `tlram_rdata_endian` in `kmac_staterd.sv`) probably needs a second pair of eyes to make sure I haven't done something really stupid.