### PR TITLE
[kmac] Rename kmac_keymgr to kmac_app

### DIFF
--- a/hw/ip/kmac/kmac.core
+++ b/hw/ip/kmac/kmac.core
@@ -21,7 +21,7 @@ filesets:
       - rtl/kmac_core.sv
       - rtl/kmac_msgfifo.sv
       - rtl/kmac_staterd.sv
-      - rtl/kmac_keymgr.sv
+      - rtl/kmac_app.sv
       - rtl/kmac_entropy.sv
       - rtl/kmac_reg_pkg.sv
       - rtl/kmac_reg_top.sv

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -668,10 +668,10 @@ module kmac
   logic unused_tlram_addr;
   assign unused_tlram_addr = &{1'b0, tlram_addr};
 
-  // KeyMgr Mux/Demux
-  kmac_keymgr #(
+  // Application interface Mux/Demux
+  kmac_app #(
     .EnMasking(EnMasking)
-  ) u_keymgr_intf (
+  ) u_app_intf (
     .clk_i,
     .rst_ni,
 


### PR DESCRIPTION
This PR defines app specific configurations in `kmac_pkg.sv` as a structure form. This compile-time parameter will be used in `kmac_app` module.

It defines three configs as of now.

- **Mode**: The app can choose KMAC/ cSHAKE/ SHA3 algorithm. In either case, the output digest length is same as sideloaded key size.
- **PrefixMode**: This parameter determines whether the app uses Prefix from CSRs (value **0**) or from **Prefix** parameter below, in cSHAKE and KMAC mode.
- **Prefix**: it defines the prefix (length same as CSRs).
