### PR TITLE
[otp_ctrl] Locally escalate upon a fatal alert/error

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -991,6 +991,9 @@
       swaccess: "rw",
       hwaccess: "hro",
       regwen:   "CHECK_REGWEN",
+      tags: [ // Do not write to this automatically, as it may trigger unintended side effects
+              // like spurious escalations / alerts.
+              "excl:CsrAllTests:CsrExclWrite"],
       fields: [
         { bits: "31:0",
           desc: '''

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -656,6 +656,9 @@
       swaccess: "rw",
       hwaccess: "hro",
       regwen:   "CHECK_REGWEN",
+      tags: [ // Do not write to this automatically, as it may trigger unintended side effects
+              // like spurious escalations / alerts.
+              "excl:CsrAllTests:CsrExclWrite"],
       fields: [
         { bits: "31:0",
           desc: '''


### PR DESCRIPTION
Previously, only the affected FSM went into a terminal error state upon
encountering a fatal alert.

This commit widens the scope of that local countermeasure, and moves all
partitions controllers and FSMs into a terminal error state if any of
them experienced a fatal error/alert.

This addresses https://github.com/lowRISC/opentitan/issues/5497#issuecomment-818292070

Signed-off-by: Michael Schaffner <msf@opentitan.org>