### PR TITLE
[flash_ctrl] Width mismatch fixes

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
@@ -10,7 +10,7 @@
 // Most of the items are TODO, at the moment only arbitration logic exists.
 
 module flash_phy_core import flash_phy_pkg::*; #(
-  parameter int ArbCnt       = 4
+  parameter int unsigned ArbCnt = 4
 ) (
   input                              clk_i,
   input                              rst_ni,
@@ -118,7 +118,7 @@ module flash_phy_core import flash_phy_pkg::*; #(
   logic op_ack;
   logic [DataWidth-1:0] scramble_mask;
 
-  assign host_req_masked = host_req_i & (arb_cnt < ArbCnt);
+  assign host_req_masked = host_req_i & (arb_cnt < ArbCnt[CntWidth-1:0]);
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin

--- a/hw/ip/flash_ctrl/rtl/flash_phy_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_pkg.sv
@@ -80,13 +80,14 @@ package flash_phy_pkg;
   } rd_attr_t;
 
   // Flash Operations Supported
-  typedef enum logic [2:0] {
-    PhyRead      = 3'h0,
-    PhyProg      = 3'h1,
-    PhyPgErase   = 3'h2,
-    PhyBkErase   = 3'h3,
-    PhyOps       = 3'h4
+  typedef enum logic [1:0] {
+    PhyRead      = 2'h0,
+    PhyProg      = 2'h1,
+    PhyPgErase   = 2'h2,
+    PhyBkErase   = 2'h3
   } flash_phy_op_e;
+
+  localparam int PhyOps = 4;
 
   // Flash Operations Selected
   typedef enum logic [1:0] {


### PR DESCRIPTION
I'm not sure that the second patch should really be required, because the errors all come about when using a literal value. I've filed an issue on the Verilator bug tracker (https://github.com/verilator/verilator/issues/2865) to discuss it. Of course, even if that behaviour changes, it'll be a while before we can assume everyone has the new version, so it probably makes sense to do the obvious fix here.