### PR TITLE
[dv/flash] Small changes to improve integration with partner env

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -44,11 +44,9 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(flash_ctrl_reg_block)
     end
   endfunction : initialize
 
-  
   // --------------------------------------------
   // Back-door access methods
   // --------------------------------------------
-
 
   virtual function void flash_mem_bkdr_init(flash_dv_part_e part = FlashPartData,
                                             flash_mem_init_e flash_mem_init);
@@ -109,7 +107,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(flash_ctrl_reg_block)
     endcase
     for (int i = 0; i < flash_op.num_words; i++) begin
       logic [TL_DW-1:0] loc_data;
-      if(flash_mem_init == FlashMemInitCustom)
+      if (flash_mem_init == FlashMemInitCustom)
         loc_data = data[i];
       else if (flash_mem_init == FlashMemInitRandomize)
         loc_data = $urandom;

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class flash_ctrl_scoreboard extends cip_base_scoreboard #(
-    .CFG_T(flash_ctrl_env_cfg),
+class flash_ctrl_scoreboard #(type CFG_T = flash_ctrl_env_cfg)
+                            extends cip_base_scoreboard #(
+    .CFG_T(CFG_T),
     .RAL_T(flash_ctrl_reg_block),
     .COV_T(flash_ctrl_env_cov)
   );
-  `uvm_component_utils(flash_ctrl_scoreboard)
+  `uvm_component_param_utils(flash_ctrl_scoreboard #(CFG_T))
 
   // local variables
 
@@ -19,17 +20,17 @@ class flash_ctrl_scoreboard extends cip_base_scoreboard #(
 
   `uvm_component_new
 
-  function void build_phase(uvm_phase phase);
+  virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     eflash_tl_a_chan_fifo = new("eflash_tl_a_chan_fifo", this);
     eflash_tl_d_chan_fifo = new("eflash_tl_d_chan_fifo", this);
   endfunction
 
-  function void connect_phase(uvm_phase phase);
+  virtual function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
   endfunction
 
-  task run_phase(uvm_phase phase);
+  virtual task run_phase(uvm_phase phase);
     super.run_phase(phase);
     fork
       process_eflash_tl_a_chan_fifo();
@@ -125,7 +126,7 @@ class flash_ctrl_scoreboard extends cip_base_scoreboard #(
     eflash_tl_d_chan_fifo.flush();
   endfunction
 
-  function void check_phase(uvm_phase phase);
+  virtual function void check_phase(uvm_phase phase);
     super.check_phase(phase);
     // post test checks - ensure that all local fifos and queues are empty
     `DV_EOT_PRINT_TLM_FIFO_CONTENTS(tl_seq_item, eflash_tl_a_chan_fifo)

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_vseq.sv
@@ -217,6 +217,12 @@ class flash_ctrl_rand_ops_vseq extends flash_ctrl_base_vseq;
       1 :/ cfg.seq_cfg.poll_fifo_status_pc
     };
   }
+  
+  // When 0, the post-transaction back-door checks
+  //  will be disabled.
+  // Added to enable other post-transaction checks
+  //  and actions.
+  bit check_mem_post_tran = 1'b1;
 
   `uvm_object_new
 
@@ -256,17 +262,17 @@ class flash_ctrl_rand_ops_vseq extends flash_ctrl_base_vseq;
             `DV_CHECK_MEMBER_RANDOMIZE_FATAL(poll_fifo_status)
             flash_ctrl_read(flash_op.num_words, flash_op_data, poll_fifo_status);
             wait_flash_op_done();
-            cfg.flash_mem_bkdr_read_check(flash_op, flash_op_data);
+            if (check_mem_post_tran) cfg.flash_mem_bkdr_read_check(flash_op, flash_op_data);
           end
           flash_ctrl_pkg::FlashOpProgram: begin
             `DV_CHECK_MEMBER_RANDOMIZE_FATAL(poll_fifo_status)
             flash_ctrl_write(flash_op_data, poll_fifo_status);
             wait_flash_op_done();
-            cfg.flash_mem_bkdr_read_check(flash_op, flash_op_data);
+            if (check_mem_post_tran) cfg.flash_mem_bkdr_read_check(flash_op, flash_op_data);
           end
           flash_ctrl_pkg::FlashOpErase: begin
             wait_flash_op_done(.timeout_ns(120_000_000));// Added because mass(bank) erase can be longer then default timeout.
-            cfg.flash_mem_bkdr_erase_check(flash_op);
+            if (check_mem_post_tran) cfg.flash_mem_bkdr_erase_check(flash_op);
           end
           default: begin
             // TODO: V2 test item.

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -81,7 +81,9 @@ module tb;
   assign flash_power_down_h = (init ? 1'b1 : 1'b0);
   initial begin
     init = 1'b1;
-    #(1us);
+    // Wait for reset, then 5 cycles more.
+    wait(rst_n);
+    clk_rst_if.wait_clks(5);
     init = 1'b0;
   end
 
@@ -97,7 +99,7 @@ module tb;
 
   for (genvar i = 0; i < flash_ctrl_pkg::NumBanks; i++) begin : gen_mem_bkdr_if_i
 
-    if(`PRIM_DEFAULT_IMPL==prim_pkg::ImplGeneric) begin : gen_generic // If using open-source flash
+    if (`PRIM_DEFAULT_IMPL==prim_pkg::ImplGeneric) begin : gen_generic // If using open-source flash
 
       flash_dv_part_e part = part.first();
 


### PR DESCRIPTION
Hi,

This PR is adding some changes in flash_ctrl DV env to improve the override possibilities by partner_flash_ctrl environment.
Main changes:
* Added parametrization to **virtual_sequencer** and **scoreboard** types in **flash_ctrl_env.sv** and to **env_cfg** type in **flash_ctrl_scoreboard.sv**.
* Made phases functions and tasks (build, connect, run & check) virtual to enable overrides.
* Get **ral.set_hdl_path** method in **flash_ctrl_env.sv** to be called only when in prim implementation to allow hierarchy change in extending partner env.
* Added  option to skip post-transaction flash backdoor check in **flash_ctrl_rand_ops_vseq.sv**.

Thanks!

Signed-off-by: Eitan Shapira <eitan.shapira@nuvoton.com>