### PR TITLE
[dv/clkmgr] Add csr autogenerated FPV check

### DIFF
--- a/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
@@ -12,4 +12,11 @@ module clkmgr_bind;
     .h2d  (tl_i),
     .d2h  (tl_o)
   );
+
+  bind clkmgr clkmgr_csr_assert_fpv clkmgr_csr_assert (
+    .clk_i,
+    .rst_ni,
+    .h2d    (tl_i),
+    .d2h    (tl_o)
+  );
 endmodule

--- a/hw/ip/clkmgr/dv/sva/clkmgr_sva.core
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_sva.core
@@ -17,10 +17,19 @@ filesets:
     depend:
       - lowrisc:systems:clkmgr
 
+generate:
+  csr_assert_gen:
+    generator: csr_assert_gen
+    parameters:
+      spec: ../../../../top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+
 targets:
   default: &default_target
     filesets:
       - files_dv
+    generate:
+      - csr_assert_gen
+
   formal:
     <<: *default_target
     filesets:


### PR DESCRIPTION
This PR adds back CSR autogenerated FPV checks to DV simulation.

Signed-off-by: Cindy Chen <chencindy@google.com>