### PR TITLE
[rom_ctrl] Expose digest to keymgr with a single wide interface

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -231,7 +231,7 @@ module rom_ctrl
     assign exp_digest_de = 1'b0;
     assign exp_digest_idx = '0;
     assign pwrmgr_data_o = '{done: 1'b1, good: 1'b1};
-    assign keymgr_data_o = '{data: '0, valid: 1'b0, last: 1'b0};
+    assign keymgr_data_o = '{data: '0, valid: 1'b0};
     assign kmac_rom_vld = 1'b0;
     assign kmac_rom_last = 1'b0;
     // Setting this to 0 ensures the mux will give access to the TL bus

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_compare.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_compare.sv
@@ -30,9 +30,6 @@ module rom_ctrl_compare #(
   input logic [NumWords*32-1:0]      digest_i,
   input logic [NumWords*32-1:0]      exp_digest_i,
 
-  // To keymgr
-  output rom_ctrl_pkg::keymgr_data_t keymgr_data_o,
-
   // To alert system
   output logic                       alert_o
 );
@@ -147,11 +144,6 @@ module rom_ctrl_compare #(
   assign digest_word = digest_i[digest_idx -: 32];
   assign exp_digest_word = exp_digest_i[digest_idx -: 32];
   assign matches_d = matches_q && (digest_word == exp_digest_word);
-
-  logic word_vld, word_last;
-  assign word_vld  = (state_q == Checking);
-  assign word_last = (addr_q == LastAddr);
-  assign keymgr_data_o = '{data: digest_word, valid: word_vld, last: word_last};
 
   assign done_o = (state_q == Done);
   assign good_o = matches_q;

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
@@ -89,7 +89,6 @@ module rom_ctrl_fsm
     .good_o        (checker_good),
     .digest_i      (digest_i),
     .exp_digest_i  (exp_digest_i),
-    .keymgr_data_o (keymgr_data_o),
     .alert_o       (checker_alert)
   );
 
@@ -225,6 +224,9 @@ module rom_ctrl_fsm
 
   // Pass the 'done' and 'good' signals directly from the checker
   assign pwrmgr_data_o = '{done: (state_q == Done), good: checker_good};
+
+  // Pass the digest all-at-once to the keymgr
+  assign keymgr_data_o = '{data: digest_i, valid: (state_q == Done)};
 
   // KMAC rom data interface
   //

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_pkg.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_pkg.sv
@@ -14,9 +14,8 @@ package rom_ctrl_pkg;
   } pwrmgr_data_t;
 
   typedef struct packed {
-    logic [31:0] data;
-    logic        valid;
-    logic        last;
+    logic [255:0] data;
+    logic         valid;
   } keymgr_data_t;
 
 endpackage


### PR DESCRIPTION
This avoids the key manager needing separate storage. Now, `valid`
should have a single posedge, after which `data` should be stable.
