### PR TITLE
[util] Fix for intermodule names

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1071,6 +1071,7 @@
           width: 1
           inst_name: usbdev
           default: ""
+          package: ""
           external: true
           top_signame: usbdev_usb_ref_val
           index: -1
@@ -1083,6 +1084,7 @@
           width: 1
           inst_name: usbdev
           default: ""
+          package: ""
           external: true
           top_signame: usbdev_usb_ref_pulse
           index: -1
@@ -1095,6 +1097,7 @@
           width: 1
           inst_name: usbdev
           default: ""
+          package: ""
           end_idx: -1
           top_type: broadcast
           top_signame: usbdev_usb_out_of_rst
@@ -1108,6 +1111,7 @@
           width: 1
           inst_name: usbdev
           default: ""
+          package: ""
           end_idx: -1
           top_type: broadcast
           top_signame: usbdev_usb_aon_wake_en
@@ -1121,6 +1125,7 @@
           width: 1
           inst_name: usbdev
           default: ""
+          package: ""
           end_idx: -1
           top_type: broadcast
           top_signame: usbdev_usb_aon_wake_ack
@@ -1134,6 +1139,7 @@
           width: 1
           inst_name: usbdev
           default: ""
+          package: ""
           end_idx: -1
           top_type: broadcast
           top_signame: usbdev_usb_suspend
@@ -2178,6 +2184,7 @@
           width: 4
           inst_name: pwrmgr_aon
           default: ""
+          package: ""
           end_idx: -1
           top_type: one-to-N
           top_signame: pwrmgr_aon_wakeups
@@ -2191,6 +2198,7 @@
           width: 1
           inst_name: pwrmgr_aon
           default: ""
+          package: ""
           end_idx: -1
           top_type: broadcast
           top_signame: pwrmgr_aon_rstreqs
@@ -2204,6 +2212,7 @@
           width: 1
           inst_name: pwrmgr_aon
           default: ""
+          package: ""
           end_idx: -1
           top_type: broadcast
           top_signame: pwrmgr_aon_strap
@@ -2217,6 +2226,7 @@
           width: 1
           inst_name: pwrmgr_aon
           default: ""
+          package: ""
           end_idx: -1
           top_type: broadcast
           top_signame: pwrmgr_aon_low_power
@@ -2496,6 +2506,7 @@
           width: 1
           inst_name: clkmgr_aon
           default: ""
+          package: ""
           external: true
           top_signame: clk_main_jitter_en
           index: -1
@@ -2508,6 +2519,7 @@
           width: 1
           inst_name: clkmgr_aon
           default: ""
+          package: ""
           external: true
           top_signame: clk_main
           index: -1
@@ -2520,6 +2532,7 @@
           width: 1
           inst_name: clkmgr_aon
           default: ""
+          package: ""
           external: true
           top_signame: clk_io
           index: -1
@@ -2532,6 +2545,7 @@
           width: 1
           inst_name: clkmgr_aon
           default: ""
+          package: ""
           external: true
           top_signame: clk_usb
           index: -1
@@ -2544,6 +2558,7 @@
           width: 1
           inst_name: clkmgr_aon
           default: ""
+          package: ""
           external: true
           top_signame: clk_aon
           index: -1
@@ -2581,6 +2596,7 @@
           width: 4
           inst_name: clkmgr_aon
           default: ""
+          package: ""
           end_idx: -1
           top_type: one-to-N
           top_signame: clkmgr_aon_idle
@@ -3196,6 +3212,7 @@
           width: 9
           inst_name: sensor_ctrl_aon
           default: ""
+          package: ""
           external: true
           top_signame: ast2pinmux
           index: -1
@@ -4578,6 +4595,7 @@
           width: 1
           inst_name: entropy_src
           default: ""
+          package: ""
           external: true
           top_signame: es_rng_fips
           index: -1
@@ -11652,6 +11670,7 @@
         width: 1
         inst_name: usbdev
         default: ""
+        package: ""
         external: true
         top_signame: usbdev_usb_ref_val
         index: -1
