### PR TITLE
[pinmux] Regenerate pinmux example and update pad attribute docs

### DIFF
--- a/hw/ip/pinmux/data/pinmux.hjson
+++ b/hw/ip/pinmux/data/pinmux.hjson
@@ -324,17 +324,17 @@
                   regwen_multi: "true",
                   cname:        "MIO_PAD",
                   fields: [
-                    { bits: "9:0",
+                    { bits: "12:0",
                       name: "ATTR",
-                      desc: '''Bit   0: input/output inversion,
-                               Bit   1: Virtual open drain enable.
-                               Bit   2: Pull enable.
-                               Bit   3: Pull select (0: pull down, 1: pull up).
-                               Bit   4: Keeper enable.
-                               Bit   5: Schmitt trigger enable.
-                               Bit   6: Slew rate (0: slow, 1: fast).
-                               Bit 7/8: Drive strength (00: weakest, 11: strongest).
-                               Bit   9: Reserved.
+                      desc: '''Bit   0:  input/output inversion,
+                               Bit   1:  Virtual open drain enable.
+                               Bit   2:  Pull enable.
+                               Bit   3:  Pull select (0: pull down, 1: pull up).
+                               Bit   4:  Keeper enable.
+                               Bit   5:  Schmitt trigger enable.
+                               Bit   6:  Open drain enable
+                               Bit 7/8:  Slew rate (0x0: slowest, 0x3: fastest).
+                               Bit 9/12: Drive strength (0x0: weakest, 0xf: strongest).
                       '''
                       resval: 0
                     }
@@ -386,17 +386,17 @@
                   regwen_multi: "true",
                   cname:        "DIO_PAD",
                   fields: [
-                    { bits: "9:0",
+                    { bits: "12:0",
                       name: "ATTR",
-                      desc: '''Bit   0: input/output inversion,
-                               Bit   1: Virtual open drain enable.
-                               Bit   2: Pull enable.
-                               Bit   3: Pull select (0: pull down, 1: pull up).
-                               Bit   4: Keeper enable.
-                               Bit   5: Schmitt trigger enable.
-                               Bit   6: Slew rate (0: slow, 1: fast).
-                               Bit 7/8: Drive strength (00: weakest, 11: strongest).
-                               Bit   9: Reserved.
+                      desc: '''Bit   0:  input/output inversion,
+                               Bit   1:  Virtual open drain enable.
+                               Bit   2:  Pull enable.
+                               Bit   3:  Pull select (0: pull down, 1: pull up).
+                               Bit   4:  Keeper enable.
+                               Bit   5:  Schmitt trigger enable.
+                               Bit   6:  Open drain enable
+                               Bit 7/8:  Slew rate (0x0: slowest, 0x3: fastest).
+                               Bit 9/12: Drive strength (0x0: weakest, 0xf: strongest).
                       '''
                       resval: 0
                     }

--- a/hw/ip/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/ip/pinmux/rtl/pinmux_reg_pkg.sv
@@ -31,12 +31,12 @@ package pinmux_reg_pkg;
   } pinmux_reg2hw_mio_outsel_mreg_t;
 
   typedef struct packed {
-    logic [9:0] q;
+    logic [12:0] q;
     logic        qe;
   } pinmux_reg2hw_mio_pad_attr_mreg_t;
 
   typedef struct packed {
-    logic [9:0] q;
+    logic [12:0] q;
     logic        qe;
   } pinmux_reg2hw_dio_pad_attr_mreg_t;
 
@@ -94,11 +94,11 @@ package pinmux_reg_pkg;
   } pinmux_reg2hw_wkup_cause_mreg_t;
 
   typedef struct packed {
-    logic [9:0] d;
+    logic [12:0] d;
   } pinmux_hw2reg_mio_pad_attr_mreg_t;
 
   typedef struct packed {
-    logic [9:0] d;
+    logic [12:0] d;
   } pinmux_hw2reg_dio_pad_attr_mreg_t;
 
   typedef struct packed {
@@ -117,10 +117,10 @@ package pinmux_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    pinmux_reg2hw_mio_periph_insel_mreg_t [32:0] mio_periph_insel; // [1285:1088]
-    pinmux_reg2hw_mio_outsel_mreg_t [31:0] mio_outsel; // [1087:896]
-    pinmux_reg2hw_mio_pad_attr_mreg_t [31:0] mio_pad_attr; // [895:544]
-    pinmux_reg2hw_dio_pad_attr_mreg_t [15:0] dio_pad_attr; // [543:368]
+    pinmux_reg2hw_mio_periph_insel_mreg_t [32:0] mio_periph_insel; // [1429:1232]
+    pinmux_reg2hw_mio_outsel_mreg_t [31:0] mio_outsel; // [1231:1040]
+    pinmux_reg2hw_mio_pad_attr_mreg_t [31:0] mio_pad_attr; // [1039:592]
+    pinmux_reg2hw_dio_pad_attr_mreg_t [15:0] dio_pad_attr; // [591:368]
     pinmux_reg2hw_mio_pad_sleep_status_mreg_t [31:0] mio_pad_sleep_status; // [367:336]
     pinmux_reg2hw_mio_pad_sleep_en_mreg_t [31:0] mio_pad_sleep_en; // [335:304]
     pinmux_reg2hw_mio_pad_sleep_mode_mreg_t [31:0] mio_pad_sleep_mode; // [303:240]
@@ -136,8 +136,8 @@ package pinmux_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    pinmux_hw2reg_mio_pad_attr_mreg_t [31:0] mio_pad_attr; // [583:264]
-    pinmux_hw2reg_dio_pad_attr_mreg_t [15:0] dio_pad_attr; // [263:104]
+    pinmux_hw2reg_mio_pad_attr_mreg_t [31:0] mio_pad_attr; // [727:312]
+    pinmux_hw2reg_dio_pad_attr_mreg_t [15:0] dio_pad_attr; // [311:104]
     pinmux_hw2reg_mio_pad_sleep_status_mreg_t [31:0] mio_pad_sleep_status; // [103:40]
     pinmux_hw2reg_dio_pad_sleep_status_mreg_t [15:0] dio_pad_sleep_status; // [39:8]
     pinmux_hw2reg_wkup_cause_mreg_t [7:0] wkup_cause; // [7:0]
@@ -559,102 +559,102 @@ package pinmux_reg_pkg;
   parameter logic [BlockAw-1:0] PINMUX_WKUP_CAUSE_OFFSET = 11'h 670;
 
   // Reset values for hwext registers and their fields
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_0_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_0_ATTR_0_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_1_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_1_ATTR_1_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_2_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_2_ATTR_2_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_3_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_3_ATTR_3_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_4_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_4_ATTR_4_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_5_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_5_ATTR_5_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_6_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_6_ATTR_6_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_7_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_7_ATTR_7_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_8_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_8_ATTR_8_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_9_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_9_ATTR_9_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_10_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_10_ATTR_10_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_11_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_11_ATTR_11_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_12_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_12_ATTR_12_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_13_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_13_ATTR_13_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_14_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_14_ATTR_14_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_15_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_15_ATTR_15_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_16_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_16_ATTR_16_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_17_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_17_ATTR_17_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_18_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_18_ATTR_18_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_19_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_19_ATTR_19_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_20_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_20_ATTR_20_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_21_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_21_ATTR_21_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_22_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_22_ATTR_22_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_23_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_23_ATTR_23_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_24_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_24_ATTR_24_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_25_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_25_ATTR_25_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_26_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_26_ATTR_26_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_27_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_27_ATTR_27_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_28_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_28_ATTR_28_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_29_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_29_ATTR_29_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_30_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_30_ATTR_30_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_31_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_MIO_PAD_ATTR_31_ATTR_31_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_0_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_0_ATTR_0_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_1_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_1_ATTR_1_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_2_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_2_ATTR_2_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_3_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_3_ATTR_3_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_4_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_4_ATTR_4_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_5_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_5_ATTR_5_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_6_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_6_ATTR_6_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_7_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_7_ATTR_7_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_8_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_8_ATTR_8_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_9_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_9_ATTR_9_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_10_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_10_ATTR_10_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_11_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_11_ATTR_11_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_12_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_12_ATTR_12_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_13_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_13_ATTR_13_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_14_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_14_ATTR_14_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_15_RESVAL = 10'h 0;
-  parameter logic [9:0] PINMUX_DIO_PAD_ATTR_15_ATTR_15_RESVAL = 10'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_0_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_0_ATTR_0_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_1_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_1_ATTR_1_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_2_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_2_ATTR_2_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_3_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_3_ATTR_3_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_4_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_4_ATTR_4_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_5_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_5_ATTR_5_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_6_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_6_ATTR_6_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_7_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_7_ATTR_7_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_8_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_8_ATTR_8_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_9_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_9_ATTR_9_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_10_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_10_ATTR_10_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_11_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_11_ATTR_11_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_12_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_12_ATTR_12_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_13_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_13_ATTR_13_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_14_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_14_ATTR_14_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_15_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_15_ATTR_15_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_16_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_16_ATTR_16_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_17_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_17_ATTR_17_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_18_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_18_ATTR_18_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_19_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_19_ATTR_19_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_20_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_20_ATTR_20_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_21_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_21_ATTR_21_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_22_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_22_ATTR_22_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_23_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_23_ATTR_23_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_24_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_24_ATTR_24_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_25_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_25_ATTR_25_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_26_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_26_ATTR_26_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_27_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_27_ATTR_27_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_28_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_28_ATTR_28_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_29_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_29_ATTR_29_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_30_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_30_ATTR_30_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_31_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_MIO_PAD_ATTR_31_ATTR_31_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_0_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_0_ATTR_0_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_1_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_1_ATTR_1_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_2_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_2_ATTR_2_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_3_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_3_ATTR_3_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_4_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_4_ATTR_4_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_5_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_5_ATTR_5_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_6_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_6_ATTR_6_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_7_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_7_ATTR_7_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_8_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_8_ATTR_8_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_9_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_9_ATTR_9_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_10_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_10_ATTR_10_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_11_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_11_ATTR_11_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_12_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_12_ATTR_12_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_13_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_13_ATTR_13_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_14_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_14_ATTR_14_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_15_RESVAL = 13'h 0;
+  parameter logic [12:0] PINMUX_DIO_PAD_ATTR_15_ATTR_15_RESVAL = 13'h 0;
   parameter logic [7:0] PINMUX_WKUP_CAUSE_RESVAL = 8'h 0;
   parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_0_RESVAL = 1'h 0;
   parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_1_RESVAL = 1'h 0;

--- a/hw/ip/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/ip/pinmux/rtl/pinmux_reg_top.sv
@@ -590,132 +590,132 @@ module pinmux_reg_top (
   logic mio_pad_attr_regwen_31_qs;
   logic mio_pad_attr_regwen_31_wd;
   logic mio_pad_attr_regwen_31_we;
-  logic [9:0] mio_pad_attr_0_qs;
-  logic [9:0] mio_pad_attr_0_wd;
+  logic [12:0] mio_pad_attr_0_qs;
+  logic [12:0] mio_pad_attr_0_wd;
   logic mio_pad_attr_0_we;
   logic mio_pad_attr_0_re;
-  logic [9:0] mio_pad_attr_1_qs;
-  logic [9:0] mio_pad_attr_1_wd;
+  logic [12:0] mio_pad_attr_1_qs;
+  logic [12:0] mio_pad_attr_1_wd;
   logic mio_pad_attr_1_we;
   logic mio_pad_attr_1_re;
-  logic [9:0] mio_pad_attr_2_qs;
-  logic [9:0] mio_pad_attr_2_wd;
+  logic [12:0] mio_pad_attr_2_qs;
+  logic [12:0] mio_pad_attr_2_wd;
   logic mio_pad_attr_2_we;
   logic mio_pad_attr_2_re;
-  logic [9:0] mio_pad_attr_3_qs;
-  logic [9:0] mio_pad_attr_3_wd;
+  logic [12:0] mio_pad_attr_3_qs;
+  logic [12:0] mio_pad_attr_3_wd;
   logic mio_pad_attr_3_we;
   logic mio_pad_attr_3_re;
-  logic [9:0] mio_pad_attr_4_qs;
-  logic [9:0] mio_pad_attr_4_wd;
+  logic [12:0] mio_pad_attr_4_qs;
+  logic [12:0] mio_pad_attr_4_wd;
   logic mio_pad_attr_4_we;
   logic mio_pad_attr_4_re;
-  logic [9:0] mio_pad_attr_5_qs;
-  logic [9:0] mio_pad_attr_5_wd;
+  logic [12:0] mio_pad_attr_5_qs;
+  logic [12:0] mio_pad_attr_5_wd;
   logic mio_pad_attr_5_we;
   logic mio_pad_attr_5_re;
-  logic [9:0] mio_pad_attr_6_qs;
-  logic [9:0] mio_pad_attr_6_wd;
+  logic [12:0] mio_pad_attr_6_qs;
+  logic [12:0] mio_pad_attr_6_wd;
   logic mio_pad_attr_6_we;
   logic mio_pad_attr_6_re;
-  logic [9:0] mio_pad_attr_7_qs;
-  logic [9:0] mio_pad_attr_7_wd;
+  logic [12:0] mio_pad_attr_7_qs;
+  logic [12:0] mio_pad_attr_7_wd;
   logic mio_pad_attr_7_we;
   logic mio_pad_attr_7_re;
-  logic [9:0] mio_pad_attr_8_qs;
-  logic [9:0] mio_pad_attr_8_wd;
+  logic [12:0] mio_pad_attr_8_qs;
+  logic [12:0] mio_pad_attr_8_wd;
   logic mio_pad_attr_8_we;
   logic mio_pad_attr_8_re;
-  logic [9:0] mio_pad_attr_9_qs;
-  logic [9:0] mio_pad_attr_9_wd;
+  logic [12:0] mio_pad_attr_9_qs;
+  logic [12:0] mio_pad_attr_9_wd;
   logic mio_pad_attr_9_we;
   logic mio_pad_attr_9_re;
-  logic [9:0] mio_pad_attr_10_qs;
-  logic [9:0] mio_pad_attr_10_wd;
+  logic [12:0] mio_pad_attr_10_qs;
+  logic [12:0] mio_pad_attr_10_wd;
   logic mio_pad_attr_10_we;
   logic mio_pad_attr_10_re;
-  logic [9:0] mio_pad_attr_11_qs;
-  logic [9:0] mio_pad_attr_11_wd;
+  logic [12:0] mio_pad_attr_11_qs;
+  logic [12:0] mio_pad_attr_11_wd;
   logic mio_pad_attr_11_we;
   logic mio_pad_attr_11_re;
-  logic [9:0] mio_pad_attr_12_qs;
-  logic [9:0] mio_pad_attr_12_wd;
+  logic [12:0] mio_pad_attr_12_qs;
+  logic [12:0] mio_pad_attr_12_wd;
   logic mio_pad_attr_12_we;
   logic mio_pad_attr_12_re;
-  logic [9:0] mio_pad_attr_13_qs;
-  logic [9:0] mio_pad_attr_13_wd;
+  logic [12:0] mio_pad_attr_13_qs;
+  logic [12:0] mio_pad_attr_13_wd;
   logic mio_pad_attr_13_we;
   logic mio_pad_attr_13_re;
-  logic [9:0] mio_pad_attr_14_qs;
-  logic [9:0] mio_pad_attr_14_wd;
+  logic [12:0] mio_pad_attr_14_qs;
+  logic [12:0] mio_pad_attr_14_wd;
   logic mio_pad_attr_14_we;
   logic mio_pad_attr_14_re;
-  logic [9:0] mio_pad_attr_15_qs;
-  logic [9:0] mio_pad_attr_15_wd;
+  logic [12:0] mio_pad_attr_15_qs;
+  logic [12:0] mio_pad_attr_15_wd;
   logic mio_pad_attr_15_we;
   logic mio_pad_attr_15_re;
-  logic [9:0] mio_pad_attr_16_qs;
-  logic [9:0] mio_pad_attr_16_wd;
+  logic [12:0] mio_pad_attr_16_qs;
+  logic [12:0] mio_pad_attr_16_wd;
   logic mio_pad_attr_16_we;
   logic mio_pad_attr_16_re;
-  logic [9:0] mio_pad_attr_17_qs;
-  logic [9:0] mio_pad_attr_17_wd;
+  logic [12:0] mio_pad_attr_17_qs;
+  logic [12:0] mio_pad_attr_17_wd;
   logic mio_pad_attr_17_we;
   logic mio_pad_attr_17_re;
-  logic [9:0] mio_pad_attr_18_qs;
-  logic [9:0] mio_pad_attr_18_wd;
+  logic [12:0] mio_pad_attr_18_qs;
+  logic [12:0] mio_pad_attr_18_wd;
   logic mio_pad_attr_18_we;
   logic mio_pad_attr_18_re;
-  logic [9:0] mio_pad_attr_19_qs;
-  logic [9:0] mio_pad_attr_19_wd;
+  logic [12:0] mio_pad_attr_19_qs;
+  logic [12:0] mio_pad_attr_19_wd;
   logic mio_pad_attr_19_we;
   logic mio_pad_attr_19_re;
-  logic [9:0] mio_pad_attr_20_qs;
-  logic [9:0] mio_pad_attr_20_wd;
+  logic [12:0] mio_pad_attr_20_qs;
+  logic [12:0] mio_pad_attr_20_wd;
   logic mio_pad_attr_20_we;
   logic mio_pad_attr_20_re;
-  logic [9:0] mio_pad_attr_21_qs;
-  logic [9:0] mio_pad_attr_21_wd;
+  logic [12:0] mio_pad_attr_21_qs;
+  logic [12:0] mio_pad_attr_21_wd;
   logic mio_pad_attr_21_we;
   logic mio_pad_attr_21_re;
-  logic [9:0] mio_pad_attr_22_qs;
-  logic [9:0] mio_pad_attr_22_wd;
+  logic [12:0] mio_pad_attr_22_qs;
+  logic [12:0] mio_pad_attr_22_wd;
   logic mio_pad_attr_22_we;
   logic mio_pad_attr_22_re;
-  logic [9:0] mio_pad_attr_23_qs;
-  logic [9:0] mio_pad_attr_23_wd;
+  logic [12:0] mio_pad_attr_23_qs;
+  logic [12:0] mio_pad_attr_23_wd;
   logic mio_pad_attr_23_we;
   logic mio_pad_attr_23_re;
-  logic [9:0] mio_pad_attr_24_qs;
-  logic [9:0] mio_pad_attr_24_wd;
+  logic [12:0] mio_pad_attr_24_qs;
+  logic [12:0] mio_pad_attr_24_wd;
   logic mio_pad_attr_24_we;
   logic mio_pad_attr_24_re;
-  logic [9:0] mio_pad_attr_25_qs;
-  logic [9:0] mio_pad_attr_25_wd;
+  logic [12:0] mio_pad_attr_25_qs;
+  logic [12:0] mio_pad_attr_25_wd;
   logic mio_pad_attr_25_we;
   logic mio_pad_attr_25_re;
-  logic [9:0] mio_pad_attr_26_qs;
-  logic [9:0] mio_pad_attr_26_wd;
+  logic [12:0] mio_pad_attr_26_qs;
+  logic [12:0] mio_pad_attr_26_wd;
   logic mio_pad_attr_26_we;
   logic mio_pad_attr_26_re;
-  logic [9:0] mio_pad_attr_27_qs;
-  logic [9:0] mio_pad_attr_27_wd;
+  logic [12:0] mio_pad_attr_27_qs;
+  logic [12:0] mio_pad_attr_27_wd;
   logic mio_pad_attr_27_we;
   logic mio_pad_attr_27_re;
-  logic [9:0] mio_pad_attr_28_qs;
-  logic [9:0] mio_pad_attr_28_wd;
+  logic [12:0] mio_pad_attr_28_qs;
+  logic [12:0] mio_pad_attr_28_wd;
   logic mio_pad_attr_28_we;
   logic mio_pad_attr_28_re;
-  logic [9:0] mio_pad_attr_29_qs;
-  logic [9:0] mio_pad_attr_29_wd;
+  logic [12:0] mio_pad_attr_29_qs;
+  logic [12:0] mio_pad_attr_29_wd;
   logic mio_pad_attr_29_we;
   logic mio_pad_attr_29_re;
-  logic [9:0] mio_pad_attr_30_qs;
-  logic [9:0] mio_pad_attr_30_wd;
+  logic [12:0] mio_pad_attr_30_qs;
+  logic [12:0] mio_pad_attr_30_wd;
   logic mio_pad_attr_30_we;
   logic mio_pad_attr_30_re;
-  logic [9:0] mio_pad_attr_31_qs;
-  logic [9:0] mio_pad_attr_31_wd;
+  logic [12:0] mio_pad_attr_31_qs;
+  logic [12:0] mio_pad_attr_31_wd;
   logic mio_pad_attr_31_we;
   logic mio_pad_attr_31_re;
   logic dio_pad_attr_regwen_0_qs;
@@ -766,68 +766,68 @@ module pinmux_reg_top (
   logic dio_pad_attr_regwen_15_qs;
   logic dio_pad_attr_regwen_15_wd;
   logic dio_pad_attr_regwen_15_we;
-  logic [9:0] dio_pad_attr_0_qs;
-  logic [9:0] dio_pad_attr_0_wd;
+  logic [12:0] dio_pad_attr_0_qs;
+  logic [12:0] dio_pad_attr_0_wd;
   logic dio_pad_attr_0_we;
   logic dio_pad_attr_0_re;
-  logic [9:0] dio_pad_attr_1_qs;
-  logic [9:0] dio_pad_attr_1_wd;
+  logic [12:0] dio_pad_attr_1_qs;
+  logic [12:0] dio_pad_attr_1_wd;
   logic dio_pad_attr_1_we;
   logic dio_pad_attr_1_re;
-  logic [9:0] dio_pad_attr_2_qs;
-  logic [9:0] dio_pad_attr_2_wd;
+  logic [12:0] dio_pad_attr_2_qs;
+  logic [12:0] dio_pad_attr_2_wd;
   logic dio_pad_attr_2_we;
   logic dio_pad_attr_2_re;
-  logic [9:0] dio_pad_attr_3_qs;
-  logic [9:0] dio_pad_attr_3_wd;
+  logic [12:0] dio_pad_attr_3_qs;
+  logic [12:0] dio_pad_attr_3_wd;
   logic dio_pad_attr_3_we;
   logic dio_pad_attr_3_re;
-  logic [9:0] dio_pad_attr_4_qs;
-  logic [9:0] dio_pad_attr_4_wd;
+  logic [12:0] dio_pad_attr_4_qs;
+  logic [12:0] dio_pad_attr_4_wd;
   logic dio_pad_attr_4_we;
   logic dio_pad_attr_4_re;
-  logic [9:0] dio_pad_attr_5_qs;
-  logic [9:0] dio_pad_attr_5_wd;
+  logic [12:0] dio_pad_attr_5_qs;
+  logic [12:0] dio_pad_attr_5_wd;
   logic dio_pad_attr_5_we;
   logic dio_pad_attr_5_re;
-  logic [9:0] dio_pad_attr_6_qs;
-  logic [9:0] dio_pad_attr_6_wd;
+  logic [12:0] dio_pad_attr_6_qs;
+  logic [12:0] dio_pad_attr_6_wd;
   logic dio_pad_attr_6_we;
   logic dio_pad_attr_6_re;
-  logic [9:0] dio_pad_attr_7_qs;
-  logic [9:0] dio_pad_attr_7_wd;
+  logic [12:0] dio_pad_attr_7_qs;
+  logic [12:0] dio_pad_attr_7_wd;
   logic dio_pad_attr_7_we;
   logic dio_pad_attr_7_re;
-  logic [9:0] dio_pad_attr_8_qs;
-  logic [9:0] dio_pad_attr_8_wd;
+  logic [12:0] dio_pad_attr_8_qs;
+  logic [12:0] dio_pad_attr_8_wd;
   logic dio_pad_attr_8_we;
   logic dio_pad_attr_8_re;
-  logic [9:0] dio_pad_attr_9_qs;
-  logic [9:0] dio_pad_attr_9_wd;
+  logic [12:0] dio_pad_attr_9_qs;
+  logic [12:0] dio_pad_attr_9_wd;
   logic dio_pad_attr_9_we;
   logic dio_pad_attr_9_re;
-  logic [9:0] dio_pad_attr_10_qs;
-  logic [9:0] dio_pad_attr_10_wd;
+  logic [12:0] dio_pad_attr_10_qs;
+  logic [12:0] dio_pad_attr_10_wd;
   logic dio_pad_attr_10_we;
   logic dio_pad_attr_10_re;
-  logic [9:0] dio_pad_attr_11_qs;
-  logic [9:0] dio_pad_attr_11_wd;
+  logic [12:0] dio_pad_attr_11_qs;
+  logic [12:0] dio_pad_attr_11_wd;
   logic dio_pad_attr_11_we;
   logic dio_pad_attr_11_re;
-  logic [9:0] dio_pad_attr_12_qs;
-  logic [9:0] dio_pad_attr_12_wd;
+  logic [12:0] dio_pad_attr_12_qs;
+  logic [12:0] dio_pad_attr_12_wd;
   logic dio_pad_attr_12_we;
   logic dio_pad_attr_12_re;
-  logic [9:0] dio_pad_attr_13_qs;
-  logic [9:0] dio_pad_attr_13_wd;
+  logic [12:0] dio_pad_attr_13_qs;
+  logic [12:0] dio_pad_attr_13_wd;
   logic dio_pad_attr_13_we;
   logic dio_pad_attr_13_re;
-  logic [9:0] dio_pad_attr_14_qs;
-  logic [9:0] dio_pad_attr_14_wd;
+  logic [12:0] dio_pad_attr_14_qs;
+  logic [12:0] dio_pad_attr_14_wd;
   logic dio_pad_attr_14_we;
   logic dio_pad_attr_14_re;
-  logic [9:0] dio_pad_attr_15_qs;
-  logic [9:0] dio_pad_attr_15_wd;
+  logic [12:0] dio_pad_attr_15_qs;
+  logic [12:0] dio_pad_attr_15_wd;
   logic dio_pad_attr_15_we;
   logic dio_pad_attr_15_re;
   logic mio_pad_sleep_status_en_0_qs;
@@ -5997,7 +5997,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_0]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_0 (
     .re     (mio_pad_attr_0_re),
     // qualified with register enable
@@ -6014,7 +6014,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_1]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_1 (
     .re     (mio_pad_attr_1_re),
     // qualified with register enable
@@ -6031,7 +6031,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_2]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_2 (
     .re     (mio_pad_attr_2_re),
     // qualified with register enable
@@ -6048,7 +6048,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_3]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_3 (
     .re     (mio_pad_attr_3_re),
     // qualified with register enable
@@ -6065,7 +6065,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_4]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_4 (
     .re     (mio_pad_attr_4_re),
     // qualified with register enable
@@ -6082,7 +6082,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_5]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_5 (
     .re     (mio_pad_attr_5_re),
     // qualified with register enable
@@ -6099,7 +6099,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_6]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_6 (
     .re     (mio_pad_attr_6_re),
     // qualified with register enable
@@ -6116,7 +6116,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_7]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_7 (
     .re     (mio_pad_attr_7_re),
     // qualified with register enable
@@ -6133,7 +6133,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_8]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_8 (
     .re     (mio_pad_attr_8_re),
     // qualified with register enable
@@ -6150,7 +6150,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_9]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_9 (
     .re     (mio_pad_attr_9_re),
     // qualified with register enable
@@ -6167,7 +6167,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_10]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_10 (
     .re     (mio_pad_attr_10_re),
     // qualified with register enable
@@ -6184,7 +6184,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_11]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_11 (
     .re     (mio_pad_attr_11_re),
     // qualified with register enable
@@ -6201,7 +6201,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_12]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_12 (
     .re     (mio_pad_attr_12_re),
     // qualified with register enable
@@ -6218,7 +6218,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_13]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_13 (
     .re     (mio_pad_attr_13_re),
     // qualified with register enable
@@ -6235,7 +6235,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_14]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_14 (
     .re     (mio_pad_attr_14_re),
     // qualified with register enable
@@ -6252,7 +6252,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_15]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_15 (
     .re     (mio_pad_attr_15_re),
     // qualified with register enable
@@ -6269,7 +6269,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_16]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_16 (
     .re     (mio_pad_attr_16_re),
     // qualified with register enable
@@ -6286,7 +6286,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_17]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_17 (
     .re     (mio_pad_attr_17_re),
     // qualified with register enable
@@ -6303,7 +6303,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_18]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_18 (
     .re     (mio_pad_attr_18_re),
     // qualified with register enable
@@ -6320,7 +6320,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_19]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_19 (
     .re     (mio_pad_attr_19_re),
     // qualified with register enable
@@ -6337,7 +6337,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_20]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_20 (
     .re     (mio_pad_attr_20_re),
     // qualified with register enable
@@ -6354,7 +6354,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_21]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_21 (
     .re     (mio_pad_attr_21_re),
     // qualified with register enable
@@ -6371,7 +6371,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_22]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_22 (
     .re     (mio_pad_attr_22_re),
     // qualified with register enable
@@ -6388,7 +6388,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_23]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_23 (
     .re     (mio_pad_attr_23_re),
     // qualified with register enable
@@ -6405,7 +6405,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_24]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_24 (
     .re     (mio_pad_attr_24_re),
     // qualified with register enable
@@ -6422,7 +6422,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_25]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_25 (
     .re     (mio_pad_attr_25_re),
     // qualified with register enable
@@ -6439,7 +6439,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_26]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_26 (
     .re     (mio_pad_attr_26_re),
     // qualified with register enable
@@ -6456,7 +6456,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_27]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_27 (
     .re     (mio_pad_attr_27_re),
     // qualified with register enable
@@ -6473,7 +6473,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_28]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_28 (
     .re     (mio_pad_attr_28_re),
     // qualified with register enable
@@ -6490,7 +6490,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_29]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_29 (
     .re     (mio_pad_attr_29_re),
     // qualified with register enable
@@ -6507,7 +6507,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_30]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_30 (
     .re     (mio_pad_attr_30_re),
     // qualified with register enable
@@ -6524,7 +6524,7 @@ module pinmux_reg_top (
   // R[mio_pad_attr_31]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_mio_pad_attr_31 (
     .re     (mio_pad_attr_31_re),
     // qualified with register enable
@@ -6977,7 +6977,7 @@ module pinmux_reg_top (
   // R[dio_pad_attr_0]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_dio_pad_attr_0 (
     .re     (dio_pad_attr_0_re),
     // qualified with register enable
@@ -6994,7 +6994,7 @@ module pinmux_reg_top (
   // R[dio_pad_attr_1]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_dio_pad_attr_1 (
     .re     (dio_pad_attr_1_re),
     // qualified with register enable
@@ -7011,7 +7011,7 @@ module pinmux_reg_top (
   // R[dio_pad_attr_2]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_dio_pad_attr_2 (
     .re     (dio_pad_attr_2_re),
     // qualified with register enable
@@ -7028,7 +7028,7 @@ module pinmux_reg_top (
   // R[dio_pad_attr_3]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_dio_pad_attr_3 (
     .re     (dio_pad_attr_3_re),
     // qualified with register enable
@@ -7045,7 +7045,7 @@ module pinmux_reg_top (
   // R[dio_pad_attr_4]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_dio_pad_attr_4 (
     .re     (dio_pad_attr_4_re),
     // qualified with register enable
@@ -7062,7 +7062,7 @@ module pinmux_reg_top (
   // R[dio_pad_attr_5]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_dio_pad_attr_5 (
     .re     (dio_pad_attr_5_re),
     // qualified with register enable
@@ -7079,7 +7079,7 @@ module pinmux_reg_top (
   // R[dio_pad_attr_6]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_dio_pad_attr_6 (
     .re     (dio_pad_attr_6_re),
     // qualified with register enable
@@ -7096,7 +7096,7 @@ module pinmux_reg_top (
   // R[dio_pad_attr_7]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_dio_pad_attr_7 (
     .re     (dio_pad_attr_7_re),
     // qualified with register enable
@@ -7113,7 +7113,7 @@ module pinmux_reg_top (
   // R[dio_pad_attr_8]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_dio_pad_attr_8 (
     .re     (dio_pad_attr_8_re),
     // qualified with register enable
@@ -7130,7 +7130,7 @@ module pinmux_reg_top (
   // R[dio_pad_attr_9]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_dio_pad_attr_9 (
     .re     (dio_pad_attr_9_re),
     // qualified with register enable
@@ -7147,7 +7147,7 @@ module pinmux_reg_top (
   // R[dio_pad_attr_10]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_dio_pad_attr_10 (
     .re     (dio_pad_attr_10_re),
     // qualified with register enable
@@ -7164,7 +7164,7 @@ module pinmux_reg_top (
   // R[dio_pad_attr_11]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_dio_pad_attr_11 (
     .re     (dio_pad_attr_11_re),
     // qualified with register enable
@@ -7181,7 +7181,7 @@ module pinmux_reg_top (
   // R[dio_pad_attr_12]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_dio_pad_attr_12 (
     .re     (dio_pad_attr_12_re),
     // qualified with register enable
@@ -7198,7 +7198,7 @@ module pinmux_reg_top (
   // R[dio_pad_attr_13]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_dio_pad_attr_13 (
     .re     (dio_pad_attr_13_re),
     // qualified with register enable
@@ -7215,7 +7215,7 @@ module pinmux_reg_top (
   // R[dio_pad_attr_14]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_dio_pad_attr_14 (
     .re     (dio_pad_attr_14_re),
     // qualified with register enable
@@ -7232,7 +7232,7 @@ module pinmux_reg_top (
   // R[dio_pad_attr_15]: V(True)
 
   prim_subreg_ext #(
-    .DW    (10)
+    .DW    (13)
   ) u_dio_pad_attr_15 (
     .re     (dio_pad_attr_15_re),
     // qualified with register enable
@@ -15378,131 +15378,131 @@ module pinmux_reg_top (
   assign mio_pad_attr_regwen_31_wd = reg_wdata[0];
 
   assign mio_pad_attr_0_we = addr_hit[162] & reg_we & !reg_error;
-  assign mio_pad_attr_0_wd = reg_wdata[9:0];
+  assign mio_pad_attr_0_wd = reg_wdata[12:0];
   assign mio_pad_attr_0_re = addr_hit[162] & reg_re & !reg_error;
 
   assign mio_pad_attr_1_we = addr_hit[163] & reg_we & !reg_error;
-  assign mio_pad_attr_1_wd = reg_wdata[9:0];
+  assign mio_pad_attr_1_wd = reg_wdata[12:0];
   assign mio_pad_attr_1_re = addr_hit[163] & reg_re & !reg_error;
 
   assign mio_pad_attr_2_we = addr_hit[164] & reg_we & !reg_error;
-  assign mio_pad_attr_2_wd = reg_wdata[9:0];
+  assign mio_pad_attr_2_wd = reg_wdata[12:0];
   assign mio_pad_attr_2_re = addr_hit[164] & reg_re & !reg_error;
 
   assign mio_pad_attr_3_we = addr_hit[165] & reg_we & !reg_error;
-  assign mio_pad_attr_3_wd = reg_wdata[9:0];
+  assign mio_pad_attr_3_wd = reg_wdata[12:0];
   assign mio_pad_attr_3_re = addr_hit[165] & reg_re & !reg_error;
 
   assign mio_pad_attr_4_we = addr_hit[166] & reg_we & !reg_error;
-  assign mio_pad_attr_4_wd = reg_wdata[9:0];
+  assign mio_pad_attr_4_wd = reg_wdata[12:0];
   assign mio_pad_attr_4_re = addr_hit[166] & reg_re & !reg_error;
 
   assign mio_pad_attr_5_we = addr_hit[167] & reg_we & !reg_error;
-  assign mio_pad_attr_5_wd = reg_wdata[9:0];
+  assign mio_pad_attr_5_wd = reg_wdata[12:0];
   assign mio_pad_attr_5_re = addr_hit[167] & reg_re & !reg_error;
 
   assign mio_pad_attr_6_we = addr_hit[168] & reg_we & !reg_error;
-  assign mio_pad_attr_6_wd = reg_wdata[9:0];
+  assign mio_pad_attr_6_wd = reg_wdata[12:0];
   assign mio_pad_attr_6_re = addr_hit[168] & reg_re & !reg_error;
 
   assign mio_pad_attr_7_we = addr_hit[169] & reg_we & !reg_error;
-  assign mio_pad_attr_7_wd = reg_wdata[9:0];
+  assign mio_pad_attr_7_wd = reg_wdata[12:0];
   assign mio_pad_attr_7_re = addr_hit[169] & reg_re & !reg_error;
 
   assign mio_pad_attr_8_we = addr_hit[170] & reg_we & !reg_error;
-  assign mio_pad_attr_8_wd = reg_wdata[9:0];
+  assign mio_pad_attr_8_wd = reg_wdata[12:0];
   assign mio_pad_attr_8_re = addr_hit[170] & reg_re & !reg_error;
 
   assign mio_pad_attr_9_we = addr_hit[171] & reg_we & !reg_error;
-  assign mio_pad_attr_9_wd = reg_wdata[9:0];
+  assign mio_pad_attr_9_wd = reg_wdata[12:0];
   assign mio_pad_attr_9_re = addr_hit[171] & reg_re & !reg_error;
 
   assign mio_pad_attr_10_we = addr_hit[172] & reg_we & !reg_error;
-  assign mio_pad_attr_10_wd = reg_wdata[9:0];
+  assign mio_pad_attr_10_wd = reg_wdata[12:0];
   assign mio_pad_attr_10_re = addr_hit[172] & reg_re & !reg_error;
 
   assign mio_pad_attr_11_we = addr_hit[173] & reg_we & !reg_error;
-  assign mio_pad_attr_11_wd = reg_wdata[9:0];
+  assign mio_pad_attr_11_wd = reg_wdata[12:0];
   assign mio_pad_attr_11_re = addr_hit[173] & reg_re & !reg_error;
 
   assign mio_pad_attr_12_we = addr_hit[174] & reg_we & !reg_error;
-  assign mio_pad_attr_12_wd = reg_wdata[9:0];
+  assign mio_pad_attr_12_wd = reg_wdata[12:0];
   assign mio_pad_attr_12_re = addr_hit[174] & reg_re & !reg_error;
 
   assign mio_pad_attr_13_we = addr_hit[175] & reg_we & !reg_error;
-  assign mio_pad_attr_13_wd = reg_wdata[9:0];
+  assign mio_pad_attr_13_wd = reg_wdata[12:0];
   assign mio_pad_attr_13_re = addr_hit[175] & reg_re & !reg_error;
 
   assign mio_pad_attr_14_we = addr_hit[176] & reg_we & !reg_error;
-  assign mio_pad_attr_14_wd = reg_wdata[9:0];
+  assign mio_pad_attr_14_wd = reg_wdata[12:0];
   assign mio_pad_attr_14_re = addr_hit[176] & reg_re & !reg_error;
 
   assign mio_pad_attr_15_we = addr_hit[177] & reg_we & !reg_error;
-  assign mio_pad_attr_15_wd = reg_wdata[9:0];
+  assign mio_pad_attr_15_wd = reg_wdata[12:0];
   assign mio_pad_attr_15_re = addr_hit[177] & reg_re & !reg_error;
 
   assign mio_pad_attr_16_we = addr_hit[178] & reg_we & !reg_error;
-  assign mio_pad_attr_16_wd = reg_wdata[9:0];
+  assign mio_pad_attr_16_wd = reg_wdata[12:0];
   assign mio_pad_attr_16_re = addr_hit[178] & reg_re & !reg_error;
 
   assign mio_pad_attr_17_we = addr_hit[179] & reg_we & !reg_error;
-  assign mio_pad_attr_17_wd = reg_wdata[9:0];
+  assign mio_pad_attr_17_wd = reg_wdata[12:0];
   assign mio_pad_attr_17_re = addr_hit[179] & reg_re & !reg_error;
 
   assign mio_pad_attr_18_we = addr_hit[180] & reg_we & !reg_error;
-  assign mio_pad_attr_18_wd = reg_wdata[9:0];
+  assign mio_pad_attr_18_wd = reg_wdata[12:0];
   assign mio_pad_attr_18_re = addr_hit[180] & reg_re & !reg_error;
 
   assign mio_pad_attr_19_we = addr_hit[181] & reg_we & !reg_error;
-  assign mio_pad_attr_19_wd = reg_wdata[9:0];
+  assign mio_pad_attr_19_wd = reg_wdata[12:0];
   assign mio_pad_attr_19_re = addr_hit[181] & reg_re & !reg_error;
 
   assign mio_pad_attr_20_we = addr_hit[182] & reg_we & !reg_error;
-  assign mio_pad_attr_20_wd = reg_wdata[9:0];
+  assign mio_pad_attr_20_wd = reg_wdata[12:0];
   assign mio_pad_attr_20_re = addr_hit[182] & reg_re & !reg_error;
 
   assign mio_pad_attr_21_we = addr_hit[183] & reg_we & !reg_error;
-  assign mio_pad_attr_21_wd = reg_wdata[9:0];
+  assign mio_pad_attr_21_wd = reg_wdata[12:0];
   assign mio_pad_attr_21_re = addr_hit[183] & reg_re & !reg_error;
 
   assign mio_pad_attr_22_we = addr_hit[184] & reg_we & !reg_error;
-  assign mio_pad_attr_22_wd = reg_wdata[9:0];
+  assign mio_pad_attr_22_wd = reg_wdata[12:0];
   assign mio_pad_attr_22_re = addr_hit[184] & reg_re & !reg_error;
 
   assign mio_pad_attr_23_we = addr_hit[185] & reg_we & !reg_error;
-  assign mio_pad_attr_23_wd = reg_wdata[9:0];
+  assign mio_pad_attr_23_wd = reg_wdata[12:0];
   assign mio_pad_attr_23_re = addr_hit[185] & reg_re & !reg_error;
 
   assign mio_pad_attr_24_we = addr_hit[186] & reg_we & !reg_error;
-  assign mio_pad_attr_24_wd = reg_wdata[9:0];
+  assign mio_pad_attr_24_wd = reg_wdata[12:0];
   assign mio_pad_attr_24_re = addr_hit[186] & reg_re & !reg_error;
 
   assign mio_pad_attr_25_we = addr_hit[187] & reg_we & !reg_error;
-  assign mio_pad_attr_25_wd = reg_wdata[9:0];
+  assign mio_pad_attr_25_wd = reg_wdata[12:0];
   assign mio_pad_attr_25_re = addr_hit[187] & reg_re & !reg_error;
 
   assign mio_pad_attr_26_we = addr_hit[188] & reg_we & !reg_error;
-  assign mio_pad_attr_26_wd = reg_wdata[9:0];
+  assign mio_pad_attr_26_wd = reg_wdata[12:0];
   assign mio_pad_attr_26_re = addr_hit[188] & reg_re & !reg_error;
 
   assign mio_pad_attr_27_we = addr_hit[189] & reg_we & !reg_error;
-  assign mio_pad_attr_27_wd = reg_wdata[9:0];
+  assign mio_pad_attr_27_wd = reg_wdata[12:0];
   assign mio_pad_attr_27_re = addr_hit[189] & reg_re & !reg_error;
 
   assign mio_pad_attr_28_we = addr_hit[190] & reg_we & !reg_error;
-  assign mio_pad_attr_28_wd = reg_wdata[9:0];
+  assign mio_pad_attr_28_wd = reg_wdata[12:0];
   assign mio_pad_attr_28_re = addr_hit[190] & reg_re & !reg_error;
 
   assign mio_pad_attr_29_we = addr_hit[191] & reg_we & !reg_error;
-  assign mio_pad_attr_29_wd = reg_wdata[9:0];
+  assign mio_pad_attr_29_wd = reg_wdata[12:0];
   assign mio_pad_attr_29_re = addr_hit[191] & reg_re & !reg_error;
 
   assign mio_pad_attr_30_we = addr_hit[192] & reg_we & !reg_error;
-  assign mio_pad_attr_30_wd = reg_wdata[9:0];
+  assign mio_pad_attr_30_wd = reg_wdata[12:0];
   assign mio_pad_attr_30_re = addr_hit[192] & reg_re & !reg_error;
 
   assign mio_pad_attr_31_we = addr_hit[193] & reg_we & !reg_error;
-  assign mio_pad_attr_31_wd = reg_wdata[9:0];
+  assign mio_pad_attr_31_wd = reg_wdata[12:0];
   assign mio_pad_attr_31_re = addr_hit[193] & reg_re & !reg_error;
 
   assign dio_pad_attr_regwen_0_we = addr_hit[194] & reg_we & !reg_error;
@@ -15554,67 +15554,67 @@ module pinmux_reg_top (
   assign dio_pad_attr_regwen_15_wd = reg_wdata[0];
 
   assign dio_pad_attr_0_we = addr_hit[210] & reg_we & !reg_error;
-  assign dio_pad_attr_0_wd = reg_wdata[9:0];
+  assign dio_pad_attr_0_wd = reg_wdata[12:0];
   assign dio_pad_attr_0_re = addr_hit[210] & reg_re & !reg_error;
 
   assign dio_pad_attr_1_we = addr_hit[211] & reg_we & !reg_error;
-  assign dio_pad_attr_1_wd = reg_wdata[9:0];
+  assign dio_pad_attr_1_wd = reg_wdata[12:0];
   assign dio_pad_attr_1_re = addr_hit[211] & reg_re & !reg_error;
 
   assign dio_pad_attr_2_we = addr_hit[212] & reg_we & !reg_error;
-  assign dio_pad_attr_2_wd = reg_wdata[9:0];
+  assign dio_pad_attr_2_wd = reg_wdata[12:0];
   assign dio_pad_attr_2_re = addr_hit[212] & reg_re & !reg_error;
 
   assign dio_pad_attr_3_we = addr_hit[213] & reg_we & !reg_error;
-  assign dio_pad_attr_3_wd = reg_wdata[9:0];
+  assign dio_pad_attr_3_wd = reg_wdata[12:0];
   assign dio_pad_attr_3_re = addr_hit[213] & reg_re & !reg_error;
 
   assign dio_pad_attr_4_we = addr_hit[214] & reg_we & !reg_error;
-  assign dio_pad_attr_4_wd = reg_wdata[9:0];
+  assign dio_pad_attr_4_wd = reg_wdata[12:0];
   assign dio_pad_attr_4_re = addr_hit[214] & reg_re & !reg_error;
 
   assign dio_pad_attr_5_we = addr_hit[215] & reg_we & !reg_error;
-  assign dio_pad_attr_5_wd = reg_wdata[9:0];
+  assign dio_pad_attr_5_wd = reg_wdata[12:0];
   assign dio_pad_attr_5_re = addr_hit[215] & reg_re & !reg_error;
 
   assign dio_pad_attr_6_we = addr_hit[216] & reg_we & !reg_error;
-  assign dio_pad_attr_6_wd = reg_wdata[9:0];
+  assign dio_pad_attr_6_wd = reg_wdata[12:0];
   assign dio_pad_attr_6_re = addr_hit[216] & reg_re & !reg_error;
 
   assign dio_pad_attr_7_we = addr_hit[217] & reg_we & !reg_error;
-  assign dio_pad_attr_7_wd = reg_wdata[9:0];
+  assign dio_pad_attr_7_wd = reg_wdata[12:0];
   assign dio_pad_attr_7_re = addr_hit[217] & reg_re & !reg_error;
 
   assign dio_pad_attr_8_we = addr_hit[218] & reg_we & !reg_error;
-  assign dio_pad_attr_8_wd = reg_wdata[9:0];
+  assign dio_pad_attr_8_wd = reg_wdata[12:0];
   assign dio_pad_attr_8_re = addr_hit[218] & reg_re & !reg_error;
 
   assign dio_pad_attr_9_we = addr_hit[219] & reg_we & !reg_error;
-  assign dio_pad_attr_9_wd = reg_wdata[9:0];
+  assign dio_pad_attr_9_wd = reg_wdata[12:0];
   assign dio_pad_attr_9_re = addr_hit[219] & reg_re & !reg_error;
 
   assign dio_pad_attr_10_we = addr_hit[220] & reg_we & !reg_error;
-  assign dio_pad_attr_10_wd = reg_wdata[9:0];
+  assign dio_pad_attr_10_wd = reg_wdata[12:0];
   assign dio_pad_attr_10_re = addr_hit[220] & reg_re & !reg_error;
 
   assign dio_pad_attr_11_we = addr_hit[221] & reg_we & !reg_error;
-  assign dio_pad_attr_11_wd = reg_wdata[9:0];
+  assign dio_pad_attr_11_wd = reg_wdata[12:0];
   assign dio_pad_attr_11_re = addr_hit[221] & reg_re & !reg_error;
 
   assign dio_pad_attr_12_we = addr_hit[222] & reg_we & !reg_error;
-  assign dio_pad_attr_12_wd = reg_wdata[9:0];
+  assign dio_pad_attr_12_wd = reg_wdata[12:0];
   assign dio_pad_attr_12_re = addr_hit[222] & reg_re & !reg_error;
 
   assign dio_pad_attr_13_we = addr_hit[223] & reg_we & !reg_error;
-  assign dio_pad_attr_13_wd = reg_wdata[9:0];
+  assign dio_pad_attr_13_wd = reg_wdata[12:0];
   assign dio_pad_attr_13_re = addr_hit[223] & reg_re & !reg_error;
 
   assign dio_pad_attr_14_we = addr_hit[224] & reg_we & !reg_error;
-  assign dio_pad_attr_14_wd = reg_wdata[9:0];
+  assign dio_pad_attr_14_wd = reg_wdata[12:0];
   assign dio_pad_attr_14_re = addr_hit[224] & reg_re & !reg_error;
 
   assign dio_pad_attr_15_we = addr_hit[225] & reg_we & !reg_error;
-  assign dio_pad_attr_15_wd = reg_wdata[9:0];
+  assign dio_pad_attr_15_wd = reg_wdata[12:0];
   assign dio_pad_attr_15_re = addr_hit[225] & reg_re & !reg_error;
 
   assign mio_pad_sleep_status_en_0_we = addr_hit[226] & reg_we & !reg_error;
@@ -17046,131 +17046,131 @@ module pinmux_reg_top (
       end
 
       addr_hit[162]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_0_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_0_qs;
       end
 
       addr_hit[163]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_1_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_1_qs;
       end
 
       addr_hit[164]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_2_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_2_qs;
       end
 
       addr_hit[165]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_3_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_3_qs;
       end
 
       addr_hit[166]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_4_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_4_qs;
       end
 
       addr_hit[167]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_5_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_5_qs;
       end
 
       addr_hit[168]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_6_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_6_qs;
       end
 
       addr_hit[169]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_7_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_7_qs;
       end
 
       addr_hit[170]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_8_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_8_qs;
       end
 
       addr_hit[171]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_9_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_9_qs;
       end
 
       addr_hit[172]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_10_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_10_qs;
       end
 
       addr_hit[173]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_11_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_11_qs;
       end
 
       addr_hit[174]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_12_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_12_qs;
       end
 
       addr_hit[175]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_13_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_13_qs;
       end
 
       addr_hit[176]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_14_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_14_qs;
       end
 
       addr_hit[177]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_15_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_15_qs;
       end
 
       addr_hit[178]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_16_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_16_qs;
       end
 
       addr_hit[179]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_17_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_17_qs;
       end
 
       addr_hit[180]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_18_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_18_qs;
       end
 
       addr_hit[181]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_19_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_19_qs;
       end
 
       addr_hit[182]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_20_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_20_qs;
       end
 
       addr_hit[183]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_21_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_21_qs;
       end
 
       addr_hit[184]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_22_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_22_qs;
       end
 
       addr_hit[185]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_23_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_23_qs;
       end
 
       addr_hit[186]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_24_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_24_qs;
       end
 
       addr_hit[187]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_25_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_25_qs;
       end
 
       addr_hit[188]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_26_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_26_qs;
       end
 
       addr_hit[189]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_27_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_27_qs;
       end
 
       addr_hit[190]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_28_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_28_qs;
       end
 
       addr_hit[191]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_29_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_29_qs;
       end
 
       addr_hit[192]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_30_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_30_qs;
       end
 
       addr_hit[193]: begin
-        reg_rdata_next[9:0] = mio_pad_attr_31_qs;
+        reg_rdata_next[12:0] = mio_pad_attr_31_qs;
       end
 
       addr_hit[194]: begin
@@ -17238,67 +17238,67 @@ module pinmux_reg_top (
       end
 
       addr_hit[210]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_0_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_0_qs;
       end
 
       addr_hit[211]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_1_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_1_qs;
       end
 
       addr_hit[212]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_2_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_2_qs;
       end
 
       addr_hit[213]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_3_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_3_qs;
       end
 
       addr_hit[214]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_4_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_4_qs;
       end
 
       addr_hit[215]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_5_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_5_qs;
       end
 
       addr_hit[216]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_6_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_6_qs;
       end
 
       addr_hit[217]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_7_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_7_qs;
       end
 
       addr_hit[218]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_8_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_8_qs;
       end
 
       addr_hit[219]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_9_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_9_qs;
       end
 
       addr_hit[220]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_10_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_10_qs;
       end
 
       addr_hit[221]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_11_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_11_qs;
       end
 
       addr_hit[222]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_12_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_12_qs;
       end
 
       addr_hit[223]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_13_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_13_qs;
       end
 
       addr_hit[224]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_14_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_14_qs;
       end
 
       addr_hit[225]: begin
-        reg_rdata_next[9:0] = dio_pad_attr_15_qs;
+        reg_rdata_next[12:0] = dio_pad_attr_15_qs;
       end
 
       addr_hit[226]: begin


### PR DESCRIPTION
This regenerates the example hjson which got out of date and hence leads to several lint messages.
Also, the pad attribute documentation is updated to reflect the newest pad wrapper implementation.

Fixes #6011 