### PR TITLE
[dv] Support multi-ral (part 1)

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.sv
@@ -342,7 +342,7 @@ class dv_base_reg extends uvm_reg;
     string parent_name = this.get_parent().get_name();
 
     // block level alert name is input alert name from hjson
-    if (parent_name == "ral") return update_err_alert_name;
+    if (get_parent().get_parent() == null) return update_err_alert_name;
 
     // top-level alert name is ${block_name} + alert name from hjson
     return ($sformatf("%0s_%0s", parent_name, update_err_alert_name));
@@ -360,7 +360,7 @@ class dv_base_reg extends uvm_reg;
     string parent_name = this.get_parent().get_name();
 
     // block level alert name is input alert name from hjson
-    if (parent_name == "ral") return storage_err_alert_name;
+    if (get_parent().get_parent() == null) return storage_err_alert_name;
 
     // top-level alert name is ${block_name} + alert name from hjson
     return ($sformatf("%0s_%0s", parent_name, storage_err_alert_name));

--- a/hw/dv/sv/dv_lib/dv_base_scoreboard.sv
+++ b/hw/dv/sv/dv_lib/dv_base_scoreboard.sv
@@ -50,9 +50,7 @@ class dv_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
   virtual function void reset(string kind = "HARD");
     // reset the ral model
-    if (cfg.has_ral) begin
-      foreach (cfg.ral_models[i]) cfg.ral_models[i].reset(kind);
-    end
+    foreach (cfg.ral_models[i]) cfg.ral_models[i].reset(kind);
   endfunction
 
   virtual function void pre_abort();

--- a/hw/dv/sv/tl_agent/dv/env/tl_agent_env_cfg.sv
+++ b/hw/dv/sv/tl_agent/dv/env/tl_agent_env_cfg.sv
@@ -18,7 +18,7 @@ class tl_agent_env_cfg extends dv_base_env_cfg;
   `uvm_object_new
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
-    has_ral = 0; // no csr in tl_agent
+    list_of_rals = {}; // no csr in tl_agent
     host_agent_cfg = tl_agent_cfg::type_id::create("host_agent_cfg");
     host_agent_cfg.max_outstanding_req = 1 << SourceWidth;
     host_agent_cfg.if_mode = dv_utils_pkg::Host;

--- a/hw/ip/tlul/generic_dv/env/xbar_env_cfg.sv
+++ b/hw/ip/tlul/generic_dv/env/xbar_env_cfg.sv
@@ -42,7 +42,7 @@ class xbar_env_cfg extends dv_base_env_cfg;
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
     is_initialized = 1'b1;
-    has_ral = 0; // no csr in xbar
+    list_of_rals = {}; // no csr in xbar
     // Host TL agent cfg
     num_hosts             = xbar_hosts.size();
     num_enabled_hosts     = xbar_hosts.size();


### PR DESCRIPTION
1. create a queue for names of ral models. RAL models will be created
automatically based the names
2. excl_item is generated in reg model and put in reg_block, don't need to supply this from
outside. Clean this up to support multi-ral

CSR seq, multiple TL agents, scb update will come in next PR

Signed-off-by: Weicai Yang <weicai@google.com>