### PR TITLE
[otbn,doc] Fix generated encoding table for instructions like JAL

### DIFF
--- a/hw/ip/otbn/util/yaml_to_doc.py
+++ b/hw/ip/otbn/util/yaml_to_doc.py
@@ -216,10 +216,11 @@ def name_op_enc_fields(name_to_operand: Dict[str, Operand],
             e2o[msb] = range_name
             continue
 
-        # Otherwise, we need to label the operands. Sorting ranges ensures that
-        # they appear LSB-first.
+        # Otherwise, we need to label the operands. We iterate over the ranges
+        # in scheme_field LSB-first (so that we can number things with the LSB
+        # field having index zero).
         o2e_list = []
-        for idx, (msb, lsb) in enumerate(sorted(scheme_field.bits.ranges)):
+        for idx, (msb, lsb) in enumerate(reversed(scheme_field.bits.ranges)):
             range_name = '{}_{}'.format(basename, idx)
             o2e_list.append(range_name)
             assert msb not in e2o


### PR DESCRIPTION
Here, `scheme_field.bits.ranges` gives the fields MSB-first for the way
the field is decoded. For example, JAL's J-type encoding (defined in
enc-schemes.yml) has the following imm field:

    imm: 31,19-12,20,30-21

Sorting these ranges threw away the information about the order these
fields appear. Now, the JAL encoding table correctly shows the weird
order in the spec:

    OFF3, OFF_0, OFF_1, OFF_2

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>