### PR TITLE
[test] Use longer timeout for maskrom tests

### DIFF
--- a/test/systemtest/earlgrey/test_sim_verilator.py
+++ b/test/systemtest/earlgrey/test_sim_verilator.py
@@ -319,7 +319,7 @@ def test_apps_selfchecking_silicon_creator(tmp_path, bin_dir,
                                rom_vmem_path,
                                otp_img_path,
                                tmp_path,
-                               boot_timeout=2500)
+                               boot_timeout=55 * 60)
 
     sim.run(app_silicon_creator_selfchecking[0],
             extra_sim_args=app_silicon_creator_selfchecking[1])


### PR DESCRIPTION
Getting through Mask ROM in a verilated simulation as we run them in CI
currently takes around 42 minutes, which exceeds the timeout of 2500s =
41.67 minutes. Extend this timeout to 55 minutes.

Jobs are killed by Azure Pipelines after 60 minutes, so staying under
that threshold gives us a chance to actually run into the timeout set in
the test harness.

The timeouts we have here remain fragile and very susceptible to
variations in the runners we get assigned from Azure. I filed #6684 to
look into more sustainable solutions.