### PR TITLE
[chip, testplan] Update chip testplan based on recent reviews

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -912,18 +912,49 @@
 
             Write a 32-byte key and a 16-byte plain text to the AES registers and trigger the AES
             computation to start. Wait for the AES operation to complete by polling the status
-            register (or interrupt if available). Check the digest registers for correctness against
-            the expected digest value.
+            register. Check the digest registers for correctness against the expected digest value.
             '''
       milestone: V2
       tests: []
     }
     {
-      name: chip_aes_shadow_reg_alert
-      desc: '''Verify shadow reg alert from AES.
+      name: chip_aes_entropy
+      desc: '''Verify the AES entropy input used by the internal PRNGs.
 
-            Inject a storage error via backdoor to generate this alert signal while the SW is
-            actively executing some piece of code. Verify alert propagation to an NMI.
+            - Write the initial key share, IV and data in CSRs (known combinations).
+            - Configure the entropy_src to generate entropy in LFSR mode.
+            - Write the PRNG_RESEED bit to reseed the internal state of the PRNG.
+            - Poll the status idle bit to ensure reseed operation is complete.
+            - Trigger the AES operation to run and wait for it to complete.
+            - Check the digest against the expected value.
+            - Write the KEY_IV_DATA_IN_CLEAR and DATA_OUT_CLEAR trigger bits to 1 and wait for it to
+              complete by polling the status idle bit.
+            - Read back the data out CSRs - they should all read garbage values.
+            - Assertion check verifies that the internal states (data_in, key share and IV are also
+              garbage, i.e. different from the originally written values.
+            - Assertion checks proves that all interfaces are connected across AST RNG, ES, CSRNG,
+              EDN and AES.
+            - Predict the generated entropy bits and check against the observed for correctness.
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: chip_aes_edn_reset
+      desc: '''Verify that the EDN clock / reset is connected to AES.
+
+            - Ensure that the PRNG within AES resets when the EDN logic is held in reset.
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: chip_aes_lc_escalate_en
+      desc: '''Verify the effect of LC escalate en signal on AES.
+
+            - Trigger an LC escalatation signal by writing to alert_test CSR (in some other IP).
+            - Trigger an AES operation to run.
+            - When the escalation kicks in, verify that the AES is in the error state.
             '''
       milestone: V2
       tests: []
@@ -940,6 +971,15 @@
             - After the AES operation is complete, verify the digest for correctness.
               Verify that the AES clk hint status within clkmgr now reads 0 again (AES is idle),
               after the AES operation is complete.
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: chip_aes_sideload
+      desc: '''Verify the AES sideload mechanism.
+
+            Details TBD, design updates pending.
             '''
       milestone: V2
       tests: []
@@ -1077,50 +1117,111 @@
       tests: []
     }
 
-    // CSRNG tests:
-    {
-      name: chip_csrng_cmd
-      desc: '''Verify the cmd interface to CSRNG.
-
-            Details TBD. SW test validates the reception of cmd req done interrupt.
-            '''
-      milestone: V2
-      tests: []
-    }
-    {
-      name: chip_csrng_entropy_src
-      desc: '''Verify the interface to entropy_src.
-
-            Details TBD.
-            '''
-      milestone: V2
-      tests: []
-    }
-    {
-      name: chip_csrng_fuse
-      desc: '''Verify the fuse input to CSRNG.
-
-            Details TBD.
-            '''
-      milestone: V2
-      tests: []
-    }
-
     // ENTROPY_SRC (pre-verified IP) integration tests:
     {
       name: chip_entropy_src_ast_rng_req
       desc: '''Verify the RNG req to ast.
 
-            Details TBD. SW test validates the reception of the entropy valid interrupt.
+            - Program the entropy src in normal RNG mode.
+            - Route the entropy data received from RNG to the FIFO.
+            - Verify that the FIFO depth is non-zero via SW - indicating the reception of data over
+              the AST RNG interface.
+            - Verify the correctness of the received data with assertion based connectivity checks.
             '''
       milestone: V2
       tests: []
     }
     {
-      name: chip_entropy_src_fuse
-      desc: '''Verify the fuse input entropy_src.
+      name: chip_entropy_src_ast_fips
+      desc: '''Verify the connectivity of rng_fips_o feedback signal to RNG.
 
             Details TBD.
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: chip_entropy_src_csrng
+      desc: '''Verify the transfer of entropy bits to CSRNG.
+
+            Verify the entropy valid interrupt.
+            At the CSRNG, validate the reception of entropy req interrupt.
+            Details TBD.
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: chip_entropy_src_cs_aes_halt
+      desc: '''Verify the aes halt handshake with CSRNG.
+
+            Details TBD.
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: chip_entropy_src_fuse_en_fw_read
+      desc: '''Verify the fuse input entropy_src.
+
+            - Initialize the OTP with this fuse bit set to 1.
+            - Perform an entropy request operation.
+            - Read the entropy_data_fifo via SW; verify that it reads valid values.
+            - Reset the chip, but this time, initialize the OTP with this fuse bit set to 0.
+            - Perform an entropy request operation.
+            - Read the internal state via SW; verify that it reads all zeros this time.
+            '''
+      milestone: V2
+      tests: []
+    }
+
+    // CSRNG tests:
+    {
+      name: chip_csrng_edn_cmd
+      desc: '''Verify incoming command interface from EDN.
+
+            - Have each EDN instance issue an instantiate command to CSRNG.
+            - When done, verify the reception of cmd req done interrupt.
+            - Check the data returned to EDN via connectivity assertion checks.
+            - TODO: explore the ability to generate predictable data and verify the received value.
+            Details TBD.
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: chip_csrng_fuse_en_sw_app_read
+      desc: '''Verify the fuse input to CSRNG.
+
+            - Initialize the OTP with this fuse bit set to 1.
+            - Issue an instantiate command to request entropy.
+            - Verify that SW can read the internal states.
+            - Reset the chip and repeat the steps above, but this time, with OTP fuse bit set to 0.
+            - Verify that the SW reads back all zeros when reading the internal states.
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: chip_csrng_lc_hw_debug_en
+      desc: '''Verify the effect of LC HW debug enable on CSRNG.
+
+            TODO: This is pending SCA security review and might be removed.
+            '''
+      milestone: V2
+      tests: []
+    }
+
+    // EDN (pre-verified IP) integration tests:
+    {
+      name: chip_edn_entropy_reqs
+      desc: '''Verify the entropy requests from all peripherals.
+
+            Verify that there are no misconnects between each peripheral requesting entropy.
+            TODO: system level scenario: have all entropy sources request entropy in the same test
+            one after to show boot to post boot load, cycling all entropy blocks off and on again.
+            Ensure there are no deadlocks and everything works as expected.
+            X'ref'ed with each IP test that requsts entropy from EDN.
             '''
       milestone: V2
       tests: []

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -298,11 +298,30 @@
       tests: []
     }
 
