### PR TITLE
[dv/sram] fix stress tests

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_stress_all_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_stress_all_vseq.sv
@@ -43,6 +43,7 @@ class sram_ctrl_stress_all_vseq extends sram_ctrl_base_vseq;
       sram_vseq.set_sequencer(p_sequencer);
       `DV_CHECK_RANDOMIZE_FATAL(sram_vseq)
       sram_vseq.cfg.cfg_sram_zero_delays(cur_vseq_name == "sram_ctrl_stress_pipeline_vseq");
+      sram_vseq.do_sram_ctrl_init = 0;
       `uvm_info(`gfn, $sformatf("iteration[%0d]: starting %0s", i, cur_vseq_name), UVM_LOW)
       sram_vseq.start(p_sequencer);
     end

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -697,6 +697,9 @@ class sram_ctrl_scoreboard extends cip_base_scoreboard #(
     // for read, update predication at address phase and compare at data phase
     case (csr.get_name())
       // add individual case item for each csr
+      "alert_test": begin
+        // do nothing
+      end
       "exec_regwen": begin
         // do nothing
       end

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -103,10 +103,6 @@
       name: "{variant}_executable"
       uvm_test_seq: sram_ctrl_executable_vseq
     }
-    {
-      name: "{variant}_stress_all"
-      uvm_test_seq: sram_ctrl_stress_all_vseq
-    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
this PR updates the stress_all and stress_all_with_rand_reset tests:

- don't run sram_ctrl_init() for each test sequence, as back to back
  initializations can cause the initialization timing logic in the scb
  to become confused and incorrectly predict the CSR value.
  We only need to run sram_ctrl_init() at the beginning of the
  stress_all vseq

- explicitly prevent access to alert_test CSR from doing anything,
  preventing failures in stress_all_with_rand_reset

- remove stress_all test from sim_cfg.hjson, as we don't particularly
  need the {variant} naming scheme

Signed-off-by: Udi Jonnalagadda <udij@google.com>