### PR TITLE
[dv/alert_handler] Fix regression error

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -49,7 +49,9 @@ class alert_monitor extends alert_esc_base_monitor;
               begin : wait_ping_handshake
                 // in case there is an alert happened before ping
                 if (alert_p != 0) wait_alert_complete();
-                wait_alert();
+                // TODO: could use "wait_alert()" but right now scb needs to be cycle accurate to
+                // predict esc_cnt.
+                while (cfg.vif.alert_tx_final.alert_p !== 1'b1) @(cfg.vif.monitor_cb);
                 req.alert_handshake_sta = AlertReceived;
                 wait_ack();
                 req.alert_handshake_sta = AlertAckReceived;

--- a/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -233,7 +233,7 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
     // if ping periodic check enabled, will not check cycle count, because cycle count might be
     // connected with ping request, which makes the length unpredictable
     // it is beyond this scb to check ping timer (FPV checks it).
-    if (ral.regwen.get_mirrored_value()) begin
+    if (ral.regwen.get_mirrored_value() && !cfg.under_reset) begin
       `DV_CHECK_EQ(cycle_cnt, esc_cnter_per_signal[esc_sig_i],
                    $sformatf("check signal_%0d", esc_sig_i))
       if (cfg.en_cov) cov.esc_sig_length_cg.sample(esc_sig_i, cycle_cnt);

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
@@ -11,7 +11,7 @@ class alert_handler_entropy_vseq extends alert_handler_smoke_vseq;
 
   // large number of num_trans to make sure covers all alerts and escalation pings
   constraint num_trans_c {
-    num_trans inside {[4_000:50_000]};
+    num_trans inside {[4_000:10_000]};
   }
 
   // increase the possibility to enable more alerts, because alert_handler only sends ping on


### PR DESCRIPTION
Two regression errors related to alert_handler:
1. If reset interrupt esc_cycle cnt, scb prediction might have one cycle
off due to reset is async, and we are only counting cycles at negedge
clock.
2. SCB is cycle accurate to predict esc_cnt, and currently scb only
support sending alert right when it finishes (not wait an extra cycle)
I will eventually try to support that in scb, but right now to pass
nightly regression, we will use this temp fix.

Finally I reduced the runtime for entropy_test. As there are 29 alerts
in top-level, it is hard to hit all corner cases by increase the
runtime. Need to fine tune and constraints.

Signed-off-by: Cindy Chen <chencindy@google.com>