### PR TITLE
[dv/kmac] implement error testing

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_env.core
+++ b/hw/ip/kmac/dv/env/kmac_env.core
@@ -36,6 +36,7 @@ filesets:
       - seq_lib/kmac_test_vectors_kmac_xof_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_burst_write_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_app_vseq.sv: {is_include_file: true}
+      - seq_lib/kmac_error_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/kmac/dv/env/kmac_env_pkg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_pkg.sv
@@ -141,6 +141,27 @@ package kmac_env_pkg;
     AppRom
   } kmac_app_e;
 
+  // state values of the App FSM
+  typedef enum bit [3:0] {
+    StIdle                  = 4'b0000,
+    StAppCfg                = 4'b1110,
+    StAppMsg                = 4'b0101,
+    StAppOutLen             = 4'b0110,
+    StAppProcess            = 4'b1010,
+    StAppWait               = 4'b0111,
+    StSw                    = 4'b0100,
+    StKeyMgrErrKeyNotValid  = 4'b1111
+  } kmac_app_st_e;
+
+  // states of the error FSM
+  typedef enum bit [2:0] {
+    ErrStIdle,
+    ErrStMsgFeed,
+    ErrStProcessing,
+    ErrStAbsorbed,
+    ErrStSqueezing
+  } kmac_err_st_e;
+
   typedef virtual pins_if#(1)       idle_vif;
   typedef virtual kmac_sideload_if  sideload_vif;
 

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -21,6 +21,8 @@ class kmac_scoreboard extends cip_base_scoreboard #(
 
   // local variables
 
+  bit do_check_digest = 1;
+
   // Represents the number of blocks that have been filled in sha3pad
   int num_blocks_filled = 0;
 
@@ -114,6 +116,22 @@ class kmac_scoreboard extends cip_base_scoreboard #(
   bit intr_fifo_empty;
   bit intr_kmac_err;
 
+  // Error tracking
+  kmac_pkg::err_t kmac_err = '{valid: 1'b0,
+                               code: kmac_pkg::ErrNone,
+                               info: '0};
+  sha3_pkg::err_t sha3_err = '{valid: 1'b0,
+                               code: sha3_pkg::ErrNone,
+                               info: '0};
+  // Need to track the FSM in `kmac_app` and the mux select value,
+  // these are used in App-related error reporting
+  kmac_app_st_e   app_st = StIdle;
+  bit             app_fsm_active = 0;
+  app_mux_sel_e   app_mux_sel = SelNone;
+
+  // Need to track the FSM in `kmac_errchk` for error reporting
+  kmac_err_st_e err_st = ErrStIdle;
+
   // Variables to track the internal write/read pointers.
   //
   // One major difference between these and standard fifo pointers is that these
@@ -124,9 +142,6 @@ class kmac_scoreboard extends cip_base_scoreboard #(
 
   // key length enum
   key_len_e key_len;
-
-  // error reporting
-  bit kmac_err;
 
   keymgr_pkg::hw_key_req_t sideload_key;
 
@@ -188,6 +203,8 @@ class kmac_scoreboard extends cip_base_scoreboard #(
     super.run_phase(phase);
     fork
       detect_kmac_app_start();
+      process_kmac_app_fsm();
+      process_kmac_err_fsm();
       process_edn();
       process_prefix_and_keys();
       process_msgfifo_write();
@@ -326,6 +343,22 @@ class kmac_scoreboard extends cip_base_scoreboard #(
                                      app_mode == AppKeymgr);
             end
 
