### PR TITLE
[dpi_memutil] Fix bug in RegisterMemoryArea

### DIFF
--- a/hw/dv/verilator/cpp/dpi_memutil.cc
+++ b/hw/dv/verilator/cpp/dpi_memutil.cc
@@ -328,8 +328,8 @@ void DpiMemUtil::RegisterMemoryArea(const std::string &name, uint32_t base,
 
   size_t new_idx = mem_areas_.size();
   auto pr = name_to_mem_.emplace(name, new_idx);
-  const MemArea &stored = *mem_areas_[pr.first->second];
   if (!pr.second) {
+    const MemArea &stored = *mem_areas_[pr.first->second];
     std::ostringstream oss;
     oss << "Cannot register '" << name << "' at: '" << mem_area->GetScope()
         << "' (Previously defined at: '" << stored.GetScope() << "')"


### PR DESCRIPTION
If `!name_to_mem_.emplace().second` then we already had a memory area
for the given name and `pr.first->second` is a valid index into the
vector called `mem_areas_`. If not, it ain't.

We grab a reference to the already-existing memory area in order to
print out an error message, but were accidentally doing so outside of
the error path. This causes a segfault, but only some of the time. (In
particular, it seems to depend on the Verilator version, which is a
bit bizarre).

Fixes a bug reported as https://github.com/lowRISC/ibex/issues/1352.