### PR TITLE
[sw/silicon_creator] Add OTBN ROM driver

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -315,3 +315,35 @@ test('sw_silicon_creator_lib_driver_pinmux_unittest', executable(
   ),
   suite: 'mask_rom',
 )
+
+# Mask ROM otbn driver
+sw_silicon_creator_lib_driver_otbn = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_lib_driver_otbn',
+    sources: [
+      hw_ip_otbn_reg_h,
+      'otbn.c',
+    ],
+    dependencies: [
+      sw_silicon_creator_lib_base_abs_mmio,
+    ],
+  ),
+)
+
+test('sw_silicon_creator_lib_driver_otbn_unittest', executable(
+    'sw_silicon_creator_lib_driver_otbn_unittest',
+    sources: [
+      'otbn_unittest.cc',
+      hw_ip_otbn_reg_h,
+      'otbn.c',
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_silicon_creator_lib_base_mock_abs_mmio,
+    ],
+    native: true,
+    c_args: ['-DMOCK_ABS_MMIO'],
+    cpp_args: ['-DMOCK_ABS_MMIO'],
+  ),
+  suite: 'mask_rom',
+)

--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -1,0 +1,107 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/otbn.h"
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/silicon_creator/lib/base/abs_mmio.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otbn_regs.h"  // Generated.
+
+#define ASSERT_ERR_BIT_MATCH(enum_val, autogen_val) \
+  static_assert(enum_val == 1 << (autogen_val),     \
+                "OTBN register bit doesn't match autogen value.");
+
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsBadDataAddr, OTBN_ERR_BITS_BAD_DATA_ADDR_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsBadInsnAddr, OTBN_ERR_BITS_BAD_INSN_ADDR_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsCallStack, OTBN_ERR_BITS_CALL_STACK_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsIllegalInsn, OTBN_ERR_BITS_ILLEGAL_INSN_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsLoop, OTBN_ERR_BITS_LOOP_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsFatalImem, OTBN_ERR_BITS_FATAL_IMEM_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsFatalDmem, OTBN_ERR_BITS_FATAL_DMEM_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsFatalReg, OTBN_ERR_BITS_FATAL_REG_BIT);
+
+const size_t kOtbnDMemSizeBytes = OTBN_DMEM_SIZE_BYTES;
+const size_t kOtbnIMemSizeBytes = OTBN_IMEM_SIZE_BYTES;
+
+enum { kBase = TOP_EARLGREY_OTBN_BASE_ADDR };
+
+/**
+ * Ensures that `offset_bytes` and `len` are valid for a given `mem_size`.
+ */
+static rom_error_t check_offset_len(uint32_t offset_bytes, size_t len,
+                                    size_t mem_size) {
+  // TODO: Update to use alignment utility functions.
+  // https://github.com/lowRISC/opentitan/issues/6112
+  if (offset_bytes % sizeof(uint32_t) != 0) {
+    return kErrorOtbnBadOffset;
+  }
+  if (offset_bytes + len * sizeof(uint32_t) < len * sizeof(uint32_t) ||
+      offset_bytes + len * sizeof(uint32_t) > mem_size) {
+    return kErrorOtbnBadOffsetLen;
+  }
+  return kErrorOk;
+}
+
+rom_error_t otbn_start(uint32_t start_addr) {
+  // TODO: Update to use alignment utility functions.
+  // https://github.com/lowRISC/opentitan/issues/6112
+  if (start_addr % sizeof(uint32_t) != 0 || start_addr >= kOtbnIMemSizeBytes) {
+    return kErrorOtbnInvalidArgument;
+  }
+
+  abs_mmio_write32(kBase + OTBN_START_ADDR_REG_OFFSET, start_addr);
+
+  uint32_t cmd_reg_val = bitfield_bit32_write(0, OTBN_CMD_START_BIT, true);
+  abs_mmio_write32(kBase + OTBN_CMD_REG_OFFSET, cmd_reg_val);
+
+  return kErrorOk;
+}
+
+bool otbn_is_busy() {
+  uint32_t status = abs_mmio_read32(kBase + OTBN_STATUS_REG_OFFSET);
+  return bitfield_bit32_read(status, OTBN_STATUS_BUSY_BIT);
+}
+
+void otbn_get_err_bits(otbn_err_bits_t *err_bits) {
+  *err_bits = abs_mmio_read32(kBase + OTBN_ERR_BITS_REG_OFFSET);
+}
+
+rom_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
+                            size_t len) {
+  RETURN_IF_ERROR(check_offset_len(offset_bytes, len, kOtbnIMemSizeBytes));
+
+  for (size_t i = 0; i < len; ++i, offset_bytes += sizeof(uint32_t)) {
+    abs_mmio_write32(kBase + OTBN_IMEM_REG_OFFSET + offset_bytes, src[i]);
+  }
+
+  return kErrorOk;
+}
+
+rom_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
+                            size_t len) {
+  RETURN_IF_ERROR(check_offset_len(offset_bytes, len, kOtbnDMemSizeBytes));
+
+  for (size_t i = 0; i < len; ++i, offset_bytes += sizeof(uint32_t)) {
+    abs_mmio_write32(kBase + OTBN_DMEM_REG_OFFSET + offset_bytes, src[i]);
+  }
+
+  return kErrorOk;
+}
+
+rom_error_t otbn_dmem_read(uint32_t offset_bytes, uint32_t *dest, size_t len) {
+  RETURN_IF_ERROR(check_offset_len(offset_bytes, len, kOtbnDMemSizeBytes));
+
+  for (size_t i = 0; i < len; ++i, offset_bytes += sizeof(uint32_t)) {
+    dest[i] = abs_mmio_read32(kBase + OTBN_DMEM_REG_OFFSET + offset_bytes);
+  }
+
+  return kErrorOk;
+}

