### PR TITLE
[pinmux/padring] Wire up the pad attribute WARL behavior modules

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl.hjson
@@ -367,6 +367,9 @@
       swaccess: "rw1c",
       hwaccess: "hwo",
       resval: "0",
+      tags: [ // the value of these regs is determined by the
+              // value on the pins, hence it cannot be predicted.
+              "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         { bits: "0",
 	  name: "cc_sink_det",

--- a/hw/ip/pinmux/pinmux_component.core
+++ b/hw/ip/pinmux/pinmux_component.core
@@ -15,6 +15,7 @@ filesets:
       - lowrisc:prim:lc_dec
       - lowrisc:prim:lc_sync
       - lowrisc:prim:pad_wrapper_pkg
+      - lowrisc:prim:pad_attr
       - lowrisc:ip:jtag_pkg
       - lowrisc:ip:usbdev
       # pinmux_wkup.sv depends on pinmux_reg_pkg.sv

--- a/hw/ip/pinmux/rtl/pinmux.sv
+++ b/hw/ip/pinmux/rtl/pinmux.sv
@@ -121,17 +121,28 @@ module pinmux
   // Connect attributes //
   ////////////////////////
 
-  // TODO(#5221): rework the WARL behavior
   for (genvar k = 0; k < NDioPads; k++) begin : gen_dio_attr
     prim_pad_wrapper_pkg::pad_attr_t warl_mask;
-    assign warl_mask = '0;
+
+    prim_pad_attr #(
+      .PadType(TargetCfg.dio_pad_type[k])
+    ) u_prim_pad_attr (
+      .attr_warl_o(warl_mask)
+    );
+
     assign dio_attr_o[k]            = dio_pad_attr_q[k] & warl_mask;
     assign hw2reg.dio_pad_attr[k].d = dio_pad_attr_q[k] & warl_mask;
   end
 
   for (genvar k = 0; k < NMioPads; k++) begin : gen_mio_attr
     prim_pad_wrapper_pkg::pad_attr_t warl_mask;
-    assign warl_mask = '0;
+
+    prim_pad_attr #(
+      .PadType(TargetCfg.mio_pad_type[k])
+    ) u_prim_pad_attr (
+      .attr_warl_o(warl_mask)
+    );
+
     assign mio_attr_o[k]            = mio_pad_attr_q[k] & warl_mask;
     assign hw2reg.mio_pad_attr[k].d = mio_pad_attr_q[k] & warl_mask;
   end

--- a/hw/ip/pinmux/rtl/pinmux_pkg.sv
+++ b/hw/ip/pinmux/rtl/pinmux_pkg.sv
@@ -5,6 +5,7 @@
 package pinmux_pkg;
 
   import pinmux_reg_pkg::*;
+  import prim_pad_wrapper_pkg::*;
 
   parameter int NumIOs     = NMioPads + NDioPads;
   parameter int NDFTStraps = 2;
@@ -15,21 +16,23 @@ package pinmux_pkg;
   // datastructure below serves this purpose. Note that all the indices below are with respect to
   // the concatenated {DIO, MIO} packed array.
   typedef struct packed {
-    logic              const_sampling; // TODO: check whether this can be eliminated.
-    logic [NumIOs-1:0] tie_offs;       // TODO: check whether this can be eliminated.
-    integer            tck_idx;
-    integer            tms_idx;
-    integer            trst_idx;
-    integer            tdi_idx;
-    integer            tdo_idx;
-    integer            tap_strap0_idx;
-    integer            tap_strap1_idx;
-    integer            dft_strap0_idx;
-    integer            dft_strap1_idx;
-    integer            usb_dp_idx;
-    integer            usb_dn_idx;
-    integer            usb_dp_pullup_idx;
-    integer            usb_dn_pullup_idx;
+    logic                     const_sampling; // TODO: check whether this can be eliminated.
+    logic        [NumIOs-1:0] tie_offs;       // TODO: check whether this can be eliminated.
+    integer                   tck_idx;
+    integer                   tms_idx;
+    integer                   trst_idx;
+    integer                   tdi_idx;
+    integer                   tdo_idx;
+    integer                   tap_strap0_idx;
+    integer                   tap_strap1_idx;
+    integer                   dft_strap0_idx;
+    integer                   dft_strap1_idx;
+    integer                   usb_dp_idx;
+    integer                   usb_dn_idx;
+    integer                   usb_dp_pullup_idx;
+    integer                   usb_dn_pullup_idx;
+    pad_type_e [NDioPads-1:0] dio_pad_type;
+    pad_type_e [NMioPads-1:0] mio_pad_type;
   } target_cfg_t;
 
   parameter target_cfg_t DefaultTargetCfg = '{
@@ -47,7 +50,9 @@ package pinmux_pkg;
     usb_dp_idx:        0,
     usb_dn_idx:        0,
     usb_dp_pullup_idx: 0,
-    usb_dn_pullup_idx: 0
+    usb_dn_pullup_idx: 0,
+    dio_pad_type: {NDioPads{BidirStd}},
+    mio_pad_type: {NMioPads{BidirStd}}
   };
 
   // Wakeup Detector Modes

