### PR TITLE
[pinmux] Remove some TODOs

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
@@ -1,0 +1,118 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Use the gen-otp-img.py script to convert this configuration into
+// a hex file for preloading the OTP in FPGA synthesis or simulation.
+//
+
+{
+    // Seed to be used for generation of partition randomized values.
+    // Can be overridden on the command line with the --seed switch.
+    seed: 01931961561863975174
+
+    // The partition and item names must correspond with the OTP memory map.
+    partitions: [
+        {
+            name:  "CREATOR_SW_CFG",
+            items: [
+                {
+                    name:  "CREATOR_SW_CFG_CONTENT",
+                    value: "0x0",
+                }
+                {
+                    name:  "CREATOR_SW_CFG_DIGEST",
+                    value: "0x0",
+                }
+            ],
+        }
+        {
+            name:  "OWNER_SW_CFG",
+            items: [
+                {
+                    name:  "OWNER_SW_CFG_CONTENT",
+                    value: "0x0"
+                }
+                {
+                    name:  "OWNER_SW_CFG_DIGEST",
+                    value: "0x0",
+                }
+            ],
+        }
+        {
+            name:  "HW_CFG",
+            // If set to true, this computes the HW digest value
+            // and locks the partition.
+            lock:  "True",
+            items: [
+                {
+                    name:  "DEVICE_ID",
+                    value: "<random>",
+                },
+                {
+                    name:  "EN_ENTROPY_SRC_FW_READ",
+                    value: "0xA5",
+                },
+            ],
+        }
+        {
+            name:  "SECRET0",
+            lock:  "True",
+            items: [
+                {
+                    name:  "TEST_UNLOCK_TOKEN",
+                    value: "<random>",
+                }
+                {
+                    name:  "TEST_EXIT_TOKEN",
+                    value: "<random>",
+                }
+            ],
+        }
+        {
+            name:  "SECRET1",
+            lock:  "True",
+            items: [
+                {
+                    name:  "FLASH_ADDR_KEY_SEED",
+                    value: "<random>",
+                }
+                {
+                    name:  "FLASH_DATA_KEY_SEED",
+                    value: "<random>",
+                }
+                {
+                    name:  "SRAM_DATA_KEY_SEED",
+                    value: "<random>",
+                }
+            ],
+        }
+        {
+            name:  "SECRET2",
+            lock:  "False",
+            items: [
+                {
+                    name:  "RMA_TOKEN",
+                    value: "<random>",
+                }
+                {
+                    name:  "CREATOR_ROOT_KEY_SHARE0",
+                    value: "<random>",
+                }
+                {
+                    name:  "CREATOR_ROOT_KEY_SHARE1",
+                    value: "<random>",
+                }
+            ],
+        }
+        {
+            name:  "LIFE_CYCLE",
+            // Can be one of the following strings:
+            // RAW, TEST_UNLOCKED0-3, TEST_LOCKED0-2, DEV, PROD, PROD_END, RMA, SCRAP
+            state: "RMA",
+            // Can range from 0 to 16.
+            // Note that a value of 0 is only permissible in RAW state.
+            count: "8"
+        }
+    ]
+}

--- a/hw/ip/pinmux/rtl/pinmux_pkg.sv
+++ b/hw/ip/pinmux/rtl/pinmux_pkg.sv
@@ -17,7 +17,6 @@ package pinmux_pkg;
   // the concatenated {DIO, MIO} packed array.
   typedef struct packed {
     logic                     const_sampling; // TODO: check whether this can be eliminated.
-    logic        [NumIOs-1:0] tie_offs;       // TODO: check whether this can be eliminated.
     integer                   tck_idx;
     integer                   tms_idx;
     integer                   trst_idx;
@@ -37,7 +36,6 @@ package pinmux_pkg;
 
   parameter target_cfg_t DefaultTargetCfg = '{
     const_sampling:    1'b0,
-    tie_offs:          '0,
     tck_idx:           0,
     tms_idx:           0,
     trst_idx:          0,

--- a/hw/ip/pinmux/rtl/pinmux_pkg.sv
+++ b/hw/ip/pinmux/rtl/pinmux_pkg.sv
@@ -16,7 +16,6 @@ package pinmux_pkg;
   // datastructure below serves this purpose. Note that all the indices below are with respect to
   // the concatenated {DIO, MIO} packed array.
   typedef struct packed {
-    logic                     const_sampling; // TODO: check whether this can be eliminated.
     integer                   tck_idx;
     integer                   tms_idx;
     integer                   trst_idx;
@@ -35,7 +34,6 @@ package pinmux_pkg;
   } target_cfg_t;
 
   parameter target_cfg_t DefaultTargetCfg = '{
-    const_sampling:    1'b0,
     tck_idx:           0,
     tms_idx:           0,
     trst_idx:          0,
@@ -49,8 +47,8 @@ package pinmux_pkg;
     usb_dn_idx:        0,
     usb_dp_pullup_idx: 0,
     usb_dn_pullup_idx: 0,
-    dio_pad_type: {NDioPads{BidirStd}},
-    mio_pad_type: {NMioPads{BidirStd}}
+    dio_pad_type:      {NDioPads{BidirStd}},
+    mio_pad_type:      {NMioPads{BidirStd}}
   };
 
   // Wakeup Detector Modes

