### PR TITLE
[syn] Correct power report regexp

### DIFF
--- a/hw/syn/tools/dc/parse-syn-report.py
+++ b/hw/syn/tools/dc/parse-syn-report.py
@@ -343,11 +343,11 @@ def _extract_power(full_file, results, key, args):
     """
 
     # extract first 3 columns on that line
-    patterns = [("net", r"^" + results["top"] + r".*\s*(" + FP_NUMBER + r")\s*" +
+    patterns = [("net", r"^" + results["top"] + r"[a-zA-Z0-9_]*\s*(" + FP_NUMBER + r")\s*" +
                  FP_NUMBER + r"\s*" + FP_NUMBER),
-                ("int", r"^" + results["top"] + r".*\s*" + FP_NUMBER + r"\s*(" +
+                ("int", r"^" + results["top"] + r"[a-zA-Z0-9_]*\s*" + FP_NUMBER + r"\s*(" +
                  FP_NUMBER + r")\s*" + FP_NUMBER),
-                ("leak", r"^" + results["top"] + r".*\s*" + FP_NUMBER + r" \s*" +
+                ("leak", r"^" + results["top"] + r"[a-zA-Z0-9_]*\s*" + FP_NUMBER + r" \s*" +
                  FP_NUMBER + r"\s*(" + FP_NUMBER + r")")]
 
     nums, errs = _match_fp_number(full_file, patterns)


### PR DESCRIPTION
The regexp I previously added to allow for appended parameters in the DUT name was too generic, and lead to wrong results (it allowed arbitrary strings including spaces to be parsed away, which led to the wrong numeric fields being exctracted).

Sorry about that.

Signed-off-by: Michael Schaffner <msf@google.com>