### PR TITLE
[reggen] Fix name for "u_reg" backdoor in RAL code

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -119,7 +119,7 @@ module rom_ctrl
   rom_ctrl_regs_hw2reg_t hw2reg;
   logic                  reg_integrity_error;
 
-  rom_ctrl_regs_reg_top u_reg_top (
+  rom_ctrl_regs_reg_top u_reg_regs (
     .clk_i      (clk_i),
     .rst_ni     (rst_ni),
     .tl_i       (regs_tl_i),

--- a/util/reggen/gen_dv.py
+++ b/util/reggen/gen_dv.py
@@ -91,10 +91,10 @@ def gen_dv(block: IpBlock, dv_base_prefix: str, outdir: str) -> int:
 
     lblock = block.name.lower()
     for if_name, rb in block.reg_blocks.items():
-        if if_name is None:
-            mod_base = lblock
-        else:
-            mod_base = lblock + '_' + if_name.lower()
+        hier_path = '' if block.hier_path is None else block.hier_path + '.'
+        if_suffix = '' if if_name is None else '_' + if_name.lower()
+        mod_base = lblock + if_suffix
+        reg_block_path = hier_path + 'u_reg' + if_suffix
 
         file_name = mod_base + '_ral_pkg.sv'
         generated.append(file_name)
@@ -104,6 +104,7 @@ def gen_dv(block: IpBlock, dv_base_prefix: str, outdir: str) -> int:
                 fout.write(uvm_reg_tpl.render(rb=rb,
                                               block=block,
                                               esc_if_name=mod_base,
+                                              reg_block_path=reg_block_path,
                                               dv_base_prefix=dv_base_prefix))
             except:  # noqa F722 for template Exception handling
                 log.error(exceptions.text_error_template().render())

--- a/util/reggen/top_uvm_reg.sv.tpl
+++ b/util/reggen/top_uvm_reg.sv.tpl
@@ -35,9 +35,10 @@
       if_suffix = '' if if_name is None else '_' + if_name
       esc_if_name = block.name.lower() + if_suffix
       if_desc = '' if if_name is None else '; interface {}'.format(if_name)
+      reg_block_path = 'u_reg' + if_suffix
 %>\
 // Block: ${block.name.lower()}${if_desc}
-${make_ral_pkg(dv_base_prefix, top.regwidth, '', rb, esc_if_name)}
+${make_ral_pkg(dv_base_prefix, top.regwidth, reg_block_path, rb, esc_if_name)}
 %   endfor
 % endfor
 ##

--- a/util/reggen/uvm_reg.sv.tpl
+++ b/util/reggen/uvm_reg.sv.tpl
@@ -11,7 +11,4 @@
 <%namespace file="uvm_reg_base.sv.tpl" import="*"/>\
 ##
 ##
-<%
-  hier_path = '' if block.hier_path is None else block.hier_path + "."
-%>\
-${make_ral_pkg(dv_base_prefix, block.regwidth, hier_path, rb, esc_if_name)}
+${make_ral_pkg(dv_base_prefix, block.regwidth, reg_block_path, rb, esc_if_name)}


### PR DESCRIPTION
The generated RAL code needs to know where to find the generated
register in the design. Before this patch, we had it hardcoded as
"u_reg" but that isn't going to work if there are multiple register
blocks in the design(!).

Here, we use the same naming convention as the rest of the reggen
code: if a device interface has an explicit name, "foo", we assume
things relating to the interface get a "_foo" suffix.

Also fix the name of the one example in the tree (in rom_ctrl.sv) to
match this convention.
