### PR TITLE
[sw/dif] CSRNG Initial Implementation

### DIFF
--- a/sw/device/lib/dif/dif_csrng.c
+++ b/sw/device/lib/dif/dif_csrng.c
@@ -1,0 +1,78 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_csrng.h"
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/mmio.h"
+
+#include "csrng_regs.h"  // Generated
+
+dif_csrng_result_t dif_csrng_init(dif_csrng_params_t params,
+                                  dif_csrng_t *csrng) {
+  if (csrng == NULL) {
+    return kDifCsrngBadArg;
+  }
+  *csrng = (dif_csrng_t){.params = params};
+  return kDifCsrngOk;
+}
+
+dif_csrng_result_t dif_csrng_configure(const dif_csrng_t *csrng,
+                                       dif_csrng_config_t config) {
+  if (csrng == NULL) {
+    return kDifCsrngBadArg;
+  }
+
+  uint32_t reg = bitfield_bit32_write(0, CSRNG_CTRL_ENABLE_BIT, 1);
+  reg = bitfield_bit32_write(reg, CSRNG_CTRL_AES_CIPHER_DISABLE_BIT,
+                             config.debug_config.bypass_aes_cipher);
+
+  // TODO: Determine if the dif library should support a diagnostics mode
+  // of operation.
+  reg = bitfield_field32_write(reg, CSRNG_CTRL_FIFO_DEPTH_STS_SEL_FIELD, 0);
+
+  mmio_region_write32(csrng->params.base_addr, CSRNG_CTRL_REG_OFFSET, reg);
+  return kDifCsrngOk;
+}
+
+dif_csrng_result_t dif_csrng_get_cmd_interface_status(
+    const dif_csrng_t *csrng, dif_csrng_cmd_status_t *status) {
+  if (csrng == NULL || status == NULL) {
+    return kDifCsrngBadArg;
+  }
+
+  uint32_t reg =
+      mmio_region_read32(csrng->params.base_addr, CSRNG_SW_CMD_STS_REG_OFFSET);
+  bool cmd_ready = bitfield_bit32_read(reg, CSRNG_SW_CMD_STS_CMD_RDY_BIT);
+  bool cmd_error = bitfield_bit32_read(reg, CSRNG_SW_CMD_STS_CMD_STS_BIT);
+
+  // The function prioritizes error detection to avoid masking errors
+  // when `cmd_ready` is set to true.
+  if (cmd_error) {
+    *status = kDifCsrngCmdStatusError;
+    return kDifCsrngOk;
+  }
+
+  if (cmd_ready) {
+    *status = kDifCsrngCmdStatusReady;
+    return kDifCsrngOk;
+  }
+
+  *status = kDifCsrngCmdStatusBusy;
+  return kDifCsrngOk;
+}
+
+dif_csrng_result_t dif_csrng_get_output_status(
+    const dif_csrng_t *csrng, dif_csrng_output_status_t *status) {
+  if (csrng == NULL || status == NULL) {
+    return kDifCsrngBadArg;
+  }
+  uint32_t reg =
+      mmio_region_read32(csrng->params.base_addr, CSRNG_GENBITS_VLD_REG_OFFSET);
+  status->valid_data =
+      bitfield_bit32_read(reg, CSRNG_GENBITS_VLD_GENBITS_VLD_BIT);
+  status->fips_mode =
+      bitfield_bit32_read(reg, CSRNG_GENBITS_VLD_GENBITS_FIPS_BIT);
+  return kDifCsrngOk;
+}

