### PR TITLE
[dv/flash] Some changes to rand_ops_vseq and added some more configurations

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
@@ -33,7 +33,7 @@ class flash_ctrl_env #(type CFG_T = flash_ctrl_env_cfg,
 
     // get the vifs from config db
     if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin // If using open-source flash
-      flash_dv_part_e part = part.first(); 
+      flash_dv_part_e part = part.first();
       for (int i = 0; i < part.num(); i++, part = part.next()) begin
         foreach (cfg.mem_bkdr_vifs[, bank]) begin
           string vif_name = $sformatf("mem_bkdr_vifs[%0s][%0d]", part.name(), bank);

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -18,7 +18,8 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // This enables memory protection regions to overlap.
   bit allow_mp_region_overlap;
 
-  // When this knob is NOT FlashOpInvalid (default) the selected operation will be the only operation to run in the test (FlashOpRead, FlashOpProgram, FlashOpErase).
+  // When this knob is NOT FlashOpInvalid (default) the selected operation will be the only
+  //  operation to run in the test (FlashOpRead, FlashOpProgram, FlashOpErase).
   flash_ctrl_pkg::flash_op_e flash_only_op;
 
   // Weights to enable read / program and erase for each mem region.
@@ -41,7 +42,7 @@ class flash_ctrl_seq_cfg extends uvm_object;
   uint max_flash_ops_per_cfg;
 
   // Flash ctrl op randomization knobs.
-  
+
   // Partition select. Make sure to keep sum equals to 100.
   uint op_on_data_partition_pc;  // Choose data partition.
   uint op_on_info_partition_pc;  // Choose info partition.
@@ -59,6 +60,19 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // Poll fifo status before writing to prog_fifo / reading from rd_fifo.
   uint poll_fifo_status_pc;
 
+  //  Set by a higher level vseq that invokes this vseq 
+  bit external_cfg;
+
+  // When 0, the post-transaction back-door checks will be disabled.
+  // Added to enable other post-transaction checks and actions.
+  bit check_mem_post_tran;
+
+  // Timeout for program transaction
+  uint prog_timeout_ns;
+
+  // Timeout for erase transaction
+  uint erase_timeout_ns;
+
   `uvm_object_new
 
   // Set partition select percentages. Make sure to keep sum equals to 100.
@@ -74,10 +88,10 @@ sel_data_part_pc=%0d , sel_info_part_pc=%0d , sel_info1_part_pc=%0d , sel_red_pa
                                    sel_data_part_pc, sel_info_part_pc, sel_info1_part_pc,
                                    sel_red_part_pc))
 
-    op_on_data_partition_pc = sel_data_part_pc;   // Percenteges to choose data partition.
-    op_on_info_partition_pc = sel_info_part_pc;   // Percenteges to choose info partition.
-    op_on_info1_partition_pc = sel_info1_part_pc; // Percenteges to choose info1 partition.
-    op_on_red_partition_pc = sel_red_part_pc;     // Percenteges to choose redundancy partition.
+    op_on_data_partition_pc = sel_data_part_pc;
+    op_on_info_partition_pc = sel_info_part_pc;
+    op_on_info1_partition_pc = sel_info1_part_pc;
+    op_on_red_partition_pc = sel_red_part_pc;
 
   endfunction : set_partition_pc
 
@@ -85,44 +99,42 @@ sel_data_part_pc=%0d , sel_info_part_pc=%0d , sel_info1_part_pc=%0d , sel_red_pa
   virtual function void configure();
     max_num_trans = 20;
 
-    // Memory protection configuration.
     num_en_mp_regions = flash_ctrl_pkg::MpRegions;
 
-    // This enables memory protection regions to overlap.
     allow_mp_region_overlap = 1'b0;
 
-    // Weights to enable read / program and erase for each mem region.
-    // TODO: Should these be per region?
     mp_region_read_en_pc = 50;
     mp_region_program_en_pc = 50;
     mp_region_erase_en_pc = 50;
     mp_region_data_partition_pc = 50;
     mp_region_max_pages = 32;
 
-    // Knob to control bank level erasability.
     bank_erase_en_pc = 50;
 
-    // Default region knobs.
     default_region_read_en_pc    = 50;
     default_region_program_en_pc = 50;
     default_region_erase_en_pc   = 50;
 
-    // When this knob is not FlashOpInvalid the selected operation will be the only operation to run in the test (FlashOpRead, FlashOpProgram, FlashOpErase).
     flash_only_op = FlashOpInvalid;
 
-    // Control the number of flash ops.
     max_flash_ops_per_cfg = 50;
 
-    // Flash ctrl op randomization knobs.
-    op_readonly_on_info_partition = 0; // Make info partition read-only.
-    op_readonly_on_info1_partition = 0; // Make info1 partition read-only.
+    op_readonly_on_info_partition = 0;
+    op_readonly_on_info1_partition = 0;
 
     op_erase_type_bank_pc = 0;
     op_max_words = 512;
     op_allow_invalid = 1'b0;
 
-    // Poll fifo status before writing to prog_fifo / reading from rd_fifo.
     poll_fifo_status_pc = 30;
+
+    external_cfg = 1'b0;
+
+    check_mem_post_tran = 1'b1;
+
+    prog_timeout_ns = 10_000_000; // 10ms
+
+    erase_timeout_ns = 120_000_000; // 120ms
 
     set_partition_pc();
 


### PR DESCRIPTION
Hi,
This PR includes:
* Removed some forgotten trailing spaces.
* Added some configurations to make it possible to externally configure and activate **flash_ctrl_rand_ops_vseq** by other sequences.
* Changed power_down signal edge creation to be correctly affected by reset in **tb.sv**.

Signed-off-by: Eitan Shapira <eitan.shapira@nuvoton.com>