### PR TITLE
[dv/sram] add executable SRAM test

### DIFF
--- a/hw/dv/sv/tl_agent/tl_monitor.sv
+++ b/hw/dv/sv/tl_agent/tl_monitor.sv
@@ -86,6 +86,7 @@ class tl_monitor extends dv_base_monitor#(
         req.a_data   = h2d.a_data;
         req.a_mask   = h2d.a_mask;
         req.a_source = h2d.a_source;
+        req.a_user   = h2d.a_user;
         `uvm_info("tl_logging", $sformatf("[%0s][a_chan] : %0s",
                    agent_name, req.convert2string()), UVM_HIGH)
 

--- a/hw/dv/sv/tl_agent/tl_seq_item.sv
+++ b/hw/dv/sv/tl_agent/tl_seq_item.sv
@@ -145,6 +145,7 @@ class tl_seq_item extends uvm_sequence_item;
     `uvm_field_int  (a_param,             UVM_DEFAULT)
     `uvm_field_int  (a_source,            UVM_DEFAULT)
     `uvm_field_int  (a_opcode,            UVM_DEFAULT)
+    `uvm_field_int  (a_user,              UVM_DEFAULT)
     `uvm_field_int  (d_param,             UVM_DEFAULT)
     `uvm_field_int  (d_source,            UVM_DEFAULT)
     `uvm_field_int  (d_data,              UVM_DEFAULT)
@@ -185,6 +186,7 @@ class tl_seq_item extends uvm_sequence_item;
            $sformatf("a_param = 0x%0h ", a_param),
            $sformatf("a_source = 0x%0h ", a_source),
            $sformatf("a_opcode = %0s ", a_opcode_name),
+           $sformatf("a_user = 0x%0h ", a_user),
            $sformatf("d_data = 0x%0h ", d_data),
            $sformatf("d_size = 0x%0h ", d_size),
            $sformatf("d_param = 0x%0h ", d_param),

