### PR TITLE
[pwm,lint] Hush an unused signal warning for regen signal

### DIFF
--- a/hw/ip/pwm/rtl/pwm.sv
+++ b/hw/ip/pwm/rtl/pwm.sv
@@ -21,10 +21,10 @@ module pwm #(
 );
 
   // TODO: Deal with Regen in this block, on TLUL clock domain
-  logic                      regen;
+  logic                     unused_regen;
   pwm_reg_pkg::pwm_reg2hw_t reg2hw;
 
-  assign regen = reg2hw.regen.q;
+  assign unused_regen = reg2hw.regen.q;
 
   pwm_reg_top u_reg (
     .clk_i,


### PR DESCRIPTION
We're not actually using this signal yet, and there's a TODO saying
that we intend to. Rename it to `unused_regen` to silence both
linters' warnings about it.
