### PR TITLE
[dv/otp_ctrl] Add more functional coverage to otp_ctrl

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cov.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cov.sv
@@ -8,11 +8,97 @@
  * Covergroups may also be wrapped inside helper classes if needed.
  */
 
+class otp_ctrl_unbuf_err_code_cg_wrap;
+  // Unbuffered partition can use TLUL interface to read out but cannot write, thus error_code does
+  // not have write_blank_err.
+  covergroup unbuf_err_code_cg(string name) with function sample(bit [TL_DW-1:0] val);
+    option.per_instance = 1;
+    option.name         = name;
+    err_code_vals: coverpoint val {
+      bins no_err              = {OtpNoError};
+      bins macro_err           = {OtpMacroError};
+      // TODO: will cover with the latest mem_bkdr_if method
+      // bins ecc_corr_err     = {'b010};
+      bins ecc_uncorr_err      = {OtpMacroEccUncorrError};
+      bins access_err          = {OtpAccessError};
+      bins check_fail          = {OtpCheckFailError};
+      bins fsm_err             = {OtpFsmStateError};
+      illegal_bins illegal_err = default;
+    }
+  endgroup
+
+  function new(string name);
+    unbuf_err_code_cg = new(name);
+  endfunction
+endclass
+
+class otp_ctrl_buf_err_code_cg_wrap;
+  // Buffered partition must use DAI interface to access partition, so it does not have access_err
+  // and write_blank err.
+  covergroup buf_err_code_cg(string name) with function sample(bit [TL_DW-1:0] val);
+    option.per_instance = 1;
+    option.name         = name;
+    err_code_vals: coverpoint val {
+      bins no_err              = {OtpNoError};
+      bins macro_err           = {OtpMacroError};
+      bins ecc_corr_err        = {OtpMacroEccCorrError};
+      bins ecc_uncorr_err      = {OtpMacroEccUncorrError};
+      bins check_fail          = {OtpCheckFailError};
+      bins fsm_err             = {OtpFsmStateError};
+      illegal_bins illegal_err = default;
+    }
+  endgroup
+
+  function new(string name);
+    buf_err_code_cg = new(name);
+  endfunction
+endclass
+
+class otp_ctrl_csr_rd_after_alert_cg_wrap;
+  // This covergroup samples CSRs being checked (via CSR read) after fatal alert is issued.
+  covergroup csr_rd_after_alert_cg(otp_ctrl_reg_block ral) with function sample(bit[TL_DW-1:0] csr_offset);
+    read_csr_after_alert_issued: coverpoint csr_offset {
+      bins unbuffered_digests  = {ral.creator_sw_cfg_digest_0.get_offset(),
+                                  ral.creator_sw_cfg_digest_1.get_offset(),
+                                  ral.owner_sw_cfg_digest_0.get_offset(),
+                                  ral.owner_sw_cfg_digest_1.get_offset()};
+      bins hw_digests          = {ral.hw_cfg_digest_0.get_offset(),
+                                  ral.hw_cfg_digest_1.get_offset()};
+      bins secret_digests      = {ral.secret0_digest_0.get_offset(),
+                                  ral.secret0_digest_1.get_offset(),
+                                  ral.secret1_digest_0.get_offset(),
+                                  ral.secret1_digest_1.get_offset(),
+                                  ral.secret2_digest_0.get_offset(),
+                                  ral.secret2_digest_1.get_offset()};
+      bins direct_access_rdata = {ral.direct_access_rdata_0.get_offset(),
+                                  ral.direct_access_rdata_1.get_offset()};
+      bins status              = {ral.status.get_offset()};
+      bins error_code          = {ral.err_code.get_offset()};
+    }
+  endgroup
+
+  function new(otp_ctrl_reg_block ral);
+    csr_rd_after_alert_cg = new(ral);
+  endfunction
+
+  function void sample(bit[TL_DW-1:0] csr_offset);
+    csr_rd_after_alert_cg.sample(csr_offset);
+  endfunction
+endclass
+
 class otp_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(otp_ctrl_env_cfg));
   `uvm_component_utils(otp_ctrl_env_cov)
 
   // the base class provides the following handles for use:
   // otp_ctrl_env_cfg: cfg
+
+  otp_ctrl_unbuf_err_code_cg_wrap     unbuf_err_code_cg_wrap[NUM_UNBUFF_PARTS];
+  otp_ctrl_buf_err_code_cg_wrap       buf_err_code_cg_wrap[NUM_BUFF_PARTS];
+  otp_ctrl_csr_rd_after_alert_cg_wrap csr_rd_after_alert_cg_wrap;
+
+  bit_toggle_cg_wrap lc_prog_cg;
+  bit_toggle_cg_wrap otbn_req_cg;
+  bit_toggle_cg_wrap status_csr_cg[OtpStatusFieldSize];
 
   // covergroups
   // This covergroup collects different conditions when outputs (hwcfg_o, keymgr_key_o) are checked
@@ -29,10 +115,7 @@ class otp_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(otp_ctrl_env_cfg));
     screct2_lock:    coverpoint parts_locked[5];
   endgroup
 
-  bit_toggle_cg_wrap lc_prog_cg;
-  bit_toggle_cg_wrap otbn_req_cg;
-
-  // This coverpoint is only collected if flash request passed scb check
+  // This covergroup is sampled only if flash request passed scb check.
   covergroup flash_req_cg with function sample (int index, bit locked);
     flash_index: coverpoint index {
       bins flash_data_key = {FlashDataKey};
@@ -43,7 +126,7 @@ class otp_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(otp_ctrl_env_cfg));
     flash_req_lock_cross: cross flash_index, secret1_lock;
   endgroup
 
-  // This coverpoint is only collected if sram request passed scb check
+  // This covergroup is sampled only if sram request passed scb check.
   covergroup sram_req_cg with function sample (int index, bit locked);
     sram_index: coverpoint index {
       bins sram_key0  = {0};
@@ -54,20 +137,155 @@ class otp_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(otp_ctrl_env_cfg));
     sram_req_lock_cross: cross sram_index, secret1_lock;
   endgroup
 
+  // This covergroup is sampled only if keymgr output passed scb check.
+  covergroup keymgr_o_cg with function sample (bit lc_seed_hw_rd_en, bit locked);
+    keymgr_rd_en: coverpoint lc_seed_hw_rd_en;
+    secret2_lock: coverpoint locked;
+    keymgr_output_conditions: cross keymgr_rd_en, secret2_lock;
+  endgroup
+
+  // This covergroup samples dai request being issued after fatal alert is issued.
+  covergroup req_dai_access_after_alert_cg with function sample(bit [TL_DW-1:0] val);
+    req_dai_access_after_alert_issued: coverpoint val {
+      bins dai_write  = {DaiWrite};
+      bins dai_read   = {DaiRead};
+      bins dai_digest = {DaiDigest};
+    }
+  endgroup
+
+  // This covergroup samples background check being issued after fatal alert is issued.
+  covergroup issue_checks_after_alert_cg with function sample(bit [TL_DW-1:0] val);
+    issue_checks_after_alert_issued: coverpoint val {
+      bins integrity_check   = {1};
+      bins consistency_check = {2};
+    }
+  endgroup
+
+  // This covergroup collects DAI err_code value.
+  // DAI access does not have checks, thus no check_fail error.
+  covergroup dai_err_code_cg with function sample(bit [TL_DW-1:0] val, int part_idx);
+    err_code_vals: coverpoint val {
+      bins no_err              = {OtpNoError};
+      bins macro_err           = {OtpMacroError};
+      bins ecc_corr_err        = {OtpMacroEccCorrError};
+      bins ecc_uncorr_err      = {OtpMacroEccUncorrError};
+      bins write_blank_err     = {OtpMacroWriteBlankError};
+      bins access_err          = {OtpAccessError};
+      bins fsm_err             = {OtpFsmStateError};
+      illegal_bins illegal_err = default;
+    }
+    partition: coverpoint part_idx {
+      bins creator_sw_cfg = {CreatorSwCfgIdx};
+      bins owner_sw_cfg   = {OwnerSwCfgIdx};
+      bins hw_cfg         = {HwCfgIdx};
+      bins secret0        = {Secret0Idx};
+      bins secret1        = {Secret1Idx};
+      bins secret2        = {Secret2Idx};
+      bins lc_or_oob      = {LifeCycleIdx};
+      bins illegal_idx    = default;
+    }
+    // LC partition has a separate LCI err_code to collect macro related errors.
+    dai_err_code_for_all_partitions: cross err_code_vals, partition {
+      ignore_bins lc_or_oob_ignore = binsof (partition.lc_or_oob) &&
+                  binsof(err_code_vals) intersect {[OtpMacroError:OtpMacroWriteBlankError]};
+    }
+  endgroup
+
+  // This covergroup collects LCI err_code value.
+  // LCI access does not have digest, thus no access_err. Check_fail, ecc_errors are covered in lc
+  // buffered partition instead of LCI here.
+  covergroup lci_err_code_cg with function sample(bit [TL_DW-1:0] val);
+    err_code_vals: coverpoint val {
+      bins no_err              = {OtpNoError};
+      bins macro_err           = {OtpMacroError};
+      bins write_blank_err     = {OtpMacroWriteBlankError};
+      bins fsm_err             = {OtpFsmStateError};
+      illegal_bins illegal_err = default;
+    }
+  endgroup
+
+  covergroup dai_access_secret2_cg with function sample(bit lc_rw_en, dai_cmd_e dai_cmd);
+    lc_creator_seed_sw_rw_en: coverpoint lc_rw_en;
+    dai_access_cmd: coverpoint dai_cmd {
+      bins dai_rd     = {DaiRead};
+      bins dai_wr     = {DaiWrite};
+      bins dai_digest = {DaiDigest};
+    }
+    dai_access_secret2: cross lc_creator_seed_sw_rw_en, dai_access_cmd;
+  endgroup
+
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    power_on_cg  = new();
-    flash_req_cg = new();
-    sram_req_cg  = new();
-    lc_prog_cg   = new("lc_prog_cg", "", 0);
-    otbn_req_cg  = new("otbn_req_cg", "", 0);
+    // Create coverage from local covergroups.
+    power_on_cg                   = new();
+    flash_req_cg                  = new();
+    sram_req_cg                   = new();
+    keymgr_o_cg                   = new();
+    req_dai_access_after_alert_cg = new();
+    issue_checks_after_alert_cg   = new();
+    dai_err_code_cg               = new();
+    lci_err_code_cg               = new();
+    dai_access_secret2_cg         = new();
   endfunction : new
 
   virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    // [or instantiate covergroups here]
-    // Please instantiate sticky_intr_cov array of objects for all interrupts that are sticky
-    // See cip_base_env_cov for details
+    // Create instances from bit_toggle_cg_wrapper.
+    lc_prog_cg  = new("lc_prog_cg", "", 0);
+    otbn_req_cg = new("otbn_req_cg", "", 0);
+    foreach (status_csr_cg[i]) begin
+      otp_status_e index = otp_status_e'(i);
+      status_csr_cg[i]= new(index.name, "status_csr_cg", 0);
+    end
+
+    // Create instances from external wrapper classes.
+    csr_rd_after_alert_cg_wrap = new(cfg.ral);
+    foreach (unbuf_err_code_cg_wrap[i]) begin
+      otp_status_e index = otp_status_e'(i);
+      unbuf_err_code_cg_wrap[i] = new($sformatf("unbuf_err_code_cg_wrap[%0s]", index.name));
+    end
+    foreach (buf_err_code_cg_wrap[i]) begin
+      otp_status_e index = otp_status_e'(i + 2);
+      buf_err_code_cg_wrap[i] = new($sformatf("buf_err_code_cg_wrap[%0s]", index.name));
+    end
+  endfunction
+
+  function void collect_status_cov(bit [TL_DW-1:0] val);
+    foreach (status_csr_cg[i]) begin
+      status_csr_cg[i].sample(val[i]);
+    end
+  endfunction
+
+  function void collect_err_code_cov(bit [TL_DW-1:0] val, int part_idx = DaiIdx);
+    dv_base_reg_field err_code_flds[$];
+    cfg.ral.err_code.get_dv_base_reg_fields(err_code_flds);
+    foreach (err_code_flds[i]) begin
+      collect_err_code_field_cov(i, get_field_val(err_code_flds[i], val), part_idx);
+    end
+  endfunction
+
+  // Collect coverage according to the field_index. For DAI index, user needs to input
+  // which partition causes the DAI error. Default part_idx `DaiIdx` won't be collected.
+  function void collect_err_code_field_cov(int field_idx, bit [TL_DW-1:0] val,
+                                           int part_idx = DaiIdx);
+    case (field_idx)
+      OtpCreatorSwCfgErrIdx, OtpOwnerSwCfgErrIdx: begin
+        unbuf_err_code_cg_wrap[field_idx].unbuf_err_code_cg.sample(val);
+      end
+      OtpHwCfgErrIdx, OtpSecret0ErrIdx, OtpSecret1ErrIdx, OtpSecret2ErrIdx,
+      OtpLifeCycleErrIdx: begin
+        buf_err_code_cg_wrap[field_idx - 2].buf_err_code_cg.sample(val);
+      end
+      OtpDaiErrIdx: begin
+        dai_err_code_cg.sample(val, part_idx);
+      end
+      OtpLciErrIdx: begin
+        lci_err_code_cg.sample(val);
+      end
+      default: begin
+        `uvm_fatal(`gfn, $sformatf("invalid err_code index %0d", field_idx))
+      end
+    endcase
   endfunction
 
 endclass

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -86,6 +86,9 @@ package otp_ctrl_env_pkg;
   parameter uint NUM_SRAM_EDN_REQ = 12;
   parameter uint NUM_OTBN_EDN_REQ = 16;
 
+  parameter uint NUM_UNBUFF_PARTS = 2;
+  parameter uint NUM_BUFF_PARTS   = 5;
+
   parameter uint CHK_TIMEOUT_CYC = 40;
 
   // When fatal alert triggered, all partitions go to error state and status will be 1.
@@ -118,7 +121,7 @@ package otp_ctrl_env_pkg;
     NumOtpCtrlIntr
   } otp_intr_e;
 
-  typedef enum bit [4:0] {
+  typedef enum bit [5:0] {
     OtpCreatorSwCfgErrIdx,
     OtpOwnerSwCfgErrIdx,
     OtpHwCfgErrIdx,
@@ -133,7 +136,8 @@ package otp_ctrl_env_pkg;
     OtpScramblingFsmErrIdx,
     OtpDerivKeyFsmErrIdx,
     OtpDaiIdleIdx,
-    OtpCheckPendingIdx
+    OtpCheckPendingIdx,
+    OtpStatusFieldSize
   } otp_status_e;
 
   typedef enum bit [2:0] {

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
@@ -187,6 +187,7 @@ class otp_ctrl_init_fail_vseq extends otp_ctrl_smoke_vseq;
         end else if (err_code != OtpFsmStateError) begin
           `uvm_error(`gfn, $sformatf("Unexpected error code_%0d: %0s", i, err_code.name));
         end
+        if (cfg.en_cov) cov.collect_err_code_field_cov(i, err_code);
       end
     end
     // More than one fatal alert causes could be triggered at the same time

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_invalid_cmd_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_invalid_cmd_vseq.sv
@@ -10,8 +10,13 @@ class otp_ctrl_macro_invalid_cmd_vseq extends otp_ctrl_smoke_vseq;
 
   rand otp_ctrl_part_pkg::part_idx_e exp_macro_err;
 
-  bit [NumPart+2:0] act_macro_err;
+  bit [NumPart+1:0] act_macro_err;
   bit               exp_buffer_err;
+
+  // This variable is declared for DAI err_code functional coverage.
+  // Default to DaiIdx that won't be sampled in dai_err_code.
+  // Only update this value if the err_code is DaiIdx.
+  int dai_macro_err_part_idx = DaiIdx;
 
   constraint macro_err_c {exp_macro_err inside {[CreatorSwCfgIdx:LciIdx]};}
 
@@ -55,7 +60,10 @@ class otp_ctrl_macro_invalid_cmd_vseq extends otp_ctrl_smoke_vseq;
               // Max delay for push-pull agent to send a request
               cfg.clk_rst_vif.wait_clks(1000);
             end
-            DaiIdx: dai_rd(dai_addr, 0, wdata0, wdata1);
+            DaiIdx: begin
+              dai_rd(dai_addr, 0, wdata0, wdata1);
+              dai_macro_err_part_idx = get_part_index(dai_addr);
+            end
             default: `uvm_fatal(`gfn, $sformatf("exp_macro_err %0h not supported", exp_macro_err))
           endcase
           act_macro_err[exp_macro_err] = 1;
@@ -78,7 +86,10 @@ class otp_ctrl_macro_invalid_cmd_vseq extends otp_ctrl_smoke_vseq;
     end
 
     foreach (act_macro_err[i]) begin
-      if (act_macro_err[i]) csr_rd_check(.ptr(err_code_flds[i]), .compare_value(OtpMacroError));
+      if (act_macro_err[i]) begin
+        csr_rd_check(.ptr(err_code_flds[i]), .compare_value(OtpMacroError));
+        if (cfg.en_cov) cov.collect_err_code_field_cov(i, OtpMacroError, dai_macro_err_part_idx);
+      end
     end
 
     // Issue reset to stop fatal alert


### PR DESCRIPTION
This PR adds the following functional coverages to OTP_CTRL:
1. Error code coverage
2. Status coverage
3. CSR read/write after alert happened
4. LC_escalation On during dai busy

Signed-off-by: Cindy Chen <chencindy@opentitan.org>