### PR TITLE
[otp_ctrl,lint] Silence remaining Verilator width warnings in otp_ctrl

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -576,7 +576,7 @@ module otp_ctrl_part_buf
   // shift the addresses appropriately.
   logic [OtpByteAddrWidth-1:0] addr_calc;
   assign addr_calc = OtpByteAddrWidth'({cnt_q, {$clog2(ScrmblBlockWidth/8){1'b0}}}) + addr_base;
-  assign otp_addr_o = addr_calc >> OtpAddrShift;
+  assign otp_addr_o = addr_calc[OtpByteAddrWidth-1:OtpAddrShift];
 
   // Always transfer 64bit blocks.
   assign otp_size_o = OtpSizeWidth'(unsigned'(ScrmblBlockWidth / OtpWidth) - 1);

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -73,9 +73,12 @@ module otp_ctrl_part_buf
 
   import prim_util_pkg::vbits;
 
-  localparam int DigestOffset = int'(Info.offset) + int'(Info.size) - ScrmblBlockWidth/8;
+  localparam int unsigned DigestOffsetInt = (int'(Info.offset) +
+                                             int'(Info.size) - ScrmblBlockWidth/8);
   localparam int NumScrmblBlocks = int'(Info.size) / (ScrmblBlockWidth/8);
   localparam int CntWidth = vbits(NumScrmblBlocks);
+
+  localparam bit [OtpByteAddrWidth-1:0] DigestOffset = DigestOffsetInt[OtpByteAddrWidth-1:0];
 
   localparam int unsigned LastScrmblBlockInt = NumScrmblBlocks - 1;
   localparam int unsigned PenultimateScrmblBlockInt = NumScrmblBlocks - 2;
@@ -85,6 +88,7 @@ module otp_ctrl_part_buf
   // Integration checks for parameters.
   `ASSERT_INIT(OffsetMustBeBlockAligned_A, (Info.offset % (ScrmblBlockWidth/8)) == 0)
   `ASSERT_INIT(SizeMustBeBlockAligned_A, (Info.size % (ScrmblBlockWidth/8)) == 0)
+  `ASSERT_INIT(DigestOffsetMustBeRepresentable_A, DigestOffsetInt == int'(DigestOffset))
   `ASSERT(ScrambledImpliesDigest_A, Info.secret |-> Info.hw_digest)
   `ASSERT(WriteLockImpliesDigest_A, Info.read_lock |-> Info.hw_digest)
   `ASSERT(ReadLockImpliesDigest_A, Info.write_lock |-> Info.hw_digest)

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
@@ -21,9 +21,12 @@ package otp_ctrl_part_pkg;
 
   parameter int NumScrmblKeys = 3;
   parameter int NumDigestSets = 5;
-  parameter int ConstSelWidth = (NumScrmblKeys > NumDigestSets) ?
-                                vbits(NumScrmblKeys) :
-                                vbits(NumDigestSets);
+
+  parameter int ScrmblKeySelWidth = vbits(NumScrmblKeys);
+  parameter int DigestSetSelWidth = vbits(NumDigestSets);
+  parameter int ConstSelWidth = (ScrmblKeySelWidth > DigestSetSelWidth) ?
+                                ScrmblKeySelWidth :
+                                DigestSetSelWidth;
 
   typedef enum logic [ConstSelWidth-1:0] {
     StandardMode,

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv.tpl
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv.tpl
@@ -39,9 +39,12 @@ package otp_ctrl_part_pkg;
 
   parameter int NumScrmblKeys = ${len(otp_mmap.config["scrambling"]["keys"])};
   parameter int NumDigestSets = ${len(otp_mmap.config["scrambling"]["digests"])};
-  parameter int ConstSelWidth = (NumScrmblKeys > NumDigestSets) ?
-                                vbits(NumScrmblKeys) :
-                                vbits(NumDigestSets);
+
+  parameter int ScrmblKeySelWidth = vbits(NumScrmblKeys);
+  parameter int DigestSetSelWidth = vbits(NumDigestSets);
+  parameter int ConstSelWidth = (ScrmblKeySelWidth > DigestSetSelWidth) ?
+                                ScrmblKeySelWidth :
+                                DigestSetSelWidth;
 
   typedef enum logic [ConstSelWidth-1:0] {
     StandardMode,

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -302,8 +302,10 @@ module otp_ctrl_part_unbuf
 
   // Note that OTP works on halfword (16bit) addresses, hence need to
   // shift the addresses appropriately.
-  assign otp_addr_o = (otp_addr_sel == DigestAddr) ? (DigestOffset >> OtpAddrShift) :
-                                                     {tlul_addr_q, 2'b00} >> OtpAddrShift;
+  logic [OtpByteAddrWidth-1:0] addr_calc;
+  assign addr_calc = (otp_addr_sel == DigestAddr) ? DigestOffset : {tlul_addr_q, 2'b00};
+  assign otp_addr_o = addr_calc[OtpByteAddrWidth-1:OtpAddrShift];
+
   // Request 32bit except in case of the digest.
   assign otp_size_o = (otp_addr_sel == DigestAddr) ?
                       OtpSizeWidth'(unsigned'(ScrmblBlockWidth / OtpWidth - 1)) :

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -59,11 +59,14 @@ module otp_ctrl_part_unbuf
 
   localparam logic [OtpByteAddrWidth:0] PartEnd = (OtpByteAddrWidth+1)'(Info.offset) +
                                                   (OtpByteAddrWidth+1)'(Info.size);
-  localparam int DigestOffset = int'(PartEnd) - ScrmblBlockWidth/8;
+  localparam int unsigned DigestOffsetInt = int'(PartEnd) - ScrmblBlockWidth/8;
+
+  localparam bit [OtpByteAddrWidth-1:0] DigestOffset = DigestOffsetInt[OtpByteAddrWidth-1:0];
 
   // Integration checks for parameters.
   `ASSERT_INIT(OffsetMustBeBlockAligned_A, (Info.offset % (ScrmblBlockWidth/8)) == 0)
   `ASSERT_INIT(SizeMustBeBlockAligned_A, (Info.size % (ScrmblBlockWidth/8)) == 0)
+  `ASSERT_INIT(DigestOffsetMustBeRepresentable_A, DigestOffsetInt == int'(DigestOffset))
 
   ///////////////////////
   // OTP Partition FSM //

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
@@ -219,6 +219,9 @@ module otp_ctrl_scrmbl
   } state_e;
 
   localparam int CntWidth = $clog2(NumPresentRounds+1);
+  localparam int unsigned LastPresentRoundInt = NumPresentRounds - 1;
+  localparam bit [CntWidth-1:0] LastPresentRound = LastPresentRoundInt[CntWidth-1:0];
+
   state_e state_d, state_q;
   logic [CntWidth-1:0] cnt_d, cnt_q;
   logic cnt_clr, cnt_en;
@@ -308,7 +311,7 @@ module otp_ctrl_scrmbl
         data_state_en  = 1'b1;
         key_state_en   = 1'b1;
         cnt_en         = 1'b1;
-        if (cnt_q == NumPresentRounds-1) begin
+        if (cnt_q == LastPresentRound) begin
           state_d = IdleSt;
           valid_d = 1'b1;
         end
@@ -321,7 +324,7 @@ module otp_ctrl_scrmbl
         data_state_en  = 1'b1;
         key_state_en   = 1'b1;
         cnt_en         = 1'b1;
-        if (cnt_q == NumPresentRounds-1) begin
+        if (cnt_q == LastPresentRound) begin
           state_d = IdleSt;
           valid_d = 1'b1;
         end
@@ -335,7 +338,7 @@ module otp_ctrl_scrmbl
         data_state_en  = 1'b1;
         key_state_en   = 1'b1;
         cnt_en         = 1'b1;
-        if (cnt_q == NumPresentRounds-1) begin
+        if (cnt_q == LastPresentRound) begin
           state_d = IdleSt;
           valid_d = 1'b1;
           // Apply XOR for Davies-Meyer construction.


### PR DESCRIPTION
There are detailed notes in the relevant commit messages. Another way of dealing with the parameter width mismatch warnings would be to waive them explicitly. I think I probably prefer the approach in this PR (putting the casts into the code), but I'd be happy to go the other way if preferred.