### PR TITLE
[otbn] Add ECC to register files and call stack

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -146,9 +146,23 @@ module otbn_core_model
     // TODO: This bind is by module, rather than by instance, because I couldn't get the by-instance
     // syntax plus upwards name referencing to work with Verilator. Obviously, this won't work with
     // multiple OTBN instances, so it would be nice to get it right.
-    bind otbn_rf_base_ff otbn_rf_snooper_if #(.Width (32), .Depth (32)) u_snooper (.rf (rf_reg));
-    bind otbn_rf_bignum_ff otbn_rf_snooper_if #(.Width (256), .Depth (32)) u_snooper (.rf (rf));
-    bind otbn_rf_base otbn_stack_snooper_if #(.StackWidth (32), .StackDepth(8))
+    bind otbn_rf_base_ff otbn_rf_snooper_if #(
+      .Width           (BaseIntgWidth),
+      .Depth           (NGpr),
+      .IntegrityEnabled(1)
+    ) u_snooper (
+      .rf (rf_reg)
+    );
+
+    bind otbn_rf_bignum_ff otbn_rf_snooper_if #(
+      .Width           (ExtWLEN),
+      .Depth           (NWdr),
+      .IntegrityEnabled(1)
+    ) u_snooper (
+      .rf (rf)
+    );
+
+    bind otbn_rf_base otbn_stack_snooper_if #(.StackIntgWidth(39), .StackWidth(32), .StackDepth(8))
       u_call_stack_snooper (
         .stack_storage(u_call_stack.stack_storage),
         .stack_wr_ptr_q(u_call_stack.stack_wr_ptr_q)

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -437,7 +437,8 @@ static bool check_regs(OtbnModel &model, ISSWrapper &iss) {
       model.design_scope_ +
       ".u_otbn_rf_base.gen_rf_base_ff.u_otbn_rf_base_inner.u_snooper";
   std::string wide_scope =
-      model.design_scope_ + ".gen_rf_bignum_ff.u_otbn_rf_bignum.u_snooper";
+      model.design_scope_ +
+      ".u_otbn_rf_bignum.gen_rf_bignum_ff.u_otbn_rf_bignum_inner.u_snooper";
 
   auto rtl_gprs = get_rtl_regs<uint32_t>(base_scope);
   auto rtl_wdrs = get_rtl_regs<ISSWrapper::u256_t>(wide_scope);

--- a/hw/ip/otbn/dv/model/otbn_rf_snooper_if.sv
+++ b/hw/ip/otbn/dv/model/otbn_rf_snooper_if.sv
@@ -7,17 +7,27 @@
 
 `ifndef SYNTHESIS
 interface otbn_rf_snooper_if #(
-  parameter int Width = 32,    // Memory width in bits
-  parameter int Depth = 32     // Number of registers
+  parameter int Width = 39,          // Memory width in bits (including integrity bits)
+  parameter int Depth = 32,          // Number of registers
+  parameter bit IntegrityEnabled = 1 // Does the RF include integrity bits?
 ) (
    input logic [Width-1:0] rf [Depth]
 );
 
   export "DPI-C" function otbn_rf_peek;
 
+  // Number of data bits per integrity code
+  localparam int IntgGranule = IntegrityEnabled ? 32 : Width;
+  localparam int IntgBitsPerGranule = IntegrityEnabled ? 7 : 0; // Bits per integrity code
+  // Number of integrity granules to cover all data bits
+  localparam int IntgGranules = Width / (IntgGranule + IntgBitsPerGranule);
+  // Width of the data portion of a register (not including integrity bits)
+  localparam int DataWidth = IntgGranules * IntgGranule;
+  localparam int IntgWidth = IntgGranule + IntgBitsPerGranule;
+
   function automatic int otbn_rf_peek(input int index, output bit [255:0] val);
-    // Function only works for register files <= 256 bits wide
-    if (Width > 256) begin
+    // Function only works for register files with 256 data bits or fewer
+    if (DataWidth > 256) begin
       return 0;
     end
 
@@ -26,7 +36,10 @@ interface otbn_rf_snooper_if #(
     end
 
     val = '0;
-    val[Width-1:0] = rf[index];
+    for (int i = 0; i < IntgGranules; ++i) begin
+      val[i * IntgGranule +: IntgGranule] = rf[index][i * IntgWidth +: IntgGranule];
+    end
+
     return 1;
   endfunction
 

--- a/hw/ip/otbn/dv/model/otbn_stack_snooper_if.sv
+++ b/hw/ip/otbn/dv/model/otbn_stack_snooper_if.sv
@@ -7,11 +7,12 @@
 
 `ifndef SYNTHESIS
 interface otbn_stack_snooper_if #(
+  parameter int StackIntgWidth = 39,
   parameter int StackWidth = 32,
   parameter int StackDepth = 4,
   localparam int StackDepthW = prim_util_pkg::vbits(StackDepth)
 ) (
-  input logic [StackWidth-1:0] stack_storage [StackDepth],
+  input logic [StackIntgWidth-1:0] stack_storage [StackDepth],
   input logic [StackDepthW:0] stack_wr_ptr_q
 );
 
@@ -30,7 +31,7 @@ interface otbn_stack_snooper_if #(
     end
 
     val = '0;
-    val[StackWidth-1:0] = stack_storage[index];
+    val[StackWidth-1:0] = stack_storage[index][StackWidth-1:0];
 
     // Return 0 to indicate a valid stack element
     return 0;

--- a/hw/ip/otbn/dv/tracer/lint/otbn_tracer_waivers.vlt
+++ b/hw/ip/otbn/dv/tracer/lint/otbn_tracer_waivers.vlt
@@ -11,4 +11,5 @@ lint_off -rule UNDRIVEN -file "*/otbn_trace_if.sv" -match "*Bits of signal are n
 
 lint_off -rule UNUSED -file "*/otbn_trace_if.sv" -match "*Bits of signal are not used: 'dmem_addr_o'*"
 lint_off -rule UNUSED -file "*/otbn_trace_if.sv" -match "*Bits of signal are not used: 'insn_dec_shared'*"
+lint_off -rule UNUSED -file "*/otbn_trace_if.sv" -match "*Bits of signal are not used: 'insn_dec_bignum'*"
 lint_off -rule UNUSED -file "*/otbn_trace_if.sv" -match "*Bits of signal are not used: 'alu_bignum_operation'*"

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
@@ -123,12 +123,12 @@ module otbn_tracer
   endfunction
 
   function automatic void trace_bignum_rf();
-    if (otbn_trace.rf_ren_a_bignum) begin
+    if (otbn_trace.rf_bignum_rd_en_a) begin
       output_trace(RegReadPrefix, $sformatf("w%02d: %s", otbn_trace.rf_bignum_rd_addr_a,
                                             otbn_wlen_data_str(otbn_trace.rf_bignum_rd_data_a)));
     end
 
-    if (otbn_trace.rf_ren_b_bignum) begin
+    if (otbn_trace.rf_bignum_rd_en_b) begin
       output_trace(RegReadPrefix, $sformatf("w%02d: %s", otbn_trace.rf_bignum_rd_addr_b,
                                             otbn_wlen_data_str(otbn_trace.rf_bignum_rd_data_b)));
     end

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -311,19 +311,19 @@ module otbn_top_sim (
   export "DPI-C" function otbn_base_call_stack_get_element;
 
   function automatic int unsigned otbn_base_call_stack_get_element(int index);
-    return u_otbn_core.u_otbn_rf_base.u_call_stack.stack_storage[index];
+    return u_otbn_core.u_otbn_rf_base.u_call_stack.stack_storage[index][31:0];
   endfunction
 
   export "DPI-C" function otbn_base_reg_get;
 
   function automatic int unsigned otbn_base_reg_get(int index);
-    return u_otbn_core.u_otbn_rf_base.gen_rf_base_ff.u_otbn_rf_base_inner.rf_reg[index];
+    return u_otbn_core.u_otbn_rf_base.gen_rf_base_ff.u_otbn_rf_base_inner.rf_reg[index][31:0];
   endfunction
 
   export "DPI-C" function otbn_bignum_reg_get;
 
   function automatic int unsigned otbn_bignum_reg_get(int index, int word);
-    return u_otbn_core.gen_rf_bignum_ff.u_otbn_rf_bignum.rf[index][word*32+:32];
+    return u_otbn_core.u_otbn_rf_bignum.gen_rf_bignum_ff.u_otbn_rf_bignum_inner.rf[index][word*39+:32];
   endfunction
 
   export "DPI-C" function otbn_err_get;

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -19,6 +19,7 @@ filesets:
       - rtl/otbn_decoder.sv
       - rtl/otbn_instruction_fetch.sv
       - rtl/otbn_rf_base.sv
+      - rtl/otbn_rf_bignum.sv
       - rtl/otbn_rf_base_ff.sv
       - rtl/otbn_rf_bignum_ff.sv
       - rtl/otbn_rf_base_fpga.sv

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -11,8 +11,11 @@ package otbn_pkg;
   // Data path width for BN (wide) instructions, in bits.
   parameter int WLEN = 256;
 
-  // "Extended" WLEN: the size of the datapath with added parity bits
+  // "Extended" WLEN: the size of the datapath with added integrity bits
   parameter int ExtWLEN = WLEN * 39 / 32;
+
+  // Width of base (32b) data path with added integrity bits
+  parameter int BaseIntgWidth = 39;
 
   // Number of 32-bit words per WLEN
   parameter int BaseWordsPerWLEN = WLEN / 32;
@@ -118,10 +121,7 @@ package otbn_pkg;
     AluOpBignumXor,
     AluOpBignumOr,
     AluOpBignumAnd,
-    AluOpBignumNot,
-
-    AluOpBignumSel,
-    AluOpBignumMov
+    AluOpBignumNot
   } alu_op_bignum_e;
 
   typedef enum logic {
@@ -167,7 +167,8 @@ package otbn_pkg;
     RfWdSelLsu,
     RfWdSelIspr,
     RfWdSelIncr,
-    RfWdSelMac
+    RfWdSelMac,
+    RfWdSelMovSel
   } rf_wd_sel_e;
 
   // Control and Status Registers (CSRs)
@@ -316,6 +317,8 @@ package otbn_pkg;
     rf_wd_sel_e              rf_wdata_sel;
     logic                    rf_ren_a;
     logic                    rf_ren_b;
+
+    logic                    sel_insn;
   } insn_dec_bignum_t;
 
   typedef struct packed {

--- a/hw/ip/otbn/rtl/otbn_rf_base_ff.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_base_ff.sv
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * 32b General Purpose Register File (GPRs)
+ * 39b General Purpose Register File (GPRs)
+ *
+ * 39b to support 32b register with 7b integrity. Integrity generation/checking implemented in
+ * wrapping otbn_rf_base module
  *
  * Features:
  * - 2 read ports
@@ -12,21 +15,21 @@
 module otbn_rf_base_ff
   import otbn_pkg::*;
 (
-  input logic          clk_i,
-  input logic          rst_ni,
+  input logic                     clk_i,
+  input logic                     rst_ni,
 
-  input logic [4:0]    wr_addr_i,
-  input logic          wr_en_i,
-  input logic [31:0]   wr_data_i,
+  input logic  [4:0]               wr_addr_i,
+  input logic                      wr_en_i,
+  input logic  [BaseIntgWidth-1:0] wr_data_i,
 
-  input  logic [4:0]   rd_addr_a_i,
-  output logic [31:0]  rd_data_a_o,
+  input  logic [4:0]               rd_addr_a_i,
+  output logic [BaseIntgWidth-1:0] rd_data_a_o,
 
-  input  logic [4:0]   rd_addr_b_i,
-  output logic [31:0]  rd_data_b_o
+  input  logic [4:0]               rd_addr_b_i,
+  output logic [BaseIntgWidth-1:0] rd_data_b_o
 );
 
-  logic [31:0] rf_reg [NGpr];
+  logic [BaseIntgWidth-1:0] rf_reg [NGpr];
   logic [31:1] we_onehot;
 
   // No write-enable for register 0 as writes to it are ignored
@@ -39,7 +42,7 @@ module otbn_rf_base_ff
 
   // Generate flops for register 1 - NGpr
   for (genvar i = 1; i < NGpr; i++) begin : g_rf_flops
-    logic [31:0] rf_reg_q;
+    logic [BaseIntgWidth-1:0] rf_reg_q;
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin

--- a/hw/ip/otbn/rtl/otbn_rf_base_fpga.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_base_fpga.sv
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * 32b General Purpose Register File (GPRs)
+ * 39b General Purpose Register File (GPRs)
+ *
+ * 39b to support 32b register with 7b integrity. Integrity generation/checking implemented in
+ * wrapping otbn_rf_base module
  *
  * Features:
  * - 2 read ports
@@ -17,21 +20,21 @@
 module otbn_rf_base_fpga
   import otbn_pkg::*;
 (
-  input logic          clk_i,
-  input logic          rst_ni,
+  input logic                     clk_i,
+  input logic                     rst_ni,
 
-  input logic [4:0]    wr_addr_i,
-  input logic          wr_en_i,
-  input logic [31:0]   wr_data_i,
+  input logic  [4:0]               wr_addr_i,
+  input logic                      wr_en_i,
+  input logic  [BaseIntgWidth-1:0] wr_data_i,
 
-  input  logic [4:0]   rd_addr_a_i,
-  output logic [31:0]  rd_data_a_o,
+  input  logic [4:0]               rd_addr_a_i,
+  output logic [BaseIntgWidth-1:0] rd_data_a_o,
 
-  input  logic [4:0]   rd_addr_b_i,
-  output logic [31:0]  rd_data_b_o
+  input  logic [4:0]               rd_addr_b_i,
+  output logic [BaseIntgWidth-1:0] rd_data_b_o
 );
-  logic [31:0] rf_reg [NGpr];
-  logic        wr_en;
+  logic [BaseIntgWidth-1:0] rf_reg [NGpr];
+  logic                    wr_en;
 
   // The reset is not used in this register file version.
   logic unused_rst_ni;

--- a/hw/ip/otbn/rtl/otbn_rf_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_bignum.sv
@@ -1,0 +1,112 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * 256b General Purpose Register File (GPRs) with integrity code detecting triple bit errors on a
+ * 32-bit granule (312 bits total).
+ *
+ * This wraps two implementations, one for FPGA (otbn_rf_base_fpga) implementation the other for
+ * ASIC (otbn_rf_base_ff).
+ *
+ * Integrity protection uses an inverted (39, 32) Hsaio code providing a Hamming distance of 4.
+ *
+ * `wr_data_no_intg_i` supplies data that requires integrity calulation and `wr_data_intg_i`
+ * supplies data that comes with integrity. `wr_data_intg_sel_i` is asserted to select the data with
+ * integrity for the write, otherwise integrity is calculated seperately from `wr_data_i`.
+ *
+ * Features:
+ * - 2 read ports
+ * - 1 write port
+ * - triple error detection
+ */
+
+module otbn_rf_bignum
+  import otbn_pkg::*;
+#(
+  // Register file implementation selection, see otbn_pkg.sv.
+  parameter regfile_e RegFile = RegFileFF
+)(
+  input  logic               clk_i,
+  input  logic               rst_ni,
+
+  input  logic [WdrAw-1:0]   wr_addr_i,
+  input  logic [1:0]         wr_en_i,
+  input  logic [WLEN-1:0]    wr_data_no_intg_i,
+  input  logic [ExtWLEN-1:0] wr_data_intg_i,
+  input  logic               wr_data_intg_sel_i,
+
+  input  logic               rd_en_a_i,
+  input  logic [WdrAw-1:0]   rd_addr_a_i,
+  output logic [ExtWLEN-1:0] rd_data_a_intg_o,
+
+  input  logic               rd_en_b_i,
+  input  logic [WdrAw-1:0]   rd_addr_b_i,
+  output logic [ExtWLEN-1:0] rd_data_b_intg_o,
+
+  output logic               rd_data_err_o
+);
+
+  logic [ExtWLEN-1:0]            wr_data_intg_mux_out, wr_data_intg_calc;
+  logic [BaseWordsPerWLEN*2-1:0] rd_data_a_err, rd_data_b_err;
+
+  if (RegFile == RegFileFF) begin : gen_rf_bignum_ff
+    otbn_rf_bignum_ff u_otbn_rf_bignum_inner (
+      .clk_i,
+      .rst_ni,
+
+      .wr_addr_i,
+      .wr_en_i,
+      .wr_data_i(wr_data_intg_mux_out),
+
+      .rd_addr_a_i,
+      .rd_data_a_o(rd_data_a_intg_o),
+
+      .rd_addr_b_i,
+      .rd_data_b_o(rd_data_b_intg_o)
+    );
+  end else if (RegFile == RegFileFPGA) begin : gen_rf_bignum_fpga
+    otbn_rf_bignum_fpga u_otbn_rf_bignum_inner (
+      .clk_i,
+      .rst_ni,
+
+      .wr_addr_i,
+      .wr_en_i,
+      .wr_data_i(wr_data_intg_mux_out),
+
+      .rd_addr_a_i,
+      .rd_data_a_o(rd_data_a_intg_o),
+
+      .rd_addr_b_i,
+      .rd_data_b_o(rd_data_b_intg_o)
+    );
+  end
+
+  // New data can have its integrity from an external source or the integrity can be calculated here
+  assign wr_data_intg_mux_out = wr_data_intg_sel_i ? wr_data_intg_i : wr_data_intg_calc;
+
+  // Seperate integrity encode and decode per 32-bit integrity granule
+  for (genvar i = 0; i < BaseWordsPerWLEN; ++i) begin : g_rf_intg_calc
+    prim_secded_39_32_enc u_wr_data_intg_enc (
+      .data_i(wr_data_no_intg_i[i * 32 +: 32]),
+      .data_o(wr_data_intg_calc[i * 39 +: 39])
+    );
+
+    // Integrity decoders used to detect errors only, corrections (`syndrome_o`/`d_o`) are ignored
+    prim_secded_39_32_dec u_rd_data_a_intg_dec (
+      .data_i    (rd_data_a_intg_o[i * 39 +: 39]),
+      .data_o    (),
+      .syndrome_o(),
+      .err_o     (rd_data_a_err[i*2 +: 2])
+    );
+
+    prim_secded_39_32_dec u_rd_data_b_intg_dec (
+      .data_i    (rd_data_b_intg_o[i * 39 +: 39]),
+      .data_o    (),
+      .syndrome_o(),
+      .err_o     (rd_data_b_err[i*2 +: 2])
+    );
+  end
+
+  assign rd_data_err_o = ((|rd_data_a_err) & rd_en_a_i) | ((|rd_data_b_err) & rd_en_b_i);
+endmodule

