### PR TITLE
[rom_ctrl] AscentLint warning fixes

### DIFF
--- a/hw/ip/rom_ctrl/lint/rom_ctrl.waiver
+++ b/hw/ip/rom_ctrl/lint/rom_ctrl.waiver
@@ -2,3 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+# In rom_ctrl_counter, the "output valid" signal must be true from one
+# cycle after reset. We do this by setting vld_q <= 1'b1 in an
+# always_ff block.
+waive -rules {CONST_FF} -location {rom_ctrl_counter.sv} \
+      -regexp {Flip-flop 'vld_q' is driven by constant one} \
+      -comment "This is intentional: the signal should be true from one cycle after reset."

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -254,7 +254,7 @@ module rom_ctrl
   // Repack signals to convert between the view expected by rom_ctrl_reg_pkg for CSRs and the view
   // expected by rom_ctrl_fsm. Register 0 of a multi-reg appears as the low bits of the packed data.
   for (genvar i = 0; i < 8; i++) begin: gen_csr_digest
-    localparam int TopBitInt = 32 * i + 31;
+    localparam int unsigned TopBitInt = 32 * i + 31;
     localparam bit [7:0] TopBit = TopBitInt[7:0];
 
     assign hw2reg.digest[i].d = digest_d[TopBit -: 32];

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_compare.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_compare.sv
@@ -41,8 +41,8 @@ module rom_ctrl_compare #(
 
   localparam int AW = vbits(NumWords);
 
-  localparam int          EndAddrInt  = NumWords;
-  localparam int          LastAddrInt = NumWords - 1;
+  localparam int unsigned EndAddrInt  = NumWords;
+  localparam int unsigned LastAddrInt = NumWords - 1;
 
   // Note that if NumWords is a power of 2 then EndAddr will be zero. That's ok: we're just using a
   // comparison with EndAddr to check that the address counter hasn't started wandering around when
@@ -89,7 +89,7 @@ module rom_ctrl_compare #(
   logic        matches_q, matches_d;
   logic        fsm_alert;
 
-  prim_flop #(.Width(5), .ResetValue(Waiting))
+  prim_flop #(.Width(5), .ResetValue({Waiting}))
   u_state_regs (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),
@@ -127,7 +127,7 @@ module rom_ctrl_compare #(
   assign done_addr_alert = (state_q == Done) && (addr_q != EndAddr);
 
   // Increment addr_q on each cycle when in Checking
-  always @(posedge clk_i or negedge rst_ni) begin
+  always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       addr_q    <= '0;
       matches_q <= 1'b1;

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_counter.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_counter.sv
@@ -56,8 +56,8 @@ module rom_ctrl_counter
 
   localparam int AW = vbits(RomDepth);
 
-  localparam int TopAddrInt = RomDepth - 1;
-  localparam int TNTAddrInt = RomNonTopCount - 2;
+  localparam int unsigned TopAddrInt = RomDepth - 1;
+  localparam int unsigned TNTAddrInt = RomNonTopCount - 2;
 
   localparam bit [AW-1:0] TopAddr = TopAddrInt[AW-1:0];
   localparam bit [AW-1:0] TNTAddr = TNTAddrInt[AW-1:0];
@@ -68,7 +68,7 @@ module rom_ctrl_counter
   logic          done_q, done_d;
   logic          last_nontop_q, last_nontop_d;
 
-  always @(posedge clk_i or negedge rst_ni) begin
+  always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       vld_q         <= 1'b0;
       addr_q        <= '0;

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
@@ -56,7 +56,7 @@ module rom_ctrl_fsm
   localparam int AW = vbits(RomDepth);
   localparam int TAW = vbits(TopCount);
 
-  localparam int          TopStartAddrInt = RomDepth - TopCount;
+  localparam int unsigned TopStartAddrInt = RomDepth - TopCount;
   localparam bit [AW-1:0] TopStartAddr    = TopStartAddrInt[AW-1:0];
 
   // The counter / address generator
@@ -148,7 +148,7 @@ module rom_ctrl_fsm
   logic [5:0]  state_q, state_d;
   logic        fsm_alert;
 
-  prim_flop #(.Width(6), .ResetValue(ReadingLow))
+  prim_flop #(.Width(6), .ResetValue({ReadingLow}))
   u_state_regs (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),
@@ -240,7 +240,7 @@ module rom_ctrl_fsm
   assign kmac_rom_last_o = counter_lnt;
 
   // Start the checker when transitioning into the "Checking" state
-  always @(posedge clk_i or negedge rst_ni) begin
+  always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       start_checker_q <= 1'b0;
     end else begin

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_pkg.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_pkg.sv
@@ -14,8 +14,8 @@ package rom_ctrl_pkg;
   } pwrmgr_data_t;
 
   parameter pwrmgr_data_t PWRMGR_DATA_DEFAULT = '{
-    done: '1,
-    good: '1
+    done: 1'b1,
+    good: 1'b1
   };
 
   typedef struct packed {


### PR DESCRIPTION
We waive one warning, and rejig code to hopefully silence most of the
rest. There are still some HIER_NET_NOT_READ warnings which I'll
address in a follow-up (once I understand what's going on!)