### PR TITLE
[dv/kmac] cycle-accurate model bugfixes - pt 3

### DIFF
--- a/hw/ip/kmac/dv/env/seq_lib/kmac_app_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_app_vseq.sv
@@ -14,6 +14,11 @@ class kmac_app_vseq extends kmac_sideload_vseq;
     };
   }
 
+  // msg size when using app interface must be non-zero
+  constraint app_msg_size_c {
+    msg.size() > 0;
+  }
+
   constraint kmac_app_c {
     if (en_app) {
       // application interface outputs 256-bit digest (32 bytes)


### PR DESCRIPTION
this PR fixes some more edge case bugs in the cycle accurate model:

- constrain message size as nonzero when using application interface
- updates `partial_msg` logic when using application interface
- add logic to handle edge case where CmdProcess is seen on the last
  cycle of keccak rounds where it is notifying sha3 logic that it has
  completed
- remove a few TODOs

Signed-off-by: Udi Jonnalagadda <udij@google.com>