### PR TITLE
[dv/sram] check sram initialization in scb

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
@@ -35,8 +35,7 @@ class sram_ctrl_base_vseq extends cip_base_vseq #(
 
   // setup basic sram_ctrl features
   virtual task sram_ctrl_init();
-    // TODO: Can this be removed? and rely on mem init below?
-    cfg.mem_bkdr_vif.clear_mem();
+    cfg.mem_bkdr_vif.init();
     req_scr_key();
     req_mem_init();
   endtask

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_pkg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_pkg.sv
@@ -41,6 +41,11 @@ package sram_ctrl_env_pkg;
   typedef virtual mem_bkdr_if #(.MEM_PARITY(1)) mem_bkdr_vif;
   typedef virtual sram_ctrl_lc_if lc_vif;
 
+  typedef enum bit {
+    SramCtrlRenewScrKey = 0,
+    SramCtrlInit        = 1
+  } sram_ctrl_e;
+
   typedef enum bit [1:0] {
     SramCtrlError           = 0,
     SramCtrlEscalated       = 1,


### PR DESCRIPTION
this PR adds support for checking `CTRL.init`in the scoreboard,
using a simple timing model to do so.

Signed-off-by: Udi Jonnalagadda <udij@google.com>