### PR TITLE
[dv] Split out the logic to connect a sequencer to a monitor

### DIFF
--- a/hw/dv/sv/csrng_agent/csrng_agent.core
+++ b/hw/dv/sv/csrng_agent/csrng_agent.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:dv_utils
       - lowrisc:dv:dv_lib
+      - lowrisc:dv:dv_seq_agent
       - lowrisc:dv:push_pull_agent
     files:
       - csrng_agent_pkg.sv

--- a/hw/dv/sv/csrng_agent/csrng_agent_cfg.sv
+++ b/hw/dv/sv/csrng_agent/csrng_agent_cfg.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class csrng_agent_cfg extends dv_base_agent_cfg;
+class csrng_agent_cfg extends dv_seq_agent_cfg;
 
   // interface handle used by driver, monitor & the sequencer, via cfg handle
   virtual csrng_if vif;

--- a/hw/dv/sv/csrng_agent/csrng_agent_pkg.sv
+++ b/hw/dv/sv/csrng_agent/csrng_agent_pkg.sv
@@ -7,6 +7,7 @@ package csrng_agent_pkg;
   import uvm_pkg::*;
   import dv_utils_pkg::*;
   import dv_lib_pkg::*;
+  import dv_seq_agent_pkg::*;
   import push_pull_agent_pkg::*;
   import csrng_pkg::*;
 

--- a/hw/dv/sv/csrng_agent/csrng_monitor.sv
+++ b/hw/dv/sv/csrng_agent/csrng_monitor.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class csrng_monitor extends dv_base_monitor #(
+class csrng_monitor extends dv_seq_monitor #(
     .ITEM_T (csrng_item),
     .CFG_T  (csrng_agent_cfg),
     .COV_T  (csrng_agent_cov)

--- a/hw/dv/sv/csrng_agent/csrng_sequencer.sv
+++ b/hw/dv/sv/csrng_agent/csrng_sequencer.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class csrng_sequencer extends dv_base_sequencer #(
+class csrng_sequencer extends dv_seq_sequencer #(
     .ITEM_T (csrng_item),
     .CFG_T  (csrng_agent_cfg)
 );

--- a/hw/dv/sv/dv_lib/dv_base_agent.sv
+++ b/hw/dv/sv/dv_lib/dv_base_agent.sv
@@ -56,12 +56,6 @@ class dv_base_agent #(type CFG_T            = dv_base_agent_cfg,
     if (cfg.is_active && cfg.has_driver) begin
       driver.seq_item_port.connect(sequencer.seq_item_export);
     end
-    if (cfg.has_req_fifo) begin
-      monitor.req_analysis_port.connect(sequencer.req_analysis_fifo.analysis_export);
-    end
-    if (cfg.has_rsp_fifo) begin
-      monitor.rsp_analysis_port.connect(sequencer.rsp_analysis_fifo.analysis_export);
-    end
   endfunction
 
 endclass

--- a/hw/dv/sv/dv_lib/dv_base_agent_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_agent_cfg.sv
@@ -13,9 +13,6 @@ class dv_base_agent_cfg extends uvm_object;
   // if this is a high-level agent, we may just call lower-level agent to send item in seq, then
   // driver isn't needed
   bit         has_driver = 1'b1;
-  // indicate if these fifo and ports exist or not
-  bit         has_req_fifo = 1'b0;
-  bit         has_rsp_fifo = 1'b0;
 
   // use for phase_ready_to_end to add additional delay after ok_to_end is set
   int ok_to_end_delay_ns = 1000;