+            wait(!in_kmac_app &&
+                 (`KMAC_APP_VALID_TRANS(AppKeymgr) ||
+                  `KMAC_APP_VALID_TRANS(AppLc) ||
+                  `KMAC_APP_VALID_TRANS(AppRom)));
+
+            in_kmac_app = 1;
+            `uvm_info(`gfn, "raised in_kmac_app", UVM_HIGH)
+
+            // we need to choose the correct application interface
+            if (`KMAC_APP_VALID_TRANS(AppKeymgr)) begin
+              app_mode = AppKeymgr;
+            end else if (`KMAC_APP_VALID_TRANS(AppLc)) begin
+              app_mode = AppLc;
+            end else if (`KMAC_APP_VALID_TRANS(AppRom)) begin
+              app_mode = AppRom;
+            end
             @(posedge sha3_idle);
           end
           ,
@@ -334,7 +367,144 @@ class kmac_scoreboard extends cip_base_scoreboard #(
       if (cfg.under_reset) begin
         @(negedge cfg.under_reset);
       end
+      wait(!cfg.under_reset);
+    end
+  endtask
 
+  // This task models the internal FSM of kmac_app module,
+  // required for error handling SW output.
+  virtual task process_kmac_app_fsm();
+    @(negedge cfg.under_reset);
+    forever begin
+      wait(!cfg.under_reset);
+      `DV_SPINWAIT_EXIT(
+          forever begin
+            app_mux_sel = SelNone;
+            case (app_st)
+              StIdle: begin
+                if (!in_kmac_app &&
+                    (cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.req_data_if.valid ||
+                     cfg.m_kmac_app_agent_cfg[AppLc].vif.req_data_if.valid ||
+                     cfg.m_kmac_app_agent_cfg[AppRom].vif.req_data_if.valid)) begin
+                  app_st = StAppCfg;
+                  app_fsm_active = 1;
+                end else if (kmac_cmd == CmdStart) begin
+                  app_st = StSw;
+                end
+              end
+              StAppCfg: begin
+                if (app_mode == AppKeymgr && !cfg.sideload_vif.sideload_key.valid) begin
+                  app_st = StKeyMgrErrKeyNotValid;
+
+                  kmac_err.valid = 1;
+                  kmac_err.code = kmac_pkg::ErrKeyNotValid;
+                  kmac_err.info = '0;
+
+                  in_kmac_app = 0;
+
+                  predict_err(.is_kmac_err(1));
+                end else begin
+                  app_st = StAppMsg;
+                end
+              end
+              StAppMsg: begin
+                app_mux_sel = SelApp;
+                if (kmac_app_last) begin
+                  if (app_mode == AppKeymgr) begin
+                    app_st = StAppOutLen;
+                  end else begin
+                    app_st = StAppProcess;
+                  end
+                end
+              end
+              StAppOutLen: begin
+                app_mux_sel = SelOutLen;
+                app_st = StAppProcess;
+              end
+              StAppProcess: begin
+                app_st = StAppWait;
+              end
+              StAppWait: begin
+                if (keccak_complete_cycle) begin
+                  app_st = StIdle;
+                  app_fsm_active = 0;
+                end
+              end
+              StSw: begin
+                app_mux_sel = SelSw;
+                if (kmac_cmd == CmdDone) begin
+                  app_st = StIdle;
+                  app_fsm_active = 0;
+                end
+              end
+              StKeyMgrErrKeyNotValid: begin
+                // infinitely loop in this state until a reset is issued
+              end
+              default: begin
+                app_st = StIdle;
+                app_fsm_active = 0;
+              end
+            endcase
+            cfg.clk_rst_vif.wait_clks(1);
+            #0;
+          end
+          ,
+          wait(cfg.under_reset);
+      )
+    end
+  endtask
+
+  // This task simulates the error handling FSM in the KMAC,
+  // as we need state information for error reporting.
+  virtual task process_kmac_err_fsm();
+    @(negedge cfg.under_reset);
+    forever begin
+      wait(!cfg.under_reset);
+      `DV_SPINWAIT_EXIT(
+          case (err_st)
+            ErrStIdle: begin
+              if (!app_fsm_active && kmac_cmd == CmdStart) begin
+                err_st = ErrStMsgFeed;
+                `uvm_info(`gfn, "moving to ErrStMsgFeed", UVM_HIGH)
+              end
+            end
+            ErrStMsgFeed: begin
+              if (kmac_cmd == CmdProcess) begin
+                err_st = ErrStProcessing;
+                `uvm_info(`gfn, "moving to ErrStProcessing", UVM_HIGH)
+              end
+            end
+            ErrStProcessing: begin
+              if (msg_digest_done) begin
+                err_st = ErrStAbsorbed;
+                `uvm_info(`gfn, "moving to ErrStAbsorbed", UVM_HIGH)
+              end
+            end
+            ErrStAbsorbed: begin
+              if (req_manual_squeeze) begin
+                err_st = ErrStSqueezing;
+                `uvm_info(`gfn, "moving to ErrStSqueezing", UVM_HIGH)
+              end else if (kmac_cmd == CmdDone) begin
+                err_st = ErrStIdle;
+                `uvm_info(`gfn, "moving to ErrStIdle", UVM_HIGH)
+              end
+            end
+            ErrStSqueezing: begin
+              if (msg_digest_done) begin
+                err_st = ErrStAbsorbed;
+                `uvm_info(`gfn, "moving to ErrStAbsorbed", UVM_HIGH)
+              end
+            end
+            default: begin
+              err_st = ErrStIdle;
+              `uvm_info(`gfn, "moving to ErrStIdle", UVM_HIGH)
+            end
+          endcase
+          cfg.clk_rst_vif.wait_clks(1);
+          #0;
+          ,
+          wait(cfg.under_reset);
+      )
     end
   endtask
 
