### PR TITLE
[otbn] Move domain paramters to lib

### DIFF
--- a/sw/otbn/code-snippets/p384.s
+++ b/sw/otbn/code-snippets/p384.s
@@ -1341,3 +1341,166 @@ scalar_mult_int_p384:
   jal       x1, proj_to_affine_p384
 
   ret
+
+
+/* constants, pointers and scratchpad memory */
+.section .data
+
+/* pointer to k (dptr_k) */
+.globl dptr_k
+dptr_k:
+  .zero 4
+
+/* pointer to rnd (dptr_rnd) */
+.globl dptr_rnd
+dptr_rnd:
+  .zero 4
+
+/* pointer to msg (dptr_msg) */
+.globl dptr_msg
+dptr_msg:
+  .zero 4
+
+/* pointer to R (dptr_r) */
+.globl dptr_r
+dptr_r:
+  .zero 4
+
+/* pointer to S (dptr_s) */
+.globl dptr_s
+dptr_s:
+  .zero 4
+
+/* pointer to X (dptr_x) */
+.globl dptr_x
+dptr_x:
+  .zero 4
+
+/* pointer to Y (dptr_y) */
+.globl dptr_y
+dptr_y:
+  .zero 4
+
+/* pointer to D (dptr_d) */
+.globl dptr_d
+dptr_d:
+  .zero 4
+
+/* P-384 domain parameter b */
+.globl p384_b
+p384_b:
+  .word 0xd3ec2aef
+  .word 0x2a85c8ed
+  .word 0x8a2ed19d
+  .word 0xc656398d
+  .word 0x5013875a
+  .word 0x0314088f
+  .word 0xfe814112
+  .word 0x181d9c6e
+  .word 0xe3f82d19
+  .word 0x988e056b
+  .word 0xe23ee7e4
+  .word 0xb3312fa7
+  .zero 16
+
+/* P-384 domain parameter p (modulus) */
+.globl p384_p
+p384_p:
+  .word 0xffffffff
+  .word 0x00000000
+  .word 0x00000000
+  .word 0xffffffff
+  .word 0xfffffffe
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .zero 16
+
+/* barrett constant u for modulus p */
+.globl p384_u_p
+p384_u_p:
+  .word 0x00000001
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0x00000000
+  .word 0x00000001
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .zero 16
+
+/* P-384 domain parameter n (order of base point) */
+p384_n:
+  .word 0xccc52973
+  .word 0xecec196a
+  .word 0x48b0a77a
+  .word 0x581a0db2
+  .word 0xf4372ddf
+  .word 0xc7634d81
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .zero 16
+
+/* barrett constant u for n */
+p384_u_n:
+  .word 0x333ad68d
+  .word 0x1313e695
+  .word 0xb74f5885
+  .word 0xa7e5f24d
+  .word 0x0bc8d220
+  .word 0x389cb27e
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .zero 16
+
+/* P-384 basepoint G affine x-coordinate */
+p384_gx:
+  .word 0x72760ab7
+  .word 0x3a545e38
+  .word 0xbf55296c
+  .word 0x5502f25d
+  .word 0x82542a38
+  .word 0x59f741e0
+  .word 0x8ba79b98
+  .word 0x6e1d3b62
+  .word 0xf320ad74
+  .word 0x8eb1c71e
+  .word 0xbe8b0537
+  .word 0xaa87ca22
+  .zero 16
+
+/* P-384 basepoint G affine y-coordinate */
+p384_gy:
+  .word 0x90ea0e5f
+  .word 0x7a431d7c
+  .word 0x1d7e819d
+  .word 0x0a60b1ce
+  .word 0xb5f0b8c0
+  .word 0xe9da3113
+  .word 0x289a147c
+  .word 0xf8f41dbd
+  .word 0x9292dc29
+  .word 0x5d9e98bf
+  .word 0x96262c6f
+  .word 0x3617de4a
+  .zero 16
+
+/* 704 bytes of scratchpad memory */
+scratchpad:
+  .zero 704

