### PR TITLE
[dv/mem_bkdr] Support memory backdoor write with ECC error injection

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_check_fail_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_check_fail_vseq.sv
@@ -14,15 +14,15 @@ class otp_ctrl_check_fail_vseq extends otp_ctrl_dai_errs_vseq;
   constraint ecc_chk_err_c {
     // TODO: currently only max to 1 error bits, once implemetned ECC in mem_bkdr_if, we can
     // fully randomize num of error bits
-    $countones(ecc_chk_err_mask) dist {0 :/ 1,
-                                       1 :/ 1};
+    ecc_chk_err dist {OtpNoEccErr   :/ 1,
+                      OtpEccCorrErr :/ 1};
   }
 
   // 50% chance of having a check timeout
   constraint check_timeout_val_c {
-    $countones(ecc_chk_err_mask) == 0 -> check_timeout_val dist {[1 : CHK_TIMEOUT_CYC] :/ 1,
-                                                                 [100_000 :'1]         :/ 1};
-    $countones(ecc_chk_err_mask) == 1 -> check_timeout_val inside {[100_000 :'1]};
+    ecc_chk_err == OtpNoEccErr   -> check_timeout_val dist {[1 : CHK_TIMEOUT_CYC] :/ 1,
+                                                            [100_000 :'1]         :/ 1};
+    ecc_chk_err == OtpEccCorrErr -> check_timeout_val inside {[100_000 :'1]};
   }
 
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
@@ -33,10 +33,10 @@ class otp_ctrl_init_fail_vseq extends otp_ctrl_smoke_vseq;
   // We set 25% possibility that OTP init check fails due to writing OTP after digest is locked.
   constraint lock_digest_c {num_to_lock_digests < num_dai_op * 4;}
   constraint num_iterations_c {num_dai_op inside {[20:100]};}
-  constraint ecc_err_c {
-    $countones(ecc_err_mask) dist {0 :/ 1,  // No ECC error
-                                   1 :/ 1,  // ECC correctable error
-                                   2 :/ 1}; // ECC uncorrectable error
+  constraint ecc_otp_err_c {
+    $countones(ecc_otp_err) dist {OtpNoEccErr     :/ 2,
+                                  OtpEccCorrErr   :/ 2,
+                                  OtpEccUncorrErr :/ 1};
   }
 
   virtual task pre_start();
@@ -94,7 +94,6 @@ class otp_ctrl_init_fail_vseq extends otp_ctrl_smoke_vseq;
 
     // If not check error, force ECC correctable and uncorrectable error
     end else begin
-      otp_ecc_err_e   ecc_err;
       bit             is_fatal, is_correctable;
       bit [TL_DW-1:0] addr;
 
@@ -109,10 +108,10 @@ class otp_ctrl_init_fail_vseq extends otp_ctrl_smoke_vseq;
           addr = $urandom_range(PartInfo[i].offset, PartInfo[i].offset + PartInfo[i].size - 1);
         end
 
-        void'(backdoor_inject_ecc_err(addr, ecc_err_mask, ecc_err));
-        if (ecc_err == OtpEccUncorrErr && !is_fatal) is_fatal = 1;
-        if (ecc_err == OtpEccCorrErr && !is_correctable) is_correctable = 1;
-        if (ecc_err != OtpNoEccErr) exp_status[i] = 1;
+        void'(backdoor_inject_ecc_err(addr, ecc_otp_err));
+        if (ecc_otp_err == OtpEccUncorrErr && !is_fatal) is_fatal = 1;
+        if (ecc_otp_err == OtpEccCorrErr && !is_correctable) is_correctable = 1;
+        if (ecc_otp_err != OtpNoEccErr) exp_status[i] = 1;
       end
 
       if (is_fatal) begin

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_errs_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_errs_vseq.sv
@@ -10,12 +10,8 @@ class otp_ctrl_macro_errs_vseq extends otp_ctrl_dai_errs_vseq;
 
   `uvm_object_new
 
-  constraint ecc_err_c {
-    // TODO: currently only max to 2 error bits, once implemetned ECC in mem_bkdr_if, we can
-    // fully randomize num of error bits
-    $countones(ecc_err_mask) dist  {0 :/ 2,
-                                    1 :/ 1,
-                                    2 :/ 1};
+  constraint ecc_otp_err_c {
+    ecc_otp_err inside {OtpEccCorrErr, OtpEccUncorrErr};
   }
 
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -22,7 +22,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
   rand bit                           check_regwen_val, check_trigger_regwen_val;
   rand bit [TL_DW-1:0]               check_timeout_val;
   rand bit [1:0]                     check_trigger_val;
-  rand bit [TL_DW-1:0]               ecc_err_mask, ecc_chk_err_mask;
+  rand otp_ecc_err_e                 ecc_otp_err, ecc_chk_err;
 
   constraint no_access_err_c {access_locked_parts == 0;}
 
@@ -60,9 +60,9 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
     check_timeout_val inside {0, [100_000:'1]};
   }
 
-  constraint ecc_err_c {ecc_err_mask == 0;}
+  constraint ecc_otp_err_c {ecc_otp_err == OtpNoEccErr;}
 
-  constraint ecc_chk_err_c {ecc_chk_err_mask == 0;}
+  constraint ecc_chk_err_c {ecc_chk_err == OtpNoEccErr;}
 
   virtual task dut_init(string reset_kind = "HARD");
     if (do_reset_in_seq && do_apply_reset) begin
@@ -112,7 +112,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
       if (check_trigger_val && `gmv(ral.check_trigger_regwen)) begin
         csr_wr(ral.check_timeout, check_timeout_val);
       end
-      trigger_checks(.val(check_trigger_val), .wait_done(1), .ecc_err_mask(ecc_chk_err_mask));
+      trigger_checks(.val(check_trigger_val), .wait_done(1), .ecc_err(ecc_chk_err));
 
       if (do_req_keys && !cfg.otp_ctrl_vif.alert_reqs) begin
         req_otbn_key();
@@ -146,7 +146,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
         if ($urandom_range(0, 1)) begin
           // OTP read via DAI, check data in scb
-          dai_rd(dai_addr, ecc_err_mask, rdata0, rdata1);
+          dai_rd(dai_addr, ecc_otp_err, rdata0, rdata1);
         end
 
         // if write sw partitions, check tlul window


### PR DESCRIPTION
This PR support memory backdoor write with ECC errors:
1. Add a input `ecc_corrupt_second_bit`, is set to 1, it will corrupt
two bits and have a ECC uncorrectable error.
2. Adjust OTP testbench to use the new write function with ECC error.

Signed-off-by: Cindy Chen <chencindy@google.com>