### PR TITLE
[rtl/prim_async_fifo] Fix async fifo typo when depth <= 2

### DIFF
--- a/hw/ip/prim/rtl/prim_fifo_async.sv
+++ b/hw/ip/prim/rtl/prim_fifo_async.sv
@@ -253,7 +253,7 @@ module prim_fifo_async #(
     assign fifo_wptr_sync_combi = {fifo_wptr_gray_sync[PTR_WIDTH-1], ^fifo_rptr_gray_sync};
 
     assign fifo_rptr_gray_d = {fifo_rptr_d[PTR_WIDTH-1], ^fifo_rptr_d};
-    assign fifo_wptr_gray_d = {fifo_wptr_d[PTR_WIDTH-1], ^fifo_rptr_d};
+    assign fifo_wptr_gray_d = {fifo_wptr_d[PTR_WIDTH-1], ^fifo_wptr_d};
 
   end else begin : g_no_gray_conversion
 
@@ -261,7 +261,7 @@ module prim_fifo_async #(
     assign fifo_wptr_sync_combi = fifo_wptr_gray_sync;
 
     assign fifo_rptr_gray_d = fifo_rptr_d;
-    assign fifo_wptr_gray_d = fifo_rptr_d;
+    assign fifo_wptr_gray_d = fifo_wptr_d;
 
   end
 


### PR DESCRIPTION
This PR fixes a typo when depth <=2. Looks like the `fifo_wptr_gray_d`
should depends on `fifo_wptr_d` instead of `fifo_rptr_d`.

Details please refer to issue https://github.com/lowRISC/opentitan/issues/6575

Signed-off-by: Cindy Chen <chencindy@google.com>