### PR TITLE
Update pulp_riscv_dbg to pulp-platform/riscv-dbg@4befe83

### DIFF
--- a/hw/ip/rv_dm/lint/rv_dm.waiver
+++ b/hw/ip/rv_dm/lint/rv_dm.waiver
@@ -49,8 +49,6 @@ waive -rules CONST_FF -location {dm_csrs.sv} -regexp {Flip-flop 'sbcs_q.sbaccess
       -comment "Parts of this struct are constantly set to zero."
 waive -rules CASE_SEL_EXPR -location {dm_csrs.sv} -regexp {Expression 'dm::dm_csr_e.*as case selector} \
       -comment "acceptable use"
-waive -rules NOT_READ -location {dm_csrs.sv} -regexp {Signal 'dmcontrol.(clrresethaltreq|dmactive|haltreq|hartreset|hartselhi|hartsello|hasel|ndmreset|resumereq|setresethaltreq|zero[0-1])' is not read from} \
-      -comment "These signals are not needed by dm_csrs module"
 waive -rules NOT_READ -location {dm_csrs.sv} -regexp {Signal 'a_abstractcs.(busy|datacount|progbufsize|zero[0-3])' is not read from} \
       -comment "These signals are not needed by dm_csrs module"
 waive -rules ARITH_CONTEXT -location {dm_csrs.sv} \

--- a/hw/vendor/pulp_riscv_dbg.lock.hjson
+++ b/hw/vendor/pulp_riscv_dbg.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/pulp-platform/riscv-dbg
-    rev: 64f48cd8ef3ed4269ab3dfcc32e8a137a871e3e1
+    rev: 4befe83b03f43cef72486e0078cca0126e2680a0
   }
 }

--- a/hw/vendor/pulp_riscv_dbg/src/dm_csrs.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dm_csrs.sv
@@ -207,7 +207,6 @@ module dm_csrs #(
   // helper variables
   dm::dm_csr_e dm_csr_addr;
   dm::sbcs_t sbcs;
-  dm::dmcontrol_t dmcontrol;
   dm::abstractcs_t a_abstractcs;
   logic [3:0] autoexecdata_idx; // 0 == Data0 ... 11 == Data11
 
@@ -282,7 +281,6 @@ module dm_csrs #(
 
     // helper variables
     sbcs         = '0;
-    dmcontrol    = '0;
     a_abstractcs = '0;
 
     // reads
@@ -368,12 +366,11 @@ module dm_csrs #(
           end
         end
         dm::DMControl: begin
-          dmcontrol = dm::dmcontrol_t'(dmi_req_i.data);
+          dmcontrol_d = dmi_req_i.data;
           // clear the havreset of the selected hart
-          if (dmcontrol.ackhavereset) begin
+          if (dmcontrol_d.ackhavereset) begin
             havereset_d_aligned[selected_hart] = 1'b0;
           end
-          dmcontrol_d = dmi_req_i.data;
         end
         dm::DMStatus:; // write are ignored to R/O register
         dm::Hartinfo:; // hartinfo is R/O


### PR DESCRIPTION
As well as updating the repository, remove an obsolete waiver (which
should no longer be needed).

Update code from upstream repository https://github.com/pulp-
platform/riscv-dbg to revision
4befe83b03f43cef72486e0078cca0126e2680a0

* Re-order some blocking assignments to avoid a helper variable
  (Rupert Swarbrick)
