### PR TITLE
Correct a documentation error regarding DIFs

### DIFF
--- a/sw/device/lib/dif/README.md
+++ b/sw/device/lib/dif/README.md
@@ -3,8 +3,15 @@
 A DIF is a "Device Interface Function". DIFs are low-level routines for
 accessing the hardware functionality directly, and are agnostic to the
 particular environment or context they are called from. The intention is that
-DIFs can be used during design verification, and during early silicon
-verification, and by the high-level driver software in production firmware.
+DIFs are high-quality software artifacts which can be used during design
+verification and early silicon verification.
+
+Although DIFs are high-quality software artifacts, they are not a hardware
+abstraction layer (HAL), nor do they follow the device driver model of
+any particular operating system, and as such, DIFs are *not* intended
+to be used by production firmware.  DIFs, in combination with the
+hardware specification, may be illustrative for writing drivers, but should
+not be considered drivers themselves.
 
 This subtree provides headers and libraries known collectively as the DIF
 libraries.


### PR DESCRIPTION
DIFs are a verification resource and are intended to make writing DV and
silicon bringup code easier.

DIFs are not primitives for writing production code such as ROM, ROM_EXT,
bootloaders or kernel drivers.

Signed-off-by: Chris Frantz <cfrantz@google.com>