### PR TITLE
[kmac] Add Error checking logic

### DIFF
--- a/hw/ip/kmac/doc/_index.md
+++ b/hw/ip/kmac/doc/_index.md
@@ -256,6 +256,12 @@ The refresh does not block the internal entropy expansion operation.
 
 ### Error Report
 
+This section explains the errors KMAC HWIP raises during the hasing operations, their meanings, and the error handling process.
+
+KMAC HWIP has the error checkers in its internal datapath.
+If the checkers detect errors, whether they are triggered by the SW mis-configure, or HW malfunctions, they report the error to !!ERR_CODE and raises an `kmac_error` interrupt.
+
+
 _TBD_
 
 # Programmers Guide

--- a/hw/ip/kmac/dv/env/kmac_env_cov.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cov.sv
@@ -308,7 +308,7 @@ class kmac_env_cov extends cip_base_env_cov #(.CFG_T(kmac_env_cfg));
       bins err_none = {kmac_pkg::ErrNone};
       bins err_key_not_valid = {kmac_pkg::ErrKeyNotValid};
       bins err_sw_pushed_msg_fifo = {kmac_pkg::ErrSwPushedMsgFifo};
-      bins err_sw_pushed_wrong_cmd = {kmac_pkg::ErrSwPushedWrongCmd};
+      bins err_sw_issued_cmd_in_app_active = {kmac_pkg::ErrSwIssuedCmdInAppActive};
       bins err_wait_timer_expired = {kmac_pkg::ErrWaitTimerExpired};
       bins err_incorrect_entropy_mode = {kmac_pkg::ErrIncorrectEntropyMode};
 

--- a/hw/ip/kmac/kmac.core
+++ b/hw/ip/kmac/kmac.core
@@ -24,6 +24,7 @@ filesets:
       - rtl/kmac_staterd.sv
       - rtl/kmac_app.sv
       - rtl/kmac_entropy.sv
+      - rtl/kmac_errchk.sv
       - rtl/kmac_reg_pkg.sv
       - rtl/kmac_reg_top.sv
       - rtl/kmac.sv

