### PR TITLE
[docs/hugo] Move to hugo version 0.82.0

### DIFF
--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -21,7 +21,7 @@ __TOOL_REQUIREMENTS__ = {
     'verilator': '4.104',
 
     'hugo_extended': {
-        'min_version': '0.71.0',
+        'min_version': '0.82.0',
         'as_needed': True
     },
     'verible': {


### PR DESCRIPTION
When adding more pinmux signals and pads, we run into a funny error where HUGO can't read the generated pinmux register documentation anymore since the file is too big. This file size limitation has just recently been removed (3 months ago).

See https://github.com/gohugoio/hugo/pull/8172 for reference.

This commit moves to HUGO 0.82.0 which contains this fix.

Signed-off-by: Michael Schaffner <msf@opentitan.org>