### PR TITLE
[entropy_src/lint] need waiver for stub mode

### DIFF
--- a/hw/ip/entropy_src/lint/entropy_src.waiver
+++ b/hw/ip/entropy_src/lint/entropy_src.waiver
@@ -4,3 +4,5 @@
 #
 # waiver file for entropy_src
 
+waive -rules RESET_MUX    -location {entropy_src.sv} -regexp {Asynchronous reset .*_rst_n' is driven by a multiplexer.*} \
+      -comment "The MUX is needed to control stub mode or not"


### PR DESCRIPTION
Since stub mode was added, a new lint message popped up.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>