### PR TITLE
[sw/dif] Entropy source implementation

### DIFF
--- a/sw/device/lib/dif/dif_entropy.c
+++ b/sw/device/lib/dif/dif_entropy.c
@@ -4,4 +4,101 @@
 
 #include "sw/device/lib/dif/dif_entropy.h"
 
-// TODO: Implement!
+#include <stddef.h>
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+
+#include "entropy_src_regs.h"  // Generated.
+
+/**
+ * Sets the `entropy` source configuration register with the settings
+ * derived from `config`.
+ */
+static void set_config_register(const dif_entropy_t *entropy,
+                                const dif_entropy_config_t *config) {
+  // TODO: Make this configurable at the API level.
+  uint32_t reg =
+      bitfield_bit32_write(0, ENTROPY_SRC_CONF_BOOT_BYPASS_DISABLE_BIT, 1);
+
+  // Configure test cases
+  reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_REPCNT_DISABLE_BIT,
+                             !config->tests[kDifEntropyTestRepCount]);
+  reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_ADAPTP_DISABLE_BIT,
+                             !config->tests[kDifEntropyTestAdaptiveProportion]);
+  reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_BUCKET_DISABLE_BIT,
+                             !config->tests[kDifEntropyTestBucket]);
+  reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_MARKOV_DISABLE_BIT,
+                             !config->tests[kDifEntropyTestMarkov]);
+  reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_HEALTH_TEST_CLR_BIT,
+                             config->reset_health_test_registers);
+  reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_EXTHT_ENABLE_BIT, 0);
+
+  // Configure single RNG bit mode
+  bool rng_bit_en = config->single_bit_mode != kDifEntropySingleBitModeDisabled;
+  reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_RNG_BIT_EN_BIT, rng_bit_en);
+
+  uint32_t rng_bit_sel = rng_bit_en ? config->single_bit_mode : 0;
+  reg = bitfield_field32_write(reg, ENTROPY_SRC_CONF_RNG_BIT_SEL_FIELD,
+                               rng_bit_sel);
+
+  // Enable configuration
+  reg =
+      bitfield_field32_write(reg, ENTROPY_SRC_CONF_ENABLE_FIELD, config->mode);
+  mmio_region_write32(entropy->params.base_addr, ENTROPY_SRC_CONF_REG_OFFSET,
+                      reg);
+}
+
+dif_entropy_result_t dif_entropy_init(dif_entropy_params_t params,
+                                      dif_entropy_t *entropy) {
+  if (entropy == NULL) {
+    return kDifEntropyBadArg;
+  }
+  *entropy = (dif_entropy_t){.params = params};
+  return kDifEntropyOk;
+}
+
+dif_entropy_result_t dif_entropy_configure(const dif_entropy_t *entropy,
+                                           dif_entropy_config_t config) {
+  if (entropy == NULL) {
+    return kDifEntropyBadArg;
+  }
+
+  if (config.lfsr_seed > ENTROPY_SRC_SEED_LFSR_SEED_MASK) {
+    return kDifEntropyBadArg;
+  }
+
+  uint32_t seed = config.mode == kDifEntropyModeLfsr ? config.lfsr_seed : 0;
+  mmio_region_write32(entropy->params.base_addr, ENTROPY_SRC_SEED_REG_OFFSET,
+                      seed);
+
+  mmio_region_write32(entropy->params.base_addr, ENTROPY_SRC_RATE_REG_OFFSET,
+                      (uint32_t)config.sample_rate);
+
+  // Conditioning bypass is hardcoded to enabled. Bypass is not intended as
+  // a regular mode of operation.
+  uint32_t reg = bitfield_bit32_write(
+      0, ENTROPY_SRC_ENTROPY_CONTROL_ES_ROUTE_BIT, config.route_to_firmware);
+  reg = bitfield_bit32_write(reg, ENTROPY_SRC_ENTROPY_CONTROL_ES_TYPE_BIT, 0);
+  mmio_region_write32(entropy->params.base_addr,
+                      ENTROPY_SRC_ENTROPY_CONTROL_REG_OFFSET, reg);
+
+  // TODO: Add test configuration parameters.
+
+  // TODO: Add support for FIFO mode.
+  mmio_region_write32(entropy->params.base_addr,
+                      ENTROPY_SRC_FW_OV_CONTROL_REG_OFFSET, 0);
+
+  set_config_register(entropy, &config);
+  return kDifEntropyOk;
+}
+
+dif_entropy_result_t dif_entropy_read(const dif_entropy_t *entropy,
+                                      uint32_t *word) {
+  if (entropy == NULL || word == NULL) {
+    return kDifEntropyBadArg;
+  }
+  *word = mmio_region_read32(entropy->params.base_addr,
+                             ENTROPY_SRC_ENTROPY_DATA_REG_OFFSET);
+  return kDifEntropyOk;
+}

