### PR TITLE
[entropy_src/rtl] halt sequence ensures sha3 cleanup

### DIFF
--- a/hw/ip/clkmgr/dv/env/clkmgr_if.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_if.sv
@@ -7,6 +7,8 @@
 interface clkmgr_if(input logic clk, input logic rst_n);
   import clkmgr_env_pkg::*;
 
+  // The ports to the dut side.
+
   // Encodes the transactional units that are idle.
   bit [NUM_TRANS-1:0] idle_i;
 
@@ -33,6 +35,48 @@ interface clkmgr_if(input logic clk, input logic rst_n);
   logic jitter_en_o;
   clkmgr_pkg::clkmgr_ast_out_t clocks_ast_o;
   clkmgr_pkg::clkmgr_out_t clocks_o;
+
+  // Types for CSR values.
+  typedef struct packed {
+    logic usb_peri_en;
+    logic io_div2_peri_en;
+    logic io_div4_peri_en;
+  } clk_enables_t;
+
+  typedef struct packed {
+    logic otbn;
+    logic kmac;
+    logic hmac;
+    logic aes;
+  } clk_hints_t;
+
+  // The CSR values from the testbench side.
+  logic extclk_sel_regwen;
+  logic extclk_sel;
+  logic jitter_enable;
+  clk_enables_t clk_enables;
+  clk_hints_t clk_hints;
+  clk_hints_t clk_hints_status;
+
+  task automatic wait_clks(int cycles);
+    repeat (cycles) @(posedge clk);
+  endtask
+
+  function automatic void update_extclk_sel_regwen(logic sel_regwen);
+    extclk_sel_regwen = sel_regwen;
+  endfunction
+
+  function automatic void update_extclk_sel(logic sel);
+    extclk_sel = sel;
+  endfunction
+
+  function automatic void update_clk_enables(logic [$bits(clk_enables)-1:0] ens);
+    clk_enables = ens;
+  endfunction
+
+  function automatic void update_hints(logic [$bits(clk_hints)-1:0] hints);
+    clk_hints = hints;
+  endfunction
 
   function automatic void update_idle(bit [NUM_TRANS-1:0] value);
     idle_i = value;
