### PR TITLE
[dv] Support multi-ral (part 2)

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -10,8 +10,8 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
 
   `uvm_component_param_utils(cip_base_env #(CFG_T, VIRTUAL_SEQUENCER_T, SCOREBOARD_T, COV_T))
 
-  tl_agent                                           m_tl_agent;
-  tl_reg_adapter#(cip_tl_seq_item)                   m_tl_reg_adapter;
+  tl_agent                                           m_tl_agents[string];
+  tl_reg_adapter#(cip_tl_seq_item)                   m_tl_reg_adapters[string];
   alert_esc_agent                                    m_alert_agent[string];
   push_pull_agent#(.DeviceDataWidth(EDN_DATA_WIDTH)) m_edn_pull_agent;
 
@@ -31,11 +31,15 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
     end
 
     // Create & configure the TL agent.
-    m_tl_agent = tl_agent::type_id::create("m_tl_agent", this);
-    m_tl_reg_adapter = tl_reg_adapter#(cip_tl_seq_item)::type_id::create("m_tl_reg_adapter");
-    m_tl_reg_adapter.cfg = cfg.m_tl_agent_cfg;
-    uvm_config_db#(tl_agent_cfg)::set(this, "m_tl_agent*", "cfg", cfg.m_tl_agent_cfg);
-    cfg.m_tl_agent_cfg.en_cov = cfg.en_cov;
+    foreach (cfg.m_tl_agent_cfgs[i]) begin
+      m_tl_agents[i] = tl_agent::type_id::create({"m_tl_agent_", i}, this);
+      m_tl_reg_adapters[i] = tl_reg_adapter#(cip_tl_seq_item)::type_id::create(
+                             {"m_tl_reg_adapter_", i});
+      m_tl_reg_adapters[i].cfg = cfg.m_tl_agent_cfgs[i];
+      uvm_config_db#(tl_agent_cfg)::set(this, $sformatf("m_tl_agent_%s*", i), "cfg",
+                                        cfg.m_tl_agent_cfgs[i]);
+      cfg.m_tl_agent_cfgs[i].en_cov = cfg.en_cov;
+    end
 
     // Create & configure the alert agents.
     foreach(cfg.list_of_alerts[i]) begin
@@ -66,14 +70,16 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
 
     // Pass on the zero_delays setting.
     if (cfg.zero_delays) begin
-      cfg.m_tl_agent_cfg.a_valid_delay_min = 0;
-      cfg.m_tl_agent_cfg.a_valid_delay_max = 0;
-      cfg.m_tl_agent_cfg.d_valid_delay_min = 0;
-      cfg.m_tl_agent_cfg.d_valid_delay_max = 0;
-      cfg.m_tl_agent_cfg.a_ready_delay_min = 0;
-      cfg.m_tl_agent_cfg.a_ready_delay_max = 0;
-      cfg.m_tl_agent_cfg.d_ready_delay_min = 0;
-      cfg.m_tl_agent_cfg.d_ready_delay_max = 0;
+      foreach (cfg.m_tl_agent_cfgs[i]) begin
+        cfg.m_tl_agent_cfgs[i].a_valid_delay_min = 0;
+        cfg.m_tl_agent_cfgs[i].a_valid_delay_max = 0;
+        cfg.m_tl_agent_cfgs[i].d_valid_delay_min = 0;
+        cfg.m_tl_agent_cfgs[i].d_valid_delay_max = 0;
+        cfg.m_tl_agent_cfgs[i].a_ready_delay_min = 0;
+        cfg.m_tl_agent_cfgs[i].a_ready_delay_max = 0;
+        cfg.m_tl_agent_cfgs[i].d_ready_delay_min = 0;
+        cfg.m_tl_agent_cfgs[i].d_ready_delay_max = 0;
+      end
       foreach (cfg.m_alert_agent_cfg[i]) begin
         cfg.m_alert_agent_cfg[i].alert_delay_min = 0;
         cfg.m_alert_agent_cfg[i].alert_delay_max = 0;
@@ -84,16 +90,23 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
 
   virtual function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
-    m_tl_agent.monitor.a_chan_port.connect(scoreboard.tl_a_chan_fifo.analysis_export);
-    m_tl_agent.monitor.d_chan_port.connect(scoreboard.tl_d_chan_fifo.analysis_export);
+    foreach (m_tl_agents[i]) begin
+      m_tl_agents[i].monitor.a_chan_port.connect(scoreboard.tl_a_chan_fifos[i].analysis_export);
+      m_tl_agents[i].monitor.d_chan_port.connect(scoreboard.tl_d_chan_fifos[i].analysis_export);
+    end
     foreach (cfg.list_of_alerts[i]) begin
       string alert_name = cfg.list_of_alerts[i];
       m_alert_agent[alert_name].monitor.alert_esc_port.connect(
           scoreboard.alert_fifos[alert_name].analysis_export);
     end
 
-    if (cfg.is_active) begin
-      virtual_sequencer.tl_sequencer_h = m_tl_agent.sequencer;
+    foreach (cfg.m_tl_agent_cfgs[i]) begin
+      if (cfg.m_tl_agent_cfgs[i].is_active) begin
+        virtual_sequencer.tl_sequencer_hs[i] = m_tl_agents[i].sequencer;
+        if (i == cfg.ral.get_type_name()) begin
+          virtual_sequencer.tl_sequencer_h = m_tl_agents[i].sequencer;
+        end
+      end
     end
     foreach(cfg.list_of_alerts[i]) begin
       if (cfg.m_alert_agent_cfg[cfg.list_of_alerts[i]].is_active) begin
@@ -111,8 +124,10 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
   virtual function void end_of_elaboration_phase(uvm_phase phase);
     super.end_of_elaboration_phase(phase);
     // Set the TL adapter / sequencer to the default_map.
-    if (cfg.m_tl_agent_cfg.is_active) begin
-      cfg.ral.default_map.set_sequencer(m_tl_agent.sequencer, m_tl_reg_adapter);
+    foreach (cfg.m_tl_agent_cfgs[i]) begin
+      if (cfg.m_tl_agent_cfgs[i].is_active) begin
+        cfg.ral.default_map.set_sequencer(m_tl_agents[i].sequencer, m_tl_reg_adapters[i]);
+      end
     end
   endfunction : end_of_elaboration_phase
 

--- a/hw/dv/sv/cip_lib/cip_base_virtual_sequencer.sv
+++ b/hw/dv/sv/cip_lib/cip_base_virtual_sequencer.sv
@@ -7,7 +7,12 @@ class cip_base_virtual_sequencer #(type CFG_T = cip_base_env_cfg,
                                    extends dv_base_virtual_sequencer #(CFG_T, COV_T);
   `uvm_component_param_utils(cip_base_virtual_sequencer #(CFG_T, COV_T))
 
+  // similar to (ral, ral_models) and (m_tl_agent_cfg, m_tl_agent_cfgs)
+  // if the block supports only one RAL, just use tl_sequencer_h
+  // if there are multiple RALs, `tl_sequencer_h` is the default one for RAL with type `RAL_T`
   tl_sequencer        tl_sequencer_h;
+  tl_sequencer        tl_sequencer_hs[string];
+
   alert_esc_sequencer alert_esc_sequencer_h[string];
   push_pull_sequencer#(.DeviceDataWidth(EDN_DATA_WIDTH)) edn_pull_sequencer_h;
 

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -473,7 +473,9 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
                             bit             do_rand_wr_and_reset = 1);
 
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(csr_access_abort_pct)
-    cfg.m_tl_agent_cfg.csr_access_abort_pct_in_adapter = csr_access_abort_pct;
+    foreach (cfg.m_tl_agent_cfgs[i]) begin
+      cfg.m_tl_agent_cfgs[i].csr_access_abort_pct_in_adapter = csr_access_abort_pct;
+    end
     // when allowing TL transaction to be aborted, TL adapter will return status UVM_NOT_OK, skip
     // checking the status.
     if (csr_access_abort_pct > 0) csr_utils_pkg::default_csr_check = UVM_NO_CHECK;
