### PR TITLE
[dv/otp] Clean up code and improve coverage

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -115,13 +115,13 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
     end
   endtask
 
-  task automatic release_sw_check_fail(bit[1:0] fail_idx);
+  task automatic release_sw_check_fail();
     @(posedge clk_i);
-    if (fail_idx[0]) begin
+    if (force_sw_parts_ecc_reg[0]) begin
       release tb.dut.gen_partitions[0].gen_unbuffered.u_part_unbuf.`ECC_REG_PATH.syndrome_o[0];
       force_sw_parts_ecc_reg[0] = 0;
     end
-    if (fail_idx[1]) begin
+    if (force_sw_parts_ecc_reg[1]) begin
       release tb.dut.gen_partitions[1].gen_unbuffered.u_part_unbuf.`ECC_REG_PATH.syndrome_o[0];
       force_sw_parts_ecc_reg[0] = 0;
     end

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
@@ -17,6 +17,14 @@ class otp_ctrl_dai_lock_vseq extends otp_ctrl_smoke_vseq;
     collect_used_addr -> num_trans * num_dai_op <= DAI_ADDR_SIZE;
   }
 
+  constraint dai_wr_legal_addr_c {
+    {dai_addr[TL_AW-1:2], 2'b0} dist {
+      {CreatorSwCfgDigestOffset, OwnerSwCfgDigestOffset,HwCfgDigestOffset, Secret0DigestOffset,
+       Secret1DigestOffset, Secret2DigestOffset} :/ 1,
+      [CreatorSwCfgOffset : (LifeCycleOffset + LifeCycleSize)] :/ 9
+    };
+  }
+
   virtual task pre_start();
     super.pre_start();
     is_valid_dai_op = 0;

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // smoke test vseq to walk through DAI states and request keys
-`define PART_ADDR_RANGE(i) \
+`define PART_CONTENT_RANGE(i) \
     {[PartInfo[``i``].offset : (PartInfo[``i``].offset + PartInfo[``i``].size - DIGEST_SIZE - 1)]}
 
 class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
@@ -30,13 +30,14 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
   constraint partition_index_c {part_idx inside {[CreatorSwCfgIdx:Secret2Idx]};}
 
   constraint dai_wr_legal_addr_c {
-    if (part_idx == CreatorSwCfgIdx) dai_addr inside `PART_ADDR_RANGE(CreatorSwCfgIdx);
-    if (part_idx == OwnerSwCfgIdx)   dai_addr inside `PART_ADDR_RANGE(OwnerSwCfgIdx);
-    if (part_idx == HwCfgIdx)        dai_addr inside `PART_ADDR_RANGE(HwCfgIdx);
-    if (part_idx == Secret0Idx)      dai_addr inside `PART_ADDR_RANGE(Secret0Idx);
-    if (part_idx == Secret1Idx)      dai_addr inside `PART_ADDR_RANGE(Secret1Idx);
-    if (part_idx == Secret2Idx)      dai_addr inside `PART_ADDR_RANGE(Secret2Idx);
-    if (part_idx == LifeCycleIdx)    dai_addr inside `PART_ADDR_RANGE(LifeCycleIdx);
+    if (part_idx == CreatorSwCfgIdx) dai_addr inside `PART_CONTENT_RANGE(CreatorSwCfgIdx);
+    if (part_idx == OwnerSwCfgIdx)   dai_addr inside `PART_CONTENT_RANGE(OwnerSwCfgIdx);
+    if (part_idx == HwCfgIdx)        dai_addr inside `PART_CONTENT_RANGE(HwCfgIdx);
+    if (part_idx == Secret0Idx)      dai_addr inside `PART_CONTENT_RANGE(Secret0Idx);
+    if (part_idx == Secret1Idx)      dai_addr inside `PART_CONTENT_RANGE(Secret1Idx);
+    if (part_idx == Secret2Idx)      dai_addr inside `PART_CONTENT_RANGE(Secret2Idx);
+    if (part_idx == LifeCycleIdx)    dai_addr inside `PART_CONTENT_RANGE(LifeCycleIdx);
+    solve part_idx before dai_addr;
   }
 
   constraint dai_wr_blank_addr_c {
@@ -201,4 +202,4 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
 endclass : otp_ctrl_smoke_vseq
 
-`undef PART_ADDR_RANGE
+`undef PART_CONTENT_RANGE


### PR DESCRIPTION
Three main purpose of this PR:
1. Improve coverage: some corner cases are harder to hit by smaller
partitions (e.g. secret2 partition), so we randomize part index before
address.
2. Digest values are hard to hit as well. So in dai_lock test, we put
more weight on digest addresses.
3. Remove some old logic in scb.

Signed-off-by: Cindy Chen <chencindy@google.com>