### PR TITLE
Update lowrisc_ibex to lowRISC/ibex@8ef06de7

### DIFF
--- a/hw/vendor/lowrisc_ibex.lock.hjson
+++ b/hw/vendor/lowrisc_ibex.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/ibex.git
-    rev: 53926b5fb9713cf1dcad340b7414ae54aa86909f
+    rev: 8ef06de73daa7c22400f0e617088aeea06a2601c
   }
 }

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_top.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_top.sv
@@ -370,7 +370,7 @@ module ibex_top #(
 
   if (ICache) begin : gen_rams
 
-    for (genvar way = 0; way < IC_NUM_WAYS; way++) begin : gen_rams
+    for (genvar way = 0; way < IC_NUM_WAYS; way++) begin : gen_rams_inner
       // Tag RAM instantiation
       prim_ram_1p #(
         .Width           (TagSizeECC),
@@ -409,9 +409,8 @@ module ibex_top #(
     logic unused_ram_inputs;
 
     assign unused_ram_cfg    = ram_cfg_i;
-    assign unused_ram_inputs = 1'b0 & (|ic_tag_req) & ic_tag_write & (|ic_tag_addr) &
-                               (|ic_tag_wdata) & (|ic_data_req) & ic_data_write & (|ic_data_addr) &
-                               (|ic_data_wdata);
+    assign unused_ram_inputs = (|ic_tag_req) & ic_tag_write & (|ic_tag_addr) & (|ic_tag_wdata) &
+                               (|ic_data_req) & ic_data_write & (|ic_data_addr) & (|ic_data_wdata);
     assign ic_tag_rdata      = '{default:'b0};
     assign ic_data_rdata     = '{default:'b0};
 


### PR DESCRIPTION
Brings in some fixes to clear up AscentLint failures.

Update code from upstream repository
https://github.com/lowRISC/ibex.git to revision
8ef06de73daa7c22400f0e617088aeea06a2601c

* [rtl] Fix lint issues (Greg Chadwick)

Signed-off-by: Greg Chadwick <gac@lowrisc.org>