### PR TITLE
[clkmgr] Avoid generating unused root-gated clocks

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -189,8 +189,8 @@ srcs = clks_attr['srcs']
     .en_o(clk_${src}_en),
     .clk_o(clk_${src}_root)
   );
-% endfor
 
+% endfor
   // an async AND of all the synchronized enables
   // return feedback to pwrmgr only when all clocks are enabled
   assign wait_enable =
@@ -360,7 +360,7 @@ srcs = clks_attr['srcs']
 % for intf, eps in export_clks.items():
   % for ep, clks in eps.items():
     % for clk in clks:
-      assign clocks_${intf}_o.clk_${intf}_${ep}_${clk} = clocks_o.clk_${clk};
+  assign clocks_${intf}_o.clk_${intf}_${ep}_${clk} = clocks_o.clk_${clk};
     % endfor
   % endfor
 % endfor

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -244,6 +244,7 @@
     .en_o(clk_main_en),
     .clk_o(clk_main_root)
   );
+
   lc_tx_t io_scanmode;
   prim_lc_sync #(
     .NumCopies(1),
@@ -263,6 +264,7 @@
     .en_o(clk_io_en),
     .clk_o(clk_io_root)
   );
+
   lc_tx_t usb_scanmode;
   prim_lc_sync #(
     .NumCopies(1),
@@ -282,6 +284,7 @@
     .en_o(clk_usb_en),
     .clk_o(clk_usb_root)
   );
+
   lc_tx_t io_div2_scanmode;
   prim_lc_sync #(
     .NumCopies(1),
@@ -301,6 +304,7 @@
     .en_o(clk_io_div2_en),
     .clk_o(clk_io_div2_root)
   );
+
   lc_tx_t io_div4_scanmode;
   prim_lc_sync #(
     .NumCopies(1),
@@ -642,15 +646,15 @@
   // Exported clocks
   ////////////////////////////////////////////////////
 
-      assign clocks_ast_o.clk_ast_usbdev_io_div4_peri = clocks_o.clk_io_div4_peri;
-      assign clocks_ast_o.clk_ast_usbdev_aon_peri = clocks_o.clk_aon_peri;
-      assign clocks_ast_o.clk_ast_usbdev_usb_peri = clocks_o.clk_usb_peri;
-      assign clocks_ast_o.clk_ast_adc_ctrl_aon_io_div4_peri = clocks_o.clk_io_div4_peri;
-      assign clocks_ast_o.clk_ast_adc_ctrl_aon_aon_peri = clocks_o.clk_aon_peri;
-      assign clocks_ast_o.clk_ast_ast_io_div4_secure = clocks_o.clk_io_div4_secure;
-      assign clocks_ast_o.clk_ast_sensor_ctrl_aon_io_div4_secure = clocks_o.clk_io_div4_secure;
-      assign clocks_ast_o.clk_ast_entropy_src_main_secure = clocks_o.clk_main_secure;
-      assign clocks_ast_o.clk_ast_edn0_main_secure = clocks_o.clk_main_secure;
+  assign clocks_ast_o.clk_ast_usbdev_io_div4_peri = clocks_o.clk_io_div4_peri;
+  assign clocks_ast_o.clk_ast_usbdev_aon_peri = clocks_o.clk_aon_peri;
+  assign clocks_ast_o.clk_ast_usbdev_usb_peri = clocks_o.clk_usb_peri;
+  assign clocks_ast_o.clk_ast_adc_ctrl_aon_io_div4_peri = clocks_o.clk_io_div4_peri;
+  assign clocks_ast_o.clk_ast_adc_ctrl_aon_aon_peri = clocks_o.clk_aon_peri;
+  assign clocks_ast_o.clk_ast_ast_io_div4_secure = clocks_o.clk_io_div4_secure;
+  assign clocks_ast_o.clk_ast_sensor_ctrl_aon_io_div4_secure = clocks_o.clk_io_div4_secure;
+  assign clocks_ast_o.clk_ast_entropy_src_main_secure = clocks_o.clk_main_secure;
+  assign clocks_ast_o.clk_ast_edn0_main_secure = clocks_o.clk_main_secure;
 
   ////////////////////////////////////////////////////
   // Assertions

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -214,8 +214,6 @@
   logic [1:0] en_status_q;
   logic [1:0] dis_status_q;
   logic clk_status;
-  logic clk_io_root;
-  logic clk_io_en;
   logic clk_io_div2_root;
   logic clk_io_div2_en;
   logic clk_io_div4_root;
@@ -224,26 +222,6 @@
   logic clk_main_en;
   logic clk_usb_root;
   logic clk_usb_en;
-
-  lc_tx_t io_scanmode;
-  prim_lc_sync #(
-    .NumCopies(1),
-    .AsyncOn(0)
-  ) u_io_scanmode_sync  (
-    .clk_i(1'b0),  //unused
-    .rst_ni(1'b1), //unused
-    .lc_en_i(scanmode_i),
-    .lc_en_o(io_scanmode)
-  );
-
-  prim_clock_gating_sync u_io_cg (
-    .clk_i(clk_io_i),
-    .rst_ni(rst_io_ni),
-    .test_en_i(io_scanmode == lc_ctrl_pkg::On),
-    .async_en_i(pwr_i.ip_clk_en),
-    .en_o(clk_io_en),
-    .clk_o(clk_io_root)
-  );
 
   lc_tx_t io_div2_scanmode;
   prim_lc_sync #(
@@ -328,7 +306,6 @@
   // an async AND of all the synchronized enables
   // return feedback to pwrmgr only when all clocks are enabled
   assign wait_enable =
-    clk_io_en &
     clk_io_div2_en &
     clk_io_div4_en &
     clk_main_en &
@@ -337,7 +314,6 @@
   // an async OR of all the synchronized enables
   // return feedback to pwrmgr only when all clocks are disabled
   assign wait_disable =
-    clk_io_en |
     clk_io_div2_en |
     clk_io_div4_en |
     clk_main_en |

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -427,6 +427,7 @@ def generate_clkmgr(top, cfg_path, out_path):
             src_aon_attr[src['name']] = False
 
     rg_srcs = [src for (src, attr) in src_aon_attr.items() if not attr]
+    rg_srcs.sort()
 
     # clocks fed through clkmgr but are not disturbed in any way
     # This maintains the clocking structure consistency


### PR DESCRIPTION
In top_earlgrey, the `io` clock is only used for feeding clock
dividers and its gated version (`clk_io_root`) is unused. Teach
topgen.py to be more careful when constructing `rg_srcs`, so that it
only adds a clock name if that clock is either exposed in `clocks_o` or
really is a source for some other clock.

While getting my head around the code, I also rejigged things a bit to
make them easier to understand (and easier to construct
`rg_srcs_set`), adding some comments about what the different
dictionaries mean.

This PR is three commits. The first is just a silly layout fix. The second should have no functional change, but arranges things so the diff for the third is easier to read (when reviewing this, I suggest you look at each commit separately!). The third is the real work, and the text above is its commit message.