### PR TITLE
[dvsim/verilator] Remove FUSESOC_IGNORE

### DIFF
--- a/hw/dv/tools/dvsim/verilator.hjson
+++ b/hw/dv/tools/dvsim/verilator.hjson
@@ -43,10 +43,7 @@
   ]
   // -- END --
 
-  // Remove {proj_root}/hw/foundry from FuseSoC cores search if it exists.
-  pre_build_cmds: ['''if [ -d {proj_root}/hw/foundry ]; then \
-                        touch {proj_root}/hw/foundry/FUSESOC_IGNORE; \
-                      fi''']
+  pre_build_cmds: []
 
   build_cmd:  "fusesoc {fusesoc_cores_root_dirs} run"
   ex_name:    "{eval_cmd} echo \"{fusesoc_core}\" | cut -d: -f3"


### PR DESCRIPTION
This workaround is not needed anymore, since the offending vendor code that was failing compilation in Verilator has been fixed.

Signed-off-by: Michael Schaffner <msf@google.com>