### PR TITLE
[dv/otp_ctrl] Update otp_ctrl ports and clean up warnings

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -15,12 +15,13 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
   otp_hw_cfg_t         otp_hw_cfg_o;
   otp_keymgr_key_t     keymgr_key_o;
   otp_lc_data_t        lc_data_o;
+  ast_pkg::ast_dif_t   otp_alert_o;
   logic                pwr_otp_done_o, pwr_otp_idle_o;
 
   // inputs to DUT
-  logic                pwr_otp_init_i;
-  lc_ctrl_pkg::lc_tx_e lc_dft_en_i, lc_escalate_en_i, lc_check_byp_en_i,
-                       lc_creator_seed_sw_rw_en_i, lc_seed_hw_rd_en_i;
+  logic                pwr_otp_init_i, scan_en_i, scan_rst_ni;
+  lc_ctrl_pkg::lc_tx_t lc_dft_en_i, lc_escalate_en_i, lc_check_byp_en_i,
+                       lc_creator_seed_sw_rw_en_i, lc_seed_hw_rd_en_i, scanmode_i;
   otp_ast_rsp_t        otp_ast_pwr_seq_h_i;
 
   // probe design signal for alert request
@@ -31,7 +32,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
   logic                lc_prog_err_dly1, lc_prog_no_sta_check;
 
   // LC_escalate_en is async, take two clock cycles to sync.
-  lc_ctrl_pkg::lc_tx_e lc_esc_dly1, lc_esc_dly2;
+  lc_ctrl_pkg::lc_tx_t lc_esc_dly1, lc_esc_dly2;
   // For lc_escalate_en, every value that is not Off is a On.
   bit                  lc_esc_on;
   // Usually the lc_check_byp will be automatically set to On when lc_prog_req is issued but reset
@@ -73,23 +74,26 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
     lc_escalate_en_i           = lc_ctrl_pkg::Off;    // drive it in specific task
     lc_check_byp_en_i          = lc_check_byp_en_val;
     pwr_otp_init_i             = 0;
-    // ast_pwr_seq is dummy in open sourced OTP memory
+    // Unused signals in open sourced OTP memory
     otp_ast_pwr_seq_h_i        = $urandom();
+    scan_en_i                  = $urandom();
+    scan_rst_ni                = $urandom();
+    scanmode_i                 = $urandom();
   endtask
 
   task automatic drive_pwr_otp_init(logic val);
     pwr_otp_init_i = val;
   endtask
 
-  task automatic drive_lc_creator_seed_sw_rw_en_i(lc_ctrl_pkg::lc_tx_e val);
+  task automatic drive_lc_creator_seed_sw_rw_en_i(lc_ctrl_pkg::lc_tx_t val);
     lc_creator_seed_sw_rw_en_i = val;
   endtask
 
-  task automatic drive_lc_dft_en(lc_ctrl_pkg::lc_tx_e val);
+  task automatic drive_lc_dft_en(lc_ctrl_pkg::lc_tx_t val);
     lc_dft_en_i = val;
   endtask
 
-  task automatic drive_lc_escalate_en(lc_ctrl_pkg::lc_tx_e val);
+  task automatic drive_lc_escalate_en(lc_ctrl_pkg::lc_tx_t val);
     lc_escalate_en_i = val;
   endtask
 

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -87,6 +87,7 @@ module tb;
     // ast
     .otp_ast_pwr_seq_o          (ast_req),
     .otp_ast_pwr_seq_h_i        (otp_ctrl_if.otp_ast_pwr_seq_h_i),
+    .otp_alert_o                (otp_ctrl_if.otp_alert_o),
     // pwrmgr
     .pwr_otp_i                  (otp_ctrl_if.pwr_otp_init_i),
     .pwr_otp_o                  ({otp_ctrl_if.pwr_otp_done_o, otp_ctrl_if.pwr_otp_idle_o}),
@@ -114,7 +115,12 @@ module tb;
     .otbn_otp_key_o             (otbn_rsp),
 
     .otp_hw_cfg_o               (otp_ctrl_if.otp_hw_cfg_o),
-    .otp_ext_voltage_h_io       (otp_ext_voltage_h)
+    .otp_ext_voltage_h_io       (otp_ext_voltage_h),
+
+    //scan
+    .scan_en_i                  (otp_ctrl_if.scan_en_i),
+    .scan_rst_ni                (otp_ctrl_if.scan_rst_ni),
+    .scanmode_i                 (otp_ctrl_if.scanmode_i)
   );
 
   for (genvar i = 0; i < NumSramKeyReqSlots; i++) begin : gen_sram_pull_if


### PR DESCRIPTION
This PR:
1. Update OTP_CTRL's ports according to PR #6394
2. Unify the interface to use only `lc_tx_t` instead of `lc_tx_e` to
avoid warnings.

Signed-off-by: Cindy Chen <chencindy@google.com>