### PR TITLE
[dvsim] Keep dependencies list

### DIFF
--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -359,6 +359,11 @@ class FlowCfg():
         deploy = []
         for item in self.cfgs:
             deploy.extend(item.deploy)
+
+        if not deploy:
+            log.fatal("Nothing to run!")
+            sys.exit(1)
+
         return Scheduler(deploy).run()
 
     def _gen_results(self, results):

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -504,21 +504,21 @@ class SimCfg(FlowCfg):
         self.runs = ([]
                      if self.build_only else self._expand_run_list(build_map))
 
-        # Discard the build_job dependency that was added earlier if --run-only
-        # switch is passed.
-        if self.run_only:
-            self.builds = []
-            for run in self.runs:
-                run.dependencies = []
+        # Add builds to the list of things to run, only if --run-only switch
+        # is not passed.
+        self.deploy = []
+        if not self.run_only:
+            self.deploy += self.builds
 
-        self.deploy = self.builds + self.runs
+        if not self.build_only:
+            self.deploy += self.runs
 
-        # Create cov_merge and cov_report objects, so long as we've got at
-        # least one run to do.
-        if self.cov and self.runs:
-            self.cov_merge_deploy = CovMerge(self.runs, self)
-            self.cov_report_deploy = CovReport(self.cov_merge_deploy, self)
-            self.deploy += [self.cov_merge_deploy, self.cov_report_deploy]
+            # Create cov_merge and cov_report objects, so long as we've got at
+            # least one run to do.
+            if self.cov and self.runs:
+                self.cov_merge_deploy = CovMerge(self.runs, self)
+                self.cov_report_deploy = CovReport(self.cov_merge_deploy, self)
+                self.deploy += [self.cov_merge_deploy, self.cov_report_deploy]
 
         # Create initial set of directories before kicking off the regression.
         self._create_dirs()


### PR DESCRIPTION
This set of changes is aimed at retaining the dependency order across
targets, even if the dependency is not scheduled to be run. The
Deploy::dependencies list once constructed, remains untouched. We
instead change the way the `FlowCfg::deploy` list is created - if targets
are not required to run (for example, when `--build-only` or `--run-only`
switch is passed), then they are not added to the deploy list. This
means that the deploy list needs to be constructed correctly - the
scheduler relies on it to know what to run.

The scheduler previously recursively went through the dependencies to
determine what all needed to be run - this required the `FlowCfg` to
delete dependencies after the fact, if flow modifier switches were
passed. This is no longer needed because we now explicitly provide it
the list of things to run instead. This also means when checking an
item's eligibility to be enqueued based on its dependencies' statuses,
it needs to ignore the deps that were not a part of the original deploy
list.

The reason for this change is our internal Google Cloud based launching
system, which runs each job (input -> process -> output) in an isolated
VM instance. The job's input and output are tarballs that flit between
the user's workstation, Google Cloud storage, and the VM instance. To
support --run-only for example, in our environment, the run deploy
object needs to be able to provide a pointer to its build dependency
(which would have run in the past) so that the built simulation
executable can be tarballed and uploaded as the run-job's input.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>