### PR TITLE
[sensor_ctrl] Update sensor_ctrl signal widths in hjson

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3168,7 +3168,7 @@
           struct: logic
           type: uni
           act: rcv
-          width: 10
+          width: 9
           inst_name: sensor_ctrl_aon
           default: ""
           external: true
@@ -9550,7 +9550,7 @@
       }
       {
         name: sensor_ctrl_aon_ast_debug_out
-        width: 10
+        width: 9
         type: output
         idx: 0
         pad: ""
@@ -9560,7 +9560,7 @@
       }
       {
         name: sensor_ctrl_aon_ast_debug_out
-        width: 10
+        width: 9
         type: output
         idx: 1
         pad: ""
@@ -9570,7 +9570,7 @@
       }
       {
         name: sensor_ctrl_aon_ast_debug_out
-        width: 10
+        width: 9
         type: output
         idx: 2
         pad: ""
@@ -9580,7 +9580,7 @@
       }
       {
         name: sensor_ctrl_aon_ast_debug_out
-        width: 10
+        width: 9
         type: output
         idx: 3
         pad: ""
@@ -9590,7 +9590,7 @@
       }
       {
         name: sensor_ctrl_aon_ast_debug_out
-        width: 10
+        width: 9
         type: output
         idx: 4
         pad: ""
@@ -9600,7 +9600,7 @@
       }
       {
         name: sensor_ctrl_aon_ast_debug_out
-        width: 10
+        width: 9
         type: output
         idx: 5
         pad: ""
@@ -9610,7 +9610,7 @@
       }
       {
         name: sensor_ctrl_aon_ast_debug_out
-        width: 10
+        width: 9
         type: output
         idx: 6
         pad: ""
@@ -9620,7 +9620,7 @@
       }
       {
         name: sensor_ctrl_aon_ast_debug_out
-        width: 10
+        width: 9
         type: output
         idx: 7
         pad: ""
@@ -9630,23 +9630,13 @@
       }
       {
         name: sensor_ctrl_aon_ast_debug_out
-        width: 10
+        width: 9
         type: output
         idx: 8
         pad: ""
         attr: ""
         connection: muxed
         glob_idx: 61
-      }
-      {
-        name: sensor_ctrl_aon_ast_debug_out
-        width: 10
-        type: output
-        idx: 9
-        pad: ""
-        attr: ""
-        connection: muxed
-        glob_idx: 62
       }
       {
         name: pwm_aon_pwm
@@ -9656,7 +9646,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 63
+        glob_idx: 62
       }
       {
         name: pwm_aon_pwm
@@ -9666,7 +9656,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 64
+        glob_idx: 63
       }
       {
         name: pwm_aon_pwm
@@ -9676,7 +9666,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 65
+        glob_idx: 64
       }
       {
         name: pwm_aon_pwm
@@ -9686,7 +9676,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 66
+        glob_idx: 65
       }
       {
         name: pwm_aon_pwm
@@ -9696,7 +9686,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 67
+        glob_idx: 66
       }
       {
         name: pwm_aon_pwm
@@ -9706,7 +9696,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 68
+        glob_idx: 67
       }
       {
         name: sysrst_ctrl_aon_bat_disable
@@ -9716,7 +9706,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 69
+        glob_idx: 68
       }
       {
         name: sysrst_ctrl_aon_ec_rst_out_l
@@ -9736,7 +9726,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 70
+        glob_idx: 69
       }
       {
         name: sysrst_ctrl_aon_key1_out
@@ -9746,7 +9736,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 71
+        glob_idx: 70
       }
       {
         name: sysrst_ctrl_aon_key2_out
@@ -9756,7 +9746,7 @@
         pad: ""
         attr: ""
         connection: muxed
-        glob_idx: 72
+        glob_idx: 71
       }
       {
         name: sysrst_ctrl_aon_pwrb_out
@@ -9782,7 +9772,7 @@
       {
         inouts: 42
         inputs: 13
-        outputs: 31
+        outputs: 30
         pads: 47
       }
     }
@@ -13118,7 +13108,7 @@
         struct: logic
         type: uni
         act: rcv
-        width: 10
+        width: 9
         inst_name: sensor_ctrl_aon
         default: ""
         external: true
@@ -15572,7 +15562,7 @@
         package: ""
         struct: logic
         signame: ast2pinmux_i
