### PR TITLE
[flash_ctrl,dv] Reformat macro declarations in testbench

### DIFF
--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -90,11 +90,13 @@ module tb;
   // -----------------------------------
   //
 
-  `define FLASH_DATA_MEM_HIER(i) \
-      dut.u_flash_eflash.u_flash.gen_generic.u_impl_generic.gen_prim_flash_banks[``i``].u_prim_flash_bank.u_mem
-  `define FLASH_INFO_MEM_HIER(i, j) \
-        dut.u_flash_eflash.u_flash.gen_generic.u_impl_generic.gen_prim_flash_banks[``i``].u_prim_flash_bank.gen_info_types[``j``].u_info_mem
+  `define FLASH_DATA_MEM_HIER(i)                                              \
+      dut.u_flash_eflash.u_flash.gen_generic.u_impl_generic.                  \
+      gen_prim_flash_banks[i].u_prim_flash_bank.u_mem
 
+  `define FLASH_INFO_MEM_HIER(i, j)                                           \
+      dut.u_flash_eflash.u_flash.gen_generic.u_impl_generic.                  \
+      gen_prim_flash_banks[i].u_prim_flash_bank.gen_info_types[j].u_info_mem
 
   for (genvar i = 0; i < flash_ctrl_pkg::NumBanks; i++) begin : gen_mem_bkdr_if_i
 


### PR DESCRIPTION
These ended up longer than 100 characters, which isn't allowed by the
style guide (a check that we're working towards enforcing in CI).
Break into multiple lines.

Also, remove some unused \`\` \`\` characters. These would be needed if we
were pasting together macro arguments to make an identifier, but here
"i" and "j" are complete well-formed expressions.
