### PR TITLE
[mask_rom] Refactor the UART to use the abs_mmio module

### DIFF
--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -76,6 +76,20 @@ extern const uint64_t kClockFreqUsbHz;
 extern const uint64_t kUartBaudrate;
 
 /**
+ * A helper macro to calculate NCO values.
+ * NOTE: the left shift value is dependent on the UART hardware.
+ * The NCO width is 16 bits and the NCO calculates a 16x oversampling clock.
+ */
+#define CALCULATE_UART_NCO(baudrate, peripheral_clock) \
+  (((baudrate) << (16 + 4)) / (peripheral_clock))
+
+/**
+ * The pre-calculated UART NCO value based on the Baudrate and Peripheral clock.
+ */
+extern const uint32_t kUartNCOValue;
+;
+
+/**
  * An address to write to to report test status.
  *
  * If this is zero, there is no address to write to to report test status.

--- a/sw/device/lib/arch/device_fpga_nexysvideo.c
+++ b/sw/device/lib/arch/device_fpga_nexysvideo.c
@@ -19,6 +19,9 @@ const uint64_t kClockFreqUsbHz = 48 * 1000 * 1000;  // 48MHz
 
 const uint64_t kUartBaudrate = 115200;
 
+const uint32_t kUartNCOValue =
+    CALCULATE_UART_NCO(kUartBaudrate, kClockFreqPeripheralHz);
+
 const uintptr_t kDeviceTestStatusAddress = 0;
 
 const uintptr_t kDeviceLogBypassUartAddress = 0;

--- a/sw/device/lib/arch/device_sim_dv.c
+++ b/sw/device/lib/arch/device_sim_dv.c
@@ -21,6 +21,9 @@ const uint64_t kClockFreqUsbHz = 48 * 1000 * 1000;  // 48MHz
 
 const uint64_t kUartBaudrate = 1 * 1000 * 1000;  // 1Mbps
 
+const uint32_t kUartNCOValue =
+    CALCULATE_UART_NCO(kUartBaudrate, kClockFreqPeripheralHz);
+
 // Defined in `hw/top_earlgrey/dv/env/chip_env_pkg.sv`
 const uintptr_t kDeviceTestStatusAddress = 0x30000000;
 

--- a/sw/device/lib/arch/device_sim_verilator.c
+++ b/sw/device/lib/arch/device_sim_verilator.c
@@ -22,6 +22,9 @@ const uint64_t kClockFreqUsbHz = 500 * 1000;  // 500kHz
 
 const uint64_t kUartBaudrate = 7200;
 
+const uint32_t kUartNCOValue =
+    CALCULATE_UART_NCO(kUartBaudrate, kClockFreqPeripheralHz);
+
 // Defined in `hw/top_earlgrey/chip_earlgrey_verilator.core`
 const uintptr_t kDeviceTestStatusAddress = 0x30000000;
 

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -57,11 +57,11 @@ test('sw_silicon_creator_lib_driver_uart_unittest', executable(
     ],
     dependencies: [
       sw_vendor_gtest,
-      sw_lib_base_testing_mock_mmio,
+      sw_silicon_creator_lib_base_mock_abs_mmio,
     ],
     native: true,
-    c_args: ['-DMOCK_MMIO'],
-    cpp_args: ['-DMOCK_MMIO'],
+    c_args: ['-DMOCK_ABS_MMIO'],
+    cpp_args: ['-DMOCK_ABS_MMIO'],
   ),
   suite: 'mask_rom',
 )

--- a/sw/device/silicon_creator/lib/drivers/uart.h
+++ b/sw/device/silicon_creator/lib/drivers/uart.h
@@ -16,51 +16,30 @@ extern "C" {
 #endif
 
 /**
- * Initialization parameters for UART.
- *
- */
-typedef struct uart {
-  /**
-   * The base address for the UART hardware registers.
-   */
-  mmio_region_t base_addr;
-  /**
-   * The desired baudrate of the UART.
-   */
-  uint32_t baudrate;
-  /**
-   * The peripheral clock frequency (used to compute the UART baudrate divisor).
-   */
-  uint32_t clk_freq_hz;
-} uart_t;
-
-/**
  * Initialize the UART with the request parameters.
  *
- * @param uart Pointer to uart_t with the requested parameters.
+ * @param precalculated_nco NCO value used to set the speed of the UART.
  * @return kErrorOk if successful, else an error code.
  */
-rom_error_t uart_init(const uart_t *uart);
+rom_error_t uart_init(uint32_t precalculated_nco);
 
 /**
  * Write a single byte to the UART.
  *
- * @param uart Pointer to uart_t represting the target UART.
  * @param byte Byte to send.
  */
-void uart_putchar(const uart_t *uart, uint8_t byte);
+void uart_putchar(uint8_t byte);
 
 /**
  * Write a buffer to the UART.
  *
  * Writes the complete buffer to the UART and wait for transmision to complete.
  *
- * @param uart Pointer to uart_t represting the target UART.
  * @param data Pointer to buffer to write.
  * @param len Length of the buffer to write.
  * @return Number of bytes written.
  */
-size_t uart_write(const uart_t *uart, const uint8_t *data, size_t len);
+size_t uart_write(const uint8_t *data, size_t len);
 
 /**
  * Sink a buffer to the UART.
@@ -68,7 +47,7 @@ size_t uart_write(const uart_t *uart, const uint8_t *data, size_t len);
  * This is a wrapper for uart_write which conforms to the type signature
  * required by the print library.
  *
- * @param uart Pointer to uart_t represting the target UART.
+ * @param uart Pointer a target so satisfy the shape of the sink API.
  * @param data Pointer to buffer to write.
  * @param len Length of the buffer to write.
  * @return Number of bytes written.

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -35,8 +35,6 @@ typedef void(boot_fn)(void);
 void mask_rom_exception_handler(void) { wait_for_interrupt(); }
 void mask_rom_nmi_handler(void) { wait_for_interrupt(); }
 
-uart_t uart;
-
 // FIXME: Temporary workaround to run functional test of SHA256.
 static int verify_rom_ext_identifier(rom_ext_manifest_t rom_ext) {
   uint32_t rom_ext_identifier = rom_ext_get_identifier(rom_ext);
@@ -62,13 +60,9 @@ void mask_rom_boot(void) {
   pinmux_init();
 
   // Configure UART0 as stdout.
-  // TODO(lowrisc/opentitan#6283): Move to constant driver handles.
-  uart.base_addr = mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR);
-  uart.baudrate = kUartBaudrate;
-  uart.clk_freq_hz = kClockFreqPeripheralHz;
-  uart_init(&uart);
+  uart_init(kUartNCOValue);
   base_set_stdout((buffer_sink_t){
-      .data = &uart,
+      .data = NULL,
       .sink = uart_sink,
   });
 


### PR DESCRIPTION
1. Refactor the uart driver to use the abs_mmio module.
2. Refactor the uart unittest to use the appropriate mock.
3. Pre-compute the desired UART NCO values in the device implementations
so we can avoid a uint64_t divide in the UART driver.

Signed-off-by: Chris Frantz <cfrantz@google.com>