### PR TITLE
Avoid premailer 3.9.0 due to API breakage

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -16,7 +16,11 @@ mako
 meson >= 0.53.0, <= 0.56 # minimum matches version in meson.build
 mistletoe>=0.7.2
 mypy
-premailer
+# Premailer 3.9.0 broke the API by introducing an allow_loading_external_files
+# argument that is now mandatory, but didn't exist in previous versions.
+# To relax the constraint we either need to do a runtime detection, or switch all
+# users to a newer version.
+premailer < 3.9.0
 pyelftools
 pyftdi
 pyserial


### PR DESCRIPTION
https://github.com/peterbe/premailer/pull/255 introduced a new, for our
use case mandatory, argument to the constructor. Since this argument
wasn't part of the constructor in 3.8, we need to runtime-detect if
we're running premailer 3.9+ and then set the option.

Let's avoid this version for now and hope upstream sorts it out in a
more backwards-compat way -- or we wait a bit longer and force our users
to use premailer 3.9+.

Fixes #6768