### PR TITLE
[dv/otp_ctrl] Fix regression error

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -200,7 +200,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
 
       // Update digest values and direct_access_regwen.
       predict_rdata(1, 0, 0);
-      void'(ral.direct_access_regwen.predict(0));
+      void'(ral.direct_access_regwen.predict(.value(0), .kind(UVM_PREDICT_READ)));
 
       // Unlike reset, OTP write won't exit immediately when lc_escalate_en is On.
       // So here wait until otp program done, then backdoor read.

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
@@ -30,7 +30,8 @@ class otp_ctrl_init_fail_vseq extends otp_ctrl_smoke_vseq;
 
   // If num_to_lock_digests is larger than num_dai_op, that means there won't be OTP init check
   // error, so this sequence will trigger ECC error instead.
-  constraint lock_digest_c {num_to_lock_digests < num_dai_op * 2;}
+  // We set 25% possibility that OTP init check fails due to writing OTP after digest is locked.
+  constraint lock_digest_c {num_to_lock_digests < num_dai_op * 4;}
   constraint num_iterations_c {num_dai_op inside {[20:100]};}
   constraint ecc_err_c {
     $countones(ecc_err_mask) dist {1 :/ 1,  // ECC correctable error


### PR DESCRIPTION
This PR fixes two regression related issue:
1. The warning of csr predict and read happened at the same time.
This is fixed by adding a `kind(UVM_PREDICT_READ)` when predicting the
direct_access_regwen

2. Add more possibility for otp_ctrl partition 0 and 1's check failure

Signed-off-by: Cindy Chen <chencindy@google.com>