### PR TITLE
[dv/csr_utils] update unmapped_addr calculation

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -235,7 +235,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   // check if it's mem addr
   virtual function bit is_mem_addr(tl_seq_item item, string ral_name);
     uvm_reg_addr_t addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
-    addr_range_t   loc_mem_ranges[$] = cfg.mem_ranges[ral_name];
+    addr_range_t   loc_mem_ranges[$] = cfg.ral_models[ral_name].mem_ranges;
     foreach (loc_mem_ranges[i]) begin
       if (addr inside {[loc_mem_ranges[i].start_addr : loc_mem_ranges[i].end_addr]}) begin
         return 1;
@@ -289,7 +289,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   virtual function bit is_tl_access_mapped_addr(tl_seq_item item, string ral_name);
     uvm_reg_addr_t addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
     // check if it's mem addr or reg addr
-    return is_mem_addr(item, ral_name) || addr inside {cfg.csr_addrs[ral_name]};
+    return is_mem_addr(item, ral_name) || addr inside {cfg.ral_models[ral_name].csr_addrs};
   endfunction
 
   // check if tl mem access will trigger error or not

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -49,7 +49,11 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
   addr_mask_t mem_exist_addr_q[string][$];
 
   // mem_ranges without base address
-  addr_range_t     updated_mem_ranges[string][$];
+  addr_range_t updated_mem_ranges[string][$];
+
+  // unmapped addr ranges without base address
+  addr_range_t updated_unmapped_addr_ranges[string][$];
+
   // mask out bits out of the csr/mem range and LSB 2 bits
   bit [BUS_AW-1:0] csr_addr_mask[string];
 
@@ -861,13 +865,13 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
   // test partial mem read with non-blocking random read/write
   virtual task run_mem_partial_access_vseq(int num_times);
     `loop_ral_models_to_create_threads(
-        if (cfg.mem_ranges[ral_name].size > 0) begin
+        if (cfg.ral_models[ral_name].mem_ranges.size() > 0) begin
           run_mem_partial_access_vseq_sub(num_times, ral_name);
         end)
   endtask
 
   virtual task run_mem_partial_access_vseq_sub(int num_times, string ral_name);
-    addr_range_t loc_mem_range[$] = cfg.mem_ranges[ral_name];
+    addr_range_t loc_mem_range[$] = cfg.ral_models[ral_name].mem_ranges;
     uint num_accesses;
     // limit to 100k accesses if mem is very big
     uint max_accesses = 100_000;

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -60,28 +60,6 @@ package csr_utils_pkg;
     under_reset = 0;
   endfunction
 
-  // Get all valid csr addrs - useful to check if incoming addr falls in the csr range.
-  function automatic void get_csr_addrs(input uvm_reg_block ral, ref uvm_reg_addr_t csr_addrs[$]);
-    uvm_reg csrs[$];
-    ral.get_registers(csrs);
-    foreach (csrs[i]) begin
-      csr_addrs.push_back(csrs[i].get_address());
-    end
-  endfunction
-
-  // Get all valid mem addr ranges - useful to check if incoming addr falls in the mem range.
-  function automatic void get_mem_addr_ranges(uvm_reg_block ral, ref addr_range_t mem_ranges[$]);
-    uvm_mem mems[$];
-    ral.get_memories(mems);
-    foreach (mems[i]) begin
-      addr_range_t mem_range;
-      mem_range.start_addr = mems[i].get_address();
-      mem_range.end_addr   = mem_range.start_addr +
-                             mems[i].get_size() * mems[i].get_n_bytes() - 1;
-      mem_ranges.push_back(mem_range);
-    end
-  endfunction
-
   // get mem object from address
   function automatic uvm_mem get_mem_by_addr(uvm_reg_block ral, uvm_reg_addr_t addr);
     uvm_mem mem;

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -16,6 +16,15 @@ class dv_base_reg_block extends uvm_reg_block;
   // This is set by compute_addr_mask(), which must run after locking the model.
   protected uvm_reg_addr_t addr_mask[uvm_reg_map];
 
+  uvm_reg_addr_t csr_addrs[$];
+
+  addr_range_t mem_ranges[$];
+
+  addr_range_t mapped_addr_ranges[$];
+
+  bit has_unmapped_addrs;
+  addr_range_t unmapped_addr_ranges[$];
+
   function new (string name = "", int has_coverage = UVM_NO_COVERAGE);
     super.new(name, has_coverage);
   endfunction
@@ -94,6 +103,98 @@ class dv_base_reg_block extends uvm_reg_block;
     `DV_CHECK_FATAL(addr_mask[map])
   endfunction
 
