### PR TITLE
[dv/dv_macros] Fix DV_PRINT_ARR_CONTENTS

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -270,7 +270,7 @@
 `define DV_PRINT_ARR_CONTENTS(ARR_, V_=uvm_pkg::UVM_MEDIUM, ID_=`gfn) \
   begin \
     foreach (ARR_[i]) begin \
-      `dv_info($sformatf("%s[%0d] = 0x%0d[0x%0h]", `"ARR_`", i, ARR_[i], ARR_[i]), V_, ID_) \
+      `dv_info($sformatf("%s[%0d] = %0d (0x%0h)", `"ARR_`", i, ARR_[i], ARR_[i]), V_, ID_) \
     end \
   end
 `endif


### PR DESCRIPTION
For array `arr` with a single value 42, DV_PRINT_ARR_CONTENTS
should print `arr[0] = 42 (0x2a)`; it currently prints
`arr[0] = 0x42[0x2a]`.

Signed-off-by: Guillermo Maturana <maturana@google.com>