### PR TITLE
[dv/kmac] enable EDN entropy

### DIFF
--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -21,6 +21,7 @@
               - Randomly set endianness of input msg and internal keccak state.
               - Randomly provide a sideloaded key, do not set cfg.sideload.
               - Set output length between 1-`keccak_rate` bytes if applicable.
+              - Randomly select either SW or EDN as the source of entropy
               - Trigger KMAC to start absorbing input message.
                 - During absorption stage randomly read from STATE window, expect 0.
               - Write message to MSG_FIFO window, maximum length of 32 bytes.

--- a/hw/ip/kmac/dv/env/kmac_env_pkg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_pkg.sv
@@ -91,7 +91,10 @@ package kmac_env_pkg;
   parameter int CYCLES_TO_FILL_ENTROPY = ENTROPY_STORAGE_WIDTH / ENTROPY_LFSR_WIDTH;
 
   // 7 cycles total:                                     5 cycles        + 2 cycles (latch/consume entropy)
-  parameter int SW_ENTROPY_ROUND_CYCLES_NO_FAST = CYCLES_TO_FILL_ENTROPY + 2;
+  parameter int ENTROPY_FULL_EXPANSION_CYCLES = CYCLES_TO_FILL_ENTROPY + 2;
+
+  // 3 cycles total:                         1 cycle, entropy is reused + 2 cycles (latch/consume)
+  parameter int ENTROPY_FAST_PROCESSING_CYCLES = 3;
 
   // interrupt types
   typedef enum int {

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -47,7 +47,7 @@ class kmac_smoke_vseq extends kmac_base_vseq;
   }
 
   constraint entropy_mode_c {
-    entropy_mode == EntropyModeSw;
+    entropy_mode inside {EntropyModeSw, EntropyModeEdn};
   }
 
   constraint entropy_ready_c {


### PR DESCRIPTION
this PR enables test sequences to randomly select EDN entropy as a
possible entropy source, and makes the necessary updates to the
cycle accurate model to support this.

at a high level, the idea is:
- if EDN is selected as entropy source, keccak will wait for EDN to return valid fresh entropy before starting to run
- if SW is selected as entropy source, keccak will wait for valid entropy to be provided through CSRs before starting to run

note that this set of changes only affects `kmac_masked` configuration,
since unmasked config does not use entropy.

Signed-off-by: Udi Jonnalagadda <udij@google.com>