### PR TITLE
[entropy_src/rtl] added debug field and unused signals

### DIFF
--- a/hw/ip/csrng/rtl/csrng_main_sm.sv
+++ b/hw/ip/csrng/rtl/csrng_main_sm.sv
@@ -28,7 +28,7 @@ module csrng_main_sm import csrng_pkg::*; (
   input logic                cmd_complete_i,
   input logic                halt_main_sm_i,
   output logic               main_sm_halted_o,
-  output logic               main_sm_err_o
+  output logic[7:0]          main_sm_err_o
 );
 
 // Encoding generated with:

--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -1091,9 +1091,9 @@
           name: "SHA3_ERR",
           desc: "This is a logic-or of all of the SHA3 error signals."
         }
-        { bits: "31",
-          name: "DIAG",
-          desc: "This bit is for internal debug only."
+        { bits: "31:24",
+          name: "MAIN_SM",
+          desc: "Main state machine current state."
         }
       ]
     },

--- a/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
@@ -6,27 +6,30 @@
 //
 //   determines when new entropy is ready to be forwarded
 
-module entropy_src_main_sm (
-  input logic                clk_i,
-  input logic                rst_ni,
+module entropy_src_main_sm #(
+  localparam int StateWidth = 8
+) (
+  input logic                   clk_i,
+  input logic                   rst_ni,
 
-  input logic                enable_i,
-  input logic                ht_done_pulse_i,
-  input logic                ht_fail_pulse_i,
-  output logic               rst_alert_cntr_o,
-  input logic                bypass_mode_i,
-  output logic               rst_bypass_mode_o,
-  input logic                main_stage_rdy_i,
-  input logic                bypass_stage_rdy_i,
-  input logic                sha3_state_vld_i,
-  output logic               main_stage_pop_o,
-  output logic               bypass_stage_pop_o,
-  output logic               sha3_start_o,
-  output logic               sha3_process_o,
-  output logic               sha3_done_o,
-  output logic               cs_aes_halt_req_o,
-  input logic                cs_aes_halt_ack_i,
-  output logic               main_sm_err_o
+  input logic                   enable_i,
+  input logic                   ht_done_pulse_i,
+  input logic                   ht_fail_pulse_i,
+  output logic                  rst_alert_cntr_o,
+  input logic                   bypass_mode_i,
+  output logic                  rst_bypass_mode_o,
+  input logic                   main_stage_rdy_i,
+  input logic                   bypass_stage_rdy_i,
+  input logic                   sha3_state_vld_i,
+  output logic                  main_stage_pop_o,
+  output logic                  bypass_stage_pop_o,
+  output logic                  sha3_start_o,
+  output logic                  sha3_process_o,
+  output logic                  sha3_done_o,
+  output logic                  cs_aes_halt_req_o,
+  input logic                   cs_aes_halt_ack_i,
+  output logic                  main_sm_err_o,
+  output logic [StateWidth-1:0] main_sm_o
 );
 
 // Encoding generated with:
