### PR TITLE
[sha3,lint] Explicitly waive unused parameter in keccak_round.sv

### DIFF
--- a/hw/ip/kmac/lint/sha3.vlt
+++ b/hw/ip/kmac/lint/sha3.vlt
@@ -8,3 +8,7 @@
 
 // index_z is of type int but we only use bits 5:0.
 lint_off -rule UNUSED -file "*/rtl/keccak_2share.sv" -match "*index_z*"
+
+// ReuseShare doesn't yet have any effect in keccak_round (this should
+// eventually be implemented in keccak_2share)
+lint_off -rule UNUSED -file "*/rtl/keccak_round.sv" -match "Parameter is not used: 'ReuseShare'"


### PR DESCRIPTION
This copies an existing AscentLint waiver to work for Verilator too.

Also, @eunchan, could you check the corresponding message in the AscentLint waiver file? It's true, but I'm not sure it really explains what's going on.