@@ -24,8 +21,6 @@ class dv_base_agent_cfg extends uvm_object;
     `uvm_field_int (is_active,            UVM_DEFAULT)
     `uvm_field_int (en_cov,               UVM_DEFAULT)
     `uvm_field_enum(if_mode_e, if_mode,   UVM_DEFAULT)
-    `uvm_field_int (has_req_fifo,         UVM_DEFAULT)
-    `uvm_field_int (has_rsp_fifo,         UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/hw/dv/sv/dv_lib/dv_base_monitor.sv
+++ b/hw/dv/sv/dv_lib/dv_base_monitor.sv
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class dv_base_monitor #(type ITEM_T = uvm_sequence_item,
+                        type REQ_ITEM_T = ITEM_T,
+                        type RSP_ITEM_T = ITEM_T,
                         type CFG_T  = dv_base_agent_cfg,
                         type COV_T  = dv_base_agent_cov) extends uvm_monitor;
   `uvm_component_param_utils(dv_base_monitor #(ITEM_T, CFG_T, COV_T))
@@ -21,9 +23,9 @@ class dv_base_monitor #(type ITEM_T = uvm_sequence_item,
   uvm_analysis_port #(ITEM_T) analysis_port;
 
   // item will be sent to this port for seq when req phase is done (last is set)
-  uvm_analysis_port #(ITEM_T) req_analysis_port;
+  uvm_analysis_port #(REQ_ITEM_T) req_analysis_port;
   // item will be sent to this port for seq when rsp phase is done (rsp_done is set)
-  uvm_analysis_port #(ITEM_T) rsp_analysis_port;
+  uvm_analysis_port #(RSP_ITEM_T) rsp_analysis_port;
 
   `uvm_component_new
 

--- a/hw/dv/sv/dv_lib/dv_base_monitor.sv
+++ b/hw/dv/sv/dv_lib/dv_base_monitor.sv
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class dv_base_monitor #(type ITEM_T = uvm_sequence_item,
-                        type REQ_ITEM_T = ITEM_T,
-                        type RSP_ITEM_T = ITEM_T,
                         type CFG_T  = dv_base_agent_cfg,
                         type COV_T  = dv_base_agent_cov) extends uvm_monitor;
   `uvm_component_param_utils(dv_base_monitor #(ITEM_T, CFG_T, COV_T))
@@ -22,18 +20,11 @@ class dv_base_monitor #(type ITEM_T = uvm_sequence_item,
   // Analysis port for the collected transfer.
   uvm_analysis_port #(ITEM_T) analysis_port;
 
-  // item will be sent to this port for seq when req phase is done (last is set)
-  uvm_analysis_port #(REQ_ITEM_T) req_analysis_port;
-  // item will be sent to this port for seq when rsp phase is done (rsp_done is set)
-  uvm_analysis_port #(RSP_ITEM_T) rsp_analysis_port;
-
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     analysis_port = new("analysis_port", this);
-    req_analysis_port = new("req_analysis_port", this);
-    rsp_analysis_port = new("rsp_analysis_port", this);
   endfunction
 
   virtual task run_phase(uvm_phase phase);

--- a/hw/dv/sv/dv_lib/dv_base_sequencer.sv
+++ b/hw/dv/sv/dv_lib/dv_base_sequencer.sv
@@ -11,21 +11,8 @@ class dv_base_sequencer #(type ITEM_T     = uvm_sequence_item,
                                                  .CFG_T      (CFG_T),
                                                  .RSP_ITEM_T (RSP_ITEM_T)))
 
