### PR TITLE
[dv/otp_ctrl] Fix corner case in dai recovery

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_invalid_cmd_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_invalid_cmd_vseq.sv
@@ -97,8 +97,13 @@ class otp_ctrl_macro_invalid_cmd_vseq extends otp_ctrl_smoke_vseq;
 
   virtual task check_and_release_macro_error();
     string alert_name = "fatal_macro_error";
+    int max_wait_cycles = (cfg.m_alert_agent_cfg[alert_name].ack_delay_max +
+                           cfg.m_alert_agent_cfg[alert_name].ack_stable_max) *
+                          ($ceil(cfg.clk_rst_vif.clk_freq_mhz) /
+                           cfg.m_alert_agent_cfg[alert_name].vif.clk_rst_async_if.clk_freq_mhz);
+
     `DV_SPINWAIT_EXIT(wait(cfg.m_alert_agent_cfg[alert_name].vif.alert_tx_final.alert_p);,
-        cfg.clk_rst_vif.wait_clks(20);,
+        cfg.clk_rst_vif.wait_clks(max_wait_cycles);,
         $sformatf("Timeout waiting for alert %0s", alert_name))
     check_fatal_alert_nonblocking(alert_name);
 


### PR DESCRIPTION
This PR fixes a corner case: when dai write with secret partition's
digest address, and this operation is interrupted with fatal error (e.g.
lc_esc_en is On, fatal macro error, or fatal check error). Then scb will
recover this write by backdoor read the address. However, this is not
needed because this DAI write operation is actually invalid - user
cannot directly write to buffer partition's digest address.
So in this PR, we won't set the flag `dai_wr_ip` unless it is a valid
write.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>