### PR TITLE
[dvsim] Spot fixes for LSF and internal launcher

### DIFF
--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -29,7 +29,7 @@
                // otherwise. The double-escaped quotes are because this needs to go inside a string
                // that gets passed to Make (stripping one level of quotes), and then needs to
                // result in an argument with an embedded space (the other one).
-               "-CFLAGS \\\"--std=c99 -fno-extended-identifiers\\\"",
+               "-CFLAGS --std=c99 -CFLAGS -fno-extended-identifiers",
                // C++11 standard is enforced for all sources, including the DPI-C constructs.
                // TODO, may need to update to c++14 to meet our requirements
                // Refer to https://docs.opentitan.org/doc/ug/install_instructions
@@ -192,7 +192,7 @@
 
   // Vars that need to exported to the env.
   exports: [
-    { FLEXLM_DIAGNOSTICS: 4 },
+    { VCS_LICENSE_WAIT: 1 },
     { VCS_ARCH_OVERRIDE: "linux" },
     { VCS_LIC_EXPIRE_WARNING: 1 }
   ]

--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -165,7 +165,9 @@
                    "-covdut {dut}",
                    // Set the coverage configuration file
                    "-covfile {xcelium_cov_cfg_file}"]
-      run_opts:   [// Coverage database output location.
+      run_opts:   [// Put the coverage model (*.ucm) and the database (*.ucd) together.
+                   "-covmodeldir {cov_db_test_dir}",
+                   // Coverage database output location.
                    "-covworkdir {cov_work_dir}",
                    // Set the scope to the build mode name.
                    "-covscope {build_mode}",

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -104,7 +104,7 @@
       sw_images: ["sw/device/otp_img/otp_img:3"],
       run_opts: ["+sw_build_bin_dir={sw_build_dir}/build-bin",
                  "+sw_build_device={sw_build_device}",
-                 "+sw_images=\\\"{sw_images}\\\""]
+                 "+sw_images='{sw_images}'"]
     }
     {
       name: sw_test_mode

--- a/util/dvsim/Launcher.py
+++ b/util/dvsim/Launcher.py
@@ -25,8 +25,11 @@ class Launcher:
     launcher object holds an instance of the deploy object.
     """
 
+    # Type of launcher used as string.
+    variant = None
+
     # Points to the python virtual env area.
-    python_venv = None
+    pyvenv = None
 
     # If a history of previous invocations is to be maintained, then keep no
     # more than this many directories.
@@ -37,7 +40,7 @@ class Launcher:
     workspace_prepared_for_cfg = set()
 
     @staticmethod
-    def set_python_venv(project):
+    def set_pyvenv(project):
         '''Activate a python virtualenv if available.
 
         The env variable <PROJECT>_PYTHON_VENV if set, points to the path
@@ -48,7 +51,7 @@ class Launcher:
         This is not applicable when running jobs locally on the user's machine.
         '''
 
-        if Launcher.python_venv is not None:
+        if Launcher.pyvenv is not None:
             return
 
         # If project-specific python virtualenv path is set, then activate it
@@ -56,8 +59,16 @@ class Launcher:
         # launching locally, but on external machines in a compute farm, which
         # may not have access to the default python installation area on the
         # host machine.
-        Launcher.python_venv = os.environ.get("{}_PYTHON_VENV".format(
-            project.upper()))
+        #
+        # The code below allows each launcher variant to set its own virtualenv
+        # because the loading / activating mechanism could be different between
+        # them.
+        Launcher.pyvenv = os.environ.get("{}_PYVENV_{}".format(
+            project.upper(), Launcher.variant.upper()))
+
+        if not Launcher.pyvenv:
+            Launcher.pyvenv = os.environ.get("{}_PYVENV".format(
+                project.upper()))
 
     @staticmethod
     def prepare_workspace(project, repo_top, args):


### PR DESCRIPTION
Over the past few weeks, the scheduling and launching mechanism were
refactored to fully support LSF and our Google cloud which is used
internally.

The fixes made in this PR are minor ones to support our internal cloud
launcher (which will not be committed to our open repo).

The fixes are as follows:
- Updates to commands and env vars in the HJson data
- Addition of `input_dirs` and `output_dirs` variables in `Deploy`
  - This is needed only for the cloud launcher because jobs with cloud
  run in a hermetically sealed VM which needs to explicitly indicate
  what the input and output data is.
  - We will refactor this again in future when we will flip the Deploy
  and Launcher hierarchy.
- Fixes to command sub-strings (ensure they are quoted properly)
- Allow remote launchers to set their own python virtualenv region
- Some cosmetic changes

Signed-off-by: Srikrishna Iyer <sriyer@google.com>