### PR TITLE
[dv/clkmgr] clkmgr uses lowrisc:systems instead of lowrisc:ip.

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson
+++ b/hw/ip/clkmgr/data/clkmgr.hjson
@@ -10,6 +10,7 @@
 #
 {
   name: "CLKMGR",
+  fusesoc_core_name: "lowrisc:ip:clkmgr_reg"
   clock_primary: "clk_i",
   other_clock_list: [
     "clk_main_i",

--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 // TODO: This module is only a draft implementation that covers most of the rstmgr
-// functoinality but is incomplete
+// functionality but is incomplete
 
 <%
 clks_attr = cfg['clocks']
@@ -15,6 +15,7 @@ num_grps = len(grps)
 #
 {
   name: "CLKMGR",
+  fusesoc_core_name: "lowrisc:systems:clkmgr"
   scan: "true",
   clock_primary: "clk_i",
   other_clock_list: [],

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -8,7 +8,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 // TODO: This module is only a draft implementation that covers most of the rstmgr
-// functoinality but is incomplete
+// functionality but is incomplete
 
 
 
@@ -16,6 +16,7 @@
 #
 {
   name: "CLKMGR",
+  fusesoc_core_name: "lowrisc:systems:clkmgr"
   scan: "true",
   clock_primary: "clk_i",
   other_clock_list: [],


### PR DESCRIPTION
The rtl code under hw/ip/clkmgr doesn't match the unit specification.

Signed-off-by: Matute <maturana@google.com>