### PR TITLE
[clkmgr/top] Connect lc_dft_en to the clock manager

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2495,6 +2495,8 @@
           act: rcv
           width: 1
           inst_name: clkmgr_aon
+          default: ""
+          top_signame: lc_ctrl_lc_dft_en
           index: -1
         }
         {
@@ -5993,6 +5995,7 @@
         otp_ctrl.lc_dft_en
         pinmux_aon.lc_dft_en
         ast.lc_dft_en
+        clkmgr_aon.lc_dft_en
       ]
       lc_ctrl.lc_nvm_debug_en:
       [
@@ -12970,6 +12973,8 @@
         act: rcv
         width: 1
         inst_name: clkmgr_aon
+        default: ""
+        top_signame: lc_ctrl_lc_dft_en
         index: -1
       }
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -932,7 +932,8 @@
       // LC function control signal broadcast
       'lc_ctrl.lc_dft_en'          : ['otp_ctrl.lc_dft_en',
                                       'pinmux_aon.lc_dft_en',
-                                      'ast.lc_dft_en'
+                                      'ast.lc_dft_en',
+                                      'clkmgr_aon.lc_dft_en'
                                      ],
       'lc_ctrl.lc_nvm_debug_en'    : ['eflash.lc_nvm_debug_en'],
       'lc_ctrl.lc_hw_debug_en'     : ['sram_ctrl_main.lc_hw_debug_en',

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1685,7 +1685,7 @@ module top_earlgrey #(
 
       // Inter-module signals
       .clocks_o(clkmgr_aon_clocks),
-      .lc_dft_en_i(lc_ctrl_pkg::LC_TX_DEFAULT),
+      .lc_dft_en_i(lc_ctrl_lc_dft_en),
       .ast_clk_byp_req_o(ast_clk_byp_req_o),
       .ast_clk_byp_ack_i(ast_clk_byp_ack_i),
       .lc_clk_byp_req_i(lc_ctrl_lc_clk_byp_req),


### PR DESCRIPTION
Signed-off-by: Michael Schaffner <msf@opentitan.org>