### PR TITLE
Add CI check for non-ASCII characters

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,6 +60,9 @@ jobs:
   - bash: ci/scripts/exec-check.sh
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Check executable bits
+  - bash: ci/scripts/check-ascii.sh
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    displayName: Check for non-ASCII characters in source code
   - bash: ci/scripts/python-lint.sh $SYSTEM_PULLREQUEST_TARGETBRANCH
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Run Python lint (flake8)

--- a/ci/jobs/quick-lint.sh
+++ b/ci/jobs/quick-lint.sh
@@ -36,6 +36,9 @@ ci/scripts/check-licence-headers.sh $tgt_branch
 echo -e "\n### Check executable bits"
 ci/scripts/exec-check.sh
 
+echo -e "\n### Check executable bits"
+ci/scripts/check-ascii.sh
+
 echo -e "\n### Run Python lint (flake8)"
 ci/scripts/python-lint.sh $tgt_branch || {
     echo "(ignoring python lint errors)"

--- a/ci/scripts/check-ascii.sh
+++ b/ci/scripts/check-ascii.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Check that there are no "source" files in the repository that
+# contain non-ASCII characters.
+
+set -e
+
+# Suffixes of files that are allowed to contain non-ASCII characters.
+# These obviously include non-text files, but we also include .md and
+# .html because we've used non-ASCII encoding in quite a few of them
+# to make documentation easier to write.
+allowed_suffixes=(
+    png
+    ico
+    bin
+    der
+    vsdx
+    elf
+
+    md
+    html
+
+    # We don't mandate 7-bit ASCII for Python or C/C++ code. The
+    # Google style guide, which we inherit suggests avoiding
+    # unnecessary non-ASCII text, but doesn't forbid it entirely.
+    py
+    c
+    cc
+    h
+    hh
+)
+suff_re=""
+for suff in "${allowed_suffixes[@]}"; do
+    suff_re="${suff_re}${suff}\\|"
+done
+suff_re="\\.\\(${suff_re:0:-2}\\)$"
+
+# Other paths that should be excluded from the check. This includes
+# vendored files (that we don't control) and other binary files
+# without a suffix or non-source files.
+excl_paths=(
+    '.*/vendor/.*'
+    COMMITTERS
+    hw/ip/usbdev/pmod/tusb1106pmod-kicad/fp-info-cache
+    site/landing/data/partner_quotes.json
+)
+excl_re=""
+for excl in "${excl_paths[@]}"; do
+    excl_re="${excl_re}${excl}\\|"
+done
+excl_re="^\\(${excl_re:0:-2}\\)$"
+
+TMPFILE="$(mktemp)" || {
+    echo >&2 "Failed to create temporary file"
+    exit 1
+}
+trap 'rm -f "$TMPFILE"' EXIT
+
+git ls-files | \
+    grep -v "${excl_re}" | \
+    grep -v "${suff_re}" | \
+    env LC_ALL=C xargs grep -P '[^\0-\x7f]' >"$TMPFILE" || true
+if [ -s "$TMPFILE" ]; then
+    echo -n "##vso[task.logissue type=error]"
+    echo "One or more files have unexpected non-ASCII text:"
+    cat "$TMPFILE"
+    exit 1
+fi

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl.sv
@@ -27,7 +27,7 @@ module adc_ctrl (
   //output logic adc_pd,//Power down ADC(used in deep sleep mode to save power)
   //output logic [1:0] adc_chnsel,
   //channel select for ADC;
-  //2’b0 means stop, 2’b01 means first channel, 2’b10 means second channel, 2’b11 ilegal
+  //2'b0 means stop, 2'b01 means first channel, 2'b10 means second channel, 2'b11 ilegal
 
   //interrupt interface
   output logic intr_debug_cable_o,
@@ -36,7 +36,7 @@ module adc_ctrl (
   //pwrmgr interface
   output logic debug_cable_wakeup_o
   //Debug cable is detected; wake up the GSC(CPU) in normal sleep and deep sleep mode
-  //input  [2:0] pwr_sts,//3’b001: deep sleep, 3’b010: normal sleep, 3’b100: fully active
+  //input  [2:0] pwr_sts,//3'b001: deep sleep, 3'b010: normal sleep, 3'b100: fully active
 );
 
   import adc_ctrl_reg_pkg::*;

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -601,13 +601,13 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
 
   // HW invalid input checks as following
   // When an advance operation is invoked:
-  //   The working state key is checked for all 0’s and all 1’s.
+  //   The working state key is checked for all 0's and all 1's.
   //   During Initialized state, creator seed, device ID and health state data is checked for all
-  //   0’s and all 1’s.
-  //   During CreatorRootKey state, the owner seed is checked for all 0’s and all 1’s.
+  //   0's and all 1's.
+  //   During CreatorRootKey state, the owner seed is checked for all 0's and all 1's.
   //   During all other states, nothing is explicitly checked.
   // When a generate output key operation is invoked:
-  //   The working state key is checked for all 0’s and all 1’s.
+  //   The working state key is checked for all 0's and all 1's.
   virtual function bit get_hw_invalid_input();
     bit is_err;
 

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_hwsw_invalid_input_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_hwsw_invalid_input_vseq.sv
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Test below HW invalid input, also combine with SW invalid input
-// 1. During Initialized state, creator seed, device ID and health state data is checked for all 0’s
-// and all 1’s.
-// 2. During CreatorRootKey state, the owner seed is checked for all 0’s and all 1’s.
+// 1. During Initialized state, creator seed, device ID and health state data is checked for all 0's
+// and all 1's.
+// 2. During CreatorRootKey state, the owner seed is checked for all 0's and all 1's.
 class keymgr_hwsw_invalid_input_vseq extends keymgr_sw_invalid_input_vseq;
   `uvm_object_utils(keymgr_hwsw_invalid_input_vseq)
   `uvm_object_new

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_kmac_rsp_err_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_kmac_rsp_err_vseq.sv
@@ -4,7 +4,7 @@
 
 // Test these 2 types error cases, also combine with hw/sw invalid input
 // 1. invalid kmac operation - The KMAC module itself reported an error.
-// 2. invalid output - The data return from KMAC is all 0’s or all 1’s.
+// 2. invalid output - The data return from KMAC is all 0's or all 1's.
 class keymgr_kmac_rsp_err_vseq extends keymgr_hwsw_invalid_input_vseq;
   `uvm_object_utils(keymgr_kmac_rsp_err_vseq)
   `uvm_object_new

--- a/hw/ip/kmac/rtl/keccak_2share.sv
+++ b/hw/ip/kmac/rtl/keccak_2share.sv
@@ -293,7 +293,7 @@ module keccak_2share #(
   endfunction : box_to_bitarray
 
   // Step Mapping =============================================================
-  // theta(θ)
+  // theta
   // XOR each bit in the state with the parity of two columns
   // C[x,z] = A[x,0,z] ^ A[x,1,z] ^ A[x,2,z] ^ A[x,3,z] ^ A[x,4,z]
   // D[x,z] = C[x-1,z] ^ C[x+1,z-1]

--- a/hw/ip/prim/rtl/prim_keccak.sv
+++ b/hw/ip/prim/rtl/prim_keccak.sv
@@ -112,7 +112,7 @@ module prim_keccak #(
   endfunction : box_to_bitarray
 
   // Step Mapping =============================================================
-  // theta(θ)
+  // theta
   // XOR each bit in the state with the parity of two columns
   // C[x,z] = A[x,0,z] ^ A[x,1,z] ^ A[x,2,z] ^ A[x,3,z] ^ A[x,4,z]
   // D[x,z] = C[x-1,z] ^ C[x+1,z-1]

--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,7 @@ project(
   ],
 )
 
-# We allow both GCC and Clang, but these minimum versions.
+# We allow both GCC and Clang, but these minimum versions.
 required_gcc_version = '>=5'
 required_clang_version = '>=3.5'
 


### PR DESCRIPTION
The first commit removes some non-ASCII characters from SystemVerilog code and our meson.build. I don't think this affects "editorial intent" at all: the changes are mostly just normalising punctuation and whitespace.

The second commit adds a CI check to make sure they don't creep back in.