### PR TITLE
[tlul] Stub off unused req_type_o signal for tlul_adapter_sram

### DIFF
--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -295,6 +295,7 @@ module hmac
     .tl_o        (tl_win_d2h[0]),
     .en_ifetch_i (tlul_pkg::InstrDis),
     .req_o       (msg_fifo_req   ),
+    .req_type_o  (),
     .gnt_i       (msg_fifo_gnt   ),
     .we_o        (msg_fifo_we    ),
     .addr_o      (msg_fifo_addr  ), // Doesn't care the address other than sub-word

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -656,6 +656,7 @@ module kmac
     .tl_o        (tl_win_d2h[WinMsgFifo]),
 
     .req_o       (tlram_req),
+    .req_type_o  (),
     .gnt_i       (tlram_gnt),
     .we_o        (tlram_we ),
     .addr_o      (tlram_addr),

--- a/hw/ip/kmac/rtl/kmac_staterd.sv
+++ b/hw/ip/kmac/rtl/kmac_staterd.sv
@@ -66,6 +66,7 @@ module kmac_staterd
     .tl_o,
     .en_ifetch_i (tlul_pkg::InstrDis),
     .req_o       (tlram_req),
+    .req_type_o  (),
     .gnt_i       (tlram_gnt),
     .we_o        (tlram_we ),
     .addr_o      (tlram_addr),

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -189,6 +189,7 @@ module otp_ctrl
     .tl_i        ( tl_win_h2d[0]      ),
     .tl_o        ( tl_win_d2h[0]      ),
     .req_o       (  tlul_req          ),
+    .req_type_o  (                    ),
     .gnt_i       (  tlul_gnt          ),
     .we_o        (                    ), // unused
     .addr_o      (  tlul_addr         ),

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -80,6 +80,7 @@ module rom_ctrl
     .tl_o         (tl_rom_d2h[0]),
     .en_ifetch_i  (tlul_pkg::InstrEn),
     .req_o        (rom_req),
+    .req_type_o   (),
     .gnt_i        (1'b1),
     .we_o         (),
     .addr_o       (rom_index),

--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -344,6 +344,7 @@ module rv_dm #(
     .rst_ni,
     .en_ifetch_i (en_ifetch),
     .req_o       (req),
+    .req_type_o  (),
     .gnt_i       (1'b1),
     .we_o        (we),
     .addr_o      (addr_w),

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -776,6 +776,7 @@ module spi_device (
     .tl_o        (tl_sram_d2h [0]),
     .en_ifetch_i (tlul_pkg::InstrDis),
     .req_o       (mem_a_req),
+    .req_type_o  (),
     .gnt_i       (mem_a_req),  //Always grant when request
     .we_o        (mem_a_write),
     .addr_o      (mem_a_addr),

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -675,6 +675,7 @@ module usbdev import usbdev_pkg::*; (
     .tl_o        (tl_sram_d2h [0]),
     .en_ifetch_i (tlul_pkg::InstrDis),
     .req_o       (mem_a_req),
+    .req_type_o  (),
     .gnt_i       (mem_a_req),  //Always grant when request
     .we_o        (mem_a_write),
     .addr_o      (mem_a_addr),


### PR DESCRIPTION
This output port was added by 4798f27 but the commit didn't stub it
off for all uses in the tree.

I did the OTBN part in a hurry to un-break CI. This PR deals with all the other uses in the tree.