### PR TITLE
Update lowrisc_ibex to lowRISC/ibex@0e7117fb

### DIFF
--- a/hw/vendor/lowrisc_ibex.lock.hjson
+++ b/hw/vendor/lowrisc_ibex.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/ibex.git
-    rev: 25cd6600c64e6eec4c3f5ee20237b53e4d5a3a52
+    rev: 0e7117fbec434fcfdf2bcce4ed379d34cdbe68b4
   }
 }

--- a/hw/vendor/lowrisc_ibex/README.md
+++ b/hw/vendor/lowrisc_ibex/README.md
@@ -2,16 +2,21 @@
 
 # Ibex RISC-V Core
 
-Ibex is a small and efficient, 32-bit, in-order RISC-V core with a 2-stage pipeline that implements
-the RV32IMC instruction set architecture.
+Ibex is a production-quality open source 32-bit RISC-V CPU core written in
+SystemVerilog. The CPU core is heavily parametrizable and well suited for
+embedded control applications. Ibex is being extensively verified and has
+seen multiple tape-outs. Ibex supports the Integer (I) or Embedded (E),
+Integer Multiplication and Division (M), Compressed (C), and B (Bit
+Manipulation) extensions.
 
+The block diagram below shows the *small* parametrization with a 2-stage
+pipeline.
 <p align="center"><img src="doc/03_reference/images/blockdiagram.svg" width="650"></p>
 
-This core was initially developed as part of the [PULP platform](https://www.pulp-platform.org)
-under the name "Zero-riscy" \[[1](https://doi.org/10.1109/PATMOS.2017.8106976)\], and has been
+Ibex was initially developed as part of the [PULP platform](https://www.pulp-platform.org)
+under the name ["Zero-riscy"](https://doi.org/10.1109/PATMOS.2017.8106976), and has been
 contributed to [lowRISC](https://www.lowrisc.org) who maintains it and develops it further. It is
-under active development, with further code cleanups, feature additions, and test and verification
-planned for the future.
+under active development.
 
 ## Configuration
 
@@ -96,9 +101,3 @@ License, Version 2.0 (see LICENSE for full text).
 
 Many people have contributed to Ibex through the years. Please have a look at
 the [credits file](CREDITS.md) and the commit history for more information.
-
-## References
-1. [Schiavone, Pasquale Davide, et al. "Slow and steady wins the race? A comparison of
- ultra-low-power RISC-V cores for Internet-of-Things applications."
- _27th International Symposium on Power and Timing Modeling, Optimization and Simulation
- (PATMOS 2017)_](https://doi.org/10.1109/PATMOS.2017.8106976)

--- a/hw/vendor/lowrisc_ibex/doc/01_overview/index.rst
+++ b/hw/vendor/lowrisc_ibex/doc/01_overview/index.rst
@@ -1,7 +1,7 @@
 Introduction to Ibex
 ====================
 
-Ibex is a production-quality open source 32 bit RISC-V CPU core written in SystemVerilog.
+Ibex is a production-quality open source 32-bit RISC-V CPU core written in SystemVerilog.
 The CPU core is heavily parametrizable and well suited for embedded control applications.
 Ibex is being extensively verified and has seen multiple tape-outs.
 

--- a/hw/vendor/lowrisc_ibex/ibex_top.core
+++ b/hw/vendor/lowrisc_ibex/ibex_top.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:ibex:ibex_pkg
       - lowrisc:ibex:ibex_core
+      - lowrisc:prim:buf
     files:
       - rtl/ibex_register_file_ff.sv # generic FF-based
       - rtl/ibex_register_file_fpga.sv # FPGA

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_controller.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_controller.sv
@@ -853,6 +853,7 @@ module ibex_controller #(
   `DV_FCOV_SIGNAL(logic, debug_entry_id,
       (ctrl_fsm_cs != DBG_TAKEN_ID) & (ctrl_fsm_ns == DBG_TAKEN_ID))
   `DV_FCOV_SIGNAL(logic, pipe_flush, (ctrl_fsm_cs != FLUSH) & (ctrl_fsm_ns == FLUSH))
+  `DV_FCOV_SIGNAL(logic, debug_req, debug_req_i & ~debug_mode_q)
 
   ////////////////
   // Assertions //

--- a/hw/vendor/lowrisc_ibex/syn/tcl/yosys_run_synth.tcl
+++ b/hw/vendor/lowrisc_ibex/syn/tcl/yosys_run_synth.tcl
@@ -33,10 +33,10 @@ yosys "chparam -set RegFile $lr_synth_ibex_regfile $lr_synth_top_module"
 yosys "synth $flatten_opt -top $lr_synth_top_module"
 yosys "opt -purge"
 
+yosys "write_verilog $lr_synth_pre_map_out"
+
 # Map latch primitives onto latch cells
 yosys "techmap -map rtl/latch_map.v"
-
-yosys "write_verilog $lr_synth_pre_map_out"
 
 yosys "dfflibmap -liberty $lr_synth_cell_library_path"
 yosys "opt"


### PR DESCRIPTION
Update code from upstream repository
https://github.com/lowRISC/ibex.git to revision
0e7117fbec434fcfdf2bcce4ed379d34cdbe68b4

* [lockstep] Introduce optimization barrier around lockstep Ibex
  (Michael Schaffner)
* [dv] Remove MISA from csr_description.yaml (Greg Chadwick)
* Update README to match design (Philipp Wagner)
* Fix a couple of synthesis bugs (Tom Roberts)
* [dv] Improvements to functional coverage (Greg Chadwick)
* [rtl] Fix RF read enables for illegal instruction/fetch error (Greg
  Chadwick)
* [rtl] illegal_csr_write shouldn't factor in csr_op_en_i (Greg
  Chadwick)
* [dv] Add known failure detection to riscv_debug_ebreakmu_test (Greg
  Chadwick)

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>