### PR TITLE
[dv/otp_ctrl] reduce reset in smoke test

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
@@ -17,6 +17,11 @@ class otp_ctrl_dai_lock_vseq extends otp_ctrl_smoke_vseq;
     collect_used_addr -> num_trans * num_dai_op <= DAI_ADDR_SIZE;
   }
 
+  constraint num_trans_c {
+    num_trans  inside {[1:10]};
+    num_dai_op inside {[1:50]};
+  }
+
   constraint dai_wr_legal_addr_c {
     {dai_addr[TL_AW-1:2], 2'b0} dist {
       {CreatorSwCfgDigestOffset, OwnerSwCfgDigestOffset,HwCfgDigestOffset, Secret0DigestOffset,

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -47,7 +47,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
   }
 
   constraint num_trans_c {
-    num_trans  inside {[1:20]};
+    num_trans  inside {[1:2]};
     num_dai_op inside {[1:50]};
   }
 
@@ -152,9 +152,6 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
         // if write sw partitions, check tlul window
         if (is_sw_part(dai_addr) && ($urandom_range(0, 1))) begin
           uvm_reg_addr_t tlul_addr = cfg.ral.get_addr_from_offset(get_sw_window_offset(dai_addr));
-
-          // random issue reset, OTP content should not be cleared
-          if ($urandom_range(0, 9) == 9) dut_init();
           // tlul error rsp is checked in scoreboard
           tl_access(.addr(tlul_addr), .write(0), .data(tlul_val), .blocking(1), .check_rsp(0));
         end


### PR DESCRIPTION
This PR tries to reduce the number of reset otp_ctrl's smoke test.
The reset is taking a very long time in closed source simulation.

Signed-off-by: Cindy Chen <chencindy@google.com>