-  // These fifos collects items when req/rsp is received, which are used to communicate between
-  // monitor and sequences. These fifos are optional
-  // When device is re-active, it gets items from req_analysis_fifo and send rsp to driver
-  // When this is a high-level agent, monitors put items to these 2 fifos for high-level seq
-  uvm_tlm_analysis_fifo #(ITEM_T)     req_analysis_fifo;
-  uvm_tlm_analysis_fifo #(RSP_ITEM_T) rsp_analysis_fifo;
-
   CFG_T cfg;
 
   `uvm_component_new
-
-  function void build_phase(uvm_phase phase);
-    super.build_phase(phase);
-    if (cfg.has_req_fifo) req_analysis_fifo = new("req_analysis_fifo", this);
-    if (cfg.has_rsp_fifo) rsp_analysis_fifo = new("rsp_analysis_fifo", this);
-  endfunction : build_phase
 
 endclass

--- a/hw/dv/sv/dv_lib/dv_base_sequencer.sv
+++ b/hw/dv/sv/dv_lib/dv_base_sequencer.sv
@@ -15,8 +15,8 @@ class dv_base_sequencer #(type ITEM_T     = uvm_sequence_item,
   // monitor and sequences. These fifos are optional
   // When device is re-active, it gets items from req_analysis_fifo and send rsp to driver
   // When this is a high-level agent, monitors put items to these 2 fifos for high-level seq
-  uvm_tlm_analysis_fifo #(ITEM_T) req_analysis_fifo;
-  uvm_tlm_analysis_fifo #(ITEM_T) rsp_analysis_fifo;
+  uvm_tlm_analysis_fifo #(ITEM_T)     req_analysis_fifo;
+  uvm_tlm_analysis_fifo #(RSP_ITEM_T) rsp_analysis_fifo;
 
   CFG_T cfg;
 

--- a/hw/dv/sv/dv_seq_agent/README.md
+++ b/hw/dv/sv/dv_seq_agent/README.md
@@ -1,0 +1,11 @@
+---
+title: "DV Seq Agent"
+---
+
+# DV Seq Agent
+
+The DV Seq Agent is a thin subclass of `dv_base_agent` (defined in the
+`dv_lib` package). It abstracts away a common task, where you want to
+connect the sequencer's list of items to the monitor, to make it easy
+to compare these sequence items with the transactions that were
+actually seen on the bus.

--- a/hw/dv/sv/dv_seq_agent/dv_seq_agent.core
+++ b/hw/dv/sv/dv_seq_agent/dv_seq_agent.core
@@ -1,0 +1,25 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:dv_seq_agent"
+description: "An agent class that connects a sequencer to its monitor"
+
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:dv_lib
+    files:
+      - dv_seq_agent_pkg.sv
+
+      - dv_seq_agent_cfg.sv: {is_include_file: true}
+      - dv_seq_monitor.sv: {is_include_file: true}
+      - dv_seq_sequencer.sv: {is_include_file: true}
+      - dv_seq_agent.sv: {is_include_file: true}
+
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/dv/sv/dv_seq_agent/dv_seq_agent.sv
+++ b/hw/dv/sv/dv_seq_agent/dv_seq_agent.sv
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// An agent base class that wires up a dv_seq_monitor with outputs from a dv_seq_sequencer. This
+// assumes that SEQUENCER_T is a subclass of dv_seq_sequencer, MONITOR_T is a subclass of
+// dv_seq_monitor and that CFG_T is a subclass of dv_seq_agent_cfg.
+//
+
+class dv_seq_agent #(type CFG_T            = dv_seq_agent_cfg,
+                     type DRIVER_T         = dv_base_driver,
+                     type HOST_DRIVER_T    = DRIVER_T,
+                     type DEVICE_DRIVER_T  = DRIVER_T,
+                     type SEQUENCER_T      = dv_seq_sequencer,
+                     type MONITOR_T        = dv_seq_monitor,
+                     type COV_T            = dv_base_agent_cov)
+  extends dv_base_agent #(.CFG_T           (CFG_T),
+                          .DRIVER_T        (DRIVER_T),
+                          .HOST_DRIVER_T   (HOST_DRIVER_T),
+                          .DEVICE_DRIVER_T (DEVICE_DRIVER_T),
+                          .SEQUENCER_T     (SEQUENCER_T),
+                          .MONITOR_T       (MONITOR_T),
+                          .COV_T           (COV_T));
+
+  `uvm_component_param_utils(dv_seq_agent #(CFG_T, DRIVER_T, HOST_DRIVER_T, DEVICE_DRIVER_T,
+                                            SEQUENCER_T, MONITOR_T, COV_T))
+  `uvm_component_new
+
+  function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+    if (cfg.has_req_fifo) begin
+      monitor.req_analysis_port.connect(sequencer.req_analysis_fifo.analysis_export);
+    end
+    if (cfg.has_rsp_fifo) begin
+      monitor.rsp_analysis_port.connect(sequencer.rsp_analysis_fifo.analysis_export);
+    end
+  endfunction
+
+endclass
+

--- a/hw/dv/sv/dv_seq_agent/dv_seq_agent_cfg.sv
+++ b/hw/dv/sv/dv_seq_agent/dv_seq_agent_cfg.sv
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class dv_seq_agent_cfg extends dv_base_agent_cfg;
+
+  // indicate if these fifo and ports exist or not
+  bit         has_req_fifo = 1'b0;
+  bit         has_rsp_fifo = 1'b0;
+
+  // use for phase_ready_to_end to add additional delay after ok_to_end is set
+  int ok_to_end_delay_ns = 1000;
+
+  `uvm_object_utils_begin(dv_seq_agent_cfg)
+    `uvm_field_int (has_req_fifo,         UVM_DEFAULT)
+    `uvm_field_int (has_rsp_fifo,         UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+endclass

--- a/hw/dv/sv/dv_seq_agent/dv_seq_agent_pkg.sv
+++ b/hw/dv/sv/dv_seq_agent/dv_seq_agent_pkg.sv
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package dv_seq_agent_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import dv_lib_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  // package variables
+  string msg_id = "dv_seq_agent_pkg";
+
+  // package sources
+  `include "dv_seq_agent_cfg.sv"
+  `include "dv_seq_monitor.sv"
+  `include "dv_seq_sequencer.sv"
+  `include "dv_seq_agent.sv"
+
+endpackage

--- a/hw/dv/sv/dv_seq_agent/dv_seq_monitor.sv
+++ b/hw/dv/sv/dv_seq_agent/dv_seq_monitor.sv
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// A simple subclass of dv_base_monitor, which adds a req_analysis_port and rsp_analysis_port. These
+// can be connected to the sequencer's req/rsp analysis FIFOs to allow the monitor to easily pair up
+// bus transactions that it has seen with the sequence items that caused them.
+//
+
+class dv_seq_monitor #(type ITEM_T = uvm_sequence_item,
+                       type REQ_ITEM_T = ITEM_T,
+                       type RSP_ITEM_T = ITEM_T,
+                       type CFG_T  = dv_seq_agent_cfg,
+                       type COV_T  = dv_base_agent_cov)
+  extends dv_base_monitor #(.ITEM_T (ITEM_T), .CFG_T (CFG_T), .COV_T (COV_T));
+
+  `uvm_component_param_utils(dv_seq_monitor #(ITEM_T, REQ_ITEM_T, RSP_ITEM_T, CFG_T, COV_T))
+
+  // item will be sent to this port for seq when req phase is done (last is set)
+  uvm_analysis_port #(REQ_ITEM_T) req_analysis_port;
+  // item will be sent to this port for seq when rsp phase is done (rsp_done is set)
+  uvm_analysis_port #(RSP_ITEM_T) rsp_analysis_port;
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    req_analysis_port = new("req_analysis_port", this);
+    rsp_analysis_port = new("rsp_analysis_port", this);
+  endfunction
+
+endclass

--- a/hw/dv/sv/dv_seq_agent/dv_seq_sequencer.sv
+++ b/hw/dv/sv/dv_seq_agent/dv_seq_sequencer.sv
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class dv_seq_sequencer #(type ITEM_T     = uvm_sequence_item,
+                         type CFG_T      = dv_seq_agent_cfg,
+                         type RSP_ITEM_T = ITEM_T)
+  extends dv_base_sequencer #(.ITEM_T (ITEM_T), .CFG_T (CFG_T), .RSP_ITEM_T (RSP_ITEM_T));
+
+  `uvm_component_param_utils(dv_seq_sequencer #(.ITEM_T     (ITEM_T),
+                                                .CFG_T      (CFG_T),
+                                                .RSP_ITEM_T (RSP_ITEM_T)))
+
+  // These fifos collects items when req/rsp is received, which are used to communicate between
+  // monitor and sequences. These fifos are optional
+  // When device is re-active, it gets items from req_analysis_fifo and send rsp to driver
+  // When this is a high-level agent, monitors put items to these 2 fifos for high-level seq
+  uvm_tlm_analysis_fifo #(ITEM_T)     req_analysis_fifo;
+  uvm_tlm_analysis_fifo #(RSP_ITEM_T) rsp_analysis_fifo;
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    if (cfg.has_req_fifo) req_analysis_fifo = new("req_analysis_fifo", this);
+    if (cfg.has_rsp_fifo) rsp_analysis_fifo = new("rsp_analysis_fifo", this);
+  endfunction : build_phase
+
+endclass