@@ -549,7 +551,9 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
 
     run_csr_vseq(.csr_test_type("hw_reset"), .do_rand_wr_and_reset(0));
     // abort should not occur after this, as the following is normal seq
-    cfg.m_tl_agent_cfg.csr_access_abort_pct_in_adapter = 0;
+    foreach (cfg.m_tl_agent_cfgs[i]) begin
+      cfg.m_tl_agent_cfgs[i].csr_access_abort_pct_in_adapter = 0;
+    end
     csr_utils_pkg::default_csr_check = UVM_CHECK;
   endtask
 

--- a/hw/dv/sv/csr_utils/csr_seq_lib.sv
+++ b/hw/dv/sv/csr_utils/csr_seq_lib.sv
@@ -23,7 +23,7 @@
 class csr_base_seq extends uvm_reg_sequence #(uvm_sequence #(uvm_reg_item));
   `uvm_object_utils(csr_base_seq)
 
-  uvm_reg_block   models[$];
+  uvm_reg_block   models[string];
   uvm_reg         all_csrs[$];
   uvm_reg         test_csrs[$];
 

--- a/hw/dv/sv/tl_agent/dv/env/tl_agent_env_cfg.sv
+++ b/hw/dv/sv/tl_agent/dv/env/tl_agent_env_cfg.sv
@@ -18,7 +18,7 @@ class tl_agent_env_cfg extends dv_base_env_cfg;
   `uvm_object_new
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
-    list_of_rals = {}; // no csr in tl_agent
+    ral_model_names = {}; // no csr in tl_agent
     host_agent_cfg = tl_agent_cfg::type_id::create("host_agent_cfg");
     host_agent_cfg.max_outstanding_req = 1 << SourceWidth;
     host_agent_cfg.if_mode = dv_utils_pkg::Host;

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_scoreboard.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_scoreboard.sv
@@ -31,7 +31,7 @@ class adc_ctrl_scoreboard extends cip_base_scoreboard #(
     join_none
   endtask
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -66,7 +66,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
   endtask
 
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg        csr;
     string         csr_name;
     aes_seq_item   input_clone;

