### PR TITLE
[spi_device] Waivers and fixes for SPI_DEVICE

### DIFF
--- a/hw/ip/spi_device/lint/spi_device.waiver
+++ b/hw/ip/spi_device/lint/spi_device.waiver
@@ -6,6 +6,11 @@
 
 set_clock_drivers prim_clock_buf prim_clock_mux2
 
+### ARITH
+waive -rules {ARITH_CONTEXT} -location {spi_readcmd.sv} \
+      -regexp {'addr_q\[31:2\] \+ 1'b1' is self-determined} \
+      -comment "Leave it as it is for readability"
+
 waive -rules HIER_NET_NOT_READ -location {spi_device.sv} -regexp {[nN]et.*a_(address|param|user).*not read from} \
       -comment "several TLUL signals are not used by register file"
 waive -rules HIER_NET_NOT_READ -location {spi_device.sv} -regexp {Net .reg2hw.*.qe. is not read from} \
@@ -27,9 +32,9 @@ waive -rules NOT_READ -location {spi_device.sv} -regexp {Signal.*sram_base_addr.
       -comment "Sram base address is given by parameter. Didn't decided if this field is used."
 waive -rules NOT_READ -location {spi_device.sv} -regexp {Signal.*[rt]xf_ptr.*' is not read} \
       -comment "Only lower bits are used for sram_addr but leaving the register fields flexible"
-waive -rules HIER_NET_NOT_READ -location {spi_device.sv} -regexp {[nN]et.*spi_mode.* is not read} \
+waive -rules HIER_NET_NOT_READ -location {spi_fwmode.sv} -regexp {[nN]et.*spi_mode.* is not read} \
       -comment "FwMode is used. This field is used when EEPROM is implemented"
-waive -rules HIER_NET_NOT_READ -location {spi_device.sv} -regexp {[nN]et.*fwm_sram_error.* is not read} \
+waive -rules HIER_NET_NOT_READ -location {spi_fwmode.sv} -regexp {[nN]et.*fwm_sram_error.* is not read} \
       -comment "SRAM error correction code is not implemented"
 waive -rules HIER_NET_NOT_READ NOT_READ -location {spi_device.sv} -regexp {.*fifo_level\..xlvl\.q} \
       -comment "RXLevel and TXLevel is used only for pointer width."
@@ -46,7 +51,8 @@ waive -rules CONST_OUTPUT -location {spi_fwm_txf_ctrl.sv} -regexp {Output 'sram_
 waive -rules CONST_OUTPUT -location {spi_fwm_*xf_ctrl.sv} -regexp {Output 'depth.*} \
       -comment "Based on the SRAM size 2kB, it cannot hit the case"
 
-waive -rules CONST_FF -location {spi_fwmode.sv} -regexp {Flip-flop 'sdo_shift\[0\]' is driven} \
+waive -rules CONST_FF -location {spi_p2s.sv} \
+      -regexp {Flip-flop 'tx_state' is driven} \
       -comment "Intended behavior"
 waive -rules CONST_FF -location {spi_device.sv} -regexp {fwm_rerr_q} \
       -comment "Will implement the interrupt later. Waive for now"
@@ -56,8 +62,11 @@ waive -rules CONST_FF -location {spi_fwmode.sv} -regexp {'tx_state' is driven by
 waive -rules TWO_STATE_TYPE -location {spi_device.sv} -regexp {'fwm_fifo_e' is of} \
       -comment "Intended declaration"
 
-waive -rules ONE_BIT_MEM_WIDTH -location {spi_device.sv} -regexp {Memory 'fwm_sram_.*' has word} \
+waive -rules ONE_BIT_MEM_WIDTH -location {spi_device.sv spi_fwmode.sv} -regexp {Memory 'fwm_sram_.*' has word} \
       -comment "Intended implementation to make it consistent with other signals"
+waive -rules {ONE_BIT_MEM_WIDTH} -location {spi_device.sv} \
+      -regexp {Memory 'sub_(sram|p2s)_.*' has word} \
+      -comment "Intended implemenetation to make it consistent"
 
 waive -rules EXPLICIT_BITLEN -location {spi_*} -regexp {for constant '1'} \
       -comment "Parameter subtract is fine"
@@ -72,18 +81,31 @@ waive -rules CONST_FF -location {spi_device.sv} -msg {Flip-flop 'fwm_rxerr_q' is
 
 # intentional terminal states
 waive -rules TERMINAL_STATE -location {spi_cmdparse.sv} -regexp {Terminal state 'St(Status|Jedec|Sfdp|ReadCmd|Upload)' is detected}
+waive -rules TERMINAL_STATE -location {spi_readcmd.sv} \
+      -regexp {Terminal state 'Main(Output|Error)' is detected} \
+      -comment "Intentional dead-end. CSb will reset"
 
 # async resets
-waive -rules RESET_DRIVER -location {spi_device.sv} -regexp {'rst_(spi|txfifo|rxfifo)_n' is driven here, and used as an asynchronous reset} \
+waive -rules RESET_DRIVER -location {spi_device.sv} \
+      -regexp {'rst_(spi|txfifo|rxfifo)_n' is driven} \
       -comment "Async reset generation is required here"
-waive -rules RESET_MUX    -location {spi_device.sv} -regexp {Asynchronous reset 'rst_(spi|txfifo|rxfifo)_n' is driven by a multiplexer} \
+waive -rules RESET_MUX    -location {spi_device.sv} \
+      -regexp {Asynchronous reset 'rst_(spi|txfifo|rxfifo)_n' is driven} \
       -comment "The MUX is needed to control the reset during scanmode (scanmode_i == 1)"
+waive -rules RESET_MUX -location {spi_device.sv} \
+      -regexp {'sram_rst_n.*' is driven by a multiplexer here} \
+      -comment "Scan reset mux, but need to have asynchronous reset"
 
 # clock inverter and muxes
 waive -rules CLOCK_MUX -location {spi_device.sv} -regexp {Clock 'sck_n' is driven by a multiplexer here, used as a clock 'clk_(out|src)_i'} \
       -comment "The multiplexer is needed to bypass the clock inverter during testing"
 waive -rules CLOCK_MUX -location {spi_device.sv} -regexp {Clock 'clk_spi_(in|out)' is driven by a multiplexer here, used as a clock 'clk_(in|out|src)_i'} \
       -comment "Thes multiplexers are needed to select between inverted and non-inverted clock based on configuration"
+
+## For Generic Ascentlint only
+waive -rules CLOCK_MUX -location {spi_device.sv} \
+      -regexp {Clock '(clk_i|sram_clk_muxed)'} \
+      -comment "ascentlint with prim generic has generated clock starting from a flop"
 
 #### INFO
 waive -rules VAR_INDEX -location {spi_fwm_rxf_ctrl.sv} -regexp {'byte_enable\[pos\]'} \
@@ -98,7 +120,7 @@ waive -rules CASE_INC -location {spi_fwm_*xf_ctrl.sv} -regexp {Case statement ta
 #### NOT used
 ####   For the convenience of the design, below signals are intentionally unused
 waive -rules {NOT_USED NOT_READ} -location {spi_device.sv} \
-      -regexp {'sub_sram_.*\[1\]' is not (used|read)} \
+      -regexp {'sub_(sram|p2s)_.*\[1\]' is not (used|read)} \
       -comment "CmdParse does not have SRAM intf"
 
 #### SRAM mux
@@ -122,3 +144,8 @@ waive -rules {TERMINAL_STATE} -location {spi_passthrough.sv} \
 
 waive -rules {NOT_READ} -location {spi_passthrough.sv} \
       -regexp {Signal 'opcode.*}
+
+#### Sign/ unsigned
+waive -rules {ASSIGN_SIGN NEG_ASSIGN} -location {spi_passthrough.sv} \
+      -regexp {'addr_size_d'} \
+      -comment "Waive the unsigned, negative value errors for readability"

--- a/hw/ip/spi_device/rtl/spi_fwm_txf_ctrl.sv
+++ b/hw/ip/spi_device/rtl/spi_fwm_txf_ctrl.sv
@@ -227,7 +227,7 @@ module spi_fwm_txf_ctrl #(
 
   always_comb begin
     fifo_wdata = '0;
-    for (int i = 0 ; i < NumBytes ; i++) begin
+    for (int unsigned i = 0 ; i < NumBytes ; i++) begin
       if (pos == i[SDW-1:0]) fifo_wdata = fifo_wdata_d[8*i+:8];
     end
   end

--- a/hw/ip/spi_device/rtl/spi_passthrough.sv
+++ b/hw/ip/spi_device/rtl/spi_passthrough.sv
@@ -521,7 +521,7 @@ module spi_passthrough
   cmd_info_t       cmd_info, cmd_info_d;
   cmd_info_t [1:0] cmd_info_7th, cmd_info_7th_d;
 
-  logic [AddrCntW-1:0] addr_size, addr_size_d;
+  logic [AddrCntW-1:0] addr_size_d;
 
   logic cmd_info_latch;
 
@@ -567,7 +567,8 @@ module spi_passthrough
   assign unused_cmd_info_fields = &{1'b0,
                                     cmd_info.addr_en,
                                     cmd_info.addr_swap_en,
-                                    cmd_info.addr_4b_affected};
+                                    cmd_info.addr_4b_affected,
+                                    cmd_info.opcode};
 
   always_comb begin
     cmd_info_d = '0;

--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -421,8 +421,8 @@ module spi_readcmd
   //- END:   SRAM Datapath ----------------------------------------------------
 
   //= BEGIN: FIFO to P2S datapath =============================================
-  assign fifo_byte = '{fifo_rdata[7:0],   fifo_rdata[15:8],
-                       fifo_rdata[23:16], fifo_rdata[31:24]};
+  assign fifo_byte = '{fifo_rdata.data[7:0],   fifo_rdata.data[15:8],
+                       fifo_rdata.data[23:16], fifo_rdata.data[31:24]};
   // TODO: addr_inc should not affect this until it is accepted.
   assign p2s_byte = fifo_byte[fifo_byteoffset];
 


### PR DESCRIPTION
While merging fwmode subblocks into a module, lint waivers were not
modified. This commit addresses the issue.
In addition to the modificatio above, this commit fixes some ascentlint
errors and adds some waivers for readability.