### PR TITLE
[WIP][sw, dif_kmac] Add implementation of SHA-3 (blocking only)

### DIFF
--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -4,4 +4,402 @@
 
 #include "sw/device/lib/dif/dif_kmac.h"
 
-// TODO: implement!
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/memory.h"
+
+#include "kmac_regs.h"
+
+/**
+ * Report whether the hardware is currently idle.
+ *
+ * If the hardware is not idle then the `CFG` register is locked.
+ *
+ * @param params Hardware parameters.
+ * @returns Whether the hardware is currently idle or not.
+ */
+static bool is_idle(dif_kmac_params_t params) {
+  uint32_t reg = mmio_region_read32(params.base_addr, KMAC_STATUS_REG_OFFSET);
+  return bitfield_bit32_read(reg, KMAC_STATUS_SHA3_IDLE_BIT);
+}
+
+/**
+ * Report whether the hardware is currently in the absorb state and accepting
+ * writes to the message FIFO.
+ *
+ * Note that writes to the message FIFO may still block if it is full.
+ *
+ * @param params Hardware parameters.
+ * @returns Whether the hardware is currently absorbing or not.
+ */
+static bool is_absorbing(dif_kmac_params_t params) {
+  uint32_t reg = mmio_region_read32(params.base_addr, KMAC_STATUS_REG_OFFSET);
+  return bitfield_bit32_read(reg, KMAC_STATUS_SHA3_ABSORB_BIT);
+}
+
+/**
+ * Wrapper around mmio_region_write32 that reads back the register after
+ * it has been written to verify that it was written successfully.
+ *
+ * @param base_addr Base address.
+ * @param offset Offset of target register.
+ * @param value The value to write to the register.
+ * @returns Whether the register was successfully set to `value`.
+ */
+static bool checked_mmio_region_write32(mmio_region_t base_addr,
+                                        ptrdiff_t offset, uint32_t value) {
+  mmio_region_write32(base_addr, offset, value);
+  return mmio_region_read32(base_addr, offset) == value;
+}
+
+dif_kmac_result_t dif_kmac_init(dif_kmac_params_t params, dif_kmac_t *kmac) {
+  if (kmac == NULL) {
+    return kDifKmacBadArg;
+  }
+
+  // If the hardware is busy then the current operation needs to be stopped
+  // before any configuration can take place.
+  // TODO: force the current operation to stop.
+  if (!is_idle(params)) {
+    return kDifKmacError;
+  }
+  *kmac = (dif_kmac_t){.params = params};
+
+  return kDifKmacOk;
+}
+
+dif_kmac_configure_result_t dif_kmac_configure(dif_kmac_t *kmac,
+                                               dif_kmac_config_t config) {
+  if (kmac == NULL) {
+    return kDifKmacConfigureBadArg;
+  }
+
+  // Entropy mode.
+  uint32_t entropy_mode_value;
+  switch (config.entropy_mode) {
+    case kDifKmacEntropyModeIdle:
+      entropy_mode_value = KMAC_CFG_ENTROPY_MODE_VALUE_IDLE_MODE;
+      break;
+    case kDifKmacEntropyModeEdn:
+      entropy_mode_value = KMAC_CFG_ENTROPY_MODE_VALUE_EDN_MODE;
+      break;
+    case kDifKmacEntropyModeSoftware:
+      entropy_mode_value = KMAC_CFG_ENTROPY_MODE_VALUE_SW_MODE;
+      break;
+    default:
+      return kDifKmacConfigureBadArg;
+  }
+
+  // Entropy fast process bit.
+  bool entropy_fast_process;
+  switch (config.entropy_fast_process) {
+    case kDifKmacToggleEnabled:
+      entropy_fast_process = true;
+      break;
+    case kDifKmacToggleDisabled:
+      entropy_fast_process = false;
+      break;
+    default:
+      return kDifKmacConfigureBadArg;
+  }
+
+  // Message endianness bit.
+  bool msg_big_endian;
+  switch (config.message_endianness) {
+    case kDifKmacEndiannessLittle:
+      msg_big_endian = false;
+      break;
+    case kDifKmacEndiannessBig:
+      msg_big_endian = true;
+      break;
+    default:
+      return kDifKmacConfigureBadArg;
+  }
+
+  // State endianness bit.
+  bool state_big_endian;
+  switch (config.output_state_endianness) {
+    case kDifKmacEndiannessLittle:
+      state_big_endian = false;
+      break;
+    case kDifKmacEndiannessBig:
+      state_big_endian = true;
+      break;
+    default:
+      return kDifKmacConfigureBadArg;
+  }
+
+  // Check that the hardware is in an idle state.
+  if (!is_idle(kmac->params)) {
+    return kDifKmacConfigureError;
+  }
+
+  // Write configuration register.
+  uint32_t cfg_reg = 0;
+  cfg_reg = bitfield_bit32_write(cfg_reg, KMAC_CFG_MSG_ENDIANNESS_BIT,
+                                 msg_big_endian);
+  cfg_reg = bitfield_bit32_write(cfg_reg, KMAC_CFG_STATE_ENDIANNESS_BIT,
+                                 state_big_endian);
+  cfg_reg = bitfield_field32_write(cfg_reg, KMAC_CFG_ENTROPY_MODE_FIELD,
+                                   entropy_mode_value);
+  cfg_reg = bitfield_bit32_write(cfg_reg, KMAC_CFG_ENTROPY_FAST_PROCESS_BIT,
+                                 entropy_fast_process);
+  if (!checked_mmio_region_write32(kmac->params.base_addr, KMAC_CFG_REG_OFFSET,
+                                   cfg_reg)) {
+    // Write to configuration register failed.
+    return kDifKmacConfigureError;
+  }
+
+  // Write entropy period register.
+  uint32_t entropy_period_reg = 0;
+  entropy_period_reg = bitfield_field32_write(
+      entropy_period_reg, KMAC_ENTROPY_PERIOD_ENTROPY_TIMER_FIELD,
+      config.entropy_reseed_interval);
+  entropy_period_reg = bitfield_field32_write(
+      entropy_period_reg, KMAC_ENTROPY_PERIOD_WAIT_TIMER_FIELD,
+      config.entropy_wait_timer);
+  if (!checked_mmio_region_write32(kmac->params.base_addr,
+                                   KMAC_ENTROPY_PERIOD_REG_OFFSET,
+                                   entropy_period_reg)) {
+    // Write to entropy period register failed.
+    return kDifKmacConfigureError;
+  }
+
+  // Write entropy seed registers.
+  if (!checked_mmio_region_write32(kmac->params.base_addr,
+                                   KMAC_ENTROPY_SEED_LOWER_REG_OFFSET,
+                                   (uint32_t)(config.entropy_seed))) {
+    // Write to lower entropy seed register failed.
+    return kDifKmacConfigureError;
+  }
+  if (!checked_mmio_region_write32(kmac->params.base_addr,
+                                   KMAC_ENTROPY_SEED_UPPER_REG_OFFSET,
+                                   (uint32_t)(config.entropy_seed >> 32))) {
+    // Write to upper entropy seed register failed.
+    return kDifKmacConfigureError;
+  }
+
+  return kDifKmacConfigureOk;
+}
+
+dif_kmac_configure_result_t dif_kmac_mode_sha3_start(
+    dif_kmac_t *kmac, dif_kmac_mode_sha3_t mode) {
+  if (kmac == NULL) {
+    return kDifKmacConfigureBadArg;
+  }
+
+  uint32_t kstrength;
+  switch (mode) {
+    case kDifKmacModeSha3Len224:
+      kstrength = KMAC_CFG_KSTRENGTH_VALUE_L224;
+      kmac->offset = 0;
+      kmac->r = 1152 / 8;
+      kmac->d = 224 / 8;
+      break;
+    case kDifKmacModeSha3Len256:
+      kstrength = KMAC_CFG_KSTRENGTH_VALUE_L256;
+      kmac->offset = 0;
+      kmac->r = 1088 / 8;
+      kmac->d = 256 / 8;
+      break;
+    case kDifKmacModeSha3Len384:
+      kstrength = KMAC_CFG_KSTRENGTH_VALUE_L384;
+      kmac->offset = 0;
+      kmac->r = 832 / 8;
+      kmac->d = 384 / 8;
+      break;
+    case kDifKmacModeSha3Len512:
+      kstrength = KMAC_CFG_KSTRENGTH_VALUE_L512;
+      kmac->offset = 0;
+      kmac->r = 576 / 8;
+      kmac->d = 512 / 8;
+      break;
+    default:
+      return kDifKmacConfigureBadArg;
+  }
+
+  // Hardware must be idle to start an operation.
+  if (!is_idle(kmac->params)) {
+    return kDifKmacConfigureError;
+  }
+
+  // Configure SHA-3 mode with the given strength.
+  uint32_t cfg_reg =
+      mmio_region_read32(kmac->params.base_addr, KMAC_CFG_REG_OFFSET);
+  cfg_reg =
+      bitfield_field32_write(cfg_reg, KMAC_CFG_KSTRENGTH_FIELD, kstrength);
+  cfg_reg = bitfield_field32_write(cfg_reg, KMAC_CFG_MODE_FIELD,
+                                   KMAC_CFG_MODE_VALUE_SHA3);
+  if (!checked_mmio_region_write32(kmac->params.base_addr, KMAC_CFG_REG_OFFSET,
+                                   cfg_reg)) {
+    // Write to configuration register failed.
+    return kDifKmacConfigureError;
+  }
+
+  // Issue start command.
+  uint32_t cmd_reg =
+      bitfield_field32_write(0, KMAC_CMD_CMD_FIELD, KMAC_CMD_CMD_VALUE_START);
+  mmio_region_write32(kmac->params.base_addr, KMAC_CMD_REG_OFFSET, cmd_reg);
+
+  // Poll until the status register is in the 'absorbing' state.
+  // TODO: is this loop necessary?
+  while (true) {
+    if (is_absorbing(kmac->params)) {
+      break;
+    }
+    // TODO: check for error?
+  }
+
+  return kDifKmacConfigureOk;
+}
+
+dif_kmac_absorb_result_t dif_kmac_absorb(dif_kmac_t *kmac, const void *msg,
+                                         size_t len, size_t *processed) {
+  if (kmac == NULL || (msg == NULL && len != 0)) {
+    return kDifKmacAbsorbBadArg;
+  }
+
+  // Check that the status register is in the 'absorbing' state.
+  if (!is_absorbing(kmac->params)) {
+    return kDifKmacAbsorbError;
+  }
+
+  // TODO: implement non-blocking version using `processed`.
+  // TODO: copy message using word-sized loads/stores (message endianness?).
+
+  for (size_t i = 0; i < len; ++i) {
+    mmio_region_write8(kmac->params.base_addr, KMAC_MSG_FIFO_REG_OFFSET,
+                       ((const uint8_t *)msg)[i]);
+  }
+
+  if (processed != NULL) {
+    *processed = len;
+  }
+  return kDifKmacAbsorbOk;
+}
+
+dif_kmac_squeeze_result_t dif_kmac_squeeze(dif_kmac_t *kmac, void *out,
+                                           size_t len, size_t *processed) {
+  if (kmac == NULL || (out == NULL && len != 0)) {
+    return kDifKmacSqueezeBadArg;
+  }
+
+  // TODO: implement non-blocking version using `processed`.
+
+  // Set `processed` to 0 so we can return early without setting it again.
+  if (processed != NULL) {
+    *processed = 0;
+  }
+
+  // Move into squeezing state (if not already in it).
+  // Do this even if the length requested is 0 or too big.
+  if (!kmac->squeezing) {
+    kmac->squeezing = true;
+
+    // Issue squeeze command.
+    uint32_t cmd_reg = bitfield_field32_write(0, KMAC_CMD_CMD_FIELD,
+                                              KMAC_CMD_CMD_VALUE_PROCESS);
+    mmio_region_write32(kmac->params.base_addr, KMAC_CMD_REG_OFFSET, cmd_reg);
+  }
+
+  // If the operation has a fixed length output then the total number of bytes
+  // requested must not exceed that length.
+  if (kmac->d != 0 && len > (kmac->d - kmac->offset)) {
+    return kDifKmacSqueezeFixedLengthExceeded;
+  }
+
+  if (len == 0) {
+    // TODO: XOF: request more state if needed to support async use case?
+    return kDifKmacSqueezeOk;
+  }
+
+  // Poll the status register until in the 'squeeze' state.
+  // TODO: poll only once if processed != NULL.
+  while (true) {
+    uint32_t status_reg =
+        mmio_region_read32(kmac->params.base_addr, KMAC_STATUS_REG_OFFSET);
+    if (bitfield_bit32_read(status_reg, KMAC_STATUS_SHA3_SQUEEZE_BIT)) {
+      break;
+    }
+  }
+
+  // Read out the state shares.
+  // TODO: figure out what big-endian digest should mean for sub-word reads.
+  while (len > 0) {
+    size_t n = len;
+    size_t remaining = (kmac->d == 0 ? kmac->r : kmac->d) - kmac->offset;
+    if (n > remaining) {
+      n = remaining;
+    }
+    if (n == 0) {
+      // TODO: XOF: request more state.
+      return kDifKmacSqueezeError;
+    }
+
+    // Copy two shares of state out of state registers.
+    // TODO: only copy the values we need.
+    uint32_t state0[168];
+    mmio_region_memcpy_from_mmio32(kmac->params.base_addr,
+                                   KMAC_STATE_REG_OFFSET, state0,
+                                   ARRAYSIZE(state0));
+    uint32_t state1[168];
+    mmio_region_memcpy_from_mmio32(kmac->params.base_addr,
+                                   KMAC_STATE_REG_OFFSET + 0x100, state1,
+                                   ARRAYSIZE(state1));
+
+    // Combine the two shares of state using XOR.
+    for (uint32_t i = 0; i < ARRAYSIZE(state0); ++i) {
+      state0[i] ^= state1[i];
+    }
+
+    // Copy the combined state into the destination array.
+    const uint8_t *src = (const uint8_t *)state0;
+    memcpy(out, &src[kmac->offset], n);
+    kmac->offset += n;
+    len -= n;
+    if (processed != NULL) {
+      *processed += n;
+    }
+  }
+  return kDifKmacSqueezeOk;
+}
+
+dif_kmac_result_t dif_kmac_end(dif_kmac_t *kmac) {
+  if (kmac == NULL) {
+    return kDifKmacBadArg;
+  }
+
+  // The hardware should (must?) complete squeeze operation before the DONE
+  // command is issued.
+  if (!kmac->squeezing) {
+    return kDifKmacError;
+  }
+  while (true) {
+    uint32_t status_reg =
+        mmio_region_read32(kmac->params.base_addr, KMAC_STATUS_REG_OFFSET);
+    if (bitfield_bit32_read(status_reg, KMAC_STATUS_SHA3_SQUEEZE_BIT)) {
+      break;
+    }
+    // TODO: check error?
+  }
+
+  // Issue done command.
+  uint32_t cmd_reg =
+      bitfield_field32_write(0, KMAC_CMD_CMD_FIELD, KMAC_CMD_CMD_VALUE_DONE);
+  mmio_region_write32(kmac->params.base_addr, KMAC_CMD_REG_OFFSET, cmd_reg);
+
+  // Reset state.
+  kmac->squeezing = false;
+  kmac->offset = 0;
+  kmac->r = 0;
+  kmac->d = 0;
+
+  // Poll status register until in idle state.
+  while (true) {
+    if (is_idle(kmac->params)) {
+      break;
+    }
+    // TODO: check error?
+  }
+
+  return kDifKmacOk;
+}

