### PR TITLE
[dpi] Fix indexing bug in ecc32_mem_area

### DIFF
--- a/hw/dv/verilator/cpp/ecc32_mem_area.cc
+++ b/hw/dv/verilator/cpp/ecc32_mem_area.cc
@@ -55,28 +55,51 @@ void Ecc32MemArea::WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
     expanded[i] = next;
   }
 
-  // Now write to buf, pulling 39 bits from each element of in_64.
+  // Now write to buf, one output byte at a time.
   for (int i = 0; i < phy_width_bytes; ++i) {
+    int out_bit = i * 8;
+
+    // Acc is the accumulator we're building up for the byte that should be
+    // written out. out_lsb is the LSB in acc to which we're writing at the
+    // moment.
     uint8_t acc = 0;
     int out_lsb = 0;
 
-    int in_word_idx = (8 * i) / 39;
-    int in_word_lsb = (8 * i) % 39;
+    // in_word_idx is the input word that we're reading from and in_word_lsb is
+    // the first bit of that word that we're reading.
+    int in_word_idx = out_bit / 39;
+    int in_word_lsb = out_bit % 39;
 
-    int bits_left = 8;
+    // bits_left is the number of bits that we need to read for this byte. It's
+    // usually initialised to 8, except for the last byte of the output word,
+    // which might just have a few bits to contribute.
+    int bits_left = std::min(8, phy_width_bits - out_bit);
     while (bits_left) {
+      // in_byte_idx is the index of the byte within the (expanded_t) input
+      // word that we're reading from. in_byte_lsb is the bit position within
+      // that byte.
       int in_byte_idx = in_word_lsb / 8;
       int in_byte_lsb = in_word_lsb % 8;
 
-      int byte_width = (in_byte_idx == 4) ? 7 : 8;
-      int bits_at_byte = std::min(byte_width - in_byte_lsb, bits_left);
+      // Most of the bytes in the expanded_t hold 8 bits of data, except the
+      // top one, which only holds 7 (bits 39:32). bits_at_byte is the number
+      // of bits that we're reading from this input byte, constrained by the
+      // number of bits available and the number of bits that we want.
+      int in_byte_width = (in_byte_idx == 4) ? 7 : 8;
+      int bits_at_byte = std::min(in_byte_width - in_byte_lsb, bits_left);
 
+      // Extract bits_at_byte bits of input data from the relevant input byte,
+      // starting at in_byte_lsb.
       uint8_t in_data = expanded[in_word_idx].bytes[in_byte_idx] >> in_byte_lsb;
       uint8_t in_mask = (((uint32_t)1 << bits_at_byte) - 1) & 0xff;
+      uint8_t masked = in_data & in_mask;
 
-      acc |= (in_data & in_mask) << out_lsb;
-
+      // Add the extracted bits to acc, shifting them into position and
+      // updating out_lsb for next time around.
+      acc |= masked << out_lsb;
       out_lsb += bits_at_byte;
+
+      // Update input pointers to step over the byte we just consumed.
       if (in_byte_idx == 4) {
         ++in_word_idx;
         in_word_lsb = 0;
@@ -84,6 +107,7 @@ void Ecc32MemArea::WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
         in_word_lsb += bits_at_byte;
       }
 
+      // Subtract the bits we just read from the count we're expecting to read.
       bits_left -= bits_at_byte;
     }
     buf[i] = acc;


### PR DESCRIPTION
This caused a Valgrind error when setting up imem for OTBN. The bug
was that we were trying to read 40 rather than 39 bits of input. The
fix is the `std::min()` when defining `bits_left`.

The rest of the patch is just variable name changes and comments to
make it more obvious how everything works (because this took me quite
some time to debug, even though wrote the code in the first place!)
