### PR TITLE
[flash_ctrl,lint] Move unused cfgs_i waiver into RTL

### DIFF
--- a/hw/ip/flash_ctrl/lint/flash_ctrl.waiver
+++ b/hw/ip/flash_ctrl/lint/flash_ctrl.waiver
@@ -11,10 +11,6 @@ waive -rules TERMINAL_STATE -location {flash_ctrl_lcmgr.sv} -regexp {.*StInvalid
 waive -rules MISSING_STATE -location {flash_ctrl_lcmgr.sv} -regexp {.*StInvalid.*} \
       -comment "Behavior is part of default state"
 
-# Not all configurations for every info type is used
-waive -rules INPUT_NOT_READ: -location {flash_ctrl_info_cfg.sv} -regexp {.*cfgs_i.*} \
-      -comment "For info types that have fewer pages, the full config is not used"
-
 # Remove errors from prim_* modules
 # TBD These should be directly addressed in primgen modules long term
 waive -rules INPUT_NOT_READ -location {prim_flop.sv} -regexp {Input port.*} \

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_info_cfg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_info_cfg.sv
@@ -45,6 +45,11 @@ module flash_ctrl_info_cfg import flash_ctrl_pkg::*; # (
     if (i > InfoTypeSize[InfoSel]) begin : gen_invalid_region
       assign cfgs_o[i] = '0;
 
+      // For info types that have fewer pages than the maximum, not the full config (cfgs_i[i] for i
+      // greater than InfoTypeSize[InfoSel]) is used.
+      logic unused_cfgs;
+      assign unused_cfgs = &{1'b0, cfgs_i[i]};
+
     // if match creator, only allow access when creator privilege is set
     end else if (CurAddr == SeedInfoPageSel[CreatorSeedIdx]) begin : gen_creator
       assign cfgs_o[i] = cfgs_i[i] & {CfgBitWidth{creator_seed_priv_i}};


### PR DESCRIPTION
The fact that we only use some bits of `cfgs_i` was waived for
AscentLint, but still caused warnings with Verilator. We could waive
it for Verilator in the same way, but instead let's define an
`unused_*` signal in the RTL to waive just the cfgs inputs that we are
actually trying to ignore.

This should be slightly safer, because it means the warning would come
back if we messed up one of the other branches in the if/else tree for
some reason.