--- a/hw/ip/prim/prim_pad_attr.core
+++ b/hw/ip/prim/prim_pad_attr.core
@@ -1,0 +1,50 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:pad_attr"
+description: "PAD wrapper attributes"
+filesets:
+  primgen_dep:
+    depend:
+      - lowrisc:prim:prim_pkg
+      - lowrisc:prim:pad_wrapper_pkg
+      - lowrisc:prim:primgen
+
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      # - lint/prim_pad_attr.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+generate:
+  impl:
+    generator: primgen
+    parameters:
+      prim_name: pad_attr
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - primgen_dep
+    generate:
+      - impl

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_pad_attr.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_pad_attr.sv
@@ -38,7 +38,7 @@ module prim_xilinx_pad_attr
       attr_warl_o.invert = 1'b1;
       attr_warl_o.virt_od_en = 1'b1;
     end
-  end else if (PadType == Analog0) begin : gen_analog0_warl
+  end else if (PadType == AnalogIn0) begin : gen_analog0_warl
     // The analog pad type is basically just a feedthrough,
     // and does hence not support any of the attributes.
     always_comb begin : p_attr

--- a/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
+++ b/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
@@ -507,6 +507,9 @@
       swaccess: "rw1c",
       hwaccess: "hwo",
       resval: "0",
+      tags: [ // the value of these regs is determined by the
+              // value on the pins, hence it cannot be predicted.
+              "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         { bits: "0",
 	  name: "combo0_H2L",
@@ -531,6 +534,9 @@
       swaccess: "rw1c",
       hwaccess: "hwo",
       resval: "0",
+      tags: [ // the value of these regs is determined by the
+              // value on the pins, hence it cannot be predicted.
+              "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         { bits: "0",
 	  name: "pwrb_H2L",

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -8196,6 +8196,7 @@
         connection: direct
         pad: SPI_HOST_CLK
         desc: ""
+        attr: BidirStd
       }
       {
         instance: spi_host0
@@ -8203,6 +8204,7 @@
         connection: direct
         pad: SPI_HOST_CS_L
         desc: ""
+        attr: BidirStd
       }
       {
         instance: spi_host0
@@ -8210,6 +8212,7 @@
         connection: direct
         pad: SPI_HOST_D0
         desc: ""
+        attr: BidirStd
       }
       {
         instance: spi_host0
@@ -8217,6 +8220,7 @@
         connection: direct
         pad: SPI_HOST_D1
         desc: ""
+        attr: BidirStd
       }
       {
         instance: spi_host0
@@ -8224,6 +8228,7 @@
         connection: direct
         pad: SPI_HOST_D2
         desc: ""
+        attr: BidirStd
       }
       {
         instance: spi_host0
@@ -8231,6 +8236,7 @@
         connection: direct
         pad: SPI_HOST_D3
         desc: ""
+        attr: BidirStd
       }
       {
         instance: spi_device
@@ -8238,6 +8244,7 @@
         connection: direct
         pad: SPI_DEV_CLK
         desc: ""
+        attr: InputStd
       }
       {
         instance: spi_device
@@ -8245,6 +8252,7 @@
         connection: direct
         pad: SPI_DEV_CS_L
         desc: ""
+        attr: InputStd
       }
       {
         instance: spi_device
@@ -8252,6 +8260,7 @@
         connection: direct
         pad: SPI_DEV_D0
         desc: ""
+        attr: BidirStd
       }
       {
         instance: spi_device
@@ -8259,6 +8268,7 @@
         connection: direct
         pad: SPI_DEV_D1
         desc: ""
+        attr: BidirStd
       }
       {
         instance: spi_device
@@ -8266,6 +8276,7 @@
         connection: direct
         pad: SPI_DEV_D2
         desc: ""
+        attr: BidirStd
       }
       {
         instance: spi_device
@@ -8273,6 +8284,7 @@
         connection: direct
         pad: SPI_DEV_D3
         desc: ""
+        attr: BidirStd
       }
       {
         instance: usbdev
@@ -8280,6 +8292,7 @@
         connection: manual
         pad: ""
         desc: ""
+        attr: BidirTol
       }
       {
         instance: gpio
@@ -8287,6 +8300,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: uart0
@@ -8294,6 +8308,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: uart1
@@ -8301,6 +8316,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: uart2
@@ -8308,6 +8324,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: uart3
@@ -8315,6 +8332,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: i2c0
@@ -8322,6 +8340,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: i2c1
@@ -8329,6 +8348,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: i2c2
@@ -8336,6 +8356,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: pattgen
@@ -8343,6 +8364,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: spi_host1
@@ -8350,6 +8372,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: flash_ctrl
@@ -8357,6 +8380,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: sensor_ctrl_aon
@@ -8364,6 +8388,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: sysrst_ctrl_aon
@@ -8371,6 +8396,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: sysrst_ctrl_aon
@@ -8378,6 +8404,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: sysrst_ctrl_aon
@@ -8385,6 +8412,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: sysrst_ctrl_aon
@@ -8392,6 +8420,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: sysrst_ctrl_aon
@@ -8399,6 +8428,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: sysrst_ctrl_aon
@@ -8406,6 +8436,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: sysrst_ctrl_aon
@@ -8413,6 +8444,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: sysrst_ctrl_aon
@@ -8420,6 +8452,7 @@
         connection: direct
         pad: IOR8
         desc: ""
+        attr: BidirOd
       }
       {
         instance: sysrst_ctrl_aon
@@ -8427,6 +8460,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: sysrst_ctrl_aon
@@ -8434,6 +8468,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: sysrst_ctrl_aon
@@ -8441,6 +8476,7 @@
         connection: muxed
         pad: ""
         desc: ""
+        attr: ""
       }
       {
         instance: sysrst_ctrl_aon
@@ -8448,6 +8484,7 @@
         connection: direct
         pad: IOR9
         desc: ""
+        attr: BidirOd
       }
     ]
     num_wkup_detect: 8
