### PR TITLE
[fpga] Reduce number of warnings

### DIFF
--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_clock_gating.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_clock_gating.sv
@@ -14,7 +14,9 @@ module prim_xilinx_clock_gating #(
   if (NoFpgaGate) begin : gen_no_gate
     assign clk_o = clk_i;
   end else begin : gen_gate
-    BUFGCE u_bufgce (
+    BUFGCE #(
+      .SIM_DEVICE("7SERIES")
+    ) u_bufgce (
       .I (clk_i),
       .CE(en_i | test_en_i),
       .O (clk_o)

--- a/hw/top_earlgrey/data/pins_cw310.xdc
+++ b/hw/top_earlgrey/data/pins_cw310.xdc
@@ -82,8 +82,8 @@ set_property -dict { PACKAGE_PIN AF14  IOSTANDARD LVCMOS18 } [get_ports { IO_UPH
 set_property -dict { PACKAGE_PIN P18   IOSTANDARD LVCMOS33 } [get_ports { IO_UPHY_SENSE }]; #USRUSB_VBUS_DETECT
 set_property -dict { PACKAGE_PIN AE15  IOSTANDARD LVCMOS18 } [get_ports { IO_UPHY_OE_N }]; #USRUSB_OE
 set_property -dict { PACKAGE_PIN V17   IOSTANDARD LVCMOS18 } [get_ports { IO_UPHY_D_RX }]; #USRUSB_RCV
-set_property -dict { PACKAGE_PIN AE16  IOSTANDARD LVCMOS18 } [get_ports { IO_UPHY_SPD  }]; #USRUSB_SPD
-set_property -dict { PACKAGE_PIN AF15  IOSTANDARD LVCMOS18 } [get_ports { IO_UPHY_SUS  }]; #USRUSB_SUS
+#set_property -dict { PACKAGE_PIN AE16  IOSTANDARD LVCMOS18 } [get_ports { IO_UPHY_SPD  }]; #USRUSB_SPD
+#set_property -dict { PACKAGE_PIN AF15  IOSTANDARD LVCMOS18 } [get_ports { IO_UPHY_SUS  }]; #USRUSB_SUS
 
 ## Not used - route to header for now?
 set_property -dict { PACKAGE_PIN A10   IOSTANDARD LVCMOS33 } [get_ports { USB_P }]; #USERIOB-19


### PR DESCRIPTION
Remove two critical warnings and a fair amount of normal warnings from the FPGA builds for CW310 and Nexys Video.

Please see the individual commit messsages for more detail.

There are still enough warnings left in the design, but getting the number down helps to see what is actually going on when debugging.