### PR TITLE
[spi_device] Some lint fixes

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -697,11 +697,7 @@ module spi_device (
     .cmd_config_idx_o ()
   );
 
-  spi_readcmd #(
-    .SramAw(SramAw),
-    .SramDw(SramDw)
-    // BaseAddr / Depth use spi_device_pkg parameters
-  ) u_readcmd (
+  spi_readcmd u_readcmd (
     .clk_i  (clk_spi_in_buf),
     .rst_ni (rst_spi_n),
 

--- a/hw/ip/spi_device/rtl/spi_fwm_txf_ctrl.sv
+++ b/hw/ip/spi_device/rtl/spi_fwm_txf_ctrl.sv
@@ -228,7 +228,7 @@ module spi_fwm_txf_ctrl #(
   always_comb begin
     fifo_wdata = '0;
     for (int i = 0 ; i < NumBytes ; i++) begin
-      if (pos == i) fifo_wdata = fifo_wdata_d[8*i+:8];
+      if (pos == i[SDW-1:0]) fifo_wdata = fifo_wdata_d[8*i+:8];
     end
   end
 

--- a/hw/ip/spi_device/rtl/spi_p2s.sv
+++ b/hw/ip/spi_device/rtl/spi_p2s.sv
@@ -210,7 +210,7 @@ module spi_p2s
       SingleIO: last_beat = (cnt == BitWidth'('h7));
       DualIO:   last_beat = (cnt == BitWidth'('h3));
       QuadIO:   last_beat = (cnt == BitWidth'('h1));
-      default:  last_beat = BitWidth'(0);
+      default:  last_beat = 1'b0;
     endcase
   end
 

--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -357,8 +357,8 @@ module spi_readcmd
   // Address conversion
   // Convert into masked address
   localparam int unsigned MailboxAw = $clog2(MailboxDepth);
-  localparam logic [31:0] MailboxMask = 32'h FFFF_FFFF
-                                      ^ {(2+MailboxAw){1'b1}};
+  localparam logic [31:0] MailboxMask = {{30-MailboxAw{1'b1}}, {2+MailboxAw{1'b0}}};
+
   assign mailbox_masked_addr = addr_d & MailboxMask;
 
   // Only valid when logic sends SRAM request

--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -385,7 +385,7 @@ module spi_readcmd
   assign sram_addr_o = sram_addr;
 
   assign sram_req_o = sram_req;
-  assign sram_write_o = 1'b 0; // always read
+  assign sram_we_o = 1'b 0;    // always read
   assign sram_wdata_o = '0;    // always read
 
   //- END:   SRAM Datapath ----------------------------------------------------
@@ -594,13 +594,13 @@ module spi_readcmd
   // Assertions //
   // FIFO should not overflow. The Main state machine shall send request only
   // when it needs the data within 2 cycles
-  `ASSERT(NotOverflow_A, sram_req_o && !sram_write_o |-> !unused_full)
+  `ASSERT(NotOverflow_A, sram_req_o && !sram_we_o |-> !unused_full)
 
   // SRAM access always read
-  `ASSERT(SramReadOnly_A, sram_req_o |-> !sram_write_o)
+  `ASSERT(SramReadOnly_A, sram_req_o |-> !sram_we_o)
 
   // SRAM data should return in next cycle
-  `ASSUME(SramDataReturnRequirement_M, sram_req_o && !sram_write_o |=> sram_rvalid_i)
+  `ASSUME(SramDataReturnRequirement_M, sram_req_o && !sram_we_o |=> sram_rvalid_i)
 
   // TODO: When main state machine returns data to SPI (via p2s), the FIFO shall
   // not be empty

--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -485,14 +485,14 @@ module spi_readcmd
             CmdReadData: main_st_d = MainOutput;
 
             // Dummy cycle for commands other than IO
-            {CmdReadFast, CmdReadDual, CmdReadQuad}: begin
+            CmdReadFast, CmdReadDual, CmdReadQuad: begin
               main_st_d = MainDummy;
               // TODO: Reset dummy counter
               load_dummycnt = 1'b 1;
             end
 
             // MByte for IO commands
-            {CmdReadDualIO, CmdReadQuadIO}: begin
+            CmdReadDualIO, CmdReadQuadIO: begin
               main_st_d = MainMByte;
             end
 
@@ -533,9 +533,9 @@ module spi_readcmd
         // Change Mode based on the input opcode
         // Return data from FIFO
         unique case (opcode_i) inside
-          {CmdReadData, CmdReadFast}:   io_mode_o = SingleIO;
-          {CmdReadDual, CmdReadDualIO}: io_mode_o = DualIO;
-          {CmdReadQuad, CmdReadQuadIO}: io_mode_o = QuadIO;
+          CmdReadData, CmdReadFast:   io_mode_o = SingleIO;
+          CmdReadDual, CmdReadDualIO: io_mode_o = DualIO;
+          CmdReadQuad, CmdReadQuadIO: io_mode_o = QuadIO;
           default: io_mode_o = SingleIO;
         endcase
 

--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -83,9 +83,6 @@
 module spi_readcmd
   import spi_device_pkg::*;
 #(
-  parameter int unsigned SramAw = 10, // 4kB
-  parameter int unsigned SramDw = 32, // 4B
-
   // Read command configurations
   // Base address: Index of DPSRAM
   // Buffer size: # of indices assigned to Read Buffer.

--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -158,7 +158,7 @@ module spi_readcmd
 );
 
   logic unused_threshold;
-  assign unused_threshold = readbuf_threshold_i;
+  assign unused_threshold = &{1'b0, readbuf_threshold_i};
   assign read_watermark_o = 1'b 0;
 
   /////////////////


### PR DESCRIPTION
This fixes some wrongly-wired-up parameters and various width mismatches. It doesn't waive the many unused signals (they'll need doing later). There are also two UNOPTFLAT warnings. One shows a genuine bug, I think, tracked as https://github.com/lowRISC/opentitan/issues/5774. The other is caused by a computed clock and needs a bit more thought.