### PR TITLE
[lc_ctrl/keymgr] Increase diversification value width to 128bit

### DIFF
--- a/hw/ip/keymgr/rtl/keymgr.sv
+++ b/hw/ip/keymgr/rtl/keymgr.sv
@@ -312,7 +312,7 @@ module keymgr
   assign adv_matrix[Creator] = AdvDataWidth'({reg2hw.sw_binding,
                                               RndCnstRevisionSeed,
                                               otp_hw_cfg_i.data.device_id,
-                                              HealthStateWidth'(lc_keymgr_div_i),
+                                              lc_keymgr_div_i,
                                               creator_seed});
 
   logic unused_otp_bits;

--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -32,19 +32,19 @@
     { name:      "RndCnstLcKeymgrDivInvalid",
       desc:      "Compile-time random bits for lc state group diversification value",
       type:      "lc_ctrl_pkg::lc_keymgr_div_t",
-      randcount: "64",
+      randcount: "128",
       randtype:  "data",
     }
     { name:      "RndCnstLcKeymgrDivTestDevRma",
       desc:      "Compile-time random bits for lc state group diversification value",
       type:      "lc_ctrl_pkg::lc_keymgr_div_t",
-      randcount: "64",
+      randcount: "128",
       randtype:  "data",
     }
     { name:      "RndCnstLcKeymgrDivProduction",
       desc:      "Compile-time random bits for lc state group diversification value",
       type:      "lc_ctrl_pkg::lc_keymgr_div_t",
-      randcount: "64",
+      randcount: "128",
       randtype:  "data",
     }
     // Regular parameters

--- a/hw/ip/lc_ctrl/doc/_index.md
+++ b/hw/ip/lc_ctrl/doc/_index.md
@@ -438,7 +438,7 @@ For all signals except ESCALATE_EN, it is recommended to structure the design su
 
 #### Key Manager Interface
 
-The `lc_keymgr_div_o` signal is a 64bit diversification constant that is output to the key manager once the life cycle controller has initialized, and is asserted at the same time as `lc_keymgr_en_o`.
+The `lc_keymgr_div_o` signal is a 128bit diversification constant that is output to the key manager once the life cycle controller has initialized, and is asserted at the same time as `lc_keymgr_en_o`.
 Depending on which group the life cycle state is in, this signal is assigned a different random netlist constant as defined in the table below.
 
 Life Cycle State Group     | Assigned Diversification Constant

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv
@@ -43,7 +43,7 @@ package lc_ctrl_pkg;
   parameter int RmaSeedWidth = 32;
   typedef logic [RmaSeedWidth-1:0] lc_flash_rma_seed_t;
 
-  parameter int LcKeymgrDivWidth = 64;
+  parameter int LcKeymgrDivWidth = 128;
   typedef logic [LcKeymgrDivWidth-1:0] lc_keymgr_div_t;
 
   ////////////////////

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1489,31 +1489,31 @@
           name: RndCnstLcKeymgrDivInvalid
           desc: Compile-time random bits for lc state group diversification value
           type: lc_ctrl_pkg::lc_keymgr_div_t
-          randcount: 64
+          randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivInvalid
-          default: 0x4440722325a93144
-          randwidth: 64
+          default: 0xfdb92558e2d9c5d24440722325a93144
+          randwidth: 128
         }
         {
           name: RndCnstLcKeymgrDivTestDevRma
           desc: Compile-time random bits for lc state group diversification value
           type: lc_ctrl_pkg::lc_keymgr_div_t
-          randcount: 64
+          randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivTestDevRma
-          default: 0xfdb92558e2d9c5d2
-          randwidth: 64
+          default: 0x6faf88f22bccd612d1c09f5c02b2c8d1
+          randwidth: 128
         }
         {
           name: RndCnstLcKeymgrDivProduction
           desc: Compile-time random bits for lc state group diversification value
           type: lc_ctrl_pkg::lc_keymgr_div_t
-          randcount: 64
+          randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivProduction
-          default: 0xd1c09f5c02b2c8d1
-          randwidth: 64
+          default: 0x79ee911ce801484ba8373086f9dd4eee
+          randwidth: 128
         }
       ]
       inter_signal_list:
@@ -1941,7 +1941,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstAlertHandlerLfsrSeed
-          default: 0x2bccd612
+          default: 0x7b93136f
           randwidth: 32
         }
         {
@@ -1951,7 +1951,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstAlertHandlerLfsrPerm
-          default: 0xb265e7161a57cd840e2d9b32b38a840dc1c7f6bb
+          default: 0xaf33379628b29df3261a1e1be933ab38a840eee0
           randwidth: 160
         }
       ]
