### PR TITLE
[rom_ctrl] Reverse nonce calculation

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_scrambled_rom.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_scrambled_rom.sv
@@ -51,8 +51,8 @@ module rom_ctrl_scrambled_rom
   input rom_cfg_t          cfg_i
 );
 
-  localparam bit [63-Aw:0] DataScrNonce = ScrNonce[Aw +: (64 - Aw)];
-  localparam bit [Aw-1:0]  AddrScrNonce = ScrNonce[Aw-1:0];
+  localparam bit [63-Aw:0] DataScrNonce = ScrNonce[63-Aw:0];
+  localparam bit [Aw-1:0]  AddrScrNonce = ScrNonce[63-:Aw];
 
   // Parameter Checks ==========================================================
 

--- a/hw/ip/rom_ctrl/util/scramble_image.py
+++ b/hw/ip/rom_ctrl/util/scramble_image.py
@@ -395,8 +395,10 @@ class Scrambler:
         assert word_width <= 64
         word_mask = (1 << word_width) - 1
 
-        data_scr_nonce = self.nonce >> self._addr_width
-        addr_scr_nonce = self.nonce & ((1 << self._addr_width) - 1)
+        data_nonce_width = 64 - self._addr_width
+
+        data_scr_nonce = self.nonce & ((1 << data_nonce_width) - 1)
+        addr_scr_nonce = self.nonce >> data_nonce_width
 
         scrambled = []
         for phy_addr in range(self.rom_size_words):


### PR DESCRIPTION
This now matches the behaviour of the SRAM scrambling code.

Fixes #6488.