--- a/sw/device/lib/dif/dif_entropy.h
+++ b/sw/device/lib/dif/dif_entropy.h
@@ -105,7 +105,7 @@ typedef enum dif_entropy_mode {
   /**
    * Indicates that the source is disabled.
    */
-  kDifEntropyModeDisabled,
+  kDifEntropyModeDisabled = 0,
 
   /**
    * The physical true random number generator mode.
@@ -113,7 +113,7 @@ typedef enum dif_entropy_mode {
    * This mode uses a physical random noise generator for operation, and is
    * truly random. This noise generator is compatible with SP 800-90B.
    */
-  kDifEntropyModePtrng,
+  kDifEntropyModePtrng = 1,
 
   /**
    * The Linear Feedback Shift Register (LFSR) mode.
@@ -124,7 +124,7 @@ typedef enum dif_entropy_mode {
    * In this mode, the `dif_entropy_config.lfsr_seed` value is used to
    * initialize the internal state of the LFSR.
    */
-  kDifEntropyModeLfsr,
+  kDifEntropyModeLfsr = 2,
 } dif_entropy_mode_t;
 
 /**
@@ -132,29 +132,25 @@ typedef enum dif_entropy_mode {
  */
 typedef enum dif_entropy_single_bit_mode {
   /**
-   * Indicates that single-bit-mode is disabled.
-   */
-  kDifEntropySingleBitModeDisabled,
-
-  /**
    * Single-bit-mode, sampling the zeroth bit.
    */
-  kDifEntropySingleBitMode0,
-
+  kDifEntropySingleBitMode0 = 0,
   /**
    * Single-bit-mode, sampling the first bit.
    */
-  kDifEntropySingleBitMode1,
-
+  kDifEntropySingleBitMode1 = 1,
   /**
    * Single-bit-mode, sampling the second bit.
    */
-  kDifEntropySingleBitMode2,
-
+  kDifEntropySingleBitMode2 = 2,
   /**
    * Single-bit-mode, sampling the third bit.
    */
-  kDifEntropySingleBitMode3,
+  kDifEntropySingleBitMode3 = 3,
+  /**
+   * Indicates that single-bit-mode is disabled.
+   */
+  kDifEntropySingleBitModeDisabled = 4,
 } dif_entropy_single_bit_mode_t;
 
 /**
@@ -436,8 +432,6 @@ dif_entropy_result_t dif_entropy_init(dif_entropy_params_t params,
  * @param config Runtime configuration parameters.
  * @return The result of the operation.
  */
-// TODO: Should we have a separate function to clear the stats, or should
-// that be handled by this function.
 DIF_WARN_UNUSED_RESULT
 dif_entropy_result_t dif_entropy_configure(const dif_entropy_t *entropy,
                                            dif_entropy_config_t config);

