### PR TITLE
[formal/conn] Support connectivity test locally

### DIFF
--- a/hw/formal/conn_csvs/top_earlgrey_conn.csv
+++ b/hw/formal/conn_csvs/top_earlgrey_conn.csv
@@ -1,0 +1,3 @@
+,NAME,SRC BLOCK,SRC SIGNAL,DEST BLOCK,DEST SIGNAL,,,,,,
+
+CONNECTION,CLKMGR_IDLE0,u_clkmgr_aon,idle_i[0],u_aes,idle_o

--- a/hw/formal/formal_conn.sh
+++ b/hw/formal/formal_conn.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Script to run connectivity test using Jasper Gold
+#
+# Usage: To run connectivity test on system level modules, type
+#   formal_conn -f top_earlgrey.csv
+#
+# More options:
+# -top: which top_level module to run
+# -p:  provide core file path
+# -gui: run with GUI
+# -cov: run coverage
+# -f: path to the csv file
+# -t: choose which formal tool to use, current only support jaspergold
+#
+# Example:
+#   formal_conn -gui -cov -f top_earlgrey_conn.csv
+#
+
+export TOP="top_earlgrey"
+gui=0
+tool="jg"
+export COV=0
+export CSV_PATH
+
+while [ "$1" != "" ]; do
+  case "$1" in
+    "-top")
+      shift
+      TOP=$1
+      ;;
+    "-p")
+      shift
+      CORE_PATH=$1
+      ;;
+    "-gui")
+      gui=1
+      echo "using GUI mode"
+      ;;
+    "-cov")
+      COV=1
+      echo "enable coverage"
+      ;;
+    "-t")
+      shift
+      tool=$1
+      echo "running in tool: $tool"
+      ;;
+    "-f")
+      shift
+      CSV_PATH=../../../../top_earlgrey/fpv/conn_csvs/$1
+      echo "csv path: $CSV_PATH"
+      ;;
+  esac
+  shift
+done
+
+echo "-------------------------------------------------------------------------"
+echo "-- Generate file list using FuseSoC"
+echo "-------------------------------------------------------------------------"
+echo ""
+echo "Top: $TOP"
+echo ""
+
+\rm -Rf build jgproject
+# we just run the setup for the default target in order to generate the filelist
+if [ "${CORE_PATH}" == "" ]; then
+  CORE_PATH=systems:top_earlgrey
+fi
+echo "core_file path: lowrisc:${CORE_PATH}"
+
+fusesoc --cores-root ../.. run\
+        --tool=icarus --target=default\
+        --flag=fileset_top\
+        --setup "lowrisc:${CORE_PATH}"
+
+echo "-------------------------------------------------------------------------"
+echo "-- Run JasperGold"
+echo "-------------------------------------------------------------------------"
+
+cd build/*${TOP}*/default-icarus
+
+if [ "${tool}" == "jg" ]; then
+  if [ "${gui}" == "1" ]; then
+    jg ../../../tools/jaspergold/conn.tcl \
+       -proj ../../../jgproject \
+       -allow_unsupported_OS \
+       | tee ../../../jg_conn.log
+  else
+    jg -batch \
+      ../../../tools/jaspergold/conn.tcl \
+      -proj ../../../jgproject \
+      -allow_unsupported_OS \
+      -command exit \
+      | tee ../../../jg_conn.log
+  fi
+else
+ echo "-- ERROR: TOOL ${tool} not supported"
+fi
+cd -
+
+echo "-------------------------------------------------------------------------"
+echo "-- Done"
+echo "-------------------------------------------------------------------------"

--- a/hw/formal/tools/jaspergold/conn.tcl
+++ b/hw/formal/tools/jaspergold/conn.tcl
@@ -1,0 +1,69 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# clear previous settings
+clear -all
+
+# We use parameter instead of localparam in packages to allow redefinition
+# at elaboration time.
+# Disabling the warning
+# "parameter declared inside package XXX shall be treated as localparam".
+set_message -disable VERI-2418
+
+if {$env(COV) == 1} {
+  check_cov -init -model {branch statement functional} \
+  -enable_prove_based_proof_core
+}
+#-------------------------------------------------------------------------
+# read design
+#-------------------------------------------------------------------------
+
+# only one scr file exists in this folder
+analyze -sv09 -f [glob *.scr]
+
+# Black-box assistant will blackbox the modules which are not needed by looking at
+# the connectivity csv.
+blackbox_assistant -config -connectivity_Map $env(CSV_PATH)
+
+# This is jg work-around when black-boxing with inout ports
+set_port_direction_handling coercion_weak_bbox
+
+elaborate -top $env(TOP)
+
+# Currently only for top_earlgrey
+if {$env(TOP) == "top_earlgrey"} {
+  clock clk_main_i
+  clock clk_io_i
+  clock clk_usb_i
+  clock clk_aon_i
+  reset -expr {rst_ni}
+}
+
+#-------------------------------------------------------------------------
+# configure proofgrid
+#-------------------------------------------------------------------------
+set_proofgrid_mode local
+set_proofgrid_per_engine_max_local_jobs 2
+
+# Uncomment below 2 lines when using LSF:
+# set_proofgrid_mode lsf
+# set_proofgrid_per_engine_max_jobs 16
+
+check_conn -load $env(CSV_PATH)
+
+#-------------------------------------------------------------------------
+# prove all assertions & report
+#-------------------------------------------------------------------------
+# time limit set to 2 hours
+prove -task Connectivity -time_limit 2h
+report -task Connectivity
+
+#-------------------------------------------------------------------------
+# check coverage and report
+#-------------------------------------------------------------------------
+if {$env(COV) == 1} {
+  check_cov -measure
+  check_cov -report -type all -no_return -report_file cover.html \
+      -html -force -exclude { reset waived }
+}

--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -68,14 +68,6 @@ if {$env(FPV_TOP) == "rv_dm"} {
   clock -rate {cio_d_i, cio_dp_i, cio_dn_i, cio_sense_i} clk_usb_48mhz_i
   reset -expr {!rst_ni !rst_aon_ni !rst_usb_48mhz_ni}
 
-  # top_earlgrey is mainly used for connectivity test
-} elseif {$env(FPV_TOP) == "top_earlgrey"} {
-  clock clk_i -both_edges
-  clock jtag_tck_i
-  # TODO: check this once pinmux/padring is updated
-  clock -rate -default clk_i
-  reset -expr {!rst_ni !jtag_trst_ni}
-
 # TODO: work with the block owner and re-define FPV checkings for xbar
 # } elseif {$env(FPV_TOP) == "xbar_main"} {
 #   clock clk_main_i -both_edges

--- a/hw/top_earlgrey/fpv/conn_csvs/top_earlgrey_conn.csv
+++ b/hw/top_earlgrey/fpv/conn_csvs/top_earlgrey_conn.csv
@@ -1,0 +1,9 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# TODO: use top_earlgrey_asic once the ast compile error fixed
+
+,NAME,SRC BLOCK,SRC SIGNAL,DEST BLOCK,DEST SIGNAL,,,,,,
+
+CONNECTION,CLKMGR_IDLE0,u_clkmgr_aon,idle_i[0],u_aes,idle_o


### PR DESCRIPTION
This PR adds basic configs to run connecivity test locally.
This is the first step to support running connecivity test using dvsim.
The reason we are adding this local option is because we can temporarily
using this script to run with GUI.

Next PR will support running the connectivity test on dvsim.

Signed-off-by: Cindy Chen <chencindy@google.com>