### PR TITLE
[simutil_verilator] Improve timeout handling

### DIFF
--- a/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -60,6 +60,52 @@ std::pair<int, bool> VerilatorSimCtrl::Exec(int argc, char **argv) {
   return std::make_pair(retcode, true);
 }
 
+static bool read_ul_arg(unsigned long *arg_val, const char *arg_name,
+                        const char *arg_text) {
+  assert(arg_val && arg_name && arg_text);
+
+  bool bad_fmt = false;
+  bool out_of_range = false;
+
+  // We have a stricter input format that strtoul: no leading space and no
+  // leading plus or minus signs (strtoul has magic behaviour if the input
+  // starts with a minus sign, but we don't want that). We're using auto base
+  // detection, but a valid number will always start with 0-9 (since hex
+  // constants start with "0x")
+  if (!(('0' <= arg_text[0]) && (arg_text[0] <= '9'))) {
+    bad_fmt = true;
+  } else {
+    char *txt_end;
+    *arg_val = strtoul(arg_text, &txt_end, 0);
+
+    // If txt_end doesn't point at a \0 then we didn't read the entire
+    // argument.
+    if (*txt_end) {
+      bad_fmt = true;
+    } else {
+      // If the value was too big to fit in an unsigned long, strtoul sets
+      // errno to ERANGE.
+      if (errno != 0) {
+        assert(errno == ERANGE);
+        out_of_range = true;
+      }
+    }
+  }
+
+  if (bad_fmt) {
+    std::cerr << "ERROR: Bad format for " << arg_name << " argument: `"
+              << arg_text << "' is not an unsigned integer.\n";
+    return false;
+  }
+  if (out_of_range) {
+    std::cerr << "ERROR: Bad format for " << arg_name << " argument: `"
+              << arg_text << "' is too big.\n";
+    return false;
+  }
+
+  return true;
+}
+
 bool VerilatorSimCtrl::ParseCommandArgs(int argc, char **argv, bool &exit_app) {
   const struct option long_options[] = {
       {"term-after-cycles", required_argument, nullptr, 'c'},
@@ -89,7 +135,10 @@ bool VerilatorSimCtrl::ParseCommandArgs(int argc, char **argv, bool &exit_app) {
         TraceOn();
         break;
       case 'c':
-        term_after_cycles_ = atoi(optarg);
+        if (!read_ul_arg(&term_after_cycles_, "term-after-cycles", optarg)) {
+          exit_app = true;
+          return false;
+        }
         break;
       case 'h':
         PrintHelp();
@@ -159,6 +208,10 @@ void VerilatorSimCtrl::SetResetDuration(unsigned int cycles) {
   reset_duration_cycles_ = cycles;
 }
 
+void VerilatorSimCtrl::SetTimeout(unsigned int cycles) {
+  term_after_cycles_ = cycles;
+}
+
 void VerilatorSimCtrl::RequestStop(bool simulation_success) {
   request_stop_ = true;
   simulation_success_ &= simulation_success;
@@ -217,7 +270,7 @@ void VerilatorSimCtrl::PrintHelp() const {
                  "  Write a trace file from the start\n\n";
   }
   std::cout << "-c|--term-after-cycles=N\n"
-               "  Terminate simulation after N cycles\n\n"
+               "  Terminate simulation after N cycles. 0 means no timeout.\n\n"
                "-h|--help\n"
                "  Show help\n\n"
                "All arguments are passed to the design and can be used "

--- a/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.h
+++ b/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.h
@@ -98,6 +98,15 @@ class VerilatorSimCtrl {
   void SetResetDuration(unsigned int cycles);
 
   /**
+   * Set a timeout in clock cycles.
+   *
+   * This can be overridden by the user (in either direction) with the
+   * --term-after-cycles command-line argument. Setting to zero means
+   * no timeout, which is the default behaviour.
+   */
+  void SetTimeout(unsigned int cycles);
+
+  /**
    * Request the simulation to stop
    */
   void RequestStop(bool simulation_success);
@@ -129,7 +138,7 @@ class VerilatorSimCtrl {
   std::chrono::steady_clock::time_point time_begin_;
   std::chrono::steady_clock::time_point time_end_;
   VerilatedTracer tracer_;
-  int term_after_cycles_;
+  unsigned long term_after_cycles_;
   std::vector<SimCtrlExtension *> extension_array_;
 
   /**


### PR DESCRIPTION
Improve argument parsing for the `--term-after-cycles` argument (now we
spot things like negative numbers or values that are out of range).
Also, add a method to the class to allow specific testbenches to set a
default timeout in cycles.

This is useful if you have a simple block that should only take 10k
cycles: maybe you'd rather time out after 100k cycles than run forever
if something goes wrong.
