### PR TITLE
[edn/rtl] refactored for unused signals

### DIFF
--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -145,10 +145,6 @@
                 EDN will be the next application to receive a seed from the entropy_src IP.
                 '''
         }
-        { bits: "31",
-          name: "INTERNAL_USE",
-          desc: "This bit is for internal use only."
-        }
       ]
     },
     { name: "SW_CMD_REQ",

--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -130,6 +130,8 @@ module edn_core import edn_pkg::*;
   logic                               fifo_write_err_sum;
   logic                               fifo_read_err_sum;
   logic                               fifo_status_err_sum;
+  logic                               unused_err_code_test_bit;
+  logic                               unused_reg2hw_regwen;
 
   // flops
   logic [31:0]                        cs_cmd_req_q, cs_cmd_req_d;
@@ -612,14 +614,11 @@ module edn_core import edn_pkg::*;
 
 
   //--------------------------------------------
-  // report edn request summary
+  // unused signals
   //--------------------------------------------
 
-  assign     hw2reg.sum_sts.internal_use.de = !edn_enable;
-  assign     hw2reg.sum_sts.internal_use.d =
-             (|err_code_test_bit[19:2]) ||
-             (|err_code_test_bit[27:22]) ||
-             reg2hw.regwen.q;
+  assign unused_err_code_test_bit = (|err_code_test_bit[19:2]) || (|err_code_test_bit[27:22]);
+  assign unused_reg2hw_regwen = reg2hw.regwen.q;
 
 
 endmodule

--- a/hw/ip/edn/rtl/edn_reg_pkg.sv
+++ b/hw/ip/edn/rtl/edn_reg_pkg.sv
@@ -111,10 +111,6 @@ package edn_reg_pkg;
       logic        d;
       logic        de;
     } boot_inst_ack;
-    struct packed {
-      logic        d;
-      logic        de;
-    } internal_use;
   } edn_hw2reg_sum_sts_reg_t;
 
   typedef struct packed {
@@ -176,8 +172,8 @@ package edn_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    edn_hw2reg_intr_state_reg_t intr_state; // [27:24]
-    edn_hw2reg_sum_sts_reg_t sum_sts; // [23:18]
+    edn_hw2reg_intr_state_reg_t intr_state; // [25:22]
+    edn_hw2reg_sum_sts_reg_t sum_sts; // [21:18]
     edn_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [17:14]
     edn_hw2reg_err_code_reg_t err_code; // [13:0]
   } edn_hw2reg_t;
@@ -234,7 +230,7 @@ package edn_reg_pkg;
     4'b 0001, // index[ 3] EDN_ALERT_TEST
     4'b 0001, // index[ 4] EDN_REGWEN
     4'b 0001, // index[ 5] EDN_CTRL
-    4'b 1111, // index[ 6] EDN_SUM_STS
+    4'b 0001, // index[ 6] EDN_SUM_STS
     4'b 1111, // index[ 7] EDN_SW_CMD_REQ
     4'b 0001, // index[ 8] EDN_SW_CMD_STS
     4'b 1111, // index[ 9] EDN_RESEED_CMD

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -140,9 +140,6 @@ module edn_reg_top (
   logic sum_sts_boot_inst_ack_qs;
   logic sum_sts_boot_inst_ack_wd;
   logic sum_sts_boot_inst_ack_we;
-  logic sum_sts_internal_use_qs;
-  logic sum_sts_internal_use_wd;
-  logic sum_sts_internal_use_we;
   logic [31:0] sw_cmd_req_wd;
   logic sw_cmd_req_we;
   logic sw_cmd_sts_cmd_rdy_qs;
@@ -480,32 +477,6 @@ module edn_reg_top (
 
     // to register interface (read)
     .qs     (sum_sts_boot_inst_ack_qs)
-  );
-
-
-  //   F[internal_use]: 31:31
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_sum_sts_internal_use (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (sum_sts_internal_use_we),
-    .wd     (sum_sts_internal_use_wd),
-
-    // from internal hardware
-    .de     (hw2reg.sum_sts.internal_use.de),
-    .d      (hw2reg.sum_sts.internal_use.d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (sum_sts_internal_use_qs)
   );
 
 
@@ -924,9 +895,6 @@ module edn_reg_top (
   assign sum_sts_boot_inst_ack_we = addr_hit[6] & reg_we & !reg_error;
   assign sum_sts_boot_inst_ack_wd = reg_wdata[1];
 
-  assign sum_sts_internal_use_we = addr_hit[6] & reg_we & !reg_error;
-  assign sum_sts_internal_use_wd = reg_wdata[31];
-
   assign sw_cmd_req_we = addr_hit[7] & reg_we & !reg_error;
   assign sw_cmd_req_wd = reg_wdata[31:0];
 
@@ -978,7 +946,6 @@ module edn_reg_top (
       addr_hit[6]: begin
         reg_rdata_next[0] = sum_sts_req_mode_sm_sts_qs;
         reg_rdata_next[1] = sum_sts_boot_inst_ack_qs;
-        reg_rdata_next[31] = sum_sts_internal_use_qs;
       end
 
       addr_hit[7]: begin


### PR DESCRIPTION
Converted rtl to use the usused_* naming convention.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>