### PR TITLE
[dv/otp_ctrl] add stress_all_test

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -35,6 +35,7 @@ filesets:
       - seq_lib/otp_ctrl_parallel_lc_req_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_test_access_vseq.sv: {is_include_file: true}
+      - seq_lib/otp_ctrl_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -35,13 +35,17 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
   // during the transition.
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      lc_prog_err_dly1 <= 0;
-      lc_esc_dly1      <= lc_ctrl_pkg::Off;
-      lc_esc_dly2      <= lc_ctrl_pkg::Off;
+      lc_prog_err_dly1  <= 0;
+      lc_esc_dly1       <= lc_ctrl_pkg::Off;
+      lc_esc_dly2       <= lc_ctrl_pkg::Off;
+      lc_check_byp_en_i <= lc_ctrl_pkg::Off;
     end else begin
       lc_prog_err_dly1 <= lc_prog_err;
       lc_esc_dly1      <= lc_escalate_en_i;
       lc_esc_dly2      <= lc_esc_dly1;
+      if (lc_prog_req && lc_check_byp_en_i == lc_ctrl_pkg::Off) begin
+        lc_check_byp_en_i <= lc_ctrl_pkg::On;
+      end
     end
   end
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -13,6 +13,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   // various knobs to enable certain routines
   bit do_otp_ctrl_init = 1'b1;
   bit do_otp_pwr_init  = 1'b1;
+  bit collect_used_addr = 1;
 
   rand bit [NumOtpCtrlIntr-1:0] en_intr;
   bit [TL_AW-1:0] used_dai_addr_q[$];
@@ -22,6 +23,8 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   bit [NumPart-2:0] digest_calculated;
 
   bit default_req_blocking = 1;
+  // TODO: set it to 0 once support reset in otp program, and remove related logic
+  bit lc_prog_blocking = 1;
 
   `uvm_object_new
 
@@ -32,7 +35,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     cfg.otp_ctrl_vif.init();
     if (do_otp_ctrl_init && do_apply_reset) otp_ctrl_init();
     cfg.clk_rst_vif.wait_clks($urandom_range(0, 10));
-    if (do_otp_pwr_init) otp_pwr_init();
+    if (do_otp_pwr_init && do_apply_reset) otp_pwr_init();
   endtask
 
   // Cfg errors are cleared after reset

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
@@ -19,11 +19,17 @@ class otp_ctrl_common_vseq extends otp_ctrl_base_vseq;
     cfg.clk_rst_vif.wait_clks(3);
   endtask
 
-  task post_start();
-    super.post_start();
+  virtual task post_start();
     // Random CSR rw might trigger alert. Some alerts will conintuously be triggered until reset
     // applied, which will cause alert_monitor phase_ready_to_end timeout.
-    apply_reset();
+    if (do_apply_reset) begin
+      apply_reset();
+    end else wait(0); // wait until upper seq resets and kills this seq
+
+    // delay to avoid race condition when sending item and checking no item after reset occur
+    // at the same time
+    #1ps;
+    super.post_start();
   endtask
 
   virtual task body();

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_req_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_req_vseq.sv
@@ -9,9 +9,6 @@ class otp_ctrl_parallel_lc_req_vseq extends otp_ctrl_parallel_base_vseq;
 
   `uvm_object_new
 
