### PR TITLE
[top / usb] Hook up differential rx enable to phy module

### DIFF
--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -23,6 +23,7 @@
     { name: "dn_pullup", desc: "USB D- pullup control" }
     { name: "tx_mode_se", desc: "USB single-ended transmit mode control" }
     { name: "suspend", desc: "USB link suspend state" }
+    { name: "rx_enable", desc: "USB phy differential receive enable" }
   ],
   inter_signal_list: [
     { name:    "usb_ref_val",

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -44,6 +44,8 @@ module usbdev import usbdev_pkg::*; (
   output logic       cio_suspend_en_o,
   output logic       cio_tx_mode_se_o,
   output logic       cio_tx_mode_se_en_o,
+  output logic       cio_rx_enable_o,
+  output logic       cio_rx_enable_en_o,
 
   // Direct pinmux aon detect connections
   output logic       usb_out_of_rst_o,
@@ -1004,6 +1006,9 @@ module usbdev import usbdev_pkg::*; (
     .usb_suspend_i          (usb_event_link_suspend)
   );
 
+  // enable rx only when in differential mode and not suspended.
+  assign cio_rx_enable_o = reg2hw.phy_config.rx_differential_mode.q & ~usb_suspend_o;
+
   ////////////////////////
   // USB Output Enables //
   ////////////////////////
@@ -1017,6 +1022,7 @@ module usbdev import usbdev_pkg::*; (
   assign cio_se0_en_o        = 1'b1;
   assign cio_suspend_en_o    = 1'b1;
   assign cio_tx_mode_se_en_o = 1'b1;
+  assign cio_rx_enable_en_o  = 1'b1;
 
   // Pullup
   assign cio_dp_pullup_o     = 1'b1;

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -8288,7 +8288,79 @@
       }
       {
         instance: usbdev
-        port: ""
+        port: d
+        connection: manual
+        pad: ""
+        desc: ""
+        attr: BidirTol
+      }
+      {
+        instance: usbdev
+        port: dp
+        connection: manual
+        pad: ""
+        desc: ""
+        attr: BidirTol
+      }
+      {
+        instance: usbdev
+        port: dn
+        connection: manual
+        pad: ""
+        desc: ""
+        attr: BidirTol
+      }
+      {
+        instance: usbdev
+        port: sense
+        connection: manual
+        pad: ""
+        desc: ""
+        attr: BidirTol
+      }
+      {
+        instance: usbdev
+        port: se0
+        connection: manual
+        pad: ""
+        desc: ""
+        attr: BidirTol
+      }
+      {
+        instance: usbdev
+        port: dp_pullup
+        connection: manual
+        pad: ""
+        desc: ""
+        attr: BidirTol
+      }
+      {
+        instance: usbdev
+        port: dn_pullup
+        connection: manual
+        pad: ""
+        desc: ""
+        attr: BidirTol
+      }
+      {
+        instance: usbdev
+        port: tx_mode_se
+        connection: manual
+        pad: ""
+        desc: ""
+        attr: BidirTol
+      }
+      {
+        instance: usbdev
+        port: suspend
+        connection: manual
+        pad: ""
+        desc: ""
+        attr: BidirTol
+      }
+      {
+        instance: usbdev
+        port: rx_enable
         connection: manual
         pad: ""
         desc: ""
@@ -9252,6 +9324,16 @@
         glob_idx: 20
       }
       {
+        name: usbdev_rx_enable
+        width: 1
+        type: output
+        idx: -1
+        pad: ""
+        attr: BidirTol
+        connection: manual
+        glob_idx: 21
+      }
+      {
         name: uart0_tx
         width: 1
         type: output
@@ -9479,7 +9561,7 @@
         pad: IOR8
         attr: BidirOd
         connection: direct
-        glob_idx: 21
+        glob_idx: 22
       }
       {
         name: sysrst_ctrl_aon_key0_out
@@ -9519,7 +9601,7 @@
         pad: IOR9
         attr: BidirOd
         connection: direct
-        glob_idx: 22
+        glob_idx: 23
       }
     ]
     io_counts:
@@ -9528,7 +9610,7 @@
       {
         inouts: 11
         inputs: 3
-        outputs: 9
+        outputs: 10
         pads: 22
       }
       muxed:

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -1163,7 +1163,17 @@
       { instance: 'spi_device',      port: 'sd[2]',        connection: 'direct', pad: 'SPI_DEV_D2'   , desc: ''},
       { instance: 'spi_device',      port: 'sd[3]',        connection: 'direct', pad: 'SPI_DEV_D3'   , desc: ''},
       // USBDEV
-      { instance: 'usbdev',          port: '',             connection: 'manual', pad: ''             , desc: '', attr: 'BidirTol'},
+      // TODO: #6043
+      { instance: 'usbdev',          port: 'd',            connection: 'manual', pad: ''             , desc: '', attr: 'BidirTol'},
+      { instance: 'usbdev',          port: 'dp',           connection: 'manual', pad: ''             , desc: '', attr: 'BidirTol'},
+      { instance: 'usbdev',          port: 'dn',           connection: 'manual', pad: ''             , desc: '', attr: 'BidirTol'},
+      { instance: 'usbdev',          port: 'sense',        connection: 'manual', pad: ''             , desc: '', attr: 'BidirTol'},
+      { instance: 'usbdev',          port: 'se0',          connection: 'manual', pad: ''             , desc: '', attr: 'BidirTol'},
+      { instance: 'usbdev',          port: 'dp_pullup',    connection: 'manual', pad: ''             , desc: '', attr: 'BidirTol'},
+      { instance: 'usbdev',          port: 'dn_pullup',    connection: 'manual', pad: ''             , desc: '', attr: 'BidirTol'},
+      { instance: 'usbdev',          port: 'tx_mode_se',   connection: 'manual', pad: ''             , desc: '', attr: 'BidirTol'},
+      { instance: 'usbdev',          port: 'suspend',      connection: 'manual', pad: ''             , desc: '', attr: 'BidirTol'},
+      { instance: 'usbdev',          port: 'rx_enable',    connection: 'manual', pad: ''             , desc: '', attr: 'BidirTol'},
       // MIOs
       { instance: "gpio",            port: '',             connection: 'muxed' , pad: ''             , desc: ''},
       { instance: "uart0",           port: '',             connection: 'muxed' , pad: ''             , desc: ''},

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -172,7 +172,7 @@
     { name: "NDioPads",
       desc: "Number of dedicated IO pads",
       type: "int",
-      default: "23",
+      default: "24",
       local: "true"
     },
     { name: "NWkupDetect",

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
@@ -11,7 +11,7 @@ package pinmux_reg_pkg;
   parameter int NMioPeriphIn = 55;
   parameter int NMioPeriphOut = 67;
   parameter int NMioPads = 47;
-  parameter int NDioPads = 23;
+  parameter int NDioPads = 24;
   parameter int NWkupDetect = 8;
   parameter int WkupCntWidth = 8;
 
@@ -117,16 +117,16 @@ package pinmux_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    pinmux_reg2hw_mio_periph_insel_mreg_t [54:0] mio_periph_insel; // [2094:1765]
-    pinmux_reg2hw_mio_outsel_mreg_t [46:0] mio_outsel; // [1764:1436]
-    pinmux_reg2hw_mio_pad_attr_mreg_t [46:0] mio_pad_attr; // [1435:778]
-    pinmux_reg2hw_dio_pad_attr_mreg_t [22:0] dio_pad_attr; // [777:456]
-    pinmux_reg2hw_mio_pad_sleep_status_mreg_t [46:0] mio_pad_sleep_status; // [455:409]
-    pinmux_reg2hw_mio_pad_sleep_en_mreg_t [46:0] mio_pad_sleep_en; // [408:362]
-    pinmux_reg2hw_mio_pad_sleep_mode_mreg_t [46:0] mio_pad_sleep_mode; // [361:268]
-    pinmux_reg2hw_dio_pad_sleep_status_mreg_t [22:0] dio_pad_sleep_status; // [267:245]
-    pinmux_reg2hw_dio_pad_sleep_en_mreg_t [22:0] dio_pad_sleep_en; // [244:222]
-    pinmux_reg2hw_dio_pad_sleep_mode_mreg_t [22:0] dio_pad_sleep_mode; // [221:176]
+    pinmux_reg2hw_mio_periph_insel_mreg_t [54:0] mio_periph_insel; // [2112:1783]
+    pinmux_reg2hw_mio_outsel_mreg_t [46:0] mio_outsel; // [1782:1454]
+    pinmux_reg2hw_mio_pad_attr_mreg_t [46:0] mio_pad_attr; // [1453:796]
+    pinmux_reg2hw_dio_pad_attr_mreg_t [23:0] dio_pad_attr; // [795:460]
+    pinmux_reg2hw_mio_pad_sleep_status_mreg_t [46:0] mio_pad_sleep_status; // [459:413]
+    pinmux_reg2hw_mio_pad_sleep_en_mreg_t [46:0] mio_pad_sleep_en; // [412:366]
+    pinmux_reg2hw_mio_pad_sleep_mode_mreg_t [46:0] mio_pad_sleep_mode; // [365:272]
+    pinmux_reg2hw_dio_pad_sleep_status_mreg_t [23:0] dio_pad_sleep_status; // [271:248]
+    pinmux_reg2hw_dio_pad_sleep_en_mreg_t [23:0] dio_pad_sleep_en; // [247:224]
+    pinmux_reg2hw_dio_pad_sleep_mode_mreg_t [23:0] dio_pad_sleep_mode; // [223:176]
     pinmux_reg2hw_wkup_detector_en_mreg_t [7:0] wkup_detector_en; // [175:168]
     pinmux_reg2hw_wkup_detector_mreg_t [7:0] wkup_detector; // [167:128]
     pinmux_reg2hw_wkup_detector_cnt_th_mreg_t [7:0] wkup_detector_cnt_th; // [127:64]
@@ -136,10 +136,10 @@ package pinmux_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    pinmux_hw2reg_mio_pad_attr_mreg_t [46:0] mio_pad_attr; // [1057:447]
-    pinmux_hw2reg_dio_pad_attr_mreg_t [22:0] dio_pad_attr; // [446:148]
-    pinmux_hw2reg_mio_pad_sleep_status_mreg_t [46:0] mio_pad_sleep_status; // [147:54]
-    pinmux_hw2reg_dio_pad_sleep_status_mreg_t [22:0] dio_pad_sleep_status; // [53:8]
+    pinmux_hw2reg_mio_pad_attr_mreg_t [46:0] mio_pad_attr; // [1072:462]
+    pinmux_hw2reg_dio_pad_attr_mreg_t [23:0] dio_pad_attr; // [461:150]
+    pinmux_hw2reg_mio_pad_sleep_status_mreg_t [46:0] mio_pad_sleep_status; // [149:56]
+    pinmux_hw2reg_dio_pad_sleep_status_mreg_t [23:0] dio_pad_sleep_status; // [55:8]
     pinmux_hw2reg_wkup_cause_mreg_t [7:0] wkup_cause; // [7:0]
   } pinmux_hw2reg_t;
 
@@ -465,283 +465,288 @@ package pinmux_reg_pkg;
   parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_20_OFFSET = 12'h 4f8;
   parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_21_OFFSET = 12'h 4fc;
   parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_22_OFFSET = 12'h 500;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_0_OFFSET = 12'h 504;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_1_OFFSET = 12'h 508;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_2_OFFSET = 12'h 50c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_3_OFFSET = 12'h 510;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_4_OFFSET = 12'h 514;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_5_OFFSET = 12'h 518;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_6_OFFSET = 12'h 51c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_7_OFFSET = 12'h 520;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_8_OFFSET = 12'h 524;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_9_OFFSET = 12'h 528;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_10_OFFSET = 12'h 52c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_11_OFFSET = 12'h 530;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_12_OFFSET = 12'h 534;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_13_OFFSET = 12'h 538;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_14_OFFSET = 12'h 53c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_15_OFFSET = 12'h 540;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_16_OFFSET = 12'h 544;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_17_OFFSET = 12'h 548;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_18_OFFSET = 12'h 54c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_19_OFFSET = 12'h 550;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_20_OFFSET = 12'h 554;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_21_OFFSET = 12'h 558;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_22_OFFSET = 12'h 55c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_STATUS_0_OFFSET = 12'h 560;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_STATUS_1_OFFSET = 12'h 564;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_0_OFFSET = 12'h 568;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_1_OFFSET = 12'h 56c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_2_OFFSET = 12'h 570;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_3_OFFSET = 12'h 574;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_4_OFFSET = 12'h 578;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_5_OFFSET = 12'h 57c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_6_OFFSET = 12'h 580;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_7_OFFSET = 12'h 584;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_8_OFFSET = 12'h 588;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_9_OFFSET = 12'h 58c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_10_OFFSET = 12'h 590;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_11_OFFSET = 12'h 594;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_12_OFFSET = 12'h 598;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_13_OFFSET = 12'h 59c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_14_OFFSET = 12'h 5a0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_15_OFFSET = 12'h 5a4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_16_OFFSET = 12'h 5a8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_17_OFFSET = 12'h 5ac;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_18_OFFSET = 12'h 5b0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_19_OFFSET = 12'h 5b4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_20_OFFSET = 12'h 5b8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_21_OFFSET = 12'h 5bc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_22_OFFSET = 12'h 5c0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_23_OFFSET = 12'h 5c4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_24_OFFSET = 12'h 5c8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_25_OFFSET = 12'h 5cc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_26_OFFSET = 12'h 5d0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_27_OFFSET = 12'h 5d4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_28_OFFSET = 12'h 5d8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_29_OFFSET = 12'h 5dc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_30_OFFSET = 12'h 5e0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_31_OFFSET = 12'h 5e4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_32_OFFSET = 12'h 5e8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_33_OFFSET = 12'h 5ec;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_34_OFFSET = 12'h 5f0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_35_OFFSET = 12'h 5f4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_36_OFFSET = 12'h 5f8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_37_OFFSET = 12'h 5fc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_38_OFFSET = 12'h 600;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_39_OFFSET = 12'h 604;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_40_OFFSET = 12'h 608;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_41_OFFSET = 12'h 60c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_42_OFFSET = 12'h 610;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_43_OFFSET = 12'h 614;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_44_OFFSET = 12'h 618;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_45_OFFSET = 12'h 61c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_46_OFFSET = 12'h 620;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_0_OFFSET = 12'h 624;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_1_OFFSET = 12'h 628;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_2_OFFSET = 12'h 62c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_3_OFFSET = 12'h 630;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_4_OFFSET = 12'h 634;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_5_OFFSET = 12'h 638;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_6_OFFSET = 12'h 63c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_7_OFFSET = 12'h 640;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_8_OFFSET = 12'h 644;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_9_OFFSET = 12'h 648;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_10_OFFSET = 12'h 64c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_11_OFFSET = 12'h 650;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_12_OFFSET = 12'h 654;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_13_OFFSET = 12'h 658;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_14_OFFSET = 12'h 65c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_15_OFFSET = 12'h 660;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_16_OFFSET = 12'h 664;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_17_OFFSET = 12'h 668;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_18_OFFSET = 12'h 66c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_19_OFFSET = 12'h 670;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_20_OFFSET = 12'h 674;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_21_OFFSET = 12'h 678;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_22_OFFSET = 12'h 67c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_23_OFFSET = 12'h 680;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_24_OFFSET = 12'h 684;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_25_OFFSET = 12'h 688;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_26_OFFSET = 12'h 68c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_27_OFFSET = 12'h 690;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_28_OFFSET = 12'h 694;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_29_OFFSET = 12'h 698;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_30_OFFSET = 12'h 69c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_31_OFFSET = 12'h 6a0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_32_OFFSET = 12'h 6a4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_33_OFFSET = 12'h 6a8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_34_OFFSET = 12'h 6ac;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_35_OFFSET = 12'h 6b0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_36_OFFSET = 12'h 6b4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_37_OFFSET = 12'h 6b8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_38_OFFSET = 12'h 6bc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_39_OFFSET = 12'h 6c0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_40_OFFSET = 12'h 6c4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_41_OFFSET = 12'h 6c8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_42_OFFSET = 12'h 6cc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_43_OFFSET = 12'h 6d0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_44_OFFSET = 12'h 6d4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_45_OFFSET = 12'h 6d8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_46_OFFSET = 12'h 6dc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_0_OFFSET = 12'h 6e0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_1_OFFSET = 12'h 6e4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_2_OFFSET = 12'h 6e8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_3_OFFSET = 12'h 6ec;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_4_OFFSET = 12'h 6f0;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_5_OFFSET = 12'h 6f4;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_6_OFFSET = 12'h 6f8;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_7_OFFSET = 12'h 6fc;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_8_OFFSET = 12'h 700;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_9_OFFSET = 12'h 704;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_10_OFFSET = 12'h 708;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_11_OFFSET = 12'h 70c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_12_OFFSET = 12'h 710;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_13_OFFSET = 12'h 714;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_14_OFFSET = 12'h 718;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_15_OFFSET = 12'h 71c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_16_OFFSET = 12'h 720;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_17_OFFSET = 12'h 724;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_18_OFFSET = 12'h 728;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_19_OFFSET = 12'h 72c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_20_OFFSET = 12'h 730;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_21_OFFSET = 12'h 734;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_22_OFFSET = 12'h 738;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_23_OFFSET = 12'h 73c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_24_OFFSET = 12'h 740;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_25_OFFSET = 12'h 744;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_26_OFFSET = 12'h 748;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_27_OFFSET = 12'h 74c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_28_OFFSET = 12'h 750;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_29_OFFSET = 12'h 754;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_30_OFFSET = 12'h 758;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_31_OFFSET = 12'h 75c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_32_OFFSET = 12'h 760;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_33_OFFSET = 12'h 764;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_34_OFFSET = 12'h 768;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_35_OFFSET = 12'h 76c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_36_OFFSET = 12'h 770;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_37_OFFSET = 12'h 774;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_38_OFFSET = 12'h 778;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_39_OFFSET = 12'h 77c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_40_OFFSET = 12'h 780;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_41_OFFSET = 12'h 784;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_42_OFFSET = 12'h 788;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_43_OFFSET = 12'h 78c;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_44_OFFSET = 12'h 790;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_45_OFFSET = 12'h 794;
-  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_46_OFFSET = 12'h 798;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_STATUS_OFFSET = 12'h 79c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_0_OFFSET = 12'h 7a0;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_1_OFFSET = 12'h 7a4;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_2_OFFSET = 12'h 7a8;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_3_OFFSET = 12'h 7ac;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_4_OFFSET = 12'h 7b0;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_5_OFFSET = 12'h 7b4;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_6_OFFSET = 12'h 7b8;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_7_OFFSET = 12'h 7bc;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_8_OFFSET = 12'h 7c0;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_9_OFFSET = 12'h 7c4;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_10_OFFSET = 12'h 7c8;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_11_OFFSET = 12'h 7cc;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_12_OFFSET = 12'h 7d0;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_13_OFFSET = 12'h 7d4;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_14_OFFSET = 12'h 7d8;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_15_OFFSET = 12'h 7dc;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_16_OFFSET = 12'h 7e0;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_17_OFFSET = 12'h 7e4;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_18_OFFSET = 12'h 7e8;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_19_OFFSET = 12'h 7ec;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_20_OFFSET = 12'h 7f0;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_21_OFFSET = 12'h 7f4;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_22_OFFSET = 12'h 7f8;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_0_OFFSET = 12'h 7fc;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_1_OFFSET = 12'h 800;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_2_OFFSET = 12'h 804;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_3_OFFSET = 12'h 808;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_4_OFFSET = 12'h 80c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_5_OFFSET = 12'h 810;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_6_OFFSET = 12'h 814;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_7_OFFSET = 12'h 818;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_8_OFFSET = 12'h 81c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_9_OFFSET = 12'h 820;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_10_OFFSET = 12'h 824;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_11_OFFSET = 12'h 828;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_12_OFFSET = 12'h 82c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_13_OFFSET = 12'h 830;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_14_OFFSET = 12'h 834;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_15_OFFSET = 12'h 838;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_16_OFFSET = 12'h 83c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_17_OFFSET = 12'h 840;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_18_OFFSET = 12'h 844;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_19_OFFSET = 12'h 848;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_20_OFFSET = 12'h 84c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_21_OFFSET = 12'h 850;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_22_OFFSET = 12'h 854;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_0_OFFSET = 12'h 858;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_1_OFFSET = 12'h 85c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_2_OFFSET = 12'h 860;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_3_OFFSET = 12'h 864;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_4_OFFSET = 12'h 868;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_5_OFFSET = 12'h 86c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_6_OFFSET = 12'h 870;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_7_OFFSET = 12'h 874;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_8_OFFSET = 12'h 878;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_9_OFFSET = 12'h 87c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_10_OFFSET = 12'h 880;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_11_OFFSET = 12'h 884;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_12_OFFSET = 12'h 888;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_13_OFFSET = 12'h 88c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_14_OFFSET = 12'h 890;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_15_OFFSET = 12'h 894;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_16_OFFSET = 12'h 898;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_17_OFFSET = 12'h 89c;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_18_OFFSET = 12'h 8a0;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_19_OFFSET = 12'h 8a4;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_20_OFFSET = 12'h 8a8;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_21_OFFSET = 12'h 8ac;
-  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_22_OFFSET = 12'h 8b0;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_0_OFFSET = 12'h 8b4;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_1_OFFSET = 12'h 8b8;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_2_OFFSET = 12'h 8bc;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_3_OFFSET = 12'h 8c0;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_4_OFFSET = 12'h 8c4;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_5_OFFSET = 12'h 8c8;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_6_OFFSET = 12'h 8cc;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_7_OFFSET = 12'h 8d0;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_0_OFFSET = 12'h 8d4;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_1_OFFSET = 12'h 8d8;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_2_OFFSET = 12'h 8dc;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_3_OFFSET = 12'h 8e0;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_4_OFFSET = 12'h 8e4;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_5_OFFSET = 12'h 8e8;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_6_OFFSET = 12'h 8ec;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_7_OFFSET = 12'h 8f0;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_0_OFFSET = 12'h 8f4;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_1_OFFSET = 12'h 8f8;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_2_OFFSET = 12'h 8fc;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_3_OFFSET = 12'h 900;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_4_OFFSET = 12'h 904;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_5_OFFSET = 12'h 908;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_6_OFFSET = 12'h 90c;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_7_OFFSET = 12'h 910;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_0_OFFSET = 12'h 914;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_1_OFFSET = 12'h 918;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_2_OFFSET = 12'h 91c;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_3_OFFSET = 12'h 920;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_4_OFFSET = 12'h 924;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_5_OFFSET = 12'h 928;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_6_OFFSET = 12'h 92c;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_7_OFFSET = 12'h 930;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_0_OFFSET = 12'h 934;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_1_OFFSET = 12'h 938;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_2_OFFSET = 12'h 93c;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_3_OFFSET = 12'h 940;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_4_OFFSET = 12'h 944;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_5_OFFSET = 12'h 948;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_6_OFFSET = 12'h 94c;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_7_OFFSET = 12'h 950;
-  parameter logic [BlockAw-1:0] PINMUX_WKUP_CAUSE_OFFSET = 12'h 954;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_REGWEN_23_OFFSET = 12'h 504;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_0_OFFSET = 12'h 508;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_1_OFFSET = 12'h 50c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_2_OFFSET = 12'h 510;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_3_OFFSET = 12'h 514;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_4_OFFSET = 12'h 518;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_5_OFFSET = 12'h 51c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_6_OFFSET = 12'h 520;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_7_OFFSET = 12'h 524;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_8_OFFSET = 12'h 528;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_9_OFFSET = 12'h 52c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_10_OFFSET = 12'h 530;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_11_OFFSET = 12'h 534;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_12_OFFSET = 12'h 538;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_13_OFFSET = 12'h 53c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_14_OFFSET = 12'h 540;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_15_OFFSET = 12'h 544;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_16_OFFSET = 12'h 548;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_17_OFFSET = 12'h 54c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_18_OFFSET = 12'h 550;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_19_OFFSET = 12'h 554;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_20_OFFSET = 12'h 558;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_21_OFFSET = 12'h 55c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_22_OFFSET = 12'h 560;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_ATTR_23_OFFSET = 12'h 564;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_STATUS_0_OFFSET = 12'h 568;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_STATUS_1_OFFSET = 12'h 56c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_0_OFFSET = 12'h 570;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_1_OFFSET = 12'h 574;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_2_OFFSET = 12'h 578;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_3_OFFSET = 12'h 57c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_4_OFFSET = 12'h 580;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_5_OFFSET = 12'h 584;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_6_OFFSET = 12'h 588;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_7_OFFSET = 12'h 58c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_8_OFFSET = 12'h 590;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_9_OFFSET = 12'h 594;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_10_OFFSET = 12'h 598;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_11_OFFSET = 12'h 59c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_12_OFFSET = 12'h 5a0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_13_OFFSET = 12'h 5a4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_14_OFFSET = 12'h 5a8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_15_OFFSET = 12'h 5ac;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_16_OFFSET = 12'h 5b0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_17_OFFSET = 12'h 5b4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_18_OFFSET = 12'h 5b8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_19_OFFSET = 12'h 5bc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_20_OFFSET = 12'h 5c0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_21_OFFSET = 12'h 5c4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_22_OFFSET = 12'h 5c8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_23_OFFSET = 12'h 5cc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_24_OFFSET = 12'h 5d0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_25_OFFSET = 12'h 5d4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_26_OFFSET = 12'h 5d8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_27_OFFSET = 12'h 5dc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_28_OFFSET = 12'h 5e0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_29_OFFSET = 12'h 5e4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_30_OFFSET = 12'h 5e8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_31_OFFSET = 12'h 5ec;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_32_OFFSET = 12'h 5f0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_33_OFFSET = 12'h 5f4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_34_OFFSET = 12'h 5f8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_35_OFFSET = 12'h 5fc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_36_OFFSET = 12'h 600;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_37_OFFSET = 12'h 604;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_38_OFFSET = 12'h 608;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_39_OFFSET = 12'h 60c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_40_OFFSET = 12'h 610;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_41_OFFSET = 12'h 614;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_42_OFFSET = 12'h 618;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_43_OFFSET = 12'h 61c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_44_OFFSET = 12'h 620;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_45_OFFSET = 12'h 624;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_REGWEN_46_OFFSET = 12'h 628;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_0_OFFSET = 12'h 62c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_1_OFFSET = 12'h 630;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_2_OFFSET = 12'h 634;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_3_OFFSET = 12'h 638;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_4_OFFSET = 12'h 63c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_5_OFFSET = 12'h 640;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_6_OFFSET = 12'h 644;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_7_OFFSET = 12'h 648;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_8_OFFSET = 12'h 64c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_9_OFFSET = 12'h 650;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_10_OFFSET = 12'h 654;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_11_OFFSET = 12'h 658;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_12_OFFSET = 12'h 65c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_13_OFFSET = 12'h 660;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_14_OFFSET = 12'h 664;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_15_OFFSET = 12'h 668;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_16_OFFSET = 12'h 66c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_17_OFFSET = 12'h 670;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_18_OFFSET = 12'h 674;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_19_OFFSET = 12'h 678;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_20_OFFSET = 12'h 67c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_21_OFFSET = 12'h 680;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_22_OFFSET = 12'h 684;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_23_OFFSET = 12'h 688;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_24_OFFSET = 12'h 68c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_25_OFFSET = 12'h 690;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_26_OFFSET = 12'h 694;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_27_OFFSET = 12'h 698;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_28_OFFSET = 12'h 69c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_29_OFFSET = 12'h 6a0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_30_OFFSET = 12'h 6a4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_31_OFFSET = 12'h 6a8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_32_OFFSET = 12'h 6ac;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_33_OFFSET = 12'h 6b0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_34_OFFSET = 12'h 6b4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_35_OFFSET = 12'h 6b8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_36_OFFSET = 12'h 6bc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_37_OFFSET = 12'h 6c0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_38_OFFSET = 12'h 6c4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_39_OFFSET = 12'h 6c8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_40_OFFSET = 12'h 6cc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_41_OFFSET = 12'h 6d0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_42_OFFSET = 12'h 6d4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_43_OFFSET = 12'h 6d8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_44_OFFSET = 12'h 6dc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_45_OFFSET = 12'h 6e0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_EN_46_OFFSET = 12'h 6e4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_0_OFFSET = 12'h 6e8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_1_OFFSET = 12'h 6ec;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_2_OFFSET = 12'h 6f0;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_3_OFFSET = 12'h 6f4;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_4_OFFSET = 12'h 6f8;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_5_OFFSET = 12'h 6fc;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_6_OFFSET = 12'h 700;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_7_OFFSET = 12'h 704;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_8_OFFSET = 12'h 708;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_9_OFFSET = 12'h 70c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_10_OFFSET = 12'h 710;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_11_OFFSET = 12'h 714;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_12_OFFSET = 12'h 718;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_13_OFFSET = 12'h 71c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_14_OFFSET = 12'h 720;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_15_OFFSET = 12'h 724;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_16_OFFSET = 12'h 728;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_17_OFFSET = 12'h 72c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_18_OFFSET = 12'h 730;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_19_OFFSET = 12'h 734;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_20_OFFSET = 12'h 738;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_21_OFFSET = 12'h 73c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_22_OFFSET = 12'h 740;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_23_OFFSET = 12'h 744;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_24_OFFSET = 12'h 748;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_25_OFFSET = 12'h 74c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_26_OFFSET = 12'h 750;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_27_OFFSET = 12'h 754;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_28_OFFSET = 12'h 758;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_29_OFFSET = 12'h 75c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_30_OFFSET = 12'h 760;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_31_OFFSET = 12'h 764;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_32_OFFSET = 12'h 768;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_33_OFFSET = 12'h 76c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_34_OFFSET = 12'h 770;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_35_OFFSET = 12'h 774;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_36_OFFSET = 12'h 778;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_37_OFFSET = 12'h 77c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_38_OFFSET = 12'h 780;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_39_OFFSET = 12'h 784;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_40_OFFSET = 12'h 788;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_41_OFFSET = 12'h 78c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_42_OFFSET = 12'h 790;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_43_OFFSET = 12'h 794;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_44_OFFSET = 12'h 798;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_45_OFFSET = 12'h 79c;
+  parameter logic [BlockAw-1:0] PINMUX_MIO_PAD_SLEEP_MODE_46_OFFSET = 12'h 7a0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_STATUS_OFFSET = 12'h 7a4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_0_OFFSET = 12'h 7a8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_1_OFFSET = 12'h 7ac;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_2_OFFSET = 12'h 7b0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_3_OFFSET = 12'h 7b4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_4_OFFSET = 12'h 7b8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_5_OFFSET = 12'h 7bc;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_6_OFFSET = 12'h 7c0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_7_OFFSET = 12'h 7c4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_8_OFFSET = 12'h 7c8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_9_OFFSET = 12'h 7cc;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_10_OFFSET = 12'h 7d0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_11_OFFSET = 12'h 7d4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_12_OFFSET = 12'h 7d8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_13_OFFSET = 12'h 7dc;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_14_OFFSET = 12'h 7e0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_15_OFFSET = 12'h 7e4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_16_OFFSET = 12'h 7e8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_17_OFFSET = 12'h 7ec;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_18_OFFSET = 12'h 7f0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_19_OFFSET = 12'h 7f4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_20_OFFSET = 12'h 7f8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_21_OFFSET = 12'h 7fc;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_22_OFFSET = 12'h 800;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_REGWEN_23_OFFSET = 12'h 804;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_0_OFFSET = 12'h 808;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_1_OFFSET = 12'h 80c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_2_OFFSET = 12'h 810;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_3_OFFSET = 12'h 814;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_4_OFFSET = 12'h 818;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_5_OFFSET = 12'h 81c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_6_OFFSET = 12'h 820;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_7_OFFSET = 12'h 824;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_8_OFFSET = 12'h 828;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_9_OFFSET = 12'h 82c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_10_OFFSET = 12'h 830;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_11_OFFSET = 12'h 834;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_12_OFFSET = 12'h 838;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_13_OFFSET = 12'h 83c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_14_OFFSET = 12'h 840;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_15_OFFSET = 12'h 844;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_16_OFFSET = 12'h 848;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_17_OFFSET = 12'h 84c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_18_OFFSET = 12'h 850;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_19_OFFSET = 12'h 854;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_20_OFFSET = 12'h 858;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_21_OFFSET = 12'h 85c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_22_OFFSET = 12'h 860;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_EN_23_OFFSET = 12'h 864;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_0_OFFSET = 12'h 868;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_1_OFFSET = 12'h 86c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_2_OFFSET = 12'h 870;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_3_OFFSET = 12'h 874;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_4_OFFSET = 12'h 878;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_5_OFFSET = 12'h 87c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_6_OFFSET = 12'h 880;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_7_OFFSET = 12'h 884;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_8_OFFSET = 12'h 888;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_9_OFFSET = 12'h 88c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_10_OFFSET = 12'h 890;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_11_OFFSET = 12'h 894;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_12_OFFSET = 12'h 898;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_13_OFFSET = 12'h 89c;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_14_OFFSET = 12'h 8a0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_15_OFFSET = 12'h 8a4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_16_OFFSET = 12'h 8a8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_17_OFFSET = 12'h 8ac;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_18_OFFSET = 12'h 8b0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_19_OFFSET = 12'h 8b4;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_20_OFFSET = 12'h 8b8;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_21_OFFSET = 12'h 8bc;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_22_OFFSET = 12'h 8c0;
+  parameter logic [BlockAw-1:0] PINMUX_DIO_PAD_SLEEP_MODE_23_OFFSET = 12'h 8c4;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_0_OFFSET = 12'h 8c8;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_1_OFFSET = 12'h 8cc;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_2_OFFSET = 12'h 8d0;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_3_OFFSET = 12'h 8d4;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_4_OFFSET = 12'h 8d8;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_5_OFFSET = 12'h 8dc;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_6_OFFSET = 12'h 8e0;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_REGWEN_7_OFFSET = 12'h 8e4;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_0_OFFSET = 12'h 8e8;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_1_OFFSET = 12'h 8ec;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_2_OFFSET = 12'h 8f0;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_3_OFFSET = 12'h 8f4;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_4_OFFSET = 12'h 8f8;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_5_OFFSET = 12'h 8fc;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_6_OFFSET = 12'h 900;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_EN_7_OFFSET = 12'h 904;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_0_OFFSET = 12'h 908;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_1_OFFSET = 12'h 90c;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_2_OFFSET = 12'h 910;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_3_OFFSET = 12'h 914;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_4_OFFSET = 12'h 918;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_5_OFFSET = 12'h 91c;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_6_OFFSET = 12'h 920;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_7_OFFSET = 12'h 924;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_0_OFFSET = 12'h 928;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_1_OFFSET = 12'h 92c;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_2_OFFSET = 12'h 930;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_3_OFFSET = 12'h 934;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_4_OFFSET = 12'h 938;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_5_OFFSET = 12'h 93c;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_6_OFFSET = 12'h 940;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_CNT_TH_7_OFFSET = 12'h 944;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_0_OFFSET = 12'h 948;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_1_OFFSET = 12'h 94c;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_2_OFFSET = 12'h 950;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_3_OFFSET = 12'h 954;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_4_OFFSET = 12'h 958;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_5_OFFSET = 12'h 95c;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_6_OFFSET = 12'h 960;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_DETECTOR_PADSEL_7_OFFSET = 12'h 964;
+  parameter logic [BlockAw-1:0] PINMUX_WKUP_CAUSE_OFFSET = 12'h 968;
 
   // Reset values for hwext registers and their fields
   parameter logic [12:0] PINMUX_MIO_PAD_ATTR_0_RESVAL = 13'h 0;
@@ -884,6 +889,8 @@ package pinmux_reg_pkg;
   parameter logic [12:0] PINMUX_DIO_PAD_ATTR_21_ATTR_21_RESVAL = 13'h 0;
   parameter logic [12:0] PINMUX_DIO_PAD_ATTR_22_RESVAL = 13'h 0;
   parameter logic [12:0] PINMUX_DIO_PAD_ATTR_22_ATTR_22_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_23_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_23_ATTR_23_RESVAL = 13'h 0;
   parameter logic [7:0] PINMUX_WKUP_CAUSE_RESVAL = 8'h 0;
   parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_0_RESVAL = 1'h 0;
   parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_1_RESVAL = 1'h 0;
@@ -1217,6 +1224,7 @@ package pinmux_reg_pkg;
     PINMUX_DIO_PAD_ATTR_REGWEN_20,
     PINMUX_DIO_PAD_ATTR_REGWEN_21,
     PINMUX_DIO_PAD_ATTR_REGWEN_22,
+    PINMUX_DIO_PAD_ATTR_REGWEN_23,
     PINMUX_DIO_PAD_ATTR_0,
     PINMUX_DIO_PAD_ATTR_1,
     PINMUX_DIO_PAD_ATTR_2,
@@ -1240,6 +1248,7 @@ package pinmux_reg_pkg;
     PINMUX_DIO_PAD_ATTR_20,
     PINMUX_DIO_PAD_ATTR_21,
     PINMUX_DIO_PAD_ATTR_22,
+    PINMUX_DIO_PAD_ATTR_23,
     PINMUX_MIO_PAD_SLEEP_STATUS_0,
     PINMUX_MIO_PAD_SLEEP_STATUS_1,
     PINMUX_MIO_PAD_SLEEP_REGWEN_0,
@@ -1407,6 +1416,7 @@ package pinmux_reg_pkg;
     PINMUX_DIO_PAD_SLEEP_REGWEN_20,
     PINMUX_DIO_PAD_SLEEP_REGWEN_21,
     PINMUX_DIO_PAD_SLEEP_REGWEN_22,
+    PINMUX_DIO_PAD_SLEEP_REGWEN_23,
     PINMUX_DIO_PAD_SLEEP_EN_0,
     PINMUX_DIO_PAD_SLEEP_EN_1,
     PINMUX_DIO_PAD_SLEEP_EN_2,
@@ -1430,6 +1440,7 @@ package pinmux_reg_pkg;
     PINMUX_DIO_PAD_SLEEP_EN_20,
     PINMUX_DIO_PAD_SLEEP_EN_21,
     PINMUX_DIO_PAD_SLEEP_EN_22,
+    PINMUX_DIO_PAD_SLEEP_EN_23,
     PINMUX_DIO_PAD_SLEEP_MODE_0,
     PINMUX_DIO_PAD_SLEEP_MODE_1,
     PINMUX_DIO_PAD_SLEEP_MODE_2,
@@ -1453,6 +1464,7 @@ package pinmux_reg_pkg;
     PINMUX_DIO_PAD_SLEEP_MODE_20,
     PINMUX_DIO_PAD_SLEEP_MODE_21,
     PINMUX_DIO_PAD_SLEEP_MODE_22,
+    PINMUX_DIO_PAD_SLEEP_MODE_23,
     PINMUX_WKUP_DETECTOR_REGWEN_0,
     PINMUX_WKUP_DETECTOR_REGWEN_1,
     PINMUX_WKUP_DETECTOR_REGWEN_2,
@@ -1497,7 +1509,7 @@ package pinmux_reg_pkg;
   } pinmux_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] PINMUX_PERMIT [598] = '{
