### PR TITLE
[kmac] Fix app_config_t to work with Verilator

### DIFF
--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -105,7 +105,7 @@ package kmac_pkg;
 
   // Application Algorithm
   // Each interface can choose algorithms among SHA3, cSHAKE, KMAC
-  typedef enum int unsigned {
+  typedef enum bit [1:0] {
     // SHA3 mode doer not nees any additional information.
     // Prefix will be tied to all zero and not used.
     AppSHA3   = 0,
@@ -118,7 +118,7 @@ package kmac_pkg;
     AppKMAC   = 2
   } app_mode_e;
 
-  typedef struct {
+  typedef struct packed {
     app_mode_e                         Mode;
 
     sha3_pkg::keccak_strength_e        Strength;


### PR DESCRIPTION
Verilator doesn't have proper support for unpacked structs. Since we
don't need one here, we can just declare `app_config_t` to be packed.

Also, it seems to have rather strange behaviour with `int` enums when
used as fields in a struct. I've reported this on the Verilator bug
tracker as [issue #2855](https://github.com/verilator/verilator/issues/2855) but there's an easy workaround here, which is
probably what we'd want for synthesizable code anyway.
