### PR TITLE
[kmac] Moving KDF struct to KMAC IP

### DIFF
--- a/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_agent.core
+++ b/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_agent.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:dv:dv_lib
       - lowrisc:dv:push_pull_agent
       - lowrisc:ip:keymgr_pkg
+      - lowrisc:ip:kmac_pkg
     files:
       - keymgr_kmac_agent_pkg.sv
       - keymgr_kmac_intf.sv

--- a/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_intf.sv
+++ b/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_intf.sv
@@ -10,8 +10,8 @@ interface keymgr_kmac_intf (input clk, input rst_n);
   dv_utils_pkg::if_mode_e if_mode; // interface mode - Host or Device
 
   // interface pins used to connect with DUT
-  wire kmac_data_req_t kmac_data_req;
-  wire kmac_data_rsp_t kmac_data_rsp;
+  wire kmac_pkg::app_req_t kmac_data_req;
+  wire kmac_pkg::app_rsp_t kmac_data_rsp;
 
   // interface pins used in driver/monitor
   push_pull_if #(.HostDataWidth(keymgr_kmac_agent_pkg::KMAC_REQ_DATA_WIDTH))

--- a/hw/ip/keymgr/data/keymgr.hjson
+++ b/hw/ip/keymgr/data/keymgr.hjson
@@ -49,11 +49,11 @@
       act:     "req",
       package: "keymgr_pkg",  // Origin package (only needs for the requester)
     },
-    { struct:  "kmac_data",   // kmac_data_req_t, kmac_data_rsp_t
+    { struct:  "app",   // kmac_pkg::app_req_t, kmac_pkg::app_rsp_t
       type:    "req_rsp",
       name:    "kmac_data",   // kmac_data_o (req), kmac_data_i (rsp)
       act:     "req",
-      package: "keymgr_pkg",  // Origin package (only needs for the requester)
+      package: "kmac_pkg",  // Origin package (only needs for the requester)
     },
     { struct:  "otp_keymgr_key",
       type:    "uni",

--- a/hw/ip/keymgr/dv/env/keymgr_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_if.sv
@@ -22,8 +22,8 @@ interface keymgr_if(input clk, input rst_n);
   keymgr_pkg::hw_key_req_t aes_key_exp;
 
   // connect KDF interface for assertion check
-  wire keymgr_pkg::kmac_data_req_t kmac_data_req;
-  wire keymgr_pkg::kmac_data_rsp_t kmac_data_rsp;
+  wire kmac_pkg::app_req_t kmac_data_req;
+  wire kmac_pkg::app_rsp_t kmac_data_rsp;
 
   // connect EDN for assertion check
   wire edn_clk, edn_rst_n, edn_req, edn_ack;

--- a/hw/ip/keymgr/keymgr.core
+++ b/hw/ip/keymgr/keymgr.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:prim:lfsr
       - lowrisc:prim:lc_sync
       - lowrisc:ip:keymgr_pkg
+      - lowrisc:ip:kmac_pkg
     files:
       - rtl/keymgr_reg_top.sv
       - rtl/keymgr_sideload_key_ctrl.sv

--- a/hw/ip/keymgr/rtl/keymgr.sv
+++ b/hw/ip/keymgr/rtl/keymgr.sv
@@ -41,8 +41,8 @@ module keymgr
   output hw_key_req_t kmac_key_o,
 
   // data interface to/from crypto modules
-  output kmac_data_req_t kmac_data_o,
-  input kmac_data_rsp_t kmac_data_i,
+  output kmac_pkg::app_req_t kmac_data_o,
+  input  kmac_pkg::app_rsp_t kmac_data_i,
 
   // the following signals should eventually be wrapped into structs from other modules
   input lc_ctrl_pkg::lc_tx_t lc_keymgr_en_i,

--- a/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
+++ b/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
@@ -26,8 +26,8 @@ module keymgr_kmac_if import keymgr_pkg::*;(
   output logic [Shares-1:0][KeyWidth-1:0] data_o,
 
   // actual connection to kmac
-  output kmac_data_req_t kmac_data_o,
-  input kmac_data_rsp_t kmac_data_i,
+  output kmac_pkg::app_req_t kmac_data_o,
+  input  kmac_pkg::app_rsp_t kmac_data_i,
 
   // entropy input
   output logic prng_en_o,

--- a/hw/ip/keymgr/rtl/keymgr_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_pkg.sv
@@ -163,40 +163,6 @@ package keymgr_pkg;
     key_share1: KeyWidth'(32'hFACEBEEF)
   };
 
-  typedef struct packed {
-    logic valid;
-    logic [KmacDataIfWidth-1:0] data;
-    logic [KmacDataIfWidth/8-1:0] strb;
-    // last indicates the last beat of the data. strb can be partial only with
-    // last.
-    logic last;
-  } kmac_data_req_t;
-
-  typedef struct packed {
-    logic ready;
-    logic done;
-    logic [KeyWidth-1:0] digest_share0;
-    logic [KeyWidth-1:0] digest_share1;
-    // Error is valid when done is high. If any error occurs during KDF, KMAC
-    // returns the garbage digest data with error. The KeyMgr discards the
-    // digest and may re-initiate the process.
-    logic error;
-  } kmac_data_rsp_t;
-
-  parameter kmac_data_req_t KMAC_DATA_REQ_DEFAULT = '{
-    valid: 1'b 0,
-    data: '0,
-    strb: '0,
-    last: 1'b 0
-  };
-  parameter kmac_data_rsp_t KMAC_DATA_RSP_DEFAULT = '{
-    ready: 1'b1,
-    done:  1'b1,
-    digest_share0: KeyWidth'(32'hDEADBEEF),
-    digest_share1: KeyWidth'(32'hFACEBEEF),
-    error: 1'b1
-  };
-
   // The following structs should be sourced from other modules
   // defined here temporarily
 

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -68,11 +68,11 @@
       act:     "rcv"
       package: "keymgr_pkg"
     }