--- a/sw/otbn/code-snippets/p384_proj_add_test.s
+++ b/sw/otbn/code-snippets/p384_proj_add_test.s
@@ -16,25 +16,27 @@
 p384_proj_add_test:
 
   /* set dmem pointer to domain parameter b */
-  li       x28, 0
+  la       x28, p384_b
 
   /* set dmem pointer to point 1 */
-  li       x26,  512
+  la       x26, p1_x
 
   /* set dmem pointer to point 2 */
-  li       x27, 704
+  la       x27, p2_x
 
   /* load domain parameter p (modulus)
-     [w1, w0] = p */
+     [w13, w12] = p */
   li       x2, 12
-  bn.lid   x2++,  64(x0)
-  bn.lid   x2++,  96(x0)
+  la       x3, p384_p
+  bn.lid   x2++, 0(x3)
+  bn.lid   x2++, 32(x3)
 
   /* load Barrett constant u for modulus p
-     [w15, w14] = p */
+     [w15, w14] = u_p */
   li       x2, 14
-  bn.lid   x2++,  128(x0)
-  bn.lid   x2++,  160(x0)
+  la       x3, p384_u_p
+  bn.lid   x2++, 0(x3)
+  bn.lid   x2++, 32(x3)
 
   /* init all-zero reg */
   bn.xor   w31, w31, w31
@@ -49,172 +51,121 @@ p384_proj_add_test:
 
   ecall
 
-
-.data
-
-/* P-384 domain parameter b */
-.word 0xd3ec2aef
-.word 0x2a85c8ed
-.word 0x8a2ed19d
-.word 0xc656398d
-.word 0x5013875a
-.word 0x0314088f
-.word 0xfe814112
-.word 0x181d9c6e
-.word 0xe3f82d19
-.word 0x988e056b
-.word 0xe23ee7e4
-.word 0xb3312fa7
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-
-/* P-384 domain parameter p (modulus) */
-.word 0xffffffff
-.word 0x00000000
-.word 0x00000000
-.word 0xffffffff
-.word 0xfffffffe
-.word 0xffffffff
-.word 0xffffffff
-.word 0xffffffff
-.word 0xffffffff
-.word 0xffffffff
-.word 0xffffffff
-.word 0xffffffff
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-
-/* barrett constant u for modulus p */
-.word 0x00000001
-.word 0xffffffff
-.word 0xffffffff
-.word 0x00000000
-.word 0x00000001
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-
-.skip 320
+.section .data
 
 /* point 1 x-cooridante p1_x */
-.word 0x1a11808b
-.word 0x02e3d5a9
-.word 0x440d8db6
-.word 0x5ef02be3
-.word 0x2a35de10
-.word 0xdbdb132e
-.word 0xf84e7899
-.word 0x7dff4c2b
-.word 0x24705317
-.word 0x30eda4ab
-.word 0xb44ba799
-.word 0x3af8f1c5
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
+p1_x:
+  .word 0x1a11808b
+  .word 0x02e3d5a9
+  .word 0x440d8db6
+  .word 0x5ef02be3
+  .word 0x2a35de10
+  .word 0xdbdb132e
+  .word 0xf84e7899
+  .word 0x7dff4c2b
+  .word 0x24705317
+  .word 0x30eda4ab
+  .word 0xb44ba799
+  .word 0x3af8f1c5
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
 
-/* point 2 y-cooridante p1_y*/
-.word 0xa9f8b96e
-.word 0x82f268be
-.word 0x8e51c662
-.word 0x92b9c4bb
-.word 0x757d4493
-.word 0x26b4d3c6
-.word 0xf491007e
-.word 0x92a5c72a
-.word 0x8d8d8641
-.word 0x87498a20
-.word 0x0fe7dbde
-.word 0x841e4949
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
+/* point 2 y-cooridante p1_y */
+p1_y:
+  .word 0xa9f8b96e
+  .word 0x82f268be
+  .word 0x8e51c662
+  .word 0x92b9c4bb
+  .word 0x757d4493
+  .word 0x26b4d3c6
+  .word 0xf491007e
+  .word 0x92a5c72a
+  .word 0x8d8d8641
+  .word 0x87498a20
+  .word 0x0fe7dbde
+  .word 0x841e4949
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
 
