### PR TITLE
[uart] Fix line continuation in DV code

### DIFF
--- a/hw/ip/uart/dv/env/uart_env_pkg.sv
+++ b/hw/ip/uart/dv/env/uart_env_pkg.sv
@@ -75,8 +75,8 @@ package uart_env_pkg;
     nco = `CALC_NCO(baud_rate, nco_width, clk_freq_mhz);
     if (nco >= (2 ** nco_width)) begin
       `uvm_fatal("uart_agent_pkg::get_nco", $sformatf(
-                 "nco (%0d) can't bigger than (2 ** %0d) - 1, it's only %0d bits \
-                 baud_rate = %0d, clk_freq_mhz = %0d",
+                 {"nco (%0d) can't bigger than (2 ** %0d) - 1, it's only %0d bits ",
+                  "baud_rate = %0d, clk_freq_mhz = %0d"},
                  nco, nco_width, nco_width, baud_rate, clk_freq_mhz))
     end
     return nco;


### PR DESCRIPTION
The backslash operator doesn't have the intended effect of line
continuation here and inserts whitespace (all spaces from the start of
the line to the of the second/continued line).

Found by Verible lint:

```
../src/lowrisc_dv_uart_env_0.1/uart_env_pkg.sv:78:18: The lines can't be continued with '\', use concatenation operator with braces [Style: forbid-line-continuations] [forbid-line-continuations]
```