### PR TITLE
[dv/otp_ctrl] add lc_esc_req sequence to stress_all and fix related issues

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -43,6 +43,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
       lc_esc_dly1       <= lc_ctrl_pkg::Off;
       lc_esc_dly2       <= lc_ctrl_pkg::Off;
       lc_check_byp_en_i <= lc_ctrl_pkg::Off;
+      lc_esc_on         <= 0;
     end else begin
       lc_prog_err_dly1 <= lc_prog_err;
       lc_esc_dly1      <= lc_escalate_en_i;
@@ -50,12 +51,13 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
       if (lc_prog_req && lc_check_byp_en_i == lc_ctrl_pkg::Off && lc_check_byp_en) begin
         lc_check_byp_en_i <= lc_ctrl_pkg::On;
       end
+      if (lc_esc_dly2 == lc_ctrl_pkg::On && !lc_esc_on) begin
+        lc_esc_on <= 1;
+      end
     end
   end
 
   assign lc_prog_no_sta_check = lc_prog_err | lc_prog_err_dly1 | lc_prog_req | lc_esc_on;
-
-  assign lc_esc_on = lc_esc_dly2 != lc_ctrl_pkg::Off;
 
   // TODO: for lc_tx, except esc_en signal, all value different from On is treated as Off,
   // technically we can randomize values here once scb supports

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
@@ -47,18 +47,12 @@ class otp_ctrl_parallel_lc_esc_vseq extends otp_ctrl_dai_errs_vseq;
     // TODO: in alert_esc_monitor, makes it auto-response like push-pull agent
     if (en_auto_alerts_response && cfg.list_of_alerts.size()) run_alert_rsp_seq_nonblocking();
 
-    // Turn off reset because if issuing lc_escalation_en during otp program, scb cannot
-    // predict if the OTP memory is programmed or not.
-    // TODO: temp disable, support it in stress_all_with_rand_reset case
-    do_reset_in_seq = 0;
-
     // Wait 5 clock cycles until async lc_escalate_en propogate to each state machine.
     cfg.clk_rst_vif.wait_clks(5);
 
     // After LC_escalate is On, we trigger the dai_errs_vseq to check interfaces will return
     // default values and the design won't hang.
     otp_ctrl_dai_errs_vseq::body();
-    do_reset_in_seq = 1;
   endtask
 
   virtual task post_start();

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_stress_all_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_stress_all_vseq.sv
@@ -18,6 +18,7 @@ class otp_ctrl_stress_all_vseq extends otp_ctrl_base_vseq;
     // Drive dft_en pins to access the test_access memory, this is used for tl_error sequence in
     // stress_all_with_rand_reset test
     cfg.otp_ctrl_vif.drive_lc_dft_en(lc_ctrl_pkg::On);
+    if ($urandom_range(0, 1)) cfg.otp_ctrl_vif.drive_lc_escalate_en(lc_ctrl_pkg::Off);
 
     // Once turn on lc_dft_en regiser, will need some time to update the state register
     // Two clock cycles for lc_async mode, one clock cycle for driving dft_en
@@ -32,6 +33,7 @@ class otp_ctrl_stress_all_vseq extends otp_ctrl_base_vseq;
                           "otp_ctrl_test_access_vseq",
                           // TODO: support this seq:
                           // "otp_ctrl_parallel_lc_req_vseq",
+                          "otp_ctrl_parallel_lc_esc_vseq",
                           "otp_ctrl_parallel_key_req_vseq"};
 
     for (int i = 1; i <= num_trans; i++) begin
@@ -76,6 +78,7 @@ class otp_ctrl_stress_all_vseq extends otp_ctrl_base_vseq;
   endtask : body
 
   virtual task read_and_check_all_csrs_after_reset();
+    cfg.otp_ctrl_vif.drive_lc_escalate_en(lc_ctrl_pkg::Off);
     otp_pwr_init();
     super.read_and_check_all_csrs_after_reset();
   endtask


### PR DESCRIPTION
Please ignore the first commit, it is separated out to a different PR #6051.

This second PR fixes three lc_esc related mismatch:
1). when lc_esc is On, the otp_lc_o should return default value.
2). when lc_esc is issued during otp write, it will wait until OTP write
complete, then backdoor align
3). when reset/lc_esc_on is issued during digest calculate, will use
backdoor to recover digest value.

This PR also adds lc_esc_en sequence to stress_all test.

Signed-off-by: Cindy Chen <chencindy@google.com>