### PR TITLE
[dv] Remove toggle coverage excl for a_user/d_user

### DIFF
--- a/hw/dv/tools/vcs/common_cov_excl.el
+++ b/hw/dv/tools/vcs/common_cov_excl.el
@@ -4,12 +4,8 @@
 
 // Exclude below TL toggle coverage as these pins won't be changed in the comportable IPs
 INSTANCE: tb.dut
-Toggle tl_i.a_user.parity "logic tl_i.a_user.parity[7:0]"
-Toggle tl_i.a_user.parity_en "logic tl_i.a_user.parity_en"
-Toggle tl_i.a_user.rsvd1 "logic tl_i.a_user.rsvd1[6:0]"
 Toggle tl_o.d_opcode [1] "logic tl_o.d_opcode[2:0]"
 Toggle tl_o.d_opcode [2] "logic tl_o.d_opcode[2:0]"
 Toggle tl_o.d_param "logic tl_o.d_param[2:0]"
 Toggle tl_o.d_sink "logic tl_o.d_sink[0:0]"
-Toggle tl_o.d_user "logic tl_o.d_user[15:0]"
 Toggle tl_i.a_param "logic tl_i.a_param[2:0]"


### PR DESCRIPTION
these 2 fields should be fully verified

@snpsverif please pull this update to run UNR

Signed-off-by: Weicai Yang <weicai@google.com>