--- a/hw/ip/kmac/rtl/kmac_errchk.sv
+++ b/hw/ip/kmac/rtl/kmac_errchk.sv
@@ -1,0 +1,300 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// KMAC Error Checking logic
+//
+// `kmac_err` module checks the SW introduced errors.
+//  1. SW command sequencing error.
+//  2. SW configuration error.
+//
+// ## SW Command Sequencing Error
+//
+// KMAC assumes the application interface and the SW register interface to
+// follow the specific sequence. It expects the requester to send the `Start`
+// command then push the message body. The `Process` command follows the message
+// body. The SW may issue `Run` command if it needs the digest result more than
+// a block rate. Then SW completes the hash operation with `Done` command.
+//
+// This `kmac_err` module checks if the SW issues the correct command. If not,
+// it reports the error via ERR_CODE register.
+//
+// However, the logic does not prevent the error-ed command to be propagated.
+// The unexpected commands are filtered by each individual submodule.
+//
+// st := { Idle, MsgFeed, Processing, Absorbed, Squeeze}
+//
+// allowed := {
+//   Idle :      { Start     },
+//   MsgFeed:    { Process   },
+//   Processing: { None      },
+//   Absorbed:   { Run, Done },
+//   Squeeze:    { None      }
+// }
+//
+// ## SW Configuration Error
+//
+// `kmac_errchk` module checks if SW configured correct combinations of the
+// configuration registers when the hashing operation begins.
+//
+// 1. Mode & Strength combinations
+// 2. Kmac Prefix
+// * sideload & key_valid -> Checker in kmac_core
+
+module kmac_errchk
+  import kmac_pkg::*;
+  import sha3_pkg::sha3_mode_e;
+  import sha3_pkg::keccak_strength_e;
+(
+  input clk_i,
+  input rst_ni,
+
+  // Configurations
+  input sha3_mode_e       cfg_mode_i,
+  input keccak_strength_e cfg_strength_i,
+
+  input        kmac_en_i,
+  input [47:0] cfg_prefix_6B_i, // first 6B of PREFIX
+
+  // SW commands
+  input kmac_cmd_e sw_cmd_i,
+
+  // Status from KMAC_APP
+  input app_active_i,
+
+  // Status from SHA3 core
+  input sha3_absorbed_i,
+  input keccak_done_i,
+
+  output err_t error_o
+);
+
+  // sha3_pkg::sha3_mode_e
+  import sha3_pkg::L128;
+  import sha3_pkg::L224;
+  import sha3_pkg::L256;
+  import sha3_pkg::L384;
+  import sha3_pkg::L512;
+
+  // sha3_pkg::keccak_strength_e
+  import sha3_pkg::Sha3;
+  import sha3_pkg::Shake;
+  import sha3_pkg::CShake;
+
+  /////////////////
+  // Definitions //
+  /////////////////
+  typedef enum logic [2:0] {
+    StIdle,
+    StMsgFeed,
+    StProcessing,
+    StAbsorbed,
+    StSqueezing
+  } st_e;
+  st_e st, st_d;
+
+  /////////////
+  // Signals //
+  /////////////
+
+  // `err_swsequence` occurs when SW issues wrong command
+  logic err_swsequence;
+
+  // `err_modestrength` occcurs when Mode & Strength combinations are not
+  // allowed. This error does not block the hashing operation.
+  logic err_modestrength;
+
+  // `err_prefix` occurs when the first 6B of !!PREFIX is not
+  // `encode_string("KMAC")` and kmac is enabled. This error does not block the
+  // KMAC operation.
+  logic err_prefix;
+
+  ///////////////////
+  // Error Checker //
+  ///////////////////
+
+  // SW sequence Error
+  // info field: Current state, Received command
+  always_comb begin
+    err_swsequence = 1'b 0;
+
+    unique case (st)
+      StIdle: begin
+        // Allow Start command only
+        if (!(sw_cmd_i inside {CmdNone, CmdStart})) begin
+          err_swsequence = 1'b 1;
+        end
+      end
+
+      StMsgFeed: begin
+        // Allow Process only
+        if (!(sw_cmd_i inside {CmdNone, CmdProcess})) begin
+          err_swsequence = 1'b 1;
+        end
+      end
+
+      StProcessing: begin
+        if (sw_cmd_i != CmdNone) begin
+          err_swsequence = 1'b 1;
+        end
+      end
+
+      StAbsorbed: begin
+        // Allow ManualRun and Done
+        if (!(sw_cmd_i inside {CmdNone, CmdManualRun, CmdDone})) begin
+          err_swsequence = 1'b 1;
+        end
+      end
+
+      StSqueezing: begin
+        if (sw_cmd_i != CmdNone) begin
+          err_swsequence = 1'b 1;
+        end
+      end
+
+      default: begin
+        err_swsequence = 1'b 0;
+      end
+    endcase
+  end
+
+  // Mode & Strength
+  always_comb begin : check_modestrength
+    err_modestrength = 1'b 0;
+
+    if (st == StIdle && st_d == StMsgFeed) begin
+      // When moving to the next stage, checks the config
+      if (!((cfg_mode_i == Sha3 &&
+             cfg_strength_i inside {L224, L256, L384, L512}) ||
+            ((cfg_mode_i == Shake || cfg_mode_i == CShake) &&
+             (cfg_strength_i inside {L128, L256})))) begin
+        err_modestrength = 1'b 1;
+      end
+    end
+  end : check_modestrength
+
+
+  // Check prefix 6B is `encode_string("KMAC")`
+  always_comb begin : check_prefix
+    err_prefix = 1'b 0;
+
+    if (st == StIdle && st_d == StMsgFeed && kmac_en_i) begin
+      if (cfg_prefix_6B_i != EncodedStringKMAC) begin
+        err_prefix = 1'b 1;
+      end
+    end
+  end : check_prefix
+
+
+  // Return error code
+  err_t err;
+  always_comb begin : err_return
+    err = '{valid: 1'b0, code: ErrNone, info: '0};
+
+    priority case (1'b 1)
+      err_swsequence: begin
+        err = '{ valid: 1'b 1,
+                 code: ErrSwCmdSequence,
+                 info: {5'h0,
+                        {err_swsequence, err_modestrength, err_prefix},
+                        8'h0,
+                        {1'b0, st, sw_cmd_i}
+                       }
+               };
+      end
+
+      err_modestrength: begin
+        err = '{ valid: 1'b 1,
+                 code:  ErrUnexpectedModeStrength,
+                 info:  { 5'h 0,
+                          {err_swsequence, err_modestrength, err_prefix},
+                          8'h 0,
+                          {2'b 00, cfg_mode_i},
+                          {1'b 0,  cfg_strength_i}
+                        }
+               };
+      end
+
+      err_prefix: begin
+        err = '{ valid: 1'b 1,
+                 code:  ErrIncorrectFunctionName,
+                 info:  { 5'h 0,
+                          {err_swsequence, err_modestrength, err_prefix},
+                          16'h 0000
+                        }
+               };
+      end
+
+      default: begin
+        err = '{valid: 1'b0, code: ErrNone, info: '0};
+      end
+    endcase
+  end : err_return
+
+  assign error_o = err;
+
+  // If below failed, revise err_swsequence error response info field.
+  `ASSERT_INIT(ExpectedStSwCmdBits_A, $bits(st) == 3 && $bits(sw_cmd_i) == 4)
+
+  // If failed, revise err_modestrength error info field.
+  `ASSERT_INIT(ExpectedModeStrengthBits_A,
+               $bits(cfg_mode_i) == 2 && $bits(cfg_strength_i) == 3)
+
+
+  ///////////////////
+  // State Machine //
+  ///////////////////
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      st <= StIdle;
+    end else begin
+      st <= st_d;
+    end
+  end
+
+  always_comb begin : next_state
+    st_d = st;
+
+    unique case (st)
+      StIdle: begin
+        if (!app_active_i && sw_cmd_i == CmdStart) begin
+          // Proceed to the next state only when the SW issues the Start command
+          // in a valid period.
+          st_d = StMsgFeed;
+        end
+      end
+
+      StMsgFeed: begin
+        if (sw_cmd_i == CmdProcess) begin
+          st_d = StProcessing;
+        end
+      end
+
+      StProcessing: begin
+        if (sha3_absorbed_i) begin
+          st_d = StAbsorbed;
+        end
+      end
+
+      StAbsorbed: begin
+        if (sw_cmd_i == CmdManualRun) begin
+          st_d = StSqueezing;
+        end else if (sw_cmd_i == CmdDone) begin
+          st_d = StIdle;
+        end
+      end
+
+      StSqueezing: begin
+        if (keccak_done_i) begin
+          st_d = StAbsorbed;
+        end
+      end
+
+      default: begin
+        st_d = StIdle;
+      end
+    endcase
+  end : next_state
+  `ASSERT_KNOWN(StKnown_A, st)
+
+endmodule : kmac_errchk

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -118,6 +118,9 @@ package kmac_pkg;
     AppKMAC   = 2
   } app_mode_e;
 
+  // Predefined encoded_string
+  parameter logic [15:0] EncodedStringEmpty = 16'h 0001;
+  parameter logic [47:0] EncodedStringKMAC = 48'h 4341_4D4B_2001;
   parameter int unsigned NSPrefixW = sha3_pkg::NSRegisterSize*8;
 
   typedef struct packed {
@@ -163,6 +166,17 @@ package kmac_pkg;
       Prefix: NSPrefixW'(96'h 4c52_5443_5f4d_4f52_4001_0001)
     }
   };
+
+  // Exporting the app internal mux selection enum into the package. So that DV
+  // can use this enum in its scoreboard.
+  typedef enum logic [2:0] {
+    SelNone   = 3'b 000,
+    SelApp    = 3'b 101,
+    SelOutLen = 3'b 110,
+    SelSw     = 3'b 010
+  } app_mux_sel_e ;
+
+
 
   // MsgWidth : 64
   // MsgStrbW : 8
@@ -227,9 +241,9 @@ package kmac_pkg;
     //   - Sw writes data into Msg FIFO when KeyMgr is in operating
     ErrSwPushedMsgFifo = 8'h 02,
 
-    // ErrSwPushWrongCmd
-    //  - Sw writes any command except CmdStart when Idle.
-    ErrSwPushedWrongCmd = 8'h 03,
+    // ErrSwIssuedCmdInAppActive
+    //  - Sw writes any command while AppIntf is in active.
+    ErrSwIssuedCmdInAppActive = 8'h 03,
 
     // ErrWaitTimerExpired
     // Entropy Wait timer expired. Something wrong on EDN i/f
@@ -237,7 +251,16 @@ package kmac_pkg;
 
     // ErrIncorrectEntropyMode
     // Incorrect Entropy mode when entropy is ready
-    ErrIncorrectEntropyMode = 8'h 05
+    ErrIncorrectEntropyMode = 8'h 05,
+
+    // ErrUnexpectedModeStrength
+    ErrUnexpectedModeStrength = 8'h 06,
+
+    // ErrIncorrectFunctionName "KMAC"
+    ErrIncorrectFunctionName = 8'h 07,
+
+    // ErrSwCmdSequence
+    ErrSwCmdSequence = 8'h 08
   } err_code_e;
 
   typedef struct packed {


### PR DESCRIPTION
This commit combines scattered error checking logics into a single
module. Still a few errors are checked in the submodules and reported
from there.

This is the follow-up commit for issue #6370 #6635 #6638

**Pending Items**
- [x] Revise SHA3 error code consistent (double process may / may not trigger error in current senario)
- [ ] ~~Remove SHA3 error report for KMAC (And waive from coverage too)~~
- [x] Revise KMAC Error handling section in the spec

![kmac_err](https://user-images.githubusercontent.com/1192814/119743882-aaa3a300-be3f-11eb-9a52-fd728c41a802.png)
![kmac_err_blockdiagram](https://user-images.githubusercontent.com/1192814/119743973-da52ab00-be3f-11eb-907b-e560a5fee480.png)
