### PR TITLE
[dv/kmac] enable fast_entropy

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_env_pkg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_pkg.sv
@@ -90,8 +90,6 @@ package kmac_env_pkg;
   // ENTROPY_LFSR_WIDTH bits per cycles
   parameter int CYCLES_TO_FILL_ENTROPY = ENTROPY_STORAGE_WIDTH / ENTROPY_LFSR_WIDTH;
 
-  // TODO - this assumes entropy_fast_process is disabled, need to support this
-  //
   // 7 cycles total:                                     5 cycles        + 2 cycles (latch/consume entropy)
   parameter int SW_ENTROPY_ROUND_CYCLES_NO_FAST = CYCLES_TO_FILL_ENTROPY + 2;
 

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -50,10 +50,6 @@ class kmac_smoke_vseq extends kmac_base_vseq;
     entropy_mode == EntropyModeSw;
   }
 
-  constraint entropy_fast_process_c {
-    entropy_fast_process == 0;
-  }
-
   constraint entropy_ready_c {
     entropy_ready == 1;
   }


### PR DESCRIPTION
this PR enables randomly setting fast_entropy in all KMAC tests.

some notes:

- all KMAC entropy settings only apply to the masked configuration
- fast entropy only changes the timing of tthe keccak rounds itself,
  and doesn't impact the rest of the timing model.
  fast entropy allows KMAC to not have to re-generate full entropy for
  every round of keccak, reducing the cycle count of each keccak round
  from 7 to 3 cycles.
  the major exception is when we are processing the secret keys, in
  which we continue to generate entropy on each round for security
  reasons.

Signed-off-by: Udi Jonnalagadda <udij@google.com>