### PR TITLE
[dv/kmac] move entropy_timer test to V3

### DIFF
--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -145,7 +145,7 @@
 
             This will be checked in the scoreboard using the cycle acurate model.
             '''
-      milestone: V2
+      milestone: V3
       tests: ["{name}_entropy"]
     }
     {


### PR DESCRIPTION
From a discussion with Eunchan, it is decided to punt verification of
the timer features to V3, pending some security/SW discussions.

Signed-off-by: Udi Jonnalagadda <udij@google.com>