### PR TITLE
[dv/otp_ctrl] align behavior for fatal error [part2]

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -88,6 +88,9 @@ package otp_ctrl_env_pkg;
 
   parameter uint CHK_TIMEOUT_CYC = 40;
 
+  // When fatal alert triggered, all partitions go to error state and status will be 1.
+  parameter bit [8:0] FATAL_EXP_STATUS = 9'b1_1111_1111;
+
   // lc does not have dai access
   parameter int PART_BASE_ADDRS [NumPart-1] = {
     CreatorSwCfgOffset,

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_background_chks_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_background_chks_vseq.sv
@@ -54,7 +54,6 @@ class otp_ctrl_background_chks_vseq extends otp_ctrl_dai_errs_vseq;
 
     cfg.clk_rst_vif.wait_clks($urandom_range(50, 1000));
     csr_rd_check(.ptr(ral.status.timeout_error), .compare_value(1));
-    csr_rd_check(.ptr(ral.status.dai_idle),      .compare_value(1));
   endtask
 
   virtual task post_start();


### PR DESCRIPTION
Follow PR #6240, this PR supports sequences that disabled scb check.

Signed-off-by: Cindy Chen <chencindy@google.com>