### PR TITLE
[dv/otp_ctrl] Fix nightly regression error

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
@@ -107,7 +107,7 @@ class otp_ctrl_init_fail_vseq extends otp_ctrl_smoke_vseq;
           addr = $urandom_range(PartInfo[i].offset, PartInfo[i].offset + PartInfo[i].size - 1);
         end
 
-        backdoor_inject_ecc_err(addr, ecc_err_mask, ecc_err);
+        void'(backdoor_inject_ecc_err(addr, ecc_err_mask, ecc_err));
         if (ecc_err == OtpEccUncorrErr && !is_fatal) is_fatal = 1;
         if (ecc_err != OtpNoEccErr) exp_status[i] = 1;
       end
@@ -185,7 +185,8 @@ class otp_ctrl_init_fail_vseq extends otp_ctrl_smoke_vseq;
         end
       end
     end
-    `DV_CHECK_EQ(error_cnt, 1)
+    // More than one fatal alert causes could be triggered at the same time
+    `DV_CHECK_GT(error_cnt, 0)
     csr_rd_check(.ptr(ral.status), .compare_value(exp_status | FATAL_EXP_STATUS));
 
     `DV_CHECK_EQ(cfg.otp_ctrl_vif.pwr_otp_done_o, 1)

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_stress_all_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_stress_all_vseq.sv
@@ -20,6 +20,9 @@ class otp_ctrl_stress_all_vseq extends otp_ctrl_base_vseq;
     cfg.otp_ctrl_vif.drive_lc_dft_en(lc_ctrl_pkg::On);
     if ($urandom_range(0, 1)) cfg.otp_ctrl_vif.drive_lc_escalate_en(lc_ctrl_pkg::Off);
 
+    // Some sequence will disable scb, here we re-enable scb after reset.
+    cfg.en_scb = 1;
+
     // Once turn on lc_dft_en regiser, will need some time to update the state register
     // Two clock cycles for lc_async mode, one clock cycle for driving dft_en
     cfg.clk_rst_vif.wait_clks(3);


### PR DESCRIPTION
This PR fixes some nightly regression error:
1. Stress_all with reset did not return on scb after background check is
done.
2. OTP_init_fail test can have more than one alert causes happen at the
same time.
3. Fix a warning that function's output should be voided.

Signed-off-by: Cindy Chen <chencindy@google.com>