### PR TITLE
[spi_device] Add COMBO_LOOP waiver on the passthrough

### DIFF
--- a/hw/top_earlgrey/lint/chip_earlgrey_asic.waiver
+++ b/hw/top_earlgrey/lint/chip_earlgrey_asic.waiver
@@ -6,3 +6,8 @@
 
 waive -rules {MULTI_DRIVEN} -location {chip_earlgrey_asic.sv} -regexp {'(IOA2|IOA3)' has 2 drivers, also driven at} \
       -comment "These two pads are shorted to AST, hence this multiple driver warning is OK."
+
+# COMBO_LOOP waiver on the Passthrough port
+waive -rules {COMBO_LOOP} -location {chip_earlgrey_asic.sv} \
+      -regexp {port 'u_passthrough.host_s_i.*' driven in module 'spi_device'} \
+      -comment "In the passthrough mode, SPI 4 lines are connected from pads to pads."


### PR DESCRIPTION
Lint tool detects the passthrough path as combo loop path. It is due to
the pad wrapper forwards any output value into the pad input value.
Passthrough connects host side pads to SPI Flash device side pads
without FF.

However, the COMBO_LOOP will not occur. The state machine in the
spi_passthrough.sv manages the output enable signal to not activate both
directions at the same time.