+  parameter logic [3:0] PINMUX_PERMIT [603] = '{
     4'b 0001, // index[  0] PINMUX_MIO_PERIPH_INSEL_REGWEN_0
     4'b 0001, // index[  1] PINMUX_MIO_PERIPH_INSEL_REGWEN_1
     4'b 0001, // index[  2] PINMUX_MIO_PERIPH_INSEL_REGWEN_2
@@ -1819,283 +1831,288 @@ package pinmux_reg_pkg;
     4'b 0001, // index[318] PINMUX_DIO_PAD_ATTR_REGWEN_20
     4'b 0001, // index[319] PINMUX_DIO_PAD_ATTR_REGWEN_21
     4'b 0001, // index[320] PINMUX_DIO_PAD_ATTR_REGWEN_22
-    4'b 0011, // index[321] PINMUX_DIO_PAD_ATTR_0
-    4'b 0011, // index[322] PINMUX_DIO_PAD_ATTR_1
-    4'b 0011, // index[323] PINMUX_DIO_PAD_ATTR_2
-    4'b 0011, // index[324] PINMUX_DIO_PAD_ATTR_3
-    4'b 0011, // index[325] PINMUX_DIO_PAD_ATTR_4
-    4'b 0011, // index[326] PINMUX_DIO_PAD_ATTR_5
-    4'b 0011, // index[327] PINMUX_DIO_PAD_ATTR_6
-    4'b 0011, // index[328] PINMUX_DIO_PAD_ATTR_7
-    4'b 0011, // index[329] PINMUX_DIO_PAD_ATTR_8
-    4'b 0011, // index[330] PINMUX_DIO_PAD_ATTR_9
-    4'b 0011, // index[331] PINMUX_DIO_PAD_ATTR_10
-    4'b 0011, // index[332] PINMUX_DIO_PAD_ATTR_11
-    4'b 0011, // index[333] PINMUX_DIO_PAD_ATTR_12
-    4'b 0011, // index[334] PINMUX_DIO_PAD_ATTR_13
-    4'b 0011, // index[335] PINMUX_DIO_PAD_ATTR_14
-    4'b 0011, // index[336] PINMUX_DIO_PAD_ATTR_15
-    4'b 0011, // index[337] PINMUX_DIO_PAD_ATTR_16
-    4'b 0011, // index[338] PINMUX_DIO_PAD_ATTR_17
-    4'b 0011, // index[339] PINMUX_DIO_PAD_ATTR_18
-    4'b 0011, // index[340] PINMUX_DIO_PAD_ATTR_19
-    4'b 0011, // index[341] PINMUX_DIO_PAD_ATTR_20
-    4'b 0011, // index[342] PINMUX_DIO_PAD_ATTR_21
-    4'b 0011, // index[343] PINMUX_DIO_PAD_ATTR_22
-    4'b 1111, // index[344] PINMUX_MIO_PAD_SLEEP_STATUS_0
-    4'b 0011, // index[345] PINMUX_MIO_PAD_SLEEP_STATUS_1
-    4'b 0001, // index[346] PINMUX_MIO_PAD_SLEEP_REGWEN_0
-    4'b 0001, // index[347] PINMUX_MIO_PAD_SLEEP_REGWEN_1
-    4'b 0001, // index[348] PINMUX_MIO_PAD_SLEEP_REGWEN_2
-    4'b 0001, // index[349] PINMUX_MIO_PAD_SLEEP_REGWEN_3
-    4'b 0001, // index[350] PINMUX_MIO_PAD_SLEEP_REGWEN_4
-    4'b 0001, // index[351] PINMUX_MIO_PAD_SLEEP_REGWEN_5
-    4'b 0001, // index[352] PINMUX_MIO_PAD_SLEEP_REGWEN_6
-    4'b 0001, // index[353] PINMUX_MIO_PAD_SLEEP_REGWEN_7
-    4'b 0001, // index[354] PINMUX_MIO_PAD_SLEEP_REGWEN_8
-    4'b 0001, // index[355] PINMUX_MIO_PAD_SLEEP_REGWEN_9
-    4'b 0001, // index[356] PINMUX_MIO_PAD_SLEEP_REGWEN_10
-    4'b 0001, // index[357] PINMUX_MIO_PAD_SLEEP_REGWEN_11
-    4'b 0001, // index[358] PINMUX_MIO_PAD_SLEEP_REGWEN_12
-    4'b 0001, // index[359] PINMUX_MIO_PAD_SLEEP_REGWEN_13
-    4'b 0001, // index[360] PINMUX_MIO_PAD_SLEEP_REGWEN_14
-    4'b 0001, // index[361] PINMUX_MIO_PAD_SLEEP_REGWEN_15
-    4'b 0001, // index[362] PINMUX_MIO_PAD_SLEEP_REGWEN_16
-    4'b 0001, // index[363] PINMUX_MIO_PAD_SLEEP_REGWEN_17
-    4'b 0001, // index[364] PINMUX_MIO_PAD_SLEEP_REGWEN_18
-    4'b 0001, // index[365] PINMUX_MIO_PAD_SLEEP_REGWEN_19
-    4'b 0001, // index[366] PINMUX_MIO_PAD_SLEEP_REGWEN_20
-    4'b 0001, // index[367] PINMUX_MIO_PAD_SLEEP_REGWEN_21
-    4'b 0001, // index[368] PINMUX_MIO_PAD_SLEEP_REGWEN_22
-    4'b 0001, // index[369] PINMUX_MIO_PAD_SLEEP_REGWEN_23
-    4'b 0001, // index[370] PINMUX_MIO_PAD_SLEEP_REGWEN_24
-    4'b 0001, // index[371] PINMUX_MIO_PAD_SLEEP_REGWEN_25
-    4'b 0001, // index[372] PINMUX_MIO_PAD_SLEEP_REGWEN_26
-    4'b 0001, // index[373] PINMUX_MIO_PAD_SLEEP_REGWEN_27
-    4'b 0001, // index[374] PINMUX_MIO_PAD_SLEEP_REGWEN_28
-    4'b 0001, // index[375] PINMUX_MIO_PAD_SLEEP_REGWEN_29
-    4'b 0001, // index[376] PINMUX_MIO_PAD_SLEEP_REGWEN_30
-    4'b 0001, // index[377] PINMUX_MIO_PAD_SLEEP_REGWEN_31
-    4'b 0001, // index[378] PINMUX_MIO_PAD_SLEEP_REGWEN_32
-    4'b 0001, // index[379] PINMUX_MIO_PAD_SLEEP_REGWEN_33
-    4'b 0001, // index[380] PINMUX_MIO_PAD_SLEEP_REGWEN_34
-    4'b 0001, // index[381] PINMUX_MIO_PAD_SLEEP_REGWEN_35
-    4'b 0001, // index[382] PINMUX_MIO_PAD_SLEEP_REGWEN_36
-    4'b 0001, // index[383] PINMUX_MIO_PAD_SLEEP_REGWEN_37
-    4'b 0001, // index[384] PINMUX_MIO_PAD_SLEEP_REGWEN_38
-    4'b 0001, // index[385] PINMUX_MIO_PAD_SLEEP_REGWEN_39
-    4'b 0001, // index[386] PINMUX_MIO_PAD_SLEEP_REGWEN_40
-    4'b 0001, // index[387] PINMUX_MIO_PAD_SLEEP_REGWEN_41
-    4'b 0001, // index[388] PINMUX_MIO_PAD_SLEEP_REGWEN_42
-    4'b 0001, // index[389] PINMUX_MIO_PAD_SLEEP_REGWEN_43
-    4'b 0001, // index[390] PINMUX_MIO_PAD_SLEEP_REGWEN_44
-    4'b 0001, // index[391] PINMUX_MIO_PAD_SLEEP_REGWEN_45
-    4'b 0001, // index[392] PINMUX_MIO_PAD_SLEEP_REGWEN_46
-    4'b 0001, // index[393] PINMUX_MIO_PAD_SLEEP_EN_0
-    4'b 0001, // index[394] PINMUX_MIO_PAD_SLEEP_EN_1
-    4'b 0001, // index[395] PINMUX_MIO_PAD_SLEEP_EN_2
-    4'b 0001, // index[396] PINMUX_MIO_PAD_SLEEP_EN_3
-    4'b 0001, // index[397] PINMUX_MIO_PAD_SLEEP_EN_4
-    4'b 0001, // index[398] PINMUX_MIO_PAD_SLEEP_EN_5
-    4'b 0001, // index[399] PINMUX_MIO_PAD_SLEEP_EN_6
-    4'b 0001, // index[400] PINMUX_MIO_PAD_SLEEP_EN_7
-    4'b 0001, // index[401] PINMUX_MIO_PAD_SLEEP_EN_8
-    4'b 0001, // index[402] PINMUX_MIO_PAD_SLEEP_EN_9
-    4'b 0001, // index[403] PINMUX_MIO_PAD_SLEEP_EN_10
-    4'b 0001, // index[404] PINMUX_MIO_PAD_SLEEP_EN_11
-    4'b 0001, // index[405] PINMUX_MIO_PAD_SLEEP_EN_12
-    4'b 0001, // index[406] PINMUX_MIO_PAD_SLEEP_EN_13
-    4'b 0001, // index[407] PINMUX_MIO_PAD_SLEEP_EN_14
-    4'b 0001, // index[408] PINMUX_MIO_PAD_SLEEP_EN_15
-    4'b 0001, // index[409] PINMUX_MIO_PAD_SLEEP_EN_16
-    4'b 0001, // index[410] PINMUX_MIO_PAD_SLEEP_EN_17
-    4'b 0001, // index[411] PINMUX_MIO_PAD_SLEEP_EN_18
-    4'b 0001, // index[412] PINMUX_MIO_PAD_SLEEP_EN_19
-    4'b 0001, // index[413] PINMUX_MIO_PAD_SLEEP_EN_20
-    4'b 0001, // index[414] PINMUX_MIO_PAD_SLEEP_EN_21
-    4'b 0001, // index[415] PINMUX_MIO_PAD_SLEEP_EN_22
-    4'b 0001, // index[416] PINMUX_MIO_PAD_SLEEP_EN_23
-    4'b 0001, // index[417] PINMUX_MIO_PAD_SLEEP_EN_24
-    4'b 0001, // index[418] PINMUX_MIO_PAD_SLEEP_EN_25
-    4'b 0001, // index[419] PINMUX_MIO_PAD_SLEEP_EN_26
-    4'b 0001, // index[420] PINMUX_MIO_PAD_SLEEP_EN_27
-    4'b 0001, // index[421] PINMUX_MIO_PAD_SLEEP_EN_28
-    4'b 0001, // index[422] PINMUX_MIO_PAD_SLEEP_EN_29
-    4'b 0001, // index[423] PINMUX_MIO_PAD_SLEEP_EN_30
-    4'b 0001, // index[424] PINMUX_MIO_PAD_SLEEP_EN_31
-    4'b 0001, // index[425] PINMUX_MIO_PAD_SLEEP_EN_32
-    4'b 0001, // index[426] PINMUX_MIO_PAD_SLEEP_EN_33
-    4'b 0001, // index[427] PINMUX_MIO_PAD_SLEEP_EN_34
-    4'b 0001, // index[428] PINMUX_MIO_PAD_SLEEP_EN_35
-    4'b 0001, // index[429] PINMUX_MIO_PAD_SLEEP_EN_36
-    4'b 0001, // index[430] PINMUX_MIO_PAD_SLEEP_EN_37
-    4'b 0001, // index[431] PINMUX_MIO_PAD_SLEEP_EN_38
-    4'b 0001, // index[432] PINMUX_MIO_PAD_SLEEP_EN_39
-    4'b 0001, // index[433] PINMUX_MIO_PAD_SLEEP_EN_40
-    4'b 0001, // index[434] PINMUX_MIO_PAD_SLEEP_EN_41
-    4'b 0001, // index[435] PINMUX_MIO_PAD_SLEEP_EN_42
-    4'b 0001, // index[436] PINMUX_MIO_PAD_SLEEP_EN_43
-    4'b 0001, // index[437] PINMUX_MIO_PAD_SLEEP_EN_44
-    4'b 0001, // index[438] PINMUX_MIO_PAD_SLEEP_EN_45
-    4'b 0001, // index[439] PINMUX_MIO_PAD_SLEEP_EN_46
-    4'b 0001, // index[440] PINMUX_MIO_PAD_SLEEP_MODE_0
-    4'b 0001, // index[441] PINMUX_MIO_PAD_SLEEP_MODE_1
-    4'b 0001, // index[442] PINMUX_MIO_PAD_SLEEP_MODE_2
-    4'b 0001, // index[443] PINMUX_MIO_PAD_SLEEP_MODE_3
-    4'b 0001, // index[444] PINMUX_MIO_PAD_SLEEP_MODE_4
-    4'b 0001, // index[445] PINMUX_MIO_PAD_SLEEP_MODE_5
-    4'b 0001, // index[446] PINMUX_MIO_PAD_SLEEP_MODE_6
-    4'b 0001, // index[447] PINMUX_MIO_PAD_SLEEP_MODE_7
-    4'b 0001, // index[448] PINMUX_MIO_PAD_SLEEP_MODE_8
-    4'b 0001, // index[449] PINMUX_MIO_PAD_SLEEP_MODE_9
-    4'b 0001, // index[450] PINMUX_MIO_PAD_SLEEP_MODE_10
-    4'b 0001, // index[451] PINMUX_MIO_PAD_SLEEP_MODE_11
-    4'b 0001, // index[452] PINMUX_MIO_PAD_SLEEP_MODE_12
-    4'b 0001, // index[453] PINMUX_MIO_PAD_SLEEP_MODE_13
-    4'b 0001, // index[454] PINMUX_MIO_PAD_SLEEP_MODE_14
-    4'b 0001, // index[455] PINMUX_MIO_PAD_SLEEP_MODE_15
-    4'b 0001, // index[456] PINMUX_MIO_PAD_SLEEP_MODE_16
-    4'b 0001, // index[457] PINMUX_MIO_PAD_SLEEP_MODE_17
-    4'b 0001, // index[458] PINMUX_MIO_PAD_SLEEP_MODE_18
-    4'b 0001, // index[459] PINMUX_MIO_PAD_SLEEP_MODE_19
-    4'b 0001, // index[460] PINMUX_MIO_PAD_SLEEP_MODE_20
-    4'b 0001, // index[461] PINMUX_MIO_PAD_SLEEP_MODE_21
-    4'b 0001, // index[462] PINMUX_MIO_PAD_SLEEP_MODE_22
-    4'b 0001, // index[463] PINMUX_MIO_PAD_SLEEP_MODE_23
-    4'b 0001, // index[464] PINMUX_MIO_PAD_SLEEP_MODE_24
-    4'b 0001, // index[465] PINMUX_MIO_PAD_SLEEP_MODE_25
-    4'b 0001, // index[466] PINMUX_MIO_PAD_SLEEP_MODE_26
-    4'b 0001, // index[467] PINMUX_MIO_PAD_SLEEP_MODE_27
-    4'b 0001, // index[468] PINMUX_MIO_PAD_SLEEP_MODE_28
-    4'b 0001, // index[469] PINMUX_MIO_PAD_SLEEP_MODE_29
-    4'b 0001, // index[470] PINMUX_MIO_PAD_SLEEP_MODE_30
-    4'b 0001, // index[471] PINMUX_MIO_PAD_SLEEP_MODE_31
-    4'b 0001, // index[472] PINMUX_MIO_PAD_SLEEP_MODE_32
-    4'b 0001, // index[473] PINMUX_MIO_PAD_SLEEP_MODE_33
-    4'b 0001, // index[474] PINMUX_MIO_PAD_SLEEP_MODE_34
-    4'b 0001, // index[475] PINMUX_MIO_PAD_SLEEP_MODE_35
-    4'b 0001, // index[476] PINMUX_MIO_PAD_SLEEP_MODE_36
-    4'b 0001, // index[477] PINMUX_MIO_PAD_SLEEP_MODE_37
-    4'b 0001, // index[478] PINMUX_MIO_PAD_SLEEP_MODE_38
-    4'b 0001, // index[479] PINMUX_MIO_PAD_SLEEP_MODE_39
-    4'b 0001, // index[480] PINMUX_MIO_PAD_SLEEP_MODE_40
-    4'b 0001, // index[481] PINMUX_MIO_PAD_SLEEP_MODE_41
-    4'b 0001, // index[482] PINMUX_MIO_PAD_SLEEP_MODE_42
-    4'b 0001, // index[483] PINMUX_MIO_PAD_SLEEP_MODE_43
-    4'b 0001, // index[484] PINMUX_MIO_PAD_SLEEP_MODE_44
-    4'b 0001, // index[485] PINMUX_MIO_PAD_SLEEP_MODE_45
-    4'b 0001, // index[486] PINMUX_MIO_PAD_SLEEP_MODE_46
-    4'b 0111, // index[487] PINMUX_DIO_PAD_SLEEP_STATUS
-    4'b 0001, // index[488] PINMUX_DIO_PAD_SLEEP_REGWEN_0
-    4'b 0001, // index[489] PINMUX_DIO_PAD_SLEEP_REGWEN_1
-    4'b 0001, // index[490] PINMUX_DIO_PAD_SLEEP_REGWEN_2
-    4'b 0001, // index[491] PINMUX_DIO_PAD_SLEEP_REGWEN_3
-    4'b 0001, // index[492] PINMUX_DIO_PAD_SLEEP_REGWEN_4
-    4'b 0001, // index[493] PINMUX_DIO_PAD_SLEEP_REGWEN_5
-    4'b 0001, // index[494] PINMUX_DIO_PAD_SLEEP_REGWEN_6
-    4'b 0001, // index[495] PINMUX_DIO_PAD_SLEEP_REGWEN_7
-    4'b 0001, // index[496] PINMUX_DIO_PAD_SLEEP_REGWEN_8
-    4'b 0001, // index[497] PINMUX_DIO_PAD_SLEEP_REGWEN_9
-    4'b 0001, // index[498] PINMUX_DIO_PAD_SLEEP_REGWEN_10
-    4'b 0001, // index[499] PINMUX_DIO_PAD_SLEEP_REGWEN_11
-    4'b 0001, // index[500] PINMUX_DIO_PAD_SLEEP_REGWEN_12
-    4'b 0001, // index[501] PINMUX_DIO_PAD_SLEEP_REGWEN_13
-    4'b 0001, // index[502] PINMUX_DIO_PAD_SLEEP_REGWEN_14
-    4'b 0001, // index[503] PINMUX_DIO_PAD_SLEEP_REGWEN_15
-    4'b 0001, // index[504] PINMUX_DIO_PAD_SLEEP_REGWEN_16
-    4'b 0001, // index[505] PINMUX_DIO_PAD_SLEEP_REGWEN_17
-    4'b 0001, // index[506] PINMUX_DIO_PAD_SLEEP_REGWEN_18
-    4'b 0001, // index[507] PINMUX_DIO_PAD_SLEEP_REGWEN_19
-    4'b 0001, // index[508] PINMUX_DIO_PAD_SLEEP_REGWEN_20
-    4'b 0001, // index[509] PINMUX_DIO_PAD_SLEEP_REGWEN_21
-    4'b 0001, // index[510] PINMUX_DIO_PAD_SLEEP_REGWEN_22
-    4'b 0001, // index[511] PINMUX_DIO_PAD_SLEEP_EN_0
-    4'b 0001, // index[512] PINMUX_DIO_PAD_SLEEP_EN_1
-    4'b 0001, // index[513] PINMUX_DIO_PAD_SLEEP_EN_2
-    4'b 0001, // index[514] PINMUX_DIO_PAD_SLEEP_EN_3
-    4'b 0001, // index[515] PINMUX_DIO_PAD_SLEEP_EN_4
-    4'b 0001, // index[516] PINMUX_DIO_PAD_SLEEP_EN_5
-    4'b 0001, // index[517] PINMUX_DIO_PAD_SLEEP_EN_6
-    4'b 0001, // index[518] PINMUX_DIO_PAD_SLEEP_EN_7
-    4'b 0001, // index[519] PINMUX_DIO_PAD_SLEEP_EN_8
-    4'b 0001, // index[520] PINMUX_DIO_PAD_SLEEP_EN_9
-    4'b 0001, // index[521] PINMUX_DIO_PAD_SLEEP_EN_10
-    4'b 0001, // index[522] PINMUX_DIO_PAD_SLEEP_EN_11
-    4'b 0001, // index[523] PINMUX_DIO_PAD_SLEEP_EN_12
-    4'b 0001, // index[524] PINMUX_DIO_PAD_SLEEP_EN_13
-    4'b 0001, // index[525] PINMUX_DIO_PAD_SLEEP_EN_14
-    4'b 0001, // index[526] PINMUX_DIO_PAD_SLEEP_EN_15
-    4'b 0001, // index[527] PINMUX_DIO_PAD_SLEEP_EN_16
-    4'b 0001, // index[528] PINMUX_DIO_PAD_SLEEP_EN_17
-    4'b 0001, // index[529] PINMUX_DIO_PAD_SLEEP_EN_18
-    4'b 0001, // index[530] PINMUX_DIO_PAD_SLEEP_EN_19
-    4'b 0001, // index[531] PINMUX_DIO_PAD_SLEEP_EN_20
-    4'b 0001, // index[532] PINMUX_DIO_PAD_SLEEP_EN_21
-    4'b 0001, // index[533] PINMUX_DIO_PAD_SLEEP_EN_22
-    4'b 0001, // index[534] PINMUX_DIO_PAD_SLEEP_MODE_0
-    4'b 0001, // index[535] PINMUX_DIO_PAD_SLEEP_MODE_1
-    4'b 0001, // index[536] PINMUX_DIO_PAD_SLEEP_MODE_2
-    4'b 0001, // index[537] PINMUX_DIO_PAD_SLEEP_MODE_3
-    4'b 0001, // index[538] PINMUX_DIO_PAD_SLEEP_MODE_4
-    4'b 0001, // index[539] PINMUX_DIO_PAD_SLEEP_MODE_5
-    4'b 0001, // index[540] PINMUX_DIO_PAD_SLEEP_MODE_6
-    4'b 0001, // index[541] PINMUX_DIO_PAD_SLEEP_MODE_7
-    4'b 0001, // index[542] PINMUX_DIO_PAD_SLEEP_MODE_8
-    4'b 0001, // index[543] PINMUX_DIO_PAD_SLEEP_MODE_9
-    4'b 0001, // index[544] PINMUX_DIO_PAD_SLEEP_MODE_10
-    4'b 0001, // index[545] PINMUX_DIO_PAD_SLEEP_MODE_11
-    4'b 0001, // index[546] PINMUX_DIO_PAD_SLEEP_MODE_12
-    4'b 0001, // index[547] PINMUX_DIO_PAD_SLEEP_MODE_13
-    4'b 0001, // index[548] PINMUX_DIO_PAD_SLEEP_MODE_14
-    4'b 0001, // index[549] PINMUX_DIO_PAD_SLEEP_MODE_15
-    4'b 0001, // index[550] PINMUX_DIO_PAD_SLEEP_MODE_16
-    4'b 0001, // index[551] PINMUX_DIO_PAD_SLEEP_MODE_17
-    4'b 0001, // index[552] PINMUX_DIO_PAD_SLEEP_MODE_18
-    4'b 0001, // index[553] PINMUX_DIO_PAD_SLEEP_MODE_19
-    4'b 0001, // index[554] PINMUX_DIO_PAD_SLEEP_MODE_20
-    4'b 0001, // index[555] PINMUX_DIO_PAD_SLEEP_MODE_21
-    4'b 0001, // index[556] PINMUX_DIO_PAD_SLEEP_MODE_22
-    4'b 0001, // index[557] PINMUX_WKUP_DETECTOR_REGWEN_0
-    4'b 0001, // index[558] PINMUX_WKUP_DETECTOR_REGWEN_1
-    4'b 0001, // index[559] PINMUX_WKUP_DETECTOR_REGWEN_2
-    4'b 0001, // index[560] PINMUX_WKUP_DETECTOR_REGWEN_3
-    4'b 0001, // index[561] PINMUX_WKUP_DETECTOR_REGWEN_4
-    4'b 0001, // index[562] PINMUX_WKUP_DETECTOR_REGWEN_5
-    4'b 0001, // index[563] PINMUX_WKUP_DETECTOR_REGWEN_6
-    4'b 0001, // index[564] PINMUX_WKUP_DETECTOR_REGWEN_7
-    4'b 0001, // index[565] PINMUX_WKUP_DETECTOR_EN_0
-    4'b 0001, // index[566] PINMUX_WKUP_DETECTOR_EN_1
-    4'b 0001, // index[567] PINMUX_WKUP_DETECTOR_EN_2
-    4'b 0001, // index[568] PINMUX_WKUP_DETECTOR_EN_3
-    4'b 0001, // index[569] PINMUX_WKUP_DETECTOR_EN_4
-    4'b 0001, // index[570] PINMUX_WKUP_DETECTOR_EN_5
-    4'b 0001, // index[571] PINMUX_WKUP_DETECTOR_EN_6
-    4'b 0001, // index[572] PINMUX_WKUP_DETECTOR_EN_7
-    4'b 0001, // index[573] PINMUX_WKUP_DETECTOR_0
-    4'b 0001, // index[574] PINMUX_WKUP_DETECTOR_1
-    4'b 0001, // index[575] PINMUX_WKUP_DETECTOR_2
-    4'b 0001, // index[576] PINMUX_WKUP_DETECTOR_3
-    4'b 0001, // index[577] PINMUX_WKUP_DETECTOR_4
-    4'b 0001, // index[578] PINMUX_WKUP_DETECTOR_5
-    4'b 0001, // index[579] PINMUX_WKUP_DETECTOR_6
-    4'b 0001, // index[580] PINMUX_WKUP_DETECTOR_7
-    4'b 0001, // index[581] PINMUX_WKUP_DETECTOR_CNT_TH_0
-    4'b 0001, // index[582] PINMUX_WKUP_DETECTOR_CNT_TH_1
-    4'b 0001, // index[583] PINMUX_WKUP_DETECTOR_CNT_TH_2
-    4'b 0001, // index[584] PINMUX_WKUP_DETECTOR_CNT_TH_3
-    4'b 0001, // index[585] PINMUX_WKUP_DETECTOR_CNT_TH_4
-    4'b 0001, // index[586] PINMUX_WKUP_DETECTOR_CNT_TH_5
-    4'b 0001, // index[587] PINMUX_WKUP_DETECTOR_CNT_TH_6
-    4'b 0001, // index[588] PINMUX_WKUP_DETECTOR_CNT_TH_7
-    4'b 0001, // index[589] PINMUX_WKUP_DETECTOR_PADSEL_0
-    4'b 0001, // index[590] PINMUX_WKUP_DETECTOR_PADSEL_1
-    4'b 0001, // index[591] PINMUX_WKUP_DETECTOR_PADSEL_2
-    4'b 0001, // index[592] PINMUX_WKUP_DETECTOR_PADSEL_3
-    4'b 0001, // index[593] PINMUX_WKUP_DETECTOR_PADSEL_4
-    4'b 0001, // index[594] PINMUX_WKUP_DETECTOR_PADSEL_5
-    4'b 0001, // index[595] PINMUX_WKUP_DETECTOR_PADSEL_6
-    4'b 0001, // index[596] PINMUX_WKUP_DETECTOR_PADSEL_7
-    4'b 0001  // index[597] PINMUX_WKUP_CAUSE
+    4'b 0001, // index[321] PINMUX_DIO_PAD_ATTR_REGWEN_23
+    4'b 0011, // index[322] PINMUX_DIO_PAD_ATTR_0
+    4'b 0011, // index[323] PINMUX_DIO_PAD_ATTR_1
+    4'b 0011, // index[324] PINMUX_DIO_PAD_ATTR_2
+    4'b 0011, // index[325] PINMUX_DIO_PAD_ATTR_3
+    4'b 0011, // index[326] PINMUX_DIO_PAD_ATTR_4
+    4'b 0011, // index[327] PINMUX_DIO_PAD_ATTR_5
+    4'b 0011, // index[328] PINMUX_DIO_PAD_ATTR_6
+    4'b 0011, // index[329] PINMUX_DIO_PAD_ATTR_7
+    4'b 0011, // index[330] PINMUX_DIO_PAD_ATTR_8
+    4'b 0011, // index[331] PINMUX_DIO_PAD_ATTR_9
+    4'b 0011, // index[332] PINMUX_DIO_PAD_ATTR_10
+    4'b 0011, // index[333] PINMUX_DIO_PAD_ATTR_11
+    4'b 0011, // index[334] PINMUX_DIO_PAD_ATTR_12
+    4'b 0011, // index[335] PINMUX_DIO_PAD_ATTR_13
+    4'b 0011, // index[336] PINMUX_DIO_PAD_ATTR_14
+    4'b 0011, // index[337] PINMUX_DIO_PAD_ATTR_15
+    4'b 0011, // index[338] PINMUX_DIO_PAD_ATTR_16
+    4'b 0011, // index[339] PINMUX_DIO_PAD_ATTR_17
+    4'b 0011, // index[340] PINMUX_DIO_PAD_ATTR_18
+    4'b 0011, // index[341] PINMUX_DIO_PAD_ATTR_19
+    4'b 0011, // index[342] PINMUX_DIO_PAD_ATTR_20
+    4'b 0011, // index[343] PINMUX_DIO_PAD_ATTR_21
+    4'b 0011, // index[344] PINMUX_DIO_PAD_ATTR_22
+    4'b 0011, // index[345] PINMUX_DIO_PAD_ATTR_23
+    4'b 1111, // index[346] PINMUX_MIO_PAD_SLEEP_STATUS_0
+    4'b 0011, // index[347] PINMUX_MIO_PAD_SLEEP_STATUS_1
+    4'b 0001, // index[348] PINMUX_MIO_PAD_SLEEP_REGWEN_0
+    4'b 0001, // index[349] PINMUX_MIO_PAD_SLEEP_REGWEN_1
+    4'b 0001, // index[350] PINMUX_MIO_PAD_SLEEP_REGWEN_2
+    4'b 0001, // index[351] PINMUX_MIO_PAD_SLEEP_REGWEN_3
+    4'b 0001, // index[352] PINMUX_MIO_PAD_SLEEP_REGWEN_4
+    4'b 0001, // index[353] PINMUX_MIO_PAD_SLEEP_REGWEN_5
+    4'b 0001, // index[354] PINMUX_MIO_PAD_SLEEP_REGWEN_6
+    4'b 0001, // index[355] PINMUX_MIO_PAD_SLEEP_REGWEN_7
+    4'b 0001, // index[356] PINMUX_MIO_PAD_SLEEP_REGWEN_8
+    4'b 0001, // index[357] PINMUX_MIO_PAD_SLEEP_REGWEN_9
+    4'b 0001, // index[358] PINMUX_MIO_PAD_SLEEP_REGWEN_10
+    4'b 0001, // index[359] PINMUX_MIO_PAD_SLEEP_REGWEN_11
+    4'b 0001, // index[360] PINMUX_MIO_PAD_SLEEP_REGWEN_12
+    4'b 0001, // index[361] PINMUX_MIO_PAD_SLEEP_REGWEN_13
+    4'b 0001, // index[362] PINMUX_MIO_PAD_SLEEP_REGWEN_14
+    4'b 0001, // index[363] PINMUX_MIO_PAD_SLEEP_REGWEN_15
+    4'b 0001, // index[364] PINMUX_MIO_PAD_SLEEP_REGWEN_16
+    4'b 0001, // index[365] PINMUX_MIO_PAD_SLEEP_REGWEN_17
+    4'b 0001, // index[366] PINMUX_MIO_PAD_SLEEP_REGWEN_18
+    4'b 0001, // index[367] PINMUX_MIO_PAD_SLEEP_REGWEN_19
+    4'b 0001, // index[368] PINMUX_MIO_PAD_SLEEP_REGWEN_20
+    4'b 0001, // index[369] PINMUX_MIO_PAD_SLEEP_REGWEN_21
+    4'b 0001, // index[370] PINMUX_MIO_PAD_SLEEP_REGWEN_22
+    4'b 0001, // index[371] PINMUX_MIO_PAD_SLEEP_REGWEN_23
+    4'b 0001, // index[372] PINMUX_MIO_PAD_SLEEP_REGWEN_24
+    4'b 0001, // index[373] PINMUX_MIO_PAD_SLEEP_REGWEN_25
+    4'b 0001, // index[374] PINMUX_MIO_PAD_SLEEP_REGWEN_26
+    4'b 0001, // index[375] PINMUX_MIO_PAD_SLEEP_REGWEN_27
+    4'b 0001, // index[376] PINMUX_MIO_PAD_SLEEP_REGWEN_28
+    4'b 0001, // index[377] PINMUX_MIO_PAD_SLEEP_REGWEN_29
+    4'b 0001, // index[378] PINMUX_MIO_PAD_SLEEP_REGWEN_30
+    4'b 0001, // index[379] PINMUX_MIO_PAD_SLEEP_REGWEN_31
+    4'b 0001, // index[380] PINMUX_MIO_PAD_SLEEP_REGWEN_32
+    4'b 0001, // index[381] PINMUX_MIO_PAD_SLEEP_REGWEN_33
+    4'b 0001, // index[382] PINMUX_MIO_PAD_SLEEP_REGWEN_34
+    4'b 0001, // index[383] PINMUX_MIO_PAD_SLEEP_REGWEN_35
+    4'b 0001, // index[384] PINMUX_MIO_PAD_SLEEP_REGWEN_36
+    4'b 0001, // index[385] PINMUX_MIO_PAD_SLEEP_REGWEN_37
+    4'b 0001, // index[386] PINMUX_MIO_PAD_SLEEP_REGWEN_38
+    4'b 0001, // index[387] PINMUX_MIO_PAD_SLEEP_REGWEN_39
+    4'b 0001, // index[388] PINMUX_MIO_PAD_SLEEP_REGWEN_40
+    4'b 0001, // index[389] PINMUX_MIO_PAD_SLEEP_REGWEN_41
+    4'b 0001, // index[390] PINMUX_MIO_PAD_SLEEP_REGWEN_42
+    4'b 0001, // index[391] PINMUX_MIO_PAD_SLEEP_REGWEN_43
+    4'b 0001, // index[392] PINMUX_MIO_PAD_SLEEP_REGWEN_44
+    4'b 0001, // index[393] PINMUX_MIO_PAD_SLEEP_REGWEN_45
+    4'b 0001, // index[394] PINMUX_MIO_PAD_SLEEP_REGWEN_46
+    4'b 0001, // index[395] PINMUX_MIO_PAD_SLEEP_EN_0
+    4'b 0001, // index[396] PINMUX_MIO_PAD_SLEEP_EN_1
+    4'b 0001, // index[397] PINMUX_MIO_PAD_SLEEP_EN_2
+    4'b 0001, // index[398] PINMUX_MIO_PAD_SLEEP_EN_3
+    4'b 0001, // index[399] PINMUX_MIO_PAD_SLEEP_EN_4
+    4'b 0001, // index[400] PINMUX_MIO_PAD_SLEEP_EN_5
+    4'b 0001, // index[401] PINMUX_MIO_PAD_SLEEP_EN_6
+    4'b 0001, // index[402] PINMUX_MIO_PAD_SLEEP_EN_7
+    4'b 0001, // index[403] PINMUX_MIO_PAD_SLEEP_EN_8
+    4'b 0001, // index[404] PINMUX_MIO_PAD_SLEEP_EN_9
+    4'b 0001, // index[405] PINMUX_MIO_PAD_SLEEP_EN_10
+    4'b 0001, // index[406] PINMUX_MIO_PAD_SLEEP_EN_11
+    4'b 0001, // index[407] PINMUX_MIO_PAD_SLEEP_EN_12
+    4'b 0001, // index[408] PINMUX_MIO_PAD_SLEEP_EN_13
+    4'b 0001, // index[409] PINMUX_MIO_PAD_SLEEP_EN_14
+    4'b 0001, // index[410] PINMUX_MIO_PAD_SLEEP_EN_15
+    4'b 0001, // index[411] PINMUX_MIO_PAD_SLEEP_EN_16
+    4'b 0001, // index[412] PINMUX_MIO_PAD_SLEEP_EN_17
+    4'b 0001, // index[413] PINMUX_MIO_PAD_SLEEP_EN_18
+    4'b 0001, // index[414] PINMUX_MIO_PAD_SLEEP_EN_19
+    4'b 0001, // index[415] PINMUX_MIO_PAD_SLEEP_EN_20
+    4'b 0001, // index[416] PINMUX_MIO_PAD_SLEEP_EN_21
+    4'b 0001, // index[417] PINMUX_MIO_PAD_SLEEP_EN_22
+    4'b 0001, // index[418] PINMUX_MIO_PAD_SLEEP_EN_23
+    4'b 0001, // index[419] PINMUX_MIO_PAD_SLEEP_EN_24
+    4'b 0001, // index[420] PINMUX_MIO_PAD_SLEEP_EN_25
+    4'b 0001, // index[421] PINMUX_MIO_PAD_SLEEP_EN_26
+    4'b 0001, // index[422] PINMUX_MIO_PAD_SLEEP_EN_27
+    4'b 0001, // index[423] PINMUX_MIO_PAD_SLEEP_EN_28
+    4'b 0001, // index[424] PINMUX_MIO_PAD_SLEEP_EN_29
+    4'b 0001, // index[425] PINMUX_MIO_PAD_SLEEP_EN_30
+    4'b 0001, // index[426] PINMUX_MIO_PAD_SLEEP_EN_31
+    4'b 0001, // index[427] PINMUX_MIO_PAD_SLEEP_EN_32
+    4'b 0001, // index[428] PINMUX_MIO_PAD_SLEEP_EN_33
+    4'b 0001, // index[429] PINMUX_MIO_PAD_SLEEP_EN_34
+    4'b 0001, // index[430] PINMUX_MIO_PAD_SLEEP_EN_35
+    4'b 0001, // index[431] PINMUX_MIO_PAD_SLEEP_EN_36
+    4'b 0001, // index[432] PINMUX_MIO_PAD_SLEEP_EN_37
+    4'b 0001, // index[433] PINMUX_MIO_PAD_SLEEP_EN_38
+    4'b 0001, // index[434] PINMUX_MIO_PAD_SLEEP_EN_39
+    4'b 0001, // index[435] PINMUX_MIO_PAD_SLEEP_EN_40
+    4'b 0001, // index[436] PINMUX_MIO_PAD_SLEEP_EN_41
+    4'b 0001, // index[437] PINMUX_MIO_PAD_SLEEP_EN_42
+    4'b 0001, // index[438] PINMUX_MIO_PAD_SLEEP_EN_43
+    4'b 0001, // index[439] PINMUX_MIO_PAD_SLEEP_EN_44
+    4'b 0001, // index[440] PINMUX_MIO_PAD_SLEEP_EN_45
+    4'b 0001, // index[441] PINMUX_MIO_PAD_SLEEP_EN_46
+    4'b 0001, // index[442] PINMUX_MIO_PAD_SLEEP_MODE_0
+    4'b 0001, // index[443] PINMUX_MIO_PAD_SLEEP_MODE_1
+    4'b 0001, // index[444] PINMUX_MIO_PAD_SLEEP_MODE_2
+    4'b 0001, // index[445] PINMUX_MIO_PAD_SLEEP_MODE_3
+    4'b 0001, // index[446] PINMUX_MIO_PAD_SLEEP_MODE_4
+    4'b 0001, // index[447] PINMUX_MIO_PAD_SLEEP_MODE_5
+    4'b 0001, // index[448] PINMUX_MIO_PAD_SLEEP_MODE_6
+    4'b 0001, // index[449] PINMUX_MIO_PAD_SLEEP_MODE_7
+    4'b 0001, // index[450] PINMUX_MIO_PAD_SLEEP_MODE_8
+    4'b 0001, // index[451] PINMUX_MIO_PAD_SLEEP_MODE_9
+    4'b 0001, // index[452] PINMUX_MIO_PAD_SLEEP_MODE_10
+    4'b 0001, // index[453] PINMUX_MIO_PAD_SLEEP_MODE_11
+    4'b 0001, // index[454] PINMUX_MIO_PAD_SLEEP_MODE_12
+    4'b 0001, // index[455] PINMUX_MIO_PAD_SLEEP_MODE_13
+    4'b 0001, // index[456] PINMUX_MIO_PAD_SLEEP_MODE_14
+    4'b 0001, // index[457] PINMUX_MIO_PAD_SLEEP_MODE_15
+    4'b 0001, // index[458] PINMUX_MIO_PAD_SLEEP_MODE_16
+    4'b 0001, // index[459] PINMUX_MIO_PAD_SLEEP_MODE_17
+    4'b 0001, // index[460] PINMUX_MIO_PAD_SLEEP_MODE_18
+    4'b 0001, // index[461] PINMUX_MIO_PAD_SLEEP_MODE_19
+    4'b 0001, // index[462] PINMUX_MIO_PAD_SLEEP_MODE_20
+    4'b 0001, // index[463] PINMUX_MIO_PAD_SLEEP_MODE_21
+    4'b 0001, // index[464] PINMUX_MIO_PAD_SLEEP_MODE_22
+    4'b 0001, // index[465] PINMUX_MIO_PAD_SLEEP_MODE_23
+    4'b 0001, // index[466] PINMUX_MIO_PAD_SLEEP_MODE_24
+    4'b 0001, // index[467] PINMUX_MIO_PAD_SLEEP_MODE_25
+    4'b 0001, // index[468] PINMUX_MIO_PAD_SLEEP_MODE_26
+    4'b 0001, // index[469] PINMUX_MIO_PAD_SLEEP_MODE_27
+    4'b 0001, // index[470] PINMUX_MIO_PAD_SLEEP_MODE_28
+    4'b 0001, // index[471] PINMUX_MIO_PAD_SLEEP_MODE_29
+    4'b 0001, // index[472] PINMUX_MIO_PAD_SLEEP_MODE_30
+    4'b 0001, // index[473] PINMUX_MIO_PAD_SLEEP_MODE_31
+    4'b 0001, // index[474] PINMUX_MIO_PAD_SLEEP_MODE_32
+    4'b 0001, // index[475] PINMUX_MIO_PAD_SLEEP_MODE_33
+    4'b 0001, // index[476] PINMUX_MIO_PAD_SLEEP_MODE_34
+    4'b 0001, // index[477] PINMUX_MIO_PAD_SLEEP_MODE_35
+    4'b 0001, // index[478] PINMUX_MIO_PAD_SLEEP_MODE_36
+    4'b 0001, // index[479] PINMUX_MIO_PAD_SLEEP_MODE_37
+    4'b 0001, // index[480] PINMUX_MIO_PAD_SLEEP_MODE_38
+    4'b 0001, // index[481] PINMUX_MIO_PAD_SLEEP_MODE_39
+    4'b 0001, // index[482] PINMUX_MIO_PAD_SLEEP_MODE_40
+    4'b 0001, // index[483] PINMUX_MIO_PAD_SLEEP_MODE_41
+    4'b 0001, // index[484] PINMUX_MIO_PAD_SLEEP_MODE_42
+    4'b 0001, // index[485] PINMUX_MIO_PAD_SLEEP_MODE_43
+    4'b 0001, // index[486] PINMUX_MIO_PAD_SLEEP_MODE_44
+    4'b 0001, // index[487] PINMUX_MIO_PAD_SLEEP_MODE_45
+    4'b 0001, // index[488] PINMUX_MIO_PAD_SLEEP_MODE_46
+    4'b 0111, // index[489] PINMUX_DIO_PAD_SLEEP_STATUS
+    4'b 0001, // index[490] PINMUX_DIO_PAD_SLEEP_REGWEN_0
+    4'b 0001, // index[491] PINMUX_DIO_PAD_SLEEP_REGWEN_1
+    4'b 0001, // index[492] PINMUX_DIO_PAD_SLEEP_REGWEN_2
+    4'b 0001, // index[493] PINMUX_DIO_PAD_SLEEP_REGWEN_3
+    4'b 0001, // index[494] PINMUX_DIO_PAD_SLEEP_REGWEN_4
+    4'b 0001, // index[495] PINMUX_DIO_PAD_SLEEP_REGWEN_5
+    4'b 0001, // index[496] PINMUX_DIO_PAD_SLEEP_REGWEN_6
+    4'b 0001, // index[497] PINMUX_DIO_PAD_SLEEP_REGWEN_7
+    4'b 0001, // index[498] PINMUX_DIO_PAD_SLEEP_REGWEN_8
+    4'b 0001, // index[499] PINMUX_DIO_PAD_SLEEP_REGWEN_9
+    4'b 0001, // index[500] PINMUX_DIO_PAD_SLEEP_REGWEN_10
+    4'b 0001, // index[501] PINMUX_DIO_PAD_SLEEP_REGWEN_11
+    4'b 0001, // index[502] PINMUX_DIO_PAD_SLEEP_REGWEN_12
+    4'b 0001, // index[503] PINMUX_DIO_PAD_SLEEP_REGWEN_13
+    4'b 0001, // index[504] PINMUX_DIO_PAD_SLEEP_REGWEN_14
+    4'b 0001, // index[505] PINMUX_DIO_PAD_SLEEP_REGWEN_15
+    4'b 0001, // index[506] PINMUX_DIO_PAD_SLEEP_REGWEN_16
+    4'b 0001, // index[507] PINMUX_DIO_PAD_SLEEP_REGWEN_17
+    4'b 0001, // index[508] PINMUX_DIO_PAD_SLEEP_REGWEN_18
+    4'b 0001, // index[509] PINMUX_DIO_PAD_SLEEP_REGWEN_19
+    4'b 0001, // index[510] PINMUX_DIO_PAD_SLEEP_REGWEN_20
+    4'b 0001, // index[511] PINMUX_DIO_PAD_SLEEP_REGWEN_21
+    4'b 0001, // index[512] PINMUX_DIO_PAD_SLEEP_REGWEN_22
+    4'b 0001, // index[513] PINMUX_DIO_PAD_SLEEP_REGWEN_23
+    4'b 0001, // index[514] PINMUX_DIO_PAD_SLEEP_EN_0
+    4'b 0001, // index[515] PINMUX_DIO_PAD_SLEEP_EN_1
+    4'b 0001, // index[516] PINMUX_DIO_PAD_SLEEP_EN_2
+    4'b 0001, // index[517] PINMUX_DIO_PAD_SLEEP_EN_3
+    4'b 0001, // index[518] PINMUX_DIO_PAD_SLEEP_EN_4
+    4'b 0001, // index[519] PINMUX_DIO_PAD_SLEEP_EN_5
+    4'b 0001, // index[520] PINMUX_DIO_PAD_SLEEP_EN_6
+    4'b 0001, // index[521] PINMUX_DIO_PAD_SLEEP_EN_7
+    4'b 0001, // index[522] PINMUX_DIO_PAD_SLEEP_EN_8
+    4'b 0001, // index[523] PINMUX_DIO_PAD_SLEEP_EN_9
+    4'b 0001, // index[524] PINMUX_DIO_PAD_SLEEP_EN_10
+    4'b 0001, // index[525] PINMUX_DIO_PAD_SLEEP_EN_11
+    4'b 0001, // index[526] PINMUX_DIO_PAD_SLEEP_EN_12
+    4'b 0001, // index[527] PINMUX_DIO_PAD_SLEEP_EN_13
+    4'b 0001, // index[528] PINMUX_DIO_PAD_SLEEP_EN_14
+    4'b 0001, // index[529] PINMUX_DIO_PAD_SLEEP_EN_15
+    4'b 0001, // index[530] PINMUX_DIO_PAD_SLEEP_EN_16
+    4'b 0001, // index[531] PINMUX_DIO_PAD_SLEEP_EN_17
+    4'b 0001, // index[532] PINMUX_DIO_PAD_SLEEP_EN_18
+    4'b 0001, // index[533] PINMUX_DIO_PAD_SLEEP_EN_19
+    4'b 0001, // index[534] PINMUX_DIO_PAD_SLEEP_EN_20
+    4'b 0001, // index[535] PINMUX_DIO_PAD_SLEEP_EN_21
+    4'b 0001, // index[536] PINMUX_DIO_PAD_SLEEP_EN_22
+    4'b 0001, // index[537] PINMUX_DIO_PAD_SLEEP_EN_23
+    4'b 0001, // index[538] PINMUX_DIO_PAD_SLEEP_MODE_0
+    4'b 0001, // index[539] PINMUX_DIO_PAD_SLEEP_MODE_1
+    4'b 0001, // index[540] PINMUX_DIO_PAD_SLEEP_MODE_2
+    4'b 0001, // index[541] PINMUX_DIO_PAD_SLEEP_MODE_3
+    4'b 0001, // index[542] PINMUX_DIO_PAD_SLEEP_MODE_4
+    4'b 0001, // index[543] PINMUX_DIO_PAD_SLEEP_MODE_5
+    4'b 0001, // index[544] PINMUX_DIO_PAD_SLEEP_MODE_6
+    4'b 0001, // index[545] PINMUX_DIO_PAD_SLEEP_MODE_7
+    4'b 0001, // index[546] PINMUX_DIO_PAD_SLEEP_MODE_8
+    4'b 0001, // index[547] PINMUX_DIO_PAD_SLEEP_MODE_9
+    4'b 0001, // index[548] PINMUX_DIO_PAD_SLEEP_MODE_10
+    4'b 0001, // index[549] PINMUX_DIO_PAD_SLEEP_MODE_11
+    4'b 0001, // index[550] PINMUX_DIO_PAD_SLEEP_MODE_12
+    4'b 0001, // index[551] PINMUX_DIO_PAD_SLEEP_MODE_13
+    4'b 0001, // index[552] PINMUX_DIO_PAD_SLEEP_MODE_14
+    4'b 0001, // index[553] PINMUX_DIO_PAD_SLEEP_MODE_15
+    4'b 0001, // index[554] PINMUX_DIO_PAD_SLEEP_MODE_16
+    4'b 0001, // index[555] PINMUX_DIO_PAD_SLEEP_MODE_17
+    4'b 0001, // index[556] PINMUX_DIO_PAD_SLEEP_MODE_18
+    4'b 0001, // index[557] PINMUX_DIO_PAD_SLEEP_MODE_19
+    4'b 0001, // index[558] PINMUX_DIO_PAD_SLEEP_MODE_20
+    4'b 0001, // index[559] PINMUX_DIO_PAD_SLEEP_MODE_21
+    4'b 0001, // index[560] PINMUX_DIO_PAD_SLEEP_MODE_22
+    4'b 0001, // index[561] PINMUX_DIO_PAD_SLEEP_MODE_23
+    4'b 0001, // index[562] PINMUX_WKUP_DETECTOR_REGWEN_0
+    4'b 0001, // index[563] PINMUX_WKUP_DETECTOR_REGWEN_1
+    4'b 0001, // index[564] PINMUX_WKUP_DETECTOR_REGWEN_2
+    4'b 0001, // index[565] PINMUX_WKUP_DETECTOR_REGWEN_3
+    4'b 0001, // index[566] PINMUX_WKUP_DETECTOR_REGWEN_4
+    4'b 0001, // index[567] PINMUX_WKUP_DETECTOR_REGWEN_5
+    4'b 0001, // index[568] PINMUX_WKUP_DETECTOR_REGWEN_6
+    4'b 0001, // index[569] PINMUX_WKUP_DETECTOR_REGWEN_7
+    4'b 0001, // index[570] PINMUX_WKUP_DETECTOR_EN_0
+    4'b 0001, // index[571] PINMUX_WKUP_DETECTOR_EN_1
+    4'b 0001, // index[572] PINMUX_WKUP_DETECTOR_EN_2
+    4'b 0001, // index[573] PINMUX_WKUP_DETECTOR_EN_3
+    4'b 0001, // index[574] PINMUX_WKUP_DETECTOR_EN_4
+    4'b 0001, // index[575] PINMUX_WKUP_DETECTOR_EN_5
+    4'b 0001, // index[576] PINMUX_WKUP_DETECTOR_EN_6
+    4'b 0001, // index[577] PINMUX_WKUP_DETECTOR_EN_7
+    4'b 0001, // index[578] PINMUX_WKUP_DETECTOR_0
+    4'b 0001, // index[579] PINMUX_WKUP_DETECTOR_1
+    4'b 0001, // index[580] PINMUX_WKUP_DETECTOR_2
+    4'b 0001, // index[581] PINMUX_WKUP_DETECTOR_3
+    4'b 0001, // index[582] PINMUX_WKUP_DETECTOR_4
+    4'b 0001, // index[583] PINMUX_WKUP_DETECTOR_5
+    4'b 0001, // index[584] PINMUX_WKUP_DETECTOR_6
+    4'b 0001, // index[585] PINMUX_WKUP_DETECTOR_7
+    4'b 0001, // index[586] PINMUX_WKUP_DETECTOR_CNT_TH_0
+    4'b 0001, // index[587] PINMUX_WKUP_DETECTOR_CNT_TH_1
+    4'b 0001, // index[588] PINMUX_WKUP_DETECTOR_CNT_TH_2
+    4'b 0001, // index[589] PINMUX_WKUP_DETECTOR_CNT_TH_3
+    4'b 0001, // index[590] PINMUX_WKUP_DETECTOR_CNT_TH_4
+    4'b 0001, // index[591] PINMUX_WKUP_DETECTOR_CNT_TH_5
+    4'b 0001, // index[592] PINMUX_WKUP_DETECTOR_CNT_TH_6
+    4'b 0001, // index[593] PINMUX_WKUP_DETECTOR_CNT_TH_7
+    4'b 0001, // index[594] PINMUX_WKUP_DETECTOR_PADSEL_0
+    4'b 0001, // index[595] PINMUX_WKUP_DETECTOR_PADSEL_1
+    4'b 0001, // index[596] PINMUX_WKUP_DETECTOR_PADSEL_2
+    4'b 0001, // index[597] PINMUX_WKUP_DETECTOR_PADSEL_3
+    4'b 0001, // index[598] PINMUX_WKUP_DETECTOR_PADSEL_4
+    4'b 0001, // index[599] PINMUX_WKUP_DETECTOR_PADSEL_5
+    4'b 0001, // index[600] PINMUX_WKUP_DETECTOR_PADSEL_6
+    4'b 0001, // index[601] PINMUX_WKUP_DETECTOR_PADSEL_7
+    4'b 0001  // index[602] PINMUX_WKUP_CAUSE
   };
 
 endpackage

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
@@ -1114,6 +1114,9 @@ module pinmux_reg_top (
   logic dio_pad_attr_regwen_22_qs;
   logic dio_pad_attr_regwen_22_wd;
   logic dio_pad_attr_regwen_22_we;
+  logic dio_pad_attr_regwen_23_qs;
+  logic dio_pad_attr_regwen_23_wd;
+  logic dio_pad_attr_regwen_23_we;
   logic [12:0] dio_pad_attr_0_qs;
   logic [12:0] dio_pad_attr_0_wd;
   logic dio_pad_attr_0_we;
@@ -1206,6 +1209,10 @@ module pinmux_reg_top (
   logic [12:0] dio_pad_attr_22_wd;
   logic dio_pad_attr_22_we;
   logic dio_pad_attr_22_re;
+  logic [12:0] dio_pad_attr_23_qs;
+  logic [12:0] dio_pad_attr_23_wd;
+  logic dio_pad_attr_23_we;
+  logic dio_pad_attr_23_re;
   logic mio_pad_sleep_status_0_en_0_qs;
   logic mio_pad_sleep_status_0_en_0_wd;
   logic mio_pad_sleep_status_0_en_0_we;
@@ -1839,6 +1846,9 @@ module pinmux_reg_top (
   logic dio_pad_sleep_status_en_22_qs;
   logic dio_pad_sleep_status_en_22_wd;
   logic dio_pad_sleep_status_en_22_we;
+  logic dio_pad_sleep_status_en_23_qs;
+  logic dio_pad_sleep_status_en_23_wd;
+  logic dio_pad_sleep_status_en_23_we;
   logic dio_pad_sleep_regwen_0_qs;
   logic dio_pad_sleep_regwen_0_wd;
   logic dio_pad_sleep_regwen_0_we;
@@ -1908,6 +1918,9 @@ module pinmux_reg_top (
   logic dio_pad_sleep_regwen_22_qs;
   logic dio_pad_sleep_regwen_22_wd;
   logic dio_pad_sleep_regwen_22_we;
+  logic dio_pad_sleep_regwen_23_qs;
+  logic dio_pad_sleep_regwen_23_wd;
+  logic dio_pad_sleep_regwen_23_we;
   logic dio_pad_sleep_en_0_qs;
   logic dio_pad_sleep_en_0_wd;
   logic dio_pad_sleep_en_0_we;
@@ -1977,6 +1990,9 @@ module pinmux_reg_top (
   logic dio_pad_sleep_en_22_qs;
   logic dio_pad_sleep_en_22_wd;
   logic dio_pad_sleep_en_22_we;
+  logic dio_pad_sleep_en_23_qs;
+  logic dio_pad_sleep_en_23_wd;
+  logic dio_pad_sleep_en_23_we;
   logic [1:0] dio_pad_sleep_mode_0_qs;
   logic [1:0] dio_pad_sleep_mode_0_wd;
   logic dio_pad_sleep_mode_0_we;
@@ -2046,6 +2062,9 @@ module pinmux_reg_top (
   logic [1:0] dio_pad_sleep_mode_22_qs;
   logic [1:0] dio_pad_sleep_mode_22_wd;
   logic dio_pad_sleep_mode_22_we;
+  logic [1:0] dio_pad_sleep_mode_23_qs;
+  logic [1:0] dio_pad_sleep_mode_23_wd;
+  logic dio_pad_sleep_mode_23_we;
   logic wkup_detector_regwen_0_qs;
   logic wkup_detector_regwen_0_wd;
   logic wkup_detector_regwen_0_we;
@@ -10458,6 +10477,33 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_22_qs)
   );
 
+  // Subregister 23 of Multireg dio_pad_attr_regwen
+  // R[dio_pad_attr_regwen_23]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W0C"),
+    .RESVAL  (1'h1)
+  ) u_dio_pad_attr_regwen_23 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (dio_pad_attr_regwen_23_we),
+    .wd     (dio_pad_attr_regwen_23_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (dio_pad_attr_regwen_23_qs)
+  );
+
 
 
   // Subregister 0 of Multireg dio_pad_attr
@@ -10849,6 +10895,23 @@ module pinmux_reg_top (
     .qe     (reg2hw.dio_pad_attr[22].qe),
     .q      (reg2hw.dio_pad_attr[22].q ),
     .qs     (dio_pad_attr_22_qs)
+  );
+
+  // Subregister 23 of Multireg dio_pad_attr
+  // R[dio_pad_attr_23]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (13)
+  ) u_dio_pad_attr_23 (
+    .re     (dio_pad_attr_23_re),
+    // qualified with register enable
+    .we     (dio_pad_attr_23_we & dio_pad_attr_regwen_23_qs),
+    .wd     (dio_pad_attr_23_wd),
+    .d      (hw2reg.dio_pad_attr[23].d),
+    .qre    (),
+    .qe     (reg2hw.dio_pad_attr[23].qe),
+    .q      (reg2hw.dio_pad_attr[23].q ),
+    .qs     (dio_pad_attr_23_qs)
   );
 
 
@@ -16497,6 +16560,32 @@ module pinmux_reg_top (
   );
 
 
+  // F[en_23]: 23:23
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W0C"),
+    .RESVAL  (1'h0)
+  ) u_dio_pad_sleep_status_en_23 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (dio_pad_sleep_status_en_23_we),
+    .wd     (dio_pad_sleep_status_en_23_wd),
+
+    // from internal hardware
+    .de     (hw2reg.dio_pad_sleep_status[23].de),
+    .d      (hw2reg.dio_pad_sleep_status[23].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.dio_pad_sleep_status[23].q ),
+
+    // to register interface (read)
+    .qs     (dio_pad_sleep_status_en_23_qs)
+  );
+
+
 
 
   // Subregister 0 of Multireg dio_pad_sleep_regwen
@@ -17118,6 +17207,33 @@ module pinmux_reg_top (
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_22_qs)
+  );
+
+  // Subregister 23 of Multireg dio_pad_sleep_regwen
+  // R[dio_pad_sleep_regwen_23]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W0C"),
+    .RESVAL  (1'h1)
+  ) u_dio_pad_sleep_regwen_23 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (dio_pad_sleep_regwen_23_we),
+    .wd     (dio_pad_sleep_regwen_23_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (dio_pad_sleep_regwen_23_qs)
   );
 
 
@@ -17743,6 +17859,33 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_22_qs)
   );
 
