### PR TITLE
[dv/otp_ctrl] Add more sequence to stress_all test

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
@@ -23,7 +23,7 @@ class otp_ctrl_common_vseq extends otp_ctrl_base_vseq;
     // Random CSR rw might trigger alert. Some alerts will conintuously be triggered until reset
     // applied, which will cause alert_monitor phase_ready_to_end timeout.
     if (do_apply_reset) begin
-      apply_reset();
+      dut_init();
     end else wait(0); // wait until upper seq resets and kills this seq
 
     // delay to avoid race condition when sending item and checking no item after reset occur

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
@@ -58,13 +58,14 @@ class otp_ctrl_parallel_lc_esc_vseq extends otp_ctrl_dai_errs_vseq;
     // After LC_escalate is On, we trigger the dai_errs_vseq to check interfaces will return
     // default values and the design won't hang.
     otp_ctrl_dai_errs_vseq::body();
+    do_reset_in_seq = 1;
   endtask
 
   virtual task post_start();
     // Use reset to clear lc interrupt error
     if (do_apply_reset) begin
-      apply_reset();
       cfg.otp_ctrl_vif.drive_lc_escalate_en(lc_ctrl_pkg::Off);
+      dut_init();
     end else wait(0); // wait until upper seq resets and kills this seq
 
     // delay to avoid race condition when sending item and checking no item after reset occur

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_req_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_req_vseq.sv
@@ -48,7 +48,7 @@ class otp_ctrl_parallel_lc_req_vseq extends otp_ctrl_parallel_base_vseq;
   virtual task post_start();
     // Use reset to clear lc interrupt error
     if (do_apply_reset) begin
-      apply_reset();
+      dut_init();
     end else wait(0); // wait until upper seq resets and kills this seq
 
     // delay to avoid race condition when sending item and checking no item after reset occur

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_stress_all_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_stress_all_vseq.sv
@@ -3,8 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // combine all otp_ctrl seqs (except below seqs) in one seq to run sequentially
-// Exception: - csr seq, which requires scb to be disabled
-//            - regwen_vseq, which is time sensitive and requires zero delays
+// Exception: - csr seq, which requires scb to be disabled.
+//            - regwen_vseq, which is time sensitive and requires zero delays.
+//            - otp_ctrl_macro_errs_vseq otp_ctrl_check_fail, these two sequences require to write
+//              back to OTP once fatal error is triggered, thus does not handle random reset.
+//            - otp_ctrl_partition_walk_vseq, this sequence assumes OTP initial value is 0.
 class otp_ctrl_stress_all_vseq extends otp_ctrl_base_vseq;
   `uvm_object_utils(otp_ctrl_stress_all_vseq)
 
@@ -22,11 +25,14 @@ class otp_ctrl_stress_all_vseq extends otp_ctrl_base_vseq;
   endtask
 
   task body();
-    // TODO: support more sequences
-    string seq_names[] = {//"otp_ctrl_common_vseq",
+    string seq_names[] = {"otp_ctrl_common_vseq",
                           "otp_ctrl_dai_errs_vseq",
                           "otp_ctrl_dai_lock_vseq",
-                          "otp_ctrl_smoke_vseq"};
+                          "otp_ctrl_smoke_vseq",
+                          "otp_ctrl_test_access_vseq",
+                          // TODO: support this seq:
+                          // "otp_ctrl_parallel_lc_req_vseq",
+                          "otp_ctrl_parallel_key_req_vseq"};
 
     for (int i = 1; i <= num_trans; i++) begin
       uvm_sequence       seq;
@@ -36,13 +42,12 @@ class otp_ctrl_stress_all_vseq extends otp_ctrl_base_vseq;
       seq = create_seq_by_name(seq_names[seq_idx]);
       `downcast(otp_ctrl_vseq, seq)
 
-      // if upper seq disables do_apply_reset for this seq, then can't issue reset
-      // as upper seq may drive reset
-      if (do_apply_reset) begin
-        otp_ctrl_vseq.do_apply_reset = $urandom_range(0, 1);
-      end else begin
-        otp_ctrl_vseq.do_apply_reset = 0;
-      end
+
+      // At the end of each vseq, design might enter terminal Error State, need to reset to
+      // recover. If upper seq disables do_apply_reset for this seq, then can't issue reset
+      // as upper seq may drive reset.
+      if (do_apply_reset) otp_ctrl_vseq.do_apply_reset = 1;
+      else                otp_ctrl_vseq.do_apply_reset = 0;
 
       otp_ctrl_vseq.set_sequencer(p_sequencer);
       `DV_CHECK_RANDOMIZE_FATAL(otp_ctrl_vseq)
@@ -61,24 +66,18 @@ class otp_ctrl_stress_all_vseq extends otp_ctrl_base_vseq;
 
       this.lc_prog_blocking = otp_ctrl_vseq.lc_prog_blocking;
       this.digest_calculated = otp_ctrl_vseq.digest_calculated;
+
+      // This is for otp_ctrl_stress_all_with_rand_reset.
+      // We need to reset for each vseq, but in otp_ctrl_stress_all_with_rand_reset, reset should be
+      // issued in upper seq. So, wait forever until reset is issued and this vseq is killed by
+      // upper seq.
+      if (!do_apply_reset) wait(0);
     end
   endtask : body
 
   virtual task read_and_check_all_csrs_after_reset();
     otp_pwr_init();
     super.read_and_check_all_csrs_after_reset();
-  endtask
-
-  virtual task post_start();
-    // Use reset to clear lc interrupt error
-    if (do_apply_reset) begin
-      apply_reset();
-    end else wait(0); // wait until upper seq resets and kills this seq
-
-    // delay to avoid race condition when sending item and checking no item after reset occur
-    // at the same time
-    #1ps;
-    super.post_start();
   endtask
 
 endclass


### PR DESCRIPTION
This PR adds all sequences to stress_all test.
And a few updates:
1. SCB when read back secret, needs to descramble it first
2. Change post_start from apply_reset to dut_init so it can be used in
stress_all sequence
3. Force to have a reset at the end of each sequence.

Signed-off-by: Cindy Chen <chencindy@google.com>