### PR TITLE
[spi_device] Assorted lint fixes

### DIFF
--- a/hw/ip/spi_device/lint/spi_device.vlt
+++ b/hw/ip/spi_device/lint/spi_device.vlt
@@ -6,3 +6,5 @@
 
 `verilator_config
 
+// The mode_i input is not currently used: we only support FwMode at the moment.
+lint_off -rule UNUSED -file "*/rtl/spi_fwmode.sv" -match "Signal is not used: 'mode_i'"

--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -255,7 +255,10 @@ module spi_readcmd
   // sram address is sent.
   logic addr_in_mailbox;
 
-  logic [31:0] mailbox_masked_addr, buffer_masked_addr;
+  logic [31:0] mailbox_masked_addr;
+
+  // TODO: implement
+  // logic [31:0] buffer_masked_addr;
 
   // Double buffering signals
   logic readbuf_idx; // 0 or 1

--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -648,6 +648,10 @@ module spi_readcmd
     .depth_o  (unused_depth)
   );
 
+  // TODO: Handle SRAM integrity errors
+  sram_err_t unused_sram_rerror;
+  assign unused_sram_rerror = sram_rerror_i;
+
   // Assertions //
   // FIFO should not overflow. The Main state machine shall send request only
   // when it needs the data within 2 cycles


### PR DESCRIPTION
Waive an unused input, explicitly mark another as unused (giving a nice place to put a TODO), and remove an unused internal signal. See commit messages for more details.