### PR TITLE
Aes alert and reset test

### DIFF
--- a/hw/ip/aes/data/aes_testplan.hjson
+++ b/hw/ip/aes/data/aes_testplan.hjson
@@ -64,7 +64,7 @@
         Run multiple messages in a random mix of encryption / decryption.
         Each message should select its mode randomly.'''
       milestone: V2
-      tests: ["aes_stress", "aes_smoke", "aes_config_error"]
+      tests: ["aes_stress", "aes_smoke", "aes_config_error", "aes_alert_reset"]
     }
     {
       name: failure_test
@@ -77,7 +77,7 @@
               Will result match plain text and vice.
             - Write unsupported configurations (Key length and mode are 1 hot, what happens if more than one bit is set.)'''
       milestone: V2
-      tests: ["aes_config_error"]
+      tests: ["aes_config_error", "aes_alert_reset"]
     }
     {
       name: trigger_clear_test
@@ -107,7 +107,7 @@
       desc: '''
             Pull reset at random times, make sure DUT recover/resets correctly and there is no residual data left in the registers.'''
       milestone: V2
-      tests: []
+      tests: ["aes_alert_reset"]
     }
     {
       name: stress

--- a/hw/ip/aes/dv/aes_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_sim_cfg.hjson
@@ -52,6 +52,20 @@
   // Update all builds to add options specific to AES C model compilation.
   en_build_modes: ["{tool}_aes_model_build_opts"]
 
+  component_a: "uvm_test_top.env.scoreboard"
+  id_a: _ALL_
+  verbosity_a: UVM_MEDIUM
+  phase_a: run
+  run_modes: [
+    {
+      name: set_verbosity_comp_a_uvm_debug
+      run_opts: ["+uvm_set_verbosity={component_a},{id_a},{verbosity_a},{phase_a}"]
+    }
+  ]
+
+
+run_opts: ["+uvm_set_verbosity={component_a},{id_a},{verbosity_a},{phase_a}"]
+
   // List of test specifications.
   tests: [
     {
@@ -85,6 +99,11 @@
       uvm_test: aes_clear_test
       uvm_test_seq: aes_stress_vseq
     }
+    {
+      name: aes_alert_reset
+      uvm_test: aes_alert_reset_test
+      uvm_test_seq: aes_alert_reset_vseq
+    }
   ]
 
   // List of regressions.
@@ -95,11 +114,11 @@
     }
     {
       name: failure
-      tests: ["aes_config_error"]
+      tests: ["aes_config_error", "aes_alert_reset"]
     }
     {
       name: stress
-      tests: ["aes_stress","aes_b2b", "aes_clear", "aes_config_error", "aes_smoke"]
+      tests: ["aes_stress","aes_b2b", "aes_clear", "aes_config_error", "aes_smoke", "aes_alert_reset"]
     }
   ]
 }

--- a/hw/ip/aes/dv/env/aes_env.core
+++ b/hw/ip/aes/dv/env/aes_env.core
@@ -30,6 +30,7 @@ filesets:
       - seq_lib/aes_common_vseq.sv: {is_include_file: true}
       - seq_lib/aes_wake_up_vseq.sv: {is_include_file: true}
       - seq_lib/aes_stress_vseq.sv: {is_include_file: true}
+      - seq_lib/aes_alert_reset_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/aes/dv/env/aes_env_pkg.sv
+++ b/hw/ip/aes/dv/env/aes_env_pkg.sv
@@ -27,6 +27,7 @@ package aes_env_pkg;
   parameter uint NUM_ALERTS = 2;
 
   typedef enum int { AES_CFG=0, AES_DATA=1, AES_ERR_INJ=2 } aes_item_type_e;
