### PR TITLE
[dv/otp_ctrl] Clean up TODO's and comments in OTP_CTRL

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -21,35 +21,41 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
   import otp_ctrl_reg_pkg::*;
   import otp_ctrl_part_pkg::*;
 
-  // output from DUT
+  // Output from DUT
   otp_hw_cfg_t         otp_hw_cfg_o;
   otp_keymgr_key_t     keymgr_key_o;
   otp_lc_data_t        lc_data_o;
   ast_pkg::ast_dif_t   otp_alert_o;
   logic                pwr_otp_done_o, pwr_otp_idle_o;
 
-  // inputs to DUT
+  // Inputs to DUT
   logic                pwr_otp_init_i, scan_en_i, scan_rst_ni;
   lc_ctrl_pkg::lc_tx_t lc_dft_en_i, lc_escalate_en_i, lc_check_byp_en_i,
                        lc_creator_seed_sw_rw_en_i, lc_seed_hw_rd_en_i, scanmode_i;
   otp_ast_rsp_t        otp_ast_pwr_seq_h_i;
 
-  // probe design signal for alert request
-  logic                alert_reqs;
+  // Connect with lc_prog push_pull interface.
+  logic lc_prog_req, lc_prog_err;
+  logic lc_prog_err_dly1, lc_prog_no_sta_check;
 
-  // connect with lc_prog push-pull interface
-  logic                lc_prog_req, lc_prog_err;
-  logic                lc_prog_err_dly1, lc_prog_no_sta_check;
-
-  // LC_escalate_en is async, take two clock cycles to sync.
+  // Variables for internal interface logic.
+  // `lc_escalate_en` is async, take two clock cycles to synchronize.
   lc_ctrl_pkg::lc_tx_t lc_esc_dly1, lc_esc_dly2;
-  // For lc_escalate_en, every value that is not Off is a On.
-  bit                  lc_esc_on;
-  // Usually the lc_check_byp will be automatically set to On when lc_prog_req is issued but reset
-  // has not been issued, otherwise internal check will fail.
-  // Set this variable to 0 might cause otp_check_fail.
-  bit                  lc_check_byp_en = 1;
-  bit [1:0]            force_sw_parts_ecc_reg;
+
+  // Variable for scoreboard.
+  // For `lc_escalate_en`, any value that is not `Off` is a `On`.
+  bit lc_esc_on;
+
+  // Probe design signal for alert request.
+  logic alert_reqs;
+
+  // Usually the `lc_check_byp_en` will be automatically set to `On` when LC program request is
+  // issued, and stays `On` until reset is issued.
+  // Set this variable to 0 after a LC program request might cause otp checks to fail.
+  bit lc_check_byp_en = 1;
+
+  // Internal veriable to track which sw partitions have ECC reg error.
+  bit [1:0] force_sw_parts_ecc_reg;
 
   // Lc_err could trigger during LC program, so check intr and status after lc_req is finished.
   // Lc_err takes one clock cycle to propogate to intr signal. So avoid intr check if it happens

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -22,9 +22,10 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   // According to spec, the period between digest calculation and reset should not issue any write.
   bit [NumPart-2:0] digest_calculated;
 
+  // LC program request will use a separate variable to automatically set to non-blocking setting
+  // when LC error bit is set.
   bit default_req_blocking = 1;
-  // TODO: set it to 0 once support reset in otp program, and remove related logic
-  bit lc_prog_blocking = 1;
+  bit lc_prog_blocking     = 1;
 
   `uvm_object_new
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_req_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_req_vseq.sv
@@ -9,12 +9,7 @@ class otp_ctrl_parallel_lc_req_vseq extends otp_ctrl_parallel_base_vseq;
 
   `uvm_object_new
 
-  // disable checks in case lc_program and check triggered at the same time
-  constraint regwens_c {
-    check_regwen_val dist {0 :/ 1, 1 :/ 9};
-    check_trigger_regwen_val == 0;
-  }
-
+  // Disable the default LC program request from otp_ctrl_smoke_vseq.
   constraint lc_trans_c {
     do_lc_trans == 0;
   }