--- a/hw/dv/sv/i2c_agent/i2c_agent.core
+++ b/hw/dv/sv/i2c_agent/i2c_agent.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:dv_utils
       - lowrisc:dv:dv_lib
+      - lowrisc:dv:dv_seq_agent
     files:
       - i2c_agent_pkg.sv
       - i2c_if.sv

--- a/hw/dv/sv/i2c_agent/i2c_agent.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class i2c_agent extends dv_base_agent #(
+class i2c_agent extends dv_seq_agent #(
       .CFG_T           (i2c_agent_cfg),
       .DRIVER_T        (i2c_driver),
       .HOST_DRIVER_T   (i2c_host_driver),

--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class i2c_agent_cfg extends dv_base_agent_cfg;
+class i2c_agent_cfg extends dv_seq_agent_cfg;
 
   bit en_monitor = 1'b1; // enable monitor
   i2c_target_addr_mode_e target_addr_mode = Addr7BitMode;

--- a/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
@@ -9,6 +9,7 @@ package i2c_agent_pkg;
   import uvm_pkg::*;
   import dv_utils_pkg::*;
   import dv_lib_pkg::*;
+  import dv_seq_agent_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class i2c_monitor extends dv_base_monitor #(
+class i2c_monitor extends dv_seq_monitor #(
     .ITEM_T (i2c_item),
     .CFG_T  (i2c_agent_cfg),
     .COV_T  (i2c_agent_cov)