--- a/hw/ip/otbn/rtl/otbn_rf_bignum_ff.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_bignum_ff.sv
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * WLEN (256b) Wide Register File (WDRs)
+ * ExtWLEN (312b) Wide Register File (WDRs)
+ *
+ * ExtWLEN allows bits to provide integrity checking to WLEN words on a 32-bit granule. Integrity
+ * generation/checking implemented in wrapping otbn_rf_bignum module
  *
  * Features:
  * - 2 read ports
@@ -16,18 +19,18 @@ module otbn_rf_bignum_ff
   input  logic             clk_i,
   input  logic             rst_ni,
 
-  input  logic [WdrAw-1:0] wr_addr_i,
-  input  logic [1:0]       wr_en_i,
-  input  logic [WLEN-1:0]  wr_data_i,
+  input  logic [WdrAw-1:0]   wr_addr_i,
+  input  logic [1:0]         wr_en_i,
+  input  logic [ExtWLEN-1:0] wr_data_i,
 
-  input  logic [WdrAw-1:0] rd_addr_a_i,
-  output logic [WLEN-1:0]  rd_data_a_o,
+  input  logic [WdrAw-1:0]   rd_addr_a_i,
+  output logic [ExtWLEN-1:0] rd_data_a_o,
 
-  input  logic [WdrAw-1:0] rd_addr_b_i,
-  output logic [WLEN-1:0]  rd_data_b_o
+  input  logic [WdrAw-1:0]   rd_addr_b_i,
+  output logic [ExtWLEN-1:0] rd_data_b_o
 );
