### PR TITLE
[otbn,dv] Factor OtbnTraceEntry into its own file

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_model.core
+++ b/hw/ip/otbn/dv/model/otbn_model.core
@@ -18,6 +18,8 @@ filesets:
       - iss_wrapper.h: { file_type: cppSource, is_include_file: true }
       - otbn_trace_checker.h: { file_type: cppSource, is_include_file: true }
       - otbn_trace_checker.cc: { file_type: cppSource }
+      - otbn_trace_entry.h: { file_type: cppSource, is_include_file: true }
+      - otbn_trace_entry.cc: { file_type: cppSource }
       - otbn_core_model.sv
       - otbn_rf_snooper_if.sv
       - otbn_stack_snooper_if.sv

--- a/hw/ip/otbn/dv/model/otbn_trace_checker.h
+++ b/hw/ip/otbn/dv/model/otbn_trace_checker.h
@@ -39,6 +39,7 @@
 #include <string>
 #include <vector>
 
+#include "otbn_trace_entry.h"
 #include "otbn_trace_listener.h"
 
 class OtbnTraceChecker : public OtbnTraceListener {
@@ -73,27 +74,13 @@ class OtbnTraceChecker : public OtbnTraceListener {
   // message to stderr and return false.
   bool MatchPair();
 
-  class TraceEntry {
-   public:
-    static TraceEntry from_rtl_trace(const std::string &trace);
-    static TraceEntry from_iss_trace(const std::vector<std::string> &lines);
-
-    bool operator==(const TraceEntry &other) const;
-    void print(const std::string &indent, std::ostream &os) const;
-
-    void take_writes(const TraceEntry &other);
-
-    std::string hdr_;
-    std::vector<std::string> writes_;
-  };
-
   bool rtl_pending_;
   bool rtl_stall_;
-  TraceEntry rtl_entry_;
-  TraceEntry rtl_stalled_entry_;
+  OtbnTraceEntry rtl_entry_;
+  OtbnTraceEntry rtl_stalled_entry_;
 
   bool iss_pending_;
-  TraceEntry iss_entry_;
+  OtbnTraceEntry iss_entry_;
 
   bool done_;
   bool seen_err_;

--- a/hw/ip/otbn/dv/model/otbn_trace_entry.cc
+++ b/hw/ip/otbn/dv/model/otbn_trace_entry.cc
@@ -1,0 +1,73 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "otbn_trace_entry.h"
+
+#include <algorithm>
+#include <sstream>
+
+void OtbnTraceEntry::from_rtl_trace(const std::string &trace) {
+  size_t eol = trace.find('\n');
+  hdr_ = trace.substr(0, eol);
+
+  while (eol != std::string::npos) {
+    size_t bol = eol + 1;
+    eol = trace.find('\n', bol);
+    size_t line_len =
+        (eol == std::string::npos) ? std::string::npos : eol - bol;
+    std::string line = trace.substr(bol, line_len);
+    if (line.size() > 0 && line[0] == '>')
+      writes_.push_back(line);
+  }
+  std::sort(writes_.begin(), writes_.end());
+}
+
+void OtbnTraceEntry::from_iss_trace(const std::vector<std::string> &lines) {
+  bool first = true;
+  for (const std::string &line : lines) {
+    if (first) {
+      hdr_ = line;
+    } else {
+      // Ignore '!' lines (which are used to tell the simulation about external
+      // register changes, not tracked by the RTL core simulation)
+      bool is_bang = (line.size() > 0 && line[0] == '!');
+      if (!is_bang) {
+        writes_.push_back(line);
+      }
+    }
+    first = false;
+  }
+  std::sort(writes_.begin(), writes_.end());
+}
+
+bool OtbnTraceEntry::operator==(const OtbnTraceEntry &other) const {
+  return hdr_ == other.hdr_ && writes_ == other.writes_;
+}
+
+void OtbnTraceEntry::print(const std::string &indent, std::ostream &os) const {
+  os << indent << hdr_ << "\n";
+  for (const std::string &write : writes_) {
+    os << indent << write << "\n";
+  }
+}
+
+void OtbnTraceEntry::take_writes(const OtbnTraceEntry &other) {
+  if (!other.writes_.empty()) {
+    for (const std::string &write : other.writes_) {
+      writes_.push_back(write);
+    }
+    std::sort(writes_.begin(), writes_.end());
+  }
+}
+
+bool OtbnTraceEntry::empty() const { return hdr_.empty(); }
+
+bool OtbnTraceEntry::is_stall() const { return !empty() && hdr_[0] == 'S'; }
+
+bool OtbnTraceEntry::is_exec() const { return !empty() && hdr_[0] == 'E'; }
+
+bool OtbnTraceEntry::is_compatible(const OtbnTraceEntry &prev) const {
+  return 0 ==
+         hdr_.compare(1, std::string::npos, prev.hdr_, 1, std::string::npos);
+}

--- a/hw/ip/otbn/dv/model/otbn_trace_entry.h
+++ b/hw/ip/otbn/dv/model/otbn_trace_entry.h
@@ -1,0 +1,38 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OPENTITAN_HW_IP_OTBN_DV_MODEL_OTBN_TRACE_ENTRY_H_
+#define OPENTITAN_HW_IP_OTBN_DV_MODEL_OTBN_TRACE_ENTRY_H_
+
+#include <string>
+#include <vector>
+
+class OtbnTraceEntry {
+ public:
+  void from_rtl_trace(const std::string &trace);
+  void from_iss_trace(const std::vector<std::string> &lines);
+
+  bool operator==(const OtbnTraceEntry &other) const;
+  void print(const std::string &indent, std::ostream &os) const;
+
+  void take_writes(const OtbnTraceEntry &other);
+
+  // True if the entry is empty (no header or other text)
+  bool empty() const;
+
+  // True if this is a stall
+  bool is_stall() const;
+
+  // True if this is an execute line
+  bool is_exec() const;
+
+  // True if this is an acceptable line to follow other (assumed to
+  // have been a stall)
+  bool is_compatible(const OtbnTraceEntry &other) const;
+
+ private:
+  std::string hdr_;
+  std::vector<std::string> writes_;
+};
+
+#endif  // OPENTITAN_HW_IP_OTBN_DV_MODEL_OTBN_TRACE_ENTRY_H_


### PR DESCRIPTION
Also make the fields private and teach the `OtbnTraceChecker` code to
use helper functions to access them. We're planning to add some extra
information to the ISS trace to help functional coverage tracking.
This refactoring should make that a bit cleaner.
