### PR TITLE
[doc] Clarify HMAC and KMAC endianness settings

### DIFF
--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -67,12 +67,30 @@
         }
         { bits: "2",
           name: "endian_swap",
-          desc: "Convert TL-UL wdata[31:0] to big-endian style {w[7:0], w[15:8], .. }",
+          desc: '''Endian swap.
+
+                If 0 then each individual multi-byte value, regardless of its
+                alignment, written to !!MSG_FIFO will be added to the message
+                in big-endian byte order.
+                If 1, each value will be added to the message in little-endian
+                byte order.
+                A message written to !!MSG_FIFO one byte at a time will not be
+                affected by this setting.
+                From a hardware perspective byte swaps are performed on a TL-UL
+                word granularity.
+                ''',
           resval: "1",
         }
         { bits: "3",
           name: "digest_swap",
-          desc: "DIGEST register byte-order. If 1, it swaps each DIGEST registers' byte-order.",
+          desc: '''Digest register byte swap.
+
+                If 1 the value contained in each digest output register is
+                converted to big-endian byte order.
+                This setting does not affect the order of the digest output
+                registers, !!DIGEST_0 still contains the first 4 bytes of
+                the digest.
+                ''',
           resval: "0",
         }
       ]

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -192,20 +192,28 @@
           name: "msg_endianness"
           desc: '''Message Endianness.
 
-                If 1, Convert TL-UL write data[31:0] to {d[7:0], d[15:8], ...}
-
-                0: Little-endian. Keep input value as it is
-                1: Big-endian. Convert incoming value
+                If 1 then each individual multi-byte value, regardless of its
+                alignment, written to !!MSG_FIFO will be added to the message
+                in big-endian byte order.
+                If 0, each value will be added to the message in little-endian
+                byte order.
+                A message written to !!MSG_FIFO one byte at a time will not be
+                affected by this setting.
+                From a hardware perspective byte swaps are performed on a TL-UL
+                word granularity.
                 '''
           resval: "0"
         } // f: msg_endianness
         { bits: "9"
           name: "state_endianness"
-          desc: '''Output state (Digest) Endianness.
+          desc: '''State Endianness.
 
-                Convert read-out state register to big-endian style.
-                If 0, keep the internal value as it is when SW reads.
-                If 1, convert the internal state value.
+                If 1 then each individual word in the !!STATE output register
+                is converted to big-endian byte order.
+                The order of the words in relation to one another is not
+                changed.
+                This setting does not affect how the state is interpreted
+                during computation.
                 '''
         } // f: state_endianness
         { bits: "12"


### PR DESCRIPTION
The intent of this change is to make it clearer the effect that the
`kmac.CFG.msg_endianness` and `hmac.CFG.byte_swap` settings have on
values written to the relevant `MSG_FIFO`. In particular how writes
smaller than a word are affected.

This also modifies the wording for the equivalent settings for the
output registers. In this case just to clarify that each individual
word in the output has its bytes reversed, as opposed to the entire
multi-word value being reversed.

Fixes #6251.