### PR TITLE
[dv/otp_ctrl] Fix regression error

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -54,8 +54,8 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
       lc_prog_err_dly1 <= lc_prog_err;
       lc_esc_dly1      <= lc_escalate_en_i;
       lc_esc_dly2      <= lc_esc_dly1;
-      if (lc_prog_req && lc_check_byp_en_i != lc_ctrl_pkg::On && lc_check_byp_en) begin
-        lc_check_byp_en_i <= lc_ctrl_pkg::On;
+      if (lc_prog_req) begin
+        lc_check_byp_en_i <= lc_check_byp_en ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off;
       end
       if (lc_esc_dly2 == lc_ctrl_pkg::On && !lc_esc_on) begin
         lc_esc_on <= 1;

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -307,7 +307,8 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     bit [TL_DW-1:0] val;
     if (cfg.otp_ctrl_vif.lc_prog_no_sta_check == 0) begin
       csr_rd(ral.intr_state, val);
-      csr_wr(ral.intr_state, val);
+      // In case lc_program request is issued after intr_state read
+      if (cfg.otp_ctrl_vif.lc_prog_no_sta_check == 0) csr_wr(ral.intr_state, val);
     end
   endtask
 

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -70,6 +70,7 @@
     {
       name: otp_ctrl_init_fail
       uvm_test_seq: otp_ctrl_init_fail_vseq
+      reseed: 100
     }
     {
       name: otp_ctrl_background_chks


### PR DESCRIPTION
This PR fixes the regression error related to recentl change: That I
randomized the `lc_check_bypass_en`, and cause the init test failure.

Another change is to increase the lc_ctrl_init_fail test reseeds to
increase coverage.

Signed-off-by: Cindy Chen <chencindy@google.com>