-  logic [WLEN-1:0] rf [NWdr];
-  logic [1:0]      we_onehot [NWdr];
+  logic [ExtWLEN-1:0] rf [NWdr];
+  logic [1:0]         we_onehot [NWdr];
 
   for (genvar i = 0; i < NWdr; i++) begin : g_rf
     assign we_onehot[i] = wr_en_i & {2{wr_addr_i == i}};
@@ -35,17 +38,17 @@ module otbn_rf_bignum_ff
     // Split registers into halves for clear seperation for the enable terms
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin
-        rf[i][0+:WLEN/2] <= '0;
+        rf[i][0+:ExtWLEN/2] <= '0;
       end else if (we_onehot[i][0]) begin
-        rf[i][0+:WLEN/2] <= wr_data_i[0+:WLEN/2];
+        rf[i][0+:ExtWLEN/2] <= wr_data_i[0+:ExtWLEN/2];
       end
     end
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin
-        rf[i][WLEN/2+:WLEN/2] <= '0;
+        rf[i][ExtWLEN/2+:ExtWLEN/2] <= '0;
       end else if (we_onehot[i][1]) begin
-        rf[i][WLEN/2+:WLEN/2] <= wr_data_i[WLEN/2+:WLEN/2];
+        rf[i][ExtWLEN/2+:ExtWLEN/2] <= wr_data_i[ExtWLEN/2+:ExtWLEN/2];
       end
     end
   end

