### PR TITLE
[rv_plic] fix Src width mismatch

### DIFF
--- a/hw/ip/rv_plic/rtl/rv_plic_target.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic_target.sv
@@ -19,8 +19,8 @@ module rv_plic_target #(
   parameter int MAX_PRIO = 7,
 
   // Local param (Do not change this through parameter
-  localparam int SrcWidth  = $clog2(N_SOURCE+1),  // derived parameter
-  localparam int PrioWidth = $clog2(MAX_PRIO+1)   // derived parameter
+  localparam int SrcWidth  = $clog2(N_SOURCE),  // derived parameter
+  localparam int PrioWidth = $clog2(MAX_PRIO+1) // derived parameter
 ) (
   input clk_i,
   input rst_ni,


### PR DESCRIPTION
In the commit 88a861588795ccd2c43603096cd007600412ec2f it removes the
necessity of adding position 0 of the interrupt source, which is
reserved as 'no interrupt'. The interrupt source [0] is tied outside of
the rv_plic by the topgen tool.

@WonHoYoo reported the DC synthesis error if the number of source is set
to the power of two ( issue #6718 ).

While revising the design in the above commit, `rv_plic_target` was
omiited by mistake. This commit addresses the issue and reduces the
`SrcWidth` to `$clot2(NumSrc)`.