### PR TITLE
[dv/clkmgr] Add clocking related covergroups.

### DIFF
--- a/hw/ip/clkmgr/dv/env/clkmgr_if.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_if.sv
@@ -74,16 +74,12 @@ interface clkmgr_if(input logic clk, input logic rst_n, input logic rst_main_n);
     clk_enables = ens;
   endfunction
 
-  function automatic void update_hints(logic [$bits(clk_hints)-1:0] hints);
+  function automatic void update_hints(clk_hints_t hints);
     clk_hints = hints;
   endfunction
 
   function automatic void update_idle(bit [NUM_TRANS-1:0] value);
     idle_i = value;
-  endfunction
-
-  function automatic void update_trans_idle(logic value, trans_e trans);
-    idle_i[trans] = value;
   endfunction
 
   task automatic go_idle(trans_e trans, int cycles);

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -73,4 +73,14 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     cfg.aon_clk_rst_vif.set_freq_mhz(7);
   endtask
 
+  virtual function void update_idle(logic [NUM_TRANS-1:0] value);
+    idle = value;
+    cfg.clkmgr_vif.update_idle(idle);
+  endfunction
+
+  virtual function void update_trans_idle(logic value, trans_e trans);
+    idle[trans] = value;
+    update_idle(idle);
+  endfunction
+
 endclass : clkmgr_base_vseq

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_peri_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_peri_vseq.sv
@@ -17,7 +17,6 @@ class clkmgr_peri_vseq extends clkmgr_base_vseq;
     logic [NUM_PERI-1:0] flipped_enables;
     `uvm_info(`gfn, $sformatf("Initializing clk_enables with 0x%0x", initial_enables), UVM_LOW)
     csr_wr(.ptr(ral.clk_enables), .value(initial_enables));
-
     cfg.clk_rst_vif.wait_clks(10);
     // Flip all bits of clk_enables.
     flipped_enables = initial_enables ^ ((1 << ral.clk_enables.get_n_bits()) - 1);

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
@@ -47,11 +47,10 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
         '{TransAes, ral.clk_hints.clk_main_otbn_hint, ral.clk_hints_status.clk_main_otbn_val}
     };
 
-    cfg.clkmgr_vif.update_idle(0);
+    update_idle(0);
     trans = trans.first;
     csr_rd(.ptr(ral.clk_hints), .value(value));
     `uvm_info(`gfn, $sformatf("Updating hints to 0x%0x", value), UVM_MEDIUM)
-    cfg.clkmgr_vif.update_hints(value);
     do begin
       trans_descriptor_t descriptor = trans_descriptors[int'(trans)];
       `uvm_info(`gfn, $sformatf("Clearing %s hint bit", descriptor.unit.name), UVM_MEDIUM)
@@ -62,7 +61,7 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
 
       `uvm_info(`gfn, $sformatf("Setting %s idle bit", descriptor.unit.name), UVM_MEDIUM)
       cfg.clkmgr_vif.wait_clks(1);
-      cfg.clkmgr_vif.update_trans_idle(1'b1, trans);
+      update_trans_idle(1'b1, trans);
       // Some cycles for the logic to settle.
       cfg.clk_rst_vif.wait_clks(3);
       csr_rd(.ptr(descriptor.value_bit), .value(bit_value));

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
@@ -23,13 +23,11 @@ class clkmgr_trans_vseq extends clkmgr_base_vseq;
     trans = trans.first;
     `uvm_info(`gfn, $sformatf("Updating hints to 0x%0x", initial_hints), UVM_MEDIUM)
     csr_wr(.ptr(ral.clk_hints), .value(initial_hints));
-    cfg.clkmgr_vif.update_hints(initial_hints);
     cfg.clkmgr_vif.wait_clks(5);
     csr_rd(.ptr(ral.clk_hints_status), .value(value));
     // We expect the status to be determined by hints and idle.
     `DV_CHECK_EQ(value, initial_hints | ~idle, "Busy units have status high")
-    idle = '1;
-    cfg.clkmgr_vif.update_idle(idle);
+    update_idle('1);
     cfg.clkmgr_vif.wait_clks(5);
     csr_rd(.ptr(ral.clk_hints_status), .value(value));
     `DV_CHECK_EQ(value, initial_hints, "All idle: units status matches hints")


### PR DESCRIPTION
Add covergroup for peripheral and transactional units clocking.
The interface updates go through the base vsequence to enable
better coverage collection.

Signed-off-by: Guillermo Maturana <maturana@google.com>