### PR TITLE
[kmac] Fix typo in kmac.waiver

### DIFF
--- a/hw/ip/kmac/lint/kmac.waiver
+++ b/hw/ip/kmac/lint/kmac.waiver
@@ -19,6 +19,6 @@ waive -rules {TWO_STATE_TYPE} -location {kmac.sv} \
     -regexp {'tl_window_e' is of two state type} \
     -comment "Window enum is used to select, not synthesized"
 
-waive -rules {TAG_OVERLAP} -location {kmac_keymgr.sv} \
+waive -rules {TAG_OVERLAP} -location {kmac_app.sv} \
     -regexp {Case tag expression '2'b1.* overlaps with previous tag} \
     -comment "priority casez makes the condition check explicitly"

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -622,7 +622,7 @@ module kmac_app
   always_comb begin
     priority casez ({fsm_err.valid, mux_err.valid})
       2'b ?1: error_o = mux_err;
-      2'b 1?: error_o = fsm_err;
+      2'b 10: error_o = fsm_err;
       default: error_o = '{valid: 1'b0, code: ErrNone, info: '0};
     endcase
   end


### PR DESCRIPTION
while renaming kmac_keymgr.sv to kmac_app.sv, kmac.waiver was left
behind having its original name in the waiver rule. This commit
corrected it and slightly revised the priority condition too.