### PR TITLE
[csrng/rtl] fix for app interface hang with two active

### DIFF
--- a/hw/ip/csrng/csrng.core
+++ b/hw/ip/csrng/csrng.core
@@ -17,6 +17,7 @@ filesets:
     files:
       - rtl/csrng_reg_top.sv
       - rtl/csrng_main_sm.sv
+      - rtl/csrng_track_sm.sv
       - rtl/csrng_state_db.sv
       - rtl/csrng_cmd_stage.sv
       - rtl/csrng_block_encrypt.sv

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -308,6 +308,8 @@ module csrng_core import csrng_pkg::*; #(
   logic                    ctr_drbg_gen_es_ack;
   logic                    block_encrypt_quiet;
 
+  logic [StateId-1:0]      track_inst_id[NApps];
+
   // flops
   logic [2:0]  acmd_q, acmd_d;
   logic [3:0]  shid_q, shid_d;
@@ -317,7 +319,7 @@ module csrng_core import csrng_pkg::*; #(
   logic        lc_hw_debug_not_on_q, lc_hw_debug_not_on_d;
   logic        lc_hw_debug_on_q, lc_hw_debug_on_d;
   logic        cmd_req_dly_q, cmd_req_dly_d;
-  logic        cs_aes_halt_q, cs_aes_halt_d;
+  logic           cs_aes_halt_q, cs_aes_halt_d;
 
   always_ff @(posedge clk_i or negedge rst_ni)
     if (!rst_ni) begin
@@ -1319,6 +1321,69 @@ module csrng_core import csrng_pkg::*; #(
   // es to cs halt request to reduce power spikes
   assign cs_aes_halt_d = ctr_drbg_upd_es_ack && ctr_drbg_gen_es_ack && block_encrypt_quiet;
   assign cs_aes_halt_o.cs_aes_halt_ack = cs_aes_halt_q;
+
+  //--------------------------------------------
+  // tracking state machine
+  //--------------------------------------------
+
+  for (genvar i = 0; i < NApps; i = i+1) begin : gen_track_sm
+
+    assign track_inst_id[i] = i;
+
+
+  csrng_track_sm #(
+    .Cmd(Cmd),
+    .StateId(StateId)
+  ) u_csrng_track_sm (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .inst_id_i(track_inst_id[i]),
+    .acmd_avail_i(acmd_avail),
+    .acmd_accept_i(acmd_accept),
+    .acmd_i(acmd_hold),
+    .shid_i(shid),
+    .ctr_drbg_cmd_req_i(ctr_drbg_cmd_req),
+    .ctr_drbg_cmd_req_rdy_i(ctr_drbg_cmd_req_rdy),
+    .ctr_drbg_cmd_ccmd_i(acmd_hold),
+    .ctr_drbg_cmd_inst_id_i(shid_q),
+    .updblk_arb_vld_i(updblk_arb_vld),
+    .updblk_arb_rdy_i(updblk_arb_rdy),
+    .updblk_arb_ccmd_i(updblk_arb_ccmd),
+    .updblk_arb_inst_id_i(updblk_arb_inst_id),
+    .benblk_arb_vld_i(benblk_arb_vld),
+    .benblk_arb_rdy_i(benblk_arb_rdy),
+    .benblk_arb_ccmd_i(benblk_arb_cmd),
+    .benblk_arb_inst_id_i(benblk_arb_inst_id),
+    .benblk_updblk_ack_i(benblk_updblk_ack),
+    .updblk_benblk_ack_rdy_i(updblk_benblk_ack_rdy),
+    .benblk_cmd_i(benblk_cmd),
+    .benblk_inst_id_i(benblk_inst_id),
+    .updblk_cmdblk_ack_i(updblk_cmdblk_ack),
+    .cmdblk_updblk_ack_rdy_i(cmdblk_updblk_ack_rdy),
+    .updblk_cmdblk_ccmd_i(updblk_ccmd),
+    .updblk_cmdblk_inst_id_i(updblk_inst_id),
+    .ctr_drbg_gen_req_i(ctr_drbg_gen_req),
+    .ctr_drbg_gen_req_rdy_i(ctr_drbg_gen_req_rdy),
+    .ctr_drbg_gen_ccmd_i(cmd_result_ccmd),
+    .ctr_drbg_gen_inst_id_i(cmd_result_inst_id),
+    .benblk_genblk_ack_i(benblk_genblk_ack),
+    .genblk_benblk_ack_rdy_i(genblk_benblk_ack_rdy),
+    .updblk_genblk_ack_i(updblk_genblk_ack),
+    .genblk_updblk_ack_rdy_i(genblk_updblk_ack_rdy),
+    .updblk_ccmd_i(updblk_ccmd),
+    .updblk_inst_id_i(updblk_inst_id),
+    .genbits_stage_vld_i(genbits_stage_vld[i]),
+    .genbits_stage_rdy_i(genbits_stage_rdy[i]),
+    .state_db_wr_req_i(state_db_wr_req),
+    .state_db_wr_req_rdy_i(state_db_wr_req_rdy),
+    .state_db_wr_ccmd_i(state_db_wr_ccmd),
+    .state_db_wr_inst_id_i(state_db_wr_inst_id),
+    .cmd_core_ack_i(cmd_core_ack[i]),
+    .cmd_stage_ack_i(cmd_stage_ack[i]),
+    .track_sm_o()
+  );
+
+  end : gen_track_sm
 
   //--------------------------------------------
   // report csrng request summary

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -123,12 +123,14 @@ module csrng_core import csrng_pkg::*; #(
   logic [BlkLen-1:0]      gen_result_bits;
 
   logic                   acmd_accept;