-/* point 1 z-cooridante p1_z*/
-.word 0x00000001
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
+/* point 1 z-cooridante p1_z */
+p1_z:
+  .word 0x00000001
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
 
 /* point 2 x-cooridante p2_x */
-.word 0xa24055fe
-.word 0x44e0b41c
-.word 0xb747a4ee
-.word 0xd5597d02
-.word 0x56cd166d
-.word 0xd147078b
-.word 0x57f91304
-.word 0x255b83b1
-.word 0x33eabb2d
-.word 0xf83f0a61
-.word 0x3ff2df87
-.word 0x77da1284
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
+p2_x:
+  .word 0xa24055fe
+  .word 0x44e0b41c
+  .word 0xb747a4ee
+  .word 0xd5597d02
+  .word 0x56cd166d
+  .word 0xd147078b
+  .word 0x57f91304
+  .word 0x255b83b1
+  .word 0x33eabb2d
+  .word 0xf83f0a61
+  .word 0x3ff2df87
+  .word 0x77da1284
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
 
 /* point 2 y-cooridante p2_y */
-.word 0x8d803d57
-.word 0x9ea243f3
-.word 0xde9000a7
-.word 0x35f5b65f
-.word 0x417d5e7c
-.word 0x21a9269f
-.word 0x98a79201
-.word 0xa9311cb0
-.word 0x8047b439
-.word 0xb7494b0d
-.word 0x63d2f480
-.word 0x699a7b9a
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
+p2_y:
+  .word 0x8d803d57
+  .word 0x9ea243f3
+  .word 0xde9000a7
+  .word 0x35f5b65f
+  .word 0x417d5e7c
+  .word 0x21a9269f
+  .word 0x98a79201
+  .word 0xa9311cb0
+  .word 0x8047b439
+  .word 0xb7494b0d
+  .word 0x63d2f480
+  .word 0x699a7b9a
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
 
 /* point 2 z-cooridante p2_z */
-.word 0x00000001
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
+p2_z:
+  .word 0x00000001
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
 
 /* Expected values wide register file (x-, y-, z-coordinates of result):
  w25 = 0xb89ab3a5653144bbde19809f8c041d592417c47c798a1333a3dbd2e105e101e2

--- a/sw/otbn/code-snippets/p384_scalar_mult_test.s
+++ b/sw/otbn/code-snippets/p384_scalar_mult_test.s
@@ -15,266 +15,96 @@
 
 p384_scalar_mult_test:
 
-  /* set dmem pointer to domain parameter b */
-  lw       x28, 32(x0)
+  /* set dmem pointer to point to x-coordinate */
+  la       x2, p1_x
+  la       x3, dptr_x
+  sw       x2, 0(x3)
 
-  /* set dmem pointer to point x-coordinate */
-  lw       x20, 20(x0)
+  /* set dmem pointer to point to y-coordinate */
+  la       x2, p1_y
+  la       x3, dptr_y
+  sw       x2, 0(x3)
 
-  /* set dmem pointer to point y-coordinate */
-  lw       x21, 24(x0)
+  /* set dmem pointer to point to scalar k */
+  la       x2, scalar
+  la       x3, dptr_k
+  sw       x2, 0(x3)
 
-  /* set dmem pointer to scalar d */
-  lw       x19, 28(x0)
+  /* set dmem pointer to point to blinding parameter */
+  la       x2, blinding_param
+  la       x3, dptr_rnd
+  sw       x2, 0(x3)
 
