### PR TITLE
[fpv] Fix compile errors and link

### DIFF
--- a/hw/_index.md
+++ b/hw/_index.md
@@ -19,7 +19,7 @@ Finally, we provide the same set of information for all available [top level des
 ## Results of tool-flows
 
 * [DV simulation summary results, with coverage (nightly)](https://reports.opentitan.org/hw/top_earlgrey/dv/summary.html)
-* [FPV summary results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/fpv/summary.html)
+* [FPV summary results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/formal/summary.html)
 * [AscentLint summary results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/ascentlint/summary.html)
 * [Verilator lint summary results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/verilator/summary.html)
 * [Style lint summary results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/veriblelint/summary.html)

--- a/hw/ip/prim/fpv/tb/prim_secded_22_16_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_22_16_bind_fpv.sv
@@ -10,8 +10,8 @@ module prim_secded_22_16_bind_fpv;
     prim_secded_22_16_assert_fpv prim_secded_22_16_assert_fpv (
     .clk_i,
     .rst_ni,
-    .in,
-    .d_o,
+    .data_i,
+    .data_o,
     .syndrome_o,
     .err_o,
     .error_inject_i

--- a/hw/ip/prim/fpv/tb/prim_secded_22_16_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_22_16_fpv.sv
@@ -7,8 +7,8 @@
 module prim_secded_22_16_fpv (
   input               clk_i,
   input               rst_ni,
-  input        [15:0] in,
-  output logic [15:0] d_o,
+  input        [15:0] data_i,
+  output logic [15:0] data_o,
   output logic [5:0] syndrome_o,
   output logic [1:0]  err_o,
   input        [21:0] error_inject_i
@@ -17,13 +17,13 @@ module prim_secded_22_16_fpv (
   logic [21:0] data_enc;
 
   prim_secded_22_16_enc prim_secded_22_16_enc (
-    .in,
-    .out(data_enc)
+    .data_i,
+    .data_o(data_enc)
   );
 
   prim_secded_22_16_dec prim_secded_22_16_dec (
-    .in(data_enc ^ error_inject_i),
-    .d_o,
+    .data_i(data_enc ^ error_inject_i),
+    .data_o,
     .syndrome_o,
     .err_o
   );

--- a/hw/ip/prim/fpv/tb/prim_secded_28_22_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_28_22_bind_fpv.sv
@@ -10,8 +10,8 @@ module prim_secded_28_22_bind_fpv;
     prim_secded_28_22_assert_fpv prim_secded_28_22_assert_fpv (
     .clk_i,
     .rst_ni,
-    .in,
-    .d_o,
+    .data_i,
+    .data_o,
     .syndrome_o,
     .err_o,
     .error_inject_i

--- a/hw/ip/prim/fpv/tb/prim_secded_28_22_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_28_22_fpv.sv
@@ -7,8 +7,8 @@
 module prim_secded_28_22_fpv (
   input               clk_i,
   input               rst_ni,
-  input        [21:0] in,
-  output logic [21:0] d_o,
+  input        [21:0] data_i,
+  output logic [21:0] data_o,
   output logic [5:0] syndrome_o,
   output logic [1:0]  err_o,
   input        [27:0] error_inject_i
@@ -17,13 +17,13 @@ module prim_secded_28_22_fpv (
   logic [27:0] data_enc;
 
   prim_secded_28_22_enc prim_secded_28_22_enc (
-    .in,
-    .out(data_enc)
+    .data_i,
+    .data_o(data_enc)
   );
 
   prim_secded_28_22_dec prim_secded_28_22_dec (
-    .in(data_enc ^ error_inject_i),
-    .d_o,
+    .data_i(data_enc ^ error_inject_i),
+    .data_o,
     .syndrome_o,
     .err_o
   );

--- a/hw/ip/prim/fpv/tb/prim_secded_39_32_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_39_32_bind_fpv.sv
@@ -10,8 +10,8 @@ module prim_secded_39_32_bind_fpv;
     prim_secded_39_32_assert_fpv prim_secded_39_32_assert_fpv (
     .clk_i,
     .rst_ni,
-    .in,
-    .d_o,
+    .data_i,
+    .data_o,
     .syndrome_o,
     .err_o,
     .error_inject_i

--- a/hw/ip/prim/fpv/tb/prim_secded_39_32_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_39_32_fpv.sv
@@ -7,8 +7,8 @@
 module prim_secded_39_32_fpv (
   input               clk_i,
   input               rst_ni,
-  input        [31:0] in,
-  output logic [31:0] d_o,
+  input        [31:0] data_i,
+  output logic [31:0] data_o,
   output logic [6:0] syndrome_o,
   output logic [1:0]  err_o,
   input        [38:0] error_inject_i
@@ -17,13 +17,13 @@ module prim_secded_39_32_fpv (
   logic [38:0] data_enc;
 
   prim_secded_39_32_enc prim_secded_39_32_enc (
-    .in,
-    .out(data_enc)
+    .data_i,
+    .data_o(data_enc)
   );
 
   prim_secded_39_32_dec prim_secded_39_32_dec (
-    .in(data_enc ^ error_inject_i),
-    .d_o,
+    .data_i(data_enc ^ error_inject_i),
+    .data_o,
     .syndrome_o,
     .err_o
   );

--- a/hw/ip/prim/fpv/tb/prim_secded_64_57_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_64_57_bind_fpv.sv
@@ -10,8 +10,8 @@ module prim_secded_64_57_bind_fpv;
     prim_secded_64_57_assert_fpv prim_secded_64_57_assert_fpv (
     .clk_i,
     .rst_ni,
-    .in,
-    .d_o,
+    .data_i,
+    .data_o,
     .syndrome_o,
     .err_o,
     .error_inject_i

--- a/hw/ip/prim/fpv/tb/prim_secded_64_57_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_64_57_fpv.sv
@@ -7,8 +7,8 @@
 module prim_secded_64_57_fpv (
   input               clk_i,
   input               rst_ni,
-  input        [56:0] in,
-  output logic [56:0] d_o,
+  input        [56:0] data_i,
+  output logic [56:0] data_o,
   output logic [6:0] syndrome_o,
   output logic [1:0]  err_o,
   input        [63:0] error_inject_i
@@ -17,13 +17,13 @@ module prim_secded_64_57_fpv (
   logic [63:0] data_enc;
 
   prim_secded_64_57_enc prim_secded_64_57_enc (
-    .in,
-    .out(data_enc)
+    .data_i,
+    .data_o(data_enc)
   );
 
   prim_secded_64_57_dec prim_secded_64_57_dec (
-    .in(data_enc ^ error_inject_i),
-    .d_o,
+    .data_i(data_enc ^ error_inject_i),
+    .data_o,
     .syndrome_o,
     .err_o
   );

--- a/hw/ip/prim/fpv/tb/prim_secded_72_64_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_72_64_bind_fpv.sv
@@ -10,8 +10,8 @@ module prim_secded_72_64_bind_fpv;
     prim_secded_72_64_assert_fpv prim_secded_72_64_assert_fpv (
     .clk_i,
     .rst_ni,
-    .in,
-    .d_o,
+    .data_i,
+    .data_o,
     .syndrome_o,
     .err_o,
     .error_inject_i

--- a/hw/ip/prim/fpv/tb/prim_secded_72_64_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_72_64_fpv.sv
@@ -7,8 +7,8 @@
 module prim_secded_72_64_fpv (
   input               clk_i,
   input               rst_ni,
-  input        [63:0] in,
-  output logic [63:0] d_o,
+  input        [63:0] data_i,
+  output logic [63:0] data_o,
   output logic [7:0] syndrome_o,
   output logic [1:0]  err_o,
   input        [71:0] error_inject_i
@@ -17,13 +17,13 @@ module prim_secded_72_64_fpv (
   logic [71:0] data_enc;
 
   prim_secded_72_64_enc prim_secded_72_64_enc (
-    .in,
-    .out(data_enc)
+    .data_i,
+    .data_o(data_enc)
   );
 
   prim_secded_72_64_dec prim_secded_72_64_dec (
-    .in(data_enc ^ error_inject_i),
-    .d_o,
+    .data_i(data_enc ^ error_inject_i),
+    .data_o,
     .syndrome_o,
     .err_o
   );

--- a/hw/ip/prim/fpv/tb/prim_secded_hamming_22_16_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_hamming_22_16_bind_fpv.sv
@@ -10,8 +10,8 @@ module prim_secded_hamming_22_16_bind_fpv;
     prim_secded_hamming_22_16_assert_fpv prim_secded_hamming_22_16_assert_fpv (
     .clk_i,
     .rst_ni,
-    .in,
-    .d_o,
+    .data_i,
+    .data_o,
     .syndrome_o,
     .err_o,
     .error_inject_i

--- a/hw/ip/prim/fpv/tb/prim_secded_hamming_22_16_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_hamming_22_16_fpv.sv
@@ -7,8 +7,8 @@
 module prim_secded_hamming_22_16_fpv (
   input               clk_i,
   input               rst_ni,
-  input        [15:0] in,
-  output logic [15:0] d_o,
+  input        [15:0] data_i,
+  output logic [15:0] data_o,
   output logic [5:0] syndrome_o,
   output logic [1:0]  err_o,
   input        [21:0] error_inject_i
@@ -17,13 +17,13 @@ module prim_secded_hamming_22_16_fpv (
   logic [21:0] data_enc;
 
   prim_secded_hamming_22_16_enc prim_secded_hamming_22_16_enc (
-    .in,
-    .out(data_enc)
+    .data_i,
+    .data_o(data_enc)
   );
 
   prim_secded_hamming_22_16_dec prim_secded_hamming_22_16_dec (
-    .in(data_enc ^ error_inject_i),
-    .d_o,
+    .data_i(data_enc ^ error_inject_i),
+    .data_o,
     .syndrome_o,
     .err_o
   );

--- a/hw/ip/prim/fpv/tb/prim_secded_hamming_39_32_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_hamming_39_32_bind_fpv.sv
@@ -10,8 +10,8 @@ module prim_secded_hamming_39_32_bind_fpv;
     prim_secded_hamming_39_32_assert_fpv prim_secded_hamming_39_32_assert_fpv (
     .clk_i,
     .rst_ni,
-    .in,
-    .d_o,
+    .data_i,
+    .data_o,
     .syndrome_o,
     .err_o,
     .error_inject_i

--- a/hw/ip/prim/fpv/tb/prim_secded_hamming_39_32_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_hamming_39_32_fpv.sv
@@ -7,8 +7,8 @@
 module prim_secded_hamming_39_32_fpv (
   input               clk_i,
   input               rst_ni,
-  input        [31:0] in,
-  output logic [31:0] d_o,
+  input        [31:0] data_i,
+  output logic [31:0] data_o,
   output logic [6:0] syndrome_o,
   output logic [1:0]  err_o,
   input        [38:0] error_inject_i
@@ -17,13 +17,13 @@ module prim_secded_hamming_39_32_fpv (
   logic [38:0] data_enc;
 
   prim_secded_hamming_39_32_enc prim_secded_hamming_39_32_enc (
-    .in,
-    .out(data_enc)
+    .data_i,
+    .data_o(data_enc)
   );
 
   prim_secded_hamming_39_32_dec prim_secded_hamming_39_32_dec (
-    .in(data_enc ^ error_inject_i),
-    .d_o,
+    .data_i(data_enc ^ error_inject_i),
+    .data_o,
     .syndrome_o,
     .err_o
   );

--- a/hw/ip/prim/fpv/tb/prim_secded_hamming_72_64_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_hamming_72_64_bind_fpv.sv
@@ -10,8 +10,8 @@ module prim_secded_hamming_72_64_bind_fpv;
     prim_secded_hamming_72_64_assert_fpv prim_secded_hamming_72_64_assert_fpv (
     .clk_i,
     .rst_ni,
-    .in,
-    .d_o,
+    .data_i,
+    .data_o,
     .syndrome_o,
     .err_o,
     .error_inject_i

--- a/hw/ip/prim/fpv/tb/prim_secded_hamming_72_64_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_hamming_72_64_fpv.sv
@@ -7,8 +7,8 @@
 module prim_secded_hamming_72_64_fpv (
   input               clk_i,
   input               rst_ni,
-  input        [63:0] in,
-  output logic [63:0] d_o,
+  input        [63:0] data_i,
+  output logic [63:0] data_o,
   output logic [7:0] syndrome_o,
   output logic [1:0]  err_o,
   input        [71:0] error_inject_i
@@ -17,13 +17,13 @@ module prim_secded_hamming_72_64_fpv (
   logic [71:0] data_enc;
 
   prim_secded_hamming_72_64_enc prim_secded_hamming_72_64_enc (
-    .in,
-    .out(data_enc)
+    .data_i,
+    .data_o(data_enc)
   );
 
   prim_secded_hamming_72_64_dec prim_secded_hamming_72_64_dec (
-    .in(data_enc ^ error_inject_i),
-    .d_o,
+    .data_i(data_enc ^ error_inject_i),
+    .data_o,
     .syndrome_o,
     .err_o
   );

--- a/hw/ip/prim/fpv/vip/prim_secded_22_16_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_22_16_assert_fpv.sv
@@ -7,8 +7,8 @@
 module prim_secded_22_16_assert_fpv (
   input        clk_i,
   input        rst_ni,
-  input [15:0] in,
-  input [15:0] d_o,
+  input [15:0] data_i,
+  input [15:0] data_o,
   input [5:0] syndrome_o,
   input [1:0]  err_o,
   input [21:0] error_inject_i
@@ -17,7 +17,7 @@ module prim_secded_22_16_assert_fpv (
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
   // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(in) || $onehot0(~in))
+  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)
@@ -25,7 +25,7 @@ module prim_secded_22_16_assert_fpv (
   `ASSERT(DoubleErrorDetect_A, $countones(error_inject_i) == 2 |-> err_o[1])
   `ASSERT(DoubleErrorDetectReverse_A, err_o[1] |-> $countones(error_inject_i) == 2)
   // Single bit error correction (implicitly tests the syndrome output)
-  `ASSERT(SingleErrorCorrect_A, $countones(error_inject_i) < 2 |-> in == d_o)
+  `ASSERT(SingleErrorCorrect_A, $countones(error_inject_i) < 2 |-> data_i == data_o)
   // Basic syndrome check
   `ASSERT(SyndromeCheck_A, |syndrome_o |-> $countones(error_inject_i) > 0)
   `ASSERT(SyndromeCheckReverse_A, $countones(error_inject_i) > 0 |-> |syndrome_o)

--- a/hw/ip/prim/fpv/vip/prim_secded_28_22_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_28_22_assert_fpv.sv
@@ -7,8 +7,8 @@
 module prim_secded_28_22_assert_fpv (
   input        clk_i,
   input        rst_ni,
-  input [21:0] in,
-  input [21:0] d_o,
+  input [21:0] data_i,
+  input [21:0] data_o,
   input [5:0] syndrome_o,
   input [1:0]  err_o,
   input [27:0] error_inject_i
@@ -17,7 +17,7 @@ module prim_secded_28_22_assert_fpv (
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
   // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(in) || $onehot0(~in))
+  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)
@@ -25,7 +25,7 @@ module prim_secded_28_22_assert_fpv (
   `ASSERT(DoubleErrorDetect_A, $countones(error_inject_i) == 2 |-> err_o[1])
   `ASSERT(DoubleErrorDetectReverse_A, err_o[1] |-> $countones(error_inject_i) == 2)
   // Single bit error correction (implicitly tests the syndrome output)
-  `ASSERT(SingleErrorCorrect_A, $countones(error_inject_i) < 2 |-> in == d_o)
+  `ASSERT(SingleErrorCorrect_A, $countones(error_inject_i) < 2 |-> data_i == data_o)
   // Basic syndrome check
   `ASSERT(SyndromeCheck_A, |syndrome_o |-> $countones(error_inject_i) > 0)
   `ASSERT(SyndromeCheckReverse_A, $countones(error_inject_i) > 0 |-> |syndrome_o)

--- a/hw/ip/prim/fpv/vip/prim_secded_39_32_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_39_32_assert_fpv.sv
@@ -7,8 +7,8 @@
 module prim_secded_39_32_assert_fpv (
   input        clk_i,
   input        rst_ni,
-  input [31:0] in,
-  input [31:0] d_o,
+  input [31:0] data_i,
+  input [31:0] data_o,
   input [6:0] syndrome_o,
   input [1:0]  err_o,
   input [38:0] error_inject_i
@@ -17,7 +17,7 @@ module prim_secded_39_32_assert_fpv (
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
   // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(in) || $onehot0(~in))
+  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)
@@ -25,7 +25,7 @@ module prim_secded_39_32_assert_fpv (
   `ASSERT(DoubleErrorDetect_A, $countones(error_inject_i) == 2 |-> err_o[1])
   `ASSERT(DoubleErrorDetectReverse_A, err_o[1] |-> $countones(error_inject_i) == 2)
   // Single bit error correction (implicitly tests the syndrome output)
-  `ASSERT(SingleErrorCorrect_A, $countones(error_inject_i) < 2 |-> in == d_o)
+  `ASSERT(SingleErrorCorrect_A, $countones(error_inject_i) < 2 |-> data_i == data_o)
   // Basic syndrome check
   `ASSERT(SyndromeCheck_A, |syndrome_o |-> $countones(error_inject_i) > 0)
   `ASSERT(SyndromeCheckReverse_A, $countones(error_inject_i) > 0 |-> |syndrome_o)

--- a/hw/ip/prim/fpv/vip/prim_secded_64_57_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_64_57_assert_fpv.sv
@@ -7,8 +7,8 @@
 module prim_secded_64_57_assert_fpv (
   input        clk_i,
   input        rst_ni,
-  input [56:0] in,
-  input [56:0] d_o,
+  input [56:0] data_i,
+  input [56:0] data_o,
   input [6:0] syndrome_o,
   input [1:0]  err_o,
   input [63:0] error_inject_i
@@ -17,7 +17,7 @@ module prim_secded_64_57_assert_fpv (
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
   // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(in) || $onehot0(~in))
+  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)
@@ -25,7 +25,7 @@ module prim_secded_64_57_assert_fpv (
   `ASSERT(DoubleErrorDetect_A, $countones(error_inject_i) == 2 |-> err_o[1])
   `ASSERT(DoubleErrorDetectReverse_A, err_o[1] |-> $countones(error_inject_i) == 2)
   // Single bit error correction (implicitly tests the syndrome output)
-  `ASSERT(SingleErrorCorrect_A, $countones(error_inject_i) < 2 |-> in == d_o)
+  `ASSERT(SingleErrorCorrect_A, $countones(error_inject_i) < 2 |-> data_i == data_o)
   // Basic syndrome check
   `ASSERT(SyndromeCheck_A, |syndrome_o |-> $countones(error_inject_i) > 0)
   `ASSERT(SyndromeCheckReverse_A, $countones(error_inject_i) > 0 |-> |syndrome_o)

--- a/hw/ip/prim/fpv/vip/prim_secded_72_64_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_72_64_assert_fpv.sv
@@ -7,8 +7,8 @@
 module prim_secded_72_64_assert_fpv (
   input        clk_i,
   input        rst_ni,
-  input [63:0] in,
-  input [63:0] d_o,
+  input [63:0] data_i,
+  input [63:0] data_o,
   input [7:0] syndrome_o,
   input [1:0]  err_o,
   input [71:0] error_inject_i
@@ -17,7 +17,7 @@ module prim_secded_72_64_assert_fpv (
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
   // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(in) || $onehot0(~in))
+  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)
@@ -25,7 +25,7 @@ module prim_secded_72_64_assert_fpv (
   `ASSERT(DoubleErrorDetect_A, $countones(error_inject_i) == 2 |-> err_o[1])
   `ASSERT(DoubleErrorDetectReverse_A, err_o[1] |-> $countones(error_inject_i) == 2)
   // Single bit error correction (implicitly tests the syndrome output)
-  `ASSERT(SingleErrorCorrect_A, $countones(error_inject_i) < 2 |-> in == d_o)
+  `ASSERT(SingleErrorCorrect_A, $countones(error_inject_i) < 2 |-> data_i == data_o)
   // Basic syndrome check
   `ASSERT(SyndromeCheck_A, |syndrome_o |-> $countones(error_inject_i) > 0)
   `ASSERT(SyndromeCheckReverse_A, $countones(error_inject_i) > 0 |-> |syndrome_o)

--- a/hw/ip/prim/fpv/vip/prim_secded_hamming_22_16_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_hamming_22_16_assert_fpv.sv
@@ -7,8 +7,8 @@
 module prim_secded_hamming_22_16_assert_fpv (
   input        clk_i,
   input        rst_ni,
-  input [15:0] in,
-  input [15:0] d_o,
+  input [15:0] data_i,
+  input [15:0] data_o,
   input [5:0] syndrome_o,
   input [1:0]  err_o,
   input [21:0] error_inject_i
@@ -17,7 +17,7 @@ module prim_secded_hamming_22_16_assert_fpv (
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
   // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(in) || $onehot0(~in))
+  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)
@@ -25,7 +25,7 @@ module prim_secded_hamming_22_16_assert_fpv (
   `ASSERT(DoubleErrorDetect_A, $countones(error_inject_i) == 2 |-> err_o[1])
   `ASSERT(DoubleErrorDetectReverse_A, err_o[1] |-> $countones(error_inject_i) == 2)
   // Single bit error correction (implicitly tests the syndrome output)
-  `ASSERT(SingleErrorCorrect_A, $countones(error_inject_i) < 2 |-> in == d_o)
+  `ASSERT(SingleErrorCorrect_A, $countones(error_inject_i) < 2 |-> data_i == data_o)
   // Basic syndrome check
   `ASSERT(SyndromeCheck_A, |syndrome_o |-> $countones(error_inject_i) > 0)
   `ASSERT(SyndromeCheckReverse_A, $countones(error_inject_i) > 0 |-> |syndrome_o)

--- a/hw/ip/prim/fpv/vip/prim_secded_hamming_39_32_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_hamming_39_32_assert_fpv.sv
@@ -7,8 +7,8 @@
 module prim_secded_hamming_39_32_assert_fpv (
   input        clk_i,
   input        rst_ni,
-  input [31:0] in,
-  input [31:0] d_o,
+  input [31:0] data_i,
+  input [31:0] data_o,
   input [6:0] syndrome_o,
   input [1:0]  err_o,
   input [38:0] error_inject_i
@@ -17,7 +17,7 @@ module prim_secded_hamming_39_32_assert_fpv (
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
   // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(in) || $onehot0(~in))
+  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)
@@ -25,7 +25,7 @@ module prim_secded_hamming_39_32_assert_fpv (
   `ASSERT(DoubleErrorDetect_A, $countones(error_inject_i) == 2 |-> err_o[1])
   `ASSERT(DoubleErrorDetectReverse_A, err_o[1] |-> $countones(error_inject_i) == 2)
   // Single bit error correction (implicitly tests the syndrome output)
-  `ASSERT(SingleErrorCorrect_A, $countones(error_inject_i) < 2 |-> in == d_o)
+  `ASSERT(SingleErrorCorrect_A, $countones(error_inject_i) < 2 |-> data_i == data_o)
   // Basic syndrome check
   `ASSERT(SyndromeCheck_A, |syndrome_o |-> $countones(error_inject_i) > 0)
   `ASSERT(SyndromeCheckReverse_A, $countones(error_inject_i) > 0 |-> |syndrome_o)

--- a/hw/ip/prim/fpv/vip/prim_secded_hamming_72_64_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_hamming_72_64_assert_fpv.sv
@@ -7,8 +7,8 @@
 module prim_secded_hamming_72_64_assert_fpv (
   input        clk_i,
   input        rst_ni,
-  input [63:0] in,
-  input [63:0] d_o,
+  input [63:0] data_i,
+  input [63:0] data_o,
   input [7:0] syndrome_o,
   input [1:0]  err_o,
   input [71:0] error_inject_i
@@ -17,7 +17,7 @@ module prim_secded_hamming_72_64_assert_fpv (
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
   // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(in) || $onehot0(~in))
+  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)
@@ -25,7 +25,7 @@ module prim_secded_hamming_72_64_assert_fpv (
   `ASSERT(DoubleErrorDetect_A, $countones(error_inject_i) == 2 |-> err_o[1])
   `ASSERT(DoubleErrorDetectReverse_A, err_o[1] |-> $countones(error_inject_i) == 2)
   // Single bit error correction (implicitly tests the syndrome output)
-  `ASSERT(SingleErrorCorrect_A, $countones(error_inject_i) < 2 |-> in == d_o)
+  `ASSERT(SingleErrorCorrect_A, $countones(error_inject_i) < 2 |-> data_i == data_o)
   // Basic syndrome check
   `ASSERT(SyndromeCheck_A, |syndrome_o |-> $countones(error_inject_i) > 0)
   `ASSERT(SyndromeCheckReverse_A, $countones(error_inject_i) > 0 |-> |syndrome_o)

--- a/util/design/secded_gen.py
+++ b/util/design/secded_gen.py
@@ -370,7 +370,7 @@ def generate(cfgs, args):
         pkg_out_str += print_fn(n, k, m, codes, suffix, codetype)
 
         if not args.no_fpv:
-            write_fpv_files(n, k, m, codes, codetype, args.fpv_outdir)
+            write_fpv_files(n, k, m, codes, suffix, args.fpv_outdir)
 
     with open(c_h_filename, "a") as f:
         f.write(C_H_FOOT)
@@ -698,7 +698,7 @@ module {}_assert_fpv (
   `ASSERT(DoubleErrorDetect_A, $countones(error_inject_i) == 2 |-> err_o[1])
   `ASSERT(DoubleErrorDetectReverse_A, err_o[1] |-> $countones(error_inject_i) == 2)
   // Single bit error correction (implicitly tests the syndrome output)
-  `ASSERT(SingleErrorCorrect_A, $countones(error_inject_i) < 2 |-> in == data_o)
+  `ASSERT(SingleErrorCorrect_A, $countones(error_inject_i) < 2 |-> data_i == data_o)
   // Basic syndrome check
   `ASSERT(SyndromeCheck_A, |syndrome_o |-> $countones(error_inject_i) > 0)
   `ASSERT(SyndromeCheckReverse_A, $countones(error_inject_i) > 0 |-> |syndrome_o)


### PR DESCRIPTION
This PR has two commits:
1. Fix fpv report file link.
2. Fix `secded_gen.py` typos when generate FPV testbenchs:
  1). The input to `write_fpv_files` should be `suffix` instead of `codetypes`
  2). Update ports namings. 