### PR TITLE
[doc] Link to broader guidance from CONTRIBUTING.md and remove confusing statement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,11 @@ involved.
   discuss multiple implementation options, discuss on the mailing list.
 * Create pull requests from a fork rather than making new branches in 
   `github.com/lowrisc/opentitan`.
-* Do not force push.
 * Do not attempt to commit code with a non-Apache license without discussing
   first.
 * If a relevant bug or tracking issue exists, reference it in the pull request
   and commits.
+
+Please see [Contributing to
+OpenTitan](https://docs.opentitan.org/doc/project/contributing/) for more
+general guidance.


### PR DESCRIPTION
As pointed out in #5169, the statement about avoiding force pushes in
CONTRIBUTING.md is confusing - it was only meant to apply to branches of
the repo, not to PRs. Plus force pushes aren't possible due to branch
protection rules.

This commit additionally adds a link to
https://docs.opentitan.org/doc/project/contributing/ for more general
contribution guidance.

The guidance in CONTRIBUTING.md dates back to the very beginning of the project. It's largely going to be made redundant by a combination of the short-form contribution guidance and the soon-to-be pushed larger form contribution guide. This PR makes the minimal fix rather than trying to restructure - IMHO this is best done once the long-form contributors guide lands.