### PR TITLE
[freestanding] Add assert.h

### DIFF
--- a/doc/rm/c_cpp_coding_style.md
+++ b/doc/rm/c_cpp_coding_style.md
@@ -347,6 +347,11 @@ typedef enum my_wonderful_option {
 } my_wonderful_option_t;
 ```
 
+### C-specific Keywords
+
+C11 introduces a number of undescore-prefixed keywords, such as `_Static_assert`, `_Bool`, and `_Noreturn`, which do not have a C++ counterpart.
+These should be avoided in preference for macros that wrap them, such as `static_assert`, `bool`, and `noreturn`.
+
 ### Preprocessor Macros
 
 Macros are often necessary and reasonable coding practice C (as opposed to C++) projects.

--- a/sw/device/lib/base/freestanding/assert.h
+++ b/sw/device/lib/base/freestanding/assert.h
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_FREESTANDING_ASSERT_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_FREESTANDING_ASSERT_H_
+
+/**
+ * @file
+ * @brief C library diagnostics
+ *
+ * This header implements the assert.h standard header, specified in S7.2 of
+ * C11.
+ *
+ * While not required by S4p6 as part of freestanding C, this file is useful
+ * because it gives us a consistent spelling of `static_assert` across C and
+ * C++. `assert` should not be used in device code.
+ */
+
+// Note that `static_assert` is a C++ keyword, so we only need this to be
+// defined for C.
+#ifndef __cplusplus
+#define static_assert _Static_assert
+#endif  // __cplusplus
+
+// `assert()` should not be used. When building with Clang, using this function
+// in device code will emit a compile-time error.
+#define assert(do_not_use) \
+  static_assert(false, "do not use assert(); use CHECK() instead")
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_FREESTANDING_ASSERT_H_

--- a/sw/device/lib/dif/dif_alert_handler.c
+++ b/sw/device/lib/dif/dif_alert_handler.c
@@ -4,16 +4,18 @@
 
 #include "sw/device/lib/dif/dif_alert_handler.h"
 
+#include <assert.h>
+
 #include "sw/device/lib/base/bitfield.h"
 
 #include "alert_handler_regs.h"  // Generated.
 
-_Static_assert(ALERT_HANDLER_PARAM_N_CLASSES == 4,
-               "Expected four alert classes!");
-_Static_assert(ALERT_HANDLER_PARAM_N_ESC_SEV == 4,
-               "Expected four escalation signals!");
-_Static_assert(ALERT_HANDLER_PARAM_N_PHASES == 4,
-               "Expected four escalation phases!");
+static_assert(ALERT_HANDLER_PARAM_N_CLASSES == 4,
+              "Expected four alert classes!");
+static_assert(ALERT_HANDLER_PARAM_N_ESC_SEV == 4,
+              "Expected four escalation signals!");
+static_assert(ALERT_HANDLER_PARAM_N_PHASES == 4,
+              "Expected four escalation phases!");
 
 dif_alert_handler_result_t dif_alert_handler_init(
     dif_alert_handler_params_t params, dif_alert_handler_t *handler) {

--- a/sw/device/lib/dif/dif_aon_timer.c
+++ b/sw/device/lib/dif/dif_aon_timer.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/dif/dif_aon_timer.h"
 
+#include <assert.h>
 #include <stddef.h>
 
 #include "sw/device/lib/base/bitfield.h"
@@ -11,12 +12,12 @@
 
 #include "aon_timer_regs.h"  // Generated.
 
-_Static_assert(AON_TIMER_INTR_STATE_WKUP_TIMER_EXPIRED_BIT ==
-                   AON_TIMER_INTR_TEST_WKUP_TIMER_EXPIRED_BIT,
-               "Wake-up IRQ have different indexes in different registers!");
-_Static_assert(AON_TIMER_INTR_STATE_WDOG_TIMER_EXPIRED_BIT ==
-                   AON_TIMER_INTR_TEST_WDOG_TIMER_EXPIRED_BIT,
-               "Watchdog IRQ have different indexes in different registers!");
+static_assert(AON_TIMER_INTR_STATE_WKUP_TIMER_EXPIRED_BIT ==
+                  AON_TIMER_INTR_TEST_WKUP_TIMER_EXPIRED_BIT,
+              "Wake-up IRQ have different indexes in different registers!");
+static_assert(AON_TIMER_INTR_STATE_WDOG_TIMER_EXPIRED_BIT ==
+                  AON_TIMER_INTR_TEST_WDOG_TIMER_EXPIRED_BIT,
+              "Watchdog IRQ have different indexes in different registers!");
 
 const size_t kAonTimerWakeupIrqIndex =
     AON_TIMER_INTR_STATE_WKUP_TIMER_EXPIRED_BIT;

--- a/sw/device/lib/dif/dif_keymgr.c
+++ b/sw/device/lib/dif/dif_keymgr.c
@@ -4,6 +4,8 @@
 
 #include "sw/device/lib/dif/dif_keymgr.h"
 
+#include <assert.h>
+
 #include "keymgr_regs.h"  // Generated.
 
 /**
@@ -11,110 +13,110 @@
  * SW_SHARE1_OUTPUT_N registers must be contiguous to be able to use
  * `mmio_region_memcpy_to/from_mmio32()`.
  */
-_Static_assert(KEYMGR_SW_BINDING_1_REG_OFFSET ==
-                   KEYMGR_SW_BINDING_0_REG_OFFSET + 4,
-               "SW_BINDING_N registers must be contiguous.");
-_Static_assert(KEYMGR_SW_BINDING_2_REG_OFFSET ==
-                   KEYMGR_SW_BINDING_0_REG_OFFSET + 8,
-               "SW_BINDING_N registers must be contiguous.");
-_Static_assert(KEYMGR_SW_BINDING_3_REG_OFFSET ==
-                   KEYMGR_SW_BINDING_0_REG_OFFSET + 12,
-               "SW_BINDING_N registers must be contiguous.");
+static_assert(KEYMGR_SW_BINDING_1_REG_OFFSET ==
+                  KEYMGR_SW_BINDING_0_REG_OFFSET + 4,
+              "SW_BINDING_N registers must be contiguous.");
+static_assert(KEYMGR_SW_BINDING_2_REG_OFFSET ==
+                  KEYMGR_SW_BINDING_0_REG_OFFSET + 8,
+              "SW_BINDING_N registers must be contiguous.");
+static_assert(KEYMGR_SW_BINDING_3_REG_OFFSET ==
+                  KEYMGR_SW_BINDING_0_REG_OFFSET + 12,
+              "SW_BINDING_N registers must be contiguous.");
 // TODO: Uncomment when lowRISC/opentitan#5194 is completed.
 // TODO: Consider defining a macro once all assertions are enabled.
-//_Static_assert(KEYMGR_SW_BINDING_4_REG_OFFSET ==
+// static_assert(KEYMGR_SW_BINDING_4_REG_OFFSET ==
 //                   KEYMGR_SW_BINDING_0_REG_OFFSET + 16,
 //               "SW_BINDING_N registers must be contiguous.");
-//_Static_assert(KEYMGR_SW_BINDING_5_REG_OFFSET ==
+// static_assert(KEYMGR_SW_BINDING_5_REG_OFFSET ==
 //                   KEYMGR_SW_BINDING_0_REG_OFFSET + 20,
 //               "SW_BINDING_N registers must be contiguous.");
-//_Static_assert(KEYMGR_SW_BINDING_6_REG_OFFSET ==
+// static_assert(KEYMGR_SW_BINDING_6_REG_OFFSET ==
 //                   KEYMGR_SW_BINDING_0_REG_OFFSET + 24,
 //               "SW_BINDING_N registers must be contiguous.");
-//_Static_assert(KEYMGR_SW_BINDING_7_REG_OFFSET ==
+// static_assert(KEYMGR_SW_BINDING_7_REG_OFFSET ==
 //                   KEYMGR_SW_BINDING_0_REG_OFFSET + 28,
 //               "SW_BINDING_N registers must be contiguous.");
 
-_Static_assert(KEYMGR_SALT_1_REG_OFFSET == KEYMGR_SALT_0_REG_OFFSET + 4,
-               "SALT_N registers must be contiguous.");
-_Static_assert(KEYMGR_SALT_2_REG_OFFSET == KEYMGR_SALT_0_REG_OFFSET + 8,
-               "SALT_N registers must be contiguous.");
-_Static_assert(KEYMGR_SALT_3_REG_OFFSET == KEYMGR_SALT_0_REG_OFFSET + 12,
-               "SALT_N registers must be contiguous.");
+static_assert(KEYMGR_SALT_1_REG_OFFSET == KEYMGR_SALT_0_REG_OFFSET + 4,
+              "SALT_N registers must be contiguous.");
+static_assert(KEYMGR_SALT_2_REG_OFFSET == KEYMGR_SALT_0_REG_OFFSET + 8,
+              "SALT_N registers must be contiguous.");
+static_assert(KEYMGR_SALT_3_REG_OFFSET == KEYMGR_SALT_0_REG_OFFSET + 12,
+              "SALT_N registers must be contiguous.");
 // TODO: Uncomment when lowRISC/opentitan#5194 is completed.
-//_Static_assert(KEYMGR_SALT_4_REG_OFFSET ==
+// static_assert(KEYMGR_SALT_4_REG_OFFSET ==
 //                   KEYMGR_SALT_0_REG_OFFSET + 16,
 //               "SALT_N registers must be contiguous.");
-//_Static_assert(KEYMGR_SALT_5_REG_OFFSET ==
+// static_assert(KEYMGR_SALT_5_REG_OFFSET ==
 //                   KEYMGR_SALT_0_REG_OFFSET + 20,
 //               "SALT_N registers must be contiguous.");
-//_Static_assert(KEYMGR_SALT_6_REG_OFFSET ==
+// static_assert(KEYMGR_SALT_6_REG_OFFSET ==
 //                   KEYMGR_SALT_0_REG_OFFSET + 24,
 //               "SALT_N registers must be contiguous.");
-//_Static_assert(KEYMGR_SALT_7_REG_OFFSET ==
+// static_assert(KEYMGR_SALT_7_REG_OFFSET ==
 //                   KEYMGR_SALT_0_REG_OFFSET + 28,
 //               "SALT_N registers must be contiguous.");
 
-_Static_assert(KEYMGR_SW_SHARE0_OUTPUT_1_REG_OFFSET ==
-                   KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 4,
-               "SW_SHARE0_OUTPUT_N registers must be contiguous.");
-_Static_assert(KEYMGR_SW_SHARE0_OUTPUT_2_REG_OFFSET ==
-                   KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 8,
-               "SW_SHARE0_OUTPUT_N registers must be contiguous.");
-_Static_assert(KEYMGR_SW_SHARE0_OUTPUT_3_REG_OFFSET ==
-                   KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 12,
-               "SW_SHARE0_OUTPUT_N registers must be contiguous.");
-_Static_assert(KEYMGR_SW_SHARE0_OUTPUT_4_REG_OFFSET ==
-                   KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 16,
-               "SW_SHARE0_OUTPUT_N registers must be contiguous.");
-_Static_assert(KEYMGR_SW_SHARE0_OUTPUT_5_REG_OFFSET ==
-                   KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 20,
-               "SW_SHARE0_OUTPUT_N registers must be contiguous.");
-_Static_assert(KEYMGR_SW_SHARE0_OUTPUT_6_REG_OFFSET ==
-                   KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 24,
-               "SW_SHARE0_OUTPUT_N registers must be contiguous.");
-_Static_assert(KEYMGR_SW_SHARE0_OUTPUT_7_REG_OFFSET ==
-                   KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 28,
-               "SW_SHARE0_OUTPUT_N registers must be contiguous.");
+static_assert(KEYMGR_SW_SHARE0_OUTPUT_1_REG_OFFSET ==
+                  KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 4,
+              "SW_SHARE0_OUTPUT_N registers must be contiguous.");
+static_assert(KEYMGR_SW_SHARE0_OUTPUT_2_REG_OFFSET ==
+                  KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 8,
+              "SW_SHARE0_OUTPUT_N registers must be contiguous.");
+static_assert(KEYMGR_SW_SHARE0_OUTPUT_3_REG_OFFSET ==
+                  KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 12,
+              "SW_SHARE0_OUTPUT_N registers must be contiguous.");
+static_assert(KEYMGR_SW_SHARE0_OUTPUT_4_REG_OFFSET ==
+                  KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 16,
+              "SW_SHARE0_OUTPUT_N registers must be contiguous.");
+static_assert(KEYMGR_SW_SHARE0_OUTPUT_5_REG_OFFSET ==
+                  KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 20,
+              "SW_SHARE0_OUTPUT_N registers must be contiguous.");
+static_assert(KEYMGR_SW_SHARE0_OUTPUT_6_REG_OFFSET ==
+                  KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 24,
+              "SW_SHARE0_OUTPUT_N registers must be contiguous.");
+static_assert(KEYMGR_SW_SHARE0_OUTPUT_7_REG_OFFSET ==
+                  KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 28,
+              "SW_SHARE0_OUTPUT_N registers must be contiguous.");
 
-_Static_assert(KEYMGR_SW_SHARE1_OUTPUT_1_REG_OFFSET ==
-                   KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 4,
-               "SW_SHARE1_OUTPUT_N registers must be contiguous.");
-_Static_assert(KEYMGR_SW_SHARE1_OUTPUT_2_REG_OFFSET ==
-                   KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 8,
-               "SW_SHARE1_OUTPUT_N registers must be contiguous.");
-_Static_assert(KEYMGR_SW_SHARE1_OUTPUT_3_REG_OFFSET ==
-                   KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 12,
-               "SW_SHARE1_OUTPUT_N registers must be contiguous.");
-_Static_assert(KEYMGR_SW_SHARE1_OUTPUT_4_REG_OFFSET ==
-                   KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 16,
-               "SW_SHARE1_OUTPUT_N registers must be contiguous.");
-_Static_assert(KEYMGR_SW_SHARE1_OUTPUT_5_REG_OFFSET ==
-                   KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 20,
-               "SW_SHARE1_OUTPUT_N registers must be contiguous.");
-_Static_assert(KEYMGR_SW_SHARE1_OUTPUT_6_REG_OFFSET ==
-                   KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 24,
-               "SW_SHARE1_OUTPUT_N registers must be contiguous.");
-_Static_assert(KEYMGR_SW_SHARE1_OUTPUT_7_REG_OFFSET ==
-                   KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 28,
-               "SW_SHARE1_OUTPUT_N registers must be contiguous.");
+static_assert(KEYMGR_SW_SHARE1_OUTPUT_1_REG_OFFSET ==
+                  KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 4,
+              "SW_SHARE1_OUTPUT_N registers must be contiguous.");
+static_assert(KEYMGR_SW_SHARE1_OUTPUT_2_REG_OFFSET ==
+                  KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 8,
+              "SW_SHARE1_OUTPUT_N registers must be contiguous.");
+static_assert(KEYMGR_SW_SHARE1_OUTPUT_3_REG_OFFSET ==
+                  KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 12,
+              "SW_SHARE1_OUTPUT_N registers must be contiguous.");
+static_assert(KEYMGR_SW_SHARE1_OUTPUT_4_REG_OFFSET ==
+                  KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 16,
+              "SW_SHARE1_OUTPUT_N registers must be contiguous.");
+static_assert(KEYMGR_SW_SHARE1_OUTPUT_5_REG_OFFSET ==
+                  KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 20,
+              "SW_SHARE1_OUTPUT_N registers must be contiguous.");
+static_assert(KEYMGR_SW_SHARE1_OUTPUT_6_REG_OFFSET ==
+                  KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 24,
+              "SW_SHARE1_OUTPUT_N registers must be contiguous.");
+static_assert(KEYMGR_SW_SHARE1_OUTPUT_7_REG_OFFSET ==
+                  KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + 28,
+              "SW_SHARE1_OUTPUT_N registers must be contiguous.");
 
 /**
  * Error code constants of `dif_keymgr_status_code_t` are masks for the bits of
  * ERR_CODE register shifted left by 1.
  */
-_Static_assert(kDifKeymgrStatusCodeInvalidOperation >> 1 ==
-                   1 << KEYMGR_ERR_CODE_INVALID_OP_BIT,
-               "Layout of ERR_CODE register changed.");
-_Static_assert(kDifKeymgrStatusCodeInvalidKmacCommand >> 1 ==
-                   1 << KEYMGR_ERR_CODE_INVALID_CMD_BIT,
-               "Layout of ERR_CODE register changed.");
-_Static_assert(kDifKeymgrStatusCodeInvalidKmacInput >> 1 ==
-                   1 << KEYMGR_ERR_CODE_INVALID_KMAC_INPUT_BIT,
-               "Layout of ERR_CODE register changed.");
-_Static_assert(kDifKeymgrStatusCodeInvalidKmacOutput >> 1 ==
-                   1 << KEYMGR_ERR_CODE_INVALID_KMAC_DATA_BIT,
-               "Layout of ERR_CODE register changed.");
+static_assert(kDifKeymgrStatusCodeInvalidOperation >> 1 ==
+                  1 << KEYMGR_ERR_CODE_INVALID_OP_BIT,
+              "Layout of ERR_CODE register changed.");
+static_assert(kDifKeymgrStatusCodeInvalidKmacCommand >> 1 ==
+                  1 << KEYMGR_ERR_CODE_INVALID_CMD_BIT,
+              "Layout of ERR_CODE register changed.");
+static_assert(kDifKeymgrStatusCodeInvalidKmacInput >> 1 ==
+                  1 << KEYMGR_ERR_CODE_INVALID_KMAC_INPUT_BIT,
+              "Layout of ERR_CODE register changed.");
+static_assert(kDifKeymgrStatusCodeInvalidKmacOutput >> 1 ==
+                  1 << KEYMGR_ERR_CODE_INVALID_KMAC_DATA_BIT,
+              "Layout of ERR_CODE register changed.");
 
 /**
  * Checks if the key manager is ready for a new operation, i.e. it is idle and

--- a/sw/device/lib/dif/dif_otbn.c
+++ b/sw/device/lib/dif/dif_otbn.c
@@ -4,29 +4,31 @@
 
 #include "sw/device/lib/dif/dif_otbn.h"
 
+#include <assert.h>
+
 #include "sw/device/lib/base/bitfield.h"
 
 #include "otbn_regs.h"  // Generated.
 
-_Static_assert(kDifOtbnErrBitsBadDataAddr ==
-                   (1 << OTBN_ERR_BITS_BAD_DATA_ADDR_BIT),
-               "Layout of error bits changed.");
-_Static_assert(kDifOtbnErrBitsBadInsnAddr ==
-                   (1 << OTBN_ERR_BITS_BAD_INSN_ADDR_BIT),
-               "Layout of error bits changed.");
-_Static_assert(kDifOtbnErrBitsCallStack == (1 << OTBN_ERR_BITS_CALL_STACK_BIT),
-               "Layout of error bits changed.");
-_Static_assert(kDifOtbnErrBitsIllegalInsn ==
-                   (1 << OTBN_ERR_BITS_ILLEGAL_INSN_BIT),
-               "Layout of error bits changed.");
-_Static_assert(kDifOtbnErrBitsLoop == (1 << OTBN_ERR_BITS_LOOP_BIT),
-               "Layout of error bits changed.");
-_Static_assert(kDifOtbnErrBitsFatalImem == (1 << OTBN_ERR_BITS_FATAL_IMEM_BIT),
-               "Layout of error bits changed.");
-_Static_assert(kDifOtbnErrBitsFatalDmem == (1 << OTBN_ERR_BITS_FATAL_DMEM_BIT),
-               "Layout of error bits changed.");
-_Static_assert(kDifOtbnErrBitsFatalReg == (1 << OTBN_ERR_BITS_FATAL_REG_BIT),
-               "Layout of error bits changed.");
+static_assert(kDifOtbnErrBitsBadDataAddr ==
+                  (1 << OTBN_ERR_BITS_BAD_DATA_ADDR_BIT),
+              "Layout of error bits changed.");
+static_assert(kDifOtbnErrBitsBadInsnAddr ==
+                  (1 << OTBN_ERR_BITS_BAD_INSN_ADDR_BIT),
+              "Layout of error bits changed.");
+static_assert(kDifOtbnErrBitsCallStack == (1 << OTBN_ERR_BITS_CALL_STACK_BIT),
+              "Layout of error bits changed.");
+static_assert(kDifOtbnErrBitsIllegalInsn ==
+                  (1 << OTBN_ERR_BITS_ILLEGAL_INSN_BIT),
+              "Layout of error bits changed.");
+static_assert(kDifOtbnErrBitsLoop == (1 << OTBN_ERR_BITS_LOOP_BIT),
+              "Layout of error bits changed.");
+static_assert(kDifOtbnErrBitsFatalImem == (1 << OTBN_ERR_BITS_FATAL_IMEM_BIT),
+              "Layout of error bits changed.");
+static_assert(kDifOtbnErrBitsFatalDmem == (1 << OTBN_ERR_BITS_FATAL_DMEM_BIT),
+              "Layout of error bits changed.");
+static_assert(kDifOtbnErrBitsFatalReg == (1 << OTBN_ERR_BITS_FATAL_REG_BIT),
+              "Layout of error bits changed.");
 
 /**
  * Data width of big number subset, in bytes.

--- a/sw/device/lib/dif/dif_pwrmgr.c
+++ b/sw/device/lib/dif/dif_pwrmgr.c
@@ -4,6 +4,8 @@
 
 #include "sw/device/lib/dif/dif_pwrmgr.h"
 
+#include <assert.h>
+
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/mmio.h"
 
@@ -21,30 +23,30 @@
  * `PWRMGR_CONTROL_CORE_CLK_EN_BIT` and be in the same order as
  * `dif_pwrmgr_domain_option_t` constants.
  */
-_Static_assert(kDifPwrmgrDomainOptionCoreClockInLowPower ==
-                   (1u << (PWRMGR_CONTROL_CORE_CLK_EN_BIT -
-                           PWRMGR_CONTROL_CORE_CLK_EN_BIT)),
-               "Layout of control register changed.");
+static_assert(kDifPwrmgrDomainOptionCoreClockInLowPower ==
+                  (1u << (PWRMGR_CONTROL_CORE_CLK_EN_BIT -
+                          PWRMGR_CONTROL_CORE_CLK_EN_BIT)),
+              "Layout of control register changed.");
 
-_Static_assert(kDifPwrmgrDomainOptionIoClockInLowPower ==
-                   (1u << (PWRMGR_CONTROL_IO_CLK_EN_BIT -
-                           PWRMGR_CONTROL_CORE_CLK_EN_BIT)),
-               "Layout of control register changed.");
+static_assert(kDifPwrmgrDomainOptionIoClockInLowPower ==
+                  (1u << (PWRMGR_CONTROL_IO_CLK_EN_BIT -
+                          PWRMGR_CONTROL_CORE_CLK_EN_BIT)),
+              "Layout of control register changed.");
 
-_Static_assert(kDifPwrmgrDomainOptionUsbClockInLowPower ==
-                   (1u << (PWRMGR_CONTROL_USB_CLK_EN_LP_BIT -
-                           PWRMGR_CONTROL_CORE_CLK_EN_BIT)),
-               "Layout of control register changed.");
+static_assert(kDifPwrmgrDomainOptionUsbClockInLowPower ==
+                  (1u << (PWRMGR_CONTROL_USB_CLK_EN_LP_BIT -
+                          PWRMGR_CONTROL_CORE_CLK_EN_BIT)),
+              "Layout of control register changed.");
 
-_Static_assert(kDifPwrmgrDomainOptionUsbClockInActivePower ==
-                   (1u << (PWRMGR_CONTROL_USB_CLK_EN_ACTIVE_BIT -
-                           PWRMGR_CONTROL_CORE_CLK_EN_BIT)),
-               "Layout of control register changed.");
+static_assert(kDifPwrmgrDomainOptionUsbClockInActivePower ==
+                  (1u << (PWRMGR_CONTROL_USB_CLK_EN_ACTIVE_BIT -
+                          PWRMGR_CONTROL_CORE_CLK_EN_BIT)),
+              "Layout of control register changed.");
 
-_Static_assert(kDifPwrmgrDomainOptionMainPowerInLowPower ==
-                   (1u << (PWRMGR_CONTROL_MAIN_PD_N_BIT -
-                           PWRMGR_CONTROL_CORE_CLK_EN_BIT)),
-               "Layout of control register changed.");
+static_assert(kDifPwrmgrDomainOptionMainPowerInLowPower ==
+                  (1u << (PWRMGR_CONTROL_MAIN_PD_N_BIT -
+                          PWRMGR_CONTROL_CORE_CLK_EN_BIT)),
+              "Layout of control register changed.");
 
 /**
  * Bitfield for interpreting the configuration options in the control
@@ -63,35 +65,35 @@ static const bitfield_field32_t kDomainConfigBitfield = {
  * Relevant bits of the WAKEUP_EN and WAKE_INFO registers must start at `0` and
  * be in the same order as `dif_pwrmgr_wakeup_request_source_t` constants.
  */
-_Static_assert(kDifPwrmgrWakeupRequestSourceOne ==
-                   (1u << PWRMGR_WAKEUP_EN_EN_0_BIT),
-               "Layout of WAKEUP_EN register changed.");
-_Static_assert(kDifPwrmgrWakeupRequestSourceOne ==
-                   (1u << PWRMGR_PARAM_DEBUG_CABLE_WAKEUP_IDX),
-               "Layout of WAKE_INFO register changed.");
-_Static_assert(kDifPwrmgrWakeupRequestSourceTwo ==
-                   (1u << PWRMGR_PARAM_AON_WKUP_REQ_IDX),
-               "Layout of WAKE_INFO register changed.");
-_Static_assert(kDifPwrmgrWakeupRequestSourceThree ==
-                   (1u << PWRMGR_PARAM_USB_WKUP_REQ_IDX),
-               "Layout of WAKE_INFO register changed.");
-_Static_assert(kDifPwrmgrWakeupRequestSourceFour ==
-                   (1u << PWRMGR_PARAM_AON_TIMER_WKUP_REQ_IDX),
-               "Layout of WAKE_INFO register changed.");
+static_assert(kDifPwrmgrWakeupRequestSourceOne ==
+                  (1u << PWRMGR_WAKEUP_EN_EN_0_BIT),
+              "Layout of WAKEUP_EN register changed.");
+static_assert(kDifPwrmgrWakeupRequestSourceOne ==
+                  (1u << PWRMGR_PARAM_DEBUG_CABLE_WAKEUP_IDX),
+              "Layout of WAKE_INFO register changed.");
+static_assert(kDifPwrmgrWakeupRequestSourceTwo ==
+                  (1u << PWRMGR_PARAM_AON_WKUP_REQ_IDX),
+              "Layout of WAKE_INFO register changed.");
+static_assert(kDifPwrmgrWakeupRequestSourceThree ==
+                  (1u << PWRMGR_PARAM_USB_WKUP_REQ_IDX),
+              "Layout of WAKE_INFO register changed.");
+static_assert(kDifPwrmgrWakeupRequestSourceFour ==
+                  (1u << PWRMGR_PARAM_AON_TIMER_WKUP_REQ_IDX),
+              "Layout of WAKE_INFO register changed.");
 
 /**
  * Relevant bits of the RESET_EN register must start at `0` and be in the same
  * order as `dif_pwrmgr_reset_request_source_t` constants.
  */
-_Static_assert(kDifPwrmgrResetRequestSourceOne ==
-                   (1u << PWRMGR_RESET_EN_EN_0_BIT),
-               "Layout of RESET_EN register changed.");
+static_assert(kDifPwrmgrResetRequestSourceOne ==
+                  (1u << PWRMGR_RESET_EN_EN_0_BIT),
+              "Layout of RESET_EN register changed.");
 
 /**
  * `dif_pwrmgr_irq_t` constants must match the corresponding generated values.
  */
-_Static_assert(kDifPwrmgrIrqWakeup == PWRMGR_INTR_COMMON_WAKEUP_BIT,
-               "Layout of interrupt registers changed.");
+static_assert(kDifPwrmgrIrqWakeup == PWRMGR_INTR_COMMON_WAKEUP_BIT,
+              "Layout of interrupt registers changed.");
 
 /**
  * Register information for a request type.

--- a/sw/device/lib/dif/dif_rstmgr.c
+++ b/sw/device/lib/dif/dif_rstmgr.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/dif/dif_rstmgr.h"
 
+#include <assert.h>
 #include <stdint.h>
 
 #include "sw/device/lib/base/bitfield.h"
@@ -11,23 +12,23 @@
 
 #include "rstmgr_regs.h"  // Generated.
 
-// This macro simplifies the `_Static_assert` check to make sure that the
+// This macro simplifies the `static_assert` check to make sure that the
 // public reset info register bitfield matches register bits.
-#define RSTMGR_RESET_INFO_CHECK(pub_name, priv_name)          \
-  _Static_assert(kDifRstmgrResetInfo##pub_name ==             \
-                     (0x1 << RSTMGR_RESET_##priv_name##_BIT), \
-                 "kDifRstmgrResetInfo" #pub_name              \
-                 " must match the register definition!")
+#define RSTMGR_RESET_INFO_CHECK(pub_name, priv_name)         \
+  static_assert(kDifRstmgrResetInfo##pub_name ==             \
+                    (0x1 << RSTMGR_RESET_##priv_name##_BIT), \
+                "kDifRstmgrResetInfo" #pub_name              \
+                " must match the register definition!")
 
 RSTMGR_RESET_INFO_CHECK(Por, INFO_POR);
 RSTMGR_RESET_INFO_CHECK(LowPowerExit, INFO_LOW_POWER_EXIT);
 RSTMGR_RESET_INFO_CHECK(Ndm, INFO_NDM_RESET);
 
-_Static_assert(kDifRstmgrResetInfoHwReq == (RSTMGR_RESET_INFO_HW_REQ_MASK
-                                            << RSTMGR_RESET_INFO_HW_REQ_OFFSET),
-               "kDifRstmgrResetInfoHwReq must match the register definition!");
+static_assert(kDifRstmgrResetInfoHwReq == (RSTMGR_RESET_INFO_HW_REQ_MASK
+                                           << RSTMGR_RESET_INFO_HW_REQ_OFFSET),
+              "kDifRstmgrResetInfoHwReq must match the register definition!");
 
-_Static_assert(
+static_assert(
     RSTMGR_PARAM_NUMSWRESETS == 7,
     "Number of software resets has changed, please update this file!");
 
@@ -36,7 +37,7 @@ _Static_assert(
 // there will be multiple of Reset Enable and Reset Control registers. The
 // appropriate offset from the peripheral base would then have to be
 // calculated.
-_Static_assert(
+static_assert(
     RSTMGR_PARAM_NUMSWRESETS <= 32,
     "Reset Enable and Control registers span across multiple registers!");
 
@@ -45,7 +46,7 @@ _Static_assert(
 // inclusive). However, in reality it only supports 15, as
 // `RSTMGR_ALERT_INFO_ATTR_CNT_AVAIL_MASK` is of the same size, but value of
 // 0 indicates that there is no alert info crash dump.
-_Static_assert(
+static_assert(
     DIF_RSTMGR_ALERT_INFO_MAX_SIZE == RSTMGR_ALERT_INFO_CTRL_INDEX_MASK,
     "Alert info dump max size has grown, please update the public define!");
 

--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/dif/dif_uart.h"
 
+#include <assert.h>
 #include <stddef.h>
 
 #include "sw/device/lib/base/bitfield.h"
@@ -159,8 +160,8 @@ dif_uart_config_result_t dif_uart_configure(const dif_uart_t *uart,
     nco_width += (UART_CTRL_NCO_MASK >> i) & 1;
   }
 
-  _Static_assert((UART_CTRL_NCO_MASK >> 28) == 0,
-                 "NCO bit width exceeds 28 bits.");
+  static_assert((UART_CTRL_NCO_MASK >> 28) == 0,
+                "NCO bit width exceeds 28 bits.");
 
   // NCO creates 16x of baudrate. So, in addition to the nco_width,
   // 2^4 should be multiplied.

--- a/sw/device/lib/dif/dif_usbdev.c
+++ b/sw/device/lib/dif/dif_usbdev.c
@@ -4,6 +4,8 @@
 
 #include "sw/device/lib/dif/dif_usbdev.h"
 
+#include <assert.h>
+
 #include "sw/device/lib/base/bitfield.h"
 
 #include "usbdev_regs.h"  // Generated.
@@ -12,8 +14,8 @@
  * Definition in the header file (and probably other places) must be updated if
  * there is a hardware change.
  */
-_Static_assert(USBDEV_NUM_ENDPOINTS == USBDEV_PARAM_NENDPOINTS,
-               "Mismatch in number of endpoints");
+static_assert(USBDEV_NUM_ENDPOINTS == USBDEV_PARAM_NENDPOINTS,
+              "Mismatch in number of endpoints");
 
 /**
  * Max packet size is equal to the size of device buffers.

--- a/sw/device/lib/runtime/log.c
+++ b/sw/device/lib/runtime/log.c
@@ -4,6 +4,8 @@
 
 #include "sw/device/lib/runtime/log.h"
 
+#include <assert.h>
+
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/mmio.h"
@@ -15,8 +17,8 @@
  * The assertion below helps prevent inadvertant changes to the struct.
  * Please see the description of log_fields_t in log.h for more details.
  */
-_Static_assert(sizeof(log_fields_t) == 20,
-               "log_fields_t must always be 20 bytes.");
+static_assert(sizeof(log_fields_t) == 20,
+              "log_fields_t must always be 20 bytes.");
 
 /**
  * Converts a severity to a static string.

--- a/sw/device/silicon_creator/rom_exts/rom_ext_manifest_parser.c
+++ b/sw/device/silicon_creator/rom_exts/rom_ext_manifest_parser.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/silicon_creator/rom_exts/rom_ext_manifest_parser.h"
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -18,8 +19,8 @@ const rom_ext_manifest_slot_t kRomExtManifestSlotA =
 const rom_ext_manifest_slot_t kRomExtManifestSlotB =
     TOP_EARLGREY_EFLASH_BASE_ADDR + (TOP_EARLGREY_EFLASH_SIZE_BYTES / 2);
 
-_Static_assert((TOP_EARLGREY_EFLASH_SIZE_BYTES % 2) == 0,
-               "Flash size is not divisible by 2");
+static_assert((TOP_EARLGREY_EFLASH_SIZE_BYTES % 2) == 0,
+              "Flash size is not divisible by 2");
 
 rom_ext_manifest_t rom_ext_get_parameters(rom_ext_manifest_slot_t slot) {
   if (kRomExtManifestSlotA) {

--- a/sw/device/tests/dif/dif_hmac_smoketest.c
+++ b/sw/device/tests/dif/dif_hmac_smoketest.c
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <assert.h>
+
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_hmac.h"
@@ -21,8 +23,8 @@ const test_config_t kTestConfig;
 // RISC-V is little-endian, so the first of these `kHmacTransactionConfig`
 // values is the one we expect to be used, but we include the other for
 // completeness.
-_Static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
-               "This test assumes the target platform is little endian.");
+static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
+              "This test assumes the target platform is little endian.");
 
 static const dif_hmac_transaction_t kHmacTransactionConfig = {
     .digest_endianness = kDifHmacEndiannessLittle,

--- a/sw/device/tests/dif/dif_otp_ctrl_smoketest.c
+++ b/sw/device/tests/dif/dif_otp_ctrl_smoketest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
 
+#include <assert.h>
 #include <stdbool.h>
 
 #include "sw/device/lib/base/bitfield.h"
@@ -16,8 +17,8 @@
 static dif_otp_ctrl_t otp;
 
 static const char kTestData[] = "abcdefghijklmno";
-_Static_assert(ARRAYSIZE(kTestData) % sizeof(uint32_t) == 0,
-               "kTestData must be a word array");
+static_assert(ARRAYSIZE(kTestData) % sizeof(uint32_t) == 0,
+              "kTestData must be a word array");
 
 const test_config_t kTestConfig;
 


### PR DESCRIPTION
The intention of this header is to give us a consistent language for
static asserts across C and C++. In particular, this allows us to use
static asserts in polyglot headers.

(@alphan asked me to put this together for his struct serialization scheme.)

This PR also adds a style provision indicating that C-specific `_Keywords` should not be used at all. If someone wants to use one that we don't have a macro for, we need to add the macro somewhere.