@@ -66,5 +110,74 @@ interface clkmgr_if(input logic clk, input logic rst_n);
     update_idle('1);
     update_clk_en(1'b1);
   endtask
+
+  // Add assertions for peripheral clocks.
+  `ASSERT(ClkmgrPeriDiv4Enabled_A,
+          clk_enables.io_div4_peri_en && pwr_i.ip_clk_en |=>
+            ##[2:6] $rose(clocks_o.clk_io_div4_peri),
+          clocks_o.clk_io_div4_powerup, !rst_n)
+  `ASSERT(ClkmgrPeriDiv4Disabled_A,
+          !clk_enables.io_div4_peri_en || pwr_i.ip_clk_en |=>
+            ##[2:6] $stable(clocks_o.clk_io_div4_peri),
+          clocks_o.clk_io_div4_powerup, !rst_n)
+
+  `ASSERT(ClkmgrPeriDiv2Enabled_A,
+          clk_enables.io_div2_peri_en && pwr_i.ip_clk_en |=>
+            ##[2:6] $rose(clocks_o.clk_io_div2_peri),
+          clocks_o.clk_io_div2_powerup, !rst_n)
+  `ASSERT(ClkmgrPeriDiv2Disabled_A,
+          !clk_enables.io_div2_peri_en || pwr_i.ip_clk_en |=>
+            ##[2:6] $stable(clocks_o.clk_io_div2_peri),
+          clocks_o.clk_io_div2_powerup, !rst_n)
+
+  `ASSERT(ClkmgrPeriUsbEnabled_A,
+          clk_enables.usb_peri_en && pwr_i.ip_clk_en |=>
+            ##[2:6] $rose(clocks_o.clk_usb_peri),
+          clocks_o.clk_usb_powerup, !rst_n)
+  `ASSERT(ClkmgrPeriUsbDisabled_A,
+          !clk_enables.usb_peri_en || pwr_i.ip_clk_en |=>
+            ##[2:6] $stable(clocks_o.clk_usb_peri),
+          clocks_o.clk_usb_powerup, !rst_n)
+
+  // Add assertions for trans unit clocks.
+  `ASSERT(ClkmgrTransAesClkEnabled_A,
+          clk_hints.aes |-> clocks_o.clk_main_aes,
+          !clocks_o.clk_main_powerup, !rst_n)
+  `ASSERT(ClkmgrTransAesClkKeepEnabled_A,
+          !clk_hints.aes && !idle_i[int'(TransAes)] |-> clocks_o.clk_main_aes,
+          !clocks_o.clk_main_powerup, !rst_n)
+  `ASSERT(ClkmgrTransAesClkDisabled_A,
+          !clk_hints.aes && idle_i[int'(TransAes)] |=> ##[2:6] !clocks_o.clk_main_aes,
+          !clocks_o.clk_main_powerup, !rst_n)
+
+  `ASSERT(ClkmgrTransHmacClkEnabled_A,
+          clk_hints.hmac |-> clocks_o.clk_main_hmac,
+          !clocks_o.clk_main_powerup, !rst_n)
+  `ASSERT(ClkmgrTransHmacClkKeepEnabled_A,
+          !clk_hints.hmac && !idle_i[int'(TransHmac)] |-> clocks_o.clk_main_hmac,
+          !clocks_o.clk_main_powerup, !rst_n)
+  `ASSERT(ClkmgrTransHmacClkDisabled_A,
+          !clk_hints.hmac && idle_i[int'(TransHmac)] |=> ##[2:6] $stable(clocks_o.clk_main_hmac),
+          clocks_o.clk_main_powerup, !rst_n)
+
+  `ASSERT(ClkmgrTransKmacClkEnabled_A,
+          clk_hints.hmac |-> clocks_o.clk_main_kmac,
+          !clocks_o.clk_main_powerup, !rst_n)
+  `ASSERT(ClkmgrTransKmacClkKeepEnabled_A,
+          !clk_hints.hmac && !idle_i[int'(TransKmac)] |-> clocks_o.clk_main_kmac,
+          !clocks_o.clk_main_powerup, !rst_n)
+  `ASSERT(ClkmgrTransKmacClkDisabled_A,
+          !clk_hints.kmac && idle_i[int'(TransKmac)] |=> ##[2:6] $stable(clocks_o.clk_main_kmac),
+          clocks_o.clk_main_powerup, !rst_n)
+
+  `ASSERT(ClkmgrTransOtbnClkEnabled_A
+          , clk_hints.otbn |-> clocks_o.clk_main_otbn,
+          !clocks_o.clk_main_powerup, !rst_n)
+  `ASSERT(ClkmgrTransOtbnClkKeepEnabled_A,
+          !clk_hints.otbn && !idle_i[int'(TransOtbn)] |-> clocks_o.clk_main_otbn,
+          !clocks_o.clk_main_powerup, !rst_n)
+  `ASSERT(ClkmgrTransOtbnClkDisabled_A,
+          !clk_hints.otbn && idle_i[int'(TransOtbn)] |=> ##[2:6] $stable(clocks_o.clk_main_otbn),
+          clocks_o.clk_main_powerup, !rst_n)
 
 endinterface

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -16,8 +16,8 @@ class clkmgr_base_vseq extends cip_base_vseq #(
   `uvm_object_new
 
   task pre_start();
+    // These are independent: do them in parallel since pre_start consumes time.
     fork
-      // Initialize the interface first since pre_start consumes time.
       cfg.clkmgr_vif.init();
       if (do_clkmgr_init) clkmgr_init();
       super.pre_start();
@@ -60,8 +60,8 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     cfg.main_clk_rst_vif.set_freq_mhz(100);
     cfg.io_clk_rst_vif.set_freq_mhz(96);
     cfg.usb_clk_rst_vif.set_freq_mhz(48);
-    // The real clock rate for aon is 200kHz, but that slows testing down.
-    // Increasing its frequency increases DV efficiency withoug compromising quality.
+    // The real clock rate for aon is 200kHz, but that can slow testing down.
+    // Increasing its frequency improves DV efficiency without compromising quality.
     cfg.aon_clk_rst_vif.set_freq_mhz(7);
   endtask
 

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
@@ -8,8 +8,73 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
 
   `uvm_object_new
 
+  bit ip_clk_en = 1'b1;
+  bit [NUM_TRANS - 1: 0] idle = '0;
+
   task body();
-    `uvm_error(`gfn, "FIXME")
+    // Set the io clk input from pwrmgr.
+    `uvm_info(`gfn, $sformatf("Setting ip_clk_en to %b", ip_clk_en), UVM_LOW)
+    cfg.clkmgr_vif.update_clk_en(ip_clk_en);
+    cfg.clkmgr_vif.update_idle(idle);
+
+    cfg.clk_rst_vif.wait_clks(10);
+    test_peri_clocks();
+    test_trans_clocks();
   endtask : body
+
+  // Flips all clk_enables bits from the reset value with all enabled. All is
+  // checked via assertions in clkmgr_if.sv.
+  task test_peri_clocks();
+    // Flip all bits of clk_enables.
+    logic [TL_DW-1:0] value = ral.clk_enables.get();
+    logic [TL_DW-1:0] flipped_value;
+    csr_rd(.ptr(ral.clk_enables), .value(value));
+    flipped_value = value ^ ((1 << ral.clk_enables.get_n_bits()) - 1);
+    csr_wr(.ptr(ral.clk_enables), .value(flipped_value));
+  endtask : test_peri_clocks
+
+  // Starts with all units busy, and for each one this clears the hint and reads the
+  // hint status, expecting it to remain at 1 since the unit is busy; then it sets
+  // the corresponding idle bit and reads status again, expecting it to be low.
+  task test_trans_clocks();
+    trans_e trans;
+    logic bit_value;
+    logic [TL_DW-1:0] value;
+    typedef struct {
+      trans_e       unit;
+      uvm_reg_field hint_bit;
+      uvm_reg_field value_bit;
+    } trans_descriptor_t;
+    trans_descriptor_t trans_descriptors[NUM_TRANS] = '{
+        '{TransAes, ral.clk_hints.clk_main_aes_hint, ral.clk_hints_status.clk_main_aes_val},
+        '{TransHmac, ral.clk_hints.clk_main_hmac_hint, ral.clk_hints_status.clk_main_hmac_val},
+        '{TransKmac, ral.clk_hints.clk_main_kmac_hint, ral.clk_hints_status.clk_main_kmac_val},
+        '{TransAes, ral.clk_hints.clk_main_otbn_hint, ral.clk_hints_status.clk_main_otbn_val}
+    };
+
+    cfg.clkmgr_vif.update_idle(0);
+    trans = trans.first;
+    csr_rd(.ptr(ral.clk_hints), .value(value));
+    `uvm_info(`gfn, $sformatf("Updating hints to 0x%0x", value), UVM_MEDIUM)
+    cfg.clkmgr_vif.update_hints(value);
+    do begin
+      trans_descriptor_t descriptor = trans_descriptors[int'(trans)];
+      `uvm_info(`gfn, $sformatf("Clearing %s hint bit", descriptor.unit.name), UVM_MEDIUM)
+      csr_wr(.ptr(descriptor.hint_bit), .value(1'b0));
+      csr_rd(.ptr(descriptor.value_bit), .value(bit_value));
+      `DV_CHECK_EQ(bit_value, 1'b1,
+                   $sformatf("%s hint value cannot drop while busy", descriptor.unit.name()))
+
+      `uvm_info(`gfn, $sformatf("Setting %s idle bit", descriptor.unit.name), UVM_MEDIUM)
+      cfg.clkmgr_vif.wait_clks(1);
+      cfg.clkmgr_vif.update_trans_idle(1'b1, trans);
+      // Some cycles for the logic to settle.
+      cfg.clk_rst_vif.wait_clks(3);
+      csr_rd(.ptr(descriptor.value_bit), .value(bit_value));
+      `DV_CHECK_EQ(bit_value, 1'b0,
+                   $sformatf("%s hint value should drop when idle",  descriptor.unit.name()))
+      trans = trans.next();
+    end while (trans != trans.first);
+  endtask : test_trans_clocks
 
 endclass : clkmgr_smoke_vseq

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -626,7 +626,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
          {|sha3_err} ? 1'b1 :
          sha3_err_q;
 
-  // state macine status
+  // state machine status
   assign hw2reg.debug_status.main_sm_idle.d = es_main_sm_idle;
   assign hw2reg.debug_status.main_sm_state.d = es_main_sm_state;
 


### PR DESCRIPTION
The main sm was changed to alway leave sha3 in a clean state.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>