### PR TITLE
[hmac,lint] Fix various width mismatch warnings from Verilator

### DIFF
--- a/hw/ip/hmac/rtl/hmac_core.sv
+++ b/hw/ip/hmac/rtl/hmac_core.sv
@@ -45,6 +45,9 @@ module hmac_core import hmac_pkg::*; (
   localparam int unsigned BlockSizeBits = $clog2(BlockSize);
   localparam int unsigned HashWordBits = $clog2($bits(sha_word_t));
 
+  localparam bit [63:0]            BlockSize64 = 64'(BlockSize);
+  localparam bit [BlockSizeBits:0] BlockSizeBSB = BlockSize[BlockSizeBits:0];
+
   logic hash_start; // generated from internal state machine
   logic hash_process; // generated from internal state machine to trigger hash
   logic hmac_hash_done;
@@ -118,12 +121,12 @@ module hmac_core import hmac_pkg::*; (
     (sel_rdata == SelFifo) ? fifo_rdata                                               :
     '{default: '0};
 
-  assign sha_message_length = (!hmac_en)                 ? message_length             :
-                              (sel_msglen == SelIPadMsg) ? message_length + BlockSize :
-                              (sel_msglen == SelOPadMsg) ? BlockSize + 256            :
+  assign sha_message_length = (!hmac_en)                 ? message_length               :
+                              (sel_msglen == SelIPadMsg) ? message_length + BlockSize64 :
+                              (sel_msglen == SelOPadMsg) ? BlockSize64 + 64'd256        :
                               '0 ;
 
-  assign txcnt_eq_blksz = (txcount[BlockSizeBits:0] == BlockSize);
+  assign txcnt_eq_blksz = (txcount[BlockSizeBits:0] == BlockSizeBSB);
 
   assign inc_txcount = sha_rready && sha_rvalid;
 

--- a/hw/ip/hmac/rtl/sha2.sv
+++ b/hw/ip/hmac/rtl/sha2.sv
@@ -38,6 +38,8 @@ module sha2 import hmac_pkg::*; (
   logic      [3:0]  w_index;
   sha_word_t [15:0] w;
 
+  localparam sha_word_t ZeroWord = '0;
+
   // w, hash, digest update logic control signals
   logic update_w_from_fifo, calculate_next_w;
   logic init_hash, run_hash, complete_one_chunk;
@@ -79,7 +81,7 @@ module sha2 import hmac_pkg::*; (
     //  end
     end else if (run_hash) begin
       // Just shift-out. There's no incoming data
-      w <= {sha_word_t'(0), w[15:1]};
+      w <= {ZeroWord, w[15:1]};
     end
   end : fill_w
 

--- a/hw/ip/hmac/rtl/sha2.sv
+++ b/hw/ip/hmac/rtl/sha2.sv
@@ -27,13 +27,15 @@ module sha2 import hmac_pkg::*; (
   output sha_word_t [7:0] digest
 );
 
+  localparam int unsigned RoundWidth = $clog2(NumRound);
+
   logic msg_feed_complete;
 
   logic      shaf_rready;
   sha_word_t shaf_rdata;
   logic      shaf_rvalid;
 
-  logic [$clog2(NumRound)-1:0] round;
+  logic [RoundWidth-1:0] round;
 
   logic      [3:0]  w_index;
   sha_word_t [15:0] w;
@@ -128,7 +130,7 @@ module sha2 import hmac_pkg::*; (
     end else if (!sha_en) begin
       round <= '0;
     end else if (run_hash) begin
-      if (round == (NumRound-1)) begin
+      if (round == RoundWidth'(NumRound-1)) begin
         round <= '0;
       end else begin
         round <= round + 1;


### PR DESCRIPTION
An alternative approach each time would be to add a waiver, but I think these changes are small enough that it's probably clearer just to amend the code.