### PR TITLE
[primgen] Minor fix to enable types with underscores

### DIFF
--- a/hw/ip/prim/util/primgen.py
+++ b/hw/ip/prim/util/primgen.py
@@ -160,6 +160,7 @@ def _parse_module_header(generic_impl_filepath, module_name):
 
 
 def test_parse_parameter_port_list():
+    assert _parse_parameter_port_list("parameter enum_t P") == {'P'}
     assert _parse_parameter_port_list("parameter integer P") == {'P'}
     assert _parse_parameter_port_list("parameter logic [W-1:0] P") == {'P'}
     assert _parse_parameter_port_list("parameter logic [W-1:0] P = '0") == {'P'}
@@ -185,7 +186,7 @@ def _parse_parameter_port_list(parameter_port_list):
     # XXX: Not covering the complete grammar, e.g. `parameter x, y`
     RE_PARAMS = (
         r'parameter\s+'
-        r'(?:[a-zA-Z0-9\]\[:\s\$-]+\s+)?'  # type
+        r'(?:[a-zA-Z0-9_\]\[:\s\$-]+\s+)?'  # type
         r'(?P<name>\w+)'  # name
         r'(?:\s*=\s*[^,;]+)?'  # initial value
     )


### PR DESCRIPTION
So far we never ran into the case where a generated prim uses a custom parameter type with the syntax `typename_t`. This fix accommodates that format.

Signed-off-by: Michael Schaffner <msf@google.com>