### PR TITLE
[spi_device] Add mbist_en port

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -58,6 +58,12 @@
       name:    "passthrough",
       act:     "req"
     }
+    { struct:  "logic"
+      package: ""
+      type:    "uni"
+      name:    "mbist_en"
+      act:     "rcv"
+    }
   ],
   regwidth: "32",
   registers: [

--- a/hw/ip/spi_device/dv/tb/tb.sv
+++ b/hw/ip/spi_device/dv/tb/tb.sv
@@ -58,6 +58,7 @@ module tb;
     .intr_rxerr_o   (intr_rxerr),
     .intr_rxoverflow_o (intr_rxoverflow),
     .intr_txunderflow_o(intr_txunderflow),
+    .mbist_en_i     (1'b0),
     .scanmode_i     (lc_ctrl_pkg::Off)
   );
 

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -38,6 +38,7 @@ module spi_device (
   input prim_ram_2p_pkg::ram_2p_cfg_t ram_cfg_i,
 
   // DFT related controls
+  input mbist_en_i,
   input scan_clk_i,
   input scan_rst_ni,
   input lc_ctrl_pkg::lc_tx_t scanmode_i
@@ -495,14 +496,14 @@ module spi_device (
   ) u_sram_clk_scan (
     .clk0_i (sram_clk_ungated),
     .clk1_i (scan_clk_i),
-    .sel_i  (scanmode[ClkSramSel] == lc_ctrl_pkg::On),
+    .sel_i  ((scanmode[ClkSramSel] == lc_ctrl_pkg::On) | mbist_en_i),
     .clk_o  (sram_clk_muxed)
   );
 
   prim_clock_gating u_sram_clk_cg (
     .clk_i  (sram_clk_muxed),
     .en_i   (sram_clk_en),
-    .test_en_i (scanmode[ClkSramSel] == lc_ctrl_pkg::On),
+    .test_en_i ((scanmode[ClkSramSel] == lc_ctrl_pkg::On) | mbist_en_i),
     .clk_o  (sram_clk)
   );
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -750,6 +750,15 @@
           index: -1
         }
         {
+          name: mbist_en
+          struct: logic
+          type: uni
+          act: rcv
+          width: 1
+          inst_name: spi_device
+          index: -1
+        }
+        {
           name: tl
           struct: tl
           package: tlul_pkg
@@ -11707,6 +11716,15 @@
         default: ""
         end_idx: -1
         top_signame: spi_device_passthrough
+        index: -1
+      }
+      {
+        name: mbist_en
+        struct: logic
+        type: uni
+        act: rcv
+        width: 1
+        inst_name: spi_device
         index: -1
       }
       {

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1181,6 +1181,7 @@ module top_earlgrey #(
       .ram_cfg_i(ast_ram_2p_cfg),
       .passthrough_o(spi_device_passthrough_req),
       .passthrough_i(spi_device_passthrough_rsp),
+      .mbist_en_i('0),
       .tl_i(spi_device_tl_req),
       .tl_o(spi_device_tl_rsp),
       .scanmode_i,


### PR DESCRIPTION
SPI_DEVICE Dual port SRAM receives muxed clock. The expected clock
frequencies are 24MHz (generic mode) and 48MHz (SPI Flash mode).

But the flash mode needs an external clock, SPI_SCK, which is the faster
clock 48MHz.

For the MBIST, it should use the faster clock to test the SPI_DEVICE
internal DPSRAM. This commit uses SCAN_CLOCK as a MBIST clock, as SCAN
clock is 48MHz at this time.