### PR TITLE
[cleanup] Convert C defines for param names to snake_case

### DIFF
--- a/sw/device/lib/dif/dif_hmac.c
+++ b/sw/device/lib/dif/dif_hmac.c
@@ -259,7 +259,7 @@ dif_hmac_result_t dif_hmac_mode_hmac_start(
   // Set the HMAC key.
   // TODO Static assert register layout.
   mmio_region_memcpy_to_mmio32(hmac->base_addr, HMAC_KEY_0_REG_OFFSET, key,
-                               HMAC_PARAM_NUMWORDS * sizeof(uint32_t));
+                               HMAC_PARAM_NUM_WORDS * sizeof(uint32_t));
 
   // Read current CFG register value.
   uint32_t device_config =
@@ -420,7 +420,7 @@ dif_hmac_digest_result_t dif_hmac_finish(const dif_hmac_t *hmac,
   // TODO Static assert register layout.
   mmio_region_memcpy_from_mmio32(hmac->base_addr, HMAC_DIGEST_0_REG_OFFSET,
                                  digest->digest,
-                                 HMAC_PARAM_NUMWORDS * sizeof(uint32_t));
+                                 HMAC_PARAM_NUM_WORDS * sizeof(uint32_t));
 
   // Disable HMAC and SHA256 until the next transaction, clearing the current
   // digest.

--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -141,13 +141,13 @@ static void plic_reset(const dif_plic_t *plic) {
   }
 
   // Clear all of the priority registers.
-  for (int i = 0; i < RV_PLIC_PARAM_NUMSRC; ++i) {
+  for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
     ptrdiff_t offset = plic_priority_reg_offset(i);
     mmio_region_write32(plic->params.base_addr, offset, 0);
   }
 
   // Clear all of the target related registers.
