### PR TITLE
[top, spi] Various updates for spi / top synthesis

### DIFF
--- a/hw/syn/tools/dc/run-syn.tcl
+++ b/hw/syn/tools/dc/run-syn.tcl
@@ -92,6 +92,7 @@ set fp [open "${BUILD_DIR}/env_variables.tcl" w+]
 puts $fp "set ::env(INTERACTIVE) 1"
 puts $fp "set ::env(syn_root) $syn_root"
 puts $fp "set ::env(foundry_root) $foundry_root"
+puts $fp "set ::env(PARAMS) $PARAMS"
 puts $fp "set ::env(SV_FLIST) $SV_FLIST"
 puts $fp "set ::env(BUILD_DIR) $BUILD_DIR"
 puts $fp "set ::env(DUT) $DUT"

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -140,6 +140,7 @@
         {
           clk_io_div4_peri: io_div4
           clk_io_div2_peri: io_div2
+          clk_io_peri: io
           clk_aon_peri: aon
           clk_usb_peri: usb
         }
@@ -347,7 +348,7 @@
           "0"
         ]
         parent: sys_src
-        clk: io_div2
+        clk: io
         sw: 1
       }
       {
@@ -773,7 +774,7 @@
       clock_srcs:
       {
         clk_i: io_div4
-        clk_core_i: io_div2
+        clk_core_i: io
       }
       clock_group: peri
       reset_connections:
@@ -784,7 +785,7 @@
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
-        clk_core_i: clkmgr_aon_clocks.clk_io_div2_peri
+        clk_core_i: clkmgr_aon_clocks.clk_io_peri
       }
       domain: "0"
       param_list: []

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -155,7 +155,7 @@
       { name: "sys_io_div4", gen: true,  type: "top", domains: ["Aon", "0"], parent: "sys_src", clk: "io_div4" }
       { name: "sys_aon",     gen: true,  type: "top", domains: ["Aon", "0"], parent: "sys_src", clk: "aon"     }
       { name: "spi_device",  gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "io_div2", sw: 1 }
-      { name: "spi_host0",   gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "io_div2", sw: 1 }
+      { name: "spi_host0",   gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "io",      sw: 1 }
       { name: "spi_host1",   gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "io_div2", sw: 1 }
       { name: "usb",         gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "usb",     sw: 1 }
       { name: "i2c0",        gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "io_div2", sw: 1 },