@@ -27,11 +22,10 @@ class otp_ctrl_parallel_lc_req_vseq extends otp_ctrl_parallel_base_vseq;
         if ($urandom_range(0, 1)) begin
           wait_clk_or_reset($urandom_range(0, 500));
           if (!base_vseq_done && !cfg.under_reset) begin
-            // TODO: current if reset is issued during OTP write, scb cannot predict if how many
-            // OTP cells have been written.
-            do_reset_in_seq = 0;
+            // Because LC program request is issued in parallel with DAI access, we disable
+            // interrupt check in this task.
+            // We only check interrupts when DAI access and LC program request are done.
             req_lc_transition(0, lc_prog_blocking);
-            do_reset_in_seq = 1;
           end
         end
       end join

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -11,8 +11,6 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
   `uvm_object_new
 
-  bit do_reset_in_seq = 1;
-
   rand bit                           do_req_keys, do_lc_trans;
   rand bit                           access_locked_parts;
   rand bit [TL_AW-1:0]               dai_addr;
@@ -65,7 +63,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
   constraint ecc_chk_err_c {ecc_chk_err == OtpNoEccErr;}
 
   virtual task dut_init(string reset_kind = "HARD");
-    if (do_reset_in_seq && do_apply_reset) begin
+    if (do_apply_reset) begin
       lc_prog_blocking = 1;
       super.dut_init(reset_kind);
       csr_wr(ral.intr_enable, en_intr);

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_stress_all_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_stress_all_vseq.sv
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// combine all otp_ctrl seqs (except below seqs) in one seq to run sequentially
-// Exception: - csr seq, which requires scb to be disabled.
-//            - regwen_vseq, which is time sensitive and requires zero delays.
-//            - otp_ctrl_macro_errs_vseq otp_ctrl_check_fail, these two sequences require to write
-//              back to OTP once fatal error is triggered, thus does not handle random reset.
-//            - otp_ctrl_partition_walk_vseq, this sequence assumes OTP initial value is 0.
+// Combine all otp_ctrl seqs (except below seqs) in one seq to run sequentially.
+// Exception: - csr seq: requires scb to be disabled
+//            - regwen_vseq and parallel_lc_vseq: time sensitive thus require zero_delays
+//            - macro_errs_vseq and check_fail_vseq: require to write back to OTP once fatal
+//              error is triggered, thus does not handle random reset
+//            - partition_walk_vseq: assume OTP initial value is 0
 class otp_ctrl_stress_all_vseq extends otp_ctrl_base_vseq;
   `uvm_object_utils(otp_ctrl_stress_all_vseq)
 
@@ -36,8 +36,6 @@ class otp_ctrl_stress_all_vseq extends otp_ctrl_base_vseq;
                           "otp_ctrl_smoke_vseq",
                           "otp_ctrl_test_access_vseq",
                           "otp_ctrl_background_chks_vseq",
-                          // TODO: support this seq:
-                          // "otp_ctrl_parallel_lc_req_vseq",
                           "otp_ctrl_parallel_lc_esc_vseq",
                           "otp_ctrl_parallel_key_req_vseq"};
 

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -82,6 +82,7 @@
     {
       name: otp_ctrl_parallel_lc_req
       uvm_test_seq: otp_ctrl_parallel_lc_req_vseq
+      run_opts: ["+zero_delays=1"]
     }
 
     {

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -26,8 +26,7 @@ module tb;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
   wire intr_otp_operation_done, intr_otp_error;
 
-  //TODO: use push-pull agent once support
-  wire otp_ctrl_pkg::otp_ast_req_t        ast_req;
+  wire otp_ctrl_pkg::otp_ast_req_t ast_req;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));


### PR DESCRIPTION
This PR cleans up some old logic and TODOs:
1. In otp_ctrl_parallel_lc_req, we remove the old logic that does not
allow reset to interrupt lc_req, and does not allow background check in
parallel.
2. Re-org otp_ctrl_if and adds more comments to make it easy to read.
3. Clean up how comments were written.
4. Add a zero-delay for otp_ctrl_parallel_lc_req_vseq to avoid corner case.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>