### PR TITLE
[util] Add version requirement for Xilinx Vivado

### DIFF
--- a/doc/ug/getting_started_fpga.md
+++ b/doc/ug/getting_started_fpga.md
@@ -47,10 +47,10 @@ The `--build` argument is optional and ensures that the boot ROM is rebuilt for 
 Alternatively, the boot ROM can be manually regenerated using the previous command.
 
 
-In the following example we synthesize the Earl Grey design for the Nexys Video board using Xilinx Vivado 2020.1.
+In the following example we synthesize the Earl Grey design for the Nexys Video board using Xilinx Vivado {{< tool_version "vivado" >}}.
 
 ```console
-$ . /tools/xilinx/Vivado/2020.1/settings64.sh
+$ . /tools/xilinx/Vivado/{{< tool_version "vivado" >}}/settings64.sh
 $ cd $REPO_TOP
 $ ./meson_init.sh
 $ ./hw/top_earlgrey/util/top_earlgrey_reduce.py
@@ -78,7 +78,7 @@ To flash the bitstream onto the FPGA you need to use either the Vivado GUI or th
 Use the following command to program the FPGA with fusesoc.
 
 ```console
-$ . /tools/xilinx/Vivado/2020.1/settings64.sh
+$ . /tools/xilinx/Vivado/{{< tool_version "vivado" >}}/settings64.sh
 $ cd $REPO_TOP
 $ fusesoc --cores-root . pgm lowrisc:systems:chip_earlgrey_nexysvideo:0.1
 ```
@@ -99,7 +99,7 @@ If you have having trouble with programming using the command line, try the GUI.
 ### Using the Vivado GUI
 
 ```console
-$ . /tools/xilinx/Vivado/2020.1/settings64.sh
+$ . /tools/xilinx/Vivado/{{< tool_version "vivado" >}}/settings64.sh
 $ cd $REPO_TOP
 $ make -C build/lowrisc_systems_chip_earlgrey_nexysvideo_0.1/synth-vivado build-gui
 ```

--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -64,7 +64,7 @@ To synthesize and simulate the hardware components of OpenTitan multiple EDA too
 Depending on how you interact with the OpenTitan hardware code, one of more of the following tools need to be available.
 
 * [Verilator](https://verilator.org) {{< tool_version "verilator" >}}
-* Xilinx Vivado 2018.3
+* Xilinx Vivado {{< tool_version "vivado" >}}
 * Synopsys VCS
 * Cadence Xcelium
 * Cadence JasperGold
@@ -300,7 +300,9 @@ Most lowRISC designs support at least one FPGA board which works with a free Web
 
 ### Install Xilinx Vivado
 
-_**Vivado Version:** Vivado 2019.1 and all its minor updates are not compatible with this project._
+_**Vivado Version:** The recommendation is to use Vivado {{< tool_version "vivado" >}}.
+The following instructions have been tested with Vivado 2020.1.
+Vivado 2019.1 and all its minor updates are not compatible with this project._
 
 Vivado can be installed in two ways: either through an "All OS installer Single-File Download", or via the "Linux Self Extracting Web Installer".
 Neither option is great:

--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -41,4 +41,8 @@ __TOOL_REQUIREMENTS__ = {
         'min_version': '1.52.1',
         'as_needed': True
     },
+    'vivado': {
+        'min_version': '2020.1',
+        'as_needed': True
+    },
 }

--- a/util/check_tool_requirements.py
+++ b/util/check_tool_requirements.py
@@ -223,6 +223,21 @@ class VeribleToolReq(ToolReq):
         return '.'.join(m.group(1, 2, 3))
 
 
+class VivadoToolReq(ToolReq):
+    tool_cmd = ['vivado', '-version']
+    version_regex = re.compile(r'Vivado v(.*)\s')
+
+    def to_semver(self, version, from_req):
+        # Regular Vivado releases just have a major and minor version.
+        # In this case, we set the patch level to 0.
+        m = re.fullmatch(r'([0-9]+)\.([0-9]+)(?:\.([0-9]+))?', version)
+        if m is None:
+            raise ValueError("{} has invalid version string format."
+                             .format(version))
+
+        return '.'.join((m.group(1), m.group(2), m.group(3) or '0'))
+
+
 class VcsToolReq(ToolReq):
     tool_cmd = ['vcs', '-full64', '-ID']
     tool_env = {'VCS_ARCH_OVERRIDE': 'linux'}
@@ -308,7 +323,8 @@ def dict_to_tool_req(path, tool, raw):
         'edalize': PyModuleToolReq,
         'vcs': VcsToolReq,
         'verible': VeribleToolReq,
-        'verilator': VerilatorToolReq
+        'verilator': VerilatorToolReq,
+        'vivado': VivadoToolReq,
     }
     cls = classes.get(tool, ToolReq)
 


### PR DESCRIPTION
As discussed in yesterday's meeting, this PR adds a minimum version requirement for Xilinx Vivado (currently set to 2020.1). We do not yet enforce a specific Vivado version but maybe will do that soon. At the moment, having a specified version allows us to more easily keep the documentation up to date.