### PR TITLE
[kmac,lint] Waive width mismatch warning in kmac_app.sv

### DIFF
--- a/hw/ip/kmac/lint/kmac.vlt
+++ b/hw/ip/kmac/lint/kmac.vlt
@@ -11,3 +11,6 @@
 // warnings.
 lint_off -rule UNUSED -file "*/rtl/kmac.sv" -match "Signal is not used: 'clk_edn_i'"
 lint_off -rule UNUSED -file "*/rtl/kmac.sv" -match "Signal is not used: 'rst_edn_ni'"
+
+// Waive warning about width mismatch when comparing "i" and "app_id".
+lint_off -rule WIDTH -file "*/rtl/kmac_app.sv" -match "Operator EQ expects 32 bits*'app_id' generates 2 bits."


### PR DESCRIPTION
When commit a3a2bc5 removed the explicit cast from the code, it
introduced a Verilator warning. Rather than introducing yet more
churn, just waive it.

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>