### PR TITLE
[entropy_src/rtl] making rep cntr reset value consistent

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_repcnt_ht.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_repcnt_ht.sv
@@ -48,7 +48,7 @@ module entropy_src_repcnt_ht #(
   //
   // Test operation
   //  This test will look for catastrophic stuck bit failures. The rep_cntr
-  //  uses zero as the starting value, differing from the NIST value of one.
+  //  uses one as the starting value, just as the NIST algorithm does.
 
 
   for (genvar sh = 0; sh < RngBusWidth; sh = sh+1) begin : gen_cntrs
@@ -65,9 +65,9 @@ module entropy_src_repcnt_ht #(
 
     // NIST B counter
     assign rep_cntr_d[sh] =
-           (!active_i || clear_i) ? '0 :
+           (!active_i || clear_i) ? RegWidth'(1) :
            samples_match_pulse[sh] ? (rep_cntr_q[sh]+1) :
-           samples_no_match_pulse[sh] ?  '0 :
+           samples_no_match_pulse[sh] ? RegWidth'(1) :
            rep_cntr_q[sh];
 
     assign rep_cnt_fail[sh] = (rep_cntr_q[sh] >= thresh_i);

--- a/hw/ip/entropy_src/rtl/entropy_src_repcnts_ht.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_repcnts_ht.sv
@@ -63,9 +63,9 @@ module entropy_src_repcnts_ht #(
 
     // NIST B counter
     assign rep_cntr_d =
-           (!active_i || clear_i) ? {{RegWidth-1{1'b0}},1'b1} :
+           (!active_i || clear_i) ? RegWidth'(1) :
            samples_match_pulse ? (rep_cntr_q+1) :
-           samples_no_match_pulse ?  '0 :
+           samples_no_match_pulse ? RegWidth'(1) :
            rep_cntr_q;
 
     assign rep_cnt_fail = (rep_cntr_q >= thresh_i);


### PR DESCRIPTION
To match the NIST algorithm, all rep count tests have the same reset value.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>