### PR TITLE
[otbn] CSR reads/writes should be suppressed for certain x0 uses

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -294,7 +294,8 @@ class CSRRS(OTBNInsn):
         new_val = old_val | bits_to_set
 
         state.gprs.get_reg(self.grd).write_unsigned(old_val)
-        state.write_csr(self.csr, new_val)
+        if self.grs1 != 0:
+            state.write_csr(self.csr, new_val)
 
 
 class CSRRW(OTBNInsn):

--- a/hw/ip/otbn/rtl/otbn_decoder.sv
+++ b/hw/ip/otbn/rtl/otbn_decoder.sv
@@ -470,10 +470,16 @@ module otbn_decoder
           rf_ren_a_base     = 1'b1;
 
           if (insn[14:12] == 3'b001) begin
-            ispr_rd_insn = 1'b1;
+            // No read if destination is x0
+            ispr_rd_insn = insn_rd != 5'b0;
             ispr_wr_insn = 1'b1;
           end else if(insn[14:12] == 3'b010) begin
-            ispr_rs_insn = 1'b1;
+            // Read and set if source register isn't x0, otherwise read only
+            if (insn_rs1 != 5'b0) begin
+              ispr_rs_insn = 1'b1;
+            end else begin
+              ispr_rd_insn = 1'b1;
+            end
           end else begin
             illegal_insn = 1'b1;
           end


### PR DESCRIPTION
For CSRRW where the destination register is x0 no read (in particular no
actions such as starting an external RND request) must occur.
For CSRRS where the source register is x0 no write (in particular no
actions such as starting an RND prefetch) must occur.

Fixes #6489

Signed-off-by: Greg Chadwick <gac@lowrisc.org>