--- a/sw/device/lib/dif/dif_csrng.h
+++ b/sw/device/lib/dif/dif_csrng.h
@@ -421,8 +421,8 @@ dif_csrng_result_t dif_csrng_get_output_status(
  * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
-dif_csrng_result_t dif_csrng_read_output(const dif_csrng *csrng, uint32_t *buf,
-                                         size_t len);
+dif_csrng_result_t dif_csrng_read_output(const dif_csrng_t *csrng,
+                                         uint32_t *buf, size_t len);
 
 /**
  * Locks out CSRNG functionality.

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -16,6 +16,20 @@ sw_lib_dif_clkmgr = declare_dependency(
   )
 )
 
+# CSRNG DIF Library (dif_csrng)
+sw_lib_dif_csrng = declare_dependency(
+  link_with: static_library(
+    'csrng_ot',
+    sources: [
+      hw_ip_csrng_reg_h,
+      'dif_csrng.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
 # UART DIF library (dif_uart)
 sw_lib_dif_uart = declare_dependency(
   link_with: static_library(

--- a/sw/device/tests/dif/dif_csrng_smoketest.c
+++ b/sw/device/tests/dif/dif_csrng_smoketest.c
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/test_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+const test_config_t kTestConfig;
+
+bool test_main() {
+  const dif_csrng_params_t params = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR),
+  };
+  dif_csrng_t csrng;
+  CHECK(dif_csrng_init(params, &csrng) == kDifCsrngOk);
+
+  const dif_csrng_config_t config = {
+      .debug_config = {.bypass_aes_cipher = false},
+  };
+  CHECK(dif_csrng_configure(&csrng, config) == kDifCsrngOk);
+
+  // TODO: Instantiate
+  // TODO: Generate
+  // TODO: Check for output ready
+  // TODO: Compare output
+
+  return true;
+}

--- a/sw/device/tests/dif/dif_csrng_unittest.cc
+++ b/sw/device/tests/dif/dif_csrng_unittest.cc
@@ -1,0 +1,136 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_csrng.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/testing/mock_mmio.h"
+
+#include "csrng_regs.h"  // Generated
+
+namespace dif_entropy_unittest {
+namespace {
+
+class DifCsrngTest : public testing::Test, public mock_mmio::MmioTest {
+ protected:
+  const dif_csrng_params_t params_ = {.base_addr = dev().region()};
+  const dif_csrng_t csrng_ = {
+      .params = {.base_addr = dev().region()},
+  };
+};
+
+class InitTest : public DifCsrngTest {};
+
+TEST_F(InitTest, BadArgs) {
+  EXPECT_EQ(dif_csrng_init(params_, nullptr), kDifCsrngBadArg);
+}
+
+TEST_F(InitTest, InitOk) {
+  dif_csrng_t csrng;
+  EXPECT_EQ(dif_csrng_init(params_, &csrng), kDifCsrngOk);
+}
+
+class ConfigTest : public DifCsrngTest {
+ protected:
+  /**
+   * Sets CTRL write register expectations.
+   */
+  void ExpectCtrlWrite(bool bypass_aes_cipher) {
+    EXPECT_WRITE32(CSRNG_CTRL_REG_OFFSET,
+                   {
+                       {CSRNG_CTRL_ENABLE_BIT, true},
+                       {CSRNG_CTRL_AES_CIPHER_DISABLE_BIT, bypass_aes_cipher},
+                       {CSRNG_CTRL_FIFO_DEPTH_STS_SEL_OFFSET, 0},
+                   });
+  }
+
+  dif_csrng_config_t config_ = {
+      .debug_config = {.bypass_aes_cipher = false},
+  };
+};
+
+TEST_F(ConfigTest, NullArgs) {
+  EXPECT_EQ(dif_csrng_configure(nullptr, {}), kDifCsrngBadArg);
+}
+
+TEST_F(ConfigTest, ConfigOk) {
+  config_.debug_config.bypass_aes_cipher = false;
+  ExpectCtrlWrite(config_.debug_config.bypass_aes_cipher);
+  EXPECT_EQ(dif_csrng_configure(&csrng_, config_), kDifCsrngOk);
+}
+
+TEST_F(ConfigTest, ConfigAesBypassOk) {
+  config_.debug_config.bypass_aes_cipher = true;
+  ExpectCtrlWrite(config_.debug_config.bypass_aes_cipher);
+  EXPECT_EQ(dif_csrng_configure(&csrng_, config_), kDifCsrngOk);
+}
+
+class GetCmdInterfaceStatusTest : public DifCsrngTest {};
+
+TEST_F(GetCmdInterfaceStatusTest, NullArgs) {
+  dif_csrng_cmd_status_t status;
+  EXPECT_EQ(dif_csrng_get_cmd_interface_status(nullptr, &status),
+            kDifCsrngBadArg);
+
+  EXPECT_EQ(dif_csrng_get_cmd_interface_status(&csrng_, nullptr),
+            kDifCsrngBadArg);
+}
+
+struct GetCmdInterfaceStatusParams {
+  bool cmd_ready;
+  bool cmd_status;
+  dif_csrng_cmd_status_t expected_status;
+};
+
+class GetCmdInterfaceStatusTestAllParams
+    : public GetCmdInterfaceStatusTest,
+      public testing::WithParamInterface<GetCmdInterfaceStatusParams> {};
+
+TEST_P(GetCmdInterfaceStatusTestAllParams, ValidConfigurationMode) {
+  const GetCmdInterfaceStatusParams &test_param = GetParam();
+  dif_csrng_cmd_status_t status;
+  EXPECT_READ32(CSRNG_SW_CMD_STS_REG_OFFSET,
+                {
+                    {CSRNG_SW_CMD_STS_CMD_RDY_BIT, test_param.cmd_ready},
+                    {CSRNG_SW_CMD_STS_CMD_STS_BIT, test_param.cmd_status},
+                });
+  EXPECT_EQ(dif_csrng_get_cmd_interface_status(&csrng_, &status), kDifCsrngOk);
+  EXPECT_EQ(status, test_param.expected_status);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GetCmdInterfaceStatusTestAllParams, GetCmdInterfaceStatusTestAllParams,
+    testing::Values(
+        GetCmdInterfaceStatusParams{true, false, kDifCsrngCmdStatusReady},
+        GetCmdInterfaceStatusParams{true, true, kDifCsrngCmdStatusError},
+        GetCmdInterfaceStatusParams{false, true, kDifCsrngCmdStatusError},
+        GetCmdInterfaceStatusParams{false, false, kDifCsrngCmdStatusBusy}));
+
+class GetOutputStatusTest : public DifCsrngTest {};
+
+TEST_F(GetOutputStatusTest, NullArgs) {
+  dif_csrng_output_status_t status;
+  EXPECT_EQ(dif_csrng_get_output_status(nullptr, &status), kDifCsrngBadArg);
+
+  EXPECT_EQ(dif_csrng_get_output_status(&csrng_, nullptr), kDifCsrngBadArg);
+}
+
+TEST_F(GetOutputStatusTest, ValidStatus) {
+  // Each option is initialized to a boolean complement of the other so
+  // that we can test both fields toggling in one pass.
+  dif_csrng_output_status_t status = {.valid_data = false, .fips_mode = true};
+  EXPECT_READ32(CSRNG_GENBITS_VLD_REG_OFFSET,
+                {
+                    {CSRNG_GENBITS_VLD_GENBITS_VLD_BIT, true},
+                    {CSRNG_GENBITS_VLD_GENBITS_FIPS_BIT, false},
+                });
+
+  EXPECT_EQ(dif_csrng_get_output_status(&csrng_, &status), kDifCsrngOk);
+  EXPECT_EQ(status.valid_data, true);
+  EXPECT_EQ(status.fips_mode, false);
+}
+
+}  // namespace
+}  // namespace dif_entropy_unittest

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -242,6 +242,22 @@ test('dif_clkmgr_unittest', executable(
   cpp_args: ['-DMOCK_MMIO'],
 ))
 