--- a/sw/device/silicon_creator/lib/drivers/otbn.h
+++ b/sw/device/silicon_creator/lib/drivers/otbn.h
@@ -1,0 +1,123 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_OTBN_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_OTBN_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * The size of OTBN's data memory in bytes.
+ */
+extern const size_t kOtbnDMemSizeBytes;
+
+/**
+ * The size of OTBN's instruction memory in bytes.
+ */
+extern const size_t kOtbnIMemSizeBytes;
+
+/**
+ * Start the execution of the application loaded into OTBN at the start address.
+ *
+ * @param start_addr The IMEM byte address to start the execution at.
+ * @return `kErrorOtbInvalidArgument` if `start_addr` is invalid, `kErrorOk`
+ *         otherwise.
+ */
+rom_error_t otbn_start(uint32_t start_addr);
+
+/**
+ * Is OTBN busy executing an application?
+ *
+ * @return OTBN is busy
+ */
+bool otbn_is_busy(void);
+
+/**
+ * OTBN Errors
+ *
+ * OTBN uses a bitfield to indicate which errors have been seen. Multiple errors
+ * can be seen at the same time. This enum gives the individual bits that may be
+ * set for different errors.
+ */
+typedef enum otbn_err_bits {
+  kOtbnErrBitsNoError = 0,
+  /** Load or store to invalid address. */
+  kOtbnErrBitsBadDataAddr = (1 << 0),
+  /** Instruction fetch from invalid address. */
+  kOtbnErrBitsBadInsnAddr = (1 << 1),
+  /** Call stack underflow or overflow. */
+  kOtbnErrBitsCallStack = (1 << 2),
+  /** Illegal instruction execution attempted */
+  kOtbnErrBitsIllegalInsn = (1 << 3),
+  /** LOOP[I] related error */
+  kOtbnErrBitsLoop = (1 << 4),
+  /** Error seen in Imem read */
+  kOtbnErrBitsFatalImem = (1 << 5),
+  /** Error seen in Dmem read */
+  kOtbnErrBitsFatalDmem = (1 << 6),
+  /** Error seen in RF read */
+  kOtbnErrBitsFatalReg = (1 << 7)
+} otbn_err_bits_t;
+
+/**
+ * Get the error bits set by the device if the operation failed.
+ *
+ * @param[out] err_bits The error bits returned by the hardware.
+ */
+void otbn_get_err_bits(otbn_err_bits_t *err_bits);
+
+/**
+ * Write an OTBN application into its instruction memory (IMEM)
+ *
+ * Only 32b-aligned 32b word accesses are allowed.
+ *
+ * @param offset_bytes the byte offset in IMEM the first word is written to
+ * @param src the main memory location to start reading from.
+ * @param len number of words to copy.
+ * @return `kErrorOtbnBadOffset` if `offset_bytes` isn't word aligned,
+ * `kErrorOtbnBadOffsetLen` if `len` is invalid , `kErrorOk` otherwise.
+ */
+rom_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
+                            size_t len);
+
+/**
+ * Write to OTBN's data memory (DMEM)
+ *
+ * Only 32b-aligned 32b word accesses are allowed.
+ *
+ * @param offset_bytes the byte offset in DMEM the first word is written to
+ * @param src the main memory location to start reading from.
+ * @param len number of words to copy.
+ * @return `kErrorOtbnBadOffset` if `offset_bytes` isn't word aligned,
+ * `kErrorOtbnBadOffsetLen` if `len` is invalid , `kErrorOk` otherwise.
+ */
+rom_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
+                            size_t len);
+
+/**
+ * Read from OTBN's data memory (DMEM)
+ *
+ * Only 32b-aligned 32b word accesses are allowed.
+ *
+ * @param offset_bytes the byte offset in DMEM the first word is read from
+ * @param[out] dest the main memory location to copy the data to (preallocated)
+ * @param len number of words to copy.
+ * @return `kErrorOtbnBadOffset` if `offset_bytes` isn't word aligned,
+ * `kErrorOtbnBadOffsetLen` if `len` is invalid , `kErrorOk` otherwise.
+ */
+rom_error_t otbn_dmem_read(uint32_t offset_bytes, uint32_t *dest, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_OTBN_H_

--- a/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
@@ -1,0 +1,193 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/otbn.h"
+
+#include <array>
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/testing/mask_rom_test.h"
+#include "sw/device/silicon_creator/lib/base/mock_abs_mmio.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otbn_regs.h"  // Generated.
+
+namespace otbn_unittest {
+namespace {
+using ::testing::ElementsAre;
+
+class OtbnTest : public mask_rom_test::MaskRomTest {
+ protected:
+  uint32_t base_ = TOP_EARLGREY_OTBN_BASE_ADDR;
+  mask_rom_test::MockAbsMmio mmio_;
+};
+
+class StartTest : public OtbnTest {};
+
+TEST_F(StartTest, BadStartAddress) {
+  // Must be 4-byte aligned.
+  EXPECT_EQ(otbn_start(1), kErrorOtbnInvalidArgument);
+  EXPECT_EQ(otbn_start(2), kErrorOtbnInvalidArgument);
+
+  // Valid addresses (ignoring alignment): 0 .. (OTBN_IMEM_SIZE_BYTES - 1)
+  EXPECT_EQ(otbn_start(OTBN_IMEM_SIZE_BYTES), kErrorOtbnInvalidArgument);
+
+  EXPECT_EQ(otbn_start(OTBN_IMEM_SIZE_BYTES + 32), kErrorOtbnInvalidArgument);
+}
+
+TEST_F(StartTest, Success) {
+  // Test assumption.
+  static_assert(OTBN_IMEM_SIZE_BYTES >= 8, "OTBN IMEM size too small.");
+
+  // Write start address.
+  EXPECT_ABS_WRITE32(mmio_, base_ + OTBN_START_ADDR_REG_OFFSET, 4);
+
+  // Set start command bit.
+  EXPECT_ABS_WRITE32(mmio_, base_ + OTBN_CMD_REG_OFFSET,
+                     {{OTBN_CMD_START_BIT, 1}});
+
+  EXPECT_EQ(otbn_start(4), kErrorOk);
+}
+
+class IsBusyTest : public OtbnTest {};
+
+TEST_F(IsBusyTest, Success) {
+  EXPECT_ABS_READ32(mmio_, base_ + OTBN_STATUS_REG_OFFSET,
+                    {{OTBN_STATUS_BUSY_BIT, true}});
+
+  EXPECT_EQ(otbn_is_busy(), true);
+}
+
+class GetErrBitsTest : public OtbnTest {};
+
+TEST_F(GetErrBitsTest, Success) {
+  EXPECT_ABS_READ32(mmio_, base_ + OTBN_ERR_BITS_REG_OFFSET,
+                    kOtbnErrBitsIllegalInsn | kOtbnErrBitsFatalReg);
+
+  otbn_err_bits_t err_bits;
+  otbn_get_err_bits(&err_bits);
+  EXPECT_EQ(err_bits, kOtbnErrBitsIllegalInsn | kOtbnErrBitsFatalReg);
+}
+
+class ImemWriteTest : public OtbnTest {};
+
+TEST_F(ImemWriteTest, BadOffset) {
+  std::array<uint32_t, 2> test_data = {0};
+
+  // `offset` must be 32b-aligned.
+  EXPECT_EQ(otbn_imem_write(1, test_data.data(), 1), kErrorOtbnBadOffset);
+  EXPECT_EQ(otbn_imem_write(2, test_data.data(), 1), kErrorOtbnBadOffset);
+}
+
+TEST_F(ImemWriteTest, BadAddressBeyondMemorySize) {
+  std::array<uint32_t, 2> test_data = {0};
+
+  EXPECT_EQ(otbn_imem_write(OTBN_IMEM_SIZE_BYTES, test_data.data(), 1),
+            kErrorOtbnBadOffsetLen);
+}
+
+TEST_F(ImemWriteTest, BadAddressIntegerOverflow) {
+  std::array<uint32_t, 4> test_data = {0};
+
+  EXPECT_EQ(otbn_imem_write(0xFFFFFFFC, test_data.data(), 1),
+            kErrorOtbnBadOffsetLen);
+}
+
+TEST_F(ImemWriteTest, SuccessWithoutOffset) {
+  // Test assumption.
+  static_assert(OTBN_IMEM_SIZE_BYTES >= 8, "OTBN IMEM size too small.");
+
+  std::array<uint32_t, 2> test_data = {0x12345678, 0xabcdef01};
+
+  EXPECT_ABS_WRITE32(mmio_, base_ + OTBN_IMEM_REG_OFFSET, test_data[0]);
+  EXPECT_ABS_WRITE32(mmio_, base_ + OTBN_IMEM_REG_OFFSET + 4, test_data[1]);
+
+  EXPECT_EQ(otbn_imem_write(0, test_data.data(), 2), kErrorOk);
+}
+
+TEST_F(ImemWriteTest, SuccessWithOffset) {
+  // Test assumption.
+  static_assert(OTBN_IMEM_SIZE_BYTES >= 12, "OTBN IMEM size too small.");
+
+  std::array<uint32_t, 2> test_data = {0x12345678, 0xabcdef01};
+
+  EXPECT_ABS_WRITE32(mmio_, base_ + OTBN_IMEM_REG_OFFSET + 4, test_data[0]);
+  EXPECT_ABS_WRITE32(mmio_, base_ + OTBN_IMEM_REG_OFFSET + 8, test_data[1]);
+
+  EXPECT_EQ(otbn_imem_write(4, test_data.data(), 2), kErrorOk);
+}
+
+class DmemWriteTest : public OtbnTest {};
+
+TEST_F(DmemWriteTest, BadOffset) {
+  std::array<uint32_t, 1> test_data = {0};
+
+  // `offset` must be 32b-aligned.
+  EXPECT_EQ(otbn_dmem_write(1, test_data.data(), 1), kErrorOtbnBadOffset);
+  EXPECT_EQ(otbn_dmem_write(2, test_data.data(), 1), kErrorOtbnBadOffset);
+}
+
+TEST_F(DmemWriteTest, SuccessWithoutOffset) {
+  // Test assumption.
+  static_assert(OTBN_DMEM_SIZE_BYTES >= 8, "OTBN DMEM size too small.");
+
+  std::array<uint32_t, 2> test_data = {0x12345678, 0xabcdef01};
+
+  EXPECT_ABS_WRITE32(mmio_, base_ + OTBN_DMEM_REG_OFFSET, test_data[0]);
+  EXPECT_ABS_WRITE32(mmio_, base_ + OTBN_DMEM_REG_OFFSET + 4, test_data[1]);
+
+  EXPECT_EQ(otbn_dmem_write(0, test_data.data(), 2), kErrorOk);
+}
+
+TEST_F(DmemWriteTest, SuccessWithOffset) {
+  // Test assumption.
+  static_assert(OTBN_DMEM_SIZE_BYTES >= 12, "OTBN DMEM size too small.");
+
+  std::array<uint32_t, 2> test_data = {0x12345678, 0xabcdef01};
+
+  EXPECT_ABS_WRITE32(mmio_, base_ + OTBN_DMEM_REG_OFFSET + 4, test_data[0]);
+  EXPECT_ABS_WRITE32(mmio_, base_ + OTBN_DMEM_REG_OFFSET + 8, test_data[1]);
+
+  EXPECT_EQ(otbn_dmem_write(4, test_data.data(), 2), kErrorOk);
+}
+
+class DmemReadTest : public OtbnTest {};
+
+TEST_F(DmemReadTest, BadOffset) {
+  std::array<uint32_t, 2> test_data = {0};
+
+  // `offset` must be 32b-aligned.
+  EXPECT_EQ(otbn_dmem_read(1, test_data.data(), 2), kErrorOtbnBadOffset);
+  EXPECT_EQ(otbn_dmem_read(2, test_data.data(), 2), kErrorOtbnBadOffset);
+}
+
+TEST_F(DmemReadTest, SuccessWithoutOffset) {
+  // Assumption in the test.
+  ASSERT_GE(OTBN_DMEM_SIZE_BYTES, 8);
+  static_assert(OTBN_DMEM_SIZE_BYTES >= 8, "OTBN DMEM size too small.");
+
+  EXPECT_ABS_READ32(mmio_, base_ + OTBN_DMEM_REG_OFFSET, 0x12345678);
+  EXPECT_ABS_READ32(mmio_, base_ + OTBN_DMEM_REG_OFFSET + 4, 0xabcdef01);
+
+  std::array<uint32_t, 2> test_data = {0};
+
+  EXPECT_EQ(otbn_dmem_read(0, test_data.data(), 2), kErrorOk);
+  EXPECT_THAT(test_data, ElementsAre(0x12345678, 0xabcdef01));
+}
+
+TEST_F(DmemReadTest, SuccessWithOffset) {
+  // Assumption in the test.
+  static_assert(OTBN_DMEM_SIZE_BYTES >= 12, "OTBN DMEM size too small.");
+
+  EXPECT_ABS_READ32(mmio_, base_ + OTBN_DMEM_REG_OFFSET + 4, 0x12345678);
+  EXPECT_ABS_READ32(mmio_, base_ + OTBN_DMEM_REG_OFFSET + 8, 0xabcdef01);
+
+  std::array<uint32_t, 2> test_data = {0};
+
+  EXPECT_EQ(otbn_dmem_read(4, test_data.data(), 2), kErrorOk);
+  EXPECT_THAT(test_data, ElementsAre(0x12345678, 0xabcdef01));
+}
+
+}  // namespace
+}  // namespace otbn_unittest

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -34,6 +34,7 @@ enum module_ {
   kModuleInterrupt = 0x5249,     // ASCII "IR".
   kModuleEpmp = 0x5045,          // ASCII "EP",
   kModuleOtp = 0x504f,           // ASCII "OP".
+  kModuleOtbn = 0x4e42,          // ASCII "BN".
 };
 
 /**
@@ -81,6 +82,9 @@ enum module_ {
   X(kErrorInterrupt,                  ERROR_(0, kModuleInterrupt, kUnknown)), \
   X(kErrorEpmpBadCheck,               ERROR_(1, kModuleEpmp, kInternal)), \
   X(kErrorOtpBadAlignment,            ERROR_(1, kModuleOtp, kInvalidArgument)), \
+  X(kErrorOtbnInvalidArgument,        ERROR_(1, kModuleOtbn, kInvalidArgument)), \
+  X(kErrorOtbnBadOffsetLen,           ERROR_(2, kModuleOtbn, kInvalidArgument)), \
+  X(kErrorOtbnBadOffset,              ERROR_(3, kModuleOtbn, kInvalidArgument)), \
   X(kErrorUnknown, 0xFFFFFFFF)
 // clang-format on
 


### PR DESCRIPTION
Adds an OTBN driver implementation with unittests. This driver is heavily based off of sw/device/lib/dif/dif_otbn*, introduced in commit 1c7cf8f8d24e ("[otbn] Initial DIF") with slimmed down error checking and irq, init, and restart routines pruned.
