### PR TITLE
[spi_device] Add necessary CSRs for passthrough

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -165,6 +165,17 @@
             '''
           resval: "0x7F",
         },
+        { bits: "16"
+          name: "addr_4b_en"
+          desc: '''4B Address Mode enable.
+
+            This field configures the internal module to receive 32 bits of the SPI commands. The affected commands are the SPI read commands except QPI, and program commands.
+
+            Even though Read SFDP command has address fields, the SFDP command
+            is not affected by this field. The command always parse 24 bits on
+            the SPI line 0 following the SPI command as the address field.
+            '''
+        }
       ]
     },
     { name: "FIFO_LEVEL",
@@ -321,6 +332,61 @@
         }
       ],
     },
+    { multireg: {
+        cname: "SPI_DEVICE"
+        name:  "CMD_FILTER"
+        desc:  '''Command Filter
+
+          If a bit in this CSR is 1, then corresponding SPI command w.r.t the
+          bit position among 256 bit is dropped in SPI Passthrough mode.
+          '''
+        count: "256"
+        swaccess: "rw"
+        hwaccess: "hro"
+        compact: true
+        fields: [
+          { bits: "0"
+            name: "filter"
+            resval: "0"
+            desc: "If 1, command will be filtered"
+          }
+        ]
+      }
+    }
+    { name: "ADDR_SWAP_MASK"
+      desc: '''Address Swap Mask register.
+
+        This register is used in the SPI passthrough mode. If any of bits in
+        this register is set, the corresponding address bit in the SPI Read
+        commands is replaced with the data from !!ADDR_SWAP_DATA.
+
+        If 3B address mode is active, upper 8bit [31:24] is ignored.
+        '''
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits:   "31:0"
+          resval: "0",
+          name:   "mask"
+          desc: '''When a bit is 1, the SPI read address to the downstream SPI
+            Flash device is swapped to !!ADDR_SWAP_DATA.
+            '''
+        }
+      ]
+    }
+    { name: "ADDR_SWAP_DATA"
+      desc: '''The address value for the address swap feature.
+        '''
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits:   "31:0"
+          resval: "0"
+          name:   "data"
+          desc:   "Desired value to be swapped for the SPI read commands."
+        }
+      ]
+    }
     { skipto: "0x1000" }
     { window: {
         name: "buffer",

--- a/hw/ip/spi_device/lint/spi_device.vlt
+++ b/hw/ip/spi_device/lint/spi_device.vlt
@@ -4,3 +4,5 @@
 //
 // waiver file for spi_device
 
+`verilator_config
+

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -119,6 +119,9 @@ package spi_device_reg_pkg;
     struct packed {
       logic [7:0]  q;
     } timer_v;
+    struct packed {
+      logic        q;
+    } addr_4b_en;
   } spi_device_reg2hw_cfg_reg_t;
 
   typedef struct packed {
@@ -159,6 +162,18 @@ package spi_device_reg_pkg;
       logic [15:0] q;
     } limit;
   } spi_device_reg2hw_txf_addr_reg_t;
+
+  typedef struct packed {
+    logic        q;
+  } spi_device_reg2hw_cmd_filter_mreg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } spi_device_reg2hw_addr_swap_mask_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } spi_device_reg2hw_addr_swap_data_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -233,16 +248,19 @@ package spi_device_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    spi_device_reg2hw_intr_state_reg_t intr_state; // [169:164]
-    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [163:158]
-    spi_device_reg2hw_intr_test_reg_t intr_test; // [157:146]
-    spi_device_reg2hw_control_reg_t control; // [145:140]
-    spi_device_reg2hw_cfg_reg_t cfg; // [139:128]
-    spi_device_reg2hw_fifo_level_reg_t fifo_level; // [127:96]
-    spi_device_reg2hw_rxf_ptr_reg_t rxf_ptr; // [95:80]
-    spi_device_reg2hw_txf_ptr_reg_t txf_ptr; // [79:64]
-    spi_device_reg2hw_rxf_addr_reg_t rxf_addr; // [63:32]
-    spi_device_reg2hw_txf_addr_reg_t txf_addr; // [31:0]
+    spi_device_reg2hw_intr_state_reg_t intr_state; // [490:485]
+    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [484:479]
+    spi_device_reg2hw_intr_test_reg_t intr_test; // [478:467]
+    spi_device_reg2hw_control_reg_t control; // [466:461]
+    spi_device_reg2hw_cfg_reg_t cfg; // [460:448]
+    spi_device_reg2hw_fifo_level_reg_t fifo_level; // [447:416]
+    spi_device_reg2hw_rxf_ptr_reg_t rxf_ptr; // [415:400]
+    spi_device_reg2hw_txf_ptr_reg_t txf_ptr; // [399:384]
+    spi_device_reg2hw_rxf_addr_reg_t rxf_addr; // [383:352]
+    spi_device_reg2hw_txf_addr_reg_t txf_addr; // [351:320]
+    spi_device_reg2hw_cmd_filter_mreg_t [255:0] cmd_filter; // [319:64]
+    spi_device_reg2hw_addr_swap_mask_reg_t addr_swap_mask; // [63:32]
+    spi_device_reg2hw_addr_swap_data_reg_t addr_swap_data; // [31:0]
   } spi_device_reg2hw_t;
 
   // HW -> register type
@@ -267,6 +285,16 @@ package spi_device_reg_pkg;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TXF_PTR_OFFSET = 13'h 24;
   parameter logic [BlockAw-1:0] SPI_DEVICE_RXF_ADDR_OFFSET = 13'h 28;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TXF_ADDR_OFFSET = 13'h 2c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_0_OFFSET = 13'h 30;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_1_OFFSET = 13'h 34;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_2_OFFSET = 13'h 38;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_3_OFFSET = 13'h 3c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_4_OFFSET = 13'h 40;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_5_OFFSET = 13'h 44;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_6_OFFSET = 13'h 48;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_7_OFFSET = 13'h 4c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_MASK_OFFSET = 13'h 50;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_DATA_OFFSET = 13'h 54;
 
   // Reset values for hwext registers and their fields
   parameter logic [5:0] SPI_DEVICE_INTR_TEST_RESVAL = 6'h 0;
@@ -300,23 +328,43 @@ package spi_device_reg_pkg;
     SPI_DEVICE_RXF_PTR,
     SPI_DEVICE_TXF_PTR,
     SPI_DEVICE_RXF_ADDR,
-    SPI_DEVICE_TXF_ADDR
+    SPI_DEVICE_TXF_ADDR,
+    SPI_DEVICE_CMD_FILTER_0,
+    SPI_DEVICE_CMD_FILTER_1,
+    SPI_DEVICE_CMD_FILTER_2,
+    SPI_DEVICE_CMD_FILTER_3,
+    SPI_DEVICE_CMD_FILTER_4,
+    SPI_DEVICE_CMD_FILTER_5,
+    SPI_DEVICE_CMD_FILTER_6,
+    SPI_DEVICE_CMD_FILTER_7,
+    SPI_DEVICE_ADDR_SWAP_MASK,
+    SPI_DEVICE_ADDR_SWAP_DATA
   } spi_device_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] SPI_DEVICE_PERMIT [12] = '{
+  parameter logic [3:0] SPI_DEVICE_PERMIT [22] = '{
     4'b 0001, // index[ 0] SPI_DEVICE_INTR_STATE
     4'b 0001, // index[ 1] SPI_DEVICE_INTR_ENABLE
     4'b 0001, // index[ 2] SPI_DEVICE_INTR_TEST
     4'b 1111, // index[ 3] SPI_DEVICE_CONTROL
-    4'b 0011, // index[ 4] SPI_DEVICE_CFG
+    4'b 0111, // index[ 4] SPI_DEVICE_CFG
     4'b 1111, // index[ 5] SPI_DEVICE_FIFO_LEVEL
     4'b 0111, // index[ 6] SPI_DEVICE_ASYNC_FIFO_LEVEL
     4'b 0001, // index[ 7] SPI_DEVICE_STATUS
     4'b 1111, // index[ 8] SPI_DEVICE_RXF_PTR
     4'b 1111, // index[ 9] SPI_DEVICE_TXF_PTR
     4'b 1111, // index[10] SPI_DEVICE_RXF_ADDR
-    4'b 1111  // index[11] SPI_DEVICE_TXF_ADDR
+    4'b 1111, // index[11] SPI_DEVICE_TXF_ADDR
+    4'b 1111, // index[12] SPI_DEVICE_CMD_FILTER_0
+    4'b 1111, // index[13] SPI_DEVICE_CMD_FILTER_1
+    4'b 1111, // index[14] SPI_DEVICE_CMD_FILTER_2
+    4'b 1111, // index[15] SPI_DEVICE_CMD_FILTER_3
+    4'b 1111, // index[16] SPI_DEVICE_CMD_FILTER_4
+    4'b 1111, // index[17] SPI_DEVICE_CMD_FILTER_5
+    4'b 1111, // index[18] SPI_DEVICE_CMD_FILTER_6
+    4'b 1111, // index[19] SPI_DEVICE_CMD_FILTER_7
+    4'b 1111, // index[20] SPI_DEVICE_ADDR_SWAP_MASK
+    4'b 1111  // index[21] SPI_DEVICE_ADDR_SWAP_DATA
   };
 
 endpackage

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -230,6 +230,9 @@ module spi_device_reg_top (
   logic [7:0] cfg_timer_v_qs;
   logic [7:0] cfg_timer_v_wd;
   logic cfg_timer_v_we;
+  logic cfg_addr_4b_en_qs;
+  logic cfg_addr_4b_en_wd;
+  logic cfg_addr_4b_en_we;
   logic [15:0] fifo_level_rxlvl_qs;
   logic [15:0] fifo_level_rxlvl_wd;
   logic fifo_level_rxlvl_we;
@@ -272,6 +275,780 @@ module spi_device_reg_top (
   logic [15:0] txf_addr_limit_qs;
   logic [15:0] txf_addr_limit_wd;
   logic txf_addr_limit_we;
+  logic cmd_filter_0_filter_0_qs;
+  logic cmd_filter_0_filter_0_wd;
+  logic cmd_filter_0_filter_0_we;
+  logic cmd_filter_0_filter_1_qs;
+  logic cmd_filter_0_filter_1_wd;
+  logic cmd_filter_0_filter_1_we;
+  logic cmd_filter_0_filter_2_qs;
+  logic cmd_filter_0_filter_2_wd;
+  logic cmd_filter_0_filter_2_we;
+  logic cmd_filter_0_filter_3_qs;
+  logic cmd_filter_0_filter_3_wd;
+  logic cmd_filter_0_filter_3_we;
+  logic cmd_filter_0_filter_4_qs;
+  logic cmd_filter_0_filter_4_wd;
+  logic cmd_filter_0_filter_4_we;
+  logic cmd_filter_0_filter_5_qs;
+  logic cmd_filter_0_filter_5_wd;
+  logic cmd_filter_0_filter_5_we;
+  logic cmd_filter_0_filter_6_qs;
+  logic cmd_filter_0_filter_6_wd;
+  logic cmd_filter_0_filter_6_we;
+  logic cmd_filter_0_filter_7_qs;
+  logic cmd_filter_0_filter_7_wd;
+  logic cmd_filter_0_filter_7_we;
+  logic cmd_filter_0_filter_8_qs;
+  logic cmd_filter_0_filter_8_wd;
+  logic cmd_filter_0_filter_8_we;
+  logic cmd_filter_0_filter_9_qs;
+  logic cmd_filter_0_filter_9_wd;
+  logic cmd_filter_0_filter_9_we;
+  logic cmd_filter_0_filter_10_qs;
+  logic cmd_filter_0_filter_10_wd;
+  logic cmd_filter_0_filter_10_we;
+  logic cmd_filter_0_filter_11_qs;
+  logic cmd_filter_0_filter_11_wd;
+  logic cmd_filter_0_filter_11_we;
+  logic cmd_filter_0_filter_12_qs;
+  logic cmd_filter_0_filter_12_wd;
+  logic cmd_filter_0_filter_12_we;
+  logic cmd_filter_0_filter_13_qs;
+  logic cmd_filter_0_filter_13_wd;
+  logic cmd_filter_0_filter_13_we;
+  logic cmd_filter_0_filter_14_qs;
+  logic cmd_filter_0_filter_14_wd;
+  logic cmd_filter_0_filter_14_we;
+  logic cmd_filter_0_filter_15_qs;
+  logic cmd_filter_0_filter_15_wd;
+  logic cmd_filter_0_filter_15_we;
+  logic cmd_filter_0_filter_16_qs;
+  logic cmd_filter_0_filter_16_wd;
+  logic cmd_filter_0_filter_16_we;
+  logic cmd_filter_0_filter_17_qs;
+  logic cmd_filter_0_filter_17_wd;
+  logic cmd_filter_0_filter_17_we;
+  logic cmd_filter_0_filter_18_qs;
+  logic cmd_filter_0_filter_18_wd;
+  logic cmd_filter_0_filter_18_we;
+  logic cmd_filter_0_filter_19_qs;
+  logic cmd_filter_0_filter_19_wd;
+  logic cmd_filter_0_filter_19_we;
+  logic cmd_filter_0_filter_20_qs;
+  logic cmd_filter_0_filter_20_wd;
+  logic cmd_filter_0_filter_20_we;
+  logic cmd_filter_0_filter_21_qs;
+  logic cmd_filter_0_filter_21_wd;
+  logic cmd_filter_0_filter_21_we;
+  logic cmd_filter_0_filter_22_qs;
+  logic cmd_filter_0_filter_22_wd;
+  logic cmd_filter_0_filter_22_we;
+  logic cmd_filter_0_filter_23_qs;
+  logic cmd_filter_0_filter_23_wd;
+  logic cmd_filter_0_filter_23_we;
+  logic cmd_filter_0_filter_24_qs;
+  logic cmd_filter_0_filter_24_wd;
+  logic cmd_filter_0_filter_24_we;
+  logic cmd_filter_0_filter_25_qs;
+  logic cmd_filter_0_filter_25_wd;
+  logic cmd_filter_0_filter_25_we;
+  logic cmd_filter_0_filter_26_qs;
+  logic cmd_filter_0_filter_26_wd;
+  logic cmd_filter_0_filter_26_we;
+  logic cmd_filter_0_filter_27_qs;
+  logic cmd_filter_0_filter_27_wd;
+  logic cmd_filter_0_filter_27_we;
+  logic cmd_filter_0_filter_28_qs;
+  logic cmd_filter_0_filter_28_wd;
+  logic cmd_filter_0_filter_28_we;
+  logic cmd_filter_0_filter_29_qs;
+  logic cmd_filter_0_filter_29_wd;
+  logic cmd_filter_0_filter_29_we;
+  logic cmd_filter_0_filter_30_qs;
+  logic cmd_filter_0_filter_30_wd;
+  logic cmd_filter_0_filter_30_we;
+  logic cmd_filter_0_filter_31_qs;
+  logic cmd_filter_0_filter_31_wd;
+  logic cmd_filter_0_filter_31_we;
+  logic cmd_filter_1_filter_32_qs;
+  logic cmd_filter_1_filter_32_wd;
+  logic cmd_filter_1_filter_32_we;
+  logic cmd_filter_1_filter_33_qs;
+  logic cmd_filter_1_filter_33_wd;
+  logic cmd_filter_1_filter_33_we;
+  logic cmd_filter_1_filter_34_qs;
+  logic cmd_filter_1_filter_34_wd;
+  logic cmd_filter_1_filter_34_we;
+  logic cmd_filter_1_filter_35_qs;
+  logic cmd_filter_1_filter_35_wd;
+  logic cmd_filter_1_filter_35_we;
+  logic cmd_filter_1_filter_36_qs;
+  logic cmd_filter_1_filter_36_wd;
+  logic cmd_filter_1_filter_36_we;
+  logic cmd_filter_1_filter_37_qs;
+  logic cmd_filter_1_filter_37_wd;
+  logic cmd_filter_1_filter_37_we;
+  logic cmd_filter_1_filter_38_qs;
+  logic cmd_filter_1_filter_38_wd;
+  logic cmd_filter_1_filter_38_we;
+  logic cmd_filter_1_filter_39_qs;
+  logic cmd_filter_1_filter_39_wd;
+  logic cmd_filter_1_filter_39_we;
+  logic cmd_filter_1_filter_40_qs;
+  logic cmd_filter_1_filter_40_wd;
+  logic cmd_filter_1_filter_40_we;
+  logic cmd_filter_1_filter_41_qs;
+  logic cmd_filter_1_filter_41_wd;
+  logic cmd_filter_1_filter_41_we;
+  logic cmd_filter_1_filter_42_qs;
+  logic cmd_filter_1_filter_42_wd;
+  logic cmd_filter_1_filter_42_we;
+  logic cmd_filter_1_filter_43_qs;
+  logic cmd_filter_1_filter_43_wd;
+  logic cmd_filter_1_filter_43_we;
+  logic cmd_filter_1_filter_44_qs;
+  logic cmd_filter_1_filter_44_wd;
+  logic cmd_filter_1_filter_44_we;
+  logic cmd_filter_1_filter_45_qs;
+  logic cmd_filter_1_filter_45_wd;
+  logic cmd_filter_1_filter_45_we;
+  logic cmd_filter_1_filter_46_qs;
+  logic cmd_filter_1_filter_46_wd;
+  logic cmd_filter_1_filter_46_we;
+  logic cmd_filter_1_filter_47_qs;
+  logic cmd_filter_1_filter_47_wd;
+  logic cmd_filter_1_filter_47_we;
+  logic cmd_filter_1_filter_48_qs;
+  logic cmd_filter_1_filter_48_wd;
+  logic cmd_filter_1_filter_48_we;
+  logic cmd_filter_1_filter_49_qs;
+  logic cmd_filter_1_filter_49_wd;
+  logic cmd_filter_1_filter_49_we;
+  logic cmd_filter_1_filter_50_qs;
+  logic cmd_filter_1_filter_50_wd;
+  logic cmd_filter_1_filter_50_we;
+  logic cmd_filter_1_filter_51_qs;
+  logic cmd_filter_1_filter_51_wd;
+  logic cmd_filter_1_filter_51_we;
+  logic cmd_filter_1_filter_52_qs;
+  logic cmd_filter_1_filter_52_wd;
+  logic cmd_filter_1_filter_52_we;
+  logic cmd_filter_1_filter_53_qs;
+  logic cmd_filter_1_filter_53_wd;
+  logic cmd_filter_1_filter_53_we;
+  logic cmd_filter_1_filter_54_qs;
+  logic cmd_filter_1_filter_54_wd;
+  logic cmd_filter_1_filter_54_we;
+  logic cmd_filter_1_filter_55_qs;
+  logic cmd_filter_1_filter_55_wd;
+  logic cmd_filter_1_filter_55_we;
+  logic cmd_filter_1_filter_56_qs;
+  logic cmd_filter_1_filter_56_wd;
+  logic cmd_filter_1_filter_56_we;
+  logic cmd_filter_1_filter_57_qs;
+  logic cmd_filter_1_filter_57_wd;
+  logic cmd_filter_1_filter_57_we;
+  logic cmd_filter_1_filter_58_qs;
+  logic cmd_filter_1_filter_58_wd;
+  logic cmd_filter_1_filter_58_we;
+  logic cmd_filter_1_filter_59_qs;
+  logic cmd_filter_1_filter_59_wd;
+  logic cmd_filter_1_filter_59_we;
+  logic cmd_filter_1_filter_60_qs;
+  logic cmd_filter_1_filter_60_wd;
+  logic cmd_filter_1_filter_60_we;
+  logic cmd_filter_1_filter_61_qs;
+  logic cmd_filter_1_filter_61_wd;
+  logic cmd_filter_1_filter_61_we;
+  logic cmd_filter_1_filter_62_qs;
+  logic cmd_filter_1_filter_62_wd;
+  logic cmd_filter_1_filter_62_we;
+  logic cmd_filter_1_filter_63_qs;
+  logic cmd_filter_1_filter_63_wd;
+  logic cmd_filter_1_filter_63_we;
+  logic cmd_filter_2_filter_64_qs;
+  logic cmd_filter_2_filter_64_wd;
+  logic cmd_filter_2_filter_64_we;
+  logic cmd_filter_2_filter_65_qs;
+  logic cmd_filter_2_filter_65_wd;
+  logic cmd_filter_2_filter_65_we;
+  logic cmd_filter_2_filter_66_qs;
+  logic cmd_filter_2_filter_66_wd;
+  logic cmd_filter_2_filter_66_we;
+  logic cmd_filter_2_filter_67_qs;
+  logic cmd_filter_2_filter_67_wd;
+  logic cmd_filter_2_filter_67_we;
+  logic cmd_filter_2_filter_68_qs;
+  logic cmd_filter_2_filter_68_wd;
+  logic cmd_filter_2_filter_68_we;
+  logic cmd_filter_2_filter_69_qs;
+  logic cmd_filter_2_filter_69_wd;
+  logic cmd_filter_2_filter_69_we;
+  logic cmd_filter_2_filter_70_qs;
+  logic cmd_filter_2_filter_70_wd;
+  logic cmd_filter_2_filter_70_we;
+  logic cmd_filter_2_filter_71_qs;
+  logic cmd_filter_2_filter_71_wd;
+  logic cmd_filter_2_filter_71_we;
+  logic cmd_filter_2_filter_72_qs;
+  logic cmd_filter_2_filter_72_wd;
+  logic cmd_filter_2_filter_72_we;
+  logic cmd_filter_2_filter_73_qs;
+  logic cmd_filter_2_filter_73_wd;
+  logic cmd_filter_2_filter_73_we;
+  logic cmd_filter_2_filter_74_qs;
+  logic cmd_filter_2_filter_74_wd;
+  logic cmd_filter_2_filter_74_we;
+  logic cmd_filter_2_filter_75_qs;
+  logic cmd_filter_2_filter_75_wd;
+  logic cmd_filter_2_filter_75_we;
+  logic cmd_filter_2_filter_76_qs;
+  logic cmd_filter_2_filter_76_wd;
+  logic cmd_filter_2_filter_76_we;
+  logic cmd_filter_2_filter_77_qs;
+  logic cmd_filter_2_filter_77_wd;
+  logic cmd_filter_2_filter_77_we;
+  logic cmd_filter_2_filter_78_qs;
+  logic cmd_filter_2_filter_78_wd;
+  logic cmd_filter_2_filter_78_we;
+  logic cmd_filter_2_filter_79_qs;
+  logic cmd_filter_2_filter_79_wd;
+  logic cmd_filter_2_filter_79_we;
+  logic cmd_filter_2_filter_80_qs;
+  logic cmd_filter_2_filter_80_wd;
+  logic cmd_filter_2_filter_80_we;
+  logic cmd_filter_2_filter_81_qs;
+  logic cmd_filter_2_filter_81_wd;
+  logic cmd_filter_2_filter_81_we;
+  logic cmd_filter_2_filter_82_qs;
+  logic cmd_filter_2_filter_82_wd;
+  logic cmd_filter_2_filter_82_we;
+  logic cmd_filter_2_filter_83_qs;
+  logic cmd_filter_2_filter_83_wd;
+  logic cmd_filter_2_filter_83_we;
+  logic cmd_filter_2_filter_84_qs;
+  logic cmd_filter_2_filter_84_wd;
+  logic cmd_filter_2_filter_84_we;
+  logic cmd_filter_2_filter_85_qs;
+  logic cmd_filter_2_filter_85_wd;
+  logic cmd_filter_2_filter_85_we;
+  logic cmd_filter_2_filter_86_qs;
+  logic cmd_filter_2_filter_86_wd;
+  logic cmd_filter_2_filter_86_we;
+  logic cmd_filter_2_filter_87_qs;
+  logic cmd_filter_2_filter_87_wd;
+  logic cmd_filter_2_filter_87_we;
+  logic cmd_filter_2_filter_88_qs;
+  logic cmd_filter_2_filter_88_wd;
+  logic cmd_filter_2_filter_88_we;
+  logic cmd_filter_2_filter_89_qs;
+  logic cmd_filter_2_filter_89_wd;
+  logic cmd_filter_2_filter_89_we;
+  logic cmd_filter_2_filter_90_qs;
+  logic cmd_filter_2_filter_90_wd;
+  logic cmd_filter_2_filter_90_we;
+  logic cmd_filter_2_filter_91_qs;
+  logic cmd_filter_2_filter_91_wd;
+  logic cmd_filter_2_filter_91_we;
+  logic cmd_filter_2_filter_92_qs;
+  logic cmd_filter_2_filter_92_wd;
+  logic cmd_filter_2_filter_92_we;
+  logic cmd_filter_2_filter_93_qs;
+  logic cmd_filter_2_filter_93_wd;
+  logic cmd_filter_2_filter_93_we;
+  logic cmd_filter_2_filter_94_qs;
+  logic cmd_filter_2_filter_94_wd;
+  logic cmd_filter_2_filter_94_we;
+  logic cmd_filter_2_filter_95_qs;
+  logic cmd_filter_2_filter_95_wd;
+  logic cmd_filter_2_filter_95_we;
+  logic cmd_filter_3_filter_96_qs;
+  logic cmd_filter_3_filter_96_wd;
+  logic cmd_filter_3_filter_96_we;
+  logic cmd_filter_3_filter_97_qs;
+  logic cmd_filter_3_filter_97_wd;
+  logic cmd_filter_3_filter_97_we;
+  logic cmd_filter_3_filter_98_qs;
+  logic cmd_filter_3_filter_98_wd;
+  logic cmd_filter_3_filter_98_we;
+  logic cmd_filter_3_filter_99_qs;
+  logic cmd_filter_3_filter_99_wd;
+  logic cmd_filter_3_filter_99_we;
+  logic cmd_filter_3_filter_100_qs;
+  logic cmd_filter_3_filter_100_wd;
+  logic cmd_filter_3_filter_100_we;
+  logic cmd_filter_3_filter_101_qs;
+  logic cmd_filter_3_filter_101_wd;
+  logic cmd_filter_3_filter_101_we;
+  logic cmd_filter_3_filter_102_qs;
+  logic cmd_filter_3_filter_102_wd;
+  logic cmd_filter_3_filter_102_we;
+  logic cmd_filter_3_filter_103_qs;
+  logic cmd_filter_3_filter_103_wd;
+  logic cmd_filter_3_filter_103_we;
+  logic cmd_filter_3_filter_104_qs;
+  logic cmd_filter_3_filter_104_wd;
+  logic cmd_filter_3_filter_104_we;
+  logic cmd_filter_3_filter_105_qs;
+  logic cmd_filter_3_filter_105_wd;
+  logic cmd_filter_3_filter_105_we;
+  logic cmd_filter_3_filter_106_qs;
+  logic cmd_filter_3_filter_106_wd;
+  logic cmd_filter_3_filter_106_we;
+  logic cmd_filter_3_filter_107_qs;
+  logic cmd_filter_3_filter_107_wd;
+  logic cmd_filter_3_filter_107_we;
+  logic cmd_filter_3_filter_108_qs;
+  logic cmd_filter_3_filter_108_wd;
+  logic cmd_filter_3_filter_108_we;
+  logic cmd_filter_3_filter_109_qs;
+  logic cmd_filter_3_filter_109_wd;
+  logic cmd_filter_3_filter_109_we;
+  logic cmd_filter_3_filter_110_qs;
+  logic cmd_filter_3_filter_110_wd;
+  logic cmd_filter_3_filter_110_we;
+  logic cmd_filter_3_filter_111_qs;
+  logic cmd_filter_3_filter_111_wd;
+  logic cmd_filter_3_filter_111_we;
+  logic cmd_filter_3_filter_112_qs;
+  logic cmd_filter_3_filter_112_wd;
+  logic cmd_filter_3_filter_112_we;
+  logic cmd_filter_3_filter_113_qs;
+  logic cmd_filter_3_filter_113_wd;
+  logic cmd_filter_3_filter_113_we;
+  logic cmd_filter_3_filter_114_qs;
+  logic cmd_filter_3_filter_114_wd;
+  logic cmd_filter_3_filter_114_we;
+  logic cmd_filter_3_filter_115_qs;
+  logic cmd_filter_3_filter_115_wd;
+  logic cmd_filter_3_filter_115_we;
+  logic cmd_filter_3_filter_116_qs;
+  logic cmd_filter_3_filter_116_wd;
+  logic cmd_filter_3_filter_116_we;
+  logic cmd_filter_3_filter_117_qs;
+  logic cmd_filter_3_filter_117_wd;
+  logic cmd_filter_3_filter_117_we;
+  logic cmd_filter_3_filter_118_qs;
+  logic cmd_filter_3_filter_118_wd;
+  logic cmd_filter_3_filter_118_we;
+  logic cmd_filter_3_filter_119_qs;
+  logic cmd_filter_3_filter_119_wd;
+  logic cmd_filter_3_filter_119_we;
+  logic cmd_filter_3_filter_120_qs;
+  logic cmd_filter_3_filter_120_wd;
+  logic cmd_filter_3_filter_120_we;
+  logic cmd_filter_3_filter_121_qs;
+  logic cmd_filter_3_filter_121_wd;
+  logic cmd_filter_3_filter_121_we;
+  logic cmd_filter_3_filter_122_qs;
+  logic cmd_filter_3_filter_122_wd;
+  logic cmd_filter_3_filter_122_we;
+  logic cmd_filter_3_filter_123_qs;
+  logic cmd_filter_3_filter_123_wd;
+  logic cmd_filter_3_filter_123_we;
+  logic cmd_filter_3_filter_124_qs;
+  logic cmd_filter_3_filter_124_wd;
+  logic cmd_filter_3_filter_124_we;
+  logic cmd_filter_3_filter_125_qs;
+  logic cmd_filter_3_filter_125_wd;
+  logic cmd_filter_3_filter_125_we;
+  logic cmd_filter_3_filter_126_qs;
+  logic cmd_filter_3_filter_126_wd;
+  logic cmd_filter_3_filter_126_we;
+  logic cmd_filter_3_filter_127_qs;
+  logic cmd_filter_3_filter_127_wd;
+  logic cmd_filter_3_filter_127_we;
+  logic cmd_filter_4_filter_128_qs;
+  logic cmd_filter_4_filter_128_wd;
+  logic cmd_filter_4_filter_128_we;
+  logic cmd_filter_4_filter_129_qs;
+  logic cmd_filter_4_filter_129_wd;
+  logic cmd_filter_4_filter_129_we;
+  logic cmd_filter_4_filter_130_qs;
+  logic cmd_filter_4_filter_130_wd;
+  logic cmd_filter_4_filter_130_we;
+  logic cmd_filter_4_filter_131_qs;
+  logic cmd_filter_4_filter_131_wd;
+  logic cmd_filter_4_filter_131_we;
+  logic cmd_filter_4_filter_132_qs;
+  logic cmd_filter_4_filter_132_wd;
+  logic cmd_filter_4_filter_132_we;
+  logic cmd_filter_4_filter_133_qs;
+  logic cmd_filter_4_filter_133_wd;
+  logic cmd_filter_4_filter_133_we;
+  logic cmd_filter_4_filter_134_qs;
+  logic cmd_filter_4_filter_134_wd;
+  logic cmd_filter_4_filter_134_we;
+  logic cmd_filter_4_filter_135_qs;
+  logic cmd_filter_4_filter_135_wd;
+  logic cmd_filter_4_filter_135_we;
+  logic cmd_filter_4_filter_136_qs;
+  logic cmd_filter_4_filter_136_wd;
+  logic cmd_filter_4_filter_136_we;
+  logic cmd_filter_4_filter_137_qs;
+  logic cmd_filter_4_filter_137_wd;
+  logic cmd_filter_4_filter_137_we;
+  logic cmd_filter_4_filter_138_qs;
+  logic cmd_filter_4_filter_138_wd;
+  logic cmd_filter_4_filter_138_we;
+  logic cmd_filter_4_filter_139_qs;
+  logic cmd_filter_4_filter_139_wd;
+  logic cmd_filter_4_filter_139_we;
+  logic cmd_filter_4_filter_140_qs;
+  logic cmd_filter_4_filter_140_wd;
+  logic cmd_filter_4_filter_140_we;
+  logic cmd_filter_4_filter_141_qs;
+  logic cmd_filter_4_filter_141_wd;
+  logic cmd_filter_4_filter_141_we;
+  logic cmd_filter_4_filter_142_qs;
+  logic cmd_filter_4_filter_142_wd;
+  logic cmd_filter_4_filter_142_we;
+  logic cmd_filter_4_filter_143_qs;
+  logic cmd_filter_4_filter_143_wd;
+  logic cmd_filter_4_filter_143_we;
+  logic cmd_filter_4_filter_144_qs;
+  logic cmd_filter_4_filter_144_wd;
+  logic cmd_filter_4_filter_144_we;
+  logic cmd_filter_4_filter_145_qs;
+  logic cmd_filter_4_filter_145_wd;
+  logic cmd_filter_4_filter_145_we;
+  logic cmd_filter_4_filter_146_qs;
+  logic cmd_filter_4_filter_146_wd;
+  logic cmd_filter_4_filter_146_we;
+  logic cmd_filter_4_filter_147_qs;
+  logic cmd_filter_4_filter_147_wd;
+  logic cmd_filter_4_filter_147_we;
+  logic cmd_filter_4_filter_148_qs;
+  logic cmd_filter_4_filter_148_wd;
+  logic cmd_filter_4_filter_148_we;
+  logic cmd_filter_4_filter_149_qs;
+  logic cmd_filter_4_filter_149_wd;
+  logic cmd_filter_4_filter_149_we;
+  logic cmd_filter_4_filter_150_qs;
+  logic cmd_filter_4_filter_150_wd;
+  logic cmd_filter_4_filter_150_we;
+  logic cmd_filter_4_filter_151_qs;
+  logic cmd_filter_4_filter_151_wd;
+  logic cmd_filter_4_filter_151_we;
+  logic cmd_filter_4_filter_152_qs;
+  logic cmd_filter_4_filter_152_wd;
+  logic cmd_filter_4_filter_152_we;
+  logic cmd_filter_4_filter_153_qs;
+  logic cmd_filter_4_filter_153_wd;
+  logic cmd_filter_4_filter_153_we;
+  logic cmd_filter_4_filter_154_qs;
+  logic cmd_filter_4_filter_154_wd;
+  logic cmd_filter_4_filter_154_we;
+  logic cmd_filter_4_filter_155_qs;
+  logic cmd_filter_4_filter_155_wd;
+  logic cmd_filter_4_filter_155_we;
+  logic cmd_filter_4_filter_156_qs;
+  logic cmd_filter_4_filter_156_wd;
+  logic cmd_filter_4_filter_156_we;
+  logic cmd_filter_4_filter_157_qs;
+  logic cmd_filter_4_filter_157_wd;
+  logic cmd_filter_4_filter_157_we;
+  logic cmd_filter_4_filter_158_qs;
+  logic cmd_filter_4_filter_158_wd;
+  logic cmd_filter_4_filter_158_we;
+  logic cmd_filter_4_filter_159_qs;
+  logic cmd_filter_4_filter_159_wd;
+  logic cmd_filter_4_filter_159_we;
+  logic cmd_filter_5_filter_160_qs;
+  logic cmd_filter_5_filter_160_wd;
+  logic cmd_filter_5_filter_160_we;
+  logic cmd_filter_5_filter_161_qs;
+  logic cmd_filter_5_filter_161_wd;
+  logic cmd_filter_5_filter_161_we;
+  logic cmd_filter_5_filter_162_qs;
+  logic cmd_filter_5_filter_162_wd;
+  logic cmd_filter_5_filter_162_we;
+  logic cmd_filter_5_filter_163_qs;
+  logic cmd_filter_5_filter_163_wd;
+  logic cmd_filter_5_filter_163_we;
+  logic cmd_filter_5_filter_164_qs;
+  logic cmd_filter_5_filter_164_wd;
+  logic cmd_filter_5_filter_164_we;
+  logic cmd_filter_5_filter_165_qs;
+  logic cmd_filter_5_filter_165_wd;
+  logic cmd_filter_5_filter_165_we;
+  logic cmd_filter_5_filter_166_qs;
+  logic cmd_filter_5_filter_166_wd;
+  logic cmd_filter_5_filter_166_we;
+  logic cmd_filter_5_filter_167_qs;
+  logic cmd_filter_5_filter_167_wd;
+  logic cmd_filter_5_filter_167_we;
+  logic cmd_filter_5_filter_168_qs;
+  logic cmd_filter_5_filter_168_wd;
+  logic cmd_filter_5_filter_168_we;
+  logic cmd_filter_5_filter_169_qs;
+  logic cmd_filter_5_filter_169_wd;
+  logic cmd_filter_5_filter_169_we;
+  logic cmd_filter_5_filter_170_qs;
+  logic cmd_filter_5_filter_170_wd;
+  logic cmd_filter_5_filter_170_we;
+  logic cmd_filter_5_filter_171_qs;
+  logic cmd_filter_5_filter_171_wd;
+  logic cmd_filter_5_filter_171_we;
+  logic cmd_filter_5_filter_172_qs;
+  logic cmd_filter_5_filter_172_wd;
+  logic cmd_filter_5_filter_172_we;
+  logic cmd_filter_5_filter_173_qs;
+  logic cmd_filter_5_filter_173_wd;
+  logic cmd_filter_5_filter_173_we;
+  logic cmd_filter_5_filter_174_qs;
+  logic cmd_filter_5_filter_174_wd;
+  logic cmd_filter_5_filter_174_we;
+  logic cmd_filter_5_filter_175_qs;
+  logic cmd_filter_5_filter_175_wd;
+  logic cmd_filter_5_filter_175_we;
+  logic cmd_filter_5_filter_176_qs;
+  logic cmd_filter_5_filter_176_wd;
+  logic cmd_filter_5_filter_176_we;
+  logic cmd_filter_5_filter_177_qs;
+  logic cmd_filter_5_filter_177_wd;
+  logic cmd_filter_5_filter_177_we;
+  logic cmd_filter_5_filter_178_qs;
+  logic cmd_filter_5_filter_178_wd;
+  logic cmd_filter_5_filter_178_we;
+  logic cmd_filter_5_filter_179_qs;
+  logic cmd_filter_5_filter_179_wd;
+  logic cmd_filter_5_filter_179_we;
+  logic cmd_filter_5_filter_180_qs;
+  logic cmd_filter_5_filter_180_wd;
+  logic cmd_filter_5_filter_180_we;
+  logic cmd_filter_5_filter_181_qs;
+  logic cmd_filter_5_filter_181_wd;
+  logic cmd_filter_5_filter_181_we;
+  logic cmd_filter_5_filter_182_qs;
+  logic cmd_filter_5_filter_182_wd;
+  logic cmd_filter_5_filter_182_we;
+  logic cmd_filter_5_filter_183_qs;
+  logic cmd_filter_5_filter_183_wd;
+  logic cmd_filter_5_filter_183_we;
+  logic cmd_filter_5_filter_184_qs;
+  logic cmd_filter_5_filter_184_wd;
+  logic cmd_filter_5_filter_184_we;
+  logic cmd_filter_5_filter_185_qs;
+  logic cmd_filter_5_filter_185_wd;
+  logic cmd_filter_5_filter_185_we;
+  logic cmd_filter_5_filter_186_qs;
+  logic cmd_filter_5_filter_186_wd;
+  logic cmd_filter_5_filter_186_we;
+  logic cmd_filter_5_filter_187_qs;
+  logic cmd_filter_5_filter_187_wd;
+  logic cmd_filter_5_filter_187_we;
+  logic cmd_filter_5_filter_188_qs;
+  logic cmd_filter_5_filter_188_wd;
+  logic cmd_filter_5_filter_188_we;
+  logic cmd_filter_5_filter_189_qs;
+  logic cmd_filter_5_filter_189_wd;
+  logic cmd_filter_5_filter_189_we;
+  logic cmd_filter_5_filter_190_qs;
+  logic cmd_filter_5_filter_190_wd;
+  logic cmd_filter_5_filter_190_we;
+  logic cmd_filter_5_filter_191_qs;
+  logic cmd_filter_5_filter_191_wd;
+  logic cmd_filter_5_filter_191_we;
+  logic cmd_filter_6_filter_192_qs;
+  logic cmd_filter_6_filter_192_wd;
+  logic cmd_filter_6_filter_192_we;
+  logic cmd_filter_6_filter_193_qs;
+  logic cmd_filter_6_filter_193_wd;
+  logic cmd_filter_6_filter_193_we;
+  logic cmd_filter_6_filter_194_qs;
+  logic cmd_filter_6_filter_194_wd;
+  logic cmd_filter_6_filter_194_we;
+  logic cmd_filter_6_filter_195_qs;
+  logic cmd_filter_6_filter_195_wd;
+  logic cmd_filter_6_filter_195_we;
+  logic cmd_filter_6_filter_196_qs;
+  logic cmd_filter_6_filter_196_wd;
+  logic cmd_filter_6_filter_196_we;
+  logic cmd_filter_6_filter_197_qs;
+  logic cmd_filter_6_filter_197_wd;
+  logic cmd_filter_6_filter_197_we;
+  logic cmd_filter_6_filter_198_qs;
+  logic cmd_filter_6_filter_198_wd;
+  logic cmd_filter_6_filter_198_we;
+  logic cmd_filter_6_filter_199_qs;
+  logic cmd_filter_6_filter_199_wd;
+  logic cmd_filter_6_filter_199_we;
+  logic cmd_filter_6_filter_200_qs;
+  logic cmd_filter_6_filter_200_wd;
+  logic cmd_filter_6_filter_200_we;
+  logic cmd_filter_6_filter_201_qs;
+  logic cmd_filter_6_filter_201_wd;
+  logic cmd_filter_6_filter_201_we;
+  logic cmd_filter_6_filter_202_qs;
+  logic cmd_filter_6_filter_202_wd;
+  logic cmd_filter_6_filter_202_we;
+  logic cmd_filter_6_filter_203_qs;
+  logic cmd_filter_6_filter_203_wd;
+  logic cmd_filter_6_filter_203_we;
+  logic cmd_filter_6_filter_204_qs;
+  logic cmd_filter_6_filter_204_wd;
+  logic cmd_filter_6_filter_204_we;
+  logic cmd_filter_6_filter_205_qs;
+  logic cmd_filter_6_filter_205_wd;
+  logic cmd_filter_6_filter_205_we;
+  logic cmd_filter_6_filter_206_qs;
+  logic cmd_filter_6_filter_206_wd;
+  logic cmd_filter_6_filter_206_we;
+  logic cmd_filter_6_filter_207_qs;
+  logic cmd_filter_6_filter_207_wd;
+  logic cmd_filter_6_filter_207_we;
+  logic cmd_filter_6_filter_208_qs;
+  logic cmd_filter_6_filter_208_wd;
+  logic cmd_filter_6_filter_208_we;
+  logic cmd_filter_6_filter_209_qs;
+  logic cmd_filter_6_filter_209_wd;
+  logic cmd_filter_6_filter_209_we;
+  logic cmd_filter_6_filter_210_qs;
+  logic cmd_filter_6_filter_210_wd;
+  logic cmd_filter_6_filter_210_we;
+  logic cmd_filter_6_filter_211_qs;
+  logic cmd_filter_6_filter_211_wd;
+  logic cmd_filter_6_filter_211_we;
+  logic cmd_filter_6_filter_212_qs;
+  logic cmd_filter_6_filter_212_wd;
+  logic cmd_filter_6_filter_212_we;
+  logic cmd_filter_6_filter_213_qs;
+  logic cmd_filter_6_filter_213_wd;
+  logic cmd_filter_6_filter_213_we;
+  logic cmd_filter_6_filter_214_qs;
+  logic cmd_filter_6_filter_214_wd;
+  logic cmd_filter_6_filter_214_we;
+  logic cmd_filter_6_filter_215_qs;
+  logic cmd_filter_6_filter_215_wd;
+  logic cmd_filter_6_filter_215_we;
+  logic cmd_filter_6_filter_216_qs;
+  logic cmd_filter_6_filter_216_wd;
+  logic cmd_filter_6_filter_216_we;
+  logic cmd_filter_6_filter_217_qs;
+  logic cmd_filter_6_filter_217_wd;
+  logic cmd_filter_6_filter_217_we;
+  logic cmd_filter_6_filter_218_qs;
+  logic cmd_filter_6_filter_218_wd;
+  logic cmd_filter_6_filter_218_we;
+  logic cmd_filter_6_filter_219_qs;
+  logic cmd_filter_6_filter_219_wd;
+  logic cmd_filter_6_filter_219_we;
+  logic cmd_filter_6_filter_220_qs;
+  logic cmd_filter_6_filter_220_wd;
+  logic cmd_filter_6_filter_220_we;
+  logic cmd_filter_6_filter_221_qs;
+  logic cmd_filter_6_filter_221_wd;
+  logic cmd_filter_6_filter_221_we;
+  logic cmd_filter_6_filter_222_qs;
+  logic cmd_filter_6_filter_222_wd;
+  logic cmd_filter_6_filter_222_we;
+  logic cmd_filter_6_filter_223_qs;
+  logic cmd_filter_6_filter_223_wd;
+  logic cmd_filter_6_filter_223_we;
+  logic cmd_filter_7_filter_224_qs;
+  logic cmd_filter_7_filter_224_wd;
+  logic cmd_filter_7_filter_224_we;
+  logic cmd_filter_7_filter_225_qs;
+  logic cmd_filter_7_filter_225_wd;
+  logic cmd_filter_7_filter_225_we;
+  logic cmd_filter_7_filter_226_qs;
+  logic cmd_filter_7_filter_226_wd;
+  logic cmd_filter_7_filter_226_we;
+  logic cmd_filter_7_filter_227_qs;
+  logic cmd_filter_7_filter_227_wd;
+  logic cmd_filter_7_filter_227_we;
+  logic cmd_filter_7_filter_228_qs;
+  logic cmd_filter_7_filter_228_wd;
+  logic cmd_filter_7_filter_228_we;
+  logic cmd_filter_7_filter_229_qs;
+  logic cmd_filter_7_filter_229_wd;
+  logic cmd_filter_7_filter_229_we;
+  logic cmd_filter_7_filter_230_qs;
+  logic cmd_filter_7_filter_230_wd;
+  logic cmd_filter_7_filter_230_we;
+  logic cmd_filter_7_filter_231_qs;
+  logic cmd_filter_7_filter_231_wd;
+  logic cmd_filter_7_filter_231_we;
+  logic cmd_filter_7_filter_232_qs;
+  logic cmd_filter_7_filter_232_wd;
+  logic cmd_filter_7_filter_232_we;
+  logic cmd_filter_7_filter_233_qs;
+  logic cmd_filter_7_filter_233_wd;
+  logic cmd_filter_7_filter_233_we;
+  logic cmd_filter_7_filter_234_qs;
+  logic cmd_filter_7_filter_234_wd;
+  logic cmd_filter_7_filter_234_we;
+  logic cmd_filter_7_filter_235_qs;
+  logic cmd_filter_7_filter_235_wd;
+  logic cmd_filter_7_filter_235_we;
+  logic cmd_filter_7_filter_236_qs;
+  logic cmd_filter_7_filter_236_wd;
+  logic cmd_filter_7_filter_236_we;
+  logic cmd_filter_7_filter_237_qs;
+  logic cmd_filter_7_filter_237_wd;
+  logic cmd_filter_7_filter_237_we;
+  logic cmd_filter_7_filter_238_qs;
+  logic cmd_filter_7_filter_238_wd;
+  logic cmd_filter_7_filter_238_we;
+  logic cmd_filter_7_filter_239_qs;
+  logic cmd_filter_7_filter_239_wd;
+  logic cmd_filter_7_filter_239_we;
+  logic cmd_filter_7_filter_240_qs;
+  logic cmd_filter_7_filter_240_wd;
+  logic cmd_filter_7_filter_240_we;
+  logic cmd_filter_7_filter_241_qs;
+  logic cmd_filter_7_filter_241_wd;
+  logic cmd_filter_7_filter_241_we;
+  logic cmd_filter_7_filter_242_qs;
+  logic cmd_filter_7_filter_242_wd;
+  logic cmd_filter_7_filter_242_we;
+  logic cmd_filter_7_filter_243_qs;
+  logic cmd_filter_7_filter_243_wd;
+  logic cmd_filter_7_filter_243_we;
+  logic cmd_filter_7_filter_244_qs;
+  logic cmd_filter_7_filter_244_wd;
+  logic cmd_filter_7_filter_244_we;
+  logic cmd_filter_7_filter_245_qs;
+  logic cmd_filter_7_filter_245_wd;
+  logic cmd_filter_7_filter_245_we;
+  logic cmd_filter_7_filter_246_qs;
+  logic cmd_filter_7_filter_246_wd;
+  logic cmd_filter_7_filter_246_we;
+  logic cmd_filter_7_filter_247_qs;
+  logic cmd_filter_7_filter_247_wd;
+  logic cmd_filter_7_filter_247_we;
+  logic cmd_filter_7_filter_248_qs;
+  logic cmd_filter_7_filter_248_wd;
+  logic cmd_filter_7_filter_248_we;
+  logic cmd_filter_7_filter_249_qs;
+  logic cmd_filter_7_filter_249_wd;
+  logic cmd_filter_7_filter_249_we;
+  logic cmd_filter_7_filter_250_qs;
+  logic cmd_filter_7_filter_250_wd;
+  logic cmd_filter_7_filter_250_we;
+  logic cmd_filter_7_filter_251_qs;
+  logic cmd_filter_7_filter_251_wd;
+  logic cmd_filter_7_filter_251_we;
+  logic cmd_filter_7_filter_252_qs;
+  logic cmd_filter_7_filter_252_wd;
+  logic cmd_filter_7_filter_252_we;
+  logic cmd_filter_7_filter_253_qs;
+  logic cmd_filter_7_filter_253_wd;
+  logic cmd_filter_7_filter_253_we;
+  logic cmd_filter_7_filter_254_qs;
+  logic cmd_filter_7_filter_254_wd;
+  logic cmd_filter_7_filter_254_we;
+  logic cmd_filter_7_filter_255_qs;
+  logic cmd_filter_7_filter_255_wd;
+  logic cmd_filter_7_filter_255_we;
+  logic [31:0] addr_swap_mask_qs;
+  logic [31:0] addr_swap_mask_wd;
+  logic addr_swap_mask_we;
+  logic [31:0] addr_swap_data_qs;
+  logic [31:0] addr_swap_data_wd;
+  logic addr_swap_data_we;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -946,6 +1723,32 @@ module spi_device_reg_top (
   );
 
 
+  //   F[addr_4b_en]: 16:16
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cfg_addr_4b_en (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cfg_addr_4b_en_we),
+    .wd     (cfg_addr_4b_en_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cfg.addr_4b_en.q ),
+
+    // to register interface (read)
+    .qs     (cfg_addr_4b_en_qs)
+  );
+
+
   // R[fifo_level]: V(False)
 
   //   F[rxlvl]: 15:0
@@ -1339,8 +2142,6744 @@ module spi_device_reg_top (
 
 
 
+  // Subregister 0 of Multireg cmd_filter
+  // R[cmd_filter_0]: V(False)
 
-  logic [11:0] addr_hit;
+  // F[filter_0]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_0_we),
+    .wd     (cmd_filter_0_filter_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[0].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_0_qs)
+  );
+
+
+  // F[filter_1]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_1_we),
+    .wd     (cmd_filter_0_filter_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[1].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_1_qs)
+  );
+
+
+  // F[filter_2]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_2_we),
+    .wd     (cmd_filter_0_filter_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[2].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_2_qs)
+  );
+
+
+  // F[filter_3]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_3_we),
+    .wd     (cmd_filter_0_filter_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[3].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_3_qs)
+  );
+
+
+  // F[filter_4]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_4 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_4_we),
+    .wd     (cmd_filter_0_filter_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[4].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_4_qs)
+  );
+
+
+  // F[filter_5]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_5 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_5_we),
+    .wd     (cmd_filter_0_filter_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[5].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_5_qs)
+  );
+
+
+  // F[filter_6]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_6 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_6_we),
+    .wd     (cmd_filter_0_filter_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[6].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_6_qs)
+  );
+
+
+  // F[filter_7]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_7 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_7_we),
+    .wd     (cmd_filter_0_filter_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[7].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_7_qs)
+  );
+
+
+  // F[filter_8]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_8 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_8_we),
+    .wd     (cmd_filter_0_filter_8_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[8].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_8_qs)
+  );
+
+
+  // F[filter_9]: 9:9
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_9 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_9_we),
+    .wd     (cmd_filter_0_filter_9_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[9].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_9_qs)
+  );
+
+
+  // F[filter_10]: 10:10
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_10 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_10_we),
+    .wd     (cmd_filter_0_filter_10_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[10].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_10_qs)
+  );
+
+
+  // F[filter_11]: 11:11
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_11 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_11_we),
+    .wd     (cmd_filter_0_filter_11_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[11].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_11_qs)
+  );
+
+
+  // F[filter_12]: 12:12
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_12 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_12_we),
+    .wd     (cmd_filter_0_filter_12_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[12].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_12_qs)
+  );
+
+
+  // F[filter_13]: 13:13
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_13 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_13_we),
+    .wd     (cmd_filter_0_filter_13_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[13].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_13_qs)
+  );
+
+
+  // F[filter_14]: 14:14
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_14 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_14_we),
+    .wd     (cmd_filter_0_filter_14_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[14].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_14_qs)
+  );
+
+
+  // F[filter_15]: 15:15
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_15 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_15_we),
+    .wd     (cmd_filter_0_filter_15_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[15].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_15_qs)
+  );
+
+
+  // F[filter_16]: 16:16
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_16 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_16_we),
+    .wd     (cmd_filter_0_filter_16_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[16].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_16_qs)
+  );
+
+
+  // F[filter_17]: 17:17
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_17 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_17_we),
+    .wd     (cmd_filter_0_filter_17_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[17].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_17_qs)
+  );
+
+
+  // F[filter_18]: 18:18
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_18 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_18_we),
+    .wd     (cmd_filter_0_filter_18_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[18].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_18_qs)
+  );
+
+
+  // F[filter_19]: 19:19
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_19 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_19_we),
+    .wd     (cmd_filter_0_filter_19_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[19].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_19_qs)
+  );
+
+
+  // F[filter_20]: 20:20
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_20 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_20_we),
+    .wd     (cmd_filter_0_filter_20_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[20].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_20_qs)
+  );
+
+
+  // F[filter_21]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_21 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_21_we),
+    .wd     (cmd_filter_0_filter_21_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[21].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_21_qs)
+  );
+
+
+  // F[filter_22]: 22:22
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_22 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_22_we),
+    .wd     (cmd_filter_0_filter_22_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[22].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_22_qs)
+  );
+
+
+  // F[filter_23]: 23:23
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_23 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_23_we),
+    .wd     (cmd_filter_0_filter_23_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[23].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_23_qs)
+  );
+
+
+  // F[filter_24]: 24:24
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_24 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_24_we),
+    .wd     (cmd_filter_0_filter_24_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[24].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_24_qs)
+  );
+
+
+  // F[filter_25]: 25:25
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_25 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_25_we),
+    .wd     (cmd_filter_0_filter_25_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[25].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_25_qs)
+  );
+
+
+  // F[filter_26]: 26:26
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_26 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_26_we),
+    .wd     (cmd_filter_0_filter_26_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[26].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_26_qs)
+  );
+
+
+  // F[filter_27]: 27:27
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_27 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_27_we),
+    .wd     (cmd_filter_0_filter_27_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[27].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_27_qs)
+  );
+
+
+  // F[filter_28]: 28:28
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_28 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_28_we),
+    .wd     (cmd_filter_0_filter_28_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[28].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_28_qs)
+  );
+
+
+  // F[filter_29]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_29 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_29_we),
+    .wd     (cmd_filter_0_filter_29_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[29].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_29_qs)
+  );
+
+
+  // F[filter_30]: 30:30
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_30 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_30_we),
+    .wd     (cmd_filter_0_filter_30_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[30].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_30_qs)
+  );
+
+
+  // F[filter_31]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_0_filter_31 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_0_filter_31_we),
+    .wd     (cmd_filter_0_filter_31_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[31].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_0_filter_31_qs)
+  );
+
+
+  // Subregister 32 of Multireg cmd_filter
+  // R[cmd_filter_1]: V(False)
+
+  // F[filter_32]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_32 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_32_we),
+    .wd     (cmd_filter_1_filter_32_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[32].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_32_qs)
+  );
+
+
+  // F[filter_33]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_33 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_33_we),
+    .wd     (cmd_filter_1_filter_33_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[33].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_33_qs)
+  );
+
+
+  // F[filter_34]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_34 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_34_we),
+    .wd     (cmd_filter_1_filter_34_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[34].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_34_qs)
+  );
+
+
+  // F[filter_35]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_35 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_35_we),
+    .wd     (cmd_filter_1_filter_35_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[35].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_35_qs)
+  );
+
+
+  // F[filter_36]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_36 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_36_we),
+    .wd     (cmd_filter_1_filter_36_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[36].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_36_qs)
+  );
+
+
+  // F[filter_37]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_37 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_37_we),
+    .wd     (cmd_filter_1_filter_37_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[37].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_37_qs)
+  );
+
+
+  // F[filter_38]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_38 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_38_we),
+    .wd     (cmd_filter_1_filter_38_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[38].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_38_qs)
+  );
+
+
+  // F[filter_39]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_39 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_39_we),
+    .wd     (cmd_filter_1_filter_39_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[39].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_39_qs)
+  );
+
+
+  // F[filter_40]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_40 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_40_we),
+    .wd     (cmd_filter_1_filter_40_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[40].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_40_qs)
+  );
+
+
+  // F[filter_41]: 9:9
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_41 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_41_we),
+    .wd     (cmd_filter_1_filter_41_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[41].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_41_qs)
+  );
+
+
+  // F[filter_42]: 10:10
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_42 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_42_we),
+    .wd     (cmd_filter_1_filter_42_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[42].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_42_qs)
+  );
+
+
+  // F[filter_43]: 11:11
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_43 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_43_we),
+    .wd     (cmd_filter_1_filter_43_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[43].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_43_qs)
+  );
+
+
+  // F[filter_44]: 12:12
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_44 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_44_we),
+    .wd     (cmd_filter_1_filter_44_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[44].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_44_qs)
+  );
+
+
+  // F[filter_45]: 13:13
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_45 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_45_we),
+    .wd     (cmd_filter_1_filter_45_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[45].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_45_qs)
+  );
+
+
+  // F[filter_46]: 14:14
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_46 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_46_we),
+    .wd     (cmd_filter_1_filter_46_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[46].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_46_qs)
+  );
+
+
+  // F[filter_47]: 15:15
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_47 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_47_we),
+    .wd     (cmd_filter_1_filter_47_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[47].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_47_qs)
+  );
+
+
+  // F[filter_48]: 16:16
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_48 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_48_we),
+    .wd     (cmd_filter_1_filter_48_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[48].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_48_qs)
+  );
+
+
+  // F[filter_49]: 17:17
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_49 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_49_we),
+    .wd     (cmd_filter_1_filter_49_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[49].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_49_qs)
+  );
+
+
+  // F[filter_50]: 18:18
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_50 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_50_we),
+    .wd     (cmd_filter_1_filter_50_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[50].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_50_qs)
+  );
+
+
+  // F[filter_51]: 19:19
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_51 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_51_we),
+    .wd     (cmd_filter_1_filter_51_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[51].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_51_qs)
+  );
+
+
+  // F[filter_52]: 20:20
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_52 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_52_we),
+    .wd     (cmd_filter_1_filter_52_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[52].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_52_qs)
+  );
+
+
+  // F[filter_53]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_53 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_53_we),
+    .wd     (cmd_filter_1_filter_53_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[53].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_53_qs)
+  );
+
+
+  // F[filter_54]: 22:22
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_54 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_54_we),
+    .wd     (cmd_filter_1_filter_54_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[54].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_54_qs)
+  );
+
+
+  // F[filter_55]: 23:23
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_55 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_55_we),
+    .wd     (cmd_filter_1_filter_55_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[55].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_55_qs)
+  );
+
+
+  // F[filter_56]: 24:24
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_56 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_56_we),
+    .wd     (cmd_filter_1_filter_56_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[56].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_56_qs)
+  );
+
+
+  // F[filter_57]: 25:25
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_57 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_57_we),
+    .wd     (cmd_filter_1_filter_57_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[57].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_57_qs)
+  );
+
+
+  // F[filter_58]: 26:26
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_58 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_58_we),
+    .wd     (cmd_filter_1_filter_58_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[58].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_58_qs)
+  );
+
+
+  // F[filter_59]: 27:27
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_59 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_59_we),
+    .wd     (cmd_filter_1_filter_59_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[59].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_59_qs)
+  );
+
+
+  // F[filter_60]: 28:28
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_60 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_60_we),
+    .wd     (cmd_filter_1_filter_60_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[60].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_60_qs)
+  );
+
+
+  // F[filter_61]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_61 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_61_we),
+    .wd     (cmd_filter_1_filter_61_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[61].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_61_qs)
+  );
+
+
+  // F[filter_62]: 30:30
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_62 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_62_we),
+    .wd     (cmd_filter_1_filter_62_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[62].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_62_qs)
+  );
+
+
+  // F[filter_63]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_1_filter_63 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_1_filter_63_we),
+    .wd     (cmd_filter_1_filter_63_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[63].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_1_filter_63_qs)
+  );
+
+
+  // Subregister 64 of Multireg cmd_filter
+  // R[cmd_filter_2]: V(False)
+
+  // F[filter_64]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_64 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_64_we),
+    .wd     (cmd_filter_2_filter_64_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[64].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_64_qs)
+  );
+
+
+  // F[filter_65]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_65 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_65_we),
+    .wd     (cmd_filter_2_filter_65_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[65].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_65_qs)
+  );
+
+
+  // F[filter_66]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_66 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_66_we),
+    .wd     (cmd_filter_2_filter_66_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[66].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_66_qs)
+  );
+
+
+  // F[filter_67]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_67 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_67_we),
+    .wd     (cmd_filter_2_filter_67_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[67].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_67_qs)
+  );
+
+
+  // F[filter_68]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_68 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_68_we),
+    .wd     (cmd_filter_2_filter_68_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[68].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_68_qs)
+  );
+
+
+  // F[filter_69]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_69 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_69_we),
+    .wd     (cmd_filter_2_filter_69_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[69].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_69_qs)
+  );
+
+
+  // F[filter_70]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_70 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_70_we),
+    .wd     (cmd_filter_2_filter_70_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[70].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_70_qs)
+  );
+
+
+  // F[filter_71]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_71 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_71_we),
+    .wd     (cmd_filter_2_filter_71_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[71].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_71_qs)
+  );
+
+
+  // F[filter_72]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_72 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_72_we),
+    .wd     (cmd_filter_2_filter_72_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[72].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_72_qs)
+  );
+
+
+  // F[filter_73]: 9:9
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_73 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_73_we),
+    .wd     (cmd_filter_2_filter_73_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[73].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_73_qs)
+  );
+
+
+  // F[filter_74]: 10:10
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_74 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_74_we),
+    .wd     (cmd_filter_2_filter_74_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[74].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_74_qs)
+  );
+
+
+  // F[filter_75]: 11:11
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_75 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_75_we),
+    .wd     (cmd_filter_2_filter_75_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[75].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_75_qs)
+  );
+
+
+  // F[filter_76]: 12:12
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_76 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_76_we),
+    .wd     (cmd_filter_2_filter_76_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[76].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_76_qs)
+  );
+
+
+  // F[filter_77]: 13:13
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_77 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_77_we),
+    .wd     (cmd_filter_2_filter_77_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[77].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_77_qs)
+  );
+
+
+  // F[filter_78]: 14:14
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_78 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_78_we),
+    .wd     (cmd_filter_2_filter_78_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[78].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_78_qs)
+  );
+
+
+  // F[filter_79]: 15:15
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_79 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_79_we),
+    .wd     (cmd_filter_2_filter_79_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[79].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_79_qs)
+  );
+
+
+  // F[filter_80]: 16:16
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_80 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_80_we),
+    .wd     (cmd_filter_2_filter_80_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[80].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_80_qs)
+  );
+
+
+  // F[filter_81]: 17:17
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_81 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_81_we),
+    .wd     (cmd_filter_2_filter_81_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[81].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_81_qs)
+  );
+
+
+  // F[filter_82]: 18:18
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_82 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_82_we),
+    .wd     (cmd_filter_2_filter_82_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[82].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_82_qs)
+  );
+
+
+  // F[filter_83]: 19:19
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_83 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_83_we),
+    .wd     (cmd_filter_2_filter_83_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[83].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_83_qs)
+  );
+
+
+  // F[filter_84]: 20:20
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_84 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_84_we),
+    .wd     (cmd_filter_2_filter_84_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[84].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_84_qs)
+  );
+
+
+  // F[filter_85]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_85 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_85_we),
+    .wd     (cmd_filter_2_filter_85_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[85].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_85_qs)
+  );
+
+
+  // F[filter_86]: 22:22
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_86 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_86_we),
+    .wd     (cmd_filter_2_filter_86_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[86].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_86_qs)
+  );
+
+
+  // F[filter_87]: 23:23
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_87 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_87_we),
+    .wd     (cmd_filter_2_filter_87_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[87].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_87_qs)
+  );
+
+
+  // F[filter_88]: 24:24
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_88 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_88_we),
+    .wd     (cmd_filter_2_filter_88_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[88].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_88_qs)
+  );
+
+
+  // F[filter_89]: 25:25
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_89 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_89_we),
+    .wd     (cmd_filter_2_filter_89_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[89].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_89_qs)
+  );
+
+
+  // F[filter_90]: 26:26
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_90 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_90_we),
+    .wd     (cmd_filter_2_filter_90_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[90].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_90_qs)
+  );
+
+
+  // F[filter_91]: 27:27
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_91 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_91_we),
+    .wd     (cmd_filter_2_filter_91_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[91].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_91_qs)
+  );
+
+
+  // F[filter_92]: 28:28
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_92 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_92_we),
+    .wd     (cmd_filter_2_filter_92_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[92].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_92_qs)
+  );
+
+
+  // F[filter_93]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_93 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_93_we),
+    .wd     (cmd_filter_2_filter_93_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[93].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_93_qs)
+  );
+
+
+  // F[filter_94]: 30:30
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_94 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_94_we),
+    .wd     (cmd_filter_2_filter_94_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[94].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_94_qs)
+  );
+
+
+  // F[filter_95]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_2_filter_95 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_2_filter_95_we),
+    .wd     (cmd_filter_2_filter_95_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[95].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_2_filter_95_qs)
+  );
+
+
+  // Subregister 96 of Multireg cmd_filter
+  // R[cmd_filter_3]: V(False)
+
+  // F[filter_96]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_96 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_96_we),
+    .wd     (cmd_filter_3_filter_96_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[96].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_96_qs)
+  );
+
+
+  // F[filter_97]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_97 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_97_we),
+    .wd     (cmd_filter_3_filter_97_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[97].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_97_qs)
+  );
+
+
+  // F[filter_98]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_98 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_98_we),
+    .wd     (cmd_filter_3_filter_98_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[98].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_98_qs)
+  );
+
+
+  // F[filter_99]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_99 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_99_we),
+    .wd     (cmd_filter_3_filter_99_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[99].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_99_qs)
+  );
+
+
+  // F[filter_100]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_100 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_100_we),
+    .wd     (cmd_filter_3_filter_100_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[100].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_100_qs)
+  );
+
+
+  // F[filter_101]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_101 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_101_we),
+    .wd     (cmd_filter_3_filter_101_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[101].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_101_qs)
+  );
+
+
+  // F[filter_102]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_102 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_102_we),
+    .wd     (cmd_filter_3_filter_102_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[102].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_102_qs)
+  );
+
+
+  // F[filter_103]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_103 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_103_we),
+    .wd     (cmd_filter_3_filter_103_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[103].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_103_qs)
+  );
+
+
+  // F[filter_104]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_104 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_104_we),
+    .wd     (cmd_filter_3_filter_104_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[104].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_104_qs)
+  );
+
+
+  // F[filter_105]: 9:9
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_105 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_105_we),
+    .wd     (cmd_filter_3_filter_105_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[105].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_105_qs)
+  );
+
+
+  // F[filter_106]: 10:10
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_106 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_106_we),
+    .wd     (cmd_filter_3_filter_106_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[106].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_106_qs)
+  );
+
+
+  // F[filter_107]: 11:11
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_107 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_107_we),
+    .wd     (cmd_filter_3_filter_107_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[107].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_107_qs)
+  );
+
+
+  // F[filter_108]: 12:12
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_108 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_108_we),
+    .wd     (cmd_filter_3_filter_108_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[108].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_108_qs)
+  );
+
+
+  // F[filter_109]: 13:13
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_109 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_109_we),
+    .wd     (cmd_filter_3_filter_109_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[109].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_109_qs)
+  );
+
+
+  // F[filter_110]: 14:14
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_110 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_110_we),
+    .wd     (cmd_filter_3_filter_110_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[110].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_110_qs)
+  );
+
+
+  // F[filter_111]: 15:15
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_111 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_111_we),
+    .wd     (cmd_filter_3_filter_111_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[111].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_111_qs)
+  );
+
+
+  // F[filter_112]: 16:16
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_112 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_112_we),
+    .wd     (cmd_filter_3_filter_112_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[112].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_112_qs)
+  );
+
+
+  // F[filter_113]: 17:17
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_113 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_113_we),
+    .wd     (cmd_filter_3_filter_113_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[113].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_113_qs)
+  );
+
+
+  // F[filter_114]: 18:18
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_114 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_114_we),
+    .wd     (cmd_filter_3_filter_114_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[114].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_114_qs)
+  );
+
+
+  // F[filter_115]: 19:19
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_115 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_115_we),
+    .wd     (cmd_filter_3_filter_115_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[115].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_115_qs)
+  );
+
+
+  // F[filter_116]: 20:20
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_116 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_116_we),
+    .wd     (cmd_filter_3_filter_116_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[116].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_116_qs)
+  );
+
+
+  // F[filter_117]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_117 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_117_we),
+    .wd     (cmd_filter_3_filter_117_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[117].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_117_qs)
+  );
+
+
+  // F[filter_118]: 22:22
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_118 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_118_we),
+    .wd     (cmd_filter_3_filter_118_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[118].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_118_qs)
+  );
+
+
+  // F[filter_119]: 23:23
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_119 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_119_we),
+    .wd     (cmd_filter_3_filter_119_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[119].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_119_qs)
+  );
+
+
+  // F[filter_120]: 24:24
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_120 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_120_we),
+    .wd     (cmd_filter_3_filter_120_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[120].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_120_qs)
+  );
+
+
+  // F[filter_121]: 25:25
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_121 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_121_we),
+    .wd     (cmd_filter_3_filter_121_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[121].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_121_qs)
+  );
+
+
+  // F[filter_122]: 26:26
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_122 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_122_we),
+    .wd     (cmd_filter_3_filter_122_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[122].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_122_qs)
+  );
+
+
+  // F[filter_123]: 27:27
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_123 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_123_we),
+    .wd     (cmd_filter_3_filter_123_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[123].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_123_qs)
+  );
+
+
+  // F[filter_124]: 28:28
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_124 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_124_we),
+    .wd     (cmd_filter_3_filter_124_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[124].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_124_qs)
+  );
+
+
+  // F[filter_125]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_125 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_125_we),
+    .wd     (cmd_filter_3_filter_125_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[125].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_125_qs)
+  );
+
+
+  // F[filter_126]: 30:30
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_126 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_126_we),
+    .wd     (cmd_filter_3_filter_126_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[126].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_126_qs)
+  );
+
+
+  // F[filter_127]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_3_filter_127 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_3_filter_127_we),
+    .wd     (cmd_filter_3_filter_127_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[127].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_3_filter_127_qs)
+  );
+
+
+  // Subregister 128 of Multireg cmd_filter
+  // R[cmd_filter_4]: V(False)
+
+  // F[filter_128]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_128 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_128_we),
+    .wd     (cmd_filter_4_filter_128_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[128].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_128_qs)
+  );
+
+
+  // F[filter_129]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_129 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_129_we),
+    .wd     (cmd_filter_4_filter_129_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[129].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_129_qs)
+  );
+
+
+  // F[filter_130]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_130 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_130_we),
+    .wd     (cmd_filter_4_filter_130_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[130].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_130_qs)
+  );
+
+
+  // F[filter_131]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_131 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_131_we),
+    .wd     (cmd_filter_4_filter_131_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[131].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_131_qs)
+  );
+
+
+  // F[filter_132]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_132 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_132_we),
+    .wd     (cmd_filter_4_filter_132_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[132].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_132_qs)
+  );
+
+
+  // F[filter_133]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_133 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_133_we),
+    .wd     (cmd_filter_4_filter_133_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[133].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_133_qs)
+  );
+
+
+  // F[filter_134]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_134 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_134_we),
+    .wd     (cmd_filter_4_filter_134_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[134].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_134_qs)
+  );
+
+
+  // F[filter_135]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_135 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_135_we),
+    .wd     (cmd_filter_4_filter_135_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[135].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_135_qs)
+  );
+
+
+  // F[filter_136]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_136 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_136_we),
+    .wd     (cmd_filter_4_filter_136_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[136].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_136_qs)
+  );
+
+
+  // F[filter_137]: 9:9
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_137 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_137_we),
+    .wd     (cmd_filter_4_filter_137_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[137].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_137_qs)
+  );
+
+
+  // F[filter_138]: 10:10
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_138 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_138_we),
+    .wd     (cmd_filter_4_filter_138_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[138].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_138_qs)
+  );
+
+
+  // F[filter_139]: 11:11
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_139 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_139_we),
+    .wd     (cmd_filter_4_filter_139_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[139].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_139_qs)
+  );
+
+
+  // F[filter_140]: 12:12
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_140 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_140_we),
+    .wd     (cmd_filter_4_filter_140_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[140].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_140_qs)
+  );
+
+
+  // F[filter_141]: 13:13
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_141 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_141_we),
+    .wd     (cmd_filter_4_filter_141_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[141].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_141_qs)
+  );
+
+
+  // F[filter_142]: 14:14
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_142 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_142_we),
+    .wd     (cmd_filter_4_filter_142_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[142].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_142_qs)
+  );
+
+
+  // F[filter_143]: 15:15
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_143 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_143_we),
+    .wd     (cmd_filter_4_filter_143_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[143].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_143_qs)
+  );
+
+
+  // F[filter_144]: 16:16
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_144 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_144_we),
+    .wd     (cmd_filter_4_filter_144_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[144].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_144_qs)
+  );
+
+
+  // F[filter_145]: 17:17
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_145 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_145_we),
+    .wd     (cmd_filter_4_filter_145_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[145].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_145_qs)
+  );
+
+
+  // F[filter_146]: 18:18
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_146 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_146_we),
+    .wd     (cmd_filter_4_filter_146_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[146].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_146_qs)
+  );
+
+
+  // F[filter_147]: 19:19
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_147 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_147_we),
+    .wd     (cmd_filter_4_filter_147_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[147].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_147_qs)
+  );
+
+
+  // F[filter_148]: 20:20
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_148 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_148_we),
+    .wd     (cmd_filter_4_filter_148_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[148].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_148_qs)
+  );
+
+
+  // F[filter_149]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_149 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_149_we),
+    .wd     (cmd_filter_4_filter_149_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[149].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_149_qs)
+  );
+
+
+  // F[filter_150]: 22:22
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_150 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_150_we),
+    .wd     (cmd_filter_4_filter_150_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[150].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_150_qs)
+  );
+
+
+  // F[filter_151]: 23:23
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_151 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_151_we),
+    .wd     (cmd_filter_4_filter_151_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[151].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_151_qs)
+  );
+
+
+  // F[filter_152]: 24:24
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_152 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_152_we),
+    .wd     (cmd_filter_4_filter_152_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[152].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_152_qs)
+  );
+
+
+  // F[filter_153]: 25:25
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_153 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_153_we),
+    .wd     (cmd_filter_4_filter_153_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[153].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_153_qs)
+  );
+
+
+  // F[filter_154]: 26:26
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_154 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_154_we),
+    .wd     (cmd_filter_4_filter_154_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[154].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_154_qs)
+  );
+
+
+  // F[filter_155]: 27:27
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_155 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_155_we),
+    .wd     (cmd_filter_4_filter_155_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[155].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_155_qs)
+  );
+
+
+  // F[filter_156]: 28:28
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_156 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_156_we),
+    .wd     (cmd_filter_4_filter_156_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[156].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_156_qs)
+  );
+
+
+  // F[filter_157]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_157 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_157_we),
+    .wd     (cmd_filter_4_filter_157_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[157].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_157_qs)
+  );
+
+
+  // F[filter_158]: 30:30
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_158 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_158_we),
+    .wd     (cmd_filter_4_filter_158_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[158].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_158_qs)
+  );
+
+
+  // F[filter_159]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_4_filter_159 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_4_filter_159_we),
+    .wd     (cmd_filter_4_filter_159_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[159].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_4_filter_159_qs)
+  );
+
+
+  // Subregister 160 of Multireg cmd_filter
+  // R[cmd_filter_5]: V(False)
+
+  // F[filter_160]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_160 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_160_we),
+    .wd     (cmd_filter_5_filter_160_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[160].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_160_qs)
+  );
+
+
+  // F[filter_161]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_161 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_161_we),
+    .wd     (cmd_filter_5_filter_161_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[161].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_161_qs)
+  );
+
+
+  // F[filter_162]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_162 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_162_we),
+    .wd     (cmd_filter_5_filter_162_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[162].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_162_qs)
+  );
+
+
+  // F[filter_163]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_163 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_163_we),
+    .wd     (cmd_filter_5_filter_163_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[163].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_163_qs)
+  );
+
+
+  // F[filter_164]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_164 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_164_we),
+    .wd     (cmd_filter_5_filter_164_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[164].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_164_qs)
+  );
+
+
+  // F[filter_165]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_165 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_165_we),
+    .wd     (cmd_filter_5_filter_165_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[165].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_165_qs)
+  );
+
+
+  // F[filter_166]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_166 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_166_we),
+    .wd     (cmd_filter_5_filter_166_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[166].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_166_qs)
+  );
+
+
+  // F[filter_167]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_167 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_167_we),
+    .wd     (cmd_filter_5_filter_167_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[167].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_167_qs)
+  );
+
+
+  // F[filter_168]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_168 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_168_we),
+    .wd     (cmd_filter_5_filter_168_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[168].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_168_qs)
+  );
+
+
+  // F[filter_169]: 9:9
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_169 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_169_we),
+    .wd     (cmd_filter_5_filter_169_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[169].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_169_qs)
+  );
+
+
+  // F[filter_170]: 10:10
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_170 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_170_we),
+    .wd     (cmd_filter_5_filter_170_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[170].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_170_qs)
+  );
+
+
+  // F[filter_171]: 11:11
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_171 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_171_we),
+    .wd     (cmd_filter_5_filter_171_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[171].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_171_qs)
+  );
+
+
+  // F[filter_172]: 12:12
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_172 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_172_we),
+    .wd     (cmd_filter_5_filter_172_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[172].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_172_qs)
+  );
+
+
+  // F[filter_173]: 13:13
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_173 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_173_we),
+    .wd     (cmd_filter_5_filter_173_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[173].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_173_qs)
+  );
+
+
+  // F[filter_174]: 14:14
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_174 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_174_we),
+    .wd     (cmd_filter_5_filter_174_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[174].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_174_qs)
+  );
+
+
+  // F[filter_175]: 15:15
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_175 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_175_we),
+    .wd     (cmd_filter_5_filter_175_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[175].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_175_qs)
+  );
+
+
+  // F[filter_176]: 16:16
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_176 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_176_we),
+    .wd     (cmd_filter_5_filter_176_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[176].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_176_qs)
+  );
+
+
+  // F[filter_177]: 17:17
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_177 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_177_we),
+    .wd     (cmd_filter_5_filter_177_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[177].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_177_qs)
+  );
+
+
+  // F[filter_178]: 18:18
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_178 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_178_we),
+    .wd     (cmd_filter_5_filter_178_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[178].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_178_qs)
+  );
+
+
+  // F[filter_179]: 19:19
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_179 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_179_we),
+    .wd     (cmd_filter_5_filter_179_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[179].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_179_qs)
+  );
+
+
+  // F[filter_180]: 20:20
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_180 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_180_we),
+    .wd     (cmd_filter_5_filter_180_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[180].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_180_qs)
+  );
+
+
+  // F[filter_181]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_181 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_181_we),
+    .wd     (cmd_filter_5_filter_181_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[181].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_181_qs)
+  );
+
+
+  // F[filter_182]: 22:22
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_182 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_182_we),
+    .wd     (cmd_filter_5_filter_182_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[182].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_182_qs)
+  );
+
+
+  // F[filter_183]: 23:23
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_183 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_183_we),
+    .wd     (cmd_filter_5_filter_183_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[183].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_183_qs)
+  );
+
+
+  // F[filter_184]: 24:24
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_184 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_184_we),
+    .wd     (cmd_filter_5_filter_184_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[184].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_184_qs)
+  );
+
+
+  // F[filter_185]: 25:25
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_185 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_185_we),
+    .wd     (cmd_filter_5_filter_185_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[185].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_185_qs)
+  );
+
+
+  // F[filter_186]: 26:26
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_186 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_186_we),
+    .wd     (cmd_filter_5_filter_186_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[186].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_186_qs)
+  );
+
+
+  // F[filter_187]: 27:27
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_187 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_187_we),
+    .wd     (cmd_filter_5_filter_187_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[187].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_187_qs)
+  );
+
+
+  // F[filter_188]: 28:28
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_188 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_188_we),
+    .wd     (cmd_filter_5_filter_188_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[188].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_188_qs)
+  );
+
+
+  // F[filter_189]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_189 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_189_we),
+    .wd     (cmd_filter_5_filter_189_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[189].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_189_qs)
+  );
+
+
+  // F[filter_190]: 30:30
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_190 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_190_we),
+    .wd     (cmd_filter_5_filter_190_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[190].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_190_qs)
+  );
+
+
+  // F[filter_191]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_5_filter_191 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_5_filter_191_we),
+    .wd     (cmd_filter_5_filter_191_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[191].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_5_filter_191_qs)
+  );
+
+
+  // Subregister 192 of Multireg cmd_filter
+  // R[cmd_filter_6]: V(False)
+
+  // F[filter_192]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_192 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_192_we),
+    .wd     (cmd_filter_6_filter_192_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[192].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_192_qs)
+  );
+
+
+  // F[filter_193]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_193 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_193_we),
+    .wd     (cmd_filter_6_filter_193_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[193].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_193_qs)
+  );
+
+
+  // F[filter_194]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_194 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_194_we),
+    .wd     (cmd_filter_6_filter_194_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[194].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_194_qs)
+  );
+
+
+  // F[filter_195]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_195 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_195_we),
+    .wd     (cmd_filter_6_filter_195_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[195].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_195_qs)
+  );
+
+
+  // F[filter_196]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_196 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_196_we),
+    .wd     (cmd_filter_6_filter_196_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[196].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_196_qs)
+  );
+
+
+  // F[filter_197]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_197 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_197_we),
+    .wd     (cmd_filter_6_filter_197_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[197].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_197_qs)
+  );
+
+
+  // F[filter_198]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_198 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_198_we),
+    .wd     (cmd_filter_6_filter_198_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[198].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_198_qs)
+  );
+
+
+  // F[filter_199]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_199 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_199_we),
+    .wd     (cmd_filter_6_filter_199_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[199].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_199_qs)
+  );
+
+
+  // F[filter_200]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_200 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_200_we),
+    .wd     (cmd_filter_6_filter_200_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[200].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_200_qs)
+  );
+
+
+  // F[filter_201]: 9:9
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_201 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_201_we),
+    .wd     (cmd_filter_6_filter_201_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[201].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_201_qs)
+  );
+
+
+  // F[filter_202]: 10:10
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_202 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_202_we),
+    .wd     (cmd_filter_6_filter_202_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[202].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_202_qs)
+  );
+
+
+  // F[filter_203]: 11:11
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_203 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_203_we),
+    .wd     (cmd_filter_6_filter_203_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[203].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_203_qs)
+  );
+
+
+  // F[filter_204]: 12:12
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_204 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_204_we),
+    .wd     (cmd_filter_6_filter_204_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[204].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_204_qs)
+  );
+
+
+  // F[filter_205]: 13:13
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_205 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_205_we),
+    .wd     (cmd_filter_6_filter_205_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[205].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_205_qs)
+  );
+
+
+  // F[filter_206]: 14:14
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_206 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_206_we),
+    .wd     (cmd_filter_6_filter_206_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[206].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_206_qs)
+  );
+
+
+  // F[filter_207]: 15:15
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_207 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_207_we),
+    .wd     (cmd_filter_6_filter_207_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[207].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_207_qs)
+  );
+
+
+  // F[filter_208]: 16:16
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_208 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_208_we),
+    .wd     (cmd_filter_6_filter_208_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[208].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_208_qs)
+  );
+
+
+  // F[filter_209]: 17:17
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_209 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_209_we),
+    .wd     (cmd_filter_6_filter_209_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[209].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_209_qs)
+  );
+
+
+  // F[filter_210]: 18:18
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_210 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_210_we),
+    .wd     (cmd_filter_6_filter_210_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[210].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_210_qs)
+  );
+
+
+  // F[filter_211]: 19:19
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_211 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_211_we),
+    .wd     (cmd_filter_6_filter_211_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[211].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_211_qs)
+  );
+
+
+  // F[filter_212]: 20:20
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_212 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_212_we),
+    .wd     (cmd_filter_6_filter_212_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[212].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_212_qs)
+  );
+
+
+  // F[filter_213]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_213 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_213_we),
+    .wd     (cmd_filter_6_filter_213_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[213].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_213_qs)
+  );
+
+
+  // F[filter_214]: 22:22
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_214 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_214_we),
+    .wd     (cmd_filter_6_filter_214_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[214].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_214_qs)
+  );
+
+
+  // F[filter_215]: 23:23
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_215 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_215_we),
+    .wd     (cmd_filter_6_filter_215_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[215].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_215_qs)
+  );
+
+
+  // F[filter_216]: 24:24
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_216 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_216_we),
+    .wd     (cmd_filter_6_filter_216_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[216].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_216_qs)
+  );
+
+
+  // F[filter_217]: 25:25
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_217 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_217_we),
+    .wd     (cmd_filter_6_filter_217_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[217].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_217_qs)
+  );
+
+
+  // F[filter_218]: 26:26
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_218 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_218_we),
+    .wd     (cmd_filter_6_filter_218_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[218].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_218_qs)
+  );
+
+
+  // F[filter_219]: 27:27
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_219 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_219_we),
+    .wd     (cmd_filter_6_filter_219_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[219].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_219_qs)
+  );
+
+
+  // F[filter_220]: 28:28
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_220 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_220_we),
+    .wd     (cmd_filter_6_filter_220_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[220].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_220_qs)
+  );
+
+
+  // F[filter_221]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_221 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_221_we),
+    .wd     (cmd_filter_6_filter_221_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[221].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_221_qs)
+  );
+
+
+  // F[filter_222]: 30:30
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_222 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_222_we),
+    .wd     (cmd_filter_6_filter_222_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[222].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_222_qs)
+  );
+
+
+  // F[filter_223]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_6_filter_223 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_6_filter_223_we),
+    .wd     (cmd_filter_6_filter_223_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[223].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_6_filter_223_qs)
+  );
+
+
+  // Subregister 224 of Multireg cmd_filter
+  // R[cmd_filter_7]: V(False)
+
+  // F[filter_224]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_224 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_224_we),
+    .wd     (cmd_filter_7_filter_224_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[224].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_224_qs)
+  );
+
+
+  // F[filter_225]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_225 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_225_we),
+    .wd     (cmd_filter_7_filter_225_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[225].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_225_qs)
+  );
+
+
+  // F[filter_226]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_226 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_226_we),
+    .wd     (cmd_filter_7_filter_226_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[226].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_226_qs)
+  );
+
+
+  // F[filter_227]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_227 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_227_we),
+    .wd     (cmd_filter_7_filter_227_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[227].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_227_qs)
+  );
+
+
+  // F[filter_228]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_228 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_228_we),
+    .wd     (cmd_filter_7_filter_228_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[228].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_228_qs)
+  );
+
+
+  // F[filter_229]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_229 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_229_we),
+    .wd     (cmd_filter_7_filter_229_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[229].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_229_qs)
+  );
+
+
+  // F[filter_230]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_230 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_230_we),
+    .wd     (cmd_filter_7_filter_230_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[230].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_230_qs)
+  );
+
+
+  // F[filter_231]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_231 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_231_we),
+    .wd     (cmd_filter_7_filter_231_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[231].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_231_qs)
+  );
+
+
+  // F[filter_232]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_232 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_232_we),
+    .wd     (cmd_filter_7_filter_232_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[232].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_232_qs)
+  );
+
+
+  // F[filter_233]: 9:9
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_233 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_233_we),
+    .wd     (cmd_filter_7_filter_233_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[233].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_233_qs)
+  );
+
+
+  // F[filter_234]: 10:10
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_234 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_234_we),
+    .wd     (cmd_filter_7_filter_234_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[234].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_234_qs)
+  );
+
+
+  // F[filter_235]: 11:11
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_235 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_235_we),
+    .wd     (cmd_filter_7_filter_235_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[235].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_235_qs)
+  );
+
+
+  // F[filter_236]: 12:12
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_236 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_236_we),
+    .wd     (cmd_filter_7_filter_236_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[236].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_236_qs)
+  );
+
+
+  // F[filter_237]: 13:13
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_237 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_237_we),
+    .wd     (cmd_filter_7_filter_237_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[237].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_237_qs)
+  );
+
+
+  // F[filter_238]: 14:14
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_238 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_238_we),
+    .wd     (cmd_filter_7_filter_238_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[238].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_238_qs)
+  );
+
+
+  // F[filter_239]: 15:15
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_239 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_239_we),
+    .wd     (cmd_filter_7_filter_239_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[239].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_239_qs)
+  );
+
+
+  // F[filter_240]: 16:16
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_240 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_240_we),
+    .wd     (cmd_filter_7_filter_240_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[240].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_240_qs)
+  );
+
+
+  // F[filter_241]: 17:17
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_241 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_241_we),
+    .wd     (cmd_filter_7_filter_241_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[241].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_241_qs)
+  );
+
+
+  // F[filter_242]: 18:18
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_242 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_242_we),
+    .wd     (cmd_filter_7_filter_242_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[242].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_242_qs)
+  );
+
+
+  // F[filter_243]: 19:19
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_243 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_243_we),
+    .wd     (cmd_filter_7_filter_243_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[243].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_243_qs)
+  );
+
+
+  // F[filter_244]: 20:20
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_244 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_244_we),
+    .wd     (cmd_filter_7_filter_244_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[244].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_244_qs)
+  );
+
+
+  // F[filter_245]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_245 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_245_we),
+    .wd     (cmd_filter_7_filter_245_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[245].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_245_qs)
+  );
+
+
+  // F[filter_246]: 22:22
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_246 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_246_we),
+    .wd     (cmd_filter_7_filter_246_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[246].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_246_qs)
+  );
+
+
+  // F[filter_247]: 23:23
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_247 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_247_we),
+    .wd     (cmd_filter_7_filter_247_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[247].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_247_qs)
+  );
+
+
+  // F[filter_248]: 24:24
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_248 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_248_we),
+    .wd     (cmd_filter_7_filter_248_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[248].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_248_qs)
+  );
+
+
+  // F[filter_249]: 25:25
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_249 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_249_we),
+    .wd     (cmd_filter_7_filter_249_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[249].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_249_qs)
+  );
+
+
+  // F[filter_250]: 26:26
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_250 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_250_we),
+    .wd     (cmd_filter_7_filter_250_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[250].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_250_qs)
+  );
+
+
+  // F[filter_251]: 27:27
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_251 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_251_we),
+    .wd     (cmd_filter_7_filter_251_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[251].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_251_qs)
+  );
+
+
+  // F[filter_252]: 28:28
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_252 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_252_we),
+    .wd     (cmd_filter_7_filter_252_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[252].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_252_qs)
+  );
+
+
+  // F[filter_253]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_253 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_253_we),
+    .wd     (cmd_filter_7_filter_253_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[253].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_253_qs)
+  );
+
+
+  // F[filter_254]: 30:30
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_254 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_254_we),
+    .wd     (cmd_filter_7_filter_254_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[254].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_254_qs)
+  );
+
+
+  // F[filter_255]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_cmd_filter_7_filter_255 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (cmd_filter_7_filter_255_we),
+    .wd     (cmd_filter_7_filter_255_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_filter[255].q ),
+
+    // to register interface (read)
+    .qs     (cmd_filter_7_filter_255_qs)
+  );
+
+
+
+  // R[addr_swap_mask]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_addr_swap_mask (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (addr_swap_mask_we),
+    .wd     (addr_swap_mask_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.addr_swap_mask.q ),
+
+    // to register interface (read)
+    .qs     (addr_swap_mask_qs)
+  );
+
+
+  // R[addr_swap_data]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_addr_swap_data (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (addr_swap_data_we),
+    .wd     (addr_swap_data_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.addr_swap_data.q ),
+
+    // to register interface (read)
+    .qs     (addr_swap_data_qs)
+  );
+
+
+
+
+  logic [21:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == SPI_DEVICE_INTR_STATE_OFFSET);
@@ -1355,6 +8894,16 @@ module spi_device_reg_top (
     addr_hit[ 9] = (reg_addr == SPI_DEVICE_TXF_PTR_OFFSET);
     addr_hit[10] = (reg_addr == SPI_DEVICE_RXF_ADDR_OFFSET);
     addr_hit[11] = (reg_addr == SPI_DEVICE_TXF_ADDR_OFFSET);
+    addr_hit[12] = (reg_addr == SPI_DEVICE_CMD_FILTER_0_OFFSET);
+    addr_hit[13] = (reg_addr == SPI_DEVICE_CMD_FILTER_1_OFFSET);
+    addr_hit[14] = (reg_addr == SPI_DEVICE_CMD_FILTER_2_OFFSET);
+    addr_hit[15] = (reg_addr == SPI_DEVICE_CMD_FILTER_3_OFFSET);
+    addr_hit[16] = (reg_addr == SPI_DEVICE_CMD_FILTER_4_OFFSET);
+    addr_hit[17] = (reg_addr == SPI_DEVICE_CMD_FILTER_5_OFFSET);
+    addr_hit[18] = (reg_addr == SPI_DEVICE_CMD_FILTER_6_OFFSET);
+    addr_hit[19] = (reg_addr == SPI_DEVICE_CMD_FILTER_7_OFFSET);
+    addr_hit[20] = (reg_addr == SPI_DEVICE_ADDR_SWAP_MASK_OFFSET);
+    addr_hit[21] = (reg_addr == SPI_DEVICE_ADDR_SWAP_DATA_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1373,7 +8922,17 @@ module spi_device_reg_top (
                (addr_hit[ 8] & (|(SPI_DEVICE_PERMIT[ 8] & ~reg_be))) |
                (addr_hit[ 9] & (|(SPI_DEVICE_PERMIT[ 9] & ~reg_be))) |
                (addr_hit[10] & (|(SPI_DEVICE_PERMIT[10] & ~reg_be))) |
-               (addr_hit[11] & (|(SPI_DEVICE_PERMIT[11] & ~reg_be)))));
+               (addr_hit[11] & (|(SPI_DEVICE_PERMIT[11] & ~reg_be))) |
+               (addr_hit[12] & (|(SPI_DEVICE_PERMIT[12] & ~reg_be))) |
+               (addr_hit[13] & (|(SPI_DEVICE_PERMIT[13] & ~reg_be))) |
+               (addr_hit[14] & (|(SPI_DEVICE_PERMIT[14] & ~reg_be))) |
+               (addr_hit[15] & (|(SPI_DEVICE_PERMIT[15] & ~reg_be))) |
+               (addr_hit[16] & (|(SPI_DEVICE_PERMIT[16] & ~reg_be))) |
+               (addr_hit[17] & (|(SPI_DEVICE_PERMIT[17] & ~reg_be))) |
+               (addr_hit[18] & (|(SPI_DEVICE_PERMIT[18] & ~reg_be))) |
+               (addr_hit[19] & (|(SPI_DEVICE_PERMIT[19] & ~reg_be))) |
+               (addr_hit[20] & (|(SPI_DEVICE_PERMIT[20] & ~reg_be))) |
+               (addr_hit[21] & (|(SPI_DEVICE_PERMIT[21] & ~reg_be)))));
   end
 
   assign intr_state_rxf_we = addr_hit[0] & reg_we & !reg_error;
@@ -1460,6 +9019,9 @@ module spi_device_reg_top (
   assign cfg_timer_v_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_timer_v_wd = reg_wdata[15:8];
 
+  assign cfg_addr_4b_en_we = addr_hit[4] & reg_we & !reg_error;
+  assign cfg_addr_4b_en_wd = reg_wdata[16];
+
   assign fifo_level_rxlvl_we = addr_hit[5] & reg_we & !reg_error;
   assign fifo_level_rxlvl_wd = reg_wdata[15:0];
 
@@ -1499,6 +9061,780 @@ module spi_device_reg_top (
 
   assign txf_addr_limit_we = addr_hit[11] & reg_we & !reg_error;
   assign txf_addr_limit_wd = reg_wdata[31:16];
+
+  assign cmd_filter_0_filter_0_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_0_wd = reg_wdata[0];
+
+  assign cmd_filter_0_filter_1_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_1_wd = reg_wdata[1];
+
+  assign cmd_filter_0_filter_2_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_2_wd = reg_wdata[2];
+
+  assign cmd_filter_0_filter_3_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_3_wd = reg_wdata[3];
+
+  assign cmd_filter_0_filter_4_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_4_wd = reg_wdata[4];
+
+  assign cmd_filter_0_filter_5_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_5_wd = reg_wdata[5];
+
+  assign cmd_filter_0_filter_6_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_6_wd = reg_wdata[6];
+
+  assign cmd_filter_0_filter_7_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_7_wd = reg_wdata[7];
+
+  assign cmd_filter_0_filter_8_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_8_wd = reg_wdata[8];
+
+  assign cmd_filter_0_filter_9_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_9_wd = reg_wdata[9];
+
+  assign cmd_filter_0_filter_10_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_10_wd = reg_wdata[10];
+
+  assign cmd_filter_0_filter_11_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_11_wd = reg_wdata[11];
+
+  assign cmd_filter_0_filter_12_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_12_wd = reg_wdata[12];
+
+  assign cmd_filter_0_filter_13_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_13_wd = reg_wdata[13];
+
+  assign cmd_filter_0_filter_14_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_14_wd = reg_wdata[14];
+
+  assign cmd_filter_0_filter_15_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_15_wd = reg_wdata[15];
+
+  assign cmd_filter_0_filter_16_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_16_wd = reg_wdata[16];
+
+  assign cmd_filter_0_filter_17_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_17_wd = reg_wdata[17];
+
+  assign cmd_filter_0_filter_18_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_18_wd = reg_wdata[18];
+
+  assign cmd_filter_0_filter_19_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_19_wd = reg_wdata[19];
+
+  assign cmd_filter_0_filter_20_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_20_wd = reg_wdata[20];
+
+  assign cmd_filter_0_filter_21_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_21_wd = reg_wdata[21];
+
+  assign cmd_filter_0_filter_22_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_22_wd = reg_wdata[22];
+
+  assign cmd_filter_0_filter_23_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_23_wd = reg_wdata[23];
+
+  assign cmd_filter_0_filter_24_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_24_wd = reg_wdata[24];
+
+  assign cmd_filter_0_filter_25_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_25_wd = reg_wdata[25];
+
+  assign cmd_filter_0_filter_26_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_26_wd = reg_wdata[26];
+
+  assign cmd_filter_0_filter_27_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_27_wd = reg_wdata[27];
+
+  assign cmd_filter_0_filter_28_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_28_wd = reg_wdata[28];
+
+  assign cmd_filter_0_filter_29_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_29_wd = reg_wdata[29];
+
+  assign cmd_filter_0_filter_30_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_30_wd = reg_wdata[30];
+
+  assign cmd_filter_0_filter_31_we = addr_hit[12] & reg_we & !reg_error;
+  assign cmd_filter_0_filter_31_wd = reg_wdata[31];
+
+  assign cmd_filter_1_filter_32_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_32_wd = reg_wdata[0];
+
+  assign cmd_filter_1_filter_33_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_33_wd = reg_wdata[1];
+
+  assign cmd_filter_1_filter_34_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_34_wd = reg_wdata[2];
+
+  assign cmd_filter_1_filter_35_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_35_wd = reg_wdata[3];
+
+  assign cmd_filter_1_filter_36_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_36_wd = reg_wdata[4];
+
+  assign cmd_filter_1_filter_37_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_37_wd = reg_wdata[5];
+
+  assign cmd_filter_1_filter_38_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_38_wd = reg_wdata[6];
+
+  assign cmd_filter_1_filter_39_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_39_wd = reg_wdata[7];
+
+  assign cmd_filter_1_filter_40_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_40_wd = reg_wdata[8];
+
+  assign cmd_filter_1_filter_41_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_41_wd = reg_wdata[9];
+
+  assign cmd_filter_1_filter_42_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_42_wd = reg_wdata[10];
+
+  assign cmd_filter_1_filter_43_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_43_wd = reg_wdata[11];
+
+  assign cmd_filter_1_filter_44_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_44_wd = reg_wdata[12];
+
+  assign cmd_filter_1_filter_45_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_45_wd = reg_wdata[13];
+
+  assign cmd_filter_1_filter_46_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_46_wd = reg_wdata[14];
+
+  assign cmd_filter_1_filter_47_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_47_wd = reg_wdata[15];
+
+  assign cmd_filter_1_filter_48_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_48_wd = reg_wdata[16];
+
+  assign cmd_filter_1_filter_49_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_49_wd = reg_wdata[17];
+
+  assign cmd_filter_1_filter_50_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_50_wd = reg_wdata[18];
+
+  assign cmd_filter_1_filter_51_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_51_wd = reg_wdata[19];
+
+  assign cmd_filter_1_filter_52_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_52_wd = reg_wdata[20];
+
+  assign cmd_filter_1_filter_53_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_53_wd = reg_wdata[21];
+
+  assign cmd_filter_1_filter_54_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_54_wd = reg_wdata[22];
+
+  assign cmd_filter_1_filter_55_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_55_wd = reg_wdata[23];
+
+  assign cmd_filter_1_filter_56_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_56_wd = reg_wdata[24];
+
+  assign cmd_filter_1_filter_57_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_57_wd = reg_wdata[25];
+
+  assign cmd_filter_1_filter_58_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_58_wd = reg_wdata[26];
+
+  assign cmd_filter_1_filter_59_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_59_wd = reg_wdata[27];
+
+  assign cmd_filter_1_filter_60_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_60_wd = reg_wdata[28];
+
+  assign cmd_filter_1_filter_61_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_61_wd = reg_wdata[29];
+
+  assign cmd_filter_1_filter_62_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_62_wd = reg_wdata[30];
+
+  assign cmd_filter_1_filter_63_we = addr_hit[13] & reg_we & !reg_error;
+  assign cmd_filter_1_filter_63_wd = reg_wdata[31];
+
+  assign cmd_filter_2_filter_64_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_64_wd = reg_wdata[0];
+
+  assign cmd_filter_2_filter_65_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_65_wd = reg_wdata[1];
+
+  assign cmd_filter_2_filter_66_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_66_wd = reg_wdata[2];
+
+  assign cmd_filter_2_filter_67_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_67_wd = reg_wdata[3];
+
+  assign cmd_filter_2_filter_68_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_68_wd = reg_wdata[4];
+
+  assign cmd_filter_2_filter_69_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_69_wd = reg_wdata[5];
+
+  assign cmd_filter_2_filter_70_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_70_wd = reg_wdata[6];
+
+  assign cmd_filter_2_filter_71_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_71_wd = reg_wdata[7];
+
+  assign cmd_filter_2_filter_72_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_72_wd = reg_wdata[8];
+
+  assign cmd_filter_2_filter_73_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_73_wd = reg_wdata[9];
+
+  assign cmd_filter_2_filter_74_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_74_wd = reg_wdata[10];
+
+  assign cmd_filter_2_filter_75_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_75_wd = reg_wdata[11];
+
+  assign cmd_filter_2_filter_76_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_76_wd = reg_wdata[12];
+
+  assign cmd_filter_2_filter_77_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_77_wd = reg_wdata[13];
+
+  assign cmd_filter_2_filter_78_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_78_wd = reg_wdata[14];
+
+  assign cmd_filter_2_filter_79_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_79_wd = reg_wdata[15];
+
+  assign cmd_filter_2_filter_80_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_80_wd = reg_wdata[16];
+
+  assign cmd_filter_2_filter_81_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_81_wd = reg_wdata[17];
+
+  assign cmd_filter_2_filter_82_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_82_wd = reg_wdata[18];
+
+  assign cmd_filter_2_filter_83_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_83_wd = reg_wdata[19];
+
+  assign cmd_filter_2_filter_84_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_84_wd = reg_wdata[20];
+
+  assign cmd_filter_2_filter_85_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_85_wd = reg_wdata[21];
+
+  assign cmd_filter_2_filter_86_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_86_wd = reg_wdata[22];
+
+  assign cmd_filter_2_filter_87_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_87_wd = reg_wdata[23];
+
+  assign cmd_filter_2_filter_88_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_88_wd = reg_wdata[24];
+
+  assign cmd_filter_2_filter_89_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_89_wd = reg_wdata[25];
+
+  assign cmd_filter_2_filter_90_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_90_wd = reg_wdata[26];
+
+  assign cmd_filter_2_filter_91_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_91_wd = reg_wdata[27];
+
+  assign cmd_filter_2_filter_92_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_92_wd = reg_wdata[28];
+
+  assign cmd_filter_2_filter_93_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_93_wd = reg_wdata[29];
+
+  assign cmd_filter_2_filter_94_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_94_wd = reg_wdata[30];
+
+  assign cmd_filter_2_filter_95_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_2_filter_95_wd = reg_wdata[31];
+
+  assign cmd_filter_3_filter_96_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_96_wd = reg_wdata[0];
+
+  assign cmd_filter_3_filter_97_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_97_wd = reg_wdata[1];
+
+  assign cmd_filter_3_filter_98_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_98_wd = reg_wdata[2];
+
+  assign cmd_filter_3_filter_99_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_99_wd = reg_wdata[3];
+
+  assign cmd_filter_3_filter_100_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_100_wd = reg_wdata[4];
+
+  assign cmd_filter_3_filter_101_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_101_wd = reg_wdata[5];
+
+  assign cmd_filter_3_filter_102_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_102_wd = reg_wdata[6];
+
+  assign cmd_filter_3_filter_103_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_103_wd = reg_wdata[7];
+
+  assign cmd_filter_3_filter_104_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_104_wd = reg_wdata[8];
+
+  assign cmd_filter_3_filter_105_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_105_wd = reg_wdata[9];
+
+  assign cmd_filter_3_filter_106_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_106_wd = reg_wdata[10];
+
+  assign cmd_filter_3_filter_107_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_107_wd = reg_wdata[11];
+
+  assign cmd_filter_3_filter_108_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_108_wd = reg_wdata[12];
+
+  assign cmd_filter_3_filter_109_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_109_wd = reg_wdata[13];
+
+  assign cmd_filter_3_filter_110_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_110_wd = reg_wdata[14];
+
+  assign cmd_filter_3_filter_111_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_111_wd = reg_wdata[15];
+
+  assign cmd_filter_3_filter_112_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_112_wd = reg_wdata[16];
+
+  assign cmd_filter_3_filter_113_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_113_wd = reg_wdata[17];
+
+  assign cmd_filter_3_filter_114_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_114_wd = reg_wdata[18];
+
+  assign cmd_filter_3_filter_115_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_115_wd = reg_wdata[19];
+
+  assign cmd_filter_3_filter_116_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_116_wd = reg_wdata[20];
+
+  assign cmd_filter_3_filter_117_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_117_wd = reg_wdata[21];
+
+  assign cmd_filter_3_filter_118_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_118_wd = reg_wdata[22];
+
+  assign cmd_filter_3_filter_119_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_119_wd = reg_wdata[23];
+
+  assign cmd_filter_3_filter_120_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_120_wd = reg_wdata[24];
+
+  assign cmd_filter_3_filter_121_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_121_wd = reg_wdata[25];
+
+  assign cmd_filter_3_filter_122_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_122_wd = reg_wdata[26];
+
+  assign cmd_filter_3_filter_123_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_123_wd = reg_wdata[27];
+
+  assign cmd_filter_3_filter_124_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_124_wd = reg_wdata[28];
+
+  assign cmd_filter_3_filter_125_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_125_wd = reg_wdata[29];
+
+  assign cmd_filter_3_filter_126_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_126_wd = reg_wdata[30];
+
+  assign cmd_filter_3_filter_127_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_3_filter_127_wd = reg_wdata[31];
+
+  assign cmd_filter_4_filter_128_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_128_wd = reg_wdata[0];
+
+  assign cmd_filter_4_filter_129_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_129_wd = reg_wdata[1];
+
+  assign cmd_filter_4_filter_130_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_130_wd = reg_wdata[2];
+
+  assign cmd_filter_4_filter_131_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_131_wd = reg_wdata[3];
+
+  assign cmd_filter_4_filter_132_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_132_wd = reg_wdata[4];
+
+  assign cmd_filter_4_filter_133_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_133_wd = reg_wdata[5];
+
+  assign cmd_filter_4_filter_134_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_134_wd = reg_wdata[6];
+
+  assign cmd_filter_4_filter_135_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_135_wd = reg_wdata[7];
+
+  assign cmd_filter_4_filter_136_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_136_wd = reg_wdata[8];
+
+  assign cmd_filter_4_filter_137_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_137_wd = reg_wdata[9];
+
+  assign cmd_filter_4_filter_138_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_138_wd = reg_wdata[10];
+
+  assign cmd_filter_4_filter_139_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_139_wd = reg_wdata[11];
+
+  assign cmd_filter_4_filter_140_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_140_wd = reg_wdata[12];
+
+  assign cmd_filter_4_filter_141_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_141_wd = reg_wdata[13];
+
+  assign cmd_filter_4_filter_142_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_142_wd = reg_wdata[14];
+
+  assign cmd_filter_4_filter_143_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_143_wd = reg_wdata[15];
+
+  assign cmd_filter_4_filter_144_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_144_wd = reg_wdata[16];
+
+  assign cmd_filter_4_filter_145_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_145_wd = reg_wdata[17];
+
+  assign cmd_filter_4_filter_146_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_146_wd = reg_wdata[18];
+
+  assign cmd_filter_4_filter_147_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_147_wd = reg_wdata[19];
+
+  assign cmd_filter_4_filter_148_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_148_wd = reg_wdata[20];
+
+  assign cmd_filter_4_filter_149_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_149_wd = reg_wdata[21];
+
+  assign cmd_filter_4_filter_150_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_150_wd = reg_wdata[22];
+
+  assign cmd_filter_4_filter_151_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_151_wd = reg_wdata[23];
+
+  assign cmd_filter_4_filter_152_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_152_wd = reg_wdata[24];
+
+  assign cmd_filter_4_filter_153_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_153_wd = reg_wdata[25];
+
+  assign cmd_filter_4_filter_154_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_154_wd = reg_wdata[26];
+
+  assign cmd_filter_4_filter_155_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_155_wd = reg_wdata[27];
+
+  assign cmd_filter_4_filter_156_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_156_wd = reg_wdata[28];
+
+  assign cmd_filter_4_filter_157_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_157_wd = reg_wdata[29];
+
+  assign cmd_filter_4_filter_158_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_158_wd = reg_wdata[30];
+
+  assign cmd_filter_4_filter_159_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_4_filter_159_wd = reg_wdata[31];
+
+  assign cmd_filter_5_filter_160_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_160_wd = reg_wdata[0];
+
+  assign cmd_filter_5_filter_161_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_161_wd = reg_wdata[1];
+
+  assign cmd_filter_5_filter_162_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_162_wd = reg_wdata[2];
+
+  assign cmd_filter_5_filter_163_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_163_wd = reg_wdata[3];
+
+  assign cmd_filter_5_filter_164_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_164_wd = reg_wdata[4];
+
+  assign cmd_filter_5_filter_165_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_165_wd = reg_wdata[5];
+
+  assign cmd_filter_5_filter_166_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_166_wd = reg_wdata[6];
+
+  assign cmd_filter_5_filter_167_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_167_wd = reg_wdata[7];
+
+  assign cmd_filter_5_filter_168_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_168_wd = reg_wdata[8];
+
+  assign cmd_filter_5_filter_169_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_169_wd = reg_wdata[9];
+
+  assign cmd_filter_5_filter_170_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_170_wd = reg_wdata[10];
+
+  assign cmd_filter_5_filter_171_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_171_wd = reg_wdata[11];
+
+  assign cmd_filter_5_filter_172_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_172_wd = reg_wdata[12];
+
+  assign cmd_filter_5_filter_173_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_173_wd = reg_wdata[13];
+
+  assign cmd_filter_5_filter_174_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_174_wd = reg_wdata[14];
+
+  assign cmd_filter_5_filter_175_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_175_wd = reg_wdata[15];
+
+  assign cmd_filter_5_filter_176_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_176_wd = reg_wdata[16];
+
+  assign cmd_filter_5_filter_177_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_177_wd = reg_wdata[17];
+
+  assign cmd_filter_5_filter_178_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_178_wd = reg_wdata[18];
+
+  assign cmd_filter_5_filter_179_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_179_wd = reg_wdata[19];
+
+  assign cmd_filter_5_filter_180_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_180_wd = reg_wdata[20];
+
+  assign cmd_filter_5_filter_181_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_181_wd = reg_wdata[21];
+
+  assign cmd_filter_5_filter_182_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_182_wd = reg_wdata[22];
+
+  assign cmd_filter_5_filter_183_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_183_wd = reg_wdata[23];
+
+  assign cmd_filter_5_filter_184_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_184_wd = reg_wdata[24];
+
+  assign cmd_filter_5_filter_185_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_185_wd = reg_wdata[25];
+
+  assign cmd_filter_5_filter_186_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_186_wd = reg_wdata[26];
+
+  assign cmd_filter_5_filter_187_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_187_wd = reg_wdata[27];
+
+  assign cmd_filter_5_filter_188_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_188_wd = reg_wdata[28];
+
+  assign cmd_filter_5_filter_189_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_189_wd = reg_wdata[29];
+
+  assign cmd_filter_5_filter_190_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_190_wd = reg_wdata[30];
+
+  assign cmd_filter_5_filter_191_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_5_filter_191_wd = reg_wdata[31];
+
+  assign cmd_filter_6_filter_192_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_192_wd = reg_wdata[0];
+
+  assign cmd_filter_6_filter_193_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_193_wd = reg_wdata[1];
+
+  assign cmd_filter_6_filter_194_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_194_wd = reg_wdata[2];
+
+  assign cmd_filter_6_filter_195_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_195_wd = reg_wdata[3];
+
+  assign cmd_filter_6_filter_196_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_196_wd = reg_wdata[4];
+
+  assign cmd_filter_6_filter_197_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_197_wd = reg_wdata[5];
+
+  assign cmd_filter_6_filter_198_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_198_wd = reg_wdata[6];
+
+  assign cmd_filter_6_filter_199_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_199_wd = reg_wdata[7];
+
+  assign cmd_filter_6_filter_200_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_200_wd = reg_wdata[8];
+
+  assign cmd_filter_6_filter_201_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_201_wd = reg_wdata[9];
+
+  assign cmd_filter_6_filter_202_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_202_wd = reg_wdata[10];
+
+  assign cmd_filter_6_filter_203_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_203_wd = reg_wdata[11];
+
+  assign cmd_filter_6_filter_204_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_204_wd = reg_wdata[12];
+
+  assign cmd_filter_6_filter_205_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_205_wd = reg_wdata[13];
+
+  assign cmd_filter_6_filter_206_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_206_wd = reg_wdata[14];
+
+  assign cmd_filter_6_filter_207_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_207_wd = reg_wdata[15];
+
+  assign cmd_filter_6_filter_208_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_208_wd = reg_wdata[16];
+
+  assign cmd_filter_6_filter_209_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_209_wd = reg_wdata[17];
+
+  assign cmd_filter_6_filter_210_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_210_wd = reg_wdata[18];
+
+  assign cmd_filter_6_filter_211_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_211_wd = reg_wdata[19];
+
+  assign cmd_filter_6_filter_212_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_212_wd = reg_wdata[20];
+
+  assign cmd_filter_6_filter_213_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_213_wd = reg_wdata[21];
+
+  assign cmd_filter_6_filter_214_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_214_wd = reg_wdata[22];
+
+  assign cmd_filter_6_filter_215_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_215_wd = reg_wdata[23];
+
+  assign cmd_filter_6_filter_216_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_216_wd = reg_wdata[24];
+
+  assign cmd_filter_6_filter_217_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_217_wd = reg_wdata[25];
+
+  assign cmd_filter_6_filter_218_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_218_wd = reg_wdata[26];
+
+  assign cmd_filter_6_filter_219_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_219_wd = reg_wdata[27];
+
+  assign cmd_filter_6_filter_220_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_220_wd = reg_wdata[28];
+
+  assign cmd_filter_6_filter_221_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_221_wd = reg_wdata[29];
+
+  assign cmd_filter_6_filter_222_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_222_wd = reg_wdata[30];
+
+  assign cmd_filter_6_filter_223_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_6_filter_223_wd = reg_wdata[31];
+
+  assign cmd_filter_7_filter_224_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_224_wd = reg_wdata[0];
+
+  assign cmd_filter_7_filter_225_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_225_wd = reg_wdata[1];
+
+  assign cmd_filter_7_filter_226_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_226_wd = reg_wdata[2];
+
+  assign cmd_filter_7_filter_227_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_227_wd = reg_wdata[3];
+
+  assign cmd_filter_7_filter_228_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_228_wd = reg_wdata[4];
+
+  assign cmd_filter_7_filter_229_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_229_wd = reg_wdata[5];
+
+  assign cmd_filter_7_filter_230_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_230_wd = reg_wdata[6];
+
+  assign cmd_filter_7_filter_231_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_231_wd = reg_wdata[7];
+
+  assign cmd_filter_7_filter_232_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_232_wd = reg_wdata[8];
+
+  assign cmd_filter_7_filter_233_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_233_wd = reg_wdata[9];
+
+  assign cmd_filter_7_filter_234_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_234_wd = reg_wdata[10];
+
+  assign cmd_filter_7_filter_235_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_235_wd = reg_wdata[11];
+
+  assign cmd_filter_7_filter_236_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_236_wd = reg_wdata[12];
+
+  assign cmd_filter_7_filter_237_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_237_wd = reg_wdata[13];
+
+  assign cmd_filter_7_filter_238_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_238_wd = reg_wdata[14];
+
+  assign cmd_filter_7_filter_239_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_239_wd = reg_wdata[15];
+
+  assign cmd_filter_7_filter_240_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_240_wd = reg_wdata[16];
+
+  assign cmd_filter_7_filter_241_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_241_wd = reg_wdata[17];
+
+  assign cmd_filter_7_filter_242_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_242_wd = reg_wdata[18];
+
+  assign cmd_filter_7_filter_243_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_243_wd = reg_wdata[19];
+
+  assign cmd_filter_7_filter_244_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_244_wd = reg_wdata[20];
+
+  assign cmd_filter_7_filter_245_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_245_wd = reg_wdata[21];
+
+  assign cmd_filter_7_filter_246_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_246_wd = reg_wdata[22];
+
+  assign cmd_filter_7_filter_247_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_247_wd = reg_wdata[23];
+
+  assign cmd_filter_7_filter_248_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_248_wd = reg_wdata[24];
+
+  assign cmd_filter_7_filter_249_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_249_wd = reg_wdata[25];
+
+  assign cmd_filter_7_filter_250_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_250_wd = reg_wdata[26];
+
+  assign cmd_filter_7_filter_251_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_251_wd = reg_wdata[27];
+
+  assign cmd_filter_7_filter_252_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_252_wd = reg_wdata[28];
+
+  assign cmd_filter_7_filter_253_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_253_wd = reg_wdata[29];
+
+  assign cmd_filter_7_filter_254_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_254_wd = reg_wdata[30];
+
+  assign cmd_filter_7_filter_255_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_7_filter_255_wd = reg_wdata[31];
+
+  assign addr_swap_mask_we = addr_hit[20] & reg_we & !reg_error;
+  assign addr_swap_mask_wd = reg_wdata[31:0];
+
+  assign addr_swap_data_we = addr_hit[21] & reg_we & !reg_error;
+  assign addr_swap_data_wd = reg_wdata[31:0];
 
   // Read data return
   always_comb begin
@@ -1545,6 +9881,7 @@ module spi_device_reg_top (
         reg_rdata_next[2] = cfg_tx_order_qs;
         reg_rdata_next[3] = cfg_rx_order_qs;
         reg_rdata_next[15:8] = cfg_timer_v_qs;
+        reg_rdata_next[16] = cfg_addr_4b_en_qs;
       end
 
       addr_hit[5]: begin
@@ -1584,6 +9921,294 @@ module spi_device_reg_top (
       addr_hit[11]: begin
         reg_rdata_next[15:0] = txf_addr_base_qs;
         reg_rdata_next[31:16] = txf_addr_limit_qs;
+      end
+
+      addr_hit[12]: begin
+        reg_rdata_next[0] = cmd_filter_0_filter_0_qs;
+        reg_rdata_next[1] = cmd_filter_0_filter_1_qs;
+        reg_rdata_next[2] = cmd_filter_0_filter_2_qs;
+        reg_rdata_next[3] = cmd_filter_0_filter_3_qs;
+        reg_rdata_next[4] = cmd_filter_0_filter_4_qs;
+        reg_rdata_next[5] = cmd_filter_0_filter_5_qs;
+        reg_rdata_next[6] = cmd_filter_0_filter_6_qs;
+        reg_rdata_next[7] = cmd_filter_0_filter_7_qs;
+        reg_rdata_next[8] = cmd_filter_0_filter_8_qs;
+        reg_rdata_next[9] = cmd_filter_0_filter_9_qs;
+        reg_rdata_next[10] = cmd_filter_0_filter_10_qs;
+        reg_rdata_next[11] = cmd_filter_0_filter_11_qs;
+        reg_rdata_next[12] = cmd_filter_0_filter_12_qs;
+        reg_rdata_next[13] = cmd_filter_0_filter_13_qs;
+        reg_rdata_next[14] = cmd_filter_0_filter_14_qs;
+        reg_rdata_next[15] = cmd_filter_0_filter_15_qs;
+        reg_rdata_next[16] = cmd_filter_0_filter_16_qs;
+        reg_rdata_next[17] = cmd_filter_0_filter_17_qs;
+        reg_rdata_next[18] = cmd_filter_0_filter_18_qs;
+        reg_rdata_next[19] = cmd_filter_0_filter_19_qs;
+        reg_rdata_next[20] = cmd_filter_0_filter_20_qs;
+        reg_rdata_next[21] = cmd_filter_0_filter_21_qs;
+        reg_rdata_next[22] = cmd_filter_0_filter_22_qs;
+        reg_rdata_next[23] = cmd_filter_0_filter_23_qs;
+        reg_rdata_next[24] = cmd_filter_0_filter_24_qs;
+        reg_rdata_next[25] = cmd_filter_0_filter_25_qs;
+        reg_rdata_next[26] = cmd_filter_0_filter_26_qs;
+        reg_rdata_next[27] = cmd_filter_0_filter_27_qs;
+        reg_rdata_next[28] = cmd_filter_0_filter_28_qs;
+        reg_rdata_next[29] = cmd_filter_0_filter_29_qs;
+        reg_rdata_next[30] = cmd_filter_0_filter_30_qs;
+        reg_rdata_next[31] = cmd_filter_0_filter_31_qs;
+      end
+
+      addr_hit[13]: begin
+        reg_rdata_next[0] = cmd_filter_1_filter_32_qs;
+        reg_rdata_next[1] = cmd_filter_1_filter_33_qs;
+        reg_rdata_next[2] = cmd_filter_1_filter_34_qs;
+        reg_rdata_next[3] = cmd_filter_1_filter_35_qs;
+        reg_rdata_next[4] = cmd_filter_1_filter_36_qs;
+        reg_rdata_next[5] = cmd_filter_1_filter_37_qs;
+        reg_rdata_next[6] = cmd_filter_1_filter_38_qs;
+        reg_rdata_next[7] = cmd_filter_1_filter_39_qs;
+        reg_rdata_next[8] = cmd_filter_1_filter_40_qs;
+        reg_rdata_next[9] = cmd_filter_1_filter_41_qs;
+        reg_rdata_next[10] = cmd_filter_1_filter_42_qs;
+        reg_rdata_next[11] = cmd_filter_1_filter_43_qs;
+        reg_rdata_next[12] = cmd_filter_1_filter_44_qs;
+        reg_rdata_next[13] = cmd_filter_1_filter_45_qs;
+        reg_rdata_next[14] = cmd_filter_1_filter_46_qs;
+        reg_rdata_next[15] = cmd_filter_1_filter_47_qs;
+        reg_rdata_next[16] = cmd_filter_1_filter_48_qs;
+        reg_rdata_next[17] = cmd_filter_1_filter_49_qs;
+        reg_rdata_next[18] = cmd_filter_1_filter_50_qs;
+        reg_rdata_next[19] = cmd_filter_1_filter_51_qs;
+        reg_rdata_next[20] = cmd_filter_1_filter_52_qs;
+        reg_rdata_next[21] = cmd_filter_1_filter_53_qs;
+        reg_rdata_next[22] = cmd_filter_1_filter_54_qs;
+        reg_rdata_next[23] = cmd_filter_1_filter_55_qs;
+        reg_rdata_next[24] = cmd_filter_1_filter_56_qs;
+        reg_rdata_next[25] = cmd_filter_1_filter_57_qs;
+        reg_rdata_next[26] = cmd_filter_1_filter_58_qs;
+        reg_rdata_next[27] = cmd_filter_1_filter_59_qs;
+        reg_rdata_next[28] = cmd_filter_1_filter_60_qs;
+        reg_rdata_next[29] = cmd_filter_1_filter_61_qs;
+        reg_rdata_next[30] = cmd_filter_1_filter_62_qs;
+        reg_rdata_next[31] = cmd_filter_1_filter_63_qs;
+      end
+
+      addr_hit[14]: begin
+        reg_rdata_next[0] = cmd_filter_2_filter_64_qs;
+        reg_rdata_next[1] = cmd_filter_2_filter_65_qs;
+        reg_rdata_next[2] = cmd_filter_2_filter_66_qs;
+        reg_rdata_next[3] = cmd_filter_2_filter_67_qs;
+        reg_rdata_next[4] = cmd_filter_2_filter_68_qs;
+        reg_rdata_next[5] = cmd_filter_2_filter_69_qs;
+        reg_rdata_next[6] = cmd_filter_2_filter_70_qs;
+        reg_rdata_next[7] = cmd_filter_2_filter_71_qs;
+        reg_rdata_next[8] = cmd_filter_2_filter_72_qs;
+        reg_rdata_next[9] = cmd_filter_2_filter_73_qs;
+        reg_rdata_next[10] = cmd_filter_2_filter_74_qs;
+        reg_rdata_next[11] = cmd_filter_2_filter_75_qs;
+        reg_rdata_next[12] = cmd_filter_2_filter_76_qs;
+        reg_rdata_next[13] = cmd_filter_2_filter_77_qs;
+        reg_rdata_next[14] = cmd_filter_2_filter_78_qs;
+        reg_rdata_next[15] = cmd_filter_2_filter_79_qs;
+        reg_rdata_next[16] = cmd_filter_2_filter_80_qs;
+        reg_rdata_next[17] = cmd_filter_2_filter_81_qs;
+        reg_rdata_next[18] = cmd_filter_2_filter_82_qs;
+        reg_rdata_next[19] = cmd_filter_2_filter_83_qs;
+        reg_rdata_next[20] = cmd_filter_2_filter_84_qs;
+        reg_rdata_next[21] = cmd_filter_2_filter_85_qs;
+        reg_rdata_next[22] = cmd_filter_2_filter_86_qs;
+        reg_rdata_next[23] = cmd_filter_2_filter_87_qs;
+        reg_rdata_next[24] = cmd_filter_2_filter_88_qs;
+        reg_rdata_next[25] = cmd_filter_2_filter_89_qs;
+        reg_rdata_next[26] = cmd_filter_2_filter_90_qs;
+        reg_rdata_next[27] = cmd_filter_2_filter_91_qs;
+        reg_rdata_next[28] = cmd_filter_2_filter_92_qs;
+        reg_rdata_next[29] = cmd_filter_2_filter_93_qs;
+        reg_rdata_next[30] = cmd_filter_2_filter_94_qs;
+        reg_rdata_next[31] = cmd_filter_2_filter_95_qs;
+      end
+
+      addr_hit[15]: begin
+        reg_rdata_next[0] = cmd_filter_3_filter_96_qs;
+        reg_rdata_next[1] = cmd_filter_3_filter_97_qs;
+        reg_rdata_next[2] = cmd_filter_3_filter_98_qs;
+        reg_rdata_next[3] = cmd_filter_3_filter_99_qs;
+        reg_rdata_next[4] = cmd_filter_3_filter_100_qs;
+        reg_rdata_next[5] = cmd_filter_3_filter_101_qs;
+        reg_rdata_next[6] = cmd_filter_3_filter_102_qs;
+        reg_rdata_next[7] = cmd_filter_3_filter_103_qs;
+        reg_rdata_next[8] = cmd_filter_3_filter_104_qs;
+        reg_rdata_next[9] = cmd_filter_3_filter_105_qs;
+        reg_rdata_next[10] = cmd_filter_3_filter_106_qs;
+        reg_rdata_next[11] = cmd_filter_3_filter_107_qs;
+        reg_rdata_next[12] = cmd_filter_3_filter_108_qs;
+        reg_rdata_next[13] = cmd_filter_3_filter_109_qs;
+        reg_rdata_next[14] = cmd_filter_3_filter_110_qs;
+        reg_rdata_next[15] = cmd_filter_3_filter_111_qs;
+        reg_rdata_next[16] = cmd_filter_3_filter_112_qs;
+        reg_rdata_next[17] = cmd_filter_3_filter_113_qs;
+        reg_rdata_next[18] = cmd_filter_3_filter_114_qs;
+        reg_rdata_next[19] = cmd_filter_3_filter_115_qs;
+        reg_rdata_next[20] = cmd_filter_3_filter_116_qs;
+        reg_rdata_next[21] = cmd_filter_3_filter_117_qs;
+        reg_rdata_next[22] = cmd_filter_3_filter_118_qs;
+        reg_rdata_next[23] = cmd_filter_3_filter_119_qs;
+        reg_rdata_next[24] = cmd_filter_3_filter_120_qs;
+        reg_rdata_next[25] = cmd_filter_3_filter_121_qs;
+        reg_rdata_next[26] = cmd_filter_3_filter_122_qs;
+        reg_rdata_next[27] = cmd_filter_3_filter_123_qs;
+        reg_rdata_next[28] = cmd_filter_3_filter_124_qs;
+        reg_rdata_next[29] = cmd_filter_3_filter_125_qs;
+        reg_rdata_next[30] = cmd_filter_3_filter_126_qs;
+        reg_rdata_next[31] = cmd_filter_3_filter_127_qs;
+      end
+
+      addr_hit[16]: begin
+        reg_rdata_next[0] = cmd_filter_4_filter_128_qs;
+        reg_rdata_next[1] = cmd_filter_4_filter_129_qs;
+        reg_rdata_next[2] = cmd_filter_4_filter_130_qs;
+        reg_rdata_next[3] = cmd_filter_4_filter_131_qs;
+        reg_rdata_next[4] = cmd_filter_4_filter_132_qs;
+        reg_rdata_next[5] = cmd_filter_4_filter_133_qs;
+        reg_rdata_next[6] = cmd_filter_4_filter_134_qs;
+        reg_rdata_next[7] = cmd_filter_4_filter_135_qs;
+        reg_rdata_next[8] = cmd_filter_4_filter_136_qs;
+        reg_rdata_next[9] = cmd_filter_4_filter_137_qs;
+        reg_rdata_next[10] = cmd_filter_4_filter_138_qs;
+        reg_rdata_next[11] = cmd_filter_4_filter_139_qs;
+        reg_rdata_next[12] = cmd_filter_4_filter_140_qs;
+        reg_rdata_next[13] = cmd_filter_4_filter_141_qs;
+        reg_rdata_next[14] = cmd_filter_4_filter_142_qs;
+        reg_rdata_next[15] = cmd_filter_4_filter_143_qs;
+        reg_rdata_next[16] = cmd_filter_4_filter_144_qs;
+        reg_rdata_next[17] = cmd_filter_4_filter_145_qs;
+        reg_rdata_next[18] = cmd_filter_4_filter_146_qs;
+        reg_rdata_next[19] = cmd_filter_4_filter_147_qs;
+        reg_rdata_next[20] = cmd_filter_4_filter_148_qs;
+        reg_rdata_next[21] = cmd_filter_4_filter_149_qs;
+        reg_rdata_next[22] = cmd_filter_4_filter_150_qs;
+        reg_rdata_next[23] = cmd_filter_4_filter_151_qs;
+        reg_rdata_next[24] = cmd_filter_4_filter_152_qs;
+        reg_rdata_next[25] = cmd_filter_4_filter_153_qs;
+        reg_rdata_next[26] = cmd_filter_4_filter_154_qs;
+        reg_rdata_next[27] = cmd_filter_4_filter_155_qs;
+        reg_rdata_next[28] = cmd_filter_4_filter_156_qs;
+        reg_rdata_next[29] = cmd_filter_4_filter_157_qs;
+        reg_rdata_next[30] = cmd_filter_4_filter_158_qs;
+        reg_rdata_next[31] = cmd_filter_4_filter_159_qs;
+      end
+
+      addr_hit[17]: begin
+        reg_rdata_next[0] = cmd_filter_5_filter_160_qs;
+        reg_rdata_next[1] = cmd_filter_5_filter_161_qs;
+        reg_rdata_next[2] = cmd_filter_5_filter_162_qs;
+        reg_rdata_next[3] = cmd_filter_5_filter_163_qs;
+        reg_rdata_next[4] = cmd_filter_5_filter_164_qs;
+        reg_rdata_next[5] = cmd_filter_5_filter_165_qs;
+        reg_rdata_next[6] = cmd_filter_5_filter_166_qs;
+        reg_rdata_next[7] = cmd_filter_5_filter_167_qs;
+        reg_rdata_next[8] = cmd_filter_5_filter_168_qs;
+        reg_rdata_next[9] = cmd_filter_5_filter_169_qs;
+        reg_rdata_next[10] = cmd_filter_5_filter_170_qs;
+        reg_rdata_next[11] = cmd_filter_5_filter_171_qs;
+        reg_rdata_next[12] = cmd_filter_5_filter_172_qs;
+        reg_rdata_next[13] = cmd_filter_5_filter_173_qs;
+        reg_rdata_next[14] = cmd_filter_5_filter_174_qs;
+        reg_rdata_next[15] = cmd_filter_5_filter_175_qs;
+        reg_rdata_next[16] = cmd_filter_5_filter_176_qs;
+        reg_rdata_next[17] = cmd_filter_5_filter_177_qs;
+        reg_rdata_next[18] = cmd_filter_5_filter_178_qs;
+        reg_rdata_next[19] = cmd_filter_5_filter_179_qs;
+        reg_rdata_next[20] = cmd_filter_5_filter_180_qs;
+        reg_rdata_next[21] = cmd_filter_5_filter_181_qs;
+        reg_rdata_next[22] = cmd_filter_5_filter_182_qs;
+        reg_rdata_next[23] = cmd_filter_5_filter_183_qs;
+        reg_rdata_next[24] = cmd_filter_5_filter_184_qs;
+        reg_rdata_next[25] = cmd_filter_5_filter_185_qs;
+        reg_rdata_next[26] = cmd_filter_5_filter_186_qs;
+        reg_rdata_next[27] = cmd_filter_5_filter_187_qs;
+        reg_rdata_next[28] = cmd_filter_5_filter_188_qs;
+        reg_rdata_next[29] = cmd_filter_5_filter_189_qs;
+        reg_rdata_next[30] = cmd_filter_5_filter_190_qs;
+        reg_rdata_next[31] = cmd_filter_5_filter_191_qs;
+      end
+
+      addr_hit[18]: begin
+        reg_rdata_next[0] = cmd_filter_6_filter_192_qs;
+        reg_rdata_next[1] = cmd_filter_6_filter_193_qs;
+        reg_rdata_next[2] = cmd_filter_6_filter_194_qs;
+        reg_rdata_next[3] = cmd_filter_6_filter_195_qs;
+        reg_rdata_next[4] = cmd_filter_6_filter_196_qs;
+        reg_rdata_next[5] = cmd_filter_6_filter_197_qs;
+        reg_rdata_next[6] = cmd_filter_6_filter_198_qs;
+        reg_rdata_next[7] = cmd_filter_6_filter_199_qs;
+        reg_rdata_next[8] = cmd_filter_6_filter_200_qs;
+        reg_rdata_next[9] = cmd_filter_6_filter_201_qs;
+        reg_rdata_next[10] = cmd_filter_6_filter_202_qs;
+        reg_rdata_next[11] = cmd_filter_6_filter_203_qs;
+        reg_rdata_next[12] = cmd_filter_6_filter_204_qs;
+        reg_rdata_next[13] = cmd_filter_6_filter_205_qs;
+        reg_rdata_next[14] = cmd_filter_6_filter_206_qs;
+        reg_rdata_next[15] = cmd_filter_6_filter_207_qs;
+        reg_rdata_next[16] = cmd_filter_6_filter_208_qs;
+        reg_rdata_next[17] = cmd_filter_6_filter_209_qs;
+        reg_rdata_next[18] = cmd_filter_6_filter_210_qs;
+        reg_rdata_next[19] = cmd_filter_6_filter_211_qs;
+        reg_rdata_next[20] = cmd_filter_6_filter_212_qs;
+        reg_rdata_next[21] = cmd_filter_6_filter_213_qs;
+        reg_rdata_next[22] = cmd_filter_6_filter_214_qs;
+        reg_rdata_next[23] = cmd_filter_6_filter_215_qs;
+        reg_rdata_next[24] = cmd_filter_6_filter_216_qs;
+        reg_rdata_next[25] = cmd_filter_6_filter_217_qs;
+        reg_rdata_next[26] = cmd_filter_6_filter_218_qs;
+        reg_rdata_next[27] = cmd_filter_6_filter_219_qs;
+        reg_rdata_next[28] = cmd_filter_6_filter_220_qs;
+        reg_rdata_next[29] = cmd_filter_6_filter_221_qs;
+        reg_rdata_next[30] = cmd_filter_6_filter_222_qs;
+        reg_rdata_next[31] = cmd_filter_6_filter_223_qs;
+      end
+
+      addr_hit[19]: begin
+        reg_rdata_next[0] = cmd_filter_7_filter_224_qs;
+        reg_rdata_next[1] = cmd_filter_7_filter_225_qs;
+        reg_rdata_next[2] = cmd_filter_7_filter_226_qs;
+        reg_rdata_next[3] = cmd_filter_7_filter_227_qs;
+        reg_rdata_next[4] = cmd_filter_7_filter_228_qs;
+        reg_rdata_next[5] = cmd_filter_7_filter_229_qs;
+        reg_rdata_next[6] = cmd_filter_7_filter_230_qs;
+        reg_rdata_next[7] = cmd_filter_7_filter_231_qs;
+        reg_rdata_next[8] = cmd_filter_7_filter_232_qs;
+        reg_rdata_next[9] = cmd_filter_7_filter_233_qs;
+        reg_rdata_next[10] = cmd_filter_7_filter_234_qs;
+        reg_rdata_next[11] = cmd_filter_7_filter_235_qs;
+        reg_rdata_next[12] = cmd_filter_7_filter_236_qs;
+        reg_rdata_next[13] = cmd_filter_7_filter_237_qs;
+        reg_rdata_next[14] = cmd_filter_7_filter_238_qs;
+        reg_rdata_next[15] = cmd_filter_7_filter_239_qs;
+        reg_rdata_next[16] = cmd_filter_7_filter_240_qs;
+        reg_rdata_next[17] = cmd_filter_7_filter_241_qs;
+        reg_rdata_next[18] = cmd_filter_7_filter_242_qs;
+        reg_rdata_next[19] = cmd_filter_7_filter_243_qs;
+        reg_rdata_next[20] = cmd_filter_7_filter_244_qs;
+        reg_rdata_next[21] = cmd_filter_7_filter_245_qs;
+        reg_rdata_next[22] = cmd_filter_7_filter_246_qs;
+        reg_rdata_next[23] = cmd_filter_7_filter_247_qs;
+        reg_rdata_next[24] = cmd_filter_7_filter_248_qs;
+        reg_rdata_next[25] = cmd_filter_7_filter_249_qs;
+        reg_rdata_next[26] = cmd_filter_7_filter_250_qs;
+        reg_rdata_next[27] = cmd_filter_7_filter_251_qs;
+        reg_rdata_next[28] = cmd_filter_7_filter_252_qs;
+        reg_rdata_next[29] = cmd_filter_7_filter_253_qs;
+        reg_rdata_next[30] = cmd_filter_7_filter_254_qs;
+        reg_rdata_next[31] = cmd_filter_7_filter_255_qs;
+      end
+
+      addr_hit[20]: begin
+        reg_rdata_next[31:0] = addr_swap_mask_qs;
+      end
+
+      addr_hit[21]: begin
+        reg_rdata_next[31:0] = addr_swap_data_qs;
       end
 
       default: begin

--- a/hw/ip/spi_device/rtl/spi_fwmode.sv
+++ b/hw/ip/spi_device/rtl/spi_fwmode.sv
@@ -26,7 +26,6 @@ module spi_fwmode
 
   // Configurations
   // No sync logic. Configuration should be static when SPI operating
-  input  spi_mode_e mode_i, // Only works at mode_i == FwMode
 
   output logic      rxf_overflow_o,
   output logic      txf_underflow_o,

--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -173,6 +173,9 @@ module spi_readcmd
   // TODO: Implement
   assign mailbox_assumed_o = 1'b 0;
 
+  sram_err_t unused_sram_rerr;
+  assign unused_sram_rerr = sram_rerror_i;
+
   /////////////////
   // Definitions //
   /////////////////


### PR DESCRIPTION
This commit adds the CSRs that control the passthrough datapath. The
register interface now has 256 bit command filter register and 2x 32 bit
for the address manipulation feature.
