### PR TITLE
[fpv] revert back the FPV compile error workarounds

### DIFF
--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -67,7 +67,7 @@ module aes
   aes_hw2reg_t               hw2reg;
 
   logic      [NumAlerts-1:0] alert;
-  lc_ctrl_pkg::lc_tx_t [0:0] lc_escalate_en; // Need a degenerate array for FPV tool.
+  lc_ctrl_pkg::lc_tx_t       lc_escalate_en;
 
   logic                      edn_req;
   logic                      edn_ack;
@@ -163,7 +163,7 @@ module aes
     .entropy_masking_ack_i  ( entropy_masking_ack  ),
     .entropy_masking_i      ( edn_data             ),
 
-    .lc_escalate_en_i       ( lc_escalate_en[0]    ),
+    .lc_escalate_en_i       ( lc_escalate_en       ),
 
     .alert_recov_o          ( alert[0]             ),
     .alert_fatal_o          ( alert[1]             ),

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -206,11 +206,11 @@ module flash_ctrl
   logic lfsr_seed_en;
 
   // life cycle connections
-  lc_ctrl_pkg::lc_tx_t [0:0] lc_creator_seed_sw_rw_en;
-  lc_ctrl_pkg::lc_tx_t [0:0] lc_owner_seed_sw_rw_en;
-  lc_ctrl_pkg::lc_tx_t [0:0] lc_iso_part_sw_rd_en;
-  lc_ctrl_pkg::lc_tx_t [0:0] lc_iso_part_sw_wr_en;
-  lc_ctrl_pkg::lc_tx_t [0:0] lc_seed_hw_rd_en;
+  lc_ctrl_pkg::lc_tx_t lc_creator_seed_sw_rw_en;
+  lc_ctrl_pkg::lc_tx_t lc_owner_seed_sw_rw_en;
+  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_rd_en;
+  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_wr_en;
+  lc_ctrl_pkg::lc_tx_t lc_seed_hw_rd_en;
 
   // synchronize enables into local domain
   prim_lc_sync #(
@@ -362,10 +362,10 @@ module flash_ctrl
   assign sw_sel        = if_sel == SwSel;
 
   // software privilege to creator seed
-  assign creator_seed_priv = lc_creator_seed_sw_rw_en[0] == lc_ctrl_pkg::On;
+  assign creator_seed_priv = lc_creator_seed_sw_rw_en == lc_ctrl_pkg::On;
 
   // software privilege to owner seed
-  assign owner_seed_priv = lc_owner_seed_sw_rw_en[0] == lc_ctrl_pkg::On;
+  assign owner_seed_priv = lc_owner_seed_sw_rw_en == lc_ctrl_pkg::On;
 
   // hardware interface
   flash_ctrl_lcmgr #(
@@ -379,7 +379,7 @@ module flash_ctrl
 
     .init_i(pwrmgr_i.flash_init),
     .init_done_o(pwrmgr_o.flash_done),
-    .provision_en_i(lc_seed_hw_rd_en[0] == lc_ctrl_pkg::On),
+    .provision_en_i(lc_seed_hw_rd_en == lc_ctrl_pkg::On),
 
     // interface to ctrl arb control ports
     .ctrl_o(hw_ctrl),
@@ -666,8 +666,8 @@ module flash_ctrl
         .cfgs_i(reg2hw_info_page_cfgs[i][j]),
         .creator_seed_priv_i(creator_seed_priv),
         .owner_seed_priv_i(owner_seed_priv),
-        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en[0] == lc_ctrl_pkg::On),
-        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en[0] == lc_ctrl_pkg::On),
+        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en == lc_ctrl_pkg::On),
+        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en == lc_ctrl_pkg::On),
         .cfgs_o(info_page_cfgs[i][j])
       );
     end

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -206,11 +206,11 @@ module flash_ctrl
   logic lfsr_seed_en;
 
   // life cycle connections
