### PR TITLE
[otp_ctrl] Align lock bits in otp_ctrl Hjson to use rw0c

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -936,7 +936,7 @@
         { bits:   "0",
           desc: '''
           When cleared to 0, the !!CHECK_TRIGGER register cannot be written anymore.
-          Write 1 to clear this bit.
+          Write 0 to clear this bit.
           '''
           resval: 1,
         },
@@ -978,7 +978,7 @@
         { bits:   "0",
           desc: '''
           When cleared to 0, !!INTEGRITY_CHECK_PERIOD and !!CONSISTENCY_CHECK_PERIOD registers cannot be written anymore.
-          Write 1 to clear this bit.
+          Write 0 to clear this bit.
           '''
           resval: 1,
         },
@@ -1058,7 +1058,7 @@
       desc: '''
             Runtime read lock for the CREATOR_SW_CFG partition.
             ''',
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hro",
       regwen:   "DIRECT_ACCESS_REGWEN",
       tags:     [ // The enable register "DIRECT_ACCESS_REGWEN" is HW controlled,
@@ -1068,7 +1068,7 @@
         { bits:   "0",
           desc: '''
           When cleared to 0, read access to the CREATOR_SW_CFG partition is locked.
-          Write 1 to clear this bit.
+          Write 0 to clear this bit.
           '''
           resval: 1,
         },
@@ -1078,7 +1078,7 @@
       desc: '''
             Runtime read lock for the OWNER_SW_CFG partition.
             ''',
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hro",
       regwen:   "DIRECT_ACCESS_REGWEN",
       tags:     [ // The enable register "DIRECT_ACCESS_REGWEN" is HW controlled,
@@ -1088,7 +1088,7 @@
         { bits:   "0",
           desc: '''
           When cleared to 0, read access to the OWNER_SW_CFG partition is locked.
-          Write 1 to clear this bit.
+          Write 0 to clear this bit.
           '''
           resval: 1,
         },

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -601,7 +601,7 @@
         { bits:   "0",
           desc: '''
           When cleared to 0, the !!CHECK_TRIGGER register cannot be written anymore.
-          Write 1 to clear this bit.
+          Write 0 to clear this bit.
           '''
           resval: 1,
         },
@@ -643,7 +643,7 @@
         { bits:   "0",
           desc: '''
           When cleared to 0, !!INTEGRITY_CHECK_PERIOD and !!CONSISTENCY_CHECK_PERIOD registers cannot be written anymore.
-          Write 1 to clear this bit.
+          Write 0 to clear this bit.
           '''
           resval: 1,
         },
@@ -725,7 +725,7 @@
       desc: '''
             Runtime read lock for the ${part["name"]} partition.
             ''',
-      swaccess: "rw1c",
+      swaccess: "rw0c",
       hwaccess: "hro",
       regwen:   "DIRECT_ACCESS_REGWEN",
       tags:     [ // The enable register "DIRECT_ACCESS_REGWEN" is HW controlled,
@@ -735,7 +735,7 @@
         { bits:   "0",
           desc: '''
           When cleared to 0, read access to the ${part["name"]} partition is locked.
-          Write 1 to clear this bit.
+          Write 0 to clear this bit.
           '''
           resval: 1,
         },

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -186,8 +186,8 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task write_sw_rd_locks(bit [1:0] do_rd_lock= $urandom());
-    if (do_rd_lock[0]) csr_wr(ral.creator_sw_cfg_read_lock, 1);
-    if (do_rd_lock[1]) csr_wr(ral.owner_sw_cfg_read_lock, 1);
+    if (do_rd_lock[0]) csr_wr(ral.creator_sw_cfg_read_lock, 0);
+    if (do_rd_lock[1]) csr_wr(ral.owner_sw_cfg_read_lock, 0);
   endtask
 
   // The digest CSR values are verified in otp_ctrl_scoreboard

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
@@ -1192,7 +1192,7 @@ module otp_ctrl_reg_top (
 
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("W0C"),
     .RESVAL  (1'h1)
   ) u_creator_sw_cfg_read_lock (
     .clk_i   (clk_i    ),
@@ -1219,7 +1219,7 @@ module otp_ctrl_reg_top (
 
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("W0C"),
     .RESVAL  (1'h1)
   ) u_owner_sw_cfg_read_lock (
     .clk_i   (clk_i    ),


### PR DESCRIPTION
Signed-off-by: Michael Schaffner <msf@opentitan.org>