-  /* set dmem pointer to scratchpad */
-  lw       x30, 60(x0)
-
-  /* set pointer to blinding parameter */
-  lw       x9, 4(x0)
-
-  /* load domain parameter p (modulus)
-     [w13, w12] = p = dmem[dptr_p] */
-  li       x2, 12
-  lw       x3, 36(x0)
-  bn.lid   x2++, 0(x3)
-  bn.lid   x2++, 32(x3)
-
-  /* load Barrett constant u for modulus p
-     [w15, w14] = u = dmem[dptr_u] */
-  li       x2, 14
-  lw       x3, 40(x0)
-  bn.lid   x2++, 0(x3)
-  bn.lid   x2++, 32(x3)
-
-  /* load domain parameter n (order of base point)
-     [w11, w10] = p = dmem[dptr_n] */
-  li       x2, 10
-  lw       x3, 44(x0)
-  bn.lid   x2++, 0(x3)
-  bn.lid   x2++, 32(x3)
-
-  /* init all-zero reg */
-  bn.xor   w31, w31, w31
-
-  jal      x1, scalar_mult_int_p384
+  jal      x1, scalar_mult_p384
 
   ecall
 
 
-.data
-
-/* pointer to k (dptr_k) */
-.word 0x00000000
-
-/* pointer to rnd (dptr_rnd) */
-.word 0x00000100
-
-/* pointer to msg (dptr_msg) */
-.word 0x00000000
-
-/* pointer to R (dptr_r) */
-.word 0x00000080
-
-/* pointer to S (dptr_s) */
-.word 0x00000000
-
-/* pointer to X (dptr_x) */
-.word 0x00000200
-
-/* pointer to Y (dptr_y) */
-.word 0x00000240
-
-/* pointer to D (dptr_d) */
-.word 0x00000280
-
-/* pointer to b (dptr_b) */
-.word 0x00000040
-
-/* pointer to p (dptr_p) */
-.word 0x00000080
-
-/* pointer to u_p (dptr_u_p) */
-.word 0x000000C0
-
-/* pointer to n (dptr_n) */
-.word 0x00000140
-
-/* pointer to u_n (dptr_u_n) */
-.word 0x00000180
-
-/* pointer reserved */
-.word 0x00000000
-
-/* pointer reserved */
-.word 0x00000000
-
-/* pointer to scratchpad (dptr_sc) */
-.word 0x00000400
-
-/* P-384 domain parameter b */
-.word 0xd3ec2aef
-.word 0x2a85c8ed
-.word 0x8a2ed19d
-.word 0xc656398d
-.word 0x5013875a
-.word 0x0314088f
-.word 0xfe814112
-.word 0x181d9c6e
-.word 0xe3f82d19
-.word 0x988e056b
-.word 0xe23ee7e4
-.word 0xb3312fa7
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-
-/* P-384 domain parameter p (modulus) */
-.word 0xffffffff
-.word 0x00000000
-.word 0x00000000
-.word 0xffffffff
-.word 0xfffffffe
-.word 0xffffffff
-.word 0xffffffff
-.word 0xffffffff
-.word 0xffffffff
-.word 0xffffffff
-.word 0xffffffff
-.word 0xffffffff
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-
-/* barrett constant u for modulus p */
-.word 0x00000001
-.word 0xffffffff
-.word 0xffffffff
-.word 0x00000000
-.word 0x00000001
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-
-/* blinding parameter rnd */
-.word 0xa82c85b0
-.word 0x163ce1c8
-.word 0x32518fd7
-.word 0xf8a428cd
-.word 0xf5b9d867
-.word 0x00906f5f
-.word 0x7387b4f2
-.word 0xa2d3da7a
-.word 0xebe0a647
-.word 0xfb2ef7ca
-.word 0x74249432
-.word 0x230e5ff6
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-
-/* P-384 domain parameter n (order of base point) */
-.word 0xccc52973
-.word 0xecec196a
-.word 0x48b0a77a
-.word 0x581a0db2
-.word 0xf4372ddf
-.word 0xc7634d81
-.word 0xffffffff
-.word 0xffffffff
-.word 0xffffffff
-.word 0xffffffff
-.word 0xffffffff
-.word 0xffffffff
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-
-/* barrett constant u for n */
-.word 0x333ad68d
-.word 0x1313e695
-.word 0xb74f5885
-.word 0xa7e5f24d
-.word 0x0bc8d220
-.word 0x389cb27e
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-
-.skip 64
+.section .data
 
 /* point 1 x-cooridante p1_x */
