### PR TITLE
[aes, prim] Encapsulate security-related synthesis attributes inside primitives 

### DIFF
--- a/hw/ip/aes/lint/aes.vlt
+++ b/hw/ip/aes/lint/aes.vlt
@@ -14,10 +14,22 @@ lint_off -rule ALWCOMBORDER -file "*/rtl/aes_key_expand.sv" -match "*'regular'"
 lint_off -rule DECLFILENAME -file "*/rtl/aes_sbox_*_masked*.sv" -match "Filename 'aes_sbox_*_masked*' does not match MODULE name: *"
 lint_off -rule DECLFILENAME -file "*/rtl/aes_sbox_dom*.sv" -match "Filename 'aes_sbox_dom*' does not match MODULE name: *"
 
-// In the sp2v_sig* arrays some members may depend on others.
+// In the following arrays some members may depend on others.
 // There are no circular dependencies but the tool must be told to analyze each member separately for simulation, i.e., to split up the arrays internally.
 // Otherwise the tool needs to evaluate corresponding statements multiple times before the entire signal settles.
 // This slows down simulation and causes the tool to print UNOPTFLAT lint warnings.
 split_var -module "aes_control" -var "*sp2v_sig*"
 split_var -module "aes_cipher_control" -var "*sp2v_sig"
 split_var -module "aes_cipher_control" -var "*sp2v_sig_chk*"
+split_var -module "aes_masked_inverse_gf2p8*" -var "b"
+split_var -module "aes_masked_inverse_gf2p8*" -var "b_buf"
+split_var -module "aes_masked_inverse_gf2p8*" -var "a1_inv"
+split_var -module "aes_masked_inverse_gf2p8*" -var "a1_inv_buf"
+split_var -module "aes_masked_inverse_gf2p8*" -var "a0_inv"
+split_var -module "aes_masked_inverse_gf2p8*" -var "a0_inv_buf"
+split_var -module "aes_masked_inverse_gf2p4*" -var "c"
+split_var -module "aes_masked_inverse_gf2p4*" -var "c_buf"
+split_var -module "aes_masked_inverse_gf2p4*" -var "b1_inv"
+split_var -module "aes_masked_inverse_gf2p4*" -var "b1_inv_buf"
+split_var -module "aes_masked_inverse_gf2p4*" -var "b0_inv"
+split_var -module "aes_masked_inverse_gf2p4*" -var "b0_inv_buf"

