### PR TITLE
[dv] Fix reg backdoor

### DIFF
--- a/hw/dv/sv/csr_utils/csr_seq_lib.sv
+++ b/hw/dv/sv/csr_utils/csr_seq_lib.sv
@@ -169,8 +169,16 @@ class csr_write_seq extends csr_base_seq;
 
     // check all hdl paths are valid
     if (!test_backdoor_path_done) begin
+      bkdr_reg_path_e path_kind;
       uvm_reg_mem_hdl_paths_seq hdl_check_seq;
       hdl_check_seq = uvm_reg_mem_hdl_paths_seq::type_id::create("hdl_check_seq");
+
+      // add all the supported path types
+      do begin
+        hdl_check_seq.abstractions.push_back(path_kind.name);
+        path_kind = path_kind.next;
+      end while (path_kind != path_kind.first);
+
       foreach (models[i]) begin
         hdl_check_seq.model = models[i];
         hdl_check_seq.start(null);

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -353,7 +353,7 @@ package csr_utils_pkg;
     if (check == UVM_CHECK && status != UVM_IS_OK) begin
       string str;
       uvm_hdl_path_concat paths[$];
-      csr_or_fld.csr.get_full_hdl_path(paths);
+      csr_or_fld.csr.get_full_hdl_path(paths, kind.name);
       foreach (paths[0].slices[i]) str = $sformatf("%0s\n%0s", str, paths[0].slices[i].path);
       `uvm_fatal(msg_id, $sformatf("poke failed for %0s, check below paths %0s",
                                    ptr.get_full_name(), str))

--- a/util/reggen/top_uvm_reg.sv.tpl
+++ b/util/reggen/top_uvm_reg.sv.tpl
@@ -36,6 +36,7 @@
       esc_if_name = block.name.lower() + if_suffix
       if_desc = '' if if_name is None else '; interface {}'.format(if_name)
       reg_block_path = 'u_reg' + if_suffix
+      reg_block_path = reg_block_path if block.hier_path is None else block.hier_path + "." + reg_block_path
 %>\
 // Block: ${block.name.lower()}${if_desc}
 ${make_ral_pkg(dv_base_prefix, top.regwidth, reg_block_path, rb, esc_if_name)}


### PR DESCRIPTION
3 fixes in this PR
1. Fix hier_path not used in top reg
2. Fix path check didn't run properly as path types weren't given
3. Fix wrong error message `does not have hdl path defined for
abstraction 'RTL'`, we don't use `RTL` as hdl path, it should be
`BkdrRegPathRtl`

Signed-off-by: Weicai Yang <weicai@google.com>