--- a/sw/device/tests/dif/dif_entropy_smoketest.c
+++ b/sw/device/tests/dif/dif_entropy_smoketest.c
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_entropy.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/test_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+const test_config_t kTestConfig;
+
+const size_t kEntropyDataNumWords = 12;
+const uint32_t kExpectedEntropyData[] = {
+    0x65585497, 0x65585497, 0x65585497, 0x65585497, 0x65585497, 0x65585497,
+    0x65585497, 0x65585497, 0x65585497, 0x65585497, 0x65585497, 0x65585497,
+};
+
+bool test_main() {
+  const dif_entropy_params_t params = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR),
+  };
+  dif_entropy_t entropy;
+  CHECK(dif_entropy_init(params, &entropy) == kDifEntropyOk);
+
+  const dif_entropy_config_t config = {
+      .mode = kDifEntropyModeLfsr,
+      .tests =
+          {
+              [kDifEntropyTestRepCount] = false,
+              [kDifEntropyTestAdaptiveProportion] = false,
+              [kDifEntropyTestBucket] = false,
+              [kDifEntropyTestMarkov] = false,
+              [kDifEntropyTestMailbox] = false,
+              [kDifEntropyTestVendorSpecific] = false,
+          },
+      .reset_health_test_registers = true,
+      .single_bit_mode = kDifEntropySingleBitModeDisabled,
+      .route_to_firmware = true,
+      .sample_rate = 2,
+      .lfsr_seed = 2,
+  };
+  CHECK(dif_entropy_configure(&entropy, config) == kDifEntropyOk);
+
+  uint32_t entropy_data[kEntropyDataNumWords];
+  for (uint32_t i = 0; i < kEntropyDataNumWords; ++i) {
+    CHECK(dif_entropy_read(&entropy, &entropy_data[i]) == kDifEntropyOk);
+    CHECK(entropy_data[i] == kExpectedEntropyData[i]);
+  }
+
+  return true;
+}