-        width: 10
+        width: 9
         type: uni
         default: ""
         direction: in

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -160,7 +160,7 @@
     { name: "NMioPeriphOut",
       desc: "Number of muxed peripheral outputs",
       type: "int",
-      default: "73",
+      default: "72",
       local: "true"
     },
     { name: "NMioPads",

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
@@ -9,7 +9,7 @@ package pinmux_reg_pkg;
   // Param list
   parameter int AttrDw = 13;
   parameter int NMioPeriphIn = 55;
-  parameter int NMioPeriphOut = 73;
+  parameter int NMioPeriphOut = 72;
   parameter int NMioPads = 47;
   parameter int NDioPads = 24;
   parameter int NWkupDetect = 8;

--- a/hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.hjson
+++ b/hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.hjson
@@ -16,7 +16,8 @@
   available_output_list: [
     { name: "ast_debug_out",
       desc: "ast debug outputs to pinmux",
-      width: "10"
+      // This must match ast_pkg::Ast2PadOutWidth
+      width: "9"
     }
   ],
   regwidth: "32",
@@ -122,7 +123,8 @@
       type:    "uni",
       name:    "ast2pinmux",
       act:     "rcv",
-      width:   10,
+      // This must match ast_pkg::Ast2PadOutWidth
+      width:   "9",
       package: ""
     },
   ],

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -81,7 +81,7 @@ module top_earlgrey #(
   input  ast_pkg::ast_alert_req_t       sensor_ctrl_ast_alert_req_i,
   output ast_pkg::ast_alert_rsp_t       sensor_ctrl_ast_alert_rsp_o,
   input  ast_pkg::ast_status_t       sensor_ctrl_ast_status_i,
-  input  logic [9:0] ast2pinmux_i,
+  input  logic [8:0] ast2pinmux_i,
   output logic       usbdev_usb_ref_val_o,
   output logic       usbdev_usb_ref_pulse_o,
   output clkmgr_pkg::clkmgr_ast_out_t       clks_ast_o,
@@ -117,8 +117,8 @@ module top_earlgrey #(
 
   // Signals
   logic [54:0] mio_p2d;
-  logic [72:0] mio_d2p;
-  logic [72:0] mio_en_d2p;
+  logic [71:0] mio_d2p;
+  logic [71:0] mio_en_d2p;
   logic [23:0] dio_p2d;
   logic [23:0] dio_d2p;
   logic [23:0] dio_en_d2p;
@@ -250,8 +250,8 @@ module top_earlgrey #(
   // pinmux_aon
   // aon_timer_aon
   // sensor_ctrl_aon
-  logic [9:0] cio_sensor_ctrl_aon_ast_debug_out_d2p;
-  logic [9:0] cio_sensor_ctrl_aon_ast_debug_out_en_d2p;
+  logic [8:0]  cio_sensor_ctrl_aon_ast_debug_out_d2p;
+  logic [8:0]  cio_sensor_ctrl_aon_ast_debug_out_en_d2p;
   // sram_ctrl_ret_aon
   // flash_ctrl
   logic        cio_flash_ctrl_tck_p2d;
@@ -2791,7 +2791,6 @@ module top_earlgrey #(
   assign mio_d2p[MioOutSensorCtrlAonAstDebugOut6] = cio_sensor_ctrl_aon_ast_debug_out_d2p[6];
   assign mio_d2p[MioOutSensorCtrlAonAstDebugOut7] = cio_sensor_ctrl_aon_ast_debug_out_d2p[7];
   assign mio_d2p[MioOutSensorCtrlAonAstDebugOut8] = cio_sensor_ctrl_aon_ast_debug_out_d2p[8];
-  assign mio_d2p[MioOutSensorCtrlAonAstDebugOut9] = cio_sensor_ctrl_aon_ast_debug_out_d2p[9];
   assign mio_d2p[MioOutPwmAonPwm0] = cio_pwm_aon_pwm_d2p[0];
   assign mio_d2p[MioOutPwmAonPwm1] = cio_pwm_aon_pwm_d2p[1];
   assign mio_d2p[MioOutPwmAonPwm2] = cio_pwm_aon_pwm_d2p[2];
@@ -2866,7 +2865,6 @@ module top_earlgrey #(
   assign mio_en_d2p[MioOutSensorCtrlAonAstDebugOut6] = cio_sensor_ctrl_aon_ast_debug_out_en_d2p[6];
   assign mio_en_d2p[MioOutSensorCtrlAonAstDebugOut7] = cio_sensor_ctrl_aon_ast_debug_out_en_d2p[7];
   assign mio_en_d2p[MioOutSensorCtrlAonAstDebugOut8] = cio_sensor_ctrl_aon_ast_debug_out_en_d2p[8];
-  assign mio_en_d2p[MioOutSensorCtrlAonAstDebugOut9] = cio_sensor_ctrl_aon_ast_debug_out_en_d2p[9];
   assign mio_en_d2p[MioOutPwmAonPwm0] = cio_pwm_aon_pwm_en_d2p[0];
   assign mio_en_d2p[MioOutPwmAonPwm1] = cio_pwm_aon_pwm_en_d2p[1];
   assign mio_en_d2p[MioOutPwmAonPwm2] = cio_pwm_aon_pwm_en_d2p[2];

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
@@ -604,18 +604,17 @@ package top_earlgrey_pkg;
     MioOutSensorCtrlAonAstDebugOut6 = 59,
     MioOutSensorCtrlAonAstDebugOut7 = 60,
     MioOutSensorCtrlAonAstDebugOut8 = 61,
