### PR TITLE
[dif_alert_handler] Use auto-generated Hjson file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -207,7 +207,7 @@ gen_hw_hdr = generator(
 # TODO: Considering moving these into hw/ip directories.
 TOPNAME='top_earlgrey'
 hw_ip_aes_reg_h = gen_hw_hdr.process('hw/ip/aes/data/aes.hjson')
-hw_ip_alert_handler_reg_h = gen_hw_hdr.process('hw/ip/alert_handler/data/alert_handler.hjson')
+hw_ip_alert_handler_reg_h = gen_hw_hdr.process('hw/' + TOPNAME + '/ip/alert_handler/data/autogen/alert_handler.hjson')
 hw_ip_aon_timer_reg_h = gen_hw_hdr.process('hw/ip/aon_timer/data/aon_timer.hjson')
 hw_ip_clkmgr_reg_h = gen_hw_hdr.process('hw/' + TOPNAME + '/ip/clkmgr/data/autogen/clkmgr.hjson')
 hw_ip_entropy_reg_h = gen_hw_hdr.process('hw/ip/entropy_src/data/entropy_src.hjson')

--- a/sw/device/lib/dif/dif_alert_handler.c
+++ b/sw/device/lib/dif/dif_alert_handler.c
@@ -51,7 +51,7 @@ static bool classify_alerts(const dif_alert_handler_t *handler,
   uint32_t enable_reg = mmio_region_read32(handler->params.base_addr,
                                            ALERT_HANDLER_ALERT_EN_REG_OFFSET);
   uint32_t alerts_reg = mmio_region_read32(
-      handler->params.base_addr, ALERT_HANDLER_ALERT_CLASS_REG_OFFSET);
+      handler->params.base_addr, ALERT_HANDLER_ALERT_CLASS_0_REG_OFFSET);
 
   for (int i = 0; i < class->alerts_len; ++i) {
     if (class->alerts[i] >= handler->params.alert_count) {
@@ -65,16 +65,16 @@ static bool classify_alerts(const dif_alert_handler_t *handler,
     uint32_t classification;
     switch (class->alert_class) {
       case kDifAlertHandlerClassA:
-        classification = ALERT_HANDLER_ALERT_CLASS_CLASS_A_0_VALUE_CLASSA;
+        classification = ALERT_HANDLER_ALERT_CLASS_0_CLASS_A_0_VALUE_CLASSA;
         break;
       case kDifAlertHandlerClassB:
-        classification = ALERT_HANDLER_ALERT_CLASS_CLASS_A_0_VALUE_CLASSB;
+        classification = ALERT_HANDLER_ALERT_CLASS_0_CLASS_A_0_VALUE_CLASSB;
         break;
       case kDifAlertHandlerClassC:
-        classification = ALERT_HANDLER_ALERT_CLASS_CLASS_A_0_VALUE_CLASSC;
+        classification = ALERT_HANDLER_ALERT_CLASS_0_CLASS_A_0_VALUE_CLASSC;
         break;
       case kDifAlertHandlerClassD:
-        classification = ALERT_HANDLER_ALERT_CLASS_CLASS_A_0_VALUE_CLASSD;
+        classification = ALERT_HANDLER_ALERT_CLASS_0_CLASS_A_0_VALUE_CLASSD;
         break;
       default:
         return false;
@@ -83,13 +83,13 @@ static bool classify_alerts(const dif_alert_handler_t *handler,
     // TODO: Currently, we assume all fields are of equal width.
     // See: #3826
     uint32_t field_width =
-        bitfield_popcount32(ALERT_HANDLER_ALERT_CLASS_CLASS_A_0_MASK);
+        bitfield_popcount32(ALERT_HANDLER_ALERT_CLASS_0_CLASS_A_0_MASK);
     uint32_t field_offset = field_width * class->alerts[i];
 
     alerts_reg = bitfield_field32_write(
         alerts_reg,
         (bitfield_field32_t){
-            .mask = ALERT_HANDLER_ALERT_CLASS_CLASS_A_0_MASK,
+            .mask = ALERT_HANDLER_ALERT_CLASS_0_CLASS_A_0_MASK,
             .index = field_offset,
         },
         classification);
@@ -98,7 +98,7 @@ static bool classify_alerts(const dif_alert_handler_t *handler,
   mmio_region_write32(handler->params.base_addr,
                       ALERT_HANDLER_ALERT_EN_REG_OFFSET, enable_reg);
   mmio_region_write32(handler->params.base_addr,
-                      ALERT_HANDLER_ALERT_CLASS_REG_OFFSET, alerts_reg);
+                      ALERT_HANDLER_ALERT_CLASS_0_REG_OFFSET, alerts_reg);
   return true;
 }
 

--- a/sw/device/tests/dif/dif_alert_handler_unittest.cc
+++ b/sw/device/tests/dif/dif_alert_handler_unittest.cc
@@ -213,7 +213,7 @@ TEST_F(ConfigTest, ClassInit) {
   // Unfortunately, we can't use EXPECT_MASK for these reads and writes,
   // since there are not sequenced exactly.
   EXPECT_READ32(ALERT_HANDLER_ALERT_EN_REG_OFFSET, 0);
-  EXPECT_READ32(ALERT_HANDLER_ALERT_CLASS_REG_OFFSET, kAllOnes);
+  EXPECT_READ32(ALERT_HANDLER_ALERT_CLASS_0_REG_OFFSET, kAllOnes);
 
   EXPECT_WRITE32(ALERT_HANDLER_ALERT_EN_REG_OFFSET, {
                                                         {1, true},
@@ -225,7 +225,7 @@ TEST_F(ConfigTest, ClassInit) {
     reg_a =
         bitfield_field32_write(reg_a, {.mask = 0b11, .index = alert * 2}, 0b00);
   }
-  EXPECT_WRITE32(ALERT_HANDLER_ALERT_CLASS_REG_OFFSET, reg_a);
+  EXPECT_WRITE32(ALERT_HANDLER_ALERT_CLASS_0_REG_OFFSET, reg_a);
 
   EXPECT_READ32(ALERT_HANDLER_LOC_ALERT_EN_REG_OFFSET, 0);
   EXPECT_READ32(ALERT_HANDLER_LOC_ALERT_CLASS_REG_OFFSET, kAllOnes);
@@ -261,7 +261,7 @@ TEST_F(ConfigTest, ClassInit) {
   EXPECT_WRITE32(ALERT_HANDLER_CLASSA_PHASE2_CYC_REG_OFFSET, 15000);
 
   EXPECT_READ32(ALERT_HANDLER_ALERT_EN_REG_OFFSET, 0);
-  EXPECT_READ32(ALERT_HANDLER_ALERT_CLASS_REG_OFFSET, kAllOnes);
+  EXPECT_READ32(ALERT_HANDLER_ALERT_CLASS_0_REG_OFFSET, kAllOnes);
 
   EXPECT_WRITE32(ALERT_HANDLER_ALERT_EN_REG_OFFSET, {
                                                         {9, true},
@@ -273,7 +273,7 @@ TEST_F(ConfigTest, ClassInit) {
     reg_b =
         bitfield_field32_write(reg_b, {.mask = 0b11, .index = alert * 2}, 0b01);
   }
-  EXPECT_WRITE32(ALERT_HANDLER_ALERT_CLASS_REG_OFFSET, reg_b);
+  EXPECT_WRITE32(ALERT_HANDLER_ALERT_CLASS_0_REG_OFFSET, reg_b);
 
   EXPECT_READ32(ALERT_HANDLER_LOC_ALERT_EN_REG_OFFSET, 0);
   EXPECT_READ32(ALERT_HANDLER_LOC_ALERT_CLASS_REG_OFFSET, kAllOnes);


### PR DESCRIPTION
The alert_handler is an IP template which is instantiated with a
top_earlgrey-specific configuration. The C header file must be generated
from the templated Hjson file, not the example Hjson file which happens
to be in the tree as well, but doesn't contain the right configuration.

Fixes #5778