### PR TITLE
[sw/spiflash] Remove OpenSSL dep. from spiflash

### DIFF
--- a/sw/host/spiflash/meson.build
+++ b/sw/host/spiflash/meson.build
@@ -12,7 +12,7 @@ spiflash_bin = executable(
   ],
   implicit_include_directories: false,
   dependencies: [
-    dependency('libcrypto', native: true),
+    vendor_cryptoc_sha256,
     # The libftdi1 dependency needs to be explicit to manage
     # include paths on some systems.
     dependency('libftdi1', native: true),

--- a/sw/host/spiflash/updater.cc
+++ b/sw/host/spiflash/updater.cc
@@ -6,7 +6,10 @@
 
 #include <algorithm>
 #include <assert.h>
+#include <string.h>
 #include <unistd.h>
+
+#include "cryptoc/sha256.h"
 
 namespace opentitan {
 namespace spiflash {
@@ -43,12 +46,13 @@ uint32_t Populate(uint32_t frame_number, uint32_t code_offset,
  * Calculate hash for frame `f` and store it in the frame header hash field.
  */
 void HashFrame(Frame *f) {
-  SHA256_CTX sha256;
-  SHA256_Init(&sha256);
-  SHA256_Update(&sha256, &f->hdr.frame_num, sizeof(f->hdr.frame_num));
-  SHA256_Update(&sha256, &f->hdr.offset, sizeof(f->hdr.offset));
-  SHA256_Update(&sha256, f->data, f->PayloadSize());
-  SHA256_Final(f->hdr.hash, &sha256);
+  LITE_SHA256_CTX sha256;
+  SHA256_init(&sha256);
+  SHA256_update(&sha256, &f->hdr.frame_num, sizeof(f->hdr.frame_num));
+  SHA256_update(&sha256, &f->hdr.offset, sizeof(f->hdr.offset));
+  SHA256_update(&sha256, f->data, f->PayloadSize());
+  const uint8_t *result = SHA256_final(&sha256);
+  memcpy(f->hdr.hash, result, SHA256_DIGEST_SIZE);
 }
 
 }  // namespace

--- a/sw/host/spiflash/updater.h
+++ b/sw/host/spiflash/updater.h
@@ -5,8 +5,6 @@
 #ifndef OPENTITAN_SW_HOST_SPIFLASH_UPDATER_H_
 #define OPENTITAN_SW_HOST_SPIFLASH_UPDATER_H_
 
-#include <openssl/sha.h>
-
 #include <algorithm>
 #include <cstdint>
 #include <cstring>

--- a/sw/host/spiflash/verilator_spi_interface.cc
+++ b/sw/host/spiflash/verilator_spi_interface.cc
@@ -4,15 +4,15 @@
 
 #include "sw/host/spiflash/verilator_spi_interface.h"
 
-#include <fcntl.h>
-#include <openssl/sha.h>
-#include <termios.h>
-#include <unistd.h>
-
 #include <cstring>
+#include <fcntl.h>
 #include <iostream>
 #include <string>
+#include <termios.h>
+#include <unistd.h>
 #include <vector>
+
+#include "cryptoc/sha256.h"
 
 namespace opentitan {
 namespace spiflash {
@@ -109,11 +109,8 @@ bool VerilatorSpiInterface::TransmitFrame(const uint8_t *tx, size_t size) {
 }
 
 bool VerilatorSpiInterface::CheckHash(const uint8_t *tx, size_t size) {
-  uint8_t hash[SHA256_DIGEST_LENGTH];
-  SHA256_CTX sha256;
-  SHA256_Init(&sha256);
-  SHA256_Update(&sha256, tx, size);
-  SHA256_Final(hash, &sha256);
+  uint8_t hash[SHA256_DIGEST_SIZE];
+  SHA256_hash(tx, size, hash);
 
   std::vector<uint8_t> rx(size);
   size_t bytes_read = ReadBytes(fd_, &rx[0], size);
@@ -122,7 +119,7 @@ bool VerilatorSpiInterface::CheckHash(const uint8_t *tx, size_t size) {
               << bytes_read << " expected: " << size << std::endl;
   }
 
-  return !std::memcmp(&rx[0], hash, SHA256_DIGEST_LENGTH);
+  return !std::memcmp(&rx[0], hash, SHA256_DIGEST_SIZE);
 }
 }  // namespace spiflash
 }  // namespace opentitan

--- a/sw/vendor/meson.build
+++ b/sw/vendor/meson.build
@@ -10,6 +10,16 @@ vendor_coremark_base_files = files([
   'eembc_coremark/core_util.c',
 ])
 
+vendor_cryptoc_sha256 = declare_dependency(
+  include_directories: include_directories(
+    'cryptoc/include',
+    is_system: true,
+  ),
+  sources: [
+    'cryptoc/sha256.c',
+  ],
+)
+
 # googletest and googlemock build definitions
 #
 # The following is inspired by the meson configuration available in


### PR DESCRIPTION
Switch spiflash to use the SHA256 implementation provided by the vendored in cryptoc library.

This fixes lowrisc/opentitan#6690.