--- a/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -242,7 +242,7 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
     esc_sig_class[esc_sig_i] = 0;
   endfunction
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();

--- a/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
@@ -31,7 +31,7 @@ class aon_timer_scoreboard extends cip_base_scoreboard #(
     join_none
   endtask
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();

--- a/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -31,7 +31,7 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
     join_none
   endtask
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -45,7 +45,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
     end
   endtask
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();

--- a/hw/ip/edn/dv/env/edn_scoreboard.sv
+++ b/hw/ip/edn/dv/env/edn_scoreboard.sv
@@ -38,7 +38,7 @@ class edn_scoreboard extends cip_base_scoreboard #(
     join_none
   endtask
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -42,7 +42,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard #(
     join_none
   endtask
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     // TODO: Add conditioning prediction, still TBD in design
     bit     do_read_check   = 1'b1;

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -57,7 +57,7 @@ class flash_ctrl_scoreboard #(type CFG_T = flash_ctrl_env_cfg)
     end
   endtask
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();

--- a/hw/ip/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/ip/gpio/dv/env/gpio_scoreboard.sv
@@ -56,7 +56,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
 
   // Task : process_tl_access
   // process monitored tl transaction
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit do_read_check       = 1'b1;
     bit write               = item.is_write();

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -27,7 +27,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
     join_none
   endtask
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit     do_read_check           = 1'b1;
     bit     do_cycle_accurate_check = 1'b1;

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -58,7 +58,7 @@ class i2c_scoreboard extends cip_base_scoreboard #(
     end
   endtask : run_phase
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg   csr;
     i2c_item  sb_exp_wr_item;
     i2c_item  sb_exp_rd_item;

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -289,7 +289,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
     return update_result;
   endfunction
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     dv_base_reg dv_reg;
     uvm_reg csr;
     bit     do_read_check   = 1'b1;

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -162,7 +162,7 @@ class kmac_scoreboard extends cip_base_scoreboard #(
     end
   endtask
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     dv_base_reg check_locked_reg;
 

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
@@ -99,7 +99,7 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
                  exp_o.lc_creator_seed_sw_rw_en_o, msg)
   endfunction
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit     do_read_check   = 1'b0;
     bit     write           = item.is_write();

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -41,7 +41,7 @@ class otbn_scoreboard extends cip_base_scoreboard #(
     // reset local fifos queues and variables
   endfunction
 
