### PR TITLE
[otbn] RSA signature verification for 3072-bit keys

### DIFF
--- a/sw/otbn/code-snippets/rsa_verify_3072.s
+++ b/sw/otbn/code-snippets/rsa_verify_3072.s
@@ -1,0 +1,717 @@
+/* Copyright lowRISC Contributors.
+ * Copyright 2016 The Chromium OS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE.dcrypto file.
+ *
+ * Derived from code in
+ * https://chromium.googlesource.com/chromiumos/platform/ec/+/refs/heads/cr50_stab/chip/g/dcrypto/dcrypto_bn.c
+ */
+
+
+.text
+.globl modexp_var
+
+/**
+ * Precomputation of a constant m0' for Montgomery modular arithmetic
+ *
+ * Word-wise Montgomery modular arithmetic requires a quantity m0' to be
+ * precomputed once per modulus M. m0' is the negative of the
+ * modular multiplicative inverse of the lowest limb m0 of the modulus M, in
+ * the field GF(2^w), where w is the number of bits per limb. w is set to 256
+ * in this subroutine.
+ *
+ * Returns: m0' = -m0^(-1) mod 2^256
+ *          with m0 being the lowest limb of the modulus M
+ *
+ * This subroutine implements the Dusse-Kaliski method for computing the
+ * multiplicative modular inverse when the modulus is of the form 2^k.
+ * [Dus] DOI https://doi.org/10.1007/3-540-46877-3_21 section 3.2
+ *       (Algorithm "Modular Inverse" on p. 235)
+ *
+ * Flags: When leaving this subroutine, flags of FG0 depend on a
+ *        the final subtraction and can be used if needed.
+ *        FG0.M, FG0.L, FG0.Z depend directly on the value of the result m0'.
+ *        FG0.C is always set.
+ *        FG1 is not modified in this subroutine.
+ *
+ * @param[in]  x16: dptr_m, pointer to modulus M in dmem
+ * @param[in]  x17: dptr_m0inv, pointer to dmem location to store m0inv
+ * @param[in]  w31: all-zero.
+ *
+ * clobbered registers: x8, w0, w1, w28, w29
+ * clobbered flag groups: FG0
+ */
+compute_m0inv:
+
+  /* load lowest limb of modulus to w28 */
+  li       x8, 28
+  bn.lid   x8, 0(x16)
+
+  /* w0 keeps track of loop iterations in one-hot encoding, i.e.
+     w0 = 2^i in the loop body below and initialized here with w0 = 1
+     It is used for both the comparison in step 4 of [Dus] and the
+     addition in step 6 of [Dus] */
+  bn.xor    w0, w0, w0
+  bn.addi   w0, w0, 1
+
+  /* according to [Dus] the result variable y is initialized with 1 */
+  /* w29 = y_0 = 1 */
+  bn.mov    w29, w0
+
+  /* iterate over all 256 bits of m0.
+     i refers to the loop cycle 0..255 in the loop body below. */
+  loopi     256, 13
+
+    /* y_i <= m*y_{i-1] */
+    bn.mulqacc.z          w28.0, w29.0,  0
+    bn.mulqacc            w28.1, w29.0, 64
+    bn.mulqacc.so   w1.L, w28.0, w29.1, 64
+    bn.mulqacc            w28.2, w29.0,  0
+    bn.mulqacc            w28.1, w29.1,  0
+    bn.mulqacc            w28.0, w29.2,  0
+    bn.mulqacc            w28.3, w29.0, 64
+    bn.mulqacc            w28.2, w29.1, 64
+    bn.mulqacc            w28.1, w29.2, 64
+    bn.mulqacc.so   w1.U, w28.0, w29.3, 64
+
+  /* This checks if w1 = y_i = m0*y_(i-1) < 2^(i-1) mod 2^i
+     Due to the mathematical properties it can be shown that y_i at this point,
+     is either 1 or (10..0..01)_(i). Therefore, just probing the i_th bit is
+     the same as the full compare. */
+    bn.and    w1, w1, w0
+
+    /* Compute
+       y_i=w29 <= w1=m0*y_(i-1) < 2^(i-1) mod 2^i y_i ? : y_{i-1}+2^i : y_{i-1}
+       there cannot be overlaps => or'ing is as good as adding */
+    bn.or     w29, w29, w1
+
+    /* double w0 (w0 <= w0 << 1) i.e. w0=2^i */
+    bn.add    w0, w0, w0
+
+  /* finally, compute m0' (negative of inverse)
+     w29 = m0' = -(m0^-1) mod 2^256 = -y_255 = 0 - y_255 = w31 - w29 */
+  bn.sub    w29, w31, w29
+
+    /* Store Montgomery constant in dmem */
+  li       x8, 29
+  bn.sid   x8, 0(x17)
+
+  ret
+
+
+/**
+ * Variable time multi-limb bigint compare
+ *
+ * Compares two bigints (a, b) located in regfile (a) and dmem (b).
+ *
+ * Flags: When leaving this subroutine, flags of FG1 depend on the comparison
+ *        result of the highest unequal limba, or, if all limbs are equal on
+ *        those of the lowest limbs.
+ *
+ * @param[in] x10: constant 3, used as pointer to w3
+ * @param[in] x11: constant 2, used as pointer to w2
+ * @param[in] x8: rptr_a, pointer to lowest limb of a in regfile
+ * @param[in] x9: rptr_a_h, pointer to highest limb of a in regfile
+ * @param[in] x17: dptr_b_h, pointer to highest limb of b in dmem
+ * @param[out] x3, bit 0: (b > a), equals FG1.C
+ * @param[out] x3, bit 3: (a == b), equals FG1.Z
+ *
+ * clobbered registers: x3, x5, x7, x9, x17, x19, w2, w3
+ * clobbered flag groups: FG1
+ */
+cmp_dmem_reg_buf:
+
+  addi      x19, x17, 0
+  addi      x7, x9, 0
+
+  cmp_loop:
+
+  /* load limbs from dmem and regfile: w2 <= a[i]; w3 <= b[i] */
+  bn.lid    x10, 0(x19)
+  bn.movr   x11, x7
+
+  /* compare limbs and store comparison result in x3 */
+  bn.cmp    w2, w3, FG1
+  csrrs     x3, 0x7c1, x0
+
+  /* leave loop if lowest limb was reached */
+  beq       x8, x7, cmp_end
+
+  /* reduce limb pointers */
+  addi      x19, x19, -32
+  addi      x7, x7, -1
+
+  /* if limbs were equal (FG1.Z == 1), compare next lower limb */
+  andi      x5, x3, 8
+  bne       x5, x0, cmp_loop
+
+  cmp_end:
+  nop
+  ret
+
+
+/**
+* Compute square of Montgomery modulus
+*
+* Returns RR = R^2 mod M
+*         with M being the Modulus of length 256..4096 bit
+*              R = 2^(256*N), N is the number of limbs per bigint
+*
+* The squared Montgomery modulus (RR) is needed to transform bigints to and
+* from the Montgomery domain.
+*
+* RR is computed in this subroutine by iteratively doubling and reduction.
+*
+* Flags: The states of both FG0 and FG1 depend on intermediate values and are
+*        not usable after return.
+*
+* @param[in]  x16: dptr_n, pointer to first limb of modulus in dmem
+* @param[in]  x18: dptr_rr: dmem pointer to first limb of output buffer for RR
+* @param[in]  x30: N, number of limbs
+* @param[in]  x31: N-1, number of limbs minus 1
+* @param[in]  w31: all-zero
+* @param[out] dmem[x18+N*32:x18]: computed RR
+*
+* clobbered registers: x3, x4, x5, x8, x9, x10, x11, x16, x18, x22, x24
+*                      w0, w2, w3, w4, w5 to w20 depending on N
+* clobbered flag groups: FG0, FG1
+*/
+compute_rr:
+  /* save pointer to modulus x22 <= dptr_m = x16 */
+  addi      x22, x16, 0
+
+  /* x17 = dptr_m + (N-1)*32 points to highest limb of modulus in dmem */
+  slli      x17, x31, 5
+  add       x17, x22, x17
+
+  li        x8, 5
+
+  /* x9 = rptr_buf_h <= rptr_buf + N-1 */
+  add       x9, x31, x8
+
+  /* compute full length of current bigint size in bits
+     N*w = x24 <= N*256 = N*2^8 = x30 << 8 */
+  slli      x24, x30, 8
+
+  /* reg pointers to current limb of buffer and modulus
+  /* x10 = rptr_limb_mod = &w3 */
+  li        x10, 3
+  /* x11 = rptr_limb_buf = &w2 */
+  li        x11, 2
+
+
+  /* clear flags */
+  bn.add    w31, w31, w31
+  /* init buffer with R - m
+     buf = w[5+N-1:5] <= R - m = unsigned(0 - m) */
+
+  loop      x30, 3
+    bn.lid    x10, 0(x16++)
+    bn.subb   w3, w31, w3
+    bn.movr   x8++, x10
+
+  /* Compute R^2 mod M = R*2^(N*w) mod M.
+     R^2 mod M can be computed by performing N*w duplications of R,
+     interleaved with conditional subtractions of modulus. Modulus is
+     subtracted if dobiling result is greater than modulus, i.e. either
+     there was a final carry at the end of the doubling procedure or the lower
+     N*w bits of the result are greater than the modulus. */
+  loop      x24, 27
+
+    /* Duplicate the intermediate bigint result. This can overflow such that
+       bit 2^(N*w) (represented by the carry flag after final loop cycle)
+       is set. */
+    li        x8, 5
+    bn.add    w31, w31, w31, FG1
+    loop      x30, 3
+      bn.movr   x11, x8
+      bn.addc   w2, w2, w2, FG1
+      bn.movr   x8++, x11
+
+    /* In case of final carry in doubling procedure substract modulus */
+    /* Jump to 'rr_sub' if FG1.C == 1 */
+    csrrs     x3, 0x7c1, x0
+    andi      x3, x3, 1
+    bne       x3, x0, rr_sub
+
+    /* In case there was no final carry in the addition, we have to check
+       wether the N*w sized bigint w/o carry is greater than the modulus. */
+    bn.lid    x10, 0(x17)
+    bn.movr   x11, x9
+    bn.cmp    w2, w3, FG1
+    csrrs     x3, 0x7c1, x0
+
+    /* If the highest limbs of buf and mod are equal we have to run a
+       multi-limb comparison. This is very unlikely to happen. If this
+       verification is not used with keys where this situation occurs, the
+       following 3 lines and (if not needed elsewhere) the compare routine
+       can be removed. */
+    andi      x5, x3, 8
+    beq       x5, x0, rr_cmp
+    jal       x1, cmp_dmem_reg_buf
+
+    /* if m > r: jump to end_loop (without subtraction) */
+    rr_cmp:
+    andi      x5, x3, 1
+    bne       x5, x0, rr_end_loop
+
+    /* subtract modulus from current buffer
+       buf = w[5+N-1:5] <= buf - m */
+    rr_sub:
+    li        x8, 5
+    addi      x16, x22, 0
+    bn.add    w31, w31, w31, FG1
+    loop      x30, 4
+      bn.lid    x10, 0(x16++)
+      bn.movr   x11, x8
+      bn.subb   w3, w2, w3, FG1
+      bn.movr   x8++, x10
+
+    rr_end_loop:
+      nop
+
+  /* store computed RR in dmem
+     [dmem[dptr_RR+N*32-1]:dmem[dptr_RR]] <= buf = w[5+N-1:5] */
+  li        x8, 5
+  loop      x30, 2
+    bn.sid    x8, 0(x18++)
+    addi      x8, x8, 1
+
+  ret
+
+
+/**
+ * Unrolled 512=256x256 bit multiplication.
+ *
+ * Returns c = a x b.
+ *
+ * Flags: No flags are set in this subroutine
+ *
+ * @param[in] w30: a, first operand
+ * @param[in] w25: b, second operand
+ * @param[out] [w26, w27]: c, result
+ *
+ * clobbered registers: w26, w27
+ * clobbered flag groups: none
+ */
+mul256_w30xw25:
+  bn.mulqacc.z          w30.0, w25.0,  0
+  bn.mulqacc            w30.1, w25.0, 64
+  bn.mulqacc.so  w27.L, w30.0, w25.1, 64
+  bn.mulqacc            w30.2, w25.0,  0
+  bn.mulqacc            w30.1, w25.1,  0
+  bn.mulqacc            w30.0, w25.2,  0
+  bn.mulqacc            w30.3, w25.0, 64
+  bn.mulqacc            w30.2, w25.1, 64
+  bn.mulqacc            w30.1, w25.2, 64
+  bn.mulqacc.so  w27.U, w30.0, w25.3, 64
+  bn.mulqacc            w30.3, w25.1,  0
+  bn.mulqacc            w30.2, w25.2,  0
+  bn.mulqacc            w30.1, w25.3,  0
+  bn.mulqacc            w30.3, w25.2, 64
+  bn.mulqacc.so  w26.L, w30.2, w25.3, 64
+  bn.mulqacc.so  w26.U, w30.3, w25.3,  0
+
+  ret
+
+
+/**
+ * Unrolled 512=256x256 bit multiplication.
+ *
+ * Returns c = a x b.
+ *
+ * Flags: No flags are set in this subroutine
+ *
+ * @param[in] w30: a, first operand
+ * @param[in] w2: b, second operand
+ * @param[out] [w26, w27]: c, result
+ *
+ * clobbered registers: w26, w27
+ * clobbered flag groups: none
+ */
+mul256_w30xw2:
+  bn.mulqacc.z          w30.0, w2.0,  0
+  bn.mulqacc            w30.1, w2.0, 64
+  bn.mulqacc.so  w27.L, w30.0, w2.1, 64
+  bn.mulqacc            w30.2, w2.0,  0
+  bn.mulqacc            w30.1, w2.1,  0
+  bn.mulqacc            w30.0, w2.2,  0
+  bn.mulqacc            w30.3, w2.0, 64
+  bn.mulqacc            w30.2, w2.1, 64
+  bn.mulqacc            w30.1, w2.2, 64
+  bn.mulqacc.so  w27.U, w30.0, w2.3, 64
+  bn.mulqacc            w30.3, w2.1,  0
+  bn.mulqacc            w30.2, w2.2,  0
+  bn.mulqacc            w30.1, w2.3,  0
+  bn.mulqacc            w30.3, w2.2, 64
+  bn.mulqacc.so  w26.L, w30.2, w2.3, 64
+  bn.mulqacc.so  w26.U, w30.3, w2.3,  0
+
+  ret
+
+
+/**
+ * Main loop body for variable-time Montgomery Modular Multiplication
+ *
+ * Returns: C <= (C + A*b_i + M*m0'*(C[0] + A[0]*b_i))/(2^WLEN) mod R
+ *
+ * This implements the main loop body for the Montgomery Modular Multiplication
+ * as well as the conditional subtraction. See e.g. Handbook of Applied
+ * Cryptography (HAC) 14.36 (steps 2.1 and 2.2) and step 3.
+ * This subroutine has to be called for every iteration of the loop in step 2
+ * of HAC 14.36, i.e. once per limb of operand B (x in HAC notation). The limb
+ * is supplied via w2. In the comments below, the index i refers to the
+ * i_th call to this subroutine within one full Montgomery Multiplication run.
+ * Step 3 of HAC 14.36 is replaced by the approach to perform the conditional
+ * subtraction when the intermediate result is larger than R instead of m. See
+ * e.g. https://eprint.iacr.org/2017/1057 section 2.4.2 for a justification.
+ * This does not omit the conditional subtraction.
+ * Variable names of HAC are mapped as follows to the ones used in the
+ * this library: x=B, y=A, A=C, b=2^WLEN, m=M, R=R, m' = m0', n=N.
+ *
+ * Flags: The states of both FG0 and FG1 depend on intermediate values and are
+ *        not usable after return.
+ *
+ * @param[in]  x16: dmem pointer to first limb of modulus M
+ * @param[in]  x19: dmem pointer to first limb operand A
+ * @param[in]  x31: N-1, number of limbs minus one
+ * @param[in]  w2:  current limb of operand B, b_i
+ * @param[in]  w3:  Montgomery constant m0'
+ * @param[in]  w31: all-zero
+ * @param[in]  [w[4+N-1]:w4] intermediate result A
+ * @param[out] [w[4+N-1]:w4] intermediate result A
+ *
+ * clobbered registers: x8, x10, x12, x13, x16, x19
+ *                      w24, w25, w26, w27, w28, w29, w30, w4 to w[4+N-1]
+ * clobbered Flag Groups: FG0, FG1
+ */
+mont_loop:
+  /* save pointer to modulus */
+  addi      x22, x16, 0
+
+  /* pointers to temp. wregs */
+  li        x12, 30
+  li        x13, 24
+
+  /* buffer read pointer */
+  li         x8,  4
+
+  /* buffer write pointer */
+  li        x10,  4
+
+  /* load 1st limb of input y (operand a): w30 = y[0] */
+  bn.lid    x12, 0(x19++)
+
+  /* This is x_i*y_0 in step 2.1 of HAC 14.36 */
+  /* [w26, w27] = w30*w2 = y[0]*x_i */
+  jal x1,   mul256_w30xw2
+
+  /* w24 = w4 = A[0] */
+  bn.movr   x13, x8++
+
+  /* add A[0]: [w29, w30] = [w26, w27] + w24 = y[0]*x_i + A[0] */
+  bn.add    w30, w27, w24
+
+  /* this serves as c_xy in the first cycle of the loop below */
+  bn.addc   w29, w26, w31
+
+  /* w25 = w3 = m0' */
+  bn.mov    w25, w3
+
+  /* multiply by m0', this concludes Step 2.1 of HAC 14.36 */
+  /* [_, u_i] = [w26, w27] = w30*w25 = (y[0]*x_i + A[0])*m0'*/
+  jal       x1, mul256_w30xw25
+
+
+  /* With the computation of u_i, the compuations for a cycle 0 for the loop
+     below are already partly done. The following instructions (until the
+     start of the loop) implement the remaining steps, such that cylce 0 can be
+     omitted in the loop */
+
+  /* [_, u_i] = [w28, w25] = [w26, w27]  */
+  bn.mov    w25, w27
+  bn.mov    w28, w26
+
+  /* w24 = w30 =  y[0]*x_i + A[0] mod b */
+  bn.mov    w24, w30
+
+  /* load first limb of modulus: w30 = m[0] */
+  bn.lid    x12, 0(x16++)
+
+  /* [w26, w27] = w30*w25 = m[0]*u_i*/
+  jal x1,   mul256_w30xw25
+
+  /* [w28, w27] = [w26, w27] + w24 = m[0]*u_i + (y[0]*x_i + A[0] mod b) */
+  bn.add    w27, w27, w24
+  /* this serves as c_m in the first cycle of the loop below */
+  bn.addc   w28, w26, w31
+
+
+  /* This loop implements step 2.2 of HAC 14.36 with a word-by-word approach.
+     The loop body is subdivided into two steps. Each step performs one
+     multiplication and subsequently adds two WLEN sized words to the
+     2WLEN-sized result, such that there are no overflows at the end of each
+     step-
+     Two carry words are required between the cycles. Those are c_xy and c_m.
+     Assume that the variable j runs from 1 to N-1 in the explanations below.
+     A cycle 0 is omitted, since the results from the computations above are
+     re-used */
+  loop      x31, 14
+    /* Step 1: First multiplication takes a limb of each of the operands and
+       computes the product. The carry word from the previous cycle c_xy and
+       the j_th limb of the buffer A, A[j] arre added to the multiplication
+       result.
+
+    /* load limb of y (operand a) and mult. with x_i: [w26, w27] <= y[j]*x_i */
+    bn.lid    x12, 0(x19++)
+    jal       x1, mul256_w30xw2
+    /* add limb of buffer: [w26, w27] <= [w26,w27] + w24 = y[j]*x_i + A[j] */
+    bn.movr   x13, x8++
+    bn.add    w27, w27, w24
+    bn.addc   w26, w26, w31
+    /* add carry word from previous cycle:
+       [c_xy, a_tmp] = [w29, w24] <= [w26,w27] + w29 = y[j]*x_i + A[j] + c_xy*/
+    bn.add    w24, w27, w29
+    bn.addc   w29, w26, w31
+
+
+    /* Step 2:  Second multiplication computes the product of a limb m[j] of
+       the modulus with u_i. The 2nd carry word from the previous loop cycle
+       c_m and the lower word a_tmp of the result of Step 1 are added. */
+
+    /* load limb m[j] of modulus and multiply with u_i:
+       [w26, w27] = w30*w25 = m[j+1]*u_i */
+    bn.lid    x12, 0(x16++)
+    jal       x1, mul256_w30xw25
+    /* add result from first step
+       [w26, w27] <= [w26,w27] + w24 = m[j+1]*u_i + a_tmp */
+    bn.add    w27, w27, w24
+    bn.addc   w26, w26, w31
+    /* [c_m, A[j]] = [w28, w24] = m[j+1]*u_i + a_tmp + c_m */
+    bn.add    w24, w27, w28, FG1
+    /* store at w[4+j] = A[j-1]
+       This includes the reduction by 2^WLEN = 2^b in step 2.2 of HAC 14.36 */
+    bn.movr   x10++, x13
+    bn.addc   w28, w26, w31, FG1
+
+
+  /* Most significant limb of A is sum of the carry words of last loop cycle
+     A[N-1] = w24 <= w29 + w28 = c_xy + c_m */
+  bn.addc   w24, w29, w28, FG1
+  bn.movr   x10++, x13
+
+  /* No subtracion if carry bit of addition of carry words not set. */
+  csrrs     x2, 0x7c1, x0
+  andi      x2, x2, 1
+  beq       x2, x0, mont_loop_no_sub
+
+  /* limb-wise subtraction */
+  li        x12, 30
+  li        x13, 24
+  addi      x16, x22, 0
+  li        x8, 4
+  loop      x30, 4
+    bn.lid    x13, 0(x16++)
+    bn.movr   x12, x8
+    bn.subb   w24, w30, w24
+    bn.movr   x8++, x13
+
+
+  mont_loop_no_sub:
+
+  /* restore pointers */
+  li        x8, 4
+  li        x10, 4
+
+  ret
+
+
+/**
+ * Variable-time Montgomery Modular Multiplication
+ *
+ * Returns: C = montmul(A,B) = A*B*R^(-1) mod M
+ *
+ * This implements the limb-by-limb interleadved Montgomory Modular
+ * Multiplication Algorithm. This is only a wrapper around the main loop body.
+ * For algorithmic implementation details see the mont_loop subroutine.
+ *
+ * Flags: The states of both FG0 and FG1 depend on intermediate values and are
+ *        not usable after return.
+ *
+ * @param[in]  x16: dptr_M, dmem pointer to first limb of modulus M
+ * @param[in]  x17: dptr_m0d, dmem pointer to Montgomery Constant m0'
+ * @param[in]  x19: dptr_a, dmem pointer to first limb of operand A
+ * @param[in]  x20: dptr_b, dmem pointer to first limb of operand B
+ * @param[in]  w31: all-zero
+ * @param[in]  x30: N, number of limbs
+ * @param[in]  x31: N-1, number of limbs minus one
+ * @param[in]  x9: pointer to temp reg, must be set to 3
+ * @param[in]  x10: pointer to temp reg, must be set to 4
+ * @param[in]  x11: pointer to temp reg, must be set to 2
+ * @param[out] [w[4+N-1]:w4]: result C
+ *
+ * clobbered registers: x5, x6, x7, x8, x10, x12, x13, x17, x19, x20, x21
+ *                      w2, w3, w24 to w30, w4 to w[4+N-1]
+ * clobbered Flag Groups: FG0, FG1
+ */
+montmul:
+  /* load Montgomery constant: w3 = dmem[x17] = dmem[dptr_m0d] = m0' */
+  bn.lid    x9, 0(x17)
+
+  /* init regfile bigint buffer with zeros */
+  bn.mov    w2, w31
+  loop      x30, 1
+    bn.movr   x10++, x11
+
+  /* iterate over limbs of operand B */
+  loop      x30, 8
+
+    /* load limb of operand b */
+    bn.lid    x11, 0(x20++)
+
+    /* save some regs */
+    addi      x6, x16, 0
+    addi      x7, x19, 0
+
+    /* Main loop body of Montgomory Multiplication algorithm */
+    jal       x1, mont_loop
+
+    /* restore regs */
+    addi      x16, x6, 0
+    addi      x19, x7, 0
+
+  /* restore pointers */
+  li        x8, 4
+  li        x10, 4
+
+  ret
+
+
+/**
+ * Variable time modular exponentiation with exponent of the form e=2^e'+1
+ *
+ * Returns: C = modexp(A,2^e'+1) = A^(2^e'+1) mod M
+ *
+ * This implements the square and multiply algorithm for exponents of the
+ * form e=2^e'+1. Thus, the routine can be used for exponentiation with Fermat
+ * primes (by setting e'=16 for e=F4=65537 and e'=1 for e=F0=3).
+ *
+ * The squared Montgomery modulus RR and the Montgomery constant m0' have to
+ * be precomputed and provided at the appropriate locations in dmem.
+ *
+ * Flags: The states of both FG0 and FG1 depend on intermediate values and are
+ *        not usable after return.
+ *
+ * The base bignum A is expected in the input buffer, the result C is written
+ * to the output buffer. Note, that the content of the input buffer is
+ * modified during execution.
+ *
+ * @param[in]  dmem[0] e': number for exponent derivation (e = 2^e+1)
+ * @param[in]  dmem[4] N: Number of limbs per bignum
+ * @param[in]  dmem[8] dptr_m0inv: pointer to m0' in dmem
+ * @param[in]  dmem[12] dptr_rr: pointer to RR in dmem
+ * @param[in]  dmem[16] dptr_m: pointer to first limb of modulus M in dmem
+ * @param[in]  dmem[20] dptr_sig: pointer to signature in dmem
+ * @param[in]  dmem[28] dptr_out: pointer to recovered message
+ *
+ * clobbered registers: x2, x5 to x13, x16 to x21, x29, x30, x31
+                        w2, w3, w24 to w31, w4 to w[4+N-1]
+ * clobbered Flag Groups: FG0, FG1
+ */
+modexp_var:
+  /* prepare all-zero reg */
+  bn.xor    w31, w31, w31
+
+  /* load number of limbs (x30 <= N; x31 = N-1 <= N1) */
+  lw        x30, 4(x0)
+  addi      x31, x30, -1
+
+  /* load pointer to modulus (x16 <= dptr_m) */
+  lw        x16, 16(x0)
+
+  /* load pointer to m0' (x17 <= dptr_m0inv)*/
+  lw        x17, 8(x0)
+
+  /* load pointer to RR (x18 <= dptr_rr) */
+  lw        x18, 12(x0)
+
+  /* load exponent (x29 <= e') */
+  lw        x29, 0(x0)
+
+  /* Compute Montgomery constants and reload clobbered pointers */
+  jal       x1, compute_m0inv
+  jal       x1, compute_rr
+  lw        x16, 16(x0)
+  lw        x17, 8(x0)
+  lw        x18, 12(x0)
+
+  /* prepare pointers to temp regs */
+  li         x8, 4
+  li         x9, 3
+  li        x10, 4
+  li        x11, 2
+
+  /* convert signature to Montgomery domain
+     out_buf = *x28 = *dmem[28]
+         <= montmul(*x19, *x20) = montmul(*dptr_sig, *dptr_rr) = sig*R mod M */
+  lw        x19, 20(x0)
+  lw        x20, 12(x0)
+  lw        x21, 28(x0)
+  jal       x1, montmul
+  /* store result in dmem starting at dmem[dptr_out] */
+  loop      x30, 2
+    bn.sid    x8, 0(x21++)
+    addi      x8, x8, 1
+
+  /* 16 consecutive Montgomery squares on the outbut buffer, i.e. after loop:
+     out_buf <= out_buf^65536*R mod M */
+  loop      x29, 8
+    /* out_buf  = *x28 = *dmem[28]
+               <= montmul(*x28, *x20) = montmul(*dptr_out, *dptr_out)
+                = out_buf^2*R mod M */
+    lw        x19, 28(x0)
+    lw        x20, 28(x0)
+    lw        x21, 28(x0)
+    jal       x1, montmul
+    /* Store result in dmem starting at dmem[dptr_out] */
+    loop      x30, 2
+      bn.sid    x8, 0(x21++)
+      addi      x8, x8, 1
+    nop
+
+  /* final multiplication and conversion of result from Montgomery domain
+     out_buf  = *x28 = *dmem[28]
+             <= montmul(*x28, *x20) = montmul(*dptr_sig, *dptr_out)
+              = out_buf*sig/R mod M = sig^65537 mod M */
+  lw        x19, 20(x0)
+  lw        x20, 28(x0)
+  lw        x21, 28(x0)
+  jal       x1, montmul
+
+  /* Final conditional subtraction of modulus if mod >= out_buf. This could
+     be done in variable time, but for the sake of reduced code we use a loop
+     with N cycles. */
+  bn.add    w31, w31, w31
+  li        x17, 16
+  loop      x30, 4
+    bn.movr   x11, x8++
+    bn.lid    x9, 0(x16++)
+    bn.subb   w2, w2, w3
+    bn.movr   x17++, x11
+  csrrs     x2, 0x7c0, x0
+  /* TODO: currently we subtract the modulus if out_buf == M. This should
+            never happen in an RSA context. We could catch this and raise an
+            alert. */
+  andi      x2, x2, 1
+  li        x8, 4
+  bne       x2, x0, no_sub
+  li        x8, 16
+  no_sub:
+
+   /* store result in dmem starting at dmem[dptr_out] */
+  lw        x21, 28(x0)
+  loop      x30, 2
+    bn.sid    x8, 0(x21++)
+    addi      x8, x8, 1
+
+  ret