--- a/sw/device/lib/dif/dif_kmac.h
+++ b/sw/device/lib/dif/dif_kmac.h
@@ -179,7 +179,28 @@ typedef struct dif_kmac_config {
 typedef struct dif_kmac {
   dif_kmac_params_t params;
 
-  // TODO: counters and offsets to support streaming APIs.
+  /**
+   * Whether the 'squeezing' phase has been started.
+   */
+  bool squeezing;
+
+  /**
+   * Offset into the output state.
+   */
+  size_t offset;
+
+  /**
+   * The rate (r).
+   */
+  size_t r;
+
+  /**
+   * The output length (d).
+   *
+   * If the output length is not fixed then this field should be set to 0.
+   */
+  size_t d;
+
 } dif_kmac_t;
 
 /**
@@ -650,8 +671,8 @@ typedef enum dif_kmac_absorb_result {
  * @preturn The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
-dif_kmac_result_t dif_kmac_absorb(dif_kmac_t *kmac, const void *msg, size_t len,
-                                  size_t *processed);
+dif_kmac_absorb_result_t dif_kmac_absorb(dif_kmac_t *kmac, const void *msg,
+                                         size_t len, size_t *processed);
 
 /**
  * The result of an squeeze operation.
@@ -699,6 +720,9 @@ typedef enum dif_kmac_squeeze_result {
  * If `processed` is not provided then this function will block until `len`
  * bytes have been written to `out` or an error occurs.
  *
+ * Issuing squeeze with a `len` of 0 will trigger the 'process' command without
+ * blocking.
+ *
  * @param kmac A KMAC handle.
  * @param[out] out Pointer to output buffer.
  * @param[out] len Number of bytes to write to output buffer.
@@ -706,8 +730,8 @@ typedef enum dif_kmac_squeeze_result {
  * @preturn The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
-dif_kmac_result_t dif_kmac_squeeze(dif_kmac_t *kmac, void *out, size_t len,
-                                   size_t *processed);
+dif_kmac_squeeze_result_t dif_kmac_squeeze(dif_kmac_t *kmac, void *out,
+                                           size_t len, size_t *processed);
 
 /**
  * Ends a squeeze operation and resets the hardware so it is ready for a new

--- a/sw/device/tests/dif/dif_kmac_smoketest.c
+++ b/sw/device/tests/dif/dif_kmac_smoketest.c
@@ -1,0 +1,139 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_kmac.h"
+#include "sw/device/lib/flash_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/test_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+const test_config_t kTestConfig;
+
+/**
+ * Digest lengths in bytes.
+ */
+#define DIGEST_LEN_SHA3_224 (224 / 8)
+#define DIGEST_LEN_SHA3_256 (256 / 8)
+#define DIGEST_LEN_SHA3_384 (384 / 8)
+#define DIGEST_LEN_SHA3_512 (512 / 8)
+#define DIGEST_LEN_SHA3_MAX DIGEST_LEN_SHA3_512
+
+/**
+ * SHA-3 test description.
+ */
+typedef struct sha3_test {
+  dif_kmac_mode_sha3_t mode;
+
+  const char *message;
+  size_t message_len;
+
+  const char *digest;
+  size_t digest_len;
+} sha3_test_t;
+
+/**
+ * SHA-3 tests.
+ */
+const sha3_test_t sha3_tests[] = {
+    // Examples taken from NIST FIPS-202 Algorithm Test Vectors:
+    // https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/sha3/sha-3bytetestvectors.zip
+    {
+        .mode = kDifKmacModeSha3Len224,
+        .message = NULL,
+        .message_len = 0,
+        .digest = "\x6b\x4e\x03\x42\x36\x67\xdb\xb7\x3b\x6e\x15\x45\x4f\x0e\xb1"
+                  "\xab\xd4\x59\x7f\x9a\x1b\x07\x8e\x3f\x5b\x5a\x6b\xc7",
+        .digest_len = DIGEST_LEN_SHA3_224,
+    },
+    {
+        .mode = kDifKmacModeSha3Len256,
+        .message = "\xe7\x37\x21\x05",
+        .message_len = 4,
+        .digest =
+            "\x3a\x42\xb6\x8a\xb0\x79\xf2\x8c\x4c\xa3\xc7\x52\x29\x6f\x27\x90"
+            "\x06\xc4\xfe\x78\xb1\xeb\x79\xd9\x89\x77\x7f\x05\x1e\x40\x46\xae",
+        .digest_len = DIGEST_LEN_SHA3_256,
+    },
+    {
+        .mode = kDifKmacModeSha3Len384,
+        .message = "\xa7\x48\x47\x93\x0a\x03\xab\xee\xa4\x73\xe1\xf3\xdc\x30"
+                   "\xb8\x88\x15",
+        .message_len = 17,
+        .digest =
+            "\xdb\xa6\xf9\x29\xfe\x55\xf9\xd6\x6c\x5f\x67\xc0\xaf\x3b\x82\xf1"
+            "\x7b\xcf\x58\xb3\x67\x52\xf3\x16\x5c\x16\x08\x3f\xea\x8f\xd4\x78"
+            "\xee\x69\x03\xf2\x7f\x82\x0a\xd2\xdd\x99\x50\xaf\xb4\x8c\x67\x00",
+        .digest_len = DIGEST_LEN_SHA3_384,
+    },
+    {
+        .mode = kDifKmacModeSha3Len512,
+        .message =
+            "\x66\x4e\xf2\xe3\xa7\x05\x9d\xaf\x1c\x58\xca\xf5\x20\x08\xc5\x22"
+            "\x7e\x85\xcd\xcb\x83\xb4\xc5\x94\x57\xf0\x2c\x50\x8d\x4f\x4f\x69"
+            "\xf8\x26\xbd\x82\xc0\xcf\xfc\x5c\xb6\xa9\x7a\xf6\xe5\x61\xc6\xf9"
+            "\x69\x70\x00\x52\x85\xe5\x8f\x21\xef\x65\x11\xd2\x6e\x70\x98\x89"
+            "\xa7\xe5\x13\xc4\x34\xc9\x0a\x3c\xf7\x44\x8f\x0c\xae\xec\x71\x14"
+            "\xc7\x47\xb2\xa0\x75\x8a\x3b\x45\x03\xa7\xcf\x0c\x69\x87\x3e\xd3"
+            "\x1d\x94\xdb\xef\x2b\x7b\x2f\x16\x88\x30\xef\x7d\xa3\x32\x2c\x3d"
+            "\x3e\x10\xca\xfb\x7c\x2c\x33\xc8\x3b\xbf\x4c\x46\xa3\x1d\xa9\x0c"
+            "\xff\x3b\xfd\x4c\xcc\x6e\xd4\xb3\x10\x75\x84\x91\xee\xba\x60\x3a"
+            "\x76",
+        .message_len = 145,
+        .digest =
+            "\xe5\x82\x5f\xf1\xa3\xc0\x70\xd5\xa5\x2f\xbb\xe7\x11\x85\x4a\x44"
+            "\x05\x54\x29\x5f\xfb\x7a\x79\x69\xa1\x79\x08\xd1\x01\x63\xbf\xbe"
+            "\x8f\x1d\x52\xa6\x76\xe8\xa0\x13\x7b\x56\xa1\x1c\xdf\x0f\xfb\xb4"
+            "\x56\xbc\x89\x9f\xc7\x27\xd1\x4b\xd8\x88\x22\x32\x54\x9d\x91\x4e",
+        .digest_len = DIGEST_LEN_SHA3_512,
+    },
+};
+
+bool test_main() {
+  LOG_INFO("Running KMAC DIF test...");
+
+  // Intialize KMAC hardware.
+  dif_kmac_t kmac;
+  CHECK(dif_kmac_init((dif_kmac_params_t){.base_addr = mmio_region_from_addr(
+                                              TOP_EARLGREY_KMAC_BASE_ADDR)},
+                      &kmac) == kDifKmacOk);
+
+  // Configure KMAC hardware using software entropy.
+  dif_kmac_config_t config = (dif_kmac_config_t){
+      .entropy_mode = kDifKmacEntropyModeSoftware,
+      .entropy_seed = 0xffff,
+      .entropy_fast_process = kDifKmacToggleEnabled,
+      .message_endianness = kDifKmacEndiannessLittle,
+      .output_state_endianness = kDifKmacEndiannessLittle,
+  };
+  CHECK(dif_kmac_configure(&kmac, config) == kDifKmacConfigureOk);
+
+  // Run SHA-3 test cases using blocking absorb/squeeze operations.
+  for (int i = 0; i < ARRAYSIZE(sha3_tests); ++i) {
+    sha3_test_t test = sha3_tests[i];
+
+    CHECK(dif_kmac_mode_sha3_start(&kmac, test.mode) == kDifKmacConfigureOk);
+    if (test.message_len > 0) {
+      CHECK(dif_kmac_absorb(&kmac, test.message, test.message_len, NULL) ==
+            kDifKmacAbsorbOk);
+    }
+    uint8_t out[DIGEST_LEN_SHA3_MAX];
+    CHECK(DIGEST_LEN_SHA3_MAX >= test.digest_len);
+    CHECK(dif_kmac_squeeze(&kmac, out, test.digest_len, NULL) ==
+          kDifKmacSqueezeOk);
+    CHECK(dif_kmac_end(&kmac) == kDifKmacOk);
+
+    for (int j = 0; j < test.digest_len; ++j) {
+      CHECK(out[j] == test.digest[j],
+            "test %d: mismatch at %d got=0x%x want=0x%x", i, j, out[j],
+            test.digest[j]);
+    }
+  }
+
+  return true;
+}

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -370,6 +370,24 @@ sw_tests += {
   }
 }
 
