### PR TITLE
[otbn,dv] Rename "fixed" covergroup to "ecall"

### DIFF
--- a/hw/ip/otbn/doc/dv/index.md
+++ b/hw/ip/otbn/doc/dv/index.md
@@ -383,7 +383,7 @@ This instruction uses the `I` encoding schema, with covergroup `enc_i_cg`.
 #### ECALL
 
 This instruction uses the `I` encoding schema, but with every field set to a fixed value.
-Encoding-level coverpoints are tracked in covergroup `enc_fixed_cg`.
+Encoding-level coverpoints are tracked in covergroup `enc_ecall_cg`.
 
 No special coverage points for this instruction.
 

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -557,8 +557,9 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     `DEF_GPR_TOGGLE_CROSS(grs2)
   endgroup
 
-  covergroup enc_fixed_cg with function sample(mnem_str_t mnemonic, logic [31:0] insn_data);
-    // Used for instructions (ECALL) with no immediate or register operands
+  covergroup enc_ecall_cg with function sample(mnem_str_t mnemonic, logic [31:0] insn_data);
+    // Used by the ECALL instruction. Although it uses the I encoding in the tooling, it has no
+    // immediate or register operands so we give it a separate covergroup here.
     mnemonic_cp: coverpoint mnemonic {
       `DEF_MNEM_BIN(mnem_ecall);
       illegal_bins other = default;
@@ -752,7 +753,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     enc_bns_cg = new;
     enc_bnxid_cg = new;
     enc_b_cg = new;
-    enc_fixed_cg = new;
+    enc_ecall_cg = new;
     enc_i_cg = new;
     enc_is_cg = new;
     enc_j_cg = new;
@@ -788,7 +789,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     insn_encodings[mnem_jalr]          = "I";
     insn_encodings[mnem_csrrs]         = "I";
     insn_encodings[mnem_csrrw]         = "I";
-    insn_encodings[mnem_ecall]         = "fixed";
+    insn_encodings[mnem_ecall]         = "ecall";
     insn_encodings[mnem_loop]          = "loop";
     insn_encodings[mnem_loopi]         = "loopi";
     insn_encodings[mnem_bn_add]        = "bnaf";
@@ -890,8 +891,8 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
         enc_bnxid_cg.sample(mnem, insn_data, rtl_item.gpr_operand_a, rtl_item.gpr_operand_b);
       "B":
         enc_b_cg.sample(mnem, insn_data, rtl_item.gpr_operand_a, rtl_item.gpr_operand_b);
-      "fixed":
-        enc_fixed_cg.sample(mnem, insn_data);
+      "ecall":
+        enc_ecall_cg.sample(mnem, insn_data);
       "I":
         enc_i_cg.sample(mnem, insn_data, rtl_item.gpr_operand_a);
       "Is":


### PR DESCRIPTION
Since ECALL is the only instruction that uses this (pseudo-)encoding,
let's name it more descriptively.

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>