### PR TITLE
[otbn,dv] Connect OTBN and ISS trace to coverage collection

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -16,6 +16,7 @@
 #include "otbn_memutil.h"
 #include "otbn_trace_checker.h"
 #include "sv_scoped.h"
+#include "sv_utils.h"
 
 // Read (the start of) the contents of a file at path as a vector of bytes.
 // Expects num_bytes bytes of data. On failure, throws a std::runtime_error.
@@ -226,15 +227,6 @@ static void set_rnd_data(uint32_t dst[8], const svLogicVecVal src[8]) {
   }
 }
 
-// Pack uint32_t-based error bitfield into a SystemVerilog bit vector that
-// represents a "bit [31:0]" (as in the SV prototype of otbn_model_step)
-static void set_err_bits(svBitVecVal *dst, uint32_t src) {
-  for (int i = 0; i < 32; ++i) {
-    svBit bit = (src >> i) & 1;
-    svPutBitselBit(dst, i, bit);
-  }
-}
-
 static bool is_xz(svLogic l) { return l == sv_x || l == sv_z; }
 
 // Step once in the model. Returns 1 if the model has finished, 0 if not and -1
@@ -272,8 +264,8 @@ static int step_model(OtbnModel &model, svLogic edn_rnd_data_valid,
         return -1;
 
       case 1:
-        // The simulation has stopped. Extract err_bits
-        set_err_bits(err_bits, ret.second);
+        // The simulation has stopped. Fill in err_bits
+        set_sv_u32(err_bits, ret.second);
         return 1;
 
       case 0:

--- a/hw/ip/otbn/dv/model/otbn_model.core
+++ b/hw/ip/otbn/dv/model/otbn_model.core
@@ -20,6 +20,7 @@ filesets:
       - otbn_trace_checker.cc: { file_type: cppSource }
       - otbn_trace_entry.h: { file_type: cppSource, is_include_file: true }
       - otbn_trace_entry.cc: { file_type: cppSource }
+      - sv_utils.h: { file_type: cppSource, is_include_file: true }
       - otbn_core_model.sv
       - otbn_rf_snooper_if.sv
       - otbn_stack_snooper_if.sv

--- a/hw/ip/otbn/dv/model/otbn_trace_checker.h
+++ b/hw/ip/otbn/dv/model/otbn_trace_checker.h
@@ -67,6 +67,10 @@ class OtbnTraceChecker : public OtbnTraceListener {
   // mismatch.
   bool Finish();
 
+  // Return and clear the ISS data for the last pair of trace entries that went
+  // through MatchPair if there is any.
+  const OtbnIssTraceEntry::IssData *PopIssData();
+
  private:
   // If rtl_pending_ and iss_pending_ are not both true, return true
   // immediately with no other change. Otherwise, compare the two pending trace
@@ -80,10 +84,15 @@ class OtbnTraceChecker : public OtbnTraceListener {
   OtbnTraceEntry rtl_stalled_entry_;
 
   bool iss_pending_;
-  OtbnTraceEntry iss_entry_;
+  OtbnIssTraceEntry iss_entry_;
 
   bool done_;
   bool seen_err_;
+
+  // The ISS entry for the last pair of trace entries that went through
+  // MatchPair.
+  bool last_data_vld_;
+  OtbnIssTraceEntry::IssData last_data_;
 };
 
 #endif  // OPENTITAN_HW_IP_OTBN_DV_MODEL_OTBN_TRACE_CHECKER_H_

--- a/hw/ip/otbn/dv/model/otbn_trace_entry.cc
+++ b/hw/ip/otbn/dv/model/otbn_trace_entry.cc
@@ -5,6 +5,8 @@
 #include "otbn_trace_entry.h"
 
 #include <algorithm>
+#include <cassert>
+#include <iostream>
 #include <sstream>
 
 void OtbnTraceEntry::from_rtl_trace(const std::string &trace) {
@@ -19,24 +21,6 @@ void OtbnTraceEntry::from_rtl_trace(const std::string &trace) {
     std::string line = trace.substr(bol, line_len);
     if (line.size() > 0 && line[0] == '>')
       writes_.push_back(line);
-  }
-  std::sort(writes_.begin(), writes_.end());
-}
-
-void OtbnTraceEntry::from_iss_trace(const std::vector<std::string> &lines) {
-  bool first = true;
-  for (const std::string &line : lines) {
-    if (first) {
-      hdr_ = line;
-    } else {
-      // Ignore '!' lines (which are used to tell the simulation about external
-      // register changes, not tracked by the RTL core simulation)
-      bool is_bang = (line.size() > 0 && line[0] == '!');
-      if (!is_bang) {
-        writes_.push_back(line);
-      }
-    }
-    first = false;
   }
   std::sort(writes_.begin(), writes_.end());
 }
@@ -70,4 +54,57 @@ bool OtbnTraceEntry::is_exec() const { return !empty() && hdr_[0] == 'E'; }
 bool OtbnTraceEntry::is_compatible(const OtbnTraceEntry &prev) const {
   return 0 ==
          hdr_.compare(1, std::string::npos, prev.hdr_, 1, std::string::npos);
+}
+
+bool OtbnIssTraceEntry::from_iss_trace(const std::vector<std::string> &lines) {
+  // Read FSM. state 0 = read header; state 1 = read mnemonic (for E
+  // lines); state 2 = read writes
+  int state = 0;
+
+  for (const std::string &line : lines) {
+    switch (state) {
+      case 0:
+        hdr_ = line;
+        state = (!line.empty() && line[0] == 'E') ? 1 : 2;
+        break;
+
+      case 1:
+        // This some "special" extra data from the ISS that we use for
+        // functional coverage calculations. The line should be of the form
+        //
+        //  # MNEMONIC
+        //
+        if (line.size() <= 2 || line[0] != '#' || line[1] != ' ') {
+          std::cerr << "Bad 'special' line for ISS trace with header `" << hdr_
+                    << "': `" << line << "'.\n";
+          return false;
+        }
+        data_.mnemonic = line.substr(2);
+
+        state = 2;
+        break;
+
+      default: {
+        assert(state == 2);
+        // Ignore '!' lines (which are used to tell the simulation about
+        // external register changes, not tracked by the RTL core simulation)
+        bool is_bang = (line.size() > 0 && line[0] == '!');
+        if (!is_bang) {
+          writes_.push_back(line);
+        }
+        break;
+      }
+    }
+  }
+
+  // We shouldn't be in state 1 here: that would mean an E line with no
+  // follow-up '#' line.
+  if (state == 1) {
+    std::cerr << "No 'special' line for ISS trace with header `" << hdr_
+              << "'.\n";
+    return false;
+  }
+
+  std::sort(writes_.begin(), writes_.end());
+  return true;
 }

--- a/hw/ip/otbn/dv/model/otbn_trace_entry.h
+++ b/hw/ip/otbn/dv/model/otbn_trace_entry.h
@@ -42,6 +42,7 @@ class OtbnIssTraceEntry : public OtbnTraceEntry {
 
   // Fields that are populated from the "special" line for ISS entries
   struct IssData {
+    uint32_t insn_addr;
     std::string mnemonic;
   };
 

--- a/hw/ip/otbn/dv/model/otbn_trace_entry.h
+++ b/hw/ip/otbn/dv/model/otbn_trace_entry.h
@@ -9,8 +9,9 @@
 
 class OtbnTraceEntry {
  public:
+  virtual ~OtbnTraceEntry(){};
+
   void from_rtl_trace(const std::string &trace);
-  void from_iss_trace(const std::vector<std::string> &lines);
 
   bool operator==(const OtbnTraceEntry &other) const;
   void print(const std::string &indent, std::ostream &os) const;
@@ -30,9 +31,21 @@ class OtbnTraceEntry {
   // have been a stall)
   bool is_compatible(const OtbnTraceEntry &other) const;
 
- private:
+ protected:
   std::string hdr_;
   std::vector<std::string> writes_;
+};
+
+class OtbnIssTraceEntry : public OtbnTraceEntry {
+ public:
+  bool from_iss_trace(const std::vector<std::string> &lines);
+
+  // Fields that are populated from the "special" line for ISS entries
+  struct IssData {
+    std::string mnemonic;
+  };
+
+  IssData data_;
 };
 
 #endif  // OPENTITAN_HW_IP_OTBN_DV_MODEL_OTBN_TRACE_ENTRY_H_

--- a/hw/ip/otbn/dv/model/sv_utils.h
+++ b/hw/ip/otbn/dv/model/sv_utils.h
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OPENTITAN_HW_IP_OTBN_DV_MODEL_SV_UTILS_H_
+#define OPENTITAN_HW_IP_OTBN_DV_MODEL_SV_UTILS_H_
+
+#include <svdpi.h>
+
+// Utility function that packs a uint32_t into a SystemVerilog bit vector that
+// represents a "bit [31:0]"
+inline void set_sv_u32(svBitVecVal *dst, uint32_t src) {
+  for (int i = 0; i < 32; ++i) {
+    svBit bit = (src >> i) & 1;
+    svPutBitselBit(dst, i, bit);
+  }
+}
+
+#endif  // OPENTITAN_HW_IP_OTBN_DV_MODEL_SV_UTILS_H_

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -93,10 +93,11 @@ def on_step(sim: OTBNSim, args: List[str]) -> None:
     insn, changes = sim.step(verbose=False, collect_stats=False)
 
     if insn is None:
-        hdr = 'STALL'
+        print('STALL')
     else:
-        hdr = 'E PC: {:#010x}, insn: {:#010x}'.format(pc, insn.raw)
-    print(hdr)
+        print(f'E PC: {pc:#010x}, insn: {insn.raw:#010x}')
+        print(f'# {insn.insn.mnemonic}')
+
     for change in changes:
         entry = change.rtl_trace()
         if entry is not None:

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -96,7 +96,7 @@ def on_step(sim: OTBNSim, args: List[str]) -> None:
         print('STALL')
     else:
         print(f'E PC: {pc:#010x}, insn: {insn.raw:#010x}')
-        print(f'# {insn.insn.mnemonic}')
+        print(f'# @{pc:#010x}: {insn.insn.mnemonic}')
 
     for change in changes:
         entry = change.rtl_trace()

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -16,6 +16,8 @@ filesets:
       - lowrisc:dv:otbn_model_agent
     files:
       - otbn_env_pkg.sv
+      - otbn_trace_item.sv: {is_include_file: true}
+      - otbn_trace_monitor.sv: {is_include_file: true}
       - otbn_env_cfg.sv: {is_include_file: true}
       - otbn_env_cov.sv: {is_include_file: true}
       - otbn_virtual_sequencer.sv: {is_include_file: true}

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.sv
@@ -10,7 +10,8 @@ class otbn_env extends cip_base_env #(
   );
   `uvm_component_utils(otbn_env)
 
-  otbn_model_agent model_agent;
+  otbn_model_agent   model_agent;
+  otbn_trace_monitor trace_monitor;
 
   `uvm_component_new
 
@@ -23,11 +24,20 @@ class otbn_env extends cip_base_env #(
     model_agent = otbn_model_agent::type_id::create("model_agent", this);
     uvm_config_db#(otbn_model_agent_cfg)::set(this, "model_agent*", "cfg", cfg.model_agent_cfg);
     cfg.model_agent_cfg.en_cov = cfg.en_cov;
+
+    if (!uvm_config_db#(virtual otbn_trace_if)::get(this, "", "trace_vif", cfg.trace_vif)) begin
+      `uvm_fatal(`gfn, "failed to get otbn_trace_if handle from uvm_config_db")
+    end
+
+    trace_monitor = otbn_trace_monitor::type_id::create("trace_monitor", this);
+    trace_monitor.cfg = cfg;
+    trace_monitor.cov = cov;
   endfunction
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
     model_agent.monitor.analysis_port.connect(scoreboard.model_fifo.analysis_export);
+    trace_monitor.analysis_port.connect(scoreboard.trace_fifo.analysis_export);
   endfunction
 
   function void final_phase(uvm_phase phase);

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -12,6 +12,9 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
 
   `uvm_object_new
 
+  // Handle used by otbn_trace_monitor
+  virtual otbn_trace_if trace_vif;
+
   // The directory in which to look for ELF files (set by the test in build_phase; controlled by the
   // +otbn_elf_dir plusarg).
   string otbn_elf_dir;
@@ -28,6 +31,9 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
   // memories. The default value matches the block-level testbench, but it can be overridden in a
   // test class for e.g. system level tests.
   string dut_instance_hier = "tb.dut";
+
+  // Copied from dv_base_agent_cfg so that we can use a monitor without defining a separate agent.
+  int ok_to_end_delay_ns = 1000;
 
   function void initialize(bit [31:0] csr_base_addr = '1);
     // Tell the CIP base code not to look for a "devmode" interface. OTBN doesn't have one.

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -11,20 +11,73 @@
 class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
   `uvm_component_utils(otbn_env_cov)
 
-  // the base class provides the following handles for use:
-  // otbn_env_cfg: cfg
+  covergroup insn_cg
+    with function sample(mnem_str_t mnemonic);
 
-  // covergroups
-  // [add covergroups here]
+    // A coverpoint for the instruction mnemonic. There's a manually specified bin for each valid
+    // instruction name. The bins are listed separately like this (rather than having a single bins
+    // line with each value) so that the names appear in the coverage report. The "mnem_" prefix is
+    // just to avoid SystemVerilog reserved words like "and".
+    mnemonic_cp: coverpoint mnemonic {
+        bins mnem_add           = {mnem_str_t'("add")};
+        bins mnem_addi          = {mnem_str_t'("addi")};
+        bins mnem_lui           = {mnem_str_t'("lui")};
+        bins mnem_sub           = {mnem_str_t'("sub")};
+        bins mnem_sll           = {mnem_str_t'("sll")};
+        bins mnem_slli          = {mnem_str_t'("slli")};
+        bins mnem_srl           = {mnem_str_t'("srl")};
+        bins mnem_srli          = {mnem_str_t'("srli")};
+        bins mnem_sra           = {mnem_str_t'("sra")};
+        bins mnem_srai          = {mnem_str_t'("srai")};
+        bins mnem_and           = {mnem_str_t'("and")};
+        bins mnem_andi          = {mnem_str_t'("andi")};
+        bins mnem_or            = {mnem_str_t'("or")};
+        bins mnem_ori           = {mnem_str_t'("ori")};
+        bins mnem_xor           = {mnem_str_t'("xor")};
+        bins mnem_xori          = {mnem_str_t'("xori")};
+        bins mnem_lw            = {mnem_str_t'("lw")};
+        bins mnem_sw            = {mnem_str_t'("sw")};
+        bins mnem_beq           = {mnem_str_t'("beq")};
+        bins mnem_bne           = {mnem_str_t'("bne")};
+        bins mnem_jal           = {mnem_str_t'("jal")};
+        bins mnem_jalr          = {mnem_str_t'("jalr")};
+        bins mnem_csrrs         = {mnem_str_t'("csrrs")};
+        bins mnem_csrrw         = {mnem_str_t'("csrrw")};
+        bins mnem_ecall         = {mnem_str_t'("ecall")};
+        bins mnem_loop          = {mnem_str_t'("loop")};
+        bins mnem_loopi         = {mnem_str_t'("loopi")};
+        bins mnem_bn_add        = {mnem_str_t'("bn.add")};
+        bins mnem_bn_addc       = {mnem_str_t'("bn.addc")};
+        bins mnem_bn_addi       = {mnem_str_t'("bn.addi")};
+        bins mnem_bn_addm       = {mnem_str_t'("bn.addm")};
+        bins mnem_bn_mulqacc    = {mnem_str_t'("bn.mulqacc")};
+        bins mnem_bn_mulqacc_wo = {mnem_str_t'("bn.mulqacc.wo")};
+        bins mnem_bn_mulqacc_so = {mnem_str_t'("bn.mulqacc.so")};
+        bins mnem_bn_sub        = {mnem_str_t'("bn.sub")};
+        bins mnem_bn_subb       = {mnem_str_t'("bn.subb")};
+        bins mnem_bn_subi       = {mnem_str_t'("bn.subi")};
+        bins mnem_bn_subm       = {mnem_str_t'("bn.subm")};
+        bins mnem_bn_and        = {mnem_str_t'("bn.and")};
+        bins mnem_bn_or         = {mnem_str_t'("bn.or")};
+        bins mnem_bn_not        = {mnem_str_t'("bn.not")};
+        bins mnem_bn_xor        = {mnem_str_t'("bn.xor")};
+        bins mnem_bn_rshi       = {mnem_str_t'("bn.rshi")};
+        bins mnem_bn_sel        = {mnem_str_t'("bn.sel")};
+        bins mnem_bn_cmp        = {mnem_str_t'("bn.cmp")};
+        bins mnem_bn_cmpb       = {mnem_str_t'("bn.cmpb")};
+        bins mnem_bn_lid        = {mnem_str_t'("bn.lid")};
+        bins mnem_bn_sid        = {mnem_str_t'("bn.sid")};
+        bins mnem_bn_mov        = {mnem_str_t'("bn.mov")};
+        bins mnem_bn_movr       = {mnem_str_t'("bn.movr")};
+        bins mnem_bn_wsrr       = {mnem_str_t'("bn.wsrr")};
+        bins mnem_bn_wsrw       = {mnem_str_t'("bn.wsrw")};
+    }
+  endgroup
 
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    // [instantiate covergroups here]
-  endfunction : new
 
-  virtual function void build_phase(uvm_phase phase);
-    super.build_phase(phase);
-    // [or instantiate covergroups here]
+    insn_cg = new;
   endfunction
 
 endclass

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
@@ -35,6 +35,9 @@ package otbn_env_pkg;
   // typedefs
   typedef virtual pins_if #(1) idle_vif;
 
+  parameter int unsigned MNEM_STR_LEN = 16;
+  typedef bit [MNEM_STR_LEN*8-1:0] mnem_str_t;
+
   // A very simple wrapper around a word that has been loaded from the input binary and needs
   // storing to OTBN's IMEM or DMEM.
   typedef struct packed {

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
@@ -53,7 +53,9 @@ package otbn_env_pkg;
 
   // package sources
   `include "otbn_env_cfg.sv"
+  `include "otbn_trace_item.sv"
   `include "otbn_env_cov.sv"
+  `include "otbn_trace_monitor.sv"
   `include "otbn_virtual_sequencer.sv"
   `include "otbn_scoreboard.sv"
   `include "otbn_env.sv"

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -98,6 +98,7 @@ class otbn_scoreboard extends cip_base_scoreboard #(
 
   task process_model_fifo();
     otbn_model_item item;
+
     forever begin
       model_fifo.get(item);
       `uvm_info(`gfn, $sformatf("received model transaction:\n%0s", item.sprint()), UVM_HIGH)
@@ -106,9 +107,18 @@ class otbn_scoreboard extends cip_base_scoreboard #(
         OtbnModelStart: begin
           this.expect_start_counter--;
         end
+
         OtbnModelDone: begin
           // TODO: Handle this signal
         end
+
+        OtbnModelInsn: begin
+          if (cfg.en_cov) begin
+            `DV_CHECK_FATAL(item.mnemonic.len() <= MNEM_STR_LEN)
+            cov.insn_cg.sample(mnem_str_t'(item.mnemonic));
+          end
+        end
+
         default: `uvm_fatal(`gfn, $sformatf("Bad item type %0d", item.item_type))
       endcase
     end

--- a/hw/ip/otbn/dv/uvm/env/otbn_trace_item.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_trace_item.sv
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class otbn_trace_item extends uvm_sequence_item;
+
+  logic [31:0] insn_addr;
+
+  `uvm_object_utils_begin(otbn_trace_item)
+    `uvm_field_int  (insn_addr, UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+endclass

--- a/hw/ip/otbn/dv/uvm/env/otbn_trace_monitor.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_trace_monitor.sv
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class otbn_trace_monitor extends dv_base_monitor #(
+    .ITEM_T (otbn_trace_item),
+    .CFG_T (otbn_env_cfg),
+    .COV_T (otbn_env_cov)
+  );
+
+  `uvm_component_utils(otbn_trace_monitor)
+  `uvm_component_new
+
+  protected task collect_trans(uvm_phase phase);
+    otbn_trace_item item;
+    forever begin
+      @(posedge cfg.trace_vif.clk_i);
+      if (cfg.trace_vif.rst_ni === 1'b1) begin
+        if (cfg.trace_vif.insn_valid && !cfg.trace_vif.insn_stall) begin
+          item = otbn_trace_item::type_id::create("item");
+          item.insn_addr = cfg.trace_vif.insn_addr;
+          analysis_port.write(item);
+        end
+      end
+    end
+  endtask
+
+endclass

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent_pkg.sv
@@ -8,7 +8,8 @@ package otbn_model_agent_pkg;
   import dv_utils_pkg::*;
   import dv_lib_pkg::*;
 
-  import "DPI-C" function bit otbn_trace_checker_pop_iss_insn(output string mnemonic);
+  import "DPI-C" function bit
+    otbn_trace_checker_pop_iss_insn(output bit [31:0] insn_addr, output string mnemonic);
 
   typedef enum {
     OtbnModelStart,

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent_pkg.sv
@@ -8,9 +8,12 @@ package otbn_model_agent_pkg;
   import dv_utils_pkg::*;
   import dv_lib_pkg::*;
 
+  import "DPI-C" function bit otbn_trace_checker_pop_iss_insn(output string mnemonic);
+
   typedef enum {
     OtbnModelStart,
-    OtbnModelDone
+    OtbnModelDone,
+    OtbnModelInsn
   } otbn_model_item_type_e;
 
   // macro includes

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_item.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_item.sv
@@ -10,9 +10,13 @@ class otbn_model_item extends uvm_sequence_item;
   // Only valid when item_type == OtbnModelDone.
   bit                    err;
 
+  // Only valid when item_type == OtbnModelInsn
+  string                 mnemonic;
+
   `uvm_object_utils_begin(otbn_model_item)
-    `uvm_field_enum (otbn_model_item_type_e, item_type, UVM_DEFAULT)
-    `uvm_field_int  (err, UVM_DEFAULT)
+    `uvm_field_enum   (otbn_model_item_type_e, item_type, UVM_DEFAULT)
+    `uvm_field_int    (err, UVM_DEFAULT)
+    `uvm_field_string (mnemonic, UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_item.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_item.sv
@@ -11,11 +11,13 @@ class otbn_model_item extends uvm_sequence_item;
   bit                    err;
 
   // Only valid when item_type == OtbnModelInsn
+  bit [31:0]             insn_addr;
   string                 mnemonic;
 
   `uvm_object_utils_begin(otbn_model_item)
     `uvm_field_enum   (otbn_model_item_type_e, item_type, UVM_DEFAULT)
     `uvm_field_int    (err, UVM_DEFAULT)
+    `uvm_field_int    (insn_addr, UVM_DEFAULT | UVM_HEX)
     `uvm_field_string (mnemonic, UVM_DEFAULT)
   `uvm_object_utils_end
 

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_monitor.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_monitor.sv
@@ -72,17 +72,19 @@ class otbn_model_monitor extends dv_base_monitor #(
   protected task collect_insns();
     otbn_model_item trans;
 
-    string insn_mnemonic;
+    bit [31:0] insn_addr;
+    string     insn_mnemonic;
 
     // Collect transactions on each clock edge when we are not in reset
     forever begin
       @(posedge cfg.vif.clk_i);
       if (cfg.vif.rst_ni === 1'b1) begin
         // Ask the trace checker for any ISS instruction that has come in since last cycle.
-        if (otbn_trace_checker_pop_iss_insn(insn_mnemonic)) begin
+        if (otbn_trace_checker_pop_iss_insn(insn_addr, insn_mnemonic)) begin
           trans = otbn_model_item::type_id::create("trans");
           trans.item_type = OtbnModelInsn;
           trans.err       = 0;
+          trans.insn_addr = insn_addr;
           trans.mnemonic  = insn_mnemonic;
           analysis_port.write(trans);
         end

--- a/hw/ip/otbn/dv/uvm/otbn_sim.core
+++ b/hw/ip/otbn/dv/uvm/otbn_sim.core
@@ -17,6 +17,7 @@ filesets:
       - lowrisc:ip:edn_pkg
     files:
       - tb.sv
+      - otbn_trace_uvm_injector.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/otbn/dv/uvm/otbn_trace_uvm_injector.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_trace_uvm_injector.sv
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A tiny fragment that grabs an otbn_trace_if interface and injects it into the UVM config
+// database. We can't do this directly in the testbench, because the interface itself is bound into
+// the DUT with a bind statement, so can't be accessed with a hierarchical reference.
+//
+// Instead, the testbench binds this module in to the DUT as well, allowing it to grab the trace
+// interface.
+
+module otbn_trace_uvm_injector(otbn_trace_if otbn_trace);
+  initial begin
+    uvm_config_db#(virtual otbn_trace_if)::set(null, "*.env", "trace_vif", otbn_trace);
+  end
+endmodule

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -84,6 +84,7 @@ module tb;
 
   bind otbn_core otbn_tracer u_otbn_tracer(.*, .otbn_trace(i_otbn_trace_if));
 
+  bind otbn_core otbn_trace_uvm_injector u_trace_injector (.otbn_trace(i_otbn_trace_if));
 
   // OTBN model, wrapping an ISS.
   //


### PR DESCRIPTION
This series of patches connects the ISS trace (over DPI) and the OTBN trace to `otbn_env_cov`, to allow us to collect coverage about what instructions actually executed. It's a bit complicated, because we want to pull instruction mnemonics from the ISS (rather than writing another possibly-buggy decoder).

The first patch connects the ISS and defines a covergroup to track which mnemonics have been executed. The second patch adds a monitor directly to the RTL trace interface. This will be used to grab things like operand values but, for now, we just grab the instruction address and use it to make sure the two traces are correctly aligned.