### PR TITLE
[dv/pwrmgr] Add smoke test

### DIFF
--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env.sv
@@ -18,6 +18,10 @@ class pwrmgr_env extends cip_base_env #(
         this, "", "slow_clk_rst_vif", cfg.slow_clk_rst_vif)) begin
       `uvm_fatal(`gfn, "failed to get slow_clk_rst_vif from uvm_config_db")
     end
+    if (!uvm_config_db#(virtual pwrmgr_if)::get(
+        this, "", "pwrmgr_vif", cfg.pwrmgr_vif)) begin
+      `uvm_fatal(`gfn, "failed to get pwrmgr_vif from uvm_config_db")
+    end
 
   endfunction
 

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_cfg.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_cfg.sv
@@ -13,6 +13,7 @@ class pwrmgr_env_cfg extends cip_base_env_cfg #(.RAL_T(pwrmgr_reg_block));
 
   // ext interfaces
   virtual clk_rst_if slow_clk_rst_vif;
+  virtual pwrmgr_if pwrmgr_vif;
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     super.initialize(csr_base_addr);

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
@@ -4,7 +4,7 @@
 //
 // pwrmgr interface.
 
-interface pwrmgr_if(input logic clk, input logic rst_n, input logic rst_slow_n);
+interface pwrmgr_if(input logic clk, input logic rst_n, input logic clk_slow, input logic rst_slow_n);
   import pwrmgr_env_pkg::*;
 
   // Ports to the dut side.
@@ -30,9 +30,9 @@ interface pwrmgr_if(input logic clk, input logic rst_n, input logic rst_slow_n);
 
   lc_ctrl_pkg::lc_tx_t fetch_en;
 
-  logic [pwrmgr_reg_pkg::NumWkups-1:0] wakeups;
+  logic [pwrmgr_reg_pkg::NumWkups-1:0] wakeups_i;
 
-  logic [pwrmgr_reg_pkg::NumRstReqs-1:0] rstreqs;
+  logic [pwrmgr_reg_pkg::NumRstReqs-1:0] rstreqs_i;
 
   logic                  strap;
   logic                  low_power;
@@ -47,17 +47,78 @@ interface pwrmgr_if(input logic clk, input logic rst_n, input logic rst_slow_n);
     pwr_ast_rsp = rsp;
   endfunction
 
+  function automatic void update_ast_main_pok(logic value);
+    pwr_ast_rsp.main_pok = value;
+  endfunction
+
+  function automatic void update_ast_core_clk_val(logic value);
+    pwr_ast_rsp.core_clk_val = value;
+  endfunction
+
+  function automatic void update_ast_io_clk_val(logic value);
+    pwr_ast_rsp.io_clk_val = value;
+  endfunction
+
+  function automatic void update_ast_usb_clk_val(logic value);
+    pwr_ast_rsp.usb_clk_val = value;
+  endfunction
+
+  function automatic void update_clk_status(logic value);
+    pwr_clk_rsp.clk_status = value;
+  endfunction
+
+  function void update_rst_lc_src(int index, logic value);
+    pwr_rst_rsp.rst_lc_src_n[index] = value;
+  endfunction
+
+  function void update_rst_sys_src(int index, logic value);
+    pwr_rst_rsp.rst_sys_src_n[index] = value;
+  endfunction
+
+  function automatic void update_otp_done(logic value);
+    pwr_otp_rsp.otp_done = value;
+  endfunction
+
+  function automatic void update_otp_idle(logic value);
+    pwr_otp_rsp.otp_idle = value;
+  endfunction
+
+  function automatic void update_lc_done(logic value);
+    pwr_lc_rsp.lc_done = value;
+  endfunction
+
+  function automatic void update_lc_idle(logic value);
+    pwr_lc_rsp.lc_idle = value;
+  endfunction
+
+  function automatic void update_flash_idle(logic value);
+    pwr_flash.flash_idle = value;
+  endfunction
+
+  function automatic void update_cpu_sleeping(logic value);
+    pwr_cpu.core_sleeping = value;
+  endfunction
+
+  function automatic void update_wakeups(logic [pwrmgr_reg_pkg::NumWkups-1:0] wakeups);
+    wakeups_i = wakeups;
+  endfunction
+
+  function automatic void update_resets(logic [pwrmgr_reg_pkg::NumRstReqs-1:0] resets);
+    rstreqs_i = resets;
+  endfunction
+
+  // FIXME Move all these initializations to sequences.
   initial begin
     // From AST.
