### PR TITLE
[sha3] Make error report consistent

### DIFF
--- a/hw/ip/kmac/rtl/sha3pad.sv
+++ b/hw/ip/kmac/rtl/sha3pad.sv
@@ -777,7 +777,7 @@ module sha3pad
   // Assumption of input mode_i and strength_i
   // SHA3 variants: SHA3-224, SHA3-256, SHA3-384, SHA3-512
   // SHAKE, cSHAKE variants: SHAKE128, SHAKE256, cSHAKE128, cSHAKE256
-  `ASSUME(ModeStrengthCombinations_M,
+  `ASSUME_FPV(ModeStrengthCombinations_M,
     start_i |->
       (mode_i == Sha3 && (strength_i inside {L224, L256, L384, L512})) ||
       ((mode_i == Shake || mode_i == CShake) && (strength_i inside {L128, L256})),


### PR DESCRIPTION
In previous design, SHA3 may or may not report the error for double
process commands depending on the current SHA3 state. If SHA3 state sits
in `StAbsorb` state, double `process` commands were accepted and
triggered `keccak_process` twice. (It does not harm the sha3 hashing
operation.)
    
This commit introduces `processing` status bit to check more than one
`process` commands while the state is in `StAbsorb`. If additional
process command is received, regardless of the state, the SHA3 reports
an error with the error code `ErrSha3SwControl`.