### PR TITLE
[hmac,lint] Waive unused input signals for Verilator

### DIFF
--- a/hw/ip/hmac/lint/hmac.vlt
+++ b/hw/ip/hmac/lint/hmac.vlt
@@ -4,3 +4,11 @@
 //
 // waiver file for hmac
 
+`verilator_config
+
+// The wipe_secret and wipe_v inputs to hmac_core and sha2_pad are not
+// currently used, but we're keeping them attached for future use.
+lint_off -rule UNUSED -file "*/rtl/hmac_core.sv" -match "Signal is not used: 'wipe_secret'"
+lint_off -rule UNUSED -file "*/rtl/hmac_core.sv" -match "Signal is not used: 'wipe_v'"
+lint_off -rule UNUSED -file "*/rtl/sha2_pad.sv" -match "Signal is not used: 'wipe_secret'"
+lint_off -rule UNUSED -file "*/rtl/sha2_pad.sv" -match "Signal is not used: 'wipe_v'"


### PR DESCRIPTION
These are already waived for AscentLint in hmac.waiver.
