### PR TITLE
[otbn] Collect statistics in ISS runs

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/Makefile
+++ b/hw/ip/otbn/dv/otbnsim/Makefile
@@ -14,7 +14,7 @@ $(build-dir):
 	mkdir -p $@
 
 py-scripts := standalone.py stepped.py
-py-files   := $(wildcard *.py sim/*.py)
+py-files   := $(wildcard *.py sim/*.py test/*.py)
 py-libs    := $(filter-out $(py-scripts),$(py-files))
 
 lint-stamps := $(foreach scr,$(py-scripts),$(build-dir)/$(scr).stamp)

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -107,6 +107,6 @@ class OTBNSim:
         return self.state.dmem.dump_le_words()
 
     def _print_trace(self, pc: int, disasm: str, changes: List[Trace]) -> None:
-        '''Print a trace of the current instruction to verbose_file'''
+        '''Print a trace of the current instruction'''
         changes_str = ', '.join([t.trace() for t in changes])
         print('{:08x} | {:45} | [{}]'.format(pc, disasm, changes_str))

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -29,6 +29,8 @@ class OTBNState:
         self.pc = 0
         self.pc_next = None  # type: Optional[int]
 
+        self.start_addr = None  # type: Optional[int]
+
         _, imem_size = get_memory_layout()['IMEM']
         self.imem_size = imem_size
 
@@ -147,6 +149,7 @@ class OTBNState:
         self._urnd_reseed_complete = False
 
         self.pc = addr
+        self.start_addr = addr
 
         # Reset CSRs, WSRs and loop stack
         self.csrs = CSRFile()

--- a/hw/ip/otbn/dv/otbnsim/sim/stats.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/stats.py
@@ -1,0 +1,298 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from collections import Counter
+import typing
+from typing import Dict, List, Optional, Tuple
+
+from elftools.dwarf.dwarfinfo import DWARFInfo  # type: ignore
+from elftools.elf.elffile import ELFFile  # type: ignore
+from elftools.elf.sections import SymbolTableSection  # type: ignore
+from tabulate import tabulate
+
+from .insn import JAL, JALR, LOOP, LOOPI
+from .isa import OTBNInsn
+from .state import OTBNState
+
+
+class ExecutionStats:
+    def __init__(self) -> None:
+        self.stall_count = 0
+        self.insn_histo = Counter()  # type: typing.Counter[str]
+        self.func_calls = []  # type: List[Dict[str, int]]
+        self.loops = []  # type: List[Dict[str, int]]
+
+    @property
+    def insn_count(self) -> int:
+        ''' Get the number of executed instructions. '''
+        return sum(self.insn_histo.values())
+
+    def record_stall(self) -> None:
+        ''' Record a single stall cycle. '''
+        self.stall_count += 1
+
+    def record_insn(self,
+                    pc: int,
+                    insn: OTBNInsn,
+                    state_before_commit: OTBNState) -> None:
+        ''' Record the execution of an instruction. '''
+
+        # Instruction histogram
+        self.insn_histo[insn.insn.mnemonic] += 1
+
+        # Function calls
+        # - Direct function calls: jal x1, <offset>
+        # - Indirect function calls: jalr x1, <grs1>, 0
+        if (isinstance(insn, JAL) or isinstance(insn, JALR)) and insn.grd == 1:
+            call_stack = state_before_commit.peek_call_stack()
+            if call_stack:
+                caller_func = call_stack[0]
+            else:
+                assert state_before_commit.start_addr is not None
+                caller_func = state_before_commit.start_addr
+
+            assert state_before_commit.pc_next is not None
+            self.func_calls.append({
+                'call_site': pc,
+                'caller_func': caller_func,
+                'callee_func': state_before_commit.pc_next,
+            })
+
+        # Loops
+        if isinstance(insn, LOOP) or isinstance(insn, LOOPI):
+            iterations = state_before_commit.loop_stack.stack[-1].loop_count
+            self.loops.append({
+                'loop_addr': pc,
+                'loop_len': insn.bodysize,
+                'iterations': iterations,
+            })
+
+
+def _dwarf_decode_file_line(dwarf_info: DWARFInfo,
+                            address: int) -> Optional[Tuple[str, int]]:
+    # Go over all the line programs in the DWARF information, looking for
+    # one that describes the given address.
+    for CU in dwarf_info.iter_CUs():
+        # First, look at line programs to find the file/line for the address
+        lineprog = dwarf_info.line_program_for_CU(CU)
+        prevstate = None
+        for entry in lineprog.get_entries():
+            # We're interested in those entries where a new state is assigned
+            if entry.state is None:
+                continue
+            if entry.state.end_sequence:
+                # if the line number sequence ends, clear prevstate.
+                prevstate = None
+                continue
+            # Looking for a range of addresses in two consecutive states that
+            # contain the required address.
+            if prevstate and prevstate.address <= address < entry.state.address:
+                filename = lineprog['file_entry'][prevstate.file - 1].name.decode('utf-8')
+                line = prevstate.line
+                return filename, line
+            prevstate = entry.state
+    return None
+
+
+def _get_addr_symbol_map(elf_file: ELFFile) -> Dict[int, str]:
+    section = elf_file.get_section_by_name('.symtab')
+
+    if not isinstance(section, SymbolTableSection):
+        return {}
+
+    return {sym.entry.st_value: sym.name for sym in section.iter_symbols()}
+
+
+class ExecutionStatAnalyzer:
+    # Assumed clock frequency of OTBN, in MHz.
+    FREQ_MHZ = 100
+
+    def __init__(self, stats: ExecutionStats, elf_file_path: str):
+        self._elf_file = ELFFile(open(elf_file_path, 'rb'))
+        self._stats = stats
+        self._addr_symbol_map = _get_addr_symbol_map(self._elf_file)
+
+    def _describe_imem_addr(self, address: int) -> str:
+        symbol_name = None
+        if address in self._addr_symbol_map:
+            symbol_name = self._addr_symbol_map[address]
+        else:
+            # |func_addr| is the largest possible |sym_addr| which is at most
+            # |address|.
+            func_addr = 0
+            for sym_addr in self._addr_symbol_map.keys():
+                if sym_addr <= address and sym_addr > func_addr:
+                    func_addr = sym_addr
+            symbol_name = self._addr_symbol_map[func_addr] + f"+{address - func_addr:#x}"
+
+        file_line = None
+        if self._elf_file.has_dwarf_info():
+            dwarf_info = self._elf_file.get_dwarf_info()
+            file_line = _dwarf_decode_file_line(dwarf_info, address)
+
+        add_info = []
+        if symbol_name:
+            add_info.append(f"{symbol_name}")
+        if file_line:
+            add_info.append(f"at {file_line[0]}:{file_line[1]}")
+
+        str = f"{address:#x}"
+        if add_info:
+            str += ' (' + ' '.join(add_info) + ')'
+        return str
+
+    def dump(self) -> str:
+        out = ""
+        out += "\n"
+        out += "Execution time\n"
+        out += "--------------\n"
+        out += self._dump_execution_time()
+        out += "\n\n"
+        out += "Instruction frequencies\n"
+        out += "-----------------------\n"
+        out += self._dump_insn_histo()
+        out += "\n\n"
+        out += "Function call statistics\n"
+        out += "------------------------\n"
+        out += self._dump_function_call_stats()
+        out += "\n\n"
+        out += "Loop statistics\n"
+        out += "---------------\n"
+        out += self._dump_loop_stats()
+        out += "\n"
+
+        return out
+
+    def _dump_execution_time(self) -> str:
+        insn_count = self._stats.insn_count
+        stall_count = self._stats.stall_count
+        stall_percent = stall_count / insn_count * 100
+        cycles = insn_count + stall_count
+        time_ms = cycles / (self.FREQ_MHZ * 1e6) * 1e3
+
+        out = f"OTBN executed {insn_count} instructions in {cycles} cycles.\n"
+
+        out += f"The execution stalled for {stall_count} cycles "
+        out += f"({stall_percent:.01f} percent).\n"
+
+        out += f"The execution would take {time_ms:.02f} ms "
+        out += f"@ {self.FREQ_MHZ} MHz.\n"
+        return out
+
+    def _dump_insn_histo(self) -> str:
+        return tabulate(self._stats.insn_histo.most_common(),
+                        headers=['instruction', 'count']) + "\n"
+
+    def _dump_function_call_stats(self) -> str:
+        """ Dump function call statistics """
+
+        if not self._stats.func_calls:
+            return "No functions were called.\n"
+
+        out = ""
+
+        # TODO: Add the start address as function?
+
+        # Build function call graphs and a call site index
+        # caller-indexed == forward, callee-indexed == reverse
+        # The call graphs are on function granularity; the call sites dictionary
+        # is indexed by the called function, but uses the call site as value.
+        callgraph = {}  # type: Dict[int, typing.Counter[int]]
+        rev_callgraph = {}  # type: Dict[int, typing.Counter[int]]
+        rev_callsites = {}  # type: Dict[int, typing.Counter[int]]
+        for c in self._stats.func_calls:
+            if c['caller_func'] not in callgraph:
+                callgraph[c['caller_func']] = Counter()
+            callgraph[c['caller_func']][c['callee_func']] += 1
+
+            if c['callee_func'] not in rev_callgraph:
+                rev_callgraph[c['callee_func']] = Counter()
+            rev_callgraph[c['callee_func']][c['caller_func']] += 1
+
+            if c['callee_func'] not in rev_callsites:
+                rev_callsites[c['callee_func']] = Counter()
+            rev_callsites[c['callee_func']][c['call_site']] += 1
+
+        total_leaf_calls = 0
+        total_calls_to_funcs_with_one_callsite = 0
+        total_func_calls = 0
+        for rev_callee_func, rev_caller_funcs in rev_callgraph.items():
+            has_one_callsite = False
+            func = self._describe_imem_addr(rev_callee_func)
+            out += f"Function {func}\n"
+            out += "  is called from the following functions\n"
+            for rev_caller_func, cnt in rev_caller_funcs.most_common():
+                func = self._describe_imem_addr(rev_caller_func)
+                out += f"    * {cnt} times by function {func}\n"
+            out += "  from the following call sites\n"
+            for rev_callsite, cnt in rev_callsites[rev_callee_func].most_common():
+                func = self._describe_imem_addr(rev_callsite)
+                out += f"    * {cnt} times from {func}\n"
+
+            has_one_callsite = len(rev_callsites[rev_callee_func]) == 1
+
+            out += "  calls\n"
+            if rev_callee_func not in callgraph:
+                out += "    no other function (leaf function).\n"
+
+                if not has_one_callsite:
+                    # We don't count it as leaf function call if it has only one
+                    # call site to prevent double-counting these as optimization
+                    # opportunity.
+                    total_leaf_calls += sum(rev_caller_funcs.values())
+            else:
+                caller_funcs = callgraph[rev_callee_func]
+                for caller_func, cnt in caller_funcs.most_common():
+                    func = self._describe_imem_addr(caller_func)
+                    out += f"    * {cnt} times function {func}\n"
+            out += "\n"
+
+            if has_one_callsite:
+                total_calls_to_funcs_with_one_callsite += (
+                    rev_caller_funcs.most_common()[0][1])
+
+            total_func_calls += sum(rev_caller_funcs.values())
+        out += "\n"
+
+        # Function call statistics
+        total_calls_req_call = (total_func_calls - total_leaf_calls -
+                                total_calls_to_funcs_with_one_callsite)
+        out += f"Of a total of {total_func_calls} function calls, there were\n"
+        out += (f"  {total_calls_to_funcs_with_one_callsite} function calls "
+                f"to a function with only one call site (call/ret can be "
+                f"replaced with static jumps)\n")
+        out += (f"  {total_leaf_calls} leaf function calls "
+                f"(no function prologue/epilogue needed)\n")
+        out += (f"Overall, {total_calls_req_call} of {total_func_calls} "
+                f"({(total_calls_req_call / total_func_calls * 100):.02f} "
+                f"percent) need full function call semantics.\n")
+
+        return out
+
+    def _dump_loop_stats(self) -> str:
+        loops = self._stats.loops
+        loop_cnt = len(loops)
+
+        out = f"Loops: {loop_cnt}\n"
+
+        if loop_cnt != 0:
+            loop_len_values = [loop['loop_len'] for loop in loops]
+            loop_len_min = min(loop_len_values)
+            loop_len_max = max(loop_len_values)
+            loop_len_avg = sum(loop_len_values) / loop_cnt
+
+            loop_iterations_values = [loop['iterations'] for loop in loops]
+            loop_iterations_min = min(loop_iterations_values)
+            loop_iterations_max = max(loop_iterations_values)
+            loop_iterations_avg = sum(loop_iterations_values) / loop_cnt
+
+            out += "Loop body length (instructions): "
+            out += f"min: {loop_len_min}, max: {loop_len_max}, "
+            out += f"avg: {loop_len_avg:.02f}\n"
+
+            out += f"Number of iterations: min: {loop_iterations_min}, "
+            out += f"max: {loop_iterations_max}, "
+            out += f"avg: {loop_iterations_avg:.02f}\n"
+
+        return out

--- a/hw/ip/otbn/dv/otbnsim/standalone.py
+++ b/hw/ip/otbn/dv/otbnsim/standalone.py
@@ -18,14 +18,15 @@ def main() -> int:
         '--dump-dmem',
         metavar="FILE",
         type=argparse.FileType('wb'),
-        help="after execution, write the data memory contents to this file")
+        help=("after execution, write the data memory contents to this file. "
+              "Use '-' to write to STDOUT.")
+    )
     parser.add_argument(
         '--dump-regs',
         metavar="FILE",
         type=argparse.FileType('w'),
-        default=sys.stdout,
-        help=
-        "after execution, write the GPR and WDR contents to this file (default: STDOUT)"
+        help=("after execution, write the GPR and WDR contents to this file. "
+              "Use '-' to write to STDOUT.")
     )
 
     args = parser.parse_args()

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -89,7 +89,7 @@ def on_step(sim: OTBNSim, args: List[str]) -> None:
     pc = sim.state.pc
     assert 0 == pc & 3
 
-    insn, changes = sim.step(verbose=False)
+    insn, changes = sim.step(verbose=False, collect_stats=False)
 
     if insn is None:
         hdr = 'STALL'
@@ -108,7 +108,7 @@ def on_run(sim: OTBNSim, args: List[str]) -> None:
         raise ValueError('run expects zero arguments. Got {}.'
                          .format(args))
 
-    num_cycles = sim.run(verbose=False)
+    num_cycles = sim.run(verbose=False, collect_stats=False)
     print(' ran for {} cycles'.format(num_cycles))
 
 

--- a/hw/ip/otbn/dv/otbnsim/test/conftest.py
+++ b/hw/ip/otbn/dv/otbnsim/test/conftest.py
@@ -1,0 +1,9 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+# Make tested code available for import
+sys.path.append(os.path.join(os.path.dirname(__file__), '../'))

--- a/hw/ip/otbn/dv/otbnsim/test/simple/subroutines/direct-call.exp
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/subroutines/direct-call.exp
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+x11 = 4

--- a/hw/ip/otbn/dv/otbnsim/test/simple/subroutines/direct-call.s
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/subroutines/direct-call.s
@@ -1,0 +1,16 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* Call a subroutine directly. */
+
+main:
+  addi    x11, x0, 5
+
+  jal     x1, subroutine
+
+  ecall
+
+subroutine:
+  addi    x11, x11, -1
+  jalr    x0, x1, 0

--- a/hw/ip/otbn/dv/otbnsim/test/simple/subroutines/indirect-call.exp
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/subroutines/indirect-call.exp
@@ -1,0 +1,6 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+x10 = 0x10
+x11 = 4

--- a/hw/ip/otbn/dv/otbnsim/test/simple/subroutines/indirect-call.s
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/subroutines/indirect-call.s
@@ -1,0 +1,17 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* Call a subroutine through a function pointer. */
+
+main:
+  addi    x11, x0, 5
+
+  addi    x10, x0, 0x10
+  jalr    x1, x10, 0
+
+  ecall
+
+subroutine:
+  addi    x11, x11, -1
+  jalr    x0, x1, 0

--- a/hw/ip/otbn/dv/otbnsim/test/simple_test.py
+++ b/hw/ip/otbn/dv/otbnsim/test/simple_test.py
@@ -16,10 +16,7 @@ import re
 import subprocess
 from typing import Any, Dict, List, Tuple
 
-
-_OTBN_DIR = os.path.join(os.path.dirname(__file__), '../../..')
-_UTIL_DIR = os.path.join(_OTBN_DIR, 'util')
-_SIM_DIR = os.path.join(os.path.dirname(__file__), '..')
+from testutil import asm_and_link_one_file, SIM_DIR
 
 _REG_RE = re.compile(r'\s*([xw][0-9]+)\s*=\s*((:?0x[0-9a-f]+)|([0-9]+))$')
 
@@ -78,22 +75,6 @@ def find_simple_tests() -> List[Tuple[str, str]]:
         assert len(exp_files) == len(asm_files)
 
     return ret
-
-
-def asm_and_link_one_file(asm_path: str, work_dir: str) -> str:
-    '''Assemble and link file at asm_path in work_dir.
-
-    Returns the path to the resulting ELF
-
-    '''
-    otbn_as = os.path.join(_UTIL_DIR, 'otbn-as')
-    otbn_ld = os.path.join(_UTIL_DIR, 'otbn-ld')
-    obj_path = os.path.join(work_dir, 'tst.o')
-    elf_path = os.path.join(work_dir, 'tst')
-
-    subprocess.run([otbn_as, '-o', obj_path, asm_path], check=True)
-    subprocess.run([otbn_ld, '-o', elf_path, obj_path], check=True)
-    return elf_path
 
 
 def get_reg_dump(stdout: str) -> Dict[str, int]:
@@ -165,7 +146,7 @@ def test_count(tmpdir: py.path.local,
 
     # Run the simulation. We can just pass a list of commands to stdin, and
     # don't need to do anything clever to track what's going on.
-    stepped_py = os.path.join(_SIM_DIR, 'stepped.py')
+    stepped_py = os.path.join(SIM_DIR, 'stepped.py')
     commands = 'load_elf {}\nstart 0\nrun\nprint_regs\n'.format(elf_file)
     sim_proc = subprocess.run([stepped_py], check=True, input=commands,
                               stdout=subprocess.PIPE, universal_newlines=True)

--- a/hw/ip/otbn/dv/otbnsim/test/simple_test.py
+++ b/hw/ip/otbn/dv/otbnsim/test/simple_test.py
@@ -159,4 +159,6 @@ def test_count(tmpdir: py.path.local,
 
 def pytest_generate_tests(metafunc: Any) -> None:
     if metafunc.function is test_count:
-        metafunc.parametrize("asm_file,expected_file", find_simple_tests())
+        tests = find_simple_tests()
+        test_ids = [os.path.basename(e[0]) for e in tests]
+        metafunc.parametrize("asm_file,expected_file", tests, ids=test_ids)

--- a/hw/ip/otbn/dv/otbnsim/test/stats_test.py
+++ b/hw/ip/otbn/dv/otbnsim/test/stats_test.py
@@ -1,0 +1,75 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import py
+import os
+
+from sim.sim import OTBNSim
+from sim.stats import ExecutionStats
+from sim.elf import load_elf
+import testutil
+
+
+def _run_sim_for_stats(asm_file: str, tmpdir: str) -> ExecutionStats:
+    """ Run the OTBN simulator, collect statistics, and return them. """
+
+    assert os.path.exists(asm_file)
+    elf_file = testutil.asm_and_link_one_file(asm_file, tmpdir)
+
+    sim = OTBNSim()
+    load_elf(sim, elf_file)
+
+    sim.state.start(0)
+    sim.run(verbose=False, collect_stats=True)
+
+    return sim.stats
+
+
+def test_general_and_loop(tmpdir: py.path.local) -> None:
+    """ Test the collection of general statistics as well as loop stats. """
+
+    asm_file = os.path.join(os.path.dirname(__file__),
+                            'simple', 'loops', 'loops.s')
+    stats = _run_sim_for_stats(asm_file, str(tmpdir))
+
+    # General statistics
+    assert stats.stall_count == 2
+    assert stats.insn_count == 28
+    assert stats.insn_histo == {'addi': 22, 'loop': 4, 'loopi': 1, 'ecall': 1}
+    assert stats.func_calls == []
+
+    # Loop statistics.
+    exp = [
+        # Outer LOOPI
+        {'iterations': 4, 'loop_addr': 8, 'loop_len': 4},
+
+        # Inner LOOP
+        {'iterations': 3, 'loop_addr': 16, 'loop_len': 1},
+        {'iterations': 3, 'loop_addr': 16, 'loop_len': 1},
+        {'iterations': 3, 'loop_addr': 16, 'loop_len': 1},
+        {'iterations': 3, 'loop_addr': 16, 'loop_len': 1}
+    ]
+    assert stats.loops == exp
+
+
+def test_func_call_direct(tmpdir: py.path.local) -> None:
+    """ Test the collection of statistics related to loops. """
+
+    asm_file = os.path.join(os.path.dirname(__file__),
+                            'simple', 'subroutines', 'direct-call.s')
+    stats = _run_sim_for_stats(asm_file, str(tmpdir))
+
+    exp = [{'call_site': 4, 'callee_func': 12, 'caller_func': 0}]
+    assert stats.func_calls == exp
+
+
+def test_func_call_indirect(tmpdir: py.path.local) -> None:
+    """ Test the collection of statistics related to loops. """
+
+    asm_file = os.path.join(os.path.dirname(__file__),
+                            'simple', 'subroutines', 'indirect-call.s')
+    stats = _run_sim_for_stats(asm_file, str(tmpdir))
+
+    exp = [{'call_site': 8, 'callee_func': 16, 'caller_func': 0}]
+    assert stats.func_calls == exp

--- a/hw/ip/otbn/dv/otbnsim/test/testutil.py
+++ b/hw/ip/otbn/dv/otbnsim/test/testutil.py
@@ -1,0 +1,27 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import subprocess
+
+
+OTBN_DIR = os.path.join(os.path.dirname(__file__), '../../..')
+UTIL_DIR = os.path.join(OTBN_DIR, 'util')
+SIM_DIR = os.path.join(os.path.dirname(__file__), '..')
+
+
+def asm_and_link_one_file(asm_path: str, work_dir: str) -> str:
+    '''Assemble and link file at asm_path in work_dir.
+
+    Returns the path to the resulting ELF
+
+    '''
+    otbn_as = os.path.join(UTIL_DIR, 'otbn-as')
+    otbn_ld = os.path.join(UTIL_DIR, 'otbn-ld')
+    obj_path = os.path.join(work_dir, 'tst.o')
+    elf_path = os.path.join(work_dir, 'tst')
+
+    subprocess.run([otbn_as, '-o', obj_path, asm_path], check=True)
+    subprocess.run([otbn_ld, '-o', elf_path, obj_path], check=True)
+    return elf_path


### PR DESCRIPTION
The ISS now has the ability to collect statistics during the program execution, and to analyze them afterwards.

The analysis is quite "opinionated" and includes things I've been looking for in the past when designing the OTBN ISA.

* Execution time
* Instruction histograms
* Function call statistics
* Loop statistics

I expect us to add more statistics in the future as we need to profile and analyze different things.

The code also reads DWARF debug information to extract file and line numbers from OTBN ELF files built with debug information (-g). This build mode is not yet enabled by default because the line numbers are off by a couple lines, probably due to the way comments and labels are folded into line numbers.

Usage example: `hw/ip/otbn/dv/otbnsim/standalone.py build-out/sw/otbn/rsa_1024_dec_test.elf --dump-stats=-`

Output:
```
Execution time
--------------
OTBN executed 2302414 instructions in 2439770 cycles.
The execution stalled for 137356 cycles (6.0 percent).
The execution would take 24.40 ms @ 100 MHz.


Instruction frequencies
-----------------------
instruction      count
-------------  -------
bn.mulqacc      887648
bn.mulqacc.so   295712
bn.movr         204988
addi            160928
bn.addc         131192
bn.lid          129147
bn.add          118129
jal              95328
jalr             95328
bn.sel           45096
bn.subb          41004
bn.mov           38951
loop             27678
bn.sid           16401
lw                8208
bn.cmpb           4100
bn.sub            2052
bn.and             256
bn.or              256
bn.xor               5
bn.addi              3
slli                 2
loopi                1
ecall                1


Function call statistics
------------------------
Function 0x520 (modload)
  is called from the following functions
    * 1 times by function 0x0 (_imem_start)
  from the following call sites
    * 1 times from 0x0 (_imem_start)
  calls
    no other function (leaf function).

Function 0x20 (m0inv)
  is called from the following functions
    * 1 times by function 0x4 (_imem_start+0x4)
  from the following call sites
    * 1 times from 0x53c (modload+0x1c)
  calls
    no other function (leaf function).

Function 0x98 (compute_rr)
  is called from the following functions
    * 1 times by function 0x4 (_imem_start+0x4)
  from the following call sites
    * 1 times from 0x548 (modload+0x28)
  calls
    no other function (leaf function).

Function 0x6c (cond_sub_mod)
  is called from the following functions
    * 2049 times by function 0x4 (_imem_start+0x4)
  from the following call sites
    * 1024 times from 0xe8 (compute_rr+0x50)
    * 1024 times from 0x10c (compute_rr+0x74)
    * 1 times from 0xc4 (compute_rr+0x2c)
  calls
    no other function (leaf function).

Function 0x36c (modexp)
  is called from the following functions
    * 1 times by function 0x0 (_imem_start)
  from the following call sites
    * 1 times from 0x4 (_imem_start+0x4)
  calls
    no other function (leaf function).

Function 0x30c (montmul)
  is called from the following functions
    * 2049 times by function 0x8 (_imem_start+0x8)
  from the following call sites
    * 1024 times from 0x3dc (modexp+0x70)
    * 1024 times from 0x3f8 (modexp+0x8c)
    * 1 times from 0x398 (modexp+0x2c)
  calls
    no other function (leaf function).

Function 0x1d8 (mont_loop)
  is called from the following functions
    * 8200 times by function 0x8 (_imem_start+0x8)
  from the following call sites
    * 8196 times from 0x330 (montmul+0x24)
    * 4 times from 0x2c8 (montmul_mul1+0x2c)
  calls
    no other function (leaf function).

Function 0x16c (mul256_w30xw2)
  is called from the following functions
    * 32800 times by function 0x8 (_imem_start+0x8)
  from the following call sites
    * 24600 times from 0x22c (mont_loop+0x54)
    * 8200 times from 0x1f0 (mont_loop+0x18)
  calls
    no other function (leaf function).

Function 0x128 (mul256_w30xw25)
  is called from the following functions
    * 41000 times by function 0x8 (_imem_start+0x8)
  from the following call sites
    * 24600 times from 0x248 (mont_loop+0x70)
    * 8200 times from 0x204 (mont_loop+0x2c)
    * 8200 times from 0x218 (mont_loop+0x40)
  calls
    no other function (leaf function).

Function 0x1b0 (cond_sub_to_reg)
  is called from the following functions
    * 8200 times by function 0x8 (_imem_start+0x8)
  from the following call sites
    * 8200 times from 0x274 (mont_loop+0x9c)
  calls
    no other function (leaf function).

Function 0x34c (sel_sqr_or_sqrmul)
  is called from the following functions
    * 1024 times by function 0x8 (_imem_start+0x8)
  from the following call sites
    * 1024 times from 0x418 (modexp+0xac)
  calls
    no other function (leaf function).

Function 0x29c (montmul_mul1)
  is called from the following functions
    * 1 times by function 0x8 (_imem_start+0x8)
  from the following call sites
    * 1 times from 0x428 (modexp+0xbc)
  calls
    no other function (leaf function).

Function 0x280 (cond_sub_to_dmem)
  is called from the following functions
    * 1 times by function 0x8 (_imem_start+0x8)
  from the following call sites
    * 1 times from 0x2fc (montmul_mul1+0x60)
  calls
    no other function (leaf function).


Of a total of 95328 function calls, there were 
  9230 function calls to a function with only one call site (call/ret can be replaced with static jumps)
  86098 leaf function calls (no function prologue/epilogue needed)
Overall, 0 of 95328 (0.00 percent) need full function call semantics.


Loop statistics
---------------
Loops: 27679
Loop body length (instructions): min: 1, max: 20, avg: 7.59
Number of iterations: min: 3, max: 1024, avg: 3.79
```