@@ -8460,6 +8497,7 @@
         type: inout
         idx: 0
         pad: SPI_HOST_D0
+        attr: BidirStd
         connection: direct
         glob_idx: 0
       }
@@ -8469,6 +8507,7 @@
         type: inout
         idx: 1
         pad: SPI_HOST_D1
+        attr: BidirStd
         connection: direct
         glob_idx: 1
       }
@@ -8478,6 +8517,7 @@
         type: inout
         idx: 2
         pad: SPI_HOST_D2
+        attr: BidirStd
         connection: direct
         glob_idx: 2
       }
@@ -8487,6 +8527,7 @@
         type: inout
         idx: 3
         pad: SPI_HOST_D3
+        attr: BidirStd
         connection: direct
         glob_idx: 3
       }
@@ -8496,6 +8537,7 @@
         type: inout
         idx: 0
         pad: SPI_DEV_D0
+        attr: BidirStd
         connection: direct
         glob_idx: 4
       }
@@ -8505,6 +8547,7 @@
         type: inout
         idx: 1
         pad: SPI_DEV_D1
+        attr: BidirStd
         connection: direct
         glob_idx: 5
       }
@@ -8514,6 +8557,7 @@
         type: inout
         idx: 2
         pad: SPI_DEV_D2
+        attr: BidirStd
         connection: direct
         glob_idx: 6
       }
@@ -8523,6 +8567,7 @@
         type: inout
         idx: 3
         pad: SPI_DEV_D3
+        attr: BidirStd
         connection: direct
         glob_idx: 7
       }
@@ -8532,6 +8577,7 @@
         type: inout
         idx: -1
         pad: ""
+        attr: BidirTol
         connection: manual
         glob_idx: 8
       }
@@ -8541,6 +8587,7 @@
         type: inout
         idx: -1
         pad: ""
+        attr: BidirTol
         connection: manual
         glob_idx: 9
       }
@@ -8550,6 +8597,7 @@
         type: inout
         idx: -1
         pad: ""
+        attr: BidirTol
         connection: manual
         glob_idx: 10
       }
@@ -8559,6 +8607,7 @@
         type: inout
         idx: 0
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 0
       }
@@ -8568,6 +8617,7 @@
         type: inout
         idx: 1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 1
       }
@@ -8577,6 +8627,7 @@
         type: inout
         idx: 2
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 2
       }
@@ -8586,6 +8637,7 @@
         type: inout
         idx: 3
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 3
       }
@@ -8595,6 +8647,7 @@
         type: inout
         idx: 4
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 4
       }
@@ -8604,6 +8657,7 @@
         type: inout
         idx: 5
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 5
       }
@@ -8613,6 +8667,7 @@
         type: inout
         idx: 6
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 6
       }
@@ -8622,6 +8677,7 @@
         type: inout
         idx: 7
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 7
       }
@@ -8631,6 +8687,7 @@
         type: inout
         idx: 8
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 8
       }
@@ -8640,6 +8697,7 @@
         type: inout
         idx: 9
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 9
       }
@@ -8649,6 +8707,7 @@
         type: inout
         idx: 10
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 10
       }
@@ -8658,6 +8717,7 @@
         type: inout
         idx: 11
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 11
       }
@@ -8667,6 +8727,7 @@
         type: inout
         idx: 12
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 12
       }
@@ -8676,6 +8737,7 @@
         type: inout
         idx: 13
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 13
       }
@@ -8685,6 +8747,7 @@
         type: inout
         idx: 14
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 14
       }
@@ -8694,6 +8757,7 @@
         type: inout
         idx: 15
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 15
       }
@@ -8703,6 +8767,7 @@
         type: inout
         idx: 16
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 16
       }
@@ -8712,6 +8777,7 @@
         type: inout
         idx: 17
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 17
       }
@@ -8721,6 +8787,7 @@
         type: inout
         idx: 18
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 18
       }
@@ -8730,6 +8797,7 @@
         type: inout
         idx: 19
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 19
       }
@@ -8739,6 +8807,7 @@
         type: inout
         idx: 20
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 20
       }
@@ -8748,6 +8817,7 @@
         type: inout
         idx: 21
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 21
       }
