### PR TITLE
[reggen,dv] Split some long lines in generated UVM code

### DIFF
--- a/util/reggen/uvm_reg_base.sv.tpl
+++ b/util/reggen/uvm_reg_base.sv.tpl
@@ -89,8 +89,11 @@ ${make_ral_pkg_window_class(dv_base_prefix, esc_if_name, window)}
       reg_offset = "{}'h{:x}".format(reg_width, r.offset)
       reg_tags = r.tags
       reg_shadowed = r.shadowed
+
+      type_id_indent = ' ' * (len(reg_name) + 4)
 %>\
-      ${reg_name} = ${gen_dv.rcname(esc_if_name, r)}::type_id::create("${reg_name}");
+      ${reg_name} = (${gen_dv.rcname(esc_if_name, r)}::
+      ${type_id_indent}type_id::create("${reg_name}"));
       ${reg_name}.configure(.blk_parent(this));
       ${reg_name}.build(csr_excl);
       default_map.add_reg(.rg(${reg_name}),
@@ -265,8 +268,10 @@ ${_create_reg_field(dv_base_prefix, reg_width, reg_block_path, reg.shadowed, reg
 %>\
       add_update_err_alert("${reg.update_err_alert}");
       add_storage_err_alert("${reg.storage_err_alert}");
-      add_hdl_path_slice("${shadowed_reg_path}.committed_reg.q", 0, ${bit_idx}, 0, "BkdrRegPathRtlCommitted");
-      add_hdl_path_slice("${shadowed_reg_path}.shadow_reg.q", 0, ${bit_idx}, 0, "BkdrRegPathRtlShadow");
+      add_hdl_path_slice("${shadowed_reg_path}.committed_reg.q",
+                         0, ${bit_idx}, 0, "BkdrRegPathRtlCommitted");
+      add_hdl_path_slice("${shadowed_reg_path}.shadow_reg.q",
+                         0, ${bit_idx}, 0, "BkdrRegPathRtlShadow");
 % endif
 % if is_ext:
       set_is_ext_reg(1);
@@ -310,8 +315,10 @@ ${_create_reg_field(dv_base_prefix, reg_width, reg_block_path, reg.shadowed, reg
   field_tags = field.tags
 
   fname = field.name.lower()
+  type_id_indent = ' ' * (len(fname) + 4)
 %>\
-      ${fname} = ${dv_base_prefix}_reg_field::type_id::create("${fname}");
+      ${fname} = (${dv_base_prefix}_reg_field::
+      ${type_id_indent}type_id::create("${fname}"));
       ${fname}.configure(
         .parent(this),
         .size(${field_size}),
@@ -327,13 +334,17 @@ ${_create_reg_field(dv_base_prefix, reg_width, reg_block_path, reg.shadowed, reg
        field.swaccess.swrd() == SwRdAccess.RD and\
        not field.swaccess.allows_write())):
       // constant reg
-      add_hdl_path_slice("${reg_block_path}.${reg_field_name}_qs", ${field.bits.lsb}, ${field_size}, 0, "BkdrRegPathRtl");
+      add_hdl_path_slice("${reg_block_path}.${reg_field_name}_qs",
+                         ${field.bits.lsb}, ${field_size}, 0, "BkdrRegPathRtl");
 % else:
-      add_hdl_path_slice("${reg_block_path}.u_${reg_field_name}.q${"s" if hwext else ""}", ${field.bits.lsb}, ${field_size}, 0, "BkdrRegPathRtl");
+      add_hdl_path_slice("${reg_block_path}.u_${reg_field_name}.q${"s" if hwext else ""}",
+                         ${field.bits.lsb}, ${field_size}, 0, "BkdrRegPathRtl");
 % endif
 % if shadowed and not hwext:
-      add_hdl_path_slice("${reg_block_path}.u_${reg_field_name}.committed_reg.q", ${field.bits.lsb}, ${field_size}, 0, "BkdrRegPathRtlCommitted");
-      add_hdl_path_slice("${reg_block_path}.u_${reg_field_name}.shadow_reg.q", ${field.bits.lsb}, ${field_size}, 0, "BkdrRegPathRtlShadow");
+      add_hdl_path_slice("${reg_block_path}.u_${reg_field_name}.committed_reg.q",
+                         ${field.bits.lsb}, ${field_size}, 0, "BkdrRegPathRtlCommitted");
+      add_hdl_path_slice("${reg_block_path}.u_${reg_field_name}.shadow_reg.q",
+                         ${field.bits.lsb}, ${field_size}, 0, "BkdrRegPathRtlShadow");
 % endif
 % if field_tags:
       // create field tags

--- a/util/topgen/top_uvm_reg.sv.tpl
+++ b/util/topgen/top_uvm_reg.sv.tpl
@@ -126,13 +126,18 @@ ${make_ral_pkg_window_class(dv_base_prefix, 'chip', window)}
         qual_if_name = (inst_name, if_name)
         base_addr = top.if_addrs[qual_if_name]
         base_addr_txt = sv_base_addr(top, qual_if_name)
+
+        hpr_indent = (len(if_inst) + len('.set_hdl_path_root(')) * ' '
 %>\
       ${if_inst} = ${bcname(esc_if_name)}::type_id::create("${if_inst}");
       ${if_inst}.configure(.parent(this));
       ${if_inst}.build(.base_addr(base_addr + ${base_addr_txt}), .csr_excl(csr_excl));
-      ${if_inst}.set_hdl_path_root("${hdl_path}", "BkdrRegPathRtl");
-      ${if_inst}.set_hdl_path_root("${hdl_path}", "BkdrRegPathRtlCommitted");
-      ${if_inst}.set_hdl_path_root("${hdl_path}", "BkdrRegPathRtlShadow");
+      ${if_inst}.set_hdl_path_root("${hdl_path}",
+      ${hpr_indent}"BkdrRegPathRtl");
+      ${if_inst}.set_hdl_path_root("${hdl_path}",
+      ${hpr_indent}"BkdrRegPathRtlCommitted");
+      ${if_inst}.set_hdl_path_root("${hdl_path}",
+      ${hpr_indent}"BkdrRegPathRtlShadow");
       default_map.add_submap(.child_map(${if_inst}.default_map),
                              .offset(base_addr + ${base_addr_txt}));
 %     endfor


### PR DESCRIPTION
In order to get a proper "longlines" check in CI, it would be nice to
drop the current Verible configuration from 150 characters down to
100, to match AscentLint. Since we use that for DV code as well as
RTL, we there are a few other places that need tidying up.

This patch avoids the long lines in the generated UVM code, such as
chip_ral_pkg.sv.
