### PR TITLE
[dv/dvsim] Provides more context on some failures.

### DIFF
--- a/util/dvsim/Launcher.py
+++ b/util/dvsim/Launcher.py
@@ -230,11 +230,6 @@ class Launcher:
                     return pattern
             return None
 
-        def _get_n_lines(pos, num):
-            "Helper function that returns next N lines starting at pos index."
-
-            return ''.join(lines[pos:pos + num - 1]).strip()
-
         if self.deploy.dry_run:
             return "P", None
 
@@ -263,9 +258,10 @@ class Launcher:
                 if chk_failed:
                     if _find_patterns(self.deploy.fail_patterns, line):
                         # If failed, then nothing else to do. Just return.
+                        # Privide some extra lines for context.
                         return "F", ErrorMessage(line_number=cnt + 1,
                                                  message=line.strip(),
-                                                 context=[])
+                                                 context=lines[cnt:cnt + 5])
 
                 if chk_passed:
                     pattern = _find_patterns(pass_patterns, line)
@@ -277,14 +273,14 @@ class Launcher:
         # exit code for whatever reason, then show the last 10 lines of the log
         # as the failure message, which might help with the debug.
         if self.exit_code != 0:
-            return "F", ErrorMessage(line_number=max(1, len(lines) - 10),
+            return "F", ErrorMessage(line_number=None,
                                      message="Job returned non-zero exit code",
-                                     context=[])
+                                     context=lines[-10:])
         if chk_passed:
             return "F", ErrorMessage(
-                line_number=max(1, len(lines) - 10),
+                line_number=None,
                 message=f"Some pass patterns missing: {pass_patterns}",
-                context=[],
+                context=lines[-10:],
             )
         return "P", None
 

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -541,14 +541,16 @@ class SimCfg(FlowCfg):
         '''
 
         def create_failure_message(test, line, context):
-            message = [f"    * {test.qual_name}"]
+            spaces = " " * 12
+            message = [f"    * {test.qual_name}", ""]
             if line:
                 message.append(
-                    f"      Line {line}, in log {test.get_log_path()}<br>")
+                    f"{spaces}Line {line}, in log {test.get_log_path()}")
             else:
-                message.append(f"      Log {test.get_log_path()}<br>")
+                message.append(f"{spaces}Log {test.get_log_path()}")
             if context:
-                message.extend([f"      {c.rstrip()}<br>" for c in context])
+                lines = [f"{spaces}{c.rstrip()}" for c in context]
+                message.extend(lines)
             message.append("")
             return message
 


### PR DESCRIPTION
* For failures with non-zero exit code the last 10 lines of the log are also
  shown.
* For build failures the 10 lines starting at the error are also shown, since
  we typically have one build per dvsim run.
* For run failures we keep the messages as they are, since failures are
  bucketized.

Fixes lowRISC#6098

Signed-off-by: Guillermo Maturana <maturana@google.com>