### PR TITLE
[dv/otp] fix number of edn required for sram

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -83,7 +83,7 @@ package otp_ctrl_env_pkg;
   parameter uint SCRAMBLE_KEY_SIZE  = 128;
   parameter uint NUM_ROUND          = 31;
 
-  parameter uint NUM_SRAM_EDN_REQ = 10;
+  parameter uint NUM_SRAM_EDN_REQ = 12;
   parameter uint NUM_OTBN_EDN_REQ = 16;
 
   parameter uint CHK_TIMEOUT_CYC = 40;


### PR DESCRIPTION
The num of EDN required for SRAM should be 12 instead of 10.
This fixes the regression failure in OTP dai_errs sequence.

Signed-off-by: Cindy Chen <chencindy@google.com>