### PR TITLE
[kmac] Prefix to be stable across App Op

### DIFF
--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -571,7 +571,7 @@ module kmac_app
     sha3_prefix_o = '0;
 
     unique case (st)
-      StAppMsg: begin
+      StAppCfg, StAppMsg, StAppOutLen, StAppProcess, StAppWait: begin
         // Check app intf cfg
         for (int unsigned i = 0 ; i < NumAppIntf ; i++) begin
           if (app_id == i) begin


### PR DESCRIPTION
This is reported by @udinator (Issue #6345 )

KMAC only sends out the predefined hard-coded Prefix value in `StAppMsg`
state. That state is short-lived state. FSM stays in that state only
while it feeds the data into the MSG_FIFO. After recevied the last beat
of the message and feeds into the MSG_FIFO, the state moves to the next
state (either StAppOutLen or StAppProcess).

If the message is short length, then even after state machine is moved
to `AppProcess`, the SHA3 engine may not complete the PREFIX
computation. Then, the prefix value is swapped to all zero value, which
results in wrong digest value.

This commit adds more state conditions in the prefix assignment block.
