### PR TITLE
[entropy_src, top, sw] Entropy src connection and software updates

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -39,12 +39,11 @@
       act:     "req",
       package: "entropy_src_pkg",
     }
-    { struct:  "logic"
-      type:    "uni"
-      name:    "efuse_es_sw_reg_en"
-      act:     "rcv"
-      width:   1
-      package: ""
+    { struct:  "otp_hw_cfg",
+      type:    "uni",
+      name:    "otp_hw_cfg",
+      act:     "rcv",
+      package: "otp_ctrl_part_pkg",
     }
     { struct:  "logic"
       type:    "uni"

--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -17,6 +17,7 @@ module tb;
   wire devmode, efuse_es_sw_reg_en;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
   wire intr_entropy_valid, intr_health_test_failed, intr_fatal_err;
+  otp_ctrl_part_pkg::otp_hw_cfg_data_t otp_hw_cfg;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
@@ -29,6 +30,12 @@ module tb;
   push_pull_if#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))
       csrng_if(.clk(clk), .rst_n(rst_n));
 
+  // TODO: Hack to enable otp values
+  always_comb begin
+    otp_hw_cfg = otp_ctrl_part_pkg::OTP_HW_CFG_DATA_DEFAULT;
+    otp_hw_cfg.en_entropy_src_fw_read = efuse_es_sw_reg_en ? 8'hA5 : '0;
+  end
+
   `DV_ALERT_IF_CONNECT
 
   // dut
@@ -39,7 +46,7 @@ module tb;
     .tl_i                         (tl_if.h2d  ),
     .tl_o                         (tl_if.d2h  ),
 
-    .efuse_es_sw_reg_en_i         (efuse_es_sw_reg_en),
+    .otp_hw_cfg_i                 (otp_hw_cfg ),
 
     .entropy_src_hw_if_o          ({csrng_if.ack,
                                     csrng_if.d_data[entropy_src_pkg::CSRNG_BUS_WIDTH-1:0],

--- a/hw/ip/entropy_src/entropy_src.core
+++ b/hw/ip/entropy_src/entropy_src.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:prim:lfsr
       - lowrisc:ip:tlul
       - lowrisc:ip:sha3
+      - lowrisc:ip:otp_ctrl_pkg
       - lowrisc:ip:entropy_src_pkg
     files:
       - rtl/entropy_src_reg_pkg.sv

--- a/hw/ip/entropy_src/rtl/entropy_src.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src.sv
@@ -21,8 +21,8 @@ module entropy_src
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
 
-  // Efuse Interface
-  input logic efuse_es_sw_reg_en_i,
+  // OTP Interface
+  input otp_ctrl_part_pkg::otp_hw_cfg_t otp_hw_cfg_i,
 
   // RNG Interface
   output logic rng_fips_o,
@@ -72,6 +72,11 @@ module entropy_src
     .devmode_i(1'b1)
   );
 
+  logic efuse_es_sw_reg_en;
+  otp_ctrl_part_pkg::otp_hw_cfg_t unused_hw_cfg;
+  assign unused_hw_cfg = otp_hw_cfg_i;
+  assign efuse_es_sw_reg_en = (otp_hw_cfg_i.data.en_entropy_src_fw_read == 8'hA5);
+
   entropy_src_core #(
     .EsFifoDepth(EsFifoDepth)
   ) u_entropy_src_core (
@@ -80,7 +85,7 @@ module entropy_src
     .reg2hw,
     .hw2reg,
 
-    .efuse_es_sw_reg_en_i,
+    .efuse_es_sw_reg_en_i(efuse_es_sw_reg_en),
     .rng_fips_o,
 
     .entropy_src_hw_if_o,

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -227,6 +227,18 @@
       default: "1",
       local: "true"
     },
+    { name: "EnEntropySrcFwReadOffset",
+      desc: "Offset of EN_ENTROPY_SRC_FW_READ",
+      type: "int",
+      default: "1569",
+      local: "true"
+    },
+    { name: "EnEntropySrcFwReadSize",
+      desc: "Size of EN_ENTROPY_SRC_FW_READ",
+      type: "int",
+      default: "1",
+      local: "true"
+    },
     { name: "HwCfgDigestOffset",
       desc: "Offset of HW_CFG_DIGEST",
       type: "int",

--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_dev.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_dev.hjson
@@ -48,7 +48,11 @@
                 {
                     name:  "DEVICE_ID",
                     value: "<random>",
-                }
+                },
+                {
+                    name:  "EN_ENTROPY_SRC_FW_READ",
+                    value: "0xA5",
+                },
             ],
         }
         {

--- a/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
@@ -147,6 +147,10 @@
                     name:    "EN_SRAM_IFETCH",
                     size:    "1",
                 },
+                {
+                    name:    "EN_ENTROPY_SRC_FW_READ",
+                    size:    "1",
+                },
             ],
             desc: '''Hardware configuration bits used to hardwire
             specific hardware functionality. E.g., raw entropy

--- a/hw/ip/otp_ctrl/doc/otp_ctrl_mmap.md
+++ b/hw/ip/otp_ctrl/doc/otp_ctrl_mmap.md
@@ -11,6 +11,7 @@ It has been generated with ./util/design/gen-otp-mmap.py
 |         |                |            |      64bit       |   [OWNER_SW_CFG_DIGEST](#Reg_owner_sw_cfg_digest_0)   |     0x5F8      |     8      |
 |    2    |     HW_CFG     |    240     |      32bit       |                       DEVICE_ID                       |     0x600      |     32     |
 |         |                |            |      32bit       |                    EN_SRAM_IFETCH                     |     0x620      |     1      |
+|         |                |            |      32bit       |                EN_ENTROPY_SRC_FW_READ                 |     0x621      |     1      |
 |         |                |            |      64bit       |         [HW_CFG_DIGEST](#Reg_hw_cfg_digest_0)         |     0x6E8      |     8      |
 |    3    |    SECRET0     |     40     |      64bit       |                   TEST_UNLOCK_TOKEN                   |     0x6F0      |     16     |
 |         |                |            |      64bit       |                    TEST_EXIT_TOKEN                    |     0x700      |     16     |

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -198,8 +198,7 @@ module otp_ctrl
     .intg_error_o(                    ),
     .rdata_i     (  tlul_rdata        ),
     .rvalid_i    (  tlul_rvalid       ),
-    .rerror_i    (  tlul_rerror       ),
-    .req_type_o  (                    )
+    .rerror_i    (  tlul_rerror       )
   );
 
   logic [NumPart-1:0] tlul_part_sel_oh;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
@@ -217,7 +217,8 @@ package otp_ctrl_part_pkg;
   // Breakout types for easier access of individual items.
   typedef struct packed {
       logic [63:0] hw_cfg_digest;
-      logic [1591:0] unallocated;
+      logic [1583:0] unallocated;
+      logic [7:0] en_entropy_src_fw_read;
       logic [7:0] en_sram_ifetch;
       logic [255:0] device_id;
   } otp_hw_cfg_data_t;
@@ -225,7 +226,8 @@ package otp_ctrl_part_pkg;
   // default value used for intermodule
   parameter otp_hw_cfg_data_t OTP_HW_CFG_DATA_DEFAULT = '{
     hw_cfg_digest: 64'hABFF25A58087D34A,
-    unallocated: 1592'h0,
+    unallocated: 1584'h0,
+    en_entropy_src_fw_read: 8'h0,
     en_sram_ifetch: 8'h0,
     device_id: 256'h37E5AE39A58FACEE41389646B3968A3B128F4AF0AFFC1AAC77ADEFF42376E09D
   };
@@ -267,7 +269,8 @@ package otp_ctrl_part_pkg;
     }),
     1920'({
       64'hABFF25A58087D34A,
-      1592'h0, // unallocated space
+      1584'h0, // unallocated space
+      8'h0,
       8'h0,
       256'h37E5AE39A58FACEE41389646B3968A3B128F4AF0AFFC1AAC77ADEFF42376E09D
     }),

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -33,6 +33,8 @@ package otp_ctrl_reg_pkg;
   parameter int DeviceIdSize = 32;
   parameter int EnSramIfetchOffset = 1568;
   parameter int EnSramIfetchSize = 1;
+  parameter int EnEntropySrcFwReadOffset = 1569;
+  parameter int EnEntropySrcFwReadSize = 1;
   parameter int HwCfgDigestOffset = 1768;
   parameter int HwCfgDigestSize = 8;
   parameter int Secret0Offset = 1776;

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -4430,12 +4430,15 @@
           index: -1
         }
         {
-          name: efuse_es_sw_reg_en
-          struct: logic
+          name: otp_hw_cfg
+          struct: otp_hw_cfg
+          package: otp_ctrl_part_pkg
           type: uni
           act: rcv
           width: 1
           inst_name: entropy_src
+          default: ""
+          top_signame: otp_ctrl_otp_hw_cfg
           index: -1
         }
         {
@@ -5617,6 +5620,7 @@
       ]
       otp_ctrl.otp_hw_cfg:
       [
+        entropy_src.otp_hw_cfg
         lc_ctrl.otp_hw_cfg
         keymgr.otp_hw_cfg
         sram_ctrl_main.otp_hw_cfg
@@ -11814,12 +11818,15 @@
         index: -1
       }
       {
-        name: efuse_es_sw_reg_en
-        struct: logic
+        name: otp_hw_cfg
+        struct: otp_hw_cfg
+        package: otp_ctrl_part_pkg
         type: uni
         act: rcv
         width: 1
         inst_name: entropy_src
+        default: ""
+        top_signame: otp_ctrl_otp_hw_cfg
         index: -1
       }
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -897,7 +897,8 @@
       'lc_ctrl.lc_otp_token'   : ['otp_ctrl.lc_otp_token'],
 
       // HW_CFG broadcast
-      'otp_ctrl.otp_hw_cfg'    : ['lc_ctrl.otp_hw_cfg', 'keymgr.otp_hw_cfg',
+      'otp_ctrl.otp_hw_cfg'    : ['entropy_src.otp_hw_cfg',
+                                  'lc_ctrl.otp_hw_cfg', 'keymgr.otp_hw_cfg',
                                   'sram_ctrl_main.otp_hw_cfg', 'sram_ctrl_ret_aon.otp_hw_cfg'],
 
       // Diversification constant coming from life cycle

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -181,6 +181,12 @@
       en_run_modes: ["sw_test_mode"]
     }
     {
+      name: chip_dif_entropy_smoketest
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/dif_entropy_smoketest:1"]
+      en_run_modes: ["sw_test_mode"]
+    }
+    {
       name: chip_dif_gpio_smoketest
       uvm_test_seq: chip_sw_gpio_smoke_vseq
       sw_images: ["sw/device/tests/dif_gpio_smoketest:1"]

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -2065,7 +2065,7 @@ module top_earlgrey #(
       .entropy_src_rng_i(es_rng_rsp_i),
       .entropy_src_xht_o(),
       .entropy_src_xht_i(entropy_src_pkg::ENTROPY_SRC_XHT_RSP_DEFAULT),
-      .efuse_es_sw_reg_en_i('0),
+      .otp_hw_cfg_i(otp_ctrl_otp_hw_cfg),
       .rng_fips_o(es_rng_fips_o),
       .tl_i(entropy_src_tl_req),
       .tl_o(entropy_src_tl_rsp),

--- a/sw/device/lib/dif/dif_entropy.h
+++ b/sw/device/lib/dif/dif_entropy.h
@@ -363,6 +363,14 @@ typedef enum dif_entropy_result {
    * succeed until hardware reset.
    */
   kDifEntropyLocked = 3,
+  /**
+   * Indicates that entropy is not yet available for software consumption
+   */
+  kDifEntropyDataUnAvailable = 4,
+  /**
+   * Indicates that entropy is not idle
+   */
+  kDifEntropyNotIdle = 5,
 } dif_entropy_result_t;
 
 /**
@@ -484,6 +492,15 @@ dif_entropy_result_t dif_entropy_lock(const dif_entropy_t *entropy);
 DIF_WARN_UNUSED_RESULT
 dif_entropy_result_t dif_entropy_is_locked(const dif_entropy_t *entropy,
                                            bool *is_locked);
+
+/**
+ * Checks to see if entropy is available for software consumption
+ *
+ * @param entropy An entropy source handle.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_entropy_result_t dif_entropy_avail(const dif_entropy_t *entropy);
 
 /**
  * Reads off a word of entropy from the entropy source.
@@ -681,6 +698,24 @@ dif_entropy_result_t dif_entropy_fifo_set_capacity(const dif_entropy_t *entropy,
  */
 DIF_WARN_UNUSED_RESULT
 dif_entropy_result_t dif_entropy_fifo_reconnect(const dif_entropy_t *entropy);
+
+/**
+ * Disables the entropy module
+ *
+ * @param entropy An entropy source handle.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_entropy_result_t dif_entropy_disable(const dif_entropy_t *entropy);
+
+/**
+ * Get main entropy fsm idle status
+ *
+ * @param entropy An entropy source handle.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_entropy_result_t dif_entropy_get_idle(const dif_entropy_t *entropy);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/tests/dif/dif_entropy_smoketest.c
+++ b/sw/device/tests/dif/dif_entropy_smoketest.c
@@ -14,9 +14,13 @@
 const test_config_t kTestConfig;
 
 const size_t kEntropyDataNumWords = 12;
+
+// TODO: These values are specific to verilator right now and will not work
+// for DV or FPGA, see #5941
 const uint32_t kExpectedEntropyData[] = {
-    0x65585497, 0x65585497, 0x65585497, 0x65585497, 0x65585497, 0x65585497,
-    0x65585497, 0x65585497, 0x65585497, 0x65585497, 0x65585497, 0x65585497,
+    0x0a3f4df0, 0x4e36fad2, 0xb5f3e0b9, 0x918f5ec0, 0x54ddd680, 0x62f04975,
+    0x700cf2f2, 0x61044bfe, 0x723d6c89, 0xe2d70e19, 0x5f02a234, 0xbf586fcc,
+
 };
 
 bool test_main() {
@@ -25,6 +29,9 @@ bool test_main() {
   };
   dif_entropy_t entropy;
   CHECK(dif_entropy_init(params, &entropy) == kDifEntropyOk);
+
+  // Disable entropy for test purpose, as it has been turned on by ROM
+  CHECK(dif_entropy_disable(&entropy) == kDifEntropyOk);
 
   const dif_entropy_config_t config = {
       .mode = kDifEntropyModeLfsr,
@@ -37,7 +44,8 @@ bool test_main() {
               [kDifEntropyTestMailbox] = false,
               [kDifEntropyTestVendorSpecific] = false,
           },
-      .reset_health_test_registers = true,
+      // this field needs to manually toggled by software.  Disable for now
+      .reset_health_test_registers = false,
       .single_bit_mode = kDifEntropySingleBitModeDisabled,
       .route_to_firmware = true,
       .sample_rate = 2,
@@ -47,7 +55,11 @@ bool test_main() {
 
   uint32_t entropy_data[kEntropyDataNumWords];
   for (uint32_t i = 0; i < kEntropyDataNumWords; ++i) {
-    CHECK(dif_entropy_read(&entropy, &entropy_data[i]) == kDifEntropyOk);
+    // wait for entropy to become available
+    while (dif_entropy_read(&entropy, &entropy_data[i]) != kDifEntropyOk)
+      ;
+    // LOG_INFO("received %x, expectecd %x", entropy_data[i],
+    // kExpectedEntropyData[i]);
     CHECK(entropy_data[i] == kExpectedEntropyData[i]);
   }
 

--- a/sw/device/tests/dif/dif_entropy_unittest.cc
+++ b/sw/device/tests/dif/dif_entropy_unittest.cc
@@ -143,9 +143,21 @@ TEST_F(ReadTest, WordBadArg) {
   EXPECT_EQ(dif_entropy_read(&entropy_, nullptr), kDifEntropyBadArg);
 }
 
+TEST_F(ReadTest, ReadDataUnAvailable) {
+  EXPECT_READ32(ENTROPY_SRC_INTR_STATE_REG_OFFSET, 0);
+  uint32_t got_word;
+  EXPECT_EQ(dif_entropy_read(&entropy_, &got_word), kDifEntropyDataUnAvailable);
+}
+
 TEST_F(ReadTest, ReadOk) {
   const uint32_t expected_word = 0x65585497;
+  EXPECT_READ32(ENTROPY_SRC_INTR_STATE_REG_OFFSET,
+                1 << ENTROPY_SRC_INTR_STATE_ES_ENTROPY_VALID_BIT);
   EXPECT_READ32(ENTROPY_SRC_ENTROPY_DATA_REG_OFFSET, expected_word);
+  EXPECT_READ32(ENTROPY_SRC_INTR_STATE_REG_OFFSET,
+                1 << ENTROPY_SRC_INTR_STATE_ES_ENTROPY_VALID_BIT);
+  EXPECT_WRITE32(ENTROPY_SRC_INTR_STATE_REG_OFFSET,
+                 {{ENTROPY_SRC_INTR_STATE_ES_ENTROPY_VALID_BIT, true}});
 
   uint32_t got_word;
   EXPECT_EQ(dif_entropy_read(&entropy_, &got_word), kDifEntropyOk);

--- a/test/systemtest/config.py
+++ b/test/systemtest/config.py
@@ -74,6 +74,7 @@ TEST_APPS_SELFCHECKING = [
     },
     {
         "name": "dif_entropy_smoketest",
+        "targets": ["sim_verilator"],
     },
     {
         "name": "flash_ctrl_test",


### PR DESCRIPTION
This PR is a hardware and software update.

@mwbranstad / @msfschaffner can you have a look at the first commit to see if the hardware updates look right to you?
I've allocated a new otp field and connected entropy src to it.

@moidx this should now ensure the seed is loaded and that the reads are different.  The test still fails right now, I need to update it later. What I've done is generally kind of hacky...the config for example needs to toggle the reset health test register (so I just excluded it for now).  let me know if you think this is headed in the right direction. I could either update per your instructions or you can take it over. both are fine with me. 