### PR TITLE
[reggen] Continued data integrity 

### DIFF
--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
@@ -67,7 +67,10 @@ module adc_ctrl_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module adc_ctrl_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -67,7 +67,10 @@ module aes_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module aes_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_top.sv
@@ -67,7 +67,10 @@ module alert_handler_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module alert_handler_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
@@ -67,7 +67,10 @@ module aon_timer_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module aon_timer_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr_reg_top.sv
@@ -67,7 +67,10 @@ module clkmgr_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module clkmgr_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -67,7 +67,10 @@ module csrng_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module csrng_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -67,7 +67,10 @@ module edn_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module edn_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -67,7 +67,10 @@ module entropy_src_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module entropy_src_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
@@ -72,7 +72,10 @@ module flash_ctrl_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -135,7 +138,8 @@ module flash_ctrl_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/gpio/rtl/gpio_reg_top.sv
+++ b/hw/ip/gpio/rtl/gpio_reg_top.sv
@@ -67,7 +67,10 @@ module gpio_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module gpio_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -72,7 +72,10 @@ module hmac_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -125,7 +128,8 @@ module hmac_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -67,7 +67,10 @@ module i2c_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module i2c_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -67,7 +67,10 @@ module keymgr_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module keymgr_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -72,7 +72,10 @@ module kmac_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -130,7 +133,8 @@ module kmac_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
@@ -67,7 +67,10 @@ module lc_ctrl_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module lc_ctrl_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/nmi_gen/rtl/nmi_gen_reg_top.sv
+++ b/hw/ip/nmi_gen/rtl/nmi_gen_reg_top.sv
@@ -67,7 +67,10 @@ module nmi_gen_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module nmi_gen_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -230,9 +230,10 @@
 
     // Imem size (given as `items` below) must be a power of two.
     { window: {
-        name: "IMEM"
-        items: "1024" // 4 kB
+        name: "IMEM",
+        items: "1024", // 4 kB
         swaccess: "rw",
+        data-intg-passthru: "true",
         byte-write: "false",
         desc: '''
           Instruction Memory.
@@ -249,9 +250,10 @@
 
     // Dmem size (given as `items` below) must be a power of two.
     { window: {
-        name: "DMEM"
-        items: "1024" // 4 kB
+        name: "DMEM",
+        items: "1024", // 4 kB
         swaccess: "rw",
+        data-intg-passthru: "true",
         byte-write: "false",
         desc: '''
           Data Memory.

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -72,7 +72,10 @@ module otbn_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(0)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -130,7 +133,8 @@ module otbn_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(1)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
@@ -72,7 +72,10 @@ module otp_ctrl_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -130,7 +133,8 @@ module otp_ctrl_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/pattgen/rtl/pattgen_reg_top.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_top.sv
@@ -67,7 +67,10 @@ module pattgen_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module pattgen_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/ip/pinmux/rtl/pinmux_reg_top.sv
@@ -67,7 +67,10 @@ module pinmux_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module pinmux_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -67,7 +67,10 @@ module pwrmgr_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module pwrmgr_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
@@ -67,7 +67,10 @@ module rom_ctrl_regs_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module rom_ctrl_regs_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_rom_reg_top.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_rom_reg_top.sv
@@ -51,7 +51,10 @@ module rom_ctrl_rom_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );

--- a/hw/ip/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_reg_top.sv
@@ -67,7 +67,10 @@ module rstmgr_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module rstmgr_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic_reg_top.sv
@@ -67,7 +67,10 @@ module rv_plic_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module rv_plic_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
@@ -67,7 +67,10 @@ module rv_timer_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module rv_timer_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -72,7 +72,10 @@ module spi_device_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -125,7 +128,8 @@ module spi_device_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -72,7 +72,10 @@ module spi_host_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -125,7 +128,8 @@ module spi_host_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_top.sv
@@ -67,7 +67,10 @@ module sram_ctrl_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module sram_ctrl_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
@@ -67,7 +67,10 @@ module sysrst_ctrl_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module sysrst_ctrl_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/trial1/rtl/trial1_reg_top.sv
+++ b/hw/ip/trial1/rtl/trial1_reg_top.sv
@@ -67,7 +67,10 @@ module trial1_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module trial1_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -67,7 +67,10 @@ module uart_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module uart_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -72,7 +72,10 @@ module usbdev_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -125,7 +128,8 @@ module usbdev_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/ip/usbuart/rtl/usbuart_reg_top.sv
+++ b/hw/ip/usbuart/rtl/usbuart_reg_top.sv
@@ -67,7 +67,10 @@ module usbuart_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module usbuart_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
@@ -67,7 +67,10 @@ module alert_handler_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module alert_handler_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
@@ -67,7 +67,10 @@ module ast_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module ast_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -67,7 +67,10 @@ module clkmgr_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module clkmgr_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_top.sv
@@ -72,7 +72,10 @@ module flash_ctrl_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -135,7 +138,8 @@ module flash_ctrl_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
@@ -67,7 +67,10 @@ module pinmux_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module pinmux_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
@@ -67,7 +67,10 @@ module pwrmgr_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module pwrmgr_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
@@ -67,7 +67,10 @@ module rstmgr_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module rstmgr_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
@@ -67,7 +67,10 @@ module rv_plic_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module rv_plic_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
@@ -67,7 +67,10 @@ module sensor_ctrl_reg_top (
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
-  tlul_rsp_intg_gen u_rsp_intg_gen (
+  tlul_rsp_intg_gen #(
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
+  ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o
   );
@@ -77,7 +80,8 @@ module sensor_ctrl_reg_top (
 
   tlul_adapter_reg #(
     .RegAw(AW),
-    .RegDw(DW)
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
   ) u_reg_if (
     .clk_i,
     .rst_ni,

--- a/util/reggen/reg_block.py
+++ b/util/reggen/reg_block.py
@@ -30,6 +30,9 @@ class RegBlock:
         self.registers = []  # type: List[Register]
         self.windows = []  # type: List[Window]
 
+        # Boolean indication whether ANY window in regblock has data integrity passthrough
+        self.has_data_intg_passthru = False
+
         # A list of all registers, expanding multiregs, ordered by offset
         self.flat_regs = []  # type: List[Register]
 
@@ -244,6 +247,8 @@ class RegBlock:
         self.entries.append(window)
         assert self.offset <= window.offset
         self.offset = window.next_offset(self._addrsep)
+
+        self.has_data_intg_passthru |= window.data_intg_passthru
 
     def validate(self) -> None:
         '''Run this to check consistency after all registers have been added'''

--- a/util/reggen/window.py
+++ b/util/reggen/window.py
@@ -19,6 +19,10 @@ REQUIRED_FIELDS = {
 # TODO potential for additional optional to give more type info?
 # eg sram-hw-port: "none", "sync", "async"
 OPTIONAL_FIELDS = {
+    'data-intg-passthru': [
+        's', "True if the window has data integrity pass through. "
+        "Defaults to false if not present."
+    ],
     'byte-write': [
         's', "True if byte writes are supported. "
         "Defaults to false if not present."
@@ -47,6 +51,7 @@ class Window:
                  desc: str,
                  unusual: bool,
                  byte_write: bool,
+                 data_intg_passthru: bool,
                  validbits: int,
                  items: int,
                  size_in_bytes: int,
@@ -59,6 +64,7 @@ class Window:
         self.desc = desc
         self.unusual = unusual
         self.byte_write = byte_write
+        self.data_intg_passthru = data_intg_passthru
         self.validbits = validbits
         self.items = items
         self.size_in_bytes = size_in_bytes
@@ -89,6 +95,8 @@ class Window:
                              'unusual field for ' + wind_desc)
         byte_write = check_bool(rd.get('byte-write', False),
                                 'byte-write field for ' + wind_desc)
+        data_intg_passthru = check_bool(rd.get('data-intg-passthru', False),
+                                        'data-intg-passthru field for ' + wind_desc)
 
         validbits = check_int(rd.get('validbits', reg_width),
                               'validbits field for ' + wind_desc)
@@ -140,7 +148,7 @@ class Window:
                              'to do this, set the "unusual" flag.'
                              .format(wind_desc, swaccess.key))
 
-        return Window(name, desc, unusual, byte_write,
+        return Window(name, desc, unusual, byte_write, data_intg_passthru,
                       validbits, items, size_in_bytes, offset, swaccess)
 
     def next_offset(self, addrsep: int) -> int:

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -790,7 +790,7 @@ def generate_top_ral(top: Dict[str, object],
     # together with a map of interface addresses.
     inst_to_block = {}  # type: Dict[str, str]
     if_addrs = {}  # type: Dict[Tuple[str, Optional[str]], int],
-    attrs = {} # type: Dict[str, str]
+    attrs = {}  # type: Dict[str, str]
 
     for module in top['module']:
         inst_name = module['name']
@@ -798,7 +798,8 @@ def generate_top_ral(top: Dict[str, object],
         block = name_to_block[block_name]
         if "attr" in module:
             if module["attr"] not in ['templated', 'reggen_top', 'reggen_only']:
-                raise ValueError('Unsupported value for attr field of {}: {!r}'.format(what, attr))
+                raise ValueError('Unsupported value for attr field of {}: {!r}'.
+                                 format(block_name, module["attr"]))
             attrs[inst_name] = module["attr"]
 
         inst_to_block[inst_name] = block_name
@@ -811,6 +812,8 @@ def generate_top_ral(top: Dict[str, object],
     for item in list(top.get("memory", [])):
         byte_write = ('byte_write' in item and
                       item["byte_write"].lower() == "true")
+        data_intg_passthru = ('data_intg_passthru' in item and
+                              item["data_intg_passthru"].lower() == "true")
         size_in_bytes = int(item['size'], 0)
         num_regs = size_in_bytes // addrsep
         swaccess = access.SWAccess('top-level memory',
@@ -820,6 +823,7 @@ def generate_top_ral(top: Dict[str, object],
                                   desc='(generated from top-level)',
                                   unusual=False,
                                   byte_write=byte_write,
+                                  data_intg_passthru=data_intg_passthru,
                                   validbits=regwidth,
                                   items=num_regs,
                                   size_in_bytes=size_in_bytes,
@@ -1134,8 +1138,6 @@ def main():
 
     # Generic Inter-module connection
     im.elab_intermodule(completecfg)
-
-    top_name = completecfg["name"]
 
     # Generate top.gen.hjson right before rendering
     genhjson_dir = out_path / "data/autogen"


### PR DESCRIPTION
Second part of #5691.  Only the last 2 commits are valid, the others will be rebased away. 

- When a module has no window or has windows with no integrity passthrough,
  data integrity can be generated at a common location. (this is the case for most modules)

- When a module window has data integrity passthrough, the regfile
  registers must separately generate data integrity so as to not
  duplicate.

- When a module has a mix of windows with and without integrity, common
  generation is not possible, and data integrity is selectively generated
  for those windows that do not directly pass them in.

- The only module that is currently impacted is otbn (and soon rom_ctrl)
  Otbn dmem / imem each contain their own integrity, and thus can directly
  pass them through.  The regfile for otbn thus no longer generates data
  integrity at a common location, and instead generates it only for data
  passed through tlul_adapter_reg.  The data integrity for the windows are
  fed through directly.