### PR TITLE
util/meson-purge-includes.sh: Fix meson 0.55+ build

### DIFF
--- a/util/meson-purge-includes.sh
+++ b/util/meson-purge-includes.sh
@@ -22,4 +22,4 @@ set -e
 # - MESON_BUILD_ROOT
 
 echo "Purging superfluous -I arguments from $MESON_BUILD_ROOT."
-perl -pi -e 's#-I[^/][^@ ]+ # #g' -- "$MESON_BUILD_ROOT/build.ninja"
+perl -pi -e 's#-I[^/][^@.p ]+ # #g' -- "$MESON_BUILD_ROOT/build.ninja"


### PR DESCRIPTION
Since meson 0.55 OpenTitan has failed to build with errors like this:

   ../sw/device/lib/dif/dif_usbdev.c:9:10: fatal error: usbdev_regs.h: No such file or directory
       9 | #include "usbdev_regs.h"  // Generated.

An issue was raised with meson: https://github.com/mesonbuild/meson/issues/7800

It turns out it's an issue with how the OpenTitan file
util/meson-purge-includes.sh is editing the include paths.

We are currently removing paths like this:

   -Isw/device/lib/dif/libdif_rv_timer_ot.a.p

which since meson 0.55 are required for the build.

This commit changes the regex to allow builds with meson greater then
0.55.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>