### PR TITLE
[csrng] Fix some width mismatches

### DIFF
--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -671,7 +671,7 @@ module csrng_core import csrng_pkg::*; #(
   // SW interface connection (only 1, and must be present)
   // cmd req
   assign cmd_stage_vld[NApps-1] = reg2hw.cmd_req.qe;
-  assign cmd_stage_shid[NApps-1] = (NApps-1);
+  assign cmd_stage_shid[NApps-1] = StateId'(NApps-1);
   assign cmd_stage_bus[NApps-1] = reg2hw.cmd_req.q;
   assign hw2reg.sw_cmd_sts.cmd_rdy.de = 1'b1;
   assign hw2reg.sw_cmd_sts.cmd_rdy.d = cmd_stage_rdy[NApps-1];

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_cmd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_cmd.sv
@@ -268,7 +268,7 @@ module csrng_ctr_drbg_cmd import csrng_pkg::*; #(
 
   // if a UNI command, reset the state values
   assign sfifo_keyvrc_wdata = (rcstage_ccmd == UNI) ?
-         {{(KeyLen+BlkLen+CtrLen+16){1'b0}},upd_cmd_inst_id_i,upd_cmd_ccmd_i} :
+         {{(KeyLen+BlkLen+CtrLen+1+SeedLen){1'b0}},upd_cmd_inst_id_i,upd_cmd_ccmd_i} :
          {upd_cmd_key_i,upd_cmd_v_i,rcstage_rc,rcstage_fips,
           rcstage_adata,upd_cmd_inst_id_i,upd_cmd_ccmd_i};
 

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
@@ -291,7 +291,7 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
          interate_ctr_q;
 
   // Supporting only 128b requests
-  assign interate_ctr_done = (interate_ctr_q >= (BlkLen/BlkLen));
+  assign interate_ctr_done = (interate_ctr_q >= 2'(BlkLen/BlkLen));
 
   //--------------------------------------------
   // state machine to send values to block_encrypt

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
@@ -316,7 +316,7 @@ module csrng_ctr_drbg_upd #(
              interate_ctr_inc ? (interate_ctr_q + 1) :
              interate_ctr_q;
 
-  assign interate_ctr_done = (interate_ctr_q >= (SeedLen/BlkLen));
+  assign interate_ctr_done = (int'(interate_ctr_q) >= SeedLen/BlkLen);
 
   //--------------------------------------------
   // state machine to send values to block_encrypt
@@ -471,7 +471,7 @@ module csrng_ctr_drbg_upd #(
   // shifting logic to receive values from block_encrypt
   //--------------------------------------------
 
-  assign concat_outblk_shifted_value = (concat_outblk_q << BlkLen);
+  assign concat_outblk_shifted_value = {concat_outblk_q, {BlkLen{1'b0}}};
 
   assign concat_outblk_d =
          sfifo_bencack_pop ? {concat_outblk_q[SeedLen-1:BlkLen],sfifo_bencack_v} :
@@ -484,7 +484,7 @@ module csrng_ctr_drbg_upd #(
          concat_ctr_inc ? (concat_ctr_q + 1) :
          concat_ctr_q;
 
-  assign concat_ctr_done = (concat_ctr_q >= (SeedLen/BlkLen));
+  assign concat_ctr_done = (int'(concat_ctr_q) >= (SeedLen/BlkLen));
 
   assign concat_inst_id_d = sfifo_bencack_pop ? sfifo_bencack_inst_id : concat_inst_id_q;
   assign concat_ccmd_d = sfifo_bencack_pop ? sfifo_bencack_ccmd : concat_ccmd_q;

--- a/hw/ip/csrng/rtl/csrng_state_db.sv
+++ b/hw/ip/csrng/rtl/csrng_state_db.sv
@@ -121,7 +121,7 @@ module csrng_state_db import csrng_pkg::*; #(
 
 
   // re-using the internal state pipeline version for better timing
-  assign internal_state_diag = {32'b0,internal_state_pl_q};
+  assign internal_state_diag = {30'b0,internal_state_pl_q};
 
 
   // Register access of internal state


### PR DESCRIPTION
These cause lint errors from Verilator. Most of the changes are
mechanical, but I've changed the left shift that computes
`concat_outblk_shifted_value` to add the `BlkLen` zeros at the bottom
explicitly (I think we might have been silently dropping the top block
before).