--- a/sw/device/tests/dif/dif_entropy_unittest.cc
+++ b/sw/device/tests/dif/dif_entropy_unittest.cc
@@ -1,0 +1,156 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_entropy.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/testing/mock_mmio.h"
+
+#include "entropy_src_regs.h"  // Generated
+
+namespace dif_entropy_unittest {
+namespace {
+
+class DifEntropyTest : public testing::Test, public mock_mmio::MmioTest {
+ protected:
+  const dif_entropy_params_t params_ = {.base_addr = dev().region()};
+  const dif_entropy_t entropy_ = {
+      .params = {.base_addr = dev().region()},
+  };
+};
+
+class InitTest : public DifEntropyTest {};
+
+TEST_F(InitTest, BadArgs) {
+  EXPECT_EQ(dif_entropy_init(params_, nullptr), kDifEntropyBadArg);
+}
+
+TEST_F(InitTest, Init) {
+  dif_entropy_t entropy;
+  EXPECT_EQ(dif_entropy_init(params_, &entropy), kDifEntropyOk);
+}
+
+class ConfigTest : public DifEntropyTest {
+ protected:
+  dif_entropy_config_t config_ = {
+      .mode = kDifEntropyModeLfsr,
+      .tests = {0},
+      .reset_health_test_registers = false,
+      .single_bit_mode = kDifEntropySingleBitModeDisabled,
+      .route_to_firmware = false,
+      .fips_mode = false,
+      .test_config = {0},
+      .sample_rate = 64,
+      .lfsr_seed = 4,
+  };
+};
+
+TEST_F(ConfigTest, NullArgs) {
+  EXPECT_EQ(dif_entropy_configure(nullptr, {}), kDifEntropyBadArg);
+}
+
+TEST_F(ConfigTest, LfsrSeedBadArg) {
+  config_.lfsr_seed = 16;
+  EXPECT_EQ(dif_entropy_configure(&entropy_, config_), kDifEntropyBadArg);
+}
+
+struct ConfigParams {
+  dif_entropy_mode_t mode;
+  dif_entropy_single_bit_mode_t single_bit_mode;
+  bool route_to_firmware;
+  bool reset_health_test_registers;
+
+  uint32_t expected_mode;
+  bool expected_rng_bit_en;
+  uint32_t expected_rng_sel;
+  uint32_t expected_seed;
+};
+
+class ConfigTestAllParams : public ConfigTest,
+                            public testing::WithParamInterface<ConfigParams> {};
+
+TEST_P(ConfigTestAllParams, ValidConfigurationMode) {
+  const ConfigParams &test_param = GetParam();
+  config_.mode = test_param.mode;
+  config_.single_bit_mode = test_param.single_bit_mode;
+  config_.route_to_firmware = test_param.route_to_firmware;
+  config_.reset_health_test_registers = test_param.reset_health_test_registers;
+
+  EXPECT_WRITE32(ENTROPY_SRC_SEED_REG_OFFSET, test_param.expected_seed);
+  EXPECT_WRITE32(ENTROPY_SRC_RATE_REG_OFFSET, 64);
+  EXPECT_WRITE32(ENTROPY_SRC_ENTROPY_CONTROL_REG_OFFSET,
+                 {
+                     {ENTROPY_SRC_ENTROPY_CONTROL_ES_ROUTE_BIT,
+                      test_param.route_to_firmware},
+                     {ENTROPY_SRC_ENTROPY_CONTROL_ES_TYPE_BIT, false},
+                 });
+  EXPECT_WRITE32(ENTROPY_SRC_FW_OV_CONTROL_REG_OFFSET, 0);
+  EXPECT_WRITE32(
+      ENTROPY_SRC_CONF_REG_OFFSET,
+      {
+          {ENTROPY_SRC_CONF_ENABLE_OFFSET, test_param.expected_mode},
+          {ENTROPY_SRC_CONF_BOOT_BYPASS_DISABLE_BIT, true},
+          {ENTROPY_SRC_CONF_REPCNT_DISABLE_BIT, true},
+          {ENTROPY_SRC_CONF_ADAPTP_DISABLE_BIT, true},
+          {ENTROPY_SRC_CONF_BUCKET_DISABLE_BIT, true},
+          {ENTROPY_SRC_CONF_MARKOV_DISABLE_BIT, true},
+          {ENTROPY_SRC_CONF_HEALTH_TEST_CLR_BIT,
+           test_param.reset_health_test_registers},
+          {ENTROPY_SRC_CONF_RNG_BIT_EN_BIT, test_param.expected_rng_bit_en},
+          {ENTROPY_SRC_CONF_RNG_BIT_SEL_OFFSET, test_param.expected_rng_sel},
+          {ENTROPY_SRC_CONF_EXTHT_ENABLE_BIT, false},
+      });
+
+  EXPECT_EQ(dif_entropy_configure(&entropy_, config_), kDifEntropyOk);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ConfigTestAllParams, ConfigTestAllParams,
+    testing::Values(
+        // Test entropy mode.
+        ConfigParams{kDifEntropyModeDisabled, kDifEntropySingleBitModeDisabled,
+                     false, 0, false, 0, 0},
+        ConfigParams{kDifEntropyModePtrng, kDifEntropySingleBitModeDisabled,
+                     false, false, 1, false, 0, 0},
+        ConfigParams{kDifEntropyModeLfsr, kDifEntropySingleBitModeDisabled,
+                     false, false, 2, false, 0, 4},
+        // Test route_to_firmware
+        ConfigParams{kDifEntropyModeLfsr, kDifEntropySingleBitModeDisabled,
+                     true, false, 2, false, 0, 4},
+        // Test reset_health_test_registers
+        ConfigParams{kDifEntropyModeLfsr, kDifEntropySingleBitModeDisabled,
+                     true, true, 2, false, 0, 4},
+        // Test single_bit_mode
+        ConfigParams{kDifEntropyModeLfsr, kDifEntropySingleBitMode0, true, true,
+                     2, true, 0, 4},
+        ConfigParams{kDifEntropyModeLfsr, kDifEntropySingleBitMode1, true, true,
+                     2, true, 1, 4},
+        ConfigParams{kDifEntropyModeLfsr, kDifEntropySingleBitMode2, true, true,
+                     2, true, 2, 4},
+        ConfigParams{kDifEntropyModeLfsr, kDifEntropySingleBitMode3, true, true,
+                     2, true, 3, 4}));
+
+class ReadTest : public DifEntropyTest {};
+
+TEST_F(ReadTest, EntropyBadArg) {
+  uint32_t word;
+  EXPECT_EQ(dif_entropy_read(nullptr, &word), kDifEntropyBadArg);
+}
+
+TEST_F(ReadTest, WordBadArg) {
+  EXPECT_EQ(dif_entropy_read(&entropy_, nullptr), kDifEntropyBadArg);
+}
+
+TEST_F(ReadTest, ReadOk) {
+  const uint32_t expected_word = 0x65585497;
+  EXPECT_READ32(ENTROPY_SRC_ENTROPY_DATA_REG_OFFSET, expected_word);
+
+  uint32_t got_word;
+  EXPECT_EQ(dif_entropy_read(&entropy_, &got_word), kDifEntropyOk);
+  EXPECT_EQ(got_word, expected_word);
+}
+
+}  // namespace
+}  // namespace dif_entropy_unittest

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -222,7 +222,7 @@ test('dif_aes_test', executable(
     sw_lib_testing_mock_mmio,
   ],
   native: true,
-  c_args: ['-DMOCK_MMIO'], 
+  c_args: ['-DMOCK_MMIO'],
   cpp_args: ['-DMOCK_MMIO'],
 ))
 
