### PR TITLE
[otbn,doc] Fix mangled sentence in LOOP documentation

### DIFF
--- a/hw/ip/otbn/data/base-insns.yml
+++ b/hw/ip/otbn/data/base-insns.yml
@@ -444,7 +444,7 @@
     If the stack is already full, OTBN stops, setting bit `loop` in `ERR_BITS`.
 
     `LOOP`, `LOOPI`, jump and branch instructions are all permitted inside a loop but may not appear as the last instruction in a loop.
-    OTBN will stop on that instruction with the, setting bit `loop` in `ERR_BITS`.
+    OTBN will stop on that instruction, setting bit `loop` in `ERR_BITS`.
 
     For more information on how to correctly use `LOOP` see [loop nesting](../#loop-nesting).
   encoding:


### PR DESCRIPTION
Something went a bit awry when re-wording things to use ERR_BITS in
5ce1cb7b63.

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>