### PR TITLE
[ spiflash, build ] Explicitly add libftdi1 to dependencies

### DIFF
--- a/sw/host/spiflash/meson.build
+++ b/sw/host/spiflash/meson.build
@@ -13,6 +13,9 @@ spiflash_bin = executable(
   implicit_include_directories: false,
   dependencies: [
     dependency('libcrypto', native: true),
+    # The libftdi1 dependency needs to be explicit to manage
+    # include paths on some systems.
+    dependency('libftdi1', native: true),
     libmpsse
   ],
   native: true,


### PR DESCRIPTION
The application spiflash requires libftdi1 to compile, and to link.  Libftdi1 is a
dependency of libmpsse, and thus it is always included as a link time flag.  However
on systems where libftdi1 is not maintained in the usual system include path, the path
to the libftdi1 include files need to be given at compile time as well.

This commit adds libftdi1 as an explicit dependency so that the proper include paths
get added at the compile stage.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>