-    { struct:  "kmac_data"
+    { struct:  "app"
       type:    "req_rsp"
-      name:    "keymgr_kdf"
+      name:    "app"
       act:     "rsp"
-      package: "keymgr_pkg"
+      package: "kmac_pkg"
     }
     { struct:  "edn"
       type:    "req_rsp"

--- a/hw/ip/kmac/dv/env/kmac_env_pkg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_pkg.sv
@@ -64,10 +64,10 @@ package kmac_env_pkg;
   parameter int SIDELOAD_KEY_SIZE = $bits(hw_key_req_t);
   // KDF request data has 1 bit for last, and the rest are for data/strb.
   // We subtract 1 from the width of the struct as it includes the valid handshake signal.
-  parameter int KDF_DATA_SIZE = $bits(kmac_data_req_t) - 1;
+  parameter int KDF_DATA_SIZE = $bits(app_req_t) - 1;
   // KDF response data has 2 bits for done/error signals and the rest are for digest shares.
   // We subtract 1 from the struct width as it includes the ready handshake signal.
-  parameter int KDF_DIGEST_SIZE = $bits(kmac_data_rsp_t) - 1;
+  parameter int KDF_DIGEST_SIZE = $bits(app_rsp_t) - 1;
 
   // types
 

--- a/hw/ip/kmac/dv/tb.sv
+++ b/hw/ip/kmac/dv/tb.sv
@@ -21,8 +21,8 @@ module tb;
   // keymgr/kmac sideload wires
   keymgr_pkg::hw_key_req_t kmac_sideload_key;
   // kdf wires
-  keymgr_pkg::kmac_data_req_t kdf_req;
-  keymgr_pkg::kmac_data_rsp_t kdf_rsp;
+  kmac_pkg::app_req_t kdf_req;
+  kmac_pkg::app_rsp_t kdf_rsp;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
@@ -56,8 +56,8 @@ module tb;
     //
     // TODO: this is set to 0 for the time being to get the csr tests passing.
     //       this will eventually be hooked up to the kmac<->keymgr agent.
-    .keymgr_kdf_i       (keymgr_kmac_if.kmac_data_req ),
-    .keymgr_kdf_o       (keymgr_kmac_if.kmac_data_rsp ),
+    .app_i       (keymgr_kmac_if.kmac_data_req ),
+    .app_o       (keymgr_kmac_if.kmac_data_rsp ),
 
     // Interrupts
     .intr_kmac_done_o   (interrupts[KmacDone]         ),

--- a/hw/ip/kmac/kmac.core
+++ b/hw/ip/kmac/kmac.core
@@ -16,8 +16,8 @@ filesets:
       - lowrisc:ip:sha3
       - lowrisc:ip:edn_pkg
       - lowrisc:prim:edn_req
+      - lowrisc:ip:kmac_pkg
     files:
-      - rtl/kmac_pkg.sv
       - rtl/kmac_core.sv
       - rtl/kmac_msgfifo.sv
       - rtl/kmac_staterd.sv

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -32,8 +32,8 @@ module kmac
   input keymgr_pkg::hw_key_req_t keymgr_key_i,
 
   // KeyMgr KDF data path
-  input  keymgr_pkg::kmac_data_req_t keymgr_kdf_i,
-  output keymgr_pkg::kmac_data_rsp_t keymgr_kdf_o,
+  input  app_req_t app_i,
+  output app_rsp_t app_o,
 
   // EDN interface
   output edn_pkg::edn_req_t entropy_o,
@@ -685,8 +685,8 @@ module kmac
     .keymgr_key_i,
 
     // KeyMgr data in / digest out interface
-    .keymgr_data_i (keymgr_kdf_i),
-    .keymgr_data_o (keymgr_kdf_o),
+    .app_i (app_i),
+    .app_o (app_o),
 
     // Secret Key output to KMAC Core
     .key_data_o (key_data),

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -90,6 +90,47 @@ package kmac_pkg;
     EntropyModeSw   = 2'h 2
   } entropy_mode_e;
 
+  ///////////////////////////
+  // Application interface //
+  ///////////////////////////
+  // MsgWidth : 64
+  // MsgStrbW : 8
+  parameter int unsigned AppDigestW = 256;
+  typedef struct packed {
+    logic valid;
+    logic [MsgWidth-1:0] data;
+    logic [MsgStrbW-1:0] strb;
+    // last indicates the last beat of the data. strb can be partial only with
+    // last.
+    logic last;
+  } app_req_t;
+
+  typedef struct packed {
+    logic ready;
+    logic done;
+    logic [AppDigestW-1:0] digest_share0;
+    logic [AppDigestW-1:0] digest_share1;
+    // Error is valid when done is high. If any error occurs during KDF, KMAC
+    // returns the garbage digest data with error. The KeyMgr discards the
+    // digest and may re-initiate the process.
+    logic error;
+  } app_rsp_t;
+
+  parameter app_req_t APP_REQ_DEFAULT = '{
+    valid: 1'b 0,
+    data: '0,
+    strb: '0,
+    last: 1'b 0
+  };
+  parameter app_rsp_t APP_RSP_DEFAULT = '{
+    ready: 1'b1,
+    done:  1'b1,
+    digest_share0: AppDigestW'(32'hDEADBEEF),
+    digest_share1: AppDigestW'(32'hFACEBEEF),
+    error: 1'b1
+  };
+
+
   ////////////////////
   // Error Handling //
   ////////////////////

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3851,15 +3851,16 @@
           index: -1
         }
         {
-          name: keymgr_kdf
-          struct: kmac_data
-          package: keymgr_pkg
+          name: app
+          struct: app
+          package: kmac_pkg
           type: req_rsp
           act: rsp
           width: 1
           inst_name: kmac
           default: ""
-          top_signame: keymgr_kmac_data
+          end_idx: -1
+          top_signame: kmac_app
           index: -1
         }
         {
@@ -4108,15 +4109,14 @@
         }
         {
           name: kmac_data
-          struct: kmac_data
-          package: keymgr_pkg
+          struct: app
+          package: kmac_pkg
           type: req_rsp
           act: req
           width: 1
           inst_name: keymgr
           default: ""
-          end_idx: -1
-          top_signame: keymgr_kmac_data
+          top_signame: kmac_app
           index: -1
         }
         {
@@ -5479,9 +5479,9 @@
       [
         kmac.keymgr_key
       ]
-      keymgr.kmac_data:
+      kmac.app:
       [
-        kmac.keymgr_kdf
+        keymgr.kmac_data
       ]
       clkmgr_aon.idle:
       [
@@ -11267,15 +11267,16 @@
         index: -1
       }
       {
-        name: keymgr_kdf
-        struct: kmac_data
-        package: keymgr_pkg
+        name: app
+        struct: app
+        package: kmac_pkg
         type: req_rsp
         act: rsp
         width: 1
         inst_name: kmac
         default: ""
-        top_signame: keymgr_kmac_data
+        end_idx: -1
+        top_signame: kmac_app
         index: -1
       }
       {
@@ -11363,15 +11364,14 @@
       }
       {
         name: kmac_data
-        struct: kmac_data
-        package: keymgr_pkg
+        struct: app
+        package: kmac_pkg
         type: req_rsp
         act: req
         width: 1
         inst_name: keymgr
         default: ""
-        end_idx: -1
-        top_signame: keymgr_kmac_data
+        top_signame: kmac_app
         index: -1
       }
       {
@@ -13906,24 +13906,24 @@
         default: ""
       }
       {
-        package: keymgr_pkg
-        struct: kmac_data_req
-        signame: keymgr_kmac_data_req
+        package: kmac_pkg
+        struct: app_req
+        signame: kmac_app_req
         width: 1
         type: req_rsp
         end_idx: -1
-        act: req
+        act: rsp
         suffix: req
         default: ""
       }
       {
-        package: keymgr_pkg
-        struct: kmac_data_rsp
-        signame: keymgr_kmac_data_rsp
+        package: kmac_pkg
+        struct: app_rsp
+        signame: kmac_app_rsp
         width: 1
         type: req_rsp
         end_idx: -1
-        act: req
+        act: rsp
         suffix: rsp
         default: ""
       }

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -893,7 +893,10 @@
       // KeyMgr Sideload & KDF function
       'otp_ctrl.otp_keymgr_key' : ['keymgr.otp_key'],
       'keymgr.kmac_key'         : ['kmac.keymgr_key']
-      'keymgr.kmac_data'        : ['kmac.keymgr_kdf']
+
+      // KMAC Application Interface
+      'kmac.app'                : ['keymgr.kmac_data']
+
       // The idle connection is automatically connected through topgen.
       // The user does not need to explicitly declare anything other than
       // an empty list.

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -470,8 +470,8 @@ module top_earlgrey #(
   edn_pkg::edn_rsp_t [6:0] edn1_edn_rsp;
   otp_ctrl_pkg::otp_keymgr_key_t       otp_ctrl_otp_keymgr_key;
   keymgr_pkg::hw_key_req_t       keymgr_kmac_key;
-  keymgr_pkg::kmac_data_req_t       keymgr_kmac_data_req;
-  keymgr_pkg::kmac_data_rsp_t       keymgr_kmac_data_rsp;
+  kmac_pkg::app_req_t       kmac_app_req;
+  kmac_pkg::app_rsp_t       kmac_app_rsp;
   logic [3:0] clkmgr_aon_idle;
   jtag_pkg::jtag_req_t       pinmux_aon_lc_jtag_req;
   jtag_pkg::jtag_rsp_t       pinmux_aon_lc_jtag_rsp;
@@ -1965,8 +1965,8 @@ module top_earlgrey #(
 
       // Inter-module signals
       .keymgr_key_i(keymgr_kmac_key),
-      .keymgr_kdf_i(keymgr_kmac_data_req),
-      .keymgr_kdf_o(keymgr_kmac_data_rsp),
+      .app_i(kmac_app_req),
+      .app_o(kmac_app_rsp),
       .entropy_o(edn0_edn_req[3]),
       .entropy_i(edn0_edn_rsp[3]),
       .idle_o(clkmgr_aon_idle[2]),
@@ -2010,8 +2010,8 @@ module top_earlgrey #(
       .aes_key_o(),
       .hmac_key_o(),
       .kmac_key_o(keymgr_kmac_key),
-      .kmac_data_o(keymgr_kmac_data_req),
-      .kmac_data_i(keymgr_kmac_data_rsp),
+      .kmac_data_o(kmac_app_req),
+      .kmac_data_i(kmac_app_rsp),
       .otp_key_i(otp_ctrl_otp_keymgr_key),
       .otp_hw_cfg_i(otp_ctrl_otp_hw_cfg),
       .flash_i(flash_ctrl_keymgr),


### PR DESCRIPTION
Previously KeyMgr KDF interface was defined in KeyMgr IP. The interface
has been used for KeyMgr to initiate KMAC operation via side channel
interface.

As rom_ctrl and otp_ctrl plan to use KMAC as signature verification
function, KMAC needs to have more general application interface now.

This commit is to move the KDF struct into KMAC and renames it to
`app_{req/rsp}_t`.