+  // Internal function, used to get a list of all valid CSR addresses.
+  protected function void compute_csr_addrs();
+    uvm_reg csrs[$];
+    get_registers(csrs);
+    foreach (csrs[i]) begin
+      csr_addrs.push_back(csrs[i].get_address());
+    end
+  endfunction
+
+  // Internal function, used to get a list of all valid memory ranges
+  protected function void compute_mem_addr_ranges();
+    uvm_mem mems[$];
+    get_memories(mems);
+    foreach (mems[i]) begin
+      addr_range_t mem_range;
+      mem_range.start_addr = mems[i].get_address();
+      mem_range.end_addr   = mem_range.start_addr +
+                             mems[i].get_size() * mems[i].get_n_bytes() - 1;
+      mem_ranges.push_back(mem_range);
+    end
+  endfunction
+
+  // Used to get a list of all valid address ranges covered by this reg block
+  function void compute_mapped_addr_ranges();
+    uvm_reg csrs[$];
+    get_registers(csrs);
+
+    // Compute all CSR addresses and mem ranges known to this reg block
+    compute_csr_addrs();
+    compute_mem_addr_ranges();
+
+    // Convert each CSR into an address range
+    foreach (csrs[i]) begin
+      addr_range_t csr_addr_range;
+      csr_addr_range.start_addr = csrs[i].get_address();
+      csr_addr_range.end_addr   = csr_addr_range.start_addr + csrs[i].get_n_bytes() - 1;
+      mapped_addr_ranges.push_back(csr_addr_range);
+    end
+
+    mapped_addr_ranges = {mapped_addr_ranges, mem_ranges};
+
+    // Sort the mapped address ranges in ascending order based on the start_addr of each range
+    mapped_addr_ranges.sort(m) with (m.start_addr);
+
+  endfunction
+
+  // Used to get a list of all invalid address ranges in this reg block
+  function void compute_unmapped_addr_ranges();
+    addr_range_t range;
+
+    // convert the address mask into a relative address,
+    // this is the highest addressable location in the register block
+    uvm_reg_addr_t highest_addr = default_map.get_base_addr() + get_addr_mask();
+
+    // unmapped address ranges consist of:
+    // - the address space between all mapped address ranges (if exists)
+    // - space between csr_base_addr and the first mapped address range (if exists)
+    // - space between the last mapped address and the highest address mapped by the address mask
+    if (mapped_addr_ranges.size() == 0) begin
+      range.start_addr = default_map.get_base_addr();
+      range.end_addr = highest_addr;
+      unmapped_addr_ranges.push_back(range);
+    end else begin
+      // 0 -> start_addr-1
+      if (mapped_addr_ranges[0].start_addr - default_map.get_base_addr() > 0) begin
+        range.start_addr = default_map.get_base_addr();
+        range.end_addr   = mapped_addr_ranges[0].start_addr - 1;
+        unmapped_addr_ranges.push_back(range);
+      end
+
+      // all address ranges in the "middle" - only applies if
+      // there are more than 1 mapped address ranges
+      if (mapped_addr_ranges.size() > 1) begin
+        for (int i = 0; i < mapped_addr_ranges.size() - 1; i++) begin
+          range.start_addr = mapped_addr_ranges[i].end_addr + 1;
+          range.end_addr   = mapped_addr_ranges[i+1].start_addr - 1;
+          if (range.start_addr < range.end_addr) begin
+            unmapped_addr_ranges.push_back(range);
+          end
+        end
+      end
+
+      // end_addr+1 -> highest_addr
+      if (mapped_addr_ranges[$].end_addr < highest_addr) begin
+        range.start_addr = mapped_addr_ranges[$].end_addr + 1;
+        range.end_addr   = highest_addr;
+        unmapped_addr_ranges.push_back(range);
+      end
+    end
+    has_unmapped_addrs = (unmapped_addr_ranges.size() > 0);
+  endfunction
+
   // Return the offset of the highest byte contained in either a register or a memory
   function uvm_reg_addr_t get_max_offset(uvm_reg_map map = null);
     uvm_reg_addr_t max_offset;
