### PR TITLE
[otbn] Use always_ff for sequential block

### DIFF
--- a/hw/ip/otbn/rtl/otbn_lsu.sv
+++ b/hw/ip/otbn/rtl/otbn_lsu.sv
@@ -88,7 +88,7 @@ module otbn_lsu
   // the cycle following the request.
   assign lsu_word_select_en = lsu_load_req_i & (lsu_req_subset_i == InsnSubsetBase);
 
-  always @(posedge clk_i) begin
+  always_ff @(posedge clk_i) begin
     if (lsu_word_select_en) begin
       lsu_word_select <= lsu_addr_i[BaseWordAddrW-1:2];
     end


### PR DESCRIPTION
Caught by AscentLint.

See https://reports.opentitan.org/hw/ip/otbn/lint/ascentlint/2021.04.27_23.07.34/results.html for the relevant report.