--- a/hw/dv/sv/i2c_agent/i2c_sequencer.sv
+++ b/hw/dv/sv/i2c_agent/i2c_sequencer.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class i2c_sequencer extends dv_base_sequencer#(i2c_item, i2c_agent_cfg);
+class i2c_sequencer extends dv_seq_sequencer#(i2c_item, i2c_agent_cfg);
   `uvm_component_utils(i2c_sequencer)
   `uvm_component_new
 

--- a/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_agent.core
+++ b/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_agent.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:dv_utils
       - lowrisc:dv:dv_lib
+      - lowrisc:dv:dv_seq_agent
       - lowrisc:dv:push_pull_agent
       - lowrisc:ip:keymgr_pkg
       - lowrisc:ip:kmac_pkg

--- a/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_agent.sv
+++ b/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_agent.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class keymgr_kmac_agent extends dv_base_agent #(
+class keymgr_kmac_agent extends dv_seq_agent #(
   .CFG_T          (keymgr_kmac_agent_cfg),
   .DRIVER_T       (keymgr_kmac_driver),
   .HOST_DRIVER_T  (keymgr_kmac_host_driver),

--- a/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_agent_cfg.sv
+++ b/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_agent_cfg.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class keymgr_kmac_agent_cfg extends dv_base_agent_cfg;
+class keymgr_kmac_agent_cfg extends dv_seq_agent_cfg;
 
   // interface handle used by driver, monitor & the sequencer, via cfg handle
   virtual keymgr_kmac_intf vif;

--- a/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_agent_pkg.sv
+++ b/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_agent_pkg.sv
@@ -7,6 +7,7 @@ package keymgr_kmac_agent_pkg;
   import uvm_pkg::*;
   import dv_utils_pkg::*;
   import dv_lib_pkg::*;
