### PR TITLE
[otbn] Remove WIP marker from documentation

### DIFF
--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -2,13 +2,6 @@
 title: OpenTitan Big Number Accelerator (OTBN) Technical Specification
 ---
 
-<div class="bd-callout bd-callout-warning">
-  <h5>Note on the status of this document</h5>
-
-  **This specification is work in progress and will see significant changes before it can be considered final.**
-  We invite input of all kind through the standard means of the OpenTitan project; a good starting point is filing an issue in our [GitHub issue tracker](https://github.com/lowRISC/opentitan/issues).
-</div>
-
 # Overview
 
 This document specifies functionality of the OpenTitan Big Number Accelerator, or OTBN.


### PR DESCRIPTION
The OTBN specification/documentation is mostly consistent, well-written,
tested and implemented, so there is no more need for a big warning sign
at the beginning. This aligns OTBN with all other IP blocks in OpenTitan,
none of which have a similar warning.

Of course, there's always more to do and OTBN (like all other IP blocks
in OpenTitan) isn't "done" yet. These improvements will happen as evolutions
to the current design.