@@ -142,6 +243,7 @@ class dv_base_reg_block extends uvm_reg_block;
 
     if (map == null) map = get_default_map();
     mask = get_addr_mask(map);
+
 
     // If base_addr is '1, randomly pick an aligned base address
     if (base_addr == '1) begin

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -38,9 +38,6 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   //     super.initialize(csr_base_addr);
   string ral_model_names[$] = {RAL_T::type_name};
 
-  bit [bus_params_pkg::BUS_AW-1:0]  csr_addrs[string][$];
-  addr_range_t                      mem_ranges[string][$];
-
   // clk_rst_if & freq
   // clk_rst_vif and clk_freq_mhz are used for default clk/rst. If more than one RAL, the other
   // clk_rst_vif and clk_freq_mhz can be found from the associative arrays
@@ -98,6 +95,7 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   endfunction
 
   virtual function void create_ral_models(bit [bus_params_pkg::BUS_AW-1:0] csr_base_addr = '1);
+
     foreach (ral_model_names[i]) begin
       string ral_name = ral_model_names[i];
       uvm_reg_addr_t base_addr;
@@ -123,8 +121,16 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
       reg_blk.set_base_addr(base_addr);
 
       // Get list of valid csr addresses (useful in seq to randomize addr as well as in scb checks)
-      get_csr_addrs(reg_blk, csr_addrs[ral_name]);
-      get_mem_addr_ranges(reg_blk, mem_ranges[ral_name]);
+      reg_blk.compute_mapped_addr_ranges();
+      reg_blk.compute_unmapped_addr_ranges();
+      `uvm_info(msg_id,
+                $sformatf("RAL[%0s] mapped addresses: %0p",
+                          ral_name, reg_blk.mapped_addr_ranges),
+                UVM_HIGH)
+      `uvm_info(msg_id,
+                $sformatf("RAL[%0s] unmapped addresses: %0p",
+                          ral_name, reg_blk.unmapped_addr_ranges),
+                UVM_HIGH)
       ral_models[ral_name] = reg_blk;
     end
 

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_scoreboard.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_scoreboard.sv
@@ -43,7 +43,7 @@ class adc_ctrl_scoreboard extends cip_base_scoreboard #(
     bit data_phase_write  = (write && channel == DataChannel);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -80,7 +80,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
     uvm_reg_addr_t csr_addr      = ral.get_word_aligned_addr(item.a_addr);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end else begin

--- a/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -249,7 +249,7 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
     uvm_reg_addr_t csr_addr = {item.a_addr[TL_AW-1:2], 2'b00};
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end

--- a/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
@@ -43,7 +43,7 @@ class aon_timer_scoreboard extends cip_base_scoreboard #(
     bit data_phase_write  = (write && channel == DataChannel);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end

--- a/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -180,7 +180,7 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
     string channel_str = channel == AddrChannel ? "address" : "data";
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -57,7 +57,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
     bit data_phase_write  = (write && channel == DataChannel);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end

--- a/hw/ip/edn/dv/env/edn_scoreboard.sv
+++ b/hw/ip/edn/dv/env/edn_scoreboard.sv
@@ -50,7 +50,7 @@ class edn_scoreboard extends cip_base_scoreboard #(
     bit data_phase_write  = (write && channel == DataChannel);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -50,7 +50,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard #(
     uvm_reg_addr_t csr_addr = ral.get_word_aligned_addr(item.a_addr);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -69,7 +69,7 @@ class flash_ctrl_scoreboard #(type CFG_T = flash_ctrl_env_cfg)
     bit data_phase_write  = (write && channel == DataChannel);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end else if (is_mem_addr(item, ral_name)) begin

--- a/hw/ip/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/ip/gpio/dv/env/gpio_scoreboard.sv
@@ -63,7 +63,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
     uvm_reg_addr_t csr_addr = ral.get_word_aligned_addr(item.a_addr);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end else begin

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -37,7 +37,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
     uvm_reg_addr_t  csr_addr        = ral.get_word_aligned_addr(item.a_addr);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
       csr_name = csr.get_name();

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -71,7 +71,7 @@ class i2c_scoreboard extends cip_base_scoreboard #(
 
     uvm_reg_addr_t csr_addr = ral.get_word_aligned_addr(item.a_addr);
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end else begin
@@ -229,8 +229,8 @@ class i2c_scoreboard extends cip_base_scoreboard #(
           if (host_init) begin
             if (rdata_cnt == 0) begin
               // for on-the-fly reset, immediately finish task to avoid blocking
-              wait(rd_pending_q.size() > 0 || cfg.under_reset);              
-              if (cfg.under_reset) return; 
+              wait(rd_pending_q.size() > 0 || cfg.under_reset);
+              if (cfg.under_reset) return;
               rd_pending_item = rd_pending_q.pop_front();
             end
             rd_pending_item.data_q.push_back(item.d_data);

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -303,7 +303,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
     bit data_phase_write  = (write && channel == DataChannel);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
       `downcast(dv_reg, csr)

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -1626,7 +1626,7 @@ class kmac_scoreboard extends cip_base_scoreboard #(
     bit data_phase_write  = (write && channel == DataChannel);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
       `downcast(check_locked_reg, csr)

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
@@ -124,7 +124,7 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
     bit data_phase_write  = (write && channel == DataChannel);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -450,7 +450,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
     bit data_phase_write  = (write && channel == DataChannel);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
       `downcast(dv_reg, csr)
@@ -1183,8 +1183,8 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
     // If sw partition is read locked, then access policy changes from RO to no access
     uvm_reg_addr_t addr = ral.get_word_aligned_addr(item.a_addr);
     if (`gmv(ral.creator_sw_cfg_read_lock) == 0 || cfg.otp_ctrl_vif.under_error_states()) begin
-      if (addr inside {[cfg.mem_ranges[ral_name][0].start_addr :
-                       cfg.mem_ranges[ral_name][0].start_addr + CreatorSwCfgSize - 1]}) begin
+      if (addr inside {[cfg.ral_models[ral_name].mem_ranges[0].start_addr :
+          cfg.ral_models[ral_name].mem_ranges[0].start_addr + CreatorSwCfgSize - 1]}) begin
         predict_err(OtpCreatorSwCfgErrIdx, OtpAccessError);
         `DV_CHECK_EQ(item.d_data, 0,
                      $sformatf("locked mem read mismatch at TLUL addr %0h in CreatorSwCfg", addr))
@@ -1192,8 +1192,9 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
       end
     end
     if (`gmv(ral.owner_sw_cfg_read_lock) == 0 ||  cfg.otp_ctrl_vif.under_error_states()) begin
-      if (addr inside {[cfg.mem_ranges[ral_name][0].start_addr + OwnerSwCfgOffset :
-          cfg.mem_ranges[ral_name][0].start_addr + OwnerSwCfgSize + OwnerSwCfgOffset - 1]}) begin
+      if (addr inside {[cfg.ral_models[ral_name].mem_ranges[0].start_addr + OwnerSwCfgOffset :
+                        cfg.ral_models[ral_name].mem_ranges[0].start_addr +
+                            OwnerSwCfgSize + OwnerSwCfgOffset - 1]}) begin
         predict_err(OtpOwnerSwCfgErrIdx, OtpAccessError);
         `DV_CHECK_EQ(item.d_data, 0,
                      $sformatf("locked mem read mismatch at TLUL addr %0h in OwnerSwCfg", addr))

--- a/hw/ip/pattgen/dv/env/pattgen_scoreboard.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_scoreboard.sv
@@ -56,7 +56,7 @@ class pattgen_scoreboard extends cip_base_scoreboard #(
 
     uvm_reg_addr_t csr_addr = ral.get_word_aligned_addr(item.a_addr);
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end else begin

--- a/hw/ip/pwm/dv/env/pwm_scoreboard.sv
+++ b/hw/ip/pwm/dv/env/pwm_scoreboard.sv
@@ -46,7 +46,7 @@ class pwm_scoreboard extends cip_base_scoreboard #(
     bit data_phase_write  = (write && channel == DataChannel);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -43,7 +43,7 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
     bit data_phase_write  = (write && channel == DataChannel);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
@@ -196,7 +196,7 @@ class rom_ctrl_scoreboard extends cip_base_scoreboard #(
     bit data_phase_write  = (write && channel == DataChannel);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end

--- a/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
@@ -42,7 +42,7 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
     uvm_reg_addr_t csr_addr = ral.get_word_aligned_addr(item.a_addr);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
       csr_name = csr.get_name();

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -71,7 +71,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
     uvm_reg_addr_t csr_addr = ral.get_word_aligned_addr(item.a_addr);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end

--- a/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
@@ -23,7 +23,7 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
   local bit [31:0] rx_word_q[$];
   // interrupt bit vector
   local bit [NumSpiHostIntr-1:0] intr_exp;
-  
+
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
@@ -58,7 +58,7 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
       `uvm_info(`gfn, $sformatf("received spi_device item:\n%0s", dev_item.sprint()), UVM_HIGH)
     end
   endtask : process_device_spi_fifo
-  
+
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
@@ -71,7 +71,7 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
     bit data_phase_write  = (write && channel  == DataChannel);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -749,7 +749,7 @@ class sram_ctrl_scoreboard extends cip_base_scoreboard #(
     bit data_phase_write  = (write && channel == DataChannel);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end

--- a/hw/ip/uart/dv/env/uart_scoreboard.sv
+++ b/hw/ip/uart/dv/env/uart_scoreboard.sv
@@ -164,7 +164,7 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
     uvm_reg_addr_t csr_addr = ral.get_word_aligned_addr(item.a_addr);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end else begin

--- a/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
@@ -54,7 +54,7 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
     uvm_reg_addr_t csr_addr = ral.get_word_aligned_addr(item.a_addr);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end

--- a/util/uvmdvgen/scoreboard.sv.tpl
+++ b/util/uvmdvgen/scoreboard.sv.tpl
@@ -76,7 +76,7 @@ class ${name}_scoreboard extends dv_base_scoreboard #(
     bit data_phase_write  = (write && channel == DataChannel);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.csr_addrs[ral_name]}) begin
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end


### PR DESCRIPTION
Addresses #6594 and #6596.

This PR is split into 2 commits.

The first commit overhauls how we calculate unmapped address ranges for a given reg block.
We now compute a list of mapped/unmapped address ranges and store them in the `dv_base_reg_block`
during the build phase.
Along with this, we move the `get_csr_addrs` and `get_mem_addr_ranges` functions into the `dv_base_reg_block`,
as this seems a more sensible place to put these methods.

The second commit updates the scoreboards for all IPs and the scoreboard template to use the
updated locations of `csr_addrs` and `mem_ranges` lists.

Signed-off-by: Udi Jonnalagadda <udij@google.com>