### PR TITLE
[otbn] Move to version 0.2

### DIFF
--- a/hw/ip/otbn/data/otbn.prj.hjson
+++ b/hw/ip/otbn/data/otbn.prj.hjson
@@ -8,9 +8,22 @@
     dv_doc:             "../doc/dv",
     hw_checklist:       "../doc/checklist",
     sw_checklist:       "/sw/device/lib/dif/dif_otbn"
-    version:            "0.1",
-    life_stage:         "L1",
-    design_stage:       "D1",
-    verification_stage: "V1",
-    dif_stage:          "S1",
+    revisions: [
+        {
+            version:            "0.1",
+            life_stage:         "L1",
+            design_stage:       "D1",
+            verification_stage: "V1",
+            dif_stage:          "S1",
+            commit_id:          "a46be154ebbcb7b0d5e310b5510a4ac700adc9df",
+            notes:              ""
+        },
+        {
+            version:            "0.2",
+            life_stage:         "L1",
+            design_stage:       "D1",
+            verification_stage: "V1",
+            dif_stage:          "S1",
+        },
+    ]
 }


### PR DESCRIPTION
OTBN is now in a consistent state from a specification, RTL,
verification, and software perspective. The respective D1/V1/S1 status
indicates that. We would like to use this opportunity to mark this state
as version 0.1 before we move out of this consistent state again.

Version 0.1 of OTBN isn't perfect -- there are known bugs and gaps in
the implementation, in the verification, in the DIF and test software,
and in the specification, as it would be expected for a design in
L1/D1/V1/S1 state. However, OTBN in its current state is good enough
to be synthesized properly, run RSA and ECDSA-P256 on it, and pass basic
verification. The specification has seen extensive review.

Going forward in version 0.2 we will (re-)open the discussion around some
aspects of the specification, mostly to add security hardening features,
and likely to be better suited for workloads we haven't considered so
far (e.g. SIMD instructions for SHA2).

For now, I'm leaving the D1/V1/S1 status in place (instead of going down
e.g. to D0), as it is still valid. In the past we were able in OTBN to
reasonably synchronously add support for new features to DIF, RTL, and
verification, which would keep the *1 status in place. However, we don't
have that many examples of version bumps in OpenTitan, and with that not
that many established guidelines that we could follow.

Finally: The version number does not have any semantic meaning whatsoever.

Documentation on versioning: https://docs.opentitan.org/doc/project/development_stages/#versioning