### PR TITLE
[entropy_src, csrng, edn] Fix Verilator lint warnings

### DIFF
--- a/hw/ip/aes/lint/aes.vlt
+++ b/hw/ip/aes/lint/aes.vlt
@@ -14,13 +14,10 @@ lint_off -rule ALWCOMBORDER -file "*/rtl/aes_key_expand.sv" -match "*'regular'"
 lint_off -rule DECLFILENAME -file "*/rtl/aes_sbox_*_masked*.sv" -match "Filename 'aes_sbox_*_masked*' does not match MODULE name: *"
 lint_off -rule DECLFILENAME -file "*/rtl/aes_sbox_dom*.sv" -match "Filename 'aes_sbox_dom*' does not match MODULE name: *"
 
-// The tool erroneously thinks there would be circular logic through the aes_mux_sel_buf_chk units inside aes_cipher_control.sv.
-// If these units are not generated inside a for loop, everything is fine.
-lint_off -rule UNOPTFLAT -file "*/rtl/aes_core.sv" -match "Signal unoptimizable: Feedback to clock or circular logic: '*cipher_out_valid'"
-lint_off -rule UNOPTFLAT -file "*/rtl/aes_control.sv" -match "Signal unoptimizable: Feedback to clock or circular logic: '*sp2v_sig'"
-lint_off -rule UNOPTFLAT -file "*/rtl/aes_cipher_control.sv" -match "Signal unoptimizable: Feedback to clock or circular logic: '*sp2v_sig_chk_raw'"
-
-// The tool erroneously thinks there would be circular logic through the aes_mux_sel_buf_chk units inside aes_control.sv.
-// If unit for cipher_out_done is not generated inside a for loop, everything is fine.
-lint_off -rule UNOPTFLAT -file "*/rtl/aes_control.sv" -match "Signal unoptimizable: Feedback to clock or circular logic: '*cipher_out_done'"
-lint_off -rule UNOPTFLAT -file "*/rtl/aes_control.sv" -match "Signal unoptimizable: Feedback to clock or circular logic: '*sp2v_sig_chk_raw'"
+// In the sp2v_sig* arrays some members may depend on others.
+// There are no circular dependencies but the tool must be told to analyze each member separately for simulation, i.e., to split up the arrays internally.
+// Otherwise the tool needs to evaluate corresponding statements multiple times before the entire signal settles.
+// This slows down simulation and causes the tool to print UNOPTFLAT lint warnings.
+split_var -module "aes_control" -var "*sp2v_sig*"
+split_var -module "aes_cipher_control" -var "*sp2v_sig"
+split_var -module "aes_cipher_control" -var "*sp2v_sig_chk*"

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
@@ -143,7 +143,7 @@ module csrng_ctr_drbg_upd #(
   logic               concat_outblk_shift;
   logic               concat_ctr_done;
   logic               concat_ctr_inc;
-  logic [SeedLen+BlkLen-1:0] concat_outblk_shifted_value; // ri lint_check_waive NOT_READ
+  logic [SeedLen+BlkLen-1:0] concat_outblk_shifted_value;
 
   // flops
   logic [CtrLen-1:0]  v_ctr_q, v_ctr_d;
@@ -492,6 +492,10 @@ module csrng_ctr_drbg_upd #(
          sfifo_bencack_pop ? {concat_outblk_q[SeedLen-1:BlkLen],sfifo_bencack_v} :
          concat_outblk_shift ? concat_outblk_shifted_value[SeedLen-1:0] :
          concat_outblk_q;
+
+  // The following signal is used to avoid possible lint errors.
+  logic [BlkLen-1:0] unused_concat_outblk_shifted_value;
+  assign unused_concat_outblk_shifted_value = concat_outblk_shifted_value[SeedLen+BlkLen-1:SeedLen];
 
   // concatination counter
   assign concat_ctr_d =

--- a/hw/ip/edn/lint/edn.waiver
+++ b/hw/ip/edn/lint/edn.waiver
@@ -3,7 +3,3 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # waiver file for edn
-
-waive -rules INPUT_NOT_READ -location {prim_arbiter_ppc.sv} \
-      -regexp {Input port 'data_i' is not read from, instance*} \
-      -comment "Because the parameter EnDataPort is not set, the data input is not used"

--- a/hw/ip/kmac/kmac.core
+++ b/hw/ip/kmac/kmac.core
@@ -43,7 +43,6 @@ filesets:
       - lowrisc:lint:common
     files:
       - lint/kmac.waiver
-      - lint/sha3.waiver
     file_type: waiver
 
   files_veriblelint_waiver:

--- a/hw/ip/kmac/lint/sha3.vlt
+++ b/hw/ip/kmac/lint/sha3.vlt
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for kmac
+
+`verilator_config
+
+// index_z is of type int but we only use bits 5:0.
+lint_off -rule UNUSED -file "*/rtl/keccak_2share.sv" -match "*index_z*"

--- a/hw/ip/kmac/rtl/sha3pad.sv
+++ b/hw/ip/kmac/rtl/sha3pad.sv
@@ -501,7 +501,6 @@ module sha3pad
   // It means always `1` is followed by the function pad.
   logic [4:0] funcpad;
 
-  logic [MsgWidth-1:0] funcpad_merged [Share];
   logic [MsgWidth-1:0] funcpad_data [Share];
 
   always_comb begin

--- a/hw/ip/kmac/sha3.core
+++ b/hw/ip/kmac/sha3.core
@@ -19,6 +19,27 @@ filesets:
       - rtl/sha3.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/sha3.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/sha3.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
 
 parameters:
   SYNTHESIS:
@@ -29,6 +50,9 @@ parameters:
 targets:
   default: &default_target
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - files_rtl
     toplevel: sha3
 
@@ -37,3 +61,13 @@ targets:
       - files_rtl
     toplevel: sha3
 
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/prim/lint/prim.vlt
+++ b/hw/ip/prim/lint/prim.vlt
@@ -4,6 +4,10 @@
 
 `verilator_config
 
+// prim_arbiter_ppc
+// ppc_out[i] depends on ppc_out[i-1]
+lint_off -rule ALWCOMBORDER -file "*/rtl/prim_arbiter_ppc.sv" -match "*ppc_out*"
+
 // prim_lfsr
 // lfsr_perm_test is just used for an SVA
 lint_off -rule UNUSED -file "*/rtl/prim_lfsr.sv" -match "*lfsr_perm_test*"

--- a/hw/ip/prim/lint/prim.waiver
+++ b/hw/ip/prim/lint/prim.waiver
@@ -16,6 +16,10 @@ waive -rules {LINE_LENGTH} -location {prim_assert.sv} -msg {Line length of} \
 waive -rules INTEGER           -location {prim_packer.sv} -msg {'i' of type int used as a non-constant value} \
       -comment "This assigns int i (signed) to a multibit logic variable (unsigned), which is fine"
 
+# prim_packer_fifo
+waive -rules {ZERO_REP} -location {prim_packer_fifo.sv} -regexp {Replication count is zero in .*DepthW.*} \
+      -comment "If InW equals OutW, DepthW is zero"
+
 # TL-UL fifo
 waive -rules {HIER_BRANCH_NOT_READ} -location {tlul_fifo_sync.sv} -regexp {Connected net '(clk_i|rst_ni)' at prim_fifo_sync.sv:.* is not read from in module 'prim_fifo_sync'} \
       -comment "In passthrough mode, clk and reset are not read form within this module"

--- a/hw/ip/prim/rtl/prim_arbiter_ppc.sv
+++ b/hw/ip/prim/rtl/prim_arbiter_ppc.sv
@@ -113,7 +113,9 @@ module prim_arbiter_ppc #(
       end
     end else begin: gen_nodatapath
       assign data_o = '1;
-      // TODO: waive data_i from NOT_READ error
+      // The following signal is used to avoid possible lint errors.
+      logic [DW-1:0] unused_data [N];
+      assign unused_data = data_i;
     end
 
     always_comb begin

--- a/hw/ip/prim/rtl/prim_packer_fifo.sv
+++ b/hw/ip/prim/rtl/prim_packer_fifo.sv
@@ -113,7 +113,7 @@ module prim_packer_fifo #(
     assign rvalid_o = (depth_q == FullDepth) && !clr_q;
 
   end else begin : gen_unpack_mode
-    logic [MaxW-1:0] rdata_shifted; // ri lint_check_waive NOT_READ
+    logic [MaxW-1:0] rdata_shifted;
     logic            pull_data;
     logic [DepthW:0] ptr_q, ptr_d;
     logic [DepthW:0] lsb_is_one;
@@ -127,7 +127,7 @@ module prim_packer_fifo #(
       end
     end
 
-    assign lsb_is_one = {{DepthW{1'b0}},1'b1}; // ri lint_check_waive ZERO_REP
+    assign lsb_is_one = {{DepthW{1'b0}},1'b1};
     assign max_value = FullDepth;
     assign rdata_shifted = data_q >> ptr_q*OutW;
     assign clear_data = (rready_i && (depth_q == lsb_is_one)) || clr_q;
@@ -152,6 +152,11 @@ module prim_packer_fifo #(
     assign rdata_o =  rdata_shifted[OutW-1:0];
     assign rvalid_o = !(depth_q == '0) && !clr_q;
 
+    // Avoid possible lint errors in case InW > OutW.
+    if (InW > OutW) begin : gen_unused
+      logic [MaxW-MinW-1:0] unused_rdata_shifted;
+      assign unused_rdata_shifted = rdata_shifted[MaxW-1:MinW];
+    end
   end
 
 


### PR DESCRIPTION
This PR contains three commits to fix Verilator lint warnings in the entropy complex. Some of these were already waived in AscentLint using inline lint waivers. However, out common practice is to move waivers into separate, tool-specific waiver files or the using a coding style that is accepted by most lint tools (e.g. `unused_name` signals, see below).

This is related to #5884.