### PR TITLE
[otbn] Wire up bus intg_error_o signals

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -207,16 +207,24 @@
       hwaccess: "hwo",
       fields: [
         { bits: "0",
+          name: "bus_integrity_error",
+          resval: 0,
+          desc: '''
+            Set by a failed integrity check on a bus access.
+            Note that this can happen even when OTBN is not running.
+          '''
+        }
+        { bits: "1",
           name: "imem_error",
           resval: 0,
           desc: "Set on any ECC error in IMEM"
         }
-        { bits: "1",
+        { bits: "2",
           name: "dmem_error",
           resval: 0,
           desc: "Set on any ECC error in DMEM"
         }
-        { bits: "2",
+        { bits: "3",
           name: "reg_error",
           resval: 0,
           desc: "Set on any ECC error in a register file"

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -97,6 +97,10 @@ package otbn_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
+    } bus_integrity_error;
+    struct packed {
+      logic        d;
+      logic        de;
     } imem_error;
     struct packed {
       logic        d;
@@ -120,10 +124,10 @@ package otbn_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    otbn_hw2reg_intr_state_reg_t intr_state; // [24:23]
-    otbn_hw2reg_status_reg_t status; // [22:22]
-    otbn_hw2reg_err_bits_reg_t err_bits; // [21:6]
-    otbn_hw2reg_fatal_alert_cause_reg_t fatal_alert_cause; // [5:0]
+    otbn_hw2reg_intr_state_reg_t intr_state; // [26:25]
+    otbn_hw2reg_status_reg_t status; // [24:24]
+    otbn_hw2reg_err_bits_reg_t err_bits; // [23:8]
+    otbn_hw2reg_fatal_alert_cause_reg_t fatal_alert_cause; // [7:0]
   } otbn_hw2reg_t;
 
   // Register offsets

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -183,6 +183,7 @@ module otbn_reg_top (
   logic err_bits_fatal_reg_qs;
   logic [31:0] start_addr_wd;
   logic start_addr_we;
+  logic fatal_alert_cause_bus_integrity_error_qs;
   logic fatal_alert_cause_imem_error_qs;
   logic fatal_alert_cause_dmem_error_qs;
   logic fatal_alert_cause_reg_error_qs;
@@ -552,7 +553,32 @@ module otbn_reg_top (
 
   // R[fatal_alert_cause]: V(False)
 
-  //   F[imem_error]: 0:0
+  //   F[bus_integrity_error]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_fatal_alert_cause_bus_integrity_error (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.fatal_alert_cause.bus_integrity_error.de),
+    .d      (hw2reg.fatal_alert_cause.bus_integrity_error.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (fatal_alert_cause_bus_integrity_error_qs)
+  );
+
+
+  //   F[imem_error]: 1:1
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RO"),
@@ -577,7 +603,7 @@ module otbn_reg_top (
   );
 
 
-  //   F[dmem_error]: 1:1
+  //   F[dmem_error]: 2:2
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RO"),
@@ -602,7 +628,7 @@ module otbn_reg_top (
   );
 
 
-  //   F[reg_error]: 2:2
+  //   F[reg_error]: 3:3
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RO"),
@@ -727,9 +753,10 @@ module otbn_reg_top (
       end
 
       addr_hit[8]: begin
-        reg_rdata_next[0] = fatal_alert_cause_imem_error_qs;
-        reg_rdata_next[1] = fatal_alert_cause_dmem_error_qs;
-        reg_rdata_next[2] = fatal_alert_cause_reg_error_qs;
+        reg_rdata_next[0] = fatal_alert_cause_bus_integrity_error_qs;
+        reg_rdata_next[1] = fatal_alert_cause_imem_error_qs;
+        reg_rdata_next[2] = fatal_alert_cause_dmem_error_qs;
+        reg_rdata_next[3] = fatal_alert_cause_reg_error_qs;
       end
 
       default: begin


### PR DESCRIPTION
These are merged together and cause a "bus integrity error", which is
a fatal alert.
