### PR TITLE
[aes] Fix lint error, correct formatting issues in documentation

### DIFF
--- a/hw/ip/aes/doc/_index.md
+++ b/hw/ip/aes/doc/_index.md
@@ -386,6 +386,7 @@ Following the [OpenTitan non-reset vs. reset flops rationale](https://github.com
 - Input/output data and IV values are (currently) not stored in multiple shares but these are less critical as they are used only once.
   Further, they are stored in banks of 32 bits leaving a larger hypothesis space compared to when glitching e.g. an 8-bit register into reset.
   In addition, they could potentially also be extracted when being transferred over the TL-UL bus interface.
+
 For this reason, the AES unit uses reset flops only.
 However, all major key and data registers are cleared with pseudo-random data upon reset.
 
@@ -606,6 +607,7 @@ Compared to first-in, first-out (FIFO) interfaces, having separate registers has
 - Supported out-of-the-box by the register tool (the FIFO would have to be implemented separately).
 - Usability: critical corner cases where software updates input data or the key partially only are easier to avoid using separate registers and the `hwqe`-signals provided by the Register Tool.
 - Easier interaction with DMA engines
+
 Also, using a FIFO interface for something that is not actually FIFO (internally, 16B of input/output data are consumed/produced at once) is less natural.
 
 For a detailed overview of the register tool, please refer to the [Register Tool documentation.]({{< relref "doc/rm/register_tool" >}})

--- a/hw/ip/aes/lint/aes.waiver
+++ b/hw/ip/aes/lint/aes.waiver
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # waiver file for aes
-waive -rules COMBO_READ_WRITE -location {aes_key_expand.sv} -regexp {'regular\[[0-9]+\]\[2:1|4:2|6:5\]' is read from within the same combinational process block} \
+waive -rules COMBO_READ_WRITE -location {aes_key_expand.sv} -regexp {'regular\[[0-9]+:?[0-9]*\]\[2:1|4:2|6:5\]' is read from within the same combinational process block} \
       -comment "regular[*] is assigned in a for loop, regular[*][1|2|5] depends on regular[*][0|1|4]"
 
 waive -rules {CLOCK_USE} -location {aes_cipher_core.sv} -regexp {clk_i' is connected to 'aes_sub_bytes' port} \


### PR DESCRIPTION
AscentLint now checks the masked version of the cipher core which requires one of the lint waivers to be adjusted. I am not 100% sure if this change will cause a lint error inside CSRNG (uses the unmasked AES cipher core). It would be great if someone with access to the tool could check both.