### PR TITLE
[spi_device,lint] Waive unused cmd_info fields in spi_passthrough.sv

### DIFF
--- a/hw/ip/spi_device/lint/spi_device.waiver
+++ b/hw/ip/spi_device/lint/spi_device.waiver
@@ -122,8 +122,3 @@ waive -rules {TERMINAL_STATE} -location {spi_passthrough.sv} \
 
 waive -rules {NOT_READ} -location {spi_passthrough.sv} \
       -regexp {Signal 'opcode.*}
-
-waive -rules {NOT_READ} -location {spi_passthrouth.sv} \
-      -regexp {Signal 'cmd_info.addr.*} \
-      -comment "cmd_info is valid after moving to Address state. So cmd_info_d was used"
-

--- a/hw/ip/spi_device/rtl/spi_passthrough.sv
+++ b/hw/ip/spi_device/rtl/spi_passthrough.sv
@@ -838,6 +838,17 @@ module spi_passthrough
     end
   end
 
+  // Some of the fields of cmd_info are used in the big FSM below. The addr_* fields are ignored
+  // because we pick them from cmd_info_d instead (in a different FSM state). We rely on the
+  // synthesis tool not to generate the unneeded flops but must explicitly waive lint warnings about
+  // unused fields.
+  logic unused_cmd_info_fields;
+  assign unused_cmd_info_fields = &{1'b0,
+                                    cmd_info.addr_en,
+                                    cmd_info.addr_swap_en,
+                                    cmd_info.addr_4b_affected,
+                                    cmd_info.addr_size};
+
   always_comb begin
     cmd_info_d = '0;
 


### PR DESCRIPTION
These were waived for AscentLint already in spi_device.waiver (except
the filename had a typo). Move the waiver into the RTL instead, which
puts it closer to the relevant code and works for Verilator too.
