### PR TITLE
[sw/silicon_creator] Add flash_ctrl driver

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -1,0 +1,112 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+
+#include <assert.h>
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/silicon_creator/lib/base/abs_mmio.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#include "flash_ctrl_regs.h"  // Generated.
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+enum {
+  kBase = TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR,
+};
+
+static bool is_busy(void) {
+  uint32_t bitfield =
+      abs_mmio_read32(kBase + FLASH_CTRL_CTRL_REGWEN_REG_OFFSET);
+  return !bitfield_bit32_read(bitfield, FLASH_CTRL_CTRL_REGWEN_EN_BIT);
+}
+
+void flash_ctrl_init(void) {
+  // Initialize the flash controller.
+  abs_mmio_write32(kBase + FLASH_CTRL_INIT_REG_OFFSET,
+                   bitfield_bit32_write(0u, FLASH_CTRL_INIT_VAL_BIT, true));
+}
+
+rom_error_t flash_ctrl_status_get(flash_ctrl_status_t *status) {
+  if (status == NULL) {
+    return kErrorFlashCtrlInvalidArgument;
+  }
+
+  // Read flash operation status.
+  uint32_t op_status = abs_mmio_read32(kBase + FLASH_CTRL_OP_STATUS_REG_OFFSET);
+  // Read flash controller status.
+  uint32_t fc_status = abs_mmio_read32(kBase + FLASH_CTRL_STATUS_REG_OFFSET);
+
+  // Extract operation status bits.
+  status->done = bitfield_bit32_read(op_status, FLASH_CTRL_OP_STATUS_DONE_BIT);
+  status->err = bitfield_bit32_read(op_status, FLASH_CTRL_OP_STATUS_ERR_BIT);
+
+  // Extract flash controller status bits.
+  status->rd_full =
+      bitfield_bit32_read(fc_status, FLASH_CTRL_STATUS_RD_FULL_BIT);
+  status->rd_empty =
+      bitfield_bit32_read(fc_status, FLASH_CTRL_STATUS_RD_EMPTY_BIT);
+  status->init_wip =
+      bitfield_bit32_read(fc_status, FLASH_CTRL_STATUS_INIT_WIP_BIT);
+
+  return kErrorOk;
+}
+
+rom_error_t flash_ctrl_read_start(uint32_t addr, uint32_t word_count,
+                                  flash_ctrl_partition_t region) {
+  if (is_busy()) {
+    return kErrorFlashCtrlBusy;
+  }
+
+  // Set the address.
+  abs_mmio_write32(kBase + FLASH_CTRL_ADDR_REG_OFFSET, addr);
+
+  // Set the operation of the transaction: read, program, or erase.
+  uint32_t control_reg_val = bitfield_field32_write(
+      0, FLASH_CTRL_CONTROL_OP_FIELD, FLASH_CTRL_CONTROL_OP_VALUE_READ);
+
+  // Ensure special enum values match register definitions.
+  static_assert(kFlashCtrlRegionData == 0u,
+                "Incorrect enum value for kFlashCtrlRegionData");
+  static_assert(
+      kFlashCtrlRegionInfo0 == 1u << FLASH_CTRL_CONTROL_PARTITION_SEL_BIT,
+      "Incorrect enum value for kFlashCtrlRegionInfo0");
+  static_assert(
+      kFlashCtrlRegionInfo1 == (1u << FLASH_CTRL_CONTROL_PARTITION_SEL_BIT |
+                                1u << FLASH_CTRL_CONTROL_INFO_SEL_OFFSET),
+      "Incorrect enum value for kFlashCtrlRegionInfo1");
+  static_assert(
+      kFlashCtrlRegionInfo2 == (1u << FLASH_CTRL_CONTROL_PARTITION_SEL_BIT |
+                                2u << FLASH_CTRL_CONTROL_INFO_SEL_OFFSET),
+      "Incorrect enum value for kFlashCtrlRegionInfo2");
+
+  // Set the partition.
+  control_reg_val |= (uint32_t)region;
+
+  // Set the number of words.
+  control_reg_val = bitfield_field32_write(
+      control_reg_val, FLASH_CTRL_CONTROL_NUM_FIELD, word_count);
+
+  // Start the transaction.
+  control_reg_val =
+      bitfield_bit32_write(control_reg_val, FLASH_CTRL_CONTROL_START_BIT, true);
+
+  // Write the configuration.
+  abs_mmio_write32(kBase + FLASH_CTRL_CONTROL_REG_OFFSET, control_reg_val);
+
+  return kErrorOk;
+}
+
+size_t flash_ctrl_fifo_read(size_t word_count, uint32_t *data_out) {
+  // Keep reading until no words remain. For large reads this may create back
+  // pressure.
+  size_t words_read = 0;
+  for (; words_read < word_count; ++words_read) {
+    data_out[words_read] =
+        abs_mmio_read32(kBase + FLASH_CTRL_RD_FIFO_REG_OFFSET);
+  }
+
+  return words_read;
+}

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -1,0 +1,118 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_FLASH_CTRL_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_FLASH_CTRL_H_
+
+#include "sw/device/silicon_creator/lib/base/abs_mmio.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Kicks of the initialization of the flash controller.
+ *
+ * This must complete before flash can be accessed. The init status can be
+ * queried by calling `flash_ctrl_status_get()` and checking `init_wip`.
+ */
+void flash_ctrl_init(void);
+
+/**
+ * Status bits.
+ */
+typedef struct flash_ctrl_status {
+  /**
+   * Flash read FIFO full, software must consume data.
+   */
+  bool rd_full;
+  /**
+   * Flash read FIFO empty.
+   */
+  bool rd_empty;
+  /**
+   * Flash controller undergoing init.
+   */
+  bool init_wip;
+  /**
+   * Flash operation done.
+   */
+  bool done;
+  /**
+   * Flash operation error.
+   */
+  bool err;
+} flash_ctrl_status_t;
+
+/**
+ * Query the status registers on the flash controller.
+ *
+ * This function checks the various status bits as described in
+ * `flash_ctrl_status_t`.
+ *
+ * @param flash_ctrl flash controller device to check the status bits for.
+ * @param[out] status_out The current status of the flash controller.
+ * @return `kErrorFlashCtrlInvalidArgument` if `status` is NULL, `kErrorOk`
+ * otherwise.
+ */
+rom_error_t flash_ctrl_status_get(flash_ctrl_status_t *status);
+
+/**
+ * Region selection enumeration. Represents both the partition and the info
+ * type.
+ */
+typedef enum flash_crtl_partition {
+  /**
+   * Select the data partition.
+   */
+  kFlashCtrlRegionData = 0x0000,
+  /**
+   * Select the info partition of type 0.
+   */
+  kFlashCtrlRegionInfo0 = 0x0100,
+  /**
+   * Select the info partition of type 1.
+   */
+  kFlashCtrlRegionInfo1 = 0x0300,
+  /**
+   * Select the info partition of type 2.
+   */
+  kFlashCtrlRegionInfo2 = 0x0500,
+} flash_ctrl_partition_t;
+
+/**
+ * Start a read transaction.
+ *
+ * The flash controller will truncate to the closest, lower word aligned
+ * address. For example, if 0x13 is supplied, the controller will perform a read
+ * at address 0x10.
+ *
+ * @param addr The address to read from.
+ * @param word_count The number of bus words the flash operation should read.
+ * @param region The region to read from.
+ * @return `kErrorFlashCtrlBusy` if the flash controller is already processing a
+ * transaction, `kErrorOk` otherwise.
+ */
+rom_error_t flash_ctrl_read_start(uint32_t addr, uint32_t word_count,
+                                  flash_ctrl_partition_t region);
+
+/**
+ * Read data from the read FIFO.
+ *
+ * Attempts to read `word_count` words from the read FIFO.
+ *
+ * It is up to the caller to call `flash_ctrl_status_get()` to ensure the
+ * flash controller completed this transaction successfully.
+ *
+ * @param word_count The number of words to read.
+ * @param data_out The region in memory to store the data read off the FIFO.
+ * @return The number of words read from the FIFO.
+ */
+size_t flash_ctrl_fifo_read(size_t word_count, uint32_t *data_out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_FLASH_CTRL_H_

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -1,0 +1,146 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/testing/mock_mmio_test_utils.h"
+#include "sw/device/silicon_creator/lib/base/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#include "flash_ctrl_regs.h"  // Generated.
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+namespace flash_ctrl_unittest {
+namespace {
+using ::testing::ElementsAre;
+
+class FlashCtrlTest : public mask_rom_test::MaskRomTest {
+ protected:
+  uint32_t base_ = TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR;
+  mask_rom_test::MockAbsMmio mmio_;
+};
+
+class InitTest : public FlashCtrlTest {};
+
+TEST_F(InitTest, Initialize) {
+  EXPECT_ABS_WRITE32(mmio_, base_ + FLASH_CTRL_INIT_REG_OFFSET,
+                     {{FLASH_CTRL_INIT_VAL_BIT, true}});
+
+  flash_ctrl_init();
+}
+
+class StatusCheckTest : public FlashCtrlTest {};
+
+TEST_F(StatusCheckTest, InvalidArgument) {
+  EXPECT_EQ(flash_ctrl_status_get(NULL), kErrorFlashCtrlInvalidArgument);
+}
+
+TEST_F(StatusCheckTest, DefaultStatus) {
+  EXPECT_ABS_READ32(mmio_, base_ + FLASH_CTRL_OP_STATUS_REG_OFFSET,
+                    {
+                        {FLASH_CTRL_OP_STATUS_DONE_BIT, false},
+                        {FLASH_CTRL_OP_STATUS_ERR_BIT, false},
+                    });
+  EXPECT_ABS_READ32(mmio_, base_ + FLASH_CTRL_STATUS_REG_OFFSET,
+                    {
+                        {FLASH_CTRL_STATUS_RD_FULL_BIT, false},
+                        {FLASH_CTRL_STATUS_RD_EMPTY_BIT, false},
+                        {FLASH_CTRL_STATUS_INIT_WIP_BIT, false},
+                    });
+
+  flash_ctrl_status_t status;
+  EXPECT_EQ(flash_ctrl_status_get(&status), kErrorOk);
+
+  EXPECT_EQ(status.done, false);
+  EXPECT_EQ(status.err, false);
+  EXPECT_EQ(status.init_wip, false);
+  EXPECT_EQ(status.rd_empty, false);
+  EXPECT_EQ(status.rd_full, false);
+}
+
+TEST_F(StatusCheckTest, AllSetStatus) {
+  EXPECT_ABS_READ32(mmio_, base_ + FLASH_CTRL_OP_STATUS_REG_OFFSET,
+                    {
+                        {FLASH_CTRL_OP_STATUS_DONE_BIT, true},
+                        {FLASH_CTRL_OP_STATUS_ERR_BIT, true},
+                    });
+  EXPECT_ABS_READ32(mmio_, base_ + FLASH_CTRL_STATUS_REG_OFFSET,
+                    {
+                        {FLASH_CTRL_STATUS_RD_FULL_BIT, true},
+                        {FLASH_CTRL_STATUS_RD_EMPTY_BIT, true},
+                        {FLASH_CTRL_STATUS_INIT_WIP_BIT, true},
+                    });
+
+  flash_ctrl_status_t status;
+  EXPECT_EQ(flash_ctrl_status_get(&status), kErrorOk);
+
+  EXPECT_EQ(status.done, true);
+  EXPECT_EQ(status.err, true);
+  EXPECT_EQ(status.init_wip, true);
+  EXPECT_EQ(status.rd_empty, true);
+  EXPECT_EQ(status.rd_full, true);
+}
+
+class ReadStartTest : public FlashCtrlTest {
+ protected:
+  void ExpectCheckBusy(bool busy) {
+    EXPECT_ABS_READ32(mmio_, base_ + FLASH_CTRL_CTRL_REGWEN_REG_OFFSET,
+                      {{FLASH_CTRL_CTRL_REGWEN_EN_BIT, !busy}});
+  }
+  void ExpectReadStart(uint8_t part_sel, uint8_t info_sel) {
+    EXPECT_ABS_WRITE32(mmio_, base_ + FLASH_CTRL_ADDR_REG_OFFSET, 0x01234567);
+    EXPECT_ABS_WRITE32(
+        mmio_, base_ + FLASH_CTRL_CONTROL_REG_OFFSET,
+        {
+            {FLASH_CTRL_CONTROL_OP_OFFSET, FLASH_CTRL_CONTROL_OP_VALUE_READ},
+            {FLASH_CTRL_CONTROL_PARTITION_SEL_BIT, part_sel},
+            {FLASH_CTRL_CONTROL_INFO_SEL_OFFSET, info_sel},
+            {FLASH_CTRL_CONTROL_NUM_OFFSET, 42},
+            {FLASH_CTRL_CONTROL_START_BIT, 1},
+        });
+  }
+};
+
+TEST_F(ReadStartTest, Busy) {
+  ExpectCheckBusy(true);
+  EXPECT_EQ(flash_ctrl_read_start(0, 0, kFlashCtrlRegionData),
+            kErrorFlashCtrlBusy);
+}
+
+TEST_F(ReadStartTest, ReadData) {
+  ExpectCheckBusy(false);
+  ExpectReadStart(0, 0);
+  EXPECT_EQ(flash_ctrl_read_start(0x01234567, 42, kFlashCtrlRegionData),
+            kErrorOk);
+}
+
+TEST_F(ReadStartTest, ReadInfo) {
+  ExpectCheckBusy(false);
+  ExpectReadStart(1, 2);
+  EXPECT_EQ(flash_ctrl_read_start(0x01234567, 42, kFlashCtrlRegionInfo2),
+            kErrorOk);
+}
+
+class ReadTest : public FlashCtrlTest {
+ protected:
+  const std::vector<uint32_t> words_ = {0x12345678, 0x90ABCDEF, 0x0F1E2D3C,
+                                        0x4B5A6978};
+  void ExpectReadData(const std::vector<uint32_t> &data) {
+    for (auto val : data) {
+      EXPECT_ABS_READ32(mmio_, base_ + FLASH_CTRL_RD_FIFO_REG_OFFSET, val);
+    }
+  }
+};
+
+TEST_F(ReadTest, ReadAll) {
+  ExpectReadData(words_);
+  std::vector<uint32_t> words_out(words_.size());
+  EXPECT_EQ(flash_ctrl_fifo_read(words_.size(), &words_out.front()),
+            words_.size());
+  EXPECT_EQ(words_out, words_);
+}
+
+}  // namespace
+}  // namespace flash_ctrl_unittest

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -401,3 +401,17 @@ mask_rom_tests += {
     'library': sw_silicon_creator_lib_driver_watchdog_functest,
   }
 }