@@ -311,7 +311,7 @@
     },
     { name: "spi_host0",
       type: "spi_host",
-      clock_srcs: {clk_i: "io_div4", clk_core_i: "io_div2"},
+      clock_srcs: {clk_i: "io_div4", clk_core_i: "io"},
       clock_group: "peri",
       reset_connections: {rst_ni: "spi_host0", rst_core_ni: "spi_host0"},
       base_addr: "0x40060000",

--- a/hw/top_earlgrey/ip/ast/rtl/aon_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/aon_osc.sv
@@ -78,11 +78,17 @@ if (Impl == prim_pkg::ImplXilinx) begin : gen_xilinx
   // FPGA Specific (place holder)
   ///////////////////////////////////////
   assign clk = (/*TODO*/ 1'b1) && en_osc;
-  assign aon_clk_o = clk;
 end else begin : gen_generic
   assign clk = (/*TODO*/ 1'b1) && en_osc;
-  assign aon_clk_o = clk;
 end
-`endif
+
+prim_buf u_buf (
+  .in_i(clk),
+  .out_o(aon_clk_o)
+);
+
+`endif // !`ifndef SYNTHESIS
+
+
 
 endmodule : aon_osc

--- a/hw/top_earlgrey/ip/ast/rtl/io_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/io_osc.sv
@@ -78,11 +78,17 @@ if (Impl == prim_pkg::ImplXilinx) begin : gen_xilinx
   // FPGA Specific (place holder)
   ///////////////////////////////////////
   assign clk = (/*TODO*/ 1'b1) && en_osc;
-  assign io_clk_o = clk;
 end else begin : gen_generic
   assign clk = (/*TODO*/ 1'b1) && en_osc;
-  assign io_clk_o = clk;
 end
+
+prim_buf u_buf (
+  .in_i(clk),
+  .out_o(io_clk_o)
+);
+
 `endif
+
+
 
 endmodule : io_osc

--- a/hw/top_earlgrey/ip/ast/rtl/sys_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/sys_osc.sv
@@ -84,11 +84,17 @@ if (Impl == prim_pkg::ImplXilinx) begin : gen_xilinx
   // FPGA Specific (place holder)
   ///////////////////////////////////////
   assign clk = (/*TODO*/ 1'b1) && en_osc;
-  assign sys_clk_o = clk;
 end else begin : gen_generic
   assign clk = (/*TODO*/ 1'b1) && en_osc;
-  assign sys_clk_o = clk;
 end
+
+prim_buf u_buf (
+  .in_i(clk),
+  .out_o(sys_clk_o)
+);
+
 `endif
+
+
 
 endmodule : sys_osc

--- a/hw/top_earlgrey/ip/ast/rtl/usb_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/usb_osc.sv
@@ -88,11 +88,17 @@ if (Impl == prim_pkg::ImplXilinx) begin : gen_xilinx
   // FPGA Specific (place holder)
   ///////////////////////////////////////
   assign clk = (/*TODO*/ 1'b1) && en_osc;
-  assign usb_clk_o = clk;
 end else begin : gen_generic
   assign clk = (/*TODO*/ 1'b1) && en_osc;
-  assign usb_clk_o = clk;
 end
+
+prim_buf u_buf (
+  .in_i(clk),
+  .out_o(usb_clk_o)
+);
+
 `endif
+
+
 
 endmodule : usb_osc

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -224,6 +224,15 @@
         }
         {
           bits: "2",
+          name: "CLK_IO_PERI_EN",
+          resval: 1,
+          desc: '''
+            0 CLK_IO_PERI is disabled.
+            1 CLK_IO_PERI is enabled.
+          '''
+        }
+        {
+          bits: "3",
           name: "CLK_USB_PERI_EN",
           resval: 1,
           desc: '''

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -42,6 +42,7 @@ package clkmgr_pkg;
     logic clk_proc_main;
     logic clk_io_div4_peri;
     logic clk_io_div2_peri;
+    logic clk_io_peri;
     logic clk_usb_peri;
 
   } clkmgr_out_t;

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
@@ -33,6 +33,9 @@ package clkmgr_reg_pkg;
     } clk_io_div2_peri_en;
     struct packed {
       logic        q;
+    } clk_io_peri_en;
+    struct packed {
+      logic        q;
     } clk_usb_peri_en;
   } clkmgr_reg2hw_clk_enables_reg_t;
 
@@ -72,9 +75,9 @@ package clkmgr_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    clkmgr_reg2hw_extclk_sel_reg_t extclk_sel; // [11:8]
-    clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [7:7]
-    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [6:4]
+    clkmgr_reg2hw_extclk_sel_reg_t extclk_sel; // [12:9]
+    clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [8:8]
+    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [7:4]
     clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [3:0]
   } clkmgr_reg2hw_t;
 

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -119,6 +119,9 @@ module clkmgr_reg_top (
   logic clk_enables_clk_io_div2_peri_en_qs;
   logic clk_enables_clk_io_div2_peri_en_wd;
   logic clk_enables_clk_io_div2_peri_en_we;
+  logic clk_enables_clk_io_peri_en_qs;
+  logic clk_enables_clk_io_peri_en_wd;
+  logic clk_enables_clk_io_peri_en_we;
   logic clk_enables_clk_usb_peri_en_qs;
   logic clk_enables_clk_usb_peri_en_wd;
   logic clk_enables_clk_usb_peri_en_we;
@@ -275,7 +278,33 @@ module clkmgr_reg_top (
   );
 
 
-  //   F[clk_usb_peri_en]: 2:2
+  //   F[clk_io_peri_en]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h1)
+  ) u_clk_enables_clk_io_peri_en (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (clk_enables_clk_io_peri_en_we),
+    .wd     (clk_enables_clk_io_peri_en_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.clk_enables.clk_io_peri_en.q ),
+
+    // to register interface (read)
+    .qs     (clk_enables_clk_io_peri_en_qs)
+  );
+
+
+  //   F[clk_usb_peri_en]: 3:3
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
@@ -550,8 +579,11 @@ module clkmgr_reg_top (
   assign clk_enables_clk_io_div2_peri_en_we = addr_hit[3] & reg_we & !reg_error;
   assign clk_enables_clk_io_div2_peri_en_wd = reg_wdata[1];
 
+  assign clk_enables_clk_io_peri_en_we = addr_hit[3] & reg_we & !reg_error;
+  assign clk_enables_clk_io_peri_en_wd = reg_wdata[2];
+
   assign clk_enables_clk_usb_peri_en_we = addr_hit[3] & reg_we & !reg_error;
-  assign clk_enables_clk_usb_peri_en_wd = reg_wdata[2];
+  assign clk_enables_clk_usb_peri_en_wd = reg_wdata[3];
 
   assign clk_hints_clk_main_aes_hint_we = addr_hit[4] & reg_we & !reg_error;
   assign clk_hints_clk_main_aes_hint_wd = reg_wdata[0];
@@ -584,7 +616,8 @@ module clkmgr_reg_top (
       addr_hit[3]: begin
         reg_rdata_next[0] = clk_enables_clk_io_div4_peri_en_qs;
         reg_rdata_next[1] = clk_enables_clk_io_div2_peri_en_qs;
-        reg_rdata_next[2] = clk_enables_clk_usb_peri_en_qs;
+        reg_rdata_next[2] = clk_enables_clk_io_peri_en_qs;
+        reg_rdata_next[3] = clk_enables_clk_usb_peri_en_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -522,7 +522,7 @@ module rstmgr import rstmgr_pkg::*; (
     .Width(1),
     .ResetValue('0)
   ) u_0_spi_host0 (
-    .clk_i(clk_io_div2_i),
+    .clk_i(clk_io_i),
     .rst_ni(rst_sys_src_n[Domain0Sel]),
     .d_i(sw_rst_ctrl_n[SPI_HOST0]),
     .q_o(rst_spi_host0_n[Domain0Sel])

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1220,7 +1220,7 @@ module top_earlgrey #(
 
       // Clock and reset connections
       .clk_i (clkmgr_aon_clocks.clk_io_div4_peri),
-      .clk_core_i (clkmgr_aon_clocks.clk_io_div2_peri),
+      .clk_core_i (clkmgr_aon_clocks.clk_io_peri),
       .rst_ni (rstmgr_aon_resets.rst_spi_host0_n[rstmgr_pkg::Domain0Sel]),
       .rst_core_ni (rstmgr_aon_resets.rst_spi_host0_n[rstmgr_pkg::Domain0Sel])
   );

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -1464,8 +1464,9 @@ typedef enum top_earlgrey_power_manager_reset_requests {
 typedef enum top_earlgrey_gateable_clocks {
   kTopEarlgreyGateableClocksIoDiv4Peri = 0, /**< Clock clk_io_div4_peri in group peri */
   kTopEarlgreyGateableClocksIoDiv2Peri = 1, /**< Clock clk_io_div2_peri in group peri */
-  kTopEarlgreyGateableClocksUsbPeri = 2, /**< Clock clk_usb_peri in group peri */
-  kTopEarlgreyGateableClocksLast = 2, /**< \internal Last Valid Gateable Clock */
+  kTopEarlgreyGateableClocksIoPeri = 2, /**< Clock clk_io_peri in group peri */
+  kTopEarlgreyGateableClocksUsbPeri = 3, /**< Clock clk_usb_peri in group peri */
+  kTopEarlgreyGateableClocksLast = 3, /**< \internal Last Valid Gateable Clock */
 } top_earlgrey_gateable_clocks_t;
 
 /**

--- a/hw/top_earlgrey/syn/asic.constraints.sdc
+++ b/hw/top_earlgrey/syn/asic.constraints.sdc
@@ -31,7 +31,8 @@ set MAIN_CLK_PIN u_ast/u_sys_clk/u_sys_osc/u_buf/out_o
 set MAIN_RST_PIN IO_RST_N
 # target is 100MHz, overconstrain by factor
 set MAIN_TCK_TARGET_PERIOD  10
-set MAIN_TCK_PERIOD [expr $MAIN_TCK_TARGET_PERIOD*$CLK_PERIOD_FACTOR] ;# over constraining
+set MAIN_TCK_FACTOR 0.85
+set MAIN_TCK_PERIOD [expr $MAIN_TCK_TARGET_PERIOD*$MAIN_TCK_FACTOR] ;# over constraining
 # For now we remove this as clock is, by default, ideal. Reset, we'll try w/o ideal_network.
 #set_ideal_network [get_pins ${MAIN_CLK_PIN}]
 #set_ideal_network [get_ports ${MAIN_RST_PIN}]
@@ -148,7 +149,7 @@ set PCB_DEL 1
 set HOST_SETUP_DEL 4
 
 # external spi host clk-to-q
-set HOST_OUT_DELY 3
+set HOST_OUT_DEL 3
 
 # external spi dev setup
 set STORAGE_SETUP_DEL 3
@@ -296,7 +297,7 @@ set_propagated_clock [get_clock SPI_HOST_PASSTHRU_CLK]
 set HALF_CYCLE [expr ${SPI_DEV_PASSTHRU_CK} / 2]
 
 # These are delays facing the host
-set SPI_DEV_PASSTHRU_HOST_IN_DEL [expr 2*${PCB_DEL} + ${HOST_OUT_DELY}]
+set SPI_DEV_PASSTHRU_HOST_IN_DEL [expr 2*${PCB_DEL} + ${HOST_OUT_DEL}]
 set SPI_DEV_PASSTHRU_HOST_OUT_DEL [expr {${PCB_DEL} + ${HOST_SETUP_DEL}}]
 
 # for transactions passing from storage into the device, they are going to be sampled


### PR DESCRIPTION
This PR does a few things.
This really should be split into multiple PRs, but in the interest of the silver milestone, some shortcuts were taken. 

- update `spi_host0`'s `clk_core` connection to 96Mhz
- update constraints for spi passthrough
- update constraints for spi host
- further constrain main clock path (no significant area impact)
- add anchor buffers to ast

Spi passthrough constraints specifically use propagated clocks to better capture passthrough timing. 
Spi host uses cascaded generated clocks so that the constraints can be easily ported to post-layout without significant change. 