@@ -8757,6 +8827,7 @@
         type: inout
         idx: 22
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 22
       }
@@ -8766,6 +8837,7 @@
         type: inout
         idx: 23
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 23
       }
@@ -8775,6 +8847,7 @@
         type: inout
         idx: 24
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 24
       }
@@ -8784,6 +8857,7 @@
         type: inout
         idx: 25
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 25
       }
@@ -8793,6 +8867,7 @@
         type: inout
         idx: 26
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 26
       }
@@ -8802,6 +8877,7 @@
         type: inout
         idx: 27
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 27
       }
@@ -8811,6 +8887,7 @@
         type: inout
         idx: 28
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 28
       }
@@ -8820,6 +8897,7 @@
         type: inout
         idx: 29
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 29
       }
@@ -8829,6 +8907,7 @@
         type: inout
         idx: 30
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 30
       }
@@ -8838,6 +8917,7 @@
         type: inout
         idx: 31
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 31
       }
@@ -8847,6 +8927,7 @@
         type: inout
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 32
       }
@@ -8856,6 +8937,7 @@
         type: inout
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 33
       }
@@ -8865,6 +8947,7 @@
         type: inout
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 34
       }
@@ -8874,6 +8957,7 @@
         type: inout
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 35
       }
@@ -8883,6 +8967,7 @@
         type: inout
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 36
       }
@@ -8892,6 +8977,7 @@
         type: inout
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 37
       }
@@ -8901,6 +8987,7 @@
         type: inout
         idx: 0
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 38
       }
@@ -8910,6 +8997,7 @@
         type: inout
         idx: 1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 39
       }
@@ -8919,6 +9007,7 @@
         type: inout
         idx: 2
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 40
       }
@@ -8928,6 +9017,7 @@
         type: inout
         idx: 3
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 41
       }
@@ -8937,6 +9027,7 @@
         type: input
         idx: -1
         pad: SPI_DEV_CLK
+        attr: InputStd
         connection: direct
         glob_idx: 11
       }
@@ -8946,6 +9037,7 @@
         type: input
         idx: -1
         pad: SPI_DEV_CS_L
+        attr: InputStd
         connection: direct
         glob_idx: 12
       }
@@ -8955,6 +9047,7 @@
         type: input
         idx: -1
         pad: ""
+        attr: BidirTol
         connection: manual
         glob_idx: 13
       }
@@ -8964,6 +9057,7 @@
         type: input
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 42
       }
@@ -8973,6 +9067,7 @@
         type: input
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 43
       }
@@ -8982,6 +9077,7 @@
         type: input
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 44
       }
@@ -8991,6 +9087,7 @@
         type: input
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 45
       }
@@ -9000,6 +9097,7 @@
         type: input
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 46
       }
@@ -9009,6 +9107,7 @@
         type: input
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 47
       }
@@ -9018,6 +9117,7 @@
         type: input
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 48
       }
@@ -9027,6 +9127,7 @@
         type: input
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 49
       }
@@ -9036,6 +9137,7 @@
         type: input
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 50
       }
@@ -9045,6 +9147,7 @@
         type: input
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 51
       }
@@ -9054,6 +9157,7 @@
         type: input
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 52
       }
@@ -9063,6 +9167,7 @@
         type: input
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 53
       }
@@ -9072,6 +9177,7 @@
         type: input
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 54
       }
@@ -9081,6 +9187,7 @@
         type: output
         idx: -1
         pad: SPI_HOST_CLK
+        attr: BidirStd
         connection: direct
         glob_idx: 14
       }
@@ -9090,6 +9197,7 @@
         type: output
         idx: -1
         pad: SPI_HOST_CS_L
+        attr: BidirStd
         connection: direct
         glob_idx: 15
       }
@@ -9099,6 +9207,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: BidirTol
         connection: manual
         glob_idx: 16
       }
@@ -9108,6 +9217,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: BidirTol
         connection: manual
         glob_idx: 17
       }
@@ -9117,6 +9227,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: BidirTol
         connection: manual
         glob_idx: 18
       }
@@ -9126,6 +9237,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: BidirTol
         connection: manual
         glob_idx: 19
       }
@@ -9135,6 +9247,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: BidirTol
         connection: manual
         glob_idx: 20
       }
@@ -9144,6 +9257,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 42
       }
@@ -9153,6 +9267,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 43
       }
@@ -9162,6 +9277,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 44
       }
@@ -9171,6 +9287,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 45
       }
@@ -9180,6 +9297,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 46
       }
@@ -9189,6 +9307,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 47
       }
@@ -9198,6 +9317,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 48
       }
@@ -9207,6 +9327,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 49
       }
@@ -9216,6 +9337,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 50
       }
@@ -9225,6 +9347,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 51
       }
@@ -9234,6 +9357,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 52
       }
@@ -9243,6 +9367,7 @@
         type: output
         idx: 0
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 53
       }
@@ -9252,6 +9377,7 @@
         type: output
         idx: 1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 54
       }
@@ -9261,6 +9387,7 @@
         type: output
         idx: 2
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 55
       }
@@ -9270,6 +9397,7 @@
         type: output
         idx: 3
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 56
       }
