### PR TITLE
[dv/otp_ctrl] Fix a fcov sample issue

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -157,17 +157,16 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
             if (cfg.otp_ctrl_vif.under_error_states() == 0) begin
               `DV_CHECK_EQ(cfg.otp_ctrl_vif.keymgr_key_o, exp_keymgr_data)
             end
-
-            if (cfg.en_cov) begin
-              bit [NumPart-2:0] parts_locked;
-              foreach (parts_locked[i]) parts_locked[i] = (get_otp_digest_val(i) != 0);
-              cov.power_on_cg.sample(cfg.otp_ctrl_vif.lc_esc_on, parts_locked);
-            end
           end else if (cfg.otp_ctrl_vif.alert_reqs) begin
             // Ignore digest CSR check when otp_ctrl initialization is interrupted by fatal errors.
             // SCB cannot predict how many partitions already finished initialization and updated
             // the digest value to CSRs.
             ignore_digest_chk = 1;
+          end
+          if (cfg.en_cov) begin
+            bit [NumPart-2:0] parts_locked;
+            foreach (parts_locked[i]) parts_locked[i] = (get_otp_digest_val(i) != 0);
+            cov.power_on_cg.sample(cfg.otp_ctrl_vif.lc_esc_on, parts_locked);
           end
         end
       end


### PR DESCRIPTION
The power_on_cg has `lc_esc_on` that is never sampled in coverage
report, this is because the sample function is placed under the `if no fatal
alert branch`. I moved the sample function out of the if condition.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>