### PR TITLE
[keymgr,lint] Fix some width mismatches; explicitly slice some enum constants

### DIFF
--- a/hw/ip/keymgr/lint/keymgr.vlt
+++ b/hw/ip/keymgr/lint/keymgr.vlt
@@ -3,3 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // waiver file for keymgr
+
+`verilator_config
+
+// Waive some width mismatch warnings in keymgr.sv and keymgr_kmac_if.sv that
+// come from addressing inputs_invalid_d by elements of the keymgr_ops_e enum.
+// The enum contains 4 actual operations plus an "OpDisable" entry, meaning
+// that its elements are represented by $clog2(5) = 3 bits. The error_o array
+// just has an entry for each of the 4 real operations, so Verilator expects to
+// address it with a 2-bit index.
+lint_off -rule WIDTH -file "*/rtl/keymgr.sv" -match "Bit extraction of var[3:0]*not 3 bits."
+lint_off -rule WIDTH -file "*/rtl/keymgr_kmac_if.sv" -match "Bit extraction of var[3:0]*not 3 bits."

--- a/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
+++ b/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
@@ -75,6 +75,13 @@ module keymgr_kmac_if import keymgr_pkg::*;(
   localparam int DecoyCopies = KmacDataIfWidth / 32;
   localparam int DecoyOutputCopies = (KeyWidth / 32) * Shares;
 
+  localparam int unsigned LastAdvRoundInt = AdvRounds - 1;
+  localparam int unsigned LastIdRoundInt = IdRounds - 1;
+  localparam int unsigned LastGenRoundInt = GenRounds - 1;
+  localparam bit [CntWidth-1:0] LastAdvRound = LastAdvRoundInt[CntWidth-1:0];
+  localparam bit [CntWidth-1:0] LastIdRound = LastIdRoundInt[CntWidth-1:0];
+  localparam bit [CntWidth-1:0] LastGenRound = LastGenRoundInt[CntWidth-1:0];
+
   // byte mask for the last transfer
   localparam logic [IfBytes-1:0] AdvByteMask = (AdvRem > 0) ? (2**(AdvRem/8)-1) : {IfBytes{1'b1}};
   localparam logic [IfBytes-1:0] IdByteMask  = (IdRem > 0)  ? (2**(IdRem/8)-1)  : {IfBytes{1'b1}};
@@ -151,11 +158,11 @@ module keymgr_kmac_if import keymgr_pkg::*;(
         if (start) begin
           cnt_set = 1'b1;
           if (adv_en_i) begin
-            rounds = AdvRounds - 1;
+            rounds = LastAdvRound;
           end else if (id_en_i) begin
-            rounds = IdRounds - 1;
+            rounds = LastIdRound;
           end else if (gen_en_i) begin
-            rounds = GenRounds - 1;
+            rounds = LastGenRound;
           end
 
           // we are sending only 1 entry
@@ -262,11 +269,11 @@ module keymgr_kmac_if import keymgr_pkg::*;(
     if (|cmd_error_o || inputs_invalid_o || fsm_error_o) begin
       kmac_data_o.data  = decoy_data;
     end else if (valid && adv_en_i) begin
-      kmac_data_o.data  = adv_data[AdvRounds-1-cnt];
+      kmac_data_o.data  = adv_data[LastAdvRound - cnt];
     end else if (valid && id_en_i) begin
-      kmac_data_o.data  = id_data[IdRounds-1-cnt];
+      kmac_data_o.data  = id_data[LastIdRound - cnt];
     end else if (valid && gen_en_i) begin
-      kmac_data_o.data  = gen_data[GenRounds-1-cnt];
+      kmac_data_o.data  = gen_data[LastGenRound - cnt];
     end
   end
 

--- a/hw/ip/keymgr/rtl/keymgr_reseed_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reseed_ctrl.sv
@@ -29,8 +29,9 @@ module keymgr_reseed_ctrl import keymgr_pkg::*; (
   output logic [LfsrWidth-1:0] seed_o
 );
 
-  localparam int EdnRounds = LfsrWidth / EdnWidth;
-  localparam int EdnCntWidth = prim_util_pkg::vbits(EdnRounds);
+  localparam int unsigned EdnRounds = LfsrWidth / EdnWidth;
+  localparam int unsigned EdnCntWidth = prim_util_pkg::vbits(EdnRounds);
+  localparam int unsigned LastEdnRound = EdnRounds - 1;
 
   // counter to track number of edn rounds
   logic [EdnCntWidth-1:0] edn_cnt;
@@ -42,7 +43,7 @@ module keymgr_reseed_ctrl import keymgr_pkg::*; (
   // This tracks how many edn rounds are required to fill up
   // one required entry.
   assign edn_txn_done = edn_req & edn_ack;
-  assign edn_done = (edn_cnt == EdnRounds - 1) & edn_txn_done;
+  assign edn_done = (edn_cnt == LastEdnRound[EdnCntWidth-1:0]) & edn_txn_done;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       edn_cnt <= '0;


### PR DESCRIPTION
Yet more minor tidy-ups in my quest to get TopEarlgrey lint-clean with Verilator :-)