### PR TITLE
[sw, dif_kmac] Add implementations of bit string encoding functions

### DIFF
--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -4,4 +4,65 @@
 
 #include "sw/device/lib/dif/dif_kmac.h"
 
+#include <assert.h>
+
+#include "sw/device/lib/base/memory.h"
+
 // TODO: implement!
+
+dif_kmac_result_t dif_kmac_customization_string_init(
+    const char *data, size_t len, dif_kmac_customization_string_t *out) {
+  if ((data == NULL && len != 0) || out == NULL) {
+    return kDifKmacBadArg;
+  }
+
+  if (len > kDifKmacMaxCustomizationStringLen) {
+    return kDifKmacBadArg;
+  }
+
+  static_assert(kDifKmacMaxCustomizationStringLen <= UINT16_MAX / 8,
+                "length requires more than 3 bytes to left encode");
+  static_assert(ARRAYSIZE(out->buffer) >= kDifKmacMaxCustomizationStringLen + 3,
+                "buffer is not large enough");
+
+  // Left encode length in bits.
+  uint16_t bits = ((uint16_t)len) * 8;
+  char *buffer = out->buffer;
+  if (bits <= UINT8_MAX) {
+    *buffer++ = 1;
+    *buffer++ = (char)bits;
+  } else {
+    *buffer++ = 2;
+    // Most significant byte is first (i.e. big-endian).
+    *buffer++ = (char)(bits >> 8);
+    *buffer++ = (char)bits;
+  }
+
+  memcpy(buffer, data, len);
+
+  return kDifKmacOk;
+}
+
+dif_kmac_result_t dif_kmac_function_name_init(const char *data, size_t len,
+                                              dif_kmac_function_name_t *out) {
+  if ((data == NULL && len != 0) || out == NULL) {
+    return kDifKmacBadArg;
+  }
+
+  if (len > kDifKmacMaxFunctionNameLen) {
+    return kDifKmacBadArg;
+  }
+
+  static_assert(kDifKmacMaxFunctionNameLen <= UINT8_MAX / 8,
+                "length requires more than 2 bytes to left encode");
+  static_assert(ARRAYSIZE(out->buffer) >= kDifKmacMaxFunctionNameLen + 2,
+                "buffer is not large enough");
+
+  // Left encode length in bits.
+  out->buffer[0] = 1;
+  out->buffer[1] = (char)(len * 8);
+
+  memcpy(&out->buffer[2], data, len);
+
+  return kDifKmacOk;
+}