@@ -232,6 +232,22 @@ test('dif_clkmgr_unittest', executable(
     hw_ip_clkmgr_reg_h,
     meson.source_root() / 'sw/device/lib/dif/dif_clkmgr.c',
     'dif_clkmgr_unittest.cc',
+  ],
+  dependencies: [
+    sw_vendor_gtest,
+    sw_lib_testing_mock_mmio,
+  ],
+  native: true,
+  c_args: ['-DMOCK_MMIO'],
+  cpp_args: ['-DMOCK_MMIO'],
+))
+
+test('dif_entropy_unittest', executable(
+  'dif_entropy_unittest',
+  sources: [
+    hw_ip_entropy_reg_h,
+    meson.source_root() / 'sw/device/lib/dif/dif_entropy.c',
+    'dif_entropy_unittest.cc',
   ],
   dependencies: [
     sw_vendor_gtest,
@@ -442,6 +458,23 @@ dif_clkmgr_smoketest_lib = declare_dependency(
 sw_tests += {
   'dif_clkmgr_smoketest': {
     'library': dif_clkmgr_smoketest_lib,
+  }
+}
+
+dif_entropy_smoketest_lib = declare_dependency(
+  link_with: static_library(
+    'dif_entropy_smoketest_lib',
+    sources: ['dif_entropy_smoketest.c'],
+    dependencies: [
+      sw_lib_dif_entropy,
+      sw_lib_mmio,
+      sw_lib_runtime_log,
+    ],
+  ),
+)
+sw_tests += {
+  'dif_entropy_smoketest': {
+    'library': dif_entropy_smoketest_lib,
   }
 }
 

--- a/test/systemtest/config.py
+++ b/test/systemtest/config.py
@@ -70,6 +70,9 @@ TEST_APPS_SELFCHECKING = [
         "name": "dif_clkmgr_smoketest",
     },
     {
+        "name": "dif_entropy_smoketest",
+    },
+    {
         "name": "flash_ctrl_test",
     },
     {


### PR DESCRIPTION
Implement the following function calls:

*   `dif_entropy_init()`
*   `dif_entropy_configure()`
*   `dif_entropy_read()`

Add the following test targets:

*   `dif_entropy_unittest`
*   `dif_entropy_smoketest`

Signed-off-by: Miguel Osorio <miguelosorio@google.com>