+
+# Mask ROM flash_ctrl driver
+sw_silicon_creator_lib_driver_flash_ctrl = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_lib_driver_flash_ctrl',
+    sources: [
+      hw_ip_flash_ctrl_reg_h,
+      'flash_ctrl.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  ),
+)

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -415,3 +415,21 @@ sw_silicon_creator_lib_driver_flash_ctrl = declare_dependency(
     ],
   ),
 )
+
+test('sw_silicon_creator_lib_driver_flash_ctrl_unittest', executable(
+    'sw_silicon_creator_lib_driver_flash_ctrl_unittest',
+    sources: [
+      'flash_ctrl_unittest.cc',
+      hw_ip_flash_ctrl_reg_h,
+      'flash_ctrl.c',
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_silicon_creator_lib_base_mock_abs_mmio,
+    ],
+    native: true,
+    c_args: ['-DMOCK_ABS_MMIO'],
+    cpp_args: ['-DMOCK_ABS_MMIO'],
+  ),
+  suite: 'mask_rom',
+)

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -35,6 +35,7 @@ enum module_ {
   kModuleEpmp = 0x5045,          // ASCII "EP",
   kModuleOtp = 0x504f,           // ASCII "OP".
   kModuleOtbn = 0x4e42,          // ASCII "BN".
+  kModuleFlashCtrl = 0x4346,     // ASCII "FC".
 };
 
 /**
@@ -87,6 +88,8 @@ enum module_ {
   X(kErrorOtbnInvalidArgument,        ERROR_(1, kModuleOtbn, kInvalidArgument)), \
   X(kErrorOtbnBadOffsetLen,           ERROR_(2, kModuleOtbn, kInvalidArgument)), \
   X(kErrorOtbnBadOffset,              ERROR_(3, kModuleOtbn, kInvalidArgument)), \
+  X(kErrorFlashCtrlInvalidArgument,   ERROR_(1, kModuleFlashCtrl, kInvalidArgument)), \
+  X(kErrorFlashCtrlBusy,              ERROR_(2, kModuleFlashCtrl, kUnavailable)), \
   X(kErrorUnknown, 0xFFFFFFFF)
 // clang-format on
 


### PR DESCRIPTION
Add a flash_ctrl driver implementation.
This driver supports:

- flash_ctrl initialization.
- Read transactions via flash_ctrl read FIFO.
- Status queries (read FIFO full/empty, init status, transaction status, error status.)

Keeping this as WIP for now as it lacks unit tests and complete error handling.

### Open Questions

- [ ] What sort of error handling do we want in mask_rom? [flash_ctrl error codes](https://docs.opentitan.org/hw/ip/flash_ctrl/doc/index.html#Reg_err_code) for reference.
- [ ] Do we need program/erase functionality also in mask_rom?