+  import dv_seq_agent_pkg::*;
   import keymgr_pkg::*;
   import push_pull_agent_pkg::*;
 

--- a/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_monitor.sv
+++ b/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_monitor.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class keymgr_kmac_monitor extends dv_base_monitor #(
+class keymgr_kmac_monitor extends dv_seq_monitor #(
     .ITEM_T (keymgr_kmac_item),
     .CFG_T  (keymgr_kmac_agent_cfg),
     .COV_T  (keymgr_kmac_agent_cov)

--- a/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_sequencer.sv
+++ b/hw/dv/sv/keymgr_kmac_agent/keymgr_kmac_sequencer.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class keymgr_kmac_sequencer extends dv_base_sequencer #(
+class keymgr_kmac_sequencer extends dv_seq_sequencer #(
     .ITEM_T (keymgr_kmac_item),
     .CFG_T  (keymgr_kmac_agent_cfg)
 );

--- a/hw/dv/sv/push_pull_agent/push_pull_agent.core
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:dv_utils
       - lowrisc:dv:dv_lib
+      - lowrisc:dv:dv_seq_agent
     files:
       - push_pull_if.sv
       - push_pull_agent_pkg.sv

--- a/hw/dv/sv/push_pull_agent/push_pull_agent.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent.sv
@@ -4,7 +4,7 @@
 
 class push_pull_agent #(parameter int HostDataWidth = 32,
                         parameter int DeviceDataWidth = HostDataWidth)
