### PR TITLE
[rom_ctrl/dv] Add checking on rom reads

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.sv
@@ -13,7 +13,7 @@ class rom_ctrl_env extends cip_base_env #(
   `uvm_component_new
 
   // TL agent for the rom interface
-  tl_agent rom_tl_agent;
+  tl_agent m_rom_tl_agent;
   // KMAC interface agent
   kmac_app_agent m_kmac_agent;
 
@@ -30,9 +30,9 @@ class rom_ctrl_env extends cip_base_env #(
     end
 
     // Build the rom TLUL agent (the regs agent is built in the CIP base class)
-    rom_tl_agent  = tl_agent::type_id::create("rom_tl_agent", this);
-    uvm_config_db#(tl_agent_cfg)::set(this, "rom_tl_agent", "cfg", cfg.rom_tl_cfg);
-    cfg.rom_tl_cfg.en_cov  = cfg.en_cov;
+    m_rom_tl_agent  = tl_agent::type_id::create("m_rom_tl_agent", this);
+    uvm_config_db#(tl_agent_cfg)::set(this, "m_rom_tl_agent", "cfg", cfg.m_rom_tl_cfg);
+    cfg.m_rom_tl_cfg.en_cov  = cfg.en_cov;
 
     // Build the KMAC agent
     m_kmac_agent = kmac_app_agent::type_id::create("m_kmac_agent", this);
@@ -46,8 +46,11 @@ class rom_ctrl_env extends cip_base_env #(
     m_kmac_agent.monitor.analysis_port.connect(scoreboard.kmac_rsp_fifo.analysis_export);
     m_kmac_agent.monitor.req_analysis_port.connect(scoreboard.kmac_req_fifo.analysis_export);
 
+    m_rom_tl_agent.monitor.a_chan_port.connect(scoreboard.rom_tl_a_chan_fifo.analysis_export);
+    m_rom_tl_agent.monitor.d_chan_port.connect(scoreboard.rom_tl_d_chan_fifo.analysis_export);
+
     virtual_sequencer.kmac_sequencer_h   = m_kmac_agent.sequencer;
-    virtual_sequencer.rom_tl_sequencer_h = rom_tl_agent.sequencer;
+    virtual_sequencer.rom_tl_sequencer_h = m_rom_tl_agent.sequencer;
 
   endfunction
 

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -5,7 +5,7 @@
 class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block));
 
   // ext component cfgs
-  rand tl_agent_cfg rom_tl_cfg;
+  rand tl_agent_cfg m_rom_tl_cfg;
   kmac_app_agent_cfg m_kmac_agent_cfg;
 
   // ext interfaces
@@ -26,8 +26,8 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
     m_kmac_agent_cfg.if_mode = dv_utils_pkg::Device;
     m_kmac_agent_cfg.start_default_device_seq = 1'b1;
 
-    rom_tl_cfg = tl_agent_cfg::type_id::create("rom_tl_cfg");
-    rom_tl_cfg.if_mode = dv_utils_pkg::Host;
+    m_rom_tl_cfg = tl_agent_cfg::type_id::create("m_rom_tl_cfg");
+    m_rom_tl_cfg.if_mode = dv_utils_pkg::Host;
 
   endfunction
 

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
@@ -20,6 +20,8 @@ class rom_ctrl_scoreboard extends cip_base_scoreboard #(
   // TLM agent fifos
   uvm_tlm_analysis_fifo #(kmac_app_item) kmac_req_fifo;
   uvm_tlm_analysis_fifo #(kmac_app_item) kmac_rsp_fifo;
+  uvm_tlm_analysis_fifo #(tl_seq_item)   rom_tl_a_chan_fifo;
+  uvm_tlm_analysis_fifo #(tl_seq_item)   rom_tl_d_chan_fifo;
 
   `uvm_component_new
 
@@ -27,6 +29,8 @@ class rom_ctrl_scoreboard extends cip_base_scoreboard #(
     super.build_phase(phase);
     kmac_req_fifo = new("kmac_req_fifo", this);
     kmac_rsp_fifo = new("kmac_rsp_fifo", this);