@@ -11664,6 +11683,7 @@
         width: 1
         inst_name: usbdev
         default: ""
+        package: ""
         external: true
         top_signame: usbdev_usb_ref_pulse
         index: -1
@@ -11676,6 +11696,7 @@
         width: 1
         inst_name: usbdev
         default: ""
+        package: ""
         end_idx: -1
         top_type: broadcast
         top_signame: usbdev_usb_out_of_rst
@@ -11689,6 +11710,7 @@
         width: 1
         inst_name: usbdev
         default: ""
+        package: ""
         end_idx: -1
         top_type: broadcast
         top_signame: usbdev_usb_aon_wake_en
@@ -11702,6 +11724,7 @@
         width: 1
         inst_name: usbdev
         default: ""
+        package: ""
         end_idx: -1
         top_type: broadcast
         top_signame: usbdev_usb_aon_wake_ack
@@ -11715,6 +11738,7 @@
         width: 1
         inst_name: usbdev
         default: ""
+        package: ""
         end_idx: -1
         top_type: broadcast
         top_signame: usbdev_usb_suspend
@@ -12554,6 +12578,7 @@
         width: 4
         inst_name: pwrmgr_aon
         default: ""
+        package: ""
         end_idx: -1
         top_type: one-to-N
         top_signame: pwrmgr_aon_wakeups
@@ -12567,6 +12592,7 @@
         width: 1
         inst_name: pwrmgr_aon
         default: ""
+        package: ""
         end_idx: -1
         top_type: broadcast
         top_signame: pwrmgr_aon_rstreqs
@@ -12580,6 +12606,7 @@
         width: 1
         inst_name: pwrmgr_aon
         default: ""
+        package: ""
         end_idx: -1
         top_type: broadcast
         top_signame: pwrmgr_aon_strap
@@ -12593,6 +12620,7 @@
         width: 1
         inst_name: pwrmgr_aon
         default: ""
+        package: ""
         end_idx: -1
         top_type: broadcast
         top_signame: pwrmgr_aon_low_power
@@ -12801,6 +12829,7 @@
         width: 1
         inst_name: clkmgr_aon
         default: ""
+        package: ""
         external: true
         top_signame: clk_main_jitter_en
         index: -1
@@ -12813,6 +12842,7 @@
         width: 1
         inst_name: clkmgr_aon
         default: ""
+        package: ""
         external: true
         top_signame: clk_main
         index: -1
@@ -12825,6 +12855,7 @@
         width: 1
         inst_name: clkmgr_aon
         default: ""
+        package: ""
         external: true
         top_signame: clk_io
         index: -1
@@ -12837,6 +12868,7 @@
         width: 1
         inst_name: clkmgr_aon
         default: ""
+        package: ""
         external: true
         top_signame: clk_usb
         index: -1
@@ -12849,6 +12881,7 @@
         width: 1
         inst_name: clkmgr_aon
         default: ""
+        package: ""
         external: true
         top_signame: clk_aon
         index: -1
@@ -12886,6 +12919,7 @@
         width: 4
         inst_name: clkmgr_aon
         default: ""
+        package: ""
         end_idx: -1
         top_type: one-to-N
         top_signame: clkmgr_aon_idle
@@ -13278,6 +13312,7 @@
         width: 9
         inst_name: sensor_ctrl_aon
         default: ""
+        package: ""
         external: true
         top_signame: ast2pinmux
         index: -1
@@ -14021,6 +14056,7 @@
         width: 1
         inst_name: entropy_src
         default: ""
+        package: ""
         external: true
         top_signame: es_rng_fips
         index: -1
@@ -15849,7 +15885,7 @@
         end_idx: -1
         act: rcv
         suffix: ""
