### PR TITLE
[dv/otp_ctrl] Add more possibility to issue lc_esc during key_req

### DIFF
--- a/hw/dv/sv/push_pull_agent/push_pull_if.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_if.sv
@@ -31,7 +31,7 @@ interface push_pull_if #(parameter int HostDataWidth = 32,
   logic req_int;
   logic ack_int;
   logic [HostDataWidth-1:0]   h_data_int;
-  logic [DeviceDataWidth-1:0]   d_data_int;
+  logic [DeviceDataWidth-1:0] d_data_int;
 
   // Interface mode - Host or Device
   dv_utils_pkg::if_mode_e if_mode;

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
@@ -41,7 +41,16 @@ class otp_ctrl_parallel_lc_esc_vseq extends otp_ctrl_dai_errs_vseq;
   endtask
 
   virtual task set_lc_esc_and_check();
-    // TODO: random drive any values instead of just on and off
+    // Random issue key requests before lc_esc_en is issued.
+    randcase
+      1: req_otbn_key(0);
+      1: req_flash_addr_key(0);
+      1: req_flash_data_key(0);
+      1: req_all_sram_keys(0);
+      1: req_lc_transition(0, 0);
+    endcase
+    cfg.clk_rst_vif.wait_clks($urandom_range(0, 50));
+
     cfg.otp_ctrl_vif.drive_lc_escalate_en(lc_ctrl_pkg::On);
 
     // TODO: in alert_esc_monitor, makes it auto-response like push-pull agent


### PR DESCRIPTION
This PR adds more possibility to issue lc_esc during key_req.

This first change is reverted as design decided to fix it with PR https://github.com/lowRISC/opentitan/pull/6607
Signed-off-by: Cindy Chen <chencindy@opentitan.org>