### PR TITLE
[top] Fix a templating bug that breaks CI 

### DIFF
--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -875,11 +875,6 @@ module chip_earlgrey_asic (
   assign manual_out_flash_test_volt = 1'b0;
   assign manual_oe_flash_test_volt = 1'b0;
 
-  assign manual_out_flash_test_mode0 = 1'b0;
-  assign manual_out_flash_test_mode1 = 1'b0;
-  assign manual_oe_flash_test_mode0 = 1'b0;
-  assign manual_oe_flash_test_mode1 = 1'b0;
-
   // These pad attributes currently tied off permanently (these are all input-only pads).
   assign manual_attr_por_n = '0;
   assign manual_attr_cc1 = '0;
@@ -887,8 +882,6 @@ module chip_earlgrey_asic (
   assign manual_attr_flash_test_mode0 = '0;
   assign manual_attr_flash_test_mode1 = '0;
   assign manual_attr_flash_test_volt = '0;
-  assign manual_attr_flash_test_mode0 = '0;
-  assign manual_attr_flash_test_mode1 = '0;
 
   logic unused_manual_sigs;
   assign unused_manual_sigs = ^{

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -546,11 +546,6 @@ module chip_${top["name"]}_${target["name"]} (
   assign manual_out_flash_test_volt = 1'b0;
   assign manual_oe_flash_test_volt = 1'b0;
 
-  assign manual_out_flash_test_mode0 = 1'b0;
-  assign manual_out_flash_test_mode1 = 1'b0;
-  assign manual_oe_flash_test_mode0 = 1'b0;
-  assign manual_oe_flash_test_mode1 = 1'b0;
-
   // These pad attributes currently tied off permanently (these are all input-only pads).
   assign manual_attr_por_n = '0;
   assign manual_attr_cc1 = '0;
@@ -558,8 +553,6 @@ module chip_${top["name"]}_${target["name"]} (
   assign manual_attr_flash_test_mode0 = '0;
   assign manual_attr_flash_test_mode1 = '0;
   assign manual_attr_flash_test_volt = '0;
-  assign manual_attr_flash_test_mode0 = '0;
-  assign manual_attr_flash_test_mode1 = '0;
 
   logic unused_manual_sigs;
   assign unused_manual_sigs = ^{


### PR DESCRIPTION
This appears to be a CI escape (possibly due to multiple colliding PRs), and causes multiply driven errors in VCS.

Signed-off-by: Michael Schaffner <msf@opentitan.org>