-  lc_ctrl_pkg::lc_tx_t [0:0] lc_creator_seed_sw_rw_en;
-  lc_ctrl_pkg::lc_tx_t [0:0] lc_owner_seed_sw_rw_en;
-  lc_ctrl_pkg::lc_tx_t [0:0] lc_iso_part_sw_rd_en;
-  lc_ctrl_pkg::lc_tx_t [0:0] lc_iso_part_sw_wr_en;
-  lc_ctrl_pkg::lc_tx_t [0:0] lc_seed_hw_rd_en;
+  lc_ctrl_pkg::lc_tx_t lc_creator_seed_sw_rw_en;
+  lc_ctrl_pkg::lc_tx_t lc_owner_seed_sw_rw_en;
+  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_rd_en;
+  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_wr_en;
+  lc_ctrl_pkg::lc_tx_t lc_seed_hw_rd_en;
 
   // synchronize enables into local domain
   prim_lc_sync #(
@@ -362,10 +362,10 @@ module flash_ctrl
   assign sw_sel        = if_sel == SwSel;
 
   // software privilege to creator seed
-  assign creator_seed_priv = lc_creator_seed_sw_rw_en[0] == lc_ctrl_pkg::On;
+  assign creator_seed_priv = lc_creator_seed_sw_rw_en == lc_ctrl_pkg::On;
 
   // software privilege to owner seed
-  assign owner_seed_priv = lc_owner_seed_sw_rw_en[0] == lc_ctrl_pkg::On;
+  assign owner_seed_priv = lc_owner_seed_sw_rw_en == lc_ctrl_pkg::On;
 
   // hardware interface
   flash_ctrl_lcmgr #(
@@ -379,7 +379,7 @@ module flash_ctrl
 
     .init_i(pwrmgr_i.flash_init),
     .init_done_o(pwrmgr_o.flash_done),
-    .provision_en_i(lc_seed_hw_rd_en[0] == lc_ctrl_pkg::On),
+    .provision_en_i(lc_seed_hw_rd_en == lc_ctrl_pkg::On),
 
     // interface to ctrl arb control ports
     .ctrl_o(hw_ctrl),
@@ -667,8 +667,8 @@ module flash_ctrl
         .cfgs_i(reg2hw_info_page_cfgs[i][j]),
         .creator_seed_priv_i(creator_seed_priv),
         .owner_seed_priv_i(owner_seed_priv),
-        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en[0] == lc_ctrl_pkg::On),
-        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en[0] == lc_ctrl_pkg::On),
+        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en == lc_ctrl_pkg::On),
+        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en == lc_ctrl_pkg::On),
         .cfgs_o(info_page_cfgs[i][j])
       );
     end

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -116,7 +116,7 @@ module otp_ctrl
   // Life Cycle Signal Synchronization //
   ///////////////////////////////////////
 
-  lc_ctrl_pkg::lc_tx_t [0:0] lc_creator_seed_sw_rw_en, lc_seed_hw_rd_en, lc_check_byp_en;
+  lc_ctrl_pkg::lc_tx_t       lc_creator_seed_sw_rw_en, lc_seed_hw_rd_en, lc_check_byp_en;
   lc_ctrl_pkg::lc_tx_t [1:0] lc_dft_en;
   // NumAgents + lfsr timer and scrambling datapath.
   lc_ctrl_pkg::lc_tx_t [NumAgentsIdx+1:0] lc_escalate_en;
@@ -1047,7 +1047,7 @@ module otp_ctrl
         // This is only supported by the life cycle partition. We need to prevent this partition
         // from escalating once the life cycle state in memory is being updated (and hence not
         // consistent with the values in the buffer regs anymore).
-        .check_byp_en_i    ( lc_check_byp_en[0]              ),
+        .check_byp_en_i    ( lc_check_byp_en                 ),
         .error_o           ( part_error[k]                   ),
         .access_i          ( part_access_csrs[k]             ),
         .access_o          ( part_access_dai[k]              ),