+  logic                   acmd_hdr_capt;
   logic                   instant_req;
   logic                   reseed_req;
   logic                   generate_req;
   logic                   update_req;
   logic                   uninstant_req;
   logic [3:0]             fifo_sel;
+  logic [Cmd-1:0]         ctr_drbg_cmd_ccmd;
   logic                   ctr_drbg_cmd_req;
   logic                   ctr_drbg_gen_req;
   logic                   ctr_drbg_gen_req_rdy;
@@ -319,6 +321,7 @@ module csrng_core import csrng_pkg::*; #(
   logic        lc_hw_debug_not_on_q, lc_hw_debug_not_on_d;
   logic        lc_hw_debug_on_q, lc_hw_debug_on_d;
   logic        cmd_req_dly_q, cmd_req_dly_d;
+  logic [Cmd-1:0] cmd_req_ccmd_dly_q, cmd_req_ccmd_dly_d;
   logic           cs_aes_halt_q, cs_aes_halt_d;
 
   always_ff @(posedge clk_i or negedge rst_ni)
@@ -331,6 +334,7 @@ module csrng_core import csrng_pkg::*; #(
       lc_hw_debug_not_on_q <= '0;
       lc_hw_debug_on_q <= '0;
       cmd_req_dly_q <= '0;
+      cmd_req_ccmd_dly_q <= '0;
       cs_aes_halt_q <= '0;
     end else begin
       acmd_q  <= acmd_d;
@@ -341,6 +345,7 @@ module csrng_core import csrng_pkg::*; #(
       lc_hw_debug_not_on_q <= lc_hw_debug_not_on_d;
       lc_hw_debug_on_q <= lc_hw_debug_on_d;
       cmd_req_dly_q <= cmd_req_dly_d;
+      cmd_req_ccmd_dly_q <= cmd_req_ccmd_dly_d;
       cs_aes_halt_q <= cs_aes_halt_d;
     end
 
@@ -809,6 +814,7 @@ module csrng_core import csrng_pkg::*; #(
     .rst_ni(rst_ni),
     .acmd_avail_i(acmd_avail),
     .acmd_accept_o(acmd_accept),
+    .acmd_hdr_capt_o(acmd_hdr_capt),
     .acmd_i(acmd_hold),
     .acmd_eop_i(acmd_eop),
     .ctr_drbg_cmd_req_rdy_i(ctr_drbg_cmd_req_rdy),
@@ -820,6 +826,7 @@ module csrng_core import csrng_pkg::*; #(
     .generate_req_o(generate_req),
     .update_req_o(update_req),
     .uninstant_req_o(uninstant_req),
+    .cmd_complete_i(state_db_wr_req),
     .halt_main_sm_i(halt_main_sm),
     .main_sm_halted_o(main_sm_sts),
     .main_sm_err_o(main_sm_err)
@@ -987,6 +994,9 @@ module csrng_core import csrng_pkg::*; #(
 
 
 
+  assign cmd_req_ccmd_dly_d = acmd_hold;
+  assign ctr_drbg_cmd_ccmd = cmd_req_ccmd_dly_q;
+
   assign cmd_req_dly_d =
          instant_req || reseed_req || generate_req || update_req || uninstant_req;
 
@@ -1005,7 +1015,7 @@ module csrng_core import csrng_pkg::*; #(
     .ctr_drbg_cmd_enable_i(cs_enable),
     .ctr_drbg_cmd_req_i(ctr_drbg_cmd_req),
     .ctr_drbg_cmd_rdy_o(ctr_drbg_cmd_req_rdy),
-    .ctr_drbg_cmd_ccmd_i(acmd_hold),
+    .ctr_drbg_cmd_ccmd_i(ctr_drbg_cmd_ccmd),
     .ctr_drbg_cmd_inst_id_i(shid_q),
     .ctr_drbg_cmd_entropy_i(cmd_entropy),
     .ctr_drbg_cmd_entropy_fips_i(cmd_entropy_fips), // send to state_db
@@ -1338,13 +1348,12 @@ module csrng_core import csrng_pkg::*; #(
     .clk_i(clk_i),
     .rst_ni(rst_ni),
     .inst_id_i(track_inst_id[i]),
-    .acmd_avail_i(acmd_avail),
-    .acmd_accept_i(acmd_accept),
+    .acmd_hdr_capt_i(acmd_hdr_capt),
     .acmd_i(acmd_hold),
-    .shid_i(shid),
+    .shid_i(shid_q),
     .ctr_drbg_cmd_req_i(ctr_drbg_cmd_req),
     .ctr_drbg_cmd_req_rdy_i(ctr_drbg_cmd_req_rdy),
