### PR TITLE
Revert "[aon_timer] Change escalate_en control to cpu_en"

### DIFF
--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -53,7 +53,7 @@
     // Broadcast from LC
     { struct:  "lc_tx"
       type:    "uni"
-      name:    "lc_cpu_en"
+      name:    "lc_escalate_en"
       act:     "rcv"
       default: "lc_ctrl_pkg::Off"
       package: "lc_ctrl_pkg"

--- a/hw/ip/aon_timer/doc/dv/domains.svg
+++ b/hw/ip/aon_timer/doc/dv/domains.svg
@@ -529,7 +529,7 @@
          id="tspan2769"
          x="-25.656269"
          y="118.78903"
-         style="text-align:end;text-anchor:end;stroke:none;stroke-width:0.264583px">lc_cpu_en_i</tspan></text>
+         style="text-align:end;text-anchor:end;stroke:none;stroke-width:0.264583px">lc_escalate_en_i</tspan></text>
     <path
        style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2805);stop-color:#000000;stop-opacity:1"
        d="M 53.716683,127.00002 H -20.366651"

--- a/hw/ip/aon_timer/dv/env/aon_timer_core_if.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_core_if.sv
@@ -9,7 +9,7 @@ interface aon_timer_core_if (
   input logic                      clk_aon_i,
   input logic                      rst_aon_ni,
 
-  input lc_ctrl_pkg::lc_tx_t [2:0] lc_cpu_en_i,
+  input lc_ctrl_pkg::lc_tx_t [2:0] lc_escalate_en_i,
   input logic                      sleep_mode_i,
 
   // Register read outputs

--- a/hw/ip/aon_timer/dv/env/aon_timer_env.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env.sv
@@ -21,8 +21,8 @@ class aon_timer_env extends cip_base_env #(
       `uvm_fatal(`gfn, "failed to get aon_clk_rst_vif from uvm_config_db")
     end
     if (!uvm_config_db#(virtual pins_if #(1))::
-        get(this, "", "cpu_en_vif", cfg.cpu_en_vif)) begin
-      `uvm_fatal(`gfn, "failed to get cpu_en_vif from uvm_config_db")
+        get(this, "", "lc_escalate_en_vif", cfg.lc_escalate_en_vif)) begin
+      `uvm_fatal(`gfn, "failed to get lc_escalate_en_vif from uvm_config_db")
     end
     if (!uvm_config_db#(virtual pins_if #(2))::
         get(this, "", "aon_intr_vif", cfg.aon_intr_vif)) begin

--- a/hw/ip/aon_timer/dv/env/aon_timer_env_cfg.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env_cfg.sv
@@ -5,7 +5,7 @@
 class aon_timer_env_cfg extends cip_base_env_cfg #(.RAL_T(aon_timer_reg_block));
 
   virtual clk_rst_if        aon_clk_rst_vif;
-  virtual pins_if #(1)      cpu_en_vif;
+  virtual pins_if #(1)      lc_escalate_en_vif;
   virtual pins_if #(2)      aon_intr_vif;
   virtual pins_if #(1)      sleep_vif;
   virtual aon_timer_core_if core_vif;

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
@@ -18,8 +18,8 @@ class aon_timer_base_vseq extends cip_base_vseq #(
   // that it starts first.
   rand bit reset_aon_first;
 
-  // Should the CPU be considered enabled at the start of time?
-  rand bit initial_cpu_enable;
+  // Should the escalation signal be enabled at the start of time?
+  rand bit initial_lc_escalate_en;
 
   // Is the chip in sleep at the start of time? In the real chip, the answer is (obviously) no, but
   // the design should work either way so we may as well test it.
@@ -43,7 +43,7 @@ class aon_timer_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task apply_reset(string kind = "HARD");
-    cfg.cpu_en_vif.drive(initial_cpu_enable);
+    cfg.lc_escalate_en_vif.drive(initial_lc_escalate_en);
     cfg.sleep_vif.drive(initial_sleep_mode);
 
     // Bring up the clocks in either order. We can't just race them by running them in parallel,

