### PR TITLE
[sw/silicon_creator] Force manifest.h dependency

### DIFF
--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -33,7 +33,10 @@ mask_rom_lib = declare_dependency(
     ],
     link_with: static_library(
       'mask_rom_lib',
-      sources: ['mask_rom.c'],
+      sources: [
+        rom_exts_manifest_offsets_header,
+        'mask_rom.c'
+      ],
       link_depends: [rom_linkfile],
   )
 )


### PR DESCRIPTION
For the generation of the manifest.h header on all targets consuming it.

This closes lowrisc/opentitan#6407.