### PR TITLE
[dv/dvsim] Fix runtime fail pattern for OTBN model

### DIFF
--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -29,7 +29,8 @@
                         "^Assert failed: ",
                         "^\\s*Offending '.*'",
                         "^TEST FAILED (UVM_)?CHECKS$",
-                        "^Error:.*$"]  // ISS errors
+                        "^ERROR:.*$",          // ISS errors from CC files
+                        "^[a-zA-Z]*Error:.*$"] // ISS errors from py files
 
   // Default TileLink widths
   tl_aw: 32


### PR DESCRIPTION
The model can exit with "^ERROR:" regex from C++ files, or
"^\w*Error:" regex from python files.

Signed-off-by: Guillermo Maturana <maturana@google.com>