### PR TITLE
[tool_requirements] Set Verilator and Ninja checks to as_needed

### DIFF
--- a/check_tool_requirements.core
+++ b/check_tool_requirements.core
@@ -12,15 +12,21 @@ filesets:
       - ./tool_requirements.py : { copyto: tool_requirements.py }
 
 scripts:
-  check_tool_requirements:
+  check_tool_requirements_verible:
     cmd:
       - python3
       - util/check_tool_requirements.py
+      - 'verible'
     # TODO: Use this syntax once https://github.com/olofk/fusesoc/issues/353 is
     # fixed. Remove the filesets from the default target, and also remove the
     # copyto.
     #filesets:
     #  - files_check_tool_requirements
+  check_tool_requirements_verilator:
+    cmd:
+      - python3
+      - util/check_tool_requirements.py
+      - 'verilator'
 
 targets:
   default:
@@ -28,5 +34,5 @@ targets:
       - files_check_tool_requirements
     hooks:
       pre_build:
-        - tool_verilator   ? (check_tool_requirements)
-        - tool_veriblelint ? (check_tool_requirements)
+        - tool_verilator   ? (check_tool_requirements_verilator)
+        - tool_veriblelint ? (check_tool_requirements_verible)

--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -17,9 +17,14 @@
 #
 __TOOL_REQUIREMENTS__ = {
     'edalize': '0.2.0',
-    'ninja': '1.8.2',
-    'verilator': '4.104',
-
+    'ninja': {
+        'min_version': '1.8.2',
+        'as_needed': True
+    },
+    'verilator': {
+        'min_version': '4.104',
+        'as_needed': True
+    },
     'hugo_extended': {
         'min_version': '0.82.0',
         'as_needed': True


### PR DESCRIPTION
Previously, we were always checking the tool version of Verilator and Ninja in lint runs even when the tools were not used.

While this is typically not a problem (these are standard tools every developer has to install locally), it can be an issue for Dvsim runs that are dispatched to cloud runners which only load the tool image needed for a given lint run. E.g. Verilator lint runs were failing due to a missing Ninja installation.

This change sets Verilator and Ninja to "as_needed", and modifies the checks in the common checker core such that only the version of the requested tool is being checked.

I am not entirely sure, but it looks like this checker script is currently only invoked in lint runs.
Let me know if I missed an invocation elsewhere.

Signed-off-by: Michael Schaffner <msf@google.com>