### PR TITLE
[sw/silicon_creator] Sign ROM_EXT images during build and integrate signature verification to Mask ROM

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -284,7 +284,7 @@ jobs:
         - "/hw/top_englishbreakfast/Vchip_englishbreakfast_verilator"
 
 - job: execute_verilated_tests
-  displayName: Execute tests on the Verilated system
+  displayName: Execute tests on the Verilated system (excl. slow tests)
   pool:
     vmImage: ubuntu-18.04
   dependsOn:
@@ -304,10 +304,39 @@ jobs:
       . util/build_consts.sh
       pytest --version
       pytest test/systemtest/earlgrey/test_sim_verilator.py \
+        -m "not slow" \
         --log-cli-level=DEBUG \
-        --test-run-title="Run system tests with Verilator simulation" \
+        --test-run-title="Run system tests with Verilator simulation (excl. slow tests)" \
         --napoleon-docstrings
     displayName: Execute tests
+
+# This test is in a separate job becuase it takes longer to complete.
+- job: execute_silicon_creator_verilated_test
+  displayName: Execute silicon_creator test on the Verilated system
+  pool:
+    vmImage: ubuntu-18.04
+  dependsOn:
+    - chip_earlgrey_verilator
+    - sw_build
+  steps:
+  - template: ci/install-package-dependencies.yml
+  - template: ci/download-artifacts-template.yml
+    parameters:
+      downloadPartialBuildBinFrom:
+        - chip_earlgrey_verilator
+        - sw_build
+  - bash: |
+      # Install an additional pytest dependency for result upload.
+      pip3 install pytest-azurepipelines
+
+      . util/build_consts.sh
+      pytest --version
+      pytest test/systemtest/earlgrey/test_sim_verilator.py \
+        -k test_apps_selfchecking_silicon_creator[dif_uart_smoketest] \
+        --log-cli-level=DEBUG \
+        --test-run-title="Run silicon_creator system test with Verilator simulation" \
+        --napoleon-docstrings
+    displayName: Execute silicon_creator test
 
 - template: ci/run-riscv-compliance.yml
   parameters:

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -13,6 +13,21 @@ rom_link_args = [
 ] + embedded_target_extra_link_args
 rom_link_deps = [rom_linkfile]
 