--- a/hw/ip/pinmux/rtl/pinmux_strap_sampling.sv
+++ b/hw/ip/pinmux/rtl/pinmux_strap_sampling.sv
@@ -250,7 +250,7 @@ module pinmux_strap_sampling
         k == TargetCfg.trst_idx ||
         k == TargetCfg.tdi_idx  ||
         k == TargetCfg.tdo_idx) begin : gen_jtag_signal
-      assign in_core_o[k] = (jtag_en) ? TargetCfg.tie_offs[k] : in_padring_i[k];
+      assign in_core_o[k] = (jtag_en) ? 1'b0 : in_padring_i[k];
     end else begin : gen_other_inputs
       assign in_core_o[k] = in_padring_i[k];
     end

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -103,7 +103,6 @@ module chip_earlgrey_asic (
 
   // DFT and Debug signal positions in the pinout.
   localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{
-    const_sampling:    1'b1,
     tck_idx:           TckPadIdx,
     tms_idx:           TmsPadIdx,
     trst_idx:          TrstNPadIdx,

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -101,16 +101,9 @@ module chip_earlgrey_asic (
   parameter int TdiPadIdx = 37;
   parameter int TdoPadIdx = 36;
 
-  // TODO: this is temporary and will be removed in the future.
-  // This specifies the tie-off values of the muxed MIO/DIOs
-  // when the JTAG is active. SPI CSB is active low.
-  localparam logic [pinmux_pkg::NumIOs-1:0] TieOffValues = pinmux_pkg::NumIOs'(1'b1 << (
-      pinmux_reg_pkg::NMioPads + DioSpiDeviceCsb));
-
   // DFT and Debug signal positions in the pinout.
   localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{
     const_sampling:    1'b1,
-    tie_offs:          TieOffValues, // TODO: can we remove this and just set it to zero?
     tck_idx:           TckPadIdx,
     tms_idx:           TmsPadIdx,
     trst_idx:          TrstNPadIdx,

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
@@ -88,16 +88,9 @@ module chip_earlgrey_nexysvideo #(
   parameter int TdiPadIdx = 51;
   parameter int TdoPadIdx = 52;
 
-  // TODO: this is temporary and will be removed in the future.
-  // This specifies the tie-off values of the muxed MIO/DIOs
-  // when the JTAG is active. SPI CSB is active low.
-  localparam logic [pinmux_pkg::NumIOs-1:0] TieOffValues = pinmux_pkg::NumIOs'(1'b1 << (
-      pinmux_reg_pkg::NMioPads + DioSpiDeviceCsb));
-
   // DFT and Debug signal positions in the pinout.
   localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{
     const_sampling:    1'b1,
-    tie_offs:          TieOffValues, // TODO: can we remove this and just set it to zero?
     tck_idx:           TckPadIdx,
     tms_idx:           TmsPadIdx,
     trst_idx:          TrstNPadIdx,

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
@@ -90,7 +90,6 @@ module chip_earlgrey_nexysvideo #(
 
   // DFT and Debug signal positions in the pinout.
   localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{
-    const_sampling:    1'b1,
     tck_idx:           TckPadIdx,
     tms_idx:           TmsPadIdx,
     trst_idx:          TrstNPadIdx,

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -126,7 +126,6 @@ module chip_earlgrey_verilator (
   // DFT and Debug signal positions in the pinout.
   localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{
     const_sampling: 1'b1,
-    tie_offs:       '0,
     tck_idx:        pinmux_reg_pkg::NMioPads +
                     top_earlgrey_pkg::DioSpiDeviceSck,
     tms_idx:        pinmux_reg_pkg::NMioPads +

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -125,7 +125,6 @@ module chip_earlgrey_verilator (
   // to be split into a Verilator TB and a Verilator chiplevel.
   // DFT and Debug signal positions in the pinout.
   localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{
-    const_sampling: 1'b1,
     tck_idx:        pinmux_reg_pkg::NMioPads +
                     top_earlgrey_pkg::DioSpiDeviceSck,
     tms_idx:        pinmux_reg_pkg::NMioPads +

--- a/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
+++ b/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
@@ -125,7 +125,6 @@ module chip_englishbreakfast_verilator (
   // to be split into a Verilator TB and a Verilator chiplevel.
   // DFT and Debug signal positions in the pinout.
   localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{
-    const_sampling: 1'b1,
     tck_idx:        pinmux_reg_pkg::NMioPads +
                     top_englishbreakfast_pkg::DioSpiDeviceSck,
     tms_idx:        pinmux_reg_pkg::NMioPads +

--- a/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
+++ b/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
@@ -126,7 +126,6 @@ module chip_englishbreakfast_verilator (
   // DFT and Debug signal positions in the pinout.
   localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{
     const_sampling: 1'b1,
-    tie_offs:       '0,
     tck_idx:        pinmux_reg_pkg::NMioPads +
                     top_englishbreakfast_pkg::DioSpiDeviceSck,
     tms_idx:        pinmux_reg_pkg::NMioPads +

--- a/sw/device/meson.build
+++ b/sw/device/meson.build
@@ -45,11 +45,13 @@ extract_sw_logs_sim_dv_depend_files = [
 
 # Generates the OTP image containing root secrets, sw configuration partitions and
 # the life cycle state.
-# TODO: This just puts the device into DEV life cycle state, with randomized root keys.
+# TODO: This just puts the device into RMA life cycle state, with randomized root keys.
+# We are using RMA in order to open up all debug and functional infrastructure
+# as our testing and emulation environments require that.
 # Need to make this more flexible in the future.
 # TODO: additional OTP partitions can be included with the --add-cfg switch
 # see also util/design/README.md
-make_otp_img_inputs = [meson.source_root() / 'hw/ip/otp_ctrl/data/otp_ctrl_img_dev.hjson']
+make_otp_img_inputs = [meson.source_root() / 'hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson']
 make_otp_img_command = [
   prog_python, meson.source_root() / 'util/design/gen-otp-img.py',
   '--quiet',

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -124,7 +124,6 @@ module chip_${top["name"]}_${target["name"]} (
 
   // DFT and Debug signal positions in the pinout.
   localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{
-    const_sampling:    1'b1,
     tck_idx:           TckPadIdx,
     tms_idx:           TmsPadIdx,
     trst_idx:          TrstNPadIdx,

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -122,16 +122,9 @@ module chip_${top["name"]}_${target["name"]} (
   % endfor
 % endif
 
-  // TODO: this is temporary and will be removed in the future.
-  // This specifies the tie-off values of the muxed MIO/DIOs
-  // when the JTAG is active. SPI CSB is active low.
-  localparam logic [pinmux_pkg::NumIOs-1:0] TieOffValues = pinmux_pkg::NumIOs'(1'b1 << (
-      pinmux_reg_pkg::NMioPads + DioSpiDeviceCsb));
-
   // DFT and Debug signal positions in the pinout.
   localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{
     const_sampling:    1'b1,
-    tie_offs:          TieOffValues, // TODO: can we remove this and just set it to zero?
     tck_idx:           TckPadIdx,
     tms_idx:           TmsPadIdx,
     trst_idx:          TrstNPadIdx,


### PR DESCRIPTION
The first commit removes a tie-off array that is not needed anymore.

The second commit updates the strap sampling behavior in DFT-enabled LC states.
We also change the life cycle state for emulation and simulation environments from DEV to RMA in order to ungate all possible DFT and functional infrastructure.


