### PR TITLE
[sw/silicon_creator] Introduce the abs_mmio module

### DIFF
--- a/sw/device/lib/base/testing/mock_mmio.h
+++ b/sw/device/lib/base/testing/mock_mmio.h
@@ -15,122 +15,9 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio_test_utils.h"
 
 namespace mock_mmio {
-/**
- * Represents a single bit field in an integer, useable with EXPECT_* macros
- * defined in this file.
- *
- * An integer can be expressed as a list of BitField values, and can be more
- * convenient to use than 0b or 0x literals in some cases. For example, the
- * integer 0b0000'0000'1100'0101 could be expressed as
- *   {{0x0, 1}, {0x2, 1}, {0x4, 12}}
- * This form makes it clearer to the reader that 0x0, 0x2, and 04 are indices
- * to bitfields, which are set to particular values.
- *
- * In practice, this might use generated register constants, and look like
- *   {{FIELD_FOO_OFFSET, 1}, {FIELD_BAR_OFFSET, 1}, {FIELD_BAZ_OFFSET, 12}}
- *
- * This type does not specify the lengths of bitfields; MaskedBitField should be
- * used for that, instead.
- */
-struct BitField {
-  uintptr_t offset;
-  uintptr_t value;
-};
-
-/**
- * Represents a single bit field in an integer, similar to BitField. It can be
- * used in most places that need a BitField, as well as in `EXPECT_MASK` macros.
- *
- * Like with BitFields, we can express the integer 0b0000'0000'1100'0101 as a
- * list of BitFieldMasks:
- *   {{0x0, 0x1, 1}, {0x1, 0x1, 0}, {0x2, 0x1, 1}, {0x3, 0x1, 0},
- *    {0x4, 0xff, 12}}
- *
- * In addition to showing how the integer is broken up, it also expresses
- * the lengths of fields, so it is clear that 0x0 and 0x2 are one-bit fields.
- * This also allows us to formally express that the fields 0x1 and 0x3 are
- * *unset*.
- *
- * In practice, this might use generated register constants, and look like
- *   {{FIELD_FOO_OFFSET, FIELD_FOO_MASK, 1}, ...}
- */
-struct MaskedBitField {
-  uintptr_t offset;
-  uintptr_t mask;
-  uintptr_t value;
-};
-
-namespace internal {
-/**
- * Implicit conversion guard around `char *`. See `LeInt()`.
- */
-struct LittleEndianBytes {
-  const char *bytes;
-};
-
-/**
- * Converts the argument into an unsigned integer of type `Int`.
- *
- * This overload is simply the identity on integers, and allows integers to be
- * converted into themselves. This enables the basic EXPECT_* macros:
- *   EXPECT_READ32(offset, 0xcafecafe);
- *
- * @param val an integer.
- * @return the value `val`.
- */
-template <typename Int>
-Int ToInt(Int val) {
-  return val;
-}
-
-/**
- * Converts the argument into an unsinged integer of type `Int`.
- *
- * This overload assumes that `str` is a valid pointer to a buffer of at least
- * `sizeof(Int)` bytes, which are memcpy'd out as an `Int`. This enables
- * memcpy-like EXPECT_* macros:
- *   EXPECT_READ32(offset, LeInt("rv32"));
- *   EXPECT_READ32(offset, LeInt("imc\0"));
- *
- * @param str a pointer to a valid buffer of length at least `sizeof(Int)`.
- * @return a value of type `Int` memcpy'd out of `str`.
- */
-template <typename Int>
-Int ToInt(LittleEndianBytes str) {
-  Int val;
-  memcpy(&val, str.bytes, sizeof(Int));
-  return val;
-}
-
-/**
- * Converts the argument into an unsigned integer of type `Int`.
- *
- * This overload performs the shifts and ors described by `fields`. See
- * `BitField`'s documentation for details one what this means. This overload
- * enables bitfield EXPECT_* macros:
- *   EXPECT_READ32(offset, {{A_OFFSET, 0x55}, {B_OFFSET, 0xaa}});
- *   EXPECT_READ32(offset, fields);
- * where `fields` is an `std::vector<BitField>`.
- *
- * @param fields a list of bit field entries.
- * @return a value of type `Int` built out of `fields`.
- */
-template <typename Int>
-Int ToInt(std::vector<BitField> fields) {
-  Int val = 0;
-  for (auto field : fields) {
-    // Due to the way that gtest ASSERT_* works, and the fact that this must be
-    // a function (since we use function overloading), these cannot be ASSERTs,
-    // and must be EXPECTs.
-    EXPECT_LE(field.offset, sizeof(Int) * 8);
-    val |= static_cast<Int>(field.value << field.offset);
-  }
-  return val;
-}
-}  // namespace internal
-
 /**
  * Reads a little-endian integer from `bytes`. This function is lazy, and will
  * only perform the converion when used with an EXPECT_* macro. For example:
@@ -140,7 +27,7 @@ Int ToInt(std::vector<BitField> fields) {
  * this is a limitation of C++'s implicit conversion rules and overload
  * resolution order.
  */
-inline internal::LittleEndianBytes LeInt(const char *bytes) { return {bytes}; }
+inline mock_mmio::LittleEndianBytes LeInt(const char *bytes) { return {bytes}; }
 
 /**
  * A MockDevice represents a mock implementation of an MMIO device.
@@ -227,8 +114,7 @@ class MmioTest {
  */
 #define EXPECT_READ8_AT(dev, offset, ...) \
   EXPECT_CALL(dev, Read8(offset))         \
-      .WillOnce(                          \
-          testing::Return(mock_mmio::internal::ToInt<uint8_t>(__VA_ARGS__)))
+      .WillOnce(testing::Return(mock_mmio::ToInt<uint8_t>(__VA_ARGS__)))
 
 /**
  * Expect a read to the device `dev` at the given offset, returning the given
@@ -242,8 +128,7 @@ class MmioTest {
  */
 #define EXPECT_READ32_AT(dev, offset, ...) \
   EXPECT_CALL(dev, Read32(offset))         \
-      .WillOnce(                           \
-          testing::Return(mock_mmio::internal::ToInt<uint32_t>(__VA_ARGS__)))
+      .WillOnce(testing::Return(mock_mmio::ToInt<uint32_t>(__VA_ARGS__)))
 
 /**
  * Expect a write to the device `dev` at the given offset with the given 8-bit
@@ -256,8 +141,7 @@ class MmioTest {
  * calls.
  */
 #define EXPECT_WRITE8_AT(dev, offset, ...) \
-  EXPECT_CALL(                             \
-      dev, Write8(offset, mock_mmio::internal::ToInt<uint8_t>(__VA_ARGS__)))
+  EXPECT_CALL(dev, Write8(offset, mock_mmio::ToInt<uint8_t>(__VA_ARGS__)))
 
 /**
  * Expect a write to the device `dev` at the given offset with the given 32-bit
@@ -270,8 +154,7 @@ class MmioTest {
  * calls.
  */
 #define EXPECT_WRITE32_AT(dev, offset, ...) \
-  EXPECT_CALL(                              \
-      dev, Write32(offset, mock_mmio::internal::ToInt<uint32_t>(__VA_ARGS__)))
+  EXPECT_CALL(dev, Write32(offset, mock_mmio::ToInt<uint32_t>(__VA_ARGS__)))
 
 /**
  * Expect a read at the given offset, returning the given 8-bit value.

--- a/sw/device/lib/base/testing/mock_mmio_test_utils.h
+++ b/sw/device/lib/base/testing/mock_mmio_test_utils.h
@@ -1,0 +1,134 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_TESTING_MOCK_MMIO_TEST_UTILS_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_TESTING_MOCK_MMIO_TEST_UTILS_H_
+
+#include <initializer_list>
+#include <memory>
+#include <random>
+#include <stdint.h>
+#include <string.h>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+
+namespace mock_mmio {
+
+/**
+ * Represents a single bit field in an integer, useable with EXPECT_* macros
+ * defined in this file.
+ *
+ * An integer can be expressed as a list of BitField values, and can be more
+ * convenient to use than 0b or 0x literals in some cases. For example, the
+ * integer 0b0000'0000'1100'0101 could be expressed as
+ *   {{0x0, 1}, {0x2, 1}, {0x4, 12}}
+ * This form makes it clearer to the reader that 0x0, 0x2, and 04 are indices
+ * to bitfields, which are set to particular values.
+ *
+ * In practice, this might use generated register constants, and look like
+ *   {{FIELD_FOO_OFFSET, 1}, {FIELD_BAR_OFFSET, 1}, {FIELD_BAZ_OFFSET, 12}}
+ *
+ * This type does not specify the lengths of bitfields; MaskedBitField should be
+ * used for that, instead.
+ */
+struct BitField {
+  uintptr_t offset;
+  uintptr_t value;
+};
+
+/**
+ * Represents a single bit field in an integer, similar to BitField. It can be
+ * used in most places that need a BitField, as well as in `EXPECT_MASK` macros.
+ *
+ * Like with BitFields, we can express the integer 0b0000'0000'1100'0101 as a
+ * list of BitFieldMasks:
+ *   {{0x0, 0x1, 1}, {0x1, 0x1, 0}, {0x2, 0x1, 1}, {0x3, 0x1, 0},
+ *    {0x4, 0xff, 12}}
+ *
+ * In addition to showing how the integer is broken up, it also expresses
+ * the lengths of fields, so it is clear that 0x0 and 0x2 are one-bit fields.
+ * This also allows us to formally express that the fields 0x1 and 0x3 are
+ * *unset*.
+ *
+ * In practice, this might use generated register constants, and look like
+ *   {{FIELD_FOO_OFFSET, FIELD_FOO_MASK, 1}, ...}
+ */
+struct MaskedBitField {
+  uintptr_t offset;
+  uintptr_t mask;
+  uintptr_t value;
+};
+
+/**
+ * Implicit conversion guard around `char *`. See `LeInt()`.
+ */
+struct LittleEndianBytes {
+  const char *bytes;
+};
+
+/**
+ * Converts the argument into an unsigned integer of type `Int`.
+ *
+ * This overload is simply the identity on integers, and allows integers to be
+ * converted into themselves. This enables the basic EXPECT_* macros:
+ *   EXPECT_READ32(offset, 0xcafecafe);
+ *
+ * @param val an integer.
+ * @return the value `val`.
+ */
+template <typename Int>
+Int ToInt(Int val) {
+  return val;
+}
+
+/**
+ * Converts the argument into an unsinged integer of type `Int`.
+ *
+ * This overload assumes that `str` is a valid pointer to a buffer of at least
+ * `sizeof(Int)` bytes, which are memcpy'd out as an `Int`. This enables
+ * memcpy-like EXPECT_* macros:
+ *   EXPECT_READ32(offset, LeInt("rv32"));
+ *   EXPECT_READ32(offset, LeInt("imc\0"));
+ *
+ * @param str a pointer to a valid buffer of length at least `sizeof(Int)`.
+ * @return a value of type `Int` memcpy'd out of `str`.
+ */
+template <typename Int>
+Int ToInt(LittleEndianBytes str) {
+  Int val;
+  memcpy(&val, str.bytes, sizeof(Int));
+  return val;
+}
+
+/**
+ * Converts the argument into an unsigned integer of type `Int`.
+ *
+ * This overload performs the shifts and ors described by `fields`. See
+ * `BitField`'s documentation for details one what this means. This overload
+ * enables bitfield EXPECT_* macros:
+ *   EXPECT_READ32(offset, {{A_OFFSET, 0x55}, {B_OFFSET, 0xaa}});
+ *   EXPECT_READ32(offset, fields);
+ * where `fields` is an `std::vector<BitField>`.
+ *
+ * @param fields a list of bit field entries.
+ * @return a value of type `Int` built out of `fields`.
+ */
+template <typename Int>
+Int ToInt(std::vector<BitField> fields) {
+  Int val = 0;
+  for (auto field : fields) {
+    // Due to the way that gtest ASSERT_* works, and the fact that this must be
+    // a function (since we use function overloading), these cannot be ASSERTs,
+    // and must be EXPECTs.
+    EXPECT_LE(field.offset, sizeof(Int) * 8);
+    val |= static_cast<Int>(field.value << field.offset);
+  }
+  return val;
+}
+}  // namespace mock_mmio
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_TESTING_MOCK_MMIO_TEST_UTILS_H_

