### PR TITLE
[dv/otp_ctrl] Add background check

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -60,7 +60,7 @@
       tests: ["otp_ctrl_partition_walk"]
     }
     {
-      name: partition_check_failure
+      name: partition_check
       desc: '''
             Randomly program partition check related registers including: `check_timeout`,
             `integrity_check_period`, `consistency_check_period`, and `check_trigger`.
@@ -68,9 +68,11 @@
 
             - Check if the corresponding alerts are triggered
             - Check if the error_code register is set correctly
+            Note that due to limited simulation time, for background checks, this test only write
+            random value that is less than 'd20 to the check period.
             '''
       milestone: V2
-      tests: ["otp_ctrl_check_fail"]
+      tests: ["otp_ctrl_check_fail", "otp_ctrl_background_chks"]
     }
     {
       name: init_fail

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -29,6 +29,7 @@ filesets:
       - seq_lib/otp_ctrl_dai_lock_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_dai_errs_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_macro_errs_vseq.sv: {is_include_file: true}
+      - seq_lib/otp_ctrl_background_chks_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_check_fail_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_parallel_base_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_regwen_vseq.sv: {is_include_file: true}

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_background_chks_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_background_chks_vseq.sv
@@ -1,0 +1,72 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This simple sequence checks if the background check can be triggered once the period is set.
+
+class otp_ctrl_background_chks_vseq extends otp_ctrl_dai_errs_vseq;
+  `uvm_object_utils(otp_ctrl_background_chks_vseq)
+
+  `uvm_object_new
+
+  rand bit [1:0] trigger_chks;
+  rand uint      check_period;
+
+  constraint regwens_c {check_regwen_val == 1;}
+
+  // At least one check will be triggered
+  constraint check_triggers_c {trigger_chks > 0;}
+
+  constraint check_period_c {
+    check_period < 20;
+    check_period > 0;
+  }
+
+  task body();
+    int check_wait_cycles;
+    super.body();
+
+    // Write background check
+    if (trigger_chks[0]) csr_wr(ral.integrity_check_period,   check_period);
+    if (trigger_chks[1]) csr_wr(ral.consistency_check_period, check_period);
+
+    cfg.en_scb = 0;
+    // According to spec, check period will append an 'hFF from the LSF. Add 10 cycle buffers for
+    // register updates.
+    check_wait_cycles = (check_period + 1) << 8 + 10;
+
+    // Wait for first check done
+    repeat($countones(trigger_chks)) begin
+      csr_spinwait(.ptr(ral.status.check_pending), .exp_data(1),
+                   .timeout_ns(cfg.clk_rst_vif.clk_period_ps / 1000 * check_wait_cycles));
+
+      csr_spinwait(.ptr(ral.status.check_pending), .exp_data(0));
+    end
+
+    // Configure timeout settings to trigger check error
+    csr_wr(ral.check_timeout, $urandom_range(1, 5));
+
+    // Wait for fatal alert
+    `DV_SPINWAIT_EXIT(wait(cfg.m_alert_agent_cfg["fatal_check_error"].vif.alert_tx_final.alert_p);,
+                      cfg.clk_rst_vif.wait_clks(check_wait_cycles);,
+                      $sformatf("Timeout waiting for alert %0s", "fatal_check_error"))
+    check_fatal_alert_nonblocking("fatal_check_error");
+
+    cfg.clk_rst_vif.wait_clks($urandom_range(50, 1000));
+    csr_rd_check(.ptr(ral.status.timeout_error), .compare_value(1));
+    csr_rd_check(.ptr(ral.status.dai_idle),      .compare_value(1));
+  endtask
+
+  virtual task post_start();
+    // Use reset to clear lc interrupt error
+    if (do_apply_reset) begin
+      dut_init();
+    end else wait(0); // wait until upper seq resets and kills this seq
+
+    // delay to avoid race condition when sending item and checking no item after reset occur
+    // at the same time
+    #1ps;
+    cfg.en_scb = 1;
+    super.post_start();
+  endtask
+endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_stress_all_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_stress_all_vseq.sv
@@ -30,6 +30,7 @@ class otp_ctrl_stress_all_vseq extends otp_ctrl_base_vseq;
                           "otp_ctrl_dai_lock_vseq",
                           "otp_ctrl_smoke_vseq",
                           "otp_ctrl_test_access_vseq",
+                          "otp_ctrl_background_chks_vseq",
                           // TODO: support this seq:
                           // "otp_ctrl_parallel_lc_req_vseq",
                           "otp_ctrl_parallel_key_req_vseq"};

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
@@ -11,6 +11,7 @@
 `include "otp_ctrl_dai_lock_vseq.sv"
 `include "otp_ctrl_dai_errs_vseq.sv"
 `include "otp_ctrl_macro_errs_vseq.sv"
+`include "otp_ctrl_background_chks_vseq.sv"
 `include "otp_ctrl_check_fail_vseq.sv"
 `include "otp_ctrl_parallel_base_vseq.sv"
 `include "otp_ctrl_parallel_key_req_vseq.sv"

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -68,6 +68,11 @@
       name: otp_ctrl_init_fail
       uvm_test_seq: otp_ctrl_init_fail_vseq
     }
+    {
+      name: otp_ctrl_background_chks
+      uvm_test_seq: otp_ctrl_background_chks_vseq
+      reseed: 10
+    }
 
     {
       name: otp_ctrl_parallel_lc_req


### PR DESCRIPTION
This PR adds a single test to check OTP_background checks. This test
wanted to ensure the background check can be triggered automatically
once we configured the check periods.

Signed-off-by: Cindy Chen <chencindy@google.com>