--- a/hw/ip/otbn/rtl/otbn_rf_bignum_fpga.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_bignum_fpga.sv
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * WLEN (256b) Wide Register File (WDRs)
+ * ExtWLEN (312b) Wide Register File (WDRs)
+ *
+ * ExtWLEN allows bits to provide integrity checking to WLEN words on a 32-bit granule. Integrity
+ * generation/checking implemented in wrapping otbn_rf_bignum module
  *
  * Features:
  * - 2 read ports
@@ -19,17 +22,17 @@ module otbn_rf_bignum_fpga
   input  logic             clk_i,
   input  logic             rst_ni,
 
-  input  logic [WdrAw-1:0] wr_addr_i,
-  input  logic [1:0]       wr_en_i,
-  input  logic [WLEN-1:0]  wr_data_i,
+  input  logic [WdrAw-1:0]   wr_addr_i,
+  input  logic [1:0]         wr_en_i,
+  input  logic [ExtWLEN-1:0] wr_data_i,
 
-  input  logic [WdrAw-1:0] rd_addr_a_i,
-  output logic [WLEN-1:0]  rd_data_a_o,
+  input  logic [WdrAw-1:0]   rd_addr_a_i,
+  output logic [ExtWLEN-1:0] rd_data_a_o,
 
-  input  logic [WdrAw-1:0] rd_addr_b_i,
-  output logic [WLEN-1:0]  rd_data_b_o
+  input  logic [WdrAw-1:0]   rd_addr_b_i,
+  output logic [ExtWLEN-1:0] rd_data_b_o
 );
