### PR TITLE
meson.build: Improve the register generation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -199,7 +199,7 @@ gen_hw_hdr = generator(
   prog_python,
   output: '@BASENAME@_regs.h',
   arguments: [
-    '@SOURCE_DIR@/util/regtool.py', '-D', '-o', '@BUILD_DIR@/@BASENAME@_regs.h',
+    '@SOURCE_DIR@/util/regtool.py', '-D', '-o', '@OUTPUT@',
     '@INPUT@',
   ],
 )


### PR DESCRIPTION
We can use the meson @OUTPUT@ variable when generating the register
header files instead of manually re-constructing the full path.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>