+dif_kmac_smoketest_lib = declare_dependency(
+  link_with: static_library(
+    'dif_kmac_smoketest_lib',
+    sources: ['dif_kmac_smoketest.c'],
+    dependencies: [
+      sw_lib_dif_kmac,
+      sw_lib_runtime_log,
+      sw_lib_mmio,
+      sw_lib_runtime_hart,
+    ],
+  ),
+)
+sw_tests += {
+  'dif_kmac_smoketest': {
+    'library': dif_kmac_smoketest_lib,
+  }
+}
+
 dif_rstmgr_smoketest_lib = declare_dependency(
   link_with: static_library(
     'dif_rstmgr_smoketest_lib',

--- a/test/systemtest/config.py
+++ b/test/systemtest/config.py
@@ -81,6 +81,9 @@ TEST_APPS_SELFCHECKING = [
     #    "targets": ["sim_verilator"],
     #},
     {
+        "name": "dif_kmac_smoketest",
+    },
+    {
         "name": "flash_ctrl_test",
     },
     {


### PR DESCRIPTION
Add support for SHA-3 operations to the KMAC DIF. These operations
do not support returning partial results (i.e. they block until the
operation is complete). Support for non-blocking operations will be
added in a future PR.

Note that some aspects of the implementation will need to be
modified when support for XOF operations, such as SHAKE, are added.
I have marked these with 'TODO: XOF:' for now.

Signed-off-by: Michael Munday <mike.munday@lowrisc.org>