@@ -3141,7 +3141,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlRetAonSramKey
-          default: 0x9fbb73a9bf8c393c12965c7de10023ec
+          default: 0x738f30d9006289a1d7d9d0ce1dd7d7c
           randwidth: 128
         }
         {
@@ -3151,7 +3151,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlRetAonSramNonce
-          default: 0x1d7d9d0ce1dd7d7c60c06703b494b3ff
+          default: 0xfe8f673fba39bb679d58aa91aeb2691c
           randwidth: 128
         }
         {
@@ -3161,7 +3161,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstSramCtrlRetAonSramLfsrPerm
-          default: 0x8c24f71703eda8a2378916b6bf80c76651ebcea1
+          default: 0x25da5869dc96fe354f1da55e9123cb082c63b331
           randwidth: 160
         }
         {
@@ -3329,7 +3329,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstFlashCtrlAddrKey
-          default: 0x48bae844c87b69111a24d5e4442bcfb7
+          default: 0x369ae283eec5e43d4b16446726a27b8f
           randwidth: 128
         }
         {
@@ -3339,7 +3339,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstFlashCtrlDataKey
-          default: 0xeec5e43d4b16446726a27b8f0b30ad50
+          default: 0x1a07eb42a37dbfb7be9bb6e69a7d3c5f
           randwidth: 128
         }
         {
@@ -3349,7 +3349,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstFlashCtrlLfsrSeed
-          default: 0x369ae283
+          default: 0x96f534d
           randwidth: 32
         }
         {
@@ -3359,7 +3359,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstFlashCtrlLfsrPerm
-          default: 0xb0dd7870ffed25342f40f3d8926051da8b96d426
+          default: 0xc0fb0f38e6bd6744364b005ec493761479f5173a
           randwidth: 160
         }
       ]

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -30,17 +30,17 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for lc state group diversification value
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivInvalid = {
-    64'h4440722325A93144
+    128'hFDB92558E2D9C5D24440722325A93144
   };
 
   // Compile-time random bits for lc state group diversification value
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivTestDevRma = {
-    64'hFDB92558E2D9C5D2
+    128'h6FAF88F22BCCD612D1C09F5C02B2C8D1
   };
 
   // Compile-time random bits for lc state group diversification value
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivProduction = {
-    64'hD1C09F5C02B2C8D1
+    128'h79EE911CE801484BA8373086F9DD4EEE
   };
 
   ////////////////////////////////////////////
@@ -48,12 +48,12 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter alert_pkg::lfsr_seed_t RndCnstAlertHandlerLfsrSeed = {
-    32'h2BCCD612
+    32'h7B93136F
   };
 
   // Compile-time random permutation for LFSR output
   parameter alert_pkg::lfsr_perm_t RndCnstAlertHandlerLfsrPerm = {
-    160'hB265E7161A57CD840E2D9B32B38A840DC1C7F6BB
+    160'hAF33379628B29DF3261A1E1BE933AB38A840EEE0
   };
 
   ////////////////////////////////////////////
@@ -61,17 +61,17 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlRetAonSramKey = {
-    128'h9FBB73A9BF8C393C12965C7DE10023EC
+    128'h738F30D9006289A1D7D9D0CE1DD7D7C
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlRetAonSramNonce = {
-    128'h1D7D9D0CE1DD7D7C60C06703B494B3FF
+    128'hFE8F673FBA39BB679D58AA91AEB2691C
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlRetAonSramLfsrPerm = {
-    160'h8C24F71703EDA8A2378916B6BF80C76651EBCEA1
+    160'h25DA5869DC96FE354F1DA55E9123CB082C63B331
   };
 
   ////////////////////////////////////////////
@@ -79,22 +79,22 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for default address key
   parameter flash_ctrl_pkg::flash_key_t RndCnstFlashCtrlAddrKey = {
-    128'h48BAE844C87B69111A24D5E4442BCFB7
+    128'h369AE283EEC5E43D4B16446726A27B8F
   };
 
   // Compile-time random bits for default data key
   parameter flash_ctrl_pkg::flash_key_t RndCnstFlashCtrlDataKey = {
-    128'hEEC5E43D4B16446726A27B8F0B30AD50
+    128'h1A07EB42A37DBFB7BE9BB6E69A7D3C5F
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter flash_ctrl_pkg::lfsr_seed_t RndCnstFlashCtrlLfsrSeed = {
-    32'h369AE283
+    32'h96F534D
   };
 
   // Compile-time random permutation for LFSR output
   parameter flash_ctrl_pkg::lfsr_perm_t RndCnstFlashCtrlLfsrPerm = {
-    160'hB0DD7870FFED25342F40F3D8926051DA8B96D426
+    160'hC0FB0F38E6BD6744364B005EC493761479F5173A
   };
 
   ////////////////////////////////////////////


### PR DESCRIPTION
This addresses #5914. 
@tjaychen, let me know if this is unnecessary and 64bit are fine.

Signed-off-by: Michael Schaffner <msf@opentitan.org>