### PR TITLE
[otbn] Implement error prioritization

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -201,6 +201,10 @@
           name: "fatal_reg"
           desc: "A fatal failure was seen on a GPR or WDR read."
         }
+        { bits: "8",
+          name: "fatal_bad_err"
+          desc: "A combination of error bits that cannot occur was seen."
+        }
       ]
     } // register : err_bits
     { name: "START_ADDR",

--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -490,6 +490,35 @@ The error that caused the alert can be determined by reading the {{< regref "FAT
 If OTBN was running, this value will also be reflected in the {{< regref "ERR_BITS" >}} register.
 A fatal alert can only be cleared by resetting OTBN through the `rst_ni` line.
 
+
+### Error Prioritization
+
+OTBN can signal multiple errors at once, by setting multiple bits of {{< regref "ERR_BITS" >}}.
+There are some scenarios where one error takes priority over another.
+In these scenarios the higher priority error will suppress some other errors.
+
+* Any error that produces a fatal alert will suppress all non fatal errors.
+* Any `call_stack` error that occurs due to a pop will suppress:
+  - `bad_data_addr`
+  - `bad_insn_addr`
+  - `loop`
+* Any `illegal_insn` error will suppress:
+  - `bad_data_addr`
+  - `bad_insn_addr`
+  - `call_stack`
+  - `loop`
+
+(See {{< regref "ERR_BITS" >}} for the error meanings).
+
+Some combinations of error bits **cannot occur** in a correctly functioning OTBN implementation.
+Should these combinations be observed the `fatal_bad_err` bit in {{< regref "ERR_BITS" >}} will be set, producing a fatal alert.
+The check for invalid combinations occurs internally, before error suppression.
+When `fatal_bad_err` is set the non-fatal error bits that produced the invalid combinations will be suppressed.
+
+{{< regref "ERR_BITS" >}} combinations that **cannot occur** are any that include the following set bits:
+* `loop` and `bad_data_addr`
+* `call_stack` (on push) and `bad_data_addr`
+
 ### Idle
 
 OTBN exposes a single-bit `idle_o` signal, intended to be used by the clock manager to clock-gate the block when it is not in use.

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -126,8 +126,8 @@ module otbn_core_model
     end
   end
 
-  assign err_bits_o = raw_err_bits_q[7:0];
-  assign unused_raw_err_bits = ^raw_err_bits_q[31:8];
+  assign err_bits_o = raw_err_bits_q[8:0];
+  assign unused_raw_err_bits = ^raw_err_bits_q[31:9];
 
   // Track negedges of running_q and expose that as a "done" output.
   bit running_r = 1'b0;

--- a/hw/ip/otbn/dv/otbnsim/sim/err_bits.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/err_bits.py
@@ -13,3 +13,4 @@ LOOP = 1 << 4
 FATAL_IMEM = 1 << 5
 FATAL_DMEM = 1 << 6
 FATAL_REG = 1 << 7
+FATAL_BAD_ERR = 1 << 8

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -436,6 +436,9 @@ module otbn
   assign hw2reg.err_bits.fatal_reg.de = done;
   assign hw2reg.err_bits.fatal_reg.d = err_bits.fatal_reg;
 
+  assign hw2reg.err_bits.fatal_bad_err.de = done;
+  assign hw2reg.err_bits.fatal_bad_err.d = err_bits.fatal_bad_err;
+
   // START_ADDR register
   assign start_addr = reg2hw.start_addr.q[ImemAddrWidth-1:0];
   logic [top_pkg::TL_DW-ImemAddrWidth-1:0] unused_start_addr_bits;

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -35,6 +35,9 @@ package otbn_pkg;
   // Width of entropy input
   parameter int EdnDataWidth = 256;
 
+  // Index of base register that accesses the call stack
+  parameter int unsigned CallStackGprIndex = 1;
+
 
   // Toplevel constants ============================================================================
 
@@ -50,8 +53,10 @@ package otbn_pkg;
   // Error bits
   //
   // Note: These errors are duplicated in the register HJSON (../data/otbn.hjson), the ISS
-  // (../dv/otbnsim/sim/alert.py), and the DIF. If updating them here, update those too.
+  // (../dv/otbnsim/sim/err_bits.py), the DIF and the OTBN IP top level (otbn.sv). If updating them
+  // here, update those too.
   typedef struct packed {
+    logic fatal_bad_err;
     logic fatal_reg;
     logic fatal_dmem;
     logic fatal_imem;

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -91,6 +91,10 @@ package otbn_reg_pkg;
       logic        d;
       logic        de;
     } fatal_reg;
+    struct packed {
+      logic        d;
+      logic        de;
+    } fatal_bad_err;
   } otbn_hw2reg_err_bits_reg_t;
 
   typedef struct packed {
@@ -124,9 +128,9 @@ package otbn_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    otbn_hw2reg_intr_state_reg_t intr_state; // [26:25]
-    otbn_hw2reg_status_reg_t status; // [24:24]
-    otbn_hw2reg_err_bits_reg_t err_bits; // [23:8]
+    otbn_hw2reg_intr_state_reg_t intr_state; // [28:27]
+    otbn_hw2reg_status_reg_t status; // [26:26]
+    otbn_hw2reg_err_bits_reg_t err_bits; // [25:8]
     otbn_hw2reg_fatal_alert_cause_reg_t fatal_alert_cause; // [7:0]
   } otbn_hw2reg_t;
 
@@ -177,7 +181,7 @@ package otbn_reg_pkg;
     4'b 0001, // index[3] OTBN_ALERT_TEST
     4'b 0001, // index[4] OTBN_CMD
     4'b 0001, // index[5] OTBN_STATUS
-    4'b 0001, // index[6] OTBN_ERR_BITS
+    4'b 0011, // index[6] OTBN_ERR_BITS
     4'b 1111, // index[7] OTBN_START_ADDR
     4'b 0001  // index[8] OTBN_FATAL_ALERT_CAUSE
   };

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -181,6 +181,7 @@ module otbn_reg_top (
   logic err_bits_fatal_imem_qs;
   logic err_bits_fatal_dmem_qs;
   logic err_bits_fatal_reg_qs;
+  logic err_bits_fatal_bad_err_qs;
   logic [31:0] start_addr_wd;
   logic start_addr_we;
   logic fatal_alert_cause_bus_integrity_error_qs;
@@ -525,6 +526,31 @@ module otbn_reg_top (
   );
 
 
+  //   F[fatal_bad_err]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_err_bits_fatal_bad_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.err_bits.fatal_bad_err.de),
+    .d      (hw2reg.err_bits.fatal_bad_err.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_bits_fatal_bad_err_qs)
+  );
+
+
   // R[start_addr]: V(False)
 
   prim_subreg #(
@@ -746,6 +772,7 @@ module otbn_reg_top (
         reg_rdata_next[5] = err_bits_fatal_imem_qs;
         reg_rdata_next[6] = err_bits_fatal_dmem_qs;
         reg_rdata_next[7] = err_bits_fatal_reg_qs;
+        reg_rdata_next[8] = err_bits_fatal_bad_err_qs;
       end
 
       addr_hit[7]: begin

--- a/hw/ip/otbn/rtl/otbn_rf_base.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_base.sv
@@ -17,7 +17,7 @@
  * Features:
  * - 2 read ports
  * - 1 write port
- * - special purpose stack on a single register (localparam `CallStackRegIndex`)
+ * - special purpose stack on a single register (otbn_pkg.sv parameter `CallStackGprIndex`)
  *   for use as a call stack
  */
 module otbn_rf_base
@@ -46,7 +46,6 @@ module otbn_rf_base
 
   output logic         call_stack_err_o
 );
-  localparam int unsigned CallStackRegIndex = 1;
   localparam int unsigned CallStackDepth = 8;
 
   // The stack implementation is shared between FF and FPGA implementations,
@@ -69,14 +68,14 @@ module otbn_rf_base
   logic [31:0] stack_data;
   logic        stack_data_valid;
 
-  assign pop_stack_a    = rd_en_a_i & (rd_addr_a_i == CallStackRegIndex[4:0]);
-  assign pop_stack_b    = rd_en_b_i & (rd_addr_b_i == CallStackRegIndex[4:0]);
+  assign pop_stack_a    = rd_en_a_i & (rd_addr_a_i == CallStackGprIndex[4:0]);
+  assign pop_stack_b    = rd_en_b_i & (rd_addr_b_i == CallStackGprIndex[4:0]);
   // pop_stack_reqd indicates a call stack pop is requested and pop_stack commands it to happen.
   assign pop_stack_reqd = (pop_stack_a | pop_stack_b);
   assign pop_stack      = rd_commit_i & pop_stack_reqd;
 
   // push_stack_reqd indicates a call stack push is requested and push_stack commands it to happen.
-  assign push_stack_reqd = wr_en_i & (wr_addr_i == CallStackRegIndex[4:0]);
+  assign push_stack_reqd = wr_en_i & (wr_addr_i == CallStackGprIndex[4:0]);
   assign push_stack      = wr_commit_i & push_stack_reqd;
 
   assign call_stack_err_o =

--- a/sw/device/lib/dif/dif_otbn.h
+++ b/sw/device/lib/dif/dif_otbn.h
@@ -88,7 +88,9 @@ typedef enum dif_otbn_err_bits {
   /** Error seen in Dmem read */
   kDifOtbnErrBitsFatalDmem = (1 << 6),
   /** Error seen in RF read */
-  kDifOtbnErrBitsFatalReg = (1 << 7)
+  kDifOtbnErrBitsFatalReg = (1 << 7),
+  /** Combination of error bits that cannot occur was seen */
+  kDifOtbnErrBitsFatalBadErr = (1 << 8)
 } dif_otbn_err_bits_t;
 
 /**


### PR DESCRIPTION
See https://github.com/lowRISC/opentitan/issues/5445 for a bit more background

Where there are multiple errors, some are suppressed as their presence
may depend upon undefined data or overly complex conditions.

In addition a new `fatal_bad_err` is introduced. This is signalled where
the raw error bits present a combination that cannot be seen in a
correctly functioning OTBN implementation.

Fixes #4996

Signed-off-by: Greg Chadwick <gac@lowrisc.org>