### PR TITLE
[flash_ctrl] Simplify defn of buf_invalid_alloc in flash_phy_rd

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
@@ -129,7 +129,7 @@ module flash_phy_rd import flash_phy_pkg::*; (
 
   assign buf_invalid_alloc[0] = buf_invalid[0];
   for (genvar i = 1; i < NumBuf; i++) begin: gen_inv_alloc_bufs
-    assign buf_invalid_alloc[i] = buf_invalid[i] & ~|buf_invalid_alloc[i-1:0];
+    assign buf_invalid_alloc[i] = buf_invalid[i] & ~|buf_invalid[i-1:0];
   end
 
   // a prim arbiter is used to somewhat fairly select among the valid buffers


### PR DESCRIPTION
The existing expression caused a Verilator UNOPTFLAT warning, because
bit k of the signal depended on bits 0..k-1. Rather than telling
Verilator to schedule things more cleverly, rewrite the definition to
something equivalent which doesn't cause a problem.

`buf_invalid_alloc[i]` is supposed to be true if it's the first bit that
is set in `buf_invalid[i]`. The existing code checked that no previous
bit was the first set bit. The new code checks that no previous bit is
set at all. This is equivalent. I'd expect any half-decent synthesis
tool to generate the same code from both versions but, if it doesn't,
the new formulation should be more efficient.
