### PR TITLE
Add formatting job to CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,6 +72,10 @@ jobs:
   - bash: ci/scripts/include-guard.sh $SYSTEM_PULLREQUEST_TARGETBRANCH
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Check formatting on header guards
+  - bash: ci/scripts/verible-format.sh
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    displayName: Check formatting of files on allow list with Verible
+    continueOnError: true
   - bash: ci/scripts/verible-lint.sh rtl
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Style-Lint RTL Verilog source files with Verible

--- a/ci/jobs/quick-lint.sh
+++ b/ci/jobs/quick-lint.sh
@@ -53,6 +53,10 @@ ci/scripts/clang-format.sh $tgt_branch
 echo -e "\n### Check formatting on header guards"
 ci/scripts/include-guard.sh $tgt_branch
 
+echo -e "\n### Check formatting of files on allow list with Verible"
+# This script is allowed to fail for now
+ci/scripts/verible-format.sh || true
+
 echo -e "\n### Style-Lint RTL Verilog source files with Verible"
 ci/scripts/verible-lint.sh rtl
 

--- a/ci/scripts/verible-format.sh
+++ b/ci/scripts/verible-format.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# A wrapper around Verible format, used for CI.
+
+set -e
+
+util/verible-format.sh || {
+  echo -n "##vso[task.logissue type=error]"
+  echo "Verilog format with Verible failed. Run 'util/verible-format.sh' to check and fix all errors."
+  echo "This flow is currently experimental and failures can be ignored."
+  exit 1
+}


### PR DESCRIPTION
This PR adds a job to the CI that checks formatting of files present in [allow list](https://github.com/lowRISC/opentitan/blob/master/util/verible-format-allowlist.txt) using Verible formatter.

For now this serves only an informational purpose and failures are ignored.