### PR TITLE
[fpv] dvsim script error

### DIFF
--- a/util/dvsim/FormalCfg.py
+++ b/util/dvsim/FormalCfg.py
@@ -266,7 +266,7 @@ class FormalCfg(OneShotCfg):
 
         if results[mode] != "P":
             results_str += "\n## List of Failures\n" + ''.join(
-                mode.launcher.fail_msg)
+                mode.launcher.fail_msg.message)
 
         messages = self.result.get("messages")
         if messages is not None:


### PR DESCRIPTION
Formal.cfg hits an error when manually kill the job. The reason is
`mode.launcher.fail_msg` (ErrorMessage) is not a string. I modify it to
`mode.launcher.fail_msg.message` then it works.

Signed-off-by: Cindy Chen <chencindy@google.com>