+# Signature verification.
+sw_silicon_creator_mask_rom_sigverify = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_mask_rom_sigverify',
+    sources: [
+      'rsa_verify.c',
+      'sig_verify_keys.c',
+      'sig_verify.c',
+    ],
+    dependencies: [
+      sw_silicon_creator_lib_driver_hmac,
+    ],
+  ),
+)
+
 # MaskROM library.
 mask_rom_lib = declare_dependency(
   sources: [
@@ -24,6 +39,7 @@ mask_rom_lib = declare_dependency(
       sw_silicon_creator_lib_driver_hmac,
       sw_silicon_creator_lib_driver_uart,
       sw_silicon_creator_lib_fake_deps,
+      sw_silicon_creator_mask_rom_sigverify,
       rom_ext_manifest_parser,
       sw_lib_crt,
       sw_lib_pinmux,

--- a/sw/device/silicon_creator/mask_rom/sig_verify.c
+++ b/sw/device/silicon_creator/mask_rom/sig_verify.c
@@ -90,7 +90,7 @@ static rom_error_t sigverify_padding_and_digest_check(
 }
 
 rom_error_t sigverify_rom_ext_signature_verify(
-    const uint8_t *signed_region, size_t signed_region_len,
+    const void *signed_region, size_t signed_region_len,
     const sigverify_rsa_buffer_t *signature, uint32_t key_id) {
   hmac_digest_t act_digest;
   hmac_sha256_init();

--- a/sw/device/silicon_creator/mask_rom/sig_verify.h
+++ b/sw/device/silicon_creator/mask_rom/sig_verify.h
@@ -26,7 +26,7 @@ extern "C" {
  * @return Result of the operation.
  */
 rom_error_t sigverify_rom_ext_signature_verify(
-    const uint8_t *signed_region, size_t signed_region_len,
+    const void *signed_region, size_t signed_region_len,
     const sigverify_rsa_buffer_t *signature, uint32_t key_id);
 
 #ifdef __cplusplus

--- a/sw/device/silicon_creator/mask_rom/sig_verify_unittest.cc
+++ b/sw/device/silicon_creator/mask_rom/sig_verify_unittest.cc
@@ -18,7 +18,6 @@ namespace sig_verify_unittest {
 namespace {
 using ::testing::DoAll;
 using ::testing::NotNull;
-using ::testing::Pointee;
 using ::testing::Return;
 using ::testing::SetArgPointee;
 

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -225,11 +225,20 @@ foreach sw_test_name, sw_test_info : sw_tests
   endforeach
 endforeach
 
+# Signing keys for ROM_EXT images.
+signing_keys = {
+  'fpga_key_0': {
+    'path': meson.source_root() / 'sw/device/silicon_creator/keys/fpga_key_0.private.der',
+  },
+  'fpga_key_1': {
+    'path': meson.source_root() / 'sw/device/silicon_creator/keys/fpga_key_1.private.der',
+  },
+}
 
 foreach sw_test_name, sw_test_info : sw_rom_ext_tests
   foreach device_name, device_lib : sw_lib_arch_core_devices
     sw_test_elf = executable(
-      sw_test_name + '_rom_ext_' + device_name,
+      '_'.join(['rom_ext', sw_test_name, device_name]),
       name_suffix: 'elf',
       dependencies: [
         # Only use ROM_EXT slot A for now.
@@ -241,7 +250,7 @@ foreach sw_test_name, sw_test_info : sw_rom_ext_tests
       ],
     )
 
-    target_name = sw_test_name + '_rom_ext_@0@_' + device_name
+    target_name = '_'.join(['rom_ext', sw_test_name, '@0@', device_name])
 
     sw_test_dis = custom_target(
       target_name.format('dis'),
@@ -255,29 +264,53 @@ foreach sw_test_name, sw_test_info : sw_rom_ext_tests
       kwargs: elf_to_bin_custom_target_args,
     )
 
-    sw_test_vmem32 = custom_target(
-      target_name.format('vmem32'),
-      input: sw_test_bin,
-      kwargs: bin_to_vmem32_custom_target_args,
-    )
+    targets_to_export = [
+      sw_test_elf,
+      sw_test_dis,
+      sw_test_bin,
+    ]
 
-    sw_test_vmem64 = custom_target(
-      target_name.format('vmem64'),
-      input: sw_test_bin,
-      kwargs: bin_to_vmem64_custom_target_args,
-    )
+    foreach key_name, key_info : signing_keys
+      signed_target_name = '_'.join(['rom_ext', sw_test_name, key_name, 'signed', '@0@', device_name])
+
+      sw_test_signed_bin = custom_target(
+        signed_target_name.format('bin'),
+        input: sw_test_bin,
+        output: '@BASENAME@.@0@.signed.bin'.format(key_name),
+        command: [
+          rom_ext_signer_export.full_path(),
+          '@INPUT@',
+          key_info['path'],
+          '@OUTPUT@',
+        ],
+        depends: rom_ext_signer_export,
+        build_by_default: true,
+      )
+
+      sw_test_signed_vmem32 = custom_target(
+        signed_target_name.format('vmem32'),
+        input: sw_test_signed_bin,
+        kwargs: bin_to_vmem32_custom_target_args,
+      )
+
+      sw_test_signed_vmem64 = custom_target(
+        signed_target_name.format('vmem64'),
+        input: sw_test_signed_bin,
+        kwargs: bin_to_vmem64_custom_target_args,
+      )
+
+      targets_to_export += [
+        sw_test_signed_bin,
+        sw_test_signed_vmem32,
+        sw_test_signed_vmem64,
+      ]
+    endforeach
 
     custom_target(
       target_name.format('export'),
       command: export_target_command,
       depend_files: [export_target_depend_files,],
-      input: [
-        sw_test_elf,
-        sw_test_dis,
-        sw_test_bin,
-        sw_test_vmem32,
-        sw_test_vmem64,
-      ],
+      input: targets_to_export,
       output: target_name.format('export'),
       build_always_stale: true,
       build_by_default: true,

--- a/test/systemtest/conftest.py
+++ b/test/systemtest/conftest.py
@@ -85,3 +85,8 @@ def openocd():
     log.info("Using OpenOCD at {}: '{}'".format(openocd_bin,
                                                 proc.stdout.splitlines()[0]))
     return Path(openocd_bin)
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow, will be excluded from the main "
+                                       "verilator job in CI")

--- a/test/systemtest/earlgrey/test_sim_verilator.py
+++ b/test/systemtest/earlgrey/test_sim_verilator.py
@@ -217,24 +217,22 @@ def app_silicon_creator_selfchecking(request, bin_dir):
 
     app_config = request.param
 
-    if 'name' not in app_config:
+    if not all(key in app_config for key in ('name', 'signing_key')):
         raise RuntimeError(
-            "Key 'name' not found in TEST_APPS_SILICON_CREATOR_SELFCHECKING")
+            "One or more required keys ('name', 'signing_key') not found in"
+            " TEST_APPS_SILICON_CREATOR_SELFCHECKING")
 
     if 'targets' in app_config and 'sim_verilator' not in app_config['targets']:
         pytest.skip("Test %s skipped on Verilator." % app_config['name'])
-
-    if 'binary_name' in app_config:
-        binary_name = app_config['binary_name']
-    else:
-        binary_name = app_config['name']
 
     if 'verilator_extra_args' in app_config:
         verilator_extra_args = app_config['verilator_extra_args']
     else:
         verilator_extra_args = []
 
-    test_filename = binary_name + '_rom_ext_sim_verilator.elf'
+    test_filename = 'rom_ext_{}_sim_verilator.{}.signed.64.vmem'.format(
+        app_config['name'],
+        app_config['signing_key'])
     bin_path = bin_dir / 'sw/device/tests' / test_filename
     assert bin_path.is_file()
 

--- a/test/systemtest/silicon_creator_config.py
+++ b/test/systemtest/silicon_creator_config.py
@@ -9,8 +9,8 @@
 #
 # name:
 #   Name of the test (required)
-# binary_name:
-#   Basename of the test binary. Default: name (optional)
+# signing_key:
+#   Name of the key used to sign the binary (required)
 # verilator_extra_args:
 #   A list of additional command-line arguments passed to the Verilator
 #   simulation (optional).
@@ -20,5 +20,6 @@
 TEST_SILICON_CREATOR_APPS_SELFCHECKING = [
     {
         "name": "dif_uart_smoketest",
+        "signing_key": "fpga_key_1",
     },
 ]


### PR DESCRIPTION
This change also increases the timeout for transitioning to SwTestStatusInTest to 2000 seconds for `dif_uart_smoketest` (silicon_creator version) and runs the test in a separate CI job to accommodate for the overhead of signature verification on Ibex.

Signed-off-by: Alphan Ulusoy <alphan@google.com>