-    pwr_ast_rsp = pwrmgr_pkg::PWR_AST_RSP_DEFAULT;
-    pwr_rst_rsp = pwrmgr_pkg::PWR_RST_RSP_DEFAULT;
+    pwr_ast_rsp = '{default: '0};
+    pwr_rst_rsp = '{default: '0};
     pwr_clk_rsp.clk_status = 1'b0;
-    pwr_otp_rsp = pwrmgr_pkg::PWR_OTP_RSP_DEFAULT;
-    pwr_lc_rsp = pwrmgr_pkg::PWR_LC_RSP_DEFAULT;
-    pwr_flash = pwrmgr_pkg::PWR_FLASH_DEFAULT;
+    pwr_otp_rsp = '{default: '0};
+    pwr_lc_rsp =  '{default: '0};
+    pwr_flash =   '{default: '0};
     pwr_cpu = pwrmgr_pkg::PWR_CPU_DEFAULT;
-    wakeups = pwrmgr_pkg::WAKEUPS_DEFAULT;
-    rstreqs = pwrmgr_pkg::RSTREQS_DEFAULT;
+    wakeups_i = pwrmgr_pkg::WAKEUPS_DEFAULT;
+    rstreqs_i = pwrmgr_pkg::RSTREQS_DEFAULT;
     rom_ctrl = rom_ctrl_pkg::PWRMGR_DATA_DEFAULT;
     esc_rst_tx = prim_esc_pkg::ESC_TX_DEFAULT;
   end

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -55,7 +55,6 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
     if (addr_phase_write) begin
       `uvm_info(`gfn, $sformatf("Writing 0x%x to %s", item.a_data, csr.get_full_name()), UVM_LOW)
       void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
