### PR TITLE
[spi_device] Lint fix

### DIFF
--- a/hw/ip/spi_device/lint/spi_device.waiver
+++ b/hw/ip/spi_device/lint/spi_device.waiver
@@ -100,4 +100,9 @@ waive -rules CASE_INC -location {spi_fwm_*xf_ctrl.sv} -regexp {Case statement ta
 waive -rules {NOT_USED NOT_READ} -location {spi_device.sv}
       -regexp {'sub_sram_.*\[1\]' is not (used|read)}
       -comment "CmdParse does not have SRAM intf"
-      
+
+#### SRAM mux
+#### SRAM has unpacked array to mux/demux. Waive one bit unpacked array
+waive -rules {ONE_BIT_MEM_WIDTH} -location {spi_device.sv}
+      -regexp {Memory 'sub_.*' has word width which is a single bit wide}
+      -comment "Unpacked array for mux/demux"

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -534,8 +534,6 @@ module spi_device (
           DpNone: begin
             io_mode = sub_iomode[IoModeCmdParse];
 
-            p2s_valid = sub_p2s_valid[IoModeCmdParse];
-            p2s_data  = sub_p2s_data[IoModeCmdParse];
             sub_p2s_sent[IoModeCmdParse] = p2s_sent;
 
             // Leave SRAM default;
@@ -565,8 +563,6 @@ module spi_device (
           default: begin
             io_mode = sub_iomode[IoModeCmdParse];
 
-            p2s_valid = sub_p2s_valid[IoModeCmdParse];
-            p2s_data  = sub_p2s_data[IoModeCmdParse];
             sub_p2s_sent[IoModeCmdParse] = p2s_sent;
           end
         endcase


### PR DESCRIPTION
- Removed undriven signals for synthesis
- Tied some unused signals to `unused_*`
- Waived unpacked array errors for one bit array signals
