### PR TITLE
[dv/lc_ctrl] Fix lc_ctrl regression error

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
@@ -102,7 +102,7 @@
             - Check if lc_trans_cnt is incremented
             '''
       milestone: V2
-      tests: []
+      tests: ["lc_ctrl_errors"]
     }
     {
       name: security_escalation

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_common_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_common_vseq.sv
@@ -10,11 +10,6 @@ class lc_ctrl_common_vseq extends lc_ctrl_base_vseq;
   }
   `uvm_object_new
 
-  virtual task dut_init(string reset_kind = "HARD");
-    super.dut_init();
-    if (do_lc_ctrl_init) lc_ctrl_init(0);
-  endtask
-
   virtual task body();
     run_common_vseq_wrapper(num_trans);
   endtask : body


### PR DESCRIPTION
This PR fixed the regression assertion failure that caused by lc_ctrl
drives otp_inputs too late after reset.

This PR also fixes an issue with unmapped testnames.

Signed-off-by: Cindy Chen <chencindy@google.com>