### PR TITLE
[doc] Fix stand-alone documentation build instructions

### DIFF
--- a/doc/ug/documentation.md
+++ b/doc/ug/documentation.md
@@ -14,14 +14,7 @@ All processing steps as well as the invocation to Hugo are combined in the scrip
 
 ### Prerequisites
 
-If you have already followed the [prepare the system]({{< relref "install_instructions#system-preparation" >}}) instructions you will have the required tools to build the documentation.
-
-If not, install the required tools by running the following command from the repository root:
-
-```console
-$ sudo apt install curl python3 python3-pip doxygen xsltproc
-$ pip3 install --user -r python-requirements.txt
-```
+The documentation build requirements are covered in the [install instructions 'System preperation' section]({{< relref "install_instructions#system-preparation" >}}). You don't need to install the compiler or fpga tools for building documentation. 
 
 ### Running the server
 

--- a/doc/ug/documentation.md
+++ b/doc/ug/documentation.md
@@ -14,10 +14,12 @@ All processing steps as well as the invocation to Hugo are combined in the scrip
 
 ### Prerequisites
 
-Install the required tools by running the following command from the repository root.
+If you have already followed the [prepare the system]({{< relref "install_instructions#system-preparation" >}}) instructions you will have the required tools to build the documentation.
+
+If not, install the required tools by running the following command from the repository root:
 
 ```console
-$ sudo apt install curl python3 python3-pip
+$ sudo apt install curl python3 python3-pip doxygen xsltproc
 $ pip3 install --user -r python-requirements.txt
 ```
 


### PR DESCRIPTION
The documentation build instructions in the docs are missing `doxygen` and `xsltproc` as required tools. If the general setup instructions are followed this will be included, so this change also adds a link to the general setup instructions.

Signed-off-by: Colin O'Flynn <coflynn@newae.com>