### PR TITLE
[dvsim] Testplan related fixes

### DIFF
--- a/hw/ip/pwrmgr/data/pwrmgr_testplan.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr_testplan.hjson
@@ -7,7 +7,7 @@
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      // "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
-  entries: [
+  testpoints: [
     {
       name: smoke
       desc: '''

--- a/hw/ip/rom_ctrl/data/rom_ctrl_testplan.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl_testplan.hjson
@@ -6,7 +6,7 @@
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
-  entries: [
+  testpoints: [
     {
       name: smoke
       desc: '''

--- a/util/dvsim/examples/testplanner/common_testplan.hjson
+++ b/util/dvsim/examples/testplanner/common_testplan.hjson
@@ -2,8 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  // only 'entries' supported in imported testplans for now
-  entries: [
+  testpoints: [
     {
       name: csr
       desc: '''Standard CSR suite of tests run from all valid interfaces to prove SW
@@ -13,10 +12,10 @@
       // importer needs to provide substitutions for these as string or a list
       // if list, then substitution occurs on all values in the list
       // if substitution is not provided, it will be replaced with an empty string
-      tests: ["{name}{intf}_csr_hw_reset",
-              "{name}{intf}_csr_rw",
-              "{name}{intf}_csr_bit_bash",
-              "{name}{intf}_csr_aliasing",]
+      tests: ["{name}_{intf}_csr_hw_reset",
+              "{name}_{intf}_csr_rw",
+              "{name}_{intf}_csr_bit_bash",
+              "{name}_{intf}_csr_aliasing",]
     }
   ]
 }

--- a/util/dvsim/examples/testplanner/foo_testplan.hjson
+++ b/util/dvsim/examples/testplanner/foo_testplan.hjson
@@ -29,7 +29,7 @@
       desc: "A single line description with single double-inverted commas."
       milestone: V2
       // testplan entry with no tests added
-      tests: ["{name}_feature1_{intf}"]
+      tests: ["{name}_{intf}_feature1"]
     }
     {
       name: feature2

--- a/util/uvmdvgen/testplan.hjson.tpl
+++ b/util/uvmdvgen/testplan.hjson.tpl
@@ -8,7 +8,7 @@
                      "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
-  entries: [
+  testpoints: [
     {
       name: smoke
       desc: '''
@@ -28,6 +28,13 @@
       desc: '''Add more test entries here like above.'''
       milestone: V1
       tests: []
+    }
+  ]
+
+  covergroups: [
+    {
+      name: ${name}_feature_cg
+      desc: '''Describe the functionality covered by this covergroup.'''
     }
   ]
 }


### PR DESCRIPTION
The first commit fixes the mis-rendered testplan in our current documentation. 

The second commit renames `entries` with `testpoints` in the last remaining testplan files that we missed in the last PR. 