### PR TITLE
[doc, testplans] Fix non-existent tests

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl_testplan.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl_testplan.hjson
@@ -5,7 +5,6 @@
   name: "adc_ctrl"
   // TODO: remove the common testplans if not applicable
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
   testpoints: [

--- a/hw/ip/csrng/data/csrng_testplan.hjson
+++ b/hw/ip/csrng/data/csrng_testplan.hjson
@@ -55,7 +55,7 @@
       name: life cycle
       desc: '''
             Verify lifecycle hardware debug mode enables AES bypass, reading CSRNG internal state.
-	    Verify CSRNG internal state for all csrng/genbits operations.
+            Verify CSRNG internal state for all csrng/genbits operations.
             '''
       milestone: V2
       tests: []
@@ -73,9 +73,11 @@
     {
       name: stress_all
       desc: '''
-            Combine the other individual testpoints while injecting TL errors and running CSR tests in parallel.'''
+            Combine the other individual testpoints while injecting TL errors and running CSR tests
+            in parallel.
+            '''
       milestone: V2
-      tests: ["csrng_stress_all"]
+      tests: []
     }
   ]
 }

--- a/hw/ip/edn/data/edn_testplan.hjson
+++ b/hw/ip/edn/data/edn_testplan.hjson
@@ -65,9 +65,11 @@
     {
       name: stress_all
       desc: '''
-            Combine the other individual testpoints while injecting TL errors and running CSR tests in parallel.'''
+            Combine the other individual testpoints while injecting TL errors and running CSR tests
+            in parallel.
+            '''
       milestone: V2
-      tests: ["csrng_stress_all"]
+      tests: []
     }
   ]
 }

--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -21,7 +21,8 @@
               - Enable DUT host
               - Clear/Enable interrupt (if needed)
               - Program OVRD, FDATA register
-              - Randomize I2C timing in TIMING 0-4 registers and other parameters such as TL agent delays
+              - Randomize I2C timing in TIMING 0-4 registers and other parameters such as TL agent
+                delays
               - Randomize address and data for read/write transactions sent to the agent by the DUT
 
             Checking:
@@ -32,15 +33,16 @@
       tests: ["i2c_smoke"]
     }
     {
-      name: host_error_intr,
+      name: host_error_intr
       desc: '''
             Test error interrupts are asserted by the Host DUT due to
             interference and unstable signals on bus.
-  
+
             Stimulus:
               - Configure DUT/Agent to Host/Target mode respectively
               - In host transmit mode, device (target/host) forces sda or scl signal low within the
-                clock pulse of host scl that asserts `sda_interference` or `scl_interference` interrupts
+                clock pulse of host scl that asserts `sda_interference` or `scl_interference`
+                interrupts
               - In host receiving mode (data or ack bits), SDA signal is changed with the
                 clock pulse of host scl that asserts `intr_sda_unstable` interrupts
               - When error interrupt assertions are detected, dut, agent, and scoreboard will be
@@ -98,7 +100,7 @@
             Stimulus:
               - Configure DUT/Agent to Host/Target mode respectively
               - Reduce access latency for all fifos
-              - Issue long read/write back-to-back transactions 
+              - Issue long read/write back-to-back transactions
               - Read rx_fifo as soon as read data valid
               - Clear interrupt quickly
 
@@ -147,8 +149,9 @@
             Test the overflow interrupt for fmt_fifo and rx_fifo.
 
             Stimulus:
-              - Configure DUT/Agent to Host/Target mode respectively      
-              - DUT keeps sending a number of format byte higher than the size of fmt_fifo and rx_fifo depth
+              - Configure DUT/Agent to Host/Target mode respectively
+              - DUT keeps sending a number of format byte higher than the size of fmt_fifo and
+                rx_fifo depth
 
             Checking:
               - Ensure excess format bytes are dropped
@@ -158,7 +161,7 @@
       tests: ["i2c_fifo_overflow"]
     }
     {
-      name: target_fifo_empty,
+      name: target_fifo_empty
       desc: '''
             Test tx_empty and tx_nonempty interrupt.
 
@@ -167,11 +170,12 @@
               - Agent sends transaction to the DUT
 
             Checking:
-              - During read transaction, ensure tx_empty interrupt is asserted when no data left in tx_fifo
+              - During read transaction, ensure tx_empty interrupt is asserted when no data left
+                in tx_fifo
                 otherwise tx_empty interrupt must be asserted
             '''
       milestone: V2
-      tests: ["i2c_fifo_empty"]
+      tests: []
     }
     {
       name: host_fifo_reset
@@ -187,7 +191,7 @@
               - Ensure the remaining entries are not show up after fmt_fifo is reset
             '''
       milestone: V2
-      tests: ["i2c_fifo_reset"]
+      tests: []
     }
     {
       name: host_fifo_full
@@ -214,14 +218,15 @@
               - Configure DUT/Agent to Host/Target mode respectively
               - Set timeout enable bit of TIMEOUT_CTRL register
               - Program timeout values (higher than host scl clock pulse) into TIMEOUT_CTRL register
-              - Configure agent to pull down target (device) scl after the bit 9 (ACK) is transmitted
+              - Configure agent to pull down target (device) scl after the bit 9 (ACK) is
+                transmitted
 
             Checking:
               - Ensure stretch_timeout is asserted and a correct number is received
 
             '''
       milestone: V2
-      tests: ["i2c_timeout"]
+      tests: []
     }
     {
       name: host_rx_oversample
@@ -236,7 +241,7 @@
               - Read rx data oversampled value and ensure it is same as driven value
             '''
       milestone: V2
-      tests: ["i2c_rx_oversample"]
+      tests: []
     }
     {
       name: host_rw_loopback
@@ -250,7 +255,7 @@
               - Ensure read data is matched with write data
             '''
       milestone: V2
-      tests: ["i2c_rw_loopback"]
+      tests: []
     }
 
     //-----------------------------------------------
@@ -266,7 +271,8 @@
               - Configure DUT/Agent to Target/Host mode respectively
               - Enable DUT target
               - Clear/Enable interrupt (if needed)
-              - Randomize I2C timing in TIMING 0-4 registers and other parameters such as TL agent delays
+              - Randomize I2C timing in TIMING 0-4 registers and other parameters such as TL agent
+                delays
               - Generate random addresses which are programmed to the DUT (target)
                 and used for transaction sent by the agent (host)
 
@@ -353,7 +359,8 @@
 
             Stimulus:
               - Configure DUT/Agent to Target/Host mode respectively
-              - Agent keeps sending a number of format byte higher than the size of tx_fifo and acq_fifo
+              - Agent keeps sending a number of format byte higher than the size of tx_fifo and
+                acq_fifo
 
             Checking:
               - Ensure excess format bytes are dropped
@@ -376,7 +383,7 @@
               - Ensure the remaining entries are not show up after fmt_fifo is reset,
             '''
       milestone: V2
-      tests: ["i2c_fifo_reset"]
+      tests: []
     }
     {
       name: target_fifo_full
@@ -409,7 +416,7 @@
 
             '''
       milestone: V2
-      tests: ["i2c_timeout"]
+      tests: []
     }
   ]
 }

--- a/hw/ip/keymgr/data/keymgr_testplan.hjson
+++ b/hw/ip/keymgr/data/keymgr_testplan.hjson
@@ -60,7 +60,7 @@
             Test command and reg access gated by CFGEN is ignored during operation.
             '''
       milestone: V2
-      tests: ["keymgr_cfgen"]
+      tests: ["keymgr_cfg_regwen"]
     }
     {
       name: cfgen_at_st_random
@@ -71,7 +71,7 @@
             Test command and reg access gated by CFGEN is ignored during `StRandom`.
             '''
       milestone: V2
-      tests: ["keymgr_cfgen"]
+      tests: ["keymgr_cfg_regwen"]
     }
     {
       name: sideload
@@ -198,7 +198,7 @@
       name: stress_all
       desc: '''
             - Combine above sequences in one test to run sequentially, except csr sequence and
-              keymgr_cfgen (requires zero_delays)
+              keymgr_cfg_regwen (requires zero_delays)
             - Randomly add reset between each sequence'''
       milestone: V2
       tests: ["keymgr_stress_all"]

--- a/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
@@ -5,8 +5,9 @@
   name: "lc_ctrl"
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
+                     // TODO: temp commented out stress_test
+                     // "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"
   testpoints: [
     {
       name: smoke

--- a/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson
+++ b/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson
@@ -30,6 +30,7 @@
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
 
@@ -45,7 +46,7 @@
 
   // additional top for coverage
   sim_tops: [ "pattgen_bind", "pattgen_cov_bind"]
-  
+
   // Pattgen functional coverage
   xcelium_cov_refine_files: ["{proj_root}/hw/ip/pattgen/dv/cov/pattgen_cov.vRefine"]
 

--- a/hw/ip/rom_ctrl/data/rom_ctrl_testplan.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl_testplan.hjson
@@ -37,7 +37,7 @@
             - Check that the digest csrs are not corrupted
             '''
       milestone: V2
-      tests: ["rom_ctrl_reset"]
+      tests: []
     }
     {
       name: mem_tl_errors
@@ -46,7 +46,7 @@
             ROM TLUL interface to verify that erroneous TLUL transactions are handled correctly.
             '''
       milestone: V2
-      tests: ["rom_ctrl_mem_tl_errors"]
+      tests: []
     }
     {
       name: ecc_mem_fault
@@ -60,7 +60,7 @@
             - TODO - should this generate an alert with xmission integrity?
             '''
       milestone: V3
-      tests: ["rom_ctrl_ecc"]
+      tests: []
     }
   ]
   covergroups: [

--- a/hw/ip/spi_device/data/spi_device_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_testplan.hjson
@@ -73,7 +73,7 @@
       desc: '''Reset async fifo when SPI interface is idle
             TODO: fifo may be fetching data from SRAM? What is the actual usage?'''
       milestone: V2
-      tests: ["spi_device_async_fifo_reset"]
+      tests: []
     }
     {
       name: interrupts
@@ -84,14 +84,14 @@
             - rx error
             - overflow/underflow'''
       milestone: V2
-      tests: ["spi_device_interrupts"]
+      tests: []
     }
     {
       name: abort
       desc: '''
             TODO: Need to clarify the behavior in spec'''
       milestone: V2
-      tests: ["spi_device_abort"]
+      tests: []
     }
     {
       name: byte_transfer_on_spi
@@ -107,7 +107,7 @@
               model the timer feature
             - Note: Timeout only for RX'''
       milestone: V2
-      tests: ["spi_device_rx_timeout"]
+      tests: []
     }
     {
       name: bit_transfer_on_spi
@@ -116,7 +116,7 @@
             - If TX drives < 7 bits, this byte will be sent in next CSB.
             - If TX drives 7 bits and set CSB to high, this byte won't be sent in next CSB'''
       milestone: V2
-      tests: ["spi_device_bit_transfer"]
+      tests: []
     }
     {
       name: extreme_fifo_setting
@@ -128,7 +128,7 @@
       name: mode
       desc: '''TODO :only support fw mode now'''
       milestone: V2
-      tests: ["spi_device_mode"]
+      tests: []
     }
     {
       name: mem_ecc
@@ -137,13 +137,13 @@
             - Just cover basic functionality and connectivity
             - Complete verification will be done by PFV'''
       milestone: V2
-      tests: ["spi_device_mem_ecc"]
+      tests: []
     }
     {
       name: perf
       desc: '''Run spi_device_fifi_full_vseq with very small delays'''
       milestone: V2
-      tests: ["spi_device_perf"]
+      tests: []
     }
   ]
 }

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -9,7 +9,6 @@
                      "hw/dv/tools/dvsim/testplans/enable_reg_testplan.hjson",
                      // TODO #5484, comment these 2 lines out because spi host memory is dummy
                      // "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
                      "hw/ip/tlul/data/tlul_testplan.hjson"]
 

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -228,7 +228,7 @@
   regressions: [
     {
       name: smoke
-      tests: ["chip_uart_tx_rx"]
+      tests: ["chip_sw_uart_tx_rx"]
     }
   ]
 }


### PR DESCRIPTION
Several testplans indicate tests that do not exist yet. It would be
better to set the name correctly when the test is actually developed.
Going forward, missing tests in the testplan and written tests that do
not map to a testpoint will be flagged as an error in the pre-submit CI.

In addition, there are some cosmetic fixes such as line length exceeding
100 chars.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>