### PR TITLE
[chip, cov] Update / fix the chip cov model

### DIFF
--- a/hw/top_earlgrey/dv/cov/chip_cover.cfg
+++ b/hw/top_earlgrey/dv/cov/chip_cover.cfg
@@ -9,6 +9,7 @@
 // Include port toggles of all IOs at these hierarchies.
 begin tgl(portsonly)
   +module chip_earlgrey_asic
+  +module ast
   +module padring
   +moduletree top_earlgrey 2
   +moduletree rv_core_ibex 2
@@ -25,13 +26,9 @@ end
 // sub-hierarchies since they are not pre-verified.
 begin line+cond+fsm+branch+assert
   +moduletree padring
-
-  +moduletree clkmgr
-  +moduletree nmi_gen
   +moduletree pinmux
-  +moduletree pwrmgr
-  +moduletree rstmgr
   +moduletree rv_plic
+  +moduletree sensor_ctrl
   +tree tb.dut.top_earlgrey.u_tl_adapter_rom
   +tree tb.dut.top_earlgrey.u_tl_adapter_ram_main
   +tree tb.dut.top_earlgrey.u_tl_adapter_ram_ret

--- a/hw/top_earlgrey/dv/cov/chip_cover_reg_top.cfg
+++ b/hw/top_earlgrey/dv/cov/chip_cover_reg_top.cfg
@@ -4,12 +4,9 @@
 
 // Only cover the `u_reg` instance of un-pre-verified modules.
 -tree *
-+tree tb.dut.top_earlgrey.u_clkmgr.u_reg
-+tree tb.dut.top_earlgrey.u_nmi_gen.u_reg
 +tree tb.dut.top_earlgrey.u_pinmux.u_reg
-+tree tb.dut.top_earlgrey.u_pwrmgr.u_reg
-+tree tb.dut.top_earlgrey.u_rstmgr.u_reg
 +tree tb.dut.top_earlgrey.u_rv_plic.u_reg
++tree tb.dut.top_earlgrey.u_sensor_ctrl_aon.u_reg
 
 // Only cover the TL interface of all sub-modules.
 +node tb.dut top_earlgrey.u_*.tl_*


### PR DESCRIPTION
- Remove clkmgr, pwrmgr and rstmgr from full coverage collection (these
are now verified at the IP level)
- Collect coverage on AST IOs
- Collect full coverage on sensor_ctrl IP since it is not verified at
the IP level

Signed-off-by: Srikrishna Iyer <sriyer@google.com>