-    .ctr_drbg_cmd_ccmd_i(acmd_hold),
+    .ctr_drbg_cmd_ccmd_i(ctr_drbg_cmd_ccmd),
     .ctr_drbg_cmd_inst_id_i(shid_q),
     .updblk_arb_vld_i(updblk_arb_vld),
     .updblk_arb_rdy_i(updblk_arb_rdy),

--- a/hw/ip/csrng/rtl/csrng_main_sm.sv
+++ b/hw/ip/csrng/rtl/csrng_main_sm.sv
@@ -13,6 +13,7 @@ module csrng_main_sm import csrng_pkg::*; (
    // ins req interface
   input logic                acmd_avail_i,
   output logic               acmd_accept_o,
+  output logic               acmd_hdr_capt_o,
   input logic [2:0]          acmd_i,
   input logic                acmd_eop_i,
   input logic                ctr_drbg_cmd_req_rdy_i,
@@ -24,25 +25,26 @@ module csrng_main_sm import csrng_pkg::*; (
   output logic               generate_req_o,
   output logic               update_req_o,
   output logic               uninstant_req_o,
+  input logic                cmd_complete_i,
   input logic                halt_main_sm_i,
   output logic               main_sm_halted_o,
   output logic               main_sm_err_o
 );
 
 // Encoding generated with:
-// $ ./util/design/sparse-fsm-encode.py -d 3 -m 11 -n 8 \
-//      -s 2773294212 --language=sv
+// $ ./util/design/sparse-fsm-encode.py -d 3 -m 12 -n 8 \
+//      -s 3745111623 --language=sv
 //
 // Hamming distance histogram:
 //
 //  0: --
 //  1: --
 //  2: --
-//  3: |||||||||||||||| (29.09%)
-//  4: |||||||||||||||||||| (34.55%)
-//  5: |||||||||| (18.18%)
-//  6: |||||||| (14.55%)
-//  7: || (3.64%)
+//  3: ||||||||||||| (25.76%)
+//  4: |||||||||||||||||||| (37.88%)
+//  5: ||||||||||||| (25.76%)
+//  6: |||| (7.58%)
+//  7: | (3.03%)
 //  8: --
 //
 // Minimum Hamming distance: 3
@@ -53,17 +55,18 @@ module csrng_main_sm import csrng_pkg::*; (
 
   localparam int StateWidth = 8;
   typedef    enum logic [StateWidth-1:0] {
-    Idle    =      8'b10100100, // idle
-    InstantPrep  = 8'b10011100, // instantiate prep
-    InstantReq   = 8'b00010010, // instantiate request (takes adata or entropy)
-    ReseedPrep   = 8'b10101001, // reseed prep
-    ReseedReq    = 8'b11010011, // reseed request (takes adata and entropy and Key,V,RC)
-    GenerateReq  = 8'b11101010, // generate request (takes adata? and Key,V,RC)
-    UpdatePrep   = 8'b00000001, // update prep
-    UpdateReq    = 8'b01010101, // update request (takes adata and Key,V,RC)
-    UninstantReq = 8'b00001110, // uninstantiate request (no input)
-    SMHalted     = 8'b01011000, // state machine halted
-    Error        = 8'b11111101  // error state, results in fatal alert
+    Idle    =      8'b00111111, // idle
+    InstantPrep  = 8'b11101010, // instantiate prep
+    InstantReq   = 8'b10011100, // instantiate request (takes adata or entropy)
+    ReseedPrep   = 8'b00100100, // reseed prep
+    ReseedReq    = 8'b11110101, // reseed request (takes adata and entropy and Key,V,RC)
+    GenerateReq  = 8'b10000011, // generate request (takes adata? and Key,V,RC)
+    UpdatePrep   = 8'b10111001, // update prep
+    UpdateReq    = 8'b00001101, // update request (takes adata and Key,V,RC)
+    UninstantReq = 8'b11011111, // uninstantiate request (no input)
+    CmdCompWait  = 8'b00010000, // wait for command to complete
+    SMHalted     = 8'b01010011, // state machine halted
+    Error        = 8'b01111000  // error state, results in fatal alert
   } state_e;
 
   state_e state_d, state_q;
@@ -87,6 +90,7 @@ module csrng_main_sm import csrng_pkg::*; (
   always_comb begin
     state_d = state_q;
     acmd_accept_o = 1'b0;
+    acmd_hdr_capt_o = 1'b0;
     cmd_entropy_req_o = 1'b0;
     instant_req_o = 1'b0;
     reseed_req_o = 1'b0;
@@ -105,19 +109,24 @@ module csrng_main_sm import csrng_pkg::*; (
               acmd_accept_o = 1'b1;
               if (acmd_i == INS) begin
                 if (acmd_eop_i) begin
+                  acmd_hdr_capt_o = 1'b1;
                   state_d = InstantPrep;
                 end
               end else if (acmd_i == RES) begin
                 if (acmd_eop_i) begin
+                  acmd_hdr_capt_o = 1'b1;
                   state_d = ReseedPrep;
                 end
               end else if (acmd_i == GEN) begin
+                acmd_hdr_capt_o = 1'b1;
                 state_d = GenerateReq;
               end else if (acmd_i == UPD) begin
                 if (acmd_eop_i) begin
+                  acmd_hdr_capt_o = 1'b1;
                   state_d = UpdatePrep;
                 end
               end else if (acmd_i == UNI) begin
+                acmd_hdr_capt_o = 1'b1;
                 state_d = UninstantReq;
               end
             end
@@ -138,10 +147,9 @@ module csrng_main_sm import csrng_pkg::*; (
       end
       InstantReq: begin
         instant_req_o = 1'b1;
-        state_d = Idle;
+        state_d = CmdCompWait;
       end
       ReseedPrep: begin
-        acmd_accept_o = 1'b1;
         cmd_entropy_req_o = 1'b1;
         // assumes all adata is present now
         if (cmd_entropy_avail_i) begin
@@ -150,25 +158,28 @@ module csrng_main_sm import csrng_pkg::*; (
       end
       ReseedReq: begin
         reseed_req_o = 1'b1;
-        state_d = Idle;
+        state_d = CmdCompWait;
       end
       GenerateReq: begin
-        acmd_accept_o = 1'b1;
         generate_req_o = 1'b1;
-        state_d = Idle;
+        state_d = CmdCompWait;
       end
       UpdatePrep: begin
         // assumes all adata is present now
-        acmd_accept_o = 1'b1;
         state_d = UpdateReq;
       end
       UpdateReq: begin
         update_req_o = 1'b1;
-        state_d = Idle;
+        state_d = CmdCompWait;
       end
       UninstantReq: begin
         uninstant_req_o = 1'b1;
-        state_d = Idle;
+        state_d = CmdCompWait;
+      end
+      CmdCompWait: begin
+        if (cmd_complete_i) begin
+          state_d = Idle;
+        end
       end
       SMHalted: begin
         main_sm_halted_o = 1'b1;

--- a/hw/ip/csrng/rtl/csrng_track_sm.sv
+++ b/hw/ip/csrng/rtl/csrng_track_sm.sv
@@ -1,0 +1,424 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Description: csrng command tracking state machine module
+//
+//   provides debugging of command flow through csrng
+
+module csrng_track_sm import csrng_pkg::*; #(
+  parameter int Cmd = 3,
+  parameter int StateId = 4
+) (
+  input logic                clk_i,
+  input logic                rst_ni,
+
+   // ins req interface
+  input logic [StateId-1:0]  inst_id_i,
+  input logic                acmd_avail_i,
+  input logic                acmd_accept_i,
+  input logic [Cmd-1:0]      acmd_i,
+  input logic [StateId-1:0]  shid_i,
+  input logic                ctr_drbg_cmd_req_i,
+  input logic                ctr_drbg_cmd_req_rdy_i,
+  input logic [Cmd-1:0]      ctr_drbg_cmd_ccmd_i,
+  input logic [StateId-1:0]  ctr_drbg_cmd_inst_id_i,
+  input logic                updblk_arb_vld_i,
+  input logic                updblk_arb_rdy_i,
+  input logic [Cmd-1:0]      updblk_arb_ccmd_i,
+  input logic [StateId-1:0]  updblk_arb_inst_id_i,
+  input logic                benblk_arb_vld_i,
+  input logic                benblk_arb_rdy_i,
+  input logic [Cmd-1:0]      benblk_arb_ccmd_i,
+  input logic [StateId-1:0]  benblk_arb_inst_id_i,
+  input logic                benblk_updblk_ack_i,
+  input logic                updblk_benblk_ack_rdy_i,
+  input logic [Cmd-1:0]      benblk_cmd_i,
+  input logic [StateId-1:0]  benblk_inst_id_i,
+  input logic                updblk_cmdblk_ack_i,
+  input logic                cmdblk_updblk_ack_rdy_i,
+  input logic [Cmd-1:0]      updblk_cmdblk_ccmd_i,
+  input logic [StateId-1:0]  updblk_cmdblk_inst_id_i,
+  input logic                ctr_drbg_gen_req_i,
+  input logic                ctr_drbg_gen_req_rdy_i,
+  input logic [Cmd-1:0]      ctr_drbg_gen_ccmd_i,
+  input logic [StateId-1:0]  ctr_drbg_gen_inst_id_i,
+  input logic                benblk_genblk_ack_i,
+  input logic                genblk_benblk_ack_rdy_i,
+  input logic                updblk_genblk_ack_i,
+  input logic                genblk_updblk_ack_rdy_i,
+  input logic [Cmd-1:0]      updblk_ccmd_i,
+  input logic [StateId-1:0]  updblk_inst_id_i,
+  input logic                state_db_wr_req_i,
+  input logic                state_db_wr_req_rdy_i,
+  input logic                genbits_stage_vld_i,
+  input logic                genbits_stage_rdy_i,
+  input logic [Cmd-1:0]      state_db_wr_ccmd_i,
+  input logic [StateId-1:0]  state_db_wr_inst_id_i,
+  input logic                cmd_core_ack_i,
+  input logic                cmd_stage_ack_i,
+  output logic [7:0]         track_sm_o
+);
+
+
+  localparam int StateWidth = 8;
+  typedef    enum logic [StateWidth-1:0] {
+    Idle           = 8'h00,
+    InsCmdCap      = 8'h11,
+    InsDrbgCmdIn   = 8'h12,
+    InsDrbgUpdIn   = 8'h13,
+    InsBlkEncIn    = 8'h14,
+    InsDrbgCmdRtn  = 8'h15,
+    InsStateDBIn   = 8'h16,
+    InsCmdStageRtn = 8'h17,
+    InsAppCmdBus   = 8'h18,
+
+    ResCmdCap      = 8'h21,
+    ResDrbgCmdIn   = 8'h22,
+    ResDrbgUpdIn   = 8'h23,
+    ResBlkEncIn    = 8'h24,
+    ResDrbgCmdRtn  = 8'h25,
+    ResStateDBIn   = 8'h26,
+    ResCmdStageRtn = 8'h27,
+    ResAppCmdBus   = 8'h28,
+
+    GenCmdCap      = 8'h31,
+    GenDrbgCmdIn   = 8'h32,
+    GenDrbgUpd1In  = 8'h33,
+    GenBlkEnc1In   = 8'h34,
+    GenDrbgUpd1Rtn = 8'h35,
+    GenDrbgCmd1Rtn = 8'h36,
+    GenDrbgGenIn   = 8'h37,
+    GenDrbgUpd2In  = 8'h38,
+    GenBlkEnc2In   = 8'h39,
+    GenDrbgUpd2Rtn = 8'h3a,
+    GenDrbgGen1Rtn = 8'h3b,
+    GenBlkEnc3In   = 8'h3c,
+    GenDrbgGen2Rtn = 8'h3d,
+    GenStateDBIn   = 8'h3e,
+    GenAppCmdBus   = 8'h3f,
+
+    UpdCmdCap      = 8'h41,
+    UpdDrbgCmdIn   = 8'h42,
+    UpdDrbgUpdIn   = 8'h43,
+    UpdBlkEncIn    = 8'h44,
+    UpdDrbgCmdRtn  = 8'h45,
+    UpdStateDBIn   = 8'h46,
+    UpdCmdStageRtn = 8'h47,
+    UpdAppCmdBus   = 8'h48,
+
+    UniCmdCap      = 8'h51,
+    UniDrbgCmdIn   = 8'h52,
+    UniDrbgUpdIn   = 8'h53,
+    UniBlkEncIn    = 8'h54,
+    UniDrbgCmdRtn  = 8'h55,
+    UniStateDBIn   = 8'h56,
+    UniCmdStageRtn = 8'h57,
+    UniAppCmdBus   = 8'h58
+  } state_e;
+
+  state_e state_d, state_q;
+
+  logic [StateWidth-1:0] state_raw_q;
+
+  // This primitive is used to place a size-only constraint on the
+  // flops in order to prevent FSM state encoding optimizations.
+  prim_flop #(
+    .Width(StateWidth),
+    .ResetValue(StateWidth'(Idle))
+  ) u_state_regs (
+    .clk_i,
+    .rst_ni,
+    .d_i ( state_d ),
+    .q_o ( state_raw_q )
+  );
+
+  assign state_q = state_e'(state_raw_q);
+  assign track_sm_o = state_raw_q;
+
+  always_comb begin
+    state_d = state_q;
+    unique case (state_q)
+      Idle: begin
+        if (acmd_avail_i && acmd_accept_i && (inst_id_i == shid_i)) begin
+          if (acmd_i == INS) begin
+            state_d = InsCmdCap;
+          end else if (acmd_i == RES) begin
+            state_d = ResCmdCap;
+          end else if (acmd_i == GEN) begin
+            state_d = GenCmdCap;
+          end else if (acmd_i == UPD) begin
+            state_d = UpdCmdCap;
+          end else if (acmd_i == UNI) begin
+            state_d = UniCmdCap;
+          end
+        end
+      end
+      //-Start of Ins Cmd-----------------------------------------------------------------
+      InsCmdCap: begin
+        state_d = InsDrbgCmdIn;
+      end
+      InsDrbgCmdIn: begin
+        if (ctr_drbg_cmd_req_i && ctr_drbg_cmd_req_rdy_i &&
+            (ctr_drbg_cmd_ccmd_i == INS) && (ctr_drbg_cmd_inst_id_i == inst_id_i)) begin
+          state_d = InsDrbgUpdIn;
+        end
+      end
+      InsDrbgUpdIn: begin
+        if (updblk_arb_vld_i && updblk_arb_rdy_i &&
+            (updblk_arb_ccmd_i == INS) && (updblk_arb_inst_id_i == inst_id_i)) begin
+          state_d = InsBlkEncIn;
+        end
+      end
+      InsBlkEncIn: begin
+        if (benblk_arb_vld_i && benblk_arb_rdy_i &&
+            (benblk_arb_ccmd_i == INS) && (benblk_arb_inst_id_i == inst_id_i)) begin
+          state_d = InsDrbgCmdRtn;
+        end
+      end
+      InsDrbgCmdRtn: begin
+        if (updblk_cmdblk_ack_i && cmdblk_updblk_ack_rdy_i &&
+            (updblk_cmdblk_ccmd_i == INS) && (updblk_cmdblk_inst_id_i == inst_id_i)) begin
+          state_d = InsStateDBIn;
+        end
+      end
+      InsStateDBIn: begin
+        if (state_db_wr_req_i && state_db_wr_req_rdy_i &&
+          (state_db_wr_ccmd_i == INS) && (state_db_wr_inst_id_i == inst_id_i)) begin
+          state_d = InsCmdStageRtn;
+        end
+      end
+      InsCmdStageRtn: begin
+        if (cmd_core_ack_i) begin
+          state_d = InsAppCmdBus;
+        end
+      end
+      InsAppCmdBus: begin
+        if (cmd_stage_ack_i) begin
+          state_d = Idle;
+        end
+      end
+      //-Start of Res Cmd-----------------------------------------------------------------
+      ResCmdCap: begin
+        state_d = ResDrbgCmdIn;
+      end
+      ResDrbgCmdIn: begin
+        if (ctr_drbg_cmd_req_i && ctr_drbg_cmd_req_rdy_i &&
+            (ctr_drbg_cmd_ccmd_i == RES) && (ctr_drbg_cmd_inst_id_i == inst_id_i)) begin
+          state_d = ResDrbgUpdIn;
+        end
+      end
+      ResDrbgUpdIn: begin
+        if (updblk_arb_vld_i && updblk_arb_rdy_i &&
+            (updblk_arb_ccmd_i == RES) && (updblk_arb_inst_id_i == inst_id_i)) begin
+          state_d = ResBlkEncIn;
+        end
+      end
+      ResBlkEncIn: begin
+        if (benblk_arb_vld_i && benblk_arb_rdy_i &&
+            (benblk_arb_ccmd_i == RES) && (benblk_arb_inst_id_i == inst_id_i)) begin
+          state_d = ResDrbgCmdRtn;
+        end
+      end
+      ResDrbgCmdRtn: begin
+        if (updblk_cmdblk_ack_i && cmdblk_updblk_ack_rdy_i &&
+            (updblk_cmdblk_ccmd_i == RES) && (updblk_cmdblk_inst_id_i == inst_id_i)) begin
+          state_d = ResStateDBIn;
+        end
+      end
+      ResStateDBIn: begin
+        if (state_db_wr_req_i && state_db_wr_req_rdy_i &&
+          (state_db_wr_ccmd_i == RES) && (state_db_wr_inst_id_i == inst_id_i)) begin
+          state_d = ResCmdStageRtn;
+        end
+      end
+      ResCmdStageRtn: begin
+        if (cmd_core_ack_i) begin
+          state_d = ResAppCmdBus;
+        end
+      end
+      ResAppCmdBus: begin
+        if (cmd_stage_ack_i) begin
+          state_d = Idle;
+        end
+      end
+      //-Start of Gen Cmd-----------------------------------------------------------------
+      GenCmdCap: begin
+        state_d = GenDrbgCmdIn;
+      end
+      GenDrbgCmdIn: begin
+        if (ctr_drbg_cmd_req_i && ctr_drbg_cmd_req_rdy_i &&
+            (ctr_drbg_cmd_ccmd_i == GEN) && (ctr_drbg_cmd_inst_id_i == inst_id_i)) begin
+          state_d = GenDrbgUpd1In;
+        end
+      end
+      GenDrbgUpd1In: begin
+        if (updblk_arb_vld_i && updblk_arb_rdy_i &&
+            (updblk_arb_ccmd_i == GEN) && (updblk_arb_inst_id_i == inst_id_i)) begin
+          state_d = GenBlkEnc1In;
+        end
+      end
+      GenBlkEnc1In: begin
+        if (benblk_arb_vld_i && benblk_arb_rdy_i &&
+            (benblk_arb_ccmd_i == GEN) && (benblk_arb_inst_id_i == inst_id_i)) begin
+          state_d = GenDrbgUpd1Rtn;
+        end
+      end
+      GenDrbgUpd1Rtn: begin
+        if (benblk_updblk_ack_i && updblk_benblk_ack_rdy_i &&
+            (benblk_cmd_i == GEN) && (benblk_inst_id_i == inst_id_i)) begin
+          state_d = GenDrbgCmd1Rtn;
+        end
+      end
+      GenDrbgCmd1Rtn: begin
+        if (updblk_cmdblk_ack_i && cmdblk_updblk_ack_rdy_i &&
+            (updblk_cmdblk_ccmd_i == GEN) && (updblk_cmdblk_inst_id_i == inst_id_i)) begin
+          state_d = GenDrbgGenIn;
+        end
+      end
+      GenDrbgGenIn: begin
+        if (ctr_drbg_gen_req_i && ctr_drbg_gen_req_rdy_i &&
+            (ctr_drbg_gen_ccmd_i == GEN) && (ctr_drbg_gen_inst_id_i == inst_id_i)) begin
+          state_d = GenBlkEnc2In;
+        end
+      end
+      GenBlkEnc2In: begin
+        if (benblk_arb_vld_i && benblk_arb_rdy_i &&
+            (benblk_arb_ccmd_i == GENB) && (benblk_arb_inst_id_i == inst_id_i)) begin
+          state_d = GenDrbgGen1Rtn;
+        end
+      end
+      GenDrbgGen1Rtn: begin
+        if (benblk_genblk_ack_i && genblk_benblk_ack_rdy_i &&
+            (benblk_cmd_i == GENB) && (benblk_inst_id_i == inst_id_i)) begin
+          state_d = GenDrbgUpd2In;
+        end
+      end
+      GenDrbgUpd2In: begin
+        if (updblk_arb_vld_i && updblk_arb_rdy_i &&
+            (updblk_arb_ccmd_i == GENU) && (updblk_arb_inst_id_i == inst_id_i)) begin
+          state_d = GenBlkEnc3In;
+        end
+      end
+      GenBlkEnc3In: begin
+        if (benblk_arb_vld_i && benblk_arb_rdy_i &&
+            (benblk_arb_ccmd_i == GENU) && (benblk_arb_inst_id_i == inst_id_i)) begin
+          state_d = GenDrbgUpd2Rtn;
+        end
+      end
+      GenDrbgUpd2Rtn: begin
+        if (benblk_updblk_ack_i && updblk_benblk_ack_rdy_i &&
+            (benblk_cmd_i == GENU) && (benblk_inst_id_i == inst_id_i)) begin
+          state_d = GenDrbgGen2Rtn;
+        end
+      end
+      GenDrbgGen2Rtn: begin
+        if (updblk_genblk_ack_i && genblk_updblk_ack_rdy_i &&
+            (updblk_ccmd_i == GENU) && (updblk_inst_id_i == inst_id_i)) begin
+          state_d = GenStateDBIn;
+        end
+      end
+      GenStateDBIn: begin
+        if (state_db_wr_req_i && state_db_wr_req_rdy_i &&
+            (state_db_wr_ccmd_i == GEN) && (state_db_wr_inst_id_i == inst_id_i)) begin
+          state_d = GenAppCmdBus;
+        end
+      end
+      GenAppCmdBus: begin
+        if (genbits_stage_vld_i && genbits_stage_rdy_i) begin
+          state_d = Idle;
+        end
+      end
+      //-Start of Upd Cmd-----------------------------------------------------------------
+      UpdCmdCap: begin
+        state_d = UpdDrbgCmdIn;
+      end
+      UpdDrbgCmdIn: begin
+        if (ctr_drbg_cmd_req_i && ctr_drbg_cmd_req_rdy_i &&
+            (ctr_drbg_cmd_ccmd_i == UPD) && (ctr_drbg_cmd_inst_id_i == inst_id_i)) begin
+          state_d = UpdDrbgUpdIn;
+        end
+      end
+      UpdDrbgUpdIn: begin
+        if (updblk_arb_vld_i && updblk_arb_rdy_i &&
+            (updblk_arb_ccmd_i == UPD) && (updblk_arb_inst_id_i == inst_id_i)) begin
+          state_d = UpdBlkEncIn;
+        end
+      end
+      UpdBlkEncIn: begin
+        if (benblk_arb_vld_i && benblk_arb_rdy_i &&
+            (benblk_arb_ccmd_i == UPD) && (benblk_arb_inst_id_i == inst_id_i)) begin
+          state_d = UpdDrbgCmdRtn;
+        end
+      end
+      UpdDrbgCmdRtn: begin
+        if (updblk_cmdblk_ack_i && cmdblk_updblk_ack_rdy_i &&
+            (updblk_cmdblk_ccmd_i == UPD) && (updblk_cmdblk_inst_id_i == inst_id_i)) begin
+          state_d = UpdStateDBIn;
+        end
+      end
+      UpdStateDBIn: begin
+        if (state_db_wr_req_i && state_db_wr_req_rdy_i &&
+          (state_db_wr_ccmd_i == UPD) && (state_db_wr_inst_id_i == inst_id_i)) begin
+          state_d = UpdCmdStageRtn;
+        end
+      end
+      UpdCmdStageRtn: begin
+        if (cmd_core_ack_i) begin
+          state_d = UpdAppCmdBus;
+        end
+      end
+      UpdAppCmdBus: begin
+        if (cmd_stage_ack_i) begin
+          state_d = Idle;
+        end
+      end
+      //-Start of Uni Cmd-----------------------------------------------------------------
+      UniCmdCap: begin
+        state_d = UniDrbgCmdIn;
+      end
+      UniDrbgCmdIn: begin
+        if (ctr_drbg_cmd_req_i && ctr_drbg_cmd_req_rdy_i &&
+            (ctr_drbg_cmd_ccmd_i == UNI) && (ctr_drbg_cmd_inst_id_i == inst_id_i)) begin
+          state_d = UniDrbgUpdIn;
+        end
+      end
+      UniDrbgUpdIn: begin
+        if (updblk_arb_vld_i && updblk_arb_rdy_i &&
+            (updblk_arb_ccmd_i == UNI) && (updblk_arb_inst_id_i == inst_id_i)) begin
+          state_d = UniBlkEncIn;
+        end
+      end
+      UniBlkEncIn: begin
+        if (benblk_arb_vld_i && benblk_arb_rdy_i &&
+            (benblk_arb_ccmd_i == UNI) && (benblk_arb_inst_id_i == inst_id_i)) begin
+          state_d = UniDrbgCmdRtn;
+        end
+      end
+      UniDrbgCmdRtn: begin
+        if (updblk_cmdblk_ack_i && cmdblk_updblk_ack_rdy_i &&
+            (updblk_cmdblk_ccmd_i == UNI) && (updblk_cmdblk_inst_id_i == inst_id_i)) begin
+          state_d = UniStateDBIn;
+        end
+      end
+      UniStateDBIn: begin
+        if (state_db_wr_req_i && state_db_wr_req_rdy_i &&
+          (state_db_wr_ccmd_i == UNI) && (state_db_wr_inst_id_i == inst_id_i)) begin
+          state_d = UniCmdStageRtn;
+        end
+      end
+      UniCmdStageRtn: begin
+        if (cmd_core_ack_i) begin
+          state_d = UniAppCmdBus;
+        end
+      end
+      UniAppCmdBus: begin
+        if (cmd_stage_ack_i) begin
+          state_d = Idle;
+        end
+      end
+      default: state_d = Idle;
+    endcase
+  end
+
+endmodule

--- a/hw/ip/csrng/rtl/csrng_track_sm.sv
+++ b/hw/ip/csrng/rtl/csrng_track_sm.sv
@@ -15,8 +15,7 @@ module csrng_track_sm import csrng_pkg::*; #(
 
    // ins req interface
   input logic [StateId-1:0]  inst_id_i,
-  input logic                acmd_avail_i,
-  input logic                acmd_accept_i,
+  input logic                acmd_hdr_capt_i,
   input logic [Cmd-1:0]      acmd_i,
   input logic [StateId-1:0]  shid_i,
   input logic                ctr_drbg_cmd_req_i,
@@ -59,6 +58,13 @@ module csrng_track_sm import csrng_pkg::*; #(
   input logic                cmd_stage_ack_i,
   output logic [7:0]         track_sm_o
 );
+
+  // signals
+  logic  ben_ack_cntr_inc;
+  logic  ben_ack_cntr_clr;
+
+  // flops
+  logic [1:0] ben_ack_cntr_q, ben_ack_cntr_d;
 
 
   localparam int StateWidth = 8;
@@ -133,14 +139,27 @@ module csrng_track_sm import csrng_pkg::*; #(
     .q_o ( state_raw_q )
   );
 
+  always_ff @(posedge clk_i or negedge rst_ni)
+    if (!rst_ni) begin
+      ben_ack_cntr_q      <= '0;
+    end else begin
+      ben_ack_cntr_q     <= ben_ack_cntr_d;
+    end
+
+  assign  ben_ack_cntr_d = ben_ack_cntr_inc ? (ben_ack_cntr_q+1) :
+                           ben_ack_cntr_clr ? '0 :
+                           ben_ack_cntr_q;
+
   assign state_q = state_e'(state_raw_q);
   assign track_sm_o = state_raw_q;
 
   always_comb begin
     state_d = state_q;
+    ben_ack_cntr_inc = 1'b0;
+    ben_ack_cntr_clr = 1'b0;
     unique case (state_q)
       Idle: begin
-        if (acmd_avail_i && acmd_accept_i && (inst_id_i == shid_i)) begin
+        if (acmd_hdr_capt_i && (inst_id_i == shid_i)) begin
           if (acmd_i == INS) begin
             state_d = InsCmdCap;
           end else if (acmd_i == RES) begin
@@ -264,10 +283,15 @@ module csrng_track_sm import csrng_pkg::*; #(
           state_d = GenDrbgUpd1Rtn;
         end
       end
-      GenDrbgUpd1Rtn: begin
+      GenDrbgUpd1Rtn: begin // wait for 3 acks
         if (benblk_updblk_ack_i && updblk_benblk_ack_rdy_i &&
             (benblk_cmd_i == GEN) && (benblk_inst_id_i == inst_id_i)) begin
-          state_d = GenDrbgCmd1Rtn;
+          if (ben_ack_cntr_q != 2) begin
+            ben_ack_cntr_inc = 1'b1;
+          end else begin
+            ben_ack_cntr_clr = 1'b1;
+            state_d = GenDrbgCmd1Rtn;
+          end
         end
       end
       GenDrbgCmd1Rtn: begin
@@ -306,10 +330,15 @@ module csrng_track_sm import csrng_pkg::*; #(
           state_d = GenDrbgUpd2Rtn;
         end
       end
-      GenDrbgUpd2Rtn: begin
+      GenDrbgUpd2Rtn: begin // wait for 3 acks
         if (benblk_updblk_ack_i && updblk_benblk_ack_rdy_i &&
             (benblk_cmd_i == GENU) && (benblk_inst_id_i == inst_id_i)) begin
-          state_d = GenDrbgGen2Rtn;
+          if (ben_ack_cntr_q != 2) begin
+            ben_ack_cntr_inc = 1'b1;
+          end else begin
+            ben_ack_cntr_clr = 1'b1;
+            state_d = GenDrbgGen2Rtn;
+          end
         end
       end
       GenDrbgGen2Rtn: begin


### PR DESCRIPTION
When two csrng application interfaces are enabled, the csrng processing hangs, which requires an RTL fix.
A tracker function has also been added for easier debug.