### PR TITLE
[prim_flop_en/aes] Update interface and include scanmode

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -13,6 +13,7 @@
   other_reset_list: [
     "rst_edn_ni"
   ]
+  scan: "true",
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }
   ],

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -37,6 +37,7 @@ module tb;
   ) dut (
     .clk_i            ( clk                           ),
     .rst_ni           ( rst_n                         ),
+    .scanmode_i       ( lc_ctrl_pkg::Off              ),
 
     .idle_o           (                               ),
     .lc_escalate_en_i ( lc_ctrl_pkg::Off              ),

--- a/hw/ip/aes/lint/aes.waiver
+++ b/hw/ip/aes/lint/aes.waiver
@@ -15,11 +15,17 @@ waive -rules {CLOCK_USE} -location {aes_sub_bytes.sv} -regexp {clk_i' is connect
 waive -rules {CLOCK_USE} -location {aes_key_expand.sv} -regexp {clk_i' is connected to 'aes_sbox' port} \
       -comment "when using fully combinational S-Box implementations, no clock is used inside aes_sbox"
 
+waive -rules {CLOCK_USE} -location {aes_sbox_dom.sv} -regexp {'clk_i' is connected to 'prim_lc_sync' port 'clk_i', and used as a clock at prim_generic_flop_en} \
+      -comment "the prim_lc_sync primitive uses the clock for assertions only in this case."
+
 waive -rules {RESET_USE} -location {aes_sub_bytes.sv} -regexp {'rst_ni' is connected to 'aes_sbox' port} \
       -comment "when using fully combinational S-Box implementations, no reset is used inside aes_sbox"
 
 waive -rules {RESET_USE} -location {aes_key_expand.sv} -regexp {'rst_ni' is connected to 'aes_sbox' port} \
       -comment "when using fully combinational S-Box implementations, no reset is used inside aes_sbox"
+
+waive -rules {RESET_USE} -location {aes_sbox_dom.sv} -regexp {'rst_ni' is connected to 'prim_lc_sync' port 'rst_ni', and used as an asynchronous reset or set at prim_generic_flop_en} \
+      -comment "the prim_lc_sync primitive uses the reset for assertions only in this case."
 
 waive -rules {CLOCK_USE} -location {aes_core.sv} -regexp {clk_i' is connected to 'aes_sel_buf_chk' port} \
       -comment "clock and reset are just used for assertions inside aes_sel_buf_chk"

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -39,6 +39,9 @@ module aes
   input  logic                                      clk_i,
   input  logic                                      rst_ni,
 
+  // Test mode enable (only relevant for ASIC)
+  input  lc_ctrl_pkg::lc_tx_t                       scanmode_i,
+
   // Idle indicator for clock manager
   output logic                                      idle_o,
 
@@ -153,8 +156,9 @@ module aes
     .RndCnstMaskingLfsrSeed   ( RndCnstMaskingLfsrSeed   ),
     .RndCnstMskgChunkLfsrPerm ( RndCnstMskgChunkLfsrPerm )
   ) u_aes_core (
-    .clk_i                  ( clk_i                ),
-    .rst_ni                 ( rst_ni               ),
+    .clk_i,
+    .rst_ni,
+    .scanmode_i,
 
     .entropy_clearing_req_o ( entropy_clearing_req ),
     .entropy_clearing_ack_i ( entropy_clearing_ack ),

--- a/hw/ip/aes/rtl/aes_cipher_core.sv
+++ b/hw/ip/aes/rtl/aes_cipher_core.sv
@@ -109,6 +109,10 @@ module aes_cipher_core import aes_pkg::*;
   input  logic                        clk_i,
   input  logic                        rst_ni,
 
+  // Test mode enable (only relevant for ASIC)
+  input  lc_ctrl_pkg::lc_tx_t         scanmode_i,
+
+
   // Input handshake signals
   input  sp2v_e                       in_valid_i,
   output sp2v_e                       in_ready_o,
@@ -349,8 +353,9 @@ module aes_cipher_core import aes_pkg::*;
   aes_sub_bytes #(
     .SBoxImpl ( SBoxImpl )
   ) u_aes_sub_bytes (
-    .clk_i     ( clk_i             ),
-    .rst_ni    ( rst_ni            ),
+    .clk_i,
+    .rst_ni,
+    .scanmode_i,
     .en_i      ( sub_bytes_en      ),
     .out_req_o ( sub_bytes_out_req ),
     .out_ack_i ( sub_bytes_out_ack ),
@@ -444,8 +449,9 @@ module aes_cipher_core import aes_pkg::*;
     .Masking      ( Masking      ),
     .SBoxImpl     ( SBoxImpl     )
   ) u_aes_key_expand (
-    .clk_i       ( clk_i              ),
-    .rst_ni      ( rst_ni             ),
+    .clk_i,
+    .rst_ni,
+    .scanmode_i,
     .cfg_valid_i ( cfg_valid_i        ),
     .op_i        ( key_expand_op      ),
     .en_i        ( key_expand_en      ),

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -29,6 +29,9 @@ module aes_core
   input  logic                        clk_i,
   input  logic                        rst_ni,
 
+  // Test mode enable (only relevant for ASIC)
+  input  lc_ctrl_pkg::lc_tx_t         scanmode_i,
+
   // Entropy request interfaces for clearing and masking PRNGs
   output logic                        entropy_clearing_req_o,
   input  logic                        entropy_clearing_ack_i,
@@ -391,8 +394,9 @@ module aes_core
     .RndCnstMaskingLfsrSeed   ( RndCnstMaskingLfsrSeed   ),
     .RndCnstMskgChunkLfsrPerm ( RndCnstMskgChunkLfsrPerm )
   ) u_aes_cipher_core (
-    .clk_i              ( clk_i                      ),
-    .rst_ni             ( rst_ni                     ),
+    .clk_i,
+    .rst_ni,
+    .scanmode_i,
 
     .in_valid_i         ( cipher_in_valid            ),
     .in_ready_o         ( cipher_in_ready            ),

--- a/hw/ip/aes/rtl/aes_key_expand.sv
+++ b/hw/ip/aes/rtl/aes_key_expand.sv
@@ -16,6 +16,7 @@ module aes_key_expand import aes_pkg::*;
 ) (
   input  logic                   clk_i,
   input  logic                   rst_ni,
+  input  lc_ctrl_pkg::lc_tx_t    scanmode_i,
   input  logic                   cfg_valid_i,
   input  ciph_op_e               op_i,
   input  sp2v_e                  en_i,
@@ -210,8 +211,9 @@ module aes_key_expand import aes_pkg::*;
     aes_sbox #(
       .SBoxImpl ( SBoxImpl )
     ) u_aes_sbox_i (
-      .clk_i     ( clk_i                                 ),
-      .rst_ni    ( rst_ni                                ),
+      .clk_i,
+      .rst_ni,
+      .scanmode_i,
       .en_i      ( en == SP2V_HIGH                       ),
       .out_req_o ( sub_word_out_req[i]                   ),
       .out_ack_i ( out_ack == SP2V_HIGH                  ),

--- a/hw/ip/aes/rtl/aes_sbox.sv
+++ b/hw/ip/aes/rtl/aes_sbox.sv
@@ -12,6 +12,7 @@ module aes_sbox import aes_pkg::*;
 ) (
   input  logic                    clk_i,
   input  logic                    rst_ni,
+  input  lc_ctrl_pkg::lc_tx_t     scanmode_i,
   input  logic                    en_i,
   output logic                    out_req_o,
   input  logic                    out_ack_i,
@@ -36,10 +37,12 @@ module aes_sbox import aes_pkg::*;
     logic                    unused_rst;
     logic              [7:0] unused_mask;
     logic [WidthPRDSBox-1:0] unused_prd;
+    logic                    unused_scanmode;
     assign unused_clk  = clk_i;
     assign unused_rst  = rst_ni;
     assign unused_mask = mask_i;
     assign unused_prd  = prd_i;
+    assign unused_scanmode = scanmode_i;
 
     if (SBoxImpl == SBoxImplCanright) begin : gen_sbox_canright
       aes_sbox_canright u_aes_sbox (
@@ -68,8 +71,9 @@ module aes_sbox import aes_pkg::*;
       end
 
       aes_sbox_dom u_aes_sbox (
-        .clk_i      ( clk_i      ),
-        .rst_ni     ( rst_ni     ),
+        .clk_i,
+        .rst_ni,
+        .scanmode_i,
         .en_i       ( en_i       ),
         .out_req_o  ( out_req_o  ),
         .out_ack_i  ( out_ack_i  ),
@@ -87,8 +91,10 @@ module aes_sbox import aes_pkg::*;
       // Tie off unused inputs.
       logic unused_clk;
       logic unused_rst;
+      logic unused_scanmode;
       assign unused_clk = clk_i;
       assign unused_rst = rst_ni;
+      assign unused_scanmode = scanmode_i;
       if (WidthPRDSBox > 18) begin : gen_unused_prd
         logic [WidthPRDSBox-1-18:0] unused_prd;
         assign unused_prd = prd_i[WidthPRDSBox-1:18];
@@ -109,8 +115,10 @@ module aes_sbox import aes_pkg::*;
       // Tie off unused inputs.
       logic  unused_clk;
       logic  unused_rst;
+      logic  unused_scanmode;
       assign unused_clk = clk_i;
       assign unused_rst = rst_ni;
+      assign unused_scanmode = scanmode_i;
       if (WidthPRDSBox > 8) begin : gen_unused_prd
         logic [WidthPRDSBox-1-8:0] unused_prd;
         assign unused_prd = prd_i[WidthPRDSBox-1:8];

--- a/hw/ip/aes/rtl/aes_sub_bytes.sv
+++ b/hw/ip/aes/rtl/aes_sub_bytes.sv
@@ -10,6 +10,7 @@ module aes_sub_bytes import aes_pkg::*;
 ) (
   input  logic                              clk_i,
   input  logic                              rst_ni,
+  input  lc_ctrl_pkg::lc_tx_t               scanmode_i,
   input  sp2v_e                             en_i,
   output sp2v_e                             out_req_o,
   input  sp2v_e                             out_ack_i,
@@ -61,8 +62,9 @@ module aes_sub_bytes import aes_pkg::*;
       aes_sbox #(
         .SBoxImpl ( SBoxImpl )
       ) u_aes_sbox_ij (
-        .clk_i     ( clk_i                ),
-        .rst_ni    ( rst_ni               ),
+        .clk_i,
+        .rst_ni,
+        .scanmode_i,
         .en_i      ( en == SP2V_HIGH      ),
         .out_req_o ( out_req[i][j]        ),
         .out_ack_i ( out_ack == SP2V_HIGH ),

--- a/hw/ip/prim_generic/rtl/prim_generic_flop_en.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flop_en.sv
@@ -10,10 +10,18 @@ module prim_generic_flop_en #(
 ) (
   input                    clk_i,
   input                    rst_ni,
+  // This is irrelevant for the generic model.
+  // In the ASIC version, this may be used to bypass
+  // the clock gate, in case the enable flop has to be
+  // constructed using a clock gate and a normal flop.
+  input                    test_en_i,
   input                    en_i,
   input        [Width-1:0] d_i,
   output logic [Width-1:0] q_o
 );
+
+  logic unused_test_en;
+  assign unused_test_en = test_en_i;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_flop_en.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_flop_en.sv
@@ -10,6 +10,8 @@ module prim_xilinx_flop_en #(
 ) (
   input clk_i,
   input rst_ni,
+  // this is irrelevant for the FPGA
+  input test_en_i,
   // Prevent Vivado from optimizing this signal away.
   (* keep = "true" *) input en_i,
   input [Width-1:0] d_i,

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1996,6 +1996,7 @@ module top_earlgrey #(
       .edn_i(edn0_edn_rsp[5]),
       .tl_i(aes_tl_req),
       .tl_o(aes_tl_rsp),
+      .scanmode_i,
 
       // Clock and reset connections
       .clk_i (clkmgr_aon_clocks.clk_main_aes),


### PR DESCRIPTION
This adds a scanmode input to the `prim_flop_en` primitive.
The reason for this is that not all std cell libraries provide enable flops, hence we have to construct the functionality with a clock gate and a regular D flop.
In that case, the clock gate needs a scanmode enable.