### PR TITLE
[pwrmgr] Add two different flavors of pwrmgr smoke test

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -198,10 +198,11 @@
       en_run_modes: ["sw_test_mode"]
     }
     {
-      name: chip_flash_ctrl_access
+      name: chip_dif_pwrmgr_smoketest
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["sw/device/tests/flash_ctrl_test:1"]
+      sw_images: ["sw/device/tests/dif_pwrmgr_smoketest:1"]
       en_run_modes: ["sw_test_mode"]
+      run_opts: ["+sw_test_timeout_ns=2000000"]
     }
     {
       name: chip_dif_otbn_smoketest
@@ -210,10 +211,23 @@
       en_run_modes: ["sw_test_mode"]
     }
     {
+      name: chip_flash_ctrl_access
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/flash_ctrl_test:1"]
+      en_run_modes: ["sw_test_mode"]
+    }
+    {
       name: chip_hmac_sha256_encr
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/sha256_test:1"]
       en_run_modes: ["sw_test_mode"]
+    }
+    {
+      name: chip_pwrmgr_usbdev_smoketest
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/pwrmgr_usbdev_smoketest:1"]
+      en_run_modes: ["sw_test_mode"]
+      run_opts: ["+sw_test_timeout_ns=2000000"]
     }
     {
       name: chip_rv_timer_irq

--- a/sw/device/lib/dif/dif_pwrmgr.c
+++ b/sw/device/lib/dif/dif_pwrmgr.c
@@ -120,7 +120,10 @@ static const request_reg_info_t request_reg_infos[2] = {
             .cur_req_sources_reg_offset = PWRMGR_WAKE_STATUS_REG_OFFSET,
             .bitfield =
                 {
-                    .mask = kDifPwrmgrWakeupRequestSourceOne,
+                    .mask = kDifPwrmgrWakeupRequestSourceOne |
+                            kDifPwrmgrWakeupRequestSourceTwo |
+                            kDifPwrmgrWakeupRequestSourceThree |
+                            kDifPwrmgrWakeupRequestSourceFour,
                     .index = 0,
                 },
         },

--- a/sw/device/lib/usbdev.c
+++ b/sw/device/lib/usbdev.c
@@ -300,3 +300,38 @@ void usbdev_init(usbdev_ctx_t *ctx, bool pinflip, bool diff_rx, bool diff_tx) {
   REG32(USBDEV_BASE_ADDR + USBDEV_USBCTRL_REG_OFFSET) =
       (1 << USBDEV_USBCTRL_ENABLE_BIT);
 }
+
+void usbdev_force_dx_pullup(line_sel_t line, bool set) {
+  // Force usb to pretend it is in suspend
+  uint32_t reg_val = REG32(USBDEV_BASE_ADDR + USBDEV_PHY_PINS_DRIVE_REG_OFFSET);
+  uint32_t mask;
+
+  mask = line == kDpSel ? USBDEV_PHY_PINS_DRIVE_DP_PULLUP_EN_O_BIT
+                        : USBDEV_PHY_PINS_DRIVE_DN_PULLUP_EN_O_BIT;
+
+  if (set) {
+    reg_val = SETBIT(reg_val, mask);
+  } else {
+    reg_val = CLRBIT(reg_val, mask);
+  }
+
+  reg_val = SETBIT(reg_val, USBDEV_PHY_PINS_DRIVE_EN_BIT);
+  REG32(USBDEV_BASE_ADDR + USBDEV_PHY_PINS_DRIVE_REG_OFFSET) = reg_val;
+}
+
+void usbdev_force_suspend() {
+  // Force usb to pretend it is in suspend
+  REG32(USBDEV_BASE_ADDR + USBDEV_PHY_PINS_DRIVE_REG_OFFSET) |=
+      1 << USBDEV_PHY_PINS_DRIVE_SUSPEND_O_BIT |
+      1 << USBDEV_PHY_PINS_DRIVE_EN_BIT;
+}
+
+void usbdev_wake(bool set) {
+  uint32_t reg_val = REG32(USBDEV_BASE_ADDR + USBDEV_WAKE_CONFIG_REG_OFFSET);
+  if (set) {
+    reg_val = SETBIT(reg_val, USBDEV_WAKE_CONFIG_WAKE_EN_BIT);
+  } else {
+    reg_val = CLRBIT(reg_val, USBDEV_WAKE_CONFIG_WAKE_EN_BIT);
+  }
+  REG32(USBDEV_BASE_ADDR + USBDEV_WAKE_CONFIG_REG_OFFSET) = reg_val;
+}

--- a/sw/device/lib/usbdev.h
+++ b/sw/device/lib/usbdev.h
@@ -36,6 +36,11 @@ struct usbdev_ctx {
 };
 
 /**
+ * Select USB lines P or N
+ */
+typedef enum line_sel { kDpSel = 0, kDnSel = 1 } line_sel_t;
+
+/**
  * Allocate a buffer for the caller to use
  *
  * @param ctx usbdev context pointer
@@ -228,6 +233,21 @@ void usbdev_endpoint_setup(usbdev_ctx_t *ctx, int ep, int enableout,
  * @param diff_tx boolean to indicate if PHY uses differential TX
  */
 void usbdev_init(usbdev_ctx_t *ctx, bool pinflip, bool diff_rx, bool diff_tx);
+
+/**
+ * Force usbdev to output suspend state for testing purposes
+ */
+void usbdev_force_suspend(void);
+
+/**
+ * Force usbdev pull-up to specific value
+ */
+void usbdev_force_dx_pullup(line_sel_t line, bool set);
+
+/**
+ * Enable usb wake
+ */
+void usbdev_wake(bool set);
 
 // Used for tracing what is going on. This may impact timing which is critical
 // when simulating with the USB DPI module.

--- a/sw/device/tests/dif/dif_pwrmgr_smoketest.c
+++ b/sw/device/tests/dif/dif_pwrmgr_smoketest.c
@@ -1,0 +1,104 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_aon_timer.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/test_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+static dif_pwrmgr_t pwrmgr;
+static dif_aon_timer_t aon_timer;
+
+const test_config_t kTestConfig;
+const dif_pwrmgr_wakeup_reason_t test_wakeup_reason = {
+    .types = kDifPwrmgrWakeupTypeRequest,
+    .request_sources = kDifPwrmgrWakeupRequestSourceFour,
+};
+
+const dif_pwrmgr_wakeup_reason_t por_wakeup_reason = {
+    .types = 0,
+    .request_sources = 0,
+};
+
+static bool compare_wakeup_reasons(const dif_pwrmgr_wakeup_reason_t *lhs,
+                                   const dif_pwrmgr_wakeup_reason_t *rhs) {
+  return lhs->types == rhs->types &&
+         lhs->request_sources == rhs->request_sources;
+}
+
+static void aon_timer_setup(dif_aon_timer_t *aon) {
+  // Make sure that wake-up timer is stopped.
+  CHECK(dif_aon_timer_wakeup_stop(aon) == kDifAonTimerOk);
+
+  // Make sure the wake-up IRQ is cleared to avoid false positive.
+  CHECK(dif_aon_timer_irq_acknowledge(aon, kDifAonTimerIrqWakeupThreshold) ==
+        kDifAonTimerOk);
+  bool is_pending;
+  CHECK(dif_aon_timer_irq_is_pending(aon, kDifAonTimerIrqWakeupThreshold,
+                                     &is_pending) == kDifAonTimerOk);
+  CHECK(!is_pending);
+
+  // Test the wake-up timer functionality by setting a small counter.
+  // Delay to compensate for AON Timer 200kHz clock (less should suffice, but
+  // to be on a cautious side - lets keep it at 100 for now).
+  CHECK(dif_aon_timer_wakeup_start(aon, 5, 0) == kDifAonTimerOk);
+  usleep(100);
+}
+
+bool test_main(void) {
+  bool test_passed = false;
+
+  // Initialize pwrmgr
+  CHECK(dif_pwrmgr_init(
+            (dif_pwrmgr_params_t){
+                .base_addr =
+                    mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR),
+            },
+            &pwrmgr) == kDifPwrmgrOk);
+
+  // Initialize aon_timer
+  dif_aon_timer_params_t params = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR),
+  };
+  CHECK(dif_aon_timer_init(params, &aon_timer) == kDifAonTimerOk);
+
+  // Assuming the chip hasn't slept yet, wakeup reason should be empty.
+  dif_pwrmgr_wakeup_reason_t wakeup_reason;
+  CHECK(dif_pwrmgr_wakeup_reason_get(&pwrmgr, &wakeup_reason) == kDifPwrmgrOk);
+
+  if (compare_wakeup_reasons(&wakeup_reason, &por_wakeup_reason)) {
+    LOG_INFO("Powered up for the first time, begin test");
+  } else if (compare_wakeup_reasons(&wakeup_reason, &test_wakeup_reason)) {
+    test_passed = true;
+    LOG_INFO("Aon timer wakeup detected");
+  } else {
+    CHECK(false);
+  }
+
+  if (!test_passed) {
+    // setup aon timer wakeup
+    aon_timer_setup(&aon_timer);
+
+    // Enable low power on the next WFI with default settings.
+    // All clocks and power domains are turned off during low power.
+    dif_pwrmgr_domain_config_t config;
+    config = 0;
+
+    CHECK(dif_pwrmgr_set_request_sources(&pwrmgr, kDifPwrmgrReqTypeWakeup,
+                                         kDifPwrmgrWakeupRequestSourceFour) ==
+          kDifPwrmgrConfigOk);
+    CHECK(dif_pwrmgr_set_domain_config(&pwrmgr, config) == kDifPwrmgrConfigOk);
+    CHECK(dif_pwrmgr_low_power_set_enabled(&pwrmgr, kDifPwrmgrToggleEnabled) ==
+          kDifPwrmgrConfigOk);
+
+    // Enter low power mode.
+    wait_for_interrupt();
+  }
+
+  return test_passed;
+}

