### PR TITLE
[otbn] Add instruction counter.

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -253,7 +253,22 @@
           desc: "Set on any ECC error in a register file"
         }
       ]
-    }
+    } // register : fatal_alert_cause
+    { name: "INSN_CNT",
+      desc: "Instruction Counter",
+      swaccess: "ro",
+      hwaccess: "hwo",
+      fields: [
+        { bits: "31:0",
+          name: "insn_cnt",
+          desc: '''
+            The number of instructions executed in the current or last OTBN run. 
+            Saturates at 2^32-1. The counter is reset to zero when a new operation
+            is started. Instructions triggering an error do not count as being executed.
+          '''
+        }
+      ]
+    } // register : insn_cnt
 
     // Give IMEM and DMEM 16 KiB address space, each, to allow for easy expansion
     // of the actual IMEM and DMEM sizes without changing the address map.

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -89,7 +89,8 @@ module otbn_top_sim (
 
     .edn_urnd_req_o  ( edn_urnd_req     ),
     .edn_urnd_ack_i  ( edn_urnd_ack     ),
-    .edn_urnd_data_i ( edn_urnd_data    )
+    .edn_urnd_data_i ( edn_urnd_data    ),
+    .insn_cnt_o      ()
   );
 
   // The top bits of IMEM rdata aren't currently used (they will eventually be used for integrity

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -520,6 +520,11 @@ module otbn
   assign hw2reg.fatal_alert_cause.reg_error.de = 0;
   assign hw2reg.fatal_alert_cause.reg_error.d  = 0;
 
+  // INSN_CNT register
+  logic [31:0] insn_cnt;
+  assign hw2reg.insn_cnt.d = insn_cnt;
+  assign hw2reg.insn_cnt.de = 1'b1;
+
   // Alerts ====================================================================
 
   logic [NumAlerts-1:0] alert_test;
@@ -698,7 +703,9 @@ module otbn
 
       .edn_urnd_req_o  (edn_urnd_req),
       .edn_urnd_ack_i  (edn_urnd_ack),
-      .edn_urnd_data_i (edn_urnd_data)
+      .edn_urnd_data_i (edn_urnd_data),
+
+      .insn_cnt_o      (insn_cnt)
     );
   `else
     otbn_core #(
@@ -741,7 +748,9 @@ module otbn
 
       .edn_urnd_req_o  (edn_urnd_req),
       .edn_urnd_ack_i  (edn_urnd_ack),
-      .edn_urnd_data_i (edn_urnd_data)
+      .edn_urnd_data_i (edn_urnd_data),
+
+      .insn_cnt_o      (insn_cnt)
     );
   `endif
 

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -64,7 +64,9 @@ module otbn_core
 
   output logic                    edn_urnd_req_o,
   input  logic                    edn_urnd_ack_i,
-  input  logic [EdnDataWidth-1:0] edn_urnd_data_i
+  input  logic [EdnDataWidth-1:0] edn_urnd_data_i,
+
+  output logic [31:0]             insn_cnt_o
 );
   // Fetch request (the next instruction)
   logic [ImemAddrWidth-1:0] insn_fetch_req_addr;
@@ -163,6 +165,8 @@ module otbn_core
 
   logic                     controller_start;
   logic [ImemAddrWidth-1:0] controller_start_addr;
+
+  logic [31:0] insn_cnt;
 
   // Start stop control start OTBN execution when requested and deals with any pre start or post
   // stop actions.
@@ -339,8 +343,12 @@ module otbn_core
 
     .rnd_req_o          (rnd_req),
     .rnd_prefetch_req_o (rnd_prefetch_req),
-    .rnd_valid_i        (rnd_valid)
+    .rnd_valid_i        (rnd_valid),
+
+    .insn_cnt_o         (insn_cnt)
   );
+
+  assign insn_cnt_o = insn_cnt;
 
   // Load store unit: read and write data from data memory
   otbn_lsu u_otbn_lsu (

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -112,6 +112,11 @@ package otbn_reg_pkg;
     } reg_error;
   } otbn_hw2reg_fatal_alert_cause_reg_t;
 
+  typedef struct packed {
+    logic [31:0] d;
+    logic        de;
+  } otbn_hw2reg_insn_cnt_reg_t;
+
   // Register -> HW type
   typedef struct packed {
     otbn_reg2hw_intr_state_reg_t intr_state; // [41:41]
@@ -124,10 +129,11 @@ package otbn_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    otbn_hw2reg_intr_state_reg_t intr_state; // [26:25]
-    otbn_hw2reg_status_reg_t status; // [24:24]
-    otbn_hw2reg_err_bits_reg_t err_bits; // [23:8]
-    otbn_hw2reg_fatal_alert_cause_reg_t fatal_alert_cause; // [7:0]
+    otbn_hw2reg_intr_state_reg_t intr_state; // [59:58]
+    otbn_hw2reg_status_reg_t status; // [57:57]
+    otbn_hw2reg_err_bits_reg_t err_bits; // [56:41]
+    otbn_hw2reg_fatal_alert_cause_reg_t fatal_alert_cause; // [40:33]
+    otbn_hw2reg_insn_cnt_reg_t insn_cnt; // [32:0]
   } otbn_hw2reg_t;
 
   // Register offsets
@@ -140,6 +146,7 @@ package otbn_reg_pkg;
   parameter logic [BlockAw-1:0] OTBN_ERR_BITS_OFFSET = 16'h 18;
   parameter logic [BlockAw-1:0] OTBN_START_ADDR_OFFSET = 16'h 1c;
   parameter logic [BlockAw-1:0] OTBN_FATAL_ALERT_CAUSE_OFFSET = 16'h 20;
+  parameter logic [BlockAw-1:0] OTBN_INSN_CNT_OFFSET = 16'h 24;
 
   // Reset values for hwext registers and their fields
   parameter logic [0:0] OTBN_INTR_TEST_RESVAL = 1'h 0;
@@ -166,11 +173,12 @@ package otbn_reg_pkg;
     OTBN_STATUS,
     OTBN_ERR_BITS,
     OTBN_START_ADDR,
-    OTBN_FATAL_ALERT_CAUSE
+    OTBN_FATAL_ALERT_CAUSE,
+    OTBN_INSN_CNT
   } otbn_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] OTBN_PERMIT [9] = '{
+  parameter logic [3:0] OTBN_PERMIT [10] = '{
     4'b 0001, // index[0] OTBN_INTR_STATE
     4'b 0001, // index[1] OTBN_INTR_ENABLE
     4'b 0001, // index[2] OTBN_INTR_TEST
@@ -179,7 +187,8 @@ package otbn_reg_pkg;
     4'b 0001, // index[5] OTBN_STATUS
     4'b 0001, // index[6] OTBN_ERR_BITS
     4'b 1111, // index[7] OTBN_START_ADDR
-    4'b 0001  // index[8] OTBN_FATAL_ALERT_CAUSE
+    4'b 0001, // index[8] OTBN_FATAL_ALERT_CAUSE
+    4'b 1111  // index[9] OTBN_INSN_CNT
   };
 
 endpackage


### PR DESCRIPTION
A 32-bit register is added to count instructions during the OTBN
procedure.

Signed-off-by: Vladimir Rozic <vrozic@lowrisc.org>