### PR TITLE
[csnrg/rtl] remove incorrect TODO

### DIFF
--- a/hw/ip/csrng/rtl/csrng_state_db.sv
+++ b/hw/ip/csrng/rtl/csrng_state_db.sv
@@ -175,7 +175,6 @@ module csrng_state_db import csrng_pkg::*; #(
                                        state_db_wr_v_i,state_db_wr_res_ctr_i,
                                        state_db_wr_inst_id_i,state_db_wr_sts_i};
 
-  // TODO: fix the case where GEN updates the internal state
   assign instance_status =
          (state_db_wr_ccmd_i == INS) ||
          (state_db_wr_ccmd_i == RES) ||


### PR DESCRIPTION
The TODO says that the GEN command does not update working state, but it does.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>