### PR TITLE
[doc] Make the doc bucket match the build output

### DIFF
--- a/site/docs/cloudbuild-deploy-docs.yaml
+++ b/site/docs/cloudbuild-deploy-docs.yaml
@@ -6,4 +6,4 @@ steps:
 - name: 'gcr.io/active-premise-257318/builder'
   args: ['./util/build_docs.py']
 - name: 'gcr.io/cloud-builders/gsutil'
-  args: ['-m', 'rsync', '-r', 'build/docs/', 'gs://active-premise-257318']
+  args: ['-m', 'rsync', '-r', '-d','build/docs/', 'gs://active-premise-257318']


### PR DESCRIPTION
Add -d option to the gsutil rsync command used to deploy the documentation website. This forces the target destination bucket to 
match the contents of the build directory.

Additional documentation details are available here: https://cloud.google.com/storage/docs/gsutil/commands/rsync

This fixes lowrisc/opentitan#6587.

Signed-off-by: Miguel Osorio <miguelosorio@google.com>