### PR TITLE
[dv/kmac] cycle accurate model bugfixes - pt 5

### DIFF
--- a/hw/ip/kmac/dv/env/seq_lib/kmac_app_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_app_vseq.sv
@@ -16,7 +16,7 @@ class kmac_app_vseq extends kmac_sideload_vseq;
 
   // msg size when using app interface must be non-zero
   constraint app_msg_size_c {
-    msg.size() > 0;
+    en_app -> msg.size() > 0;
   }
 
   constraint kmac_app_c {

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_common_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_common_vseq.sv
@@ -12,6 +12,7 @@ class kmac_common_vseq extends kmac_base_vseq;
 
   virtual task pre_start();
     do_kmac_init = 1'b0;
+    entropy_mode_c.constraint_mode(0);
     super.pre_start();
   endtask
 

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -78,7 +78,6 @@ class kmac_smoke_vseq extends kmac_base_vseq;
   // a message hash.
   virtual task pre_start();
     do_kmac_init = 0;
-    entropy_mode.rand_mode(0);
     super.pre_start();
   endtask
 
@@ -89,8 +88,6 @@ class kmac_smoke_vseq extends kmac_base_vseq;
     logic [keymgr_pkg::KeyWidth-1:0] sideload_share1;
 
     `uvm_info(`gfn, $sformatf("Starting %0d message hashes", num_trans), UVM_LOW)
-
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(entropy_mode, entropy_mode inside {EntropyModeSw, EntropyModeEdn};)
 
     for (int i = 0; i < num_trans; i++) begin
       bit [7:0] share0[];


### PR DESCRIPTION
this PR makes more fixes to the cycle accurate model, this time relating
to the EDN entropy interface - specifically, overhauling how we time the
first round of a keccak hash.

Some related fixes have also been made to the base sequence, with how we
calculate a "static" entropy mode that is then applied to each hash
iteration.

Signed-off-by: Udi Jonnalagadda <udij@google.com>