### PR TITLE
Require Vivado 2020.2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ variables:
   TOOLCHAIN_VERSION: 20210412-1
   # This controls where builds happen, and gets picked up by build_consts.sh.
   BUILD_ROOT: $(Build.ArtifactStagingDirectory)
-  VIVADO_VERSION: "2020.1"
+  VIVADO_VERSION: "2020.2"
 
 trigger:
   batch: true

--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -65,6 +65,7 @@ Depending on how you interact with the OpenTitan hardware code, one of more of t
 
 * [Verilator](https://verilator.org) {{< tool_version "verilator" >}}
 * Xilinx Vivado {{< tool_version "vivado" >}}
+  (Do not use versions earlier than 2020.2 due to a [critical synthesis bug](https://forums.xilinx.com/t5/Synthesis/Simulation-Synthesis-Mismatch-with-Vivado-2018-3/m-p/1065923#M33849).)
 * Synopsys VCS
 * Cadence Xcelium
 * Cadence JasperGold

--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -42,7 +42,7 @@ __TOOL_REQUIREMENTS__ = {
         'as_needed': True
     },
     'vivado': {
-        'min_version': '2020.1',
+        'min_version': '2020.2',
         'as_needed': True
     },
 }


### PR DESCRIPTION
Switch to Vivado 2020.2 as minimum requirement. This version fixes a
critical synthesis mismatch bug, as discussed in more detail at
https://forums.xilinx.com/t5/Synthesis/Simulation-Synthesis-Mismatch-with-Vivado-2018-3/m-p/1065923#M33849.

We did work around this Vivado bug in the past (see #1355, #1408),
but can avoid these workarounds now, as they collide slightly with
syntax that is works better for Verilator (#6639).