### PR TITLE
[rom_ctrl] Fix gnt/rvalid timing just after initial check finishes

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_mux.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_mux.sv
@@ -51,8 +51,8 @@ module rom_ctrl_mux #(
   // Spot if the select signal becomes one again after it went to zero
   assign alert_o = sel_i & ~sel_q;
 
-  // The bus can have access every cycle, once the select signal has gone to zero
-  assign bus_gnt_o    = ~sel_q;
+  // The bus can have access every cycle, once the select signal is zero.
+  assign bus_gnt_o    = ~sel_i;
   assign bus_rdata_o  = rom_clr_rdata_i;
   // A high rom_rvalid_i is a response to a bus request if sel_i was zero on the previous cycle.
   assign bus_rvalid_o = ~sel_q & rom_rvalid_i;


### PR DESCRIPTION
The `rom_ctrl` block is supposed to give access just to the checker
until the checker is finished, at which point the bus can start
accessing data.

To control this, there is a mux with a `sel_i` signal. When `sel_i` is 1,
the checker is still running. When it drops to zero (a one-time
event), the bus should have access.

Before this patch, there was a bug where the block would seemingly
respond to a request in zero time, raising the bus grant signal and
`rvalid` at the same time. The problem was just that we were incorrectly
using a registered signal for the grant: the ROM had taken the request
a cycle earlier but we didn't tell the bus.

Fixes #6516.