### PR TITLE
[dv/otp_ctrl] drive lc_seed_rw_en

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -61,6 +61,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
   // technically we can randomize values here once scb supports
   task automatic init();
     lc_creator_seed_sw_rw_en_i = lc_ctrl_pkg::On;
+    // TODO: check with designer if we will remove this
     lc_seed_hw_rd_en_i         = lc_ctrl_pkg::Off;
     lc_dft_en_i                = lc_ctrl_pkg::Off;
     lc_escalate_en_i           = lc_ctrl_pkg::Off;
@@ -72,6 +73,10 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
 
   task automatic drive_pwr_otp_init(logic val);
     pwr_otp_init_i = val;
+  endtask
+
+  task automatic drive_lc_creator_seed_sw_rw_en_i(lc_ctrl_pkg::lc_tx_e val);
+    lc_creator_seed_sw_rw_en_i = val;
   endtask
 
   task automatic drive_lc_dft_en(lc_ctrl_pkg::lc_tx_e val);

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
@@ -21,4 +21,10 @@ class otp_ctrl_dai_lock_vseq extends otp_ctrl_smoke_vseq;
     super.pre_start();
     is_valid_dai_op = 0;
   endtask
+
+  virtual task dut_init(string reset_kind = "HARD");
+    super.dut_init(reset_kind);
+    if ($urandom_range(0, 1)) cfg.otp_ctrl_vif.drive_lc_creator_seed_sw_rw_en_i(lc_ctrl_pkg::Off);
+  endtask;
+
 endclass


### PR DESCRIPTION
This PR is to cover toggle coverage for lc_seed_rw_en.
This signal can lock secret2 partition's read/write access.

Signed-off-by: Cindy Chen <chencindy@google.com>