### PR TITLE
[dv/lc_ctrl] randomize otp_ctrl if's token input

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
@@ -36,8 +36,10 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(lc_ctrl_reg_block));
                                  .HostDataWidth(lc_ctrl_state_pkg::LcTokenWidth))
         ::type_id::create("m_otp_token_pull_agent_cfg");
     `DV_CHECK_RANDOMIZE_FATAL(m_otp_token_pull_agent_cfg)
-    m_otp_token_pull_agent_cfg.agent_type = PullAgent;
-    m_otp_token_pull_agent_cfg.if_mode    = Device;
+    m_otp_token_pull_agent_cfg.agent_type                 = PullAgent;
+    m_otp_token_pull_agent_cfg.if_mode                    = Device;
+    m_otp_token_pull_agent_cfg.in_bidirectional_mode      = 1;
+    m_otp_token_pull_agent_cfg.hold_d_data_until_next_req = 1;
 
     m_esc_wipe_secrets_agent_cfg = alert_esc_agent_cfg::type_id::create(
         "m_esc_wipe_secrets_agent_cfg");

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -44,9 +44,9 @@ interface lc_ctrl_if(input clk, input rst_n);
     otp_i.error = 0;
     otp_i.state = lc_state;
     otp_i.count = lc_cnt;
-    otp_i.test_unlock_token = 0;
-    otp_i.test_exit_token = 0;
-    otp_i.rma_token = 0;
+    otp_i.test_unlock_token = $urandom();
+    otp_i.test_exit_token = $urandom();
+    otp_i.rma_token = $urandom();
     otp_i.id_state = LcIdBlank;
 
     otp_hw_cfg_i.valid = Off;
@@ -54,7 +54,6 @@ interface lc_ctrl_if(input clk, input rst_n);
 
     clk_byp_ack_i = clk_byp_ack;
     flash_rma_ack_i = flash_rma_ack;
-    hashed_token = '0;
   endtask
 
   task automatic set_clk_byp_ack(lc_tx_t val);
@@ -65,7 +64,4 @@ interface lc_ctrl_if(input clk, input rst_n);
     flash_rma_ack_i = val;
   endtask
 
-  task automatic set_hashed_token(lc_token_t val);
-    hashed_token = val;
-  endtask
 endinterface

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -18,8 +18,6 @@ module tb;
   wire clk, rst_n;
   wire devmode;
   wire [LcPwrIfWidth-1:0] pwr_lc;
-  // TODO: can delete once push-pull agent support constraint data
-  wire otp_ctrl_pkg::lc_otp_token_rsp_t   otp_token_rsp;
 
   // interfaces
   clk_rst_if   clk_rst_if(.clk(clk), .rst_n(rst_n));
@@ -36,10 +34,6 @@ module tb;
                otp_token_if(.clk(clk), .rst_n(rst_n));
 
   `DV_ALERT_IF_CONNECT
-
-  assign otp_token_rsp.ack = otp_token_if.ack;
-  // TODO: temp constraint to 0 because it has to equal to otp_lc_data_i tokens
-  assign otp_token_rsp.hashed_token = lc_ctrl_if.hashed_token;
 
   // dut
   lc_ctrl dut (
@@ -67,7 +61,7 @@ module tb;
     .lc_otp_program_i           ({otp_prog_if.d_data, otp_prog_if.ack}),
 
     .lc_otp_token_o             ({otp_token_if.req, otp_token_if.h_data}),
-    .lc_otp_token_i             (otp_token_rsp),
+    .lc_otp_token_i             ({ otp_token_if.ack, otp_token_if.d_data}),
 
     .otp_lc_data_i              (lc_ctrl_if.otp_i),
 


### PR DESCRIPTION
This PR support randomize otp_ctrl interface's token input by:
1. Remove the hardcoded 0 that tied to token decode, and use push-pull
agent.
2. Constraint the decoded token by checking the state transition.

Signed-off-by: Cindy Chen <chencindy@google.com>