### PR TITLE
[rom_ctrl] Add scrambling to block

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -368,7 +368,7 @@ jobs:
 
       ./hw/top_earlgrey/util/top_earlgrey_reduce.py
 
-      BOOTROM_VMEM="$BIN_DIR/sw/device/boot_rom/boot_rom_fpga_nexysvideo.32.vmem"
+      BOOTROM_VMEM="$BIN_DIR/sw/device/boot_rom/boot_rom_fpga_nexysvideo.scr.40.vmem"
       test -f "$BOOTROM_VMEM"
       OTP_VMEM="$BIN_DIR/sw/device/otp_img/otp_img_fpga_nexysvideo.vmem"
       test -f "$OTP_VMEM"
@@ -425,7 +425,7 @@ jobs:
       mkdir -p "$OBJ_DIR/hw"
       mkdir -p "$BIN_DIR/hw/top_englishbreakfast"
 
-      BOOTROM_VMEM="$BIN_DIR/sw/device/boot_rom/boot_rom_fpga_nexysvideo.32.vmem"
+      BOOTROM_VMEM="$BIN_DIR/sw/device/boot_rom/boot_rom_fpga_nexysvideo.scr.40.vmem"
       test -f "$BOOTROM_VMEM"
 
       fusesoc --cores-root=. \

--- a/ci/scripts/mypy.sh
+++ b/ci/scripts/mypy.sh
@@ -11,6 +11,7 @@ dirs_with_lint_makefile=(
     hw/ip/otbn/dv/rig
     hw/ip/otbn/dv/otbnsim
     hw/ip/otbn/util
+    hw/ip/rom_ctrl/util
 )
 
 retcode=0

--- a/doc/ug/getting_started_verilator.md
+++ b/doc/ug/getting_started_verilator.md
@@ -47,7 +47,7 @@ The programs listed after `--meminit` are loaded into the system's specified mem
 ```console
 $ cd $REPO_TOP
 $ build/lowrisc_systems_chip_earlgrey_verilator_0.1/sim-verilator/Vchip_earlgrey_verilator \
-  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.elf \
+  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.scr.40.vmem \
   --meminit=flash,build-bin/sw/device/examples/hello_world/hello_world_sim_verilator.elf \
   --meminit=otp,build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem
 ```
@@ -104,7 +104,7 @@ A full command-line invocation of the simulation could then look like that:
 ```console
 $ cd $REPO_TOP
 $ build/lowrisc_systems_chip_earlgrey_verilator_0.1/sim-verilator/Vchip_earlgrey_verilator \
-  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.elf \
+  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.scr.40.vmem \
   --meminit=flash,build-bin/sw/device/examples/hello_world/hello_world_sim_verilator.elf \
   --meminit=otp,build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem \
   +UARTDPI_LOG_uart0=-
@@ -196,7 +196,7 @@ Tracing slows down the simulation by roughly factor of 1000.
 ```console
 $ cd $REPO_TOP
 $ build/lowrisc_systems_chip_earlgrey_verilator_0.1/sim-verilator/Vchip_earlgrey_verilator \
-  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.elf \
+  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.scr.40.vmem \
   --meminit=flash,build-bin/sw/device/examples/hello_world/hello_world_sim_verilator.elf \
   --meminit=otp,build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem \
   --trace

--- a/doc/ug/quickstart.md
+++ b/doc/ug/quickstart.md
@@ -36,7 +36,7 @@ $ tar -C $OT_TOP -xvf opentitan-snapshot-20191101-1.tar.xz --strip-components=1
 Run the provided simulator binary with
 ```console
 $ cd $OT_TOP
-$ ./hw/top_earlgrey/Vchip_earlgrey_verilator --rominit=./sw/device/sim/boot_rom/rom.vmem --flashinit=./sw/device/sim/examples/hello_world/sw.vmem
+$ ./hw/top_earlgrey/Vchip_earlgrey_verilator --rominit=./sw/device/sim/boot_rom/boot_rom_sim_verilator.scr.40.vmem --flashinit=./sw/device/sim/examples/hello_world/sw.vmem
 
 Simulation of OpenTitan Earl Grey
 =================================

--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -105,7 +105,7 @@ simulation run, e.g.
 
 ```sh
 build/lowrisc_systems_chip_earlgrey_verilator_0.1/sim-verilator/Vchip_earlgrey_verilator \
-  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.elf  \
+  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.scr.40.vmem \
   --meminit=flash,build-bin/sw/device/tests/dif_otbn_smoketest_sim_verilator.elf \
   --meminit=otp,build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem \
   +UARTDPI_LOG_uart0=- \

--- a/hw/ip/rom_ctrl/data/rom_ctrl.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl.hjson
@@ -18,6 +18,20 @@
       local:   "false",
       expose:  "true"
     }
