### PR TITLE
[dv/unr] Fix unr clk rst ports

### DIFF
--- a/hw/dv/tools/vcs/unr.cfg
+++ b/hw/dv/tools/vcs/unr.cfg
@@ -6,9 +6,9 @@
 -covDUT $dut_instance
 
 # Provide the clock specification
--clock clk 100
+-clock clk_i 100
 # Provide the reset specification: signal_name, active_value, num clk cycles reset to be active
--reset rst_n 0 20
+-reset rst_ni 0 20
 
 # Black box some of the modules
 # -blackBoxes -type design *


### PR DESCRIPTION
This PR fixes an UNR clk rst ports naming mismatch.
In previous version, this is a warning so it is not idenfitied as
failure. But the latest version flaged it as an error.
Also this affect some of the UNR analysis - in OTP_CTRL's case, it
affects the FSM coverage.
Thanks Will for helping me debugging that.

Signed-off-by: Cindy Chen <chencindy@google.com>