### PR TITLE
[top] Address reset bypass during DFT

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -7,6 +7,7 @@
     { protocol: "tlul", direction: "device" }
   ],
   scan: "true", // Enable `scanmode_i` port
+  scan_reset: "true", // Enable `scan_rst_ni` port
   regwidth: "32",
 
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -773,6 +773,7 @@ module top_earlgrey #(
     .rst_ni        (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel]),
     .hw_debug_en_i (lc_ctrl_lc_hw_debug_en),
     .scanmode_i,
+    .scan_rst_ni,
     .ndmreset_o    (ndmreset_req),
     .dmactive_o    (),
     .debug_req_o   (debug_req),
@@ -1554,6 +1555,7 @@ module top_earlgrey #(
       .tl_i(lc_ctrl_tl_req),
       .tl_o(lc_ctrl_tl_rsp),
       .scanmode_i,
+      .scan_rst_ni  (scan_rst_ni),
 
       // Clock and reset connections
       .clk_i (clkmgr_aon_clocks.clk_io_div4_timers),

--- a/util/topgen/templates/toplevel.sv.tpl
+++ b/util/topgen/templates/toplevel.sv.tpl
@@ -318,6 +318,7 @@ module top_${top["name"]} #(
     .rst_ni        (${dm_rst}[rstmgr_pkg::Domain0Sel]),
     .hw_debug_en_i (lc_ctrl_lc_hw_debug_en),
     .scanmode_i,
+    .scan_rst_ni,
     .ndmreset_o    (ndmreset_req),
     .dmactive_o    (),
     .debug_req_o   (debug_req),


### PR DESCRIPTION
This is a fix for #6191, however we need to confirm that scanmode
does not depend on trst_n before approving and merging.

Signed-off-by: Timothy Chen <timothytim@google.com>