### PR TITLE
[dv/dvsim] Adds failure bucketizer for triage.

### DIFF
--- a/util/dvsim/LocalLauncher.py
+++ b/util/dvsim/LocalLauncher.py
@@ -6,7 +6,7 @@ import os
 import shlex
 import subprocess
 
-from Launcher import Launcher, LauncherError
+from Launcher import ErrorMessage, Launcher, LauncherError
 
 
 class LocalLauncher(Launcher):
@@ -99,7 +99,9 @@ class LocalLauncher(Launcher):
         except subprocess.TimeoutExpired:
             self.process.kill()
 
-        self._post_finish('K', 'Job killed!')
+        self._post_finish('K', ErrorMessage(line_number=None,
+                                            message='Job killed!',
+                                            context=[]))
 
     def _post_finish(self, status, err_msg):
         super()._post_finish(status, err_msg)

--- a/util/dvsim/LsfLauncher.py
+++ b/util/dvsim/LsfLauncher.py
@@ -9,7 +9,7 @@ import subprocess
 import tarfile
 from pathlib import Path
 
-from Launcher import Launcher, LauncherError
+from Launcher import ErrorMessage, Launcher, LauncherError
 from utils import VERBOSE, clean_odirs
 
 
@@ -264,7 +264,11 @@ class LsfLauncher(Launcher):
             except IOError as e:
                 self._post_finish(
                     "F",
-                    "ERROR: Failed to open {}\n{}.".format(self.bsub_out, e))
+                    ErrorMessage(
+                        line_number=None,
+                        message="ERROR: Failed to open {}\n{}.".format(
+                            self.bsub_out, e),
+                        context=[]))
                 return "F"
 
         # Now that the job has completed, we need to determine its status.
@@ -299,7 +303,9 @@ class LsfLauncher(Launcher):
             status, err_msg = self._check_status()
             # Prioritize error messages from bsub over the job's log file.
             if self.bsub_out_err_msg:
-                err_msg = self.bsub_out_err_msg
+                err_msg = ErrorMessage(line_number=None,
+                                       message=self.bsub_out_err_msg,
+                                       context=[])
             self._post_finish(status, err_msg)
             return status
 
