### PR TITLE
[doc,hugo] Make blockquote do something

### DIFF
--- a/site/docs/assets/scss/_markdown.scss
+++ b/site/docs/assets/scss/_markdown.scss
@@ -49,6 +49,10 @@
     font-size: inherit;
   }
 
+  blockquote {
+    padding-left: 2em;
+  }
+
   a {
     color: $dark-purple;
     color: var(--text-color);


### PR DESCRIPTION
Without this patch, a block quote is rendered exactly the same as any
other paragraph. Add a couple of em's of padding to the left to indent
it.

Don't put e.g. a vertical bar on the left: for the technical
documentation we're writing, a blockquote is much more useful as a
"here's a side note" than as an actual quote.

This PR is because I want to include "asides" in the OTBN DV document and blockquotes look like the easiest way to encode this in Hugo flavoured markdown.

I *think* I've tagged the right people as reviewers, but if there's someone obvious I've missed, please bring them in!