### PR TITLE
[otbn] Wrap non-synthesizeable code with defines

### DIFF
--- a/hw/ip/otbn/dv/memutil/otbn_memutil_pkg.sv
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil_pkg.sv
@@ -4,7 +4,7 @@
 
 // Imports for the functions defined in otbn_memutil.h. There are documentation comments explaining
 // what the functions do there.
-
+`ifndef SYNTHESIS
 package otbn_memutil_pkg;
 
   import "DPI-C" function chandle OtbnMemUtilMake(string top_scope);
@@ -25,3 +25,4 @@ package otbn_memutil_pkg;
                                                     output bit [31:0] data_value);
 
 endpackage
+`endif // SYNTHESIS


### PR DESCRIPTION
Some dv code in otbn is included as part of the design core files
to do side by side comparisons.  These files need to be wrapped with
the SYNTHESIS flag to ensure they do not get parsed for synthesis.

Applying this fix to otbn_memutil_pkg.sv (the same fix is already applied
to various other model files).

Signed-off-by: Timothy Chen <timothytim@google.com>