-    MioOutSensorCtrlAonAstDebugOut9 = 62,
-    MioOutPwmAonPwm0 = 63,
-    MioOutPwmAonPwm1 = 64,
-    MioOutPwmAonPwm2 = 65,
-    MioOutPwmAonPwm3 = 66,
-    MioOutPwmAonPwm4 = 67,
-    MioOutPwmAonPwm5 = 68,
-    MioOutSysrstCtrlAonBatDisable = 69,
-    MioOutSysrstCtrlAonKey0Out = 70,
-    MioOutSysrstCtrlAonKey1Out = 71,
-    MioOutSysrstCtrlAonKey2Out = 72,
-    MioOutCount = 73
+    MioOutPwmAonPwm0 = 62,
+    MioOutPwmAonPwm1 = 63,
+    MioOutPwmAonPwm2 = 64,
+    MioOutPwmAonPwm3 = 65,
+    MioOutPwmAonPwm4 = 66,
+    MioOutPwmAonPwm5 = 67,
+    MioOutSysrstCtrlAonBatDisable = 68,
+    MioOutSysrstCtrlAonKey0Out = 69,
+    MioOutSysrstCtrlAonKey1Out = 70,
+    MioOutSysrstCtrlAonKey2Out = 71,
+    MioOutCount = 72
   } mio_out_e;
 
   // Enumeration for DIO signals, used on both the top and chip-levels.

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -1404,18 +1404,17 @@ typedef enum top_earlgrey_pinmux_outsel {
   kTopEarlgreyPinmuxOutselSensorCtrlAonAstDebugOut6 = 62, /**< Peripheral Output 59 */
   kTopEarlgreyPinmuxOutselSensorCtrlAonAstDebugOut7 = 63, /**< Peripheral Output 60 */
   kTopEarlgreyPinmuxOutselSensorCtrlAonAstDebugOut8 = 64, /**< Peripheral Output 61 */
-  kTopEarlgreyPinmuxOutselSensorCtrlAonAstDebugOut9 = 65, /**< Peripheral Output 62 */
-  kTopEarlgreyPinmuxOutselPwmAonPwm0 = 66, /**< Peripheral Output 63 */
-  kTopEarlgreyPinmuxOutselPwmAonPwm1 = 67, /**< Peripheral Output 64 */
-  kTopEarlgreyPinmuxOutselPwmAonPwm2 = 68, /**< Peripheral Output 65 */
-  kTopEarlgreyPinmuxOutselPwmAonPwm3 = 69, /**< Peripheral Output 66 */
-  kTopEarlgreyPinmuxOutselPwmAonPwm4 = 70, /**< Peripheral Output 67 */
-  kTopEarlgreyPinmuxOutselPwmAonPwm5 = 71, /**< Peripheral Output 68 */
-  kTopEarlgreyPinmuxOutselSysrstCtrlAonBatDisable = 72, /**< Peripheral Output 69 */
-  kTopEarlgreyPinmuxOutselSysrstCtrlAonKey0Out = 73, /**< Peripheral Output 70 */
-  kTopEarlgreyPinmuxOutselSysrstCtrlAonKey1Out = 74, /**< Peripheral Output 71 */
-  kTopEarlgreyPinmuxOutselSysrstCtrlAonKey2Out = 75, /**< Peripheral Output 72 */
-  kTopEarlgreyPinmuxOutselLast = 75, /**< \internal Last valid outsel value */
+  kTopEarlgreyPinmuxOutselPwmAonPwm0 = 65, /**< Peripheral Output 62 */
+  kTopEarlgreyPinmuxOutselPwmAonPwm1 = 66, /**< Peripheral Output 63 */
+  kTopEarlgreyPinmuxOutselPwmAonPwm2 = 67, /**< Peripheral Output 64 */
+  kTopEarlgreyPinmuxOutselPwmAonPwm3 = 68, /**< Peripheral Output 65 */
+  kTopEarlgreyPinmuxOutselPwmAonPwm4 = 69, /**< Peripheral Output 66 */
+  kTopEarlgreyPinmuxOutselPwmAonPwm5 = 70, /**< Peripheral Output 67 */
+  kTopEarlgreyPinmuxOutselSysrstCtrlAonBatDisable = 71, /**< Peripheral Output 68 */
+  kTopEarlgreyPinmuxOutselSysrstCtrlAonKey0Out = 72, /**< Peripheral Output 69 */
+  kTopEarlgreyPinmuxOutselSysrstCtrlAonKey1Out = 73, /**< Peripheral Output 70 */
+  kTopEarlgreyPinmuxOutselSysrstCtrlAonKey2Out = 74, /**< Peripheral Output 71 */
+  kTopEarlgreyPinmuxOutselLast = 74, /**< \internal Last valid outsel value */
 } top_earlgrey_pinmux_outsel_t;
 
 /**


### PR DESCRIPTION
The `ast_pkg::Ast2PadOutWidth` parameter changed to 9 in commit 683f9ec.
The widths in the hjson file here need to match (because they are used
to size a couple of top-level signals).

Note: The only manual changes in this PR are to sensor_ctrl.hjson.