+  typedef enum bit { Flip_bits = 0, Pull_reset = 1 } flip_rst_e;
 
   typedef struct packed {
     bit          dataout;

--- a/hw/ip/aes/dv/env/seq_lib/aes_alert_reset_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_alert_reset_vseq.sv
@@ -1,0 +1,67 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test that injects random resets &
+// bit errors into FSMs
+class aes_alert_reset_vseq extends aes_base_vseq;
+  `uvm_object_utils(aes_alert_reset_vseq)
+
+  `uvm_object_new
+  aes_message_item my_message;
+  status_t aes_status;
+  bit  finished_all_msgs = 0;
+
+  rand bit [$bits(aes_mode_e) -1 : 0] mal_error;
+ // constraint mal_error_c { $countones(mal_error.mode) > 1; };
+
+  task body();
+    `uvm_info(`gfn, $sformatf("\n\n\t ----| STARTING AES MAIN SEQUENCE |----\n %s",
+                              cfg.convert2string()), UVM_LOW)
+
+    // generate list of messages //
+    generate_message_queue();
+
+
+    // process all messages //
+    fork
+      begin: isolation_fork
+        fork
+          error: begin
+            cfg.clk_rst_vif.wait_clks(cfg.inj_delay);
+            if (cfg.error_types.mal_inject && (cfg.flip_rst == Flip_bits)) begin
+              randomize(mal_error)  with { $countones(mal_error) > 1; };
+              if (!uvm_hdl_check_path("tb.dut.u_aes_core.u_ctrl_reg_shadowed.committed_q")) begin
+                `uvm_fatal(`gfn, $sformatf("\n\t ----| PATH NOT FOUND"))
+              end else begin
+                $assertoff(0, "tb.dut.u_aes_core.AesModeValid");
+                $assertoff(0, "tb.dut.u_aes_core.u_aes_control.AesModeValid");
+                uvm_hdl_force("tb.dut.u_aes_core.u_ctrl_reg_shadowed.committed_q[6:1]", mal_error);
+                wait(!cfg.clk_rst_vif.rst_n);
+                uvm_hdl_release("tb.dut.u_aes_core.u_ctrl_reg_shadowed.committed_q[6:1]");
+                // turn assertions back on
+                $asserton(0, "tb.dut.u_aes_core.AesModeValid");
+                $asserton(0, "tb.dut.u_aes_core.u_aes_control.AesModeValid");
+              end
+            end else if (cfg.error_types.reset && (cfg.flip_rst == Pull_reset)) begin
+              // only do reset injection if we are not already
+              // injecting other errors (which will pull reset anyway)
+
+              aes_reset();
+              #10ps;
+              wait(!cfg.under_reset);
+            end
+          end
+          basic: begin
+            send_msg_queue(cfg.unbalanced, cfg.read_prob, cfg.write_prob);
+            finished_all_msgs = 1;
+          end
+        join_none
+        // make sure we don't wait for a reset that never comes
+        // in case the inject happened efter test finished
+        wait (finished_all_msgs);
+        disable fork;
+      end // fork
+    join
+  endtask : body
+endclass

--- a/hw/ip/aes/dv/env/seq_lib/aes_stress_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_stress_vseq.sv
@@ -11,11 +11,13 @@ class aes_stress_vseq extends aes_base_vseq;
 
   task body();
     `uvm_info(`gfn, $sformatf("\n\n\t ----| STARTING AES MAIN SEQUENCE |----\n %s",
-               cfg.convert2string()), UVM_LOW)
+                              cfg.convert2string()), UVM_LOW)
 
     // generate list of messages //
     generate_message_queue();
     // process all messages //
+
     send_msg_queue(cfg.unbalanced, cfg.read_prob, cfg.write_prob);
+
   endtask : body
 endclass

--- a/hw/ip/aes/dv/env/seq_lib/aes_vseq_list.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_vseq_list.sv
@@ -6,3 +6,4 @@
 `include "aes_wake_up_vseq.sv"
 `include "aes_common_vseq.sv"
 `include "aes_stress_vseq.sv"
+`include "aes_alert_reset_vseq.sv"

--- a/hw/ip/aes/dv/tests/aes_alert_reset_test.sv
+++ b/hw/ip/aes/dv/tests/aes_alert_reset_test.sv
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class aes_smoke_test extends aes_base_test;
+class aes_alert_reset_test extends aes_base_test;
 
