### PR TITLE
[rom_ctrl] Enable connection to KMAC

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -74,14 +74,14 @@ module rom_ctrl
   logic                     kmac_done;
   logic [255:0]             kmac_digest;
 
-  assign kmac_data_o = '{valid: kmac_rom_vld & ~SkipCheck,
+  assign kmac_data_o = '{valid: kmac_rom_vld,
                          data: kmac_rom_data,
                          strb: '1,
                          last: kmac_rom_last};
 
-  assign kmac_rom_rdy = kmac_data_i.ready | SkipCheck;
-  assign kmac_done = kmac_data_i.done | SkipCheck;
-  assign kmac_digest = SkipCheck ? '1 : kmac_data_i.digest_share0 ^ kmac_data_i.digest_share1;
+  assign kmac_rom_rdy = kmac_data_i.ready;
+  assign kmac_done = kmac_data_i.done;
+  assign kmac_digest = kmac_data_i.digest_share0 ^ kmac_data_i.digest_share1;
 
   logic unused_kmac_error;
   assign unused_kmac_error = &{1'b0, kmac_data_i.error};

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -305,12 +305,35 @@ module rom_ctrl
   end
 
   // Asserts ===================================================================
-
-  // All outputs should be known value after reset
+  //
+  // "ROM" TL interface: The d_valid and a_ready signals should be unconditionally defined. The
+  // other signals in rom_tl_o (which are the other D channel signals) should be defined if d_valid.
   `ASSERT_KNOWN(RomTlODValidKnown_A, rom_tl_o.d_valid)
   `ASSERT_KNOWN(RomTlOAReadyKnown_A, rom_tl_o.a_ready)
-  `ASSERT_KNOWN(RegTlODValidKnown_A, regs_tl_o.d_valid)
-  `ASSERT_KNOWN(RegTlOAReadyKnown_A, regs_tl_o.a_ready)
+  `ASSERT_KNOWN_IF(RomTlODDataKnown_A, rom_tl_o, rom_tl_o.d_valid)
+
+  // "regs" TL interface: The d_valid and a_ready signals should be unconditionally defined. The
+  // other signals in rom_tl_o (which are the other D channel signals) should be defined if d_valid.
+  `ASSERT_KNOWN(RegsTlODValidKnown_A, regs_tl_o.d_valid)
+  `ASSERT_KNOWN(RegsTlOAReadyKnown_A, regs_tl_o.a_ready)
+  `ASSERT_KNOWN_IF(RegsTlODDataKnown_A, regs_tl_o, regs_tl_o.d_valid)
+
+  // The assert_tx_o output should have a known value when out of reset
   `ASSERT_KNOWN(AlertTxOKnown_A, alert_tx_o)
+
+  // The pwrmgr_data_o output (the "done" and "good" signals) should have a known value when out of
+  // reset. (In theory, the "good" signal could be unknown when !done, but the stronger and simpler
+  // assertion is also true, so we use that)
+  `ASSERT_KNOWN(PwrmgrDataOKnown_A, pwrmgr_data_o)
+
+  // The valid signal for keymgr_data_o should always be known when out of reset. The rest of the
+  // struct (a data signal) should be known whenever the valid signal is true.
+  `ASSERT_KNOWN(KeymgrDataOValidKnown_A, keymgr_data_o.valid)
+  `ASSERT_KNOWN_IF(KeymgrDataODataKnown_A, keymgr_data_o, keymgr_data_o.valid)
+
+  // The valid signal for kmac_data_o should always be known when out of reset. The rest of the
+  // struct (data, strb and last) should be known whenever the valid signal is true.
+  `ASSERT_KNOWN(KmacDataOValidKnown_A, kmac_data_o.valid)
+  `ASSERT_KNOWN_IF(KmacDataODataKnown_A, kmac_data_o, kmac_data_o.valid)
 
 endmodule

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -49,7 +49,7 @@ class chip_env extends cip_base_env #(
       `uvm_fatal(`gfn, "failed to get rst_n_mon_vif from uvm_config_db")
     end
 
