### PR TITLE
[tool, xcel] Support dumping the array of struct in shm/vcd

### DIFF
--- a/hw/dv/tools/waves.tcl
+++ b/hw/dv/tools/waves.tcl
@@ -110,7 +110,7 @@ proc wavedumpScope {scope fid {depth 0} {fsdb_flags "+all"} {probe_flags  "-all"
       if {$depth == 0} {
         set depth "all"
       }
-      probe "$scope" $probe_flags -depth $depth -shm
+      probe "$scope" $probe_flags -depth $depth -memories -shm
     }
 
     "vpd" {
@@ -124,7 +124,7 @@ proc wavedumpScope {scope fid {depth 0} {fsdb_flags "+all"} {probe_flags  "-all"
         if {$depth == 0} {
           set depth "all"
         }
-        probe "$scope" $probe_flags -depth $depth -vcd
+        probe "$scope" $probe_flags -depth $depth -memories -vcd
       }
     }
 


### PR DESCRIPTION
Add -memories switch into probe command that enables dumping the arrays of struct
into the shm/vcd waveform database of the Xcelium simulation

Thanks to @rasmus-madsen

Signed-off-by: Tung Hoang hoang.tung@wdc.com