### PR TITLE
[sram_ctrl] Use the correct tl_instr_en_e

### DIFF
--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -243,14 +243,12 @@ module sram_ctrl
   // SRAM Execution //
   ////////////////////
 
-  import tlul_pkg::tl_instr_en_e;
-
   if (InstrExec) begin : gen_instr_ctrl
-    tl_instr_en_e lc_ifetch_en;
-    tl_instr_en_e reg_ifetch_en;
+    tlul_pkg::tl_instr_en_e lc_ifetch_en;
+    tlul_pkg::tl_instr_en_e reg_ifetch_en;
     assign lc_ifetch_en = (lc_hw_debug_en_i == lc_ctrl_pkg::On) ? tlul_pkg::InstrEn :
                                                                   tlul_pkg::InstrDis;
-    assign reg_ifetch_en = tl_instr_en_e'(reg2hw.exec.q);
+    assign reg_ifetch_en = tlul_pkg::tl_instr_en_e'(reg2hw.exec.q);
     assign en_ifetch_o = (otp_hw_cfg_i.data.en_sram_ifetch == EnSramIfetch) ? reg_ifetch_en :
                                                                               lc_ifetch_en;
   end else begin : gen_tieoff


### PR DESCRIPTION
This enum type is defined in both `sram_ctrl_pkg.sv` (as an 8-bit type
with values `EnSramIfetch` and `DisSramIfetch`) and in `tlul_pkg.sv` (as a
3-bit type with values `InstrEn` and `InstrDis`).

Importing the `tlul_pkg` version into scope in `sram_ctrl` is actually a
spec violation (SystemVerilog doesn't do shadowing, so you're not
allowed to import two things that clash) and also happens to confuse
Verilator's width inference.

Fortunately, everything sort of worked because the external ports used
the narrower type and the enum values had the same bottom bits, but it
was all a bit magic and kind of worked by luck. This patch explicitly
qualifies the name when we use `tlul_pkg::tl_instr_en_e`, which should
sort everything out.
