### PR TITLE
[dv/otp_ctrl] align the behavior for fatal error

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -59,7 +59,7 @@ package otp_ctrl_env_pkg;
   parameter uint SECRET2_DIGEST_ADDR = Secret2DigestOffset / (TL_DW / 8);
   parameter uint SECRET2_END_ADDR    = SECRET2_DIGEST_ADDR - 1;
 
-  // TODO: did not count for LC partition
+  // LC has its own storage in scb
   parameter uint OTP_ARRAY_SIZE = (CreatorSwCfgSize + OwnerSwCfgSize + HwCfgSize + Secret0Size +
                                    Secret1Size + Secret2Size) / (TL_DW / 8);
 
@@ -150,8 +150,18 @@ package otp_ctrl_env_pkg;
     OtpEccUncorrErr
   } otp_ecc_err_e;
 
+  typedef enum bit [1:0] {
+    OtpNoAlert,
+    OtpCheckAlert,
+    OtpMacroAlert
+  } otp_alert_e;
+
   typedef virtual mem_bkdr_if #(.MEM_ECC(1)) mem_bkdr_vif;
   typedef virtual otp_ctrl_if otp_ctrl_vif;
+
+  parameter otp_err_code_e OTP_TERMINAL_ERRS[3] = {OtpMacroEccUncorrError,
+                                                   OtpCheckFailError,
+                                                   OtpFsmStateError};
 
   // functions
   function automatic int get_part_index(bit [TL_DW-1:0] addr);

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -283,7 +283,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
             cfg.clk_rst_vif.wait_clks(1);
             csr_rd(.ptr(ral.err_code.err_code_7), .value(err_val), .backdoor(1));
             // Break if error will cause fatal alerts
-            if (err_val inside {OtpMacroEccUncorrError, OtpFsmStateError}) break;
+            if (err_val inside {OTP_TERMINAL_ERRS}) break;
           end
         end
       join_any

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -57,6 +57,11 @@ module tb;
 
   assign otp_ctrl_if.lc_prog_req = lc_prog_if.req;
   assign otp_ctrl_if.lc_prog_err = lc_prog_if.d_data;
+  // This signal probes design's alert request to avoid additional logic for triggering alert and
+  // disable assertions.
+  // Alert checkings are done independently in otp_ctrl's scb.
+  // The correctness of this probed signal is checked in otp_ctrl's scb as well.
+  assign otp_ctrl_if.alert_reqs = dut.alerts[0] | dut.alerts[1];
 
   // leave this unconnected for now.
   wire otp_ext_voltage_h;


### PR DESCRIPTION
This PR aligns the behavior for PR #6077.
What changes here is - now if any alert triggered, the otp_ctrl will go
to terminal stage for all partitions (previously only the partition that
has error will go to terminal stage)
This PR works on scb and interface. The coming PR will work on sequence
that does not enable scb.

Signed-off-by: Cindy Chen <chencindy@google.com>