### PR TITLE
[dv/kmac] update testplan

### DIFF
--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -33,6 +33,13 @@
                 - In unmasked configuration: Share1 is the result digest, Share2 should be 0.
               - Signal cmd.done to tell KMAC to clear internal state.
               - Try reading output digest again, confirm that it is 0.
+
+              This test, and all other tests in the testplan, will be checked for correctness
+              in two different ways:
+              - first, a DPI-C model is used to check that the correct digest value is produced
+              - a cycle-accurate model is implemented in the scoreboard to provide constant checks
+                during each hash operation and ensure that internal state is being updated
+                correctly
             '''
       milestone: V1
       tests: ["{name}_smoke"]
@@ -125,6 +132,23 @@
       tests: ["{name}_error"]
     }
     {
+      name: entropy_timers
+      desc: ''' Test entropy interface for KMAC.
+
+            This test randomly chooses to execute either a SW-controlled hash or a hash
+            from the App interface.
+            All configuration fields are left as is, but now we set both of the internal timer CSRs:
+            - the entropy_timer value is the number of cycles that KMAC will wait before
+              sending a new request to EDN for more entropy
+            - the wait_timer value is the number of cycles that KMAC will wait for an EDN response
+              before raising an error
+
+            This will be checked in the scoreboard using the cycle acurate model.
+            '''
+      milestone: V2
+      tests: ["{name}_entropy"]
+    }
+    {
       name: throughput
       desc: '''
             Measure the throughput of the various hashing calculations and make sure they correspond
@@ -132,17 +156,6 @@
             '''
       milestone: V3
       tests: ["{name}_throughput"]
-    }
-
-    // TODO: Entropy functionality is not finalized, needs to be captured here.
-    {
-      name: entropy
-      desc: ''' Test entropy interface for KMAC.
-
-            TODO.
-            '''
-      milestone: V2
-      tests: ["{name}_entropy"]
     }
   ]
 }


### PR DESCRIPTION
this PR updates the testplan to add a quick description about how tests
are checked, and adds a new `entropy_timers` test entry.

Signed-off-by: Udi Jonnalagadda <udij@google.com>