### PR TITLE
[ prim ] Suppress unneeded assertion when clearing prim_packer_fifo

### DIFF
--- a/hw/ip/prim/rtl/prim_packer_fifo.sv
+++ b/hw/ip/prim/rtl/prim_packer_fifo.sv
@@ -165,13 +165,12 @@ module prim_packer_fifo #(
   //////////////////////////////////////////////
 
   // If not acked, valid_o should keep asserting
-  `ASSERT(ValidOPairedWidthReadyI_A,
-          rvalid_o && !rready_i |=> rvalid_o)
+  `ASSERT(ValidOPairedWithReadyI_A,
+          rvalid_o && !rready_i && !clr_i |=> rvalid_o)
 
   // If output port doesn't accept the data, the data should be stable
   `ASSERT(DataOStableWhenPending_A,
           ##1 rvalid_o && $past(rvalid_o)
-          && !$past(rready_i) |-> $stable(rdata_o))
-
+          && !$past(rready_i) && !$past(clr_i) |-> $stable(rdata_o))
 
 endmodule


### PR DESCRIPTION
Previous implementation did not allow for clearing this block if it were full.

Fixes #6296

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>