--- a/sw/device/silicon_creator/lib/base/abs_mmio.c
+++ b/sw/device/silicon_creator/lib/base/abs_mmio.c
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/base/abs_mmio.h"
+
+// `extern` declarations to give the inline functions in the corresponding
+// header a link location.
+extern uint32_t abs_mmio_read8(uint32_t addr);
+extern void abs_mmio_write8(uint32_t addr, uint8_t value);
+extern uint32_t abs_mmio_read32(uint32_t addr);
+extern void abs_mmio_write32(uint32_t addr, uint32_t value);

--- a/sw/device/silicon_creator/lib/base/abs_mmio.h
+++ b/sw/device/silicon_creator/lib/base/abs_mmio.h
@@ -1,0 +1,95 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BASE_ABS_MMIO_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BASE_ABS_MMIO_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/mmio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file
+ * @brief Absolute Memory-mapped IO functions, for volatile access.
+ *
+ * Memory-mapped IO functions, which map to volatile accesses. Use this module
+ * for register operations in mask ROM and ROM Extension production libraries.
+ *
+ * Compiling translation units that pull in this header with `-DMOCK_ABS_MMIO`
+ * will disable the definitions of `abs_mmio_read` and `abs_mmio_write`. These
+ * symbols can then be defined by a test harness to allow for instrumentation of
+ * MMIO accesses.
+ */
+
+/**
+ * All MMIO functions return their results using return values, rather than out-
+ * parameters. Where the return types are non-void, it is prudent to ensure
+ * these results are used, or explicitly discarded (in the case of a volatile
+ * read that is needed for side effects only).
+ */
+#define ABS_MMIO_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+
+#ifndef MOCK_ABS_MMIO
+
+/**
+ * Reads uint8_t from MMIO `addr`.
+ *
+ * @param addr the address to read from.
+ * @return the read value.
+ */
+ABS_MMIO_WARN_UNUSED_RESULT
+inline uint32_t abs_mmio_read8(uint32_t addr) {
+  return *((volatile uint8_t *)addr);
+}
+
+/**
+ * Writes uint8_t to the MMIO `addr`.
+ *
+ * @param addr the address to write to.
+ * @param value the value to write.
+ */
+inline void abs_mmio_write8(uint32_t addr, uint8_t value) {
+  *((volatile uint8_t *)addr) = value;
+}
+
+/**
+ * Reads an aligned uint32_t from MMIO `addr`.
+ *
+ * @param addr the address to read from.
+ * @return the read value.
+ */
+ABS_MMIO_WARN_UNUSED_RESULT
+inline uint32_t abs_mmio_read32(uint32_t addr) {
+  return *((volatile uint32_t *)addr);
+}
+
+/**
+ * Writes an aligned uint32_t to the MMIO region `addr`.
+ *
+ * @param addr the address to write to.
+ * @param value the value to write.
+ */
+inline void abs_mmio_write32(uint32_t addr, uint32_t value) {
+  *((volatile uint32_t *)addr) = value;
+}
+
+#else  // MOCK_ABS_MMIO
+
+extern uint32_t abs_mmio_read8(uint32_t addr);
+extern void abs_mmio_write8(uint32_t addr, uint8_t value);
+extern uint32_t abs_mmio_read32(uint32_t addr);
+extern void abs_mmio_write32(uint32_t addr, uint32_t value);
+
+#endif  // MOCK_ABS_MMIO
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BASE_ABS_MMIO_H_