@@ -9279,6 +9407,7 @@
         type: output
         idx: 4
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 57
       }
@@ -9288,6 +9417,7 @@
         type: output
         idx: 5
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 58
       }
@@ -9297,6 +9427,7 @@
         type: output
         idx: 6
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 59
       }
@@ -9306,6 +9437,7 @@
         type: output
         idx: 7
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 60
       }
@@ -9315,6 +9447,7 @@
         type: output
         idx: 8
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 61
       }
@@ -9324,6 +9457,7 @@
         type: output
         idx: 9
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 62
       }
@@ -9333,6 +9467,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 63
       }
@@ -9342,6 +9477,7 @@
         type: output
         idx: -1
         pad: IOR8
+        attr: BidirOd
         connection: direct
         glob_idx: 21
       }
@@ -9351,6 +9487,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 64
       }
@@ -9360,6 +9497,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 65
       }
@@ -9369,6 +9507,7 @@
         type: output
         idx: -1
         pad: ""
+        attr: ""
         connection: muxed
         glob_idx: 66
       }
@@ -9378,6 +9517,7 @@
         type: output
         idx: -1
         pad: IOR9
+        attr: BidirOd
         connection: direct
         glob_idx: 22
       }

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -1142,6 +1142,11 @@
     //        This is not required for 'muxed' and 'manual' connections.
     //
     // - desc: Optional description field.
+    //
+    // - attr: Manual direct IOs may specify an additional pad attr field.
+    //         This is used to create the correct pad attribute CSR for that DIO channel (since the
+    //         DIO is manual, there is no way to automatically infer the corresponding pad type).
+    //
     signals: [
       // SPI Host0
       { instance: 'spi_host0',       port: 'sck',          connection: 'direct', pad: 'SPI_HOST_CLK' , desc: ''},
@@ -1158,7 +1163,7 @@
       { instance: 'spi_device',      port: 'sd[2]',        connection: 'direct', pad: 'SPI_DEV_D2'   , desc: ''},
       { instance: 'spi_device',      port: 'sd[3]',        connection: 'direct', pad: 'SPI_DEV_D3'   , desc: ''},
       // USBDEV
-      { instance: 'usbdev',          port: '',             connection: 'manual', pad: ''             , desc: ''},
+      { instance: 'usbdev',          port: '',             connection: 'manual', pad: ''             , desc: '', attr: 'BidirTol'},
       // MIOs
       { instance: "gpio",            port: '',             connection: 'muxed' , pad: ''             , desc: ''},
       { instance: "uart0",           port: '',             connection: 'muxed' , pad: ''             , desc: ''},

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -172,6 +172,15 @@ module tb;
   );
 
   // connect signals
+  // TODO: Replace this weak pull to a known value with initialization
+  // in the agent/interface.
+  // Without these pulls, we may get Xes that propagate through the design
+  // (one example is the interference IRQ of the I2C that propagates into the PLIC).
+  assign (weak0, weak1) jtag_tck = 1'b0;
+  assign (weak0, weak1) jtag_tms = 1'b0;
+  assign (weak0, weak1) jtag_trst_n = 1'b0;
+  assign (weak0, weak1) jtag_tdi = 1'b0;
+  assign (weak0, weak1) jtag_tdo = 1'b0;
   assign jtag_tck         = jtag_if.tck;
   assign jtag_tms         = jtag_if.tms;
   assign jtag_trst_n      = jtag_if.trst_n;

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -124,7 +124,82 @@ module chip_earlgrey_asic (
     usb_dp_idx:        DioUsbdevDp,
     usb_dn_idx:        DioUsbdevDn,
     usb_dp_pullup_idx: DioUsbdevDpPullup,
-    usb_dn_pullup_idx: DioUsbdevDnPullup
+    usb_dn_pullup_idx: DioUsbdevDnPullup,
+    // Pad types for attribute WARL behavior
+    dio_pad_type: {
+      BidirOd, // DIO sysrst_ctrl_aon_pwrb_out
+      BidirOd, // DIO sysrst_ctrl_aon_ec_rst_out_l
+      BidirTol, // DIO usbdev_suspend
+      BidirTol, // DIO usbdev_tx_mode_se
+      BidirTol, // DIO usbdev_dn_pullup
+      BidirTol, // DIO usbdev_dp_pullup
+      BidirTol, // DIO usbdev_se0
+      BidirStd, // DIO spi_host0_csb
+      BidirStd, // DIO spi_host0_sck
+      BidirTol, // DIO usbdev_sense
+      InputStd, // DIO spi_device_csb
+      InputStd, // DIO spi_device_sck
+      BidirTol, // DIO usbdev_dn
+      BidirTol, // DIO usbdev_dp
+      BidirTol, // DIO usbdev_d
+      BidirStd, // DIO spi_device_sd
+      BidirStd, // DIO spi_device_sd
+      BidirStd, // DIO spi_device_sd
+      BidirStd, // DIO spi_device_sd
+      BidirStd, // DIO spi_host0_sd
+      BidirStd, // DIO spi_host0_sd
+      BidirStd, // DIO spi_host0_sd
+      BidirStd  // DIO spi_host0_sd
+    },
+    mio_pad_type: {
+      BidirOd, // MIO Pad 46
+      BidirOd, // MIO Pad 45
+      BidirOd, // MIO Pad 44
+      BidirOd, // MIO Pad 43
+      BidirStd, // MIO Pad 42
+      BidirStd, // MIO Pad 41
+      BidirStd, // MIO Pad 40
+      BidirStd, // MIO Pad 39
+      BidirStd, // MIO Pad 38
+      BidirStd, // MIO Pad 37
+      BidirStd, // MIO Pad 36
+      BidirStd, // MIO Pad 35
+      BidirOd, // MIO Pad 34
+      BidirOd, // MIO Pad 33
+      BidirOd, // MIO Pad 32
+      BidirStd, // MIO Pad 31
+      BidirStd, // MIO Pad 30
+      BidirStd, // MIO Pad 29
+      BidirStd, // MIO Pad 28
+      BidirStd, // MIO Pad 27
+      BidirStd, // MIO Pad 26
+      BidirStd, // MIO Pad 25
+      BidirStd, // MIO Pad 24
+      BidirStd, // MIO Pad 23
+      BidirStd, // MIO Pad 22
+      BidirOd, // MIO Pad 21
+      BidirOd, // MIO Pad 20
+      BidirOd, // MIO Pad 19
+      BidirOd, // MIO Pad 18
+      BidirStd, // MIO Pad 17
+      BidirStd, // MIO Pad 16
+      BidirStd, // MIO Pad 15
+      BidirStd, // MIO Pad 14
+      BidirStd, // MIO Pad 13
+      BidirStd, // MIO Pad 12
+      BidirStd, // MIO Pad 11
+      BidirStd, // MIO Pad 10
+      BidirStd, // MIO Pad 9
+      BidirOd, // MIO Pad 8
+      BidirOd, // MIO Pad 7
+      BidirOd, // MIO Pad 6
+      BidirStd, // MIO Pad 5
+      BidirStd, // MIO Pad 4
+      BidirStd, // MIO Pad 3
+      BidirStd, // MIO Pad 2
+      BidirStd, // MIO Pad 1
+      BidirStd  // MIO Pad 0
+    }
   };
 
   ////////////////////////