+
+    { name:      "RndCnstScrNonce",
+      type:      "bit [63:0]",
+      desc:      "Fixed nonce used for address / data scrambling"
+      randcount: "64",
+      randtype:  "data"
+    }
+
+    { name:      "RndCnstScrKey",
+      type:      "bit [127:0]",
+      desc:      "Randomised constant used as a scrambling key for ROM data"
+      randcount: "128",
+      randtype:  "data"
+    }
   ]
   alert_list: [
     { name: "fatal"

--- a/hw/ip/rom_ctrl/data/rom_ctrl.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl.hjson
@@ -122,6 +122,9 @@
 
     rom: [
       // ROM size (given as `items` below) must be a power of two.
+      //
+      // NOTE: This number is replicated in ../util/scramble_image.py: keep the
+      // two in sync.
       { window: {
           name: "ROM"
           items: "4096" // 16 KiB

--- a/hw/ip/rom_ctrl/rom_ctrl.core
+++ b/hw/ip/rom_ctrl/rom_ctrl.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:prim:alert
       - lowrisc:prim:assert
+      - lowrisc:prim:cipher
       - lowrisc:prim:rom_adv
       - lowrisc:prim:subreg
       - lowrisc:prim:util
@@ -25,6 +26,7 @@ filesets:
       - rtl/rom_ctrl_counter.sv
       - rtl/rom_ctrl_fsm.sv
       - rtl/rom_ctrl_mux.sv
+      - rtl/rom_ctrl_scrambled_rom.sv
     file_type: systemVerilogSource
 
   files_verilator_waiver:

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_mux.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_mux.sv
@@ -29,7 +29,8 @@ module rom_ctrl_mux #(
   // Interface for ROM
   output logic [AW-1:0] rom_addr_o,
   output logic          rom_req_o,
-  input logic [39:0]    rom_rdata_i,
+  input logic [39:0]    rom_scr_rdata_i,
+  input logic [39:0]    rom_clr_rdata_i,
   input logic           rom_rvalid_i,
 
   // Alert output
@@ -52,11 +53,11 @@ module rom_ctrl_mux #(
 
   // The bus can have access every cycle, once the select signal has gone to zero
   assign bus_gnt_o    = ~sel_q;
-  assign bus_rdata_o  = rom_rdata_i;
+  assign bus_rdata_o  = rom_clr_rdata_i;
   // A high rom_rvalid_i is a response to a bus request if sel_i was zero on the previous cycle.
   assign bus_rvalid_o = ~sel_q & rom_rvalid_i;
 
-  assign chk_rdata_o = rom_rdata_i;
+  assign chk_rdata_o = rom_scr_rdata_i;
 
   assign rom_addr_o = sel_i ? chk_addr_i : bus_addr_i;
   assign rom_req_o  = sel_i ? 1'b1       : bus_req_i;

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_scrambled_rom.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_scrambled_rom.sv
@@ -1,0 +1,142 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+//
+// A scrambled ROM. This is scrambled with a fixed key, passed in as a parameter (this parameter
+// will be a compile-time random constant).
+//
+// This code follows the structure of prim_ram_1p_scr.sv (although it's much simplified because the
+// key is fixed and we don't support writes). For more information about what is going on, see that
+// file. Using the parameter names in prim_ram_1p_scr, we have NumPrinceRoundsHalf = 2 (so
+// approximately 5 effective rounds), NumDiffRounds = 2 and NumAddrScrRounds = 2 (enabling address
+// scrambling with 2 rounds).
+//
+
+module rom_ctrl_scrambled_rom
+  import prim_rom_pkg::rom_cfg_t;
+#(
+  // The initial contents of the ROM. This is used for synthesis. For simulation, this is not used;
+  // instead, the simulator loads the contents of ROM over DPI.
+  //
+  // In either case, the input file should be scrambled. That is, it should contain the bits that
+  // will appear in the physical ROM.
+  parameter MemInitFile = "",
+
+  // The width of ROM words in bits
+  parameter int Width = 40,
+
+  // The number of words in the ROM
+  parameter int Depth = 16,
+
+  // The nonce for data and address scrambling
+  parameter bit [63:0] ScrNonce = '0,
+
+  // The (fixed) key for the PRINCE cipher
+  parameter bit [127:0] ScrKey = '0,
+
+  localparam int Aw = $clog2(Depth)
+) (
+  input logic              clk_i,
+  input logic              rst_ni,
+
+  input  logic             req_i,
+  input  logic [Aw-1:0]    addr_i,
+  output logic             rvalid_o,
+  output logic [Width-1:0] scr_rdata_o,
+  output logic [Width-1:0] clr_rdata_o,
+
+  input rom_cfg_t          cfg_i
+);
+
+  localparam bit [63-Aw:0] DataScrNonce = ScrNonce[Aw +: (64 - Aw)];
+  localparam bit [Aw-1:0]  AddrScrNonce = ScrNonce[Aw-1:0];
+
+  // Parameter Checks ==========================================================
+
+  // The depth needs to be a power of 2 to use address scrambling
+  `ASSERT_INIT(DepthPow2Check_A, (Depth & (Depth - 1)) == 0)
+  // We only support a width up to 64
+  `ASSERT_INIT(MaxWidthCheck_A, Width <= 64)
+
+  // Address scrambling ========================================================
+
+  logic [Aw-1:0] addr_scr;
+  prim_subst_perm #(
+    .DataWidth (Aw),
+    .NumRounds (2),
+    .Decrypt   (0)
+  ) u_sp_addr (
+    .data_i (addr_i),
+    .key_i  (AddrScrNonce),
+    .data_o (addr_scr)
+  );
+
+  // Keystream generation ======================================================
+
+  logic [63:0] keystream;
+
+  prim_prince #(
+    .DataWidth      (64),
+    .KeyWidth       (128),
+    .NumRoundsHalf  (2),
+    .HalfwayDataReg (1'b1),
+    .HalfwayKeyReg  (1'b1)
+  ) u_prince (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+    .valid_i (req_i),
+    .data_i  ({DataScrNonce, addr_i}),
+    .key_i   (ScrKey),
+    .dec_i   (1'b0),
+    .data_o  (keystream),
+    .valid_o ()
+  );
+
+  if (Width < 64) begin : gen_unread_keystream
+    // Ignore top bits of keystream: we just use the bottom Width bits.
+    logic unused_top_keystream;
+    assign unused_top_keystream = &{1'b0, keystream[63:Width]};
+  end
+
+  // The physical ROM ==========================================================
+
+  logic [Width-1:0] rdata_scr;
+
+  prim_rom_adv #(
+    .Width       (Width),
+    .Depth       (Depth),
+    .MemInitFile (MemInitFile)
+  ) u_rom (
+    .clk_i    (clk_i),
+    .rst_ni   (rst_ni),
+    .req_i    (req_i),
+    .addr_i   (addr_scr),
+    .rvalid_o (rvalid_o),
+    .rdata_o  (rdata_scr),
+    .cfg_i    (cfg_i)
+  );
+
+  assign scr_rdata_o = rdata_scr;
+
+  // Data scrambling ===========================================================
+
+  logic [Width-1:0] rdata_xor;
+
+  prim_subst_perm #(
+    .DataWidth (Width),
+    .NumRounds (2),
+    .Decrypt   (1)
+  ) u_sp_data (
+    .data_i (rdata_scr),
+    .key_i  ('0),
+    .data_o (rdata_xor)
+  );
+
+  // XOR rdata with keystream ==================================================
+
+  assign clr_rdata_o = rdata_xor ^ keystream[Width-1:0];
+
+endmodule

--- a/hw/ip/rom_ctrl/util/Makefile
+++ b/hw/ip/rom_ctrl/util/Makefile
@@ -1,0 +1,30 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+.PHONY: all
+all: lint asm-check
+
+# We need a directory to build stuff and use the "rom_ctrl/util" namespace
+# in the top-level build-out directory.
+repo-top := ../../../..
+build-dir := $(repo-top)/build-out/otbn/util
+lint-build-dir := $(build-dir)/lint
+
+$(build-dir) $(lint-build-dir):
+	mkdir -p $@
+
+pyscripts := scramble_image.py
+pylibs := $(filter-out $(pyscripts),$(wildcard *.py))
+
+lint-stamps := $(foreach s,$(pyscripts),$(lint-build-dir)/$(s).stamp)
+$(lint-build-dir)/%.stamp: % $(pylibs) | $(lint-build-dir)
+	mypy --strict $< $(pylibs)
+	touch $@
+
+.PHONY: lint
+lint: $(lint-stamps)
+
+.PHONY: clean
+clean:
+	rm -rf $(build-dir)

--- a/hw/ip/rom_ctrl/util/scramble_image.py
+++ b/hw/ip/rom_ctrl/util/scramble_image.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+'''Script for scrambling a ROM image'''
+
+import argparse
+from typing import Dict, List
+
+import hjson  # type: ignore
+
+from mem import MemChunk, MemFile
+
+ROM_BASE_WORD = 0x8000 // 4
+ROM_SIZE_WORDS = 4096
+
+PRINCE_SBOX4 = [
+    0xb, 0xf, 0x3, 0x2,
+    0xa, 0xc, 0x9, 0x1,
+    0x6, 0x7, 0x8, 0x0,
+    0xe, 0x5, 0xd, 0x4
+]
+
+PRINCE_SBOX4_INV = [
+    0xb, 0x7, 0x3, 0x2,
+    0xf, 0xd, 0x8, 0x9,
+    0xa, 0x6, 0x4, 0x0,
+    0x5, 0xe, 0xc, 0x1
+]
+
+PRESENT_SBOX4 = [
+    0xc, 0x5, 0x6, 0xb,
+    0x9, 0x0, 0xa, 0xd,
+    0x3, 0xe, 0xf, 0x8,
+    0x4, 0x7, 0x1, 0x2
+]
+
+PRESENT_SBOX4_INV = [
+    0x5, 0xe, 0xf, 0x8,
+    0xc, 0x1, 0x2, 0xd,
+    0xb, 0x4, 0x6, 0x3,
+    0x0, 0x7, 0x9, 0xa
+]
+
+PRINCE_SHIFT_ROWS64 = [
+    0x4, 0x9, 0xe, 0x3,
+    0x8, 0xd, 0x2, 0x7,
+    0xc, 0x1, 0x6, 0xb,
+    0x0, 0x5, 0xa, 0xf
+]
+
+PRINCE_SHIFT_ROWS64_INV = [
+    0xc, 0x9, 0x6, 0x3,
+    0x0, 0xd, 0xa, 0x7,
+    0x4, 0x1, 0xe, 0xb,
+    0x8, 0x5, 0x2, 0xf
+]
+
+PRINCE_ROUND_CONSTS = [
+    0x0000000000000000,
+    0x13198a2e03707344,
+    0xa4093822299f31d0,
+    0x082efa98ec4e6c89,
+    0x452821e638d01377,
+    0xbe5466cf34e90c6c,
+    0x7ef84f78fd955cb1,
+    0x85840851f1ac43aa,
+    0xc882d32f25323c54,
+    0x64a51195e0e3610d,
+    0xd3b5a399ca0c2399,
+    0xc0ac29b7c97c50dd
+]
+
+PRINCE_SHIFT_ROWS_CONSTS = [0x7bde, 0xbde7, 0xde7b, 0xe7bd]
+
+_UDict = Dict[object, object]
+
+
+def sbox(data: int, width: int, coeffs: List[int]) -> int:
+    assert 0 <= width
+    assert 0 <= data < (1 << width)
+
+    full_mask = (1 << width) - 1
+    sbox_mask = (1 << (4 * (width // 4))) - 1
+
+    ret = data & (full_mask & ~sbox_mask)
+    for i in range(width // 4):
+        nibble = (data >> (4 * i)) & 0xf
+        sb_nibble = coeffs[nibble]
+        ret |= sb_nibble << (4 * i)
+
+    return ret
+
+
+def subst_perm_enc(data: int, key: int, width: int, num_rounds: int) -> int:
+    '''A model of prim_subst_perm in encrypt mode'''
+    assert 0 <= width
+    assert 0 <= data < (1 << width)
+    assert 0 <= key < (1 << width)
+
+    full_mask = (1 << width) - 1
+    bfly_mask = (1 << (2 * (width // 2))) - 1
+
+    for rnd in range(num_rounds):
+        data_xor = data ^ key
+
+        # SBox layer
+        data_sbox = sbox(data_xor, width, PRESENT_SBOX4)
+
+        # Reverse the vector
+        data_rev = 0
+        for i in range(width):
+            bit = (data_sbox >> i) & 1
+            data_rev |= bit << (width - 1 - i)
+
+        # Butterfly
+        data_bfly = data_rev & (full_mask & ~bfly_mask)
+        for i in range(width // 2):
+            # data_bfly[i] = data_rev[2i]
+            bit = (data_rev >> (2 * i)) & 1
+            data_bfly |= bit << i
+            # data_bfly[width/2 + i] = data_rev[2i+1]
+            bit = (data_rev >> (2 * i + 1)) & 1
+            data_bfly |= bit << (width // 2 + i)
+
+        data = data_bfly
+
+    return data ^ key
+
+
+def subst_perm_dec(data: int, key: int, width: int, num_rounds: int) -> int:
+    '''A model of prim_subst_perm in decrypt mode'''
+    assert 0 <= width
+    assert 0 <= data < (1 << width)
+    assert 0 <= key < (1 << width)
+
+    full_mask = (1 << width) - 1
+    bfly_mask = (1 << (2 * (width // 2))) - 1
+
+    for rnd in range(num_rounds):
+        data_xor = data ^ key
+
+        # Butterfly
+        data_bfly = data_xor & (full_mask & ~bfly_mask)
+        for i in range(width // 2):
+            # data_bfly[2i] = data_xor[i]
+            bit = (data_xor >> i) & 1
+            data_bfly |= bit << (2 * i)
+            # data_bfly[2i+1] = data_xor[i + width // 2]
+            bit = (data_xor >> (i + width // 2)) & 1
+            data_bfly |= bit << (2 * i + 1)
+
+        # Reverse the vector
+        data_rev = 0
+        for i in range(width):
+            bit = (data_bfly >> i) & 1
+            data_rev |= bit << (width - 1 - i)
+
+        # Inverse SBox layer
+        data = sbox(data_rev, width, PRESENT_SBOX4_INV)
+
+    return data ^ key
+
+
+def prince_nibble_red16(data: int) -> int:
+    assert 0 <= data < (1 << 16)
+    nib0 = (data >> 0) & 0xf
+    nib1 = (data >> 4) & 0xf
+    nib2 = (data >> 8) & 0xf
+    nib3 = (data >> 12) & 0xf
+    return nib0 ^ nib1 ^ nib2 ^ nib3
+
+
+def prince_mult_prime(data: int) -> int:
+    assert 0 <= data < (1 << 64)
+    ret = 0
+    for blk_idx in range(4):
+        data_hw = (data >> (16 * blk_idx)) & 0xffff
+        start_sr_idx = 0 if blk_idx in [0, 3] else 1
+        for nibble_idx in range(4):
+            sr_idx = (start_sr_idx + 3 - nibble_idx) % 4
+            sr_const = PRINCE_SHIFT_ROWS_CONSTS[sr_idx]
+            nibble = prince_nibble_red16(data_hw & sr_const)
+            ret |= nibble << (16 * blk_idx + 4 * nibble_idx)
+    return ret
+
+
+def prince_shiftrows(data: int, inv: bool) -> int:
+    assert 0 <= data < (1 << 64)
+    shifts = PRINCE_SHIFT_ROWS64_INV if inv else PRINCE_SHIFT_ROWS64
+
+    ret = 0
+    for nibble_idx in range(64 // 4):
+        src_nibble_idx = shifts[nibble_idx]
+        src_nibble = (data >> (4 * src_nibble_idx)) & 0xf
+        ret |= src_nibble << (4 * nibble_idx)
+    return ret
+
+
+def prince_fwd_round(rc: int, key: int, data: int) -> int:
+    assert 0 <= rc < (1 << 64)
+    assert 0 <= key < (1 << 64)
+    assert 0 <= data < (1 << 64)
+
+    data = sbox(data, 64, PRINCE_SBOX4)
+    data = prince_mult_prime(data)
+    data = prince_shiftrows(data, False)
+    data ^= rc
+    data ^= key
+    return data
+
+
+def prince_inv_round(rc: int, key: int, data: int) -> int:
+    assert 0 <= rc < (1 << 64)
+    assert 0 <= key < (1 << 64)
+    assert 0 <= data < (1 << 64)
+
+    data ^= key
+    data ^= rc
+    data = prince_shiftrows(data, True)
+    data = prince_mult_prime(data)
+    data = sbox(data, 64, PRINCE_SBOX4_INV)
+    return data
+
+
+def prince(data: int, key: int, num_rounds_half: int) -> int:
+    '''Run the PRINCE cipher
+
+    This uses the new keyschedule proposed by Dinur in "Cryptanalytic
+    Time-Memory-Data Tradeoffs for FX-Constructions with Applications to PRINCE
+    and PRIDE".
+
+    '''
+    assert 0 <= data < (1 << 64)
+    assert 0 <= key < (1 << 128)
+    assert 0 <= num_rounds_half <= 5
+
+    # TODO: This matches the RTL in prim_prince.sv, but seems to be the other
+    #       way around in the original paper.
+    k1 = key & ((1 << 64) - 1)
+    k0 = key >> 64
+
+    k0_rot1 = ((k0 & 1) << 63) | (k0 >> 1)
+    k0_prime = k0_rot1 ^ (k0 >> 63)
+
+    data ^= k0
+    data ^= k1
+    data ^= PRINCE_ROUND_CONSTS[0]
+
+    for hri in range(num_rounds_half):
+        round_idx = 1 + hri
+        rc = PRINCE_ROUND_CONSTS[round_idx]
+        rk = k0 if round_idx & 1 else k1
+        data = prince_fwd_round(rc, rk, data)
+
+    data = sbox(data, 64, PRINCE_SBOX4)
+    data = prince_mult_prime(data)
+    data = sbox(data, 64, PRINCE_SBOX4_INV)
+
+    for hri in range(num_rounds_half):
+        round_idx = 11 - num_rounds_half + hri
+        rc = PRINCE_ROUND_CONSTS[round_idx]
+        rk = k1 if round_idx & 1 else k0
+        data = prince_inv_round(rc, rk, data)
+
+    data ^= PRINCE_ROUND_CONSTS[11]
+    data ^= k1
+
+    data ^= k0_prime
+
+    return data
+
+
+class Scrambler:
+    def __init__(self, nonce: int, key: int, rom_size_words: int):
+        assert 0 <= nonce < (1 << 64)
+        assert 0 <= key < (1 << 128)
+        assert 0 < rom_size_words < (1 << 64)
+
+        self.nonce = nonce
+        self.key = key
+        self.rom_size_words = rom_size_words
+
+        self._addr_width = (rom_size_words - 1).bit_length()
+
+    @staticmethod
+    def _get_rom_ctrl(modules: List[object]) -> _UDict:
+        rom_ctrls = []  # type: List[_UDict]
+        for entry in modules:
+            assert isinstance(entry, dict)
+            entry_type = entry.get('type')
+            assert isinstance(entry_type, str)
+
+            if entry_type == 'rom_ctrl':
+                rom_ctrls.append(entry)
+
+        assert len(rom_ctrls) == 1
+        return rom_ctrls[0]
+
+    @staticmethod
+    def _get_params(module: _UDict) -> Dict[str, _UDict]:
+        params = module.get('param_list')
+        assert isinstance(params, list)
+
+        named_params = {}  # type: Dict[str, _UDict]
+        for param in params:
+            name = param.get('name')
+            assert isinstance(name, str)
+            assert name not in named_params
+            named_params[name] = param
+
+        return named_params
+
+    @staticmethod
+    def _get_param_value(params: Dict[str, _UDict],
+                         name: str,
+                         width: int) -> int:
+        param = params.get(name)
+        assert isinstance(param, dict)
+
+        default = param.get('default')
+        assert isinstance(default, str)
+        int_val = int(default, 0)
+        assert 0 <= int_val < (1 << width)
+        return int_val
+
+    @staticmethod
+    def from_hjson_path(path: str, rom_size_words: int) -> 'Scrambler':
+        assert 0 < rom_size_words
+
+        with open(path) as handle:
+            top = hjson.load(handle, use_decimal=True)
+
+        assert isinstance(top, dict)
+        modules = top.get('module')
+        assert isinstance(modules, list)
+
+        rom_ctrl = Scrambler._get_rom_ctrl(modules)
+
+        params = Scrambler._get_params(rom_ctrl)
+        nonce = Scrambler._get_param_value(params, 'RndCnstScrNonce', 64)
+        key = Scrambler._get_param_value(params, 'RndCnstScrKey', 128)
+
+        return Scrambler(nonce, key, rom_size_words)
+
+    def flatten(self, mem: MemFile) -> MemFile:
+        '''Flatten and pad mem up to the correct size
+
+        This adds 8 trailing zero words as space to store the expected hash.
+        These are (obviously!) not the right hash: we inject them properly
+        later.
+
+        '''
+        digest_size_words = 8
+        initial_len = self.rom_size_words - digest_size_words
+        seed = self.key + self.nonce
+
+        flattened = mem.flatten(initial_len, seed)
+        assert len(flattened.chunks) == 1
+        assert len(flattened.chunks[0].words) == initial_len
+
+        # Add the 8 trailing zero words. We do it here, rather than passing
+        # rom_size_words to mem.flatten, to make sure that we see the error if
+        # mem is too big.
+        flattened.chunks[0].words += [0] * digest_size_words
+
+        return flattened
+
+    def scramble40(self, mem: MemFile) -> MemFile:
+        assert len(mem.chunks) == 1
+        assert len(mem.chunks[0].words) == self.rom_size_words
+
+        word_width = 40
+
+        # Write addr_sp, data_sp for the S&P networks for address and data,
+        # respectively. Write clr[i] for unscrambled data word i and scr[i] for
+        # scrambled data word i. We need to construct scr[0], scr[1], ...,
+        # scr[self.rom_size_words].
+        #
+        # Then, for all i, we have:
+        #
+        #   clr[i] = PRINCE(i) ^ data_sp(scr[addr_sp(i)])
+        #
+        # Change coordinates by evaluating at addr_sp_inv(i):
+        #
+        #   clr[addr_sp_inv(i)] = PRINCE(addr_sp_inv(i)) ^ data_sp(scr[i])
+        #
+        # so
+        #
+        #   scr[i] = data_sp_inv(clr[addr_sp_inv(i)] ^ PRINCE(addr_sp_inv(i)))
+        subst_perm_rounds = 2
+        num_rounds_half = 2
+
+        assert word_width <= 64
+        word_mask = (1 << word_width) - 1
+
+        data_scr_nonce = self.nonce >> self._addr_width
+        addr_scr_nonce = self.nonce & ((1 << self._addr_width) - 1)
+
+        scrambled = []
+        for phy_addr in range(self.rom_size_words):
+            log_addr = subst_perm_dec(phy_addr, addr_scr_nonce,
+                                      self._addr_width, subst_perm_rounds)
+            assert 0 <= log_addr < self.rom_size_words
+
+            to_scramble = (data_scr_nonce << self._addr_width) | log_addr
+            keystream = prince(to_scramble, self.key, num_rounds_half)
+
+            keystream_trunc = keystream & word_mask
+            clr_data = mem.chunks[0].words[log_addr]
+            assert 0 <= clr_data < word_mask
+
+            sp_scr_data = keystream_trunc ^ clr_data
+            scr_data = subst_perm_enc(sp_scr_data, 0, word_width, subst_perm_rounds)
+
+            assert 0 <= scr_data < word_mask
+
+            scrambled.append(scr_data)
+
+        return MemFile(mem.width, [MemChunk(0, scrambled)])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('hjson')
+    parser.add_argument('infile', type=argparse.FileType('rb'))
+    parser.add_argument('outfile', type=argparse.FileType('w'))
+
+    args = parser.parse_args()
+    scrambler = Scrambler.from_hjson_path(args.hjson, ROM_SIZE_WORDS)
+
+    # Load the input ELF file
+    clr_mem = MemFile.load_elf32(args.infile, 4 * ROM_BASE_WORD)
+
+    # Flatten the file, padding with pseudo-random data and ensuring it's
+    # exactly scrambler.rom_size_words words long.
+    clr_flat = scrambler.flatten(clr_mem)
+
+    # Extend from 32 bits to 39 by adding Hsiao (39,32) ECC bits.
+    clr_flat.add_ecc32()
+
+    # Zero-extend the cleartext memory by one more bit (this is the size we
+    # actually use in the physical ROM)
+    assert clr_flat.width == 39
+    clr_flat.width = 40
+
+    # Scramble the memory
+    scr_mem = scrambler.scramble40(clr_flat)
+
+    # TODO: Calculate and insert the expected hash here.
+
+    scr_mem.write_vmem(args.outfile)
+
+
+if __name__ == '__main__':
+    main()

--- a/hw/top_earlgrey/chip_earlgrey_nexysvideo.core
+++ b/hw/top_earlgrey/chip_earlgrey_nexysvideo.core
@@ -35,14 +35,14 @@ filesets:
 parameters:
   # XXX: This parameter needs to be absolute, or relative to the *.runs/synth_1
   # directory. It's best to pass it as absolute path when invoking fusesoc, e.g.
-  # --BootRomInitFile=$PWD/build-bin/sw/device/boot_rom/boot_rom_fpga_nexysvideo.32.vmem
+  # --BootRomInitFile=$PWD/build-bin/sw/device/boot_rom/boot_rom_fpga_nexysvideo.scr.40.vmem
   # XXX: The VMEM file should be added to the sources of the Vivado project to
   # make the Vivado dependency tracking work. However this requires changes to
   # fusesoc first.
   BootRomInitFile:
     datatype: str
-    description: Boot ROM initialization file in 32 bit vmem hex format
-    default: "../../../../../build-bin/sw/device/boot_rom/boot_rom_fpga_nexysvideo.32.vmem"
+    description: Scrambled boot ROM initialization file in 40 bit vmem hex format
+    default: "../../../../../build-bin/sw/device/boot_rom/boot_rom_fpga_nexysvideo.scr.40.vmem"
     paramtype: vlogparam
   OtpCtrlMemInitFile:
     datatype: str

--- a/hw/top_earlgrey/chip_earlgrey_verilator.cc
+++ b/hw/top_earlgrey/chip_earlgrey_verilator.cc
@@ -21,9 +21,9 @@ int main(int argc, char **argv) {
       "u_prim_ram_1p_adv.u_mem."
       "gen_generic.u_impl_generic");
 
-  MemArea rom(
-      top_scope + ".u_rom_ctrl.u_rom.u_prim_rom.gen_generic.u_impl_generic",
-      0x4000 / 4, 4);
+  MemArea rom(top_scope + (".u_rom_ctrl.u_rom.u_rom."
+                           "u_prim_rom.gen_generic.u_impl_generic"),
+              0x4000 / 4, 4);
   MemArea ram(top_scope + ".u_ram1p_ram_main." + ram1p_adv_scope, 0x20000 / 4,
               4);
   MemArea flash(top_scope +

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -5040,6 +5040,26 @@
           expose: "true"
           name_top: RomCtrlBootRomInitFile
         }
+        {
+          name: RndCnstScrNonce
+          desc: Fixed nonce used for address / data scrambling
+          type: bit [63:0]
+          randcount: 64
+          randtype: data
+          name_top: RndCnstRomCtrlScrNonce
+          default: 0xfc00de9d9734c3fe
+          randwidth: 64
+        }
+        {
+          name: RndCnstScrKey
+          desc: Randomised constant used as a scrambling key for ROM data
+          type: bit [127:0]
+          randcount: 128
+          randtype: data
+          name_top: RndCnstRomCtrlScrKey
+          default: 0x23c074e020fd502869582e71443c8be0
+          randwidth: 128
+        }
       ]
       inter_signal_list:
       [

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -37,7 +37,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     cfg.flash_bank1_bkdr_vif.set_mem();
 
     // Backdoor load memories with sw images.
-    cfg.rom_bkdr_vif.load_mem_from_file({cfg.sw_images[SwTypeRom], ".32.vmem"});
+    cfg.rom_bkdr_vif.load_mem_from_file({cfg.sw_images[SwTypeRom], ".scr.40.vmem"});
 
     // TODO: the location of the main execution image should be randomized for either bank in future
     if (cfg.use_spi_load_bootstrap) begin

--- a/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
+++ b/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
@@ -11,7 +11,7 @@
 `define CPU_HIER           `CHIP_HIER.u_rv_core_ibex
 `define RAM_MAIN_HIER      `CHIP_HIER.u_ram1p_ram_main.u_prim_ram_1p_adv.u_mem
 `define RAM_RET_HIER       `CHIP_HIER.u_ram1p_ram_ret_aon.u_prim_ram_1p_adv.u_mem
-`define ROM_HIER           `CHIP_HIER.u_rom_ctrl.u_rom.u_prim_rom
+`define ROM_HIER           `CHIP_HIER.u_rom_ctrl.u_rom.u_rom.u_prim_rom
 `define FLASH_HIER         `CHIP_HIER.u_flash_eflash.u_flash
 `define RSTMGR_HIER        `CHIP_HIER.u_rstmgr_aon
 `define CLKMGR_HIER        `CHIP_HIER.u_clkmgr_aon

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -2274,7 +2274,9 @@ module top_earlgrey #(
 
   rom_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[30:30]),
-    .BootRomInitFile(RomCtrlBootRomInitFile)
+    .BootRomInitFile(RomCtrlBootRomInitFile),
+    .RndCnstScrNonce(RndCnstRomCtrlScrNonce),
+    .RndCnstScrKey(RndCnstRomCtrlScrKey)
   ) u_rom_ctrl (
       // [30]: fatal
       .alert_tx_o  ( alert_tx[30:30] ),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -228,4 +228,17 @@ package top_earlgrey_rnd_cnst_pkg;
     256'hA46ED80E5942BC02513FBDFD5A98A66805BC17DDED6CCD3271A3E37A08C92847
   };
 
+  ////////////////////////////////////////////
+  // rom_ctrl
+  ////////////////////////////////////////////
+  // Fixed nonce used for address / data scrambling
+  parameter bit [63:0] RndCnstRomCtrlScrNonce = {
+    64'hFC00DE9D9734C3FE
+  };
+
+  // Randomised constant used as a scrambling key for ROM data
+  parameter bit [127:0] RndCnstRomCtrlScrKey = {
+    128'h23C074E020FD502869582E71443C8BE0
+  };
+
 endpackage : top_earlgrey_rnd_cnst_pkg

--- a/hw/top_earlgrey/util/opentitan_earlgrey_usbdev_pin_config_sim.sh
+++ b/hw/top_earlgrey/util/opentitan_earlgrey_usbdev_pin_config_sim.sh
@@ -7,7 +7,7 @@
 VERILATOR=build/lowrisc_systems_chip_earlgrey_verilator_0.1/sim-verilator/Vchip_earlgrey_verilator
 
 # Code to load
-ROMCODE=build-bin/sw/device/boot_rom/boot_rom_sim_verilator.elf
+ROMCODE=build-bin/sw/device/boot_rom/boot_rom_sim_verilator.scr.40.vmem
 FLASH=build-bin/sw/device/examples/hello_usbdev/hello_usbdev_sim_verilator.elf
 OTP=build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem
 

--- a/sw/device/boot_rom/meson.build
+++ b/sw/device/boot_rom/meson.build
@@ -75,6 +75,15 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
     build_by_default: true,
   )
 
+  boot_rom_scrambled = custom_target(
+    'boot_rom_scrambled_' + device_name,
+    command: scramble_image_command,
+    depend_files: scramble_image_depend_files,
+    input: boot_rom_elf,
+    output: scramble_image_outputs,
+    build_by_default: true,
+  )
+
   boot_rom_sim_dv_logs = []
   if device_name == 'sim_dv'
     boot_rom_sim_dv_logs = custom_target(

--- a/sw/device/boot_rom/meson.build
+++ b/sw/device/boot_rom/meson.build
@@ -103,7 +103,12 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
     'boot_rom_export_' + device_name,
     command: export_target_command,
     depend_files: [export_target_depend_files,],
-    input: [boot_rom_elf, boot_rom_embedded, boot_rom_sim_dv_logs,],
+    input: [
+      boot_rom_elf,
+      boot_rom_embedded,
+      boot_rom_scrambled,
+      boot_rom_sim_dv_logs,
+    ],
     output: 'boot_rom_export_' + device_name,
     build_always_stale: true,
     build_by_default: true,

--- a/sw/device/boot_rom/rom_link.ld
+++ b/sw/device/boot_rom/rom_link.ld
@@ -39,8 +39,9 @@ _flash_start = ORIGIN(eflash);
  */
 _flash_header = _flash_start;
 
+_rom_digest_size = 32;
 _chip_info_size = 128;
-_chip_info_start = ORIGIN(rom) + LENGTH(rom) - _chip_info_size;
+_chip_info_start = ORIGIN(rom) + LENGTH(rom) - _rom_digest_size - _chip_info_size;
 
 /* DV Log offset (has to be different to other boot stages). */
 _dv_log_offset = 0x0;

--- a/sw/device/meson.build
+++ b/sw/device/meson.build
@@ -62,6 +62,29 @@ make_otp_img_depend_files = [
   meson.source_root() / 'util/design/gen-otp-img.py',
 ]
 
+# Generates a scrambled version of a ROM image from an ELF
+#
+# TODO: This is currently top_earlgrey-specific. That's fine for now, because
+#       top_earlgrey is the only top-level with a rom_ctrl block, but we'll
+#       need to make this more generic if we support more top-levels.
+scramble_image_hjson = [
+  meson.source_root() / 'hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson'
+]
+scramble_image_outputs = [
+  '@BASENAME@.scr.40.vmem',
+]
+scramble_image_command = [
+    prog_python,
+    meson.source_root() / 'hw/ip/rom_ctrl/util/scramble_image.py',
+    scramble_image_hjson,
+    '@INPUT@',
+    '@OUTPUT@',
+]
+scramble_image_depend_files = [
+    meson.source_root() / 'hw/ip/rom_ctrl/util/scramble_image.py',
+    scramble_image_hjson
+]
+
 subdir('boot_rom')
 subdir('otp_img')
 subdir('silicon_creator')

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -55,11 +55,24 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
     build_by_default: true,
   )
 
+  mask_rom_scrambled = custom_target(
+    'mask_rom_scrambled_' + device_name,
+    command: scramble_image_command,
+    depend_files: scramble_image_depend_files,
+    input: mask_rom_elf,
+    output: scramble_image_outputs,
+    build_by_default: true,
+  )
+
   custom_target(
     'mask_rom_export_' + device_name,
     command: export_target_command,
     depend_files: [export_target_depend_files,],
-    input: [mask_rom_elf, mask_rom_embedded],
+    input: [
+      mask_rom_elf,
+      mask_rom_embedded,
+      mask_rom_scrambled,
+    ],
     output: 'mask_rom_export_' + device_name,
     build_always_stale: true,
     build_by_default: true,

--- a/test/systemtest/earlgrey/test_sim_verilator.py
+++ b/test/systemtest/earlgrey/test_sim_verilator.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 class VerilatorSimEarlgrey:
     UART0_SPEED = 7200  # see device/lib/arch/device_sim_verilator.c
 
-    def __init__(self, sim_path: Path, rom_elf_path: Path, otp_img_path: Path,
+    def __init__(self, sim_path: Path, rom_vmem_path: Path, otp_img_path: Path,
                  work_dir: Path):
         """ A verilator simulation of the Earl Grey toplevel """
         assert sim_path.is_file()
@@ -25,9 +25,9 @@ class VerilatorSimEarlgrey:
 
         self.p_sim = None
 
-        assert rom_elf_path.is_file()
+        assert rom_vmem_path.is_file()
         assert otp_img_path.is_file()
-        self._rom_elf_path = rom_elf_path
+        self._rom_vmem_path = rom_vmem_path
         self._otp_img_path = otp_img_path
 
         assert work_dir.is_dir()
@@ -47,7 +47,7 @@ class VerilatorSimEarlgrey:
         self.uart0_log_path = self._work_dir / 'uart0.log'
 
         cmd_sim = [
-            self._sim_path, '--meminit=rom,' + str(self._rom_elf_path),
+            self._sim_path, '--meminit=rom,' + str(self._rom_vmem_path),
             '--meminit=otp,' + str(self._otp_img_path),
             '+UARTDPI_LOG_uart0=' + str(self.uart0_log_path)
         ]
@@ -280,10 +280,10 @@ def test_apps_selfchecking(tmp_path, bin_dir, app_selfchecking):
     """
 
     sim_path = bin_dir / "hw/top_earlgrey/Vchip_earlgrey_verilator"
-    rom_elf_path = bin_dir / "sw/device/boot_rom/boot_rom_sim_verilator.elf"
+    rom_vmem_path = bin_dir / "sw/device/boot_rom/boot_rom_sim_verilator.scr.40.vmem"
     otp_img_path = bin_dir / "sw/device/otp_img/otp_img_sim_verilator.vmem"
 
-    sim = VerilatorSimEarlgrey(sim_path, rom_elf_path, otp_img_path, tmp_path)
+    sim = VerilatorSimEarlgrey(sim_path, rom_vmem_path, otp_img_path, tmp_path)
 
     sim.run(app_selfchecking[0], extra_sim_args=app_selfchecking[1])
 
@@ -304,10 +304,11 @@ def test_apps_selfchecking_silicon_creator(tmp_path, bin_dir,
     """
 
     sim_path = bin_dir / "hw/top_earlgrey/Vchip_earlgrey_verilator"
-    rom_elf_path = bin_dir / "sw/device/silicon_creator/mask_rom/mask_rom_sim_verilator.elf"
+    rom_vmem_path = bin_dir / ("sw/device/silicon_creator/mask_rom/"
+                               "mask_rom_sim_verilator.scr.40.vmem")
     otp_img_path = bin_dir / "sw/device/otp_img/otp_img_sim_verilator.vmem"
 
-    sim = VerilatorSimEarlgrey(sim_path, rom_elf_path, otp_img_path, tmp_path)
+    sim = VerilatorSimEarlgrey(sim_path, rom_vmem_path, otp_img_path, tmp_path)
 
     sim.run(app_silicon_creator_selfchecking[0],
             extra_sim_args=app_silicon_creator_selfchecking[1])
@@ -323,10 +324,10 @@ def test_spiflash(tmp_path, bin_dir):
     """ Load a single application to the Verilator simulation using spiflash """
 
     sim_path = bin_dir / "hw/top_earlgrey/Vchip_earlgrey_verilator"
-    rom_elf_path = bin_dir / "sw/device/boot_rom/boot_rom_sim_verilator.elf"
+    rom_vmem_path = bin_dir / "sw/device/boot_rom/boot_rom_sim_verilator.scr.40.vmem"
     otp_img_path = bin_dir / "sw/device/otp_img/otp_img_sim_verilator.vmem"
 
-    sim = VerilatorSimEarlgrey(sim_path, rom_elf_path, otp_img_path, tmp_path)
+    sim = VerilatorSimEarlgrey(sim_path, rom_vmem_path, otp_img_path, tmp_path)
     sim.run()
 
     log.debug("Waiting for simulation to be ready for SPI input")
@@ -353,10 +354,10 @@ def test_openocd_basic_connectivity(tmp_path, bin_dir, topsrcdir, openocd):
     """
     # Run a simulation (bootrom only, no app beyond that)
     sim_path = bin_dir / "hw/top_earlgrey/Vchip_earlgrey_verilator"
-    rom_elf_path = bin_dir / "sw/device/boot_rom/boot_rom_sim_verilator.elf"
+    rom_vmem_path = bin_dir / "sw/device/boot_rom/boot_rom_sim_verilator.scr.40.vmem"
     otp_img_path = bin_dir / "sw/device/otp_img/otp_img_sim_verilator.vmem"
 
-    sim = VerilatorSimEarlgrey(sim_path, rom_elf_path, otp_img_path, tmp_path)
+    sim = VerilatorSimEarlgrey(sim_path, rom_vmem_path, otp_img_path, tmp_path)
     sim.run()
 
     # Wait a bit until the system has reached the bootrom and a first arbitrary


### PR DESCRIPTION
The first two commits tweak the build process. The first saves 8 words at the top of ROM for an expected hash and the second models the (un)scrambling logic so that it can pre-scramble a ROM image.

The final commit actually instantiates the logic to scramble ROM images. The RTL of this last commit isn't very complicated (it's basically a very cut down version of `sram_ctrl`), but there's quite a lot of re-wiring required, pointing documentation and the chip-level testbench at the new scrambled image.