### PR TITLE
[dv/otp_ctrl] Not issue dai write after digest is calculated

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -88,7 +88,7 @@ package otp_ctrl_env_pkg;
 
   parameter uint CHK_TIMEOUT_CYC = 40;
 
-  // lc does not have digest
+  // lc does not have dai access
   parameter int PART_BASE_ADDRS [NumPart-1] = {
     CreatorSwCfgOffset,
     OwnerSwCfgOffset,
@@ -96,6 +96,16 @@ package otp_ctrl_env_pkg;
     Secret0Offset,
     Secret1Offset,
     Secret2Offset
+  };
+
+  // lc does not have digest
+  parameter int PART_OTP_DIGEST_ADDRS [NumPart-1] = {
+    CreatorSwCfgDigestOffset >> 2,
+    OwnerSwCfgDigestOffset   >> 2,
+    HwCfgDigestOffset        >> 2,
+    Secret0DigestOffset      >> 2,
+    Secret1DigestOffset      >> 2,
+    Secret2DigestOffset      >> 2
   };
 
   // types

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -18,6 +18,9 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   bit [TL_AW-1:0] used_dai_addr_q[$];
   bit is_valid_dai_op = 1;
 
+  // According to spec, the period between digest calculation and reset should not issue any write.
+  bit [NumPart-2:0] digest_calculated;
+
   bit default_req_blocking = 1;
 
   `uvm_object_new
@@ -48,6 +51,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     cfg.otp_ctrl_vif.drive_pwr_otp_init(1);
     wait(cfg.otp_ctrl_vif.pwr_otp_done_o == 1);
     cfg.otp_ctrl_vif.drive_pwr_otp_init(0);
+    digest_calculated = 0;
   endtask
 
   // setup basic otp_ctrl features
@@ -151,6 +155,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     end
 
     wait_dai_op_done();
+    digest_calculated[part_idx] = 1;
     rd_and_clear_intrs();
   endtask
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -118,7 +118,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
                   i, num_dai_op, dai_addr, part_idx), UVM_HIGH)
 
         // OTP write via DAI
-        if ($urandom_range(0, 1)) begin
+        if ($urandom_range(0, 1) && !digest_calculated[part_idx]) begin
           dai_wr(dai_addr, wdata0, wdata1);
           if (collect_used_addr) used_dai_addr_q.push_back(dai_addr);
         end


### PR DESCRIPTION
According to the spec, the period between digest calculation and reset
is not allowed to issue any write. This illegal case will be covered in
a separate sequence.

This PR also cleans up scb's digest logic. Previously we have three
places to store digest:
1. A digests variable to store all digests written into OTP
2. otp_a[{digests_addr}] that stores written digests
3. *digest* registers to store digest value after a power cycle

1) and 2) can actually be combined.

Signed-off-by: Cindy Chen <chencindy@google.com>