### PR TITLE
[uart,lint] Waive warning about unused field in uart reg2hw

### DIFF
--- a/hw/ip/uart/lint/uart.vlt
+++ b/hw/ip/uart/lint/uart.vlt
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`verilator_config
+
+// The STATUS register is marked hrw because we need access to its
+// read-enables (e.g. reg2hw.status.txfull.re). We don't look at the
+// rest of the exposed signals, though: waive the resulting warnings.
+lint_off -rule UNUSED -file "*/rtl/uart_core.sv" -match "Bits of signal are not used: 'reg2hw'[*]"


### PR DESCRIPTION
Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>