### PR TITLE
[dv/otp] force some signals to improve FSM error coverage

### DIFF
--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -67,7 +67,6 @@
     {
       name: otp_ctrl_init_fail
       uvm_test_seq: otp_ctrl_init_fail_vseq
-      run_opts: ["+en_scb=0"]
     }
 
     {


### PR DESCRIPTION
This PR tries to improve OTP_CTRL's FSM coverage below:
1. sw partition check_fail: Since sw partition does not really do
otp_checks, the check_fail comes from internal ECC reg calculation
error. In this sequence, I force the error to bit 1 in order to trigger
check fail.

2. LC check fail: This is done when we program lc partition via LC
interface but did not perform a reset. This is not recommanded in OTP
spec so I did not support that in scb, but just use this sequence to
check.

Signed-off-by: Cindy Chen <chencindy@google.com>