### PR TITLE
[util] Add a --quiet mode to gen-otp-img.py and use in Meson

### DIFF
--- a/sw/device/meson.build
+++ b/sw/device/meson.build
@@ -52,6 +52,7 @@ extract_sw_logs_sim_dv_depend_files = [
 make_otp_img_inputs = [meson.source_root() / 'hw/ip/otp_ctrl/data/otp_ctrl_img_dev.hjson']
 make_otp_img_command = [
   prog_python, meson.source_root() / 'util/design/gen-otp-img.py',
+  '--quiet',
   '--img-cfg', '@INPUT@',
   '--out', '@OUTPUT@',
 ]

--- a/util/design/gen-otp-img.py
+++ b/util/design/gen-otp-img.py
@@ -71,6 +71,8 @@ def main():
         description=wrapped_docstring(),
         formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.register('action', 'extend', ExtendAction)
+    parser.add_argument('--quiet', '-q', action='store_true',
+                        help='''Don't print out progress messages.''')
     parser.add_argument('--img-seed',
                         type=int,
                         metavar='<seed>',
@@ -141,6 +143,9 @@ def main():
                         ''')
 
     args = parser.parse_args()
+
+    if args.quiet:
+        log.getLogger().setLevel(log.WARNING)
 
     log.info('Loading LC state definition file {}'.format(lc_state_def_file))
     with open(lc_state_def_file, 'r') as infile:


### PR DESCRIPTION
This avoids printing its large info messages to the terminal on every
software build.