### PR TITLE
[otp_ctrl] Waive some spurious UNSIGNED/CMPCONST verilator warnings

### DIFF
--- a/hw/ip/otp_ctrl/lint/otp_ctrl.vlt
+++ b/hw/ip/otp_ctrl/lint/otp_ctrl.vlt
@@ -1,6 +1,19 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-//
-// waiver file for OTP controller
 
+`verilator_config
+
+// Some code in this block checks that an address is greater than or equal to
+// the offset of a fixed part_info_t (supplied via a parameter). If that
+// part_info_t happens to have a zero offset, Verilator warns that the
+// comparison is always true. Waive the warning.
+lint_off -rule UNSIGNED -file "*/rtl/otp_ctrl.sv"
+lint_off -rule UNSIGNED -file "*/rtl/otp_ctrl_dai.sv"
+lint_off -rule UNSIGNED -file "*/rtl/otp_ctrl_part_unbuf.sv"
+
+// In otp_ctrl_scrmbl, there are some comparisons between the "sel_i" signal
+// and LastDigestSet. If the parameter NumDigestSets is a power of 2 (which it
+// is at the moment), these checks will always be true, causing a Verilator
+// warning.
+lint_off -rule CMPCONST -file "*/rtl/otp_ctrl_scrmbl.sv"


### PR DESCRIPTION
Sadly, the warnings don't have any keywords in their text to let us
waive them more precisely.