### PR TITLE
[otbn] Add ASSERT_KNOWN to done_o output from core

### DIFF
--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -499,5 +499,8 @@ module otbn_core
     .edn_urnd_data_i
   );
 
+  // Asserts =======================================================================================
+
   `ASSERT(edn_req_stable, edn_rnd_req_o & ~edn_rnd_ack_i |=> edn_rnd_req_o)
+  `ASSERT_KNOWN(DoneOKnown_A, done_o)
 endmodule


### PR DESCRIPTION
This signal doesn't make it out to top-level unless the interrupt is
enabled. Spotting X's here gives a rather more obvious symptom than
what did happen (a mismatch in the idle-checking interface).

@GregAC: This check was triggered by the mis-wired ECC stuff you fixed earlier and it showed up in the nightly tests. It would probably have been a little easier to diagnose if we'd had an assertion here too.