### PR TITLE
[sysrst_ctrl] Declare the gsc_rst_o signal in the hjson

### DIFF
--- a/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
+++ b/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
@@ -42,6 +42,15 @@
     { name: "key2_out", desc: "Passthrough from key2_in, can be configured to invert" }
     { name: "pwrb_out", desc: "Passthrough from pwrb_in, can be configured to invert" }
   ],
+  inter_signal_list: [
+    { name:    "gsc_rst",
+      package: "",
+      struct:  "logic",
+      act:     "req"
+      type:    "uni",
+      width:   "1"
+    }
+  ],
   regwidth: "32",
   registers: [
     { name: "REGWEN",

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2604,6 +2604,15 @@
       inter_signal_list:
       [
         {
+          name: gsc_rst
+          struct: logic
+          type: uni
+          act: req
+          width: 1
+          inst_name: sysrst_ctrl_aon
+          index: -1
+        }
+        {
           name: tl
           struct: tl
           package: tlul_pkg
@@ -12418,6 +12427,15 @@
         default: ""
         end_idx: -1
         top_signame: clkmgr_aon_tl
+        index: -1
+      }
+      {
+        name: gsc_rst
+        struct: logic
+        type: uni
+        act: req
+        width: 1
+        inst_name: sysrst_ctrl_aon
         index: -1
       }
       {

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1701,6 +1701,7 @@ module top_earlgrey #(
       .intr_sysrst_ctrl_o (intr_sysrst_ctrl_aon_sysrst_ctrl),
 
       // Inter-module signals
+      .gsc_rst_o(),
       .tl_i(sysrst_ctrl_aon_tl_req),
       .tl_o(sysrst_ctrl_aon_tl_rsp),
 


### PR DESCRIPTION
Declaring this as an inter-signal means that it gets wired up properly
in the auto-generated `top_earlgrey.sv`
