### PR TITLE
[dvsim] Add GUI mode for running simulations

### DIFF
--- a/hw/dv/tools/common.tcl
+++ b/hw/dv/tools/common.tcl
@@ -16,6 +16,11 @@ if {[info exists ::env(WAVES)]} {
   set waves "$::env(WAVES)"
 }
 
+set gui 0
+if {[info exists ::env(GUI)]} {
+  set gui "$::env(GUI)"
+}
+
 set tb_top "tb"
 if {[info exists ::env(TB_TOP)]} {
   set tb_top "$::env(TB_TOP)"

--- a/hw/dv/tools/dvsim/common_modes.hjson
+++ b/hw/dv/tools/dvsim/common_modes.hjson
@@ -8,6 +8,11 @@
   // options are appended to actual build_modes
   build_modes: [
     {
+      name: gui
+      is_sim_mode: 1
+      en_build_modes: ["{tool}_gui"]
+    }
+    {
       name: waves
       is_sim_mode: 1
       en_build_modes: ["{tool}_waves"]

--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -72,6 +72,7 @@
   exports: [
     { dv_root: "{dv_root}" },
     { SIMULATOR: "{tool}" },
+    { GUI: "{gui}"},
     { WAVES: "{waves}" },
     { DUT_TOP: "{dut}" },
     { TB_TOP: "{tb}" },

--- a/hw/dv/tools/dvsim/dsim.hjson
+++ b/hw/dv/tools/dvsim/dsim.hjson
@@ -93,6 +93,12 @@
 
   build_modes: [
     {
+      name: dsim_gui
+      is_sim_mode: 1
+      build_opts: []
+      run_opts: []
+    }
+    {
       name: dsim_waves
       is_sim_mode: 1
       build_opts: ["+acc+b"]

--- a/hw/dv/tools/dvsim/riviera.hjson
+++ b/hw/dv/tools/dvsim/riviera.hjson
@@ -64,6 +64,12 @@
 
   build_modes: [
     {
+      name: riviera_gui
+      is_sim_mode: 1
+      build_opts: []
+      run_opts: []
+    }
+    {
       name: riviera_waves
       is_sim_mode: 1
     }

--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -11,12 +11,16 @@
                "-Mdir={build_ex}.csrc",
                "-o {build_ex}",
                "-f {sv_flist}",
+               // Enable LCA features. It does not require separate licenses.
+               "-lca",
                // List multiple tops for the simulation. Prepend each top level with `-top`.
                "{eval_cmd} echo {sim_tops} | sed -E 's/(\\S+)/-top \\1/g'",
                "+incdir+{build_dir}",
                // Turn on warnings for non-void functions called with return values ignored
                "+warn=SV-NFIVC",
                "+warn=noUII-L",
+               // Disable unnecessary LCA warning.
+               "+warn=noLCA_FEATURES_ENABLED",
                // Below option required for $error/$fatal system calls
                "-assert svaext",
                // Force unique and priority to evaluate compliance checking only on the stable
@@ -217,6 +221,12 @@
   run_fail_patterns:   ["^Error-.*$"] // Null pointer error
 
   build_modes: [
+    {
+      name: vcs_gui
+      is_sim_mode: 1
+      build_opts: ["-debug_access+all+reverse"]
+      run_opts: ["-gui", "-l {run_dir}/simv.log"]
+    }
     {
       name: vcs_waves
       is_sim_mode: 1

--- a/hw/dv/tools/dvsim/verilator.hjson
+++ b/hw/dv/tools/dvsim/verilator.hjson
@@ -108,6 +108,14 @@
   cov_db_test_dir: ""
 
   build_modes: [
+    // TODO: Verilator will likely never have GUI. Find a better way to support
+    // --gui when the tool itself doesn't support it.
+    {
+      name: verilator_gui
+      is_sim_mode: 1
+      build_opts: []
+      run_opts: []
+    }
     {
       name: verilator_waves
       is_sim_mode: 1

--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -5,7 +5,7 @@
   build_cmd:  "{job_prefix} xrun"
   run_cmd:    "{job_prefix} xrun"
 
-  build_opts: ["-elaborate -64bit -access +r -sv",
+  build_opts: ["-elaborate -64bit -sv",
                "-licqueue",
                // TODO: duplicate primitives between OT and Ibex #1231
                "-ALLOWREDEFINITION",
@@ -153,8 +153,15 @@
 
   build_modes: [
     {
+      name: xcelium_gui
+      is_sim_mode: 1
+      build_opts: ["-createdebugdb", "-access +c"]
+      run_opts: ["-gui"]
+    }
+    {
       name: xcelium_waves
       is_sim_mode: 1
+      build_opts: ["-access +c"]
     }
     {
       name: xcelium_cov

--- a/hw/dv/tools/sim.tcl
+++ b/hw/dv/tools/sim.tcl
@@ -17,5 +17,9 @@ if {[info exists ::env(dv_root)]} {
 source "${dv_root}/tools/common.tcl"
 source "${dv_root}/tools/waves.tcl"
 
-run
-quit
+# In GUI mode, let the user take control of running the simulation.
+global gui
+if {$gui == 0} {
+  run
+  quit
+}

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -435,8 +435,11 @@ class RunTest(Deploy):
         self.job_name = "{}_{}_{}".format(self.sim_cfg.name, self.target,
                                           self.build_mode)
         self.output_dirs += [self.cov_db_test_dir]
-        self.pass_patterns = self.run_pass_patterns
-        self.fail_patterns = self.run_fail_patterns
+
+        # In GUI mode, the log file is not updated; hence, nothing to check.
+        if not self.sim_cfg.gui:
+            self.pass_patterns = self.run_pass_patterns
+            self.fail_patterns = self.run_fail_patterns
 
     def post_finish(self, status):
         if status != 'P':

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -47,6 +47,7 @@ class FlowCfg():
         self.scratch_root = args.scratch_root
         self.branch = args.branch
         self.job_prefix = args.job_prefix
+        self.gui = args.gui
 
         # Options set from hjson cfg.
         self.project = ""
@@ -348,6 +349,12 @@ class FlowCfg():
         '''Public facing API for _create_deploy_objects().
         '''
         self.prune_selected_cfgs()
+
+        # GUI mode is allowed only for one cfg.
+        if self.gui and len(self.cfgs) > 1:
+            log.fatal("In GUI mode, only one cfg can be run.")
+            sys.exit(1)
+
         for item in self.cfgs:
             item._create_deploy_objects()
 

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -126,6 +126,8 @@ class SimCfg(FlowCfg):
         self.map_full_testplan = args.map_full_testplan
 
         # Set default sim modes for unpacking
+        if args.gui:
+            self.en_build_modes.append("gui")
         if args.waves is not None:
             self.en_build_modes.append("waves")
         if self.cov is True:
@@ -504,6 +506,12 @@ class SimCfg(FlowCfg):
         self.runs = ([]
                      if self.build_only else self._expand_run_list(build_map))
 
+        # In GUI mode, only allow one test to run.
+        if self.gui and len(self.runs) > 1:
+            self.runs = self.runs[:1]
+            log.warning("In GUI mode, only one test is allowed to run. "
+                        "Picking {}".format(self.runs[0].full_name))
+
         # Add builds to the list of things to run, only if --run-only switch
         # is not passed.
         self.deploy = []
@@ -545,7 +553,7 @@ class SimCfg(FlowCfg):
         '''
         # TODO, Only support VCS
         if self.tool not in ['vcs', 'xcelium']:
-            log.error("Currently only support VCS and Xcelium for coverage UNR")
+            log.error("Only VCS and Xcelium are supported for the UNR flow.")
             sys.exit(1)
         # Create initial set of directories, such as dispatched, passed etc.
         self._create_dirs()

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -402,6 +402,11 @@ def parse_args():
                         help=('The options for each build_mode in this list '
                               'are applied to all build and run targets.'))
 
+    disg.add_argument("--gui",
+                      action='store_true',
+                      help=('Run the flow in interactive mode instead of the '
+                            'batch mode.'))
+
     rung = parser.add_argument_group('Options for running')
 
     rung.add_argument("--run-only",


### PR DESCRIPTION
The adds support for running simulations in GUI mode. This change plumbs
the dvsim switch `--gui` to the underlying tools. With VCS and Xcelium,
the respective GUI windows will open, exposing the UCLI prompt, where
the user can take control of running the simulation (debugging, adding
breakpoints etc).

If GUI mode is enabled and multiple tests are provided for run, it picks
the first and drops everything else. The onus is on the user to pick
correctly (pass a single test with `--items` and a specific seed with
`--seed`).

Further, in GUI mode, it drops the pass and fail patterns, since the
whole simulation is run from inside the tool (the log file is not
generated).

Only VCS and Xcelium are currently fully supported. For all others,
`--gui` has no effect.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>