### PR TITLE
Ignore files created by rust's Cargo build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ hw/top_englishbreakfast/ip/alert_handler/dv/alert_handler_env_pkg__params.sv
 hw/top_englishbreakfast/ip/sensor_ctrl/rtl/*
 hw/top_englishbreakfast/ip/xbar_main/xbar_main.core
 hw/top_englishbreakfast/ip/xbar_peri/xbar_peri.core
+
+# Rust Cargo build system files.
+Cargo.lock
+sw/host/**/target


### PR DESCRIPTION
The file `Cargo.lock` and the `target` subdirectory are used by the
Cargo build system and package manager.  As such, they should be
ignored by git.

Signed-off-by: Chris Frantz <cfrantz@google.com>