### PR TITLE
[pwm,lint] Waive Verilator warnings for unused signals in pwm_chan

### DIFF
--- a/hw/ip/pwm/lint/pwm.vlt
+++ b/hw/ip/pwm/lint/pwm.vlt
@@ -1,6 +1,11 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-//
-// waiver file for pwm
 
+`verilator_config
+
+// The pwm_chan module isn't really implemented yet, so has lots of inputs that
+// it ignores. Waive all of these warnings for now, but these waivers should be
+// removed again before signing off the block at e.g. D2.
+lint_off -rule UNUSED -file "*/rtl/pwm_chan.sv" -match "Signal is not used: 'rst_ni'"
+lint_off -rule UNUSED -file "*/rtl/pwm_chan.sv" -match "Signal is not used: '*_i'"

--- a/hw/ip/pwm/rtl/pwm_chan.sv
+++ b/hw/ip/pwm/rtl/pwm_chan.sv
@@ -23,6 +23,9 @@ module pwm_chan (
   output logic pwm_o
 );
 
+  // TODO: This block is currently incomplete, so doesn't use several of its input signals. These
+  //       are waived in pwm.vlt. When implementing the block, delete the waivers there.
+
    logic [15:0] duty_cycle_actual;
    logic [15:0] on_phase;
    logic [15:0] off_phase;


### PR DESCRIPTION
This block is not yet implemented, so lots of its input signals are
currently unused. Tell Verilator not to worry about it: we'll get
there eventually :-)
