### PR TITLE
[fpv/spi_host] Fix undecleared variable issue

### DIFF
--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -96,7 +96,7 @@ module spi_host
   end                   : gen_passthrough_implementation
   else begin            : gen_passthrough_ignore
      // Passthrough only supported for instances with one CSb line
-    `ASSERT(PassthroughNumCSCompat_A, !passthrough_en, clk_i, rst_ni)
+    `ASSERT(PassthroughNumCSCompat_A, !passthrough_i.passthrough_en, clk_i, rst_ni)
 
     assign cio_sck_o    = sck;
     assign cio_sck_en_o = 1'b1;


### PR DESCRIPTION
There is an assertion that used a varaible declared in the "if"
statement, while the assertion is in the "else" branch.
Please feel free to let me know if you prefer some other approaches to
fix that.

Signed-off-by: Cindy Chen <chencindy@google.com>