### PR TITLE
[rom_ctrl] Fix backdoor path

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -119,7 +119,7 @@ module rom_ctrl
   rom_ctrl_regs_hw2reg_t hw2reg;
   logic                  reg_integrity_error;
 
-  rom_ctrl_regs_reg_top u_reg_top (
+  rom_ctrl_regs_reg_top u_reg (
     .clk_i      (clk_i),
     .rst_ni     (rst_ni),
     .tl_i       (regs_tl_i),


### PR DESCRIPTION
We assume u_reg is the instance name of reg top in RAL model.
Need to find a better way to handle multiple regfile in one IP.
This still works for one CSR regfile and one mem regfile in a IP, as we
treat the mem backdoor separately. But can't handle if there are 2 CSR
regfiles in a IP.
@rswarbrick can you advise how to know the instance name of reg top
when generating the register in RAL.

Signed-off-by: Weicai Yang <weicai@google.com>