### PR TITLE
[lc_ctrl] Add cSHAKE128 token hashing to the LC scripts 

### DIFF
--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv
@@ -262,10 +262,10 @@ package lc_ctrl_state_pkg;
     128'h1C8BE2FF12790AE2E6D6A68151CBD084
   };
   parameter lc_token_t AllZeroTokenHashed = {
-    128'h0
+    128'h8D05B96D5FD2C1D5F15FCFAE5B305238
   };
   parameter lc_token_t RndCnstRawUnlockTokenHashed = {
-    128'h1C8BE2FF12790AE2E6D6A68151CBD084
+    128'h14150A19925EFAC7CAB0921065A33FEE
   };
 
 endpackage : lc_ctrl_state_pkg

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -16,7 +16,6 @@ meson >= 0.53.0, <= 0.54 # minimum matches version in meson.build
 mistletoe>=0.7.2
 mypy
 premailer
-pycryptodome
 pyelftools
 pyftdi
 pyserial
@@ -40,3 +39,8 @@ git+https://github.com/lowRISC/edalize.git@ot#egg=edalize >= 0.2.0
 # (The chipwhisperer repository is rather large and uses additionally uses
 # submodules, which need to be fetched as well.)
 https://github.com/newaetech/chipwhisperer/archive/9b6825b495f14f85aae8b11007c63c59a1654584.tar.gz
+
+# Development version with OT-specific changes
+# TODO(#6694): this is temporary and should be replaced with the standard package release,
+# once the cSHAKE patches have landed upstream.
+git+https://github.com/lowRISC/pycryptodome.git@master#egg=pycryptodome >= 3.10.1

--- a/util/design/lib/LcStEnc.py
+++ b/util/design/lib/LcStEnc.py
@@ -7,6 +7,7 @@ used to generate new life cycle encodings.
 import logging as log
 import random
 from collections import OrderedDict
+from Crypto.Hash import cSHAKE128
 
 from lib.common import (check_int, ecc_encode, get_hd, hd_histogram,
                         is_valid_codeword, random_or_hexvalue, scatter_bits)
@@ -181,14 +182,24 @@ def _validate_tokens(config):
     '''Validates and hashes the tokens'''
     config.setdefault('token_size', 128)
     config['token_size'] = check_int(config['token_size'])
+    # This needs to be byte aligned
+    if config['token_size'] % 8:
+        raise ValueError('Size of token {} must be byte aligned'
+                         .format(token['name']))
+
+    num_bytes = config['token_size'] // 8
 
     hashed_tokens = []
     for token in config['tokens']:
         random_or_hexvalue(token, 'value', config['token_size'])
         hashed_token = OrderedDict()
         hashed_token['name'] = token['name'] + 'Hashed'
-        # TODO: plug in PRESENT-based hashing algo or KMAC
-        hashed_token['value'] = token['value']
+        data = token['value'].to_bytes(num_bytes, byteorder='big')
+        # Custom string chosen for life cycle KMAC App interface
+        custom = 'LC_CTRL'.encode('UTF-8')
+        hashobj = cSHAKE128.new(data=data, custom=custom)
+        hashed_token['value'] = int.from_bytes(hashobj.read(num_bytes),
+                                               byteorder='big')
         hashed_tokens.append(hashed_token)
 
     config['tokens'] += hashed_tokens


### PR DESCRIPTION
This switches to the development version of pycryptodome (see #6694), and uses the new cSHAKE library function in the life cycle generation scripts to precompute the design constants.

This addresses #6548.