### PR TITLE
Update Verible to latest upstream

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ variables:
   VERILATOR_VERSION: 4.104
   OPENOCD_VERSION: 0.11.0
   TOOLCHAIN_PATH: /opt/buildcache/riscv
-  VERIBLE_VERSION: v0.0-808-g1e17daa
+  VERIBLE_VERSION: v0.0-1213-g9e5c085
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
   TOOLCHAIN_VERSION: 20210412-1
   # This controls where builds happen, and gets picked up by build_consts.sh.

--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -25,7 +25,7 @@ __TOOL_REQUIREMENTS__ = {
         'as_needed': True
     },
     'verible': {
-        'min_version': 'v0.0-808-g1e17daa',
+        'min_version': 'v0.0-1213-g9e5c085',
         'as_needed': True
     },
     'vcs': {


### PR DESCRIPTION
Verible is providing lint and formatting tooling and is evolving
rapidly in response to OpenTitan requirements.

It is an optional productivity tool; developers are recommended to have
it installed to run lint and early/experimental formatting on their own
machine. Lint is also done in CI.

Update Verible to the latest upstream version to unblock other work,
e.g. #4613 and to include recent lint improvements.