### PR TITLE
[formal/conn] Support dvsim to publish regression result summary

### DIFF
--- a/hw/_index.md
+++ b/hw/_index.md
@@ -43,7 +43,7 @@ Finally, we provide the same set of information for all available [top level des
   * [Design specification]({{< relref "hw/top_earlgrey/doc" >}})
   * [dv document]({{< relref "hw/top_earlgrey/doc/dv" >}})
   * [DV simulation results, with coverage (nightly)](https://reports.opentitan.org/hw/top_earlgrey/dv/latest/results.html)
-  * FPV results (nightly) (TBD)
+  * [Connectivity results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/conn/jaspergold/latest/results.html)
   * [AscentLint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/ascentlint/latest/results.html)
   * [Verilator lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/verilator/latest/results.html)
   * [Style lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/veriblelint/latest/results.html)

--- a/hw/formal/tools/dvsim/common_formal_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_formal_cfg.hjson
@@ -48,4 +48,12 @@
     { COV:      "{cov}" },
     { sub_flow: "{sub_flow}"}
   ]
+
+  overrides: [
+    // Add formal sub_flow to the scratch path
+    {
+      name:  scratch_path
+      value: "{scratch_base_path}/{dut}-{flow}-{sub_flow}-{tool}"
+    }
+  ]
 }

--- a/hw/formal/tools/dvsim/common_fpv_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_fpv_cfg.hjson
@@ -2,6 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  sub_flow:    "fpv"
+  sub_flow:    fpv
   import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_formal_cfg.hjson"]
 }

--- a/hw/top_earlgrey/formal/chip_conn_cfg.hjson
+++ b/hw/top_earlgrey/formal/chip_conn_cfg.hjson
@@ -13,4 +13,8 @@
 
   // TODO: reduce run time and turn on coverage
   cov: false
+
+  rel_path: "hw/top_earlgrey/{sub_flow}/{tool}"
+
+  publish_report: true
 }

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
+  // TODO: flow and sub_flow should not needed here. Update dvsim to support it.
   flow: formal
+
+  sub_flow: fpv
 
   // This is the primary cfg hjson for FPV. It imports ALL individual FPV
   // cfgs of the IPs and the full chip used in top_earlgrey. This enables to run


### PR DESCRIPTION
This PR adds following support:
1. Add sub-flow to output path to better distinguish different formal
sub-flows.
2. Add a switch `publish_child_cfg_result` to publish result summary
when not running from batch cfgs (thus no result summary).
3. Add a URL path to top-level connectivity test dashboard.

Signed-off-by: Cindy Chen <chencindy@google.com>