--- a/sw/device/tests/dif/dif_pwrmgr_unittest.cc
+++ b/sw/device/tests/dif/dif_pwrmgr_unittest.cc
@@ -636,7 +636,8 @@ TEST_F(WakeupRecording, GetReason) {
                   .types = kDifPwrmgrWakeupTypeAbort |
                            kDifPwrmgrWakeupTypeFallThrough |
                            kDifPwrmgrWakeupTypeRequest,
-                  .request_sources = kDifPwrmgrWakeupRequestSourceOne,
+                  .request_sources = kDifPwrmgrWakeupRequestSourceOne |
+                                     kDifPwrmgrWakeupRequestSourceTwo,
               },
       },
       // Only abort.

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -494,3 +494,21 @@ sw_tests += {
     'library': dif_aon_timer_smoketest_lib,
   }
 }
+
+dif_pwrmgr_smoketest_lib = declare_dependency(
+  link_with: static_library(
+    'dif_pwrmgr_smoketest_lib',
+    sources: ['dif_pwrmgr_smoketest.c'],
+    dependencies: [
+      sw_lib_dif_pwrmgr,
+      sw_lib_dif_aon_timer,
+      sw_lib_mmio,
+      sw_lib_runtime_log,
+    ],
+  ),
+)
+sw_tests += {
+  'dif_pwrmgr_smoketest': {
+    'library': dif_pwrmgr_smoketest_lib,
+  }
+}

