### PR TITLE
[dv/clkmgr] Adds more clock gating tests.

### DIFF
--- a/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -56,7 +56,14 @@
       name: clkmgr_smoke
       uvm_test_seq: clkmgr_smoke_vseq
     }
-
+    {
+      name: clkmgr_peri
+      uvm_test_seq: clkmgr_peri_vseq
+    }
+    {
+      name: clkmgr_trans
+      uvm_test_seq: clkmgr_trans_vseq
+    }
     // TODO: add more tests here
   ]
 

--- a/hw/ip/clkmgr/dv/env/clkmgr_env.core
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env.core
@@ -19,7 +19,9 @@ filesets:
       - seq_lib/clkmgr_vseq_list.sv: {is_include_file: true}
       - seq_lib/clkmgr_base_vseq.sv: {is_include_file: true}
       - seq_lib/clkmgr_common_vseq.sv: {is_include_file: true}
+      - seq_lib/clkmgr_peri_vseq.sv: {is_include_file: true}
       - seq_lib/clkmgr_smoke_vseq.sv: {is_include_file: true}
+      - seq_lib/clkmgr_trans_vseq.sv: {is_include_file: true}
       - clkmgr_if.sv
     file_type: systemVerilogSource
 

--- a/hw/ip/clkmgr/dv/env/clkmgr_env_pkg.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env_pkg.sv
@@ -22,6 +22,7 @@ package clkmgr_env_pkg;
   typedef virtual clk_rst_if clk_rst_vif;
 
   // parameters
+  localparam int  NUM_PERI = 3;
   localparam int  NUM_TRANS = 4;
 
   // types

--- a/hw/ip/clkmgr/dv/env/clkmgr_if.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_if.sv
@@ -4,13 +4,13 @@
 //
 // clkmgr interface.
 
-interface clkmgr_if(input logic clk, input logic rst_n);
+interface clkmgr_if(input logic clk, input logic rst_n, input logic rst_main_n);
   import clkmgr_env_pkg::*;
 
   // The ports to the dut side.
 
   // Encodes the transactional units that are idle.
-  bit [NUM_TRANS-1:0] idle_i;
+  logic [NUM_TRANS-1:0] idle_i;
 
   // pwrmgr req contains ip_clk_en, set to enable the gated clocks.
   pwrmgr_pkg::pwr_clk_req_t pwr_i;
@@ -51,12 +51,12 @@ interface clkmgr_if(input logic clk, input logic rst_n);
   } clk_hints_t;
 
   // The CSR values from the testbench side.
-  logic extclk_sel_regwen;
-  logic extclk_sel;
-  logic jitter_enable;
+  logic         extclk_sel_regwen;
+  logic         extclk_sel;
+  logic         jitter_enable;
   clk_enables_t clk_enables;
-  clk_hints_t clk_hints;
-  clk_hints_t clk_hints_status;
+  clk_hints_t   clk_hints;
+  clk_hints_t   clk_hints_status;
 
   task automatic wait_clks(int cycles);
     repeat (cycles) @(posedge clk);
@@ -70,7 +70,7 @@ interface clkmgr_if(input logic clk, input logic rst_n);
     extclk_sel = sel;
   endfunction
 
-  function automatic void update_clk_enables(logic [$bits(clk_enables)-1:0] ens);
+  function automatic void update_clk_enables(clk_enables_t ens);
     clk_enables = ens;
   endfunction
 
@@ -93,7 +93,7 @@ interface clkmgr_if(input logic clk, input logic rst_n);
     end
   endtask
 
-  function automatic void update_clk_en(bit value);
+  function automatic void update_ip_clk_en(bit value);
     pwr_i.ip_clk_en = value;
   endfunction
 
@@ -101,83 +101,99 @@ interface clkmgr_if(input logic clk, input logic rst_n);
     return pwr_o.clk_status;
   endfunction
 
