### PR TITLE
[spi_device/dv] Disable overflow assertion for overflow seq

### DIFF
--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_cmd_invalid_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_cmd_invalid_vseq.sv
@@ -42,7 +42,7 @@ class keymgr_cmd_invalid_vseq extends keymgr_lc_disable_vseq;
     do_reset_at_end_of_seq = 1;
     super.post_start();
     cfg.en_scb = 1;
-    $assertoff(1, "tb.keymgr_kmac_intf");
-    $assertoff(1, "tb.dut.tlul_assert_device.gen_device.dDataKnown_A");
+    $asserton(0, "tb.keymgr_kmac_intf");
+    $asserton(0, "tb.dut.tlul_assert_device.gen_device.dDataKnown_A");
   endtask
 endclass : keymgr_cmd_invalid_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_fifo_underflow_overflow_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_fifo_underflow_overflow_vseq.sv
@@ -13,11 +13,16 @@ class spi_device_fifo_underflow_overflow_vseq extends spi_device_txrx_vseq;
   }
 
   virtual task body();
+    // overflow will occur in this test, disable overflow assertion in RTL
+    $assertoff(0, "tb.dut.u_s2p.BitcountOverflow_A");
+
     allow_underflow_overflow = 1;
     // when underflow, sio may be unknown, disable checking it
     cfg.m_spi_agent_cfg.en_monitor_checks = 0;
     super.body();
     cfg.m_spi_agent_cfg.en_monitor_checks = 1;
+
+    $asserton(0, "tb.dut.u_s2p.BitcountOverflow_A");
   endtask
 
   // there may be some data left due to under/overflow, need to flush out all data


### PR DESCRIPTION
The overflow is intentional, disable the assertion check in RTL
Signed-off-by: Weicai Yang <weicai@google.com>
