### PR TITLE
[dv/otp_ctrl] increase init fail seeds

### DIFF
--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -70,7 +70,7 @@
     {
       name: otp_ctrl_init_fail
       uvm_test_seq: otp_ctrl_init_fail_vseq
-      reseed: 100
+      reseed: 300
     }
     {
       name: otp_ctrl_background_chks


### PR DESCRIPTION
This PR increases the otp_init test nightly regression seeds to hit more
corner cases in FSM coverage.

Signed-off-by: Cindy Chen <chencindy@google.com>