--- a/hw/ip/rstmgr/data/rstmgr.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.sv.tpl
@@ -54,8 +54,7 @@ module rstmgr import rstmgr_pkg::*; (
   for (genvar i = 0; i < PowerDomains; i++) begin : gen_rst_por_aon
     if (i == DomainAonSel) begin : gen_rst_por_aon_normal
 
-      // Workaround due to FPV compile error
-      lc_ctrl_pkg::lc_tx_t [0:0] por_aon_scanmode;
+      lc_ctrl_pkg::lc_tx_t por_aon_scanmode;
       prim_lc_sync #(
         .NumCopies(1),
         .AsyncOn(0)
@@ -70,7 +69,7 @@ module rstmgr import rstmgr_pkg::*; (
         .clk_i(clk_aon_i),
         .rst_ni, // this is the only use of rst_ni in this module
         .scan_rst_ni,
-        .scanmode_i(por_aon_scanmode[0] == lc_ctrl_pkg::On),
+        .scanmode_i(por_aon_scanmode == lc_ctrl_pkg::On),
         .rst_no(rst_por_aon_n[i])
       );
     end else begin : gen_rst_por_aon_tieoff
@@ -135,8 +134,7 @@ module rstmgr import rstmgr_pkg::*; (
   logic [PowerDomains-1:0] rst_lc_src_n;
   logic [PowerDomains-1:0] rst_sys_src_n;
 
-  // Workaround due to FPV compile error
-  lc_ctrl_pkg::lc_tx_t [0:0] rst_ctrl_scanmode;
+  lc_ctrl_pkg::lc_tx_t rst_ctrl_scanmode;
   prim_lc_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -150,7 +148,7 @@ module rstmgr import rstmgr_pkg::*; (
   // lc reset sources
   rstmgr_ctrl u_lc_src (
     .clk_i,
-    .scanmode_i(rst_ctrl_scanmode[0] == lc_ctrl_pkg::On),
+    .scanmode_i(rst_ctrl_scanmode == lc_ctrl_pkg::On),
     .scan_rst_ni,
     .rst_ni(local_rst_n),
     .rst_req_i(pwr_i.rst_lc_req),

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -144,7 +144,7 @@ module sram_ctrl
   // Lifecycle Escalation Synchronization //
   //////////////////////////////////////////
 
-  lc_ctrl_pkg::lc_tx_t [0:0] escalate_en;
+  lc_ctrl_pkg::lc_tx_t escalate_en;
   prim_lc_sync #(
     .NumCopies (1)
   ) u_prim_lc_sync (

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -212,11 +212,11 @@ module flash_ctrl
   logic lfsr_seed_en;
 
   // life cycle connections
-  lc_ctrl_pkg::lc_tx_t [0:0] lc_creator_seed_sw_rw_en;
-  lc_ctrl_pkg::lc_tx_t [0:0] lc_owner_seed_sw_rw_en;
-  lc_ctrl_pkg::lc_tx_t [0:0] lc_iso_part_sw_rd_en;
-  lc_ctrl_pkg::lc_tx_t [0:0] lc_iso_part_sw_wr_en;
-  lc_ctrl_pkg::lc_tx_t [0:0] lc_seed_hw_rd_en;
+  lc_ctrl_pkg::lc_tx_t lc_creator_seed_sw_rw_en;
+  lc_ctrl_pkg::lc_tx_t lc_owner_seed_sw_rw_en;
+  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_rd_en;
+  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_wr_en;
+  lc_ctrl_pkg::lc_tx_t lc_seed_hw_rd_en;
 
   // synchronize enables into local domain
   prim_lc_sync #(
@@ -368,10 +368,10 @@ module flash_ctrl
   assign sw_sel        = if_sel == SwSel;
 
   // software privilege to creator seed
-  assign creator_seed_priv = lc_creator_seed_sw_rw_en[0] == lc_ctrl_pkg::On;
+  assign creator_seed_priv = lc_creator_seed_sw_rw_en == lc_ctrl_pkg::On;
 
   // software privilege to owner seed
-  assign owner_seed_priv = lc_owner_seed_sw_rw_en[0] == lc_ctrl_pkg::On;
+  assign owner_seed_priv = lc_owner_seed_sw_rw_en == lc_ctrl_pkg::On;
 
   // hardware interface
   flash_ctrl_lcmgr #(
@@ -385,7 +385,7 @@ module flash_ctrl
 
     .init_i(pwrmgr_i.flash_init),
     .init_done_o(pwrmgr_o.flash_done),
-    .provision_en_i(lc_seed_hw_rd_en[0] == lc_ctrl_pkg::On),
+    .provision_en_i(lc_seed_hw_rd_en == lc_ctrl_pkg::On),
 
     // interface to ctrl arb control ports
     .ctrl_o(hw_ctrl),
@@ -673,8 +673,8 @@ module flash_ctrl
         .cfgs_i(reg2hw_info_page_cfgs[i][j]),
         .creator_seed_priv_i(creator_seed_priv),
         .owner_seed_priv_i(owner_seed_priv),
-        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en[0] == lc_ctrl_pkg::On),
-        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en[0] == lc_ctrl_pkg::On),
+        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en == lc_ctrl_pkg::On),
+        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en == lc_ctrl_pkg::On),
         .cfgs_o(info_page_cfgs[i][j])
       );
     end

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -61,8 +61,7 @@ module rstmgr import rstmgr_pkg::*; (
   for (genvar i = 0; i < PowerDomains; i++) begin : gen_rst_por_aon
     if (i == DomainAonSel) begin : gen_rst_por_aon_normal
 
-      // Workaround due to FPV compile error
-      lc_ctrl_pkg::lc_tx_t [0:0] por_aon_scanmode;
+      lc_ctrl_pkg::lc_tx_t por_aon_scanmode;
       prim_lc_sync #(
         .NumCopies(1),
         .AsyncOn(0)
@@ -77,7 +76,7 @@ module rstmgr import rstmgr_pkg::*; (
         .clk_i(clk_aon_i),
         .rst_ni, // this is the only use of rst_ni in this module
         .scan_rst_ni,
-        .scanmode_i(por_aon_scanmode[0] == lc_ctrl_pkg::On),
+        .scanmode_i(por_aon_scanmode == lc_ctrl_pkg::On),
         .rst_no(rst_por_aon_n[i])
       );
     end else begin : gen_rst_por_aon_tieoff
@@ -142,8 +141,7 @@ module rstmgr import rstmgr_pkg::*; (
   logic [PowerDomains-1:0] rst_lc_src_n;
   logic [PowerDomains-1:0] rst_sys_src_n;
 
-  // Workaround due to FPV compile error
-  lc_ctrl_pkg::lc_tx_t [0:0] rst_ctrl_scanmode;
+  lc_ctrl_pkg::lc_tx_t rst_ctrl_scanmode;
   prim_lc_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -157,7 +155,7 @@ module rstmgr import rstmgr_pkg::*; (
   // lc reset sources
   rstmgr_ctrl u_lc_src (
     .clk_i,
-    .scanmode_i(rst_ctrl_scanmode[0] == lc_ctrl_pkg::On),
+    .scanmode_i(rst_ctrl_scanmode == lc_ctrl_pkg::On),
     .scan_rst_ni,
     .rst_ni(local_rst_n),
     .rst_req_i(pwr_i.rst_lc_req),


### PR DESCRIPTION
This PR revert back the previous workaround to avoid the compile error.
Now the JasperGold is fixed to support this `prim_lc_sync` syntax.

Signed-off-by: Cindy Chen <chencindy@google.com>