### PR TITLE
[dv/lc_ctrl] Use push-pull agent data constrains

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
@@ -28,8 +28,9 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(lc_ctrl_reg_block));
     m_otp_prog_pull_agent_cfg = push_pull_agent_cfg#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),
         .DeviceDataWidth(OTP_PROG_DDATA_WIDTH))::type_id::create("m_otp_prog_pull_agent_cfg");
     `DV_CHECK_RANDOMIZE_FATAL(m_otp_prog_pull_agent_cfg)
-    m_otp_prog_pull_agent_cfg.agent_type = PullAgent;
-    m_otp_prog_pull_agent_cfg.if_mode    = Device;
+    m_otp_prog_pull_agent_cfg.agent_type            = PullAgent;
+    m_otp_prog_pull_agent_cfg.if_mode               = Device;
+    m_otp_prog_pull_agent_cfg.in_bidirectional_mode = 1;
 
     m_otp_token_pull_agent_cfg = push_pull_agent_cfg#(
                                  .HostDataWidth(lc_ctrl_state_pkg::LcTokenWidth))

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
@@ -31,8 +31,7 @@ package lc_ctrl_env_pkg;
 
   // lc_otp_program host data width: lc_state_e width + lc_cnt_e width
   parameter uint OTP_PROG_HDATA_WIDTH = LcStateWidth + LcCountWidth;
-  // TODO: temp set to 0, once push-pull agent can constraint data, it will set to 1 for error bit
-  parameter uint OTP_PROG_DDATA_WIDTH = 0;
+  parameter uint OTP_PROG_DDATA_WIDTH = 1;
 
   typedef struct packed {
     lc_ctrl_pkg::lc_tx_e lc_dft_en_o;

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -11,7 +11,6 @@ interface lc_ctrl_if(input clk, input rst_n);
   import otp_ctrl_part_pkg::*;
 
   logic tdo_oe; // TODO: add assertions
-  logic prog_err; // TODO: remove once push-pull can constrain data
   otp_lc_data_t otp_i;
   otp_hw_cfg_t  otp_hw_cfg_i;
   lc_token_t    hashed_token;
@@ -55,7 +54,6 @@ interface lc_ctrl_if(input clk, input rst_n);
 
     clk_byp_ack_i = clk_byp_ack;
     flash_rma_ack_i = flash_rma_ack;
-    prog_err = 0;
     hashed_token = '0;
   endtask
 

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
@@ -76,7 +76,7 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
       push_pull_item#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),
                       .DeviceDataWidth(OTP_PROG_DDATA_WIDTH)) item_rcv;
       otp_prog_fifo.get(item_rcv);
-      if (cfg.lc_ctrl_vif.prog_err == 1) begin
+      if (item_rcv.d_data == 1) begin
         set_exp_alert(.alert_name("fatal_prog_error"), .is_fatal(1));
       end
     end

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -19,7 +19,6 @@ module tb;
   wire devmode;
   wire [LcPwrIfWidth-1:0] pwr_lc;
   // TODO: can delete once push-pull agent support constraint data
-  wire otp_ctrl_pkg::lc_otp_program_rsp_t otp_prog_rsp;
   wire otp_ctrl_pkg::lc_otp_token_rsp_t   otp_token_rsp;
 
   // interfaces
@@ -38,9 +37,6 @@ module tb;
 
   `DV_ALERT_IF_CONNECT
 
-  // TODO: remove once OTP_PROG_DDATA_WIDTH is set to 1
-  assign otp_prog_rsp.err = lc_ctrl_if.prog_err;
-  assign otp_prog_rsp.ack = otp_prog_if.ack;
   assign otp_token_rsp.ack = otp_token_if.ack;
   // TODO: temp constraint to 0 because it has to equal to otp_lc_data_i tokens
   assign otp_token_rsp.hashed_token = lc_ctrl_if.hashed_token;
@@ -68,7 +64,7 @@ module tb;
     .pwr_lc_o                   (pwr_lc[LcPwrDoneRsp:LcPwrIdleRsp]),
 
     .lc_otp_program_o           ({otp_prog_if.req, otp_prog_if.h_data}),
-    .lc_otp_program_i           (otp_prog_rsp),
+    .lc_otp_program_i           ({otp_prog_if.d_data, otp_prog_if.ack}),
 
     .lc_otp_token_o             ({otp_token_if.req, otp_token_if.h_data}),
     .lc_otp_token_i             (otp_token_rsp),


### PR DESCRIPTION
This PR finishes a TODO to remove hard-coded program_error input, and
replace that with a pull-push agent driver with constrained device data.

Signed-off-by: Cindy Chen <chencindy@google.com>