### PR TITLE
[rom_ctrl/top] Carry over instantiation to englishbreakfast

### DIFF
--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -583,7 +583,7 @@
     }
   ]
 
-  // Memories (ROM, RAM, eFlash) are defined at the top.
+  // Memories (RAM, eFlash) are defined at the top.
   // It utilizes the primitive cells but configurable
   memory: [
     { name: "ram_main",

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -198,6 +198,13 @@
           act:     "rcv",
           package: "lc_ctrl_pkg",
         },
+
+        { struct:  "ram_1p_cfg_t",
+          type:    "uni",
+          name:    "ram_cfg",
+          act:     "rcv",
+          package: "prim_ram_1p_pkg"
+        }
       ],
     }
     { name: "rv_dm",
@@ -398,30 +405,18 @@
       reset_connections: {rst_ni: "sys", rst_otp_ni: "lc_io_div4"},
       base_addr: "0x411C0000",
     },
-  ]
-
-  // Memories (ROM, RAM, eFlash) are defined at the top.
-  // It utilizes the primitive cells but configurable
-  memory: [
-    { name: "rom",
+    { name: "rom_ctrl",
+      type: "rom_ctrl",
       clock_srcs: {clk_i: "main"},
       clock_group: "infra",
       reset_connections: {rst_ni: "sys"},
-      type: "rom",
-      base_addr: "0x00008000",
-      swaccess: "ro",
-      size: "0x4000",
-      // data integrity width
-      integ_width: 8,
-      inter_signal_list: [
-        { struct: "tl"
-          package: "tlul_pkg"
-          type: "req_rsp"
-          act: "rsp"
-          name: "tl"
-        }
-      ]
-    },
+      base_addrs: {rom: "0x00008000", regs: "0x411e0000"}
+    }
+  ]
+
+  // Memories (RAM, eFlash) are defined at the top.
+  // It utilizes the primitive cells but configurable
+  memory: [
     { name: "ram_main",
       clock_srcs: {clk_i: "main"},
       clock_group: "infra",
@@ -465,6 +460,13 @@
           name:    "intg_error",
           act:     "req",
         },
+        // Interface to memory configuration
+        { struct:  "ram_1p_cfg",
+          package: "prim_ram_1p_pkg",
+          type:    "uni",
+          name:    "cfg",
+          act:     "rcv"
+        }
       ]
     },
     { name: "ram_ret_aon",
@@ -511,6 +513,13 @@
           name:    "intg_error",
           act:     "req",
         },
+        // Interface to memory configuration
+        { struct:  "ram_1p_cfg",
+          package: "prim_ram_1p_pkg",
+          type:    "uni",
+          name:    "cfg",
+          act:     "rcv"
+        }
       ]
     },
     { name: "eflash",
@@ -639,6 +648,9 @@
   //  e.g flash_ctrl0.flash: [flash_phy0.flash_ctrl]
   inter_module: {
     'connect': {
+      'ast.ram_1p_cfg'          : ['ram_main.cfg', 'ram_ret_aon.cfg', 'rv_core_ibex.ram_cfg'],
+      'ast.ram_2p_cfg'          : ['spi_device.ram_cfg', 'usbdev.ram_cfg'],
+      'ast.rom_cfg'             : ['rom_ctrl.rom_cfg'],
       'alert_handler.crashdump' : ['rstmgr_aon.alert_dump'],
       'alert_handler.esc_rx'    : ['rv_core_ibex.esc_nmi_rx',
                                    'lc_ctrl.esc_wipe_secrets_rx',

--- a/hw/top_englishbreakfast/data/xbar_main.hjson
+++ b/hw/top_englishbreakfast/data/xbar_main.hjson
@@ -30,7 +30,13 @@
       pipeline_byp: "false"
 
     },
-    { name:      "rom",
+    { name:      "rom_ctrl.rom",
+      type:      "device",
+      clock:     "clk_main_i",
+      reset:     "rst_main_ni",
+      pipeline:  "false",
+    },
+    { name:      "rom_ctrl.regs",
       type:      "device",
       clock:     "clk_main_i",
       reset:     "rst_main_ni",
@@ -97,12 +103,12 @@
     },
   ],
   connections: {
-    corei:  ["rom", "debug_mem", "ram_main", "eflash"],
-    cored:  ["rom", "debug_mem", "ram_main", "eflash", "peri", "flash_ctrl",
-    "aes",
-    "hmac", "rv_plic", "sram_ctrl_main"],
-    dm_sba: ["rom",              "ram_main", "eflash", "peri", "flash_ctrl",
-    "aes",
+    corei:  ["rom_ctrl.rom", "debug_mem", "ram_main", "eflash"],
+    cored:  ["rom_ctrl.rom", "rom_ctrl.regs", "debug_mem", "ram_main",
+    "eflash", "peri", "flash_ctrl", "aes", "hmac", "rv_plic",
+    "sram_ctrl_main"],
+    dm_sba: ["rom_ctrl.rom", "rom_ctrl.regs", "ram_main", "eflash",
+    "peri", "flash_ctrl", "aes",
     "hmac", "rv_plic", "sram_ctrl_main"],
   },
 }

--- a/hw/top_englishbreakfast/rtl/top_englishbreakfast_cw305.sv
+++ b/hw/top_englishbreakfast/rtl/top_englishbreakfast_cw305.sv
@@ -297,7 +297,7 @@ module top_englishbreakfast_cw305 #(
     .IbexRegFile(ibex_pkg::RegFileFPGA),
     .IbexICache(0),
     .IbexPipeLine(1),
-    .BootRomInitFile(BootRomInitFile),
+    .RomCtrlBootRomInitFile(BootRomInitFile),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_englishbreakfast (
     // Clocks, resets

--- a/hw/top_englishbreakfast/top_englishbreakfast.core
+++ b/hw/top_englishbreakfast/top_englishbreakfast.core
@@ -38,6 +38,7 @@ filesets:
       - lowrisc:ip:nmi_gen
       - lowrisc:ip:otp_ctrl
       - lowrisc:ip:lc_ctrl
+      - lowrisc:ip:rom_ctrl
       - lowrisc:ip:usbdev
       - lowrisc:ip:rstmgr
       - lowrisc:ip:pwrmgr


### PR DESCRIPTION
This carries over the rom_ctrl instance to Englishbreakfast.

Signed-off-by: Michael Schaffner <msf@google.com>