### PR TITLE
[otbn] Move from V0 to V1

### DIFF
--- a/hw/ip/otbn/data/otbn.prj.hjson
+++ b/hw/ip/otbn/data/otbn.prj.hjson
@@ -11,6 +11,6 @@
     version:            "0.1",
     life_stage:         "L1",
     design_stage:       "D1",
-    verification_stage: "V0",
+    verification_stage: "V1",
     dif_stage:          "S1",
 }

--- a/hw/ip/otbn/doc/checklist.md
+++ b/hw/ip/otbn/doc/checklist.md
@@ -120,17 +120,17 @@ Testbench     | [CSR_CHECK_GEN_AUTOMATED][]           | Done        |
 Testbench     | [TB_GEN_AUTOMATED][]                  | N/A         |
 Tests         | [SIM_SMOKE_TEST_PASSING][]            | Done        |
 Tests         | [SIM_CSR_MEM_TEST_SUITE_PASSING][]    | Done        |
-Tests         | [FPV_MAIN_ASSERTIONS_PROVEN][]        | Not Started |
-Tool Setup    | [SIM_ALT_TOOL_SETUP][]                | Not Started |
-Regression    | [SIM_SMOKE_REGRESSION_SETUP][]        | In progress | This needs feedback from the Google side. [Draft PR](https://github.com/lowRISC/opentitan/pull/4189) available.
-Regression    | [SIM_NIGHTLY_REGRESSION_SETUP][]      | In progress | As above.
-Regression    | [FPV_REGRESSION_SETUP][]              | Not Started |
-Coverage      | [SIM_COVERAGE_MODEL_ADDED][]          | Done        | No sub-blocks, so auto-generated framework will work
+Tests         | [FPV_MAIN_ASSERTIONS_PROVEN][]        | N/A         |
+Tool Setup    | [SIM_ALT_TOOL_SETUP][]                | Done        | Alt tool: xcelium
+Regression    | [SIM_SMOKE_REGRESSION_SETUP][]        | Done        |
+Regression    | [SIM_NIGHTLY_REGRESSION_SETUP][]      | Done        |
+Regression    | [FPV_REGRESSION_SETUP][]              | N/A         |
+Coverage      | [SIM_COVERAGE_MODEL_ADDED][]          | Done        |
 Integration   | [PRE_VERIFIED_SUB_MODULES_V1][]       | N/A         |
-Review        | [DESIGN_SPEC_REVIEWED][]              | Not Started |
-Review        | [DV_PLAN_REVIEWED][]                  | Not Started |
-Review        | [STD_TEST_CATEGORIES_PLANNED][]       | Not Started | Exception (?)
-Review        | [V2_CHECKLIST_SCOPED][]               | Not Started |
+Review        | [DESIGN_SPEC_REVIEWED][]              | Done        |
+Review        | [DV_PLAN_REVIEWED][]                  | Done        |
+Review        | [STD_TEST_CATEGORIES_PLANNED][]       | Done        | Exception (Debug)
+Review        | [V2_CHECKLIST_SCOPED][]               | Done        |
 
 [DV_DOC_DRAFT_COMPLETED]:             {{<relref "/doc/project/checklist.md#dv_doc_draft_completed" >}}
 [DV_PLAN_COMPLETED]:                  {{<relref "/doc/project/checklist.md#dv_plan_completed" >}}


### PR DESCRIPTION
For the checklist items that have changed:

 - We're not using FPV for OTBN at the moment

 - We've seen OTBN tests run on xcelium

 - The nightly and CI regressions are now running (at last!)

 - The design spec has had innumerable reviews and discussions, as
   you'd expect given how complicated the block is.

 - We've had a DV plan / testplan review (with Cindy, Sri, Weicai,
   Chris Gori, Philipp and me) and the testplan has been updated as a
   result.

 - I've added what seem to be the standard exceptions to
   STD_TEST_CATEGORIES_PLANNED. I'm not convinced that any of the
   blocks in the design (except possibly AES) have put much thought
   into these categories yet.

Fixes #3362.