+test('dif_csrng_unittest', executable(
+  'dif_csrng_unittest',
+  sources: [
+    hw_ip_csrng_reg_h,
+    meson.source_root() / 'sw/device/lib/dif/dif_csrng.c',
+    'dif_csrng_unittest.cc',
+  ],
+  dependencies: [
+    sw_vendor_gtest,
+    sw_lib_testing_mock_mmio,
+  ],
+  native: true,
+  c_args: ['-DMOCK_MMIO'],
+  cpp_args: ['-DMOCK_MMIO'],
+))
+
 test('dif_entropy_unittest', executable(
   'dif_entropy_unittest',
   sources: [
@@ -458,6 +474,23 @@ dif_clkmgr_smoketest_lib = declare_dependency(
 sw_tests += {
   'dif_clkmgr_smoketest': {
     'library': dif_clkmgr_smoketest_lib,
+  }
+}
+
+dif_csrng_smoketest_lib = declare_dependency(
+  link_with: static_library(
+    'dif_csrng_smoketest_lib',
+    sources: ['dif_csrng_smoketest.c'],
+    dependencies: [
+      sw_lib_dif_csrng,
+      sw_lib_mmio,
+      sw_lib_runtime_log,
+    ],
+  ),
+)
+sw_tests += {
+  'dif_csrng_smoketest': {
+    'library': dif_csrng_smoketest_lib,
   }
 }
 

--- a/test/systemtest/config.py
+++ b/test/systemtest/config.py
@@ -70,6 +70,9 @@ TEST_APPS_SELFCHECKING = [
         "name": "dif_clkmgr_smoketest",
     },
     {
+        "name": "dif_csrng_smoketest",
+    },
+    {
         "name": "dif_entropy_smoketest",
     },
     {


### PR DESCRIPTION
This commits adds the following dif_csrng functions:

*   `dif_csrng_init()`
*   `dif_csrng_configure()`
*   `dif_csrng_get_cmd_interface()`
*   `dif_csrng_get_output_status()`

Added unittest and smoketest boilerplate.

Signed-off-by: Miguel Osorio <miguelosorio@google.com>