### PR TITLE
[hmac,lint] Be explicit about expansion when counting 1's

### DIFF
--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -311,12 +311,13 @@ module hmac
 
   assign msg_write = msg_fifo_req & msg_fifo_we & ~hmac_fifo_wsel & msg_allowed;
 
-  logic [$clog2(32+1)-1:0] wmask_ones;
+  localparam int unsigned WmaskAccWidth = $clog2(32 + 1);
+  logic [WmaskAccWidth-1:0] wmask_ones;
 
   always_comb begin
     wmask_ones = '0;
     for (int i = 0 ; i < 32 ; i++) begin
-      wmask_ones = wmask_ones + msg_fifo_wmask[i];
+      wmask_ones = wmask_ones + WmaskAccWidth'(msg_fifo_wmask[i]);
     end
   end
 


### PR DESCRIPTION
The `wmask_ones` signal counts the number of ones in `msg_fifo_wmask`, but
Verilator complains about the implicit expansion of the single bits in
`msg_fifo_wmask`. This patch makes the expansion explicit with a static
cast.

Other equivalent formulations:
```systemverilog
if (msg_fifo_wmask[i]) wmask_ones += WmaskAccWidth'(1);
wmask_ones += msg_fifo_wmask[i] ? WmaskAccWidth'(1) : 0;
```
I went for the version that most closely matched the original, but I don't really have an opinion on what's best.