### PR TITLE
[docs] Fix Hugo version sniffing

### DIFF
--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -354,7 +354,7 @@ def hugo_match_version(hugo_bin_path, version):
     logging.info("Checking for correct Hugo version: %s", version)
     # Hugo version string example:
     # "Hugo Static Site Generator v0.59.0-1DD0C69C/extended linux/amd64 BuildDate: 2019-10-21T09:45:38Z"  # noqa: E501
-    return bool(re.search("v" + version + ".*/extended", process.stdout))
+    return bool(re.search("v" + version + ".*[/+]extended", process.stdout))
 
 
 def install_hugo(install_dir):


### PR DESCRIPTION
Recent versions of Hugo seem to have slightly changed their version
string syntax. For example, the one that we're currently downloading
prints out:

    hugo v0.82.0-9D960784+extended linux/amd64 (...snip...)

It seems that the format used to use "/extended". Weaken the regex to
allow either format, avoiding re-downloading Hugo on each call to
build_docs.

(Sorry for the slightly random list of people I've tagged as reviewers: I'm not entirely sure who's maintaining this script at the moment)