### PR TITLE
[dv] Support multi-ral (part 4)

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -49,6 +49,7 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
       uvm_config_db#(alert_esc_agent_cfg)::set(this, agent_name, "cfg",
           cfg.m_alert_agent_cfg[alert_name]);
       cfg.m_alert_agent_cfg[alert_name].en_cov = cfg.en_cov;
+      // TODO, should be async clk?
       cfg.m_alert_agent_cfg[alert_name].clk_freq_mhz = int'(cfg.clk_freq_mhz);
     end
 

--- a/hw/dv/sv/dv_lib/dv_base_env.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env.sv
@@ -16,17 +16,42 @@ class dv_base_env #(type CFG_T               = dv_base_env_cfg,
   `uvm_component_new
 
   virtual function void build_phase(uvm_phase phase);
+    string default_ral_name;
     super.build_phase(phase);
     // get dv_base_env_cfg object from uvm_config_db
     if (!uvm_config_db#(CFG_T)::get(this, "", "cfg", cfg)) begin
       `uvm_fatal(`gfn, $sformatf("failed to get %s from uvm_config_db", cfg.get_type_name()))
     end
 
-    // get vifs
-    if (!uvm_config_db#(virtual clk_rst_if)::get(this, "", "clk_rst_vif", cfg.clk_rst_vif)) begin
-      `uvm_fatal(get_full_name(), "failed to get clk_rst_if from uvm_config_db")
+    // get vifs for RAL models
+    if (cfg.ral_model_names.size > 0) begin
+      default_ral_name = cfg.ral.get_type_name();
+      foreach (cfg.ral_model_names[i]) begin
+        string ral_name = cfg.ral_model_names[i];
+        string if_name;
+
+        if (ral_name == default_ral_name) if_name = "clk_rst_vif";
+        else                              if_name = {"clk_rst_vif_", ral_name};
+        if (!uvm_config_db#(virtual clk_rst_if)::get(this, "", if_name,
+            cfg.clk_rst_vifs[ral_name])) begin
+          `uvm_fatal(`gfn, $sformatf("failed to get clk_rst_if for %0s from uvm_config_db", ral_name))
+        end
+        cfg.clk_rst_vifs[ral_name].set_freq_mhz(cfg.clk_freqs_mhz[ral_name]);
+      end
+
+      // assign default clk_rst_vif
+      `DV_CHECK_FATAL(cfg.clk_rst_vifs.exists(default_ral_name))
+      cfg.clk_rst_vif = cfg.clk_rst_vifs[default_ral_name];
+    end else begin
+      // no RAL model, get the default clk_rst_vif for the block
+      // such as xbar, it doesn't has ral model, but it also needs a default clk_rst_vif
+      if (!uvm_config_db#(virtual clk_rst_if)::get(this, "", "clk_rst_vif", cfg.clk_rst_vif))
+      begin
+        `uvm_fatal(`gfn, "failed to get clk_rst_if from uvm_config_db")
+      end
+      cfg.clk_rst_vif.set_freq_mhz(cfg.clk_freq_mhz);
     end
-    cfg.clk_rst_vif.set_freq_mhz(cfg.clk_freq_mhz);
+
 
     // create components
     if (cfg.en_cov) begin

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -42,15 +42,18 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   addr_range_t                      mem_ranges[string][$];
 
   // clk_rst_if & freq
+  // clk_rst_vif and clk_freq_mhz are used for default clk/rst. If more than one RAL, the other
+  // clk_rst_vif and clk_freq_mhz can be found from the associative arrays
   virtual clk_rst_if  clk_rst_vif;
+  virtual clk_rst_if  clk_rst_vifs[string];
   rand clk_freq_mhz_e clk_freq_mhz;
+  rand clk_freq_mhz_e clk_freqs_mhz[string];
 
   `uvm_object_param_utils_begin(dv_base_env_cfg #(RAL_T))
     `uvm_field_int   (is_active,                    UVM_DEFAULT)
     `uvm_field_int   (en_scb,                       UVM_DEFAULT)
     `uvm_field_int   (en_cov,                       UVM_DEFAULT)
     `uvm_field_int   (zero_delays,                  UVM_DEFAULT)
-    `uvm_field_enum  (clk_freq_mhz_e, clk_freq_mhz, UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new
@@ -59,11 +62,23 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
     `DV_CHECK_FATAL(is_initialized, "Please invoke initialize() before randomizing this object.")
   endfunction
 
+  function void post_randomize();
+    if (clk_freqs_mhz.size > 0) begin
+      `DV_CHECK_FATAL(clk_freqs_mhz.exists(RAL_T::type_name))
+      clk_freqs_mhz[RAL_T::type_name] = clk_freq_mhz;
+    end
+  endfunction
+
   virtual function void initialize(bit [bus_params_pkg::BUS_AW-1:0] csr_base_addr = '1);
     is_initialized = 1'b1;
 
     // build the ral model
     create_ral_models(csr_base_addr);
+
+    // add items to clk_freqs_mhz before randomizing it
+    foreach (ral_model_names[i]) begin
+      clk_freqs_mhz[ral_model_names[i]] = ClkFreq24Mhz;
+    end
   endfunction
 
   // ral flow is limited in terms of setting correct field access policies and reset values

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -149,7 +149,8 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
-    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
+    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent_flash_ctrl_core_reg_block*", "vif",
+                                       tl_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_eflash_tl_agent*", "vif", eflash_tl_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();


### PR DESCRIPTION
Just realized we should have different clock/rst for different TL
interface.
store multiple tl_vif in `clk_rst_vifs` and keep the default
`clk_rst_vif`

This is probably the final part for multi-ral support, except docs

Signed-off-by: Weicai Yang <weicai@google.com>