-  task automatic init();
+  task automatic init(logic ip_clk_en, clk_enables_t clk_enables,
+                      logic [NUM_TRANS-1:0] idle, clk_hints_t clk_hints);
     `uvm_info("clkmgr_if.init", "initializing inputs", UVM_LOW)
     lc_clk_byp_req = lc_ctrl_pkg::Off;
     ast_clk_byp_ack = lc_ctrl_pkg::Off;
     scanmode_i = lc_ctrl_pkg::Off;
     lc_dft_en_i = lc_ctrl_pkg::Off;
-    update_idle('1);
-    update_clk_en(1'b1);
+    update_ip_clk_en(ip_clk_en);
+    update_clk_enables(clk_enables);
+    update_idle(idle);
+    update_hints(clk_hints);
   endtask
+
+  // Assertions for gated clocks need to use preponed values.
+  // We implement them on negedge of the reference clock.
+  // - A clock is enabled requires the gated clock to be high.
+  // - A clock is disabled requires the gated clock to be low.
 
   // Add assertions for peripheral clocks.
   `ASSERT(ClkmgrPeriDiv4Enabled_A,
-          clk_enables.io_div4_peri_en && pwr_i.ip_clk_en |=>
-            ##[2:6] $rose(clocks_o.clk_io_div4_peri),
-          clocks_o.clk_io_div4_powerup, !rst_n)
+          $rose(clk_enables.io_div4_peri_en && pwr_i.ip_clk_en) |=>
+            ##[2:3] clocks_o.clk_io_div4_peri,
+          !clocks_o.clk_io_div4_powerup, !rst_n)
   `ASSERT(ClkmgrPeriDiv4Disabled_A,
-          !clk_enables.io_div4_peri_en || pwr_i.ip_clk_en |=>
-            ##[2:6] $stable(clocks_o.clk_io_div4_peri),
-          clocks_o.clk_io_div4_powerup, !rst_n)
+          $fell(clk_enables.io_div4_peri_en && pwr_i.ip_clk_en) |=>
+            ##[2:3] !clocks_o.clk_io_div4_peri,
+          !clocks_o.clk_io_div4_powerup, !rst_n)
 
   `ASSERT(ClkmgrPeriDiv2Enabled_A,
-          clk_enables.io_div2_peri_en && pwr_i.ip_clk_en |=>
-            ##[2:6] $rose(clocks_o.clk_io_div2_peri),
-          clocks_o.clk_io_div2_powerup, !rst_n)
+          $rose(clk_enables.io_div2_peri_en && pwr_i.ip_clk_en) |=>
+            ##[2:3] clocks_o.clk_io_div2_peri,
+          !clocks_o.clk_io_div2_powerup, !rst_n)
   `ASSERT(ClkmgrPeriDiv2Disabled_A,
-          !clk_enables.io_div2_peri_en || pwr_i.ip_clk_en |=>
-            ##[2:6] $stable(clocks_o.clk_io_div2_peri),
-          clocks_o.clk_io_div2_powerup, !rst_n)
+          $fell(clk_enables.io_div2_peri_en && pwr_i.ip_clk_en) |=>
+            ##[2:3] !clocks_o.clk_io_div2_peri,
+          !clocks_o.clk_io_div2_powerup, !rst_n)
 
   `ASSERT(ClkmgrPeriUsbEnabled_A,
-          clk_enables.usb_peri_en && pwr_i.ip_clk_en |=>
-            ##[2:6] $rose(clocks_o.clk_usb_peri),
-          clocks_o.clk_usb_powerup, !rst_n)
+          $rose(clk_enables.usb_peri_en && pwr_i.ip_clk_en) |=>
+            ##[2:3] clocks_o.clk_usb_peri,
+          !clocks_o.clk_usb_powerup, !rst_n)
   `ASSERT(ClkmgrPeriUsbDisabled_A,
-          !clk_enables.usb_peri_en || pwr_i.ip_clk_en |=>
-            ##[2:6] $stable(clocks_o.clk_usb_peri),
-          clocks_o.clk_usb_powerup, !rst_n)
+          $fell(clk_enables.usb_peri_en && pwr_i.ip_clk_en) |=>
+            ##[2:3] !clocks_o.clk_usb_peri,
+          !clocks_o.clk_usb_powerup, !rst_n)
 
   // Add assertions for trans unit clocks.
   `ASSERT(ClkmgrTransAesClkEnabled_A,
-          clk_hints.aes |-> clocks_o.clk_main_aes,
-          !clocks_o.clk_main_powerup, !rst_n)
+          $rose(clk_hints.aes && pwr_i.ip_clk_en) |=> ##[2:3] clocks_o.clk_main_aes,
+          !clocks_o.clk_main_powerup, !rst_main_n)
   `ASSERT(ClkmgrTransAesClkKeepEnabled_A,
-          !clk_hints.aes && !idle_i[int'(TransAes)] |-> clocks_o.clk_main_aes,
-          !clocks_o.clk_main_powerup, !rst_n)
+          $rose(!clk_hints.aes && !idle_i[int'(TransAes)] && pwr_i.ip_clk_en) |=>
+            ##[2:3] clocks_o.clk_main_aes,
+          !clocks_o.clk_main_powerup, !rst_main_n)
   `ASSERT(ClkmgrTransAesClkDisabled_A,
-          !clk_hints.aes && idle_i[int'(TransAes)] |=> ##[2:6] !clocks_o.clk_main_aes,
-          !clocks_o.clk_main_powerup, !rst_n)
+          $rose(!clk_hints.aes && idle_i[int'(TransAes)] || !pwr_i.ip_clk_en) |=>
+            ##[2:3] !clocks_o.clk_main_aes,
+          !clocks_o.clk_main_powerup, !rst_main_n)
 
   `ASSERT(ClkmgrTransHmacClkEnabled_A,
-          clk_hints.hmac |-> clocks_o.clk_main_hmac,
-          !clocks_o.clk_main_powerup, !rst_n)
+          $rose(clk_hints.hmac && pwr_i.ip_clk_en) |=> ##[2:3] clocks_o.clk_main_hmac,
+          !clocks_o.clk_main_powerup, !rst_main_n)
   `ASSERT(ClkmgrTransHmacClkKeepEnabled_A,
-          !clk_hints.hmac && !idle_i[int'(TransHmac)] |-> clocks_o.clk_main_hmac,
-          !clocks_o.clk_main_powerup, !rst_n)
+          $rose(!clk_hints.hmac && !idle_i[int'(TransHmac)] && pwr_i.ip_clk_en) |=>
+            ##[2:3] clocks_o.clk_main_hmac,
+          !clocks_o.clk_main_powerup, !rst_main_n)
   `ASSERT(ClkmgrTransHmacClkDisabled_A,
-          !clk_hints.hmac && idle_i[int'(TransHmac)] |=> ##[2:6] $stable(clocks_o.clk_main_hmac),
-          clocks_o.clk_main_powerup, !rst_n)
+          $rose(!clk_hints.hmac && idle_i[int'(TransHmac)] || !pwr_i.ip_clk_en) |=>
+            ##[2:3] !clocks_o.clk_main_hmac,
+          !clocks_o.clk_main_powerup, !rst_main_n)
 
   `ASSERT(ClkmgrTransKmacClkEnabled_A,
-          clk_hints.hmac |-> clocks_o.clk_main_kmac,
-          !clocks_o.clk_main_powerup, !rst_n)
+          $rose(clk_hints.kmac && pwr_i.ip_clk_en) |=> ##[2:3] clocks_o.clk_main_kmac,
+          !clocks_o.clk_main_powerup, !rst_main_n)
   `ASSERT(ClkmgrTransKmacClkKeepEnabled_A,
-          !clk_hints.hmac && !idle_i[int'(TransKmac)] |-> clocks_o.clk_main_kmac,
-          !clocks_o.clk_main_powerup, !rst_n)
+          $rose(!clk_hints.kmac && !idle_i[int'(TransKmac)] && pwr_i.ip_clk_en) |=>
+            ##[2:3] clocks_o.clk_main_kmac,
+          !clocks_o.clk_main_powerup, !rst_main_n)
   `ASSERT(ClkmgrTransKmacClkDisabled_A,
-          !clk_hints.kmac && idle_i[int'(TransKmac)] |=> ##[2:6] $stable(clocks_o.clk_main_kmac),
-          clocks_o.clk_main_powerup, !rst_n)
+          $rose(!clk_hints.kmac && idle_i[int'(TransKmac)] || !pwr_i.ip_clk_en) |=>
+            ##[2:3] !clocks_o.clk_main_kmac,
+          !clocks_o.clk_main_powerup, !rst_main_n)
 
-  `ASSERT(ClkmgrTransOtbnClkEnabled_A
-          , clk_hints.otbn |-> clocks_o.clk_main_otbn,
-          !clocks_o.clk_main_powerup, !rst_n)
+  `ASSERT(ClkmgrTransOtbnClkEnabled_A,
+          $rose(clk_hints.otbn && pwr_i.ip_clk_en) |=> ##[2:3] clocks_o.clk_main_otbn,
+          !clocks_o.clk_main_powerup, !rst_main_n)
   `ASSERT(ClkmgrTransOtbnClkKeepEnabled_A,
-          !clk_hints.otbn && !idle_i[int'(TransOtbn)] |-> clocks_o.clk_main_otbn,
-          !clocks_o.clk_main_powerup, !rst_n)
+          $rose(!clk_hints.otbn && !idle_i[int'(TransOtbn)] && pwr_i.ip_clk_en) |=>
+            ##[2:3] clocks_o.clk_main_otbn,
+          !clocks_o.clk_main_powerup, !rst_main_n)
   `ASSERT(ClkmgrTransOtbnClkDisabled_A,
-          !clk_hints.otbn && idle_i[int'(TransOtbn)] |=> ##[2:6] $stable(clocks_o.clk_main_otbn),
-          clocks_o.clk_main_powerup, !rst_n)
+          $rose(!clk_hints.otbn && idle_i[int'(TransOtbn)] || !pwr_i.ip_clk_en) |=>
+            ##[2:3] !clocks_o.clk_main_otbn,
+          !clocks_o.clk_main_powerup, !rst_main_n)
 
 endinterface

--- a/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -56,7 +56,7 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
 
     // If incoming access is a write to a valid csr, update prediction right away.
     if (addr_phase_write) begin
-      `uvm_info(`gfn, $sformatf("Writing 0x%0x to %s", item.a_data, csr.get_name()), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("Writing 0x%0x to %s", item.a_data, csr.get_name()), UVM_MEDIUM)
       void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
     end
 

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -10,6 +10,9 @@ class clkmgr_base_vseq extends cip_base_vseq #(
   );
   `uvm_object_utils(clkmgr_base_vseq)
 
+  rand bit ip_clk_en;
+  rand bit [NUM_TRANS-1:0] idle;
+
   // various knobs to enable certain routines
   bit do_clkmgr_init = 1'b1;
 
@@ -18,7 +21,12 @@ class clkmgr_base_vseq extends cip_base_vseq #(
   task pre_start();
     // These are independent: do them in parallel since pre_start consumes time.
     fork
-      cfg.clkmgr_vif.init();
+      // The clk_enables and clk_hints are initialized with their reset values.
+      cfg.clkmgr_vif.init(
+          .ip_clk_en(ip_clk_en),
+          .clk_enables(ral.clk_enables.get_reset()),
+          .idle(idle),
+          .clk_hints(ral.clk_hints.get_reset()));
       if (do_clkmgr_init) clkmgr_init();
       super.pre_start();
     join

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_peri_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_peri_vseq.sv
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// peri test vseq
+//
+// This is more general than the corresponding smoke test since it randomizes the initial
+// value of clk_enables CSR and the ip_clk_en input.
+class clkmgr_peri_vseq extends clkmgr_base_vseq;
+  `uvm_object_utils(clkmgr_peri_vseq)
+
+  `uvm_object_new
+
+  rand logic [NUM_PERI-1:0] initial_enables;
+
+  task body();
+    logic [NUM_PERI-1:0] flipped_enables;
+    `uvm_info(`gfn, $sformatf("Initializing clk_enables with 0x%0x", initial_enables), UVM_LOW)
+    csr_wr(.ptr(ral.clk_enables), .value(initial_enables));
+
+    cfg.clk_rst_vif.wait_clks(10);
+    // Flip all bits of clk_enables.
+    flipped_enables = initial_enables ^ ((1 << ral.clk_enables.get_n_bits()) - 1);
+    csr_wr(.ptr(ral.clk_enables), .value(flipped_enables));
+  endtask : body
+endclass : clkmgr_peri_vseq

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
@@ -8,15 +8,10 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
 
   `uvm_object_new
 
-  bit ip_clk_en = 1'b1;
-  bit [NUM_TRANS - 1: 0] idle = '0;
+  constraint enable_ip_clk_en { ip_clk_en == 1'b1; }
+  constraint all_busy { idle == '0; }
 
   task body();
-    // Set the io clk input from pwrmgr.
-    `uvm_info(`gfn, $sformatf("Setting ip_clk_en to %b", ip_clk_en), UVM_LOW)
-    cfg.clkmgr_vif.update_clk_en(ip_clk_en);
-    cfg.clkmgr_vif.update_idle(idle);
-
     cfg.clk_rst_vif.wait_clks(10);
     test_peri_clocks();
     test_trans_clocks();
@@ -26,8 +21,8 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
   // checked via assertions in clkmgr_if.sv.
   task test_peri_clocks();
     // Flip all bits of clk_enables.
-    logic [TL_DW-1:0] value = ral.clk_enables.get();
-    logic [TL_DW-1:0] flipped_value;
+    logic [NUM_PERI-1:0] value = ral.clk_enables.get();
+    logic [NUM_PERI-1:0] flipped_value;
     csr_rd(.ptr(ral.clk_enables), .value(value));
     flipped_value = value ^ ((1 << ral.clk_enables.get_n_bits()) - 1);
     csr_wr(.ptr(ral.clk_enables), .value(flipped_value));

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
@@ -1,0 +1,44 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// trans test vseq
+// This is a more randomized version of the corresponding test in the smoke sequence.
+// FIXME Add randomized scanmode dut input.
+class clkmgr_trans_vseq extends clkmgr_base_vseq;
+  `uvm_object_utils(clkmgr_trans_vseq)
+
+  `uvm_object_new
+
+  rand bit [NUM_TRANS-1:0] initial_hints;
+
+  // Starts with random units busy, set the hints at random. The idle units will be
+  // disabled, but the others will remain enabled. Then all units are made idle.
+  task body();
+    trans_e trans;
+    logic bit_value;
+    logic [NUM_TRANS-1:0] value;
+
+    cfg.clk_rst_vif.wait_clks(10);
+    trans = trans.first;
+    `uvm_info(`gfn, $sformatf("Updating hints to 0x%0x", initial_hints), UVM_MEDIUM)
+    csr_wr(.ptr(ral.clk_hints), .value(initial_hints));
+    cfg.clkmgr_vif.update_hints(initial_hints);
+    cfg.clkmgr_vif.wait_clks(5);
+    csr_rd(.ptr(ral.clk_hints_status), .value(value));
+    // We expect the status to be determined by hints and idle.
+    `DV_CHECK_EQ(value, initial_hints | ~idle, "Busy units have status high")
+    idle = '1;
+    cfg.clkmgr_vif.update_idle(idle);
+    cfg.clkmgr_vif.wait_clks(5);
+    csr_rd(.ptr(ral.clk_hints_status), .value(value));
+    `DV_CHECK_EQ(value, initial_hints, "All idle: units status matches hints")
+    // Now enable them all.
+    csr_wr(.ptr(ral.clk_hints), .value('1));
+    cfg.clkmgr_vif.wait_clks(5);
+    csr_rd(.ptr(ral.clk_hints_status), .value(value));
+    // We expect all units to be on.
+    `DV_CHECK_EQ(value, '1, "All idle and all hints high: units status should be high")
+  endtask : body
+
+endclass : clkmgr_trans_vseq

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_vseq_list.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_vseq_list.sv
@@ -3,5 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 `include "clkmgr_base_vseq.sv"
-`include "clkmgr_smoke_vseq.sv"
 `include "clkmgr_common_vseq.sv"
+`include "clkmgr_peri_vseq.sv"
+`include "clkmgr_smoke_vseq.sv"
+`include "clkmgr_trans_vseq.sv"

--- a/hw/ip/clkmgr/dv/tb.sv
+++ b/hw/ip/clkmgr/dv/tb.sv
@@ -32,7 +32,7 @@ module tb;
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
 
   // The clkmgr interface.
-  clkmgr_if clkmgr_if(.clk(clk), .rst_n(rst_n));
+  clkmgr_if clkmgr_if(.clk(clk), .rst_n(rst_n), .rst_main_n(rst_main_n));
 
   initial begin
     // Clocks must be set to active at time 0. The rest of the clock configuration happens


### PR DESCRIPTION
Adds more randomized tests for the peripheral and transactional
units clocking.
Fixes the concurrent assertions in clkmgr_if.

Signed-off-by: Guillermo Maturana <maturana@google.com>