+  // Subregister 23 of Multireg dio_pad_sleep_en
+  // R[dio_pad_sleep_en_23]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_dio_pad_sleep_en_23 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (dio_pad_sleep_en_23_we & dio_pad_sleep_regwen_23_qs),
+    .wd     (dio_pad_sleep_en_23_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.dio_pad_sleep_en[23].q ),
+
+    // to register interface (read)
+    .qs     (dio_pad_sleep_en_23_qs)
+  );
+
 
 
   // Subregister 0 of Multireg dio_pad_sleep_mode
@@ -18364,6 +18507,33 @@ module pinmux_reg_top (
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_22_qs)
+  );
+
+  // Subregister 23 of Multireg dio_pad_sleep_mode
+  // R[dio_pad_sleep_mode_23]: V(False)
+
+  prim_subreg #(
+    .DW      (2),
+    .SWACCESS("RW"),
+    .RESVAL  (2'h2)
+  ) u_dio_pad_sleep_mode_23 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (dio_pad_sleep_mode_23_we & dio_pad_sleep_regwen_23_qs),
+    .wd     (dio_pad_sleep_mode_23_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.dio_pad_sleep_mode[23].q ),
+
+    // to register interface (read)
+    .qs     (dio_pad_sleep_mode_23_qs)
   );
 
 