@@ -438,7 +608,7 @@ class kmac_scoreboard extends cip_base_scoreboard #(
                     kmac_app_digest_share0 = kmac_app_rsp.rsp_digest_share0;
                     kmac_app_digest_share1 = kmac_app_rsp.rsp_digest_share1;
 
-                    check_digest();
+                    if (do_check_digest) check_digest();
 
                     in_kmac_app = 0;
                     `uvm_info(`gfn, "dropped in_kmac_app", UVM_HIGH)
@@ -583,8 +753,9 @@ class kmac_scoreboard extends cip_base_scoreboard #(
       @(negedge sha3_idle);
       `DV_SPINWAIT_EXIT(
           wait(sha3_squeeze);
-          // interrupt goes high 2 cycles after internal status is updated
-          cfg.clk_rst_vif.wait_clks(2);
+          // Done interrupt goes high 1 cycle after reaching sha3_squeeze state
+          cfg.clk_rst_vif.wait_clks(1);
+          #0;
           // only assert kmac_done intr when not in KMAC_APP mode
           if (!in_kmac_app) intr_kmac_done = 1;
           `uvm_info(`gfn, "raised intr_kmac_done", UVM_HIGH)
@@ -1738,6 +1909,10 @@ class kmac_scoreboard extends cip_base_scoreboard #(
     case (csr_name)
       // add individual case item for each csr
       "intr_state": begin
+        `uvm_info(`gfn, $sformatf("intr_kmac_done: %0d", intr_kmac_done), UVM_HIGH)
+        `uvm_info(`gfn, $sformatf("intr_fifo_empty: %0d", intr_fifo_empty), UVM_HIGH)
+        `uvm_info(`gfn, $sformatf("intr_kmac_err: %0d", intr_kmac_err), UVM_HIGH)
+
         if (data_phase_write) begin
           // clear internal state on a write
           if (item.a_data[KmacDone])      intr_kmac_done = 0;
@@ -1794,9 +1969,7 @@ class kmac_scoreboard extends cip_base_scoreboard #(
       "cfg": begin
         if (addr_phase_write) begin
           // don't continue if the KMAC is currently operating
-          //
-          // TODO this is an error case that needs to be handled
-          if (!(kmac_cmd inside {CmdNone, CmdDone})) begin
+          if (!sha3_idle) begin
             return;
           end
 
@@ -1813,6 +1986,31 @@ class kmac_scoreboard extends cip_base_scoreboard #(
           // sample sideload-related coverage
           if (cfg.en_cov) begin
             cov.sideload_cg.sample(item.a_data[KmacSideload], kmac_en, 0);
+          end
+
+          // Entropy mode configuration error
+          if (cfg.enable_masking && !(entropy_mode inside {EntropyModeSw, EntropyModeEdn})) begin
+            kmac_err.valid  = 1;
+            kmac_err.code   = kmac_pkg::ErrIncorrectEntropyMode;
+            kmac_err.info   = 24'(entropy_mode);
+
+            predict_err(.is_kmac_err(1));
+          end
+
+          // Mode/Strength configuration error
+          if ((hash_mode inside {sha3_pkg::Shake, sha3_pkg::CShake} &&
+                !(strength inside {sha3_pkg::L128, sha3_pkg::L256})) ||
+               (hash_mode == sha3_pkg::Sha3 &&
+                strength == sha3_pkg::L128)) begin
+            kmac_err.valid  = 1;
+            kmac_err.code   = kmac_pkg::ErrUnexpectedModeStrength;
+            kmac_err.info   = {8'h2, 10'h0, 2'(hash_mode), 1'b0, 3'(strength)};
+
+            predict_err(.is_kmac_err(1));
+
+            // If the mode/strength are mis-configured, the IP will finish running a hash with the
+            // incorrect configuration, producing a garbage digest that should not be checked.
+            do_check_digest = 1'b0;
           end
 
           if (entropy_mode == EntropyModeEdn &&
@@ -1834,64 +2032,128 @@ class kmac_scoreboard extends cip_base_scoreboard #(
         //
         // TODO - handle error cases
         if (addr_phase_write) begin
-          case (kmac_cmd_e'(item.a_data))
-            CmdStart: begin
-              // msgfifo will now be written
-              kmac_cmd = CmdStart;
-            end
-            CmdProcess: begin
-              // kmac will now compute the digest
-              kmac_cmd = CmdProcess;
+          if (app_fsm_active) begin
+            // Do not assign `kmac_data` here to avoid potentially corrupting scoreboard state
+            if (kmac_cmd_e'(item.a_data) != CmdNone) begin
+              kmac_err.valid  = 1;
+              kmac_err.code   = kmac_pkg::ErrSwIssuedCmdInAppActive;
+              kmac_err.info   = 24'(item.a_data);
 
-              if (cfg.en_cov) begin
-                cov.cmd_process_cg.sample(in_keccak_rounds, keccak_complete_cycle);
+              predict_err(.is_kmac_err(1));
+            end
+          end else begin
+            case (kmac_cmd_e'(item.a_data))
+              CmdStart: begin
+                if (kmac_cmd == CmdNone) begin
+                  // the first 6B of the prefix (function name),
+                  // need to check that it is "KMAC" when `kmac_en == 1`
+                  bit [47:0] function_name_6B;
+                  bit [TL_DW-1:0] prefix_val;
+
+                  // msgfifo will now be written
+                  kmac_cmd = CmdStart;
+
+                  function_name_6B[31:0]  = `gmv(ral.prefix_0);
+                  prefix_val = `gmv(ral.prefix_1);
+                  function_name_6B[47:32] = prefix_val[15:0];
+
+                  if (kmac_en && function_name_6B != kmac_pkg::EncodedStringKMAC) begin
+                    kmac_err.valid  = 1;
+                    kmac_err.code   = kmac_pkg::ErrIncorrectFunctionName;
+                    kmac_err.info   = {8'h1, 16'h0};
+
+                    // If incorrect function name is given, KMAC will finish the current hash
+                    // operation and produce an incorrect digest, do not check this.
+                    predict_err(.is_kmac_err(1));
+
+                    do_check_digest = 0;
+                  end
+                end else begin // SW sent wrong command
+
+                  kmac_err.valid = 1;
+                  kmac_err.code  = kmac_pkg::ErrSwCmdSequence;
+                  kmac_err.info  = {6'h1, 11'h0, 3'(err_st), item.a_data[3:0]};
+
+                  predict_err(.is_kmac_err(1));
+                end
               end
+              CmdProcess: begin
+                if (kmac_cmd == CmdStart) begin
+                  // kmac will now compute the digest
+                  kmac_cmd = CmdProcess;
 
-              // Raise this bit after a small delay to handle an edge case where
-              // fifo_wr_ptr and fifo_rd_ptr both increment on same cycle that CmdProcess
-              // is latched by internal scoreboard logic
-              #1 req_cmd_process_dly = 1;
-              `uvm_info(`gfn, "raised req_cmd_process_dly", UVM_HIGH)
-            end
-            CmdManualRun: begin
-              // kmac will now squeeze more output data
-              kmac_cmd = CmdManualRun;
-              req_manual_squeeze = 1;
-              `uvm_info(`gfn, "raised req_manual_squeeze", UVM_HIGH)
-            end
-            CmdDone: begin
-              kmac_cmd = CmdDone;
+                  // Raise this bit after a small delay to handle an edge case where
+                  // fifo_wr_ptr and fifo_rd_ptr both increment on same cycle that CmdProcess
+                  // is latched by internal scoreboard logic
+                  #1 req_cmd_process_dly = 1;
+                  `uvm_info(`gfn, "raised req_cmd_process_dly", UVM_HIGH)
+                end else begin // SW sent wrong command
 
-              // sample coverage of message length
-              if (cfg.en_cov) begin
-                cov.msg_len_cg.sample(msg.size());
+                  kmac_err.valid = 1;
+                  kmac_err.code  = kmac_pkg::ErrSwCmdSequence;
+                  kmac_err.info  = {6'h1, 11'h0, 3'(err_st), item.a_data[3:0]};
+
+                  predict_err(.is_kmac_err(1));
+                end
               end
+              CmdManualRun: begin
+                if (kmac_cmd inside {CmdProcess, CmdManualRun}) begin
+                  // kmac will now squeeze more output data
+                  kmac_cmd = CmdManualRun;
+                  req_manual_squeeze = 1;
+                  `uvm_info(`gfn, "raised req_manual_squeeze", UVM_HIGH)
+                end else begin // SW sent wrong command
 
-              // Calculate the digest using DPI and check for correctness
-              check_digest();
+                  kmac_err.valid = 1;
+                  kmac_err.code  = kmac_pkg::ErrSwCmdSequence;
+                  kmac_err.info  = {6'h1, 11'h0, 3'(err_st), item.a_data[3:0]};
 
-              // Flush all scoreboard state to prepare for the next hash operation
-              clear_state();
-
-              // IDLE should go high one cycle after issuing Done cmd
-              cfg.clk_rst_vif.wait_clks(1);
-              sha3_idle = 1;
-
-              // if using EDN, KMAC will refresh entropy after finishing a hash operation
-              if (entropy_mode == EntropyModeEdn) begin
-                cfg.clk_rst_vif.wait_clks(1);
-                in_edn_fetch = cfg.enable_masking;
-                refresh_entropy = cfg.enable_masking;
-                `uvm_info(`gfn, "refreshing entropy from EDN", UVM_HIGH)
+                  predict_err(.is_kmac_err(1));
+                end
               end
-            end
-            CmdNone: begin
-              // RTL internal value, doesn't actually do anything
-            end
-            default: begin
-              `uvm_fatal(`gfn, $sformatf("%0d is an illegal CMD value", item.a_data))
-            end
-          endcase
+              CmdDone: begin
+                if (kmac_cmd inside {CmdProcess, CmdManualRun}) begin
+                  kmac_cmd = CmdDone;
+
+                  // sample coverage of message length
+                  if (cfg.en_cov) begin
+                    cov.msg_len_cg.sample(msg.size());
+                  end
+
+                  // Calculate the digest using DPI and check for correctness
+                  if (do_check_digest) check_digest();
+
+                  // Flush all scoreboard state to prepare for the next hash operation
+                  clear_state();
+
+                  // IDLE should go high one cycle after issuing Done cmd
+                  cfg.clk_rst_vif.wait_clks(1);
+                  sha3_idle = 1;
+
+                  // if using EDN, KMAC will refresh entropy after finishing a hash operation
+                  if (entropy_mode == EntropyModeEdn) begin
+                    cfg.clk_rst_vif.wait_clks(1);
+                    in_edn_fetch = cfg.enable_masking;
+                    refresh_entropy = cfg.enable_masking;
+                    `uvm_info(`gfn, "refreshing entropy from EDN", UVM_HIGH)
+                  end
+                end else begin // SW sent wrong command
+
+                  kmac_err.valid = 1;
+                  kmac_err.code  = kmac_pkg::ErrSwCmdSequence;
+                  kmac_err.info  = {6'h1, 11'h0, 3'(err_st), item.a_data[3:0]};
+
+                  predict_err(.is_kmac_err(1));
+                end
+              end
+              CmdNone: begin
+                // RTL internal value, doesn't actually do anything
+              end
+              default: begin
+                `uvm_fatal(`gfn, $sformatf("%0d is an illegal CMD value", item.a_data))
+              end
+            endcase
+          end
         end else begin
           // this bit will be set to 0 during the data phase of the write,
           // providing better detection of when exactly a manual squeeze command
@@ -1980,7 +2242,12 @@ class kmac_scoreboard extends cip_base_scoreboard #(
     // digest comparison.
     if (msgfifo_access) begin
       if (addr_phase_write) begin
-        if (kmac_cmd != CmdStart) begin
+        if (in_kmac_app) begin
+          kmac_err.valid  = 1;
+          kmac_err.code   = kmac_pkg::ErrSwPushedMsgFifo;
+          kmac_err.info   = {8'h0, 8'(app_st), 8'(app_mux_sel)};
+          predict_err(.is_kmac_err(1));
+        end else if (kmac_cmd != CmdStart) begin
           // TODO
           //
           // If we get here we are writing to the msgfifo in an invalid state.
@@ -2095,12 +2362,25 @@ class kmac_scoreboard extends cip_base_scoreboard #(
     end
   endtask : process_tl_access
 
+  virtual function predict_err(bit is_sha3_err = 0, bit is_kmac_err = 0);
+    // set interrupt
+    if (!intr_kmac_err) intr_kmac_err = 1;
+    `uvm_info(`gfn, "raised intr_kmac_err", UVM_HIGH)
+    if (is_sha3_err) `uvm_info(`gfn, $sformatf("sha3_err: %0p", sha3_err), UVM_HIGH)
+    if (is_kmac_err) `uvm_info(`gfn, $sformatf("kmac_err: %0p", kmac_err), UVM_HIGH)
+
+    // predict error CSR
+    if (is_sha3_err) begin
+      void'(ral.err_code.predict(.value(TL_DW'(sha3_err)), .kind(UVM_PREDICT_DIRECT)));
+    end else if (is_kmac_err) begin
+      void'(ral.err_code.predict(.value(TL_DW'(kmac_err)), .kind(UVM_PREDICT_DIRECT)));
+    end
+  endfunction
+
   virtual function void reset(string kind = "HARD");
     super.reset(kind);
 
     clear_state();
-
-    kmac_cmd = CmdNone;
 
     first_op_after_rst = 1;
 
@@ -2121,6 +2401,10 @@ class kmac_scoreboard extends cip_base_scoreboard #(
 
     if (first_op_after_rst) first_op_after_rst = 0;
 
+    kmac_cmd = CmdNone;
+
+    do_check_digest = 1;
+
     msg.delete();
     kmac_app_msg.delete();
 
@@ -2140,6 +2424,16 @@ class kmac_scoreboard extends cip_base_scoreboard #(
 
     in_edn_fetch    = 0;
     refresh_entropy = 0;
+
+    kmac_err = '{valid: 1'b0,
+                 code: kmac_pkg::ErrNone,
+                 info: '0};
+    sha3_err = '{valid: 1'b0,
+                 code: sha3_pkg::ErrNone,
+                 info: '0};
+
+    app_st = StIdle;
+    err_st = ErrStIdle;
 
     keys          = '0;
     keymgr_keys   = '0;

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_app_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_app_vseq.sv
@@ -41,6 +41,7 @@ class kmac_app_vseq extends kmac_sideload_vseq;
       hash_mode == sha3_pkg::CShake;
       if (app_mode == AppKeymgr) {
         kmac_en == 1;
+        en_sideload == 1;
       } else {
         kmac_en == 0;
       }
@@ -52,5 +53,10 @@ class kmac_app_vseq extends kmac_sideload_vseq;
       }
     }
   }
+
+  virtual task pre_start();
+    en_sideload_c.constraint_mode(0);
+    super.pre_start();
+  endtask
 
 endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_error_vseq.sv
@@ -1,0 +1,54 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class kmac_error_vseq extends kmac_app_vseq;
+
+  `uvm_object_utils(kmac_error_vseq)
+  `uvm_object_new
+
+  virtual function string convert2string();
+    return {$sformatf("en_kmac_err: %0b\n", en_kmac_err),
+            $sformatf("kmac_err_type: %0s\n", kmac_err_type.name()),
+            $sformatf("err_sw_cmd_seq_st: %0s\n", err_sw_cmd_seq_st.name()),
+            $sformatf("err_sw_cmd_seq_cmd: %0s\n", err_sw_cmd_seq_cmd.name()),
+            super.convert2string()};
+  endfunction
+
+  virtual task pre_start();
+    disable_err_c.constraint_mode(0);
+    en_app_c.constraint_mode(0);
+    super.pre_start();
+  endtask
+
+  constraint en_err_c {
+    en_kmac_err dist {
+      0 :/ 3,
+      1 :/ 7
+    };
+  }
+
+  constraint kmac_err_type_c {
+    if (en_kmac_err) {
+      kmac_err_type != kmac_pkg::ErrNone;
+    } else {
+      kmac_err_type == kmac_pkg::ErrNone;
+    }
+
+    (kmac_err_type == kmac_pkg::ErrSwPushedMsgFifo) -> (en_app == 1);
+
+    (kmac_err_type == kmac_pkg::ErrSwIssuedCmdInAppActive) -> (en_app == 1);
+
+    (kmac_err_type == kmac_pkg::ErrIncorrectFunctionName) -> (kmac_en == 1);
+
+    (kmac_err_type == kmac_pkg::ErrUnexpectedModeStrength) -> (en_app == 0);
+
+    (kmac_err_type == kmac_pkg::ErrSwCmdSequence) -> (en_app == 0);
+
+    if (kmac_err_type == kmac_pkg::ErrKeyNotValid) {
+      en_app == 1;
+      app_mode == AppKeymgr;
+    }
+  }
+
+endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
@@ -14,4 +14,5 @@
 `include "kmac_test_vectors_kmac_xof_vseq.sv"
 `include "kmac_burst_write_vseq.sv"
 `include "kmac_app_vseq.sv"
+`include "kmac_error_vseq.sv"
 `include "kmac_stress_all_vseq.sv"

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -140,6 +140,10 @@
       uvm_test_seq: kmac_app_vseq
     }
     {
+      name: "{variant}_error"
+      uvm_test_seq: kmac_error_vseq
+    }
+    {
       name: kmac_stress_all
       run_opts: ["+test_timeout_ns=10_000_000_000",
                  "+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]


### PR DESCRIPTION
This PR implements the last manual functional test required for V2 - error testing.

However, there are several dependencies (only 1 is mandatory):

- [x] #6753 needs to be merged first - this PR overhauls the KMAC error handling, and is what this PR is based on (this dependency is mandatory for this PR to be merged)
- [ ] #6672 may potentially lead to RTL updates, this PR should be updated accordingly
- [ ] #6831 should ideally be resolved - this relates to a possible bug when entropy mode configuration errors are driven, and an RTL fix may require changes to the logic in this PR
- [ ] #6842 should ideally be resolved - this relates to a possible bug when sending a `CmdDone` at the incorrect time, and an RTL fix may require changes to the logic in this PR
- [ ] #6843 should ideally be resolved - this relates to an unexpected assertion error when issuing a `CmdProcess` at an incorrect time

Signed-off-by: Udi Jonnalagadda <udij@google.com>