### PR TITLE
[dv/otp_ctrl] improve condition coverage

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -54,7 +54,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
       lc_prog_err_dly1 <= lc_prog_err;
       lc_esc_dly1      <= lc_escalate_en_i;
       lc_esc_dly2      <= lc_esc_dly1;
-      if (lc_prog_req && lc_check_byp_en_i == lc_ctrl_pkg::Off && lc_check_byp_en) begin
+      if (lc_prog_req && lc_check_byp_en_i != lc_ctrl_pkg::On && lc_check_byp_en) begin
         lc_check_byp_en_i <= lc_ctrl_pkg::On;
       end
       if (lc_esc_dly2 == lc_ctrl_pkg::On && !lc_esc_on) begin
@@ -65,14 +65,13 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
 
   assign lc_prog_no_sta_check = lc_prog_err | lc_prog_err_dly1 | lc_prog_req | lc_esc_on;
 
-  // TODO: for lc_tx, except esc_en signal, all value different from On is treated as Off,
-  // technically we can randomize values here once scb supports
-  task automatic init(lc_ctrl_pkg::lc_tx_t lc_seed_hw_rd_en_val = lc_ctrl_pkg::On);
-    lc_creator_seed_sw_rw_en_i = lc_ctrl_pkg::On;
+  task automatic init(lc_ctrl_pkg::lc_tx_t lc_seed_hw_rd_en_val = lc_ctrl_pkg::On,
+                      lc_ctrl_pkg::lc_tx_t lc_check_byp_en_val  = lc_ctrl_pkg::Off);
+    lc_creator_seed_sw_rw_en_i = lc_ctrl_pkg::On;     // drive it in specific task
     lc_seed_hw_rd_en_i         = lc_seed_hw_rd_en_val;
-    lc_dft_en_i                = lc_ctrl_pkg::Off;
-    lc_escalate_en_i           = lc_ctrl_pkg::Off;
-    lc_check_byp_en_i          = lc_ctrl_pkg::Off;
+    lc_dft_en_i                = lc_ctrl_pkg::Off;    // drive it in specific task
+    lc_escalate_en_i           = lc_ctrl_pkg::Off;    // drive it in specific task
+    lc_check_byp_en_i          = lc_check_byp_en_val;
     pwr_otp_init_i             = 0;
     // ast_pwr_seq is dummy in open sourced OTP memory
     otp_ast_pwr_seq_h_i        = $urandom();

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -32,7 +32,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     super.dut_init(reset_kind);
     cfg.backdoor_clear_mem = 0;
     // reset power init pin and lc pins
-    cfg.otp_ctrl_vif.init(randomize_lc_tx_t_val());
+    cfg.otp_ctrl_vif.init(randomize_lc_tx_t_val(), randomize_lc_tx_t_val());
     if (do_otp_ctrl_init && do_apply_reset) otp_ctrl_init();
     cfg.clk_rst_vif.wait_clks($urandom_range(0, 10));
     if (do_otp_pwr_init && do_apply_reset) otp_pwr_init();

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -146,7 +146,8 @@ module tb;
   bind `OTP_CTRL_MEM_HIER mem_bkdr_if #(.MEM_ECC(1)) mem_bkdr_if();
 
   initial begin
-    // These SVA checks the lc_escalate_en is either Off or On, we will use more than these 2 values.
+    // These SVA checks the lc_escalate_en is either Off or On, we will use more than these
+    // 2 values.
     // If it's not Off, it should be On.
     $assertoff(0, tb.dut.u_prim_lc_sync_escalate_en.CheckTransients_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_escalate_en.CheckTransients0_A);
@@ -158,6 +159,13 @@ module tb;
     $assertoff(0, tb.dut.u_prim_lc_sync_seed_hw_rd_en.CheckTransients_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_seed_hw_rd_en.CheckTransients0_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_seed_hw_rd_en.CheckTransients1_A);
+
+    // These SVA checks the lc_check_byp_en is either Off or On, we will use more than these
+    // 2 values.
+    // If it's not On, it should be Off.
+    $assertoff(0, tb.dut.u_prim_lc_sync_check_byp_en.CheckTransients_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_check_byp_en.CheckTransients0_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_check_byp_en.CheckTransients1_A);
 
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();


### PR DESCRIPTION
This PR improves the conditional coverage by randomly drive the
lc_check_byp_en signal. This bypass signal will bypass the checking for
lc parition's background check if lc_programmed but reset was not
issued. (Otherwise a false alarm will trigger)
Intially I only intend to turn this On after lc_partition is programmed.
But I realized this might lower some conditional coverage.
This PR will randomly drive this signal after dut_init with 25% of
chance of bypassing the check, and 75% chance of keeping the check on.

Signed-off-by: Cindy Chen <chencindy@google.com>