### PR TITLE
[hmac] Idle logic

### DIFF
--- a/hw/ip/hmac/rtl/hmac_core.sv
+++ b/hw/ip/hmac/rtl/hmac_core.sv
@@ -38,7 +38,9 @@ module hmac_core import hmac_pkg::*; (
   input              fifo_wready,
 
   input  [63:0] message_length,
-  output [63:0] sha_message_length
+  output [63:0] sha_message_length,
+
+  output logic idle
 );
 
   localparam int unsigned BlockSize = 512;
@@ -306,4 +308,8 @@ module hmac_core import hmac_pkg::*; (
 
     endcase
   end
+
+  // Idle: Idle in HMAC_CORE only represents the idle status when hmac mode is
+  // set. If hmac_en is 0, this logic sends the idle signal always.
+  assign idle = (st_q == StIdle) && !reg_hash_start;
 endmodule

--- a/hw/ip/hmac/rtl/sha2.sv
+++ b/hw/ip/hmac/rtl/sha2.sv
@@ -24,7 +24,9 @@ module sha2 import hmac_pkg::*; (
   output logic hash_done,
 
   input        [63:0] message_length,   // bits but byte based
-  output sha_word_t [7:0] digest
+  output sha_word_t [7:0] digest,
+
+  output logic idle
 );
 
   localparam int unsigned RoundWidth = $clog2(NumRound);
@@ -315,5 +317,7 @@ module sha2 import hmac_pkg::*; (
     .msg_feed_complete
   );
 
+  // Idle
+  assign idle = (fifo_st_q == FifoIdle) && (sha_st_q == ShaIdle) && !hash_start;
 
 endmodule : sha2


### PR DESCRIPTION
This commit implements the idle signal. Idle signal is used in the
clkmgr to ensure the safe clock off by checking the logic's idle status.

HMAC implements the idle logic by checking four submodules' idle status:

- packer: packer does not have empty status signal sending out. So,
  currently, the logic relies on the fifo valid out signal. However, the
  case that packer has partial data and not sending out the write signal
  is covered by HMAC_CORE or SHA_CORE idle signals.
- msg_fifo: fifo_wvalid output signal is used as an idle signal.
- HMAC_CORE: the core raises an idle signal when the core sits in the
  Idle state or HMAC mode is not set.
- SHA_CORE: If the FIFO FSM sits in Idle state, SHA core is in idle. SHA
  state machine is dependent on the Fifo FSM.

This is related to #6650
