### PR TITLE
[dv/kmac] increase test timeout period

### DIFF
--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -40,7 +40,7 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
-  run_opts: ["+test_timeout_ns=4000000000"]
+  run_opts: ["+test_timeout_ns=8000000000"]
 
   // Need to override the default output directory
   overrides: [


### PR DESCRIPTION
this PR doubles the test timeout period to try and avoid
timeout failures appearing in the nightly regressions
(mostly kmac_app tests).

Signed-off-by: Udi Jonnalagadda <udij@google.com>