### PR TITLE
 [pwm, rtl] Support all pwm operational modes

### DIFF
--- a/hw/ip/pwm/rtl/pwm_core.sv
+++ b/hw/ip/pwm/rtl/pwm_core.sv
@@ -108,6 +108,7 @@ module pwm_core #(
       .phase_ctr_i      (phase_ctr_q),
       .clr_blink_cntr_i (clr_blink_cntr[ii]),
       .cycle_end_i      (cycle_end),
+      .dc_resn_i        (dc_resn_sync),
       .pwm_o            (pwm_o[ii])
     );
 


### PR DESCRIPTION
Add RTL design for PWM IP

- Completed the RTL design of standard blink mode and heartbeat mode for the PWM IP
- Fixed the bug for issue #6526

Signed-off-by: Muqing Liu muqing.liu@wdc.com