-  extends dv_base_agent #(
+  extends dv_seq_agent #(
   .CFG_T          (push_pull_agent_cfg#(HostDataWidth, DeviceDataWidth)),
   .DRIVER_T       (push_pull_driver#(HostDataWidth, DeviceDataWidth)),
   .HOST_DRIVER_T  (push_pull_host_driver#(HostDataWidth, DeviceDataWidth)),

--- a/hw/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
@@ -4,7 +4,7 @@
 
 class push_pull_agent_cfg #(parameter int HostDataWidth = 32,
                             parameter int DeviceDataWidth = HostDataWidth)
-  extends dv_base_agent_cfg;
+  extends dv_seq_agent_cfg;
 
   // interface handle used by driver, monitor & the sequencer, via cfg handle
   virtual push_pull_if#(HostDataWidth, DeviceDataWidth) vif;

--- a/hw/dv/sv/push_pull_agent/push_pull_agent_pkg.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent_pkg.sv
@@ -7,6 +7,7 @@ package push_pull_agent_pkg;
   import uvm_pkg::*;
   import dv_utils_pkg::*;
   import dv_lib_pkg::*;
+  import dv_seq_agent_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/dv/sv/push_pull_agent/push_pull_monitor.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_monitor.sv
@@ -4,7 +4,7 @@
 
 class push_pull_monitor #(parameter int HostDataWidth = 32,
                           parameter int DeviceDataWidth = HostDataWidth)
-  extends dv_base_monitor #(
+  extends dv_seq_monitor #(
     .ITEM_T (push_pull_item#(HostDataWidth, DeviceDataWidth)),
     .CFG_T  (push_pull_agent_cfg#(HostDataWidth, DeviceDataWidth)),
     .COV_T  (push_pull_agent_cov#(HostDataWidth, DeviceDataWidth))

--- a/hw/dv/sv/push_pull_agent/push_pull_sequencer.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_sequencer.sv
@@ -4,7 +4,7 @@
 
 class push_pull_sequencer #(parameter int HostDataWidth = 32,
                             parameter int DeviceDataWidth = HostDataWidth)
-  extends dv_base_sequencer #(
+  extends dv_seq_sequencer #(
     .ITEM_T (push_pull_item#(HostDataWidth, DeviceDataWidth)),
     .CFG_T  (push_pull_agent_cfg#(HostDataWidth, DeviceDataWidth))
 );

--- a/hw/dv/sv/spi_agent/spi_agent.core
+++ b/hw/dv/sv/spi_agent/spi_agent.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:dv_utils
       - lowrisc:dv:dv_lib
+      - lowrisc:dv:dv_seq_agent
     files:
       - spi_if.sv
       - spi_agent_pkg.sv

--- a/hw/dv/sv/spi_agent/spi_agent.sv
+++ b/hw/dv/sv/spi_agent/spi_agent.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class spi_agent extends dv_base_agent#(
+class spi_agent extends dv_seq_agent#(
     .CFG_T          (spi_agent_cfg),
     .DRIVER_T       (spi_driver),
     .HOST_DRIVER_T  (spi_host_driver),

--- a/hw/dv/sv/spi_agent/spi_agent_cfg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_cfg.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class spi_agent_cfg extends dv_base_agent_cfg;
+class spi_agent_cfg extends dv_seq_agent_cfg;
 
   // enable checkers in monitor
   bit en_monitor_checks = 1'b1;

--- a/hw/dv/sv/spi_agent/spi_agent_pkg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_pkg.sv
@@ -7,6 +7,7 @@ package spi_agent_pkg;
   import uvm_pkg::*;
   import dv_utils_pkg::*;
   import dv_lib_pkg::*;
+  import dv_seq_agent_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/dv/sv/spi_agent/spi_monitor.sv
+++ b/hw/dv/sv/spi_agent/spi_monitor.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class spi_monitor extends dv_base_monitor#(
+class spi_monitor extends dv_seq_monitor#(
     .ITEM_T (spi_item),
     .CFG_T  (spi_agent_cfg),
     .COV_T  (spi_agent_cov)

--- a/hw/dv/sv/spi_agent/spi_sequencer.sv
+++ b/hw/dv/sv/spi_agent/spi_sequencer.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class spi_sequencer extends dv_base_sequencer#(spi_item, spi_agent_cfg);
+class spi_sequencer extends dv_seq_sequencer#(spi_item, spi_agent_cfg);
   `uvm_component_utils(spi_sequencer)
 
   `uvm_component_new

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent.sv
@@ -4,9 +4,7 @@
 
 class otbn_model_agent extends dv_base_agent #(
   .CFG_T          (otbn_model_agent_cfg),
-  .MONITOR_T      (otbn_model_monitor),
-  .DRIVER_T       (otbn_dummy_driver),
-  .SEQUENCER_T    (otbn_dummy_sequencer)
+  .MONITOR_T      (otbn_model_monitor)
 );
 
   `uvm_component_utils(otbn_model_agent)

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent_pkg.sv
@@ -19,11 +19,6 @@ package otbn_model_agent_pkg;
 
   typedef otbn_model_item;
   typedef otbn_model_agent_cfg;
-  // driver and sequencer are not used in this agent. Create these dummy components to avoid compile
-  // error due to the TLM connection between monitor and sequencer in dv_base_*.
-  // Both TLM fifo/port need to use the same item object (otbn_model_item)
-  typedef dv_base_sequencer #(otbn_model_item, otbn_model_agent_cfg) otbn_dummy_sequencer;
-  typedef dv_base_driver #(otbn_model_item, otbn_model_agent_cfg) otbn_dummy_driver;
 
   // package sources
   `include "otbn_model_item.sv"


### PR DESCRIPTION
*Note: This is in draft because it depends on #5861. That is a quick bodge to get things working again; this is supposed to be a more considered fix.*

This connection is handy, but not very generic. In particular, it
implies some slightly unnecessary parameterisations for types in the
dv_lib base classes: not impossible, but a cost to users who don't
want the feature.

This patch splits that logic into a new "dv_seq_agent" core file. This
subclasses the parts of an agent that need to know about the special
behaviour (the agent itself, its configuration, the monitor and the
sequencer). Now, the code that uses this feature (csrng, i2c, spi and
push_pull) can use it explicitly, and the rest of the code doesn't see
it.

