### PR TITLE
[top] Fixes for optimized modules

### DIFF
--- a/hw/top_earlgrey/ip/ast/rtl/aon_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/aon_osc.sv
@@ -53,7 +53,6 @@ always begin
   #(AonClkPeriod/2) clk = ~clk && en_osc;
 end
 
-assign aon_clk_o = clk;
 `else  // of SYNTHESIS
 localparam prim_pkg::impl_e Impl = `PRIM_DEFAULT_IMPL;
 
@@ -78,11 +77,14 @@ if (Impl == prim_pkg::ImplXilinx) begin : gen_xilinx
   // FPGA Specific (place holder)
   ///////////////////////////////////////
   assign clk = (/*TODO*/ 1'b1) && en_osc;
-  assign aon_clk_o = clk;
 end else begin : gen_generic
   assign clk = (/*TODO*/ 1'b1) && en_osc;
-  assign aon_clk_o = clk;
 end
 `endif
+
+prim_buf u_buf (
+  .in_i(clk),
+  .out_o(aon_clk_o)
+);
 
 endmodule : aon_osc

--- a/hw/top_earlgrey/ip/ast/rtl/io_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/io_osc.sv
@@ -53,7 +53,6 @@ always begin
    #(IoClkPeriod/2000) clk = ~clk && en_osc;
 end
 
-assign io_clk_o = clk;
 `else  // of SYNTHESIS
 localparam prim_pkg::impl_e Impl = `PRIM_DEFAULT_IMPL;
 
@@ -78,11 +77,14 @@ if (Impl == prim_pkg::ImplXilinx) begin : gen_xilinx
   // FPGA Specific (place holder)
   ///////////////////////////////////////
   assign clk = (/*TODO*/ 1'b1) && en_osc;
-  assign io_clk_o = clk;
 end else begin : gen_generic
   assign clk = (/*TODO*/ 1'b1) && en_osc;
-  assign io_clk_o = clk;
 end
 `endif
+
+prim_buf u_buf (
+  .in_i(clk),
+  .out_o(io_clk_o)
+);
 
 endmodule : io_osc

--- a/hw/top_earlgrey/ip/ast/rtl/sys_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/sys_osc.sv
@@ -58,7 +58,6 @@ always begin
   #((SysClkPeriod+jitter)/2000) clk = ~clk && en_osc;
 end
 
-assign sys_clk_o = clk;
 `else  // of SYNTHESIS
 localparam prim_pkg::impl_e Impl = `PRIM_DEFAULT_IMPL;
 
@@ -84,11 +83,16 @@ if (Impl == prim_pkg::ImplXilinx) begin : gen_xilinx
   // FPGA Specific (place holder)
   ///////////////////////////////////////
   assign clk = (/*TODO*/ 1'b1) && en_osc;
-  assign sys_clk_o = clk;
 end else begin : gen_generic
   assign clk = (/*TODO*/ 1'b1) && en_osc;
-  assign sys_clk_o = clk;
+
 end
 `endif
+
+prim_buf u_buf (
+  .in_i(clk),
+  .out_o(sys_clk_o)
+);
+
 
 endmodule : sys_osc

--- a/hw/top_earlgrey/ip/ast/rtl/usb_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/usb_osc.sv
@@ -63,7 +63,6 @@ always begin
   #((UsbClkPeriod + drift)/2000) clk = ~clk && en_osc;
 end
 
-assign usb_clk_o = clk;
 `else  // of SYNTHESIS
 localparam prim_pkg::impl_e Impl = `PRIM_DEFAULT_IMPL;
 
@@ -88,11 +87,14 @@ if (Impl == prim_pkg::ImplXilinx) begin : gen_xilinx
   // FPGA Specific (place holder)
   ///////////////////////////////////////
   assign clk = (/*TODO*/ 1'b1) && en_osc;
-  assign usb_clk_o = clk;
 end else begin : gen_generic
   assign clk = (/*TODO*/ 1'b1) && en_osc;
-  assign usb_clk_o = clk;
 end
 `endif
+
+prim_buf u_buf (
+  .in_i(clk),
+  .out_o(usb_clk_o)
+);
 
 endmodule : usb_osc

--- a/hw/top_earlgrey/syn/asic.constraints.sdc
+++ b/hw/top_earlgrey/syn/asic.constraints.sdc
@@ -27,7 +27,7 @@ set_ideal_network [get_pins -hier u_clkgate/Q]
 #####################
 # main clock        #
 #####################
-set MAIN_CLK_PIN u_ast/u_sys_clk/u_sys_osc/sys_clk_o
+set MAIN_CLK_PIN u_ast/u_sys_clk/u_sys_osc/u_buf/out_o
 set MAIN_RST_PIN IO_RST_N
 # target is 100MHz, overconstrain by factor
 set MAIN_TCK_TARGET_PERIOD  10
@@ -42,7 +42,7 @@ set_clock_uncertainty ${SETUP_CLOCK_UNCERTAINTY} [get_clocks MAIN_CLK]
 #####################
 # USB clock         #
 #####################
-set USB_CLK_PIN u_ast/u_usb_clk/u_usb_osc/usb_clk_o
+set USB_CLK_PIN u_ast/u_usb_clk/u_usb_osc/u_buf/out_o
 # target is 48MHz, overconstrain by 5%
 set USB_TCK_TARGET_PERIOD 20.8
 set USB_TCK_PERIOD [expr $USB_TCK_TARGET_PERIOD*$CLK_PERIOD_FACTOR]
@@ -59,7 +59,7 @@ set_max_delay 1 -from [get_pins top_earlgrey/u_usbdev/usbdev_impl/u_usb_fs_nb_pe
 #####################
 # IO clk            #
 #####################
-set IO_CLK_PIN u_ast/u_io_clk/u_io_osc/io_clk_o
+set IO_CLK_PIN u_ast/u_io_clk/u_io_osc/u_buf/out_o
 # target is 96MHz, overconstrain by factor
 set IO_TCK_TARGET_PERIOD 10.416
 set IO_TCK_PERIOD [expr $IO_TCK_TARGET_PERIOD*$CLK_PERIOD_FACTOR]
@@ -115,7 +115,7 @@ set_max_delay -from ${IO_BANKS} -to ${IO_BANKS} -through [get_cells top_earlgrey
 #####################
 # AON clk           #
 #####################
-set AON_CLK_PIN u_ast/u_aon_clk/u_aon_osc/aon_clk_o
+set AON_CLK_PIN u_ast/u_aon_clk/u_aon_osc/u_buf/out_o
 # target is 200KHz, overconstrain by factor
 set AON_TCK_TARGET_PERIOD 5000.0
 set AON_TCK_PERIOD [expr $AON_TCK_TARGET_PERIOD*$CLK_PERIOD_FACTOR]


### PR DESCRIPTION
- The pins used for creating ast clocks were sometimes being removed
  during synthesis optimization.  This caused a whole set of logic to
  not have a clock, even though the initial constraint definition was
  successful.

- Add buffers to anchor where the constraints would go and ensure logic is
  not removed.  Note this is only needed for open source synthesis since
  AST is not real

Signed-off-by: Timothy Chen <timothytim@google.com>