### PR TITLE
[kmac] Remove sideload key valid condition

### DIFF
--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -329,7 +329,7 @@ module kmac_app
 
     unique case (st)
       StIdle: begin
-        if (arb_valid && keymgr_key_i.valid) begin
+        if (arb_valid) begin
           st_d = StAppCfg;
 
           // choose app_id


### PR DESCRIPTION
While adding multiple app interfaces, sideloaded key valid check
condition in the StIdle state wasn't removed even the condition is
checked in the StAppCfg state.

This commit removes the condition, so that the AppIntf that does not use
KMAC can move forward without the valid sideloaded key.

This issue is reported by @udinator (Issue #6344 )
