### PR TITLE
[otp_ctrl] Put req_type_o signal back again

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -197,7 +197,8 @@ module otp_ctrl
     .intg_error_o(                    ),
     .rdata_i     (  tlul_rdata        ),
     .rvalid_i    (  tlul_rvalid       ),
-    .rerror_i    (  tlul_rerror       )
+    .rerror_i    (  tlul_rerror       ),
+    .req_type_o  (                    )
   );
 
   logic [NumPart-1:0] tlul_part_sel_oh;


### PR DESCRIPTION
This has been a rather complicated history, because of PRs colliding
in mid-air. The signal was added by commit 564683d and added a second
time by 5174eaf (a broken rebase). We then removed one copy in
05ef653, fixing the resulting compile error. And then 8d33919 removed
the other one: presumably another broken rebase.

Put one back!
