### PR TITLE
[spi_host, spi_device, top_earlgrey] spi_host side passthrough

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -82,6 +82,9 @@
                 '''
             },
           ]
+          tags: [// Changing modes randomly can result in unknown values being
+                 // passed between spi_dev/host due to passthrough
+                 "excl:CsrNonInitTests:CsrExclWrite"]
         },
         { bits: "16",
           name: "rst_txfifo",

--- a/hw/ip/spi_device/rtl/spi_device_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_pkg.sv
@@ -35,7 +35,7 @@ package spi_device_pkg;
     logic [3:0] s;
   } passthrough_rsp_t;
 
-  parameter passthrough_req_t PASSTHROUGH_RSQ_DEFAULT = '{
+  parameter passthrough_req_t PASSTHROUGH_REQ_DEFAULT = '{
     passthrough_en: 1'b 0,
     sck:            1'b 0,
     sck_gate_en:    1'b 0,

--- a/hw/ip/spi_device/spi_device.core
+++ b/hw/ip/spi_device/spi_device.core
@@ -16,10 +16,9 @@ filesets:
       - lowrisc:prim:ram_2p_adv
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:prim:lc_sync
+      - lowrisc:ip:spi_device_pkg
     files:
-      - rtl/spi_device_reg_pkg.sv
       - rtl/spi_device_reg_top.sv
-      - rtl/spi_device_pkg.sv
       - rtl/spi_fwm_rxf_ctrl.sv
       - rtl/spi_fwm_txf_ctrl.sv
       - rtl/spi_fwmode.sv

--- a/hw/ip/spi_device/spi_device_pkg.core
+++ b/hw/ip/spi_device/spi_device_pkg.core
@@ -1,0 +1,18 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:ip:spi_device_pkg:0.1"
+description: "spi_device_pkg"
+
+filesets:
+  files_rtl:
+    files:
+      - rtl/spi_device_reg_pkg.sv
+      - rtl/spi_device_pkg.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -9,6 +9,15 @@
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }
   ],
+  inter_signal_list: [
+    { struct:  "passthrough",
+      package: "spi_device_pkg",
+      type:    "req_rsp",
+      name:    "passthrough",
+      act:     "rsp",
+      width:   "1"
+    }
+  ]
   regwidth: "32",
   scan: "true",
   param_list: [

--- a/hw/ip/spi_host/spi_host.core
+++ b/hw/ip/spi_host/spi_host.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:ip:lc_ctrl
       - lowrisc:ip:tlul
+      - lowrisc:ip:spi_device_pkg
     files:
       - rtl/spi_host_reg_pkg.sv
       - rtl/spi_host_cmd_pkg.sv

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -743,6 +743,9 @@
           act: req
           width: 1
           inst_name: spi_device
+          default: ""
+          end_idx: -1
+          top_signame: spi_device_passthrough
           index: -1
         }
         {
@@ -788,6 +791,18 @@
       inter_signal_list:
       [
         {
+          name: passthrough
+          struct: passthrough
+          package: spi_device_pkg
+          type: req_rsp
+          act: rsp
+          width: 1
+          inst_name: spi_host0
+          default: ""
+          top_signame: spi_device_passthrough
+          index: -1
+        }
+        {
           name: tl
           struct: tl
           package: tlul_pkg
@@ -829,6 +844,16 @@
       param_list: []
       inter_signal_list:
       [
+        {
+          name: passthrough
+          struct: passthrough
+          package: spi_device_pkg
+          type: req_rsp
+          act: rsp
+          width: 1
+          inst_name: spi_host1
+          index: -1
+        }
         {
           name: tl
           struct: tl
@@ -5972,6 +5997,10 @@
       [
         otp_ctrl.lc_seed_hw_rd_en
         flash_ctrl.lc_seed_hw_rd_en
+      ]
+      spi_device.passthrough:
+      [
+        spi_host0.passthrough
       ]
       pwrmgr_aon.wakeups:
       [
@@ -11603,6 +11632,9 @@
         act: req
         width: 1
         inst_name: spi_device
+        default: ""
+        end_idx: -1
+        top_signame: spi_device_passthrough
         index: -1
       }
       {
@@ -11619,6 +11651,18 @@
         index: -1
       }
       {
+        name: passthrough
+        struct: passthrough
+        package: spi_device_pkg
+        type: req_rsp
+        act: rsp
+        width: 1
+        inst_name: spi_host0
+        default: ""
+        top_signame: spi_device_passthrough
+        index: -1
+      }
+      {
         name: tl
         struct: tl
         package: tlul_pkg
@@ -11629,6 +11673,16 @@
         default: ""
         end_idx: -1
         top_signame: spi_host0_tl
+        index: -1
+      }
+      {
+        name: passthrough
+        struct: passthrough
+        package: spi_device_pkg
+        type: req_rsp
+        act: rsp
+        width: 1
+        inst_name: spi_host1
         index: -1
       }
       {
@@ -16894,6 +16948,28 @@
         act: req
         suffix: ""
         default: lc_ctrl_pkg::Off
+      }
+      {
+        package: spi_device_pkg
+        struct: passthrough_req
+        signame: spi_device_passthrough_req
+        width: 1
+        type: req_rsp
+        end_idx: -1
+        act: req
+        suffix: req
+        default: ""
+      }
+      {
+        package: spi_device_pkg
+        struct: passthrough_rsp
+        signame: spi_device_passthrough_rsp
+        width: 1
+        type: req_rsp
+        end_idx: -1
+        act: req
+        suffix: rsp
+        default: spi_device_pkg::PASSTHROUGH_RSP_DEFAULT
       }
       {
         package: ""

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -951,7 +951,7 @@
       'lc_ctrl.lc_seed_hw_rd_en'           : ['otp_ctrl.lc_seed_hw_rd_en',
                                               'flash_ctrl.lc_seed_hw_rd_en'],
 
-      //'spi_device.passthrough': ['spi_host0.passthrough']
+      'spi_device.passthrough'     : ['spi_host0.passthrough']
     }
 
     // top is to connect to top net/struct.

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -532,6 +532,8 @@ module top_earlgrey #(
   lc_ctrl_pkg::lc_tx_t       lc_ctrl_lc_iso_part_sw_rd_en;
   lc_ctrl_pkg::lc_tx_t       lc_ctrl_lc_iso_part_sw_wr_en;
   lc_ctrl_pkg::lc_tx_t       lc_ctrl_lc_seed_hw_rd_en;
+  spi_device_pkg::passthrough_req_t       spi_device_passthrough_req;
+  spi_device_pkg::passthrough_rsp_t       spi_device_passthrough_rsp;
   logic [4:0] pwrmgr_aon_wakeups;
   logic [1:0] pwrmgr_aon_rstreqs;
   tlul_pkg::tl_h2d_t       rom_ctrl_rom_tl_req;
@@ -1174,8 +1176,8 @@ module top_earlgrey #(
 
       // Inter-module signals
       .ram_cfg_i(ast_ram_2p_cfg),
-      .passthrough_o(),
-      .passthrough_i(spi_device_pkg::PASSTHROUGH_RSP_DEFAULT),
+      .passthrough_o(spi_device_passthrough_req),
+      .passthrough_i(spi_device_passthrough_rsp),
       .tl_i(spi_device_tl_req),
       .tl_o(spi_device_tl_rsp),
       .scanmode_i,
@@ -1205,6 +1207,8 @@ module top_earlgrey #(
       .intr_spi_event_o (intr_spi_host0_spi_event),
 
       // Inter-module signals
+      .passthrough_i(spi_device_passthrough_req),
+      .passthrough_o(spi_device_passthrough_rsp),
       .tl_i(spi_host0_tl_req),
       .tl_o(spi_host0_tl_rsp),
       .scanmode_i,
@@ -1234,6 +1238,8 @@ module top_earlgrey #(
       .intr_spi_event_o (intr_spi_host1_spi_event),
 
       // Inter-module signals
+      .passthrough_i(spi_device_pkg::PASSTHROUGH_REQ_DEFAULT),
+      .passthrough_o(),
       .tl_i(spi_host1_tl_req),
       .tl_o(spi_host1_tl_rsp),
       .scanmode_i,


### PR DESCRIPTION
    [ spi_device, spi_host, top_earlgrey ] Add SPI passthrough to spi_host
    
    - Create new corefile for spi_device_pkg
    - Add passthrough structure I/O to spi_host
    - Uncomment intermodule connections in top_earlgrey
    - Correct typo in spi_device PASSTHROUGH_DEFAULT_REQ interhost
    - Create temporary workaround for poor naming of intermodule defaults
    
    Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>

