### PR TITLE
[dv/cov] exclude prim_lfsr and prim_prince

### DIFF
--- a/hw/dv/tools/vcs/cover.cfg
+++ b/hw/dv/tools/vcs/cover.cfg
@@ -9,9 +9,13 @@
 -module pins_if     // DV construct.
 -module clk_rst_if  // DV construct.
 -moduletree prim_alert_sender  // prim_alert_sender is verified in FPV.
+-moduletree prim_prince // prim_prince is verified in a separate DV environment.
+-moduletree prim_lfsr // prim_lfsr is verified in FPV.
 
 begin tgl
   -tree tb
   +tree tb.dut 1
   +module prim_alert_sender
+  +module prim_prince
+  +module prim_lfsr
 end


### PR DESCRIPTION
this PR adds prim_lfsr and prim_prince to the common `cover.cfg` file
and adds option to only collect toggle coverage on their I/O ports,
as they are both verified in separate DV/FPV testbenches.

Signed-off-by: Udi Jonnalagadda <udij@google.com>