### PR TITLE
[dv/otp] build-in fcov

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -73,6 +73,9 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
         num_interrupts = ral.intr_state.get_n_used_bits();
       end
     end
+
+    // only support 1 outstanding TL items in tlul_adapter
+    m_tl_agent_cfg.max_outstanding_req = 1;
   endfunction
 
 endclass

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -448,6 +448,10 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
             otp_intr_e intr = otp_intr_e'(i);
             `DV_CHECK_CASE_EQ(cfg.intr_vif.pins[i], (intr_en[i] & intr_exp[i]),
                               $sformatf("Interrupt_pin: %0s", intr.name));
+            if (cfg.en_cov) begin
+              cov.intr_cg.sample(i, intr_en[i], item.d_data[i]);
+              cov.intr_pins_cg.sample(i, cfg.intr_vif.pins[i]);
+            end
           end
         end
       end


### PR DESCRIPTION
This PR adds interrupt related build-in fcov. And it updates
max_outstanding_item to 1, according to design : https://github.com/lowRISC/opentitan/blob/master/hw/ip/otp_ctrl/rtl/otp_ctrl.sv#L182.

Signed-off-by: Cindy Chen <chencindy@google.com>