--- a/sw/device/tests/sim_dv/meson.build
+++ b/sw/device/tests/sim_dv/meson.build
@@ -69,3 +69,21 @@ sw_tests += {
     'library': spi_tx_rx_test_lib,
   }
 }
+
+pwrmgr_usbdev_smoketest_lib = declare_dependency(
+  link_with: static_library(
+    'pwrmgr_usbdev_smoketest_lib',
+    sources: ['pwrmgr_usbdev_smoketest.c'],
+    dependencies: [
+      sw_lib_dif_pwrmgr,
+      sw_lib_usb,
+      sw_lib_mmio,
+      sw_lib_runtime_log,
+    ],
+  ),
+)
+sw_tests += {
+  'pwrmgr_usbdev_smoketest': {
+    'library': pwrmgr_usbdev_smoketest_lib,
+  }
+}

--- a/sw/device/tests/sim_dv/pwrmgr_usbdev_smoketest.c
+++ b/sw/device/tests/sim_dv/pwrmgr_usbdev_smoketest.c
@@ -1,0 +1,90 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// This is a DV specific pwrmgr usbdev smoketest that fakes usb activity.
+// Using the phy drive function of usbdev, we present the usbdev is in suspend
+// and thus trigger low power entry.
+// Once the system enters low power entry, the incoming USBP/USBN lines are
+// immediately different from what the wake module expects and thus causes
+// a wakeup.
+// This test just smoke checks the pwrmgr's ability to enter / exit low power
+// and the usbdev's aon wake function that has been de-coupled from the main
+// usbdev.
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/test_main.h"
+#include "sw/device/lib/usbdev.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+static dif_pwrmgr_t pwrmgr;
+
+const test_config_t kTestConfig;
+
+static bool compare_wakeup_reasons(dif_pwrmgr_wakeup_reason_t lhs,
+                                   dif_pwrmgr_wakeup_reason_t rhs) {
+  return lhs.types == rhs.types && lhs.request_sources == rhs.request_sources;
+}
+
+bool test_main(void) {
+  CHECK(dif_pwrmgr_init(
+            (dif_pwrmgr_params_t){
+                .base_addr =
+                    mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR),
+            },
+            &pwrmgr) == kDifPwrmgrOk);
+
+  // Assuming the chip hasn't slept yet, wakeup reason should be empty.
+  dif_pwrmgr_wakeup_reason_t wakeup_reason;
+  CHECK(dif_pwrmgr_wakeup_reason_get(&pwrmgr, &wakeup_reason) == kDifPwrmgrOk);
+
+  const dif_pwrmgr_wakeup_reason_t exp_por_wakeup_reason = {
+      .types = 0,
+      .request_sources = 0,
+  };
+
+  const dif_pwrmgr_wakeup_reason_t exp_test_wakeup_reason = {
+      .types = kDifPwrmgrWakeupTypeRequest,
+      .request_sources = kDifPwrmgrWakeupRequestSourceThree,
+  };
+
+  bool low_power_exit = false;
+  if (compare_wakeup_reasons(wakeup_reason, exp_por_wakeup_reason)) {
+    LOG_INFO("Powered up for the first time, begin test");
+  } else if (compare_wakeup_reasons(wakeup_reason, exp_test_wakeup_reason)) {
+    low_power_exit = true;
+    LOG_INFO("USB wakeup detected");
+  } else {
+    LOG_ERROR("Unexpected wakeup reason (types: %2x, sources: %8x)",
+              wakeup_reason.types, wakeup_reason.request_sources);
+    return false;
+  }
+
+  // Fake low power entry through usb
+  // Force usb to output suspend indication
+  if (!low_power_exit) {
+    usbdev_wake(true);
+    usbdev_force_suspend();
+    usbdev_force_dx_pullup(kDpSel, true);
+    usbdev_force_dx_pullup(kDnSel, true);
+
+    // Enable low power on the next WFI with default settings.
+    CHECK(dif_pwrmgr_set_request_sources(&pwrmgr, kDifPwrmgrReqTypeWakeup,
+                                         kDifPwrmgrWakeupRequestSourceThree) ==
+          kDifPwrmgrConfigOk);
+    CHECK(dif_pwrmgr_set_domain_config(
+              &pwrmgr, kDifPwrmgrDomainOptionUsbClockInActivePower) ==
+          kDifPwrmgrConfigOk);
+    CHECK(dif_pwrmgr_low_power_set_enabled(&pwrmgr, kDifPwrmgrToggleEnabled) ==
+          kDifPwrmgrConfigOk);
+
+    // Enter low power mode.
+    wait_for_interrupt();
+  }
+
+  return true;
+}


### PR DESCRIPTION
PR for #5592 

This adds two flavors of pwrmgr smoke test

- The first test (`pwrmgr_usbdev_smoketest`) uses `usbdev` as a wakeup (as a way to test #5380).
   - This test can only be run in the DV environment as it relies on specific pin behavior

- The second test (`dif_pwrmgr_smoketest`) uses `aon_timer` as a wakeup and is more self contained
   - This test can be run on all targets. 

@alphan can you have a look first and let me know what you think? 