### PR TITLE
[hmac,lint] Ignore an unused output in a way that linters understand

### DIFF
--- a/hw/ip/hmac/lint/hmac.waiver
+++ b/hw/ip/hmac/lint/hmac.waiver
@@ -34,9 +34,6 @@ waive -rules {ARITH_CONTEXT} -location {sha2_pad.sv} -regexp {Bitlength of arith
 waive -rules {ARITH_CONTEXT} -location {sha2_pad.sv} -regexp {Bitlength of arithmetic operation 'message_length.63:9. \+ (1'b1|2'b10)'} \
       -comment "Bitwidth overflow is intended"
 
-waive -rules {NOT_READ HIER_NET_NOT_READ} -location {hmac.sv} -regexp {msg_fifo_addr.* is not read} \
-      -comment "Ignore Address intentionally"
-
 waive -rules {INTEGER}        -location {hmac_pkg.sv} -regexp {'amt' of type int used as a}
 waive -rules {TWO_STATE_TYPE} -location {hmac_pkg.sv} -regexp {'amt' is of two state type 'int'} \
       -comment "shift function behaves as static, it is called with constant in the design"

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -51,7 +51,6 @@ module hmac
   logic        msg_fifo_req;
   logic        msg_fifo_gnt;
   logic        msg_fifo_we;
-  logic [8:0]  msg_fifo_addr;   // NOT_READ
   logic [31:0] msg_fifo_wdata;
   logic [31:0] msg_fifo_wmask;
   logic [31:0] msg_fifo_rdata;
@@ -295,10 +294,10 @@ module hmac
     .tl_o        (tl_win_d2h[0]),
     .en_ifetch_i (tlul_pkg::InstrDis),
     .req_o       (msg_fifo_req   ),
-    .req_type_o  (),
+    .req_type_o  (               ),
     .gnt_i       (msg_fifo_gnt   ),
     .we_o        (msg_fifo_we    ),
-    .addr_o      (msg_fifo_addr  ), // Doesn't care the address other than sub-word
+    .addr_o      (               ), // Doesn't care the address other than sub-word
     .wdata_o     (msg_fifo_wdata ),
     .wmask_o     (msg_fifo_wmask ),
     .intg_error_o(               ),


### PR DESCRIPTION
To ignore outputs from a module, the usual practice is to just connect
them to nothing (with an explicit empty port connection). Connecting
up a signal and then ignoring that signal gives a lint warning, which
we were waiving for AscentLint but not for Verilator.

Switch to the more normal way of doing things and remove the
now-unneeded waiver.