### PR TITLE
[tool, xcelium] Enable dumping the arrays of struct into shm/vcd

### DIFF
--- a/hw/dv/sv/spi_agent/seq_lib/spi_device_seq.sv
+++ b/hw/dv/sv/spi_agent/seq_lib/spi_device_seq.sv
@@ -12,21 +12,44 @@ class spi_device_seq extends spi_base_seq;
 
   spi_item req_q[$];
 
+  // data to be sent
+  rand bit [7:0] data[$];
+
+  // constrain size of data sent / received to be at most 64kB
+  constraint data_size_c {
+    data.size() inside {[1:65536]};
+  }
+
   virtual task body();
-    fork
-      forever begin
-        spi_item  req;
-        p_sequencer.req_analysis_fifo.get(req);
-        req_q.push_back(req);
-      end
-      forever begin
-        spi_item  rsp;
-        wait(req_q.size > 0);
-        rsp = req_q.pop_front();
-        start_item(rsp);
-        finish_item(rsp);
-      end
-    join
+    // if mode = Dual/Quad then adopting re-active slave agent (half duplex)
+    if (cfg.spi_mode != "Single") begin
+      fork
+        forever begin
+          spi_item  req;
+          p_sequencer.req_analysis_fifo.get(req);
+          req_q.push_back(req);
+        end
+        forever begin
+          spi_item  rsp;
+          wait(req_q.size > 0);
+          rsp = req_q.pop_front();
+          start_item(rsp);
+          finish_item(rsp);
+        end
+      join
+    end else begin
+    // if mode = Single then adopt full duplex
+      req = spi_item::type_id::create("req");
+      start_item(req);
+      `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
+                                     item_type == SpiTransNormal;
+                                     data.size() == local::data.size();
+                                     foreach (data[i]) {
+                                       data[i] == local::data[i];
+                                     })
+      finish_item(req);
+      get_response(rsp);
+    end
   endtask : body
   
 endclass : spi_device_seq

--- a/hw/dv/sv/spi_agent/spi_agent.core
+++ b/hw/dv/sv/spi_agent/spi_agent.core
@@ -10,8 +10,8 @@ filesets:
       - lowrisc:dv:dv_utils
       - lowrisc:dv:dv_lib
     files:
-      - spi_if.sv
       - spi_agent_pkg.sv
+      - spi_if.sv
       - spi_item.sv: {is_include_file: true}
       - spi_agent_cfg.sv: {is_include_file: true}
       - spi_agent_cov.sv: {is_include_file: true}

--- a/hw/dv/sv/spi_agent/spi_agent_cfg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_cfg.sv
@@ -8,18 +8,29 @@ class spi_agent_cfg extends dv_base_agent_cfg;
   bit en_monitor_checks = 1'b1;
 
   // host mode cfg knobs
-  time sck_period_ps = 50_000; // 20MHz
-  bit sck_polarity;       // aka CPOL
-  bit sck_phase;          // aka CPHA
-  bit host_bit_dir;       // 1 - lsb -> msb, 0 - msb -> lsb
-  bit device_bit_dir;     // 1 - lsb -> msb, 0 - msb -> lsb
-  bit sck_on;             // keep sck on
+  time sck_period_ps = 50_000;  // 20MHz
+  bit host_bit_dir;             // 0 - msb -> lsb, 1 - lsb -> msb (not support)
+  bit device_bit_dir;           // 0 - msb -> lsb, 1 - lsb -> msb
+  bit sck_on;                   // keep sck on
 
-  // spi mode knob
-  spi_mode_e spi_mode;
-
-  // spi config
-  spi_regs_t spi_agent_regs;
+  //-------------------------
+  // SPI_HOST regs
+  //-------------------------
+  // CSID reg
+  bit [31:0]   csid;
+  // CONFIGOPTS registers fields
+  bit          sck_polarity[MAX_CS-1:0];       // aka CPOL
+  bit          sck_phase[MAX_CS-1:0];          // aka CPHA
+  bit          fullcyc[MAX_CS-1:0];
+  bit [3:0]    csnlead[MAX_CS-1:0];
+  bit [3:0]    csntrail[MAX_CS-1:0];
+  bit [3:0]    csnidle[MAX_CS-1:0];
+  bit [15:0]   clkdiv[MAX_CS-1:0];
+  // COMMAND register fields
+  spi_dir_e    direction;
+  spi_mode_e   spi_mode;
+  bit          csaat;
+  bit [8:0]    len;
 
   // how many bytes monitor samples per transaction
   int num_bytes_per_trans_in_mon = 4;
@@ -41,8 +52,6 @@ class spi_agent_cfg extends dv_base_agent_cfg;
 
   `uvm_object_utils_begin(spi_agent_cfg)
     `uvm_field_int (sck_period_ps,  UVM_DEFAULT)
-    `uvm_field_int (sck_polarity,   UVM_DEFAULT)
-    `uvm_field_int (sck_phase,      UVM_DEFAULT)
     `uvm_field_int (host_bit_dir,   UVM_DEFAULT)
     `uvm_field_int (device_bit_dir, UVM_DEFAULT)
     `uvm_field_int (en_extra_dly_btw_sck,         UVM_DEFAULT)
