### PR TITLE
[dvsim] Add verilator to nightly

### DIFF
--- a/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
+++ b/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
@@ -47,5 +47,6 @@
              "{proj_root}/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
             // Top level.
-             "{proj_root}/hw/top_earlgrey/dv/chip_sim_cfg.hjson"]
+             "{proj_root}/hw/top_earlgrey/dv/chip_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/dv/verilator_sim_cfg.hjson"]
 }

--- a/hw/top_earlgrey/dv/verilator_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/verilator_sim_cfg.hjson
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   // Name of the sim cfg - typically same as the name of the DUT.
-  name: chip_earlgrey_verilator
+  name: chip_verilator
 
   // Top level dut name (sv module).
-  dut: "{name}"
+  dut: chip_earlgrey_verilator
 
   // Top level testbench name (sv module).
-  tb: "{name}"
+  tb: chip_earlgrey_verilator
 
   // Default simulator used to sign off.
   tool: verilator


### PR DESCRIPTION
This PR adds verilator based simulations to the CI and nightly runs.
We cannot sustainably keep adding more and more tests to `systemtest` -
it puts a strain on our CI runtime.

Plus, there are some benefits of running Verilator sims within DVSim:
- Testplanning for a more doc-oriented approach
- Report generation
- Triaging failures
- Parallelize deployment to external compute systems over LSF / GCP
- Defining regression sets

For CI, the smoke regression is not enabled. This is because we already
have `systemtest` approach hooked up and running.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>