### PR TITLE
[formal] unify export name and small clean up

### DIFF
--- a/hw/formal/formal_conn.sh
+++ b/hw/formal/formal_conn.sh
@@ -26,7 +26,7 @@ set -e
 CORE_PATH=systems:top_earlgrey
 REPO_PATH=$(readlink -f ../..)
 
-export TOP="top_earlgrey"
+export DUT_TOP="top_earlgrey"
 gui="-batch -command exit"  # default Batch mode
 tool="jg"
 export COV=0
@@ -36,7 +36,7 @@ while [ "$1" != "" ]; do
   case "$1" in
     "-top")
       shift
-      TOP=$1
+      DUT_TOP=$1
       ;;
     "-p")
       shift
@@ -72,7 +72,7 @@ echo "-------------------------------------------------------------------------"
 echo "-- Generate file list using FuseSoC"
 echo "-------------------------------------------------------------------------"
 echo ""
-echo "Top: $TOP"
+echo "Top: $DUT_TOP"
 echo ""
 
 rm -Rf build jgproject
@@ -87,7 +87,7 @@ echo "-------------------------------------------------------------------------"
 echo "-- Run JasperGold"
 echo "-------------------------------------------------------------------------"
 
-cd build/*${TOP}*/default-icarus
+cd build/*${DUT_TOP}*/default-icarus
 
 if [ "${tool}" == "jg" ]; then
     jg ${gui} \

--- a/hw/formal/fpv
+++ b/hw/formal/fpv
@@ -27,7 +27,7 @@
 # Note that the module to be tested needs to have an _fpv testbench
 # and a corresponding core file for this to work.
 
-export FPV_TOP=$1
+export DUT_TOP=$1
 shift
 gui=0
 tool="jg"
@@ -71,16 +71,16 @@ echo "-------------------------------------------------------------------------"
 echo "-- Generate file list using FuseSoC"
 echo "-------------------------------------------------------------------------"
 echo ""
-echo "Top: $FPV_TOP"
+echo "Top: $DUT_TOP"
 echo ""
 
 \rm -Rf build jgproject
 # we just run the setup for the default target in order to generate the filelist
 if [ "${CORE_PATH}" == "" ]; then
-  if [[ $FPV_TOP == *"_fpv" ]]; then
-    CORE_PATH="fpv:${FPV_TOP}"
+  if [[ $DUT_TOP == *"_fpv" ]]; then
+    CORE_PATH="fpv:${DUT_TOP}"
   else
-    CORE_PATH="dv:${FPV_TOP}_sva"
+    CORE_PATH="dv:${DUT_TOP}_sva"
   fi
 fi
 echo "core_file path: lowrisc:${CORE_PATH}"

--- a/hw/formal/tools/dvsim/common_conn_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_conn_cfg.hjson
@@ -10,11 +10,17 @@
     {CSV_PATH: "{csv_path}"}
   ]
 
-  // Connectivity test should all be in top_level design
   overrides: [
+    // Connectivity test should all be in top_level design
     {
       name:  design_level
       value: "top"
+    }
+
+    // Connectivity test won't run any assertions, so here we use default RTL target
+    {
+      name:  fusesoc_target
+      value: "default"
     }
   ]
 }

--- a/hw/formal/tools/dvsim/common_formal_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_formal_cfg.hjson
@@ -15,21 +15,22 @@
   // Default directory structure for the output
   dut:              "{name}"
   build_dir:        "{scratch_path}/{build_mode}"
-  build_log:        "{build_dir}/{tool}.log"
+  build_log:        "{build_dir}/{sub_flow}.log"
 
   // we rely on Fusesoc to generate the filelist for formal
   sv_flist_gen_cmd:  fusesoc
 
   // TODO: switch the tool to formal once the corresponding edalize backend is avaiable
 
+  fusesoc_target:    formal
   sv_flist_gen_opts: ["--cores-root {proj_root}",
                       "run",
                       "--flag=fileset_{design_level}",
                       "--tool=icarus",
-                      "--target=default",
+                      "--target={fusesoc_target}",
                       "--build-root={build_dir}",
                       "--setup {fusesoc_core}"]
-  sv_flist_gen_dir:  "{build_dir}/default-icarus"
+  sv_flist_gen_dir:  "{build_dir}/{fusesoc_target}-icarus"
 
   report_cmd:  "python3 {formal_root}/tools/{tool}/parse-formal-report.py"
   report_opts: ["--logpath={build_log}",
@@ -43,8 +44,8 @@
 
   // Vars that need to exported to the env
   exports: [
-    { DUT_TOP: "{dut}" },
-    { COV: "{cov}" },
+    { DUT_TOP:  "{dut}" },
+    { COV:      "{cov}" },
     { sub_flow: "{sub_flow}"}
   ]
 }

--- a/hw/formal/tools/jaspergold/conn.tcl
+++ b/hw/formal/tools/jaspergold/conn.tcl
@@ -29,10 +29,10 @@ blackbox_assistant -config -connectivity_Map $env(CSV_PATH)
 # This is jg work-around when black-boxing with inout ports
 set_port_direction_handling coercion_weak_bbox
 
-elaborate -top $env(TOP)
+elaborate -top $env(DUT_TOP)
 
 # Currently only for top_earlgrey
-if {$env(TOP) == "top_earlgrey"} {
+if {$env(DUT_TOP) == "top_earlgrey"} {
   clock clk_main_i
   clock clk_io_i
   clock clk_usb_i

--- a/hw/formal/tools/jaspergold/parse-formal-report.py
+++ b/hw/formal/tools/jaspergold/parse-formal-report.py
@@ -205,7 +205,6 @@ def main():
                   len(err_msgs.get("unreachable")))
     if n_errors > 0 or n_failures > 0:
         log.info("Found %d errors,  %d failures", n_errors, n_failures)
-        return 1
 
     log.info("Formal logfile parsed succesfully")
     return 0


### PR DESCRIPTION
This PR has two purposes:
1. Unify the export names for fpv.tcl(use DUT_TOP) and conn.tcl(use TOP).
   This can help dvsim common_formal_cfg.hjson file to have one export.
2. Connectivity test uses default target instead of formal target.
Because it does not run any assertions and won't need to bind all extra
interfaces. It can just use design's default target.

Signed-off-by: Cindy Chen <chencindy@google.com>