### PR TITLE
[otbn] add base point multiplication and point test

### DIFF
--- a/sw/otbn/code-snippets/p384_scalar_mult_test.s
+++ b/sw/otbn/code-snippets/p384_scalar_mult_test.s
@@ -2,10 +2,11 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- *   Standalone test for P-384 point addition in projective space
+ *   Standalone test for P-384 scalar multiplication
  *
- *   Performs addition of two valid P-384 points in projective space.
- *   Constant coordinates for the two points contained in the .data section.
+ *   Performs multiplication of a P-384 curve point by a scalar. Both, the
+ *   scalar and the affine coordinates of the point are contained in the
+ *   .data section below.
  *
  *   See comment at the end of the file for expected values of coordinates
  *   of resulting point.

--- a/sw/otbn/code-snippets/p384_verify.s
+++ b/sw/otbn/code-snippets/p384_verify.s
@@ -2,10 +2,142 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- *   P-384 specific routines for ECDSA signature verification.
+ *   P-384 specific routines for ECDSA signature verification and curve point
+ *   test.
  */
 
  .section .text
+
+/**
+ * Checks if a point is a valid curve point on curve P-384
+ *
+ * Returns r = x^3 + ax + b  mod p
+ *     and s = y^2  mod p
+ *         where x,y are the affine coordinates of the curve point and
+ *              a, b and p being the domain parameters of curve P-384.
+ *
+ * This routine checks if a point with given x- and y-coordinate is a valid
+ * curve point on P-384.
+ * The routine checks whether the coordinates are a solution of the
+ * Weierstrass equation y^2 = x^3 + ax + b  mod p.
+ * The routine makes use of the property that the domain parameter 'a' can be
+ * written as a=-3 for the P-384 curve, hence the routine is limited to P-384.
+ * The routine does not return a boolean result but computes the left side
+ * and the right sight of the Weierstrass equation and leaves the final
+ * comparison to the caller.
+ * The routine runs in constant time.
+ *
+ * Flags: Flags have no meaning beyond the scope of this subroutine.
+ *
+ * @param[in]  dmem[12]: dptr_r, pointer to dmem location where right
+ *                               side result r will be stored
+ * @param[in]  dmem[16]: dptr_s, pointer to dmem location where left side
+ *                               result s will be stored
+ * @param[in]  dmem[20]: dptr_x, pointer to dmem location containing affine
+ *                               x-coordinate of input point
+ * @param[in]  dmem[24]: dptr_y, pointer to dmem location containing affine
+ *                               y-coordinate of input point
+ *
+ * clobbered registers: x2, x3, w0 to w5, w10 to w17
+ * clobbered flag groups: FG0
+ */
+ .globl p384_isoncurve
+p384_isoncurve:
+
+  /* setup all-zero reg */
+  bn.xor    w31, w31, w31
+
+  /* load affine x-coordinate of curve point from dmem
+     [w1, w0] <= dmem[dptr_x] = dmem[20] */
+  la        x3, dptr_x
+  lw        x3, 0(x3)
+  li        x2, 0
+  bn.lid    x2++, 0(x3)
+  bn.lid    x2++, 32(x3)
+
+  /* load affine y-coordinate of curve point from dmem
+     [w3, w2] <= dmem[dptr_y] = dmem[24] */
+  la        x3, dptr_y
+  lw        x3, 0(x3)
+  bn.lid    x2++, 0(x3)
+  bn.lid    x2, 32(x3)
+
+  /* load domain parameter p (modulus) from dmem
+     [w13, w12] = p = dmem[p384_p] */
+  li        x2, 12
+  la        x3, p384_p
+  bn.lid    x2++, 0(x3)
+  bn.lid    x2++, 32(x3)
+
+  /* load Barrett constant u for modulus p from dmem
+     [w15, w14] = u_p = dmem[p384_u_p] */
+  li        x2, 14
+  la        x3, p384_u_p
+  bn.lid    x2++, 0(x3)
+  bn.lid    x2++, 32(x3)
+
+  /* load domain parameter b from dmem
+     [w4, w5] = b = dmem[p384_b] */
+  li        x2, 4
+  la        x3, p384_b
+  bn.lid    x2++, 0(x3)
+  bn.lid    x2++, 32(x3)
+
+  /* y^2 = [w17,w16] <= y*y = [w3,w2]*w[w3,w2] */
+  bn.mov    w10, w2
+  bn.mov    w11, w3
+  bn.mov    w16, w2
+  bn.mov    w17, w3
+  jal       x1, barrett384_p384
+
+  /* store result (left side): dmem[dptr_s] <= y^2 = [w17,w16] */
+  la        x3, dptr_s
+  lw        x3, 0(x3)
+  li        x2, 16
+  bn.sid    x2++, 0(x3)
+  bn.sid    x2++, 32(x3)
+
+  /*  x^3 = [w17,w16] <= (x*x)*x = ([w1,w0]*(w1,w0])*[w1,w0] */
+  bn.mov    w10, w0
+  bn.mov    w11, w1
+  bn.mov    w16, w0
+  bn.mov    w17, w1
+  jal       x1, barrett384_p384
+  bn.mov    w10, w0
+  bn.mov    w11, w1
+  jal       x1, barrett384_p384
+
+  /* for curve P-384, 'a' can be written as a = -3, therefore we subtract
+     x three times from x^3.
+     x^3 + ax  mod p = [w17,w16] <= x^3 -3 x mod p
+                     = [w17,w16] - [w1,w0] - [w1,w0] - [w1,w0] mod [w13,w12] */
+  loopi     3, 6
+    bn.sub    w16, w16, w0
+    bn.subb   w17, w17, w1
+    bn.add    w10, w16, w12
+    bn.addc   w11, w17, w13
+    bn.sel    w16, w10, w16, C
+    bn.sel    w17, w11, w17, C
+
+  /* add domain parameter b
+     x^3 + ax + b mod p = [w17,w16] <= [w17,w16] + [w5,w4] mod [w13,w12] */
+  bn.add    w16, w16, w4
+  bn.addc   w17, w17, w5
+  bn.sub    w10, w16, w12
+  bn.subb   w11, w17, w13
+  bn.sel    w16, w16, w10, C
+  bn.sel    w17, w17, w11, C
+
+  /* store result (right side)
+     dmem[dptr_r] <= x^3 + ax + b mod p = [w17,w16] */
+  la        x3, dptr_r
+  lw        x3, 0(x3)
+  li        x2, 16
+  bn.sid    x2++, 0(x3)
+  bn.sid    x2++, 32(x3)
+
+  ret
+
 
 /**
  * 384-bit variable time modular multiplicative inverse computation

--- a/sw/otbn/code-snippets/rules.mk
+++ b/sw/otbn/code-snippets/rules.mk
@@ -169,6 +169,14 @@ $(otbn-code-snippets-bin-dir)/p384_scalar_mult_test.elf: \
   otbn-libs += $(otbn-code-snippets-obj-dir)/p384_sign.o \
                $(otbn-code-snippets-obj-dir)/p384_base.o
 
+# p384_base_mult_test depends on p384_base_mult defined in p384_sign.s
+$(otbn-code-snippets-bin-dir)/p384_base_mult_test.elf: \
+  $(otbn-code-snippets-obj-dir)/p384_sign.o \
+  $(otbn-code-snippets-obj-dir)/p384_base.o
+$(otbn-code-snippets-bin-dir)/p384_base_mult_test.elf: \
+  otbn-libs += $(otbn-code-snippets-obj-dir)/p384_sign.o \
+               $(otbn-code-snippets-obj-dir)/p384_base.o
+
 # p384_ecdsa_sign_test depends on p384_sign defined in p384_sign.s
 $(otbn-code-snippets-bin-dir)/p384_ecdsa_sign_test.elf: \
   $(otbn-code-snippets-obj-dir)/p384_sign.o \

--- a/sw/otbn/code-snippets/rules.mk
+++ b/sw/otbn/code-snippets/rules.mk
@@ -198,3 +198,11 @@ $(otbn-code-snippets-bin-dir)/p384_ecdsa_verify_test.elf: \
 $(otbn-code-snippets-bin-dir)/p384_ecdsa_verify_test.elf: \
   otbn-libs += $(otbn-code-snippets-obj-dir)/p384_verify.o \
                $(otbn-code-snippets-obj-dir)/p384_base.o
+
+# p384_isoncurve_test depends on p384_isoncurve defined in p384_verify.s
+$(otbn-code-snippets-bin-dir)/p384_isoncurve_test.elf: \
+  $(otbn-code-snippets-obj-dir)/p384_verify.o \
+  $(otbn-code-snippets-obj-dir)/p384_base.o
+$(otbn-code-snippets-bin-dir)/p384_isoncurve_test.elf: \
+  otbn-libs += $(otbn-code-snippets-obj-dir)/p384_verify.o \
+               $(otbn-code-snippets-obj-dir)/p384_base.o


### PR DESCRIPTION
This adds the remaining two routines needed for P-384

- basepoint multiplication (needed for computation of public keys)
- curve point test

This PR concludes the P-384 implementation (#2856).