### PR TITLE
[dv/otp_ctrl] Two cleanups regarding OTP_CTRL testbench

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -991,9 +991,6 @@
       swaccess: "rw",
       hwaccess: "hro",
       regwen:   "CHECK_REGWEN",
-      tags: [ // Do not write to this automatically, as it may trigger unintended side effects
-              // like spurious escalations / alerts.
-              "excl:CsrAllTests:CsrExclWrite"],
       fields: [
         { bits: "31:0",
           desc: '''

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -656,9 +656,6 @@
       swaccess: "rw",
       hwaccess: "hro",
       regwen:   "CHECK_REGWEN",
-      tags: [ // Do not write to this automatically, as it may trigger unintended side effects
-              // like spurious escalations / alerts.
-              "excl:CsrAllTests:CsrExclWrite"],
       fields: [
         { bits: "31:0",
           desc: '''

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -67,10 +67,9 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
 
   // TODO: for lc_tx, except esc_en signal, all value different from On is treated as Off,
   // technically we can randomize values here once scb supports
-  task automatic init();
+  task automatic init(lc_ctrl_pkg::lc_tx_t lc_seed_hw_rd_en_val = lc_ctrl_pkg::On);
     lc_creator_seed_sw_rw_en_i = lc_ctrl_pkg::On;
-    // TODO: check with designer if we will remove this
-    lc_seed_hw_rd_en_i         = lc_ctrl_pkg::Off;
+    lc_seed_hw_rd_en_i         = lc_seed_hw_rd_en_val;
     lc_dft_en_i                = lc_ctrl_pkg::Off;
     lc_escalate_en_i           = lc_ctrl_pkg::Off;
     lc_check_byp_en_i          = lc_ctrl_pkg::Off;

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -32,7 +32,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     super.dut_init(reset_kind);
     cfg.backdoor_clear_mem = 0;
     // reset power init pin and lc pins
-    cfg.otp_ctrl_vif.init();
+    cfg.otp_ctrl_vif.init(randomize_lc_tx_t_val());
     if (do_otp_ctrl_init && do_apply_reset) otp_ctrl_init();
     cfg.clk_rst_vif.wait_clks($urandom_range(0, 10));
     if (do_otp_pwr_init && do_apply_reset) otp_pwr_init();
@@ -70,6 +70,17 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     otp_pwr_init();
     super.read_and_check_all_csrs_after_reset();
   endtask
+
+  // This function randomizes lc_tx_t with 25% lc_ctrl_pkg::On, 25% lc_ctrl_pkg::Off,
+  // and 50% random values
+  virtual function lc_ctrl_pkg::lc_tx_t randomize_lc_tx_t_val();
+    randomize_lc_tx_t_val = $urandom();
+    if ($urandom_range(0, 1)) begin
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(randomize_lc_tx_t_val,
+          randomize_lc_tx_t_val inside {lc_ctrl_pkg::On, lc_ctrl_pkg::Off};)
+    end
+
+  endfunction
 
   // this task triggers an OTP write sequence via the DAI interface
   virtual task dai_wr(bit [TL_DW-1:0] addr,

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -146,11 +146,18 @@ module tb;
   bind `OTP_CTRL_MEM_HIER mem_bkdr_if #(.MEM_ECC(1)) mem_bkdr_if();
 
   initial begin
-    // these SVA checks the lc_escalate_en is either Off or On, we will use more than these 2 values.
-    // If it's not Off, it should be On
+    // These SVA checks the lc_escalate_en is either Off or On, we will use more than these 2 values.
+    // If it's not Off, it should be On.
     $assertoff(0, tb.dut.u_prim_lc_sync_escalate_en.CheckTransients_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_escalate_en.CheckTransients0_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_escalate_en.CheckTransients1_A);
+
+    // These SVA checks the lc_sync_seed_hw_rd_en is either Off or On, we will use more than these
+    // 2 values.
+    // If it's not On, it should be Off.
+    $assertoff(0, tb.dut.u_prim_lc_sync_seed_hw_rd_en.CheckTransients_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_seed_hw_rd_en.CheckTransients0_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_seed_hw_rd_en.CheckTransients1_A);
 
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();


### PR DESCRIPTION
1. Takes away the temp exclusion for `timeout` csr. Even though it
will trigger alert, we still can find a way to verify that. (#6240 fixed
the assertion error)

2. Drive random value to `lc_seed_hw_rd_en_i` input. Thanks to the
coverage result, i found this input was tied to Off and never driven
value `On` in testbench.

Signed-off-by: Cindy Chen <chencindy@google.com>