### PR TITLE
[dv/otp_ctrl] Clean up backdoor write to trigger ECC error

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -120,8 +120,12 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     bit backdoor_wr;
     addr = randomize_dai_addr(addr);
     if (cfg.ecc_err != OtpEccUncorrErr && addr < LifeCycleOffset) begin
-      backdoor_rd_val = backdoor_inject_ecc_err(addr, ecc_err_mask, cfg.ecc_err);
-      backdoor_wr = 1;
+      if (ecc_err_mask == 0) begin
+        cfg.ecc_err = OtpNoEccErr;
+      end else begin
+        backdoor_rd_val = backdoor_inject_ecc_err(addr, ecc_err_mask, cfg.ecc_err);
+        backdoor_wr = 1;
+      end
     end
 
     csr_wr(ral.direct_access_address, addr);


### PR DESCRIPTION
From the Thursday meeting, we found the logic to backdoor write OTP
memory to create ECC error is not very clear.
This PR won't backdoor write if ecc_err_mask is 0.

Signed-off-by: Cindy Chen <chencindy@google.com>