### PR TITLE
[rom_ctrl] Only raise ROM req line when not in reset

### DIFF
--- a/hw/ip/rom_ctrl/lint/rom_ctrl.waiver
+++ b/hw/ip/rom_ctrl/lint/rom_ctrl.waiver
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# In rom_ctrl_counter, the "output valid" signal must be true from one
-# cycle after reset. We do this by setting vld_q <= 1'b1 in an
-# always_ff block.
+# In rom_ctrl_counter, the request signal must be true from one cycle
+# after reset. We do this by setting req_q <= 1'b1 in an always_ff
+# block.
 waive -rules {CONST_FF} -location {rom_ctrl_counter.sv} \
-      -regexp {Flip-flop 'vld_q' is driven by constant one} \
+      -regexp {Flip-flop 'req_q' is driven by constant one} \
       -comment "This is intentional: the signal should be true from one cycle after reset."

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -62,6 +62,7 @@ module rom_ctrl
   logic                     bus_rom_rvalid;
 
   logic [RomIndexWidth-1:0] checker_rom_index;
+  logic                     checker_rom_req;
   logic [39:0]              checker_rom_rdata;
 
   // Pack / unpack kmac connection data ========================================
@@ -154,6 +155,7 @@ module rom_ctrl
     .bus_rdata_o     (bus_rom_rdata),
     .bus_rvalid_o    (bus_rom_rvalid),
     .chk_addr_i      (checker_rom_index),
+    .chk_req_i       (checker_rom_req),
     .chk_rdata_o     (checker_rom_rdata),
     .rom_addr_o      (rom_index),
     .rom_req_o       (rom_req),
@@ -243,6 +245,7 @@ module rom_ctrl
     .kmac_digest_i        (kmac_digest),
     .rom_select_o         (rom_select),
     .rom_addr_o           (checker_rom_index),
+    .rom_req_o            (checker_rom_req),
     .rom_data_i           (checker_rom_rdata[31:0]),
     .alert_o              (checker_alert)
   );

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
@@ -45,6 +45,7 @@ module rom_ctrl_fsm
   // To ROM mux
   output logic                       rom_select_o,
   output logic [vbits(RomDepth)-1:0] rom_addr_o,
+  output logic                       rom_req_o,
 
   // Raw bits from ROM
   input logic [31:0]                 rom_data_i,
@@ -61,7 +62,9 @@ module rom_ctrl_fsm
 
   // The counter / address generator
   logic          counter_done;
-  logic [AW-1:0] counter_read_addr, counter_data_addr;
+  logic [AW-1:0] counter_read_addr;
+  logic          counter_read_req;
+  logic [AW-1:0] counter_data_addr;
   logic          counter_data_rdy, counter_data_vld;
   logic          counter_lnt;
   rom_ctrl_counter #(
@@ -72,6 +75,7 @@ module rom_ctrl_fsm
     .rst_ni             (rst_ni),
     .done_o             (counter_done),
     .read_addr_o        (counter_read_addr),
+    .read_req_o         (counter_read_req),
     .data_addr_o        (counter_data_addr),
     .data_rdy_i         (counter_data_rdy),
     .data_vld_o         (counter_data_vld),
@@ -252,6 +256,7 @@ module rom_ctrl_fsm
   // We keep control of the ROM mux from reset until we're done
   assign rom_select_o = (state_q != Done);
   assign rom_addr_o = counter_read_addr;
+  assign rom_req_o = counter_read_req;
 
   // TODO: There are lots more checks that we could do here (things like spotting vld signals that
   //       occur when we're in an FSM state that doesn't expect them)

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_mux.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_mux.sv
@@ -24,6 +24,7 @@ module rom_ctrl_mux #(
 
   // Interface for ROM checker
   input logic [AW-1:0]  chk_addr_i,
+  input logic           chk_req_i,
   output logic [39:0]   chk_rdata_o,
 
   // Interface for ROM
@@ -60,6 +61,6 @@ module rom_ctrl_mux #(
   assign chk_rdata_o = rom_scr_rdata_i;
 
   assign rom_addr_o = sel_i ? chk_addr_i : bus_addr_i;
-  assign rom_req_o  = sel_i ? 1'b1       : bus_req_i;
+  assign rom_req_o  = sel_i ? chk_req_i  : bus_req_i;
 
 endmodule


### PR DESCRIPTION
*This PR is in draft because it depends on #6473 (no logical connection, but they touch the same lines and rebasing would be a mess). The first commit is from there; the second commit is the "real" PR.*

The previous code assumed that the checker always requested ROM
accesses. This is logically correct, but meant that we were raising
the ROM's req line when in reset. Since the ROM doesn't itself have a
reset signal, this would mean spurious activations of the ROM
macrocell.

This patch explicitly registers the req signal in the checker's
address counter and passes it through the rest of the design.
