### PR TITLE
[prim] Waive unused parameter warnings for an FPGA-specific param

### DIFF
--- a/hw/ip/prim_generic/lint/prim_generic_clock_gating.vlt
+++ b/hw/ip/prim_generic/lint/prim_generic_clock_gating.vlt
@@ -2,3 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
+
+`verilator_config
+
+lint_off -rule UNUSED -file "*/rtl/prim_generic_clock_gating.sv" -match "Parameter is not used: 'NoFpgaGate'"

--- a/hw/ip/prim_generic/lint/prim_generic_clock_mux2.vlt
+++ b/hw/ip/prim_generic/lint/prim_generic_clock_mux2.vlt
@@ -2,3 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
+
+`verilator_config
+
+lint_off -rule UNUSED -file "*/rtl/prim_generic_clock_mux2.sv" -match "Parameter is not used: 'NoFpgaBufG'"


### PR DESCRIPTION
These are already waived for AscentLint: add matching waivers for
Verilator.
