### PR TITLE
[pattgen] Fix width of literal in pattgen_chan.sv

### DIFF
--- a/hw/ip/pattgen/rtl/pattgen_chan.sv
+++ b/hw/ip/pattgen/rtl/pattgen_chan.sv
@@ -82,7 +82,7 @@ module pattgen_chan
   assign bit_cnt_en = (pcl_int_q & (clk_cnt_q == prediv_q) ) | (~enable);
   assign bit_cnt_d  = (!enable) ? 6'h0:
                       (bit_cnt_q == len_q) ? 6'h0 : bit_cnt_q + 6'h1;
-  assign pda_o      = (!enable) ? 6'h0 : data_q[bit_cnt_q];
+  assign pda_o      = (!enable) ? 1'b0 : data_q[bit_cnt_q];
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin


### PR DESCRIPTION
I think this was probably copied from the previous line. `pda_o` should
be a single bit output.
