### PR TITLE
[spi] Define Passthrough interface

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_pkg.sv
@@ -7,6 +7,49 @@
 
 package spi_device_pkg;
 
+  // Passthrough Inter-module signals
+  typedef struct packed {
+    // passthrough_en: switch the mux for downstream SPI pad to host system not
+    // the internal SPI_HOST IP
+    logic       passthrough_en;
+
+    // Passthrough includes SCK also. The sck_en is pad out enable not CG
+    // enable. The CG is placed in SPI_DEVICE IP.
+    logic       sck;
+    logic       sck_gate_en; // TBD: place for CG?
+    logic       sck_en;
+
+    // CSb should be pull-up pad. In passthrough mode, CSb is directly connected
+    // to the host systems CSb except when SPI_DEVICE decides to drop the
+    // command.
+    logic       csb;
+    logic       csb_en;
+
+    // SPI data from host system to downstream flash device.
+    logic [3:0] s;
+    logic [3:0] s_en;
+  } passthrough_req_t;
+
+  typedef struct packed {
+    // SPI data from downstream flash device to host system.
+    logic [3:0] s;
+  } passthrough_rsp_t;
+
+  parameter passthrough_req_t PASSTHROUGH_RSQ_DEFAULT = '{
+    passthrough_en: 1'b 0,
+    sck:            1'b 0,
+    sck_gate_en:    1'b 0,
+    sck_en:         1'b 0,
+    csb:            1'b 1,
+    csb_en:         1'b 0,
+    s:              4'h 0,
+    s_en:           4'h 0
+  };
+
+  parameter passthrough_rsp_t PASSTHROUGH_RSP_DEFAULT = '{
+    s: 4'h 0
+  };
+
   // SPI Operation mode
   typedef enum logic [1:0] {
     FwMode      = 'h0,


### PR DESCRIPTION
`passthrough_req/rsp_t` are for SPI passthrough communications between
SPI_DEVICE and SPI_HOST, more broadly between host system and downstream
flash device.