-  // TODO: set it to 0 once support reset in otp program, and remove related logic
-  bit lc_prog_blocking = 1;
-
   // disable checks in case lc_program and check triggered at the same time
   constraint regwens_c {
     check_regwen_val dist {0 :/ 1, 1 :/ 9};
@@ -21,16 +18,6 @@ class otp_ctrl_parallel_lc_req_vseq extends otp_ctrl_parallel_base_vseq;
   constraint lc_trans_c {
     do_lc_trans == 0;
   }
-
-  virtual task pre_start();
-    super.pre_start();
-    check_lc_err();
-  endtask
-
-  virtual task dut_init(string reset_kind = "HARD");
-    super.dut_init(reset_kind);
-    if (do_reset_in_seq) lc_prog_blocking = 1;
-  endtask
 
   virtual task run_parallel_seq(ref bit base_vseq_done);
     forever begin
@@ -56,16 +43,6 @@ class otp_ctrl_parallel_lc_req_vseq extends otp_ctrl_parallel_base_vseq;
         end
       end join
     end
-  endtask
-
-  virtual task check_lc_err();
-    fork
-      forever begin
-        wait(cfg.otp_ctrl_vif.lc_prog_err == 1);
-        lc_prog_blocking = 0;
-        wait(lc_prog_blocking == 1);
-      end
-    join_none;
   endtask
 
   virtual task post_start();

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_stress_all_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_stress_all_vseq.sv
@@ -1,0 +1,66 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// combine all otp_ctrl seqs (except below seqs) in one seq to run sequentially
+// Exception: - csr seq, which requires scb to be disabled
+//            - regwen_vseq, which is time sensitive and requires zero delays
+class otp_ctrl_stress_all_vseq extends otp_ctrl_base_vseq;
+  `uvm_object_utils(otp_ctrl_stress_all_vseq)
+
+  `uvm_object_new
+
+  task body();
+    // TODO: support more sequences
+    string seq_names[] = {//"otp_ctrl_common_vseq",
+                          "otp_ctrl_dai_errs_vseq",
+                          "otp_ctrl_dai_lock_vseq",
+                          "otp_ctrl_smoke_vseq"};
+
+    for (int i = 1; i <= num_trans; i++) begin
+      uvm_sequence       seq;
+      otp_ctrl_base_vseq otp_ctrl_vseq;
+      uint seq_idx = $urandom_range(0, seq_names.size - 1);
+
+      seq = create_seq_by_name(seq_names[seq_idx]);
+      `downcast(otp_ctrl_vseq, seq)
+
+      // if upper seq disables do_apply_reset for this seq, then can't issue reset
+      // as upper seq may drive reset
+      if (do_apply_reset) begin
+        otp_ctrl_vseq.do_apply_reset = $urandom_range(0, 1);
+      end else begin
+        otp_ctrl_vseq.do_apply_reset = 0;
+      end
+
+      otp_ctrl_vseq.set_sequencer(p_sequencer);
+      `DV_CHECK_RANDOMIZE_FATAL(otp_ctrl_vseq)
+      if (seq_names[seq_idx] == "otp_ctrl_common_vseq") begin
+        otp_ctrl_common_vseq common_vseq;
+        `downcast(common_vseq, otp_ctrl_vseq);
+        common_vseq.common_seq_type = "intr_test";
+      end
+
+      // Pass local variables to next sequence due to randomly issued reset.
+      otp_ctrl_vseq.collect_used_addr = 0;
+      otp_ctrl_vseq.is_valid_dai_op = 0;
+      otp_ctrl_vseq.lc_prog_blocking = this.lc_prog_blocking;
+      otp_ctrl_vseq.digest_calculated = this.digest_calculated;
+      otp_ctrl_vseq.start(p_sequencer);
+
+      this.lc_prog_blocking = otp_ctrl_vseq.lc_prog_blocking;
+      this.digest_calculated = otp_ctrl_vseq.digest_calculated;
+    end
+  endtask : body
+
+  virtual task post_start();
+    apply_reset();
+
+    // delay to avoid race condition when sending item and checking no item after reset occur
+    // at the same time
+    #1ps;
+    super.post_start();
+  endtask
+
+endclass
+

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
@@ -17,3 +17,4 @@
 `include "otp_ctrl_parallel_lc_esc_vseq.sv"
 `include "otp_ctrl_regwen_vseq.sv"
 `include "otp_ctrl_test_access_vseq.sv"
+`include "otp_ctrl_stress_all_vseq.sv"

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -112,6 +112,12 @@
       name: otp_ctrl_test_access
       uvm_test_seq: otp_ctrl_test_access_vseq
     }
+
+    {
+      name: otp_ctrl_stress_all
+      uvm_test_seq: otp_ctrl_stress_all_vseq
+    }
+
   ]
 
   // List of regressions.


### PR DESCRIPTION
This PR adds a few sequences to stress_all_test.
The chanllege for stress_all test is that otp_ctrl digest function
requires a reset to issue after it to make it work. Not following up
with a reset creates many corner cases on either RTL and DV side.

This PR moves a few variable to otp_ctrl_base_vseq to share among
all sequences within stress_all test.

Coming PRs will add more tests to stress_all.

Signed-off-by: Cindy Chen <chencindy@google.com>