--- a/hw/ip/aes/rtl/aes_sbox_canright_masked.sv
+++ b/hw/ip/aes/rtl/aes_sbox_canright_masked.sv
@@ -191,7 +191,7 @@ module aes_masked_inverse_gf2p8 (
   assign r = m1[3:2];
 
   // b is masked by q, b_inv is masked by m1.
-  aes_masked_inverse_gf2p4 aes_masked_inverse_gf2p4 (
+  aes_masked_inverse_gf2p4 u_aes_masked_inverse_gf2p4 (
     .b     ( b     ),
     .q     ( q     ),
     .r     ( r     ),
@@ -280,7 +280,7 @@ module aes_sbox_canright_masked (
                                                  aes_mvm(mask_o, S2X);
 
   // Do the inversion in normal basis X.
-  aes_masked_inverse_gf2p8 aes_masked_inverse_gf2p8 (
+  aes_masked_inverse_gf2p8 u_aes_masked_inverse_gf2p8 (
     .a     ( in_data_basis_x  ), // input
     .m     ( in_mask_basis_x  ), // input
     .n     ( out_mask_basis_x ), // input

--- a/hw/ip/aes/rtl/aes_sbox_canright_masked.sv
+++ b/hw/ip/aes/rtl/aes_sbox_canright_masked.sv
@@ -13,8 +13,8 @@
 // vulnerable to higher-order differential side-channel analysis, but it remains secure against
 // first-order attacks. This implementation is commonly referred to as THE Canright Masked SBox.
 //
-// A formal analysis using REBECCA (static mode) shows that this implementation is not secure.
-// It is thus recommended to use the "noreuse" variant of the masked Canright S-Box.
+// A formal analysis using REBECCA (stable and transient mode) shows that this implementation is
+// not secure. It's usage is thus discouraged. It's included here mainly for reference.
 //
 // For details on the REBECCA tool, see the following paper:
 // Bloem, "Formal verification of masked hardware implementations in the presence of glitches"

--- a/hw/ip/aes/rtl/aes_sbox_canright_masked_noreuse.sv
+++ b/hw/ip/aes/rtl/aes_sbox_canright_masked_noreuse.sv
@@ -9,9 +9,11 @@
 // available at https://eprint.iacr.org/2009/011.pdf
 //
 // Note: This module implements the original masked inversion algorithm without re-using masks.
-// For details, see Section 2.2 of the paper. In addition, a formal analysis using REBECCA (static
+// For details, see Section 2.2 of the paper. In addition, a formal analysis using REBECCA (stable
 // mode) shows that the intermediate masks cannot be created by re-using bits from the input and
-// output masks. Instead, fresh random bits need to be used for these intermediate masks.
+// output masks. Instead, fresh random bits need to be used for these intermediate masks. Still,
+// the implmentation cannot be made to pass formal analysis in transient mode. It's usage is thus
+// discouraged. It's included here mainly for reference.
 //
 // For details on the REBECCA tool, see the following paper:
 // Bloem, "Formal verification of masked hardware implementations in the presence of glitches"

--- a/hw/ip/aes/rtl/aes_sbox_canright_masked_noreuse.sv
+++ b/hw/ip/aes/rtl/aes_sbox_canright_masked_noreuse.sv
@@ -199,7 +199,7 @@ module aes_masked_inverse_gf2p8_noreuse (
   assign b   = b_4 ^ mul_m0_m1;
 
   // b is masked by q, b_inv is masked by t.
-  aes_masked_inverse_gf2p4_noreuse aes_masked_inverse_gf2p4 (
+  aes_masked_inverse_gf2p4_noreuse u_aes_masked_inverse_gf2p4 (
     .b     ( b     ),
     .q     ( q     ),
     .r     ( r     ),
@@ -286,7 +286,7 @@ module aes_sbox_canright_masked_noreuse (
                                                  aes_mvm(mask_o, S2X);
 
   // Do the inversion in normal basis X.
-  aes_masked_inverse_gf2p8_noreuse aes_masked_inverse_gf2p8 (
+  aes_masked_inverse_gf2p8_noreuse u_aes_masked_inverse_gf2p8 (
     .a     ( in_data_basis_x  ), // input
     .m     ( in_mask_basis_x  ), // input
     .n     ( out_mask_basis_x ), // input

--- a/hw/ip/aes/rtl/aes_sbox_dom.sv
+++ b/hw/ip/aes/rtl/aes_sbox_dom.sv
@@ -19,6 +19,14 @@
 // [2] Canright, "A very compact 'perfectly masked' S-box for AES (corrected)" available at
 //     https://eprint.iacr.org/2009/011.pdf
 // [3] Canright, "A very compact Rijndael S-box" available at https://hdl.handle.net/10945/25608
+//
+// Using the Coco-Alma tool in transient mode, this implementation has been formally verified to be
+// secure against first-order side-channel analysis (SCA). For more information on the tool,
+// refer to the following papers:
+// [4] Gigerl, "COCO: Co-design and co-verification of masked software implementations on CPUs"
+//     available at https://eprint.iacr.org/2020/1294.pdf
+// [5] Bloem, "Formal verification of masked hardware implementations in the presence of glitches"
+//     available at https://eprint.iacr.org/2017/897.pdf
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // IMPORTANT NOTE:                                                                               //

--- a/hw/ip/aes/rtl/aes_sbox_dom.sv
+++ b/hw/ip/aes/rtl/aes_sbox_dom.sv
@@ -207,7 +207,7 @@ module aes_dom_dep_mul_gf2pn_unopt #(
   aes_dom_indep_mul_gf2pn #(
     .NPower   ( NPower   ),
     .Pipeline ( Pipeline )
-  ) aes_dom_indep_mul_gf2pn (
+  ) u_aes_dom_indep_mul_gf2pn (
     .clk_i  ( clk_i     ),
     .rst_ni ( rst_ni    ),
     .we_i   ( we_i      ),
@@ -558,7 +558,7 @@ module aes_dom_inverse_gf2p4 (
     .NPower      ( 2    ),
     .Pipeline    ( 1'b1 ),
     .PreDomIndep ( 1'b0 )
-  ) aes_dom_mul_gamma1_gamma0 (
+  ) u_aes_dom_mul_gamma1_gamma0 (
     .clk_i  ( clk_i           ),
     .rst_ni ( rst_ni          ),
     .we_i   ( we_i[0]         ),
@@ -602,7 +602,7 @@ module aes_dom_inverse_gf2p4 (
     .NPower      ( 2    ),
     .Pipeline    ( 1'b1 ),
     .PreDomIndep ( 1'b0 )
-  ) aes_dom_mul_omega_gamma1 (
+  ) u_aes_dom_mul_omega_gamma1 (
     .clk_i  ( clk_i            ),
     .rst_ni ( rst_ni           ),
     .we_i   ( we_i[1]          ),
@@ -620,7 +620,7 @@ module aes_dom_inverse_gf2p4 (
     .NPower      ( 2    ),
     .Pipeline    ( 1'b1 ),
     .PreDomIndep ( 1'b0 )
-  ) aes_dom_mul_omega_gamma0 (
+  ) u_aes_dom_mul_omega_gamma0 (
     .clk_i  ( clk_i            ),
     .rst_ni ( rst_ni           ),
     .we_i   ( we_i[1]          ),
@@ -681,7 +681,7 @@ module aes_dom_inverse_gf2p8 (
     .NPower      ( 4    ),
     .Pipeline    ( 1'b1 ),
     .PreDomIndep ( 1'b0 )
-  ) aes_dom_mul_y1_y0 (
+  ) u_aes_dom_mul_y1_y0 (
     .clk_i  ( clk_i          ),
     .rst_ni ( rst_ni         ),
     .we_i   ( we_i[0]        ),
@@ -705,7 +705,7 @@ module aes_dom_inverse_gf2p8 (
   logic [3:0] a_theta, b_theta;
 
   // a_gamma is masked by b_gamma, a_gamma_inv is masked by b_gamma_inv.
-  aes_dom_inverse_gf2p4 aes_dom_inverse_gf2p4 (
+  aes_dom_inverse_gf2p4 u_aes_dom_inverse_gf2p4 (
     .clk_i       ( clk_i     ),
     .rst_ni      ( rst_ni    ),
     .we_i        ( we_i[2:1] ),
@@ -740,7 +740,7 @@ module aes_dom_inverse_gf2p8 (
   aes_dom_indep_mul_gf2pn #(
     .NPower   ( 4    ),
     .Pipeline ( 1'b1 )
-  ) aes_dom_mul_theta_y1 (
+  ) u_aes_dom_mul_theta_y1 (
     .clk_i  ( clk_i          ),
     .rst_ni ( rst_ni         ),
     .we_i   ( we_i[3]        ),
@@ -756,7 +756,7 @@ module aes_dom_inverse_gf2p8 (
   aes_dom_indep_mul_gf2pn #(
     .NPower   ( 4    ),
     .Pipeline ( 1'b1 )
-  ) aes_dom_mul_theta_y0 (
+  ) u_aes_dom_mul_theta_y0 (
     .clk_i  ( clk_i          ),
     .rst_ni ( rst_ni         ),
     .we_i   ( we_i[3]        ),
@@ -804,7 +804,7 @@ module aes_sbox_dom (
                                                  aes_mvm(mask_i, S2X);
 
   // Do the inversion in normal basis X.
-  aes_dom_inverse_gf2p8 aes_dom_inverse_gf2p8 (
+  aes_dom_inverse_gf2p8 u_aes_dom_inverse_gf2p8 (
     .clk_i   ( clk_i            ),
     .rst_ni  ( rst_ni           ),
     .we_i    ( we               ),

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -24,6 +24,7 @@ filesets:
       - lowrisc:prim:alert
       - lowrisc:prim:subreg
       - lowrisc:prim:cipher
+      - lowrisc:prim:xor2
     files:
       - rtl/prim_clock_gating_sync.sv
       - rtl/prim_esc_pkg.sv

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -17,6 +17,7 @@ filesets:
       - lowrisc:prim:clock_mux2
       - lowrisc:prim:buf
       - lowrisc:prim:flop
+      - lowrisc:prim:flop_en
       - lowrisc:prim:flop_2sync
       - lowrisc:prim:arbiter
       - lowrisc:prim:fifo

--- a/hw/ip/prim/prim_flop_en.core
+++ b/hw/ip/prim/prim_flop_en.core
@@ -3,13 +3,13 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: "lowrisc:prim_xilinx:flop"
-description: "Xilinx flop"
+name: "lowrisc:prim:flop_en"
+description: "Generic enable flop"
 filesets:
-  files_rtl:
-    files:
-      - rtl/prim_xilinx_flop.sv
-    file_type: systemVerilogSource
+  primgen_dep:
+    depend:
+      - lowrisc:prim:prim_pkg
+      - lowrisc:prim:primgen
 
   files_verilator_waiver:
     depend:
@@ -23,6 +23,7 @@ filesets:
       # common waivers
       - lowrisc:lint:common
     files:
+      - lint/prim_flop_en.waiver
     file_type: waiver
 
   files_veriblelint_waiver:
@@ -30,10 +31,18 @@ filesets:
       # common waivers
       - lowrisc:lint:common
 
+generate:
+  impl:
+    generator: primgen
+    parameters:
+      prim_name: flop_en
+
 targets:
   default:
     filesets:
       - tool_verilator   ? (files_verilator_waiver)
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
-      - files_rtl
+      - primgen_dep
+    generate:
+      - impl

--- a/hw/ip/prim/prim_xor2.core
+++ b/hw/ip/prim/prim_xor2.core
@@ -1,0 +1,46 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:xor2"
+description: "Generic 2-input xor"
+filesets:
+  primgen_dep:
+    depend:
+      - lowrisc:prim:prim_pkg
+      - lowrisc:prim:primgen
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+generate:
+  impl:
+    generator: primgen
+    parameters:
+      prim_name: xor2
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - primgen_dep
+    generate:
+      - impl

--- a/hw/ip/prim_generic/prim_generic_flop_en.core
+++ b/hw/ip/prim_generic/prim_generic_flop_en.core
@@ -3,12 +3,12 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: "lowrisc:prim_xilinx:flop"
-description: "Xilinx flop"
+name: "lowrisc:prim_generic:flop_en"
+description: "generic enable flop"
 filesets:
   files_rtl:
     files:
-      - rtl/prim_xilinx_flop.sv
+      - rtl/prim_generic_flop_en.sv
     file_type: systemVerilogSource
 
   files_verilator_waiver:

--- a/hw/ip/prim_generic/prim_generic_xor2.core
+++ b/hw/ip/prim_generic/prim_generic_xor2.core
@@ -1,0 +1,39 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_generic:xor2"
+description: "Generic 2-input xor"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_generic_xor2.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim_generic/rtl/prim_generic_buf.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_buf.sv
@@ -4,11 +4,13 @@
 
 `include "prim_assert.sv"
 
-module prim_generic_buf (
-  input in_i,
-  output logic out_o
+module prim_generic_buf #(
+  parameter int Width = 1
+) (
+  input        [Width-1:0] in_i,
+  output logic [Width-1:0] out_o
 );
 
   assign out_o = in_i;
 
-endmodule : prim_generic_buf
+endmodule

--- a/hw/ip/prim_generic/rtl/prim_generic_flop.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flop.sv
@@ -8,9 +8,9 @@ module prim_generic_flop #(
   parameter int               Width      = 1,
   parameter logic [Width-1:0] ResetValue = 0
 ) (
-  input clk_i,
-  input rst_ni,
-  input [Width-1:0] d_i,
+  input                    clk_i,
+  input                    rst_ni,
+  input        [Width-1:0] d_i,
   output logic [Width-1:0] q_o
 );
 

--- a/hw/ip/prim_generic/rtl/prim_generic_flop.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flop.sv
@@ -4,10 +4,9 @@
 
 `include "prim_assert.sv"
 
-module prim_generic_flop # (
-  parameter int Width      = 1,
-  localparam int WidthSubOne = Width-1,
-  parameter logic [WidthSubOne:0] ResetValue = 0
+module prim_generic_flop #(
+  parameter int               Width      = 1,
+  parameter logic [Width-1:0] ResetValue = 0
 ) (
   input clk_i,
   input rst_ni,
@@ -23,4 +22,4 @@ module prim_generic_flop # (
     end
   end
 
-endmodule // prim_generic_flop
+endmodule

--- a/hw/ip/prim_generic/rtl/prim_generic_flop_2sync.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flop_2sync.sv
@@ -7,11 +7,10 @@
 // for synchronization
 
 module prim_generic_flop_2sync #(
-  parameter int Width       = 16,
-  localparam int WidthSubOne = Width-1, // temp work around #2679
-  parameter logic [WidthSubOne:0] ResetValue = '0
+  parameter int               Width      = 16,
+  parameter logic [Width-1:0] ResetValue = '0
 ) (
-  input                    clk_i,       // receive clock
+  input                    clk_i,
   input                    rst_ni,
   input        [Width-1:0] d_i,
   output logic [Width-1:0] q_o
@@ -38,6 +37,5 @@ module prim_generic_flop_2sync #(
     .d_i(intq),
     .q_o
   );
-
 
 endmodule

--- a/hw/ip/prim_generic/rtl/prim_generic_flop_en.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flop_en.sv
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+module prim_generic_flop_en #(
+  parameter int               Width      = 1,
+  parameter logic [Width-1:0] ResetValue = 0
+) (
+  input clk_i,
+  input rst_ni,
+  input en_i,
+  input [Width-1:0] d_i,
+  output logic [Width-1:0] q_o
+);
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      q_o <= ResetValue;
+    end else if (en_i) begin
+      q_o <= d_i;
+    end
+  end
+
+endmodule

--- a/hw/ip/prim_generic/rtl/prim_generic_flop_en.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flop_en.sv
@@ -8,10 +8,10 @@ module prim_generic_flop_en #(
   parameter int               Width      = 1,
   parameter logic [Width-1:0] ResetValue = 0
 ) (
-  input clk_i,
-  input rst_ni,
-  input en_i,
-  input [Width-1:0] d_i,
+  input                    clk_i,
+  input                    rst_ni,
+  input                    en_i,
+  input        [Width-1:0] d_i,
   output logic [Width-1:0] q_o
 );
 

--- a/hw/ip/prim_generic/rtl/prim_generic_xor2.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_xor2.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+module prim_generic_xor2 #(
+  parameter int Width = 1
+) (
+  input        [Width-1:0] in0_i,
+  input        [Width-1:0] in1_i,
+  output logic [Width-1:0] out_o
+);
+
+  assign out_o = in0_i ^ in1_i;
+
+endmodule

--- a/hw/ip/prim_xilinx/prim_xilinx_flop_en.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_flop_en.core
@@ -3,12 +3,12 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: "lowrisc:prim_xilinx:flop"
-description: "Xilinx flop"
+name: "lowrisc:prim_xilinx:flop_en"
+description: "Xilinx enable flop"
 filesets:
   files_rtl:
     files:
-      - rtl/prim_xilinx_flop.sv
+      - rtl/prim_xilinx_flop_en.sv
     file_type: systemVerilogSource
 
   files_verilator_waiver:

--- a/hw/ip/prim_xilinx/prim_xilinx_xor2.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_xor2.core
@@ -1,0 +1,39 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_xilinx:xor2"
+description: "Xilinx 2-input xor"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_xilinx_xor2.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_buf.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_buf.sv
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-module prim_xilinx_buf (
-  input in_i,
-  (* keep = "true" *) output logic out_o
+module prim_xilinx_buf  #(
+  parameter int Width = 1
+) (
+  input [Width-1:0] in_i,
+  (* keep = "true" *) output logic [Width-1:0] out_o
 );
 
   assign out_o = in_i;
 
-endmodule : prim_xilinx_buf
+endmodule

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_flop.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_flop.sv
@@ -4,10 +4,9 @@
 
 `include "prim_assert.sv"
 
-module prim_xilinx_flop # (
-  parameter int Width      = 1,
-  localparam int WidthSubOne = Width-1,
-  parameter logic [WidthSubOne:0] ResetValue = 0
+module prim_xilinx_flop #(
+  parameter int               Width      = 1,
+  parameter logic [Width-1:0] ResetValue = 0
 ) (
   input clk_i,
   input rst_ni,
@@ -24,4 +23,4 @@ module prim_xilinx_flop # (
     end
   end
 
-endmodule // prim_xilinx_flop
+endmodule

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_flop_en.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_flop_en.sv
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+module prim_xilinx_flop_en #(
+  parameter int               Width      = 1,
+  parameter logic [Width-1:0] ResetValue = 0
+) (
+  input clk_i,
+  input rst_ni,
+  // Prevent Vivado from optimizing this signal away.
+  (* keep = "true" *) input en_i,
+  input [Width-1:0] d_i,
+  // Prevent Vivado from optimizing this signal away.
+  (* keep = "true" *) output logic [Width-1:0] q_o
+);
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      q_o <= ResetValue;
+    end else if (en_i) begin
+      q_o <= d_i;
+    end
+  end
+
+endmodule

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_xor2.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_xor2.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+module prim_xilinx_xor2 #(
+  parameter int Width = 1
+) (
+  input [Width-1:0] in0_i,
+  input [Width-1:0] in1_i,
+  // Prevent Vivado from optimizing this signal away.
+  (* keep = "true" *) output logic [Width-1:0] out_o
+);
+
+  assign out_o = in0_i ^ in1_i;
+
+endmodule


### PR DESCRIPTION
This is related to #4238.

We encapsulate security-related tool-specific synthesis attributes in primitives such that security-critical building blocks can also be safely synthesized with other tools by switching the primitives. This PR is a first step in that direction. To this end, two relevant additions to the primitives are made:
- A width parameter is added to the prim_buf cell. The default is set to one, so this shouldn't affect other designs using this primitive. The reason for adding this parameter is that it is heavily used inside the DOM S-Box. Placing loops around it as we did so far would make the code even harder to read.
- A new enable flip flop primitive is added. So far we just had a regular FF. Having no write enable can be very bad for SCA.

I've verified both functionality and security (formal) of the resulting DOM S-Box. What is left to do:
- [ ] Check FPGA implmentation.
- [x] Do the same for the masked Canright S-Boxes.