### PR TITLE
[otbn,dv] Add missing wiring for "bnan" instruction data

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -910,8 +910,8 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
         enc_u_cg.sample(mnem, insn_data);
       "wcsr":
         enc_wcsr_cg.sample(mnem, insn_data);
-      default:
-        `DV_CHECK_FATAL(0, "Unknown encoding")
+      default: `dv_fatal($sformatf("Unknown encoding (%0s) for instruction `%0s'", encoding, mnem),
+                         `gfn)
     endcase
   endfunction
 


### PR DESCRIPTION
This fixes an overnight test failure (apparently, my local testing never executed a `bn.not` instruction). Also, expand an error message slightly to make it more obvious what's going wrong if we break this again.