--- a/hw/ip/aon_timer/rtl/aon_timer.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer.sv
@@ -16,7 +16,7 @@ module aon_timer (
   output tlul_pkg::tl_d2h_t   tl_o,
 
   // clk_i domain
-  input  lc_ctrl_pkg::lc_tx_t lc_cpu_en_i,
+  input  lc_ctrl_pkg::lc_tx_t lc_escalate_en_i,
   output logic                intr_wkup_timer_expired_o,
   output logic                intr_wdog_timer_bark_o,
 
@@ -63,7 +63,7 @@ module aon_timer (
   logic                      wdog_count_reg_wr;
   logic [31:0]               wdog_count_wr_data;
   // Other sync signals
-  lc_ctrl_pkg::lc_tx_t [2:0] lc_cpu_en;
+  lc_ctrl_pkg::lc_tx_t [2:0] lc_escalate_en;
   // Wakeup signals
   logic                      aon_wkup_req_d, aon_wkup_req_q;
   logic                      wkup_ack, aon_wkup_ack;
@@ -254,11 +254,11 @@ module aon_timer (
   // Lifecycle sync
   prim_lc_sync #(
     .NumCopies(3)
-  ) u_lc_sync_cpu_en (
+  ) u_lc_sync_escalate_en (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
-    .lc_en_i (lc_cpu_en_i),
-    .lc_en_o (lc_cpu_en)
+    .lc_en_i (lc_escalate_en_i),
+    .lc_en_o (lc_escalate_en)
   );
 
   ////////////////
@@ -279,7 +279,7 @@ module aon_timer (
     .clk_aon_i,
     .rst_aon_ni,
     .sleep_mode_i              (sleep_mode),
-    .lc_cpu_en_i               (lc_cpu_en),
+    .lc_escalate_en_i          (lc_escalate_en),
     .wkup_enable_o             (wkup_enable),
     .wkup_prescaler_o          (wkup_prescaler),
     .wkup_thold_o              (wkup_thold),

--- a/hw/ip/aon_timer/rtl/aon_timer_core.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_core.sv
@@ -7,7 +7,7 @@ module aon_timer_core (
   input  logic                      clk_aon_i,
   input  logic                      rst_aon_ni,
 
-  input  lc_ctrl_pkg::lc_tx_t [2:0] lc_cpu_en_i,
+  input  lc_ctrl_pkg::lc_tx_t [2:0] lc_escalate_en_i,
   input  logic                      sleep_mode_i,
 
   // Register read outputs
@@ -94,7 +94,7 @@ module aon_timer_core (
 
   // Prescaler counter
   assign prescale_count_d = wkup_incr ? 12'h000 : (prescale_count_q + 12'h001);
-  assign prescale_en      = wkup_enable_q & (lc_cpu_en_i[0] == lc_ctrl_pkg::On);
+  assign prescale_en      = wkup_enable_q & (lc_escalate_en_i[0] == lc_ctrl_pkg::Off);
 
   always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
     if (!rst_aon_ni) begin
@@ -105,7 +105,7 @@ module aon_timer_core (
   end
 
   // Wakeup timer count
-  assign wkup_incr     = (lc_cpu_en_i[1] == lc_ctrl_pkg::On) & wkup_enable_q &
+  assign wkup_incr     = (lc_escalate_en_i[1] == lc_ctrl_pkg::Off) & wkup_enable_q &
                          (prescale_count_q == wkup_prescaler_q);
   assign wkup_count_d  = wkup_count_reg_wr_i ? wkup_count_wr_data_i :
                                                (wkup_count_q + 32'd1);
@@ -172,7 +172,7 @@ module aon_timer_core (
   assign wdog_bite_thold_o = wdog_bite_thold_q;
 
   // Watchdog timer count
-  assign wdog_incr     = wdog_enable_q & (lc_cpu_en_i[2] == lc_ctrl_pkg::On) &
+  assign wdog_incr     = wdog_enable_q & (lc_escalate_en_i[2] == lc_ctrl_pkg::Off) &
                          ~(sleep_mode_i & wdog_pause_q);
   assign wdog_count_d  = wdog_count_reg_wr_i ? wdog_count_wr_data_i :
                                                (wdog_count_q + 32'd1);

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3147,7 +3147,7 @@
           index: 1
         }
         {
-          name: lc_cpu_en
+          name: lc_escalate_en
           struct: lc_tx
           package: lc_ctrl_pkg
           type: uni
@@ -3155,7 +3155,6 @@
           width: 1
           default: lc_ctrl_pkg::Off
           inst_name: aon_timer_aon
-          top_signame: lc_ctrl_lc_cpu_en
           index: -1
         }
         {
@@ -6008,7 +6007,6 @@
       lc_ctrl.lc_cpu_en:
       [
         rv_core_ibex.lc_cpu_en
-        aon_timer_aon.lc_cpu_en
       ]
       lc_ctrl.lc_keymgr_en:
       [
@@ -13463,7 +13461,7 @@
         index: 1
       }
       {
-        name: lc_cpu_en
+        name: lc_escalate_en
         struct: lc_tx
         package: lc_ctrl_pkg
         type: uni
@@ -13471,7 +13469,6 @@
         width: 1
         default: lc_ctrl_pkg::Off
         inst_name: aon_timer_aon
-        top_signame: lc_ctrl_lc_cpu_en
         index: -1
       }
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -938,7 +938,7 @@
       'lc_ctrl.lc_hw_debug_en'     : ['sram_ctrl_main.lc_hw_debug_en',
                                       'sram_ctrl_ret_aon.lc_hw_debug_en',
                                       'pinmux_aon.lc_hw_debug_en'],
-      'lc_ctrl.lc_cpu_en'          : ['rv_core_ibex.lc_cpu_en', 'aon_timer_aon.lc_cpu_en'],
+      'lc_ctrl.lc_cpu_en'          : ['rv_core_ibex.lc_cpu_en'],
       'lc_ctrl.lc_keymgr_en'       : ['keymgr.lc_keymgr_en'],
       'lc_ctrl.lc_escalate_en'     : ['aes.lc_escalate_en',
                                       'otp_ctrl.lc_escalate_en',

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1852,7 +1852,7 @@ module top_earlgrey #(
       // Inter-module signals
       .aon_timer_wkup_req_o(pwrmgr_aon_wakeups[4]),
       .aon_timer_rst_req_o(pwrmgr_aon_rstreqs[1]),
-      .lc_cpu_en_i(lc_ctrl_lc_cpu_en),
+      .lc_escalate_en_i(lc_ctrl_pkg::Off),
       .sleep_mode_i(pwrmgr_aon_low_power),
       .tl_i(aon_timer_aon_tl_req),
       .tl_o(aon_timer_aon_tl_rsp),


### PR DESCRIPTION
This reverts commit 0481a821c01424bb2271964104ce8849c258474b.

See #6505 for context.