@@ -396,4 +402,6 @@ class LsfLauncher(Launcher):
         err_msg is the error message indicating the cause of failure.'''
 
         for job in LsfLauncher.jobs[cfg][job_name]:
-            job._post_finish("F", err_msg)
+            job._post_finish("F", ErrorMessage(line_number=None,
+                                               message=err_msg,
+                                               context=[]))

--- a/util/dvsim/SimResults.py
+++ b/util/dvsim/SimResults.py
@@ -1,0 +1,121 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+r"""
+Class describing simulation results
+"""
+
+import collections
+import re
+from testplanner.class_defs import TestResult
+
+
+_REGEX_REMOVE = [
+    # Remove UVM time.
+    re.compile(r'@\s+[\d.]+\s+[np]s: '),
+    re.compile(r'\[[\d.]+\s+[np]s\] '),
+    # Remove assertion time.
+    re.compile(r'\(time [\d.]+ [PF]S\) '),
+    # Remove leading spaces.
+    re.compile(r'^\s+'),
+    # Remove extra white spaces.
+    re.compile(r'\s+(?=\s)'),
+]
+
+_REGEX_STRIP = [
+    # Strip TB instance name.
+    re.compile(r'[\w_]*top\.\S+\.(\w+)'),
+    # Strip assertion.
+    re.compile(r'(?<=Assertion )\S+\.(\w+)'),
+]
+
+# Regular expression for a separator: EOL or some of punctuation marks.
+_SEPARATOR_RE = '($|[ ,.:;])'
+
+_REGEX_STAR = [
+    # Replace hex numbers with 0x (needs to be called before other numbers).
+    re.compile(r'0x\s*[\da-fA-F]+'),
+    # Replace hex numbers with 'h (needs to be called before other numbers).
+    re.compile(r'\'h\s*[\da-fA-F]+'),
+    # Floating point numbers at the beginning of a word, example "10.1ns".
+    # (needs to be called before other numbers).
+    re.compile(r'(?<=[^a-zA-Z0-9])\d+\.\d+'),
+    # Replace all isolated numbers. Isolated numbers are numbers surrounded by
+    # special symbols, for example ':' or '+' or '_', excluding parenthesis.
+    # So a number with a letter or a round bracket on any one side, is
+    # considered non-isolated number and is not starred by these expressions.
+    re.compile(r'(?<=[^a-zA-Z0-9\(\)])\d+(?=($|[^a-zA-Z0-9\(\)]))'),
+    # Replace numbers surrounded by parenthesis after a space and followed by a
+    # separator.
+    re.compile(r'(?<= \()\s*\d+\s*(?=\)%s)' % _SEPARATOR_RE),
+    # Replace hex/decimal numbers after an equal sign or a semicolon and
+    # followed by a separator. Uses look-behind pattern which need a
+    # fixed width, thus the apparent redundancy.
+    re.compile(r'(?<=[\w\]][=:])[\da-fA-F]+(?=%s)' % _SEPARATOR_RE),
+    re.compile(r'(?<=[\w\]][=:] )[\da-fA-F]+(?=%s)' % _SEPARATOR_RE),
+    re.compile(r'(?<=[\w\]] [=:])[\da-fA-F]+(?=%s)' % _SEPARATOR_RE),
+    re.compile(r'(?<=[\w\]] [=:] )[\da-fA-F]+(?=%s)' % _SEPARATOR_RE),
+    # Replace decimal number at the beginning of the word.
+    re.compile(r'(?<= )\d+(?=\S)'),
+    # Remove decimal number at end of the word and before '=' or '[' or
+    # ',' or '.' or '('.
+    re.compile(r'(?<=\S)\d+(?=($|[ =\[,\.\(]))'),
+    # Replace the instance string.
+    re.compile(r'(?<=instance)\s*=\s*\S+'),
+]
+
+
+class SimResults:
+    '''An object wrapping up a table of results for some tests
+
+    self.table is a list of TestResult objects, each of which
+    corresponds to one or more runs of the test with a given name.
+
+    self.buckets contains a dictionary accessed by the failure signature,
+    holding all failing tests with the same signature.
+    '''
+
+    def __init__(self, items, results):
+        self.table = []
+        self.buckets = collections.defaultdict(list)
+        self._name_to_row = {}
+        for item in items:
+            self._add_item(item, results)
+
+    def _add_item(self, item, results):
+        '''Recursively add a single item to the table of results'''
+        status = results[item]
+        if status == "F":
+            bucket = self._bucketize(item.launcher.fail_msg.message)
+            self.buckets[bucket].append(
+                (item, item.launcher.fail_msg.line_number,
+                 item.launcher.fail_msg.context))
+
+        # Runs get added to the table directly
+        if item.target == "run":
+            self._add_run(item, status)
+
+    def _add_run(self, item, status):
+        '''Add an entry to table for item'''
+        row = self._name_to_row.get(item.name)
+        if row is None:
+            row = TestResult(item.name)
+            self.table.append(row)
+            self._name_to_row[item.name] = row
+
+        if status == 'P':
+            row.passing += 1
+        row.total += 1
+
+    def _bucketize(self, fail_msg):
+        bucket = fail_msg
+        # Remove stuff.
+        for regex in _REGEX_REMOVE:
+            bucket = regex.sub('', bucket)
+        # Strip stuff.
+        for regex in _REGEX_STRIP:
+            bucket = regex.sub(r'\g<1>', bucket)
+        # Replace with '*'.
+        for regex in _REGEX_STAR:
+            bucket = regex.sub('*', bucket)
+        return bucket


### PR DESCRIPTION
Moves class SimCfg's Results to its own file and renames it to SimResults.
The bucketizer is called when initializing SimResults.
This will change when reruns are implemented, since we would want to
rerun one test per bucket as soon as the failing test completes.

Signed-off-by: Guillermo Maturana <maturana@google.com>