### PR TITLE
[rom_ctrl] Properly exclude DIGEST/EXP_DIGEST from CSR tests

### DIFF
--- a/hw/ip/rom_ctrl/data/rom_ctrl.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl.hjson
@@ -126,7 +126,7 @@
           //       its value will change under the feet of the CSR package as
           //       the ROM checker computes a digest. Re-enable this (and add
           //       RAL reflection) once we have a working testbench.
-          tags: ["excl:CsrNonInitTests:CsrExclCheck"]
+          tags: ["excl:CsrAllTests:CsrExclCheck"]
         }
       }
       {
@@ -145,7 +145,7 @@
             }
           ]
           // TODO: As with DIGEST, re-enable this when we have a working testbench
-          tags: ["excl:CsrNonInitTests:CsrExclCheck"]
+          tags: ["excl:CsrAllTests:CsrExclCheck"]
         }
       }
     ],


### PR DESCRIPTION
The previous temporary "fix" (in 532aa80) excluded them from
everything except for the HwReset tests... which promptly failed. Turn
those off too.

This is currently breaking CI on master (I merged the previous "almost fix" and presumably something else merged in the meantime has perturbed the RNG so that we now see the failures).