-    ///////////////////////////////////////////////////////////////////////////////
-    // System Peripherals                                                        //
-    // RV_DM, RV_TIMER, AON_TIMER, PLIC, CLK/RST/PWR MGR, ALERT_HANDLER, LC_CTRL //
-    ///////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////////////
+    // System Peripherals                                                              //
+    // XBAR, RV_DM, RV_TIMER, AON_TIMER, PLIC, CLK/RST/PWR MGR, ALERT_HANDLER, LC_CTRL //
+    /////////////////////////////////////////////////////////////////////////////////////
 
+    // XBAR (pre-verified IP) tests:
+    {
+      name: chip_data_integrity
+      desc: '''
+            Verify the alert signaling mechanism due to data integrity violation.
+
+            An automated SW test which performs the following for each IP:
+            - Pick a CSR to write.
+            - Corrupt a random control / data / integrity bit at the CPU source using SV force.
+            - Verify that the device detects the integrity violation causing an alert.
+            - Verify the alert upto the NMI stage.
+            - Now pick a CSR to read.
+            - Corrupt a random control / data / integrity bit at the device using SV force.
+            - Verify that the CPU detects the integrity violation causing an alert.
+            - Verify the alert upto the NMI stage.
+            '''
+      milestone: V2
+      tests: []
+    }
 
     // RV_DM (JTAG) tests:
     {
@@ -316,7 +335,7 @@
             - Read all CSRs back and check their values for correctness while adhering to the CSR's
               access policies.
             '''
-      milestone: V1
+      milestone: V2
       tests: []
     }
     {
@@ -656,7 +675,24 @@
       name: chip_alert_handler_alerts
       desc: '''Verify all alerts coming into the alert_handler.
 
-            X-ref'ed with all IP tests.
+            An automated SW test, which does the following (applies to all alerts in all IPs):
+            - Program the alert_test CSR in each block to trigger each alert one by one.
+            - Ensure that all alerts are properly connected to the alert handler and cause the
+              escalation paths to trigger.
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: chip_alert_handler_escalations
+      desc: '''Verify all alert escalation paths.
+
+            Verify all escalation paths triggered by an alert.
+            - Verify the first escalation results in NMI interrupt serviced by the CPU.
+            - Verify the second results in device secrets to be wiped - read via SW to confirm.
+            - Verify the third results in device being put in scrap state, via the LC JTAG TAP.
+            - Verify the fourth results in chip reset.
+            - Ensure that all escalation handshakes complete without errors.
             '''
       milestone: V2
       tests: []
@@ -665,19 +701,7 @@
       name: chip_alert_handler_irqs
       desc: '''Verify all classes of alert handler interrupts to the CPU.
 
-
-            Program each alert to cause an interrupt in each class. SW validates the reception of
-            the interrupt. X-ref'ed with all IP tests.
-            '''
-      milestone: V2
-      tests: []
-    }
-    {
-      name: chip_alert_handler_esc_irqs
-      desc: '''Verify all alert handler escalation irqs.
-
-
-            Details TBD.
+            X-ref'ed with the automated PLIC test.
             '''
       milestone: V2
       tests: []
@@ -686,8 +710,20 @@
       name: chip_alert_handler_entropy
       desc: '''Verify the alert handler entropy input to ensure pseudo-random ping timer.
 
+            - Force `alert_handler_ping_timer` input signal `wait_cyc_mask_i` to `4'bff` to shorten
+              the simulation time.
+            - Verify that the alert_handler can request EDN to provide entropy.
+            - Ensure that the alert ping handshake to all alert sources and escalation receivers
+              complete without errors.
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: chip_alert_handler_edn_reset
+      desc: '''Verify that the EDN clock / reset is connected to alert_handler.
 
-            Details TBD.
+            - Ensure that the ping timer LFSR resets when the EDN logic is held in reset.
             '''
       milestone: V2
       tests: []
@@ -696,18 +732,8 @@
       name: chip_alert_handler_crashdump
       desc: '''Verify the alert handler crashdump signal.
 
-
-            Details TBD.
-            '''
-      milestone: V2
-      tests: []
-    }
-    {
-      name: chip_alert_handler_ping_fail
-      desc: '''Verify the alert ping failure results in an escalation.
-
-
-            Details TBD.
+            When the chip resets due to alert escalating to cause the chip to reset, verify the
+            reset cause to verify the alert crashdump.
             '''
       milestone: V2
       tests: []
@@ -960,29 +986,76 @@
       tests: []
     }
     {
-      name: chip_kmac_sram_uncorrectable_alert
-      desc: '''Verify the SRAM uncorrectable alert from KMAC.
-
-            Inject 2 bit errors within the SRAM inside KMAC via backdoor and ensure that this alert
-            propagates to an NMI.
-            '''
-      milestone: V2
-      tests: []
-    }
-    {
-      name: chip_kmac_sram_data_parity_alert
-      desc: '''Verify the data parity alert from KMAC.
-
-            Details TBD.
-            '''
-      milestone: V2
-      tests: []
-    }
-    {
-      name: chip_kmac_keymgr_key_data
+      name: chip_kmac_app_keymgr
       desc: '''Verify the keymgr interface to KMAC.
 
+            - Configure the keymgr to start sending known message data to the KMAC.
+            - Keymgr should transmit a sideloaded key to the KMAC as well.
+            - KMAC should finish hashing successfully (not visible to SW) and return digest to
+              keymgr.
+            - This digest is compared against the known digest value for correctness.
+            - Verify that the keymgr has received valid output from the KMAC.
+
             X-ref'ed with keymgr test.
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: chip_kmac_app_lc
+      desc: '''Verify the LC interface to KMAC.
+
+            - Configure the LC_CTRL to start a token hash using KMAC interface.
+            - KMAC should finish hashing successfully (not visible to SW) and return digest to
+            LC_CTRL.
+
+            X-ref'ed with LC_CTRL test/env.
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: chip_kmac_app_rom
+      desc: '''Verify the ROM interface to KMAC.
+
+            - Backdoor initialize ROM memory immediately out of reset.
+            - ROM will send message to the KMAC containing its memory contents,
+            - KMAC will hash and return the digest to the ROM.
+            - ROM will compare received digest against its first 8 logical memory lines for
+            correctness.
+
+            X-ref'ed with ROM_CTRL test/env.
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: chip_kmac_entropy
+      desc: '''Verify the EDN interface to KMAC.
+
+            Requires `EnMasking` parameter to be enabled.
+            SW randomly configures the KMAC in any hashing mode/strength, and enable EDN mode.
+            Randomly enable/disable the `entropy_timer`.
+            // TODO - error handling is not complete, do not enable `wait_timer` yet.
+            KMAC should send request to EDN once `CmdStart` is written, and should send out another
+            request to EDN when either:
+              - `entropy_timer` runs down (assuming it is non-zero)
+              - a hash operation is completed, KMAC will refresh its internal entropy state
+            SW verifies that KMAC produces the correct digest value.
+
+            TODO: This is pending security review discussion. It is unclear if this feature will be
+            implemented.
+
+            X-ref'ed with EDN test/env.
+            '''
+      milestone: V3
+      tests: []
+    }
+    {
+      name: chip_kmac_edn_reset
+      desc: '''Verify that the EDN clock / reset is connected to KMAC.
+
+            - Ensure that the `entropy_timer` resets when the EDN logic is held in reset.
             '''
       milestone: V2
       tests: []


### PR DESCRIPTION
The first commit addresses updates to alert_handler, KMAC and some additional minor fixes, based on the review in the Google-internal meeting on 5/24/2021. 

The second commit addresses updates to AES and some of the entropy blocks based on the review with WD on 5/25/2021. 