### PR TITLE
[sram_ctrl,lint] Fix width of RndCnstSramLfsrPermDefault

### DIFF
--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_pkg.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_pkg.sv
@@ -25,9 +25,8 @@ package sram_ctrl_pkg;
       128'hbecda03b34bc0418a30a33861a610f71;
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramNonceDefault =
       128'h22f296f8f95efb84a75cd435a5541e9f;
-  parameter lfsr_perm_t RndCnstSramLfsrPermDefault = {
-      128'h1cf6cd183310ef2203bb344b679cdff1
-  };
+  parameter lfsr_perm_t RndCnstSramLfsrPermDefault =
+      160'h8c24f71703eda8a2378916b6bf80c76651ebcea1;
 
   /////////////////////
   // Interface Types //


### PR DESCRIPTION
This is a 160-bit parameter, so we should use a 160-bit
default (silencing a lint warning). This is grabbed from the random
constant we've currently got in top_earlgrey.
