### PR TITLE
[otbn,dv] Use "done" directly in the idle checker module

### DIFF
--- a/hw/ip/otbn/dv/uvm/sva/otbn_bind.sv
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_bind.sv
@@ -24,7 +24,7 @@ module otbn_bind;
     .clk_i    (clk_i),
     .rst_ni   (rst_ni),
     .reg2hw   (reg2hw),
-    .hw2reg   (hw2reg),
+    .done_i   (done),
     .idle_o_i (idle_o)
   );
 


### PR DESCRIPTION
We were reconstructing "done" by looking at the hw2reg signals. This
is sort of nice, because you can do it by just looking at OTBN's
output ports. Unfortunately, it doesn't quite work because these
signals are also triggered by writes to the INTR_TEST register.

Since we're binding otbn_idle_checker into otbn anyway, just snoop on
the internal "done" signal that we actually want.
