### PR TITLE
[sw/silicon_creator] Introduce the keymgr driver

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -1,0 +1,105 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/keymgr.h"
+
+#include "sw/device/silicon_creator/lib/base/abs_mmio.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "keymgr_regs.h"  // Generated.
+
+enum {
+  kBase = TOP_EARLGREY_KEYMGR_BASE_ADDR,
+};
+
+/**
+ * Checks the key manager `expected_state`.
+ *
+ * This function reads and clears the status and error code registers.
+ *
+ * @return `kErrorOk` if the key manager is at the `expected_state` and the
+ * status is idle or success.
+ */
+static rom_error_t check_expected_state(uint32_t expected_state,
+                                        uint32_t expected_status) {
+  // Read and clear the status register by writing back the read value,
+  // polling until the status is non-WIP.
+  uint32_t op_status;
+  uint32_t op_status_field;
+  do {
+    op_status = abs_mmio_read32(kBase + KEYMGR_OP_STATUS_REG_OFFSET);
+    abs_mmio_write32(kBase + KEYMGR_OP_STATUS_REG_OFFSET, op_status);
+    op_status_field =
+        bitfield_field32_read(op_status, KEYMGR_OP_STATUS_STATUS_FIELD);
+  } while (op_status_field == KEYMGR_OP_STATUS_STATUS_VALUE_WIP);
+
+  // Read and clear the error register by writing back the read value.
+  uint32_t error_code = abs_mmio_read32(kBase + KEYMGR_ERR_CODE_REG_OFFSET);
+  abs_mmio_write32(kBase + KEYMGR_ERR_CODE_REG_OFFSET, error_code);
+
+  uint32_t got_state = abs_mmio_read32(kBase + KEYMGR_WORKING_STATE_REG_OFFSET);
+  if (op_status_field == expected_status && error_code == 0u &&
+      got_state == expected_state) {
+    return kErrorOk;
+  }
+  return kErrorKeymgrInternal;
+}
+
+/**
+ * Advances the sate of the key manager.
+ *
+ * The `check_expected_state()` function must be called before this function
+ * no ensure the key manager is ready to receive op commands.
+ */
+static void advance_state(void) {
+  uint32_t reg = bitfield_bit32_write(0, KEYMGR_CONTROL_START_BIT, true);
+  reg = bitfield_field32_write(reg, KEYMGR_CONTROL_DEST_SEL_FIELD,
+                               KEYMGR_CONTROL_DEST_SEL_VALUE_NONE);
+  reg = bitfield_field32_write(reg, KEYMGR_CONTROL_OPERATION_FIELD,
+                               KEYMGR_CONTROL_OPERATION_VALUE_ADVANCE);
+  abs_mmio_write32(kBase + KEYMGR_CONTROL_REG_OFFSET, reg);
+}
+
+rom_error_t keymgr_init(uint16_t entropy_reseed_interval) {
+  RETURN_IF_ERROR(check_expected_state(KEYMGR_WORKING_STATE_STATE_VALUE_RESET,
+                                       KEYMGR_OP_STATUS_STATUS_VALUE_IDLE));
+
+  uint32_t reg = bitfield_field32_write(0, KEYMGR_RESEED_INTERVAL_VAL_FIELD,
+                                        entropy_reseed_interval);
+  abs_mmio_write32(kBase + KEYMGR_RESEED_INTERVAL_REG_OFFSET, reg);
+
+  // Advance to INIT state.
+  advance_state();
+  return kErrorOk;
+}
+
+rom_error_t keymgr_state_advance_to_creator(const uint32_t binding_value[8],
+                                            uint32_t max_key_ver) {
+  RETURN_IF_ERROR(
+      check_expected_state(KEYMGR_WORKING_STATE_STATE_VALUE_INIT,
+                           KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS));
+
+  // Write and lock (rw0c) the software binding value. This register is unlocked
+  // by hardware upon a successful state transition.
+  // FIXME: Consider using sec_mmio module for the following register writes.
+  for (size_t i = 0; i < 8; ++i) {
+    abs_mmio_write32(
+        kBase + KEYMGR_SW_BINDING_0_REG_OFFSET + i * sizeof(uint32_t),
+        binding_value[i]);
+  }
+  abs_mmio_write32(kBase + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 0);
+
+  // Write and lock (rw0c) the max key version.
+  abs_mmio_write32(kBase + KEYMGR_MAX_CREATOR_KEY_VER_REG_OFFSET, max_key_ver);
+  abs_mmio_write32(kBase + KEYMGR_MAX_CREATOR_KEY_VER_REGWEN_REG_OFFSET, 0);
+
+  // Advance to CREATOR_ROOT_KEY state.
+  advance_state();
+  return kErrorOk;
+}
+
+rom_error_t keymgr_state_creator_check() {
+  return check_expected_state(KEYMGR_WORKING_STATE_STATE_VALUE_CREATOR_ROOT_KEY,
+                              KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+}

--- a/sw/device/silicon_creator/lib/drivers/keymgr.h
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.h
@@ -1,0 +1,62 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_KEYMGR_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_KEYMGR_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initializes the key manager.
+ *
+ * Initializes the key manager `entropy_reseed_interval` and advances the state
+ * into initialized.
+ *
+ * The working status of the key manager must be set to reset before
+ * calling this function otherwise it will return `kErrorKeymgrInternal`.
+ *
+ * @param entropy_reseed_interval Number of key manager cycles before the
+ * entropy is reseeded.
+ * @return The result of the operation.
+ */
+rom_error_t keymgr_init(uint16_t entropy_reseed_interval);
+
+/**
+ * Advances the state of the key manager to Creator Root Key state.
+ *
+ * This operation is non-blocking to allow the software to continue with other
+ * operations while the key manager is advancing its state. The caller is
+ * responsible for calling the `keymgr_state_creator_check()` at a later time
+ * to ensure the advance transition completed without errors.
+ *
+ * @param binding_value Software binding value extracted from the ROM_EXT
+ * manifest.
+ * @param max_key_version Maximum key version extracted from the ROM_EXT
+ * manifest.
+ * @return The result of the operation.
+ */
+// TODO: Switch binding_value to a wrapped struct parameter.
+rom_error_t keymgr_state_advance_to_creator(const uint32_t binding_value[8],
+                                            uint32_t max_key_version);
+
+/**
+ * Checks the state of the key manager.
+ *
+ * @return `kErrorOk` if the key manager is in Creator Root Key state and the
+ * status is idle of success; otherwise retuns `kErrorKeymgrInternal`.
+ */
+rom_error_t keymgr_state_creator_check(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_KEYMGR_H_

--- a/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
@@ -1,0 +1,156 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/keymgr.h"
+
+#include <array>
+#include <limits>
+
+#include "gtest/gtest.h"
+#include "sw/device/silicon_creator/lib/base/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "keymgr_regs.h"  // Generated.
+
+namespace keymgr_unittest {
+namespace {
+using ::testing::ElementsAreArray;
+using ::testing::Test;
+
+struct SwBindingCfg {
+  uint32_t max_key_ver;
+  uint32_t sw_binding_value[8];
+};
+
+class KeymgrTest : public mask_rom_test::MaskRomTest {
+ protected:
+  void ExpectStatusCheck(uint32_t op_status, uint32_t km_state,
+                         uint32_t err_code) {
+    EXPECT_ABS_READ32(mmio_, base_ + KEYMGR_OP_STATUS_REG_OFFSET, op_status);
+    EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_OP_STATUS_REG_OFFSET, op_status);
+
+    EXPECT_ABS_READ32(mmio_, base_ + KEYMGR_ERR_CODE_REG_OFFSET, err_code);
+    EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_ERR_CODE_REG_OFFSET, err_code);
+
+    EXPECT_ABS_READ32(mmio_, base_ + KEYMGR_WORKING_STATE_REG_OFFSET, km_state);
+  }
+  uint32_t base_ = TOP_EARLGREY_KEYMGR_BASE_ADDR;
+  SwBindingCfg cfg_ = {
+      .max_key_ver = 0xA5A5A5A5,
+      .sw_binding_value = {0, 1, 2, 3, 4, 6, 7, 8},
+  };
+  mask_rom_test::MockAbsMmio mmio_;
+};
+
+TEST_F(KeymgrTest, Initialize) {
+  ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_WORKING_STATE_STATE_VALUE_RESET,
+                    /*err_code=*/0u);
+
+  EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_RESEED_INTERVAL_REG_OFFSET, 0u);
+
+  EXPECT_ABS_WRITE32(
+      mmio_, base_ + KEYMGR_CONTROL_REG_OFFSET,
+      {
+          {KEYMGR_CONTROL_START_BIT, true},
+          {KEYMGR_CONTROL_DEST_SEL_OFFSET, KEYMGR_CONTROL_DEST_SEL_VALUE_NONE},
+          {KEYMGR_CONTROL_OPERATION_OFFSET,
+           KEYMGR_CONTROL_OPERATION_VALUE_ADVANCE},
+      });
+
+  EXPECT_EQ(keymgr_init(0u), kErrorOk);
+}
+
+TEST_F(KeymgrTest, StateAdvanceToCreator) {
+  // Simulate an WIP OP status to exercise the polling check, followed by the
+  // DONE_SUCCESS expectation.
+  EXPECT_ABS_READ32(
+      mmio_, base_ + KEYMGR_OP_STATUS_REG_OFFSET,
+      {{KEYMGR_OP_STATUS_STATUS_OFFSET, KEYMGR_OP_STATUS_STATUS_VALUE_WIP}});
+  EXPECT_ABS_WRITE32(
+      mmio_, base_ + KEYMGR_OP_STATUS_REG_OFFSET,
+      {{KEYMGR_OP_STATUS_STATUS_OFFSET, KEYMGR_OP_STATUS_STATUS_VALUE_WIP}});
+  ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS,
+                    KEYMGR_WORKING_STATE_STATE_VALUE_INIT,
+                    /*err_code=*/0u);
+
+  EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_SW_BINDING_0_REG_OFFSET,
+                     cfg_.sw_binding_value[0]);
+  EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_SW_BINDING_1_REG_OFFSET,
+                     cfg_.sw_binding_value[1]);
+  EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_SW_BINDING_2_REG_OFFSET,
+                     cfg_.sw_binding_value[2]);
+  EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_SW_BINDING_3_REG_OFFSET,
+                     cfg_.sw_binding_value[3]);
+  EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_SW_BINDING_4_REG_OFFSET,
+                     cfg_.sw_binding_value[4]);
+  EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_SW_BINDING_5_REG_OFFSET,
+                     cfg_.sw_binding_value[5]);
+  EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_SW_BINDING_6_REG_OFFSET,
+                     cfg_.sw_binding_value[6]);
+  EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_SW_BINDING_7_REG_OFFSET,
+                     cfg_.sw_binding_value[7]);
+  EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 0);
+
+  EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_MAX_CREATOR_KEY_VER_REG_OFFSET,
+                     cfg_.max_key_ver);
+  EXPECT_ABS_WRITE32(mmio_,
+                     base_ + KEYMGR_MAX_CREATOR_KEY_VER_REGWEN_REG_OFFSET, 0);
+
+  EXPECT_ABS_WRITE32(
+      mmio_, base_ + KEYMGR_CONTROL_REG_OFFSET,
+      {
+          {KEYMGR_CONTROL_START_BIT, true},
+          {KEYMGR_CONTROL_DEST_SEL_OFFSET, KEYMGR_CONTROL_DEST_SEL_VALUE_NONE},
+          {KEYMGR_CONTROL_OPERATION_OFFSET,
+           KEYMGR_CONTROL_OPERATION_VALUE_ADVANCE},
+      });
+
+  EXPECT_EQ(
+      keymgr_state_advance_to_creator(cfg_.sw_binding_value, cfg_.max_key_ver),
+      kErrorOk);
+}
+
+TEST_F(KeymgrTest, StateAdvanceToCreatorInvalid) {
+  // Any state different than INIT is expected to fail.
+  ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS,
+                    KEYMGR_WORKING_STATE_STATE_VALUE_RESET,
+                    /*err_code=*/0u);
+  EXPECT_EQ(
+      keymgr_state_advance_to_creator(cfg_.sw_binding_value, cfg_.max_key_ver),
+      kErrorKeymgrInternal);
+
+  // Any non-idle status is expected to fail.
+  ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_DONE_ERROR,
+                    KEYMGR_WORKING_STATE_STATE_VALUE_INIT,
+                    /*err_code=*/0u);
+  EXPECT_EQ(
+      keymgr_state_advance_to_creator(cfg_.sw_binding_value, cfg_.max_key_ver),
+      kErrorKeymgrInternal);
+}
+
+TEST_F(KeymgrTest, StateCreatorCheck) {
+  ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS,
+                    KEYMGR_WORKING_STATE_STATE_VALUE_CREATOR_ROOT_KEY,
+                    /*err_code=*/0u);
+  EXPECT_EQ(keymgr_state_creator_check(), kErrorOk);
+}
+
+TEST_F(KeymgrTest, StateCreatorCheckInvalidResponse) {
+  // Any state different than CREATOR_ROOT is expected to fail.
+  ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS,
+                    KEYMGR_WORKING_STATE_STATE_VALUE_INVALID,
+                    /*err_code=*/0u);
+  EXPECT_EQ(keymgr_state_creator_check(), kErrorKeymgrInternal);
+
+  // Any non-idle status is expected to fail.
+  ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_DONE_ERROR,
+                    KEYMGR_WORKING_STATE_STATE_VALUE_CREATOR_ROOT_KEY,
+                    /*err_code=*/0u);
+  EXPECT_EQ(keymgr_state_creator_check(), kErrorKeymgrInternal);
+}
+
+}  // namespace
+}  // namespace keymgr_unittest

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -34,6 +34,38 @@ test('sw_silicon_creator_lib_driver_hmac_unittest', executable(
   suite: 'mask_rom',
 )
 
+# Mask ROM keymgr driver
+sw_silicon_creator_lib_driver_keymgr = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_lib_driver_keymgr',
+    sources: [
+      hw_ip_keymgr_reg_h,
+      'keymgr.c',
+    ],
+    dependencies: [
+      sw_silicon_creator_lib_base_abs_mmio,
+    ],
+  ),
+)
+
+test('sw_silicon_creator_lib_driver_keymgr_unittest', executable(
+    'sw_silicon_creator_lib_driver_keymgr_unittest',
+    sources: [
+      'keymgr_unittest.cc',
+      hw_ip_keymgr_reg_h,
+      'keymgr.c',
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_silicon_creator_lib_base_mock_abs_mmio,
+    ],
+    native: true,
+    c_args: ['-DMOCK_ABS_MMIO'],
+    cpp_args: ['-DMOCK_ABS_MMIO'],
+    ),
+  suite: 'mask_rom',
+)
+
 # Mask ROM uart driver
 sw_silicon_creator_lib_driver_uart = declare_dependency(
   link_with: static_library(

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -25,6 +25,7 @@ enum module_ {
   kModuleHmac = 0x4d48,       // ASCII "HM".
   kModuleSigverify = 0x5653,  // ASCII "SV".
   kModuleOtp = 0x504f,        // ASCII "OP".
+  kModuleKeymgr = 0x4d4b,     // ASCII "KM".
 };
 
 /**
@@ -50,6 +51,7 @@ enum module_ {
   X(kErrorSigverifyInvalidArgument, ERROR_(1, kModuleSigverify, kInvalidArgument)), \
   X(kErrorOtpBusy,                  ERROR_(1, kModuleOtp, kUnavailable)),  \
   X(kErrorOtpUnknown,               ERROR_(2, kModuleOtp, kUnknown)), \
+  X(kErrorKeymgrInternal,           ERROR_(1, kModuleKeymgr, kInternal)), \
   X(kErrorUnknown, 0xFFFFFFFF)
 // clang-format on
 

--- a/sw/device/silicon_creator/mask_rom/mask_rom_start.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_start.S
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+#include "entropy_src_regs.h"
+#include "csrng_regs.h"
+#include "edn_regs.h"
 
 /**
  * Mask ROM Interrupt Vector
@@ -140,6 +143,21 @@ _mask_rom_start_boot:
   // of `mie`.
   li   t0, 0xFFFF0888
   csrc mie, t0
+
+  // The following sequence enables the minimum level of entropy required to
+  // initialize memory scrambling, as well as the entropy distribution network.
+  // FIXME: Enable entropy complex - this is not the full enable.
+  li   a0, TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR
+  li   t0, 0x2
+  sw   t0, ENTROPY_SRC_CONF_REG_OFFSET(a0)
+
+  li   a0, TOP_EARLGREY_CSRNG_BASE_ADDR
+  li   t0, 0x1
+  sw   t0, CSRNG_CTRL_REG_OFFSET(a0)
+
+  li   a0, TOP_EARLGREY_EDN0_BASE_ADDR
+  li   t0, 0x9
+  sw   t0, EDN_CTRL_REG_OFFSET(a0)
 
   // Set up the stack pointer.
   //

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -31,12 +31,16 @@ sw_silicon_creator_mask_rom_sigverify = declare_dependency(
 # MaskROM library.
 mask_rom_lib = declare_dependency(
   sources: [
+    hw_ip_entropy_src_reg_h,
+    hw_ip_csrng_reg_h,
+    hw_ip_edn_reg_h,
     'mask_rom_start.S',
   ],
     link_args: rom_link_args,
     dependencies: [
       freestanding_headers,
       sw_silicon_creator_lib_driver_hmac,
+      sw_silicon_creator_lib_driver_keymgr,
       sw_silicon_creator_lib_driver_uart,
       sw_silicon_creator_lib_fake_deps,
       sw_silicon_creator_mask_rom_sigverify,


### PR DESCRIPTION
The key manager is initialized with an entropy reseed interval provided by the mask rom and advanced into the initialized state. It is later configured with the software binding tag and maximum key version information extracted from the ROM_EXT manifest. The mask rom checks the status of the key manager before handing over execution to the ROM_EXT.

This PR also adds an entropy complex initialization sequence as a workaround to be able to initialize the key manager. 

Signed-off-by: Miguel Osorio <miguelosorio@google.com>