--- a/sw/device/silicon_creator/lib/base/meson.build
+++ b/sw/device/silicon_creator/lib/base/meson.build
@@ -1,0 +1,31 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Mask ROM Secure MMIO module
+sw_silicon_creator_lib_base_abs_mmio = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_lib_base_abs_mmio',
+    sources: [
+      'abs_mmio.c',
+    ],
+    dependencies: [],
+  ),
+)
+
+sw_silicon_creator_lib_base_mock_abs_mmio = declare_dependency(
+  link_with: static_library(
+    'mock_abs_mmio',
+    sources: [
+      'abs_mmio.c',
+      'mock_abs_mmio.h',
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_lib_testing_bitfield,
+    ],
+    native: true,
+    c_args: ['-DMOCK_ABS_MMIO'],
+    cpp_args: ['-DMOCK_ABS_MMIO'],
+  )
+)

--- a/sw/device/silicon_creator/lib/base/mock_abs_mmio.h
+++ b/sw/device/silicon_creator/lib/base/mock_abs_mmio.h
@@ -1,0 +1,109 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BASE_MOCK_ABS_MMIO_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BASE_MOCK_ABS_MMIO_H_
+
+#include "sw/device/lib/base/testing/mock_mmio_test_utils.h"
+#include "sw/device/lib/testing/mask_rom_test.h"
+#include "sw/device/silicon_creator/lib/base/abs_mmio.h"
+
+namespace mask_rom_test {
+namespace internal {
+/**
+ * Mock class for abs_mmio.c.
+ */
+class MockAbsMmio {
+ public:
+  MOCK_METHOD(uint32_t, Read8, (uint32_t addr));
+  MOCK_METHOD(void, Write8, (uint32_t addr, uint32_t value));
+  MOCK_METHOD(uint32_t, Read32, (uint32_t addr));
+  MOCK_METHOD(void, Write32, (uint32_t addr, uint32_t value));
+
+  virtual ~MockAbsMmio() {}
+};
+}  // namespace internal
+
+using MockAbsMmio = GlobalMock<testing::StrictMock<internal::MockAbsMmio>>;
+
+/**
+ * Expect a read to the device `dev` at the given offset, returning the given
+ * 8-bit value.
+ *
+ * The value may be given as an integer, a pointer to little-endian data,
+ * or a `std::initializer_list<BitField>`.
+ *
+ * This expectation is sequenced with all other `EXPECT_READ` and `EXPECT_WRITE`
+ * calls.
+ */
+#define EXPECT_ABS_READ8(mmio, addr, ...) \
+  EXPECT_CALL(mmio, Read8(addr))          \
+      .WillOnce(testing::Return(mock_mmio::ToInt<uint8_t>(__VA_ARGS__)))
+
+/**
+ * Expect a write to the given offset with the given 8-bit value.
+ *
+ * The value may be given as an integer, a pointer to little-endian data,
+ * or a `std::initializer_list<BitField>`.
+ *
+ * This function is only available in tests using a fixture that derives
+ * `MmioTest`.
+ *
+ * This expectation is sequenced with all other `EXPECT_READ` and `EXPECT_WRITE`
+ * calls.
+ */
+#define EXPECT_ABS_WRITE8(mmio, addr, ...) \
+  EXPECT_CALL(mmio, Write8(addr, mock_mmio::ToInt<uint8_t>(__VA_ARGS__)));
+
+/**
+ * Expect a read to the device `dev` at the given offset, returning the given
+ * 32-bit value.
+ *
+ * The value may be given as an integer, a pointer to little-endian data,
+ * or a `std::initializer_list<BitField>`.
+ *
+ * This expectation is sequenced with all other `EXPECT_READ` and `EXPECT_WRITE`
+ * calls.
+ */
+#define EXPECT_ABS_READ32(mmio, addr, ...) \
+  EXPECT_CALL(mmio, Read32(addr))          \
+      .WillOnce(testing::Return(mock_mmio::ToInt<uint32_t>(__VA_ARGS__)))
+
+/**
+ * Expect a write to the given offset with the given 32-bit value.
+ *
+ * The value may be given as an integer, a pointer to little-endian data,
+ * or a `std::initializer_list<BitField>`.
+ *
+ * This function is only available in tests using a fixture that derives
+ * `MmioTest`.
+ *
+ * This expectation is sequenced with all other `EXPECT_READ` and `EXPECT_WRITE`
+ * calls.
+ */
+#define EXPECT_ABS_WRITE32(mmio, addr, ...) \
+  EXPECT_CALL(mmio, Write32(addr, mock_mmio::ToInt<uint32_t>(__VA_ARGS__)));
+
+extern "C" {
+
+uint32_t abs_mmio_read8(uint32_t addr) {
+  return MockAbsMmio::Instance().Read8(addr);
+}
+
+void abs_mmio_write8(uint32_t addr, uint32_t value) {
+  return MockAbsMmio::Instance().Write8(addr, value);
+}
+
+uint32_t abs_mmio_read32(uint32_t addr) {
+  return MockAbsMmio::Instance().Read32(addr);
+}
+
+void abs_mmio_write32(uint32_t addr, uint32_t value) {
+  return MockAbsMmio::Instance().Write32(addr, value);
+}
+
+}  // extern "C"
+}  // namespace mask_rom_test
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BASE_MOCK_ABS_MMIO_H_


