### PR TITLE
[sw, rom_ext_signer] Add minimal rustfmt configuration file

### DIFF
--- a/sw/host/rom_ext_image_tools/signer/config/src/parser.rs
+++ b/sw/host/rom_ext_image_tools/signer/config/src/parser.rs
@@ -46,13 +46,14 @@ pub struct Extension {
 impl ParsedConfig {
     pub fn new(config: &Path) -> Self {
         // Read the entire configuration file.
-        let config_data = fs::read_to_string(config).expect("Failed to read the config file!");
+        let config_data = fs::read_to_string(config)
+            .expect("Failed to read the config file!");
 
-        let data: Value =
-            serde_hjson::from_str(&config_data).expect("Failed to parse the hjson config file!");
+        let data: Value = serde_hjson::from_str(&config_data)
+            .expect("Failed to parse the hjson config file!");
 
-        let deserialized: ParsedConfig =
-            serde_hjson::from_value(data).expect("Failed to deserialize hjson config data!");
+        let deserialized: ParsedConfig = serde_hjson::from_value(data)
+            .expect("Failed to deserialize hjson config data!");
 
         deserialized
     }

--- a/sw/host/rom_ext_image_tools/signer/image/src/image.rs
+++ b/sw/host/rom_ext_image_tools/signer/image/src/image.rs
@@ -106,7 +106,10 @@ impl RawImage {
 
     /// Updates ROM_EXT manifest signature key modulus field.
     pub fn update_modulus_field(&mut self, modulus: &[u8]) {
-        self.update_field(modulus, manifest::ROM_EXT_SIGNATURE_KEY_MODULUS_OFFSET);
+        self.update_field(
+            modulus,
+            manifest::ROM_EXT_SIGNATURE_KEY_MODULUS_OFFSET,
+        );
     }
 
     /// Updates ROM_EXT manifest signature field.
@@ -128,20 +131,23 @@ impl RawImage {
     ///
     /// Places the new file alongside the original, with a "new_" prefix.
     pub fn write_file(&self) {
-        let file_name = self.path.file_name().expect("Failed to get file stem!");
+        let file_name =
+            self.path.file_name().expect("Failed to get file stem!");
 
         let mut new_file_name = OsString::from("new_");
         new_file_name.push(file_name);
 
         let output_file = self.path.with_file_name(new_file_name);
 
-        fs::write(output_file, &self.data).expect("Failed to write the new binary file!");
+        fs::write(output_file, &self.data)
+            .expect("Failed to write the new binary file!");
     }
 
     /// Updates ROM_EXT manifest usage constraints field.
     fn update_usage_constraints_field(&mut self, path: &Path) {
         // Update fields from config.
-        let usage_constraints = fs::read(path).expect("Failed to read usage constraints!");
+        let usage_constraints =
+            fs::read(path).expect("Failed to read usage constraints!");
         self.update_field(
             &usage_constraints,
             manifest::ROM_EXT_USAGE_CONSTRAINTS_OFFSET,
@@ -151,7 +157,10 @@ impl RawImage {
     /// Updates ROM_EXT manifest peripheral lockdown info field.
     ///
     /// The information is encoded into the 128-bit binary blob.
-    fn update_peripheral_lockdown_info_field(&mut self, _info: &PeripheralLockdownInfo) {
+    fn update_peripheral_lockdown_info_field(
+        &mut self,
+        _info: &PeripheralLockdownInfo,
+    ) {
         // TODO: generate the peripheral_lockdown_blob from
         //       PeripheralLockdownInfo, meanwhile use a hard-coded vector.
 

--- a/sw/host/rom_ext_image_tools/signer/meson.build
+++ b/sw/host/rom_ext_image_tools/signer/meson.build
@@ -7,7 +7,6 @@ cargo = find_program('cargo', required: false, disabler: true)
 build_type = 'release'
 build_dir = meson.current_build_dir()
 manifest_path = meson.current_source_dir() / 'Cargo.toml'
-toolchain_file = meson.current_source_dir() / '..' / 'rust-toolchain'
 
 # CARGO FLAGS:
 # These flags will only apply to the final binary, and won't get propogated
@@ -39,14 +38,13 @@ rom_ext_signer_raw = custom_target(
     cargo,
     cargo_flags,
     rust_flags,
-    toolchain_file,
+    '',
     meson.source_root(),
     meson.build_root(),
   ],
   depend_files: [
     cargo_invoke_cmd,
     manifest_path,
-    toolchain_file,
   ],
   output: '.',
   console: true,

--- a/sw/host/rom_ext_image_tools/signer/rustfmt.toml
+++ b/sw/host/rom_ext_image_tools/signer/rustfmt.toml
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+max_width = 80

--- a/sw/host/rom_ext_image_tools/signer/src/main.rs
+++ b/sw/host/rom_ext_image_tools/signer/src/main.rs
@@ -34,15 +34,15 @@ fn main() {
 
     // Get the private key used for signature generation. It is also used to
     // extract key public exponent and modulus.
-    let private_key_der =
-        fs::read(&config.input_files.private_key_der_path).expect("Failed to read the image!");
+    let private_key_der = fs::read(&config.input_files.private_key_der_path)
+        .expect("Failed to read the image!");
 
     // Update "signed" manifest fields.
     image.update_static_fields(&config);
 
     // Convert ASN.1 DER private key into Mundane RsaPrivKey.
-    let private_key =
-        RsaPrivKey::parse_from_der(&private_key_der).expect("Failed to parse private key!");
+    let private_key = RsaPrivKey::parse_from_der(&private_key_der)
+        .expect("Failed to parse private key!");
 
     let mut exponent = private_key.public_exponent_be();
     // Encode public key components in little-endian byte order.
@@ -57,17 +57,21 @@ fn main() {
     // Produce the signature from concatenated system_state_value,
     // device_usage_value and the portion of the "signed" portion of the image.
     let image_sign_data = image.data_to_sign();
-    let device_usage_value = &device_usage_value(&config.input_files.usage_constraints_path);
-    let system_state_value = &system_state_value(&config.input_files.system_state_value_path);
+    let device_usage_value =
+        &device_usage_value(&config.input_files.usage_constraints_path);
+    let system_state_value =
+        &system_state_value(&config.input_files.system_state_value_path);
 
     let mut message_to_sign = Vec::<u8>::new();
     message_to_sign.extend_from_slice(system_state_value);
     message_to_sign.extend_from_slice(device_usage_value);
     message_to_sign.extend_from_slice(image_sign_data);
 
-    let signature =
-        RsaSignature::<B3072, RsaPkcs1v15, Sha256>::sign(&private_key, &message_to_sign)
-            .expect("Failed to sign!");
+    let signature = RsaSignature::<B3072, RsaPkcs1v15, Sha256>::sign(
+        &private_key,
+        &message_to_sign,
+    )
+    .expect("Failed to sign!");
 
     image.update_signature_field(&signature.bytes());
 
@@ -80,7 +84,8 @@ fn main() {
 /// This value is extrapolated from the ROM_EXT manifest usage_constraints
 /// field, and does not reside in the ROM_EXT manifest directly.
 pub fn device_usage_value(path: &Path) -> Vec<u8> {
-    let _usage_constraints = fs::read(path).expect("Failed to read usage constraints!");
+    let _usage_constraints =
+        fs::read(path).expect("Failed to read usage constraints!");
 
     // TODO: generate the device_usage_value from usage_constraints.
     //       meanwhile use a "dummy" hard-coded vector.


### PR DESCRIPTION
This PR makes sure that lines over 80 characters are split.

Please note that toolchain removal commit is a duplicate of another PR, and one of them will have to be rebased dependent on which lands first.