### PR TITLE
[dv/dvsim] Add "^Error:" as a run fail pattern.

### DIFF
--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -28,7 +28,8 @@
                         "^UVM_WARNING\\s[^:].*$",
                         "^Assert failed: ",
                         "^\\s*Offending '.*'",
-                        "^TEST FAILED (UVM_)?CHECKS$"]
+                        "^TEST FAILED (UVM_)?CHECKS$",
+                        "^Error:.*$"]  // ISS errors
 
   // Default TileLink widths
   tl_aw: 32


### PR DESCRIPTION
This failure message is generated by the ISS model.

Signed-off-by: Guillermo Maturana <maturana@google.com>