### PR TITLE
[pinmux] connected tdo dft hook bufs to const 0

### DIFF
--- a/hw/ip/pinmux/rtl/pinmux_jtag_buf.sv
+++ b/hw/ip/pinmux/rtl/pinmux_jtag_buf.sv
@@ -26,11 +26,11 @@ module pinmux_jtag_buf (
     .out_o(req_o.tdi)
   );
   prim_buf prim_buf_tdo (
-    .in_i (rsp_i.tdo),
+    .in_i (1'b0),
     .out_o(rsp_o.tdo)
   );
   prim_buf prim_buf_tdo_oe (
-    .in_i (rsp_i.tdo_oe),
+    .in_i (1'b0),
     .out_o(rsp_o.tdo_oe)
   );
 


### PR DESCRIPTION
Signed-off-by: Arnon Sharlin <arnon.sharlin@opentitan.org>

The old code also connected to const 0, but through SV package type.
Unfortunately Tessent fails reading this code. changing to const 1'b0 solves this.