### PR TITLE
[verilator] Don't build chip_earlgrey_verilator with debug symbols

### DIFF
--- a/hw/top_earlgrey/chip_earlgrey_verilator.core
+++ b/hw/top_earlgrey/chip_earlgrey_verilator.core
@@ -108,7 +108,7 @@ targets:
           - '--trace-params'
           - '--trace-max-array 1024'
           - '--unroll-count 512'
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DVL_USER_STOP -DTOPLEVEL_NAME=chip_earlgrey_verilator -g"'
+          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DVL_USER_STOP -DTOPLEVEL_NAME=chip_earlgrey_verilator"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - '-Wall'
           # Execute simulation with four threads by default, which works best

--- a/hw/top_englishbreakfast/chip_englishbreakfast_verilator.core
+++ b/hw/top_englishbreakfast/chip_englishbreakfast_verilator.core
@@ -100,7 +100,7 @@ targets:
           - '--trace-params'
           - '--trace-max-array 1024'
           - '--unroll-count 512'
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DVL_USER_STOP -DTOPLEVEL_NAME=chip_englishbreakfast_verilator -g"'
+          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DVL_USER_STOP -DTOPLEVEL_NAME=chip_englishbreakfast_verilator"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - '-Wall'
           # Execute simulation with four threads by default, which works best


### PR DESCRIPTION
The resulting binary shrinks from 421MiB to 80MiB. The compilation
time on my laptop drops from 873s to 725s real time, and from 5715s to
4771s user time. (Both drops are roughly 17%).

While we might plausibly want to debug DPI code in GDB, it seems like
this won't happen often and (if we do want to) it's not particularly
hard to put the `-g` back again.