-  `uvm_component_utils(aes_smoke_test)
+  `uvm_component_utils(aes_alert_reset_test)
   `uvm_component_new
 
 
@@ -15,9 +15,11 @@ class aes_smoke_test extends aes_base_test;
 
   function void configure_env();
     super.configure_env();
-    cfg.error_types              = 0;     // no errors in smoke test
-    cfg.num_messages_min         = 1;
-    cfg.num_messages_max         = 5;
+    cfg.error_types              = 3'b110; // inject errors in regs and fsm errors
+    cfg.flip_rst_split_pct       = 60;
+    cfg.num_messages_min         = 3;
+    cfg.num_messages_max         = 6;
+    cfg.unbalanced               = 1;
     // message related knobs
     cfg.ecb_weight               = 10;
     cfg.cbc_weight               = 10;
@@ -25,9 +27,9 @@ class aes_smoke_test extends aes_base_test;
     cfg.ofb_weight               = 10;
     cfg.cfb_weight               = 10;
 
-    cfg.message_len_min          = 16;    // one block (16bytes=128bits)
-    cfg.message_len_max          = 32;    //
-    cfg.manual_operation_pct     = 50;
+    cfg.message_len_min          = 7;    // one block (16bytes=128bits)
+    cfg.message_len_max          = 300;
+    cfg.manual_operation_pct     = 0;
     cfg.use_key_mask             = 0;
 
     cfg.fixed_data_en            = 0;
@@ -41,10 +43,10 @@ class aes_smoke_test extends aes_base_test;
 
     cfg.fixed_iv_en              = 0;
 
-    cfg.random_data_key_iv_order = 0;
-    cfg.read_prob                = 100;
-    cfg.write_prob               = 100;
+    cfg.random_data_key_iv_order = 1;
+    cfg.read_prob                = 70;
+    cfg.write_prob               = 90;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
   endfunction
-endclass : aes_smoke_test
+endclass : aes_alert_reset_test

--- a/hw/ip/aes/dv/tests/aes_base_test.sv
+++ b/hw/ip/aes/dv/tests/aes_base_test.sv
@@ -16,6 +16,14 @@ class aes_base_test extends cip_base_test #(
 
   //this will serve as the default setting.
   // overrides should happen in the specific testcase.
+
+  virtual function void end_of_elaboration_phase(uvm_phase phase);
+    super.end_of_elaboration_phase(phase);
+    if (uvm_top.get_report_verbosity_level() > UVM_LOW) begin
+      uvm_top.print_topology();
+    end
+  endfunction // end_of_elaboration
+
   virtual function void configure_env();
 
 
@@ -73,7 +81,7 @@ class aes_base_test extends cip_base_test #(
   //  010: malicous injection
   //  100: random resets
     cfg.error_types                 = 3'b111;
-
     cfg.config_error_pct            = 0;           // percentage of configuration errors
+    cfg.flip_rst_split_pct           = 60;
   endfunction
 endclass : aes_base_test

--- a/hw/ip/aes/dv/tests/aes_stress_test.sv
+++ b/hw/ip/aes/dv/tests/aes_stress_test.sv
@@ -45,7 +45,8 @@ class aes_stress_test extends aes_base_test;
     cfg.fixed_iv_en              = 0;
 
     cfg.random_data_key_iv_order = 1;
-
+    cfg.read_prob                = 65;
+    cfg.write_prob               = 80;
     cfg.manual_operation_pct     = 30;
   endfunction // configure_env
 endclass : aes_stress_test

--- a/hw/ip/aes/dv/tests/aes_test.core
+++ b/hw/ip/aes/dv/tests/aes_test.core
@@ -17,6 +17,7 @@ filesets:
       - aes_b2b_test.sv: {is_include_file: true}
       - aes_config_error_test.sv: {is_include_file: true}
       - aes_clear_test.sv: {is_include_file: true}
+      - aes_alert_reset_test.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/aes/dv/tests/aes_test_pkg.sv
+++ b/hw/ip/aes/dv/tests/aes_test_pkg.sv
@@ -24,5 +24,6 @@ package aes_test_pkg;
   `include "aes_b2b_test.sv"
   `include "aes_config_error_test.sv"
   `include "aes_clear_test.sv"
+  `include "aes_alert_reset_test.sv"
 
 endpackage


### PR DESCRIPTION
This PR contains a new alert/reset test
that will either flip a bit in a onehot state machine and verify that:

- the fatal alert gets set
- that we cannot get information (like the state of the core)
- that the module can recover on a reset

or it will just pull reset at a random time and verify that we can recover.

