### PR TITLE
[dv/otp_ctrl] Enable ECC errors in lc partitions

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -228,7 +228,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     bit [TL_DW-1:0] val, backdoor_val;
     addr = {addr[TL_DW-1:2], 2'b00};
     val = cfg.mem_bkdr_vif.read32(addr);
-    if (err_mask == 0 || addr >= LifeCycleOffset) begin
+    if (err_mask == 0 || addr >= (LifeCycleOffset + LifeCycleSize)) begin
       ecc_err_type = OtpNoEccErr;
       return val;
     end

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
@@ -97,14 +97,14 @@ class otp_ctrl_init_fail_vseq extends otp_ctrl_smoke_vseq;
       bit             is_fatal;
       bit [TL_DW-1:0] addr;
 
-      for (int i = 0; i < NumPart-1; i++) begin
+      for (int i = 0; i < NumPart; i++) begin
         `DV_CHECK_RANDOMIZE_FATAL(this);
 
         if (i inside {CreatorSwCfgIdx, OwnerSwCfgIdx}) begin
-          // During OTP init, SW partition only reads digest value
+          // During OTP init, SW partitions only read digest value
           addr = PART_OTP_DIGEST_ADDRS[i] << 2;
         end else begin
-          // During OTP init, non SW partition only read all value
+          // During OTP init, non SW partitions read all value
           addr = $urandom_range(PartInfo[i].offset, PartInfo[i].offset + PartInfo[i].size - 1);
         end
 


### PR DESCRIPTION
There is an old logic that I forgot to clean up, which only limits to
inject ECC errors in all partitoins except LC.
This PR removes that constraints and fixed a few comment wording.

Signed-off-by: Cindy Chen <chencindy@google.com>