### PR TITLE
[clkmgr] Wire up lc_dft_en_i at top-level

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -52,6 +52,13 @@ num_grps = len(grps)
 
     { struct:  "lc_tx",
       type:    "uni",
+      name:    "lc_dft_en",
+      act:     "rcv",
+      package: "lc_ctrl_pkg",
+    },
+
+    { struct:  "lc_tx",
+      type:    "uni",
       name:    "ast_clk_byp_req",
       act:     "req",
       package: "lc_ctrl_pkg",

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2403,6 +2403,16 @@
           index: -1
         }
         {
+          name: lc_dft_en
+          struct: lc_tx
+          package: lc_ctrl_pkg
+          type: uni
+          act: rcv
+          width: 1
+          inst_name: clkmgr_aon
+          index: -1
+        }
+        {
           name: ast_clk_byp_req
           struct: lc_tx
           package: lc_ctrl_pkg
@@ -10481,6 +10491,16 @@
         inst_name: clkmgr_aon
         default: ""
         top_signame: clkmgr_aon_clocks
+        index: -1
+      }
+      {
+        name: lc_dft_en
+        struct: lc_tx
+        package: lc_ctrl_pkg
+        type: uni
+        act: rcv
+        width: 1
+        inst_name: clkmgr_aon
         index: -1
       }
       {

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -50,6 +50,13 @@
 
     { struct:  "lc_tx",
       type:    "uni",
+      name:    "lc_dft_en",
+      act:     "rcv",
+      package: "lc_ctrl_pkg",
+    },
+
+    { struct:  "lc_tx",
+      type:    "uni",
       name:    "ast_clk_byp_req",
       act:     "req",
       package: "lc_ctrl_pkg",

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1602,6 +1602,7 @@ module top_earlgrey #(
 
       // Inter-module signals
       .clocks_o(clkmgr_aon_clocks),
+      .lc_dft_en_i(lc_ctrl_pkg::LC_TX_DEFAULT),
       .ast_clk_byp_req_o(ast_clk_byp_req_o),
       .ast_clk_byp_ack_i(ast_clk_byp_ack_i),
       .lc_clk_byp_req_i(lc_ctrl_lc_clk_byp_req),


### PR DESCRIPTION
This port was added in fa60a60581 but wasn't added to
clkmgr.hjson.tpl, so we have a missing pin in top_earlgrey.sv, causing
lint errors. Wire it up with a default value for now.
