### PR TITLE
[dv] Allow monitor items to have different types from sequence items

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_monitor.sv
+++ b/hw/dv/sv/dv_lib/dv_base_monitor.sv
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class dv_base_monitor #(type ITEM_T = uvm_sequence_item,
+                        type REQ_ITEM_T = ITEM_T,
+                        type RSP_ITEM_T = ITEM_T,
                         type CFG_T  = dv_base_agent_cfg,
                         type COV_T  = dv_base_agent_cov) extends uvm_monitor;
   `uvm_component_param_utils(dv_base_monitor #(ITEM_T, CFG_T, COV_T))
@@ -21,9 +23,9 @@ class dv_base_monitor #(type ITEM_T = uvm_sequence_item,
   uvm_analysis_port #(ITEM_T) analysis_port;
 
   // item will be sent to this port for seq when req phase is done (last is set)
-  uvm_analysis_port #(ITEM_T) req_analysis_port;
+  uvm_analysis_port #(REQ_ITEM_T) req_analysis_port;
   // item will be sent to this port for seq when rsp phase is done (rsp_done is set)
-  uvm_analysis_port #(ITEM_T) rsp_analysis_port;
+  uvm_analysis_port #(RSP_ITEM_T) rsp_analysis_port;
 
   `uvm_component_new
 

--- a/hw/dv/sv/dv_lib/dv_base_sequencer.sv
+++ b/hw/dv/sv/dv_lib/dv_base_sequencer.sv
@@ -15,8 +15,8 @@ class dv_base_sequencer #(type ITEM_T     = uvm_sequence_item,
   // monitor and sequences. These fifos are optional
   // When device is re-active, it gets items from req_analysis_fifo and send rsp to driver
   // When this is a high-level agent, monitors put items to these 2 fifos for high-level seq
-  uvm_tlm_analysis_fifo #(ITEM_T) req_analysis_fifo;
-  uvm_tlm_analysis_fifo #(ITEM_T) rsp_analysis_fifo;
+  uvm_tlm_analysis_fifo #(ITEM_T)     req_analysis_fifo;
+  uvm_tlm_analysis_fifo #(RSP_ITEM_T) rsp_analysis_fifo;
 
   CFG_T cfg;
 


### PR DESCRIPTION
This was broken by 47c9510. This isn't the cleanest fix, because the
monitor class is still parameterised by types that it has no business
knowing about.

This isn't a particularly nice solution, but it's enough to get things working in Ibex again for now. I'm pushing up a follow-up in a minute, but I suspect there might be some discussion about namings, so I'd like to get this in quickly as a stop-gap if possible.