### PR TITLE
[csrng/rtl] white space added to align statement

### DIFF
--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -239,7 +239,7 @@ module csrng_cmd_stage import csrng_pkg::*; #(
     state_d = state_q;
     cmd_fifo_pop = 1'b0;
     cmd_len_dec = 1'b0;
-    cmd_gen_cnt_dec= 1'b0;
+    cmd_gen_cnt_dec = 1'b0;
     cmd_gen_1st_req = 1'b0;
     cmd_gen_inc_req = 1'b0;
     cmd_gen_cnt_last = 1'b0;


### PR DESCRIPTION
This is a trivial format change.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>