@@ -796,17 +871,26 @@ module chip_earlgrey_asic (
   assign manual_out_flash_test_volt = 1'b0;
   assign manual_oe_flash_test_volt = 1'b0;
 
+  assign manual_out_flash_test_mode0 = 1'b0;
+  assign manual_out_flash_test_mode1 = 1'b0;
+  assign manual_oe_flash_test_mode0 = 1'b0;
+  assign manual_oe_flash_test_mode1 = 1'b0;
+
   // These pad attributes currently tied off permanently (these are all input-only pads).
   assign manual_attr_por_n = '0;
   assign manual_attr_cc1 = '0;
   assign manual_attr_cc2 = '0;
   assign manual_attr_flash_test_volt = '0;
+  assign manual_attr_flash_test_mode0 = '0;
+  assign manual_attr_flash_test_mode1 = '0;
 
   logic unused_manual_sigs;
   assign unused_manual_sigs = ^{
     manual_in_cc2,
     manual_in_cc1,
-    manual_in_flash_test_volt
+    manual_in_flash_test_volt,
+    manual_in_flash_test_mode0,
+    manual_in_flash_test_mode1
   };
 
   ///////////////////////////////

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
@@ -111,7 +111,82 @@ module chip_earlgrey_nexysvideo #(
     usb_dp_idx:        DioUsbdevDp,
     usb_dn_idx:        DioUsbdevDn,
     usb_dp_pullup_idx: DioUsbdevDpPullup,
-    usb_dn_pullup_idx: DioUsbdevDnPullup
+    usb_dn_pullup_idx: DioUsbdevDnPullup,
+    // Pad types for attribute WARL behavior
+    dio_pad_type: {
+      BidirOd, // DIO sysrst_ctrl_aon_pwrb_out
+      BidirOd, // DIO sysrst_ctrl_aon_ec_rst_out_l
+      BidirTol, // DIO usbdev_suspend
+      BidirTol, // DIO usbdev_tx_mode_se
+      BidirTol, // DIO usbdev_dn_pullup
+      BidirTol, // DIO usbdev_dp_pullup
+      BidirTol, // DIO usbdev_se0
+      BidirStd, // DIO spi_host0_csb
+      BidirStd, // DIO spi_host0_sck
+      BidirTol, // DIO usbdev_sense
+      InputStd, // DIO spi_device_csb
+      InputStd, // DIO spi_device_sck
+      BidirTol, // DIO usbdev_dn
+      BidirTol, // DIO usbdev_dp
+      BidirTol, // DIO usbdev_d
+      BidirStd, // DIO spi_device_sd
+      BidirStd, // DIO spi_device_sd
+      BidirStd, // DIO spi_device_sd
+      BidirStd, // DIO spi_device_sd
+      BidirStd, // DIO spi_host0_sd
+      BidirStd, // DIO spi_host0_sd
+      BidirStd, // DIO spi_host0_sd
+      BidirStd  // DIO spi_host0_sd
+    },
+    mio_pad_type: {
+      BidirOd, // MIO Pad 46
+      BidirOd, // MIO Pad 45
+      BidirOd, // MIO Pad 44
+      BidirOd, // MIO Pad 43
+      BidirStd, // MIO Pad 42
+      BidirStd, // MIO Pad 41
+      BidirStd, // MIO Pad 40
+      BidirStd, // MIO Pad 39
+      BidirStd, // MIO Pad 38
+      BidirStd, // MIO Pad 37
+      BidirStd, // MIO Pad 36
+      BidirStd, // MIO Pad 35
+      BidirOd, // MIO Pad 34
+      BidirOd, // MIO Pad 33
+      BidirOd, // MIO Pad 32
+      BidirStd, // MIO Pad 31
+      BidirStd, // MIO Pad 30
+      BidirStd, // MIO Pad 29
+      BidirStd, // MIO Pad 28
+      BidirStd, // MIO Pad 27
+      BidirStd, // MIO Pad 26
+      BidirStd, // MIO Pad 25
+      BidirStd, // MIO Pad 24
+      BidirStd, // MIO Pad 23
+      BidirStd, // MIO Pad 22
+      BidirOd, // MIO Pad 21
+      BidirOd, // MIO Pad 20
+      BidirOd, // MIO Pad 19
+      BidirOd, // MIO Pad 18
+      BidirStd, // MIO Pad 17
+      BidirStd, // MIO Pad 16
+      BidirStd, // MIO Pad 15
+      BidirStd, // MIO Pad 14
+      BidirStd, // MIO Pad 13
+      BidirStd, // MIO Pad 12
+      BidirStd, // MIO Pad 11
+      BidirStd, // MIO Pad 10
+      BidirStd, // MIO Pad 9
+      BidirOd, // MIO Pad 8
+      BidirOd, // MIO Pad 7
+      BidirOd, // MIO Pad 6
+      BidirStd, // MIO Pad 5
+      BidirStd, // MIO Pad 4
+      BidirStd, // MIO Pad 3
+      BidirStd, // MIO Pad 2
+      BidirStd, // MIO Pad 1
+      BidirStd  // MIO Pad 0
+    }
   };
 
   ////////////////////////

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -144,7 +144,10 @@ module chip_earlgrey_verilator (
     usb_dp_idx:        DioUsbdevDp,
     usb_dn_idx:        DioUsbdevDn,
     usb_dp_pullup_idx: DioUsbdevDpPullup,
-    usb_dn_pullup_idx: DioUsbdevDnPullup
+    usb_dn_pullup_idx: DioUsbdevDnPullup,
+    // TODO: connect these once the verilator chip-level has been merged with the chiplevel.sv.tpl
+    dio_pad_type: {pinmux_reg_pkg::NDioPads{prim_pad_wrapper_pkg::BidirStd}},
+    mio_pad_type: {pinmux_reg_pkg::NMioPads{prim_pad_wrapper_pkg::BidirStd}}
   };
 
   lc_ctrl_pkg::lc_tx_t lc_clk_bypass;

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -907,6 +907,11 @@
     //        This is not required for 'muxed' and 'manual' connections.
     //
     // - desc: Optional description field.