@@ -51,13 +60,25 @@ class spi_agent_cfg extends dv_base_agent_cfg;
     `uvm_field_int (en_extra_dly_btw_word,        UVM_DEFAULT)
     `uvm_field_int (max_extra_dly_ns_btw_word,    UVM_DEFAULT)
     `uvm_field_int (extra_dly_chance_pc_btw_word, UVM_DEFAULT)
-    `uvm_field_enum(spi_mode_e, spi_mode,         UVM_DEFAULT)
+
+    `uvm_field_sarray_int(sck_polarity,   UVM_DEFAULT)
+    `uvm_field_sarray_int(sck_phase,      UVM_DEFAULT)
+    `uvm_field_sarray_int(fullcyc,        UVM_DEFAULT)
+    `uvm_field_sarray_int(csnlead,        UVM_DEFAULT)
+    `uvm_field_sarray_int(csntrail,       UVM_DEFAULT)
+    `uvm_field_sarray_int(csnidle,        UVM_DEFAULT)
+    `uvm_field_sarray_int(clkdiv,         UVM_DEFAULT)
+    `uvm_field_enum(spi_mode_e, spi_mode, UVM_DEFAULT)
+    `uvm_field_enum(spi_dir_e, direction, UVM_DEFAULT)
+    `uvm_field_int(csaat,                 UVM_DEFAULT)
+    `uvm_field_int(len,                   UVM_DEFAULT)
+
   `uvm_object_utils_end
 
   `uvm_object_new
 
-  virtual task wait_sck_edge(sck_edge_type_e sck_edge_type);
-    bit [1:0] sck_mode = {sck_polarity, sck_phase};
+  virtual task wait_sck_edge(sck_edge_type_e sck_edge_type, int channel = 0);
+    bit [1:0] sck_mode = {sck_polarity[channel], sck_phase[channel]};
     bit       wait_posedge;
 
     // sck polarity   slk_phase       mode

--- a/hw/dv/sv/spi_agent/spi_agent_pkg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_pkg.sv
@@ -12,7 +12,10 @@ package spi_agent_pkg;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
-  // local types
+  // parameter
+  parameter uint MAX_CS = 4;
+  parameter uint BYTE_ORDER = 1;  // must be same as ByteOrder defined in spi_host_reg_pkg
+
   // transaction type
   typedef enum {
     SpiTransNormal,    // normal SPI trans
@@ -29,34 +32,40 @@ package spi_agent_pkg;
   } sck_edge_type_e;
 
   // spi mode
-  typedef enum {
-    Single = 0,  // Full duplex, tx: sio[0], rx: sio[1]
-    Dual   = 1,  // Half duplex, tx and rx: sio[1:0]
-    Quad   = 2   // Half duplex, tx and rx: sio[3:0]
+  typedef enum logic [1:0] {
+    Single  = 2'b00,  // Full duplex, tx: sio[0], rx: sio[1]
+    Dual    = 2'b01,  // Half duplex, tx and rx: sio[1:0]
+    Quad    = 2'b10,  // Half duplex, tx and rx: sio[3:0]
+    Reserve = 2'b11
   } spi_mode_e;
+
+  // spi direction
+  typedef enum logic [1:0] {
+    DummyCycles = 2'b00,
+    RxOnly      = 2'b01,
+    TxOnly      = 2'b10,
+    RxTx        = 2'b11
+  } spi_dir_e;
 
   // spi config
   typedef struct {
     // CONTROL register field
     rand bit [8:0]  tx_watermark;
     rand bit [6:0]  rx_watermark;
+    rand bit        passthru;
     // CONFIGOPTS register field
     rand bit        cpol;
     rand bit        cpha;
     rand bit        fullcyc;
-    rand bit        csaat;
     rand bit [3:0]  csnlead;
     rand bit [3:0]  csntrail;
     rand bit [3:0]  csnidle;
     rand bit [15:0] clkdiv;
     // COMMAND register field
-    rand bit        fulldplx;
-    rand bit        highz;
-    rand bit        speed;
-    rand bit [3:0]  tx1_cnt;
-    rand bit [8:0]  txn_cnt;
-    rand bit [8:0]  rx_cnt;
-    rand bit [3:0]  dummy_cycles;
+    rand spi_dir_e  direction;
+    rand spi_mode_e speed;
+    rand bit        csaat;
+    rand bit [8:0]  len;
   } spi_regs_t;
 
   // forward declare classes to allow typedefs below

--- a/hw/dv/sv/spi_agent/spi_device_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_device_driver.sv
@@ -9,34 +9,79 @@ class spi_device_driver extends spi_driver;
   virtual task reset_signals();
     forever begin
       @(negedge cfg.vif.rst_n);
+      `uvm_info(`gfn, "\n  spi_device_driver in reset progress", UVM_LOW)
       under_reset = 1'b1;
-      cfg.vif.sio <= 'hz;
+      cfg.vif.sio <= 4'd0;
       @(posedge cfg.vif.rst_n);
       under_reset = 1'b0;
+      `uvm_info(`gfn, "\n  spi_device_driver out of reset", UVM_LOW)
     end
   endtask
 
   virtual task get_and_drive();
     forever begin
+      wait(!under_reset);
       seq_item_port.get_next_item(req);
       $cast(rsp, req.clone());
       rsp.set_id_info(req);
-      `uvm_info(`gfn, $sformatf("spi_host_driver: rcvd item:\n%0s", req.sprint()), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("  spi_device_driver: req item:\n%0s", req.sprint()), UVM_HIGH)
       fork
-        drive_rx_sio();
-        drive_tx_sio();
+        drive_rx_item(req);
+        drive_tx_item(req);
       join
-      `uvm_info(`gfn, "spi_host_driver: item sent", UVM_HIGH)
+      `uvm_info(`gfn, "  spi_device_driver: item sent", UVM_HIGH)
       seq_item_port.item_done(rsp);
     end
   endtask : get_and_drive
 
-  virtual task drive_rx_sio();
-    // TODO
-  endtask : drive_rx_sio
+  virtual task drive_rx_item(spi_item item);
+    bit [3:0] rx_data;
+    cfg.wait_sck_edge(SamplingEdge);
+    drive_rx_sio(cfg.spi_mode, rx_data);
+  endtask : drive_rx_item
 
-  virtual task drive_tx_sio();
+  virtual task drive_tx_item(spi_item item);
+    bit [7:0] tx_data;
+
     // TODO
+  endtask : drive_tx_item
+
+  virtual task drive_tx_sio(ref spi_mode_e mode, input bit [3:0] tx_data);
+    unique case (mode)
+      Single: begin
+        cfg.vif.sio[1] = tx_data[1];
+      end
+      Dual: begin
+        cfg.vif.sio[3:2] = 2'bzz;
+        cfg.vif.sio[1:0] = tx_data[1:0];
+      end
+      Quad: begin
+        cfg.vif.sio = tx_data;
+      end
+      Reserve: begin
+        cfg.vif.sio = 4'd0;
+      end
+    endcase
   endtask : drive_tx_sio
 
+  virtual task drive_rx_sio(ref spi_mode_e mode, output bit [3:0] rx_data);
+    unique case (mode)
+      Single: begin
+        rx_data[3:2] = 2'bzz;
+        rx_data[1]   = cfg.vif.sio[1];
+        rx_data[0]   = 1'bz;
+      end
+      Dual: begin
+        rx_data[3:2] = 2'bzz;
+        rx_data[1:0] = cfg.vif.sio[1:0];
+      end
+      Quad: begin
+        rx_data = cfg.vif.sio;
+      end
+      Reserve: begin
+        rx_data = 4'bzzzz;
+      end
+    endcase
+  endtask : drive_rx_sio
+  
 endclass : spi_device_driver

--- a/hw/dv/sv/spi_agent/spi_host_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_host_driver.sv
@@ -20,9 +20,9 @@ class spi_host_driver extends spi_driver;
     forever begin
       @(negedge cfg.vif.rst_n);
       under_reset = 1'b1;
-      cfg.vif.sck <= cfg.sck_polarity;
-      cfg.vif.csb <= 'hf;
+      cfg.vif.sck <= cfg.sck_polarity[0];
       cfg.vif.sio <= 'hz;
+      cfg.vif.csb <= 'h1;
       sck_pulses = 0;
       @(posedge cfg.vif.rst_n);
       under_reset = 1'b0;
@@ -31,6 +31,7 @@ class spi_host_driver extends spi_driver;
 
   // generate sck
   task gen_sck();
+    @(posedge cfg.vif.rst_n);
     fork
       forever begin
         if (sck_pulses > 0 || cfg.sck_on) begin
@@ -45,23 +46,23 @@ class spi_host_driver extends spi_driver;
           @(cfg.sck_on, sck_pulses);
           if (sck_pulses > 0) begin
             // drive half cycle first
-            cfg.vif.sck <= cfg.sck_polarity;
+            cfg.vif.sck <= cfg.sck_polarity[0];
             #(cfg.sck_period_ps / 2 * 1ps);
           end
         end
         cfg.vif.sck_pulses = sck_pulses;
       end
       forever begin
-        @(cfg.sck_polarity);
-        cfg.vif.sck_polarity = cfg.sck_polarity;
-        if (sck_pulses == 0) cfg.vif.sck <= cfg.sck_polarity;
+        @(cfg.sck_polarity[0]);
+        cfg.vif.sck_polarity = cfg.sck_polarity[0];
+        if (sck_pulses == 0) cfg.vif.sck <= cfg.sck_polarity[0];
       end
       forever begin
-        @(cfg.sck_phase);
-        cfg.vif.sck_phase = cfg.sck_phase;
+        @(cfg.sck_phase[0]);
+        cfg.vif.sck_phase = cfg.sck_phase[0];
       end
     join
-  endtask
+  endtask : gen_sck
 
   task get_and_drive();
     forever begin
@@ -108,7 +109,7 @@ class spi_host_driver extends spi_driver;
 
     wait(sck_pulses == 0);
     cfg.vif.csb[0] <= 1'b1;
-    cfg.vif.sio[0] <= 1'bx;
+    cfg.vif.sio[0] <= 1'bz;
   endtask
 
   task drive_sck_no_csb_item();
@@ -116,7 +117,7 @@ class spi_host_driver extends spi_driver;
       #($urandom_range(1, 100) * 1ns);
       cfg.vif.sck <= ~cfg.vif.sck;
     end
-    cfg.vif.sck <= cfg.sck_polarity;
+    cfg.vif.sck <= cfg.sck_polarity[0];
     #1ps; // make sure sck and csb (for next item) not change at the same time
   endtask
 

--- a/hw/dv/sv/spi_agent/spi_if.sv
+++ b/hw/dv/sv/spi_agent/spi_if.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+import spi_agent_pkg::*;
+
 interface spi_if (
   input rst_n
 );
@@ -20,4 +22,11 @@ interface spi_if (
   bit         sck_polarity;
   bit         sck_phase;
 
+  //---------------------------------
+  // common tasks
+  //---------------------------------
+  task automatic wait_for_dly(int dly);
+    repeat (dly) @(posedge sck);
+  endtask : wait_for_dly
+  
 endinterface : spi_if

--- a/hw/dv/tools/waves.tcl
+++ b/hw/dv/tools/waves.tcl
@@ -110,7 +110,7 @@ proc wavedumpScope {scope fid {depth 0} {fsdb_flags "+all"} {probe_flags  "-all"
       if {$depth == 0} {
         set depth "all"
       }
-      probe "$scope" $probe_flags -depth $depth -shm
+      probe "$scope" $probe_flags -depth $depth -memories -shm
     }
 
     "vpd" {
@@ -124,7 +124,7 @@ proc wavedumpScope {scope fid {depth 0} {fsdb_flags "+all"} {probe_flags  "-all"
         if {$depth == 0} {
           set depth "all"
         }
-        probe "$scope" $probe_flags -depth $depth -vcd
+        probe "$scope" $probe_flags -depth $depth -memories -vcd
       }
     }
 

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -117,8 +117,8 @@ class spi_device_base_vseq extends cip_base_vseq #(
       cfg.m_spi_agent_cfg.sck_period_ps = cfg.clk_rst_vif.clk_period_ps * core_spi_freq_ratio;
     end
     // update host agent
-    cfg.m_spi_agent_cfg.sck_polarity = sck_polarity;
-    cfg.m_spi_agent_cfg.sck_phase = sck_phase;
+    cfg.m_spi_agent_cfg.sck_polarity[0] = sck_polarity;
+    cfg.m_spi_agent_cfg.sck_phase[0] = sck_phase;
     cfg.m_spi_agent_cfg.host_bit_dir = host_bit_dir;
     cfg.m_spi_agent_cfg.device_bit_dir = device_bit_dir;
     // update device rtl
@@ -225,7 +225,7 @@ class spi_device_base_vseq extends cip_base_vseq #(
       `uvm_info(`gfn, $sformatf({"tx_wptr[SRAM_MSB:0] = 0x%0h, tx_wptr_phase_bit = 0x%0h, ",
                                  "tx_sram_size_bytes = 0x%0h, tx_wptr_addr = 0x%0h"},
                                  tx_wptr[SRAM_MSB:0], tx_wptr[SRAM_PTR_PHASE_BIT],
-                                 tx_sram_size_bytes, tx_wptr_addr), UVM_MEDIUM)
+                                 tx_sram_size_bytes, tx_wptr_addr), UVM_LOW)
       tl_access(.addr(tx_wptr_addr), .write(1'b1), .data(device_data[i])); // TODO: bkdr wr?
 
       // advance tx wptr by SRAM_WORD_SIZE

--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -20,7 +20,7 @@
                a Little-Endian ordering is used for these registers, and the LSB of each
                gets priority for receiving and transmitting data.'''
       type: "logic",
-      default: "1"
+      default: "0"
     },
     { name: "NumCS",
       desc: "The number of active-low chip select (cs_n) lines to create.",
@@ -115,6 +115,7 @@
       desc: "Status register",
       swaccess: "ro",
       hwaccess: "hwo",
+      hwext: "true",
       fields: [
         { bits: "31",
           name: "READY",
@@ -178,8 +179,9 @@
         { bits: "22",
           name: "BYTEORDER",
           desc: '''The value of the ByteOrder parameter, provided so that firmware
-                   can confirm proper IP configuration.'''
-        }
+                   can confirm proper IP configuration.''',
+          resval: "0x0"
+        },
         { bits: "20",
           name: "RXWM",
           desc: '''If high, the number of 32-bits in the RX FIFO now exceeds the
@@ -202,10 +204,9 @@
           resval: "0x0"
         }
       ]
-      tags: [// Updated by the hw. Exclude from init and write-checks.
+      tags: [// Updated by the hw. Exclude from init or write-checks.
              "excl:CsrAllTests:CsrExclCheck"]
-
-    },
+    }
     { multireg: { name: "CONFIGOPTS",
         desc: '''Configuration options register.
 
@@ -500,7 +501,10 @@
                    goes high''',
           resval: "0x0"
         },
-      ]
+      ],
+      tags: [// Exclude from write checks because
+             // it might lead to unpreditable values on intr_spi_event register
+             "excl:CsrAllTests:CsrExclWrite"]
     }
   ]
 }

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
@@ -12,65 +12,157 @@ class spi_host_base_vseq extends cip_base_vseq #(
   `uvm_object_new
 
   // local variables
-  local uint                  num_rd_words = 0;
+  local dv_base_reg    base_reg;
 
   // random variables
-  rand uint                   tx_fifo_access_dly;
-  rand uint                   rx_fifo_access_dly;
-  rand uint                   clear_intr_dly;
-  rand uint                   num_runs;
-  rand spi_regs_t             spi_host_regs;
-  // constraints
+  rand uint             tx_fifo_access_dly;
+  rand uint             rx_fifo_access_dly;
+  rand uint             clear_intr_dly;
+  rand uint             num_runs;
+  rand uint             num_wr_bytes;
+  rand uint             num_rd_bytes;
+  // SPI mode
+  rand spi_mode_e spi_mode;
+  // CSID register
+  rand bit [31:0]       csid;
+  // CONTROL register fields
+  rand bit [7:0]        tx_watermark;
+  rand bit [7:0]        rx_watermark;
+  rand bit              passthru;
+  // CONFIGOPTS register fields
+  rand bit              sck_polarity[SPI_HOST_NUM_CS-1:0];
+  rand bit              sck_phase[SPI_HOST_NUM_CS-1:0];
+  rand bit              fullcyc[SPI_HOST_NUM_CS-1:0];
+  rand bit [3:0]        csnlead[SPI_HOST_NUM_CS-1:0];
+  rand bit [3:0]        csntrail[SPI_HOST_NUM_CS-1:0];
+  rand bit [3:0]        csnidle[SPI_HOST_NUM_CS-1:0];
+  rand bit [15:0]       clkdiv[SPI_HOST_NUM_CS-1:0];
+  // COMMAND register fields
+  rand spi_dir_e        direction;
+  rand spi_mode_e       speed;
+  rand bit              csaat;
+  rand bit [8:0]        len;
+  // FIFO: address used to access fifos
+  rand bit [TL_AW:0]    fifo_baddr;
+  rand bit [7:0]        data_q[$];
+
+  semaphore             rxtx_atomic = new(1);
+
+  // constraints for simulation loops
   constraint num_trans_c {
     num_trans inside {[cfg.seq_cfg.host_spi_min_trans : cfg.seq_cfg.host_spi_max_trans]};
   }
   constraint num_runs_c {
     num_runs inside {[cfg.seq_cfg.host_spi_min_runs : cfg.seq_cfg.host_spi_max_runs]};
   }
-  // contraints for fifo access delay
-  constraint clear_intr_dly_c {
+  constraint num_wr_bytes_c {
+    num_wr_bytes inside {[cfg.seq_cfg.host_spi_min_num_wr_bytes :
+                          cfg.seq_cfg.host_spi_max_num_wr_bytes]};
+  }
+  constraint num_rd_bytes_c {
+    num_rd_bytes inside {[cfg.seq_cfg.host_spi_min_num_rd_bytes :
+                          cfg.seq_cfg.host_spi_max_num_rd_bytes]};
+  }
+  // contraints for fifos
+  constraint fifo_baddr_c {
+    fifo_baddr inside {[SPI_HOST_FIFO_BASE : SPI_HOST_FIFO_END]};
+  }
+
+  constraint intr_c {
     clear_intr_dly inside {[cfg.seq_cfg.host_spi_min_dly : cfg.seq_cfg.host_spi_max_dly]};
   }
-  constraint tx_fifo_access_dly_c {
+  constraint control_reg_c {
+    tx_watermark dist {
+      [0:7]   :/ 1,
+      [8:15]  :/ 2,
+      [16:31] :/ 3,
+      [32:cfg.seq_cfg.host_spi_max_txwm] :/ 1
+    };
+    rx_watermark dist {
+      [0:7]   :/ 1,
+      [8:15]  :/ 2,
+      [16:31] :/ 3,
+      [32:cfg.seq_cfg.host_spi_max_rxwm] :/ 1
+    };
+    rx_fifo_access_dly inside {[cfg.seq_cfg.host_spi_min_dly : cfg.seq_cfg.host_spi_max_dly]};
     tx_fifo_access_dly inside {[cfg.seq_cfg.host_spi_min_dly : cfg.seq_cfg.host_spi_max_dly]};
   }
-  constraint rx_fifo_access_dly_c {
-    rx_fifo_access_dly inside {[cfg.seq_cfg.host_spi_min_dly : cfg.seq_cfg.host_spi_max_dly]};
+  constraint passthru_c {
+    passthru dist {
+      1'b0 :/ 1,
+      1'b1 :/ 0   // TODO: currently disable passthru mode until specification is updated
+    };
   }
-  constraint spi_host_regs_c {
-    spi_host_regs.csnlead      inside {[cfg.seq_cfg.host_spi_min_csn_hcyc :
-                                        cfg.seq_cfg.host_spi_max_csn_hcyc]};
-    spi_host_regs.csntrail     inside {[cfg.seq_cfg.host_spi_min_csn_hcyc :
-                                        cfg.seq_cfg.host_spi_max_csn_hcyc]};
-    spi_host_regs.csnidle      inside {[cfg.seq_cfg.host_spi_min_csn_hcyc :
-                                        cfg.seq_cfg.host_spi_max_csn_hcyc]};
-    spi_host_regs.clkdiv       inside {[cfg.seq_cfg.host_spi_min_csn_hcyc :
-                                        cfg.seq_cfg.host_spi_max_csn_hcyc]};
-    spi_host_regs.tx1_cnt      inside {[cfg.seq_cfg.host_spi_min_tx1 :
-                                        cfg.seq_cfg.host_spi_max_tx1]};
-    spi_host_regs.txn_cnt      inside {[cfg.seq_cfg.host_spi_min_txn :
-                                        cfg.seq_cfg.host_spi_max_txn]};
-    spi_host_regs.rx_cnt       inside {[cfg.seq_cfg.host_spi_min_rx :
-                                        cfg.seq_cfg.host_spi_max_rx]};
-    spi_host_regs.dummy_cycles inside {[cfg.seq_cfg.host_spi_min_dummy :
-                                        cfg.seq_cfg.host_spi_max_dummy]};
-    spi_host_regs.tx_watermark inside {[cfg.seq_cfg.host_spi_min_txwm :
-                                        cfg.seq_cfg.host_spi_max_txwm]};
-    spi_host_regs.rx_watermark inside {[cfg.seq_cfg.host_spi_min_rxwm :
-                                        cfg.seq_cfg.host_spi_max_rxwm]};
-    spi_host_regs.speed        inside {[cfg.seq_cfg.host_spi_min_speed :
-                                        cfg.seq_cfg.host_spi_max_speed]};
+  constraint csid_c {
+    csid inside {[0 : SPI_HOST_NUM_CS-1]};
+  }
+  constraint configopts_regs_c {
+    foreach (csnlead[i]) {
+      csnlead[i] inside {[cfg.seq_cfg.host_spi_min_csn_hcyc : cfg.seq_cfg.host_spi_max_csn_hcyc]};
+    }
+    foreach (csntrail[i]) {
+      csntrail[i] inside {[cfg.seq_cfg.host_spi_min_csn_hcyc : cfg.seq_cfg.host_spi_max_csn_hcyc]};
+    }
+    foreach (csnidle[i]) {
+      csnidle[i] inside {[cfg.seq_cfg.host_spi_min_csn_hcyc : cfg.seq_cfg.host_spi_max_csn_hcyc]};
+    }
+    foreach (clkdiv[i]) {
+      clkdiv[i] inside {[cfg.seq_cfg.host_spi_min_csn_hcyc : cfg.seq_cfg.host_spi_max_csn_hcyc]};
+    }
+  }
+  constraint command_reg_c {
+    direction dist {
+      DummyCycles :/ 1,
+      RxOnly      :/ 1,
+      TxOnly      :/ 1,
+      RxTx        :/ 1
+    };
+    speed dist {
+      Single :/ 2,
+      Dual   :/ 0,  // TODO
+      Quad   :/ 0   // TODO
+    };
+    len inside {[cfg.seq_cfg.host_spi_min_len : cfg.seq_cfg.host_spi_max_len]};
   }
 
   virtual task body();
     initialization();
 
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(spi_host_regs)
-    `uvm_info(`gfn, $sformatf("\n  tx_watermark %0d, rx_watermark %0d",
-        spi_host_regs.tx_watermark, spi_host_regs.rx_watermark), UVM_LOW)
-    cfg.clk_rst_core_vif.wait_clks(100);
+    `DV_CHECK_RANDOMIZE_FATAL(this)
+    prog_spi_host_reg();
+    activate_spi_host();
+    `uvm_info(`gfn, "\n  start access fifos", UVM_DEBUG)
+    write_tx_data();
   endtask : body
-  
+
+  virtual task bk_body();
+    initialization();
+    cfg.seq_cfg.host_spi_max_num_wr_bytes = 5;
+
+    rxtx_atomic = new(1);
+    for (int trans = 0; trans < num_trans; trans++) begin
+      `uvm_info(`gfn, $sformatf("\n--> running tran. %0d/%0d", trans, num_trans), UVM_DEBUG)
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      prog_spi_host_reg();
+      activate_spi_host();
+      `uvm_info(`gfn, "\n  start access fifos", UVM_DEBUG)
+      fork
+        begin
+          //rxtx_atomic.get(1);
+          write_tx_data();
+          //rxtx_atomic.put(1);
+        end
+        begin
+          //rxtx_atomic.get(1);
+          //read_rx_data();
+          //cfg.clk_rst_vif.wait_clks(10);
+          //rxtx_atomic.put(1);
+        end
+      join
+      wait_for_fifos_empty();
+    end
+  endtask : body
+
   virtual task pre_start();
     // sync monitor and scoreboard setting
     cfg.m_spi_agent_cfg.en_monitor_checks = cfg.en_scb;
@@ -92,16 +184,16 @@ class spi_host_base_vseq extends cip_base_vseq #(
 
   // setup basic spi_host features
   virtual task spi_host_init();
-    // initialize spi_host by programming CONTROL register
-    ral.control.spien.set(1'b1);
-    ral.control.rst_fsm.set(1'b1);
-    ral.control.rst_txfifo.set(1'b1);
-    ral.control.rst_rxfifo.set(1'b1);
-    ral.control.passthru.set(1'b0);   // TODO: enable and verify with special_modes test
-    ral.control.manual_cs.set(1'b0);  // TODO: enable and verify with special_modes test
-    ral.control.mancs_en.set($urandom_range(0, 1));
+    // reset spit_host dut
+    ral.control.sw_rst.set(1'b1);
     csr_update(ral.control);
-
+    // make sure data completely drained from fifo then release reset
+    wait_for_fifos_empty();
+    ral.control.sw_rst.set(1'b0);
+    csr_update(ral.control);
+    // set passthru mode
+    ral.control.passthru.set(passthru);
+    csr_update(ral.control);
     // enable then clear interrupts
     csr_wr(.ptr(ral.intr_enable), .value({TL_DW{1'b1}}));
     process_interrupts();
@@ -110,7 +202,6 @@ class spi_host_base_vseq extends cip_base_vseq #(
   virtual task spi_agent_init();
     // spi_agent is configured in the Denive mode
     spi_device_seq m_device_seq;
-
     m_device_seq = spi_device_seq::type_id::create("m_device_seq");
     `uvm_info(`gfn, "\n  start spi_device sequence", UVM_DEBUG)
     fork
@@ -118,73 +209,117 @@ class spi_host_base_vseq extends cip_base_vseq #(
     join_none
   endtask : spi_agent_init
 
-  virtual task program_command();
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(spi_host_regs)
-    `uvm_info(`gfn, $sformatf("\n  tx_watermark %0d, rx_watermark %0d",
-        spi_host_regs.tx_watermark, spi_host_regs.rx_watermark), UVM_LOW)
-    // TODO: V1 complete
-    /*
-    // CONTROLL register fields
-    ral.control.tx_watermark.set(spi_host_regs.tx_watermark);
-    ral.control.rx_watermark.set(spi_host_regs.rx_watermark);
+  virtual task activate_spi_host();
+    // update spi_agent regs
+    update_spi_agent_regs();
+    // enable one of CS lines
+    csr_wr(.ptr(ral.csid), .value(csid));
+    // activate spi_host dut
+    ral.control.spien.set(1'b1);
+    csr_update(ral.control);
+  endtask : activate_spi_host
 
+  virtual task prog_spi_host_reg();
+    prog_control_reg();
+    prog_configopts_reg();
+    prog_command_reg();
+  endtask : prog_spi_host_regs
+
+  virtual task prog_control_reg();
+    ral.control.tx_watermark.set(tx_watermark);
+    ral.control.rx_watermark.set(rx_watermark);
+    csr_update(ral.control);
+  endtask : prog_control_reg
+
+  virtual task prog_configopts_reg();
     // CONFIGOPTS register fields
-    ral.configopts[0].cpol.set(spi_host_regs.cpol);        // clock phase
-    ral.configopts[0].cpha.set(spi_host_regs.cpha);        // sampling data phase
-    ral.configopts.fullcyc.set(spi_host_regs.fullcyc);
-    ral.configopts.csaat.set(spi_host_regs.csaat);
-    ral.configopts.csnlead.set(spi_host_regs.csnlead);
-    ral.configopts.csntrail.set(spi_host_regs.csntrail);
-    ral.configopts.csnidle.set(spi_host_regs.csnidle);
-    ral.configopts.clkdiv.set(spi_host_regs.clkdiv);
-    // TXDATA register fields
-    ral.txdata.set($urandom_range(0, (1 << TL_DW) - 1));
-    // COMMAND register fields
-    ral.command.tx1_cnt.set(spi_host_regs.tx1_cnt);
-    ral.command.txn_cnt.set(spi_host_regs.txn_cnt);
-    ral.command.rx_cnt.set(spi_host_regs.rx_cnt);
-    num_rd_words = $floor(spi_host_regs.rx_cnt / 2);    // word-level data
-    `uvm_info(`gfn, $sformatf("\n  rx_cnt %0d, num_rd_words %0d",
-        spi_host_regs.rx_cnt, num_rd_words), UVM_DEBUG)
-    ral.command.dummy_cycles.set(spi_host_regs.dummy_cycles);
-    ral.command.fulldplx.set(spi_host_regs.fulldplx);
-    ral.command.highz.set(spi_host_regs.highz);
-    ral.command.speed.set(spi_host_regs.speed);         // spi mode
-    ral.command.go.set(1'b1);                           // submit command to tx_fifo (self-clear)
-
-    // update spi_host registers
-      csr_update(ral.control);
-    csr_update(ral.configopts);
-    //csr_update(ral.txdata);                           // TODO: error in spi_host.hjson
-    csr_update(ral.command);                            // command is finally submitted
-
-    // update spi_agent registers
-    cfg.m_spi_agent_cfg.spi_agent_regs = spi_host_regs;
-    */
-  endtask : program_command
-
-  virtual task send_transactions();
-    `uvm_info(`gfn, "\n  send_transactions task running ...", UVM_DEBUG)
-
-    for (uint cur_tran = 1; cur_tran <= num_trans; cur_tran++) begin
-      csr_spinwait(.ptr(ral.status.txfull), .exp_data(1'b0));
-      program_command();
-      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(tx_fifo_access_dly)
-      cfg.clk_rst_vif.wait_clks(tx_fifo_access_dly);
+    base_reg = get_dv_base_reg_by_name("configopts");
+    for (int i = 0; i < SPI_HOST_NUM_CS; i++) begin
+      set_dv_base_reg_field_by_name(base_reg, "cpol",     sck_polarity[i], i);
+      set_dv_base_reg_field_by_name(base_reg, "cpha",     sck_phase[i], i);
+      set_dv_base_reg_field_by_name(base_reg, "fullcyc",  fullcyc[i], i);
+      set_dv_base_reg_field_by_name(base_reg, "csnlead",  csnlead[i], i);
+      set_dv_base_reg_field_by_name(base_reg, "csntrail", csntrail[i], i);
+      set_dv_base_reg_field_by_name(base_reg, "csnidle",  csnidle[i], i);
+      set_dv_base_reg_field_by_name(base_reg, "clkdiv",   clkdiv[i], i);
+      csr_update(base_reg);
     end
-  endtask : send_transactions
+  endtask : prog_configopts_reg
 
-  virtual task get_transactions(uint num_rd_words);
-    bit [TL_DW-1:0] rxdata;
-    
-    while (!num_rd_words) begin
-      csr_spinwait(.ptr(ral.status.rxempty), .exp_data(1'b1));
-      csr_rd(.ptr(ral.rxdata), .value(rxdata));
+  virtual task prog_command_reg();
+    // COMMAND register fields
+    ral.command.set(direction);
+    ral.command.set(speed);
+    ral.command.set(csaat);
+    ral.command.set(len);
+    csr_update(ral.command);
+  endtask : prog_command_reg
+
+  virtual task write_tx_data();
+    bit [TL_DW-1:0] tx_wdata;
+    bit [TL_AW-1:0] fifo_waddr;
+
+    //uvm_reg_map map = ral.get_default_map();
+    //uvm_reg_addr_t reg_base_addr = map.get_base_addr();
+    //`uvm_info(`gfn, $sformatf("\n base_vseq, base_addr: 0x%0x", int'(reg_base_addr)), UVM_LOW)
+
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(fifo_baddr)
+    fifo_waddr = ral.get_addr_from_offset(fifo_baddr);
+    `uvm_info(`gfn, $sformatf("\n base_vseq, tx_byte_addr: 0x%0x", fifo_baddr), UVM_LOW)
+    `uvm_info(`gfn, $sformatf("\n base_vseq, tx_word_addr: 0x%0x", fifo_waddr), UVM_LOW)
+    `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(data_q,
+                                          data_q.size() == num_wr_bytes;
+                                         )
+    swap_array_byte_order(data_q);
+
+    // iterate through the data queue and pop off bytes to write to tx_fifo
+    while (data_q.size() > 0) begin
+      wait_for_fifos_available(TxFifo);
+      tx_wdata = '0;
+      for (int i = 0; i < TL_DBW; i++) begin
+        if (data_q.size() > 0) begin
+          tx_wdata[8*i +: 8] = data_q.pop_front();
+        end
+      end
+      tx_wdata = 32'hcafecafe; //TODO: override random value for debug
+      send_tl_access(.addr(fifo_waddr), .data(tx_wdata), .write(1'b1), .blocking(1'b0));
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rx_fifo_access_dly)
       cfg.clk_rst_vif.wait_clks(rx_fifo_access_dly);
-      num_rd_words--;
     end
-  endtask : get_transactions
+    // wait for all accesses to complete
+    wait_no_outstanding_access();
+    // read out status/intr_state CSRs to check
+    check_status_and_clear_intrs();
+  endtask : write_tx_data
+
+  virtual task send_tl_access(bit [TL_AW-1:0] addr, bit [TL_DW-1:0] data, bit write,
+                              bit [TL_DBW-1:0] mask = {TL_DBW{1'b1}},
+                              bit blocking = $urandom_range(0, 1));
+    tl_access(.addr(addr), .write(write), .data(data), .mask(mask), .blocking(blocking));
+    `uvm_info(`gfn, $sformatf("\n base_vseq, %s to address 0x%0x, data: 0x%0x, mask %b, blk %b",
+          write ? "write" : "read", data, addr, mask, blocking), UVM_LOW)
+  endtask : send_tl_access
+
+  virtual task read_rx_data();
+    bit [TL_DW-1:0] rx_data;
+    bit [TL_AW-1:0] fifo_waddr;
+    uint cnt_rx_bytes = 0;
+
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(fifo_baddr)
+    fifo_waddr = ral.get_addr_from_offset(fifo_baddr);
+    `uvm_info(`gfn, $sformatf("\n  base_vseq, rx_byte_addr 0x%0x", fifo_baddr), UVM_LOW)
+    `uvm_info(`gfn, $sformatf("\n  base_vseq, rx_word_addr 0x%0x", fifo_waddr), UVM_LOW)
+    while (cnt_rx_bytes < num_rd_bytes) begin
+      send_tl_access(.addr(fifo_waddr), .data(rx_data), .write(1'b0));
+      cnt_rx_bytes += 4;
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rx_fifo_access_dly)
+      cfg.clk_rst_vif.wait_clks(rx_fifo_access_dly);
+    end
+    // wait for all accesses to complete
+    wait_no_outstanding_access();
+    // read out status/intr_state CSRs to check
+    check_status_and_clear_intrs();
+  endtask : read_rx_data
 
   // read interrupts and randomly clear interrupts if set
   virtual task process_interrupts();
@@ -195,9 +330,8 @@ class spi_host_base_vseq extends cip_base_vseq #(
     // clear interrupt if it is set
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(intr_clear,
                                        foreach (intr_clear[i]) {
-                                           intr_state[i] -> intr_clear[i] == 1;
+                                         intr_state[i] -> intr_clear[i] == 1;
                                        })
-    
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(clear_intr_dly)
     cfg.clk_rst_vif.wait_clks(clear_intr_dly);
     csr_wr(.ptr(ral.intr_state), .value(intr_clear));
@@ -206,25 +340,23 @@ class spi_host_base_vseq extends cip_base_vseq #(
   // override apply_reset to handle core_reset domain
   virtual task apply_reset(string kind = "HARD");
     fork
-      if (kind == "HARD" || kind == "TL_IF") begin
-        super.apply_reset("HARD");
-      end
-      if (kind == "HARD" || kind == "CORE_IF") begin
-        cfg.clk_rst_core_vif.apply_reset();
+      super.apply_reset(kind);
+      begin
+        if (kind == "HARD") begin
+          cfg.clk_rst_core_vif.apply_reset();
+        end
       end
     join
-  endtask
+  endtask : apply_reset
 
   // override wait_for_reset to to handle core_reset domain
-  virtual task wait_for_reset(string reset_kind     = "HARD",
-                              bit wait_for_assert   = 1,
-                              bit wait_for_deassert = 1);
+  virtual task wait_for_reset(string reset_kind = "HARD",
+                              bit wait_for_assert = 1'b1,
+                              bit wait_for_deassert = 1'b1);
 
     fork
-      if (reset_kind == "HARD" || reset_kind == "TL_IF") begin
-        super.wait_for_reset(reset_kind, wait_for_assert, wait_for_deassert);
-      end
-      if (reset_kind == "HARD" || reset_kind == "CORE_IF") begin
+      super.wait_for_reset(reset_kind, wait_for_assert, wait_for_deassert);
+      begin
         if (wait_for_assert) begin
           `uvm_info(`gfn, "waiting for core rst_n assertion...", UVM_MEDIUM)
           @(negedge cfg.clk_rst_core_vif.rst_n);
@@ -233,10 +365,93 @@ class spi_host_base_vseq extends cip_base_vseq #(
           `uvm_info(`gfn, "waiting for core rst_n de-assertion...", UVM_MEDIUM)
           @(posedge cfg.clk_rst_core_vif.rst_n);
         end
-        `uvm_info(`gfn, "core wait_for_reset done", UVM_HIGH)
+        `uvm_info(`gfn, "core wait_for_reset done", UVM_LOW)
       end
     join
   endtask : wait_for_reset
+
+  // wait until fifos empty
+  virtual task wait_for_fifos_empty(spi_host_fifo_e fifo = AllFifos);
+    if (fifo == TxFifo || TxFifo == AllFifos) begin
+      csr_spinwait(.ptr(ral.status.txempty), .exp_data(1'b1));
+    end
+    if (fifo == RxFifo || TxFifo == AllFifos) begin
+      csr_spinwait(.ptr(ral.status.rxempty), .exp_data(1'b1));
+    end
+  endtask : wait_for_fifos_empty
+
+  // reads out the STATUS and INTR_STATE csrs so scb can check the status
+  virtual task check_status_and_clear_intrs();
+    bit [TL_DW-1:0] data;
+
+    // read then clear interrupts
+    csr_rd(.ptr(ral.intr_state), .value(data));
+    csr_wr(.ptr(ral.intr_state), .value(data));
+    // read status register
+    csr_rd(.ptr(ral.status), .value(data));
+  endtask : check_status_and_clear_intrs
+
+  // wait until fifos has available entries to read/write
+  virtual task wait_for_fifos_available(spi_host_fifo_e fifo = AllFifos);
+    if (fifo == TxFifo || TxFifo == AllFifos) begin
+      csr_spinwait(.ptr(ral.status.txfull), .exp_data(1'b0));
+    end
+    if (fifo == RxFifo || TxFifo == AllFifos) begin
+      csr_spinwait(.ptr(ral.status.rxfull), .exp_data(1'b0));
+    end
+  endtask
+
+  // update spi_agent registers
+  virtual function void update_spi_agent_regs();
+    for (int i = 0; i < SPI_HOST_NUM_CS; i++) begin
+      cfg.m_spi_agent_cfg.sck_polarity[i] = sck_polarity[i];
+      cfg.m_spi_agent_cfg.sck_phase[i]    = sck_phase[i];
+      cfg.m_spi_agent_cfg.fullcyc[i]      = fullcyc[i];
+      cfg.m_spi_agent_cfg.csnlead[i]      = csnlead[i];
+    end
+    cfg.m_spi_agent_cfg.csid              = csid;
+    cfg.m_spi_agent_cfg.direction         = direction;
+    cfg.m_spi_agent_cfg.spi_mode          = speed;
+    cfg.m_spi_agent_cfg.csaat             = csaat;
+    cfg.m_spi_agent_cfg.len               = len;
+  endfunction : update_spi_agent_regs
+
+  // set reg/mreg using name and index
+  virtual function dv_base_reg get_dv_base_reg_by_name(string csr_name,
+                                               int    csr_idx = -1);
+    string  reg_name;
+    uvm_reg reg_uvm;
+
+    reg_name = (csr_idx == -1) ? csr_name : $sformatf("%s_%0d", csr_name, csr_idx);
+    reg_uvm  = ral.get_reg_by_name(reg_name);
+    `DV_CHECK_NE_FATAL(reg_uvm, null, reg_name)
+    `downcast(get_dv_base_reg_by_name, reg_uvm)
+  endfunction
+
+  // set field of reg/mreg using name and index, need to call csr_update after setting
+  virtual function void set_dv_base_reg_field_by_name(dv_base_reg csr_reg,
+                                              string      csr_field,
+                                              uint        value,
+                                              int         csr_idx = -1);
+    uvm_reg_field reg_field;
+    string reg_name;
+
+    reg_name = (csr_idx == -1) ? csr_field : $sformatf("%s_%0d", csr_field, csr_idx);
+    reg_field = csr_reg.get_field_by_name(reg_name);
+    `DV_CHECK_NE_FATAL(reg_field, null, reg_name)
+    reg_field.set(value);
+  endfunction
+
+  virtual function void swap_array_byte_order(ref bit [7:0] data[$]);
+    if (SPI_HOST_BYTEORDER) begin
+      bit [7:0] data_arr[];
+      data_arr = data;
+      `uvm_info(`gfn, $sformatf("\n base_vseq, data_q_baseline: %0p", data), UVM_LOW)
+      dv_utils_pkg::endian_swap_byte_arr(data_arr);
+      data = data_arr;
+      `uvm_info(`gfn, $sformatf("\n base_vseq, data_q_swapped:  %0p", data), UVM_LOW)
+    end
+  endfunction : swap_array_byte_order
 
   // phase alignment for resets signal of core and bus domain
   virtual task do_phase_align_reset(bit en_phase_align_reset = 1'b0);

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_smoke_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_smoke_vseq.sv
@@ -5,16 +5,6 @@
 // smoke test vseq
 class spi_host_smoke_vseq extends spi_host_base_vseq;
   `uvm_object_utils(spi_host_smoke_vseq)
-
   `uvm_object_new
-
-  task body();
-    `uvm_info(`gfn, "\n--> start of spi_host_smoke_vseq", UVM_DEBUG)
-    // TODO: host sends transactions to spi_agent
-    for (uint i = 0; i < 10; i++) begin
-      program_command();
-    end
-    `uvm_info(`gfn, "\n--> end of spi_host_smoke_vseq", UVM_DEBUG)
-  endtask : body
 
 endclass : spi_host_smoke_vseq

--- a/hw/ip/spi_host/dv/env/spi_host_env.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_env.sv
@@ -21,6 +21,8 @@ class spi_host_env extends cip_base_env #(
     m_spi_agent = spi_agent::type_id::create("m_spi_agent", this);
     uvm_config_db#(spi_agent_cfg)::set(this, "m_spi_agent*", "cfg", cfg.m_spi_agent_cfg);
     cfg.m_spi_agent_cfg.en_cov = cfg.en_cov;
+    // spi_host dut only supports msb->lsb
+    cfg.m_spi_agent_cfg.host_bit_dir = 1'b0;
 
     if (!uvm_config_db#(virtual clk_rst_if)::get(this, "", "clk_rst_core_vif",
         cfg.clk_rst_core_vif)) begin

--- a/hw/ip/spi_host/dv/env/spi_host_env_cfg.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_env_cfg.sv
@@ -30,6 +30,8 @@ class spi_host_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_host_reg_block));
     m_spi_agent_cfg.ok_to_end_delay_ns = 8000;
     // create req_analysis_fifo for re-active slave agent
     m_spi_agent_cfg.has_req_fifo = 1'b1;
+    // default spi_mode
+    m_spi_agent_cfg.spi_mode = Single;
 
     // create the seq_cfg
     seq_cfg = spi_host_seq_cfg::type_id::create("seq_cfg");
@@ -59,7 +61,6 @@ class spi_host_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_host_reg_block));
     end else begin  // bus and core has same clock frequency
       clk_core_mhz = clk_rst_vif.clk_freq_mhz;
     end
-
     return clk_core_mhz;
   endfunction : get_clk_core_freq
   

--- a/hw/ip/spi_host/dv/env/spi_host_env_pkg.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_env_pkg.sv
@@ -13,20 +13,34 @@ package spi_host_env_pkg;
   import spi_agent_pkg::*;
   import cip_base_pkg::*;
   import dv_base_reg_pkg::*;
-  import spi_host_reg_pkg::*;
   import spi_host_ral_pkg::*;
+
+  // parameters
+  parameter uint SPI_HOST_NUM_CS      = spi_host_reg_pkg::NumCS;
+  parameter uint SPI_HOST_TX_DEPTH    = spi_host_reg_pkg::TxDepth;
+  parameter uint SPI_HOST_RX_DEPTH    = spi_host_reg_pkg::RxDepth;
+  parameter bit  SPI_HOST_BYTEORDER   = spi_host_reg_pkg::ByteOrder;
+  parameter uint SPI_HOST_BLOCK_AW    = spi_host_reg_pkg::BlockAw;
+  parameter uint SPI_HOST_FIFO_BASE   = spi_host_reg_pkg::SPI_HOST_DATA_OFFSET;
+  parameter uint SPI_HOST_FIFO_END    = (SPI_HOST_FIFO_BASE - 1) +
+                                        spi_host_reg_pkg::SPI_HOST_DATA_SIZE;
 
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
   // types
-  // parameters
   typedef enum int {
     SpiHostError     = 0,
     SpiHostEvent     = 1,
     NumSpiHostIntr   = 2
   } spi_host_intr_e;
+
+  typedef enum int {
+    TxFifo   = 0,
+    RxFifo   = 1,
+    AllFifos = 2
+  } spi_host_fifo_e;
 
   // functions
 

--- a/hw/ip/spi_host/dv/env/spi_host_seq_cfg.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_seq_cfg.sv
@@ -20,22 +20,17 @@ class spi_host_seq_cfg extends uvm_object;
   uint host_spi_max_csn_hcyc          = 15;
   uint host_spi_min_clkdiv            = 0;
   uint host_spi_max_clkdiv            = 15;
-  uint host_spi_min_tx1               = 0;
-  uint host_spi_max_tx1               = 15;
-  uint host_spi_min_txn               = 0;
-  uint host_spi_max_txn               = 15;
-  uint host_spi_min_rx                = 0;
-  uint host_spi_max_rx                = 15;
-  uint host_spi_min_dummy             = 0;
-  uint host_spi_max_dummy             = 15;
-  uint host_spi_min_speed             = 0;
-  uint host_spi_max_speed             = 2;
+  uint host_spi_min_len               = 0;
+  uint host_spi_max_len               = 15;
   uint host_spi_min_dly               = 0;
   uint host_spi_max_dly               = 5;
-  uint host_spi_min_txwm              = 0;
-  uint host_spi_max_txwm              = (1 << 9) - 1;
-  uint host_spi_min_rxwm              = 0;
-  uint host_spi_max_rxwm              = (1 << 7) - 1;
+  uint host_spi_max_rxwm              = SPI_HOST_RX_DEPTH;
+  uint host_spi_max_txwm              = SPI_HOST_TX_DEPTH;
+
+  uint host_spi_min_num_wr_bytes      = 1;
+  uint host_spi_max_num_wr_bytes      = SPI_HOST_TX_DEPTH;
+  uint host_spi_min_num_rd_bytes      = 1;
+  uint host_spi_max_num_rd_bytes      = SPI_HOST_RX_DEPTH;
 
   // scale factor, core clock is a random value
   // which is in range [bus_clk*(1-scale) : bus_clk*(1+scale)]

--- a/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson
+++ b/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson
@@ -29,6 +29,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
                 // TODO: comment out for V2
                 //"{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson",
@@ -46,10 +47,10 @@
 
   // List of test specifications.
   tests: [
-//    {
-//      name: spi_host_smoke
-//      uvm_test_seq: spi_host_smoke_vseq
-//    }
+    {
+      name: spi_host_smoke
+      uvm_test_seq: spi_host_smoke_vseq
+    }
     // TODO: add more tests here
   ]
 

--- a/hw/ip/spi_host/dv/tb.sv
+++ b/hw/ip/spi_host/dv/tb.sv
@@ -24,8 +24,8 @@ module tb;
   lc_tx_t           scanmode_i;
   wire              cio_sck_o;
   wire              cio_sck_en_o;
-  wire  [MaxCS-1:0] cio_csb_o;
-  wire  [MaxCS-1:0] cio_csb_en_o;
+  wire  [NumCS-1:0] cio_csb_o;
+  wire  [NumCS-1:0] cio_csb_en_o;
   logic [3:0]       cio_sd_o;
   logic [3:0]       cio_sd_en_o;
   logic [3:0]       cio_sd_i;
@@ -41,7 +41,7 @@ module tb;
   spi_if       spi_if(.rst_n(rst_core_n));
 
   // dut
-  spi_host spi_host (
+  spi_host dut (
     .clk_i                (clk),
     .rst_ni               (rst_n),
 
@@ -65,15 +65,18 @@ module tb;
     .intr_spi_event_o     (intr_event)
   );
 
-  assign spi_if.sck = (cio_sck_en_o) ? cio_sck_o : 1'b0;
-  initial begin
+  assign spi_if.sck = (cio_sck_en_o) ? cio_sck_o : 1'bz;
+  assign cio_sd_i   = spi_if.sio;
+  always_comb begin
     for (int i = 0; i < 4; i++) begin
-      if (cio_sd_en_o[i] == 1'b1) begin
+      if (cio_sd_en_o[i]) begin
         spi_if.sio[i] = cio_sd_o[i];
-      end else begin
-        cio_sd_i[i] = spi_if.sio[i];
       end
-      spi_if.csb[i] = (cio_csb_en_o == 1'b1 && i < MaxCS) ? cio_csb_o[i] : 1'b1;
+      if (i < NumCS) begin
+        spi_if.csb[i] = (cio_csb_en_o[i]) ? cio_csb_o[i] : 1'b1;
+      end else begin
+        spi_if.csb[i] = 1'b1;
+      end
     end
   end
 


### PR DESCRIPTION
Add -memories switch into probe command that enables dumping the array of struct 
into the shm/vcd waveform database of the Xcelium simulation

Thanks to @rasmus-madsen

Signed-off-by: Tung Hoang <hoang.tung@wdc.com>
