### PR TITLE
[dvsim] Separate publish report from dvsim flow [PART1]

### DIFF
--- a/util/dvsim/FormalCfg.py
+++ b/util/dvsim/FormalCfg.py
@@ -272,16 +272,11 @@ class FormalCfg(OneShotCfg):
         if messages is not None:
             results_str += self.parse_dict_to_str(messages)
 
-        # Write results to the scratch area
         self.results_md = results_str
-        results_file = self.scratch_path + "/results_" + self.timestamp + ".md"
-        with open(results_file, 'w') as f:
-            f.write(self.results_md)
 
         # Generate result summary
         self.result_summary[self.name] = summary
 
-        log.log(VERBOSE, "[results page]: [%s] [%s]", self.name, results_file)
         return self.results_md
 
     def _publish_results(self):

--- a/util/dvsim/LintCfg.py
+++ b/util/dvsim/LintCfg.py
@@ -218,10 +218,4 @@ class LintCfg(OneShotCfg):
             self.email_results_md = self.results_md
             self.publish_results_md = self.results_md
 
-        # Write results to the scratch area
-        results_file = self.scratch_path + "/results_" + self.timestamp + ".md"
-        with open(results_file, 'w') as f:
-            f.write(self.results_md)
-
-        log.log(VERBOSE, "[results page]: [%s] [%s]", self.name, results_file)
         return self.results_md

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -671,14 +671,6 @@ class SimCfg(FlowCfg):
             results_str += "\n".join(create_bucket_report(results.buckets))
 
         self.results_md = results_str
-
-        # Write results to the scratch area
-        results_path = self.scratch_path + "/results_" + self.timestamp + ".md"
-        with open(results_path, 'w') as results_file:
-            results_file.write(self.results_md)
-
-        # Return only the tables
-        log.log(VERBOSE, "[results page]: [%s] [%s]", self.name, results_path)
         return results_str
 
     def gen_results_summary(self):

--- a/util/dvsim/SynCfg.py
+++ b/util/dvsim/SynCfg.py
@@ -392,10 +392,4 @@ class SynCfg(OneShotCfg):
             # TODO: add support for pie / bar charts for area splits and
             # QoR history
 
-        # Write results to the scratch area
-        results_file = self.scratch_path + "/results_" + self.timestamp + ".md"
-        with open(results_file, 'w') as f:
-            f.write(self.results_md)
-
-        log.log(VERBOSE, "[results page]: [%s] [%s]", self.name, results_file)
         return self.results_md

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -555,6 +555,20 @@ def rm_path(path, ignore_error=False):
             raise exc
 
 
+def mk_path(path):
+    '''Create the specified path if it does not exist.
+
+    'path' is a Path-like object. If it does exist, the function simply
+    returns. If it does not exist, the function creates the path and its
+    parent dictories if necessary.
+    '''
+    try:
+        Path(path).mkdir(parents=True, exist_ok=True)
+    except PermissionError as e:
+        log.fatal("Failed to create dirctory {}:\n{}.".format(path, e))
+        sys.exit(1)
+
+
 def clean_odirs(odir, max_odirs, ts_format=TS_FORMAT):
     """Clean previous output directories.
 


### PR DESCRIPTION
This PR is the first part of moving publish report to a separate script.
This PR moves the generated results into a separate /scratch_root/report
folder.
The result summary will be located at: /scratch_root/{branch}/report
The individual summary will be located at: /scratch_path/report

I also update the --purge option so it won't delete the report folders.

For output results, this PR modifies the dvsim to output:
1. results_{date-time}.html
2. publish_results_{date-time}.html (different from the previous file, this one has a URL link to all previous published results)
3. summary_{data-time}.html 

Signed-off-by: Cindy Chen <chencindy@opentitan.org>