-  for (dif_plic_target_t target = 0; target < RV_PLIC_PARAM_NUMTARGET;
+  for (dif_plic_target_t target = 0; target < RV_PLIC_PARAM_NUM_TARGET;
        ++target) {
     // Clear interrupt enable registers.
     ptrdiff_t offset = plic_irq_enable_base_for_target(target);
@@ -183,8 +183,8 @@ dif_plic_result_t dif_plic_irq_get_enabled(const dif_plic_t *plic,
                                            dif_plic_irq_id_t irq,
                                            dif_plic_target_t target,
                                            dif_plic_toggle_t *state) {
-  if (plic == NULL || irq >= RV_PLIC_PARAM_NUMSRC ||
-      target >= RV_PLIC_PARAM_NUMTARGET) {
+  if (plic == NULL || irq >= RV_PLIC_PARAM_NUM_SRC ||
+      target >= RV_PLIC_PARAM_NUM_TARGET) {
     return kDifPlicBadArg;
   }
 
@@ -201,8 +201,8 @@ dif_plic_result_t dif_plic_irq_set_enabled(const dif_plic_t *plic,
                                            dif_plic_irq_id_t irq,
                                            dif_plic_target_t target,
                                            dif_plic_toggle_t state) {
-  if (plic == NULL || irq >= RV_PLIC_PARAM_NUMSRC ||
-      target >= RV_PLIC_PARAM_NUMTARGET) {
+  if (plic == NULL || irq >= RV_PLIC_PARAM_NUM_SRC ||
+      target >= RV_PLIC_PARAM_NUM_TARGET) {
     return kDifPlicBadArg;
   }
 
@@ -230,7 +230,7 @@ dif_plic_result_t dif_plic_irq_set_enabled(const dif_plic_t *plic,
 dif_plic_result_t dif_plic_irq_set_trigger(const dif_plic_t *plic,
                                            dif_plic_irq_id_t irq,
                                            dif_plic_irq_trigger_t trigger) {
-  if (plic == NULL || irq >= RV_PLIC_PARAM_NUMSRC) {
+  if (plic == NULL || irq >= RV_PLIC_PARAM_NUM_SRC) {
     return kDifPlicBadArg;
   }
 
@@ -258,7 +258,7 @@ dif_plic_result_t dif_plic_irq_set_trigger(const dif_plic_t *plic,
 dif_plic_result_t dif_plic_irq_set_priority(const dif_plic_t *plic,
                                             dif_plic_irq_id_t irq,
                                             uint32_t priority) {
-  if (plic == NULL || irq >= RV_PLIC_PARAM_NUMSRC ||
+  if (plic == NULL || irq >= RV_PLIC_PARAM_NUM_SRC ||
       priority > kDifPlicMaxPriority) {
     return kDifPlicBadArg;
   }
@@ -272,7 +272,7 @@ dif_plic_result_t dif_plic_irq_set_priority(const dif_plic_t *plic,
 dif_plic_result_t dif_plic_target_set_threshold(const dif_plic_t *plic,
                                                 dif_plic_target_t target,
                                                 uint32_t threshold) {
-  if (plic == NULL || target >= RV_PLIC_PARAM_NUMTARGET ||
+  if (plic == NULL || target >= RV_PLIC_PARAM_NUM_TARGET ||
       threshold > kDifPlicMaxPriority) {
     return kDifPlicBadArg;
   }
@@ -286,7 +286,7 @@ dif_plic_result_t dif_plic_target_set_threshold(const dif_plic_t *plic,
 dif_plic_result_t dif_plic_irq_is_pending(const dif_plic_t *plic,
                                           dif_plic_irq_id_t irq,
                                           bool *is_pending) {
-  if (plic == NULL || irq >= RV_PLIC_PARAM_NUMSRC || is_pending == NULL) {
+  if (plic == NULL || irq >= RV_PLIC_PARAM_NUM_SRC || is_pending == NULL) {
     return kDifPlicBadArg;
   }
 
@@ -300,7 +300,8 @@ dif_plic_result_t dif_plic_irq_is_pending(const dif_plic_t *plic,
 dif_plic_result_t dif_plic_irq_claim(const dif_plic_t *plic,
                                      dif_plic_target_t target,
                                      dif_plic_irq_id_t *claim_data) {
-  if (plic == NULL || target >= RV_PLIC_PARAM_NUMTARGET || claim_data == NULL) {
+  if (plic == NULL || target >= RV_PLIC_PARAM_NUM_TARGET ||
+      claim_data == NULL) {
     return kDifPlicBadArg;
   }
 
@@ -313,7 +314,7 @@ dif_plic_result_t dif_plic_irq_claim(const dif_plic_t *plic,
 dif_plic_result_t dif_plic_irq_complete(
     const dif_plic_t *plic, dif_plic_target_t target,
     const dif_plic_irq_id_t *complete_data) {
-  if (plic == NULL || target >= RV_PLIC_PARAM_NUMTARGET ||
+  if (plic == NULL || target >= RV_PLIC_PARAM_NUM_TARGET ||
       complete_data == NULL) {
     return kDifPlicBadArg;
   }
@@ -329,7 +330,7 @@ dif_plic_result_t dif_plic_irq_complete(
 
 dif_plic_result_t dif_plic_software_irq_force(const dif_plic_t *plic,
                                               dif_plic_target_t target) {
-  if (plic == NULL || target >= RV_PLIC_PARAM_NUMTARGET) {
+  if (plic == NULL || target >= RV_PLIC_PARAM_NUM_TARGET) {
     return kDifPlicBadArg;
   }
 
@@ -341,7 +342,7 @@ dif_plic_result_t dif_plic_software_irq_force(const dif_plic_t *plic,
 
 dif_plic_result_t dif_plic_software_irq_acknowledge(const dif_plic_t *plic,
                                                     dif_plic_target_t target) {
-  if (plic == NULL || target >= RV_PLIC_PARAM_NUMTARGET) {
+  if (plic == NULL || target >= RV_PLIC_PARAM_NUM_TARGET) {
     return kDifPlicBadArg;
   }
 
@@ -354,7 +355,8 @@ dif_plic_result_t dif_plic_software_irq_acknowledge(const dif_plic_t *plic,
 dif_plic_result_t dif_plic_software_irq_is_pending(const dif_plic_t *plic,
                                                    dif_plic_target_t target,
                                                    bool *is_pending) {
-  if (plic == NULL || target >= RV_PLIC_PARAM_NUMTARGET || is_pending == NULL) {
+  if (plic == NULL || target >= RV_PLIC_PARAM_NUM_TARGET ||
+      is_pending == NULL) {
     return kDifPlicBadArg;
   }
 

--- a/sw/device/lib/dif/dif_plic_unittest.cc
+++ b/sw/device/lib/dif/dif_plic_unittest.cc
@@ -20,9 +20,9 @@ using testing::Test;
 
 // If either of these static assertions fail, then the unit-tests for related
 // API should be revisited.
-static_assert(RV_PLIC_PARAM_NUMSRC == 179,
+static_assert(RV_PLIC_PARAM_NUM_SRC == 179,
               "PLIC instantiation parameters have changed.");
-static_assert(RV_PLIC_PARAM_NUMTARGET == 1,
+static_assert(RV_PLIC_PARAM_NUM_TARGET == 1,
               "PLIC instantiation parameters have changed.");
 
 constexpr uint32_t kTarget0 = 0;
@@ -47,7 +47,7 @@ class InitTest : public PlicTest {
     EXPECT_WRITE32(RV_PLIC_LE_5_REG_OFFSET, 0);
 
     // Priority registers.
-    for (int i = 0; i < RV_PLIC_PARAM_NUMSRC; ++i) {
+    for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
       ptrdiff_t offset = RV_PLIC_PRIO0_REG_OFFSET + (sizeof(uint32_t) * i);
       EXPECT_WRITE32(offset, 0);
     }
@@ -82,7 +82,7 @@ TEST_F(InitTest, Success) {
 class IrqTest : public PlicTest {
  protected:
   IrqTest() {
-    // Make sure to change the `last_bit` when `RV_PLIC_PARAM_NUMSRC` changes.
+    // Make sure to change the `last_bit` when `RV_PLIC_PARAM_NUM_SRC` changes.
     // As `last_bit` represents the bit index in a register, we need to count
     // all of the last bits of a multireg to get the total number of bits.
     // The bit count in IE, LE and IP registers is expected to be the same.
@@ -95,10 +95,10 @@ class IrqTest : public PlicTest {
     for (const auto &reg : kEnableRegisters) {
       number_of_sources += (reg.last_bit + 1);
     }
-    EXPECT_EQ(RV_PLIC_PARAM_NUMSRC, number_of_sources)
+    EXPECT_EQ(RV_PLIC_PARAM_NUM_SRC, number_of_sources)
         << "make sure to update the IrqTest register arrays!";
 
-    EXPECT_EQ(RV_PLIC_PARAM_NUMTARGET, 1);
+    EXPECT_EQ(RV_PLIC_PARAM_NUM_TARGET, 1);
   }
 
   struct Register {
@@ -178,7 +178,7 @@ TEST_F(IrqEnableSetTest, Target0Enable) {
   ExpectIrqSetTests(kEnableRegisters, true);
 
   // Enable every IRQ, one at a time.
-  for (int i = 0; i < RV_PLIC_PARAM_NUMSRC; ++i) {
+  for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
     EXPECT_EQ(
         dif_plic_irq_set_enabled(&plic_, i, kTarget0, kDifPlicToggleEnabled),
         kDifPlicOk);
@@ -189,7 +189,7 @@ TEST_F(IrqEnableSetTest, Target0Disable) {
   ExpectIrqSetTests(kEnableRegisters, false);
 
   // Disable every bit, one at a time.
-  for (int i = 0; i < RV_PLIC_PARAM_NUMSRC; ++i) {
+  for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
     EXPECT_EQ(
         dif_plic_irq_set_enabled(&plic_, i, kTarget0, kDifPlicToggleDisabled),
         kDifPlicOk);
@@ -208,7 +208,7 @@ TEST_F(IrqTriggerTypeSetTest, Enable) {
   ExpectIrqSetTests(kTriggerRegisters, true);
 
   // Enable every IRQ, one at a time.
-  for (int i = 0; i < RV_PLIC_PARAM_NUMSRC; ++i) {
+  for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
     EXPECT_EQ(dif_plic_irq_set_trigger(&plic_, i, kDifPlicIrqTriggerEdge),
               kDifPlicOk);
   }
@@ -218,7 +218,7 @@ TEST_F(IrqTriggerTypeSetTest, Disable) {
   ExpectIrqSetTests(kTriggerRegisters, false);
 
   // Enable every IRQ, one at a time.
-  for (int i = 0; i < RV_PLIC_PARAM_NUMSRC; ++i) {
+  for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
     EXPECT_EQ(dif_plic_irq_set_trigger(&plic_, i, kDifPlicIrqTriggerLevel),
               kDifPlicOk);
   }
@@ -238,7 +238,7 @@ TEST_F(IrqPrioritySetTest, PriorityInvalid) {
 }
 
 TEST_F(IrqPrioritySetTest, Success) {
-  for (int i = 0; i < RV_PLIC_PARAM_NUMSRC; ++i) {
+  for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
     // Set expectations for every priority set call.
     ptrdiff_t offset = RV_PLIC_PRIO0_REG_OFFSET + (sizeof(uint32_t) * i);
     EXPECT_WRITE32(offset, kDifPlicMaxPriority);
@@ -289,7 +289,7 @@ TEST_F(IrqPendingStatusGetTest, Enabled) {
   ExpectIrqGetTests(kPendingRegisters, true);
 
   // Get status of every IRQ, one at a time.
-  for (int i = 0; i < RV_PLIC_PARAM_NUMSRC; ++i) {
+  for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
     bool status;
     dif_plic_result_t result = dif_plic_irq_is_pending(&plic_, i, &status);
     EXPECT_EQ(result, kDifPlicOk);
@@ -301,7 +301,7 @@ TEST_F(IrqPendingStatusGetTest, Disabled) {
   ExpectIrqGetTests(kPendingRegisters, false);
 
   // Get status of every IRQ, one at a time.
-  for (int i = 0; i < RV_PLIC_PARAM_NUMSRC; ++i) {
+  for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
     bool status;
     dif_plic_result_t result = dif_plic_irq_is_pending(&plic_, i, &status);
     EXPECT_EQ(result, kDifPlicOk);
@@ -310,7 +310,7 @@ TEST_F(IrqPendingStatusGetTest, Disabled) {
 }
 
 class IrqClaimTest : public PlicTest {
-  static_assert(RV_PLIC_PARAM_NUMTARGET == 1, "");
+  static_assert(RV_PLIC_PARAM_NUM_TARGET == 1, "");
 };
 
 TEST_F(IrqClaimTest, NullArgs) {
@@ -324,12 +324,12 @@ TEST_F(IrqClaimTest, NullArgs) {
 
 TEST_F(IrqClaimTest, Target0Success) {
   // Set expectations for every claim call.
-  for (int i = 0; i < RV_PLIC_PARAM_NUMSRC; ++i) {
+  for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
     EXPECT_READ32(RV_PLIC_CC0_REG_OFFSET, i);
   }
 
   // Claim every IRQ, one per a call.
-  for (int i = 0; i < RV_PLIC_PARAM_NUMSRC; ++i) {
+  for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
     dif_plic_irq_id_t data;
     EXPECT_EQ(dif_plic_irq_claim(&plic_, kTarget0, &data), kDifPlicOk);
     EXPECT_EQ(data, i);
@@ -337,7 +337,7 @@ TEST_F(IrqClaimTest, Target0Success) {
 }
 
 class IrqCompleteTest : public PlicTest {
-  static_assert(RV_PLIC_PARAM_NUMTARGET == 1, "");
+  static_assert(RV_PLIC_PARAM_NUM_TARGET == 1, "");
 };
 
 TEST_F(IrqCompleteTest, NullArgs) {
@@ -351,19 +351,19 @@ TEST_F(IrqCompleteTest, NullArgs) {
 
 TEST_F(IrqCompleteTest, Target0Success) {
   // Set expectations for every complete call.
-  for (int i = 0; i < RV_PLIC_PARAM_NUMSRC; ++i) {
+  for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
     EXPECT_WRITE32(RV_PLIC_CC0_REG_OFFSET, i);
   }
 
   // Complete all of the IRQs.
-  for (int i = 0; i < RV_PLIC_PARAM_NUMSRC; ++i) {
+  for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
     dif_plic_irq_id_t data = i;
     EXPECT_EQ(dif_plic_irq_complete(&plic_, kTarget0, &data), kDifPlicOk);
   }
 }
 
 class SoftwareIrqForceTest : public PlicTest {
-  static_assert(RV_PLIC_PARAM_NUMTARGET == 1, "");
+  static_assert(RV_PLIC_PARAM_NUM_TARGET == 1, "");
 };
 
 TEST_F(SoftwareIrqForceTest, NullArgs) {
@@ -371,7 +371,7 @@ TEST_F(SoftwareIrqForceTest, NullArgs) {
 }
 
 TEST_F(SoftwareIrqForceTest, BadTarget) {
-  EXPECT_EQ(dif_plic_software_irq_force(&plic_, RV_PLIC_PARAM_NUMTARGET),
+  EXPECT_EQ(dif_plic_software_irq_force(&plic_, RV_PLIC_PARAM_NUM_TARGET),
             kDifPlicBadArg);
 }
 
@@ -381,7 +381,7 @@ TEST_F(SoftwareIrqForceTest, Target0Success) {
 }
 
 class SoftwareIrqAcknowledgeTest : public PlicTest {
-  static_assert(RV_PLIC_PARAM_NUMTARGET == 1, "");
+  static_assert(RV_PLIC_PARAM_NUM_TARGET == 1, "");
 };
 
 TEST_F(SoftwareIrqAcknowledgeTest, NullArgs) {
@@ -390,7 +390,7 @@ TEST_F(SoftwareIrqAcknowledgeTest, NullArgs) {
 }
 
 TEST_F(SoftwareIrqAcknowledgeTest, BadTarget) {
-  EXPECT_EQ(dif_plic_software_irq_acknowledge(&plic_, RV_PLIC_PARAM_NUMTARGET),
+  EXPECT_EQ(dif_plic_software_irq_acknowledge(&plic_, RV_PLIC_PARAM_NUM_TARGET),
             kDifPlicBadArg);
 }
 
@@ -400,7 +400,7 @@ TEST_F(SoftwareIrqAcknowledgeTest, Target0Success) {
 }
 
 class SoftwareIrqIsPendingTest : public PlicTest {
-  static_assert(RV_PLIC_PARAM_NUMTARGET == 1, "");
+  static_assert(RV_PLIC_PARAM_NUM_TARGET == 1, "");
 };
 
 TEST_F(SoftwareIrqIsPendingTest, NullArgs) {
@@ -417,7 +417,7 @@ TEST_F(SoftwareIrqIsPendingTest, NullArgs) {
 
 TEST_F(SoftwareIrqIsPendingTest, BadTarget) {
   bool is_pending;
-  EXPECT_EQ(dif_plic_software_irq_is_pending(&plic_, RV_PLIC_PARAM_NUMTARGET,
+  EXPECT_EQ(dif_plic_software_irq_is_pending(&plic_, RV_PLIC_PARAM_NUM_TARGET,
                                              &is_pending),
             kDifPlicBadArg);
 }

--- a/sw/device/lib/dif/dif_rstmgr.c
+++ b/sw/device/lib/dif/dif_rstmgr.c
@@ -29,7 +29,7 @@ static_assert(kDifRstmgrResetInfoHwReq == (RSTMGR_RESET_INFO_HW_REQ_MASK
               "kDifRstmgrResetInfoHwReq must match the register definition!");
 
 static_assert(
-    RSTMGR_PARAM_NUMSWRESETS == 7,
+    RSTMGR_PARAM_NUM_SW_RESETS == 7,
     "Number of software resets has changed, please update this file!");
 
 // The Reset Manager implementation will have to be updated if the number
@@ -38,7 +38,7 @@ static_assert(
 // appropriate offset from the peripheral base would then have to be
 // calculated.
 static_assert(
-    RSTMGR_PARAM_NUMSWRESETS <= 32,
+    RSTMGR_PARAM_NUM_SW_RESETS <= 32,
     "Reset Enable and Control registers span across multiple registers!");
 
 // Make sure that the public alert info crash dump size matches the HW.
@@ -115,7 +115,7 @@ dif_rstmgr_result_t dif_rstmgr_reset(const dif_rstmgr_t *handle) {
 
 dif_rstmgr_result_t dif_rstmgr_reset_lock(const dif_rstmgr_t *handle,
                                           dif_rstmgr_peripheral_t peripheral) {
-  if (handle == NULL || peripheral >= RSTMGR_PARAM_NUMSWRESETS) {
+  if (handle == NULL || peripheral >= RSTMGR_PARAM_NUM_SW_RESETS) {
     return kDifRstmgrBadArg;
   }
 
@@ -133,7 +133,7 @@ dif_rstmgr_result_t dif_rstmgr_reset_is_locked(
     const dif_rstmgr_t *handle, dif_rstmgr_peripheral_t peripheral,
     bool *is_locked) {
   if (handle == NULL || is_locked == NULL ||
-      peripheral >= RSTMGR_PARAM_NUMSWRESETS) {
+      peripheral >= RSTMGR_PARAM_NUM_SW_RESETS) {
     return kDifRstmgrBadArg;
   }
 
@@ -244,7 +244,7 @@ dif_rstmgr_result_t dif_rstmgr_alert_info_dump_read(
 dif_rstmgr_software_reset_result_t dif_rstmgr_software_reset(
     const dif_rstmgr_t *handle, dif_rstmgr_peripheral_t peripheral,
     dif_rstmgr_software_reset_t reset) {
-  if (handle == NULL || peripheral >= RSTMGR_PARAM_NUMSWRESETS) {
+  if (handle == NULL || peripheral >= RSTMGR_PARAM_NUM_SW_RESETS) {
     return kDifRstmgrSoftwareResetBadArg;
   }
 
@@ -275,7 +275,7 @@ dif_rstmgr_result_t dif_rstmgr_software_reset_is_held(
     const dif_rstmgr_t *handle, dif_rstmgr_peripheral_t peripheral,
     bool *asserted) {
   if (handle == NULL || asserted == NULL ||
-      peripheral >= RSTMGR_PARAM_NUMSWRESETS) {
+      peripheral >= RSTMGR_PARAM_NUM_SW_RESETS) {
     return kDifRstmgrBadArg;
   }
 

--- a/sw/device/lib/dif/dif_rstmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_rstmgr_unittest.cc
@@ -63,12 +63,12 @@ TEST_F(ResetLockTest, NullArgs) {
 }
 
 TEST_F(ResetLockTest, BadPeripheral) {
-  EXPECT_EQ(dif_rstmgr_reset_lock(&rstmgr_, RSTMGR_PARAM_NUMSWRESETS),
+  EXPECT_EQ(dif_rstmgr_reset_lock(&rstmgr_, RSTMGR_PARAM_NUM_SW_RESETS),
             kDifRstmgrBadArg);
 }
 
 TEST_F(ResetLockTest, Success) {
-  for (uint32_t bit_index = 0; bit_index < RSTMGR_PARAM_NUMSWRESETS;
+  for (uint32_t bit_index = 0; bit_index < RSTMGR_PARAM_NUM_SW_RESETS;
        ++bit_index) {
     // When bit is set to `0`, it means that the software reset for the
     // peripheral is locked. One by one lock every peripheral software reset,
@@ -94,13 +94,13 @@ TEST_F(ResetIsLockedTest, NullArgs) {
 
 TEST_F(ResetIsLockedTest, BadPeripheral) {
   bool is_locked;
-  EXPECT_EQ(dif_rstmgr_reset_is_locked(&rstmgr_, RSTMGR_PARAM_NUMSWRESETS,
+  EXPECT_EQ(dif_rstmgr_reset_is_locked(&rstmgr_, RSTMGR_PARAM_NUM_SW_RESETS,
                                        &is_locked),
             kDifRstmgrBadArg);
 }
 
 TEST_F(ResetIsLockedTest, Success) {
-  for (uint32_t bit_index = 0; bit_index < RSTMGR_PARAM_NUMSWRESETS;
+  for (uint32_t bit_index = 0; bit_index < RSTMGR_PARAM_NUM_SW_RESETS;
        ++bit_index) {
     // When bit is set to `0`, it means that the software reset for the
     // peripheral is locked. One by one we check every peripheral, by setting
@@ -383,13 +383,13 @@ TEST_F(SoftwareResetTest, NullArgs) {
 }
 
 TEST_F(SoftwareResetTest, BadPeripheral) {
-  EXPECT_EQ(dif_rstmgr_software_reset(&rstmgr_, RSTMGR_PARAM_NUMSWRESETS,
+  EXPECT_EQ(dif_rstmgr_software_reset(&rstmgr_, RSTMGR_PARAM_NUM_SW_RESETS,
                                       kDifRstmgrSoftwareReset),
             kDifRstmgrBadArg);
 }
 
 TEST_F(SoftwareResetTest, SoftwareResetIsLocked) {
-  for (uint32_t bit_index = 0; bit_index < RSTMGR_PARAM_NUMSWRESETS;
+  for (uint32_t bit_index = 0; bit_index < RSTMGR_PARAM_NUM_SW_RESETS;
        ++bit_index) {
     // When bit is set to `0`, it means that the software reset for the
     // peripheral is locked. One by one we check every peripheral, by setting
@@ -406,7 +406,7 @@ TEST_F(SoftwareResetTest, SoftwareResetIsLocked) {
 }
 
 TEST_F(SoftwareResetTest, SuccessHold) {
-  for (uint32_t bit_index = 0; bit_index < RSTMGR_PARAM_NUMSWRESETS;
+  for (uint32_t bit_index = 0; bit_index < RSTMGR_PARAM_NUM_SW_RESETS;
        ++bit_index) {
     // Software reset is not locked for any of the supported peripherals.
     EXPECT_READ32(RSTMGR_SW_RST_REGEN_REG_OFFSET,
@@ -430,7 +430,7 @@ TEST_F(SoftwareResetTest, SuccessHold) {
 }
 
 TEST_F(SoftwareResetTest, SuccessRelease) {
-  for (uint32_t bit_index = 0; bit_index < RSTMGR_PARAM_NUMSWRESETS;
+  for (uint32_t bit_index = 0; bit_index < RSTMGR_PARAM_NUM_SW_RESETS;
        ++bit_index) {
     // Software reset is not locked for any of the supported peripherals.
     EXPECT_READ32(RSTMGR_SW_RST_REGEN_REG_OFFSET,
@@ -447,7 +447,7 @@ TEST_F(SoftwareResetTest, SuccessRelease) {
 }
 
 TEST_F(SoftwareResetTest, SuccessReset) {
-  for (uint32_t bit_index = 0; bit_index < RSTMGR_PARAM_NUMSWRESETS;
+  for (uint32_t bit_index = 0; bit_index < RSTMGR_PARAM_NUM_SW_RESETS;
        ++bit_index) {
     // Software reset is not locked for any of the supported peripherals.
     EXPECT_READ32(RSTMGR_SW_RST_REGEN_REG_OFFSET,
@@ -491,12 +491,12 @@ TEST_F(SoftwareResetIsHeldTest, NullArgs) {
 TEST_F(SoftwareResetIsHeldTest, BadPeripheral) {
   bool asserted;
   EXPECT_EQ(dif_rstmgr_software_reset_is_held(
-                &rstmgr_, RSTMGR_PARAM_NUMSWRESETS, &asserted),
+                &rstmgr_, RSTMGR_PARAM_NUM_SW_RESETS, &asserted),
             kDifRstmgrBadArg);
 }
 
 TEST_F(SoftwareResetIsHeldTest, Success) {
-  for (uint32_t bit_index = 0; bit_index < RSTMGR_PARAM_NUMSWRESETS;
+  for (uint32_t bit_index = 0; bit_index < RSTMGR_PARAM_NUM_SW_RESETS;
        ++bit_index) {
     uint32_t reset_is_held = bitfield_bit32_write(
         std::numeric_limits<uint32_t>::max(), bit_index, false);

--- a/sw/device/lib/dif/dif_usbdev.c
+++ b/sw/device/lib/dif/dif_usbdev.c
@@ -14,7 +14,7 @@
  * Definition in the header file (and probably other places) must be updated if
  * there is a hardware change.
  */
-static_assert(USBDEV_NUM_ENDPOINTS == USBDEV_PARAM_NENDPOINTS,
+static_assert(USBDEV_NUM_ENDPOINTS == USBDEV_PARAM_N_ENDPOINTS,
               "Mismatch in number of endpoints");
 
 /**

--- a/sw/device/lib/flash_ctrl.c
+++ b/sw/device/lib/flash_ctrl.c
@@ -10,7 +10,7 @@
 
 #define FLASH_CTRL0_BASE_ADDR TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR
 #define PROGRAM_RESOLUTION_WORDS \
-  (FLASH_CTRL_PARAM_REGBUSPGMRESBYTES / sizeof(uint32_t))
+  (FLASH_CTRL_PARAM_REG_BUS_PGM_RES_BYTES / sizeof(uint32_t))
 
 #define REG32(add) *((volatile uint32_t *)(add))
 #define SETBIT(val, bit) (val | 1 << bit)
@@ -224,21 +224,21 @@ void flash_cfg_region(const mp_region_t *region_cfg) {
   }
 }
 
-uint32_t flash_get_banks(void) { return FLASH_CTRL_PARAM_REGNUMBANKS; }
+uint32_t flash_get_banks(void) { return FLASH_CTRL_PARAM_REG_NUM_BANKS; }
 
 uint32_t flash_get_pages_per_bank(void) {
-  return FLASH_CTRL_PARAM_REGPAGESPERBANK;
+  return FLASH_CTRL_PARAM_REG_PAGES_PER_BANK;
 }
 
 uint32_t flash_get_words_per_page(void) {
-  return FLASH_CTRL_PARAM_WORDSPERPAGE;
+  return FLASH_CTRL_PARAM_WORDS_PER_PAGE;
 }
 
-uint32_t flash_get_bank_size(void) { return FLASH_CTRL_PARAM_BYTESPERBANK; }
+uint32_t flash_get_bank_size(void) { return FLASH_CTRL_PARAM_BYTES_PER_BANK; }
 
-uint32_t flash_get_page_size(void) { return FLASH_CTRL_PARAM_BYTESPERPAGE; }
+uint32_t flash_get_page_size(void) { return FLASH_CTRL_PARAM_BYTES_PER_PAGE; }
 
-uint32_t flash_get_word_size(void) { return FLASH_CTRL_PARAM_BYTESPERWORD; }
+uint32_t flash_get_word_size(void) { return FLASH_CTRL_PARAM_BYTES_PER_WORD; }
 
 void flash_write_scratch_reg(uint32_t value) {
   REG32(FLASH_CTRL0_BASE_ADDR + FLASH_CTRL_SCRATCH_REG_OFFSET) = value;

--- a/util/reggen/gen_cheader.py
+++ b/util/reggen/gen_cheader.py
@@ -25,6 +25,13 @@ from .window import Window
 def genout(outfile: TextIO, msg: str) -> None:
     outfile.write(msg)
 
+def to_snake_case(s: str) -> str:
+    val = []
+    for i, ch in enumerate(s):
+      if i > 0 and ch.isupper():
+        val.append('_')
+      val.append(ch)
+    return ''.join(val)
 
 def as_define(s: str) -> str:
     s = s.upper()
@@ -200,7 +207,10 @@ def gen_cdefines_module_param(outstr: TextIO,
 
     if param.desc is not None:
         genout(outstr, format_comment(first_line(param.desc)))
-    define_name = as_define(module_name + '_PARAM_' + param.name)
+    # Heuristic: if the name already has underscores, it's already snake_case,
+    # otherwise, assume StudlyCaps and covert it to snake_case.
+    param_name = param.name if '_' in param.name else to_snake_case(param.name)
+    define_name = as_define(module_name + '_PARAM_' + param_name)
     if param.param_type == "int":
         define = gen_define(define_name, [], param.value,
                             existing_defines)


### PR DESCRIPTION
Many module parameters are converted from UPPER_SNAKE_CASE in their
hjson files to a variant of CamelCase for use in SystemVerilog files.
These parameter names are then converted to the all-caps form of the
CAMLECASE name in C header files.

The UPPERCASEWITHOUTUNDERSCORES form is too hard to read.  This change
converts back to UPPER_SNAKE_CASE for C header files and fixes all
existing uses for the previous naming scheme.

Signed-off-by: Chris Frantz <cfrantz@google.com>