### PR TITLE
[rom_ctrl/dv] Add checking on outputs

### DIFF
--- a/hw/ip/rom_ctrl/data/rom_ctrl.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl.hjson
@@ -122,10 +122,9 @@
               desc: "32 bits of the digest"
             }
           ]
-          // TODO: We're disabling CSR checks for this register for now, since
-          //       its value will change under the feet of the CSR package as
-          //       the ROM checker computes a digest. Re-enable this (and add
-          //       RAL reflection) once we have a working testbench.
+          // Disable CSR checks for digest registers, since their values will
+          // change under the feet of the CSR package as the ROM checker computes
+          // a digest. These values are checked instead by the rom_ctrl TB.
           tags: ["excl:CsrAllTests:CsrExclCheck"]
         }
       }
@@ -144,7 +143,7 @@
               desc: "32 bits of the digest"
             }
           ]
-          // TODO: As with DIGEST, re-enable this when we have a working testbench
+          // As with DIGEST, these values are checked by the rom_ctrl TB.
           tags: ["excl:CsrAllTests:CsrExclCheck"]
         }
       }

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
@@ -26,6 +26,13 @@ package rom_ctrl_env_pkg;
   parameter string LIST_OF_ALERTS[] = {"fatal"};
   parameter uint   NUM_ALERTS = 1;
 