--- a/sw/otbn/code-snippets/rsa_verify_3072_test.s
+++ b/sw/otbn/code-snippets/rsa_verify_3072_test.s
@@ -1,0 +1,400 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+
+.text
+
+/**
+ * Standalone RSA 1024 encrypt
+ *
+ * Uses OTBN modexp bignum lib to encrypt the message from the .data segment
+ * in this file with the public key consisting of e=65537 and modulus from
+ * .data segment in this file.
+ *
+ * Copies the encrypted message to wide registers for comparison (starting at
+ * w0). See comment at the end of the file for expected values.
+ */
+run_rsa_verify:
+  jal      x1, modexp_var
+  /* pointer to out buffer */
+  lw        x21, 28(x0)
+
+  /* copy all limbs of result to wide reg file */
+  li       x8, 0
+  loop     x30, 2
+    bn.lid   x8, 0(x21++)
+    addi     x8, x8, 1
+
+  ecall
+
+
+.data
+
+/* exponent of the exponent (e') (Full exponent is e=2^e'+1) */
+.word 0x00000010
+
+/* number of limbs (N) */
+.word 0x0000000C
+
+/* pointer to m0' (dptr_m0d) */
+.word 0x00000280
+
+/* pointer to RR (dptr_rr) */
+.word 0x000002c0
+
+/* load pointer to modulus (dptr_m) */
+.word 0x00000080
+
+/* pointer to base bignum buffer (dptr_in) */
+.word 0x000004c0
+
+/* pointer to exponent buffer (dptr_exp, unused for encrypt) */
+.word 0x000006c0
+
+/* pointer to out buffer (dptr_out) */
+.word 0x000008c0
+
+/* Modulus */
+.org 0x80
+.word 0x6a6a75e1
+.word 0xa018ddc5
+.word 0x687bb168
+.word 0x8e8205a5
+.word 0x7dbfffa7
+.word 0xc8722ac5
+.word 0xf84d21cf
+.word 0xe1312531
+.word 0x0ce3f8a3
+.word 0xa825f988
+.word 0x57f51964
+.word 0xb27e206a
+.word 0x8e1dd008
+.word 0x1c4fb8d7
+.word 0x824fb142
+.word 0x1c8be7b3
+.word 0x7b9d6366
+.word 0xc56ad0f2
+.word 0xef762d5b
+.word 0x4b1431e3
+.word 0x8ae28eb9
+.word 0xd41db7aa
+.word 0x43cccdf7
+.word 0x91b74a84
+.word 0x80183850
+.word 0x30e74d0d
+.word 0xb62ed015
+.word 0x235574d2
+.word 0x8c28f251
+.word 0x4f40def2
+.word 0x24e2efdb
+.word 0x9ebd1ff2
+.word 0xfa7b49ee
+.word 0x2819a938
+.word 0x6e66b8c8
+.word 0x24e41546
+.word 0x4d783a7c
+.word 0xd2947d3d
+.word 0x1ab269e9
+.word 0xfad39f16
+.word 0xaab78f7b
+.word 0x49d8b510
+.word 0x35bf0dfb
+.word 0xeb274754
+.word 0x069eccc9
+.word 0xc13c437e
+.word 0xe3bc0f60
+.word 0xc9e0e12f
+.word 0xc253ac43
+.word 0x89c240e0
+.word 0xc4aba4e5
+.word 0xedf34bc0
+.word 0x5402c462
+.word 0x4021b0bd
+.word 0x996b6241
+.word 0xc3d9945f
+.word 0xa137ac60
+.word 0xf0250bf5
+.word 0xc8c7100f
+.word 0xb70d6b88
+.word 0x78916a8c
+.word 0x33370e5d
+.word 0x3970dcb9
+.word 0xaf4c58b4
+.word 0x5f78cb0d
+.word 0xb02d90b7
+.word 0xeb6c3d05
+.word 0x04afc71a
+.word 0x45185f0f
+.word 0x987caa5b
+.word 0x33976249
+.word 0x565afdbc
+.word 0x80a85056
+.word 0x59e07655
+.word 0x9a29e77d
+.word 0x7a8dfb7f
+.word 0x782e0204
+.word 0x4d6713ff
+.word 0x131000ea
+.word 0xe18e1206
+.word 0x21f57f30
+.word 0xf24f038b
+.word 0x59cf874d
+.word 0x24c50525
+.word 0xb52f170d
+.word 0x46c9adde
+.word 0x90e82c73
+.word 0x1344ceaf
+.word 0x663209f2
+.word 0x24bd4fbf
+.word 0x5e4ed04d
+.word 0x0fce770a
+.word 0x81f78793
+.word 0xa792e13e
+.word 0xa6c7bf58
+.word 0xe1df9be8
+
+/* Montgomery constant m0' */
+.org 0x280
+.word 0xf09b71df
+.word 0xfd3e34f7
+.word 0x0b908e3b
+.word 0x95d310b2
+.word 0x49659950
+.word 0xa96ced37
+.word 0x711cad8b
+.word 0x1dfc9779
+.word 0xcdf1cc06
+.word 0x12e25f1f
+.word 0x8f25ef95
+.word 0xc90a2582
+.word 0xbda827cf
+.word 0x1406fb58
+.word 0xadf07cd1
+.word 0x7da9803a
+
+/* Squared Mongomery Radix RR = (2^3072)^2 mod N */
+.org 0x2c0
+.word 0xa3eb77fa
+.word 0x9db9a2ac
+.word 0x2c19d4ae
+.word 0xfb5be1e7
+.word 0xdd38f5fb
+.word 0xd0f4fdda
+.word 0xeb165cd3
+.word 0x546a7cfe
+.word 0xcd410c5c
+.word 0x73f5cf6b
+.word 0x1185bcae
+.word 0xda2e2103
+.word 0xbab5ae26
+.word 0x76e77aba
+.word 0xf49dd5f7
+.word 0x32318a29
+.word 0x689a85bc
+.word 0x8aa862a9
+.word 0x538c240e
+.word 0xb61eab77
+.word 0x9ccd73f2
+.word 0x6563c81a
+.word 0x6c65ac0e
+.word 0x90b209bf
+.word 0xe642e25e
+.word 0x7e351549
+.word 0x879a1830
+.word 0xc75cbb02
+.word 0xe0112362
+.word 0xebc2405f
+.word 0x01dc7990
+.word 0x3d3d07f3
+.word 0xc5b9a5be
+.word 0x98d8cc33
+.word 0xdd65e108
+.word 0xce301343
+.word 0x0dbdc0cb
+.word 0xc204b9ca
+.word 0xeabe1810
+.word 0x9849163a
+.word 0x234c8ff7
+.word 0x9bc14e3b
+.word 0x4b4c2226
+.word 0x079883be
+.word 0xba59c5f5
+.word 0xd9c77317
+.word 0x1ce689f5
+.word 0x05f49af5
+.word 0x7a83d42a
+.word 0xc509b5ca
+.word 0x0811a95f
+.word 0x093520a2
+.word 0x73649941
+.word 0xd9691ef5
+.word 0x6878ec0d
+.word 0x4043add6
+.word 0x7516d8b7
+.word 0x5c7070ff
+.word 0x4ce52e1d
+.word 0xf209e123
+.word 0xfe4319c4
+.word 0x9774620a
+.word 0x7a58d047
+.word 0x524b09b7
+.word 0x96cbf044
+.word 0x2a9044a2
+.word 0x514995dc
+.word 0xe4b83ed6
+.word 0xd21be300
+.word 0x2966d4f8
+.word 0xd9ee19c4
+.word 0xb60788f6
+.word 0xf8d074ab
+.word 0xa7e13295
+.word 0x93718edc
+.word 0xba9fc096
+.word 0x0ad2fbbc
+.word 0x9fe0c363
+.word 0x472a10b4
+.word 0xda9c946b
+.word 0x37276997
+.word 0x04e452fc
+.word 0xd19233b5
+.word 0xa277ef0e
+.word 0x49619ddd
+.word 0xb5822d56
+.word 0x6ca4d02f
+.word 0x7d0c0fc3
+.word 0xa29196e2
+.word 0xb6988a4f
+.word 0x785b7552
+.word 0xeaee3c24
+.word 0x87993424
+.word 0xfcb49693
+.word 0x21e64d84
+.word 0x9e2dcea8
+
+/* signature */
+.org 0x4c0
+.word 0xceb7e983
+.word 0xe693b200
+.word 0xf9153989
+.word 0xcf899599
+.word 0x1ec09fae
+.word 0xf2f88007
+.word 0x2a24eed5
+.word 0x9c5b7c4e
+.word 0x21a153b2
+.word 0xaf7583ae
+.word 0x04fdd694
+.word 0x7550094b
+.word 0xb2a69ac4
+.word 0xe49d8022
+.word 0x7ed6f162
+.word 0x14bb3a1b
+.word 0xbb29d8dd
+.word 0x5c5815c2
+.word 0x7a80d848
+.word 0xb122f449
+.word 0x59dca808
+.word 0xbc1443e2
+.word 0xe304ff93
+.word 0xcc97ee4b
+.word 0x42ef6b57
+.word 0x1436839f
+.word 0xae860b45
+.word 0x6a843a17
+.word 0x2381fb91
+.word 0x09fd0635
+.word 0xa431aac3
+.word 0xd7220269
+.word 0xdf3e2697
+.word 0x35e2915e
+.word 0xedba6956
+.word 0x1d387448
+.word 0x930006df
+.word 0x961e5f00
+.word 0xf2a7e960
+.word 0x884e4add
+.word 0x7dfe76b1
+.word 0x4079aa79
+.word 0x1f3a378d
+.word 0x96c20697
+.word 0x268aea57
+.word 0x2c8569a4
+.word 0x0474f512
+.word 0x2388555c
+.word 0x58679953
+.word 0xe73da3a0
+.word 0x43431b9a
+.word 0x699f04d3
+.word 0xfc0be066
+.word 0xcce606f2
+.word 0xd94cdfa0
+.word 0x6c1ddca3
+.word 0xe96c11f6
+.word 0xfc635db4
+.word 0x3bdb4f69
+.word 0xa621c3e7
+.word 0x9f292111
+.word 0xb86e1e6b
+.word 0xb74f923b
+.word 0x592967a0
+.word 0xc412097f
+.word 0x8c1c8ca7
+.word 0x494fcdb6
+.word 0x87c5fe0f
+.word 0x50c01aee
+.word 0x8a26368e
+.word 0xeaf12232
+.word 0x7dade4d8
+.word 0x39eb2ac6
+.word 0x744f8aaa
+.word 0xf34908ca
+.word 0x1e0c656c
+.word 0xe96d4e29
+.word 0x8575d194
+.word 0xe439bd31
+.word 0xa74a77e3
+.word 0x0f465b88
+.word 0xf4e21152
+.word 0x80400ad8
+.word 0xe58501ec
+.word 0xa29d7536
+.word 0x55c19326
+.word 0x9ebbc63e
+.word 0x20c75aee
+.word 0xef6783d7
+.word 0x59ffdba5
+.word 0x879b937b
+.word 0x43a5c74c
+.word 0x82b8f825
+.word 0xfdf04b3a
+.word 0x8fc62fbe
+.word 0x114e6da5
+
+
+/* Full key for reference:
+   modulus                       n = 0xe1df9be8a6c7bf58a792e13e81f787930fce770a5e4ed04d24bd4fbf663209f21344ceaf90e82c7346c9addeb52f170d24c5052559cf874df24f038b21f57f30e18e1206131000ea4d6713ff782e02047a8dfb7f9a29e77d59e0765580a85056565afdbc33976249987caa5b45185f0f04afc71aeb6c3d05b02d90b75f78cb0daf4c58b43970dcb933370e5d78916a8cb70d6b88c8c7100ff0250bf5a137ac60c3d9945f996b62414021b0bd5402c462edf34bc0c4aba4e589c240e0c253ac43c9e0e12fe3bc0f60c13c437e069eccc9eb27475435bf0dfb49d8b510aab78f7bfad39f161ab269e9d2947d3d4d783a7c24e415466e66b8c82819a938fa7b49ee9ebd1ff224e2efdb4f40def28c28f251235574d2b62ed01530e74d0d8018385091b74a8443cccdf7d41db7aa8ae28eb94b1431e3ef762d5bc56ad0f27b9d63661c8be7b3824fb1421c4fb8d78e1dd008b27e206a57f51964a825f9880ce3f8a3e1312531f84d21cfc8722ac57dbfffa78e8205a5687bb168a018ddc56a6a75e1
+   private exponent              d = 0x6041730707bffad6947efef72cdaa80f6f3e7cb351f2434984bd1a5585ff1006f5d82e3e5a41dee37748ae0c48e91ae93280b58b2fc545335dedf7241d222a045232c1928e20154bc41587cba852eef02aac03ffe25a3638d08adbd2df239b2cd7db29e34097243f19b912be176965e51809b28f51c14c15f6f8cc01a1317052d21ff67343414a06b081276184e66f622d060e8bf987ff5bd36a6e38cc6dd5cb5cdb05a461d485c829c4d1b5352e82b36814f4f4debb08e7fab769ff7e40bb19514af9168c9b773570c58f2c3e177edfe43d4e29ae72329a25d7da234ce73407d2619e5072dffbec1d9601446417d968de1e8772ce4b46fd5224cc0a6ddc889aedec8247de9a6b93f166df6981c487dc111b4eb0ec7bc15782db65570158da4523eab41c7455bd70c72a52e015a7cba482581bed16fef89213158c94f15592482069a742973b55372ced7d20dc9312980ce4696fa4d5715098c927fc12ab013af8df4b83869ef22b53c176f4a83b89cab93ce7f6e619ae0c59d7e511bebf06e3
+   public exponent               e = 65537
+   squared Montgomery radix     RR = 0x9e2dcea821e64d84fcb4969387993424eaee3c24785b7552b6988a4fa29196e27d0c0fc36ca4d02fb5822d5649619ddda277ef0ed19233b504e452fc37276997da9c946b472a10b49fe0c3630ad2fbbcba9fc09693718edca7e13295f8d074abb60788f6d9ee19c42966d4f8d21be300e4b83ed6514995dc2a9044a296cbf044524b09b77a58d0479774620afe4319c4f209e1234ce52e1d5c7070ff7516d8b74043add66878ec0dd9691ef573649941093520a20811a95fc509b5ca7a83d42a05f49af51ce689f5d9c77317ba59c5f5079883be4b4c22269bc14e3b234c8ff79849163aeabe1810c204b9ca0dbdc0cbce301343dd65e10898d8cc33c5b9a5be3d3d07f301dc7990ebc2405fe0112362c75cbb02879a18307e351549e642e25e90b209bf6c65ac0e6563c81a9ccd73f2b61eab77538c240e8aa862a9689a85bc32318a29f49dd5f776e77ababab5ae26da2e21031185bcae73f5cf6bcd410c5c546a7cfeeb165cd3d0f4fddadd38f5fbfb5be1e72c19d4ae9db9a2aca3eb77fa
+   Montgomery constant       d0inv = 0x98a44f84397e684144214c83228ab43e1972189cbba34b5a4edbef91d022772d589d52b3b503299cf32a0c7b9aa9f8ed9c9c366b607da6fdb89991c29ccb146c2a85b6f413e358be5d5dc40e0aa492340f1f6d2a6eb015203f7b91bfe789377dfeed5e6ba3ea7bb2efeb980bce2895730b4b884748224db64040f5917fab212b3e8a289c370861d6760493e5323d6bf82669e60cd77df7f292c7833225f0b060359d1271ff80f3647dd87f7c876d545bdd643fd577de4ec7c80fe2308ecbd78cdaabc95e174c58c3b93cabc138c679a617c756ff3fb6fca8d912be11297cf059830b54188eb1161e1a7476270a3514789414cf662c4e04da7672f3ea877446b2996af70106f38a77aafcc273ff441e5f0fc30d8cef33be30b15cfe44727c0936dc64262c4c771d236ad834fefc6f3228def492fa69ece22f8cdd6115f0a5133e7da9803aadf07cd11406fb58bda827cfc90a25828f25ef9512e25f1fcdf1cc061dfc9779711cad8ba96ced374965995095d310b20b908e3bfd3e34f7f09b71df
+*/
+
+/* Expected recovered message in regfile:
+ w0  = 0x5555555555555555555555555555555555555555555555555555555555555555
+ w1  = 0x5555555555555555555555555555555555555555555555555555555555555555
+ w2  = 0x5555555555555555555555555555555555555555555555555555555555555555
+ w3  = 0x5555555555555555555555555555555555555555555555555555555555555555
+ w4  = 0x5555555555555555555555555555555555555555555555555555555555555555
+ w5  = 0x5555555555555555555555555555555555555555555555555555555555555555
+ w6  = 0x5555555555555555555555555555555555555555555555555555555555555555
+ w7  = 0x5555555555555555555555555555555555555555555555555555555555555555
+ w8  = 0x5555555555555555555555555555555555555555555555555555555555555555
+ w9  = 0x5555555555555555555555555555555555555555555555555555555555555555
+ w10 = 0x5555555555555555555555555555555555555555555555555555555555555555
+ w11 = 0x5555555555555555555555555555555555555555555555555555555555555555
+ w12 = 0x5555555555555555555555555555555555555555555555555555555555555555
+ w13 = 0x5555555555555555555555555555555555555555555555555555555555555555
+ w14 = 0x5555555555555555555555555555555555555555555555555555555555555555
+ w15 = 0x5555555555555555555555555555555555555555555555555555555555555555
+*/