-.word 0x1a11808b
-.word 0x02e3d5a9
-.word 0x440d8db6
-.word 0x5ef02be3
-.word 0x2a35de10
-.word 0xdbdb132e
-.word 0xf84e7899
-.word 0x7dff4c2b
-.word 0x24705317
-.word 0x30eda4ab
-.word 0xb44ba799
-.word 0x3af8f1c5
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
+p1_x:
+  .word 0x1a11808b
+  .word 0x02e3d5a9
+  .word 0x440d8db6
+  .word 0x5ef02be3
+  .word 0x2a35de10
+  .word 0xdbdb132e
+  .word 0xf84e7899
+  .word 0x7dff4c2b
+  .word 0x24705317
+  .word 0x30eda4ab
+  .word 0xb44ba799
+  .word 0x3af8f1c5
+  .zero 16
 
 /* point 1 y-cooridante p1_y*/
-.word 0xa9f8b96e
-.word 0x82f268be
-.word 0x8e51c662
-.word 0x92b9c4bb
-.word 0x757d4493
-.word 0x26b4d3c6
-.word 0xf491007e
-.word 0x92a5c72a
-.word 0x8d8d8641
-.word 0x87498a20
-.word 0x0fe7dbde
-.word 0x841e4949
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
+p1_y:
+  .word 0xa9f8b96e
+  .word 0x82f268be
+  .word 0x8e51c662
+  .word 0x92b9c4bb
+  .word 0x757d4493
+  .word 0x26b4d3c6
+  .word 0xf491007e
+  .word 0x92a5c72a
+  .word 0x8d8d8641
+  .word 0x87498a20
+  .word 0x0fe7dbde
+  .word 0x841e4949
+  .zero 16
 
-/* scalar d */
-.word 0xe8791ba3
-.word 0xf549e1f7
-.word 0x893be358
-.word 0x100794fe
-.word 0xbc9db95d
-.word 0xfd7ed624
-.word 0xc60ebab6
-.word 0x97ba9586
-.word 0xa026b431
-.word 0x37112316
-.word 0x8b26eef1
-.word 0xc1a0cf66
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
-.word 0x00000000
+/* scalar k */
+scalar:
+  .word 0xe8791ba3
+  .word 0xf549e1f7
+  .word 0x893be358
+  .word 0x100794fe
+  .word 0xbc9db95d
+  .word 0xfd7ed624
+  .word 0xc60ebab6
+  .word 0x97ba9586
+  .word 0xa026b431
+  .word 0x37112316
+  .word 0x8b26eef1
+  .word 0xc1a0cf66
+  .zero 16
+
+   /* blinding parameter rnd */
+ blinding_param:
+  .word 0xa82c85b0
+  .word 0x163ce1c8
+  .word 0x32518fd7
+  .word 0xf8a428cd
+  .word 0xf5b9d867
+  .word 0x00906f5f
+  .word 0x7387b4f2
+  .word 0xa2d3da7a
+  .word 0xebe0a647
+  .word 0xfb2ef7ca
+  .word 0x74249432
+  .word 0x230e5ff6
+  .zero 16
 
 
 /* Expected values in wide register file (x- and y-coordinates of result):


### PR DESCRIPTION
This moves the P-384 domain parameters to the lib assembly file, such that they do not have to be provided by test assembly or CPU SW.

This builds up on the now enabled `la` instruction for loading label addresses.

This also provides a external callable routine for scalar point multiplication, removes symbol export for the internal one and provides a test for this.

This finishes #6177