### PR TITLE
[spi_device] cmdparse to use cmd_info CSR

### DIFF
--- a/hw/ip/spi_device/lint/spi_device.waiver
+++ b/hw/ip/spi_device/lint/spi_device.waiver
@@ -122,6 +122,15 @@ waive -rules CASE_INC -location {spi_fwm_*xf_ctrl.sv} -regexp {Case statement ta
 waive -rules {NOT_USED NOT_READ} -location {spi_device.sv} \
       -regexp {'sub_(sram|p2s)_.*\[1\]' is not (used|read)} \
       -comment "CmdParse does not have SRAM intf"
+waive -rules {INPUT_NOT_READ HIER_BRANCH_NOT_READ} -location {spi_cmdparse.sv} \
+      -regexp {'cmd_info_i\[0:15\].*' is not read} \
+      -comment "Cmdparse uses opcode only"
+waive -rules {INPUT_NOT_READ HIER_BRANCH_NOT_READ} -location {spi_cmdparse.sv} \
+      -regexp {'cmd_info_i\[11:15\]\.opcode' is not read} \
+      -comment "Upper 5 slots are for passthrough only"
+waive -rules {INPUT_NOT_READ} -location {spi_cmdparse.sv} \
+      -regexp {'cmd_info_i\[15:11\]' is not read} \
+      -comment "Upper 5 slots are for the passthrough logic"
 
 #### SRAM mux
 #### SRAM has unpacked array to mux/demux. Waive one bit unpacked array

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -780,6 +780,8 @@ module spi_device (
 
     .upload_mask_i (cfg_upload_mask),
 
+    .cmd_info_i   (cmd_info),
+
     .io_mode_o    (sub_iomode[IoModeCmdParse]),
 
     .sel_dp_o     (cmd_dp_sel),


### PR DESCRIPTION
This PR is follow-up PR of #6556 .

This commit revises the command parse submodule in the SPI Flash mode.
It previously used the pre-defined opcode value to activate submodule
datapath. Now, it uses the SW configurable cmd_info CSR to check the
incoming data to the cmd_info opcodes and trigger the sub command
processor modules.