### PR TITLE
[dv/common] Fix mem_rw_with_rand_reset regression error and display issue

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -19,7 +19,8 @@
     tl_seq.req_abort_pct = $urandom_range(0, 100); \
     `DV_CHECK_RANDOMIZE_WITH_FATAL(tl_seq, with_c_) \
     csr_utils_pkg::increment_outstanding_access(); \
-    `DV_SPINWAIT(`uvm_send_pri(tl_seq, 1), 10_000) \
+    `DV_SPINWAIT(`uvm_send_pri(tl_seq, 1), \
+        $sformatf("Timeout: %0s with addr %0h", `"task_name_`", tl_seq.addr), 100_000_000) \
     csr_utils_pkg::decrement_outstanding_access(); \
   end
 


### PR DESCRIPTION
This PR fixes the timeout display issue for mem_rw_with_rand_reset. It
used to display a `^P` for the error message.

This PR also gives a larger number for timeout value: because if many mem/csr accesses issued together,
this sequence has very low priority (1) compares to other sequences (100). So the wait time for driver to
issue this sequence should be longer to avoid timeout.

Signed-off-by: Cindy Chen <chencindy@google.com>