### PR TITLE
 [dvsim] Scheduler updates - max_parallel, max_poll 

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -6,6 +6,7 @@ import logging as log
 import pprint
 import random
 import shlex
+from pathlib import Path
 
 from LauncherFactory import get_launcher
 from sim_utils import get_cov_summary_table
@@ -143,8 +144,11 @@ class Deploy():
         # 'aes:default', 'uart:default' builds.
         self.full_name = self.sim_cfg.name + ":" + self.qual_name
 
-        # Job name is used to group the job by cfg and target.
-        self.job_name = "{}_{}".format(self.sim_cfg.name, self.target)
+        # Job name is used to group the job by cfg and target. The scratch path
+        # directory name is assumed to be uniquified, in case there are more
+        # than one sim_cfgs with the same name.
+        self.job_name = "{}_{}".format(
+            Path(self.sim_cfg.scratch_path).name, self.target)
 
         # Input directories (other than self) this job depends on.
         self.input_dirs = []
@@ -316,8 +320,7 @@ class CompileSim(Deploy):
 
         # 'build_mode' is used as a substitution variable in the HJson.
         self.build_mode = self.name
-        self.job_name = "{}_{}_{}".format(self.sim_cfg.name, self.target,
-                                          self.build_mode)
+        self.job_name += f"_{self.build_mode}"
         if self.sim_cfg.cov:
             self.output_dirs += [self.cov_db_dir]
         self.pass_patterns = self.build_pass_patterns
@@ -370,8 +373,7 @@ class CompileOneShot(Deploy):
 
         # 'build_mode' is used as a substitution variable in the HJson.
         self.build_mode = self.name
-        self.job_name = "{}_{}_{}".format(self.sim_cfg.name, self.target,
-                                          self.build_mode)
+        self.job_name += f"_{self.build_mode}"
         self.fail_patterns = self.build_fail_patterns
 
 
@@ -433,8 +435,7 @@ class RunTest(Deploy):
         self.build_mode = self.test_obj.build_mode.name
         self.qual_name = self.run_dir_name + "." + str(self.seed)
         self.full_name = self.sim_cfg.name + ":" + self.qual_name
-        self.job_name = "{}_{}_{}".format(self.sim_cfg.name, self.target,
-                                          self.build_mode)
+        self.job_name += f"_{self.build_mode}"
         if self.sim_cfg.cov:
             self.output_dirs += [self.cov_db_test_dir]
 

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -12,6 +12,7 @@ from shutil import which
 
 import hjson
 from CfgJson import set_target_attribute
+from LauncherFactory import get_launcher_cls
 from Scheduler import Scheduler
 from utils import (VERBOSE, find_and_substitute_wildcards, md_results_to_html,
                    rm_path, subst_wildcards)
@@ -371,7 +372,7 @@ class FlowCfg():
             log.fatal("Nothing to run!")
             sys.exit(1)
 
-        return Scheduler(deploy).run()
+        return Scheduler(deploy, get_launcher_cls()).run()
 
     def _gen_results(self, results):
         '''

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -31,9 +31,9 @@ from pathlib import Path
 
 import Launcher
 import LauncherFactory
+import LocalLauncher
 from CfgFactory import make_cfg
 from Deploy import RunTest
-from Scheduler import Scheduler
 from Timer import Timer
 from utils import (TS_FORMAT, TS_FORMAT_LONG, VERBOSE, rm_path,
                    run_cmd_with_timeout)
@@ -327,7 +327,8 @@ def parse_args():
                       help=('Run only up to N builds/tests at a time. '
                             'Default value 16, unless the DVSIM_MAX_PARALLEL '
                             'environment variable is set, in which case that '
-                            'is used.'))
+                            'is used. Only applicable when launching jobs '
+                            'locally.'))
 
     pathg = parser.add_argument_group('File management')
 
@@ -645,7 +646,7 @@ def main():
 
     # Register the common deploy settings.
     Timer.print_interval = args.print_interval
-    Scheduler.max_parallel = args.max_parallel
+    LocalLauncher.LocalLauncher.max_parallel = args.max_parallel
     Launcher.Launcher.max_odirs = args.max_odirs
     LauncherFactory.set_launcher_type(args.local)
 


### PR DESCRIPTION
The max_parallel setting previously was a Scheduler class variable. It
has now been moved to the Launcher class, since each launcher variant
has different needs.

Likewise, 2 new features are added - `max_poll` and `poll_freq`. By
default, the max_poll 4K, and the polling frequency is set to 1 second.
The purpose of adding these knobs is to reduce the polling rate and the
number of jobs polled at a given time. With external launchers such as
LSF and cloud, polling for a job completion could involve multiple steps
and some external command invocations that are time-consuming. These
features help limit the time taken by the Scheduler to poll the entire
set of jobs. If we do not provide a way to fine-tune / adjust these
parameters, DVSim will appear to have hung (or worse, it could crash the
system).

The max_poll needs to cycle through the list of running jobs, rather
than just the first N ones. For example, if there are 5 jobs running [a,
b, c, d, e], and max_poll is set to 2, on the first poll window, it
polls for jobs a and b to complete. Then it polls b and c, followed by e
and a and so on. To allow this to happen, the list of running jobs now
needs to be maintained as a circular linked list, that supports
iterating through the list, while allowing jobs to be added or removed
from the list in realtime. This is achieved in the newly added
`CircularList` class.