### PR TITLE
[otp_ctrl] Change behavior of write blank check error

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -880,9 +880,13 @@
               { value: "4",
                 name: "MACRO_WRITE_BLANK_ERROR",
                 desc: '''
-                A blank write check has failed during an OTP write operation. This effectively
-                aborts the write operation such that no harm is done to the OTP. The corresponding
-                controller automatically recovers from this error when issuing a new command.
+                This error is returned if a programming operation attempted to clear a bit that has previously been programmed to 1.
+                The corresponding controller automatically recovers from this error when issuing a new command.
+
+                Note however that the affected OTP word may be left in an inconsistent state if this error occurs.
+                This can cause several issues when the word is accessed again (either as part of a regular read operation, as part of the readout at boot, or as part of a background check).
+
+                It is important that SW ensures that each word is only written once, since this can render the device useless.
                 '''
               },
               { value: "5",

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -437,9 +437,13 @@
               { value: "4",
                 name: "MACRO_WRITE_BLANK_ERROR",
                 desc: '''
-                A blank write check has failed during an OTP write operation. This effectively
-                aborts the write operation such that no harm is done to the OTP. The corresponding
-                controller automatically recovers from this error when issuing a new command.
+                This error is returned if a programming operation attempted to clear a bit that has previously been programmed to 1.
+                The corresponding controller automatically recovers from this error when issuing a new command.
+
+                Note however that the affected OTP word may be left in an inconsistent state if this error occurs.
+                This can cause several issues when the word is accessed again (either as part of a regular read operation, as part of the readout at boot, or as part of a background check).
+
+                It is important that SW ensures that each word is only written once, since this can render the device useless.
                 '''
               },
               { value: "5",


### PR DESCRIPTION
After an internal discussion, we decided to change the behavior of the write blank check error to accommodate a simpler implementation in the OTP macro wrapper.

In particular, the HW performed a writeability check before initiating a programming operation in order to ensure that the location being accessed has not been programmed before.

While nice to have, this check is not needed under the assumption that provisioning SW keeps track of already programmed OTP locations, and that the provisioning process takes place in a controlled environment with well tested SW.
