### PR TITLE
[all] Minor lint fixes

### DIFF
--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -230,7 +230,7 @@ module kmac_app
   // clear digest right after done to not leak info to other interface
   always_comb begin
     for (int unsigned i = 0 ; i < NumAppIntf ; i++) begin
-      if (AppIdxW'(i) == app_id) begin
+      if (i == app_id) begin
         app_o[i] = '{
           ready:         app_data_ready,
           done:          app_digest_done,
@@ -574,7 +574,7 @@ module kmac_app
       StAppMsg: begin
         // Check app intf cfg
         for (int unsigned i = 0 ; i < NumAppIntf ; i++) begin
-          if (app_id == AppIdxW'(i)) begin
+          if (app_id == i) begin
             if (AppCfg[i].PrefixMode == 1'b 0) begin
               sha3_prefix_o = reg_prefix_i;
             end else begin

--- a/hw/ip/spi_device/rtl/spi_p2s.sv
+++ b/hw/ip/spi_device/rtl/spi_p2s.sv
@@ -111,9 +111,9 @@ module spi_p2s
     data_sent_o = 1'b 0;
 
     unique case (io_mode)
-      SingleIO: data_sent_o = (cnt == BitWidth'(6));
-      DualIO:   data_sent_o = (cnt == BitWidth'(2));
-      QuadIO:   data_sent_o = (cnt == BitWidth'(0));
+      SingleIO: data_sent_o = (cnt == 6);
+      DualIO:   data_sent_o = (cnt == 2);
+      QuadIO:   data_sent_o = (cnt == 0);
       default:  data_sent_o = '0;
     endcase
   end

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -507,12 +507,12 @@ module spi_host
       tx_empty_q <= 1'b0;
       rx_full_q  <= 1'b0;
     end else begin
-      idle_q     <= idle_q;
-      ready_q    <= ready_q;
-      tx_wm_q    <= tx_wm_q;
-      rx_wm_q    <= rx_wm_q;
-      tx_empty_q <= tx_empty_q;
-      rx_full_q  <= rx_full_q;
+      idle_q     <= idle_d;
+      ready_q    <= ready_d;
+      tx_wm_q    <= tx_wm_d;
+      rx_wm_q    <= rx_wm_d;
+      tx_empty_q <= tx_empty_d;
+      rx_full_q  <= rx_full_d;
     end
   end
 

--- a/hw/top_earlgrey/lint/top_earlgrey.waiver
+++ b/hw/top_earlgrey/lint/top_earlgrey.waiver
@@ -24,6 +24,10 @@ waive -rules CLOCK_USE -location {top_earlgrey.sv} -regexp {'clkmgr_aon_clocks.c
 waive -rules CLOCK_MUX -location {clkmgr.sv top_earlgrey.sv} -regexp {.*clk_io_div.* is driven by a multiplexer here} \
       -comment "Divided clocks go through prim_clock_div, which use muxes for scan bypass and clock step down"
 
+# scan reset is a legal asynchronous reset
+waive -rules RESET_USE -location {top_earlgrey.sv} -regexp {'scan_rst_ni' is connected to .* port 'scan_rst_ni', and used as an asynchronous reset or set 'rst_ni' at} \
+      -comment "Scan reset is a legal asynchronous reset"
+
 # Combo loops through uart loopback can be ignored
 waive -rules {COMBO_LOOP} -location {chip_earlgrey_asic.sv} -regexp {'tx' driven in module 'uart_core' by 'rx' at uart_core.sv} \
       -comment "there is technically a loopback path through uart, however RX / TX should never be configured to the same pin"


### PR DESCRIPTION
- wire up spi_host q/d correctly
- remove constant casting and let ascentlint deal with any large values

Signed-off-by: Timothy Chen <timothytim@google.com>