### PR TITLE
[kmac] Add a condition to move to Idle directly

### DIFF
--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -519,7 +519,12 @@ module kmac
       KmacMsgFeed: begin
         entropy_in_progress = 1'b 1;
         // If absorbed, move to Digest
-        if (sha3_absorbed) begin
+        if (sha3_absorbed && sha3_done) begin
+          // absorbed and done can be asserted at a cycle if Applications have
+          // requested the hash operation. kmac_app FSM issues CmdDone command
+          // if it receives absorbed signal.
+          kmac_st_d = KmacIdle;
+        end else if (sha3_absorbed && !sha3_done) begin
           kmac_st_d = KmacDigest;
         end else begin
           kmac_st_d = KmacMsgFeed;


### PR DESCRIPTION
This commit addresses the issue #6408

kmac_app FSM asserts CmdDone right at the same cycle it receives
absorbed signal. The main FSM in kmac.sv assumes absorbed and done
signals are separated.

This commit adds one condition in KmacWait state. If both signals are
high, then the FSM skips Digest state and moves to the Idle state
directly.