### PR TITLE
[entropy_src/rtl] drop entropy bits when final FIFO is full

### DIFF
--- a/hw/ip/entropy_src/doc/_index.md
+++ b/hw/ip/entropy_src/doc/_index.md
@@ -169,7 +169,9 @@ The control bit `ES_TYPE` sets whether the entropy will come from the conditioni
 A status bit will be set that can either be polled or generate an interrupt when the entropy bits are available to be read from the {{< regref "ENTROPY_DATA" >}} register.
 The firmware needs to read the {{< regref "ENTROPY_DATA" >}} register twelve times in order to cleanly evacuate the 384-bit seed from the hardware path (12*32bits=384bits total).
 The firmware will directly read out of the main entropy FIFO, and when the control bit `ES_ROUTE` is set, no entropy is being passed to the block hardware interface.
-If the main entropy FIFO fills up, additional entropy that has been health checked and conditioned will be dropped at that point.
+
+If the `esfinal` FIFO fills up, additional entropy that has been health checked will be dropped before entering the conditioner.
+This drop point will save on conditioner power, and still preserve `esfinal` FIFO entropy that has already been collected.
 
 The above process will be repeated for as long as entropy bits are to be collected and processed.
 

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -1906,7 +1906,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
 
   assign pfifo_cond_push = pfifo_precon_pop && sha3_msgfifo_ready &&
-  !cs_aes_halt_req && !es_bypass_mode;
+  !cs_aes_halt_req && !es_bypass_mode && !sfifo_esfinal_full;
 
   assign pfifo_cond_wdata = pfifo_precon_rdata;
 
@@ -2001,27 +2001,28 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   entropy_src_main_sm
     u_entropy_src_main_sm (
-    .clk_i              (clk_i),
-    .rst_ni             (rst_ni),
-    .enable_i           (es_enable),
-    .ht_done_pulse_i    (health_test_done_pulse),
-    .ht_fail_pulse_i    (any_fail_pulse),
-    .rst_alert_cntr_o   (rst_alert_cntr),
-    .bypass_mode_i      (es_bypass_mode),
-    .rst_bypass_mode_o  (rst_bypass_mode),
-    .main_stage_rdy_i   (pfifo_cond_not_empty),
-    .bypass_stage_rdy_i (pfifo_bypass_not_empty),
-    .sha3_state_vld_i   (sha3_state_vld),
-    .main_stage_pop_o   (main_stage_pop),
-    .bypass_stage_pop_o (bypass_stage_pop),
-    .sha3_start_o       (sha3_start),
-    .sha3_process_o     (sha3_process),
-    .sha3_done_o        (sha3_done),
-    .cs_aes_halt_req_o  (cs_aes_halt_req),
-    .cs_aes_halt_ack_i  (cs_aes_halt_i.cs_aes_halt_ack),
-    .main_sm_idle_o     (es_main_sm_idle),
-    .main_sm_state_o    (es_main_sm_state),
-    .main_sm_err_o      (es_main_sm_err)
+    .clk_i                (clk_i),
+    .rst_ni               (rst_ni),
+    .enable_i             (es_enable),
+    .ht_done_pulse_i      (health_test_done_pulse),
+    .ht_fail_pulse_i      (any_fail_pulse),
+    .sfifo_esfinal_full_i (sfifo_esfinal_full),
+    .rst_alert_cntr_o     (rst_alert_cntr),
+    .bypass_mode_i        (es_bypass_mode),
+    .rst_bypass_mode_o    (rst_bypass_mode),
+    .main_stage_rdy_i     (pfifo_cond_not_empty),
+    .bypass_stage_rdy_i   (pfifo_bypass_not_empty),
+    .sha3_state_vld_i     (sha3_state_vld),
+    .main_stage_pop_o     (main_stage_pop),
+    .bypass_stage_pop_o   (bypass_stage_pop),
+    .sha3_start_o         (sha3_start),
+    .sha3_process_o       (sha3_process),
+    .sha3_done_o          (sha3_done),
+    .cs_aes_halt_req_o    (cs_aes_halt_req),
+    .cs_aes_halt_ack_i    (cs_aes_halt_i.cs_aes_halt_ack),
+    .main_sm_idle_o       (es_main_sm_idle),
+    .main_sm_state_o      (es_main_sm_state),
+    .main_sm_err_o        (es_main_sm_err)
   );
 
   // es to cs halt request to reduce power spikes

--- a/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
@@ -15,6 +15,7 @@ module entropy_src_main_sm #(
   input logic                   enable_i,
   input logic                   ht_done_pulse_i,
   input logic                   ht_fail_pulse_i,
+  input logic                   sfifo_esfinal_full_i,
   output logic                  rst_alert_cntr_o,
   input logic                   bypass_mode_i,
   output logic                  rst_bypass_mode_o,
@@ -137,7 +138,7 @@ module entropy_src_main_sm #(
         end
       end
       NormHTStart: begin
-        if (!enable_i) begin
+        if (!enable_i || sfifo_esfinal_full_i) begin
           state_d = Idle;
         end else begin
           sha3_start_o = 1'b1;


### PR DESCRIPTION
When the esfinal FIFO is full, new entropy bits will be dropped at the 64b packer FIFO.
Additionally, the sha3 block will sit idle in this state.
This fixes #6084.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>