### PR TITLE
[dv/otp_ctrl] stress_all_with_rand_reset test

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -7,7 +7,8 @@
                      "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"]
   entries: [
     {
       name: wake_up
@@ -198,7 +199,7 @@
             - Randomly add reset between each sequence
             '''
       milestone: V2
-      tests: []
+      tests: ["otp_ctrl_stress_all"]
     }
   ]
 }

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -664,7 +664,8 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
       "direct_access_wdata_1", "direct_access_address", "direct_access_rdata_0",
       "direct_access_rdata_1", "check_regwen", "check_trigger_regwen", "check_trigger",
       "check_timeout", "intr_enable", "creator_sw_cfg_read_lock",
-      "owner_sw_cfg_read_lock": begin
+      "owner_sw_cfg_read_lock", "integrity_check_period", "consistency_check_period",
+      "alert_test": begin
         // Do nothing
       end
       default: begin

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -334,6 +334,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
 
   virtual task req_sram_key_sub(int index);
     push_pull_host_seq#(.DeviceDataWidth(SRAM_DATA_SIZE)) sram_pull_seq;
+    wait(cfg.under_reset == 0);
     `uvm_create_on(sram_pull_seq, p_sequencer.sram_pull_sequencer_h[index]);
     `DV_CHECK_RANDOMIZE_FATAL(sram_pull_seq)
     `uvm_send(sram_pull_seq)
@@ -361,6 +362,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
 
   virtual task req_otbn_key_sub();
     push_pull_host_seq#(.DeviceDataWidth(OTBN_DATA_SIZE)) otbn_pull_seq;
+    wait(cfg.under_reset == 0);
     `uvm_create_on(otbn_pull_seq, p_sequencer.otbn_pull_sequencer_h);
     `DV_CHECK_RANDOMIZE_FATAL(otbn_pull_seq)
     `uvm_send(otbn_pull_seq)
@@ -384,6 +386,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
 
   virtual task req_flash_addr_key_sub();
     push_pull_host_seq#(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_addr_pull_seq;
+    wait(cfg.under_reset == 0);
     `uvm_create_on(flash_addr_pull_seq, p_sequencer.flash_addr_pull_sequencer_h);
     `DV_CHECK_RANDOMIZE_FATAL(flash_addr_pull_seq)
     `uvm_send(flash_addr_pull_seq)
@@ -407,6 +410,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
 
   virtual task req_flash_data_key_sub();
     push_pull_host_seq#(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_data_pull_seq;
+    wait(cfg.under_reset == 0);
     `uvm_create_on(flash_data_pull_seq, p_sequencer.flash_data_pull_sequencer_h);
     `DV_CHECK_RANDOMIZE_FATAL(flash_data_pull_seq)
     `uvm_send(flash_data_pull_seq)
@@ -434,6 +438,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     bit [TL_DW-1:0]               intr_val;
     push_pull_host_seq#(.HostDataWidth(LC_PROG_DATA_SIZE), .DeviceDataWidth(1))
                         lc_prog_pull_seq;
+    wait(cfg.under_reset == 0);
     `uvm_create_on(lc_prog_pull_seq, p_sequencer.lc_prog_pull_sequencer_h);
 
     // Even though OTP does not check input lc_state or lc_cnt is valid enum,
@@ -443,7 +448,6 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
       `DV_CHECK_STD_RANDOMIZE_FATAL(lc_cnt)
       cfg.m_lc_prog_pull_agent_cfg.add_h_user_data({lc_state, lc_cnt});
     end
-
     `DV_CHECK_RANDOMIZE_FATAL(lc_prog_pull_seq)
     `uvm_send(lc_prog_pull_seq)
 
@@ -468,6 +472,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
 
   virtual task req_lc_token_sub();
     push_pull_host_seq#(.HostDataWidth(lc_ctrl_state_pkg::LcTokenWidth)) lc_token_pull_seq;
+    wait(cfg.under_reset == 0);
     `uvm_create_on(lc_token_pull_seq, p_sequencer.lc_token_pull_sequencer_h);
     `DV_CHECK_RANDOMIZE_FATAL(lc_token_pull_seq)
     `uvm_send(lc_token_pull_seq)

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
@@ -11,7 +11,7 @@ class otp_ctrl_dai_errs_vseq extends otp_ctrl_dai_lock_vseq;
 
   `uvm_object_new
 
-  constraint num_iterations_c {
+  constraint num_trans_c {
     num_trans  inside {[1:5]};
     num_dai_op inside {[100:500]};
   }

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_base_vseq.sv
@@ -13,7 +13,7 @@ class otp_ctrl_parallel_base_vseq extends otp_ctrl_dai_errs_vseq;
 
   `uvm_object_new
 
-  constraint num_iterations_c {
+  constraint num_trans_c {
     num_trans  inside {[1:5]};
     num_dai_op inside {[1:500]};
   }

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -45,7 +45,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
     if (part_idx inside {[Secret0Idx:Secret2Idx]}) dai_addr % 8 == 0;
   }
 
-  constraint num_iterations_c {
+  constraint num_trans_c {
     num_trans  inside {[1:20]};
     num_dai_op inside {[1:50]};
   }

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -31,9 +31,8 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
-                // TODO: enable this test once support
-                //"{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
+                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
   sim_tops: ["otp_ctrl_bind"]
@@ -118,12 +117,6 @@
       name: otp_ctrl_test_access
       uvm_test_seq: otp_ctrl_test_access_vseq
     }
-
-    {
-      name: otp_ctrl_stress_all
-      uvm_test_seq: otp_ctrl_stress_all_vseq
-    }
-
   ]
 
   // List of regressions.


### PR DESCRIPTION
This PR clears up stress_all_with_rand_reset test compile issues.
1. Fix the constraint names that does not match the base constraint name
2. Clean up cfg.hjson and testplan
3. Turn on the access mode for test_access region, so tl_error in
stress_all_with_reset sequence won't hang

Signed-off-by: Cindy Chen <chencindy@google.com>