### PR TITLE
[sha3] Recast an always_comb block to avoid a lint warning

### DIFF
--- a/hw/ip/kmac/rtl/sha3.sv
+++ b/hw/ip/kmac/rtl/sha3.sv
@@ -264,9 +264,7 @@ module sha3
   //  - Sw set process_i, run_i, done_i without start_i
 
   always_comb begin
-    error_o.valid = 1'b 0;
-    error_o.code  = ErrNone;
-    error_o.info  = '0;
+    error_o = '{valid: 1'b0, code: ErrNone, info: '0};
 
     unique case (st)
       StIdle: begin


### PR DESCRIPTION
This lint warning from Verilator is about an inferred latch. It seems
that Verilator version v4.108 doesn't spot that the three fields of
`error_o` are all assigned at the top of the `always_comb` block.
Recasting the statement as an equivalent assignment to `error_o` fixes
the problem.

This spurious warning is already fixed in Verilator, by commit 4f36e3e
which appears in release v4.202. So this won't be a problem long-term,
but there's no real reason to depend on newer versions of the tool at
the moment: if anything, the rewritten code looks easier to
understand.
