### PR TITLE
[dv/sram] stress_all test

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_lc_escalation_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_lc_escalation_vseq.sv
@@ -56,7 +56,7 @@ class sram_ctrl_lc_escalation_vseq extends sram_ctrl_multiple_keys_vseq;
       fork
         begin
           // randomly enable zero delays in the SRAM TLUL agent
-          if ($urandom_range(0, 1)) cfg.set_sram_zero_delays();
+          cfg.cfg_sram_zero_delays($urandom_range(0, 1));
           req_scr_key();
           csr_spinwait(.ptr(ral.status.scr_key_valid), .exp_data(1));
           `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_ops)

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_stress_all_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_stress_all_vseq.sv
@@ -1,0 +1,51 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// combine all sram_ctrl vseqs (except the ones belwo) in one top level vseq to run sequentially
+// 1. common vseq: csr/alert tests disable scb, and sram does not have interrupts
+// 2. lc_escalation_vseq can issue an internal reset, so it is included in stress_all_vseq,
+//    but excluded from stress_all_with_rand_reset
+class sram_ctrl_stress_all_vseq extends sram_ctrl_base_vseq;
+
+  `uvm_object_utils(sram_ctrl_stress_all_vseq)
+  `uvm_object_new
+
+  string vseq_names[$] = {"sram_ctrl_smoke_vseq",
+                         "sram_ctrl_multiple_keys_vseq",
+                         "sram_ctrl_bijection_vseq",
+                         "sram_ctrl_stress_pipeline_vseq",
+                         "sram_ctrl_mem_tl_errors_vseq",
+                         "sram_ctrl_access_during_key_req_vseq",
+                         "sram_ctrl_executable_vseq"};
+
+  virtual task pre_start();
+    super.pre_start();
+    if (common_seq_type != "stress_all_with_rand_reset") begin
+      vseq_names.push_back("sram_ctrl_lc_escalation_vseq");
+    end
+  endtask
+
+  task body();
+    `uvm_info(`gfn, $sformatf("Running %0d random sequences", num_trans), UVM_LOW)
+    for (int i = 0; i < num_trans; i++) begin
+      uvm_sequence        seq;
+      sram_ctrl_base_vseq sram_vseq;
+      uint                seq_idx = $urandom_range(0, vseq_names.size() - 1);
+      string              cur_vseq_name = vseq_names[seq_idx];
+
+      seq = create_seq_by_name(cur_vseq_name);
+      `downcast(sram_vseq, seq)
+
+      sram_vseq.do_apply_reset = (do_apply_reset) ? $urandom_range(0, 1) : 0;
+
+
+      sram_vseq.set_sequencer(p_sequencer);
+      `DV_CHECK_RANDOMIZE_FATAL(sram_vseq)
+      sram_vseq.cfg.cfg_sram_zero_delays(cur_vseq_name == "sram_ctrl_stress_pipeline_vseq");
+      `uvm_info(`gfn, $sformatf("iteration[%0d]: starting %0s", i, cur_vseq_name), UVM_LOW)
+      sram_vseq.start(p_sequencer);
+    end
+  endtask
+
+endclass

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_vseq_list.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_vseq_list.sv
@@ -12,3 +12,4 @@
 `include "sram_ctrl_mem_tl_errors_vseq.sv"
 `include "sram_ctrl_access_during_key_req_vseq.sv"
 `include "sram_ctrl_executable_vseq.sv"
+`include "sram_ctrl_stress_all_vseq.sv"

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
@@ -30,6 +30,7 @@ filesets:
       - seq_lib/sram_ctrl_mem_tl_errors_vseq.sv: {is_include_file: true}
       - seq_lib/sram_ctrl_access_during_key_req_vseq.sv: {is_include_file: true}
       - seq_lib/sram_ctrl_executable_vseq.sv: {is_include_file: true}
+      - seq_lib/sram_ctrl_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.sv
@@ -55,9 +55,7 @@ class sram_ctrl_env extends cip_base_env #(
       this, "m_kdi_agent", "cfg", cfg.m_kdi_cfg);
     cfg.m_kdi_cfg.en_cov = cfg.en_cov;
 
-    if (cfg.zero_delays) begin
-      cfg.set_sram_zero_delays();
-    end
+    cfg.cfg_sram_zero_delays(cfg.zero_delays);
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
@@ -52,18 +52,21 @@ class sram_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(sram_ctrl_reg_block));
 
   // utility function to zero protocol delays for the TLUL agent
   // that is bound to the SRAM memory interface
-  virtual function void set_sram_zero_delays();
-    m_sram_cfg.a_valid_delay_min = 0;
-    m_sram_cfg.a_valid_delay_max = 0;
+  virtual function void cfg_sram_zero_delays(bit enable);
+    int min = enable ? 0 : 1;
+    int max = enable ? 0 : 10;
 
-    m_sram_cfg.a_ready_delay_min = 0;
-    m_sram_cfg.a_ready_delay_max = 0;
+    m_sram_cfg.a_valid_delay_min = min;
+    m_sram_cfg.a_valid_delay_max = max;
 
-    m_sram_cfg.d_valid_delay_min = 0;
-    m_sram_cfg.d_valid_delay_max = 0;
+    m_sram_cfg.a_ready_delay_min = min;
+    m_sram_cfg.a_ready_delay_max = max;
 
-    m_sram_cfg.d_ready_delay_min = 0;
-    m_sram_cfg.d_ready_delay_max = 0;
+    m_sram_cfg.d_valid_delay_min = min;
+    m_sram_cfg.d_valid_delay_max = max;
+
+    m_sram_cfg.d_ready_delay_min = min;
+    m_sram_cfg.d_ready_delay_max = max;
   endfunction
 
 endclass

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -94,7 +94,6 @@
     {
       name: "{variant}_mem_tl_errors"
       uvm_test_seq: sram_ctrl_mem_tl_errors_vseq
-      run_opts: ["+run_tl_errors"]
     }
     {
       name: "{variant}_access_during_key_req"
@@ -103,6 +102,10 @@
     {
       name: "{variant}_executable"
       uvm_test_seq: sram_ctrl_executable_vseq
+    }
+    {
+      name: "{variant}_stress_all"
+      uvm_test_seq: sram_ctrl_stress_all_vseq
     }
   ]
 


### PR DESCRIPTION
this PR adds the sram_ctrl_stress_all test, along with a few minor
modifications to how the vseqs can enable/disable zero delays for the
memory TL agent.

Signed-off-by: Udi Jonnalagadda <udij@google.com>