### PR TITLE
[dv/otp_ctrl] Add more coverage exclusion

### DIFF
--- a/hw/ip/otp_ctrl/dv/cov/otp_ctrl_cov_excl.el
+++ b/hw/ip/otp_ctrl/dv/cov/otp_ctrl_cov_excl.el
@@ -88,6 +88,68 @@ INSTANCE: tb.dut.u_otp_ctrl_dai
 Fsm error_q "2961818352"
 ANNOTATION: "[UNR]: this error state is a terminal state"
 Transition FsmStateError->AccessError "7->5"
+CHECKSUM: "2423918326 938275392"
+INSTANCE: tb.dut.gen_partitions[2].gen_buffered.u_part_buf
+ANNOTATION: "[UNR]: HwCfg partition does not not have InitDescrSt."
+Condition 1 "1999344180" "(scrmbl_mtx_gnt_i && scrmbl_ready_i) 1 -1"
+CHECKSUM: "2423918326 2948134846"
+INSTANCE: tb.dut.gen_partitions[6].gen_lifecycle.u_part_buf
+ANNOTATION: "[UNR]: LC partition cannot be locked."
+Condition 15 "2704968129" "((dout_gate_q != Unlocked) || (access_i.read_lock != Unlocked)) 1 -1" (3 "10")
+ANNOTATION: "[UNR]: LC partition cannot be locked."
+Condition 15 "2704968129" "((dout_gate_q != Unlocked) || (access_i.read_lock != Unlocked)) 1 -1" (1 "00")
+ANNOTATION: "[UNR]: LC partition cannot be locked."
+Condition 14 "1525320899" "(((dout_gate_q != Unlocked) || (access_i.read_lock != Unlocked)) ? Locked : Unlocked) 1 -1" (1 "0")
+ANNOTATION: "[UNR]: LC partition cannot be locked."
+Condition 13 "521310057" "((dout_gate_q != Unlocked) || (access_i.write_lock != Unlocked)) 1 -1" (3 "10")
+ANNOTATION: "[UNR]: LC partition cannot be locked."
+Condition 13 "521310057" "((dout_gate_q != Unlocked) || (access_i.write_lock != Unlocked)) 1 -1" (1 "00")
+ANNOTATION: "[UNR]: LC partition does not have digest."
+Condition 10 "705391888" "((data_sel == ScrmblData) ? scrmbl_data_i : otp_rdata_i) 1 -1" (2 "1")
+ANNOTATION: "[UNR]: LC partition does not have digest."
+Condition 9 "184804254" "((base_sel == DigOffset) ? DigestOffset : 11'b11111001000) 1 -1" (2 "1")
+ANNOTATION: "[UNR]: LC partition does not have digest."
+Condition 12 "3749993138" "(((dout_gate_q != Unlocked) || (access_i.write_lock != Unlocked)) ? Locked : Unlocked) 1 -1" (1 "0")
+CHECKSUM: "2423918326 2728757326"
+INSTANCE: tb.dut.gen_partitions[6].gen_lifecycle.u_part_buf
+ANNOTATION: "[UNR] LC partition does not have integrity check."
+Branch 6 "3245307921" "state_q" (32) "state_q IntegDigClrSt ,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,1,1,1,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-"
+ANNOTATION: "[UNR] LC partition does not have integrity check."
+Branch 6 "3245307921" "state_q" (40) "state_q IntegScrWaitSt ,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,1,-,-,-,-,-,-,-,-,-,-,-"
+ANNOTATION: "[UNR] LC partition does not have integrity check."
+Branch 6 "3245307921" "state_q" (34) "state_q IntegDigClrSt ,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,1,0,-,1,-,-,-,-,-,-,-,-,-,-,-,-,-,-"
+ANNOTATION: "[UNR] LC partition does not have integrity check."
+Branch 6 "3245307921" "state_q" (42) "state_q IntegDigSt ,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,1,1,1,-,-,-,-,-,-,-,-"
+ANNOTATION: "[UNR] LC partition does not have integrity check."
+Branch 6 "3245307921" "state_q" (55) "state_q IntegDigWaitSt ,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,1,0,-,-"
+ANNOTATION: "[UNR] LC partition does not have integrity check."
+Branch 6 "3245307921" "state_q" (54) "state_q IntegDigWaitSt ,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,1,1,0,-"
+ANNOTATION: "[UNR] LC partition does not have integrity check."
+Branch 6 "3245307921" "state_q" (53) "state_q IntegDigWaitSt ,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,1,1,1,-"
+ANNOTATION: "[UNR] LC partition does not have integrity check."
+Branch 6 "3245307921" "state_q" (51) "state_q IntegDigFinSt ,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,1,-,-,-,-"
+ANNOTATION: "[UNR] LC partition does not have integrity check."
+Branch 6 "3245307921" "state_q" (49) "state_q IntegDigPadSt ,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,1,-,-,-,-,-"
+ANNOTATION: "[UNR] LC partition does not have integrity check."
+Branch 6 "3245307921" "state_q" (46) "state_q IntegDigSt ,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,1,0,-,-,1,-,-,-,-,-,-"
+ANNOTATION: "[UNR] LC partition does not have integrity check."
+Branch 6 "3245307921" "state_q" (44) "state_q IntegDigSt ,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,1,0,-,1,-,-,-,-,-,-,-"
+ANNOTATION: "[UNR] LC partition does not have integrity check."
+Branch 6 "3245307921" "state_q" (43) "state_q IntegDigSt ,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,1,1,0,-,-,-,-,-,-,-,-"
+ANNOTATION: "[UNR] LC partition does not have integrity check."
+Branch 6 "3245307921" "state_q" (33) "state_q IntegDigClrSt ,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,1,1,0,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-"
+ANNOTATION: "[UNR] LC partition does not have integrity check."
+Branch 6 "3245307921" "state_q" (47) "state_q IntegDigSt ,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,1,0,-,-,0,-,-,-,-,-,-"
+ANNOTATION: "[UNR] LC partition does not have integrity check."
+Branch 6 "3245307921" "state_q" (45) "state_q IntegDigSt ,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,1,0,-,0,-,-,-,-,-,-,-"
+ANNOTATION: "[UNR] LC partition does not have integrity check."
+Branch 6 "3245307921" "state_q" (35) "state_q IntegDigClrSt ,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,1,0,-,0,-,-,-,-,-,-,-,-,-,-,-,-,-,-"
 CHECKSUM: "3767637819"
 ANNOTATION: "[EXTERNAL] alert_sender is fully verified by FPV testbench."
 MODULE:prim_diff_decode
+CHECKSUM: "1713188235"
+ANNOTATION: "[TODO]: include this once support tlul ECC error cases."
+MODULE:tlul_err_resp
+CHECKSUM: "2966200294"
+ANNOTATION: "[EXTERNAL]: this module is verified in a separate testbench"
+MODULE:prim_lfsr

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -70,7 +70,7 @@
     {
       name: otp_ctrl_init_fail
       uvm_test_seq: otp_ctrl_init_fail_vseq
-      reseed: 100
+      reseed: 300
     }
     {
       name: otp_ctrl_background_chks


### PR DESCRIPTION
This PR adds a few more exclusion to reach V2 status coverage
requirement:
1. Exclude external modules: prim_lfs (already fully verified by a
separate TB)
2. tlul_err_resp: currently have not been supported in DV. We will add a
common test to verify that.
3. Condtition coverage:
  1). HwCfg partition does not have init descramble.
  2). LC partition: cannot be locked and do not have digest.
4. Branch coverage:
  1). LC partition does not have integrity teck.

Signed-off-by: Cindy Chen <chencindy@google.com>