### PR TITLE
[topgen] Fix enum type warnings

### DIFF
--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
@@ -482,7 +482,7 @@ package top_earlgrey_pkg;
   } pwr_dom_e;
 
   // Enumeration for MIO signals on the top-level.
-  typedef enum {
+  typedef enum int unsigned {
     MioInGpioGpio0 = 0,
     MioInGpioGpio1 = 1,
     MioInGpioGpio2 = 2,
@@ -619,7 +619,7 @@ package top_earlgrey_pkg;
   } mio_out_e;
 
   // Enumeration for DIO signals, used on both the top and chip-levels.
-  typedef enum {
+  typedef enum int unsigned {
     DioSpiHost0Sd0 = 0,
     DioSpiHost0Sd1 = 1,
     DioSpiHost0Sd2 = 2,
@@ -650,7 +650,7 @@ package top_earlgrey_pkg;
   // Raw MIO/DIO input array indices on chip-level.
   // TODO: Does not account for target specific stubbed/added pads.
   // Need to make a target-specific package for those.
-  typedef enum {
+  typedef enum int unsigned {
     MioPadIoa0 = 0,
     MioPadIoa1 = 1,
     MioPadIoa2 = 2,
@@ -701,7 +701,7 @@ package top_earlgrey_pkg;
     MioPadCount
   } mio_pad_e;
 
-  typedef enum {
+  typedef enum int unsigned {
     DioPadPorN = 0,
     DioPadUsbP = 1,
     DioPadUsbN = 2,

--- a/util/topgen/templates/toplevel_pkg.sv.tpl
+++ b/util/topgen/templates/toplevel_pkg.sv.tpl
@@ -50,7 +50,7 @@ package top_${top["name"]}_pkg;
   } pwr_dom_e;
 
   // Enumeration for MIO signals on the top-level.
-  typedef enum {
+  typedef enum int unsigned {
 % for sig in top["pinmux"]["ios"]:
   % if sig['type'] in ['inout', 'input'] and sig['connection'] == 'muxed':
     ${lib.get_io_enum_literal(sig, 'mio_in')} = ${sig['glob_idx']},
@@ -73,7 +73,7 @@ package top_${top["name"]}_pkg;
   } mio_out_e;
 
   // Enumeration for DIO signals, used on both the top and chip-levels.
-  typedef enum {
+  typedef enum int unsigned {
 % for sig in top["pinmux"]["ios"]:
   % if sig['connection'] != 'muxed':
     ${lib.get_io_enum_literal(sig, 'dio')} = ${sig['glob_idx']},
@@ -88,7 +88,7 @@ package top_${top["name"]}_pkg;
   // Raw MIO/DIO input array indices on chip-level.
   // TODO: Does not account for target specific stubbed/added pads.
   // Need to make a target-specific package for those.
-  typedef enum {
+  typedef enum int unsigned {
 % for pad in top["pinout"]["pads"]:
   % if pad["connection"] == "muxed":
     ${lib.Name.from_snake_case("mio_pad_" + pad["name"]).as_camel_case()} = ${pad["idx"]},
@@ -97,7 +97,7 @@ package top_${top["name"]}_pkg;
     ${lib.Name.from_snake_case("mio_pad_count").as_camel_case()}
   } mio_pad_e;
 
-  typedef enum {
+  typedef enum int unsigned {
 % for pad in top["pinout"]["pads"]:
   % if pad["connection"] != "muxed":
     ${lib.Name.from_snake_case("dio_pad_" + pad["name"]).as_camel_case()} = ${pad["idx"]},


### PR DESCRIPTION
enum for top package did not define any type. Change them to `int
unsigned`.