--- a/sw/device/lib/dif/dif_kmac_unittest.cc
+++ b/sw/device/lib/dif/dif_kmac_unittest.cc
@@ -1,0 +1,92 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_kmac.h"
+
+#include <string>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace dif_kmac_unittest {
+namespace {
+using ::testing::ElementsAre;
+
+TEST(CustomizationStringTest, Encode) {
+  dif_kmac_customization_string_t cs;
+
+  EXPECT_EQ(dif_kmac_customization_string_init(nullptr, 0, &cs), kDifKmacOk);
+  EXPECT_THAT(std::string(&cs.buffer[0], 2), ElementsAre(1, 0));
+
+  EXPECT_EQ(dif_kmac_customization_string_init("", 0, &cs), kDifKmacOk);
+  EXPECT_THAT(std::string(&cs.buffer[0], 2), ElementsAre(1, 0));
+
+  EXPECT_EQ(dif_kmac_customization_string_init("\x00\x00", 2, &cs), kDifKmacOk);
+  EXPECT_THAT(std::string(&cs.buffer[0], 2), ElementsAre(1, 16));
+  EXPECT_THAT(std::string(&cs.buffer[2], 2), ElementsAre(0, 0));
+
+  EXPECT_EQ(dif_kmac_customization_string_init("SHA-3", 5, &cs), kDifKmacOk);
+  EXPECT_THAT(std::string(&cs.buffer[0], 2), ElementsAre(1, 40));
+  EXPECT_EQ(std::string(&cs.buffer[2], 5), "SHA-3");
+
+  std::string max(kDifKmacMaxCustomizationStringLen, 0x12);
+  EXPECT_EQ(dif_kmac_customization_string_init(max.data(), max.size(), &cs),
+            kDifKmacOk);
+  static_assert(kDifKmacMaxCustomizationStringLen == 32,
+                "encoding needs to be updated");
+  EXPECT_THAT(std::string(&cs.buffer[0], 3), ElementsAre(2, 1, 0));
+  EXPECT_EQ(std::string(&cs.buffer[3], max.size()), max);
+}
+
+TEST(CustomizationStringTest, BadArg) {
+  EXPECT_EQ(dif_kmac_customization_string_init("", 0, nullptr), kDifKmacBadArg);
+
+  dif_kmac_customization_string_t cs;
+  EXPECT_EQ(dif_kmac_customization_string_init(nullptr, 1, &cs),
+            kDifKmacBadArg);
+  EXPECT_EQ(dif_kmac_customization_string_init(
+                "", kDifKmacMaxCustomizationStringLen + 1, &cs),
+            kDifKmacBadArg);
+  EXPECT_EQ(dif_kmac_customization_string_init("", -1, &cs), kDifKmacBadArg);
+}
+
+TEST(FunctionNameTest, Encode) {
+  dif_kmac_function_name_t fn;
+
+  EXPECT_EQ(dif_kmac_function_name_init(nullptr, 0, &fn), kDifKmacOk);
+  EXPECT_THAT(std::string(&fn.buffer[0], 2), ElementsAre(1, 0));
+
+  EXPECT_EQ(dif_kmac_function_name_init("", 0, &fn), kDifKmacOk);
+  EXPECT_THAT(std::string(&fn.buffer[0], 2), ElementsAre(1, 0));
+
+  EXPECT_EQ(dif_kmac_function_name_init("\x00\x00", 2, &fn), kDifKmacOk);
+  EXPECT_THAT(std::string(&fn.buffer[0], 2), ElementsAre(1, 16));
+  EXPECT_THAT(std::string(&fn.buffer[2], 2), ElementsAre(0, 0));
+
+  EXPECT_EQ(dif_kmac_function_name_init("KMAC", 4, &fn), kDifKmacOk);
+  EXPECT_THAT(std::string(&fn.buffer[0], 2), ElementsAre(1, 32));
+  EXPECT_EQ(std::string(&fn.buffer[2], 4), "KMAC");
+
+  std::string max(kDifKmacMaxFunctionNameLen, 0x34);
+  EXPECT_EQ(dif_kmac_function_name_init(max.data(), max.size(), &fn),
+            kDifKmacOk);
+  static_assert(kDifKmacMaxFunctionNameLen == 4,
+                "encoding needs to be updated");
+  EXPECT_THAT(std::string(&fn.buffer[0], 2), ElementsAre(1, 32));
+  EXPECT_EQ(std::string(&fn.buffer[2], max.size()), max);
+}
+
+TEST(FunctionNameTest, BadArg) {
+  EXPECT_EQ(dif_kmac_function_name_init("", 0, nullptr), kDifKmacBadArg);
+
+  dif_kmac_function_name_t fn;
+  EXPECT_EQ(dif_kmac_function_name_init(nullptr, 1, &fn), kDifKmacBadArg);
+  EXPECT_EQ(
+      dif_kmac_function_name_init("", kDifKmacMaxFunctionNameLen + 1, &fn),
+      kDifKmacBadArg);
+  EXPECT_EQ(dif_kmac_function_name_init("", -1, &fn), kDifKmacBadArg);
+}
+
+}  // namespace
+}  // namespace dif_kmac_unittest

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -316,6 +316,24 @@ sw_lib_dif_kmac = declare_dependency(
   )
 )
 
+test('dif_kmac_unittest', executable(
+    'dif_kmac_unittest',
+    sources: [
+      'dif_kmac_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/dif_kmac.c',
+      hw_ip_kmac_reg_h,
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_lib_base_testing_mock_mmio,
+    ],
+    native: true,
+    c_args: ['-DMOCK_MMIO'],
+    cpp_args: ['-DMOCK_MMIO'],
+  ),
+  suite: 'dif',
+)
+
 # OTBN DIF library
 sw_lib_dif_otbn = declare_dependency(
   link_with: static_library(


### PR DESCRIPTION
These functions are helper functions to make using cSHAKE and KMAC
easier.