--- a/hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson
@@ -113,8 +113,28 @@
       tests: ["{name}_lc_escalation"]
     }
     {
+      name: executable
+      desc: '''
+            This test is intended to test the "execute from SRAM" feature, in which TLUL memory
+            transactions tagged with the `InstrType` value in the user bits are allowed to be
+            handled by the SRAM memory.
+
+            This behavior is enabled by either setting the `exec` CSR to 1 or by driving a second
+            lifecycle input to `On` - both of these are muxed between with a `otp_hw_cfg_t` input
+            from the OTP controller.
+
+            If this functionality is disabled, any memory transaction NOT tagged as `DataType` should
+            error out, however `DataType` transactions should be successful when the SRAM is
+            configured to be executable.
+            '''
+      milestone: V2
+      tests: ["{name}_executable"]
+    }
+    {
       name: parity
       desc: '''
+            TODO - to be changed into an ECC test
+
             This test is the same as the multiple_keys test, except we randomly inject a parity
             error into the memory (TODO: figure out how exactly to do this).
             Verify that the SRAM reports the error and the faulty address correctly, and that the
@@ -123,25 +143,8 @@
             This error is terminal, so like the lc_escalation test, issue a reset and then perform
             some memory accesses to make sure everything comes back online correctly.
             '''
-      milestone: V2
-      tests: ["{name}_parity"]
-    }
-    {
-      name: executable
-      desc: '''
-            TODO: This feature is not yet implemented, so this description will become
-                  more detailed at that time.
-
-            This test is meant to test executable SRAM (Ibex fetching  data from SRAM).
-
-            This test is the same as the multiple_keys test, except now we randomly set the
-            `sram_fetch` (name TBD) input(s) from the OTP controller.
-
-            Verify that in this scenario all memory transactions matching the Host user ID go
-            through, but all transactions with mismatched user IDs error out.
-            '''
       milestone: V3
-      tests: ["{name}_executable"]
+      tests: ["{name}_parity"]
     }
   ]
 }

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_executable_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_executable_vseq.sv
@@ -1,0 +1,98 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence tests the "execute from SRAM" feature - TL transactions tagged as InstrType are
+// allowed to be executed by the SRAM if configured properly.
+//
+// This sequence fully randomizes this configuration setting and randomly updates the configuration
+// in parallel with the main sequence body.
+// The scoreboard will handle all checks to ensure that transactions are dropped as necessary.
+class sram_ctrl_executable_vseq extends sram_ctrl_multiple_keys_vseq;
+
+  `uvm_object_utils(sram_ctrl_executable_vseq)
+  `uvm_object_new
+
+  bit [3:0] hw_debug_en;
+  bit [7:0] en_sram_ifetch;
+  bit [2:0] en_exec_csr;
+
+  // These bits are used to create pseudo-weights for the constraint distributions
+  // of the above values
+  bit       is_valid;
+  bit [1:0] is_off;
+
+  virtual task pre_start();
+    en_ifetch = 1;
+    super.pre_start();
+  endtask
+
+  task body();
+    `DV_SPINWAIT_EXIT(
+        forever begin
+          randomize_and_drive_ifetch_en();
+          cfg.clk_rst_vif.wait_clks($urandom_range(100, 500));
+        end
+        ,
+        super.body();
+    )
+  endtask
+
+  task randomize_and_drive_ifetch_en();
+    `DV_CHECK_STD_RANDOMIZE_FATAL(is_valid);
+    `DV_CHECK_STD_RANDOMIZE_FATAL(is_off);
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(en_exec_csr,
+        // 50% chance to enable
+        if (is_valid) {
+          en_exec_csr == tlul_pkg::InstrEn;
+        } else {
+          // 75% chance to set garbage invalid data
+          if (is_off == 0) {
+            en_exec_csr == tlul_pkg::InstrDis;
+          } else {
+            !(en_exec_csr inside {tlul_pkg::InstrEn, tlul_pkg::InstrDis});
+          }
+        }
+    )
+    `uvm_info(`gfn, $sformatf("en_exec_csr: 0b%0b", en_exec_csr), UVM_HIGH)
+
+    `DV_CHECK_STD_RANDOMIZE_FATAL(is_valid);
+    `DV_CHECK_STD_RANDOMIZE_FATAL(is_off);
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(en_sram_ifetch,
+        // 50% chance to enable
+        if (is_valid) {
+          en_sram_ifetch == sram_ctrl_pkg::EnSramIfetch;
+        } else {
+          // 75% chance to set garbage invalid data
+          if (is_off == 0) {
+            en_sram_ifetch == sram_ctrl_pkg::DisSramIfetch;
+          } else {
+            !(en_sram_ifetch inside {sram_ctrl_pkg::EnSramIfetch, sram_ctrl_pkg::DisSramIfetch});
+          }
+        }
+    )
+    `uvm_info(`gfn, $sformatf("en_sram_ifetch: 0b%0b", en_sram_ifetch), UVM_HIGH)
+
+    `DV_CHECK_STD_RANDOMIZE_FATAL(is_valid);
+    `DV_CHECK_STD_RANDOMIZE_FATAL(is_off);
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(hw_debug_en,
+        // 50% chance to enable
+        if (is_valid) {
+          hw_debug_en == lc_ctrl_pkg::On;
+        } else {
+          // 75% chance to set garbage invalid data
+          if (is_off == 0) {
+            hw_debug_en == lc_ctrl_pkg::Off;
+          } else {
+            !(hw_debug_en inside {lc_ctrl_pkg::On, lc_ctrl_pkg::Off});
+          }
+        }
+    )
+    `uvm_info(`gfn, $sformatf("hw_debug_en: 0b%0b",  hw_debug_en), UVM_HIGH)
+
+    csr_wr(ral.exec, en_exec_csr);
+    cfg.exec_vif.drive_lc_hw_debug_en(hw_debug_en);
+    cfg.exec_vif.drive_otp_hw_cfg(en_sram_ifetch);
+  endtask
+
+endclass

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
@@ -10,6 +10,8 @@ class sram_ctrl_smoke_vseq extends sram_ctrl_base_vseq;
 
   bit access_during_key_req = 0;
 
+  bit en_ifetch = 0;
+
   // Indicates the number of memory accesses to be performed
   // before requesting a new scrambling key
   rand int num_ops;
@@ -48,7 +50,8 @@ class sram_ctrl_smoke_vseq extends sram_ctrl_base_vseq;
     `uvm_info(`gfn,
               $sformatf("Performing %0d random memory accesses after reset!", num_ops_after_reset),
               UVM_LOW)
-    do_rand_ops(num_ops_after_reset);
+    do_rand_ops(.num_ops(num_ops_after_reset),
+                .en_ifetch(en_ifetch));
 
     `uvm_info(`gfn, $sformatf("Starting %0d SRAM transactions", num_trans), UVM_LOW)
     for (int i = 0; i < num_trans; i++) begin
@@ -69,7 +72,9 @@ class sram_ctrl_smoke_vseq extends sram_ctrl_base_vseq;
         begin
           if (access_during_key_req) begin
             `uvm_info(`gfn, "accessing during key req", UVM_HIGH)
-            do_rand_ops(.num_ops($urandom_range(100, 500)), .abort(1));
+            do_rand_ops(.num_ops($urandom_range(100, 500)),
+                        .abort(1),
+                        .en_ifetch(en_ifetch));
             csr_utils_pkg::wait_no_outstanding_access();
           end
         end
@@ -84,7 +89,8 @@ class sram_ctrl_smoke_vseq extends sram_ctrl_base_vseq;
           do_stress_ops($urandom(), $urandom_range(5, 20));
         end
       end else begin
-        do_rand_ops(num_ops);
+        do_rand_ops(.num_ops(num_ops),
+                    .en_ifetch(en_ifetch));
       end
     end
   endtask : body

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_vseq_list.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_vseq_list.sv
@@ -11,3 +11,4 @@
 `include "sram_ctrl_lc_escalation_vseq.sv"
 `include "sram_ctrl_mem_tl_errors_vseq.sv"
 `include "sram_ctrl_access_during_key_req_vseq.sv"
+`include "sram_ctrl_executable_vseq.sv"

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
@@ -13,6 +13,7 @@ filesets:
     files:
       - sram_ctrl_env_pkg.sv
       - sram_ctrl_lc_if.sv
+      - sram_ctrl_exec_if.sv
       - sram_ctrl_env_cfg.sv: {is_include_file: true}
       - sram_ctrl_env_cov.sv: {is_include_file: true}
       - sram_ctrl_virtual_sequencer.sv: {is_include_file: true}
@@ -28,6 +29,7 @@ filesets:
       - seq_lib/sram_ctrl_lc_escalation_vseq.sv: {is_include_file: true}
       - seq_lib/sram_ctrl_mem_tl_errors_vseq.sv: {is_include_file: true}
       - seq_lib/sram_ctrl_access_during_key_req_vseq.sv: {is_include_file: true}
+      - seq_lib/sram_ctrl_executable_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.sv
@@ -32,6 +32,11 @@ class sram_ctrl_env extends cip_base_env #(
       `uvm_fatal(`gfn, "failed to get lc_vif from uvm_config_db")
     end
 
+    // Get the SRAM execution interface
+    if (!uvm_config_db#(virtual sram_ctrl_exec_if)::get(this, "", "exec_vif", cfg.exec_vif)) begin
+      `uvm_fatal(`gfn, "failed to get exec_vif from uvm_config_db")
+    end
+
     // Get the mem_bkdr interface
     if (!uvm_config_db#(mem_bkdr_vif)::get(this, "", "mem_bkdr_vif", cfg.mem_bkdr_vif)) begin
       `uvm_fatal(`gfn, "failed to get mem_bkdr_vif from uvm_config_db")

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
@@ -16,6 +16,7 @@ class sram_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(sram_ctrl_reg_block));
   // ext interfaces
   virtual clk_rst_if otp_clk_rst_vif;
   virtual sram_ctrl_lc_if lc_vif;
+  virtual sram_ctrl_exec_if exec_vif;
   mem_bkdr_vif mem_bkdr_vif;
 
   // otp clk freq

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_pkg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_pkg.sv
@@ -40,6 +40,7 @@ package sram_ctrl_env_pkg;
   // types
   typedef virtual mem_bkdr_if #(.MEM_PARITY(1)) mem_bkdr_vif;
   typedef virtual sram_ctrl_lc_if lc_vif;
+  typedef virtual sram_ctrl_exec_if exec_vif;
 
   typedef enum bit {
     SramCtrlRenewScrKey = 0,

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_exec_if.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_exec_if.sv
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+interface sram_ctrl_exec_if;
+  string path = "exec_if";
+
+  lc_ctrl_pkg::lc_tx_t lc_hw_debug_en;
+
+  otp_ctrl_part_pkg::otp_hw_cfg_t otp_hw_cfg;
+
+  // LC escalation signal must be stable before reset ends
+  task automatic init();
+    lc_hw_debug_en = lc_ctrl_pkg::Off;
+    otp_hw_cfg = otp_ctrl_part_pkg::OTP_HW_CFG_DEFAULT;
+  endtask
+
+  task automatic drive_lc_hw_debug_en(bit [3:0] hw_debug_en);
+    lc_hw_debug_en = lc_ctrl_pkg::lc_tx_t'(hw_debug_en);
+  endtask
+
+  // The only field that matters of the otp_cfg is the `en_sram_ifetch` value
+  task automatic drive_otp_hw_cfg(bit [7:0] en_sram_ifetch);
+    otp_ctrl_part_pkg::otp_hw_cfg_t rand_cfg;
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(rand_cfg, rand_cfg.data.en_sram_ifetch == en_sram_ifetch;, , path)
+    otp_hw_cfg = rand_cfg;
+  endtask
+
+endinterface

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -100,6 +100,10 @@
       name: "{variant}_access_during_key_req"
       uvm_test_seq: sram_ctrl_access_during_key_req_vseq
     }
+    {
+      name: "{variant}_executable"
+      uvm_test_seq: sram_ctrl_executable_vseq
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_wrapper.sv
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_wrapper.sv
@@ -34,7 +34,10 @@ module sram_ctrl_wrapper
   input lc_ctrl_pkg::lc_tx_t                        lc_escalate_en_i,
   // Key request to OTP
   output otp_ctrl_pkg::sram_otp_key_req_t           sram_otp_key_o,
-  input otp_ctrl_pkg::sram_otp_key_rsp_t            sram_otp_key_i
+  input otp_ctrl_pkg::sram_otp_key_rsp_t            sram_otp_key_i,
+  // Executable SRAM inputs
+  input lc_ctrl_pkg::lc_tx_t                        lc_hw_debug_en_i,
+  input otp_ctrl_part_pkg::otp_hw_cfg_t             otp_hw_cfg_i
 );
 
   // Scrambling key interface between sram_ctrl and scrambling RAM
@@ -45,15 +48,16 @@ module sram_ctrl_wrapper
 
 
   // SRAM interface between TLUL adapter and scrambling RAM
-  wire                  req;
-  wire                  gnt;
-  wire                  we;
-  wire [AddrWidth-1:0]  addr;
-  wire [DataWidth-1:0]  wdata;
-  wire [DataWidth-1:0]  wmask;
-  wire [DataWidth-1:0]  rdata;
-  wire                  rvalid;
-  wire                  intg_error;
+  wire                    req;
+  wire                    gnt;
+  wire                    we;
+  wire [AddrWidth-1:0]    addr;
+  wire [DataWidth-1:0]    wdata;
+  wire [DataWidth-1:0]    wmask;
+  wire [DataWidth-1:0]    rdata;
+  wire                    rvalid;
+  wire                    intg_error;
+  tlul_pkg::tl_instr_en_e en_ifetch;
 
   // SRAM Controller
   sram_ctrl u_sram_ctrl (
@@ -80,7 +84,11 @@ module sram_ctrl_wrapper
     .sram_scr_init_o  (scr_init_req     ),
     .sram_scr_init_i  (scr_init_rsp     ),
     // Integrity error
-    .intg_error_i     (intg_error)
+    .intg_error_i     (intg_error       ),
+    // Executable SRAM
+    .lc_hw_debug_en_i (lc_hw_debug_en_i ),
+    .otp_hw_cfg_i     (otp_hw_cfg_i     ),
+    .en_ifetch_o      (en_ifetch        )
   );
 
   // TLUL Adapter SRAM
@@ -89,21 +97,23 @@ module sram_ctrl_wrapper
     .SramDw(DataWidth),
     .Outstanding(2)
   ) u_tl_adapter_sram (
-    .clk_i    (clk_i          ),
-    .rst_ni   (rst_ni         ),
+    .clk_i        (clk_i          ),
+    .rst_ni       (rst_ni         ),
     // TLUL interface to SRAM memory
-    .tl_i     (sram_tl_i      ),
-    .tl_o     (sram_tl_o      ),
+    .tl_i         (sram_tl_i      ),
+    .tl_o         (sram_tl_o      ),
+    // Ifetch control interface
+    .en_ifetch_i  (en_ifetch),
     // Corresponding SRAM request interface
-    .req_o    (req            ),
-    .gnt_i    (gnt            ),
-    .we_o     (we             ),
-    .addr_o   (addr           ),
-    .wdata_o  (wdata          ),
-    .wmask_o  (wmask          ),
-    .rdata_i  (rdata          ),
-    .rvalid_i (rvalid         ),
-    .rerror_i (scr_rsp.rerror )
+    .req_o        (req            ),
+    .gnt_i        (gnt            ),
+    .we_o         (we             ),
+    .addr_o       (addr           ),
+    .wdata_o      (wdata          ),
+    .wmask_o      (wmask          ),
+    .rdata_i      (rdata          ),
+    .rvalid_i     (rvalid         ),
+    .rerror_i     (scr_rsp.rerror )
   );
 
   // Scrambling memory

--- a/hw/ip/sram_ctrl/dv/tb.sv
+++ b/hw/ip/sram_ctrl/dv/tb.sv
@@ -32,6 +32,9 @@ module tb;
 
   lc_ctrl_pkg::lc_tx_t lc_esc_en;
 
+  lc_ctrl_pkg::lc_tx_t lc_hw_debug_en;
+  otp_ctrl_part_pkg::otp_hw_cfg_t otp_hw_cfg;
+
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
@@ -49,6 +52,9 @@ module tb;
 
   // Interface for lifecycle escalation
   sram_ctrl_lc_if lc_if();
+
+  // Interface for SRAM execution
+  sram_ctrl_exec_if exec_if();
 
   `DV_ALERT_IF_CONNECT
 
@@ -72,25 +78,28 @@ module tb;
     .DataWidth(`SRAM_DATA_WIDTH)
   ) dut (
     // main clock
-    .clk_i(clk),
-    .rst_ni(rst_n),
+    .clk_i            (clk                    ),
+    .rst_ni           (rst_n                  ),
     // OTP clock
-    .clk_otp_i(clk_otp),
-    .rst_otp_ni(rst_otp_n),
+    .clk_otp_i        (clk_otp                ),
+    .rst_otp_ni       (rst_otp_n              ),
     // TLUL interface for CSR regfile
-    .csr_tl_i(tl_if.h2d),
-    .csr_tl_o(tl_if.d2h),
+    .csr_tl_i         (tl_if.h2d              ),
+    .csr_tl_o         (tl_if.d2h              ),
     // TLUL interface for SRAM memory
-    .sram_tl_i(sram_tl_if.h2d),
-    .sram_tl_o(sram_tl_if.d2h),
+    .sram_tl_i        (sram_tl_if.h2d         ),
+    .sram_tl_o        (sram_tl_if.d2h         ),
     // Alert I/O
-    .alert_rx_i(alert_rx),
-    .alert_tx_o(alert_tx),
+    .alert_rx_i       (alert_rx               ),
+    .alert_tx_o       (alert_tx               ),
     // Life cycle escalation
-    .lc_escalate_en_i(lc_if.lc_esc_en),
+    .lc_escalate_en_i (lc_if.lc_esc_en        ),
     // OTP key derivation interface
-    .sram_otp_key_o(key_req),
-    .sram_otp_key_i(key_rsp)
+    .sram_otp_key_o   (key_req                ),
+    .sram_otp_key_i   (key_rsp                ),
+    // SRAM ifetch interface
+    .lc_hw_debug_en_i (exec_if.lc_hw_debug_en ),
+    .otp_hw_cfg_i     (exec_if.otp_hw_cfg     )
   );
 
   // KDI interface assignments
@@ -121,6 +130,7 @@ module tb;
     uvm_config_db#(virtual push_pull_if#(.DeviceDataWidth(KDI_DATA_SIZE)))::set(null,
       "*.env.m_kdi_agent*", "vif", kdi_if);
     uvm_config_db#(virtual sram_ctrl_lc_if)::set(null, "*.env", "lc_vif", lc_if);
+    uvm_config_db#(virtual sram_ctrl_exec_if)::set(null, "*.env", "exec_vif", exec_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_sram_tl_agent*", "vif", sram_tl_if);
     uvm_config_db#(mem_bkdr_vif)::set(null, "*.env", "mem_bkdr_vif",


### PR DESCRIPTION
This PR implements the sram_ctrl_executable test as described by the
testplan.

In this test, we fully randomize all DUT config knobs used to set the
SRAM into "executable" mode, and then drive TL transactions that are
randomized between DataType and InstrType.

The scoreboard is updated to handle the new set of error cases that is
introduced with this testing.

The tl_monitor and tl_seq_item have also had minor updates made to them
to copy the a_user bits, as this is required to drive the right kind of
stimulus to the SRAM.

Signed-off-by: Udi Jonnalagadda <udij@google.com>