+    rom_tl_a_chan_fifo = new("rom_tl_a_chan_fifo", this);
+    rom_tl_d_chan_fifo = new("rom_tl_d_chan_fifo", this);
   endfunction
 
   task run_phase(uvm_phase phase);
@@ -35,6 +39,8 @@ class rom_ctrl_scoreboard extends cip_base_scoreboard #(
       process_kmac_req_fifo();
       process_kmac_rsp_fifo();
       monitor_rom_ctrl_if();
+      process_rom_tl_a_chan_fifo();
+      process_rom_tl_d_chan_fifo();
     join
   endtask
 
@@ -141,6 +147,43 @@ class rom_ctrl_scoreboard extends cip_base_scoreboard #(
     end
   endtask
 
+  virtual task process_rom_tl_a_chan_fifo();
+    tl_seq_item item;
+    forever begin
+      rom_tl_a_chan_fifo.get(item);
+      `uvm_info(`gfn, $sformatf("Rcvd rom_tl_a_chan item:\n%0s", item.sprint()), UVM_HIGH)
+    end
+  endtask
+
+  virtual task process_rom_tl_d_chan_fifo();
+    tl_seq_item item;
+    forever begin
+      rom_tl_d_chan_fifo.get(item);
+      `uvm_info(`gfn, $sformatf("Rcvd rom_tl_d_chan item:\n%0s", item.sprint()), UVM_HIGH)
+      // check packet integrity
+      void'(item.is_ok());
+      if (item.is_write()) begin
+        `DV_CHECK_EQ(item.d_error, 1'b1, "Attempted write did not return error")
+      end else begin
+        check_mem_read(item);
+      end
+    end
+  endtask
+
+  virtual function check_mem_read(tl_seq_item item);
+    bit [ROM_MEM_W-1:0] exp_data;
+
+    exp_data = cfg.mem_bkdr_vif.rom_encrypt_read32(
+        item.a_addr, RND_CNST_SCR_KEY, RND_CNST_SCR_NONCE, 1'b1);
+
+    `DV_CHECK_EQ(item.d_error, item.get_exp_d_error(), "TLUL ROM read error incorrect")
+    for (int i = 0; i < TL_DW / 8; i++) begin
+      if (item.a_mask[i]) begin
+        `DV_CHECK_EQ(item.d_data[i*8+:8], exp_data[i*8+:8], "TLUL ROM read data incorrect")
+      end
+    end
+  endfunction
+
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
@@ -205,6 +248,8 @@ class rom_ctrl_scoreboard extends cip_base_scoreboard #(
     rom_check_complete = 1'b0;
     pwrmgr_complete = 1'b0;
     keymgr_complete = 1'b0;
+    rom_tl_a_chan_fifo.flush();
+    rom_tl_d_chan_fifo.flush();
   endfunction
 
   function void check_phase(uvm_phase phase);
@@ -213,6 +258,8 @@ class rom_ctrl_scoreboard extends cip_base_scoreboard #(
     `DV_CHECK_EQ(rom_check_complete, 1'b1, "rom check didn't finish")
     `DV_CHECK_EQ(pwrmgr_complete, 1'b1, "pwrmgr signals never checked")
     `DV_CHECK_EQ(keymgr_complete, 1'b1, "keymgr signals never checked")
+    `DV_EOT_PRINT_TLM_FIFO_CONTENTS(tl_seq_item, rom_tl_a_chan_fifo)
+    `DV_EOT_PRINT_TLM_FIFO_CONTENTS(tl_seq_item, rom_tl_d_chan_fifo)
   endfunction
 
 endclass

--- a/hw/ip/rom_ctrl/dv/tb.sv
+++ b/hw/ip/rom_ctrl/dv/tb.sv
@@ -73,7 +73,7 @@ module tb;
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
-    uvm_config_db#(virtual tl_if)::set(null, "*.env.rom_tl_agent*", "vif", tl_rom_if);
+    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_rom_tl_agent*", "vif", tl_rom_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(mem_bkdr_vif)::set(null, "*.env", "mem_bkdr_vif",
         `ROM_CTRL_MEM_HIER.mem_bkdr_if);


### PR DESCRIPTION
Read data are checked against backdoor memory reads for correctness.
This patch also corrects some naming of the rom_tl_agent.

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>