### PR TITLE
[rv_core_ibex] Fix Ibex AscentLint waivers

### DIFF
--- a/hw/ip/rv_core_ibex/lint/rv_core_ibex.waiver
+++ b/hw/ip/rv_core_ibex/lint/rv_core_ibex.waiver
@@ -80,17 +80,17 @@ waive -rules NOT_READ             -location {ibex_id_stage.sv} -regexp {Signal '
       -comment "This signal is actually used (not via a port but through hierarchical path) in ibex_top.sv"
 waive -rules INTEGER              -location {ibex_register_file_ff.sv rv_core_ibex.sv} -msg {'i' of type int used as a non-constant value} \
       -comment "This assigns int i (signed) to a multibit logic variable (unsigned), which is fine"
-waive -rules ONE_BIT_MEM_WIDTH             -location {ibex_top.sv} -regexp {Memory 'pmp_req_err' has word width which is single bit wide} \
+waive -rules ONE_BIT_MEM_WIDTH             -location {ibex_core.sv} -regexp {Memory 'pmp_req_err' has word width which is single bit wide} \
       -comment "For consistency with related signals, we use an unpacked array for this signal."
 waive -rules HIER_BRANCH_NOT_READ -location {ibex_decoder.sv ibex_compressed_decoder.sv} -regexp {Net '(clk_i|rst_ni)' is not read from in module '(ibex_decoder|ibex_compressed_decoder)'.*} \
       -comment "These signals are only used for assertions inside these two modules"
 waive -rules INPUT_NOT_READ -location {ibex_decoder.sv ibex_compressed_decoder.sv} -regexp {Input port '(clk_i|rst_ni)' is not read from in module '(ibex_decoder|ibex_compressed_decoder)'.*} \
       -comment "These signals are only used for assertions inside these two modules"
-waive -rules IFDEF_CODE -location {ibex_top.sv} -regexp {Assignment to 'unused_instr_new_id' contained within `else block} \
+waive -rules IFDEF_CODE -location {ibex_core.sv} -regexp {Assignment to 'unused_instr_new_id' contained within `else block} \
       -comment "Declaration of signal and assignment to it are in same `else block"
-waive -rules IFDEF_CODE -location {ibex_top.sv} -regexp {Assignment to 'unused_instr_id_done' contained within `else block} \
+waive -rules IFDEF_CODE -location {ibex_core.sv} -regexp {Assignment to 'unused_instr_id_done' contained within `else block} \
       -comment "Declaration of signal and assignment to it are in same `else block"
-waive -rules IFDEF_CODE -location {ibex_top.sv} -regexp {Assignment to 'unused_instr_done_wb' contained within `else block} \
+waive -rules IFDEF_CODE -location {ibex_core.sv} -regexp {Assignment to 'unused_instr_done_wb' contained within `else block} \
       -comment "Declaration of signal and assignment to it are in same `else block"
 waive -rules IFDEF_CODE -location {rv_core_ibex.sv} -regexp {Assignment to 'tl_d_o' contained within `else block} \
       -comment "DV environment will drive things when `else block isn't used so assignment only occurs in `else block"


### PR DESCRIPTION
Think these should have been left unchanged in the ibex_core -> ibex_top changes for the lockstep implementation.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>