-      $finish();
     end
 
     // process the csr req

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -10,6 +10,137 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   );
   `uvm_object_utils(pwrmgr_base_vseq)
 
+  localparam int ActiveTimeoutInNanoSeconds = 4_000;
+  localparam int PropagationToSlowTimeoutInNanoSeconds = 15_000;
+
+  rand int cycles_before_pwrok;
+  rand int cycles_before_clks_ok;
+  rand int cycles_between_clks_ok;
+  rand int cycles_before_clk_status_on;
+  rand int cycles_before_clk_status_off;
+  rand int cycles_before_rst_lc_src;
+  rand int cycles_before_otp_done;
+  rand int cycles_before_lc_done;
+  rand int cycles_before_wakeup;
+  rand int cycles_before_core_clk_en;
+  rand int cycles_before_io_clk_en;
+  rand int cycles_before_usb_clk_en;
+  rand int cycles_before_main_pd_n;
+
+  constraint cycles_before_pwrok_c { cycles_before_pwrok inside {[3:10]}; }
+  constraint cycles_before_clks_ok_c { cycles_before_clks_ok inside {[3:10]}; }
+  constraint cycles_between_clks_ok_c { cycles_between_clks_ok inside {[3:10]}; }
+  constraint cycles_before_clk_status_on_c { cycles_before_clk_status_on inside {[0:4]}; }
+  constraint cycles_before_clk_status_off_c { cycles_before_clk_status_off inside {[0:4]}; }
+  constraint cycles_before_rst_lc_src_base_c { cycles_before_rst_lc_src inside {[0:4]}; }
+  constraint cycles_before_otp_done_base_c { cycles_before_otp_done inside {[0:4]}; }
+  constraint cycles_before_lc_done_base_c { cycles_before_lc_done inside {[0:4]}; }
+  constraint cycles_before_wakeup_c { cycles_before_wakeup inside {[2:6]}; }
+  constraint cycles_before_core_clk_en_c { cycles_before_core_clk_en inside {[2:6]}; }
+  constraint cycles_before_io_clk_en_c { cycles_before_io_clk_en inside {[2:6]}; }
+  constraint cycles_before_usb_clk_en_c { cycles_before_usb_clk_en inside {[2:6]}; }
+  constraint cycles_before_main_pd_n_c { cycles_before_main_pd_n inside {[2:6]}; }
+
+  // This rstmgr response enables the fast fsm to proceed from a reset.
+  task assert_rstmgr_resets();
+    staged_update_rst_lc_src('0);
+    staged_update_rst_sys_src('0);
+  endtask
+
+  task staged_update_rst_lc_src(logic [pwrmgr_pkg::PowerDomains-1:0] value);
+    for (int i = 0; i < pwrmgr_pkg::PowerDomains; ++i) begin
+      @cfg.clk_rst_vif.cb;
+      cfg.pwrmgr_vif.update_rst_lc_src(i, value[i]);
+    end
+  endtask
+
+  task staged_update_rst_sys_src(logic [pwrmgr_pkg::PowerDomains-1:0] value);
+    for (int i = 0; i < pwrmgr_pkg::PowerDomains; ++i) begin
+      @cfg.clk_rst_vif.cb;
+      cfg.pwrmgr_vif.update_rst_sys_src(i, value[i]);
+    end
+  endtask
+
+  // This sets input sequence to start the slow fsm till it requests the fast fsm
+  // to wake up from low power. If the sequence is not followed the slow fsm just waits
+  // so it is not useful to change it. The delays setting the inputs are randomized
+  // for good measure.
+  task start_slow_fsm();
+    cfg.slow_clk_rst_vif.wait_clks(cycles_before_pwrok);
+    cfg.pwrmgr_vif.update_ast_main_pok(1'b1);
+    cfg.slow_clk_rst_vif.wait_clks(cycles_before_clks_ok);
+    cfg.pwrmgr_vif.update_ast_core_clk_val(1'b1);
+    cfg.slow_clk_rst_vif.wait_clks(cycles_between_clks_ok);
+    cfg.pwrmgr_vif.update_ast_io_clk_val(1'b1);
+    cfg.slow_clk_rst_vif.wait_clks(cycles_between_clks_ok);
+    cfg.pwrmgr_vif.update_ast_usb_clk_val(1'b1);
+  endtask
+
+  task start_fast_from_low_power();
+    cfg.clk_rst_vif.wait_clks(cycles_before_clk_status_on);
+    cfg.pwrmgr_vif.update_clk_status(1'b1);
+    cfg.clk_rst_vif.wait_clks(cycles_before_rst_lc_src);
+    staged_update_rst_lc_src('1);
+    cfg.clk_rst_vif.wait_clks(cycles_before_otp_done);
+    cfg.pwrmgr_vif.update_otp_done(1'b1);
+    cfg.clk_rst_vif.wait_clks(cycles_before_lc_done);
+    cfg.pwrmgr_vif.update_lc_done(1'b1);
+    // Soon after this clr_cfg_lock_o and wkup_o are asserted in fast fsm.
+  endtask
+
+  // This sends the fast fsm to low power after the transition is enabled by software
+  // and cpu WFI.
+  // FIXME Allow some units not being idle to defeat or postpone transition to low power.
+  virtual task fast_to_low_power();
+    cfg.pwrmgr_vif.update_otp_idle(1'b1);
+    cfg.pwrmgr_vif.update_lc_idle(1'b1);
+    cfg.pwrmgr_vif.update_flash_idle(1'b1);
+    cfg.clk_rst_vif.wait_clks(cycles_before_clk_status_off);
+    cfg.pwrmgr_vif.update_clk_status(1'b0);
+  endtask
+
+  // Orchestrates the ast turning clocks off as required by the slow fsm going to low power.
+  task turn_clocks_off_for_slow_to_low_power();
+    fork
+      if (!ral.control.core_clk_en.get_mirrored_value()) begin
+        wait (!cfg.pwrmgr_vif.pwr_ast_req.core_clk_en);
+        cfg.clk_rst_vif.wait_clks(cycles_before_core_clk_en);
+        cfg.pwrmgr_vif.update_ast_core_clk_val(1'b0);
+      end
+      if (!ral.control.io_clk_en.get_mirrored_value()) begin
+        wait (!cfg.pwrmgr_vif.pwr_ast_req.io_clk_en);
+        cfg.clk_rst_vif.wait_clks(cycles_before_io_clk_en);
+        cfg.pwrmgr_vif.update_ast_io_clk_val(1'b0);
+      end
+      if (!ral.control.usb_clk_en_lp.get_mirrored_value()) begin
+        wait (!cfg.pwrmgr_vif.pwr_ast_req.usb_clk_en);
+        cfg.clk_rst_vif.wait_clks(cycles_before_usb_clk_en);
+        cfg.pwrmgr_vif.update_ast_usb_clk_val(1'b0);
+      end
+      if (!ral.control.main_pd_n.get_mirrored_value()) begin
+        wait (!cfg.pwrmgr_vif.pwr_ast_req.main_pd_n);
+        cfg.slow_clk_rst_vif.wait_clks(cycles_before_main_pd_n);
+        cfg.pwrmgr_vif.update_ast_main_pok(1'b0);
+      end
+    join
+    `uvm_info(`gfn, "Requested clocks are turned off.", UVM_LOW)
+  endtask
+
+  // Waits for the fast fsm becoming active after SW initiated low power, indicated by reading 1
+  // from the ctrl_cfg_regwen CSR.
+  task wait_for_fast_fsm_active();
+    csr_spinwait(.ptr(ral.ctrl_cfg_regwen), .exp_data(1'b1),
+                 .timeout_ns(ActiveTimeoutInNanoSeconds));
+    `uvm_info(`gfn, "pwrmgr fast fsm active", UVM_MEDIUM)
+  endtask
+
+  task wait_for_csr_to_propagate_to_slow_domain();
+    csr_wr(.ptr(ral.cfg_cdc_sync), .value(1'b1));
+    csr_spinwait(.ptr(ral.cfg_cdc_sync), .exp_data(1'b0),
+                 .timeout_ns(PropagationToSlowTimeoutInNanoSeconds));
+    `uvm_info(`gfn, "CSR updates made it to the slow domain", UVM_LOW)
+  endtask
+
   // various knobs to enable certain routines
   bit do_pwrmgr_init = 1'b1;
 

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_smoke_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_smoke_vseq.sv
@@ -2,14 +2,85 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// The smoke test brings the pwrmgr through a POR reset, followed by a low
+// power sequence, followed by reset.
+
 // smoke test vseq
 class pwrmgr_smoke_vseq extends pwrmgr_base_vseq;
   `uvm_object_utils(pwrmgr_smoke_vseq)
 
   `uvm_object_new
+  constraint cycles_before_rst_lc_src_c { cycles_before_rst_lc_src inside {[1:2]}; }
+  constraint cycles_before_otp_done_c { cycles_before_otp_done inside {[1:2]}; }
+  constraint cycles_before_lc_done_c { cycles_before_lc_done inside {[1:2]}; }
+
+  rand bit [pwrmgr_reg_pkg::NumWkups-1:0] wakeups;
+  rand bit [pwrmgr_reg_pkg::NumRstReqs-1:0] resets;
+
+  constraint wakeups_c { wakeups != 0; }
+  constraint resets_c { resets != 0; }
+
+  task wait_for_reset_cause(pwrmgr_pkg::reset_cause_e cause);
+    wait (cfg.pwrmgr_vif.pwr_rst_req.reset_cause == cause);
+    `uvm_info(`gfn, $sformatf("Observed reset cause_match 0x%x", cause), UVM_MEDIUM)
+  endtask
 
   task body();
-    `uvm_error(`gfn, "FIXME")
-  endtask : body
+    logic [TL_DW-1:0] value;
+    bit [pwrmgr_reg_pkg::NumWkups-1:0] wakeup_en;
+    bit [pwrmgr_reg_pkg::NumRstReqs-1:0] reset_en;
+    cfg.slow_clk_rst_vif.wait_for_reset(.wait_negedge(0));
+    start_slow_fsm();
+    start_fast_from_low_power();
+    cfg.slow_clk_rst_vif.wait_clks(10);
+
+    wait_for_fast_fsm_active();
+    csr_rd_check(.ptr(ral.wake_status), .compare_value(0));
+    csr_rd_check(.ptr(ral.reset_status), .compare_value(0));
+
+    // Enable all wakeups so a peripheral can cause a wakeup.
+    wakeup_en = '1;
+    csr_wr(.ptr(ral.wakeup_en), .value(wakeup_en));
+    wait_for_csr_to_propagate_to_slow_domain();
+
+    // Initiate low power transition.
+    csr_wr(.ptr(ral.control.low_power_hint), .value(1'b1));
+    cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
+    fast_to_low_power();
+    turn_clocks_off_for_slow_to_low_power();
+    wait_for_reset_cause(pwrmgr_pkg::LowPwrEntry);
+
+    // Now bring it back.
+    cfg.clk_rst_vif.wait_clks(cycles_before_wakeup);
+    cfg.pwrmgr_vif.update_wakeups(wakeups);
+
+    start_slow_fsm();
+    start_fast_from_low_power();
+    cfg.slow_clk_rst_vif.wait_clks(10);
+
+    wait_for_fast_fsm_active();
+
+    csr_rd_check(.ptr(ral.wake_status), .compare_value(wakeups & wakeup_en));
+    csr_rd_check(.ptr(ral.reset_status), .compare_value(0));
+
+    // Enable resets.
+    reset_en = '1;
+    csr_wr(.ptr(ral.reset_en), .value(reset_en));
+    wait_for_csr_to_propagate_to_slow_domain();
+
+    // Trigger a reset.
+    cfg.pwrmgr_vif.update_resets(resets);
+    cfg.slow_clk_rst_vif.wait_clks(2);
+    fast_to_low_power();
+    wait_for_reset_cause(pwrmgr_pkg::HwReq);
+
+    // Now bring it back: the slow fsm doesn't participate on this.
+    assert_rstmgr_resets();
+    start_fast_from_low_power();
+    cfg.slow_clk_rst_vif.wait_clks(10);
+
+    csr_rd_check(.ptr(ral.wake_status), .compare_value(wakeups & wakeup_en));
+    csr_rd_check(.ptr(ral.reset_status), .compare_value(resets & reset_en));
+  endtask
 
 endclass : pwrmgr_smoke_vseq

--- a/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -57,6 +57,7 @@
     {
       name: pwrmgr_smoke
       uvm_test_seq: pwrmgr_smoke_vseq
+      run_opts: ["+test_timeout_ns=100000"]
     }
 
     // TODO: add more tests here

--- a/hw/ip/pwrmgr/dv/tb.sv
+++ b/hw/ip/pwrmgr/dv/tb.sv
@@ -25,7 +25,7 @@ module tb;
   pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
 
-  pwrmgr_if pwrmgr_intf(clk, rst_n, rst_slow_n);
+  pwrmgr_if pwrmgr_if(clk, rst_n, clk_slow, rst_slow_n);
 
   // dut
   pwrmgr dut (
@@ -37,37 +37,37 @@ module tb;
     .tl_i                 (tl_if.h2d),
     .tl_o                 (tl_if.d2h),
 
-    .pwr_ast_i            (pwrmgr_intf.pwr_ast_rsp),
-    .pwr_ast_o            (pwrmgr_intf.pwr_ast_req),
+    .pwr_ast_i            (pwrmgr_if.pwr_ast_rsp),
+    .pwr_ast_o            (pwrmgr_if.pwr_ast_req),
 
-    .pwr_rst_i            (pwrmgr_intf.pwr_rst_rsp),
-    .pwr_rst_o            (pwrmgr_intf.pwr_rst_req),
+    .pwr_rst_i            (pwrmgr_if.pwr_rst_rsp),
+    .pwr_rst_o            (pwrmgr_if.pwr_rst_req),
 
-    .pwr_clk_i            (pwrmgr_intf.pwr_clk_rsp),
-    .pwr_clk_o            (pwrmgr_intf.pwr_clk_req),
+    .pwr_clk_i            (pwrmgr_if.pwr_clk_rsp),
+    .pwr_clk_o            (pwrmgr_if.pwr_clk_req),
 
-    .pwr_otp_i            (pwrmgr_intf.pwr_otp_rsp),
-    .pwr_otp_o            (pwrmgr_intf.pwr_otp_req),
+    .pwr_otp_i            (pwrmgr_if.pwr_otp_rsp),
+    .pwr_otp_o            (pwrmgr_if.pwr_otp_req),
 
-    .pwr_lc_i             (pwrmgr_intf.pwr_lc_rsp ),
-    .pwr_lc_o             (pwrmgr_intf.pwr_lc_req ),
+    .pwr_lc_i             (pwrmgr_if.pwr_lc_rsp ),
+    .pwr_lc_o             (pwrmgr_if.pwr_lc_req ),
 
-    .pwr_flash_i          (pwrmgr_intf.pwr_flash  ),
-    .pwr_cpu_i            (pwrmgr_intf.pwr_cpu    ),
+    .pwr_flash_i          (pwrmgr_if.pwr_flash  ),
+    .pwr_cpu_i            (pwrmgr_if.pwr_cpu    ),
 
-    .fetch_en_o           (pwrmgr_intf.fetch_en   ),
-    .wakeups_i            (pwrmgr_intf.wakeups    ),
-    .rstreqs_i            (pwrmgr_intf.rstreqs    ),
+    .fetch_en_o           (pwrmgr_if.fetch_en   ),
+    .wakeups_i            (pwrmgr_if.wakeups_i  ),
+    .rstreqs_i            (pwrmgr_if.rstreqs_i  ),
 
-    .strap_o              (pwrmgr_intf.strap      ),
-    .low_power_o          (pwrmgr_intf.low_power  ),
+    .strap_o              (pwrmgr_if.strap      ),
+    .low_power_o          (pwrmgr_if.low_power  ),
 
-    .rom_ctrl_i           (pwrmgr_intf.rom_ctrl   ),
+    .rom_ctrl_i           (pwrmgr_if.rom_ctrl   ),
 
-    .esc_rst_tx_i         (pwrmgr_intf.esc_rst_tx ),
-    .esc_rst_rx_o         (pwrmgr_intf.esc_rst_rx ),
+    .esc_rst_tx_i         (pwrmgr_if.esc_rst_tx ),
+    .esc_rst_rx_o         (pwrmgr_if.esc_rst_rx ),
 
-    .intr_wakeup_o        (pwrmgr_intf.intr_wakeup)
+    .intr_wakeup_o        (pwrmgr_if.intr_wakeup)
   );
 
   initial begin
@@ -77,8 +77,9 @@ module tb;
 
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "slow_clk_rst_vif", slow_clk_rst_if);
-    uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
+    uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
+    uvm_config_db#(virtual pwrmgr_if)::set(null, "*.env", "pwrmgr_vif", pwrmgr_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();

--- a/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
@@ -91,7 +91,7 @@ package pwrmgr_pkg;
     logic ip_clk_en;
   } pwr_clk_req_t;
 
-  // clkmgr to powrmgr
+  // clkmgr to pwrmgr
   typedef struct packed {
     logic clk_status;
   } pwr_clk_rsp_t;


### PR DESCRIPTION
Add smoke test that brings pwrmgr up from POR, drives it to
low power and back, and to reset and back.

Signed-off-by: Guillermo Maturana <maturana@google.com>