### PR TITLE
[dvsim/conn] Add formal connectivity flow in dvsim

### DIFF
--- a/hw/formal/formal_conn.sh
+++ b/hw/formal/formal_conn.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Script to run connectivity test using Jasper Gold
+#
+# Usage: To run connectivity test on system level modules, type
+#   formal_conn -f top_earlgrey.csv
+#
+# More options:
+# -top: which top_level module to run
+# -p:  provide core file path
+# -batch: run batch mode without GUI
+# -cov: run coverage
+# -f: path to the csv file
+# -t: choose which formal tool to use, current only support jaspergold
+#
+# Example:
+#   formal_conn -cov -f top_earlgrey_conn.csv
+#
+
+set -e
+
+CORE_PATH=systems:top_earlgrey
+REPO_PATH=$(readlink -f ../..)
+
+export TOP="top_earlgrey"
+batch=""
+tool="jg"
+export COV=0
+export CSV_PATH
+
+while [ "$1" != "" ]; do
+  case "$1" in
+    "-top")
+      shift
+      TOP=$1
+      ;;
+    "-p")
+      shift
+      CORE_PATH=$1
+      ;;
+    "-batch")
+      batch="-batch"
+      echo "runnin in batch mode"
+      ;;
+    "-cov")
+      COV=1
+      echo "enable coverage"
+      ;;
+    "-t")
+      shift
+      tool=$1
+      echo "running in tool: $tool"
+      ;;
+    "-f")
+      shift
+      CSV_PATH=../../../../top_earlgrey/fpv/fconn_csvs/$1
+      echo "csv path: $CSV_PATH"
+      ;;
+    *)
+      echo "ERROR: no match found for input $1"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+echo "-------------------------------------------------------------------------"
+echo "-- Generate file list using FuseSoC"
+echo "-------------------------------------------------------------------------"
+echo ""
+echo "Top: $TOP"
+echo ""
+
+rm -Rf build jgproject
+echo "core_file path: lowrisc:${CORE_PATH}"
+
+fusesoc --cores-root ../.. run\
+        --tool=icarus --target=default\
+        --flag=fileset_top\
+        --setup "lowrisc:${CORE_PATH}"
+
+echo "-------------------------------------------------------------------------"
+echo "-- Run JasperGold"
+echo "-------------------------------------------------------------------------"
+
+cd build/*${TOP}*/default-icarus
+
+if [ "${tool}" == "jg" ]; then
+    jg ${batch} \
+      ${REPO_PATH}/hw/formal/tools/jaspergold/fconn.tcl \
+      -proj {REPO_PATH}/hw/formal/jgproject \
+      -allow_unsupported_OS \
+      -command exit \
+      | tee ${REPO_PATH}/hw/formal/jg_conn.log
+else
+ echo "ERROR: TOOL ${tool} not supported"
+ exit 1
+fi
+cd -
+
+echo "-------------------------------------------------------------------------"
+echo "-- Done"
+echo "-------------------------------------------------------------------------"

--- a/hw/formal/tools/dvsim/common_conn_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_conn_cfg.hjson
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   flow:             fpv
-  sub_flow:         fpv
+  sub_flow:         fconn
   fpv_root:         "{proj_root}/hw/formal"
   flow_makefile:    "{fpv_root}/tools/dvsim/fpv.mk"
 
@@ -26,20 +26,30 @@
                       "run",
                       "--flag=fileset_{design_level}",
                       "--tool=icarus",
-                      "--target=formal",
+                      "--target=default",
                       "--build-root={build_dir}",
                       "--setup {fusesoc_core}"]
-  sv_flist_gen_dir:  "{build_dir}/formal-icarus"
+  sv_flist_gen_dir:  "{build_dir}/default-icarus"
 
   // Vars that need to exported to the env
   exports: [
-    { FPV_TOP: "{dut}" },
-    { COV: "{cov}" }
+    { TOP: "{dut}" },
+    { COV: "{cov}" },
+    { CSV_PATH: "{csv_path}"}
   ]
 
   report_cmd:  "python3 {fpv_root}/tools/{tool}/parse-fpv-report.py"
+  // TODO: the output name should be conn.log instead of fpv.log
   report_opts: ["--logpath={build_dir}/fpv.log",
                 "--reppath={build_dir}/results.hjson",
                 "--cov={cov}",
                 "--dut={name}"]
+
+  // Connectivity test should all be in top_level design
+  overrides: [
+    {
+      name: design_level
+      value: "top"
+    }
+  ]
 }

