### PR TITLE
[entropy_src/rtl] add a clean halt/start sequence

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -66,8 +66,9 @@
   registers: [
     { name: "REGWEN",
       desc: "Register write enable for all control registers",
-      swaccess: "rw0c",
-      hwaccess: "hro",
+      swaccess: "ro", // lock is managed by HW
+      hwaccess: "hwo",
+      hwext: "true",
       fields: [
         {
             bits: "0",
@@ -105,7 +106,6 @@
       desc: "Configuration register",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGWEN",
       fields: [
         { bits: "1:0",
           name: "ENABLE",

--- a/hw/ip/entropy_src/rtl/entropy_src_ack_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_ack_sm.sv
@@ -9,6 +9,7 @@ module entropy_src_ack_sm (
   input logic                clk_i,
   input logic                rst_ni,
 
+  input logic                enable_i,
   input logic                req_i,
   output logic               ack_o,
   input logic                fifo_not_empty_i,
@@ -70,11 +71,13 @@ module entropy_src_ack_sm (
     ack_sm_err_o = 1'b0;
     unique case (state_q)
       Idle: begin
-        if (req_i) begin
-          if (fifo_not_empty_i) begin
-            state_d = AckImmed;
-          end else begin
-            state_d = AckWait;
+        if (enable_i) begin
+          if (req_i) begin
+            if (fifo_not_empty_i) begin
+              state_d = AckImmed;
+            end else begin
+              state_d = AckWait;
+            end
           end
         end
       end
@@ -84,10 +87,15 @@ module entropy_src_ack_sm (
         state_d = Idle;
       end
       AckWait: begin
-        if (fifo_not_empty_i) begin
+        if (!enable_i) begin
           ack_o = 1'b1;
-          fifo_pop_o = 1'b1;
           state_d = Idle;
+        end else begin
+          if (fifo_not_empty_i) begin
+            ack_o = 1'b1;
+            fifo_pop_o = 1'b1;
+            state_d = Idle;
+          end
         end
       end
       Error: begin

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -67,10 +67,6 @@ package entropy_src_reg_pkg;
   } entropy_src_reg2hw_alert_test_reg_t;
 
   typedef struct packed {
-    logic        q;
-  } entropy_src_reg2hw_regwen_reg_t;
-
-  typedef struct packed {
     struct packed {
       logic [1:0]  q;
     } enable;
@@ -285,6 +281,10 @@ package entropy_src_reg_pkg;
       logic        de;
     } es_fatal_err;
   } entropy_src_hw2reg_intr_state_reg_t;
+
+  typedef struct packed {
+    logic        d;
+  } entropy_src_hw2reg_regwen_reg_t;
 
   typedef struct packed {
     logic [31:0] d;
@@ -594,11 +594,10 @@ package entropy_src_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    entropy_src_reg2hw_intr_state_reg_t intr_state; // [536:534]
-    entropy_src_reg2hw_intr_enable_reg_t intr_enable; // [533:531]
-    entropy_src_reg2hw_intr_test_reg_t intr_test; // [530:525]
-    entropy_src_reg2hw_alert_test_reg_t alert_test; // [524:521]
-    entropy_src_reg2hw_regwen_reg_t regwen; // [520:520]
+    entropy_src_reg2hw_intr_state_reg_t intr_state; // [535:533]
+    entropy_src_reg2hw_intr_enable_reg_t intr_enable; // [532:530]
+    entropy_src_reg2hw_intr_test_reg_t intr_test; // [529:524]
+    entropy_src_reg2hw_alert_test_reg_t alert_test; // [523:520]
     entropy_src_reg2hw_conf_reg_t conf; // [519:507]
     entropy_src_reg2hw_rate_reg_t rate; // [506:491]
     entropy_src_reg2hw_entropy_control_reg_t entropy_control; // [490:489]
@@ -624,7 +623,8 @@ package entropy_src_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    entropy_src_hw2reg_intr_state_reg_t intr_state; // [1035:1030]
+    entropy_src_hw2reg_intr_state_reg_t intr_state; // [1036:1031]
+    entropy_src_hw2reg_regwen_reg_t regwen; // [1030:1030]
     entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [1029:998]
     entropy_src_hw2reg_repcnt_thresholds_reg_t repcnt_thresholds; // [997:966]
     entropy_src_hw2reg_repcnts_thresholds_reg_t repcnts_thresholds; // [965:934]
@@ -723,6 +723,8 @@ package entropy_src_reg_pkg;
   parameter logic [1:0] ENTROPY_SRC_ALERT_TEST_RESVAL = 2'h 0;
   parameter logic [0:0] ENTROPY_SRC_ALERT_TEST_RECOV_ALERT_RESVAL = 1'h 0;
   parameter logic [0:0] ENTROPY_SRC_ALERT_TEST_FATAL_ALERT_RESVAL = 1'h 0;
+  parameter logic [0:0] ENTROPY_SRC_REGWEN_RESVAL = 1'h 1;
+  parameter logic [0:0] ENTROPY_SRC_REGWEN_REGWEN_RESVAL = 1'h 1;
   parameter logic [31:0] ENTROPY_SRC_ENTROPY_DATA_RESVAL = 32'h 0;
   parameter logic [31:0] ENTROPY_SRC_REPCNT_THRESHOLDS_RESVAL = 32'h ffffffff;
   parameter logic [15:0] ENTROPY_SRC_REPCNT_THRESHOLDS_FIPS_THRESH_RESVAL = 16'h ffff;

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -133,8 +133,7 @@ module entropy_src_reg_top (
   logic alert_test_fatal_alert_wd;
   logic alert_test_fatal_alert_we;
   logic regwen_qs;
-  logic regwen_wd;
-  logic regwen_we;
+  logic regwen_re;
   logic [7:0] rev_abi_revision_qs;
   logic [7:0] rev_hw_revision_qs;
   logic [7:0] rev_chip_type_qs;
@@ -624,29 +623,18 @@ module entropy_src_reg_top (
   );
 
 
-  // R[regwen]: V(False)
+  // R[regwen]: V(True)
 
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
+  prim_subreg_ext #(
+    .DW    (1)
   ) u_regwen (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (regwen_we),
-    .wd     (regwen_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
+    .re     (regwen_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.regwen.d),
+    .qre    (),
     .qe     (),
-    .q      (reg2hw.regwen.q ),
-
-    // to register interface (read)
+    .q      (),
     .qs     (regwen_qs)
   );
 
@@ -679,8 +667,8 @@ module entropy_src_reg_top (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
-    // from register interface (qualified with register enable)
-    .we     (conf_enable_we & regwen_qs),
+    // from register interface
+    .we     (conf_enable_we),
     .wd     (conf_enable_wd),
 
     // from internal hardware
@@ -705,8 +693,8 @@ module entropy_src_reg_top (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
-    // from register interface (qualified with register enable)
-    .we     (conf_boot_bypass_disable_we & regwen_qs),
+    // from register interface
+    .we     (conf_boot_bypass_disable_we),
     .wd     (conf_boot_bypass_disable_wd),
 
     // from internal hardware
@@ -731,8 +719,8 @@ module entropy_src_reg_top (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
-    // from register interface (qualified with register enable)
-    .we     (conf_repcnt_disable_we & regwen_qs),
+    // from register interface
+    .we     (conf_repcnt_disable_we),
     .wd     (conf_repcnt_disable_wd),
 
     // from internal hardware
@@ -757,8 +745,8 @@ module entropy_src_reg_top (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
-    // from register interface (qualified with register enable)
-    .we     (conf_adaptp_disable_we & regwen_qs),
+    // from register interface
+    .we     (conf_adaptp_disable_we),
     .wd     (conf_adaptp_disable_wd),
 
     // from internal hardware
@@ -783,8 +771,8 @@ module entropy_src_reg_top (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
-    // from register interface (qualified with register enable)
-    .we     (conf_bucket_disable_we & regwen_qs),
+    // from register interface
+    .we     (conf_bucket_disable_we),
     .wd     (conf_bucket_disable_wd),
 
     // from internal hardware
@@ -809,8 +797,8 @@ module entropy_src_reg_top (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
-    // from register interface (qualified with register enable)
-    .we     (conf_markov_disable_we & regwen_qs),
+    // from register interface
+    .we     (conf_markov_disable_we),
     .wd     (conf_markov_disable_wd),
 
     // from internal hardware
@@ -835,8 +823,8 @@ module entropy_src_reg_top (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
-    // from register interface (qualified with register enable)
-    .we     (conf_health_test_clr_we & regwen_qs),
+    // from register interface
+    .we     (conf_health_test_clr_we),
     .wd     (conf_health_test_clr_wd),
 
     // from internal hardware
@@ -861,8 +849,8 @@ module entropy_src_reg_top (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
-    // from register interface (qualified with register enable)
-    .we     (conf_rng_bit_en_we & regwen_qs),
+    // from register interface
+    .we     (conf_rng_bit_en_we),
     .wd     (conf_rng_bit_en_wd),
 
     // from internal hardware
@@ -887,8 +875,8 @@ module entropy_src_reg_top (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
-    // from register interface (qualified with register enable)
-    .we     (conf_rng_bit_sel_we & regwen_qs),
+    // from register interface
+    .we     (conf_rng_bit_sel_we),
     .wd     (conf_rng_bit_sel_wd),
 
     // from internal hardware
@@ -913,8 +901,8 @@ module entropy_src_reg_top (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
-    // from register interface (qualified with register enable)
-    .we     (conf_extht_enable_we & regwen_qs),
+    // from register interface
+    .we     (conf_extht_enable_we),
     .wd     (conf_extht_enable_wd),
 
     // from internal hardware
@@ -939,8 +927,8 @@ module entropy_src_reg_top (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
-    // from register interface (qualified with register enable)
-    .we     (conf_repcnts_disable_we & regwen_qs),
+    // from register interface
+    .we     (conf_repcnts_disable_we),
     .wd     (conf_repcnts_disable_wd),
 
     // from internal hardware
@@ -2694,8 +2682,7 @@ module entropy_src_reg_top (
   assign alert_test_fatal_alert_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_fatal_alert_wd = reg_wdata[1];
 
-  assign regwen_we = addr_hit[4] & reg_we & !reg_error;
-  assign regwen_wd = reg_wdata[0];
+  assign regwen_re = addr_hit[4] & reg_re & !reg_error;
 
   assign conf_enable_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_enable_wd = reg_wdata[1:0];


### PR DESCRIPTION
This change allows entropy_src to stop immediately when disabled.
It also locks all registers when enabled, except for the CONF register.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>