### PR TITLE
[csrng/rtl] AES cipher input and output state transposed

### DIFF
--- a/hw/ip/csrng/rtl/csrng_block_encrypt.sv
+++ b/hw/ip/csrng/rtl/csrng_block_encrypt.sv
@@ -70,10 +70,10 @@ module csrng_block_encrypt #(
 
   assign     prd_clearing[0] = '0;
 
-  assign     state_init[0] = block_encrypt_v_i;
+  assign     state_init[0] = aes_pkg::aes_transpose(block_encrypt_v_i);
 
   assign     key_init[0] = block_encrypt_key_i;
-  assign     state_out = state_done[0];
+  assign     state_out = aes_pkg::aes_transpose(state_done[0]);
   assign     cipher_data_out =  state_out;
 
 


### PR DESCRIPTION
The input state_init and output state_done need to be transposed.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>