### PR TITLE
[sw/silicon_creator] Fix type issues on abs_mmio

### DIFF
--- a/sw/device/silicon_creator/lib/base/abs_mmio.c
+++ b/sw/device/silicon_creator/lib/base/abs_mmio.c
@@ -6,7 +6,7 @@
 
 // `extern` declarations to give the inline functions in the corresponding
 // header a link location.
-extern uint32_t abs_mmio_read8(uint32_t addr);
+extern uint8_t abs_mmio_read8(uint32_t addr);
 extern void abs_mmio_write8(uint32_t addr, uint8_t value);
 extern uint32_t abs_mmio_read32(uint32_t addr);
 extern void abs_mmio_write32(uint32_t addr, uint32_t value);

--- a/sw/device/silicon_creator/lib/base/abs_mmio.h
+++ b/sw/device/silicon_creator/lib/base/abs_mmio.h
@@ -44,7 +44,7 @@ extern "C" {
  * @return the read value.
  */
 ABS_MMIO_WARN_UNUSED_RESULT
-inline uint32_t abs_mmio_read8(uint32_t addr) {
+inline uint8_t abs_mmio_read8(uint32_t addr) {
   return *((volatile uint8_t *)addr);
 }
 
@@ -81,7 +81,7 @@ inline void abs_mmio_write32(uint32_t addr, uint32_t value) {
 
 #else  // MOCK_ABS_MMIO
 
-extern uint32_t abs_mmio_read8(uint32_t addr);
+extern uint8_t abs_mmio_read8(uint32_t addr);
 extern void abs_mmio_write8(uint32_t addr, uint8_t value);
 extern uint32_t abs_mmio_read32(uint32_t addr);
 extern void abs_mmio_write32(uint32_t addr, uint32_t value);

--- a/sw/device/silicon_creator/lib/base/meson.build
+++ b/sw/device/silicon_creator/lib/base/meson.build
@@ -17,7 +17,6 @@ sw_silicon_creator_lib_base_mock_abs_mmio = declare_dependency(
   link_with: static_library(
     'mock_abs_mmio',
     sources: [
-      'abs_mmio.c',
       'mock_abs_mmio.h',
     ],
     dependencies: [

--- a/sw/device/silicon_creator/lib/base/mock_abs_mmio.h
+++ b/sw/device/silicon_creator/lib/base/mock_abs_mmio.h
@@ -16,8 +16,8 @@ namespace internal {
  */
 class MockAbsMmio {
  public:
-  MOCK_METHOD(uint32_t, Read8, (uint32_t addr));
-  MOCK_METHOD(void, Write8, (uint32_t addr, uint32_t value));
+  MOCK_METHOD(uint8_t, Read8, (uint32_t addr));
+  MOCK_METHOD(void, Write8, (uint32_t addr, uint8_t value));
   MOCK_METHOD(uint32_t, Read32, (uint32_t addr));
   MOCK_METHOD(void, Write32, (uint32_t addr, uint32_t value));
 
@@ -87,11 +87,11 @@ using MockAbsMmio = GlobalMock<testing::StrictMock<internal::MockAbsMmio>>;
 
 extern "C" {
 
-uint32_t abs_mmio_read8(uint32_t addr) {
+uint8_t abs_mmio_read8(uint32_t addr) {
   return MockAbsMmio::Instance().Read8(addr);
 }
 
-void abs_mmio_write8(uint32_t addr, uint32_t value) {
+void abs_mmio_write8(uint32_t addr, uint8_t value) {
   return MockAbsMmio::Instance().Write8(addr, value);
 }
 

--- a/sw/device/silicon_creator/lib/meson.build
+++ b/sw/device/silicon_creator/lib/meson.build
@@ -1,6 +1,7 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+subdir('base')
 subdir('drivers')
 
 # Mask ROM fake dependencies.  These are temporary dependencies until we
@@ -28,4 +29,3 @@ test('sw_silicon_creator_lib_error_unittest', executable(
   ),
   suite: 'mask_rom',
 )
-


### PR DESCRIPTION
Fix type issues on `abs_mmio_read8()` and `abs_mmio_write8()` functions.