--- a/sw/otbn/code-snippets/rules.mk
+++ b/sw/otbn/code-snippets/rules.mk
@@ -107,6 +107,12 @@ $(otbn-code-snippets-bin-dir)/rsa_verify_test_exp3.elf: \
 $(otbn-code-snippets-bin-dir)/rsa_verify_test_exp3.elf: \
   otbn-libs += $(otbn-code-snippets-obj-dir)/rsa_verify.o
 
+# rsa_verify_3072_test depends on code defined in rsa_verify_3072.s
+$(otbn-code-snippets-bin-dir)/rsa_verify_3072_test.elf: \
+  $(otbn-code-snippets-obj-dir)/rsa_verify_3072.o
+$(otbn-code-snippets-bin-dir)/rsa_verify_3072_test.elf: \
+  otbn-libs += $(otbn-code-snippets-obj-dir)/rsa_verify_3072.o
+
 # p256 curve point test depends on p256isoncurve defined in p256.s
 $(otbn-code-snippets-bin-dir)/p256_isoncurve_test.elf: \
   $(otbn-code-snippets-obj-dir)/p256.o

--- a/util/licence-checker.hjson
+++ b/util/licence-checker.hjson
@@ -67,6 +67,7 @@
     'sw/otbn/code-snippets/modexp.s',
     'sw/otbn/code-snippets/p256.s',
     'sw/otbn/code-snippets/rsa_verify.s',
+    'sw/otbn/code-snippets/rsa_verify_3072.s',
     # Mersenne Twister PRNG
     'sw/device/sca/lib/prng.c',
   ],


### PR DESCRIPTION
This forks the RSA signature verification algorithm to create a dedicated variant for 3072-bit sized keys and the F4 (65537) exponent.

This implements #6566 