### PR TITLE
Update lowrisc_ibex to lowRISC/ibex@5c60b094

### DIFF
--- a/hw/vendor/lowrisc_ibex.lock.hjson
+++ b/hw/vendor/lowrisc_ibex.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/ibex.git
-    rev: 0e7117fbec434fcfdf2bcce4ed379d34cdbe68b4
+    rev: 5c60b094fe550cde031b7d544a5a1791e7403a22
   }
 }

--- a/hw/vendor/lowrisc_ibex/doc/02_user/integration.rst
+++ b/hw/vendor/lowrisc_ibex/doc/02_user/integration.rst
@@ -36,6 +36,7 @@ Instantiation Template
       .clk_i          (),
       .rst_ni         (),
       .test_en_i      (),
+      .scan_rst_ni    (),
       .ram_cfg_i      (),
 
       // Configuration
@@ -160,7 +161,11 @@ Interfaces
 +-------------------------+-------------------------+-----+----------------------------------------+
 | ``rst_ni``              | 1                       | in  | Active-low asynchronous reset          |
 +-------------------------+-------------------------+-----+----------------------------------------+
-| ``test_en_i``           | 1                       | in  | Test input, enables clock              |
+| ``test_en_i``           | 1                       | in  | Test input, enables clock and allows   |
+|                         |                         |     | test control of reset.                 |
++-------------------------+-------------------------+-----+----------------------------------------+
+| ``scan_rst_ni``         | 1                       | in  | Test controlled reset.  If DFT not     |
+|                         |                         |     | used, tie off to 1.                    |
 +-------------------------+-------------------------+-----+----------------------------------------+
 | ``ram_cfg_i``           | 10                      | in  | RAM configuration inputs, routed to    |
 |                         |                         |     | the icache RAMs                        |

--- a/hw/vendor/lowrisc_ibex/examples/fpga/artya7/rtl/top_artya7.sv
+++ b/hw/vendor/lowrisc_ibex/examples/fpga/artya7/rtl/top_artya7.sv
@@ -51,6 +51,7 @@ module top_artya7 (
      .rst_ni                (rst_sys_n),
 
      .test_en_i             ('b0),
+     .scan_rst_ni           (1'b1),
      .ram_cfg_i             ('b0),
 
      .hart_id_i             (32'b0),

--- a/hw/vendor/lowrisc_ibex/examples/simple_system/rtl/ibex_simple_system.sv
+++ b/hw/vendor/lowrisc_ibex/examples/simple_system/rtl/ibex_simple_system.sv
@@ -183,6 +183,7 @@ module ibex_simple_system (
       .rst_ni                (rst_sys_n),
 
       .test_en_i             ('b0),
+      .scan_rst_ni           (1'b1),
       .ram_cfg_i             ('b0),
 
       .hart_id_i             (32'b0),

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_lockstep.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_lockstep.sv
@@ -88,7 +88,9 @@ module ibex_lockstep import ibex_pkg::*; #(
 
     output logic                         alert_minor_o,
     output logic                         alert_major_o,
-    input  logic                         core_busy_i
+    input  logic                         core_busy_i,
+    input  logic                         test_en_i,
+    input  logic                         scan_rst_ni
 );
 
   localparam int unsigned LockstepOffsetW = $clog2(LockstepOffset);
@@ -98,9 +100,9 @@ module ibex_lockstep import ibex_pkg::*; #(
   //////////////////////
 
   logic [LockstepOffsetW-1:0] rst_shadow_cnt_d, rst_shadow_cnt_q;
-  logic                       rst_shadow_set_d, rst_shadow_set_q;
   // Internally generated resets cause IMPERFECTSCH warnings
   /* verilator lint_off IMPERFECTSCH */
+  logic                       rst_shadow_set_d, rst_shadow_set_q;
   logic                       rst_shadow_n;
   /* verilator lint_on IMPERFECTSCH */
 
@@ -118,7 +120,7 @@ module ibex_lockstep import ibex_pkg::*; #(
     end
   end
 
-  assign rst_shadow_n = rst_shadow_set_q;
+  assign rst_shadow_n = test_en_i ? scan_rst_ni : rst_shadow_set_q;
 
   //////////////////
   // Input delays //

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_top.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_top.sv
@@ -106,7 +106,10 @@ module ibex_top #(
     input  logic                         fetch_enable_i,
     output logic                         alert_minor_o,
     output logic                         alert_major_o,
-    output logic                         core_sleep_o
+    output logic                         core_sleep_o,
+
+    // DFT bypass controls
+    input logic                          scan_rst_ni
 );
 
   import ibex_pkg::*;
@@ -626,7 +629,7 @@ module ibex_top #(
           .out_o(ic_tag_rdata_local[k][j])
         );
       end
-      for (genvar j = 0; j < TagSizeECC; j++) begin : gen_data_bufs
+      for (genvar j = 0; j < LineSizeECC; j++) begin : gen_data_bufs
         prim_buf u_prim_buf (
           .in_i(ic_data_rdata[k][j]),
           .out_o(ic_data_rdata_local[k][j])
@@ -716,7 +719,9 @@ module ibex_top #(
 
       .alert_minor_o     (lockstep_alert_minor_local),
       .alert_major_o     (lockstep_alert_major_local),
-      .core_busy_i       (core_busy_local)
+      .core_busy_i       (core_busy_local),
+      .test_en_i         (test_en_i),
+      .scan_rst_ni       (scan_rst_ni)
     );
 
     // Manually buffer the output signals.
@@ -733,6 +738,8 @@ module ibex_top #(
   end else begin : gen_no_lockstep
     assign lockstep_alert_major = 1'b0;
     assign lockstep_alert_minor = 1'b0;
+    logic unused_scan;
+    assign unused_scan = scan_rst_ni;
   end
 
   // TODO - need a config to reset all registers before the lockstep alert can be used

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_top_tracing.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_top_tracing.sv
@@ -32,6 +32,7 @@ module ibex_top_tracing #(
     input  logic                         rst_ni,
 
     input  logic                         test_en_i,     // enable all clock gates for testing
+    input  logic                         scan_rst_ni,
     input  prim_ram_1p_pkg::ram_1p_cfg_t ram_cfg_i,
 
 
@@ -132,6 +133,7 @@ module ibex_top_tracing #(
     .rst_ni,
 
     .test_en_i,
+    .scan_rst_ni,
     .ram_cfg_i,
 
     .hart_id_i,


### PR DESCRIPTION
Update code from upstream repository
https://github.com/lowRISC/ibex.git to revision
5c60b094fe550cde031b7d544a5a1791e7403a22

* [rtl] Break long lines in icache (Rupert Swarbrick)
* [rtl] Wire scan_rst_ni through ibex_top_tracing (Tom Roberts)
* [ibex] Add reset bypass controls (Timothy Chen)
* [ibex] Fix buffer instantiations (Timothy Chen)
* add cast to enum (Dawid Zimonczyk)

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>