### PR DESCRIPTION
This commit introduces the abs_mmio module, which removes the need for `mmio_region_t` inside the mask_rom and switches to addresses encoded in `uint32_t`. This commit does not consider DIF changes. ROM drivers can now use `base_address + offset` calculations to access registers.

```cc
abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CFG_REG_OFFSET, reg);
```

Test cases now require the instantiation of the mock mmio handle inside the test class, for example:

```cc
class HmacTest : public Test {
 protected:
  uint32_t base_ = TOP_EARLGREY_HMAC_BASE_ADDR;
  mask_rom_test::MockAbsMmio mmio_;  // This handle is required.
};
```

Expectations are similar to the dif mock mmio version, with the difference that the `mmio_` handle and the `base_` address need to be explicitly set inside the macro:

```cc
 EXPECT_ABS_WRITE32(mmio_, base_ + HMAC_CFG_REG_OFFSET,
                      {
                          {HMAC_CFG_DIGEST_SWAP_BIT, false},
                          {HMAC_CFG_ENDIAN_SWAP_BIT, true},
                          {HMAC_CFG_SHA_EN_BIT, true},
                          {HMAC_CFG_HMAC_EN_BIT, false},
                      });
```

This PR also  moves common mock mmio bit manipulation utility classes and functions inside a `mock_mmio_utils` namespace, and updates all impacted dependencies.