### PR TITLE
[dv/otp_ctrl] Add a direct sequence to check otp_macro error

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -168,7 +168,7 @@
             - If error is unrecoverable, ensure that OTP entered terminal state
             '''
       milestone: V2
-      tests: ["otp_ctrl_macro_errs"]
+      tests: ["otp_ctrl_macro_errs", "otp_ctrl_macro_invalid_cmd"]
     }
     {
       name: otp_ctrl_errors

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -28,6 +28,7 @@ filesets:
       - seq_lib/otp_ctrl_init_fail_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_dai_lock_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_dai_errs_vseq.sv: {is_include_file: true}
+      - seq_lib/otp_ctrl_macro_invalid_cmd_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_macro_errs_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_background_chks_vseq.sv: {is_include_file: true}
       - seq_lib/otp_ctrl_check_fail_vseq.sv: {is_include_file: true}

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -162,9 +162,10 @@ package otp_ctrl_env_pkg;
   typedef virtual mem_bkdr_if #(.MEM_ECC(prim_secded_pkg::SecdedHamming_22_16)) mem_bkdr_vif;
   typedef virtual otp_ctrl_if otp_ctrl_vif;
 
-  parameter otp_err_code_e OTP_TERMINAL_ERRS[3] = {OtpMacroEccUncorrError,
+  parameter otp_err_code_e OTP_TERMINAL_ERRS[4] = {OtpMacroEccUncorrError,
                                                    OtpCheckFailError,
-                                                   OtpFsmStateError};
+                                                   OtpFsmStateError,
+                                                   OtpMacroError};
 
   // functions
   function automatic int get_part_index(bit [TL_DW-1:0] addr);

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_invalid_cmd_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_invalid_cmd_vseq.sv
@@ -1,0 +1,109 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test triggers otp_macro error by forcing an invalid cmd_i into prim_generic_otp.
+class otp_ctrl_macro_invalid_cmd_vseq extends otp_ctrl_smoke_vseq;
+  `uvm_object_utils(otp_ctrl_macro_invalid_cmd_vseq)
+
+  `uvm_object_new
+
+  rand otp_ctrl_part_pkg::part_idx_e exp_macro_err;
+
+  bit [NumPart+2:0] act_macro_err;
+  bit               exp_buffer_err;
+
+  constraint macro_err_c {exp_macro_err inside {[CreatorSwCfgIdx:LciIdx]};}
+
+  virtual task pre_start();
+    super.pre_start();
+    exp_macro_err.rand_mode(0);
+  endtask
+
+ task body();
+    otp_err_code_e    err_code;
+    dv_base_reg_field err_code_flds[$];
+    ral.err_code.get_dv_base_reg_fields(err_code_flds);
+    is_valid_dai_op = 0;
+    exp_buffer_err  = exp_macro_err inside {[HwCfgIdx : LifeCycleIdx]};
+
+    for (uint i = 0; i <= num_dai_op; i++) begin
+      bit [TL_DW-1:0] tlul_val;
+
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      `uvm_info(`gfn, $sformatf("starting dai access seq %0d/%0d with addr %0h in partition %0d",
+                i, num_dai_op, dai_addr, part_idx), UVM_MEDIUM)
+
+        if (act_macro_err == 0 && ($urandom_range(0, 1) || i == num_dai_op)) begin
+          `uvm_info(`gfn, $sformatf("Force otp macro error with part %0d", exp_macro_err), UVM_LOW)
+          force_macro_error();
+          case (exp_macro_err)
+            CreatorSwCfgIdx, OwnerSwCfgIdx: begin
+              bit [TL_DW-1:0] sw_dai_addr;
+              uvm_reg_addr_t tlul_addr;
+              sw_dai_addr = (exp_macro_err == CreatorSwCfgIdx) ?
+                            $urandom_range(CreatorSwCfgOffset, CreatorSwCfgDigestOffset) :
+                            $urandom_range(OwnerSwCfgOffset, OwnerSwCfgDigestOffset);
+              tlul_addr = cfg.ral.get_addr_from_offset(get_sw_window_offset(sw_dai_addr));
+              tl_access(.addr(tlul_addr), .write(0), .data(tlul_val), .blocking(1), .check_rsp(0));
+            end
+            HwCfgIdx, Secret0Idx, Secret1Idx, Secret2Idx, LifeCycleIdx: begin
+              trigger_checks('1);
+            end
+            LciIdx: begin
+              req_lc_transition(.check_intr(0), .blocking(0));
+              // Max delay for push-pull agent to send a request
+              cfg.clk_rst_vif.wait_clks(1000);
+            end
+            DaiIdx: dai_rd(dai_addr, 0, wdata0, wdata1);
+            default: `uvm_fatal(`gfn, $sformatf("exp_macro_err %0h not supported", exp_macro_err))
+          endcase
+          act_macro_err[exp_macro_err] = 1;
+          check_and_release_macro_error();
+        end
+
+      dai_wr(dai_addr, wdata0, wdata1);
+      used_dai_addr_q.push_back(dai_addr);
+
+      // OTP read via DAI, check data in scb
+      dai_rd(dai_addr, 0, wdata0, wdata1);
+
+      // If write sw partitions, check tlul window
+      if (is_sw_part(dai_addr)) begin
+        uvm_reg_addr_t tlul_addr = cfg.ral.get_addr_from_offset(get_sw_window_offset(dai_addr));
+        tl_access(.addr(tlul_addr), .write(0), .data(tlul_val), .blocking(1), .check_rsp(0));
+      end
+
+      csr_rd(ral.status, tlul_val);
+    end
+
+    foreach (act_macro_err[i]) begin
+      if (act_macro_err[i]) csr_rd_check(.ptr(err_code_flds[i]), .compare_value(OtpMacroError));
+    end
+
+    // Issue reset to stop fatal alert
+    apply_reset();
+    // delay to avoid race condition when sending item and checking no item after reset occur
+    // at the same time
+    #1ps;
+  endtask
+
+  virtual task force_macro_error();
+    if (exp_buffer_err) cfg.otp_ctrl_vif.force_invalid_part_cmd_o(exp_macro_err);
+    else                cfg.otp_ctrl_vif.force_invalid_otp_cmd_i();
+    cfg.en_scb = 0;
+    cfg.en_scb_tl_err_chk = 0;
+  endtask
+
+  virtual task check_and_release_macro_error();
+    string alert_name = "fatal_macro_error";
+    `DV_SPINWAIT_EXIT(wait(cfg.m_alert_agent_cfg[alert_name].vif.alert_tx_final.alert_p);,
+        cfg.clk_rst_vif.wait_clks(20);,
+        $sformatf("Timeout waiting for alert %0s", alert_name))
+    check_fatal_alert_nonblocking(alert_name);
+
+    if (exp_buffer_err) cfg.otp_ctrl_vif.release_invalid_part_cmd_o(exp_macro_err);
+    else                cfg.otp_ctrl_vif.release_invalid_otp_cmd_i();
+  endtask
+
+endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_vseq_list.sv
@@ -8,6 +8,7 @@
 `include "otp_ctrl_common_vseq.sv"
 `include "otp_ctrl_partition_walk_vseq.sv"
 `include "otp_ctrl_init_fail_vseq.sv"
+`include "otp_ctrl_macro_invalid_cmd_vseq.sv"
 `include "otp_ctrl_dai_lock_vseq.sv"
 `include "otp_ctrl_dai_errs_vseq.sv"
 `include "otp_ctrl_macro_errs_vseq.sv"

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -110,6 +110,12 @@
     }
 
     {
+      name: otp_ctrl_macro_invalid_cmd
+      uvm_test_seq: otp_ctrl_macro_invalid_cmd_vseq
+      reseed: 20
+    }
+
+    {
       name: otp_ctrl_parallel_key_req
       uvm_test_seq: otp_ctrl_parallel_key_req_vseq
     }

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -169,6 +169,12 @@ module tb;
     $assertoff(0, tb.dut.u_prim_lc_sync_check_byp_en.CheckTransients0_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_check_byp_en.CheckTransients1_A);
 
+    // DV forced otp_cmd_i to reach invalid state, thus violate the assertions
+    $assertoff(0, tb.dut.gen_partitions[2].gen_buffered.u_part_buf.OtpErrorState_A);
+    $assertoff(0, tb.dut.gen_partitions[3].gen_buffered.u_part_buf.OtpErrorState_A);
+    $assertoff(0, tb.dut.gen_partitions[4].gen_buffered.u_part_buf.OtpErrorState_A);
+    $assertoff(0, tb.dut.gen_partitions[5].gen_buffered.u_part_buf.OtpErrorState_A);
+
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);


### PR DESCRIPTION
This PR adds a direct sequence to check otp_macro error.
Two reasons to add this direct sequence:

1. Current one fatal error will cause the OTP_ctrl to escalation stage,
then this macro error can easily be ingored by other macro errors such
as: ECC uncorrectable error, fatal check error, etc.

2. This sequence will give all partitions a chance to trigger Macro
error by directly probing the macro cmd_i. And when we do closed-source
verification, this path should be easier to identify and overide with
the real OTP macro path.

Signed-off-by: Cindy Chen <chencindy@google.com>