### PR TITLE
[dvsim] Scratch root default to $REPO_TOP/scratch

### DIFF
--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -41,9 +41,6 @@ from utils import (TS_FORMAT, TS_FORMAT_LONG, VERBOSE, rm_path,
 # TODO: add dvsim_cfg.hjson to retrieve this info
 version = 0.1
 
-# By default, all build and run artifacts go here.
-DEFAULT_SCRATCH_ROOT = os.getcwd() + "/scratch"
-
 # The different categories that can be passed to the --list argument.
 _LIST_CATEGORIES = ["build_modes", "run_modes", "tests", "regressions"]
 
@@ -51,13 +48,14 @@ _LIST_CATEGORIES = ["build_modes", "run_modes", "tests", "regressions"]
 # Function to resolve the scratch root directory among the available options:
 # If set on the command line, then use that as a preference.
 # Else, check if $SCRATCH_ROOT env variable exists and is a directory.
-# Else use the default (<cwd>/scratch)
+# Else use the default (<proj_root>/scratch)
 # Try to create the directory if it does not already exist.
-def resolve_scratch_root(arg_scratch_root):
+def resolve_scratch_root(arg_scratch_root, proj_root):
+    default_scratch_root = proj_root + "/scratch"
     scratch_root = os.environ.get('SCRATCH_ROOT')
     if not arg_scratch_root:
         if scratch_root is None:
-            arg_scratch_root = DEFAULT_SCRATCH_ROOT
+            arg_scratch_root = default_scratch_root
         else:
             # Scratch space could be mounted in a filesystem (such as NFS) on a network drive.
             # If the network is down, it could cause the access access check to hang. So run a
@@ -68,7 +66,7 @@ def resolve_scratch_root(arg_scratch_root):
             if status == 0 and out != "":
                 arg_scratch_root = scratch_root
             else:
-                arg_scratch_root = DEFAULT_SCRATCH_ROOT
+                arg_scratch_root = default_scratch_root
                 log.warning(
                     "Env variable $SCRATCH_ROOT=\"{}\" is not accessible.\n"
                     "Using \"{}\" instead.".format(scratch_root,
@@ -618,9 +616,9 @@ def main():
     if args.publish:
         args.map_full_testplan = True
 
-    args.scratch_root = resolve_scratch_root(args.scratch_root)
     args.branch = resolve_branch(args.branch)
     proj_root_src, proj_root = resolve_proj_root(args)
+    args.scratch_root = resolve_scratch_root(args.scratch_root, proj_root)
     log.info("[proj_root]: %s", proj_root)
 
     # Create an empty FUSESOC_IGNORE file in scratch_root. This ensures that


### PR DESCRIPTION
Use $REPO_TOP/scratch rather than CWD/scratch as the default scratch
area.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>