### PR TITLE
[pwrmgr] Add exclusion for reset en

### DIFF
--- a/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
@@ -447,6 +447,8 @@
             ''',
           },
         ]
+        tags: [// Self resets should never be triggered by automated tests
+        "excl:CsrAllTests:CsrExclWrite"]
       },
     },
 

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
@@ -472,6 +472,8 @@
             ''',
           },
         ]
+        tags: [// Self resets should never be triggered by automated tests
+        "excl:CsrAllTests:CsrExclWrite"]
       },
     },
 


### PR DESCRIPTION
Ensure self reset triggers are only ever activated in directed tests.
Addresses #6335.

Signed-off-by: Timothy Chen <timothytim@google.com>