### PR TITLE
[ci] Run verilated system tests on faster machines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -237,7 +237,7 @@ jobs:
         run --flag=fileset_top --target=sim --setup --build \
         --build-root="$OBJ_DIR/hw" \
         lowrisc:systems:chip_earlgrey_verilator \
-        --verilator_options="--no-threads"
+        --verilator_options="--threads 4"
 
       cp "$OBJ_DIR/hw/sim-verilator/Vchip_earlgrey_verilator" \
         "$BIN_DIR/hw/top_earlgrey"
@@ -285,8 +285,7 @@ jobs:
 
 - job: execute_verilated_tests
   displayName: Execute tests on the Verilated system (excl. slow tests)
-  pool:
-    vmImage: ubuntu-18.04
+  pool: ci-public
   dependsOn:
     - chip_earlgrey_verilator
     - sw_build
@@ -313,8 +312,7 @@ jobs:
 # This test is in a separate job becuase it takes longer to complete.
 - job: execute_silicon_creator_verilated_test
   displayName: Execute silicon_creator test on the Verilated system
-  pool:
-    vmImage: ubuntu-18.04
+  pool: ci-public
   dependsOn:
     - chip_earlgrey_verilator
     - sw_build


### PR DESCRIPTION
Continue to build the Verilator simulation on Azure-provided machines,
but run them on our own, internal CI runners. These runners in the
ci-public pool are GCP C2 machines, which we identified in having
around 2x higher simulation performance as N2 machines.

Simulations are built by Verilator and run with four internal threads,
which gives a roughly 2x simulation speed-up, compared to using just a
single thread, as we did before.

In addition to providing higher performance, internal runners provide
more predictable performance compared to the Azure-provided runners,
making CI timeouts less likely.
