### PR TITLE
[dv/tlul_common_test] Add a testplan for TLUL integrity check

### DIFF
--- a/hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson
@@ -12,21 +12,22 @@
     {
       name: tl_d_illegal_access
       desc: '''Drive unsupported requests via TL interface and verify correctness of response
-            / behavior. Below error cases are tested
+            / behavior. Below error cases are tested bases on the
+            [TLUL spec]({{< relref "hw/ip/tlul/doc/_index.md#explicit-error-cases" >}})
             - TL-UL protocol error cases
-              - Unsupported opcode. e.g a_opcode isn't Get, PutPartialData or PutFullData
-              - Mask isn't all active if opcode = PutFullData
-              - Mask isn't in enabled lanes, e.g. a_address = 0x00, a_size = 0, a_mask = 'b0010
-              - Mask doesn't align with address, e.g. a_address = 0x01, a_mask = 'b0001
-              - Address and size aren't aligned, e.g. a_address = 0x01, a_size != 0
-              - Size is over 2.
+              - invalid opcode
+              - some mask bits not set when opcode is `PutFullData`
+              - mask does not match the transfer size, e.g. `a_address = 0x00`, `a_size = 0`,
+                `a_mask = 'b0010`
+              - mask and address misaligned, e.g. `a_address = 0x01`, `a_mask = 'b0001`
+              - address and size aren't aligned, e.g. `a_address = 0x01`, `a_size != 0`
+              - size is greater than 2
             - OpenTitan defined error cases
-              - Access unmapped address, return d_error = 1 when devmode_i == 1
-              - Write CSR with unaligned address, e.g. a_address[1:0] != 0
-              - Write CSR less than its width, e.g. when CSR is 2 bytes wide, only write 1 byte
-              - Write a memory without enabling all lanes (a_mask = '1) if memory doesn't support
-                byte enabled write
-              - Read a WO (write-only) memory'''
+              - access unmapped address, expect `d_error = 1` when `devmode_i == 1`
+              - write a CSR with unaligned address, e.g. `a_address[1:0] != 0`
+              - write a CSR less than its width, e.g. when CSR is 2 bytes wide, only write 1 byte
+              - write a memory with `a_mask = '1` when it doesn't support partial accesses
+              - read a WO (write-only) memory'''
       milestone: V2
       tests: ["{name}_tl_errors"]
     }
@@ -43,14 +44,23 @@
     }
     {
       name: tl_d_partial_access
-      desc: '''Access CSR with one or more bytes of data
-            For read, expect to return all word value of the CSR
-            For write, enabling bytes should cover all CSR valid fields'''
+      desc: '''Access CSR with one or more bytes of data.
+            For read, expect to return all word value of the CSR.
+            For write, enabling bytes should cover all CSR valid fields.'''
       milestone: V2
       tests: ["{name}_csr_hw_reset",
               "{name}_csr_rw",
               "{name}_csr_aliasing",
               "{name}_same_csr_outstanding"]
+    }
+    {
+      name: tl_integrity_check
+      desc: ''' Verify that the data integrity check violation generates an alert.
+
+            Randomly inject errors on the control, data, or the ECC bits during CSR accesses.
+            Verify that triggers the correct fatal alert.'''
+      milestone: V3
+      tests: []
     }
   ]
 }


### PR DESCRIPTION
This PR:

1. Add a V3 testplan for TLUL integrity check.
2. Fix small bullet related syntax in the file.

Signed-off-by: Cindy Chen <chencindy@google.com>