### PR TITLE
[otbn] Fix error when using the last x1 value as a base address

### DIFF
--- a/hw/ip/otbn/rtl/otbn_rf_base.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_base.sv
@@ -80,7 +80,7 @@ module otbn_rf_base
   assign push_stack      = wr_commit_i & push_stack_reqd;
 
   assign call_stack_err_o =
-      (push_stack_reqd & stack_full & ~pop_stack_reqd) | (pop_stack_reqd & ~stack_data_valid);
+      (push_stack_reqd & stack_full & ~pop_stack_reqd) | (pop_stack & ~stack_data_valid);
 
   // Prevent any write to the stack register from going to the register file,
   // all other committed writes are passed straight through


### PR DESCRIPTION
The `pop_i` input to `otbn_stack` was correctly using `pop_stack`, which
checks that the current instruction (which requests a stack pop) is
being committed. This avoids a double stack pop from code like

    lw  x2, 100(x1)

However, we didn't do the same conditioning on `call_stack_err_o`. This
means that if an instruction like the above happened to read the last
element of the stack then we'd see `call_stack_err_o` go high on the
second cycle (when `rd_commit_i` is false, but the stack is now empty).

To reproduce (without the fix), run:

    util/dvsim/dvsim.py \
        hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson \
        --fixed-seed 4100705798 -i otbn_single