### PR TITLE
Initial base for OpenTitanTool

### DIFF
--- a/sw/host/opentitanlib/Cargo.toml
+++ b/sw/host/opentitanlib/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "opentitanlib"
+version = "0.1.0"
+authors = ["cfrantz <cfrantz@google.com>"]
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+lazy_static = "1.4.0"
+regex = "1"
+nix = "0.17.0"
+bitflags = "1.0"
+log = "0.4"

--- a/sw/host/opentitanlib/src/io/gpio.rs
+++ b/sw/host/opentitanlib/src/io/gpio.rs
@@ -1,0 +1,10 @@
+use anyhow::Result;
+
+/// A trait which represents a GPIO interface.
+pub trait Gpio {
+    /// Reads the value of the the GPIO pin `id`.
+    fn read(&self, id: usize) -> Result<bool>;
+
+    /// Sets the value of the GPIO pin `id` to `value`.
+    fn write(&self, id: usize, value: bool) -> Result<()>;
+}

--- a/sw/host/opentitanlib/src/io/mod.rs
+++ b/sw/host/opentitanlib/src/io/mod.rs
@@ -1,0 +1,3 @@
+pub mod gpio;
+pub mod spi;
+pub mod uart;

--- a/sw/host/opentitanlib/src/io/spi.rs
+++ b/sw/host/opentitanlib/src/io/spi.rs
@@ -1,0 +1,40 @@
+use anyhow::Result;
+
+/// Represents the SPI transfer mode.
+pub enum TransferMode {
+    Mode0,
+    Mode1,
+    Mode2,
+    Mode3,
+}
+
+/// Represents a SPI transfer.
+pub enum Transfer<'a, 'b> {
+    Read(&'a mut [u8]),
+    Write(&'b [u8]),
+    Both(&'a mut [u8], &'b [u8]),
+}
+
+/// A trait which represents a SPI Target.
+pub trait Target {
+    /// Gets the current SPI transfer mode.
+    fn get_transfer_mode(&self) -> Result<TransferMode>;
+    /// Sets the current SPI transfer mode.
+    fn set_transfer_mode(&mut self, mode: TransferMode) -> Result<()>;
+
+    /// Gets the current number of bits per word.
+    fn get_bits_per_word(&self) -> Result<u32>;
+    /// Sets the current number of bits per word.
+    fn set_bits_per_word(&mut self, bits_per_word: u32) -> Result<()>;
+
+    /// Gets the maximum allowed speed of the SPI bus.
+    fn get_max_speed(&self) -> Result<u32>;
+    /// Sets the maximum allowed speed of the SPI bus.
+    fn set_max_speed(&mut self, max_speed: u32) -> Result<()>;
+
+    /// Returns the maximum number of transfers allowed in a single transaction.
+    fn get_max_transfer_count(&self) -> usize;
+
+    /// Runs a SPI transaction composed from the slice of [`Transfer`] objects.
+    fn run_transaction(&self, transaction: &[Transfer]) -> Result<()>;
+}

--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+use std::io::{Read, Write};
+use std::time::Duration;
+
+/// A trait which represents a UART.
+pub trait Uart: Read + Write {
+    /// Returns the UART baudrate.  May return zero for virtual UARTs.
+    fn get_baudrate(&self) -> u32;
+
+    /// Sets the UART baudrate.  May do nothing for virtual UARTs.
+    fn set_baudrate(&mut self, baudrate: u32) -> Result<()>;
+
+    /// Reads UART recieve data into `buf`, returning the number of bytes read.
+    /// The `timeout` may be used to specify a duration to wait for data.
+    fn read_timeout(&mut self, buf: &mut [u8], timeout: Duration) -> Result<usize>;
+}

--- a/sw/host/opentitanlib/src/lib.rs
+++ b/sw/host/opentitanlib/src/lib.rs
@@ -1,0 +1,10 @@
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate bitflags;
+#[macro_use]
+extern crate log;
+
+pub mod io;
+pub mod transport;
+pub mod util;

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -1,0 +1,90 @@
+use anyhow::anyhow;
+use anyhow::Result;
+
+use crate::io::gpio::Gpio;
+use crate::io::spi::Target;
+use crate::io::uart::Uart;
+
+pub mod verilator;
+
+bitflags! {
+    /// A bitmap of capabilities which may be provided by a transport.
+    pub struct Capability: u32 {
+        const NONE = 0x00000000;
+        const UART = 0x00000001;
+        const SPI = 0x00000002;
+        const GPIO = 0x00000004;
+    }
+}
+
+/// A struct which can check that needed capability requirements are met.
+pub struct Capabilities {
+    capabilities: Capability,
+    needed: Capability,
+}
+
+impl Capabilities {
+    /// Create a new Capabilities object representing a provider of
+    /// capabilities specified by `cap`.
+    pub fn new(cap: Capability) -> Self {
+        Self {
+            capabilities: cap,
+            needed: Capability::NONE,
+        }
+    }
+
+    /// Request the capabilities specified by `cap`.
+    pub fn request(&mut self, cap: Capability) -> &mut Self {
+        self.needed |= cap;
+        self
+    }
+
+    /// Checks that the requested capabilities are provided.
+    pub fn ok(&self) -> Result<()> {
+        if self.capabilities & self.needed != self.needed {
+            Err(anyhow!(
+                "Requested capabilities {:?}, but capabilities {:?} are supplied",
+                self.needed,
+                self.capabilities
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// A transport object is a factory for the low-level interfaces provided
+/// by a given communications backend.
+pub trait Transport {
+    /// Returns a `Capabilities` object to check the capabilities of this
+    /// transport object.
+    fn capabilities(&self) -> Capabilities;
+
+    /// Returns a SPI [`Target`] implementation.
+    fn spi(&self) -> Result<Box<dyn Target>> {
+        unimplemented!();
+    }
+    /// Returns a [`Uart`] implementation.
+    fn uart(&self) -> Result<Box<dyn Uart>> {
+        unimplemented!();
+    }
+    /// Returns a [`Gpio`] implementation.
+    fn gpio(&self) -> Result<Box<dyn Gpio>> {
+        unimplemented!();
+    }
+}
+
+/// An `EmptyTransport` provides no communications backend.
+pub struct EmptyTransport;
+
+impl EmptyTransport {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Transport for EmptyTransport {
+    fn capabilities(&self) -> Capabilities {
+        Capabilities::new(Capability::NONE)
+    }
+}

--- a/sw/host/opentitanlib/src/transport/verilator/mod.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/mod.rs
@@ -1,0 +1,207 @@
+use anyhow::Result;
+use regex::Regex;
+use std::fs::File;
+use std::fs::OpenOptions;
+use std::io::{Read, Write};
+use std::ops::Drop;
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use crate::io::uart::Uart;
+use crate::transport::{Capabilities, Capability, Transport};
+use crate::util::file;
+
+/// Verilator startup options.
+pub struct Options {
+    /// The verilator executable.
+    pub executable: String,
+    /// The ROM image used to boot the CPU.
+    pub rom_image: String,
+    /// The flash image stored in internal flash memory.
+    pub flash_image: String,
+    /// The OTP settings.
+    pub otp_image: String,
+    /// Any extra arguments to verilator.
+    pub extra_args: Vec<String>,
+}
+
+struct Subprocess {
+    child: Child,
+    stdout: ChildStdout,
+    accumulated_output: String,
+}
+
+impl Subprocess {
+    /// Starts a verilator [`Subprocess`] based on [`Options`].
+    fn from_options(options: Options) -> Result<Self> {
+        let mut command = Command::new(&options.executable);
+        let mut args = Vec::new();
+
+        if !options.rom_image.is_empty() {
+            args.push(format!("--meminit=rom,{}", options.rom_image));
+        }
+        if !options.flash_image.is_empty() {
+            args.push(format!("--meminit=flash,{}", options.flash_image));
+        }
+        if !options.otp_image.is_empty() {
+            args.push(format!("--meminit=otp,{}", options.otp_image));
+        }
+        args.extend_from_slice(&options.extra_args[..]);
+        command.args(&args[..]);
+
+        info!("Spawning verilator: {:?} {:?}", options.executable, args);
+
+        let mut child = command
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()?;
+        let stdout = child.stdout.take().unwrap();
+        Ok(Subprocess {
+            child: child,
+            stdout: stdout,
+            accumulated_output: String::default(),
+        })
+    }
+
+    /// Accumulates output from verilator's `stdout`.
+    fn accumulate(&mut self, timeout: Duration) -> Result<()> {
+        let mut buf = [0u8; 256];
+        file::wait_read_timeout(&self.stdout, timeout)?;
+        let n = self.stdout.read(&mut buf)?;
+        let s = String::from_utf8_lossy(&buf[..n]);
+        self.accumulated_output.push_str(&s);
+        Ok(())
+    }
+
+    /// Finds a string within the verilator output.
+    /// It is assumed that the [`Regex`] `re` has exactly one capture.
+    fn find(&mut self, re: &Regex, timeout: Duration) -> Result<String> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(captures) = re.captures(&self.accumulated_output) {
+                let val = captures.get(1).expect("expected a capture");
+                return Ok(val.as_str().to_owned());
+            } else {
+                let delta = deadline - Instant::now();
+                self.accumulate(delta)?;
+            }
+        }
+    }
+
+    /// Kill the verilator subprocess.
+    fn kill(&mut self) -> Result<()> {
+        self.child.kill()?;
+        Ok(())
+    }
+}
+
+/// Represents the verilator transport object.
+pub struct Verilator {
+    subprocess: Option<Subprocess>,
+    pub uart_file: String,
+    pub spi_file: String,
+    pub gpio_read_file: String,
+    pub gpio_write_file: String,
+}
+
+impl Verilator {
+    /// Creates a verilator subprocess-hosting transport from [`options`].
+    pub fn from_options(options: Options) -> Result<Self> {
+        lazy_static! {
+            static ref UART: Regex = Regex::new("UART: Created ([^ ]+) for uart0").unwrap();
+            static ref SPI: Regex = Regex::new("SPI: Created ([^ ]+) for spi0").unwrap();
+            static ref GPIO_RD: Regex =
+                Regex::new(r#"GPIO: FIFO pipes created at ([^ ]+) \(read\) and [^ ]+ \(write\) for 32-bit wide GPIO."#).unwrap();
+            static ref GPIO_WR: Regex =
+                Regex::new(r#"GPIO: FIFO pipes created at [^ ]+ \(read\) and ([^ ]+) \(write\) for 32-bit wide GPIO."#).unwrap();
+        }
+
+        let mut subprocess = Subprocess::from_options(options)?;
+        let gpio_rd = subprocess.find(&GPIO_RD, Duration::from_secs(5))?;
+        let gpio_wr = subprocess.find(&GPIO_WR, Duration::from_secs(5))?;
+        let uart = subprocess.find(&UART, Duration::from_secs(5))?;
+        let spi = subprocess.find(&SPI, Duration::from_secs(5))?;
+
+        info!("Verilator started with the following interaces:");
+        info!("gpio_read = {}", gpio_rd);
+        info!("gpio_write = {}", gpio_wr);
+        info!("uart = {}", uart);
+        info!("spi = {}", spi);
+        Ok(Verilator {
+            subprocess: Some(subprocess),
+            uart_file: uart,
+            spi_file: spi,
+            gpio_read_file: gpio_rd,
+            gpio_write_file: gpio_wr,
+        })
+    }
+
+    /// Shuts down the verilator subprocess.
+    pub fn shutdown(&mut self) -> Result<()> {
+        if let Some(mut subprocess) = self.subprocess.take() {
+            subprocess.kill()
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for Verilator {
+    fn drop(&mut self) {
+        self.shutdown().expect("Kill verilator subprocess");
+    }
+}
+
+impl Transport for Verilator {
+    fn capabilities(&self) -> Capabilities {
+        Capabilities::new(Capability::UART)
+    }
+
+    fn uart(&self) -> Result<Box<dyn Uart>> {
+        Ok(Box::new(VerilatorUart::open(&self.uart_file)?))
+    }
+}
+
+/// Represents the verilator virtual UART.
+struct VerilatorUart {
+    file: File,
+}
+
+impl VerilatorUart {
+    pub fn open(path: &str) -> Result<Self> {
+        let file = OpenOptions::new().read(true).write(true).open(path)?;
+        Ok(VerilatorUart { file: file })
+    }
+}
+
+impl Uart for VerilatorUart {
+    fn get_baudrate(&self) -> u32 {
+        7200
+    }
+    fn set_baudrate(&mut self, _baudrate: u32) -> Result<()> {
+        Ok(())
+    }
+
+    fn read_timeout(&mut self, buf: &mut [u8], timeout: Duration) -> Result<usize> {
+        file::wait_read_timeout(&self.file, timeout)?;
+        let n = self.file.read(buf)?;
+        Ok(n)
+    }
+}
+
+impl Read for VerilatorUart {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.file.read(buf)
+    }
+}
+
+impl Write for VerilatorUart {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.file.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.file.flush()
+    }
+}

--- a/sw/host/opentitanlib/src/util/file.rs
+++ b/sw/host/opentitanlib/src/util/file.rs
@@ -1,0 +1,31 @@
+use nix::libc::c_int;
+use nix::poll;
+use std::cmp;
+use std::io::{Error, ErrorKind, Result};
+use std::os::unix::io::AsRawFd;
+use std::time::Duration;
+
+/// Waits for an event on `fd` or for `timeout` to expire.
+pub fn wait_timeout<FD: AsRawFd>(
+    fd: &FD,
+    events: poll::PollFlags,
+    timeout: Duration,
+) -> Result<()> {
+    let timeout = cmp::min(timeout.as_millis(), c_int::max_value() as u128) as c_int;
+
+    let mut pfd = [poll::PollFd::new(fd.as_raw_fd(), events)];
+    let retval = poll::poll(&mut pfd, timeout).map_err(|e| Error::new(ErrorKind::Other, e))?;
+    if retval == 0 {
+        Err(Error::new(
+            ErrorKind::TimedOut,
+            "timed out waiting for fd to be ready",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+/// Waits for `fd` to become ready to read or `timeout` to expire.
+pub fn wait_read_timeout<FD: AsRawFd>(fd: &FD, timeout: Duration) -> Result<()> {
+    wait_timeout(fd, poll::PollFlags::POLLIN, timeout)
+}

--- a/sw/host/opentitanlib/src/util/mod.rs
+++ b/sw/host/opentitanlib/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub mod file;

--- a/sw/host/opentitantool/Cargo.toml
+++ b/sw/host/opentitantool/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "opentitantool"
+version = "0.1.0"
+authors = ["cfrantz <cfrantz@google.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0"
+thiserror = "1.0"
+opentitanlib = {version="*", path="../opentitanlib"}
+structopt = "0.3"
+log = "0.4"
+env_logger = "0.8.3"
+raw_tty = "0.1.0"
+regex = "1"
+nix = "0.17.0"
+
+serde = {version="1", features=["serde_derive"]}
+serde_json = "1"
+erased-serde = "0.3.12"
+opentitantool_derive = {path = "opentitantool_derive"}

--- a/sw/host/opentitantool/opentitantool_derive/Cargo.toml
+++ b/sw/host/opentitantool/opentitantool_derive/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "opentitantool_derive"
+version = "0.1.0"
+authors = ["cfrantz <cfrantz@google.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = "1.0"

--- a/sw/host/opentitantool/opentitantool_derive/src/lib.rs
+++ b/sw/host/opentitantool/opentitantool_derive/src/lib.rs
@@ -1,0 +1,46 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DataEnum, DeriveInput, Fields, Ident, Variant};
+
+#[proc_macro_derive(CommandDispatch)]
+pub fn derive_command_dispatch(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let expanded = match &input.data {
+        Data::Enum(e) => dispatch_enum(&input.ident, e),
+        _ => unimplemented!("CommandDispatch is only implemented for enums"),
+    };
+    proc_macro::TokenStream::from(expanded)
+}
+
+fn dispatch_enum(name: &Ident, e: &DataEnum) -> TokenStream {
+    let arms = e
+        .variants
+        .iter()
+        .map(|variant| dispatch_variant(name, variant))
+        .collect::<Vec<_>>();
+
+    quote! {
+        impl crate::command::CommandDispatch for #name {
+            fn run(&self, backend: &mut dyn opentitanlib::transport::Transport) -> anyhow::Result<Option<Box<dyn erased_serde::Serialize>>> {
+                match self {
+                    #(#arms),*
+                }
+            }
+        }
+    }
+}
+
+fn dispatch_variant(name: &Ident, variant: &Variant) -> TokenStream {
+    let ident = &variant.ident;
+    let unnamed = match &variant.fields {
+        Fields::Unnamed(u) => u.unnamed.iter().collect::<Vec<_>>(),
+        _ => unimplemented!("CommandDispatch is only implemented for Newtype variants"),
+    };
+    if unnamed.len() != 1 {
+        unimplemented!("CommandDispatch is only implemented for Newtype variants");
+    }
+    quote! {
+        #name::#ident(ref __field) => __field.run(backend)
+    }
+}

--- a/sw/host/opentitantool/src/backend/mod.rs
+++ b/sw/host/opentitantool/src/backend/mod.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use structopt::StructOpt;
+use thiserror::Error;
+
+use opentitanlib::transport::{EmptyTransport, Transport};
+
+pub mod verilator;
+
+#[derive(Debug, StructOpt)]
+pub struct BackendOpts {
+    #[structopt(long, default_value)]
+    interface: String,
+
+    #[structopt(flatten)]
+    verilator_opts: verilator::VerilatorOpts,
+}
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("unknown interface {0}")]
+    UnknownInterface(String),
+}
+
+/// Creates the requested backend interface according to [`BackendOpts`].
+pub fn create(args: &BackendOpts) -> Result<Box<dyn Transport>> {
+    match args.interface.as_str() {
+        "" => Ok(Box::new(EmptyTransport::new())),
+        "verilator" => verilator::create(&args.verilator_opts),
+        _ => Err(Error::UnknownInterface(args.interface.clone()).into()),
+    }
+}

--- a/sw/host/opentitantool/src/backend/verilator.rs
+++ b/sw/host/opentitantool/src/backend/verilator.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use opentitanlib::transport::verilator::{Options, Verilator};
+use opentitanlib::transport::Transport;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct VerilatorOpts {
+    #[structopt(long, default_value)]
+    verilator_bin: String,
+
+    #[structopt(long, default_value)]
+    verilator_rom: String,
+    #[structopt(long, default_value)]
+    verilator_flash: String,
+    #[structopt(long, default_value)]
+    verilator_otp: String,
+
+    #[structopt(long, required = false)]
+    verilator_args: Vec<String>,
+}
+
+pub fn create(args: &VerilatorOpts) -> Result<Box<dyn Transport>> {
+    let options = Options {
+        executable: args.verilator_bin.clone(),
+        rom_image: args.verilator_rom.clone(),
+        flash_image: args.verilator_flash.clone(),
+        otp_image: args.verilator_otp.clone(),
+        extra_args: args.verilator_args.clone(),
+    };
+    Ok(Box::new(Verilator::from_options(options)?))
+}

--- a/sw/host/opentitantool/src/command/console.rs
+++ b/sw/host/opentitantool/src/command/console.rs
@@ -1,0 +1,246 @@
+use anyhow::{anyhow, Result};
+use erased_serde::Serialize;
+use nix::unistd::isatty;
+use raw_tty::TtyModeGuard;
+use regex::Regex;
+use std::fs::File;
+use std::io;
+use std::io::{ErrorKind, Read, Write};
+use std::os::unix::io::AsRawFd;
+use std::time::{Duration, Instant};
+use structopt::StructOpt;
+
+use crate::command::CommandDispatch;
+use opentitanlib::io::uart::Uart;
+use opentitanlib::transport::{Capability, Transport};
+use opentitanlib::util::file;
+
+#[derive(Debug, StructOpt)]
+pub struct Console {
+    #[structopt(short, long, help = "Do not print console start end exit messages.")]
+    quiet: bool,
+
+    #[structopt(short, long, help = "Log console output to a file")]
+    logfile: Option<String>,
+
+    #[structopt(short, long, help = "Exit after a timeout in seconds.")]
+    timeout: Option<u64>,
+
+    #[structopt(long, help = "Exit with success if the specified regex is matched.")]
+    exit_success: Option<String>,
+
+    #[structopt(long, help = "Exit with failure if the specified regex is matched.")]
+    exit_failure: Option<String>,
+}
+
+impl CommandDispatch for Console {
+    fn run(&self, transport: &mut dyn Transport) -> Result<Option<Box<dyn Serialize>>> {
+        // We need the UART for the console command to operate.
+        transport.capabilities().request(Capability::UART).ok()?;
+        let mut stdout = std::io::stdout();
+        let mut stdin = std::io::stdin();
+
+        // Set up resources specified by the command line parameters.
+        let logfile = if let Some(filename) = &self.logfile {
+            Some(File::create(filename)?)
+        } else {
+            None
+        };
+        let deadline = if let Some(timeout) = self.timeout {
+            Some(Instant::now() + Duration::new(timeout, 0))
+        } else {
+            None
+        };
+        let exit_success = if let Some(rx) = &self.exit_success {
+            Some(Regex::new(rx)?)
+        } else {
+            None
+        };
+        let exit_failure = if let Some(rx) = &self.exit_failure {
+            Some(Regex::new(rx)?)
+        } else {
+            None
+        };
+
+        let mut console = InnerConsole {
+            logfile: logfile,
+            deadline: deadline,
+            exit_success: exit_success,
+            exit_failure: exit_failure,
+            ..Default::default()
+        };
+
+        if !self.quiet {
+            println!("Starting interactive console");
+            println!("[CTRL+C] to exit.\n");
+        }
+        {
+            // Put the terminal into raw mode.  The tty guard will restore the
+            // console settings when it goes out of scope.
+            let _stdin_guard = if isatty(stdin.as_raw_fd())? {
+                let mut guard = TtyModeGuard::new(stdin.as_raw_fd())?;
+                guard.set_raw_mode()?;
+                Some(guard)
+            } else {
+                None
+            };
+            let _stdout_guard = if isatty(stdout.as_raw_fd())? {
+                let mut guard = TtyModeGuard::new(stdout.as_raw_fd())?;
+                guard.set_raw_mode()?;
+                Some(guard)
+            } else {
+                None
+            };
+            console.interact(transport, &mut stdin, &mut stdout)?;
+        }
+        if !self.quiet {
+            println!("\n\nExiting interactive console.");
+        }
+        Ok(None)
+    }
+}
+
+#[derive(Default)]
+struct InnerConsole {
+    logfile: Option<File>,
+    deadline: Option<Instant>,
+    exit_success: Option<Regex>,
+    exit_failure: Option<Regex>,
+    buffer: String,
+}
+
+enum ExitStatus {
+    None,
+    ExitSuccess,
+    ExitFailure,
+}
+
+impl InnerConsole {
+    const CTRL_C: u8 = 3;
+    const BUFFER_LEN: usize = 1024;
+
+    // Runs an interactive console until CTRL_C is received.
+    fn interact<R>(
+        &mut self,
+        transport: &mut dyn Transport,
+        stdin: &mut R,
+        stdout: &mut impl Write,
+    ) -> Result<()>
+    where
+        R: Read + AsRawFd,
+    {
+        let mut uart = transport.uart()?;
+        let mut buf = [0u8; 256];
+
+        loop {
+            if let Some(deadline) = self.deadline {
+                if Instant::now() > deadline {
+                    // If we have an exit success condition, then a timeout
+                    // should be an error.
+                    if self.exit_success.is_some() {
+                        return Err(anyhow!("Console timeout exceeded"));
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            // This loop _should_ really use `poll` to learn when the
+            // console or uart file descriptors become ready, but some UART
+            // backends will bury their implementation in libusb and make
+            // discovering the file descriptor difficult or impossible.
+            //
+            // As a pragmatic implementation detail, we wait for the UART
+            // for a short period of time and then service the console.
+
+            // Check for input on the uart.
+            match self.uart_read(&mut *uart, Duration::from_millis(10), stdout)? {
+                ExitStatus::None => {}
+                ExitStatus::ExitSuccess => {
+                    break;
+                }
+                ExitStatus::ExitFailure => {
+                    return Err(anyhow!("Matched exit_failure expression"));
+                }
+            };
+
+            // Wait for input from the user.
+            match file::wait_read_timeout(&*stdin, Duration::from_millis(0)) {
+                Ok(_) => {
+                    let len = stdin.read(&mut buf)?;
+                    if len == 1 && buf[0] == InnerConsole::CTRL_C {
+                        break;
+                    }
+                    uart.write(&buf[..len])?;
+                }
+                Err(_) => {
+                    // Can only be timeout.  Do nothing.
+                }
+            };
+        }
+        Ok(())
+    }
+
+    // Maintain a buffer for the exit regexes to match against.
+    fn append_buffer(&mut self, data: &[u8]) {
+        self.buffer.push_str(&String::from_utf8_lossy(&data[..]));
+        if self.buffer.len() > InnerConsole::BUFFER_LEN {
+            let (_, end) = self
+                .buffer
+                .split_at(self.buffer.len() - InnerConsole::BUFFER_LEN);
+            self.buffer = end.to_string();
+        }
+    }
+
+    // Read from the uart and process the data read.
+    fn uart_read(
+        &mut self,
+        uart: &mut dyn Uart,
+        timeout: Duration,
+        stdout: &mut impl Write,
+    ) -> Result<ExitStatus> {
+        let mut buf = [0u8; 256];
+        match uart.read_timeout(&mut buf, timeout) {
+            Ok(len) => {
+                stdout.write_all(&buf[..len])?;
+                stdout.flush()?;
+
+                // If we're logging, save it to the logfile.
+                if let Some(logfile) = &mut self.logfile {
+                    logfile.write_all(&buf[..len])?;
+                }
+
+                // If we have exit condition regexes check them.
+                self.append_buffer(&buf[..len]);
+                if self
+                    .exit_success
+                    .as_ref()
+                    .map(|rx| rx.is_match(&self.buffer))
+                    == Some(true)
+                {
+                    return Ok(ExitStatus::ExitSuccess);
+                }
+                if self
+                    .exit_failure
+                    .as_ref()
+                    .map(|rx| rx.is_match(&self.buffer))
+                    == Some(true)
+                {
+                    return Ok(ExitStatus::ExitFailure);
+                }
+            }
+            Err(e) => {
+                // If we got a timeout from the uart, ignore it.
+                // Return all other errors.
+                if let Some(ioerr) = e.downcast_ref::<io::Error>() {
+                    if ioerr.kind() != ErrorKind::TimedOut {
+                        return Err(e);
+                    }
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+        Ok(ExitStatus::None)
+    }
+}

--- a/sw/host/opentitantool/src/command/mod.rs
+++ b/sw/host/opentitantool/src/command/mod.rs
@@ -1,0 +1,11 @@
+use anyhow::Result;
+use erased_serde::Serialize;
+use opentitanlib::transport::Transport;
+pub use opentitantool_derive::*;
+
+pub mod console;
+pub mod hello;
+
+pub trait CommandDispatch {
+    fn run(&self, transport: &mut dyn Transport) -> Result<Option<Box<dyn Serialize>>>;
+}

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -1,0 +1,51 @@
+extern crate env_logger;
+extern crate log;
+extern crate opentitanlib;
+extern crate opentitantool_derive;
+extern crate serde;
+extern crate serde_json;
+extern crate structopt;
+
+use anyhow::Result;
+use log::LevelFilter;
+use structopt::StructOpt;
+
+mod backend;
+mod command;
+use command::CommandDispatch;
+
+#[derive(Debug, StructOpt, CommandDispatch)]
+enum RootCommandHierarchy {
+    // Not flattened because `Console` is a leaf command.
+    Console(command::console::Console),
+
+    // Flattened because `Greetings` is a subcommand hierarchy.
+    #[structopt(flatten)]
+    Greetings(command::hello::Greetings),
+}
+
+#[derive(Debug, StructOpt)]
+struct Opts {
+    #[structopt(long, default_value = "off")]
+    logging: LevelFilter,
+
+    #[structopt(flatten)]
+    backend_opts: backend::BackendOpts,
+
+    #[structopt(subcommand)]
+    command: RootCommandHierarchy,
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::from_args();
+
+    let mut builder = env_logger::Builder::from_default_env();
+    builder.filter(None, opts.logging).init();
+
+    let mut interface = backend::create(&opts.backend_opts)?;
+
+    if let Some(value) = opts.command.run(&mut *interface)? {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+    }
+    Ok(())
+}


### PR DESCRIPTION
See the draft [Design Document](https://docs.google.com/document/d/1B9zMaxgNUDB3ZYZvzgoqFZ-Yy1rBLTx0BwIXUAt2b8o/edit) for the motivation and high-level structure of `opentitantool`.

1. Basic framework for opentitanlib:
1a. Traits for hardware interfaces (spi, uart, gpio).
1b. Trait for a tranport, which is a collection of hardware interfaces.
1c. Implementation of an empty do-nothing transport.
1d. Partial implementation of a verilator hosting transport.

2. Basic framework for opentitantool:
2a. Backend transport creation from command line arguments.
2b. StructOpt based command hierarchy, with CommandDispatch trait.
2c. Uniform return from dispatch: a serde Serializable object which can
    be formatted for output according to the user's needs (currently
    json only).
2c. A "hello world" example command hierarchy.
2d. An interactive serial console command.

Demonstration of the `console` command:

```
./sw/host/opentitantool/target/debug/opentitantool \
  --logging=info \
  --interface=verilator \
    --verilator-bin=build/lowrisc_systems_chip_earlgrey_verilator_0.1/sim-verilator/Vchip_earlgrey_verilator \
    --verilator-rom=build-bin/sw/device/boot_rom/boot_rom_sim_verilator.scr.40.vmem \
    --verilator-flash=build-bin/sw/device/examples/hello_world/hello_world_sim_verilator.elf \
    --verilator-otp=build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem \
  console
```

Signed-off-by: Chris Frantz <cfrantz@google.com>