### PR TITLE
[dv/lc_ctrl] Fix regression error

### DIFF
--- a/hw/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
@@ -87,6 +87,18 @@ class push_pull_agent_cfg #(parameter int HostDataWidth = 32,
     d_user_data_q.push_back(data);
   endfunction
 
+  // Clear method for the user data queues - must be called externally to clear user-data queue
+  // which was being set by add_h_user_data method.
+  function void clear_h_user_data();
+    h_user_data_q.delete();
+  endfunction
+
+  // Clear method for the user data queues - must be called externally to clear user-data queue
+  // which was being set by add_d_user_data method.
+  function void clear_d_user_data();
+    d_user_data_q.delete();
+  endfunction
+
   // Getter method for the user data queues - returns the first data entry.
   function bit [HostDataWidth-1:0] get_h_user_data();
     `DV_CHECK_NE_FATAL(has_h_user_data(), 0, "h_user_data_q is empty!")

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -44,10 +44,10 @@ interface lc_ctrl_if(input clk, input rst_n);
     otp_i.error = 0;
     otp_i.state = lc_state;
     otp_i.count = lc_cnt;
-    otp_i.test_unlock_token = $urandom();
-    otp_i.test_exit_token = $urandom();
-    otp_i.rma_token = $urandom();
-    otp_i.id_state = LcIdBlank;
+    otp_i.test_unlock_token = get_random_token();
+    otp_i.test_exit_token   = get_random_token();
+    otp_i.rma_token         = get_random_token();
+    otp_i.id_state          = LcIdBlank;
 
     otp_hw_cfg_i.valid = Off;
     otp_hw_cfg_i.data = 0;
@@ -64,4 +64,7 @@ interface lc_ctrl_if(input clk, input rst_n);
     flash_rma_ack_i = val;
   endtask
 
+  function automatic lc_ctrl_state_pkg::lc_token_t get_random_token();
+    get_random_token = {$urandom(), $urandom(), $urandom(), $urandom()};
+  endfunction
 endinterface

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
@@ -46,7 +46,7 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
         bit [TL_DW*4-1:0] token_val = {$urandom(), $urandom(), $urandom(), $urandom()};
         randomize_next_lc_state(dec_lc_state(lc_state));
         `uvm_info(`gfn, $sformatf("next_LC_state is %0s, input token is %0h", next_lc_state.name,
-                                  token_val), UVM_DEBUG)
+                                  token_val), UVM_HIGH)
 
         set_hashed_token();
         sw_transition_req(next_lc_state, token_val);
@@ -75,6 +75,10 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
   endfunction
 
   virtual function void set_hashed_token();
+    // Clear the user_data_q here cause previous data might not be used due to some other lc_ctrl
+    // error: for example: lc_program error
+    cfg.m_otp_token_pull_agent_cfg.clear_d_user_data();
+
     // Raw Token
     if (lc_state == LcStRaw && next_lc_state inside {DecLcStTestUnlocked0,
         DecLcStTestUnlocked1, DecLcStTestUnlocked2, DecLcStTestUnlocked3}) begin


### PR DESCRIPTION
This PR fixes LC_ctrl regression error.
The issue comes when lc_ctrl smoke sequence pushes expected token data
to the push-pull data queue, but in the meantime, the pull request could
be interrupted by other lc_ctrl errors. So we push some data to the
queue that is not being used.
To solve this issue, I add a function to clear push-pull agent's data
when user do not need it.

This PR also has some small fixes in lc_ctrl testbench.

Signed-off-by: Cindy Chen <chencindy@google.com>