### PR TITLE
[kmac] Use AppCfg and expose array to the top-level

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -73,6 +73,7 @@
       name:    "app"
       act:     "rsp"
       package: "kmac_pkg"
+      width:   "3"
     }
     { struct:  "edn"
       type:    "req_rsp"

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_kdf_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_kdf_vseq.sv
@@ -9,7 +9,13 @@ class kmac_kdf_vseq extends kmac_sideload_vseq;
 
   constraint kdf_c {
     // KDF outputs 256-bit digest (32 bytes)
-    (kmac_en == 1) -> (output_len == 32);
+    if (kmac_en) {
+      // KDF outputs 256-bit digest (32 bytes)
+      output_len == 32;
+
+      // application interface locked at 256-bit strength
+      strength == sha3_pkg::L256;
+    }
 
     // KDF will never use XOF mode
     xof_en == 0;

--- a/hw/ip/kmac/dv/tb.sv
+++ b/hw/ip/kmac/dv/tb.sv
@@ -41,6 +41,16 @@ module tb;
   `DV_EDN_IF_CONNECT
 
   // dut
+  // TODO: Make TB to support arb array of application interface
+  kmac_pkg::app_req_t [kmac_pkg::NumAppIntf-1:0] app_req;
+  kmac_pkg::app_rsp_t [kmac_pkg::NumAppIntf-1:0] app_rsp;
+
+  assign app_req[0] = keymgr_kmac_if.kmac_data_req;
+  assign app_req[1] = kmac_pkg::APP_REQ_DEFAULT;
+  assign app_req[2] = kmac_pkg::APP_REQ_DEFAULT;
+
+  assign keymgr_kmac_if.kmac_data_rsp = app_rsp[0];
+
   kmac #(.EnMasking(`EN_MASKING), .ReuseShare(`REUSE_SHARE)) dut (
     .clk_i              (clk                          ),
     .rst_ni             (rst_n                        ),
@@ -56,8 +66,8 @@ module tb;
     //
     // TODO: this is set to 0 for the time being to get the csr tests passing.
     //       this will eventually be hooked up to the kmac<->keymgr agent.
-    .app_i       (keymgr_kmac_if.kmac_data_req ),
-    .app_o       (keymgr_kmac_if.kmac_data_rsp ),
+    .app_i       (app_req ),
+    .app_o       (app_rsp ),
 
     // Interrupts
     .intr_kmac_done_o   (interrupts[KmacDone]         ),

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -32,8 +32,8 @@ module kmac
   input keymgr_pkg::hw_key_req_t keymgr_key_i,
 
   // KeyMgr KDF data path
-  input  app_req_t app_i,
-  output app_rsp_t app_o,
+  input  app_req_t [NumAppIntf-1:0] app_i,
+  output app_rsp_t [NumAppIntf-1:0] app_o,
 
   // EDN interface
   output edn_pkg::edn_req_t entropy_o,
@@ -680,15 +680,6 @@ module kmac
   logic unused_tlram_addr;
   assign unused_tlram_addr = &{1'b0, tlram_addr};
 
-  // Temporary app intf connect
-  app_req_t app_req_temp [NumAppIntf];
-  app_rsp_t app_rsp_temp [NumAppIntf];
-
-  assign app_req_temp[0] = app_i;
-  assign app_req_temp[1] = APP_REQ_DEFAULT;
-  assign app_req_temp[2] = APP_REQ_DEFAULT;
-
-  assign app_o = app_rsp_temp[0];
   // Application interface Mux/Demux
   kmac_app #(
     .EnMasking(EnMasking)
@@ -715,8 +706,8 @@ module kmac
     .keymgr_key_i,
 
     // Application data in / digest out interface
-    .app_i (app_req_temp),
-    .app_o (app_rsp_temp),
+    .app_i,
+    .app_o,
 
     // Secret Key output to KMAC Core
     .key_data_o (key_data),

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -120,6 +120,7 @@ module kmac
   // For given default value 32, 256 bits, the max
   // encode_string(N) || encode_string(S) is 328. So 11 Prefix registers are
   // created.
+  logic [sha3_pkg::NSRegisterSize*8-1:0] reg_ns_prefix;
   logic [sha3_pkg::NSRegisterSize*8-1:0] ns_prefix;
 
   // NumWordsPrefix from kmac_reg_pkg
@@ -236,7 +237,7 @@ module kmac
   // Function-name N and Customization input string S
   always_comb begin
     for (int i = 0 ; i < NumWordsPrefix; i++) begin
-      ns_prefix[32*i+:32] = reg2hw.prefix[i].q;
+      reg_ns_prefix[32*i+:32] = reg2hw.prefix[i].q;
     end
   end
 
@@ -687,6 +688,8 @@ module kmac
     .reg_key_data_i (sw_key_data),
     .reg_key_len_i  (sw_key_len),
 
+    .reg_prefix_i (reg_ns_prefix),
+
     // data from tl_adapter
     .sw_valid_i (sw_msg_valid),
     .sw_data_i  (sw_msg_data),
@@ -709,6 +712,9 @@ module kmac
     .kmac_data_o  (mux2fifo_data),
     .kmac_mask_o  (mux2fifo_mask),
     .kmac_ready_i (mux2fifo_ready),
+
+    // to SHA3 Core
+    .sha3_prefix_o (ns_prefix),
 
     // Keccak state from SHA3 core
     .keccak_state_valid_i (state_valid),

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -38,8 +38,8 @@ module kmac_app
   input keymgr_pkg::hw_key_req_t keymgr_key_i,
 
   // Application Message in/ Digest out interface + control signals
-  input  app_req_t app_i [NumAppIntf],
-  output app_rsp_t app_o [NumAppIntf],
+  input  app_req_t [NumAppIntf-1:0] app_i,
+  output app_rsp_t [NumAppIntf-1:0] app_o,
 
   // to KMAC Core: Secret key
   output [MaxKeyLen-1:0] key_data_o [Share],

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -23,6 +23,11 @@ module kmac_app
   // Prefix from register
   input [sha3_pkg::NSRegisterSize*8-1:0] reg_prefix_i,
 
+  // mode, strength, kmac_en from register
+  input                             reg_kmac_en_i,
+  input sha3_pkg::sha3_mode_e       reg_sha3_mode_i,
+  input sha3_pkg::keccak_strength_e reg_keccak_strength_i,
+
   // Data from Software
   input                sw_valid_i,
   input [MsgWidth-1:0] sw_data_i,
@@ -46,8 +51,13 @@ module kmac_app
   output logic [MsgWidth-1:0] kmac_mask_o,
   input                       kmac_ready_i,
 
+  // KMAC Core
+  output logic kmac_en_o,
+
   // To Sha3 Core
   output logic [sha3_pkg::NSRegisterSize*8-1:0] sha3_prefix_o,
+  output sha3_pkg::sha3_mode_e                  sha3_mode_o,
+  output sha3_pkg::keccak_strength_e            keccak_strength_o,
 
   // STATE from SHA3 Core
   input                        keccak_state_valid_i,
@@ -146,6 +156,11 @@ module kmac_app
     // (after the transaction is accepted regardless of partial writes or not)
     // When absorbed by SHA3 core, the logic sends digest to the requested App
     // and right next cycle, it triggers done command to downstream.
+
+    // In StAppCfg state, it latches the cfg from AppCfg parameter to determine
+    // the kmac_mode, sha3_mode, keccak strength.
+    StAppCfg = 4'b 1110,
+
     StAppMsg = 4'b 0101,
 
     // In StKeyOutLen, this module pushes encoded outlen to the MSG_FIFO.
@@ -315,26 +330,33 @@ module kmac_app
     unique case (st)
       StIdle: begin
         if (arb_valid && keymgr_key_i.valid) begin
-          st_d = StAppMsg;
-          // KeyMgr initiates the data
-          cmd_o = CmdStart;
+          st_d = StAppCfg;
 
           // choose app_id
           set_appid = 1'b 1;
-        // app_id is not valid at this time. use app_id_d or arb_idx
-        // TODO: arb_isx OoR case?
-        end else if (arb_valid && (AppCfg[arb_idx].Mode == AppKMAC) && !keymgr_key_i.valid) begin
-          st_d = StKeyMgrErrKeyNotValid;
-
-          fsm_err.valid = 1'b 1;
-          fsm_err.code = ErrKeyNotValid;
-          fsm_err.info = '0;
         end else if (sw_cmd_i == CmdStart) begin
           st_d = StSw;
           // Software initiates the sequence
           cmd_o = CmdStart;
         end else begin
           st_d = StIdle;
+        end
+      end
+
+      StAppCfg: begin
+
+        if ((AppCfg[app_id].Mode == AppKMAC) && !keymgr_key_i.valid) begin
+          st_d = StKeyMgrErrKeyNotValid;
+
+          fsm_err.valid = 1'b 1;
+          fsm_err.code = ErrKeyNotValid;
+          fsm_err.info = '0;
+        end else begin
+          // As Cfg is stable now, it sends cmd
+          st_d = StAppMsg;
+
+          // App initiates the data
+          cmd_o = CmdStart;
         end
       end
 
@@ -570,6 +592,30 @@ module kmac_app
         sha3_prefix_o = reg_prefix_i;
       end
     endcase
+  end
+
+  // KMAC en / SHA3 mode / Strength
+  //  by default, it uses reg cfg. When app intf reqs come, it uses AppCfg.
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      kmac_en_o         <= 1'b 0;
+      sha3_mode_o       <= sha3_pkg::Sha3;
+      keccak_strength_o <= sha3_pkg::L256;
+    end else if (clr_appid) begin
+      // As App completed, latch reg value
+      kmac_en_o         <= reg_kmac_en_i;
+      sha3_mode_o       <= reg_sha3_mode_i;
+      keccak_strength_o <= reg_keccak_strength_i;
+    end else if (set_appid) begin
+      kmac_en_o         <= AppCfg[arb_idx].Mode == AppKMAC ? 1'b 1 : 1'b 0;
+      sha3_mode_o       <= AppCfg[arb_idx].Mode == AppSHA3
+                           ? sha3_pkg::Sha3 : sha3_pkg::CShake;
+      keccak_strength_o <= AppCfg[arb_idx].Strength ;
+    end else if (st == StIdle) begin
+      kmac_en_o         <= reg_kmac_en_i;
+      sha3_mode_o       <= reg_sha3_mode_i;
+      keccak_strength_o <= reg_keccak_strength_i;
+    end
   end
 
   // Error Reporting ==========================================================

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -119,6 +119,8 @@ package kmac_pkg;
   typedef struct {
     app_mode_e                         Mode;
 
+    sha3_pkg::keccak_strength_e        Strength;
+
     // PrefixMode determines the origin value of Prefix that is used in KMAC
     // and cSHAKE operations.
     // Choose **0** for CSRs (!!PREFIX), or **1** to use `Prefix` parameter
@@ -134,6 +136,7 @@ package kmac_pkg;
     // KeyMgr
     '{
       Mode:       AppKMAC, // KeyMgr uses KMAC operation
+      Strength:   sha3_pkg::L256,
       PrefixMode: 1'b 0,   // Use CSR for prefix
       Prefix:     '0       // Not used in CSR prefix mode
     },
@@ -141,6 +144,7 @@ package kmac_pkg;
     // OTP
     '{
       Mode:       AppCShake,
+      Strength:   sha3_pkg::L256,
       PrefixMode: 1'b 1,     // Use prefix parameter
       Prefix:     'h 0       // TODO: Determine the prefix value
     },
@@ -148,6 +152,7 @@ package kmac_pkg;
     // ROM_CTRL
     '{
       Mode:       AppCShake,
+      Strength:   sha3_pkg::L256,
       PrefixMode: 1'b 1,     // Use prefix parameter
       Prefix:     'h 0       // TODO: Determine the prefix value
     }

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -99,6 +99,8 @@ package kmac_pkg;
   // 0: KeyMgr
   // 1: OTP_CTRL
   // 2: ROM_CTRL
+  // Make sure to change `width` of app inter-module signal definition
+  // if this value is changed.
   parameter int unsigned NumAppIntf = 3;
 
   // Application Algorithm

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -127,7 +127,7 @@ package kmac_pkg;
 
     // If `PrefixMode` is 1'b 1, then this `Prefix` value will be used in
     // cSHAKE or KMAC operation.
-    logic [sha3_pkg::PrefixIndexW-1:0] Prefix;
+    logic [sha3_pkg::NSRegisterSize*8-1:0] Prefix;
   } app_config_t;
 
   parameter app_config_t AppCfg [NumAppIntf] = '{

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3882,10 +3882,11 @@
           package: kmac_pkg
           type: req_rsp
           act: rsp
-          width: 1
+          width: 3
           inst_name: kmac
           default: ""
-          end_idx: -1
+          end_idx: 1
+          top_type: partial-one-to-N
           top_signame: kmac_app
           index: -1
         }
@@ -4143,7 +4144,7 @@
           inst_name: keymgr
           default: ""
           top_signame: kmac_app
-          index: -1
+          index: 0
         }
         {
           name: otp_key
@@ -11397,10 +11398,11 @@
         package: kmac_pkg
         type: req_rsp
         act: rsp
-        width: 1
+        width: 3
         inst_name: kmac
         default: ""
-        end_idx: -1
+        end_idx: 1
+        top_type: partial-one-to-N
         top_signame: kmac_app
         index: -1
       }
@@ -11497,7 +11499,7 @@
         inst_name: keymgr
         default: ""
         top_signame: kmac_app
-        index: -1
+        index: 0
       }
       {
         name: otp_key
@@ -14059,9 +14061,9 @@
         package: kmac_pkg
         struct: app_req
         signame: kmac_app_req
-        width: 1
+        width: 3
         type: req_rsp
-        end_idx: -1
+        end_idx: 1
         act: rsp
         suffix: req
         default: ""
@@ -14070,9 +14072,9 @@
         package: kmac_pkg
         struct: app_rsp
         signame: kmac_app_rsp
-        width: 1
+        width: 3
         type: req_rsp
-        end_idx: -1
+        end_idx: 1
         act: rsp
         suffix: rsp
         default: ""

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -471,8 +471,8 @@ module top_earlgrey #(
   edn_pkg::edn_rsp_t [6:0] edn1_edn_rsp;
   otp_ctrl_pkg::otp_keymgr_key_t       otp_ctrl_otp_keymgr_key;
   keymgr_pkg::hw_key_req_t       keymgr_kmac_key;
-  kmac_pkg::app_req_t       kmac_app_req;
-  kmac_pkg::app_rsp_t       kmac_app_rsp;
+  kmac_pkg::app_req_t [2:0] kmac_app_req;
+  kmac_pkg::app_rsp_t [2:0] kmac_app_rsp;
   logic [3:0] clkmgr_aon_idle;
   jtag_pkg::jtag_req_t       pinmux_aon_lc_jtag_req;
   jtag_pkg::jtag_rsp_t       pinmux_aon_lc_jtag_rsp;
@@ -615,6 +615,8 @@ module top_earlgrey #(
   edn_pkg::edn_rsp_t unused_edn1_edn_rsp4;
   edn_pkg::edn_rsp_t unused_edn1_edn_rsp5;
   edn_pkg::edn_rsp_t unused_edn1_edn_rsp6;
+  kmac_pkg::app_rsp_t unused_kmac_app_rsp1;
+  kmac_pkg::app_rsp_t unused_kmac_app_rsp2;
 
   // assign partial inter-module tie-off
   assign unused_edn1_edn_rsp1 = edn1_edn_rsp[1];
@@ -623,12 +625,16 @@ module top_earlgrey #(
   assign unused_edn1_edn_rsp4 = edn1_edn_rsp[4];
   assign unused_edn1_edn_rsp5 = edn1_edn_rsp[5];
   assign unused_edn1_edn_rsp6 = edn1_edn_rsp[6];
+  assign unused_kmac_app_rsp1 = kmac_app_rsp[1];
+  assign unused_kmac_app_rsp2 = kmac_app_rsp[2];
   assign edn1_edn_req[1] = '0;
   assign edn1_edn_req[2] = '0;
   assign edn1_edn_req[3] = '0;
   assign edn1_edn_req[4] = '0;
   assign edn1_edn_req[5] = '0;
   assign edn1_edn_req[6] = '0;
+  assign kmac_app_req[1] = kmac_pkg::APP_REQ_DEFAULT;
+  assign kmac_app_req[2] = kmac_pkg::APP_REQ_DEFAULT;
 
 
   // Unused reset signals
@@ -1969,8 +1975,8 @@ module top_earlgrey #(
       .aes_key_o(),
       .hmac_key_o(),
       .kmac_key_o(keymgr_kmac_key),
-      .kmac_data_o(kmac_app_req),
-      .kmac_data_i(kmac_app_rsp),
+      .kmac_data_o(kmac_app_req[0]),
+      .kmac_data_i(kmac_app_rsp[0]),
       .otp_key_i(otp_ctrl_otp_keymgr_key),
       .otp_hw_cfg_i(otp_ctrl_otp_hw_cfg),
       .flash_i(flash_ctrl_keymgr),

--- a/util/topgen/intermodule.py
+++ b/util/topgen/intermodule.py
@@ -880,7 +880,9 @@ def im_netname(sig: OrderedDict,
             if obj.get("package") == "tlul_pkg" and obj["struct"] == "tl":
                 return "{package}::{struct}_H2D_DEFAULT".format(
                     package=obj["package"], struct=obj["struct"].upper())
-            return "{package}::{struct}_REQ_DEFAULT".format(
+            # default is used for dangling ports in definitions.
+            # the struct name already has `_req` suffix
+            return "{package}::{struct}_DEFAULT".format(
                 package=obj.get("package", ''), struct=obj["struct"].upper())
         if obj["act"] == "rcv" and suffix == "" and obj["struct"] == "logic":
             # custom default has been specified


### PR DESCRIPTION
[kmac] Expose multi-array app intf to top
    
    This commit exposes app intf array to the top-level.
    
[kmac] kmac_app to use AppCfg parameter
    
    This commit implements that kmac_app submodule uses AppCfg parameter for
    Application interface.