-  task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     case (channel)
       AddrChannel: process_tl_addr(item);
       DataChannel: process_tl_data(item);

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -373,7 +373,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
     end
   endtask
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg     csr;
     dv_base_reg dv_reg;
     bit         do_read_check = 1;

--- a/hw/ip/pattgen/dv/env/pattgen_scoreboard.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_scoreboard.sv
@@ -45,7 +45,7 @@ class pattgen_scoreboard extends cip_base_scoreboard #(
     end
   endtask : run_phase
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg         csr;
     bit [TL_DW-1:0] reg_value;
     bit             do_read_check = 1'b1;

--- a/hw/ip/pwm/dv/env/pwm_scoreboard.sv
+++ b/hw/ip/pwm/dv/env/pwm_scoreboard.sv
@@ -34,7 +34,7 @@ class pwm_scoreboard extends cip_base_scoreboard #(
     join_none
   endtask
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();

--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -98,12 +98,12 @@ class rv_dm_scoreboard extends dv_base_scoreboard #(
   endtask
 
   // task to process tl access
-  virtual task process_tl_host_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_host_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     `uvm_fatal(`gfn, "this method is not supposed to be called directly!")
   endtask
 
   // task to process tl access
-  virtual task process_tl_device_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_device_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     `uvm_fatal(`gfn, "this method is not supposed to be called directly!")
   endtask
 

--- a/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
@@ -34,7 +34,7 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
     compute_and_check_interrupt();
   endtask
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     string  csr_name;
     bit     do_read_check   = 1'b1;

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -64,7 +64,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
 
   // process_tl_access:this task processes incoming access into the IP over tl interface
   // this is already called in cip_base_scoreboard::process_tl_a/d_chan_fifo tasks
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit     do_read_check   = 1'b0; // TODO: fixme
     bit     write           = item.is_write();

--- a/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
@@ -59,7 +59,7 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
     end
   endtask : process_device_spi_fifo
   
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -590,7 +590,7 @@ class sram_ctrl_scoreboard extends cip_base_scoreboard #(
   endfunction
 
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();

--- a/hw/ip/tlul/generic_dv/env/xbar_env_cfg.sv
+++ b/hw/ip/tlul/generic_dv/env/xbar_env_cfg.sv
@@ -42,7 +42,7 @@ class xbar_env_cfg extends dv_base_env_cfg;
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
     is_initialized = 1'b1;
-    list_of_rals = {}; // no csr in xbar
+    ral_model_names = {}; // no csr in xbar
     // Host TL agent cfg
     num_hosts             = xbar_hosts.size();
     num_enabled_hosts     = xbar_hosts.size();

--- a/hw/ip/uart/dv/env/uart_scoreboard.sv
+++ b/hw/ip/uart/dv/env/uart_scoreboard.sv
@@ -157,7 +157,7 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
     endcase
   endfunction
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();

--- a/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
@@ -47,7 +47,7 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
     end
   endtask
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();

--- a/hw/top_earlgrey/dv/env/chip_scoreboard.sv
+++ b/hw/top_earlgrey/dv/env/chip_scoreboard.sv
@@ -50,7 +50,7 @@ class chip_scoreboard extends cip_base_scoreboard #(
   endtask
 
   // TODO, may add some checking later
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     return;
   endtask
 

--- a/util/uvmdvgen/scoreboard.sv.tpl
+++ b/util/uvmdvgen/scoreboard.sv.tpl
@@ -64,7 +64,7 @@ class ${name}_scoreboard extends dv_base_scoreboard #(
 % endfor
 % if is_cip:
 
-  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();


### PR DESCRIPTION
Add change tl agent, cfg, adapter and related fifos to associative
arrays
keep `m_tl_agent_cfg` and `tl_sequencer_h`, when it only has one RAL, we
can continue to use the same way to control tl cfg and sequencer.
in scb, add a new args for `process_tl_access` to indicate which TL interface drives the item

No need to review the 2nd commit, which only contains `process_tl_access` args update

In next PR, will update vseq and scb tl_err/mem predict.

Signed-off-by: Weicai Yang <weicai@google.com>