@@ -20016,7 +20186,7 @@ module pinmux_reg_top (
 
 
 
-  logic [597:0] addr_hit;
+  logic [602:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[  0] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_0_OFFSET);
@@ -20340,283 +20510,288 @@ module pinmux_reg_top (
     addr_hit[318] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_20_OFFSET);
     addr_hit[319] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_21_OFFSET);
     addr_hit[320] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_22_OFFSET);
-    addr_hit[321] = (reg_addr == PINMUX_DIO_PAD_ATTR_0_OFFSET);
-    addr_hit[322] = (reg_addr == PINMUX_DIO_PAD_ATTR_1_OFFSET);
-    addr_hit[323] = (reg_addr == PINMUX_DIO_PAD_ATTR_2_OFFSET);
-    addr_hit[324] = (reg_addr == PINMUX_DIO_PAD_ATTR_3_OFFSET);
-    addr_hit[325] = (reg_addr == PINMUX_DIO_PAD_ATTR_4_OFFSET);
-    addr_hit[326] = (reg_addr == PINMUX_DIO_PAD_ATTR_5_OFFSET);
-    addr_hit[327] = (reg_addr == PINMUX_DIO_PAD_ATTR_6_OFFSET);
-    addr_hit[328] = (reg_addr == PINMUX_DIO_PAD_ATTR_7_OFFSET);
-    addr_hit[329] = (reg_addr == PINMUX_DIO_PAD_ATTR_8_OFFSET);
-    addr_hit[330] = (reg_addr == PINMUX_DIO_PAD_ATTR_9_OFFSET);
-    addr_hit[331] = (reg_addr == PINMUX_DIO_PAD_ATTR_10_OFFSET);
-    addr_hit[332] = (reg_addr == PINMUX_DIO_PAD_ATTR_11_OFFSET);
-    addr_hit[333] = (reg_addr == PINMUX_DIO_PAD_ATTR_12_OFFSET);
-    addr_hit[334] = (reg_addr == PINMUX_DIO_PAD_ATTR_13_OFFSET);
-    addr_hit[335] = (reg_addr == PINMUX_DIO_PAD_ATTR_14_OFFSET);
-    addr_hit[336] = (reg_addr == PINMUX_DIO_PAD_ATTR_15_OFFSET);
-    addr_hit[337] = (reg_addr == PINMUX_DIO_PAD_ATTR_16_OFFSET);
-    addr_hit[338] = (reg_addr == PINMUX_DIO_PAD_ATTR_17_OFFSET);
-    addr_hit[339] = (reg_addr == PINMUX_DIO_PAD_ATTR_18_OFFSET);
-    addr_hit[340] = (reg_addr == PINMUX_DIO_PAD_ATTR_19_OFFSET);
-    addr_hit[341] = (reg_addr == PINMUX_DIO_PAD_ATTR_20_OFFSET);
-    addr_hit[342] = (reg_addr == PINMUX_DIO_PAD_ATTR_21_OFFSET);
-    addr_hit[343] = (reg_addr == PINMUX_DIO_PAD_ATTR_22_OFFSET);
-    addr_hit[344] = (reg_addr == PINMUX_MIO_PAD_SLEEP_STATUS_0_OFFSET);
-    addr_hit[345] = (reg_addr == PINMUX_MIO_PAD_SLEEP_STATUS_1_OFFSET);
-    addr_hit[346] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_0_OFFSET);
-    addr_hit[347] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_1_OFFSET);
-    addr_hit[348] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_2_OFFSET);
-    addr_hit[349] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_3_OFFSET);
-    addr_hit[350] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_4_OFFSET);
-    addr_hit[351] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_5_OFFSET);
-    addr_hit[352] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_6_OFFSET);
-    addr_hit[353] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_7_OFFSET);
-    addr_hit[354] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_8_OFFSET);
-    addr_hit[355] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_9_OFFSET);
-    addr_hit[356] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_10_OFFSET);
-    addr_hit[357] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_11_OFFSET);
-    addr_hit[358] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_12_OFFSET);
-    addr_hit[359] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_13_OFFSET);
-    addr_hit[360] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_14_OFFSET);
-    addr_hit[361] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_15_OFFSET);
-    addr_hit[362] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_16_OFFSET);
-    addr_hit[363] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_17_OFFSET);
-    addr_hit[364] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_18_OFFSET);
-    addr_hit[365] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_19_OFFSET);
-    addr_hit[366] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_20_OFFSET);
-    addr_hit[367] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_21_OFFSET);
-    addr_hit[368] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_22_OFFSET);
-    addr_hit[369] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_23_OFFSET);
-    addr_hit[370] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_24_OFFSET);
-    addr_hit[371] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_25_OFFSET);
-    addr_hit[372] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_26_OFFSET);
-    addr_hit[373] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_27_OFFSET);
-    addr_hit[374] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_28_OFFSET);
-    addr_hit[375] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_29_OFFSET);
-    addr_hit[376] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_30_OFFSET);
-    addr_hit[377] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_31_OFFSET);
-    addr_hit[378] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_32_OFFSET);
-    addr_hit[379] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_33_OFFSET);
-    addr_hit[380] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_34_OFFSET);
-    addr_hit[381] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_35_OFFSET);
-    addr_hit[382] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_36_OFFSET);
-    addr_hit[383] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_37_OFFSET);
-    addr_hit[384] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_38_OFFSET);
-    addr_hit[385] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_39_OFFSET);
-    addr_hit[386] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_40_OFFSET);
-    addr_hit[387] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_41_OFFSET);
-    addr_hit[388] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_42_OFFSET);
-    addr_hit[389] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_43_OFFSET);
-    addr_hit[390] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_44_OFFSET);
-    addr_hit[391] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_45_OFFSET);
-    addr_hit[392] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_46_OFFSET);
-    addr_hit[393] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_0_OFFSET);
-    addr_hit[394] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_1_OFFSET);
-    addr_hit[395] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_2_OFFSET);
-    addr_hit[396] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_3_OFFSET);
-    addr_hit[397] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_4_OFFSET);
-    addr_hit[398] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_5_OFFSET);
-    addr_hit[399] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_6_OFFSET);
-    addr_hit[400] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_7_OFFSET);
-    addr_hit[401] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_8_OFFSET);
-    addr_hit[402] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_9_OFFSET);
-    addr_hit[403] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_10_OFFSET);
-    addr_hit[404] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_11_OFFSET);
-    addr_hit[405] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_12_OFFSET);
-    addr_hit[406] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_13_OFFSET);
-    addr_hit[407] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_14_OFFSET);
-    addr_hit[408] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_15_OFFSET);
-    addr_hit[409] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_16_OFFSET);
-    addr_hit[410] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_17_OFFSET);
-    addr_hit[411] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_18_OFFSET);
-    addr_hit[412] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_19_OFFSET);
-    addr_hit[413] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_20_OFFSET);
-    addr_hit[414] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_21_OFFSET);
-    addr_hit[415] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_22_OFFSET);
-    addr_hit[416] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_23_OFFSET);
-    addr_hit[417] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_24_OFFSET);
-    addr_hit[418] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_25_OFFSET);
-    addr_hit[419] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_26_OFFSET);
-    addr_hit[420] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_27_OFFSET);
-    addr_hit[421] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_28_OFFSET);
-    addr_hit[422] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_29_OFFSET);
-    addr_hit[423] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_30_OFFSET);
-    addr_hit[424] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_31_OFFSET);
-    addr_hit[425] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_32_OFFSET);
-    addr_hit[426] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_33_OFFSET);
-    addr_hit[427] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_34_OFFSET);
-    addr_hit[428] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_35_OFFSET);
-    addr_hit[429] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_36_OFFSET);
-    addr_hit[430] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_37_OFFSET);
-    addr_hit[431] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_38_OFFSET);
-    addr_hit[432] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_39_OFFSET);
-    addr_hit[433] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_40_OFFSET);
-    addr_hit[434] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_41_OFFSET);
-    addr_hit[435] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_42_OFFSET);
-    addr_hit[436] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_43_OFFSET);
-    addr_hit[437] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_44_OFFSET);
-    addr_hit[438] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_45_OFFSET);
-    addr_hit[439] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_46_OFFSET);
-    addr_hit[440] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_0_OFFSET);
-    addr_hit[441] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_1_OFFSET);
-    addr_hit[442] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_2_OFFSET);
-    addr_hit[443] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_3_OFFSET);
-    addr_hit[444] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_4_OFFSET);
-    addr_hit[445] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_5_OFFSET);
-    addr_hit[446] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_6_OFFSET);
-    addr_hit[447] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_7_OFFSET);
-    addr_hit[448] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_8_OFFSET);
-    addr_hit[449] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_9_OFFSET);
-    addr_hit[450] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_10_OFFSET);
-    addr_hit[451] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_11_OFFSET);
-    addr_hit[452] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_12_OFFSET);
-    addr_hit[453] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_13_OFFSET);
-    addr_hit[454] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_14_OFFSET);
-    addr_hit[455] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_15_OFFSET);
-    addr_hit[456] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_16_OFFSET);
-    addr_hit[457] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_17_OFFSET);
-    addr_hit[458] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_18_OFFSET);
-    addr_hit[459] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_19_OFFSET);
-    addr_hit[460] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_20_OFFSET);
-    addr_hit[461] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_21_OFFSET);
-    addr_hit[462] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_22_OFFSET);
-    addr_hit[463] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_23_OFFSET);
-    addr_hit[464] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_24_OFFSET);
-    addr_hit[465] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_25_OFFSET);
-    addr_hit[466] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_26_OFFSET);
-    addr_hit[467] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_27_OFFSET);
-    addr_hit[468] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_28_OFFSET);
-    addr_hit[469] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_29_OFFSET);
-    addr_hit[470] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_30_OFFSET);
-    addr_hit[471] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_31_OFFSET);
-    addr_hit[472] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_32_OFFSET);
-    addr_hit[473] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_33_OFFSET);
-    addr_hit[474] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_34_OFFSET);
-    addr_hit[475] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_35_OFFSET);
-    addr_hit[476] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_36_OFFSET);
-    addr_hit[477] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_37_OFFSET);
-    addr_hit[478] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_38_OFFSET);
-    addr_hit[479] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_39_OFFSET);
-    addr_hit[480] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_40_OFFSET);
-    addr_hit[481] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_41_OFFSET);
-    addr_hit[482] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_42_OFFSET);
-    addr_hit[483] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_43_OFFSET);
-    addr_hit[484] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_44_OFFSET);
-    addr_hit[485] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_45_OFFSET);
-    addr_hit[486] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_46_OFFSET);
-    addr_hit[487] = (reg_addr == PINMUX_DIO_PAD_SLEEP_STATUS_OFFSET);
-    addr_hit[488] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_0_OFFSET);
-    addr_hit[489] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_1_OFFSET);
-    addr_hit[490] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_2_OFFSET);
-    addr_hit[491] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_3_OFFSET);
-    addr_hit[492] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_4_OFFSET);
-    addr_hit[493] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_5_OFFSET);
-    addr_hit[494] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_6_OFFSET);
-    addr_hit[495] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_7_OFFSET);
-    addr_hit[496] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_8_OFFSET);
-    addr_hit[497] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_9_OFFSET);
-    addr_hit[498] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_10_OFFSET);
-    addr_hit[499] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_11_OFFSET);
-    addr_hit[500] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_12_OFFSET);
-    addr_hit[501] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_13_OFFSET);
-    addr_hit[502] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_14_OFFSET);
-    addr_hit[503] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_15_OFFSET);
-    addr_hit[504] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_16_OFFSET);
-    addr_hit[505] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_17_OFFSET);
-    addr_hit[506] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_18_OFFSET);
-    addr_hit[507] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_19_OFFSET);
-    addr_hit[508] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_20_OFFSET);
-    addr_hit[509] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_21_OFFSET);
-    addr_hit[510] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_22_OFFSET);
-    addr_hit[511] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_0_OFFSET);
-    addr_hit[512] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_1_OFFSET);
-    addr_hit[513] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_2_OFFSET);
-    addr_hit[514] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_3_OFFSET);
-    addr_hit[515] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_4_OFFSET);
-    addr_hit[516] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_5_OFFSET);
-    addr_hit[517] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_6_OFFSET);
-    addr_hit[518] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_7_OFFSET);
-    addr_hit[519] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_8_OFFSET);
-    addr_hit[520] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_9_OFFSET);
-    addr_hit[521] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_10_OFFSET);
-    addr_hit[522] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_11_OFFSET);
-    addr_hit[523] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_12_OFFSET);
-    addr_hit[524] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_13_OFFSET);
-    addr_hit[525] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_14_OFFSET);
-    addr_hit[526] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_15_OFFSET);
-    addr_hit[527] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_16_OFFSET);
-    addr_hit[528] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_17_OFFSET);
-    addr_hit[529] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_18_OFFSET);
-    addr_hit[530] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_19_OFFSET);
-    addr_hit[531] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_20_OFFSET);
-    addr_hit[532] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_21_OFFSET);
-    addr_hit[533] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_22_OFFSET);
-    addr_hit[534] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_0_OFFSET);
-    addr_hit[535] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_1_OFFSET);
-    addr_hit[536] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_2_OFFSET);
-    addr_hit[537] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_3_OFFSET);
-    addr_hit[538] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_4_OFFSET);
-    addr_hit[539] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_5_OFFSET);
-    addr_hit[540] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_6_OFFSET);
-    addr_hit[541] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_7_OFFSET);
-    addr_hit[542] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_8_OFFSET);
-    addr_hit[543] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_9_OFFSET);
-    addr_hit[544] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_10_OFFSET);
-    addr_hit[545] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_11_OFFSET);
-    addr_hit[546] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_12_OFFSET);
-    addr_hit[547] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_13_OFFSET);
-    addr_hit[548] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_14_OFFSET);
-    addr_hit[549] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_15_OFFSET);
-    addr_hit[550] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_16_OFFSET);
-    addr_hit[551] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_17_OFFSET);
-    addr_hit[552] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_18_OFFSET);
-    addr_hit[553] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_19_OFFSET);
-    addr_hit[554] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_20_OFFSET);
-    addr_hit[555] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_21_OFFSET);
-    addr_hit[556] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_22_OFFSET);
-    addr_hit[557] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_0_OFFSET);
-    addr_hit[558] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_1_OFFSET);
-    addr_hit[559] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_2_OFFSET);
-    addr_hit[560] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_3_OFFSET);
-    addr_hit[561] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_4_OFFSET);
-    addr_hit[562] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_5_OFFSET);
-    addr_hit[563] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_6_OFFSET);
-    addr_hit[564] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_7_OFFSET);
-    addr_hit[565] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_0_OFFSET);
-    addr_hit[566] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_1_OFFSET);
-    addr_hit[567] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_2_OFFSET);
-    addr_hit[568] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_3_OFFSET);
-    addr_hit[569] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_4_OFFSET);
-    addr_hit[570] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_5_OFFSET);
-    addr_hit[571] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_6_OFFSET);
-    addr_hit[572] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_7_OFFSET);
-    addr_hit[573] = (reg_addr == PINMUX_WKUP_DETECTOR_0_OFFSET);
-    addr_hit[574] = (reg_addr == PINMUX_WKUP_DETECTOR_1_OFFSET);
-    addr_hit[575] = (reg_addr == PINMUX_WKUP_DETECTOR_2_OFFSET);
-    addr_hit[576] = (reg_addr == PINMUX_WKUP_DETECTOR_3_OFFSET);
-    addr_hit[577] = (reg_addr == PINMUX_WKUP_DETECTOR_4_OFFSET);
-    addr_hit[578] = (reg_addr == PINMUX_WKUP_DETECTOR_5_OFFSET);
-    addr_hit[579] = (reg_addr == PINMUX_WKUP_DETECTOR_6_OFFSET);
-    addr_hit[580] = (reg_addr == PINMUX_WKUP_DETECTOR_7_OFFSET);
-    addr_hit[581] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_0_OFFSET);
-    addr_hit[582] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_1_OFFSET);
-    addr_hit[583] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_2_OFFSET);
-    addr_hit[584] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_3_OFFSET);
-    addr_hit[585] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_4_OFFSET);
-    addr_hit[586] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_5_OFFSET);
-    addr_hit[587] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_6_OFFSET);
-    addr_hit[588] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_7_OFFSET);
-    addr_hit[589] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_0_OFFSET);
-    addr_hit[590] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_1_OFFSET);
-    addr_hit[591] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_2_OFFSET);
-    addr_hit[592] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_3_OFFSET);
-    addr_hit[593] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_4_OFFSET);
-    addr_hit[594] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_5_OFFSET);
-    addr_hit[595] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_6_OFFSET);
-    addr_hit[596] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_7_OFFSET);
-    addr_hit[597] = (reg_addr == PINMUX_WKUP_CAUSE_OFFSET);
+    addr_hit[321] = (reg_addr == PINMUX_DIO_PAD_ATTR_REGWEN_23_OFFSET);
+    addr_hit[322] = (reg_addr == PINMUX_DIO_PAD_ATTR_0_OFFSET);
+    addr_hit[323] = (reg_addr == PINMUX_DIO_PAD_ATTR_1_OFFSET);
+    addr_hit[324] = (reg_addr == PINMUX_DIO_PAD_ATTR_2_OFFSET);
+    addr_hit[325] = (reg_addr == PINMUX_DIO_PAD_ATTR_3_OFFSET);
+    addr_hit[326] = (reg_addr == PINMUX_DIO_PAD_ATTR_4_OFFSET);
+    addr_hit[327] = (reg_addr == PINMUX_DIO_PAD_ATTR_5_OFFSET);
+    addr_hit[328] = (reg_addr == PINMUX_DIO_PAD_ATTR_6_OFFSET);
+    addr_hit[329] = (reg_addr == PINMUX_DIO_PAD_ATTR_7_OFFSET);
+    addr_hit[330] = (reg_addr == PINMUX_DIO_PAD_ATTR_8_OFFSET);
+    addr_hit[331] = (reg_addr == PINMUX_DIO_PAD_ATTR_9_OFFSET);
+    addr_hit[332] = (reg_addr == PINMUX_DIO_PAD_ATTR_10_OFFSET);
+    addr_hit[333] = (reg_addr == PINMUX_DIO_PAD_ATTR_11_OFFSET);
+    addr_hit[334] = (reg_addr == PINMUX_DIO_PAD_ATTR_12_OFFSET);
+    addr_hit[335] = (reg_addr == PINMUX_DIO_PAD_ATTR_13_OFFSET);
+    addr_hit[336] = (reg_addr == PINMUX_DIO_PAD_ATTR_14_OFFSET);
+    addr_hit[337] = (reg_addr == PINMUX_DIO_PAD_ATTR_15_OFFSET);
+    addr_hit[338] = (reg_addr == PINMUX_DIO_PAD_ATTR_16_OFFSET);
+    addr_hit[339] = (reg_addr == PINMUX_DIO_PAD_ATTR_17_OFFSET);
+    addr_hit[340] = (reg_addr == PINMUX_DIO_PAD_ATTR_18_OFFSET);
+    addr_hit[341] = (reg_addr == PINMUX_DIO_PAD_ATTR_19_OFFSET);
+    addr_hit[342] = (reg_addr == PINMUX_DIO_PAD_ATTR_20_OFFSET);
+    addr_hit[343] = (reg_addr == PINMUX_DIO_PAD_ATTR_21_OFFSET);
+    addr_hit[344] = (reg_addr == PINMUX_DIO_PAD_ATTR_22_OFFSET);
+    addr_hit[345] = (reg_addr == PINMUX_DIO_PAD_ATTR_23_OFFSET);
+    addr_hit[346] = (reg_addr == PINMUX_MIO_PAD_SLEEP_STATUS_0_OFFSET);
+    addr_hit[347] = (reg_addr == PINMUX_MIO_PAD_SLEEP_STATUS_1_OFFSET);
+    addr_hit[348] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_0_OFFSET);
+    addr_hit[349] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_1_OFFSET);
+    addr_hit[350] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_2_OFFSET);
+    addr_hit[351] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_3_OFFSET);
+    addr_hit[352] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_4_OFFSET);
+    addr_hit[353] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_5_OFFSET);
+    addr_hit[354] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_6_OFFSET);
+    addr_hit[355] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_7_OFFSET);
+    addr_hit[356] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_8_OFFSET);
+    addr_hit[357] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_9_OFFSET);
+    addr_hit[358] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_10_OFFSET);
+    addr_hit[359] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_11_OFFSET);
+    addr_hit[360] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_12_OFFSET);
+    addr_hit[361] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_13_OFFSET);
+    addr_hit[362] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_14_OFFSET);
+    addr_hit[363] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_15_OFFSET);
+    addr_hit[364] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_16_OFFSET);
+    addr_hit[365] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_17_OFFSET);
+    addr_hit[366] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_18_OFFSET);
+    addr_hit[367] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_19_OFFSET);
+    addr_hit[368] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_20_OFFSET);
+    addr_hit[369] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_21_OFFSET);
+    addr_hit[370] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_22_OFFSET);
+    addr_hit[371] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_23_OFFSET);
+    addr_hit[372] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_24_OFFSET);
+    addr_hit[373] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_25_OFFSET);
+    addr_hit[374] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_26_OFFSET);
+    addr_hit[375] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_27_OFFSET);
+    addr_hit[376] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_28_OFFSET);
+    addr_hit[377] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_29_OFFSET);
+    addr_hit[378] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_30_OFFSET);
+    addr_hit[379] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_31_OFFSET);
+    addr_hit[380] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_32_OFFSET);
+    addr_hit[381] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_33_OFFSET);
+    addr_hit[382] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_34_OFFSET);
+    addr_hit[383] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_35_OFFSET);
+    addr_hit[384] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_36_OFFSET);
+    addr_hit[385] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_37_OFFSET);
+    addr_hit[386] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_38_OFFSET);
+    addr_hit[387] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_39_OFFSET);
+    addr_hit[388] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_40_OFFSET);
+    addr_hit[389] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_41_OFFSET);
+    addr_hit[390] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_42_OFFSET);
+    addr_hit[391] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_43_OFFSET);
+    addr_hit[392] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_44_OFFSET);
+    addr_hit[393] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_45_OFFSET);
+    addr_hit[394] = (reg_addr == PINMUX_MIO_PAD_SLEEP_REGWEN_46_OFFSET);
+    addr_hit[395] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_0_OFFSET);
+    addr_hit[396] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_1_OFFSET);
+    addr_hit[397] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_2_OFFSET);
+    addr_hit[398] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_3_OFFSET);
+    addr_hit[399] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_4_OFFSET);
+    addr_hit[400] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_5_OFFSET);
+    addr_hit[401] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_6_OFFSET);
+    addr_hit[402] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_7_OFFSET);
+    addr_hit[403] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_8_OFFSET);
+    addr_hit[404] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_9_OFFSET);
+    addr_hit[405] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_10_OFFSET);
+    addr_hit[406] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_11_OFFSET);
+    addr_hit[407] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_12_OFFSET);
+    addr_hit[408] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_13_OFFSET);
+    addr_hit[409] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_14_OFFSET);
+    addr_hit[410] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_15_OFFSET);
+    addr_hit[411] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_16_OFFSET);
+    addr_hit[412] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_17_OFFSET);
+    addr_hit[413] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_18_OFFSET);
+    addr_hit[414] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_19_OFFSET);
+    addr_hit[415] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_20_OFFSET);
+    addr_hit[416] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_21_OFFSET);
+    addr_hit[417] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_22_OFFSET);
+    addr_hit[418] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_23_OFFSET);
+    addr_hit[419] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_24_OFFSET);
+    addr_hit[420] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_25_OFFSET);
+    addr_hit[421] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_26_OFFSET);
+    addr_hit[422] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_27_OFFSET);
+    addr_hit[423] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_28_OFFSET);
+    addr_hit[424] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_29_OFFSET);
+    addr_hit[425] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_30_OFFSET);
+    addr_hit[426] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_31_OFFSET);
+    addr_hit[427] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_32_OFFSET);
+    addr_hit[428] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_33_OFFSET);
+    addr_hit[429] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_34_OFFSET);
+    addr_hit[430] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_35_OFFSET);
+    addr_hit[431] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_36_OFFSET);
+    addr_hit[432] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_37_OFFSET);
+    addr_hit[433] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_38_OFFSET);
+    addr_hit[434] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_39_OFFSET);
+    addr_hit[435] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_40_OFFSET);
+    addr_hit[436] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_41_OFFSET);
+    addr_hit[437] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_42_OFFSET);
+    addr_hit[438] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_43_OFFSET);
+    addr_hit[439] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_44_OFFSET);
+    addr_hit[440] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_45_OFFSET);
+    addr_hit[441] = (reg_addr == PINMUX_MIO_PAD_SLEEP_EN_46_OFFSET);
+    addr_hit[442] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_0_OFFSET);
+    addr_hit[443] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_1_OFFSET);
+    addr_hit[444] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_2_OFFSET);
+    addr_hit[445] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_3_OFFSET);
+    addr_hit[446] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_4_OFFSET);
+    addr_hit[447] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_5_OFFSET);
+    addr_hit[448] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_6_OFFSET);
+    addr_hit[449] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_7_OFFSET);
+    addr_hit[450] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_8_OFFSET);
+    addr_hit[451] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_9_OFFSET);
+    addr_hit[452] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_10_OFFSET);
+    addr_hit[453] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_11_OFFSET);
+    addr_hit[454] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_12_OFFSET);
+    addr_hit[455] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_13_OFFSET);
+    addr_hit[456] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_14_OFFSET);
+    addr_hit[457] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_15_OFFSET);
+    addr_hit[458] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_16_OFFSET);
+    addr_hit[459] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_17_OFFSET);
+    addr_hit[460] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_18_OFFSET);
+    addr_hit[461] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_19_OFFSET);
+    addr_hit[462] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_20_OFFSET);
+    addr_hit[463] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_21_OFFSET);
+    addr_hit[464] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_22_OFFSET);
+    addr_hit[465] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_23_OFFSET);
+    addr_hit[466] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_24_OFFSET);
+    addr_hit[467] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_25_OFFSET);
+    addr_hit[468] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_26_OFFSET);
+    addr_hit[469] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_27_OFFSET);
+    addr_hit[470] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_28_OFFSET);
+    addr_hit[471] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_29_OFFSET);
+    addr_hit[472] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_30_OFFSET);
+    addr_hit[473] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_31_OFFSET);
+    addr_hit[474] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_32_OFFSET);
+    addr_hit[475] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_33_OFFSET);
+    addr_hit[476] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_34_OFFSET);
+    addr_hit[477] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_35_OFFSET);
+    addr_hit[478] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_36_OFFSET);
+    addr_hit[479] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_37_OFFSET);
+    addr_hit[480] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_38_OFFSET);
+    addr_hit[481] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_39_OFFSET);
+    addr_hit[482] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_40_OFFSET);
+    addr_hit[483] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_41_OFFSET);
+    addr_hit[484] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_42_OFFSET);
+    addr_hit[485] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_43_OFFSET);
+    addr_hit[486] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_44_OFFSET);
+    addr_hit[487] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_45_OFFSET);
+    addr_hit[488] = (reg_addr == PINMUX_MIO_PAD_SLEEP_MODE_46_OFFSET);
+    addr_hit[489] = (reg_addr == PINMUX_DIO_PAD_SLEEP_STATUS_OFFSET);
+    addr_hit[490] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_0_OFFSET);
+    addr_hit[491] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_1_OFFSET);
+    addr_hit[492] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_2_OFFSET);
+    addr_hit[493] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_3_OFFSET);
+    addr_hit[494] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_4_OFFSET);
+    addr_hit[495] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_5_OFFSET);
+    addr_hit[496] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_6_OFFSET);
+    addr_hit[497] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_7_OFFSET);
+    addr_hit[498] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_8_OFFSET);
+    addr_hit[499] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_9_OFFSET);
+    addr_hit[500] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_10_OFFSET);
+    addr_hit[501] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_11_OFFSET);
+    addr_hit[502] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_12_OFFSET);
+    addr_hit[503] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_13_OFFSET);
+    addr_hit[504] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_14_OFFSET);
+    addr_hit[505] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_15_OFFSET);
+    addr_hit[506] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_16_OFFSET);
+    addr_hit[507] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_17_OFFSET);
+    addr_hit[508] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_18_OFFSET);
+    addr_hit[509] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_19_OFFSET);
+    addr_hit[510] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_20_OFFSET);
+    addr_hit[511] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_21_OFFSET);
+    addr_hit[512] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_22_OFFSET);
+    addr_hit[513] = (reg_addr == PINMUX_DIO_PAD_SLEEP_REGWEN_23_OFFSET);
+    addr_hit[514] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_0_OFFSET);
+    addr_hit[515] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_1_OFFSET);
+    addr_hit[516] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_2_OFFSET);
+    addr_hit[517] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_3_OFFSET);
+    addr_hit[518] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_4_OFFSET);
+    addr_hit[519] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_5_OFFSET);
+    addr_hit[520] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_6_OFFSET);
+    addr_hit[521] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_7_OFFSET);
+    addr_hit[522] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_8_OFFSET);
+    addr_hit[523] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_9_OFFSET);
+    addr_hit[524] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_10_OFFSET);
+    addr_hit[525] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_11_OFFSET);
+    addr_hit[526] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_12_OFFSET);
+    addr_hit[527] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_13_OFFSET);
+    addr_hit[528] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_14_OFFSET);
+    addr_hit[529] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_15_OFFSET);
+    addr_hit[530] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_16_OFFSET);
+    addr_hit[531] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_17_OFFSET);
+    addr_hit[532] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_18_OFFSET);
+    addr_hit[533] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_19_OFFSET);
+    addr_hit[534] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_20_OFFSET);
+    addr_hit[535] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_21_OFFSET);
+    addr_hit[536] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_22_OFFSET);
+    addr_hit[537] = (reg_addr == PINMUX_DIO_PAD_SLEEP_EN_23_OFFSET);
+    addr_hit[538] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_0_OFFSET);
+    addr_hit[539] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_1_OFFSET);
+    addr_hit[540] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_2_OFFSET);
+    addr_hit[541] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_3_OFFSET);
+    addr_hit[542] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_4_OFFSET);
+    addr_hit[543] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_5_OFFSET);
+    addr_hit[544] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_6_OFFSET);
+    addr_hit[545] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_7_OFFSET);
+    addr_hit[546] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_8_OFFSET);
+    addr_hit[547] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_9_OFFSET);
+    addr_hit[548] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_10_OFFSET);
+    addr_hit[549] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_11_OFFSET);
+    addr_hit[550] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_12_OFFSET);
+    addr_hit[551] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_13_OFFSET);
+    addr_hit[552] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_14_OFFSET);
+    addr_hit[553] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_15_OFFSET);
+    addr_hit[554] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_16_OFFSET);
+    addr_hit[555] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_17_OFFSET);
+    addr_hit[556] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_18_OFFSET);
+    addr_hit[557] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_19_OFFSET);
+    addr_hit[558] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_20_OFFSET);
+    addr_hit[559] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_21_OFFSET);
+    addr_hit[560] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_22_OFFSET);
+    addr_hit[561] = (reg_addr == PINMUX_DIO_PAD_SLEEP_MODE_23_OFFSET);
+    addr_hit[562] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_0_OFFSET);
+    addr_hit[563] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_1_OFFSET);
+    addr_hit[564] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_2_OFFSET);
+    addr_hit[565] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_3_OFFSET);
+    addr_hit[566] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_4_OFFSET);
+    addr_hit[567] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_5_OFFSET);
+    addr_hit[568] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_6_OFFSET);
+    addr_hit[569] = (reg_addr == PINMUX_WKUP_DETECTOR_REGWEN_7_OFFSET);
+    addr_hit[570] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_0_OFFSET);
+    addr_hit[571] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_1_OFFSET);
+    addr_hit[572] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_2_OFFSET);
+    addr_hit[573] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_3_OFFSET);
+    addr_hit[574] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_4_OFFSET);
+    addr_hit[575] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_5_OFFSET);
+    addr_hit[576] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_6_OFFSET);
+    addr_hit[577] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_7_OFFSET);
+    addr_hit[578] = (reg_addr == PINMUX_WKUP_DETECTOR_0_OFFSET);
+    addr_hit[579] = (reg_addr == PINMUX_WKUP_DETECTOR_1_OFFSET);
+    addr_hit[580] = (reg_addr == PINMUX_WKUP_DETECTOR_2_OFFSET);
+    addr_hit[581] = (reg_addr == PINMUX_WKUP_DETECTOR_3_OFFSET);
+    addr_hit[582] = (reg_addr == PINMUX_WKUP_DETECTOR_4_OFFSET);
+    addr_hit[583] = (reg_addr == PINMUX_WKUP_DETECTOR_5_OFFSET);
+    addr_hit[584] = (reg_addr == PINMUX_WKUP_DETECTOR_6_OFFSET);
+    addr_hit[585] = (reg_addr == PINMUX_WKUP_DETECTOR_7_OFFSET);
+    addr_hit[586] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_0_OFFSET);
+    addr_hit[587] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_1_OFFSET);
+    addr_hit[588] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_2_OFFSET);
+    addr_hit[589] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_3_OFFSET);
+    addr_hit[590] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_4_OFFSET);
+    addr_hit[591] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_5_OFFSET);
+    addr_hit[592] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_6_OFFSET);
+    addr_hit[593] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH_7_OFFSET);
+    addr_hit[594] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_0_OFFSET);
+    addr_hit[595] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_1_OFFSET);
+    addr_hit[596] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_2_OFFSET);
+    addr_hit[597] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_3_OFFSET);
+    addr_hit[598] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_4_OFFSET);
+    addr_hit[599] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_5_OFFSET);
+    addr_hit[600] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_6_OFFSET);
+    addr_hit[601] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL_7_OFFSET);
+    addr_hit[602] = (reg_addr == PINMUX_WKUP_CAUSE_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -21222,6 +21397,11 @@ module pinmux_reg_top (
     if (addr_hit[595] && reg_we && (PINMUX_PERMIT[595] != (PINMUX_PERMIT[595] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[596] && reg_we && (PINMUX_PERMIT[596] != (PINMUX_PERMIT[596] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[597] && reg_we && (PINMUX_PERMIT[597] != (PINMUX_PERMIT[597] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[598] && reg_we && (PINMUX_PERMIT[598] != (PINMUX_PERMIT[598] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[599] && reg_we && (PINMUX_PERMIT[599] != (PINMUX_PERMIT[599] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[600] && reg_we && (PINMUX_PERMIT[600] != (PINMUX_PERMIT[600] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[601] && reg_we && (PINMUX_PERMIT[601] != (PINMUX_PERMIT[601] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[602] && reg_we && (PINMUX_PERMIT[602] != (PINMUX_PERMIT[602] & reg_be))) wr_err = 1'b1 ;
   end
 
   assign mio_periph_insel_regwen_0_we = addr_hit[0] & reg_we & !reg_error;
@@ -22234,1137 +22414,1156 @@ module pinmux_reg_top (
   assign dio_pad_attr_regwen_22_we = addr_hit[320] & reg_we & !reg_error;
   assign dio_pad_attr_regwen_22_wd = reg_wdata[0];
 
-  assign dio_pad_attr_0_we = addr_hit[321] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_23_we = addr_hit[321] & reg_we & !reg_error;
+  assign dio_pad_attr_regwen_23_wd = reg_wdata[0];
+
+  assign dio_pad_attr_0_we = addr_hit[322] & reg_we & !reg_error;
   assign dio_pad_attr_0_wd = reg_wdata[12:0];
-  assign dio_pad_attr_0_re = addr_hit[321] & reg_re & !reg_error;
+  assign dio_pad_attr_0_re = addr_hit[322] & reg_re & !reg_error;
 
-  assign dio_pad_attr_1_we = addr_hit[322] & reg_we & !reg_error;
+  assign dio_pad_attr_1_we = addr_hit[323] & reg_we & !reg_error;
   assign dio_pad_attr_1_wd = reg_wdata[12:0];
-  assign dio_pad_attr_1_re = addr_hit[322] & reg_re & !reg_error;
+  assign dio_pad_attr_1_re = addr_hit[323] & reg_re & !reg_error;
 
-  assign dio_pad_attr_2_we = addr_hit[323] & reg_we & !reg_error;
+  assign dio_pad_attr_2_we = addr_hit[324] & reg_we & !reg_error;
   assign dio_pad_attr_2_wd = reg_wdata[12:0];
-  assign dio_pad_attr_2_re = addr_hit[323] & reg_re & !reg_error;
+  assign dio_pad_attr_2_re = addr_hit[324] & reg_re & !reg_error;
 
-  assign dio_pad_attr_3_we = addr_hit[324] & reg_we & !reg_error;
+  assign dio_pad_attr_3_we = addr_hit[325] & reg_we & !reg_error;
   assign dio_pad_attr_3_wd = reg_wdata[12:0];
-  assign dio_pad_attr_3_re = addr_hit[324] & reg_re & !reg_error;
+  assign dio_pad_attr_3_re = addr_hit[325] & reg_re & !reg_error;
 
-  assign dio_pad_attr_4_we = addr_hit[325] & reg_we & !reg_error;
+  assign dio_pad_attr_4_we = addr_hit[326] & reg_we & !reg_error;
   assign dio_pad_attr_4_wd = reg_wdata[12:0];
-  assign dio_pad_attr_4_re = addr_hit[325] & reg_re & !reg_error;
+  assign dio_pad_attr_4_re = addr_hit[326] & reg_re & !reg_error;
 
-  assign dio_pad_attr_5_we = addr_hit[326] & reg_we & !reg_error;
+  assign dio_pad_attr_5_we = addr_hit[327] & reg_we & !reg_error;
   assign dio_pad_attr_5_wd = reg_wdata[12:0];
-  assign dio_pad_attr_5_re = addr_hit[326] & reg_re & !reg_error;
+  assign dio_pad_attr_5_re = addr_hit[327] & reg_re & !reg_error;
 
-  assign dio_pad_attr_6_we = addr_hit[327] & reg_we & !reg_error;
+  assign dio_pad_attr_6_we = addr_hit[328] & reg_we & !reg_error;
   assign dio_pad_attr_6_wd = reg_wdata[12:0];
-  assign dio_pad_attr_6_re = addr_hit[327] & reg_re & !reg_error;
+  assign dio_pad_attr_6_re = addr_hit[328] & reg_re & !reg_error;
 
-  assign dio_pad_attr_7_we = addr_hit[328] & reg_we & !reg_error;
+  assign dio_pad_attr_7_we = addr_hit[329] & reg_we & !reg_error;
   assign dio_pad_attr_7_wd = reg_wdata[12:0];
-  assign dio_pad_attr_7_re = addr_hit[328] & reg_re & !reg_error;
+  assign dio_pad_attr_7_re = addr_hit[329] & reg_re & !reg_error;
 
-  assign dio_pad_attr_8_we = addr_hit[329] & reg_we & !reg_error;
+  assign dio_pad_attr_8_we = addr_hit[330] & reg_we & !reg_error;
   assign dio_pad_attr_8_wd = reg_wdata[12:0];
-  assign dio_pad_attr_8_re = addr_hit[329] & reg_re & !reg_error;
+  assign dio_pad_attr_8_re = addr_hit[330] & reg_re & !reg_error;
 
-  assign dio_pad_attr_9_we = addr_hit[330] & reg_we & !reg_error;
+  assign dio_pad_attr_9_we = addr_hit[331] & reg_we & !reg_error;
   assign dio_pad_attr_9_wd = reg_wdata[12:0];
-  assign dio_pad_attr_9_re = addr_hit[330] & reg_re & !reg_error;
+  assign dio_pad_attr_9_re = addr_hit[331] & reg_re & !reg_error;
 
-  assign dio_pad_attr_10_we = addr_hit[331] & reg_we & !reg_error;
+  assign dio_pad_attr_10_we = addr_hit[332] & reg_we & !reg_error;
   assign dio_pad_attr_10_wd = reg_wdata[12:0];
-  assign dio_pad_attr_10_re = addr_hit[331] & reg_re & !reg_error;
+  assign dio_pad_attr_10_re = addr_hit[332] & reg_re & !reg_error;
 
-  assign dio_pad_attr_11_we = addr_hit[332] & reg_we & !reg_error;
+  assign dio_pad_attr_11_we = addr_hit[333] & reg_we & !reg_error;
   assign dio_pad_attr_11_wd = reg_wdata[12:0];
-  assign dio_pad_attr_11_re = addr_hit[332] & reg_re & !reg_error;
+  assign dio_pad_attr_11_re = addr_hit[333] & reg_re & !reg_error;
 
-  assign dio_pad_attr_12_we = addr_hit[333] & reg_we & !reg_error;
+  assign dio_pad_attr_12_we = addr_hit[334] & reg_we & !reg_error;
   assign dio_pad_attr_12_wd = reg_wdata[12:0];
-  assign dio_pad_attr_12_re = addr_hit[333] & reg_re & !reg_error;
+  assign dio_pad_attr_12_re = addr_hit[334] & reg_re & !reg_error;
 
-  assign dio_pad_attr_13_we = addr_hit[334] & reg_we & !reg_error;
+  assign dio_pad_attr_13_we = addr_hit[335] & reg_we & !reg_error;
   assign dio_pad_attr_13_wd = reg_wdata[12:0];
-  assign dio_pad_attr_13_re = addr_hit[334] & reg_re & !reg_error;
+  assign dio_pad_attr_13_re = addr_hit[335] & reg_re & !reg_error;
 
-  assign dio_pad_attr_14_we = addr_hit[335] & reg_we & !reg_error;
+  assign dio_pad_attr_14_we = addr_hit[336] & reg_we & !reg_error;
   assign dio_pad_attr_14_wd = reg_wdata[12:0];
-  assign dio_pad_attr_14_re = addr_hit[335] & reg_re & !reg_error;
+  assign dio_pad_attr_14_re = addr_hit[336] & reg_re & !reg_error;
 
-  assign dio_pad_attr_15_we = addr_hit[336] & reg_we & !reg_error;
+  assign dio_pad_attr_15_we = addr_hit[337] & reg_we & !reg_error;
   assign dio_pad_attr_15_wd = reg_wdata[12:0];
-  assign dio_pad_attr_15_re = addr_hit[336] & reg_re & !reg_error;
+  assign dio_pad_attr_15_re = addr_hit[337] & reg_re & !reg_error;
 
-  assign dio_pad_attr_16_we = addr_hit[337] & reg_we & !reg_error;
+  assign dio_pad_attr_16_we = addr_hit[338] & reg_we & !reg_error;
   assign dio_pad_attr_16_wd = reg_wdata[12:0];
-  assign dio_pad_attr_16_re = addr_hit[337] & reg_re & !reg_error;
+  assign dio_pad_attr_16_re = addr_hit[338] & reg_re & !reg_error;
 
-  assign dio_pad_attr_17_we = addr_hit[338] & reg_we & !reg_error;
+  assign dio_pad_attr_17_we = addr_hit[339] & reg_we & !reg_error;
   assign dio_pad_attr_17_wd = reg_wdata[12:0];
-  assign dio_pad_attr_17_re = addr_hit[338] & reg_re & !reg_error;
+  assign dio_pad_attr_17_re = addr_hit[339] & reg_re & !reg_error;
 
-  assign dio_pad_attr_18_we = addr_hit[339] & reg_we & !reg_error;
+  assign dio_pad_attr_18_we = addr_hit[340] & reg_we & !reg_error;
   assign dio_pad_attr_18_wd = reg_wdata[12:0];
-  assign dio_pad_attr_18_re = addr_hit[339] & reg_re & !reg_error;
+  assign dio_pad_attr_18_re = addr_hit[340] & reg_re & !reg_error;
 
-  assign dio_pad_attr_19_we = addr_hit[340] & reg_we & !reg_error;
+  assign dio_pad_attr_19_we = addr_hit[341] & reg_we & !reg_error;
   assign dio_pad_attr_19_wd = reg_wdata[12:0];
-  assign dio_pad_attr_19_re = addr_hit[340] & reg_re & !reg_error;
+  assign dio_pad_attr_19_re = addr_hit[341] & reg_re & !reg_error;
 
-  assign dio_pad_attr_20_we = addr_hit[341] & reg_we & !reg_error;
+  assign dio_pad_attr_20_we = addr_hit[342] & reg_we & !reg_error;
   assign dio_pad_attr_20_wd = reg_wdata[12:0];
-  assign dio_pad_attr_20_re = addr_hit[341] & reg_re & !reg_error;
+  assign dio_pad_attr_20_re = addr_hit[342] & reg_re & !reg_error;
 
-  assign dio_pad_attr_21_we = addr_hit[342] & reg_we & !reg_error;
+  assign dio_pad_attr_21_we = addr_hit[343] & reg_we & !reg_error;
   assign dio_pad_attr_21_wd = reg_wdata[12:0];
-  assign dio_pad_attr_21_re = addr_hit[342] & reg_re & !reg_error;
+  assign dio_pad_attr_21_re = addr_hit[343] & reg_re & !reg_error;
 
-  assign dio_pad_attr_22_we = addr_hit[343] & reg_we & !reg_error;
+  assign dio_pad_attr_22_we = addr_hit[344] & reg_we & !reg_error;
   assign dio_pad_attr_22_wd = reg_wdata[12:0];
-  assign dio_pad_attr_22_re = addr_hit[343] & reg_re & !reg_error;
+  assign dio_pad_attr_22_re = addr_hit[344] & reg_re & !reg_error;
 
-  assign mio_pad_sleep_status_0_en_0_we = addr_hit[344] & reg_we & !reg_error;
+  assign dio_pad_attr_23_we = addr_hit[345] & reg_we & !reg_error;
+  assign dio_pad_attr_23_wd = reg_wdata[12:0];
+  assign dio_pad_attr_23_re = addr_hit[345] & reg_re & !reg_error;
+
+  assign mio_pad_sleep_status_0_en_0_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_0_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_status_0_en_1_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_1_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_1_wd = reg_wdata[1];
 
-  assign mio_pad_sleep_status_0_en_2_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_2_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_2_wd = reg_wdata[2];
 
-  assign mio_pad_sleep_status_0_en_3_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_3_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_3_wd = reg_wdata[3];
 
-  assign mio_pad_sleep_status_0_en_4_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_4_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_4_wd = reg_wdata[4];
 
-  assign mio_pad_sleep_status_0_en_5_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_5_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_5_wd = reg_wdata[5];
 
-  assign mio_pad_sleep_status_0_en_6_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_6_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_6_wd = reg_wdata[6];
 
-  assign mio_pad_sleep_status_0_en_7_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_7_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_7_wd = reg_wdata[7];
 
-  assign mio_pad_sleep_status_0_en_8_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_8_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_8_wd = reg_wdata[8];
 
-  assign mio_pad_sleep_status_0_en_9_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_9_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_9_wd = reg_wdata[9];
 
-  assign mio_pad_sleep_status_0_en_10_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_10_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_10_wd = reg_wdata[10];
 
-  assign mio_pad_sleep_status_0_en_11_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_11_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_11_wd = reg_wdata[11];
 
-  assign mio_pad_sleep_status_0_en_12_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_12_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_12_wd = reg_wdata[12];
 
-  assign mio_pad_sleep_status_0_en_13_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_13_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_13_wd = reg_wdata[13];
 
-  assign mio_pad_sleep_status_0_en_14_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_14_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_14_wd = reg_wdata[14];
 
-  assign mio_pad_sleep_status_0_en_15_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_15_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_15_wd = reg_wdata[15];
 
-  assign mio_pad_sleep_status_0_en_16_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_16_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_16_wd = reg_wdata[16];
 
-  assign mio_pad_sleep_status_0_en_17_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_17_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_17_wd = reg_wdata[17];
 
-  assign mio_pad_sleep_status_0_en_18_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_18_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_18_wd = reg_wdata[18];
 
-  assign mio_pad_sleep_status_0_en_19_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_19_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_19_wd = reg_wdata[19];
 
-  assign mio_pad_sleep_status_0_en_20_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_20_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_20_wd = reg_wdata[20];
 
-  assign mio_pad_sleep_status_0_en_21_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_21_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_21_wd = reg_wdata[21];
 
-  assign mio_pad_sleep_status_0_en_22_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_22_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_22_wd = reg_wdata[22];
 
-  assign mio_pad_sleep_status_0_en_23_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_23_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_23_wd = reg_wdata[23];
 
-  assign mio_pad_sleep_status_0_en_24_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_24_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_24_wd = reg_wdata[24];
 
-  assign mio_pad_sleep_status_0_en_25_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_25_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_25_wd = reg_wdata[25];
 
-  assign mio_pad_sleep_status_0_en_26_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_26_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_26_wd = reg_wdata[26];
 
-  assign mio_pad_sleep_status_0_en_27_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_27_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_27_wd = reg_wdata[27];
 
-  assign mio_pad_sleep_status_0_en_28_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_28_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_28_wd = reg_wdata[28];
 
-  assign mio_pad_sleep_status_0_en_29_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_29_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_29_wd = reg_wdata[29];
 
-  assign mio_pad_sleep_status_0_en_30_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_30_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_30_wd = reg_wdata[30];
 
-  assign mio_pad_sleep_status_0_en_31_we = addr_hit[344] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_0_en_31_we = addr_hit[346] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_31_wd = reg_wdata[31];
 
-  assign mio_pad_sleep_status_1_en_32_we = addr_hit[345] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_32_we = addr_hit[347] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_32_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_status_1_en_33_we = addr_hit[345] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_33_we = addr_hit[347] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_33_wd = reg_wdata[1];
 
-  assign mio_pad_sleep_status_1_en_34_we = addr_hit[345] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_34_we = addr_hit[347] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_34_wd = reg_wdata[2];
 
-  assign mio_pad_sleep_status_1_en_35_we = addr_hit[345] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_35_we = addr_hit[347] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_35_wd = reg_wdata[3];
 
-  assign mio_pad_sleep_status_1_en_36_we = addr_hit[345] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_36_we = addr_hit[347] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_36_wd = reg_wdata[4];
 
-  assign mio_pad_sleep_status_1_en_37_we = addr_hit[345] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_37_we = addr_hit[347] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_37_wd = reg_wdata[5];
 
-  assign mio_pad_sleep_status_1_en_38_we = addr_hit[345] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_38_we = addr_hit[347] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_38_wd = reg_wdata[6];
 
-  assign mio_pad_sleep_status_1_en_39_we = addr_hit[345] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_39_we = addr_hit[347] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_39_wd = reg_wdata[7];
 
-  assign mio_pad_sleep_status_1_en_40_we = addr_hit[345] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_40_we = addr_hit[347] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_40_wd = reg_wdata[8];
 
-  assign mio_pad_sleep_status_1_en_41_we = addr_hit[345] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_41_we = addr_hit[347] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_41_wd = reg_wdata[9];
 
-  assign mio_pad_sleep_status_1_en_42_we = addr_hit[345] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_42_we = addr_hit[347] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_42_wd = reg_wdata[10];
 
-  assign mio_pad_sleep_status_1_en_43_we = addr_hit[345] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_43_we = addr_hit[347] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_43_wd = reg_wdata[11];
 
-  assign mio_pad_sleep_status_1_en_44_we = addr_hit[345] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_44_we = addr_hit[347] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_44_wd = reg_wdata[12];
 
-  assign mio_pad_sleep_status_1_en_45_we = addr_hit[345] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_45_we = addr_hit[347] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_45_wd = reg_wdata[13];
 
-  assign mio_pad_sleep_status_1_en_46_we = addr_hit[345] & reg_we & !reg_error;
+  assign mio_pad_sleep_status_1_en_46_we = addr_hit[347] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_46_wd = reg_wdata[14];
 
-  assign mio_pad_sleep_regwen_0_we = addr_hit[346] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_0_we = addr_hit[348] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_0_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_1_we = addr_hit[347] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_1_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_1_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_2_we = addr_hit[348] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_2_we = addr_hit[350] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_2_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_3_we = addr_hit[349] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_3_we = addr_hit[351] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_3_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_4_we = addr_hit[350] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_4_we = addr_hit[352] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_4_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_5_we = addr_hit[351] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_5_we = addr_hit[353] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_5_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_6_we = addr_hit[352] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_6_we = addr_hit[354] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_6_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_7_we = addr_hit[353] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_7_we = addr_hit[355] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_7_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_8_we = addr_hit[354] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_8_we = addr_hit[356] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_8_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_9_we = addr_hit[355] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_9_we = addr_hit[357] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_9_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_10_we = addr_hit[356] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_10_we = addr_hit[358] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_10_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_11_we = addr_hit[357] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_11_we = addr_hit[359] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_11_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_12_we = addr_hit[358] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_12_we = addr_hit[360] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_12_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_13_we = addr_hit[359] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_13_we = addr_hit[361] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_13_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_14_we = addr_hit[360] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_14_we = addr_hit[362] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_14_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_15_we = addr_hit[361] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_15_we = addr_hit[363] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_15_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_16_we = addr_hit[362] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_16_we = addr_hit[364] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_16_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_17_we = addr_hit[363] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_17_we = addr_hit[365] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_17_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_18_we = addr_hit[364] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_18_we = addr_hit[366] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_18_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_19_we = addr_hit[365] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_19_we = addr_hit[367] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_19_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_20_we = addr_hit[366] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_20_we = addr_hit[368] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_20_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_21_we = addr_hit[367] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_21_we = addr_hit[369] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_21_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_22_we = addr_hit[368] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_22_we = addr_hit[370] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_22_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_23_we = addr_hit[369] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_23_we = addr_hit[371] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_23_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_24_we = addr_hit[370] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_24_we = addr_hit[372] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_24_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_25_we = addr_hit[371] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_25_we = addr_hit[373] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_25_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_26_we = addr_hit[372] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_26_we = addr_hit[374] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_26_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_27_we = addr_hit[373] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_27_we = addr_hit[375] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_27_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_28_we = addr_hit[374] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_28_we = addr_hit[376] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_28_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_29_we = addr_hit[375] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_29_we = addr_hit[377] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_29_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_30_we = addr_hit[376] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_30_we = addr_hit[378] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_30_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_31_we = addr_hit[377] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_31_we = addr_hit[379] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_31_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_32_we = addr_hit[378] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_32_we = addr_hit[380] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_32_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_33_we = addr_hit[379] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_33_we = addr_hit[381] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_33_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_34_we = addr_hit[380] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_34_we = addr_hit[382] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_34_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_35_we = addr_hit[381] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_35_we = addr_hit[383] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_35_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_36_we = addr_hit[382] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_36_we = addr_hit[384] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_36_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_37_we = addr_hit[383] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_37_we = addr_hit[385] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_37_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_38_we = addr_hit[384] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_38_we = addr_hit[386] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_38_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_39_we = addr_hit[385] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_39_we = addr_hit[387] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_39_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_40_we = addr_hit[386] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_40_we = addr_hit[388] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_40_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_41_we = addr_hit[387] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_41_we = addr_hit[389] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_41_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_42_we = addr_hit[388] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_42_we = addr_hit[390] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_42_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_43_we = addr_hit[389] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_43_we = addr_hit[391] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_43_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_44_we = addr_hit[390] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_44_we = addr_hit[392] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_44_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_45_we = addr_hit[391] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_45_we = addr_hit[393] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_45_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_regwen_46_we = addr_hit[392] & reg_we & !reg_error;
+  assign mio_pad_sleep_regwen_46_we = addr_hit[394] & reg_we & !reg_error;
   assign mio_pad_sleep_regwen_46_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_0_we = addr_hit[393] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_0_we = addr_hit[395] & reg_we & !reg_error;
   assign mio_pad_sleep_en_0_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_1_we = addr_hit[394] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_1_we = addr_hit[396] & reg_we & !reg_error;
   assign mio_pad_sleep_en_1_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_2_we = addr_hit[395] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_2_we = addr_hit[397] & reg_we & !reg_error;
   assign mio_pad_sleep_en_2_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_3_we = addr_hit[396] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_3_we = addr_hit[398] & reg_we & !reg_error;
   assign mio_pad_sleep_en_3_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_4_we = addr_hit[397] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_4_we = addr_hit[399] & reg_we & !reg_error;
   assign mio_pad_sleep_en_4_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_5_we = addr_hit[398] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_5_we = addr_hit[400] & reg_we & !reg_error;
   assign mio_pad_sleep_en_5_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_6_we = addr_hit[399] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_6_we = addr_hit[401] & reg_we & !reg_error;
   assign mio_pad_sleep_en_6_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_7_we = addr_hit[400] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_7_we = addr_hit[402] & reg_we & !reg_error;
   assign mio_pad_sleep_en_7_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_8_we = addr_hit[401] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_8_we = addr_hit[403] & reg_we & !reg_error;
   assign mio_pad_sleep_en_8_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_9_we = addr_hit[402] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_9_we = addr_hit[404] & reg_we & !reg_error;
   assign mio_pad_sleep_en_9_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_10_we = addr_hit[403] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_10_we = addr_hit[405] & reg_we & !reg_error;
   assign mio_pad_sleep_en_10_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_11_we = addr_hit[404] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_11_we = addr_hit[406] & reg_we & !reg_error;
   assign mio_pad_sleep_en_11_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_12_we = addr_hit[405] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_12_we = addr_hit[407] & reg_we & !reg_error;
   assign mio_pad_sleep_en_12_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_13_we = addr_hit[406] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_13_we = addr_hit[408] & reg_we & !reg_error;
   assign mio_pad_sleep_en_13_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_14_we = addr_hit[407] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_14_we = addr_hit[409] & reg_we & !reg_error;
   assign mio_pad_sleep_en_14_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_15_we = addr_hit[408] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_15_we = addr_hit[410] & reg_we & !reg_error;
   assign mio_pad_sleep_en_15_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_16_we = addr_hit[409] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_16_we = addr_hit[411] & reg_we & !reg_error;
   assign mio_pad_sleep_en_16_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_17_we = addr_hit[410] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_17_we = addr_hit[412] & reg_we & !reg_error;
   assign mio_pad_sleep_en_17_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_18_we = addr_hit[411] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_18_we = addr_hit[413] & reg_we & !reg_error;
   assign mio_pad_sleep_en_18_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_19_we = addr_hit[412] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_19_we = addr_hit[414] & reg_we & !reg_error;
   assign mio_pad_sleep_en_19_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_20_we = addr_hit[413] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_20_we = addr_hit[415] & reg_we & !reg_error;
   assign mio_pad_sleep_en_20_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_21_we = addr_hit[414] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_21_we = addr_hit[416] & reg_we & !reg_error;
   assign mio_pad_sleep_en_21_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_22_we = addr_hit[415] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_22_we = addr_hit[417] & reg_we & !reg_error;
   assign mio_pad_sleep_en_22_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_23_we = addr_hit[416] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_23_we = addr_hit[418] & reg_we & !reg_error;
   assign mio_pad_sleep_en_23_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_24_we = addr_hit[417] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_24_we = addr_hit[419] & reg_we & !reg_error;
   assign mio_pad_sleep_en_24_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_25_we = addr_hit[418] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_25_we = addr_hit[420] & reg_we & !reg_error;
   assign mio_pad_sleep_en_25_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_26_we = addr_hit[419] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_26_we = addr_hit[421] & reg_we & !reg_error;
   assign mio_pad_sleep_en_26_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_27_we = addr_hit[420] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_27_we = addr_hit[422] & reg_we & !reg_error;
   assign mio_pad_sleep_en_27_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_28_we = addr_hit[421] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_28_we = addr_hit[423] & reg_we & !reg_error;
   assign mio_pad_sleep_en_28_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_29_we = addr_hit[422] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_29_we = addr_hit[424] & reg_we & !reg_error;
   assign mio_pad_sleep_en_29_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_30_we = addr_hit[423] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_30_we = addr_hit[425] & reg_we & !reg_error;
   assign mio_pad_sleep_en_30_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_31_we = addr_hit[424] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_31_we = addr_hit[426] & reg_we & !reg_error;
   assign mio_pad_sleep_en_31_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_32_we = addr_hit[425] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_32_we = addr_hit[427] & reg_we & !reg_error;
   assign mio_pad_sleep_en_32_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_33_we = addr_hit[426] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_33_we = addr_hit[428] & reg_we & !reg_error;
   assign mio_pad_sleep_en_33_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_34_we = addr_hit[427] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_34_we = addr_hit[429] & reg_we & !reg_error;
   assign mio_pad_sleep_en_34_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_35_we = addr_hit[428] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_35_we = addr_hit[430] & reg_we & !reg_error;
   assign mio_pad_sleep_en_35_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_36_we = addr_hit[429] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_36_we = addr_hit[431] & reg_we & !reg_error;
   assign mio_pad_sleep_en_36_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_37_we = addr_hit[430] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_37_we = addr_hit[432] & reg_we & !reg_error;
   assign mio_pad_sleep_en_37_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_38_we = addr_hit[431] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_38_we = addr_hit[433] & reg_we & !reg_error;
   assign mio_pad_sleep_en_38_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_39_we = addr_hit[432] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_39_we = addr_hit[434] & reg_we & !reg_error;
   assign mio_pad_sleep_en_39_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_40_we = addr_hit[433] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_40_we = addr_hit[435] & reg_we & !reg_error;
   assign mio_pad_sleep_en_40_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_41_we = addr_hit[434] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_41_we = addr_hit[436] & reg_we & !reg_error;
   assign mio_pad_sleep_en_41_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_42_we = addr_hit[435] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_42_we = addr_hit[437] & reg_we & !reg_error;
   assign mio_pad_sleep_en_42_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_43_we = addr_hit[436] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_43_we = addr_hit[438] & reg_we & !reg_error;
   assign mio_pad_sleep_en_43_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_44_we = addr_hit[437] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_44_we = addr_hit[439] & reg_we & !reg_error;
   assign mio_pad_sleep_en_44_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_45_we = addr_hit[438] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_45_we = addr_hit[440] & reg_we & !reg_error;
   assign mio_pad_sleep_en_45_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_en_46_we = addr_hit[439] & reg_we & !reg_error;
+  assign mio_pad_sleep_en_46_we = addr_hit[441] & reg_we & !reg_error;
   assign mio_pad_sleep_en_46_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_mode_0_we = addr_hit[440] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_0_we = addr_hit[442] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_0_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_1_we = addr_hit[441] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_1_we = addr_hit[443] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_1_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_2_we = addr_hit[442] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_2_we = addr_hit[444] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_2_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_3_we = addr_hit[443] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_3_we = addr_hit[445] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_3_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_4_we = addr_hit[444] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_4_we = addr_hit[446] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_4_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_5_we = addr_hit[445] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_5_we = addr_hit[447] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_5_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_6_we = addr_hit[446] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_6_we = addr_hit[448] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_6_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_7_we = addr_hit[447] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_7_we = addr_hit[449] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_7_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_8_we = addr_hit[448] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_8_we = addr_hit[450] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_8_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_9_we = addr_hit[449] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_9_we = addr_hit[451] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_9_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_10_we = addr_hit[450] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_10_we = addr_hit[452] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_10_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_11_we = addr_hit[451] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_11_we = addr_hit[453] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_11_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_12_we = addr_hit[452] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_12_we = addr_hit[454] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_12_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_13_we = addr_hit[453] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_13_we = addr_hit[455] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_13_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_14_we = addr_hit[454] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_14_we = addr_hit[456] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_14_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_15_we = addr_hit[455] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_15_we = addr_hit[457] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_15_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_16_we = addr_hit[456] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_16_we = addr_hit[458] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_16_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_17_we = addr_hit[457] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_17_we = addr_hit[459] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_17_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_18_we = addr_hit[458] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_18_we = addr_hit[460] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_18_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_19_we = addr_hit[459] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_19_we = addr_hit[461] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_19_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_20_we = addr_hit[460] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_20_we = addr_hit[462] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_20_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_21_we = addr_hit[461] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_21_we = addr_hit[463] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_21_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_22_we = addr_hit[462] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_22_we = addr_hit[464] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_22_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_23_we = addr_hit[463] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_23_we = addr_hit[465] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_23_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_24_we = addr_hit[464] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_24_we = addr_hit[466] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_24_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_25_we = addr_hit[465] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_25_we = addr_hit[467] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_25_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_26_we = addr_hit[466] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_26_we = addr_hit[468] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_26_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_27_we = addr_hit[467] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_27_we = addr_hit[469] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_27_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_28_we = addr_hit[468] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_28_we = addr_hit[470] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_28_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_29_we = addr_hit[469] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_29_we = addr_hit[471] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_29_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_30_we = addr_hit[470] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_30_we = addr_hit[472] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_30_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_31_we = addr_hit[471] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_31_we = addr_hit[473] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_31_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_32_we = addr_hit[472] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_32_we = addr_hit[474] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_32_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_33_we = addr_hit[473] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_33_we = addr_hit[475] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_33_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_34_we = addr_hit[474] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_34_we = addr_hit[476] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_34_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_35_we = addr_hit[475] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_35_we = addr_hit[477] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_35_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_36_we = addr_hit[476] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_36_we = addr_hit[478] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_36_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_37_we = addr_hit[477] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_37_we = addr_hit[479] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_37_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_38_we = addr_hit[478] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_38_we = addr_hit[480] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_38_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_39_we = addr_hit[479] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_39_we = addr_hit[481] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_39_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_40_we = addr_hit[480] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_40_we = addr_hit[482] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_40_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_41_we = addr_hit[481] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_41_we = addr_hit[483] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_41_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_42_we = addr_hit[482] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_42_we = addr_hit[484] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_42_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_43_we = addr_hit[483] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_43_we = addr_hit[485] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_43_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_44_we = addr_hit[484] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_44_we = addr_hit[486] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_44_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_45_we = addr_hit[485] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_45_we = addr_hit[487] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_45_wd = reg_wdata[1:0];
 
-  assign mio_pad_sleep_mode_46_we = addr_hit[486] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_46_we = addr_hit[488] & reg_we & !reg_error;
   assign mio_pad_sleep_mode_46_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_status_en_0_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_0_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_0_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_status_en_1_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_1_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_1_wd = reg_wdata[1];
 
-  assign dio_pad_sleep_status_en_2_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_2_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_2_wd = reg_wdata[2];
 
-  assign dio_pad_sleep_status_en_3_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_3_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_3_wd = reg_wdata[3];
 
-  assign dio_pad_sleep_status_en_4_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_4_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_4_wd = reg_wdata[4];
 
-  assign dio_pad_sleep_status_en_5_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_5_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_5_wd = reg_wdata[5];
 
-  assign dio_pad_sleep_status_en_6_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_6_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_6_wd = reg_wdata[6];
 
-  assign dio_pad_sleep_status_en_7_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_7_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_7_wd = reg_wdata[7];
 
-  assign dio_pad_sleep_status_en_8_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_8_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_8_wd = reg_wdata[8];
 
-  assign dio_pad_sleep_status_en_9_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_9_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_9_wd = reg_wdata[9];
 
-  assign dio_pad_sleep_status_en_10_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_10_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_10_wd = reg_wdata[10];
 
-  assign dio_pad_sleep_status_en_11_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_11_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_11_wd = reg_wdata[11];
 
-  assign dio_pad_sleep_status_en_12_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_12_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_12_wd = reg_wdata[12];
 
-  assign dio_pad_sleep_status_en_13_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_13_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_13_wd = reg_wdata[13];
 
-  assign dio_pad_sleep_status_en_14_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_14_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_14_wd = reg_wdata[14];
 
-  assign dio_pad_sleep_status_en_15_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_15_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_15_wd = reg_wdata[15];
 
-  assign dio_pad_sleep_status_en_16_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_16_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_16_wd = reg_wdata[16];
 
-  assign dio_pad_sleep_status_en_17_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_17_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_17_wd = reg_wdata[17];
 
-  assign dio_pad_sleep_status_en_18_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_18_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_18_wd = reg_wdata[18];
 
-  assign dio_pad_sleep_status_en_19_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_19_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_19_wd = reg_wdata[19];
 
-  assign dio_pad_sleep_status_en_20_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_20_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_20_wd = reg_wdata[20];
 
-  assign dio_pad_sleep_status_en_21_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_21_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_21_wd = reg_wdata[21];
 
-  assign dio_pad_sleep_status_en_22_we = addr_hit[487] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_22_we = addr_hit[489] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_22_wd = reg_wdata[22];
 
-  assign dio_pad_sleep_regwen_0_we = addr_hit[488] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_23_we = addr_hit[489] & reg_we & !reg_error;
+  assign dio_pad_sleep_status_en_23_wd = reg_wdata[23];
+
+  assign dio_pad_sleep_regwen_0_we = addr_hit[490] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_0_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_1_we = addr_hit[489] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_1_we = addr_hit[491] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_1_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_2_we = addr_hit[490] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_2_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_2_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_3_we = addr_hit[491] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_3_we = addr_hit[493] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_3_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_4_we = addr_hit[492] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_4_we = addr_hit[494] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_4_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_5_we = addr_hit[493] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_5_we = addr_hit[495] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_5_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_6_we = addr_hit[494] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_6_we = addr_hit[496] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_6_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_7_we = addr_hit[495] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_7_we = addr_hit[497] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_7_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_8_we = addr_hit[496] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_8_we = addr_hit[498] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_8_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_9_we = addr_hit[497] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_9_we = addr_hit[499] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_9_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_10_we = addr_hit[498] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_10_we = addr_hit[500] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_10_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_11_we = addr_hit[499] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_11_we = addr_hit[501] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_11_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_12_we = addr_hit[500] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_12_we = addr_hit[502] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_12_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_13_we = addr_hit[501] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_13_we = addr_hit[503] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_13_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_14_we = addr_hit[502] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_14_we = addr_hit[504] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_14_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_15_we = addr_hit[503] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_15_we = addr_hit[505] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_15_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_16_we = addr_hit[504] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_16_we = addr_hit[506] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_16_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_17_we = addr_hit[505] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_17_we = addr_hit[507] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_17_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_18_we = addr_hit[506] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_18_we = addr_hit[508] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_18_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_19_we = addr_hit[507] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_19_we = addr_hit[509] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_19_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_20_we = addr_hit[508] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_20_we = addr_hit[510] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_20_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_21_we = addr_hit[509] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_21_we = addr_hit[511] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_21_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_regwen_22_we = addr_hit[510] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_22_we = addr_hit[512] & reg_we & !reg_error;
   assign dio_pad_sleep_regwen_22_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_0_we = addr_hit[511] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_23_we = addr_hit[513] & reg_we & !reg_error;
+  assign dio_pad_sleep_regwen_23_wd = reg_wdata[0];
+
+  assign dio_pad_sleep_en_0_we = addr_hit[514] & reg_we & !reg_error;
   assign dio_pad_sleep_en_0_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_1_we = addr_hit[512] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_1_we = addr_hit[515] & reg_we & !reg_error;
   assign dio_pad_sleep_en_1_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_2_we = addr_hit[513] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_2_we = addr_hit[516] & reg_we & !reg_error;
   assign dio_pad_sleep_en_2_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_3_we = addr_hit[514] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_3_we = addr_hit[517] & reg_we & !reg_error;
   assign dio_pad_sleep_en_3_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_4_we = addr_hit[515] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_4_we = addr_hit[518] & reg_we & !reg_error;
   assign dio_pad_sleep_en_4_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_5_we = addr_hit[516] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_5_we = addr_hit[519] & reg_we & !reg_error;
   assign dio_pad_sleep_en_5_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_6_we = addr_hit[517] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_6_we = addr_hit[520] & reg_we & !reg_error;
   assign dio_pad_sleep_en_6_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_7_we = addr_hit[518] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_7_we = addr_hit[521] & reg_we & !reg_error;
   assign dio_pad_sleep_en_7_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_8_we = addr_hit[519] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_8_we = addr_hit[522] & reg_we & !reg_error;
   assign dio_pad_sleep_en_8_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_9_we = addr_hit[520] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_9_we = addr_hit[523] & reg_we & !reg_error;
   assign dio_pad_sleep_en_9_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_10_we = addr_hit[521] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_10_we = addr_hit[524] & reg_we & !reg_error;
   assign dio_pad_sleep_en_10_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_11_we = addr_hit[522] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_11_we = addr_hit[525] & reg_we & !reg_error;
   assign dio_pad_sleep_en_11_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_12_we = addr_hit[523] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_12_we = addr_hit[526] & reg_we & !reg_error;
   assign dio_pad_sleep_en_12_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_13_we = addr_hit[524] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_13_we = addr_hit[527] & reg_we & !reg_error;
   assign dio_pad_sleep_en_13_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_14_we = addr_hit[525] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_14_we = addr_hit[528] & reg_we & !reg_error;
   assign dio_pad_sleep_en_14_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_15_we = addr_hit[526] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_15_we = addr_hit[529] & reg_we & !reg_error;
   assign dio_pad_sleep_en_15_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_16_we = addr_hit[527] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_16_we = addr_hit[530] & reg_we & !reg_error;
   assign dio_pad_sleep_en_16_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_17_we = addr_hit[528] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_17_we = addr_hit[531] & reg_we & !reg_error;
   assign dio_pad_sleep_en_17_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_18_we = addr_hit[529] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_18_we = addr_hit[532] & reg_we & !reg_error;
   assign dio_pad_sleep_en_18_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_19_we = addr_hit[530] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_19_we = addr_hit[533] & reg_we & !reg_error;
   assign dio_pad_sleep_en_19_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_20_we = addr_hit[531] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_20_we = addr_hit[534] & reg_we & !reg_error;
   assign dio_pad_sleep_en_20_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_21_we = addr_hit[532] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_21_we = addr_hit[535] & reg_we & !reg_error;
   assign dio_pad_sleep_en_21_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_en_22_we = addr_hit[533] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_22_we = addr_hit[536] & reg_we & !reg_error;
   assign dio_pad_sleep_en_22_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_mode_0_we = addr_hit[534] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_23_we = addr_hit[537] & reg_we & !reg_error;
+  assign dio_pad_sleep_en_23_wd = reg_wdata[0];
+
+  assign dio_pad_sleep_mode_0_we = addr_hit[538] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_0_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_1_we = addr_hit[535] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_1_we = addr_hit[539] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_1_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_2_we = addr_hit[536] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_2_we = addr_hit[540] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_2_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_3_we = addr_hit[537] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_3_we = addr_hit[541] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_3_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_4_we = addr_hit[538] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_4_we = addr_hit[542] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_4_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_5_we = addr_hit[539] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_5_we = addr_hit[543] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_5_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_6_we = addr_hit[540] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_6_we = addr_hit[544] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_6_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_7_we = addr_hit[541] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_7_we = addr_hit[545] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_7_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_8_we = addr_hit[542] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_8_we = addr_hit[546] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_8_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_9_we = addr_hit[543] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_9_we = addr_hit[547] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_9_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_10_we = addr_hit[544] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_10_we = addr_hit[548] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_10_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_11_we = addr_hit[545] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_11_we = addr_hit[549] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_11_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_12_we = addr_hit[546] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_12_we = addr_hit[550] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_12_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_13_we = addr_hit[547] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_13_we = addr_hit[551] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_13_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_14_we = addr_hit[548] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_14_we = addr_hit[552] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_14_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_15_we = addr_hit[549] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_15_we = addr_hit[553] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_15_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_16_we = addr_hit[550] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_16_we = addr_hit[554] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_16_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_17_we = addr_hit[551] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_17_we = addr_hit[555] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_17_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_18_we = addr_hit[552] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_18_we = addr_hit[556] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_18_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_19_we = addr_hit[553] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_19_we = addr_hit[557] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_19_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_20_we = addr_hit[554] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_20_we = addr_hit[558] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_20_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_21_we = addr_hit[555] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_21_we = addr_hit[559] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_21_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_mode_22_we = addr_hit[556] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_22_we = addr_hit[560] & reg_we & !reg_error;
   assign dio_pad_sleep_mode_22_wd = reg_wdata[1:0];
 
-  assign wkup_detector_regwen_0_we = addr_hit[557] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_23_we = addr_hit[561] & reg_we & !reg_error;
+  assign dio_pad_sleep_mode_23_wd = reg_wdata[1:0];
+
+  assign wkup_detector_regwen_0_we = addr_hit[562] & reg_we & !reg_error;
   assign wkup_detector_regwen_0_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_1_we = addr_hit[558] & reg_we & !reg_error;
+  assign wkup_detector_regwen_1_we = addr_hit[563] & reg_we & !reg_error;
   assign wkup_detector_regwen_1_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_2_we = addr_hit[559] & reg_we & !reg_error;
+  assign wkup_detector_regwen_2_we = addr_hit[564] & reg_we & !reg_error;
   assign wkup_detector_regwen_2_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_3_we = addr_hit[560] & reg_we & !reg_error;
+  assign wkup_detector_regwen_3_we = addr_hit[565] & reg_we & !reg_error;
   assign wkup_detector_regwen_3_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_4_we = addr_hit[561] & reg_we & !reg_error;
+  assign wkup_detector_regwen_4_we = addr_hit[566] & reg_we & !reg_error;
   assign wkup_detector_regwen_4_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_5_we = addr_hit[562] & reg_we & !reg_error;
+  assign wkup_detector_regwen_5_we = addr_hit[567] & reg_we & !reg_error;
   assign wkup_detector_regwen_5_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_6_we = addr_hit[563] & reg_we & !reg_error;
+  assign wkup_detector_regwen_6_we = addr_hit[568] & reg_we & !reg_error;
   assign wkup_detector_regwen_6_wd = reg_wdata[0];
 
-  assign wkup_detector_regwen_7_we = addr_hit[564] & reg_we & !reg_error;
+  assign wkup_detector_regwen_7_we = addr_hit[569] & reg_we & !reg_error;
   assign wkup_detector_regwen_7_wd = reg_wdata[0];
 
-  assign wkup_detector_en_0_we = addr_hit[565] & reg_we & !reg_error;
+  assign wkup_detector_en_0_we = addr_hit[570] & reg_we & !reg_error;
   assign wkup_detector_en_0_wd = reg_wdata[0];
 
-  assign wkup_detector_en_1_we = addr_hit[566] & reg_we & !reg_error;
+  assign wkup_detector_en_1_we = addr_hit[571] & reg_we & !reg_error;
   assign wkup_detector_en_1_wd = reg_wdata[0];
 
-  assign wkup_detector_en_2_we = addr_hit[567] & reg_we & !reg_error;
+  assign wkup_detector_en_2_we = addr_hit[572] & reg_we & !reg_error;
   assign wkup_detector_en_2_wd = reg_wdata[0];
 
-  assign wkup_detector_en_3_we = addr_hit[568] & reg_we & !reg_error;
+  assign wkup_detector_en_3_we = addr_hit[573] & reg_we & !reg_error;
   assign wkup_detector_en_3_wd = reg_wdata[0];
 
-  assign wkup_detector_en_4_we = addr_hit[569] & reg_we & !reg_error;
+  assign wkup_detector_en_4_we = addr_hit[574] & reg_we & !reg_error;
   assign wkup_detector_en_4_wd = reg_wdata[0];
 
-  assign wkup_detector_en_5_we = addr_hit[570] & reg_we & !reg_error;
+  assign wkup_detector_en_5_we = addr_hit[575] & reg_we & !reg_error;
   assign wkup_detector_en_5_wd = reg_wdata[0];
 
-  assign wkup_detector_en_6_we = addr_hit[571] & reg_we & !reg_error;
+  assign wkup_detector_en_6_we = addr_hit[576] & reg_we & !reg_error;
   assign wkup_detector_en_6_wd = reg_wdata[0];
 
-  assign wkup_detector_en_7_we = addr_hit[572] & reg_we & !reg_error;
+  assign wkup_detector_en_7_we = addr_hit[577] & reg_we & !reg_error;
   assign wkup_detector_en_7_wd = reg_wdata[0];
 
-  assign wkup_detector_0_mode_0_we = addr_hit[573] & reg_we & !reg_error;
+  assign wkup_detector_0_mode_0_we = addr_hit[578] & reg_we & !reg_error;
   assign wkup_detector_0_mode_0_wd = reg_wdata[2:0];
 
-  assign wkup_detector_0_filter_0_we = addr_hit[573] & reg_we & !reg_error;
+  assign wkup_detector_0_filter_0_we = addr_hit[578] & reg_we & !reg_error;
   assign wkup_detector_0_filter_0_wd = reg_wdata[3];
 
-  assign wkup_detector_0_miodio_0_we = addr_hit[573] & reg_we & !reg_error;
+  assign wkup_detector_0_miodio_0_we = addr_hit[578] & reg_we & !reg_error;
   assign wkup_detector_0_miodio_0_wd = reg_wdata[4];
 
-  assign wkup_detector_1_mode_1_we = addr_hit[574] & reg_we & !reg_error;
+  assign wkup_detector_1_mode_1_we = addr_hit[579] & reg_we & !reg_error;
   assign wkup_detector_1_mode_1_wd = reg_wdata[2:0];
 
-  assign wkup_detector_1_filter_1_we = addr_hit[574] & reg_we & !reg_error;
+  assign wkup_detector_1_filter_1_we = addr_hit[579] & reg_we & !reg_error;
   assign wkup_detector_1_filter_1_wd = reg_wdata[3];
 
-  assign wkup_detector_1_miodio_1_we = addr_hit[574] & reg_we & !reg_error;
+  assign wkup_detector_1_miodio_1_we = addr_hit[579] & reg_we & !reg_error;
   assign wkup_detector_1_miodio_1_wd = reg_wdata[4];
 
-  assign wkup_detector_2_mode_2_we = addr_hit[575] & reg_we & !reg_error;
+  assign wkup_detector_2_mode_2_we = addr_hit[580] & reg_we & !reg_error;
   assign wkup_detector_2_mode_2_wd = reg_wdata[2:0];
 
-  assign wkup_detector_2_filter_2_we = addr_hit[575] & reg_we & !reg_error;
+  assign wkup_detector_2_filter_2_we = addr_hit[580] & reg_we & !reg_error;
   assign wkup_detector_2_filter_2_wd = reg_wdata[3];
 
-  assign wkup_detector_2_miodio_2_we = addr_hit[575] & reg_we & !reg_error;
+  assign wkup_detector_2_miodio_2_we = addr_hit[580] & reg_we & !reg_error;
   assign wkup_detector_2_miodio_2_wd = reg_wdata[4];
 
-  assign wkup_detector_3_mode_3_we = addr_hit[576] & reg_we & !reg_error;
+  assign wkup_detector_3_mode_3_we = addr_hit[581] & reg_we & !reg_error;
   assign wkup_detector_3_mode_3_wd = reg_wdata[2:0];
 
-  assign wkup_detector_3_filter_3_we = addr_hit[576] & reg_we & !reg_error;
+  assign wkup_detector_3_filter_3_we = addr_hit[581] & reg_we & !reg_error;
   assign wkup_detector_3_filter_3_wd = reg_wdata[3];
 
-  assign wkup_detector_3_miodio_3_we = addr_hit[576] & reg_we & !reg_error;
+  assign wkup_detector_3_miodio_3_we = addr_hit[581] & reg_we & !reg_error;
   assign wkup_detector_3_miodio_3_wd = reg_wdata[4];
 
-  assign wkup_detector_4_mode_4_we = addr_hit[577] & reg_we & !reg_error;
+  assign wkup_detector_4_mode_4_we = addr_hit[582] & reg_we & !reg_error;
   assign wkup_detector_4_mode_4_wd = reg_wdata[2:0];
 
-  assign wkup_detector_4_filter_4_we = addr_hit[577] & reg_we & !reg_error;
+  assign wkup_detector_4_filter_4_we = addr_hit[582] & reg_we & !reg_error;
   assign wkup_detector_4_filter_4_wd = reg_wdata[3];
 
-  assign wkup_detector_4_miodio_4_we = addr_hit[577] & reg_we & !reg_error;
+  assign wkup_detector_4_miodio_4_we = addr_hit[582] & reg_we & !reg_error;
   assign wkup_detector_4_miodio_4_wd = reg_wdata[4];
 
-  assign wkup_detector_5_mode_5_we = addr_hit[578] & reg_we & !reg_error;
+  assign wkup_detector_5_mode_5_we = addr_hit[583] & reg_we & !reg_error;
   assign wkup_detector_5_mode_5_wd = reg_wdata[2:0];
 
-  assign wkup_detector_5_filter_5_we = addr_hit[578] & reg_we & !reg_error;
+  assign wkup_detector_5_filter_5_we = addr_hit[583] & reg_we & !reg_error;
   assign wkup_detector_5_filter_5_wd = reg_wdata[3];
 
-  assign wkup_detector_5_miodio_5_we = addr_hit[578] & reg_we & !reg_error;
+  assign wkup_detector_5_miodio_5_we = addr_hit[583] & reg_we & !reg_error;
   assign wkup_detector_5_miodio_5_wd = reg_wdata[4];
 
-  assign wkup_detector_6_mode_6_we = addr_hit[579] & reg_we & !reg_error;
+  assign wkup_detector_6_mode_6_we = addr_hit[584] & reg_we & !reg_error;
   assign wkup_detector_6_mode_6_wd = reg_wdata[2:0];
 
-  assign wkup_detector_6_filter_6_we = addr_hit[579] & reg_we & !reg_error;
+  assign wkup_detector_6_filter_6_we = addr_hit[584] & reg_we & !reg_error;
   assign wkup_detector_6_filter_6_wd = reg_wdata[3];
 
-  assign wkup_detector_6_miodio_6_we = addr_hit[579] & reg_we & !reg_error;
+  assign wkup_detector_6_miodio_6_we = addr_hit[584] & reg_we & !reg_error;
   assign wkup_detector_6_miodio_6_wd = reg_wdata[4];
 
-  assign wkup_detector_7_mode_7_we = addr_hit[580] & reg_we & !reg_error;
+  assign wkup_detector_7_mode_7_we = addr_hit[585] & reg_we & !reg_error;
   assign wkup_detector_7_mode_7_wd = reg_wdata[2:0];
 
-  assign wkup_detector_7_filter_7_we = addr_hit[580] & reg_we & !reg_error;
+  assign wkup_detector_7_filter_7_we = addr_hit[585] & reg_we & !reg_error;
   assign wkup_detector_7_filter_7_wd = reg_wdata[3];
 
-  assign wkup_detector_7_miodio_7_we = addr_hit[580] & reg_we & !reg_error;
+  assign wkup_detector_7_miodio_7_we = addr_hit[585] & reg_we & !reg_error;
   assign wkup_detector_7_miodio_7_wd = reg_wdata[4];
 
-  assign wkup_detector_cnt_th_0_we = addr_hit[581] & reg_we & !reg_error;
+  assign wkup_detector_cnt_th_0_we = addr_hit[586] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_0_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_1_we = addr_hit[582] & reg_we & !reg_error;
+  assign wkup_detector_cnt_th_1_we = addr_hit[587] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_1_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_2_we = addr_hit[583] & reg_we & !reg_error;
+  assign wkup_detector_cnt_th_2_we = addr_hit[588] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_2_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_3_we = addr_hit[584] & reg_we & !reg_error;
+  assign wkup_detector_cnt_th_3_we = addr_hit[589] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_3_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_4_we = addr_hit[585] & reg_we & !reg_error;
+  assign wkup_detector_cnt_th_4_we = addr_hit[590] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_4_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_5_we = addr_hit[586] & reg_we & !reg_error;
+  assign wkup_detector_cnt_th_5_we = addr_hit[591] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_5_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_6_we = addr_hit[587] & reg_we & !reg_error;
+  assign wkup_detector_cnt_th_6_we = addr_hit[592] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_6_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th_7_we = addr_hit[588] & reg_we & !reg_error;
+  assign wkup_detector_cnt_th_7_we = addr_hit[593] & reg_we & !reg_error;
   assign wkup_detector_cnt_th_7_wd = reg_wdata[7:0];
 
-  assign wkup_detector_padsel_0_we = addr_hit[589] & reg_we & !reg_error;
+  assign wkup_detector_padsel_0_we = addr_hit[594] & reg_we & !reg_error;
   assign wkup_detector_padsel_0_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_1_we = addr_hit[590] & reg_we & !reg_error;
+  assign wkup_detector_padsel_1_we = addr_hit[595] & reg_we & !reg_error;
   assign wkup_detector_padsel_1_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_2_we = addr_hit[591] & reg_we & !reg_error;
+  assign wkup_detector_padsel_2_we = addr_hit[596] & reg_we & !reg_error;
   assign wkup_detector_padsel_2_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_3_we = addr_hit[592] & reg_we & !reg_error;
+  assign wkup_detector_padsel_3_we = addr_hit[597] & reg_we & !reg_error;
   assign wkup_detector_padsel_3_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_4_we = addr_hit[593] & reg_we & !reg_error;
+  assign wkup_detector_padsel_4_we = addr_hit[598] & reg_we & !reg_error;
   assign wkup_detector_padsel_4_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_5_we = addr_hit[594] & reg_we & !reg_error;
+  assign wkup_detector_padsel_5_we = addr_hit[599] & reg_we & !reg_error;
   assign wkup_detector_padsel_5_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_6_we = addr_hit[595] & reg_we & !reg_error;
+  assign wkup_detector_padsel_6_we = addr_hit[600] & reg_we & !reg_error;
   assign wkup_detector_padsel_6_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel_7_we = addr_hit[596] & reg_we & !reg_error;
+  assign wkup_detector_padsel_7_we = addr_hit[601] & reg_we & !reg_error;
   assign wkup_detector_padsel_7_wd = reg_wdata[5:0];
 
-  assign wkup_cause_cause_0_we = addr_hit[597] & reg_we & !reg_error;
+  assign wkup_cause_cause_0_we = addr_hit[602] & reg_we & !reg_error;
   assign wkup_cause_cause_0_wd = reg_wdata[0];
-  assign wkup_cause_cause_0_re = addr_hit[597] & reg_re & !reg_error;
+  assign wkup_cause_cause_0_re = addr_hit[602] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_1_we = addr_hit[597] & reg_we & !reg_error;
+  assign wkup_cause_cause_1_we = addr_hit[602] & reg_we & !reg_error;
   assign wkup_cause_cause_1_wd = reg_wdata[1];
-  assign wkup_cause_cause_1_re = addr_hit[597] & reg_re & !reg_error;
+  assign wkup_cause_cause_1_re = addr_hit[602] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_2_we = addr_hit[597] & reg_we & !reg_error;
+  assign wkup_cause_cause_2_we = addr_hit[602] & reg_we & !reg_error;
   assign wkup_cause_cause_2_wd = reg_wdata[2];
-  assign wkup_cause_cause_2_re = addr_hit[597] & reg_re & !reg_error;
+  assign wkup_cause_cause_2_re = addr_hit[602] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_3_we = addr_hit[597] & reg_we & !reg_error;
+  assign wkup_cause_cause_3_we = addr_hit[602] & reg_we & !reg_error;
   assign wkup_cause_cause_3_wd = reg_wdata[3];
-  assign wkup_cause_cause_3_re = addr_hit[597] & reg_re & !reg_error;
+  assign wkup_cause_cause_3_re = addr_hit[602] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_4_we = addr_hit[597] & reg_we & !reg_error;
+  assign wkup_cause_cause_4_we = addr_hit[602] & reg_we & !reg_error;
   assign wkup_cause_cause_4_wd = reg_wdata[4];
-  assign wkup_cause_cause_4_re = addr_hit[597] & reg_re & !reg_error;
+  assign wkup_cause_cause_4_re = addr_hit[602] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_5_we = addr_hit[597] & reg_we & !reg_error;
+  assign wkup_cause_cause_5_we = addr_hit[602] & reg_we & !reg_error;
   assign wkup_cause_cause_5_wd = reg_wdata[5];
-  assign wkup_cause_cause_5_re = addr_hit[597] & reg_re & !reg_error;
+  assign wkup_cause_cause_5_re = addr_hit[602] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_6_we = addr_hit[597] & reg_we & !reg_error;
+  assign wkup_cause_cause_6_we = addr_hit[602] & reg_we & !reg_error;
   assign wkup_cause_cause_6_wd = reg_wdata[6];
-  assign wkup_cause_cause_6_re = addr_hit[597] & reg_re & !reg_error;
+  assign wkup_cause_cause_6_re = addr_hit[602] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_7_we = addr_hit[597] & reg_we & !reg_error;
+  assign wkup_cause_cause_7_we = addr_hit[602] & reg_we & !reg_error;
   assign wkup_cause_cause_7_wd = reg_wdata[7];
-  assign wkup_cause_cause_7_re = addr_hit[597] & reg_re & !reg_error;
+  assign wkup_cause_cause_7_re = addr_hit[602] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin
@@ -24655,98 +24854,106 @@ module pinmux_reg_top (
       end
 
       addr_hit[321]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_0_qs;
+        reg_rdata_next[0] = dio_pad_attr_regwen_23_qs;
       end
 
       addr_hit[322]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_1_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_0_qs;
       end
 
       addr_hit[323]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_2_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_1_qs;
       end
 
       addr_hit[324]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_3_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_2_qs;
       end
 
       addr_hit[325]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_4_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_3_qs;
       end
 
       addr_hit[326]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_5_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_4_qs;
       end
 
       addr_hit[327]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_6_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_5_qs;
       end
 
       addr_hit[328]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_7_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_6_qs;
       end
 
       addr_hit[329]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_8_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_7_qs;
       end
 
       addr_hit[330]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_9_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_8_qs;
       end
 
       addr_hit[331]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_10_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_9_qs;
       end
 
       addr_hit[332]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_11_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_10_qs;
       end
 
       addr_hit[333]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_12_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_11_qs;
       end
 
       addr_hit[334]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_13_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_12_qs;
       end
 
       addr_hit[335]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_14_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_13_qs;
       end
 
       addr_hit[336]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_15_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_14_qs;
       end
 
       addr_hit[337]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_16_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_15_qs;
       end
 
       addr_hit[338]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_17_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_16_qs;
       end
 
       addr_hit[339]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_18_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_17_qs;
       end
 
       addr_hit[340]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_19_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_18_qs;
       end
 
       addr_hit[341]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_20_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_19_qs;
       end
 
       addr_hit[342]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_21_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_20_qs;
       end
 
       addr_hit[343]: begin
-        reg_rdata_next[12:0] = dio_pad_attr_22_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_21_qs;
       end
 
       addr_hit[344]: begin
+        reg_rdata_next[12:0] = dio_pad_attr_22_qs;
+      end
+
+      addr_hit[345]: begin
+        reg_rdata_next[12:0] = dio_pad_attr_23_qs;
+      end
+
+      addr_hit[346]: begin
         reg_rdata_next[0] = mio_pad_sleep_status_0_en_0_qs;
         reg_rdata_next[1] = mio_pad_sleep_status_0_en_1_qs;
         reg_rdata_next[2] = mio_pad_sleep_status_0_en_2_qs;
@@ -24781,7 +24988,7 @@ module pinmux_reg_top (
         reg_rdata_next[31] = mio_pad_sleep_status_0_en_31_qs;
       end
 
-      addr_hit[345]: begin
+      addr_hit[347]: begin
         reg_rdata_next[0] = mio_pad_sleep_status_1_en_32_qs;
         reg_rdata_next[1] = mio_pad_sleep_status_1_en_33_qs;
         reg_rdata_next[2] = mio_pad_sleep_status_1_en_34_qs;
@@ -24799,571 +25006,571 @@ module pinmux_reg_top (
         reg_rdata_next[14] = mio_pad_sleep_status_1_en_46_qs;
       end
 
-      addr_hit[346]: begin
+      addr_hit[348]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_0_qs;
       end
 
-      addr_hit[347]: begin
+      addr_hit[349]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_1_qs;
       end
 
-      addr_hit[348]: begin
+      addr_hit[350]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_2_qs;
       end
 
-      addr_hit[349]: begin
+      addr_hit[351]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_3_qs;
       end
 
-      addr_hit[350]: begin
+      addr_hit[352]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_4_qs;
       end
 
-      addr_hit[351]: begin
+      addr_hit[353]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_5_qs;
       end
 
-      addr_hit[352]: begin
+      addr_hit[354]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_6_qs;
       end
 
-      addr_hit[353]: begin
+      addr_hit[355]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_7_qs;
       end
 
-      addr_hit[354]: begin
+      addr_hit[356]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_8_qs;
       end
 
-      addr_hit[355]: begin
+      addr_hit[357]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_9_qs;
       end
 
-      addr_hit[356]: begin
+      addr_hit[358]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_10_qs;
       end
 
-      addr_hit[357]: begin
+      addr_hit[359]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_11_qs;
       end
 
-      addr_hit[358]: begin
+      addr_hit[360]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_12_qs;
       end
 
-      addr_hit[359]: begin
+      addr_hit[361]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_13_qs;
       end
 
-      addr_hit[360]: begin
+      addr_hit[362]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_14_qs;
       end
 
-      addr_hit[361]: begin
+      addr_hit[363]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_15_qs;
       end
 
-      addr_hit[362]: begin
+      addr_hit[364]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_16_qs;
       end
 
-      addr_hit[363]: begin
+      addr_hit[365]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_17_qs;
       end
 
-      addr_hit[364]: begin
+      addr_hit[366]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_18_qs;
       end
 
-      addr_hit[365]: begin
+      addr_hit[367]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_19_qs;
       end
 
-      addr_hit[366]: begin
+      addr_hit[368]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_20_qs;
       end
 
-      addr_hit[367]: begin
+      addr_hit[369]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_21_qs;
       end
 
-      addr_hit[368]: begin
+      addr_hit[370]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_22_qs;
       end
 
-      addr_hit[369]: begin
+      addr_hit[371]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_23_qs;
       end
 
-      addr_hit[370]: begin
+      addr_hit[372]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_24_qs;
       end
 
-      addr_hit[371]: begin
+      addr_hit[373]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_25_qs;
       end
 
-      addr_hit[372]: begin
+      addr_hit[374]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_26_qs;
       end
 
-      addr_hit[373]: begin
+      addr_hit[375]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_27_qs;
       end
 
-      addr_hit[374]: begin
+      addr_hit[376]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_28_qs;
       end
 
-      addr_hit[375]: begin
+      addr_hit[377]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_29_qs;
       end
 
-      addr_hit[376]: begin
+      addr_hit[378]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_30_qs;
       end
 
-      addr_hit[377]: begin
+      addr_hit[379]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_31_qs;
       end
 
-      addr_hit[378]: begin
+      addr_hit[380]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_32_qs;
       end
 
-      addr_hit[379]: begin
+      addr_hit[381]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_33_qs;
       end
 
-      addr_hit[380]: begin
+      addr_hit[382]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_34_qs;
       end
 
-      addr_hit[381]: begin
+      addr_hit[383]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_35_qs;
       end
 
-      addr_hit[382]: begin
+      addr_hit[384]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_36_qs;
       end
 
-      addr_hit[383]: begin
+      addr_hit[385]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_37_qs;
       end
 
-      addr_hit[384]: begin
+      addr_hit[386]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_38_qs;
       end
 
-      addr_hit[385]: begin
+      addr_hit[387]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_39_qs;
       end
 
-      addr_hit[386]: begin
+      addr_hit[388]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_40_qs;
       end
 
-      addr_hit[387]: begin
+      addr_hit[389]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_41_qs;
       end
 
-      addr_hit[388]: begin
+      addr_hit[390]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_42_qs;
       end
 
-      addr_hit[389]: begin
+      addr_hit[391]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_43_qs;
       end
 
-      addr_hit[390]: begin
+      addr_hit[392]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_44_qs;
       end
 
-      addr_hit[391]: begin
+      addr_hit[393]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_45_qs;
       end
 
-      addr_hit[392]: begin
+      addr_hit[394]: begin
         reg_rdata_next[0] = mio_pad_sleep_regwen_46_qs;
       end
 
-      addr_hit[393]: begin
+      addr_hit[395]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_0_qs;
       end
 
-      addr_hit[394]: begin
+      addr_hit[396]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_1_qs;
       end
 
-      addr_hit[395]: begin
+      addr_hit[397]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_2_qs;
       end
 
-      addr_hit[396]: begin
+      addr_hit[398]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_3_qs;
       end
 
-      addr_hit[397]: begin
+      addr_hit[399]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_4_qs;
       end
 
-      addr_hit[398]: begin
+      addr_hit[400]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_5_qs;
       end
 
-      addr_hit[399]: begin
+      addr_hit[401]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_6_qs;
       end
 
-      addr_hit[400]: begin
+      addr_hit[402]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_7_qs;
       end
 
-      addr_hit[401]: begin
+      addr_hit[403]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_8_qs;
       end
 
-      addr_hit[402]: begin
+      addr_hit[404]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_9_qs;
       end
 
-      addr_hit[403]: begin
+      addr_hit[405]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_10_qs;
       end
 
-      addr_hit[404]: begin
+      addr_hit[406]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_11_qs;
       end
 
-      addr_hit[405]: begin
+      addr_hit[407]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_12_qs;
       end
 
-      addr_hit[406]: begin
+      addr_hit[408]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_13_qs;
       end
 
-      addr_hit[407]: begin
+      addr_hit[409]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_14_qs;
       end
 
-      addr_hit[408]: begin
+      addr_hit[410]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_15_qs;
       end
 
-      addr_hit[409]: begin
+      addr_hit[411]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_16_qs;
       end
 
-      addr_hit[410]: begin
+      addr_hit[412]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_17_qs;
       end
 
-      addr_hit[411]: begin
+      addr_hit[413]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_18_qs;
       end
 
-      addr_hit[412]: begin
+      addr_hit[414]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_19_qs;
       end
 
-      addr_hit[413]: begin
+      addr_hit[415]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_20_qs;
       end
 
-      addr_hit[414]: begin
+      addr_hit[416]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_21_qs;
       end
 
-      addr_hit[415]: begin
+      addr_hit[417]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_22_qs;
       end
 
-      addr_hit[416]: begin
+      addr_hit[418]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_23_qs;
       end
 
-      addr_hit[417]: begin
+      addr_hit[419]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_24_qs;
       end
 
-      addr_hit[418]: begin
+      addr_hit[420]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_25_qs;
       end
 
-      addr_hit[419]: begin
+      addr_hit[421]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_26_qs;
       end
 
-      addr_hit[420]: begin
+      addr_hit[422]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_27_qs;
       end
 
-      addr_hit[421]: begin
+      addr_hit[423]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_28_qs;
       end
 
-      addr_hit[422]: begin
+      addr_hit[424]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_29_qs;
       end
 
-      addr_hit[423]: begin
+      addr_hit[425]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_30_qs;
       end
 
-      addr_hit[424]: begin
+      addr_hit[426]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_31_qs;
       end
 
-      addr_hit[425]: begin
+      addr_hit[427]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_32_qs;
       end
 
-      addr_hit[426]: begin
+      addr_hit[428]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_33_qs;
       end
 
-      addr_hit[427]: begin
+      addr_hit[429]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_34_qs;
       end
 
-      addr_hit[428]: begin
+      addr_hit[430]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_35_qs;
       end
 
-      addr_hit[429]: begin
+      addr_hit[431]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_36_qs;
       end
 
-      addr_hit[430]: begin
+      addr_hit[432]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_37_qs;
       end
 
-      addr_hit[431]: begin
+      addr_hit[433]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_38_qs;
       end
 
-      addr_hit[432]: begin
+      addr_hit[434]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_39_qs;
       end
 
-      addr_hit[433]: begin
+      addr_hit[435]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_40_qs;
       end
 
-      addr_hit[434]: begin
+      addr_hit[436]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_41_qs;
       end
 
-      addr_hit[435]: begin
+      addr_hit[437]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_42_qs;
       end
 
-      addr_hit[436]: begin
+      addr_hit[438]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_43_qs;
       end
 
-      addr_hit[437]: begin
+      addr_hit[439]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_44_qs;
       end
 
-      addr_hit[438]: begin
+      addr_hit[440]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_45_qs;
       end
 
-      addr_hit[439]: begin
+      addr_hit[441]: begin
         reg_rdata_next[0] = mio_pad_sleep_en_46_qs;
       end
 
-      addr_hit[440]: begin
+      addr_hit[442]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_0_qs;
       end
 
-      addr_hit[441]: begin
+      addr_hit[443]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_1_qs;
       end
 
-      addr_hit[442]: begin
+      addr_hit[444]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_2_qs;
       end
 
-      addr_hit[443]: begin
+      addr_hit[445]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_3_qs;
       end
 
-      addr_hit[444]: begin
+      addr_hit[446]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_4_qs;
       end
 
-      addr_hit[445]: begin
+      addr_hit[447]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_5_qs;
       end
 
-      addr_hit[446]: begin
+      addr_hit[448]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_6_qs;
       end
 
-      addr_hit[447]: begin
+      addr_hit[449]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_7_qs;
       end
 
-      addr_hit[448]: begin
+      addr_hit[450]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_8_qs;
       end
 
-      addr_hit[449]: begin
+      addr_hit[451]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_9_qs;
       end
 
-      addr_hit[450]: begin
+      addr_hit[452]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_10_qs;
       end
 
-      addr_hit[451]: begin
+      addr_hit[453]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_11_qs;
       end
 
-      addr_hit[452]: begin
+      addr_hit[454]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_12_qs;
       end
 
-      addr_hit[453]: begin
+      addr_hit[455]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_13_qs;
       end
 
-      addr_hit[454]: begin
+      addr_hit[456]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_14_qs;
       end
 
-      addr_hit[455]: begin
+      addr_hit[457]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_15_qs;
       end
 
-      addr_hit[456]: begin
+      addr_hit[458]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_16_qs;
       end
 
-      addr_hit[457]: begin
+      addr_hit[459]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_17_qs;
       end
 
-      addr_hit[458]: begin
+      addr_hit[460]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_18_qs;
       end
 
-      addr_hit[459]: begin
+      addr_hit[461]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_19_qs;
       end
 
-      addr_hit[460]: begin
+      addr_hit[462]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_20_qs;
       end
 
-      addr_hit[461]: begin
+      addr_hit[463]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_21_qs;
       end
 
-      addr_hit[462]: begin
+      addr_hit[464]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_22_qs;
       end
 
-      addr_hit[463]: begin
+      addr_hit[465]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_23_qs;
       end
 
-      addr_hit[464]: begin
+      addr_hit[466]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_24_qs;
       end
 
-      addr_hit[465]: begin
+      addr_hit[467]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_25_qs;
       end
 
-      addr_hit[466]: begin
+      addr_hit[468]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_26_qs;
       end
 
-      addr_hit[467]: begin
+      addr_hit[469]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_27_qs;
       end
 
-      addr_hit[468]: begin
+      addr_hit[470]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_28_qs;
       end
 
-      addr_hit[469]: begin
+      addr_hit[471]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_29_qs;
       end
 
-      addr_hit[470]: begin
+      addr_hit[472]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_30_qs;
       end
 
-      addr_hit[471]: begin
+      addr_hit[473]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_31_qs;
       end
 
-      addr_hit[472]: begin
+      addr_hit[474]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_32_qs;
       end
 
-      addr_hit[473]: begin
+      addr_hit[475]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_33_qs;
       end
 
-      addr_hit[474]: begin
+      addr_hit[476]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_34_qs;
       end
 
-      addr_hit[475]: begin
+      addr_hit[477]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_35_qs;
       end
 
-      addr_hit[476]: begin
+      addr_hit[478]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_36_qs;
       end
 
-      addr_hit[477]: begin
+      addr_hit[479]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_37_qs;
       end
 
-      addr_hit[478]: begin
+      addr_hit[480]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_38_qs;
       end
 
-      addr_hit[479]: begin
+      addr_hit[481]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_39_qs;
       end
 
-      addr_hit[480]: begin
+      addr_hit[482]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_40_qs;
       end
 
-      addr_hit[481]: begin
+      addr_hit[483]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_41_qs;
       end
 
-      addr_hit[482]: begin
+      addr_hit[484]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_42_qs;
       end
 
-      addr_hit[483]: begin
+      addr_hit[485]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_43_qs;
       end
 
-      addr_hit[484]: begin
+      addr_hit[486]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_44_qs;
       end
 
-      addr_hit[485]: begin
+      addr_hit[487]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_45_qs;
       end
 
-      addr_hit[486]: begin
+      addr_hit[488]: begin
         reg_rdata_next[1:0] = mio_pad_sleep_mode_46_qs;
       end
 
-      addr_hit[487]: begin
+      addr_hit[489]: begin
         reg_rdata_next[0] = dio_pad_sleep_status_en_0_qs;
         reg_rdata_next[1] = dio_pad_sleep_status_en_1_qs;
         reg_rdata_next[2] = dio_pad_sleep_status_en_2_qs;
@@ -25387,461 +25594,474 @@ module pinmux_reg_top (
         reg_rdata_next[20] = dio_pad_sleep_status_en_20_qs;
         reg_rdata_next[21] = dio_pad_sleep_status_en_21_qs;
         reg_rdata_next[22] = dio_pad_sleep_status_en_22_qs;
-      end
-
-      addr_hit[488]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_0_qs;
-      end
-
-      addr_hit[489]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_1_qs;
+        reg_rdata_next[23] = dio_pad_sleep_status_en_23_qs;
       end
 
       addr_hit[490]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_2_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_0_qs;
       end
 
       addr_hit[491]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_3_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_1_qs;
       end
 
       addr_hit[492]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_4_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_2_qs;
       end
 
       addr_hit[493]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_5_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_3_qs;
       end
 
       addr_hit[494]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_6_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_4_qs;
       end
 
       addr_hit[495]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_7_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_5_qs;
       end
 
       addr_hit[496]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_8_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_6_qs;
       end
 
       addr_hit[497]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_9_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_7_qs;
       end
 
       addr_hit[498]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_10_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_8_qs;
       end
 
       addr_hit[499]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_11_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_9_qs;
       end
 
       addr_hit[500]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_12_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_10_qs;
       end
 
       addr_hit[501]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_13_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_11_qs;
       end
 
       addr_hit[502]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_14_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_12_qs;
       end
 
       addr_hit[503]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_15_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_13_qs;
       end
 
       addr_hit[504]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_16_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_14_qs;
       end
 
       addr_hit[505]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_17_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_15_qs;
       end
 
       addr_hit[506]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_18_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_16_qs;
       end
 
       addr_hit[507]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_19_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_17_qs;
       end
 
       addr_hit[508]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_20_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_18_qs;
       end
 
       addr_hit[509]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_21_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_19_qs;
       end
 
       addr_hit[510]: begin
-        reg_rdata_next[0] = dio_pad_sleep_regwen_22_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_20_qs;
       end
 
       addr_hit[511]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_0_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_21_qs;
       end
 
       addr_hit[512]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_1_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_22_qs;
       end
 
       addr_hit[513]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_2_qs;
+        reg_rdata_next[0] = dio_pad_sleep_regwen_23_qs;
       end
 
       addr_hit[514]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_3_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_0_qs;
       end
 
       addr_hit[515]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_4_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_1_qs;
       end
 
       addr_hit[516]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_5_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_2_qs;
       end
 
       addr_hit[517]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_6_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_3_qs;
       end
 
       addr_hit[518]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_7_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_4_qs;
       end
 
       addr_hit[519]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_8_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_5_qs;
       end
 
       addr_hit[520]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_9_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_6_qs;
       end
 
       addr_hit[521]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_10_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_7_qs;
       end
 
       addr_hit[522]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_11_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_8_qs;
       end
 
       addr_hit[523]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_12_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_9_qs;
       end
 
       addr_hit[524]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_13_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_10_qs;
       end
 
       addr_hit[525]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_14_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_11_qs;
       end
 
       addr_hit[526]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_15_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_12_qs;
       end
 
       addr_hit[527]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_16_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_13_qs;
       end
 
       addr_hit[528]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_17_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_14_qs;
       end
 
       addr_hit[529]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_18_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_15_qs;
       end
 
       addr_hit[530]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_19_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_16_qs;
       end
 
       addr_hit[531]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_20_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_17_qs;
       end
 
       addr_hit[532]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_21_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_18_qs;
       end
 
       addr_hit[533]: begin
-        reg_rdata_next[0] = dio_pad_sleep_en_22_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_19_qs;
       end
 
       addr_hit[534]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_0_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_20_qs;
       end
 
       addr_hit[535]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_1_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_21_qs;
       end
 
       addr_hit[536]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_2_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_22_qs;
       end
 
       addr_hit[537]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_3_qs;
+        reg_rdata_next[0] = dio_pad_sleep_en_23_qs;
       end
 
       addr_hit[538]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_4_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_0_qs;
       end
 
       addr_hit[539]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_5_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_1_qs;
       end
 
       addr_hit[540]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_6_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_2_qs;
       end
 
       addr_hit[541]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_7_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_3_qs;
       end
 
       addr_hit[542]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_8_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_4_qs;
       end
 
       addr_hit[543]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_9_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_5_qs;
       end
 
       addr_hit[544]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_10_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_6_qs;
       end
 
       addr_hit[545]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_11_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_7_qs;
       end
 
       addr_hit[546]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_12_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_8_qs;
       end
 
       addr_hit[547]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_13_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_9_qs;
       end
 
       addr_hit[548]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_14_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_10_qs;
       end
 
       addr_hit[549]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_15_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_11_qs;
       end
 
       addr_hit[550]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_16_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_12_qs;
       end
 
       addr_hit[551]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_17_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_13_qs;
       end
 
       addr_hit[552]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_18_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_14_qs;
       end
 
       addr_hit[553]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_19_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_15_qs;
       end
 
       addr_hit[554]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_20_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_16_qs;
       end
 
       addr_hit[555]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_21_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_17_qs;
       end
 
       addr_hit[556]: begin
-        reg_rdata_next[1:0] = dio_pad_sleep_mode_22_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_18_qs;
       end
 
       addr_hit[557]: begin
-        reg_rdata_next[0] = wkup_detector_regwen_0_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_19_qs;
       end
 
       addr_hit[558]: begin
-        reg_rdata_next[0] = wkup_detector_regwen_1_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_20_qs;
       end
 
       addr_hit[559]: begin
-        reg_rdata_next[0] = wkup_detector_regwen_2_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_21_qs;
       end
 
       addr_hit[560]: begin
-        reg_rdata_next[0] = wkup_detector_regwen_3_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_22_qs;
       end
 
       addr_hit[561]: begin
-        reg_rdata_next[0] = wkup_detector_regwen_4_qs;
+        reg_rdata_next[1:0] = dio_pad_sleep_mode_23_qs;
       end
 
       addr_hit[562]: begin
-        reg_rdata_next[0] = wkup_detector_regwen_5_qs;
+        reg_rdata_next[0] = wkup_detector_regwen_0_qs;
       end
 
       addr_hit[563]: begin
-        reg_rdata_next[0] = wkup_detector_regwen_6_qs;
+        reg_rdata_next[0] = wkup_detector_regwen_1_qs;
       end
 
       addr_hit[564]: begin
-        reg_rdata_next[0] = wkup_detector_regwen_7_qs;
+        reg_rdata_next[0] = wkup_detector_regwen_2_qs;
       end
 
       addr_hit[565]: begin
-        reg_rdata_next[0] = wkup_detector_en_0_qs;
+        reg_rdata_next[0] = wkup_detector_regwen_3_qs;
       end
 
       addr_hit[566]: begin
-        reg_rdata_next[0] = wkup_detector_en_1_qs;
+        reg_rdata_next[0] = wkup_detector_regwen_4_qs;
       end
 
       addr_hit[567]: begin
-        reg_rdata_next[0] = wkup_detector_en_2_qs;
+        reg_rdata_next[0] = wkup_detector_regwen_5_qs;
       end
 
       addr_hit[568]: begin
-        reg_rdata_next[0] = wkup_detector_en_3_qs;
+        reg_rdata_next[0] = wkup_detector_regwen_6_qs;
       end
 
       addr_hit[569]: begin
-        reg_rdata_next[0] = wkup_detector_en_4_qs;
+        reg_rdata_next[0] = wkup_detector_regwen_7_qs;
       end
 
       addr_hit[570]: begin
-        reg_rdata_next[0] = wkup_detector_en_5_qs;
+        reg_rdata_next[0] = wkup_detector_en_0_qs;
       end
 
       addr_hit[571]: begin
-        reg_rdata_next[0] = wkup_detector_en_6_qs;
+        reg_rdata_next[0] = wkup_detector_en_1_qs;
       end
 
       addr_hit[572]: begin
-        reg_rdata_next[0] = wkup_detector_en_7_qs;
+        reg_rdata_next[0] = wkup_detector_en_2_qs;
       end
 
       addr_hit[573]: begin
+        reg_rdata_next[0] = wkup_detector_en_3_qs;
+      end
+
+      addr_hit[574]: begin
+        reg_rdata_next[0] = wkup_detector_en_4_qs;
+      end
+
+      addr_hit[575]: begin
+        reg_rdata_next[0] = wkup_detector_en_5_qs;
+      end
+
+      addr_hit[576]: begin
+        reg_rdata_next[0] = wkup_detector_en_6_qs;
+      end
+
+      addr_hit[577]: begin
+        reg_rdata_next[0] = wkup_detector_en_7_qs;
+      end
+
+      addr_hit[578]: begin
         reg_rdata_next[2:0] = wkup_detector_0_mode_0_qs;
         reg_rdata_next[3] = wkup_detector_0_filter_0_qs;
         reg_rdata_next[4] = wkup_detector_0_miodio_0_qs;
       end
 
-      addr_hit[574]: begin
+      addr_hit[579]: begin
         reg_rdata_next[2:0] = wkup_detector_1_mode_1_qs;
         reg_rdata_next[3] = wkup_detector_1_filter_1_qs;
         reg_rdata_next[4] = wkup_detector_1_miodio_1_qs;
       end
 
-      addr_hit[575]: begin
+      addr_hit[580]: begin
         reg_rdata_next[2:0] = wkup_detector_2_mode_2_qs;
         reg_rdata_next[3] = wkup_detector_2_filter_2_qs;
         reg_rdata_next[4] = wkup_detector_2_miodio_2_qs;
       end
 
-      addr_hit[576]: begin
+      addr_hit[581]: begin
         reg_rdata_next[2:0] = wkup_detector_3_mode_3_qs;
         reg_rdata_next[3] = wkup_detector_3_filter_3_qs;
         reg_rdata_next[4] = wkup_detector_3_miodio_3_qs;
       end
 
-      addr_hit[577]: begin
+      addr_hit[582]: begin
         reg_rdata_next[2:0] = wkup_detector_4_mode_4_qs;
         reg_rdata_next[3] = wkup_detector_4_filter_4_qs;
         reg_rdata_next[4] = wkup_detector_4_miodio_4_qs;
       end
 
-      addr_hit[578]: begin
+      addr_hit[583]: begin
         reg_rdata_next[2:0] = wkup_detector_5_mode_5_qs;
         reg_rdata_next[3] = wkup_detector_5_filter_5_qs;
         reg_rdata_next[4] = wkup_detector_5_miodio_5_qs;
       end
 
-      addr_hit[579]: begin
+      addr_hit[584]: begin
         reg_rdata_next[2:0] = wkup_detector_6_mode_6_qs;
         reg_rdata_next[3] = wkup_detector_6_filter_6_qs;
         reg_rdata_next[4] = wkup_detector_6_miodio_6_qs;
       end
 
-      addr_hit[580]: begin
+      addr_hit[585]: begin
         reg_rdata_next[2:0] = wkup_detector_7_mode_7_qs;
         reg_rdata_next[3] = wkup_detector_7_filter_7_qs;
         reg_rdata_next[4] = wkup_detector_7_miodio_7_qs;
       end
 
-      addr_hit[581]: begin
+      addr_hit[586]: begin
         reg_rdata_next[7:0] = wkup_detector_cnt_th_0_qs;
       end
 
-      addr_hit[582]: begin
+      addr_hit[587]: begin
         reg_rdata_next[7:0] = wkup_detector_cnt_th_1_qs;
       end
 
-      addr_hit[583]: begin
+      addr_hit[588]: begin
         reg_rdata_next[7:0] = wkup_detector_cnt_th_2_qs;
       end
 
-      addr_hit[584]: begin
+      addr_hit[589]: begin
         reg_rdata_next[7:0] = wkup_detector_cnt_th_3_qs;
       end
 
-      addr_hit[585]: begin
+      addr_hit[590]: begin
         reg_rdata_next[7:0] = wkup_detector_cnt_th_4_qs;
       end
 
-      addr_hit[586]: begin
+      addr_hit[591]: begin
         reg_rdata_next[7:0] = wkup_detector_cnt_th_5_qs;
       end
 
-      addr_hit[587]: begin
+      addr_hit[592]: begin
         reg_rdata_next[7:0] = wkup_detector_cnt_th_6_qs;
       end
 
-      addr_hit[588]: begin
+      addr_hit[593]: begin
         reg_rdata_next[7:0] = wkup_detector_cnt_th_7_qs;
       end
 
-      addr_hit[589]: begin
+      addr_hit[594]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel_0_qs;
       end
 
-      addr_hit[590]: begin
+      addr_hit[595]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel_1_qs;
       end
 
-      addr_hit[591]: begin
+      addr_hit[596]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel_2_qs;
       end
 
-      addr_hit[592]: begin
+      addr_hit[597]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel_3_qs;
       end
 
-      addr_hit[593]: begin
+      addr_hit[598]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel_4_qs;
       end
 
-      addr_hit[594]: begin
+      addr_hit[599]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel_5_qs;
       end
 
-      addr_hit[595]: begin
+      addr_hit[600]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel_6_qs;
       end
 
-      addr_hit[596]: begin
+      addr_hit[601]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel_7_qs;
       end
 
-      addr_hit[597]: begin
+      addr_hit[602]: begin
         reg_rdata_next[0] = wkup_cause_cause_0_qs;
         reg_rdata_next[1] = wkup_cause_cause_1_qs;
         reg_rdata_next[2] = wkup_cause_cause_2_qs;

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
@@ -108,6 +108,7 @@ module chip_earlgrey_nexysvideo #(
     dio_pad_type: {
       BidirOd, // DIO sysrst_ctrl_aon_pwrb_out
       BidirOd, // DIO sysrst_ctrl_aon_ec_rst_out_l
+      BidirTol, // DIO usbdev_rx_enable
       BidirTol, // DIO usbdev_suspend
       BidirTol, // DIO usbdev_tx_mode_se
       BidirTol, // DIO usbdev_dn_pullup
@@ -740,6 +741,9 @@ module chip_earlgrey_nexysvideo #(
                                              manual_in_io_usb_sense0;
   assign manual_out_io_uphy_sense = 1'b0;
   assign manual_oe_io_uphy_sense = 1'b0;
+
+  // DioUsbdevRxEnable
+  assign dio_in[DioUsbdevRxEnable] = 1'b0;
 
   // Additional outputs for uphy
   assign manual_oe_io_uphy_dppullup = 1'b1;

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -40,9 +40,9 @@ module top_earlgrey #(
   output logic [46:0] mio_out_o,
   output logic [46:0] mio_oe_o,
   // Dedicated I/O
-  input        [22:0] dio_in_i,
-  output logic [22:0] dio_out_o,
-  output logic [22:0] dio_oe_o,
+  input        [23:0] dio_in_i,
+  output logic [23:0] dio_out_o,
+  output logic [23:0] dio_oe_o,
 
   // pad attributes to padring
   output prim_pad_wrapper_pkg::pad_attr_t [pinmux_reg_pkg::NMioPads-1:0] mio_attr_o,
@@ -119,9 +119,9 @@ module top_earlgrey #(
   logic [54:0] mio_p2d;
   logic [66:0] mio_d2p;
   logic [66:0] mio_en_d2p;
-  logic [22:0] dio_p2d;
-  logic [22:0] dio_d2p;
-  logic [22:0] dio_en_d2p;
+  logic [23:0] dio_p2d;
+  logic [23:0] dio_d2p;
+  logic [23:0] dio_en_d2p;
   // uart0
   logic        cio_uart0_rx_p2d;
   logic        cio_uart0_tx_d2p;
@@ -210,6 +210,8 @@ module top_earlgrey #(
   logic        cio_usbdev_tx_mode_se_en_d2p;
   logic        cio_usbdev_suspend_d2p;
   logic        cio_usbdev_suspend_en_d2p;
+  logic        cio_usbdev_rx_enable_d2p;
+  logic        cio_usbdev_rx_enable_en_d2p;
   logic        cio_usbdev_d_d2p;
   logic        cio_usbdev_d_en_d2p;
   logic        cio_usbdev_dp_d2p;
@@ -1401,6 +1403,8 @@ module top_earlgrey #(
       .cio_tx_mode_se_en_o (cio_usbdev_tx_mode_se_en_d2p),
       .cio_suspend_o       (cio_usbdev_suspend_d2p),
       .cio_suspend_en_o    (cio_usbdev_suspend_en_d2p),
+      .cio_rx_enable_o     (cio_usbdev_rx_enable_d2p),
+      .cio_rx_enable_en_o  (cio_usbdev_rx_enable_en_d2p),
       .cio_d_o             (cio_usbdev_d_d2p),
       .cio_d_en_o          (cio_usbdev_d_en_d2p),
       .cio_dp_o            (cio_usbdev_dp_d2p),
@@ -2835,7 +2839,7 @@ module top_earlgrey #(
   assign mio_en_d2p[MioOutSysrstCtrlAonKey2Out] = cio_sysrst_ctrl_aon_key2_out_en_d2p;
 
   // All dedicated inputs
-  logic [22:0] unused_dio_p2d;
+  logic [23:0] unused_dio_p2d;
   assign unused_dio_p2d = dio_p2d;
   assign cio_spi_host0_sd_p2d[0] = dio_p2d[DioSpiHost0Sd0];
   assign cio_spi_host0_sd_p2d[1] = dio_p2d[DioSpiHost0Sd1];
@@ -2874,6 +2878,7 @@ module top_earlgrey #(
   assign dio_d2p[DioUsbdevDnPullup] = cio_usbdev_dn_pullup_d2p;
   assign dio_d2p[DioUsbdevTxModeSe] = cio_usbdev_tx_mode_se_d2p;
   assign dio_d2p[DioUsbdevSuspend] = cio_usbdev_suspend_d2p;
+  assign dio_d2p[DioUsbdevRxEnable] = cio_usbdev_rx_enable_d2p;
   assign dio_d2p[DioSysrstCtrlAonEcRstOutL] = cio_sysrst_ctrl_aon_ec_rst_out_l_d2p;
   assign dio_d2p[DioSysrstCtrlAonPwrbOut] = cio_sysrst_ctrl_aon_pwrb_out_d2p;
 
@@ -2899,6 +2904,7 @@ module top_earlgrey #(
   assign dio_en_d2p[DioUsbdevDnPullup] = cio_usbdev_dn_pullup_en_d2p;
   assign dio_en_d2p[DioUsbdevTxModeSe] = cio_usbdev_tx_mode_se_en_d2p;
   assign dio_en_d2p[DioUsbdevSuspend] = cio_usbdev_suspend_en_d2p;
+  assign dio_en_d2p[DioUsbdevRxEnable] = cio_usbdev_rx_enable_en_d2p;
   assign dio_en_d2p[DioSysrstCtrlAonEcRstOutL] = cio_sysrst_ctrl_aon_ec_rst_out_l_en_d2p;
   assign dio_en_d2p[DioSysrstCtrlAonPwrbOut] = cio_sysrst_ctrl_aon_pwrb_out_en_d2p;
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
@@ -625,9 +625,10 @@ package top_earlgrey_pkg;
     DioUsbdevDnPullup = 18,
     DioUsbdevTxModeSe = 19,
     DioUsbdevSuspend = 20,
-    DioSysrstCtrlAonEcRstOutL = 21,
-    DioSysrstCtrlAonPwrbOut = 22,
-    DioCount = 23
+    DioUsbdevRxEnable = 21,
+    DioSysrstCtrlAonEcRstOutL = 22,
+    DioSysrstCtrlAonPwrbOut = 23,
+    DioCount = 24
   } dio_e;
 
   // Raw MIO/DIO input array indices on chip-level.

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -1141,7 +1141,7 @@ extern const top_earlgrey_alert_peripheral_t
 // PERIPH_INSEL ranges from 0 to NUM_MIO_PADS + 2 -1}
 //  0 and 1 are tied to value 0 and 1
 #define NUM_MIO_PADS 47
-#define NUM_DIO_PADS 23
+#define NUM_DIO_PADS 24
 
 #define PINMUX_PERIPH_OUTSEL_IDX_OFFSET 3
 

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -498,6 +498,9 @@ module chip_${top["name"]}_${target["name"]} (
   assign manual_out_io_uphy_sense = 1'b0;
   assign manual_oe_io_uphy_sense = 1'b0;
 
+  // DioUsbdevRxEnable
+  assign dio_in[DioUsbdevRxEnable] = 1'b0;
+
   // Additional outputs for uphy
   assign manual_oe_io_uphy_dppullup = 1'b1;
   assign manual_out_io_uphy_dppullup = manual_out_io_usb_dppullup0 &
@@ -578,10 +581,10 @@ module chip_${top["name"]}_${target["name"]} (
   assign usb_pullup_p_en = dio_out[DioUsbdevDpPullup] & dio_oe[DioUsbdevDpPullup];
   assign usb_pullup_n_en = dio_out[DioUsbdevDnPullup] & dio_oe[DioUsbdevDnPullup];
 
-  // TODO(#5925): connect this to AST?
-  logic usbdev_aon_usb_rx_enable;
+  logic usb_rx_enable;
+  assign usb_rx_enable = dio_out[DioUsbdevRxEnable] & dio_oe[DioUsbdevRxEnable];
+
   logic [ast_pkg::UsbCalibWidth-1:0] usb_io_pu_cal;
-  assign usbdev_aon_usb_rx_enable = 1'b0;
 
   // pwrmgr interface
   pwrmgr_pkg::pwr_ast_req_t base_ast_pwr;
@@ -590,14 +593,14 @@ module chip_${top["name"]}_${target["name"]} (
   prim_usb_diff_rx #(
     .CalibW(ast_pkg::UsbCalibWidth)
   ) u_prim_usb_diff_rx (
-    .input_pi      ( USB_P                    ),
-    .input_ni      ( USB_N                    ),
-    .input_en_i    ( usbdev_aon_usb_rx_enable ),
-    .core_pok_i    ( ast_base_pwr.main_pok    ),
-    .pullup_p_en_i ( usb_pullup_p_en          ),
-    .pullup_n_en_i ( usb_pullup_n_en          ),
-    .calibration_i ( usb_io_pu_cal            ),
-    .input_o       ( dio_in[DioUsbdevD]  )
+    .input_pi      ( USB_P                 ),
+    .input_ni      ( USB_N                 ),
+    .input_en_i    ( usb_rx_enable         ),
+    .core_pok_i    ( ast_base_pwr.main_pok ),
+    .pullup_p_en_i ( usb_pullup_p_en       ),
+    .pullup_n_en_i ( usb_pullup_n_en       ),
+    .calibration_i ( usb_io_pu_cal         ),
+    .input_o       ( dio_in[DioUsbdevD]    )
   );
 
   // Tie-off unused signals
@@ -607,6 +610,7 @@ module chip_${top["name"]}_${target["name"]} (
   assign dio_in[DioUsbdevDnPullup] = 1'b0;
   assign dio_in[DioUsbdevTxModeSe] = 1'b0;
   assign dio_in[DioUsbdevSuspend] = 1'b0;
+  assign dio_in[DioUsbdevRxEnable] = 1'b0;
 
   logic unused_usb_sigs;
   assign unused_usb_sigs = ^{
@@ -626,6 +630,8 @@ module chip_${top["name"]}_${target["name"]} (
     dio_out[DioUsbdevSuspend],
     dio_oe[DioUsbdevSuspend],
     dio_attr[DioUsbdevSuspend],
+    // Rx enable
+    dio_attr[DioUsbdevRxEnable],
     // D is used as an input only
     dio_out[DioUsbdevD],
     dio_oe[DioUsbdevD],


### PR DESCRIPTION
Fixes #5932

- Currently the rx enable is assumed to be dynamic, but this may
  change based on Nuvoton feedback.

There was a discussion regarding whether we should make most of the usbdev inter-signals instead of pinmux signals.
See below for rationale.

In addition to dp/dn, sense and dp/dn_pullup_en all have to remain pinmux-able signals.
Sense may need to come through pinmux since it is used to detect vbus power.  As long as the vbus voltage is not too high (or is clamped to a safe range), it can be muxed on nay pin.
dp/dn_pullup_en make use of pinmux's sleep capture as part of usbdev's suspend / resume feature.

This ends up leaving a few scattered signals that may or may not fall into the pinmux category.
Ultimateily, it is difficult from the perspective of the usbdev to know whether a signal should be pinmuxed or directly signaled out.

The ideal solution are two-fold

1. Make all signals inter-signal, and use a top specific wrapper that connects the necessary signals to pinmux.
2. Make all signals pinmuxable, and manually handle the pad connections where required.

In our design, we currently have most of the support needed for 2, (see #6042) for possible enhancements