### PR TITLE
[keymgr,lint] Correct width for keymgr_stage_e enum

### DIFF
--- a/hw/ip/keymgr/rtl/keymgr_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_pkg.sv
@@ -82,7 +82,7 @@ package keymgr_pkg;
   parameter int KDFMaxWidth = 1600;
 
   // Enumeration for operations
-  typedef enum logic [2:0] {
+  typedef enum logic [1:0] {
     Creator   = 0,
     OwnerInt  = 1,
     Owner     = 2,


### PR DESCRIPTION
The code in `keymgr.sv` sizes arrays (like `adv_matrix`, `adv_dvalid`,
`id_matrix`) to have `2**StageWidth` entries. Here, `StageWidth` is
`$clog2(KeyMgrStages)` and is the number of bits needed to index into
the 3 possible stages (corresponding to the three valid enum values of
`keymgr_stage_e`).

In fact, we index into these arrays with the `stage_sel_o` output of
`keymgr_ctrl`, which can also have value 3 (= `Disable`).

Anyway, Verilator was complaining because we used a 3-bit enum
constant to index into an array of 4 entries. Fixing the enum width to
2 bits silences the warnings.

It's not in this PR, but as a follow-up I wonder whether these arrays should actually be sized like this:
```systemverilog
  logic [Disable:0][AdvDataWidth-1:0] adv_matrix;
  logic [Disable:0] adv_dvalid;
  logic [Disable:0][IdDataWidth-1:0] id_matrix;
```
which wouldn't rely on the coincidence that 3+1 is a power of 2.

@tjaychen: I spent quite some time squinting at this code to understand how it worked. If I've completely misunderstood something, sorry!