+  // The top bytes in memory hold the digest
+  parameter uint MAX_CHECK_ADDR = rom_ctrl_reg_pkg::ROM_CTRL_ROM_SIZE - (kmac_pkg::AppDigestW / 8);
+  // The data for each line in rom up to the digest is padded out to the kmac message width
+  parameter uint KMAC_DATA_SIZE = MAX_CHECK_ADDR / (TL_DW / 8) * (kmac_pkg::MsgWidth / 8);
+  // The rom width is rounded up to 40 for scrambling symmetry
+  parameter uint ROM_MEM_W = 40;
+
   // types
   typedef virtual mem_bkdr_if #(.MEM_ECC(prim_secded_pkg::Secded_39_32)) mem_bkdr_vif;
   typedef virtual rom_ctrl_if rom_ctrl_vif;

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
@@ -9,6 +9,14 @@ class rom_ctrl_scoreboard extends cip_base_scoreboard #(
   );
   `uvm_component_utils(rom_ctrl_scoreboard)
 
+  // local variables
+  bit [kmac_pkg::AppDigestW-1:0] expected_digest;
+  bit [kmac_pkg::AppDigestW-1:0] kmac_digest;
+  bit                            rom_check_complete;
+  bit                            digest_good;
+  bit                            pwrmgr_complete;
+  bit                            keymgr_complete;
+
   // TLM agent fifos
   uvm_tlm_analysis_fifo #(kmac_app_item) kmac_req_fifo;
   uvm_tlm_analysis_fifo #(kmac_app_item) kmac_rsp_fifo;
@@ -35,23 +43,101 @@ class rom_ctrl_scoreboard extends cip_base_scoreboard #(
     forever begin
       kmac_req_fifo.get(kmac_req);
       `uvm_info(`gfn, $sformatf("Detected a KMAC req:\n%0s", kmac_req.sprint()), UVM_HIGH)
+      // We shouldn't see any further requests one the check has completed
+      `DV_CHECK_EQ(rom_check_complete, 1'b0, "Spurious ROM request received")
+      // Check the data is valid
+      check_kmac_data(kmac_req.byte_data_q);
     end
   endtask
 
+  // Read data sent to the kmac block and check it against memory data
+  virtual function void check_kmac_data(const ref byte byte_data_q[$]);
+    int dword = 0;
+    int addr = 0;
+    // Check that we received the expected amount of data
+    `DV_CHECK_EQ(byte_data_q.size(), KMAC_DATA_SIZE, "Unexpected kmac data size")
+    // Read out the data 8 bytes at a time
+    while (dword < byte_data_q.size()) begin
+      bit [kmac_pkg::MsgWidth-1:0] exp, act;
+      bit [ROM_MEM_W-1:0]          mem_data;
+      mem_data = cfg.mem_bkdr_vif.rom_encrypt_read32(
+          addr, RND_CNST_SCR_KEY, RND_CNST_SCR_NONCE, 1'b0);
+      exp = {{kmac_pkg::MsgWidth-ROM_MEM_W{1'b0}}, mem_data};
+      for (int i = 0; i < kmac_pkg::MsgWidth / 8; i++) begin
+        act[i*8+:8] = byte_data_q[dword+i];
+      end
+      // Check the data matches
+      `DV_CHECK_EQ(act, exp, $sformatf("Unexpected data at addr: %0x", addr))
+      // Check the address is within range
+      `DV_CHECK_LT(addr, MAX_CHECK_ADDR,
+          $sformatf("Check address out of range: %0x", addr))
+      addr  += (TL_DW / 8);
+      dword += (kmac_pkg::MsgWidth / 8);
+    end
+  endfunction
 
   virtual task process_kmac_rsp_fifo();
     kmac_app_item kmac_rsp;
     forever begin
       kmac_rsp_fifo.get(kmac_rsp);
       `uvm_info(`gfn, $sformatf("Detected a KMAC response:\n%0s", kmac_rsp.sprint()), UVM_HIGH)
+      // We shouldn't see any further responses one the check has completed
+      `DV_CHECK_EQ(rom_check_complete, 1'b0, "Spurious ROM response received")
+      kmac_digest = kmac_rsp.rsp_digest_share0 ^ kmac_rsp.rsp_digest_share1;
+      get_expected_digest();
+      update_ral_digests();
+      digest_good = (kmac_digest == expected_digest);
+      rom_check_complete = 1'b1;
     end
   endtask
+
+  // Pull the expected digest value from the top of rom
+  virtual function void get_expected_digest();
+    bit [kmac_pkg::AppDigestW-1:0]    digest;
+    bit [rom_ctrl_reg_pkg::RomAw-1:0] dig_addr;
+    // Get the digest from rom
+    // The digest is the top 8 words in memory (unscrambled)
+    dig_addr = MAX_CHECK_ADDR;
+    for (int i = 0; i < kmac_pkg::AppDigestW / TL_DW; i++) begin
+      bit [ROM_MEM_W-1:0] mem_data = cfg.mem_bkdr_vif.rom_encrypt_read32(
+          dig_addr, RND_CNST_SCR_KEY, RND_CNST_SCR_NONCE, 1'b0);
+      digest[i*TL_DW+:TL_DW] = mem_data[TL_DW-1:0];
+      dig_addr += (TL_DW / 8);
+    end
+    expected_digest = digest;
+  endfunction
+
+  // Update the RAL model with expected values for the digest registers
+  virtual function void update_ral_digests();
+    for (int i = 0; i < kmac_pkg::AppDigestW / TL_DW; i++) begin
+      string digest_name = $sformatf("digest_%0d", i);
+      uvm_reg csr = ral.get_reg_by_name(digest_name);
+      void'(csr.predict(.value(kmac_digest[i*TL_DW+:TL_DW]), .kind(UVM_PREDICT_READ)));
+    end
+    for (int i = 0; i < kmac_pkg::AppDigestW / TL_DW; i++) begin
+      string digest_name = $sformatf("exp_digest_%0d", i);
+      uvm_reg csr = ral.get_reg_by_name(digest_name);
+      void'(csr.predict(.value(expected_digest[i*TL_DW+:TL_DW]), .kind(UVM_PREDICT_READ)));
+    end
+  endfunction
 
   // Montitor and check outputs sent to pwrmgr and keymgr
   virtual task monitor_rom_ctrl_if();
     forever begin
       @(cfg.rom_ctrl_vif.pwrmgr_data or cfg.rom_ctrl_vif.keymgr_data or cfg.under_reset);
       if (cfg.under_reset) continue;
+      // Check data sent to pwrmgr
+      if (cfg.rom_ctrl_vif.pwrmgr_data.done) begin
+        `DV_CHECK_EQ(pwrmgr_complete, 1'b0, "Spurious pwrmgr signal")
+        `DV_CHECK_EQ(cfg.rom_ctrl_vif.pwrmgr_data.good, digest_good, "Incorrect pwrmgr result")
+        pwrmgr_complete = 1'b1;
+      end
+      // Check data sent to keymgr
+      if (cfg.rom_ctrl_vif.keymgr_data.valid) begin
+        `DV_CHECK_EQ(keymgr_complete, 1'b0, "Spurious keymgr signal")
+        `DV_CHECK_EQ(cfg.rom_ctrl_vif.keymgr_data.data, kmac_digest, "Incorrect keymgr digest")
+        keymgr_complete = 1'b1;
+      end
     end
   endtask
 
@@ -91,6 +177,13 @@ class rom_ctrl_scoreboard extends cip_base_scoreboard #(
       "fatal_alert_cause": begin
         // do_nothing
       end
+      "digest_0", "digest_1", "digest_2", "digest_3", "digest_4", "digest_5", "digest_6",
+          "digest_7", "exp_digest_0", "exp_digest_1", "exp_digest_2", "exp_digest_3",
+          "exp_digest_4", "exp_digest_5", "exp_digest_6", "exp_digest_7": begin
+        if (!rom_check_complete) begin
+          do_read_check = 1'b0;
+        end
+      end
       default: begin
         `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
       end
@@ -109,11 +202,17 @@ class rom_ctrl_scoreboard extends cip_base_scoreboard #(
   virtual function void reset(string kind = "HARD");
     super.reset(kind);
     // reset local fifos queues and variables
+    rom_check_complete = 1'b0;
+    pwrmgr_complete = 1'b0;
+    keymgr_complete = 1'b0;
   endfunction
 
   function void check_phase(uvm_phase phase);
     super.check_phase(phase);
     // post test checks - ensure that all local fifos and queues are empty
+    `DV_CHECK_EQ(rom_check_complete, 1'b1, "rom check didn't finish")
+    `DV_CHECK_EQ(pwrmgr_complete, 1'b1, "pwrmgr signals never checked")
+    `DV_CHECK_EQ(keymgr_complete, 1'b1, "keymgr signals never checked")
   endfunction
 
 endclass

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
@@ -61,4 +61,18 @@ class rom_ctrl_base_vseq extends cip_base_vseq #(
     csr_utils_pkg::wait_no_outstanding_access();
   endtask
 
+  virtual task read_digest_regs();
+    bit [TL_DW-1:0] rdata;
+    for (int i = 0; i < kmac_pkg::AppDigestW / TL_DW; i++) begin
+      string digest_name = $sformatf("digest_%0d", i);
+      uvm_reg csr = ral.get_reg_by_name(digest_name);
+      csr_rd(.ptr(csr), .value(rdata));
+    end
+    for (int i = 0; i < kmac_pkg::AppDigestW / TL_DW; i++) begin
+      string digest_name = $sformatf("exp_digest_%0d", i);
+      uvm_reg csr = ral.get_reg_by_name(digest_name);
+      csr_rd(.ptr(csr), .value(rdata));
+    end
+  endtask
+
 endclass : rom_ctrl_base_vseq

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_smoke_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_smoke_vseq.sv
@@ -18,6 +18,7 @@ class rom_ctrl_smoke_vseq extends rom_ctrl_base_vseq;
   task body();
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_mem_reads)
     do_rand_ops(num_mem_reads);
+    read_digest_regs();
   endtask : body
 
 endclass : rom_ctrl_smoke_vseq


### PR DESCRIPTION
This commit adds checking to the scoreboard for outputs sent to kmac,
keymgr and pwrmgr as well as updating expected values for the digest
csrs and reading them back in the smoke test.

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>