@@ -51,7 +54,6 @@ module entropy_src_main_sm (
 // Maximum Hamming weight: 5
 //
 
-  localparam int StateWidth = 8;
   typedef enum logic [StateWidth-1:0] {
     Idle              = 8'b01110110, // idle
     BootHTRunning     = 8'b01011011, // boot mode, wait for health test done pulse
@@ -82,6 +84,7 @@ module entropy_src_main_sm (
   );
 
   assign state_q = state_e'(state_raw_q);
+  assign main_sm_o = state_raw_q;
 
   always_comb begin
     state_d = state_q;

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -553,8 +553,8 @@ package entropy_src_reg_pkg;
       logic        d;
     } sha3_err;
     struct packed {
-      logic        d;
-    } diag;
+      logic [7:0]  d;
+    } main_sm;
   } entropy_src_hw2reg_debug_status_reg_t;
 
   typedef struct packed {
@@ -624,41 +624,41 @@ package entropy_src_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    entropy_src_hw2reg_intr_state_reg_t intr_state; // [1035:1030]
-    entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [1029:998]
-    entropy_src_hw2reg_repcnt_thresholds_reg_t repcnt_thresholds; // [997:966]
-    entropy_src_hw2reg_repcnts_thresholds_reg_t repcnts_thresholds; // [965:934]
-    entropy_src_hw2reg_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [933:902]
-    entropy_src_hw2reg_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [901:870]
-    entropy_src_hw2reg_bucket_thresholds_reg_t bucket_thresholds; // [869:838]
-    entropy_src_hw2reg_markov_hi_thresholds_reg_t markov_hi_thresholds; // [837:806]
-    entropy_src_hw2reg_markov_lo_thresholds_reg_t markov_lo_thresholds; // [805:774]
-    entropy_src_hw2reg_extht_hi_thresholds_reg_t extht_hi_thresholds; // [773:742]
-    entropy_src_hw2reg_extht_lo_thresholds_reg_t extht_lo_thresholds; // [741:710]
-    entropy_src_hw2reg_repcnt_hi_watermarks_reg_t repcnt_hi_watermarks; // [709:678]
-    entropy_src_hw2reg_repcnts_hi_watermarks_reg_t repcnts_hi_watermarks; // [677:646]
-    entropy_src_hw2reg_adaptp_hi_watermarks_reg_t adaptp_hi_watermarks; // [645:614]
-    entropy_src_hw2reg_adaptp_lo_watermarks_reg_t adaptp_lo_watermarks; // [613:582]
-    entropy_src_hw2reg_extht_hi_watermarks_reg_t extht_hi_watermarks; // [581:550]
-    entropy_src_hw2reg_extht_lo_watermarks_reg_t extht_lo_watermarks; // [549:518]
-    entropy_src_hw2reg_bucket_hi_watermarks_reg_t bucket_hi_watermarks; // [517:486]
-    entropy_src_hw2reg_markov_hi_watermarks_reg_t markov_hi_watermarks; // [485:454]
-    entropy_src_hw2reg_markov_lo_watermarks_reg_t markov_lo_watermarks; // [453:422]
-    entropy_src_hw2reg_repcnt_total_fails_reg_t repcnt_total_fails; // [421:390]
-    entropy_src_hw2reg_repcnts_total_fails_reg_t repcnts_total_fails; // [389:358]
-    entropy_src_hw2reg_adaptp_hi_total_fails_reg_t adaptp_hi_total_fails; // [357:326]
-    entropy_src_hw2reg_adaptp_lo_total_fails_reg_t adaptp_lo_total_fails; // [325:294]
-    entropy_src_hw2reg_bucket_total_fails_reg_t bucket_total_fails; // [293:262]
-    entropy_src_hw2reg_markov_hi_total_fails_reg_t markov_hi_total_fails; // [261:230]
-    entropy_src_hw2reg_markov_lo_total_fails_reg_t markov_lo_total_fails; // [229:198]
-    entropy_src_hw2reg_extht_hi_total_fails_reg_t extht_hi_total_fails; // [197:166]
-    entropy_src_hw2reg_extht_lo_total_fails_reg_t extht_lo_total_fails; // [165:134]
-    entropy_src_hw2reg_alert_summary_fail_counts_reg_t alert_summary_fail_counts; // [133:102]
-    entropy_src_hw2reg_alert_fail_counts_reg_t alert_fail_counts; // [101:74]
-    entropy_src_hw2reg_extht_fail_counts_reg_t extht_fail_counts; // [73:66]
-    entropy_src_hw2reg_fw_ov_rd_data_reg_t fw_ov_rd_data; // [65:34]
-    entropy_src_hw2reg_fw_ov_fifo_sts_reg_t fw_ov_fifo_sts; // [33:27]
-    entropy_src_hw2reg_debug_status_reg_t debug_status; // [26:16]
+    entropy_src_hw2reg_intr_state_reg_t intr_state; // [1042:1037]
+    entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [1036:1005]
+    entropy_src_hw2reg_repcnt_thresholds_reg_t repcnt_thresholds; // [1004:973]
+    entropy_src_hw2reg_repcnts_thresholds_reg_t repcnts_thresholds; // [972:941]
+    entropy_src_hw2reg_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [940:909]
+    entropy_src_hw2reg_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [908:877]
+    entropy_src_hw2reg_bucket_thresholds_reg_t bucket_thresholds; // [876:845]
+    entropy_src_hw2reg_markov_hi_thresholds_reg_t markov_hi_thresholds; // [844:813]
+    entropy_src_hw2reg_markov_lo_thresholds_reg_t markov_lo_thresholds; // [812:781]
+    entropy_src_hw2reg_extht_hi_thresholds_reg_t extht_hi_thresholds; // [780:749]
+    entropy_src_hw2reg_extht_lo_thresholds_reg_t extht_lo_thresholds; // [748:717]
+    entropy_src_hw2reg_repcnt_hi_watermarks_reg_t repcnt_hi_watermarks; // [716:685]
+    entropy_src_hw2reg_repcnts_hi_watermarks_reg_t repcnts_hi_watermarks; // [684:653]
+    entropy_src_hw2reg_adaptp_hi_watermarks_reg_t adaptp_hi_watermarks; // [652:621]
+    entropy_src_hw2reg_adaptp_lo_watermarks_reg_t adaptp_lo_watermarks; // [620:589]
+    entropy_src_hw2reg_extht_hi_watermarks_reg_t extht_hi_watermarks; // [588:557]
+    entropy_src_hw2reg_extht_lo_watermarks_reg_t extht_lo_watermarks; // [556:525]
+    entropy_src_hw2reg_bucket_hi_watermarks_reg_t bucket_hi_watermarks; // [524:493]
+    entropy_src_hw2reg_markov_hi_watermarks_reg_t markov_hi_watermarks; // [492:461]
+    entropy_src_hw2reg_markov_lo_watermarks_reg_t markov_lo_watermarks; // [460:429]
+    entropy_src_hw2reg_repcnt_total_fails_reg_t repcnt_total_fails; // [428:397]
+    entropy_src_hw2reg_repcnts_total_fails_reg_t repcnts_total_fails; // [396:365]
+    entropy_src_hw2reg_adaptp_hi_total_fails_reg_t adaptp_hi_total_fails; // [364:333]
+    entropy_src_hw2reg_adaptp_lo_total_fails_reg_t adaptp_lo_total_fails; // [332:301]
+    entropy_src_hw2reg_bucket_total_fails_reg_t bucket_total_fails; // [300:269]
+    entropy_src_hw2reg_markov_hi_total_fails_reg_t markov_hi_total_fails; // [268:237]
+    entropy_src_hw2reg_markov_lo_total_fails_reg_t markov_lo_total_fails; // [236:205]
+    entropy_src_hw2reg_extht_hi_total_fails_reg_t extht_hi_total_fails; // [204:173]
+    entropy_src_hw2reg_extht_lo_total_fails_reg_t extht_lo_total_fails; // [172:141]
+    entropy_src_hw2reg_alert_summary_fail_counts_reg_t alert_summary_fail_counts; // [140:109]
+    entropy_src_hw2reg_alert_fail_counts_reg_t alert_fail_counts; // [108:81]
+    entropy_src_hw2reg_extht_fail_counts_reg_t extht_fail_counts; // [80:73]
+    entropy_src_hw2reg_fw_ov_rd_data_reg_t fw_ov_rd_data; // [72:41]
+    entropy_src_hw2reg_fw_ov_fifo_sts_reg_t fw_ov_fifo_sts; // [40:34]
+    entropy_src_hw2reg_debug_status_reg_t debug_status; // [33:16]
     entropy_src_hw2reg_err_code_reg_t err_code; // [15:0]
   } entropy_src_hw2reg_t;
 

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -367,8 +367,8 @@ module entropy_src_reg_top (
   logic debug_status_sha3_absorbed_re;
   logic debug_status_sha3_err_qs;
   logic debug_status_sha3_err_re;
-  logic debug_status_diag_qs;
-  logic debug_status_diag_re;
+  logic [7:0] debug_status_main_sm_qs;
+  logic debug_status_main_sm_re;
   logic [3:0] seed_qs;
   logic [3:0] seed_wd;
   logic seed_we;
@@ -2274,18 +2274,18 @@ module entropy_src_reg_top (
   );
 
 
-  //   F[diag]: 31:31
+  //   F[main_sm]: 31:24
   prim_subreg_ext #(
-    .DW    (1)
-  ) u_debug_status_diag (
-    .re     (debug_status_diag_re),
+    .DW    (8)
+  ) u_debug_status_main_sm (
+    .re     (debug_status_main_sm_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.debug_status.diag.d),
+    .d      (hw2reg.debug_status.main_sm.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (debug_status_diag_qs)
+    .qs     (debug_status_main_sm_qs)
   );
 
 
@@ -2927,7 +2927,7 @@ module entropy_src_reg_top (
 
   assign debug_status_sha3_err_re = addr_hit[47] & reg_re & !reg_error;
 
-  assign debug_status_diag_re = addr_hit[47] & reg_re & !reg_error;
+  assign debug_status_main_sm_re = addr_hit[47] & reg_re & !reg_error;
 
   assign seed_we = addr_hit[48] & reg_we & !reg_error;
   assign seed_wd = reg_wdata[3:0];
@@ -3182,7 +3182,7 @@ module entropy_src_reg_top (
         reg_rdata_next[7] = debug_status_sha3_squeezing_qs;
         reg_rdata_next[8] = debug_status_sha3_absorbed_qs;
         reg_rdata_next[9] = debug_status_sha3_err_qs;
-        reg_rdata_next[31] = debug_status_diag_qs;
+        reg_rdata_next[31:24] = debug_status_main_sm_qs;
       end
 
       addr_hit[48]: begin


### PR DESCRIPTION
Instead of running unused signals into a register, the common
unused_ scheme was used, and the debug_status register now used
to look at the main state machine.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>