### PR TITLE
[dv/spi_device] Fix spi_device_csr_wr_with_rand_reset timeout issue

### DIFF
--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -14,7 +14,7 @@ package csr_utils_pkg;
 
   // local types and variables
   uint        outstanding_accesses        = 0;
-  uint        default_timeout_ns          = 1_000_000; // 1ms
+  uint        default_timeout_ns          = 2_000_000; // 2ms
   uint        default_spinwait_timeout_ns = 10_000_000; // 10ms
   string      msg_id                      = "csr_utils";
   bit         default_csr_blocking        = 1;


### PR DESCRIPTION
This PR fixes a timeout issue in spi_device_csr_wr_with_rand_reset. The
issue is because in this test, spi_device has too many concurrent CSRs
(via csr_rw vseq) and memory (via mem_walk vseq) issued together.
The timeout counter starts when the parallel accesses issued but not
when the tl_bus actually sends the request.
So this PR doubles the default timeout value from 1ms to 2ms to avoid
spi_device timeout.

Signed-off-by: Cindy Chen <chencindy@google.com>