### PR TITLE
[dv/sram] fix initialization checks

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
@@ -37,15 +37,13 @@ class sram_ctrl_base_vseq extends cip_base_vseq #(
   // setup basic sram_ctrl features
   virtual task sram_ctrl_init();
     cfg.mem_bkdr_vif.init();
-    req_scr_key();
     req_mem_init();
   endtask
 
   // Request a memory init.
   //
   virtual task req_mem_init();
-    ral.ctrl.init.set(1'b1);
-    csr_update(.csr(ral.ctrl));
+    csr_wr(.ptr(ral.ctrl), .value(3));
     csr_spinwait(.ptr(ral.ctrl.init), .exp_data(0));
   endtask
 


### PR DESCRIPTION
currently to trigger memory initialization the base sequence calls
`csr_wr` to fetch a new key, then calls `csr_update` to write the next
control bit, however due to the behavior of `csr_update`, a new key
request is also triggered at the same time.

This sometimes messes up the scoreboard timing model, but is also
entirely unnecessary, so this PR removes it and replaces with a single
call to `csr_wr` to write both bits at once to simplify things.

Signed-off-by: Udi Jonnalagadda <udij@google.com>