### PR TITLE
[mask_rom] Create initial functional tests

### DIFF
--- a/hw/top_earlgrey/dv/verilator_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/verilator_sim_cfg.hjson
@@ -193,6 +193,14 @@
       name: usbdev_test
       sw_images: ["sw/device/tests/usbdev_test:1"]
     }
+    {
+      name: sw_silicon_creator_lib_driver_hmac_functest
+      sw_images: ["sw/device/silicon_creator/testing/sw_silicon_creator_lib_driver_hmac_functest:1"]
+    }
+    {
+      name: sw_silicon_creator_lib_driver_uart_functest
+      sw_images: ["sw/device/silicon_creator/testing/sw_silicon_creator_lib_driver_uart_functest:1"]
+    }
   ]
 
   // List of regressions.

--- a/sw/device/silicon_creator/lib/drivers/hmac_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac_functest.c
@@ -1,0 +1,62 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/test_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// From: http://www.abrahamlincolnonline.org/lincoln/speeches/gettysburg.htm
+static const char kGettysburgPrelude[] =
+    "Four score and seven years ago our fathers brought forth on this "
+    "continent, a new nation, conceived in Liberty, and dedicated to the "
+    "proposition that all men are created equal.";
+
+// The following shell command will produce the sha256sum and convert the
+// digest into valid C hexadecimal constants:
+//
+// $ echo -n "Four score and seven years ago our fathers brought forth on this
+// continent, a new nation, conceived in Liberty, and dedicated to the
+// proposition that all men are created equal." |
+//     sha256sum - | cut -f1 -d' ' | sed -e "s/......../0x&,\n/g" | tac
+//
+static const uint32_t kGettysburgDigest[] = {
+    0x8b8cc7ba, 0xe29f6ac0, 0xeb3dd433, 0x420ec587,
+    0x96c324ed, 0x775708a3, 0x0f9034cd, 0x1e6fd403,
+};
+
+rom_error_t hmac_test(void) {
+  hmac_sha256_init();
+  RETURN_IF_ERROR(
+      hmac_sha256_update(kGettysburgPrelude, sizeof(kGettysburgPrelude) - 1));
+
+  hmac_digest_t digest;
+  RETURN_IF_ERROR(hmac_sha256_final(&digest));
+
+  const size_t len = ARRAYSIZE(digest.digest);
+  for (int i = 0; i < len; ++i) {
+    LOG_INFO("word %d = 0x%08x", i, digest.digest[i]);
+    if (digest.digest[i] != kGettysburgDigest[i]) {
+      return kErrorUnknown;
+    }
+  }
+  return kErrorOk;
+}
+
+const test_config_t kTestConfig;
+
+bool test_main(void) {
+  rom_error_t result = kErrorOk;
+  EXECUTE_TEST(result, hmac_test);
+  return result == kErrorOk;
+}

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -34,6 +34,21 @@ test('sw_silicon_creator_lib_driver_hmac_unittest', executable(
   suite: 'mask_rom',
 )
 
+sw_silicon_creator_lib_driver_hmac_functest = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_lib_driver_hmac_functest',
+    sources: ['hmac_functest.c'],
+    dependencies: [
+      sw_silicon_creator_lib_driver_hmac,
+    ],
+  ),
+)
+mask_rom_tests += {
+  'sw_silicon_creator_lib_driver_hmac_functest': {
+    'library': sw_silicon_creator_lib_driver_hmac_functest,
+  }
+}
+
 # Mask ROM keymgr driver
 sw_silicon_creator_lib_driver_keymgr = declare_dependency(
   link_with: static_library(
@@ -97,6 +112,22 @@ test('sw_silicon_creator_lib_driver_uart_unittest', executable(
   ),
   suite: 'mask_rom',
 )
+
+sw_silicon_creator_lib_driver_uart_functest = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_lib_driver_uart_functest',
+    sources: ['uart_functest.c'],
+    dependencies: [
+      sw_silicon_creator_lib_driver_uart,
+    ],
+  ),
+)
+mask_rom_tests += {
+  'sw_silicon_creator_lib_driver_uart_functest': {
+    'library': sw_silicon_creator_lib_driver_uart_functest,
+  }
+}
+
 
 # Mask OTP uart driver
 sw_silicon_creator_lib_driver_otp = declare_dependency(

--- a/sw/device/silicon_creator/lib/drivers/uart_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/uart_functest.c
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/silicon_creator/lib/drivers/uart.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/test_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+const test_config_t kTestConfig = {
+    .can_clobber_uart = true,
+};
+
+rom_error_t uart_test(void) {
+  // Configure UART0 as stdout.
+  uart_init(kUartNCOValue);
+  base_set_stdout((buffer_sink_t){
+      .data = NULL,
+      .sink = uart_sink,
+  });
+
+  base_printf("uart functional test!\r\n");
+  return kErrorOk;
+}
+
+bool test_main(void) {
+  rom_error_t result = kErrorOk;
+  EXECUTE_TEST(result, uart_test);
+  return result == kErrorOk;
+}

--- a/sw/device/silicon_creator/lib/test_main.h
+++ b/sw/device/silicon_creator/lib/test_main.h
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_TEST_MAIN_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_TEST_MAIN_H_
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_main.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+/**
+ * Execute a test function and log the test result.  Update the result value
+ * if there is a failure code.
+ */
+#define EXECUTE_TEST(result_, test_function_)                               \
+  do {                                                                      \
+    rom_error_t local_error;                                                \
+    LOG_INFO("Starting test " #test_function_ "...");                       \
+    local_error = test_function_();                                         \
+    if (local_error == kErrorOk) {                                          \
+      LOG_INFO("Finished test " #test_function_ ": ok.");                   \
+    } else {                                                                \
+      result_ = local_error;                                                \
+      LOG_ERROR("Finished test " #test_function_ ": 0x%08x.", local_error); \
+    }                                                                       \
+  } while (0)
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_TEST_MAIN_H_

--- a/sw/device/silicon_creator/meson.build
+++ b/sw/device/silicon_creator/meson.build
@@ -2,6 +2,15 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+# This is defined here so it is visible in all child subdirectories.
+mask_rom_tests = {
+  # 'test_name': {
+  #   'library': test_lib,
+  #   'dv_frames': true/false, # (can be omitted, defaults to `false`)
+  # },
+}
+
 subdir('lib')
 subdir('rom_exts')
 subdir('mask_rom')
+subdir('testing')

--- a/sw/device/silicon_creator/testing/meson.build
+++ b/sw/device/silicon_creator/testing/meson.build
@@ -1,0 +1,123 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# All tests added to this dictionary will result in build targets that have
+# names starting `sw/device/silicon_creator/tests/<test_name>`. They will not
+# contain the subdirectory name, because the build targets are really declared
+# at the bottom of this file, rather than in the subdirectories.
+## mask_rom_tests = {
+##   # 'test_name': {
+##   #   'library': test_lib,
+##   #   'dv_frames': true/false, # (can be omitted, defaults to `false`)
+##   # },
+## }
+
+foreach mask_rom_test_name, mask_rom_test_info : mask_rom_tests
+  foreach device_name, device_lib : sw_lib_arch_core_devices
+    mask_rom_test_elf = executable(
+      mask_rom_test_name + '_' + device_name,
+      name_suffix: 'elf',
+      dependencies: [
+        riscv_crt,
+        device_lib,
+        mask_rom_test_info['library'],
+        sw_lib_irq_handlers,
+        sw_lib_testing_test_main,
+      ],
+    )
+
+    target_name = mask_rom_test_name + '_@0@_' + device_name
+
+    mask_rom_test_dis = custom_target(
+      target_name.format('dis'),
+      input: mask_rom_test_elf,
+      kwargs: elf_to_dis_custom_target_args,
+    )
+
+    mask_rom_test_bin = custom_target(
+      target_name.format('bin'),
+      input: mask_rom_test_elf,
+      kwargs: elf_to_bin_custom_target_args,
+    )
+
+    mask_rom_test_vmem32 = custom_target(
+      target_name.format('vmem32'),
+      input: mask_rom_test_bin,
+      kwargs: bin_to_vmem32_custom_target_args,
+    )
+
+    mask_rom_test_vmem64 = custom_target(
+      target_name.format('vmem64'),
+      input: mask_rom_test_bin,
+      kwargs: bin_to_vmem64_custom_target_args,
+    )
+
+    mask_rom_test_sim_dv_frames = []
+    if device_name == 'sim_dv' and \
+        mask_rom_test_info.has_key('dv_frames') and mask_rom_test_info['dv_frames']
+      mask_rom_test_sim_dv_frames_bin = custom_target(
+        mask_rom_test_name + '_sim_dv_frames_bin',
+        command: [
+          spiflash_bin,
+          '--input=@INPUT@',
+          '--dump-frames=@OUTPUT@',
+        ],
+        input: mask_rom_test_bin,
+        output: '@BASENAME@.frames.bin',
+      )
+
+      mask_rom_test_sim_dv_frames_vmem = custom_target(
+        mask_rom_test_name + '_sim_dv_frames_vmem',
+        command: [
+          prog_srec_cat,
+          '@INPUT@',
+          '--binary',
+          '--offset', '0x0',
+          '--byte-swap', '4',
+          '--fill', '0xff',
+          '-within', '@INPUT@',
+          '-binary',
+          '-range-pad', '4',
+          '--output', '@OUTPUT@',
+          '--vmem',
+        ],
+        input: mask_rom_test_sim_dv_frames_bin,
+        output: '@BASENAME@.vmem',
+      )
+      mask_rom_test_sim_dv_frames = [
+        mask_rom_test_sim_dv_frames_bin,
+        mask_rom_test_sim_dv_frames_vmem,
+      ]
+    endif
+
+    mask_rom_test_sim_dv_logs = []
+    if device_name == 'sim_dv'
+      mask_rom_test_sim_dv_logs = custom_target(
+        mask_rom_test_name + '_sim_dv_logs',
+        command: extract_sw_logs_sim_dv_command,
+        depend_files: [extract_sw_logs_sim_dv_depend_files,],
+        input: mask_rom_test_elf,
+        output: extract_sw_logs_sim_dv_outputs,
+      )
+    endif
+
+    custom_target(
+      target_name.format('export'),
+      command: export_target_command,
+      depend_files: [export_target_depend_files,],
+      input: [
+        mask_rom_test_elf,
+        mask_rom_test_dis,
+        mask_rom_test_bin,
+        mask_rom_test_vmem32,
+        mask_rom_test_vmem64,
+        mask_rom_test_sim_dv_frames,
+        mask_rom_test_sim_dv_logs,
+      ],
+      output: target_name.format('export'),
+      build_always_stale: true,
+      build_by_default: true,
+    )
+  endforeach
+endforeach

--- a/test/systemtest/config.py
+++ b/test/systemtest/config.py
@@ -118,4 +118,12 @@ TEST_APPS_SELFCHECKING = [
         "name": "dif_gpio_smoketest",
         "targets": ["fpga_cw310", "fpga_nexysvideo"],
     },
+    {
+        "name": "sw_silicon_creator_lib_driver_hmac_functest",
+        "test_dir": "sw/device/silicon_creator/testing",
+    },
+    {
+        "name": "sw_silicon_creator_lib_driver_uart_functest",
+        "test_dir": "sw/device/silicon_creator/testing",
+    },
 ]

--- a/test/systemtest/earlgrey/test_fpga_cw310.py
+++ b/test/systemtest/earlgrey/test_fpga_cw310.py
@@ -62,8 +62,11 @@ def app_selfchecking_bin(request, bin_dir):
     else:
         binary_name = app_config['name']
 
+    # Allow tests to optionally specify their subdir within the project.
+    test_dir = app_config.get('test_dir', 'sw/device/tests')
+
     test_filename = binary_name + '_fpga_nexysvideo.bin'
-    bin_path = bin_dir / 'sw/device/tests' / test_filename
+    bin_path = bin_dir / test_dir / test_filename
     assert bin_path.is_file()
     return bin_path
 

--- a/test/systemtest/earlgrey/test_fpga_nexysvideo.py
+++ b/test/systemtest/earlgrey/test_fpga_nexysvideo.py
@@ -69,8 +69,11 @@ def app_selfchecking_bin(request, bin_dir):
     else:
         binary_name = app_config['name']
 
+    # Allow tests to optionally specify their subdir within the project.
+    test_dir = app_config.get('test_dir', 'sw/device/tests')
+
     test_filename = binary_name + '_fpga_nexysvideo.bin'
-    bin_path = bin_dir / 'sw/device/tests' / test_filename
+    bin_path = bin_dir / test_dir / test_filename
     assert bin_path.is_file()
     return bin_path
 

--- a/test/systemtest/earlgrey/test_sim_verilator.py
+++ b/test/systemtest/earlgrey/test_sim_verilator.py
@@ -206,8 +206,11 @@ def app_selfchecking(request, bin_dir):
     else:
         verilator_extra_args = []
 
+    # Allow tests to optionally specify their subdir within the project.
+    test_dir = app_config.get('test_dir', 'sw/device/tests')
+
     test_filename = binary_name + '_sim_verilator.elf'
-    bin_path = bin_dir / 'sw/device/tests' / test_filename
+    bin_path = bin_dir / test_dir / test_filename
     assert bin_path.is_file()
 
     return (bin_path, verilator_extra_args)


### PR DESCRIPTION
Initial functional tests for mask ROM modules.  These tests utilize
the existing RV32I test infrastructure: they are built as unsigned
code which executes from flash and rely on the primitive boot_rom to
execute them.  The test infrastructure uses the UART DIF to communicate
test results via the UART.

1. Functional test for UART.
2. Functional test for HMAC.

Below is a sample of how to execute the functional tests.  I plan to automate this
as part of the build-system refactoring.

```
build/lowrisc_systems_chip_earlgrey_verilator_0.1/sim-verilator/Vchip_earlgrey_verilator \
    --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.scr.40.vmem \
    --meminit=otp,build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem \
    --meminit=flash,build-bin/sw/device/silicon_creator/testing/sw_silicon_creator_lib_driver_hmac_functest_sim_verilator.elf
```