-        default: ""
+        default: prim_ram_1p_pkg::RAM_1P_CFG_DEFAULT
       }
       {
         package: prim_ram_2p_pkg
@@ -15860,7 +15896,7 @@
         end_idx: -1
         act: rcv
         suffix: ""
-        default: ""
+        default: prim_ram_2p_pkg::RAM_2P_CFG_DEFAULT
       }
       {
         package: prim_rom_pkg
@@ -15871,7 +15907,7 @@
         end_idx: -1
         act: rcv
         suffix: ""
-        default: ""
+        default: prim_rom_pkg::ROM_CFG_DEFAULT
       }
       {
         package: alert_pkg
@@ -15882,7 +15918,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: alert_pkg::ALERT_CRASHDUMP_DEFAULT
       }
       {
         package: prim_esc_pkg
@@ -15893,7 +15929,7 @@
         end_idx: -1
         act: rcv
         suffix: ""
-        default: ""
+        default: prim_esc_pkg::ESC_RX_DEFAULT
       }
       {
         package: prim_esc_pkg
@@ -15904,7 +15940,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: prim_esc_pkg::ESC_TX_DEFAULT
       }
       {
         package: csrng_pkg
@@ -15915,7 +15951,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: csrng_pkg::CSRNG_REQ_DEFAULT
       }
       {
         package: csrng_pkg
@@ -15948,7 +15984,7 @@
         end_idx: -1
         act: req
         suffix: rsp
-        default: ""
+        default: entropy_src_pkg::ENTROPY_SRC_HW_IF_RSP_DEFAULT
       }
       {
         package: entropy_src_pkg
@@ -15959,7 +15995,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: entropy_src_pkg::CS_AES_HALT_REQ_DEFAULT
       }
       {
         package: entropy_src_pkg
@@ -15992,7 +16028,7 @@
         end_idx: -1
         act: req
         suffix: rsp
-        default: ""
+        default: flash_ctrl_pkg::FLASH_RSP_DEFAULT
       }
       {
         package: flash_ctrl_pkg
@@ -16003,7 +16039,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: flash_ctrl_pkg::KEYMGR_FLASH_DEFAULT
       }
       {
         package: otp_ctrl_pkg
@@ -16025,7 +16061,7 @@
         end_idx: -1
         act: req
         suffix: rsp
-        default: ""
+        default: otp_ctrl_pkg::FLASH_OTP_KEY_RSP_DEFAULT
       }
       {
         package: lc_ctrl_pkg
@@ -16036,7 +16072,7 @@
         end_idx: -1
         act: rcv
         suffix: ""
-        default: ""
+        default: lc_ctrl_pkg::LC_TX_DEFAULT
       }
       {
         package: lc_ctrl_pkg
@@ -16047,7 +16083,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: lc_ctrl_pkg::LC_TX_DEFAULT
       }
       {
         package: lc_ctrl_pkg
@@ -16058,7 +16094,7 @@
         end_idx: -1
         act: rcv
         suffix: ""
-        default: ""
+        default: lc_ctrl_pkg::LC_FLASH_RMA_SEED_DEFAULT
       }
       {
         package: sram_ctrl_pkg
@@ -16069,7 +16105,7 @@
         end_idx: -1
         act: req
         suffix: req
-        default: "'0"
+        default: ""
       }
       {
         package: sram_ctrl_pkg
@@ -16091,7 +16127,7 @@
         end_idx: -1
         act: req
         suffix: req
-        default: "'0"
+        default: ""
       }
       {
         package: sram_ctrl_pkg
@@ -16113,7 +16149,7 @@
         end_idx: -1
         act: req
         suffix: req
-        default: "'0"
+        default: ""
       }
       {
         package: sram_ctrl_pkg
@@ -16135,7 +16171,7 @@
         end_idx: -1
         act: req
         suffix: req
-        default: "'0"
+        default: ""
       }
       {
         package: sram_ctrl_pkg
@@ -16157,7 +16193,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: tlul_pkg::TL_INSTR_EN_DEFAULT
       }
       {
         package: tlul_pkg
@@ -16168,7 +16204,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: tlul_pkg::TL_INSTR_EN_DEFAULT
       }
       {
         package: ""
@@ -16179,7 +16215,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: "'0"
       }
       {
         package: ""
@@ -16190,7 +16226,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: "'0"
       }
       {
         package: otp_ctrl_pkg
@@ -16212,7 +16248,7 @@
         end_idx: -1
         act: rsp
         suffix: rsp
-        default: "'0"
+        default: ""
       }
       {
         package: pwrmgr_pkg
@@ -16223,7 +16259,7 @@
         end_idx: -1
         act: rcv
         suffix: ""
-        default: ""
+        default: pwrmgr_pkg::PWR_FLASH_DEFAULT
       }
       {
         package: pwrmgr_pkg
@@ -16245,7 +16281,7 @@
         end_idx: -1
         act: req
         suffix: rsp
-        default: ""
+        default: pwrmgr_pkg::PWR_RST_RSP_DEFAULT
       }
       {
         package: pwrmgr_pkg
@@ -16267,7 +16303,7 @@
         end_idx: -1
         act: req
         suffix: rsp
-        default: ""
+        default: pwrmgr_pkg::PWR_CLK_RSP_DEFAULT
       }
       {
         package: pwrmgr_pkg
@@ -16289,7 +16325,7 @@
         end_idx: -1
         act: req
         suffix: rsp
-        default: ""
+        default: pwrmgr_pkg::PWR_OTP_RSP_DEFAULT
       }
       {
         package: pwrmgr_pkg
@@ -16311,7 +16347,7 @@
         end_idx: -1
         act: req
         suffix: rsp
-        default: ""
+        default: pwrmgr_pkg::PWR_LC_RSP_DEFAULT
       }
       {
         package: ""
@@ -16322,7 +16358,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: "'0"
       }
       {
         package: ""
@@ -16333,7 +16369,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: "'0"
       }
       {
         package: rom_ctrl_pkg
@@ -16344,7 +16380,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: rom_ctrl_pkg::PWRMGR_DATA_DEFAULT
       }
       {
         package: rom_ctrl_pkg
@@ -16355,7 +16391,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: rom_ctrl_pkg::KEYMGR_DATA_DEFAULT
       }
       {
         package: ibex_pkg
@@ -16366,7 +16402,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: ibex_pkg::CRASH_DUMP_DEFAULT
       }
       {
         package: ""
@@ -16377,7 +16413,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: "'0"
       }
       {
         package: ""
@@ -16388,7 +16424,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: "'0"
       }
       {
         package: ""
@@ -16399,7 +16435,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: "'0"
       }
       {
         package: ""
@@ -16410,7 +16446,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: "'0"
       }
       {
         package: usbdev_pkg
@@ -16421,7 +16457,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: usbdev_pkg::AWK_STATE_DEFAULT
       }
       {
         package: edn_pkg
@@ -16443,7 +16479,7 @@
         end_idx: -1
         act: rsp
         suffix: rsp
-        default: "'0"
+        default: ""
       }
       {
         package: edn_pkg
@@ -16465,7 +16501,7 @@
         end_idx: 1
         act: rsp
         suffix: rsp
-        default: "'0"
+        default: ""
       }
       {
         package: otp_ctrl_pkg
@@ -16487,7 +16523,7 @@
         end_idx: -1
         act: req
         suffix: ""
-        default: ""
+        default: keymgr_pkg::HW_KEY_REQ_DEFAULT
       }
       {
         package: kmac_pkg
@@ -16498,7 +16534,7 @@
         end_idx: 2
         act: rsp
         suffix: req
-        default: ""
+        default: kmac_pkg::APP_REQ_DEFAULT
       }
       {
         package: kmac_pkg
@@ -16520,7 +16556,7 @@
         end_idx: -1
         act: rcv
         suffix: ""
-        default: ""
+        default: "'0"
       }
       {
         package: jtag_pkg
@@ -16542,7 +16578,7 @@
         end_idx: -1
         act: req
         suffix: rsp
-        default: ""
+        default: jtag_pkg::JTAG_RSP_DEFAULT
       }
       {
         package: jtag_pkg
@@ -16564,7 +16600,7 @@
         end_idx: -1
         act: req
         suffix: rsp
-        default: ""
+        default: jtag_pkg::JTAG_RSP_DEFAULT
       }
       {
         package: otp_ctrl_pkg
@@ -16586,7 +16622,7 @@
         end_idx: -1
         act: req
         suffix: req
-        default: "'0"
+        default: ""
       }
       {
         package: otp_ctrl_pkg
@@ -16608,7 +16644,7 @@
         end_idx: -1
         act: req
         suffix: req
-        default: "'0"
+        default: ""
       }
       {
         package: otp_ctrl_pkg
@@ -16806,7 +16842,7 @@
         end_idx: -1
         act: rcv
         suffix: ""
-        default: ""
+        default: "'0"
       }
       {
         package: ""
@@ -16817,7 +16853,7 @@
         end_idx: -1
         act: rcv
         suffix: ""
-        default: ""
+        default: "'0"
       }
       {
         package: tlul_pkg
@@ -16828,7 +16864,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -16850,7 +16886,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -16872,7 +16908,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -16894,7 +16930,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -16927,7 +16963,7 @@
         end_idx: -1
         act: req
         suffix: rsp
-        default: ""
+        default: tlul_pkg::TL_D2H_DEFAULT
       }
       {
         package: tlul_pkg
@@ -16938,7 +16974,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -16960,7 +16996,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -16982,7 +17018,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17004,7 +17040,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17026,7 +17062,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17048,7 +17084,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17070,7 +17106,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17092,7 +17128,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17114,7 +17150,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17136,7 +17172,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17158,7 +17194,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17180,7 +17216,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17202,7 +17238,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17224,7 +17260,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17246,7 +17282,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17268,7 +17304,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17290,7 +17326,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17312,7 +17348,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17334,7 +17370,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17356,7 +17392,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17378,7 +17414,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17400,7 +17436,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17422,7 +17458,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17444,7 +17480,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17466,7 +17502,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17488,7 +17524,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17510,7 +17546,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17532,7 +17568,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17554,7 +17590,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17576,7 +17612,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17598,7 +17634,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17620,7 +17656,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17642,7 +17678,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17664,7 +17700,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17686,7 +17722,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17708,7 +17744,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17730,7 +17766,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17752,7 +17788,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17774,7 +17810,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17796,7 +17832,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg
@@ -17818,7 +17854,7 @@
         end_idx: -1
         act: rsp
         suffix: req
-        default: ""
+        default: tlul_pkg::TL_H2D_DEFAULT
       }
       {
         package: tlul_pkg

--- a/util/topgen/templates/toplevel.sv.tpl
+++ b/util/topgen/templates/toplevel.sv.tpl
@@ -237,7 +237,7 @@ module top_${top["name"]} #(
 % endfor
 % for sig in undriven_im_defs:
   % for idx in range(sig['end_idx'], sig['width']):
-  assign ${sig["signame"]}[${idx}] = ${lib.im_netname(sig, sig['suffix'], True)};
+  assign ${sig["signame"]}[${idx}] = ${sig["default"]};
   % endfor
 % endfor
 


### PR DESCRIPTION
This issue was originally discovered by @eunchan.

The top level template code originally used im_netname for determining
the code for dangling nets at both the module instantiation level, as well
as the broadcast tie-off (for modules like kmac_app and edn1).

However, the input to im_netname was different in each case.
For module level instantiation, the input was the module `inter_signal` definition which does not include `req/rsp` as part of the struct name.

For broadcast tie-off, such as kmac_app and edn1, the input was the top level inter_module definition that includes `req/rsp` as part of the struct name already.

This creates a conflict where either the module level didn't contain the suffix or the top level had an extra suffix.

The fix moves the default net name creation directly to when the top level defintion is created and avoids this conflict.

Eventually this same scheme can be ported to im_netname as well without needing to construct on the fly.  But that will be done in a separate PR.

Signed-off-by: Timothy Chen <timothytim@google.com>