### PR TITLE
[rom_ctrl] Change the meaning of SkipCheck

### DIFF
--- a/hw/ip/rom_ctrl/data/rom_ctrl.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl.hjson
@@ -122,6 +122,11 @@
               desc: "32 bits of the digest"
             }
           ]
+          // TODO: We're disabling CSR checks for this register for now, since
+          //       its value will change under the feet of the CSR package as
+          //       the ROM checker computes a digest. Re-enable this (and add
+          //       RAL reflection) once we have a working testbench.
+          tags: ["excl:CsrNonInitTests:CsrExclCheck"]
         }
       }
       {
@@ -139,6 +144,8 @@
               desc: "32 bits of the digest"
             }
           ]
+          // TODO: As with DIGEST, re-enable this when we have a working testbench
+          tags: ["excl:CsrNonInitTests:CsrExclCheck"]
         }
       }
     ],

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_compare.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_compare.sv
@@ -17,7 +17,8 @@
 `include "prim_assert.sv"
 
 module rom_ctrl_compare #(
-  parameter int NumWords = 2
+  parameter int NumWords = 2,
+  parameter bit SkipCheck = 1'b1
 ) (
   input logic                        clk_i,
   input logic                        rst_ni,
@@ -146,7 +147,7 @@ module rom_ctrl_compare #(
   assign matches_d = matches_q && (digest_word == exp_digest_word);
 
   assign done_o = (state_q == Done);
-  assign good_o = matches_q;
+  assign good_o = matches_q | SkipCheck;
 
   assign alert_o = fsm_alert | start_alert | wait_addr_alert | done_addr_alert;
 

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
@@ -212,9 +212,9 @@ module rom_ctrl_fsm
   assign rel_addr_wide = counter_addr - TopStartAddr;
   assign rel_addr = rel_addr_wide[TAW-1:0];
 
-  // The top bits of rel_addr_wide should always be zero (because TAW bits should be enough to
-  // encode the difference between counter_addr and TopStartAddr)
-  `ASSERT(RelAddrWide_A, ~|rel_addr_wide[AW-1:TAW])
+  // The top bits of rel_addr_wide should always be zero if we're reading the top bits (because TAW
+  // bits should be enough to encode the difference between counter_addr and TopStartAddr)
+  `ASSERT(RelAddrWide_A, exp_digest_vld_o |-> ~|rel_addr_wide[AW-1:TAW])
   logic unused_top_rel_addr_wide;
   assign unused_top_rel_addr_wide = |rel_addr_wide[AW-1:TAW];
 

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
@@ -10,7 +10,8 @@ module rom_ctrl_fsm
   import prim_util_pkg::vbits;
 #(
   parameter int RomDepth = 16,
-  parameter int TopCount = 8
+  parameter int TopCount = 8,
+  parameter bit SkipCheck = 1'b0
 ) (
   input logic                        clk_i,
   input logic                        rst_ni,
@@ -80,16 +81,17 @@ module rom_ctrl_fsm
   logic start_checker_q;
   logic checker_done, checker_good, checker_alert;
   rom_ctrl_compare #(
-    .NumWords (TopCount)
+    .NumWords  (TopCount),
+    .SkipCheck (SkipCheck)
   ) u_compare (
-    .clk_i         (clk_i),
-    .rst_ni        (rst_ni),
-    .start_i       (start_checker_q),
-    .done_o        (checker_done),
-    .good_o        (checker_good),
-    .digest_i      (digest_i),
-    .exp_digest_i  (exp_digest_i),
-    .alert_o       (checker_alert)
+    .clk_i        (clk_i),
+    .rst_ni       (rst_ni),
+    .start_i      (start_checker_q),
+    .done_o       (checker_done),
+    .good_o       (checker_good),
+    .digest_i     (digest_i),
+    .exp_digest_i (exp_digest_i),
+    .alert_o      (checker_alert)
   );
 
   // Main FSM

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
@@ -208,7 +208,7 @@ module rom_ctrl_fsm
   logic [AW-1:0] rel_addr_wide;
   logic [TAW-1:0] rel_addr;
 
-  assign reading_top = (state_q == ReadingHigh || state_q == KmacAhead);
+  assign reading_top = (state_q == ReadingHigh || state_q == KmacAhead) & ~counter_done;
   assign rel_addr_wide = counter_addr - TopStartAddr;
   assign rel_addr = rel_addr_wide[TAW-1:0];
 


### PR DESCRIPTION
This flag originally disabled the initial ROM check. The point was to
allow pwrmgr integration to happen after the code was merged. This
integration is now done, but there are several other integration
changes that aren't yet done:

  - KMAC doesn't yet signal rdy on its app interface (this seems to
    expect a key input, which doesn't make sense for the cSHAKE
    computation we want to do: probably a bit of proper re-work needed
    before this will work.

  - We don't yet have a sensible expected hash stored in the ROM.

If SkipCheck is set, we fake up the connections to KMAC, so that it
always looks like KMAC is ready for ROM data (but don't actually pass
anything through). We then fake things up so that it looks like KMAC
has immediately responded.

Finally, we force the comparison with the expected hash to always look
like it succeeded.

Once KMAC integration is done, we can remove the hacks on the KMAC
connection and sort out the ROM scrambling script to put something
sensible in the top 8 words. When *that* is done, we can remove
SkipCheck entirely.

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>