### PR TITLE
[dv/common] enable Instr/Data TL access types

### DIFF
--- a/hw/dv/sv/cip_lib/cip_lib.core
+++ b/hw/dv/sv/cip_lib/cip_lib.core
@@ -28,6 +28,7 @@ filesets:
       - seq_lib/cip_base_vseq.sv: {is_include_file: true}
       - seq_lib/cip_base_vseq__tl_errors.svh: {is_include_file: true}
       - seq_lib/cip_tl_seq_item.sv: {is_include_file: true}
+      - seq_lib/cip_tl_host_single_seq.sv: {is_include_file: true}
       - cip_base_test.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -124,10 +124,11 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
                          input bit [BUS_DW-1:0]  compare_mask = '1,
                          input bit               check_exp_data = 1'b0,
                          input bit               blocking = csr_utils_pkg::default_csr_blocking,
+                         input tl_type_e         tl_type = DataType,
                          tl_sequencer            tl_sequencer_h = p_sequencer.tl_sequencer_h);
     uvm_status_e status;
     tl_access_w_abort(addr, write, data, status, mask, check_rsp, exp_err_rsp, exp_data,
-                      compare_mask, check_exp_data, blocking, tl_sequencer_h);
+                      compare_mask, check_exp_data, blocking, tl_type, tl_sequencer_h);
   endtask
 
   // this tl_access can input req_abort_pct (pertentage to enable req abort) and output status for
@@ -144,16 +145,17 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
       input bit [BUS_DW-1:0]  compare_mask = '1,
       input bit               check_exp_data = 1'b0,
       input bit               blocking = csr_utils_pkg::default_csr_blocking,
+      input tl_type_e         tl_type = DataType,
       tl_sequencer            tl_sequencer_h = p_sequencer.tl_sequencer_h,
       input int               req_abort_pct = 0);
 
     if (blocking) begin
       tl_access_sub(addr, write, data, status, mask, check_rsp, exp_err_rsp, exp_data,
-                    compare_mask, check_exp_data, req_abort_pct, tl_sequencer_h);
+                    compare_mask, check_exp_data, req_abort_pct, tl_type, tl_sequencer_h);
     end else begin
       fork
         tl_access_sub(addr, write, data, status, mask, check_rsp, exp_err_rsp, exp_data,
-                      compare_mask, check_exp_data, req_abort_pct, tl_sequencer_h);
+                      compare_mask, check_exp_data, req_abort_pct, tl_type, tl_sequencer_h);
       join_none
       // Add #0 to ensure that this thread starts executing before any subsequent call
       #0;
@@ -171,11 +173,13 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
                              input bit [BUS_DW-1:0]  compare_mask = '1,
                              input bit               check_exp_data = 1'b0,
                              input int               req_abort_pct = 0,
+                             input tl_type_e         tl_type = DataType,
                              tl_sequencer            tl_sequencer_h = p_sequencer.tl_sequencer_h);
     `DV_SPINWAIT(
         // thread to read/write tlul
-        tl_host_single_seq #(cip_tl_seq_item) tl_seq;
+        cip_tl_host_single_seq tl_seq;
         `uvm_create_on(tl_seq, tl_sequencer_h)
+        tl_seq.tl_type = tl_type;
         if (cfg.zero_delays) begin
           tl_seq.min_req_delay = 0;
           tl_seq.max_req_delay = 0;

--- a/hw/dv/sv/cip_lib/seq_lib/cip_seq_list.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_seq_list.sv
@@ -2,8 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// customized tl seq for CIP
+// customized tl_seq_item for cmd integrity
 `include "cip_tl_seq_item.sv"
+
+// customized tl_host_single_seq for cmd integrity
+`include "cip_tl_host_single_seq.sv"
 
 // vseqs
 `include "cip_base_vseq.sv"

--- a/hw/dv/sv/cip_lib/seq_lib/cip_tl_host_single_seq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_tl_host_single_seq.sv
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Extends tl_host_single_seq to enable control over command integrity fields.
+//
+// This is useful to set up integrity error sequences,
+// test execution of Instr/Data transactions, etc...
+class cip_tl_host_single_seq extends tl_host_single_seq #(cip_tl_seq_item);
+
+  `uvm_object_utils(cip_tl_host_single_seq)
+  `uvm_object_new
+
+  tlul_pkg::tl_type_e tl_type = DataType;
+
+  virtual function void randomize_req(REQ req, int idx);
+    super.randomize_req(req, idx);
+    req.tl_type = tl_type;
+  endfunction
+
+endclass

--- a/hw/dv/sv/cip_lib/seq_lib/cip_tl_seq_item.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_tl_seq_item.sv
@@ -10,6 +10,8 @@ class cip_tl_seq_item extends tl_seq_item;
 
   `uvm_object_new
 
+  tlul_pkg::tl_type_e tl_type = DataType;
+
   function void post_randomize();
     a_user = get_a_user_val();
     d_user = get_d_user_val();
@@ -23,7 +25,7 @@ class cip_tl_seq_item extends tl_seq_item;
     logic [D2HRspFullWidth - 1 : 0] data_intg;
 
     // construct command integrity
-    cmd_intg_payload.tl_type = DataType;
+    cmd_intg_payload.tl_type = tl_type;
     cmd_intg_payload.addr = a_addr;
     cmd_intg_payload.opcode = tl_a_op_e'(a_opcode);
     cmd_intg_payload.mask = a_mask;
@@ -33,7 +35,7 @@ class cip_tl_seq_item extends tl_seq_item;
     data_intg = prim_secded_pkg::prim_secded_64_57_enc(DataMaxWidth'(a_data));
 
     user.rsvd = '0;
-    user.tl_type = DataType;
+    user.tl_type = tl_type;
     user.cmd_intg = payload_intg[H2DCmdFullWidth -1 -: H2DCmdIntgWidth];
     user.data_intg = data_intg[DataFullWidth -1 -: DataIntgWidth];;
     return user;


### PR DESCRIPTION
this PR creates a custom extension of `tl_host_single_seq` to allow for
full flexibility in creating cmd integrity related test sequences, and
adds basic functionality to swap between TL access types (DataType or
InstrType).

Signed-off-by: Udi Jonnalagadda <udij@google.com>