-    if (!uvm_config_db#(mem_bkdr_vif)::get(this, "", "rom_bkdr_vif", cfg.rom_bkdr_vif)) begin
+    if (!uvm_config_db#(rom_mem_bkdr_vif)::get(this, "", "rom_bkdr_vif", cfg.rom_bkdr_vif)) begin
       `uvm_fatal(`gfn, "failed to get rom_bkdr_vif from uvm_config_db")
     end
 
@@ -83,7 +83,7 @@ class chip_env extends cip_base_env #(
       `uvm_fatal(`gfn, "failed to get flash_info1_bkdr_vif from uvm_config_db")
     end
 
-    if (!uvm_config_db#(ecc_mem_bkdr_vif)::get(this, "", "otp_bkdr_vif", cfg.otp_bkdr_vif)) begin
+    if (!uvm_config_db#(otp_mem_bkdr_vif)::get(this, "", "otp_bkdr_vif", cfg.otp_bkdr_vif)) begin
       `uvm_fatal(`gfn, "failed to get otp_bkdr_vif from uvm_config_db")
     end
 

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -26,14 +26,14 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
   virtual pins_if#(1) rst_n_mon_vif;
 
   // mem backdoors
-  mem_bkdr_vif        rom_bkdr_vif;
+  rom_mem_bkdr_vif    rom_bkdr_vif;
   parity_mem_bkdr_vif ram_main_bkdr_vif;
   parity_mem_bkdr_vif ram_ret_bkdr_vif;
   mem_bkdr_vif        flash_bank0_bkdr_vif;
   mem_bkdr_vif        flash_bank1_bkdr_vif;
   mem_bkdr_vif        flash_info0_bkdr_vif;
   mem_bkdr_vif        flash_info1_bkdr_vif;
-  ecc_mem_bkdr_vif    otp_bkdr_vif;
+  otp_mem_bkdr_vif    otp_bkdr_vif;
 
   // sw related
   // Directory from where to pick up the SW test images -default to PWD {run_dir}.

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -48,7 +48,8 @@ package chip_env_pkg;
   // backdoors
   typedef virtual mem_bkdr_if mem_bkdr_vif;
   typedef virtual mem_bkdr_if #(.MEM_PARITY(1)) parity_mem_bkdr_vif;
-  typedef virtual mem_bkdr_if #(.MEM_ECC(prim_secded_pkg::SecdedHamming_22_16)) ecc_mem_bkdr_vif;
+  typedef virtual mem_bkdr_if #(.MEM_ECC(prim_secded_pkg::SecdedHamming_22_16)) otp_mem_bkdr_vif;
+  typedef virtual mem_bkdr_if #(.MEM_ECC(prim_secded_pkg::Secded_39_32)) rom_mem_bkdr_vif;
 
   // Types of memories in the chip.
   typedef enum {

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -52,6 +52,9 @@ class chip_base_vseq extends cip_base_vseq #(
     cfg.flash_info1_bkdr_vif.set_mem();
     // Backdoor load the OTP image.
     cfg.otp_bkdr_vif.load_mem_from_file({cfg.sw_images[SwTypeOtp], ".vmem"});
+    // Randomize the ROM image. Subclasses that have an actual ROM image will load it later.
+    cfg.rom_bkdr_vif.randomize_mem();
+
     // Bring the chip out of reset.
     super.dut_init(reset_kind);
   endtask

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -10,6 +10,35 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
   }
   `uvm_object_new
 
+  virtual task apply_reset(string kind = "HARD");
+    // The CSR tests (handled by this class) need to wait until the rom_ctrl block has finished
+    // running KMAC before they can start issuing reads and writes. Otherwise, they might write to a
+    // KMAC register while KMAC is in operation. This would have no effect and a subsequent read
+    // from the register would show a mismatched value. We handle this by considering rom_ctrl's
+    // operation as "part of reset".
+    //
+    // Once the base class reset is finished, we're just after a chip reset. In a second, rom_ctrl
+    // is going to start asking KMAC to do an operation. At that point, KMAC's CFG_REGWEN register
+    // will go low. When the operation is finished, it will go high again. Wait until then.
+    int unsigned rc_phase = 0;
+
+    super.apply_reset(kind);
+
+    `uvm_info(`gfn, "waiting for rom_ctrl after reset", UVM_MEDIUM)
+    while (rc_phase < 2) begin
+      bit [BUS_DW-1:0] rd_data;
+      tl_access(.addr(ral.kmac.cfg_regwen.get_address()),
+                .write(1'b0),
+                .data(rd_data),
+                .blocking(1'b1));
+      if (rd_data[0] == rc_phase[0]) begin
+        `uvm_info(`gfn, "KMAC's cfg_regwen has changed; bumping phase", UVM_HIGH)
+        rc_phase++;
+      end
+    end
+    `uvm_info(`gfn, "rom_ctrl done after reset", UVM_HIGH)
+  endtask
+
   virtual task body();
     run_common_vseq_wrapper(num_trans);
   endtask : body

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -77,7 +77,7 @@ module tb;
   assign (weak0, weak1) spi_dev_tie_off = '0;
 
   // backdoors
-  bind `ROM_HIER mem_bkdr_if rom_mem_bkdr_if();
+  bind `ROM_HIER mem_bkdr_if #(.MEM_ECC(prim_secded_pkg::Secded_39_32)) rom_mem_bkdr_if();
   bind `RAM_MAIN_HIER mem_bkdr_if #(.MEM_PARITY(1)) ram_mem_bkdr_if();
   bind `RAM_RET_HIER mem_bkdr_if #(.MEM_PARITY(1)) ram_mem_bkdr_if();
   bind `FLASH0_MEM_HIER mem_bkdr_if flash0_mem_bkdr_if();
@@ -281,7 +281,7 @@ module tb;
         null, "*.env", "rst_n_mon_vif", rst_n_mon_if);
 
     // Backdoors
-    uvm_config_db#(mem_bkdr_vif)::set(
+    uvm_config_db#(rom_mem_bkdr_vif)::set(
         null, "*.env", "rom_bkdr_vif", `ROM_HIER.rom_mem_bkdr_if);
     uvm_config_db#(parity_mem_bkdr_vif)::set(
         null, "*.env", "ram_main_bkdr_vif", `RAM_MAIN_HIER.ram_mem_bkdr_if);
@@ -295,7 +295,7 @@ module tb;
         null, "*.env", "flash_info0_bkdr_vif", `FLASH0_INFO_HIER.flash0_info_bkdr_if);
     uvm_config_db#(mem_bkdr_vif)::set(
         null, "*.env", "flash_info1_bkdr_vif", `FLASH1_INFO_HIER.flash1_info_bkdr_if);
-    uvm_config_db#(ecc_mem_bkdr_vif)::set(
+    uvm_config_db#(otp_mem_bkdr_vif)::set(
         null, "*.env", "otp_bkdr_vif", `OTP_MEM_HIER.otp_bkdr_if);
 
     // SW logger and test status interfaces.


### PR DESCRIPTION
This changes the meaning of the SkipCheck parameter once again.
Before, it disabled the connection with KMAC (essentially making KMAC
seem to return after a single cycle, with a digest of '1) and then
also disabled the comparison with the expected contents.

After this commit, rom_ctrl does the handshaking with KMAC and
calculates whether it matches. The only thing that SkipCheck now
controls is the "good" signal sent out to the pwrmgr. We can't
get *that* working yet, because we don't yet model the cSHAKE digest
calculation in the Python code, so can't put the right values in the
top of ROM.

This change should hopefully mean that synthesis results give roughly
the right area, even when SkipCheck is set: since the calculated
digest is exposed as a "DIGEST" register, the synthesis tool will be
forced to generate all the flops to hold it's (not feasibly
predictable) value.

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>