### PR TITLE
Update to rebuilt device toolchain

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ variables:
   VERIBLE_VERSION: v0.0-808-g1e17daa
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
   # if you update this, update the definition in util/container/Dockerfile
-  TOOLCHAIN_VERSION: 20200904-1
+  TOOLCHAIN_VERSION: 20210412-1
   # This controls where builds happen, and gets picked up by build_consts.sh.
   BUILD_ROOT: $(Build.ArtifactStagingDirectory)
   VIVADO_VERSION: "2020.1"

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -9,7 +9,7 @@
 ARG VERILATOR_VERSION=4.104
 
 # The RISCV toolchain version should match the release tag used in GitHub.
-ARG RISCV_TOOLCHAIN_TAR_VERSION=20200904-1
+ARG RISCV_TOOLCHAIN_TAR_VERSION=20210412-1
 
 # Build OpenOCD
 # OpenOCD is a tool to connect with the target chip over JTAG and similar


### PR DESCRIPTION
The previously used toolchain in version 20200904-1 was targeting Ubuntu
16.04 or RHEL7 and newer. The version this commit switches to targets
RHEL6/CentOS6 or newer.

Beyond a rebuild to be more compatible with older Linux distributions
nothing changed: the toolchain contains the same versions of GCC, clang,
and all associated tools.