### PR TITLE
[formal] Clean up some formal warnings

### DIFF
--- a/hw/formal/formal_conn.sh
+++ b/hw/formal/formal_conn.sh
@@ -31,6 +31,7 @@ gui="-batch -command exit"  # default Batch mode
 tool="jg"
 export COV=0
 export CSV_PATH
+export COMMON_MSG_TCL_PATH=$(readlink -f tools/jaspergold/jaspergold_common_message_process.tcl)
 
 while [ "$1" != "" ]; do
   case "$1" in

--- a/hw/formal/fpv
+++ b/hw/formal/fpv
@@ -27,6 +27,8 @@
 # Note that the module to be tested needs to have an _fpv testbench
 # and a corresponding core file for this to work.
 
+set -e
+
 export DUT_TOP=$1
 shift
 gui=0
@@ -34,6 +36,7 @@ tool="jg"
 flag="fileset_top"
 export COV=0
 export CHECK=0
+export COMMON_MSG_TCL_PATH=$(readlink -f tools/jaspergold/jaspergold_common_message_process.tcl)
 
 while [ "$1" != "" ]; do
   case "$1" in

--- a/hw/formal/tools/jaspergold/conn.tcl
+++ b/hw/formal/tools/jaspergold/conn.tcl
@@ -5,11 +5,7 @@
 # clear previous settings
 clear -all
 
-# We use parameter instead of localparam in packages to allow redefinition
-# at elaboration time.
-# Disabling the warning
-# "parameter declared inside package XXX shall be treated as localparam".
-set_message -disable VERI-2418
+source $env(COMMON_MSG_TCL_PATH)
 
 if {$env(COV) == 1} {
   check_cov -init -model {branch statement functional} \
@@ -20,7 +16,9 @@ if {$env(COV) == 1} {
 #-------------------------------------------------------------------------
 
 # only one scr file exists in this folder
-analyze -sv09 -f [glob *.scr]
+analyze -sv09                 \
+  +define+FPV_ON              \
+  -f [glob *.scr]
 
 # Black-box assistant will blackbox the modules which are not needed by looking at
 # the connectivity csv.
@@ -63,7 +61,7 @@ report -task Connectivity
 # check coverage and report
 #-------------------------------------------------------------------------
 if {$env(COV) == 1} {
-  check_cov -measure
+  check_cov -measure -time_limit 2h
   check_cov -report -type all -no_return -report_file cover.html \
       -html -force -exclude { reset waived }
 }

--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -5,11 +5,7 @@
 # clear previous settings
 clear -all
 
-# We use parameter instead of localparam in packages to allow redefinition
-# at elaboration time.
-# Disabling the warning
-# "parameter declared inside package XXX shall be treated as localparam".
-set_message -disable VERI-2418
+source $env(COMMON_MSG_TCL_PATH)
 
 if {$env(COV) == 1} {
   check_cov -init -model {branch statement functional} \

--- a/hw/formal/tools/jaspergold/jaspergold.hjson
+++ b/hw/formal/tools/jaspergold/jaspergold.hjson
@@ -8,6 +8,7 @@
                "-allow_unsupported_OS",
                "-command exit"]
 
-  // Jaspergold error patterns.
-  build_fail_patterns: ["^ERROR (.*): .*$"]
+  exports: [
+    {COMMON_MSG_TCL_PATH: "{formal_root}/tools/{tool}/jaspergold_common_message_process.tcl"}
+  ]
 }

--- a/hw/formal/tools/jaspergold/jaspergold_common_message_process.tcl
+++ b/hw/formal/tools/jaspergold/jaspergold_common_message_process.tcl
@@ -1,0 +1,28 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# This file sets common message configurations for all JasperGold tcl files.
+
+# Save debug effort to escalate the following error messages
+# Error out on use of undeclared signals
+set_message -error VERI-9030
+
+# Error out when a parameter is defined twice for an instance
+set_message -error VERI-1402
+
+# Disabling warnings:
+# We use parameter instead of localparam in packages to allow redefinition
+# at elaboration time.
+# Formal isunknown does not support non-constant.
+# Formal will skip initial construct.
+
+# "parameter declared inside package XXX shall be treated as localparam"
+set_message -disable VERI-2418
+
+# "system function call isunknown with non-constant argument is not synthesizable"
+set_message -disable VERI-1796
+
+# "initial construct ignored"
+set_message -disable VERI-1060
+

--- a/hw/ip/prim/rtl/prim_assert_standard_macros.svh
+++ b/hw/ip/prim/rtl/prim_assert_standard_macros.svh
@@ -11,13 +11,22 @@
       `ASSERT_ERROR(__name)      \
     end
 
-`define ASSERT_INIT(__name, __prop) \
-  initial begin                     \
-    __name: assert (__prop)         \
-      else begin                    \
-        `ASSERT_ERROR(__name)       \
-      end                           \
-  end
+// Formal tools will ignore the initial construct, so use static assertion as a workaround.
+// This workaround terminates design elaboration if the __prop predict is false.
+// It calls $fatal() with the first argument equal to 2, it outputs the statistics about the memory
+// and CPU time.
+`define ASSERT_INIT(__name, __prop)                                          \
+`ifdef FPV_ON                                                                \
+  if (!(__prop)) $fatal(2, "Fatal static assertion [%s]: (%s) is not true.", \
+                        (__name), (__prop));                                 \
+`else                                                                        \
+  initial begin                                                              \
+    __name: assert (__prop)                                                  \
+      else begin                                                             \
+        `ASSERT_ERROR(__name)                                                \
+      end                                                                    \
+  end                                                                        \
+`endif
 
 `define ASSERT_FINAL(__name, __prop)                                         \
   final begin                                                                \


### PR DESCRIPTION
This PR cleans up some formal warnings:
1. Formal will ignore the initial struct. For macros using initial (such
as `ASSERT_INIT), I added a workaround.
2. Disable formal warning for isunknown for non-constant argument. This
assertion is mainly used for simulation. In formal, it will randomly
pick a 1 or 0 if it unknown. So this warning will be ignored.
3. Add a two warnings to escalate into errors and stop the simulation.

Signed-off-by: Cindy Chen <chencindy@google.com>