### PR TITLE
[top] Updates for silver

### DIFF
--- a/hw/ip/prim/rtl/prim_lc_sender.sv
+++ b/hw/ip/prim/rtl/prim_lc_sender.sv
@@ -20,10 +20,10 @@ module prim_lc_sender (
   logic [lc_ctrl_pkg::TxWidth-1:0] lc_en, lc_en_out;
   assign lc_en = lc_ctrl_pkg::TxWidth'(lc_en_i);
 
-  prim_generic_flop #(
+  prim_flop #(
     .Width(lc_ctrl_pkg::TxWidth),
     .ResetValue(lc_ctrl_pkg::TxWidth'(lc_ctrl_pkg::Off))
-  ) u_prim_generic_flop (
+  ) u_prim_flop (
     .clk_i,
     .rst_ni,
     .d_i   ( lc_en     ),

--- a/hw/ip/prim/rtl/prim_multibit_sync.sv
+++ b/hw/ip/prim/rtl/prim_multibit_sync.sv
@@ -59,10 +59,10 @@ module prim_multibit_sync #(
   logic [NumChecks:0][Width-1:0]   data_check_d;
   logic [NumChecks-1:0][Width-1:0] data_check_q;
 
-  prim_generic_flop_2sync #(
+  prim_flop_2sync #(
     .Width(Width),
     .ResetValue(ResetValue)
-  ) i_prim_generic_flop_2sync (
+  ) i_prim_flop_2sync (
     .clk_i,
     .rst_ni,
     .d_i(data_i),

--- a/hw/ip/pwm/rtl/pwm_cdc.sv
+++ b/hw/ip/pwm/rtl/pwm_cdc.sv
@@ -29,7 +29,7 @@ module pwm_cdc #(
 
   reg [31:0] common_sync_q;
 
-  prim_generic_flop_2sync #(
+  prim_flop_2sync #(
     .Width(32),
     .ResetValue(32'h0)
   ) u_common_sync (
@@ -79,7 +79,7 @@ module pwm_cdc #(
 
     reg [83:0] chan_sync_q;
 
-    prim_generic_flop_2sync #(
+    prim_flop_2sync #(
       .Width(84),
       .ResetValue(84'h0)
     ) u_common_sync (

--- a/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
@@ -25,7 +25,7 @@ package pwrmgr_pkg;
   // pwrmgr to ast
   typedef struct packed {
     logic main_pd_n;
-    logic pwr_clamp_early;
+    logic pwr_clamp_env;
     logic pwr_clamp;
     logic slow_clk_en;
     logic core_clk_en;

--- a/hw/ip/pwrmgr/rtl/pwrmgr_slow_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_slow_fsm.sv
@@ -46,7 +46,7 @@ module pwrmgr_slow_fsm import pwrmgr_pkg::*; (
   // All power signals and signals going to analog logic are flopped to avoid transitional glitches
   logic pd_nq, pd_nd;
   logic pwr_clamp_q, pwr_clamp_d;
-  logic pwr_clamp_early_q, pwr_clamp_early_d;
+  logic pwr_clamp_env_q, pwr_clamp_env_d;
   logic core_clk_en_q, core_clk_en_d;
   logic io_clk_en_q, io_clk_en_d;
   logic usb_clk_en_q, usb_clk_en_d;
@@ -74,7 +74,7 @@ module pwrmgr_slow_fsm import pwrmgr_pkg::*; (
       // pwrmgr resets assuming main power domain is already ready
       pd_nq          <= 1'b1;
       pwr_clamp_q    <= 1'b0;
-      pwr_clamp_early_q <= 1'b0;
+      pwr_clamp_env_q <= 1'b0;
       core_clk_en_q  <= 1'b0;
       io_clk_en_q    <= 1'b0;
       usb_clk_en_q   <= 1'b0;
@@ -86,7 +86,7 @@ module pwrmgr_slow_fsm import pwrmgr_pkg::*; (
       cause_toggle_q <= cause_toggle_d;
       pd_nq          <= pd_nd;
       pwr_clamp_q    <= pwr_clamp_d;
-      pwr_clamp_early_q <= pwr_clamp_early_d;
+      pwr_clamp_env_q <= pwr_clamp_env_d;
       core_clk_en_q  <= core_clk_en_d;
       io_clk_en_q    <= io_clk_en_d;
       usb_clk_en_q   <= usb_clk_en_d;
@@ -101,7 +101,7 @@ module pwrmgr_slow_fsm import pwrmgr_pkg::*; (
     pd_nd          = pd_nq;
     cause_toggle_d = cause_toggle_q;
     pwr_clamp_d    = pwr_clamp_q;
-    pwr_clamp_early_d = pwr_clamp_early_q;
+    pwr_clamp_env_d = pwr_clamp_env_q;
     core_clk_en_d  = core_clk_en_q;
     io_clk_en_d    = io_clk_en_q;
     usb_clk_en_d   = usb_clk_en_q;
@@ -130,7 +130,7 @@ module pwrmgr_slow_fsm import pwrmgr_pkg::*; (
         pd_nd = 1'b1;
 
         if (ast_i.main_pok) begin
-          pwr_clamp_early_d = 1'b0;
+          pwr_clamp_env_d = 1'b0;
           state_d = SlowPwrStatePwrClampOff;
         end
       end
@@ -187,14 +187,14 @@ module pwrmgr_slow_fsm import pwrmgr_pkg::*; (
 
         if (all_clks_invalid) begin
           // if main power is turned off, assert early clamp ahead
-          pwr_clamp_early_d = ~main_pd_ni;
+          pwr_clamp_env_d = ~main_pd_ni;
           state_d = SlowPwrStatePwrClampOn;
         end
       end
 
       SlowPwrStatePwrClampOn: begin
         // if main power is turned off, assert clamp ahead
-        pwr_clamp_d = pwr_clamp_early_q;
+        pwr_clamp_d = pwr_clamp_env_q;
         state_d = SlowPwrStateMainPowerOff;
       end
 
@@ -230,7 +230,7 @@ module pwrmgr_slow_fsm import pwrmgr_pkg::*; (
   assign ast_o.io_clk_en = io_clk_en_q;
   assign ast_o.usb_clk_en = usb_clk_en_q;
   assign ast_o.main_pd_n = pd_nq;
-  assign ast_o.pwr_clamp_early = pwr_clamp_early_q;
+  assign ast_o.pwr_clamp_env = pwr_clamp_env_q;
   assign ast_o.pwr_clamp = pwr_clamp_q;
   // This is hardwired to 1 all the time
   assign ast_o.slow_clk_en = 1'b1;

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -357,7 +357,7 @@ module spi_host
   assign sw_rst     = reg2hw.control.sw_rst.q;
   assign en_sw      = reg2hw.control.spien.q;
 
-  prim_generic_flop_2sync #(
+  prim_flop_2sync #(
     .Width(3)
   ) u_sync_stat_from_core (
     .clk_i,
@@ -366,7 +366,7 @@ module spi_host
     .q_o      ({     rx_stall,      tx_stall,      active})
   );
 
-  prim_generic_flop_2sync #(
+  prim_flop_2sync #(
     .Width(2)
   ) u_sync_en_to_core (
     .clk_i    (clk_core_i),

--- a/hw/ip/usbdev/rtl/usbdev_iomux.sv
+++ b/hw/ip/usbdev/rtl/usbdev_iomux.sv
@@ -126,7 +126,7 @@ module usbdev_iomux
   // D+/D- can be swapped based on a config register.
   assign pinflip = sys_reg2hw_config_i.pinflip.q;
 
-  prim_generic_clock_mux2 #(
+  prim_clock_mux2 #(
     .NoFpgaBufG(1)
   ) i_mux_tx_d_flip (
     .clk0_i (usb_tx_d_i),
@@ -134,7 +134,7 @@ module usbdev_iomux
     .sel_i  (pinflip),
     .clk_o  (cio_usb_d_flipped)
   );
-  prim_generic_clock_mux2 #(
+  prim_clock_mux2 #(
     .NoFpgaBufG(1)
   ) i_mux_dp_pull_flip (
     .clk0_i (usb_pullup_en_i),
@@ -142,7 +142,7 @@ module usbdev_iomux
     .sel_i  (pinflip),
     .clk_o  (cio_usb_dp_pullup_en)
   );
-  prim_generic_clock_mux2 #(
+  prim_clock_mux2 #(
     .NoFpgaBufG(1)
   ) i_mux_dn_pull_flip (
     .clk0_i (1'b0),
@@ -195,7 +195,7 @@ module usbdev_iomux
   // Clock muxes should be used here to achieve the best match between
   // rising and falling edges on an ASIC. This mismatch on the data line
   // degrades performance in the JK-KJ jitter test.
-  prim_generic_clock_mux2 #(
+  prim_clock_mux2 #(
     .NoFpgaBufG(1)
   ) i_mux_tx_d (
     .clk0_i (cio_usb_d_flipped),
@@ -203,7 +203,7 @@ module usbdev_iomux
     .sel_i  (sys_reg2hw_drive_i.en.q),
     .clk_o  (cio_usb_d_o)
   );
-  prim_generic_clock_mux2 #(
+  prim_clock_mux2 #(
     .NoFpgaBufG(1)
   ) i_mux_tx_se0 (
     .clk0_i (usb_tx_se0_i),
@@ -211,7 +211,7 @@ module usbdev_iomux
     .sel_i  (sys_reg2hw_drive_i.en.q),
     .clk_o  (cio_usb_se0_o)
   );
-  prim_generic_clock_mux2 #(
+  prim_clock_mux2 #(
     .NoFpgaBufG(1)
   ) i_mux_tx_oe (
     .clk0_i (usb_tx_oe_i),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3168,7 +3168,7 @@
           struct: logic
           type: uni
           act: rcv
-          width: 10
+          width: 9
           inst_name: sensor_ctrl_aon
           default: ""
           external: true
@@ -9530,7 +9530,7 @@
       }
       {
         name: sensor_ctrl_aon_ast_debug_out
-        width: 10
+        width: 9
         type: output
         idx: 0
         pad: ""
@@ -9540,7 +9540,7 @@
       }
       {
         name: sensor_ctrl_aon_ast_debug_out
-        width: 10
+        width: 9
         type: output
         idx: 1
         pad: ""
@@ -9550,7 +9550,7 @@
       }
       {
         name: sensor_ctrl_aon_ast_debug_out
-        width: 10
+        width: 9
         type: output
         idx: 2
         pad: ""
@@ -9560,7 +9560,7 @@
       }
       {
         name: sensor_ctrl_aon_ast_debug_out
-        width: 10
+        width: 9
         type: output
         idx: 3
         pad: ""
@@ -9570,7 +9570,7 @@
       }
       {
         name: sensor_ctrl_aon_ast_debug_out
-        width: 10
+        width: 9
         type: output
         idx: 4
         pad: ""
@@ -9580,7 +9580,7 @@
       }
       {
         name: sensor_ctrl_aon_ast_debug_out
-        width: 10
+        width: 9
         type: output
         idx: 5
         pad: ""
@@ -9590,7 +9590,7 @@
       }
       {
         name: sensor_ctrl_aon_ast_debug_out
-        width: 10
+        width: 9
         type: output
         idx: 6
         pad: ""
@@ -9600,7 +9600,7 @@
       }
       {
         name: sensor_ctrl_aon_ast_debug_out
-        width: 10
+        width: 9
         type: output
         idx: 7
         pad: ""
@@ -9610,23 +9610,13 @@
       }
       {
         name: sensor_ctrl_aon_ast_debug_out
-        width: 10
+        width: 9
         type: output
         idx: 8
         pad: ""
         attr: ""
         connection: muxed
         glob_idx: 61
-      }
-      {
-        name: sensor_ctrl_aon_ast_debug_out
-        width: 10
-        type: output
-        idx: 9
-        pad: ""
-        attr: ""
-        connection: muxed
-        glob_idx: 62
       }
       {
         name: pwm_aon_pwm
@@ -9636,7 +9626,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 63
+        glob_idx: 62
       }
       {
         name: pwm_aon_pwm
@@ -9646,7 +9636,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 64
+        glob_idx: 63
       }
       {
         name: pwm_aon_pwm
@@ -9656,7 +9646,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 65
+        glob_idx: 64
       }
       {
         name: pwm_aon_pwm
@@ -9666,7 +9656,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 66
+        glob_idx: 65
       }
       {
         name: pwm_aon_pwm
@@ -9676,7 +9666,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 67
+        glob_idx: 66
       }
       {
         name: pwm_aon_pwm
@@ -9686,7 +9676,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 68
+        glob_idx: 67
       }
       {
         name: sysrst_ctrl_aon_bat_disable
@@ -9696,7 +9686,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 69
+        glob_idx: 68
       }
       {
         name: sysrst_ctrl_aon_ec_rst_out_l
@@ -9716,7 +9706,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 70
+        glob_idx: 69
       }
       {
         name: sysrst_ctrl_aon_key1_out
@@ -9726,7 +9716,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 71
+        glob_idx: 70
       }
       {
         name: sysrst_ctrl_aon_key2_out
@@ -9736,7 +9726,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 72
+        glob_idx: 71
       }
       {
         name: sysrst_ctrl_aon_pwrb_out
@@ -9762,7 +9752,7 @@
       {
         inouts: 42
         inputs: 13
-        outputs: 31
+        outputs: 30
         pads: 47
       }
     }
@@ -13098,7 +13088,7 @@
         struct: logic
         type: uni
         act: rcv
-        width: 10
+        width: 9
         inst_name: sensor_ctrl_aon
         default: ""
         external: true
@@ -15552,7 +15542,7 @@
         package: ""
         struct: logic
         signame: ast2pinmux_i
-        width: 10
+        width: 9
         type: uni
         default: ""
         direction: in

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -160,7 +160,7 @@
     { name: "NMioPeriphOut",
       desc: "Number of muxed peripheral outputs",
       type: "int",
-      default: "73",
+      default: "72",
       local: "true"
     },
     { name: "NMioPads",

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
@@ -9,7 +9,7 @@ package pinmux_reg_pkg;
   // Param list
   parameter int AttrDw = 13;
   parameter int NMioPeriphIn = 55;
-  parameter int NMioPeriphOut = 73;
+  parameter int NMioPeriphOut = 72;
   parameter int NMioPads = 47;
   parameter int NDioPads = 24;
   parameter int NWkupDetect = 8;

--- a/hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.hjson
+++ b/hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.hjson
@@ -16,7 +16,7 @@
   available_output_list: [
     { name: "ast_debug_out",
       desc: "ast debug outputs to pinmux",
-      width: "10"
+      width: "9"
     }
   ],
   regwidth: "32",
@@ -122,7 +122,7 @@
       type:    "uni",
       name:    "ast2pinmux",
       act:     "rcv",
-      width:   10,
+      width:   9,
       package: ""
     },
   ],

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -980,7 +980,7 @@ module chip_earlgrey_asic (
     .vioa_pok_o            ( ast_status.io_pok[0] ),
     .viob_pok_o            ( ast_status.io_pok[1] ),
     // main regulator
-    .main_env_iso_en_i     ( base_ast_pwr.pwr_clamp ),
+    .main_env_iso_en_i     ( base_ast_pwr.pwr_clamp_env ),
     .main_pd_ni            ( base_ast_pwr.main_pd_n ),
     // pdm control (flash)/otp
     .flash_power_down_h_o  ( flash_power_down_h ),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -81,7 +81,7 @@ module top_earlgrey #(
   input  ast_pkg::ast_alert_req_t       sensor_ctrl_ast_alert_req_i,
   output ast_pkg::ast_alert_rsp_t       sensor_ctrl_ast_alert_rsp_o,
   input  ast_pkg::ast_status_t       sensor_ctrl_ast_status_i,
-  input  logic [9:0] ast2pinmux_i,
+  input  logic [8:0] ast2pinmux_i,
   output logic       usbdev_usb_ref_val_o,
   output logic       usbdev_usb_ref_pulse_o,
   output clkmgr_pkg::clkmgr_ast_out_t       clks_ast_o,
@@ -117,8 +117,8 @@ module top_earlgrey #(
 
   // Signals
   logic [54:0] mio_p2d;
-  logic [72:0] mio_d2p;
-  logic [72:0] mio_en_d2p;
+  logic [71:0] mio_d2p;
+  logic [71:0] mio_en_d2p;
   logic [23:0] dio_p2d;
   logic [23:0] dio_d2p;
   logic [23:0] dio_en_d2p;
@@ -250,8 +250,8 @@ module top_earlgrey #(
   // pinmux_aon
   // aon_timer_aon
   // sensor_ctrl_aon
-  logic [9:0] cio_sensor_ctrl_aon_ast_debug_out_d2p;
-  logic [9:0] cio_sensor_ctrl_aon_ast_debug_out_en_d2p;
+  logic [8:0]  cio_sensor_ctrl_aon_ast_debug_out_d2p;
+  logic [8:0]  cio_sensor_ctrl_aon_ast_debug_out_en_d2p;
   // sram_ctrl_ret_aon
   // flash_ctrl
   logic        cio_flash_ctrl_tck_p2d;
@@ -2789,7 +2789,6 @@ module top_earlgrey #(
   assign mio_d2p[MioOutSensorCtrlAonAstDebugOut6] = cio_sensor_ctrl_aon_ast_debug_out_d2p[6];
   assign mio_d2p[MioOutSensorCtrlAonAstDebugOut7] = cio_sensor_ctrl_aon_ast_debug_out_d2p[7];
   assign mio_d2p[MioOutSensorCtrlAonAstDebugOut8] = cio_sensor_ctrl_aon_ast_debug_out_d2p[8];
-  assign mio_d2p[MioOutSensorCtrlAonAstDebugOut9] = cio_sensor_ctrl_aon_ast_debug_out_d2p[9];
   assign mio_d2p[MioOutPwmAonPwm0] = cio_pwm_aon_pwm_d2p[0];
   assign mio_d2p[MioOutPwmAonPwm1] = cio_pwm_aon_pwm_d2p[1];
   assign mio_d2p[MioOutPwmAonPwm2] = cio_pwm_aon_pwm_d2p[2];
@@ -2864,7 +2863,6 @@ module top_earlgrey #(
   assign mio_en_d2p[MioOutSensorCtrlAonAstDebugOut6] = cio_sensor_ctrl_aon_ast_debug_out_en_d2p[6];
   assign mio_en_d2p[MioOutSensorCtrlAonAstDebugOut7] = cio_sensor_ctrl_aon_ast_debug_out_en_d2p[7];
   assign mio_en_d2p[MioOutSensorCtrlAonAstDebugOut8] = cio_sensor_ctrl_aon_ast_debug_out_en_d2p[8];
-  assign mio_en_d2p[MioOutSensorCtrlAonAstDebugOut9] = cio_sensor_ctrl_aon_ast_debug_out_en_d2p[9];
   assign mio_en_d2p[MioOutPwmAonPwm0] = cio_pwm_aon_pwm_en_d2p[0];
   assign mio_en_d2p[MioOutPwmAonPwm1] = cio_pwm_aon_pwm_en_d2p[1];
   assign mio_en_d2p[MioOutPwmAonPwm2] = cio_pwm_aon_pwm_en_d2p[2];

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
@@ -604,18 +604,17 @@ package top_earlgrey_pkg;
     MioOutSensorCtrlAonAstDebugOut6 = 59,
     MioOutSensorCtrlAonAstDebugOut7 = 60,
     MioOutSensorCtrlAonAstDebugOut8 = 61,
-    MioOutSensorCtrlAonAstDebugOut9 = 62,
-    MioOutPwmAonPwm0 = 63,
-    MioOutPwmAonPwm1 = 64,
-    MioOutPwmAonPwm2 = 65,
-    MioOutPwmAonPwm3 = 66,
-    MioOutPwmAonPwm4 = 67,
-    MioOutPwmAonPwm5 = 68,
-    MioOutSysrstCtrlAonBatDisable = 69,
-    MioOutSysrstCtrlAonKey0Out = 70,
-    MioOutSysrstCtrlAonKey1Out = 71,
-    MioOutSysrstCtrlAonKey2Out = 72,
-    MioOutCount = 73
+    MioOutPwmAonPwm0 = 62,
+    MioOutPwmAonPwm1 = 63,
+    MioOutPwmAonPwm2 = 64,
+    MioOutPwmAonPwm3 = 65,
+    MioOutPwmAonPwm4 = 66,
+    MioOutPwmAonPwm5 = 67,
+    MioOutSysrstCtrlAonBatDisable = 68,
+    MioOutSysrstCtrlAonKey0Out = 69,
+    MioOutSysrstCtrlAonKey1Out = 70,
+    MioOutSysrstCtrlAonKey2Out = 71,
+    MioOutCount = 72
   } mio_out_e;
 
   // Enumeration for DIO signals, used on both the top and chip-levels.

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -1404,18 +1404,17 @@ typedef enum top_earlgrey_pinmux_outsel {
   kTopEarlgreyPinmuxOutselSensorCtrlAonAstDebugOut6 = 62, /**< Peripheral Output 59 */
   kTopEarlgreyPinmuxOutselSensorCtrlAonAstDebugOut7 = 63, /**< Peripheral Output 60 */
   kTopEarlgreyPinmuxOutselSensorCtrlAonAstDebugOut8 = 64, /**< Peripheral Output 61 */
-  kTopEarlgreyPinmuxOutselSensorCtrlAonAstDebugOut9 = 65, /**< Peripheral Output 62 */
-  kTopEarlgreyPinmuxOutselPwmAonPwm0 = 66, /**< Peripheral Output 63 */
-  kTopEarlgreyPinmuxOutselPwmAonPwm1 = 67, /**< Peripheral Output 64 */
-  kTopEarlgreyPinmuxOutselPwmAonPwm2 = 68, /**< Peripheral Output 65 */
-  kTopEarlgreyPinmuxOutselPwmAonPwm3 = 69, /**< Peripheral Output 66 */
-  kTopEarlgreyPinmuxOutselPwmAonPwm4 = 70, /**< Peripheral Output 67 */
-  kTopEarlgreyPinmuxOutselPwmAonPwm5 = 71, /**< Peripheral Output 68 */
-  kTopEarlgreyPinmuxOutselSysrstCtrlAonBatDisable = 72, /**< Peripheral Output 69 */
-  kTopEarlgreyPinmuxOutselSysrstCtrlAonKey0Out = 73, /**< Peripheral Output 70 */
-  kTopEarlgreyPinmuxOutselSysrstCtrlAonKey1Out = 74, /**< Peripheral Output 71 */
-  kTopEarlgreyPinmuxOutselSysrstCtrlAonKey2Out = 75, /**< Peripheral Output 72 */
-  kTopEarlgreyPinmuxOutselLast = 75, /**< \internal Last valid outsel value */
+  kTopEarlgreyPinmuxOutselPwmAonPwm0 = 65, /**< Peripheral Output 62 */
+  kTopEarlgreyPinmuxOutselPwmAonPwm1 = 66, /**< Peripheral Output 63 */
+  kTopEarlgreyPinmuxOutselPwmAonPwm2 = 67, /**< Peripheral Output 64 */
+  kTopEarlgreyPinmuxOutselPwmAonPwm3 = 68, /**< Peripheral Output 65 */
+  kTopEarlgreyPinmuxOutselPwmAonPwm4 = 69, /**< Peripheral Output 66 */
+  kTopEarlgreyPinmuxOutselPwmAonPwm5 = 70, /**< Peripheral Output 67 */
+  kTopEarlgreyPinmuxOutselSysrstCtrlAonBatDisable = 71, /**< Peripheral Output 68 */
+  kTopEarlgreyPinmuxOutselSysrstCtrlAonKey0Out = 72, /**< Peripheral Output 69 */
+  kTopEarlgreyPinmuxOutselSysrstCtrlAonKey1Out = 73, /**< Peripheral Output 70 */
+  kTopEarlgreyPinmuxOutselSysrstCtrlAonKey2Out = 74, /**< Peripheral Output 71 */
+  kTopEarlgreyPinmuxOutselLast = 74, /**< \internal Last valid outsel value */
 } top_earlgrey_pinmux_outsel_t;
 
 /**

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -845,7 +845,7 @@ module chip_${top["name"]}_${target["name"]} (
     .vioa_pok_o            ( ast_status.io_pok[0] ),
     .viob_pok_o            ( ast_status.io_pok[1] ),
     // main regulator
-    .main_env_iso_en_i     ( base_ast_pwr.pwr_clamp ),
+    .main_env_iso_en_i     ( base_ast_pwr.pwr_clamp_env ),
     .main_pd_ni            ( base_ast_pwr.main_pd_n ),
     // pdm control (flash)/otp
     .flash_power_down_h_o  ( flash_power_down_h ),


### PR DESCRIPTION
- rename pwrmgr clamp envelope signal
- minor correction for ast2pinmux bit width

Signed-off-by: Timothy Chen <timothytim@google.com>