### PR TITLE
[spi_device,lint] Waive unused sram_error input for spi_fwm_*xf_ctrl

### DIFF
--- a/hw/ip/spi_device/lint/spi_device.vlt
+++ b/hw/ip/spi_device/lint/spi_device.vlt
@@ -8,3 +8,7 @@
 
 // The mode_i input is not currently used: we only support FwMode at the moment.
 lint_off -rule UNUSED -file "*/rtl/spi_fwmode.sv" -match "Signal is not used: 'mode_i'"
+
+// SRAM error protection is not yet implemented
+lint_off -rule UNUSED -file "*/rtl/spi_fwm_rxf_ctrl.sv" -match "Signal is not used: 'sram_error'"
+lint_off -rule UNUSED -file "*/rtl/spi_fwm_txf_ctrl.sv" -match "Signal is not used: 'sram_error'"


### PR DESCRIPTION
This is unused and already waived for AscentLint.

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>