### PR TITLE
Update lowrisc_ibex to lowRISC/ibex@53926b5f

### DIFF
--- a/hw/vendor/lowrisc_ibex.lock.hjson
+++ b/hw/vendor/lowrisc_ibex.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/ibex.git
-    rev: 5c60b094fe550cde031b7d544a5a1791e7403a22
+    rev: 53926b5fb9713cf1dcad340b7414ae54aa86909f
   }
 }

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_tracer.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_tracer.sv
@@ -117,7 +117,8 @@ module ibex_tracer (
 
       $display("%m: Writing execution trace to %s", file_name);
       file_handle = $fopen(file_name, "w");
-      $fwrite(file_handle, "Time\tCycle\tPC\tInsn\tDecoded instruction\tRegister and memory contents\n");
+      $fwrite(file_handle,
+              "Time\tCycle\tPC\tInsn\tDecoded instruction\tRegister and memory contents\n");
     end
 
     // Write compressed instructions as four hex digits (16 bit word), and
@@ -128,7 +129,8 @@ module ibex_tracer (
       rvfi_insn_str = $sformatf("%h", rvfi_insn);
     end
 
-    $fwrite(file_handle, "%15t\t%d\t%h\t%s\t%s\t", $time, cycle, rvfi_pc_rdata, rvfi_insn_str, decoded_str);
+    $fwrite(file_handle, "%15t\t%d\t%h\t%s\t%s\t",
+            $time, cycle, rvfi_pc_rdata, rvfi_insn_str, decoded_str);
 
     if ((data_accessed & RS1) != 0) begin
       $fwrite(file_handle, " %s:0x%08x", reg_addr_to_str(rvfi_rs1_addr), rvfi_rs1_rdata);
@@ -489,7 +491,8 @@ module ibex_tracer (
     branch_target = rvfi_pc_rdata + imm;
 
     data_accessed = RS1 | RS2 | RD;
-    decoded_str = $sformatf("%s\tx%0d,x%0d,%0x", mnemonic, rvfi_rs1_addr, rvfi_rs2_addr, branch_target);
+    decoded_str = $sformatf("%s\tx%0d,x%0d,%0x",
+                            mnemonic, rvfi_rs1_addr, rvfi_rs2_addr, branch_target);
   endfunction
 
   function automatic void decode_csr_insn(input string mnemonic);
@@ -502,9 +505,11 @@ module ibex_tracer (
 
     if (!rvfi_insn[14]) begin
       data_accessed |= RS1;
-      decoded_str = $sformatf("%s\tx%0d,%s,x%0d", mnemonic, rvfi_rd_addr, csr_name, rvfi_rs1_addr);
+      decoded_str = $sformatf("%s\tx%0d,%s,x%0d",
+                              mnemonic, rvfi_rd_addr, csr_name, rvfi_rs1_addr);
     end else begin
-      decoded_str = $sformatf("%s\tx%0d,%s,%0d", mnemonic, rvfi_rd_addr, csr_name, { 27'b0, rvfi_insn[19:15]});
+      decoded_str = $sformatf("%s\tx%0d,%s,%0d",
+                              mnemonic, rvfi_rd_addr, csr_name, {27'b0, rvfi_insn[19:15]});
     end
   endfunction
 
@@ -695,8 +700,11 @@ module ibex_tracer (
     if (!rvfi_insn[14]) begin
       // regular store
       data_accessed = RS1 | RS2 | MEM;
-      decoded_str = $sformatf("%s\tx%0d,%0d(x%0d)", mnemonic, rvfi_rs2_addr,
-                      $signed({ {20 {rvfi_insn[31]}}, rvfi_insn[31:25], rvfi_insn[11:7] }), rvfi_rs1_addr);
+      decoded_str = $sformatf("%s\tx%0d,%0d(x%0d)",
+                              mnemonic,
+                              rvfi_rs2_addr,
+                              $signed({{20{rvfi_insn[31]}}, rvfi_insn[31:25], rvfi_insn[11:7]}),
+                              rvfi_rs1_addr);
     end else begin
       decode_mnemonic("INVALID");
     end

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_tracer_pkg.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_tracer_pkg.sv
@@ -263,12 +263,12 @@ parameter logic [31:0] INSN_CLMULR = {7'b0000101, 10'h?, 3'b010, 5'h?, {OPCODE_O
 parameter logic [31:0] INSN_CLMULH = {7'b0000101, 10'h?, 3'b011, 5'h?, {OPCODE_OP} };
 
 // ZBR
-parameter logic [31:0] INSN_CRC32_B  = {7'b0110000, 5'b10000, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CRC32_H  = {7'b0110000, 5'b10001, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CRC32_W  = {7'b0110000, 5'b10010, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CRC32C_B = {7'b0110000, 5'b11000, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CRC32C_H = {7'b0110000, 5'b11001, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CRC32C_W = {7'b0110000, 5'b11010, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CRC32_B  = {7'b0110000, 5'b10000, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CRC32_H  = {7'b0110000, 5'b10001, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CRC32_W  = {7'b0110000, 5'b10010, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CRC32C_B = {7'b0110000, 5'b11000, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CRC32C_H = {7'b0110000, 5'b11001, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CRC32C_W = {7'b0110000, 5'b11010, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
 
 // LOAD & STORE
 parameter logic [31:0] INSN_LOAD    = {25'h?,                            {OPCODE_LOAD } };


### PR DESCRIPTION
This is to get all our vendored code below 100 characters (I updated our synthesized RTL with a vendoring commit yesterday, but it turns out that DV code also depends on the Ibex tracer, which also had overly long lines).

Update code from upstream repository
https://github.com/lowRISC/ibex.git to revision
53926b5fb9713cf1dcad340b7414ae54aa86909f

* [rtl] Break long lines in Ibex tracer (Rupert Swarbrick)
