### PR TITLE
[csrng/rtl] prevent x's from entering prim_arbiter_ppc_acmd

### DIFF
--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -139,7 +139,8 @@ module csrng_cmd_stage import csrng_pkg::*; #(
   assign cmd_arb_bus_o =
          cmd_gen_inc_req ? {16'b0,cmd_stage_shid_i,cmd_gen_cmd_q} :
          cmd_gen_1st_req ? {16'b0,cmd_stage_shid_i,sfifo_cmd_rdata[11:0]} :  // pad,id,f,clen,cmd
-         sfifo_cmd_rdata;
+         cmd_arb_mop_o   ? sfifo_cmd_rdata :
+         '0;
 
   assign cmd_stage_rdy_o = !sfifo_cmd_full;
 


### PR DESCRIPTION
Changing the data bus mux that feeds the app cmd arbiter to send zeros instead of x's when the mop signal is active.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>