-  logic [WLEN-1:0] rf [NWdr];
+  logic [ExtWLEN-1:0] rf [NWdr];
 
   // The reset is not used in this register file version.
   logic unused_rst_ni;
@@ -40,7 +43,7 @@ module otbn_rf_bignum_fpga
     // Split registers into halves for clear separation for the enable terms.
     always_ff @(posedge clk_i) begin
       if (wr_en_i[i] == 1'b1) begin
-        rf[wr_addr_i][i*WLEN/2+:WLEN/2] <= wr_data_i[i*WLEN/2+:WLEN/2];
+        rf[wr_addr_i][i*ExtWLEN/2+:ExtWLEN/2] <= wr_data_i[i*ExtWLEN/2+:ExtWLEN/2];
       end
     end
   end


### PR DESCRIPTION
ECC SECDED is applied to both base and bignum register files. For the
base register file a single ECC is applied to whole 32-bit word. For the
bignum register file there is a seperate ECC per 32-bits (8 in all to
cover a 256-bit register).

ECC encode and decode is implemented by the register file. No error
correction is applied, ECCs are only used for error detection.

The register file interfaces are expanded to allow a direct ECC write.
This is used where whatever is supplying the data already has an ECC so
it doesn't need to be recalculated (e.g. during a bignum register move
or select).

Fixes #6186

Signed-off-by: Greg Chadwick <gac@lowrisc.org>