+    //
+    // - attr: Manual direct IOs may specify an additional pad attr field.
+    //         This is used to create the correct pad attribute CSR for that DIO channel (since the
+    //         DIO is manual, there is no way to automatically infer the corresponding pad type).
+    //
     signals: [
       // SPI Host0
       { instance: 'spi_host0',       port: 'sck',   connection: 'direct', pad: 'SPI_HOST_CLK' , desc: ''},
@@ -923,7 +928,7 @@
       { instance: 'spi_device',      port: 'sd[2]', connection: 'direct', pad: 'SPI_DEV_D2'   , desc: ''},
       { instance: 'spi_device',      port: 'sd[3]', connection: 'direct', pad: 'SPI_DEV_D3'   , desc: ''},
       // USBDEV
-      { instance: 'usbdev',          port: '',      connection: 'manual', pad: ''             , desc: ''},
+      { instance: 'usbdev',          port: '',      connection: 'manual', pad: ''             , desc: '', attr: 'BidirTol'},
       // MIOs
       { instance: "gpio",            port: '',      connection: 'muxed' , pad: ''             , desc: ''},
       { instance: "uart0",           port: '',      connection: 'muxed' , pad: ''             , desc: ''},

--- a/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
+++ b/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
@@ -144,8 +144,12 @@ module chip_englishbreakfast_verilator (
     usb_dp_idx:        DioUsbdevDp,
     usb_dn_idx:        DioUsbdevDn,
     usb_dp_pullup_idx: DioUsbdevDpPullup,
-    usb_dn_pullup_idx: DioUsbdevDnPullup
+    usb_dn_pullup_idx: DioUsbdevDnPullup,
+    // TODO: connect these once the verilator chip-level has been merged with the chiplevel.sv.tpl
+    dio_pad_type: {pinmux_reg_pkg::NDioPads{prim_pad_wrapper_pkg::BidirStd}},
+    mio_pad_type: {pinmux_reg_pkg::NMioPads{prim_pad_wrapper_pkg::BidirStd}}
   };
+
 
   lc_ctrl_pkg::lc_tx_t lc_clk_bypass;
   // Top-level design

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -945,6 +945,7 @@ def amend_pinmux_io(top: Dict, name_to_block: Dict[str, IpBlock]):
             # Augment this signal instance with additional information.
             sig_inst.update({'idx': idx,
                              'pad': sig['pad'],
+                             'attr': sig['attr'],
                              'connection': sig['connection']})
             sig_inst['name'] = mod_name + '_' + sig_inst['name']
             append_io_signal(temp, sig_inst)
@@ -962,12 +963,14 @@ def amend_pinmux_io(top: Dict, name_to_block: Dict[str, IpBlock]):
                         sig_inst_copy = deepcopy(sig_inst)
                         sig_inst_copy.update({'idx': idx,
                                               'pad': sig['pad'],
+                                              'attr': sig['attr'],
                                               'connection': sig['connection']})
                         sig_inst_copy['name'] = sig['instance'] + '_' + sig_inst_copy['name']
                         append_io_signal(temp, sig_inst_copy)
                 else:
                     sig_inst.update({'idx': -1,
                                      'pad': sig['pad'],
+                                     'attr': sig['attr'],
                                      'connection': sig['connection']})
                     sig_inst['name'] = sig['instance'] + '_' + sig_inst['name']
                     append_io_signal(temp, sig_inst)

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -145,7 +145,30 @@ module chip_${top["name"]}_${target["name"]} (
     usb_dp_idx:        DioUsbdevDp,
     usb_dn_idx:        DioUsbdevDn,
     usb_dp_pullup_idx: DioUsbdevDpPullup,
-    usb_dn_pullup_idx: DioUsbdevDnPullup
+    usb_dn_pullup_idx: DioUsbdevDnPullup,
+    // Pad types for attribute WARL behavior
+    dio_pad_type: {
+<%
+  pad_attr = []
+  for sig in list(reversed(top["pinmux"]["ios"])):
+    if sig["connection"] != "muxed":
+      pad_attr.append((sig['name'], sig["attr"]))
+%>\
+% for name, attr in pad_attr:
+      ${attr}${" " if loop.last else ","} // DIO ${name}
+% endfor
+    },
+    mio_pad_type: {
+<%
+  pad_attr = []
+  for pad in list(reversed(pinout["pads"])):
+    if pad["connection"] == "muxed":
+      pad_attr.append(pad["type"])
+%>\
+% for attr in pad_attr:
+      ${attr}${" " if loop.last else ","} // MIO Pad ${len(pad_attr) - loop.index - 1}
+% endfor
+    }
   };
 
   ////////////////////////
@@ -519,17 +542,26 @@ module chip_${top["name"]}_${target["name"]} (
   assign manual_out_flash_test_volt = 1'b0;
   assign manual_oe_flash_test_volt = 1'b0;
 
+  assign manual_out_flash_test_mode0 = 1'b0;
+  assign manual_out_flash_test_mode1 = 1'b0;
+  assign manual_oe_flash_test_mode0 = 1'b0;
+  assign manual_oe_flash_test_mode1 = 1'b0;
+
   // These pad attributes currently tied off permanently (these are all input-only pads).
   assign manual_attr_por_n = '0;
   assign manual_attr_cc1 = '0;
   assign manual_attr_cc2 = '0;
   assign manual_attr_flash_test_volt = '0;
+  assign manual_attr_flash_test_mode0 = '0;
+  assign manual_attr_flash_test_mode1 = '0;
 
   logic unused_manual_sigs;
   assign unused_manual_sigs = ^{
     manual_in_cc2,
     manual_in_cc1,
-    manual_in_flash_test_volt
+    manual_in_flash_test_volt,
+    manual_in_flash_test_mode0,
+    manual_in_flash_test_mode1
   };
 
   ///////////////////////////////


### PR DESCRIPTION
This connects the WARL modules for the pad attribute CSRs in the pinmux. Note that the pad type information has to be passed down as a parameter from the chiplevel where the padring templating is implemented.

Note that the pad / peripheral signal correspondence is different for muxed pads than for dedicated ones.

Muxed peripheral signals first go into the pinmux array, which in turn is connected to an array of muxed pads.
The muxed pad attribute CSRs directly correspond to that array of pads, so figuring out the correct pad type for CSR WARL configuraration purposes is straightforward.

For dedicated peripheral signals, the story is a bit different. In general each **directly connected** peripheral signal can be directly associated with the pad, in which case pad type inference is easy.

However, we do have a couple of **manually connected** dedicated peripheral signals in the system (mostly USB), and the pad type for CSR WARL configuration cannot be automatically inferred in that case.
Hence, we provide that information via an additional flag in the pinmux Hjson configuration.

~~This is dependent on https://github.com/lowRISC/opentitan/pull/6024.~~
