### PR TITLE
[keymgr,lint] Fix remaining width mismatches in keymgr code

### DIFF
--- a/hw/ip/keymgr/lint/keymgr.vlt
+++ b/hw/ip/keymgr/lint/keymgr.vlt
@@ -14,3 +14,11 @@
 // address it with a 2-bit index.
 lint_off -rule WIDTH -file "*/rtl/keymgr.sv" -match "Bit extraction of var[3:0]*not 3 bits."
 lint_off -rule WIDTH -file "*/rtl/keymgr_kmac_if.sv" -match "Bit extraction of var[3:0]*not 3 bits."
+
+// Waive some width mismatch warnings in keymgr_ctrl.sv that come from
+// addressing error_o by elements of the keymgr_err_pos_e enum. The enum
+// contains 4 actual error positions plus a "last" entry, meaning that its
+// elements are represented by $clog2(5) = 3 bits. The error_o array just has
+// an entry for each of the 4 error positions, so Verilator expects to address
+// it with a 2-bit index.
+lint_off -rule WIDTH -file "*/rtl/keymgr_ctrl.sv" -match "Bit extraction of var[3:0]*not 3 bits."

--- a/hw/ip/keymgr/rtl/keymgr_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_ctrl.sv
@@ -56,6 +56,9 @@ module keymgr_ctrl import keymgr_pkg::*;(
   localparam int EntropyRounds = KeyWidth / EntropyWidth;
   localparam int CntWidth = $clog2(EntropyRounds);
 
+  localparam int unsigned LastEntropyRoundInt = EntropyRounds - 1;
+  localparam bit [CntWidth-1:0] LastEntropyRound = LastEntropyRoundInt[CntWidth-1:0];
+
   // Enumeration for working state
   typedef enum logic [3:0] {
     StCtrlReset,
@@ -301,7 +304,7 @@ module keymgr_ctrl import keymgr_pkg::*;(
         // This is the default mask
         update_sel = KeyUpdateRandom;
 
-        if (cnt < EntropyRounds-1) begin
+        if (cnt < LastEntropyRound) begin
           cnt_en = 1'b1;
         end
         // when mask population is complete, xor the root_key into the zero share


### PR DESCRIPTION
This fixes or waives some width mismatches reported by Verilator in the keymgr code. The first commit sorts out something that can easily be fixed in the RTL. The second waives the "wrong size enum" problem, which is really hard to deal with in a way that both AscentLint and Verilator accept.