### PR TITLE
[fpv/rstmgr] FPV compile error

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.sv.tpl
@@ -54,7 +54,8 @@ module rstmgr import rstmgr_pkg::*; (
   for (genvar i = 0; i < PowerDomains; i++) begin : gen_rst_por_aon
     if (i == DomainAonSel) begin : gen_rst_por_aon_normal
 
-      lc_ctrl_pkg::lc_tx_t por_aon_scanmode;
+      // Workaround due to FPV compile error
+      lc_ctrl_pkg::lc_tx_t [0:0] por_aon_scanmode;
       prim_lc_sync #(
         .NumCopies(1),
         .AsyncOn(0)
@@ -69,7 +70,7 @@ module rstmgr import rstmgr_pkg::*; (
         .clk_i(clk_aon_i),
         .rst_ni, // this is the only use of rst_ni in this module
         .scan_rst_ni,
-        .scanmode_i(por_aon_scanmode == lc_ctrl_pkg::On),
+        .scanmode_i(por_aon_scanmode[0] == lc_ctrl_pkg::On),
         .rst_no(rst_por_aon_n[i])
       );
     end else begin : gen_rst_por_aon_tieoff
@@ -134,7 +135,8 @@ module rstmgr import rstmgr_pkg::*; (
   logic [PowerDomains-1:0] rst_lc_src_n;
   logic [PowerDomains-1:0] rst_sys_src_n;
 
-  lc_ctrl_pkg::lc_tx_t rst_ctrl_scanmode;
+  // Workaround due to FPV compile error
+  lc_ctrl_pkg::lc_tx_t [0:0] rst_ctrl_scanmode;
   prim_lc_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -148,7 +150,7 @@ module rstmgr import rstmgr_pkg::*; (
   // lc reset sources
   rstmgr_ctrl u_lc_src (
     .clk_i,
-    .scanmode_i(rst_ctrl_scanmode == lc_ctrl_pkg::On),
+    .scanmode_i(rst_ctrl_scanmode[0] == lc_ctrl_pkg::On),
     .scan_rst_ni,
     .rst_ni(local_rst_n),
     .rst_req_i(pwr_i.rst_lc_req),

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -61,7 +61,8 @@ module rstmgr import rstmgr_pkg::*; (
   for (genvar i = 0; i < PowerDomains; i++) begin : gen_rst_por_aon
     if (i == DomainAonSel) begin : gen_rst_por_aon_normal
 
-      lc_ctrl_pkg::lc_tx_t por_aon_scanmode;
+      // Workaround due to FPV compile error
+      lc_ctrl_pkg::lc_tx_t [0:0] por_aon_scanmode;
       prim_lc_sync #(
         .NumCopies(1),
         .AsyncOn(0)
@@ -76,7 +77,7 @@ module rstmgr import rstmgr_pkg::*; (
         .clk_i(clk_aon_i),
         .rst_ni, // this is the only use of rst_ni in this module
         .scan_rst_ni,
-        .scanmode_i(por_aon_scanmode == lc_ctrl_pkg::On),
+        .scanmode_i(por_aon_scanmode[0] == lc_ctrl_pkg::On),
         .rst_no(rst_por_aon_n[i])
       );
     end else begin : gen_rst_por_aon_tieoff
@@ -141,7 +142,8 @@ module rstmgr import rstmgr_pkg::*; (
   logic [PowerDomains-1:0] rst_lc_src_n;
   logic [PowerDomains-1:0] rst_sys_src_n;
 
-  lc_ctrl_pkg::lc_tx_t rst_ctrl_scanmode;
+  // Workaround due to FPV compile error
+  lc_ctrl_pkg::lc_tx_t [0:0] rst_ctrl_scanmode;
   prim_lc_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -155,7 +157,7 @@ module rstmgr import rstmgr_pkg::*; (
   // lc reset sources
   rstmgr_ctrl u_lc_src (
     .clk_i,
-    .scanmode_i(rst_ctrl_scanmode == lc_ctrl_pkg::On),
+    .scanmode_i(rst_ctrl_scanmode[0] == lc_ctrl_pkg::On),
     .scan_rst_ni,
     .rst_ni(local_rst_n),
     .rst_req_i(pwr_i.rst_lc_req),


### PR DESCRIPTION
This PR fixes a compile error in FPV. I will contact the AE and see if
they can fix it. Right now the prim_lc_sync syntax works for simulation
but not FPV.

Signed-off-by: Cindy Chen <chencindy@google.com>