### PR TITLE
[docker] Install Verilator and OpenOCD from OBS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,12 +6,15 @@
 # Documentation at https://aka.ms/yaml
 
 variables:
+  #
+  # If updating VERILATOR_VERSION, OPENOCD_VERSION or TOOLCHAIN_VERSION, update
+  # the definitions in util/container/Dockerfile as well.
+  #
   VERILATOR_VERSION: 4.104
   OPENOCD_VERSION: 0.11.0
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   VERIBLE_VERSION: v0.0-808-g1e17daa
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
-  # if you update this, update the definition in util/container/Dockerfile
   TOOLCHAIN_VERSION: 20210412-1
   # This controls where builds happen, and gets picked up by build_consts.sh.
   BUILD_ROOT: $(Build.ArtifactStagingDirectory)

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -7,59 +7,41 @@
 
 # Global configuration options.
 ARG VERILATOR_VERSION=4.104
+ARG OPENOCD_VERSION=0.11.0
 
 # The RISCV toolchain version should match the release tag used in GitHub.
 ARG RISCV_TOOLCHAIN_TAR_VERSION=20210412-1
 
-# Build OpenOCD
-# OpenOCD is a tool to connect with the target chip over JTAG and similar
-# transports.
-FROM ubuntu:18.04 AS openocd
-RUN apt-get update && apt-get install -y \
-    autoconf \
-    git \
-    libftdi1-dev \
-    libtool \
-    libusb-1.0.0-dev \
-    pkg-config \
-    texinfo
-RUN git clone --depth=1 https://github.com/riscv/riscv-openocd.git /usr/local/src/openocd
-RUN cd /usr/local/src/openocd && ./bootstrap && mkdir build && cd build && \
-    ../configure --enable-ftdi --enable-verbose-jtag-io --disable-vsllink \
-    --enable-remote-bitbang --prefix=/tools/openocd && \
-    make -j$(nproc) && make install
-
-# Build Verilator.
-FROM ubuntu:18.04 as verilator
-ARG VERILATOR_VERSION
-RUN apt-get update && apt-get install -y \
-    autoconf \
-    automake \
-    autotools-dev \
-    bison \
-    build-essential \
-    flex \
-    git
-RUN git clone --depth=1 -b  v${VERILATOR_VERSION} \
-    https://github.com/verilator/verilator.git /usr/local/src/verilator
-RUN cd /usr/local/src/verilator && \
-    autoconf && ./configure --prefix=/tools/verilator/${VERILATOR_VERSION} && \
-    make -j$(nproc) && make install
-
-
 # Main container image.
 FROM ubuntu:18.04 AS opentitan
 ARG VERILATOR_VERSION
+ARG OPENOCD_VERSION
 ARG RISCV_TOOLCHAIN_TAR_VERSION
 
 LABEL version="1.0"
 LABEL description="OpenTitan container for hardware development."
 LABEL maintainer="miguelosorio@google.com"
 
-# Copy tools from previous build stages
 WORKDIR /tools
-COPY --from=openocd /tools/openocd openocd
-COPY --from=verilator /tools/verilator/${VERILATOR_VERSION} verilator/${VERILATOR_VERSION}
+
+# Add OBS repository to apt sources
+RUN OBS_URL="https://download.opensuse.org/repositories"; \
+    OBS_PATH="/home:/phiwag:/edatools/xUbuntu_18.04"; \
+    REPO_URL="${OBS_URL}${OBS_PATH}"; \
+    \
+    EDATOOLS_REPO_KEY="${REPO_URL}/Release.key"; \
+    EDATOOLS_REPO="deb ${REPO_URL}/ /"; \
+    \
+    apt-get update && \
+    apt-get install -y curl && \
+    \
+    curl -f -sL -o "$TMPDIR/obs.asc" "$EDATOOLS_REPO_KEY" || { \
+        error "Failed to download repository key from ${REPO_URL}"; \
+    } && \
+    echo "$EDATOOLS_REPO" > "$TMPDIR/obs.list" && \
+    mv "$TMPDIR/obs.asc"  /etc/apt/trusted.gpg.d/obs.asc && \
+    mv "$TMPDIR/obs.list" /etc/apt/sources.list.d/edatools.list && \
+    apt-get update
 
 # Install (and cleanup) required packages (from apt-requirements.txt)
 # The list of extra packages is leftover from before this Dockerfile used
@@ -67,10 +49,11 @@ COPY --from=verilator /tools/verilator/${VERILATOR_VERSION} verilator/${VERILATO
 #
 # This also adds `locales` and `locales-all` so we can set the locale to utf-8
 COPY apt-requirements.txt /tmp/apt-requirements.txt
-RUN apt-get update && \
-    sed 's/#.*//' /tmp/apt-requirements.txt \
-        | xargs apt-get install -y && \
-    apt-get install -y \
+RUN echo "verilator-${VERILATOR_VERSION}" >>/tmp/apt-requirements.txt && \
+    echo "openocd-${OPENOCD_VERSION}"     >>/tmp/apt-requirements.txt && \
+    sed -i -e '/^$/d' -e '/^#/d' -e 's/#.*//' /tmp/apt-requirements.txt && \
+    xargs apt-get install -y </tmp/apt-requirements.txt && \
+    apt-get update && apt-get install -y \
         locales \
         locales-all \
         gnupg2 \
@@ -78,7 +61,7 @@ RUN apt-get update && \
         libtool \
         minicom \
         screen && \
-    apt-get clean ; \
+    apt-get clean; \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 # Set Locale to utf-8 everywhere


### PR DESCRIPTION
This matches what we do in CI and should be both more stable and also
a bit quicker.
