### PR TITLE
[dv/otp_ctrl] Fix regression stress_all_with_reset error

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
@@ -14,7 +14,7 @@ class otp_ctrl_dai_lock_vseq extends otp_ctrl_smoke_vseq;
 
   // access locked means no memory clear, constraint to ensure there are enough dai address
   constraint num_iterations_up_to_num_valid_addr_c {
-    num_trans * num_dai_op <= DAI_ADDR_SIZE;
+    collect_used_addr -> num_trans * num_dai_op <= DAI_ADDR_SIZE;
   }
 
   virtual task pre_start();


### PR DESCRIPTION
This PR fixes two errors in stress_all_with_reset test:
1. Constraint conflict: I will disable this constriant when
stress_all_with_reset test is running.

2. When reset is issued during OTP write, the scb cannot accurately
predict how much writing has OTP memory done. So the plan is to backdoor
read back the specific address after reset is issued.

Signed-off-by: Cindy Chen <chencindy@google.com>