--- a/hw/formal/tools/jaspergold/fconn.tcl
+++ b/hw/formal/tools/jaspergold/fconn.tcl
@@ -1,0 +1,69 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# clear previous settings
+clear -all
+
+# We use parameter instead of localparam in packages to allow redefinition
+# at elaboration time.
+# Disabling the warning
+# "parameter declared inside package XXX shall be treated as localparam".
+set_message -disable VERI-2418
+
+if {$env(COV) == 1} {
+  check_cov -init -model {branch statement functional} \
+  -enable_prove_based_proof_core
+}
+#-------------------------------------------------------------------------
+# read design
+#-------------------------------------------------------------------------
+
+# only one scr file exists in this folder
+analyze -sv09 -f [glob *.scr]
+
+# Black-box assistant will blackbox the modules which are not needed by looking at
+# the connectivity csv.
+blackbox_assistant -config -connectivity_Map $env(CSV_PATH)
+
+# This is jg work-around when black-boxing with inout ports
+set_port_direction_handling coercion_weak_bbox
+
+elaborate -top $env(TOP)
+
+# Currently only for top_earlgrey
+if {$env(TOP) == "top_earlgrey"} {
+  clock clk_main_i
+  clock clk_io_i
+  clock clk_usb_i
+  clock clk_aon_i
+  reset -expr {rst_ni}
+}
+
+#-------------------------------------------------------------------------
+# configure proofgrid
+#-------------------------------------------------------------------------
+set_proofgrid_mode local
+set_proofgrid_per_engine_max_local_jobs 2
+
+# Uncomment below 2 lines when using LSF:
+# set_proofgrid_mode lsf
+# set_proofgrid_per_engine_max_jobs 16
+
+check_conn -load $env(CSV_PATH)
+
+#-------------------------------------------------------------------------
+# prove all assertions & report
+#-------------------------------------------------------------------------
+# time limit set to 2 hours
+prove -task Connectivity -time_limit 2h
+report -task Connectivity
+
+#-------------------------------------------------------------------------
+# check coverage and report
+#-------------------------------------------------------------------------
+if {$env(COV) == 1} {
+  check_cov -measure
+  check_cov -report -type all -no_return -report_file cover.html \
+      -html -force -exclude { reset waived }
+}

--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -68,14 +68,6 @@ if {$env(FPV_TOP) == "rv_dm"} {
   clock -rate {cio_d_i, cio_dp_i, cio_dn_i, cio_sense_i} clk_usb_48mhz_i
   reset -expr {!rst_ni !rst_aon_ni !rst_usb_48mhz_ni}
 
-  # top_earlgrey is mainly used for connectivity test
-} elseif {$env(FPV_TOP) == "top_earlgrey"} {
-  clock clk_i -both_edges
-  clock jtag_tck_i
-  # TODO: check this once pinmux/padring is updated
-  clock -rate -default clk_i
-  reset -expr {!rst_ni !jtag_trst_ni}
-
 # TODO: work with the block owner and re-define FPV checkings for xbar
 # } elseif {$env(FPV_TOP) == "xbar_main"} {
 #   clock clk_main_i -both_edges

--- a/hw/formal/tools/jaspergold/jaspergold.hjson
+++ b/hw/formal/tools/jaspergold/jaspergold.hjson
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   build_cmd: "{job_prefix} jg"
-  build_opts: ["-batch {fpv_root}/tools/{tool}/fpv.tcl",
+  build_opts: ["-batch {fpv_root}/tools/{tool}/{sub_flow}.tcl",
                "-proj jgproject",
                "-allow_unsupported_OS",
                "-command exit"]

--- a/hw/top_earlgrey/fpv/chip_fconn_cfg.hjson
+++ b/hw/top_earlgrey/fpv/chip_fconn_cfg.hjson
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: top_earlgrey
+
+  import_cfgs: [// common server configuration for results upload
+                "{proj_root}/hw/formal/tools/dvsim/common_conn_cfg.hjson"]
+
+  fusesoc_core: lowrisc:systems:top_earlgrey
+
+  csv_path: "{proj_root}/hw/top_earlgrey/fpv/fconn_csvs/top_earlgrey_conn.csv"
+
+  // TODO: reduce run time and turn on coverage
+  cov: false
+}

--- a/hw/top_earlgrey/fpv/fconn_csvs/top_earlgrey_conn.csv
+++ b/hw/top_earlgrey/fpv/fconn_csvs/top_earlgrey_conn.csv
@@ -1,0 +1,9 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# TODO: use top_earlgrey_asic once the ast compile error fixed
+
+,NAME,SRC BLOCK,SRC SIGNAL,DEST BLOCK,DEST SIGNAL,,,,,,
+
+CONNECTION,CLKMGR_IDLE0,u_clkmgr_aon,idle_i[0],u_aes,idle_o


### PR DESCRIPTION
The first commit is from PR #5768.

This PR adds support using dvsim to run formal connectivity test.
The flow is very similar to FPV, so I reused most of the fpv stuff.
The new supports are:

1. Add common_conn_cfg.hjson which pass an "app" name to specify it is
connectivity test, and add "CSV_PATH" that points to the connectivity
CSV file, finally overrides "design_level" as it should always be
top-level.

2. Add a batch script to run connectivity test.

To run connectivity test, simply use the script:
`{proj}/util/dvsim.py top_earlgrey_conn_cfg.hjson`

Next PR is to change common flow to "formal" instead of "fpv".

Signed-off-by: Cindy Chen <chencindy@google.com>