### PR TITLE
[otp_ctrl/lc_ctrl] Add LC TAP register to control OTP test mechanisms

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -80,6 +80,12 @@
       default: "2",
       local:   "true"
     }
+    { name:    "CsrOtpTestCtrlWidth",
+      desc:    "Number of vendor/test specific OTP control bits.",
+      type:    "int"
+      default: "8",
+      local:   "true"
+    }
     { name:    "NumDeviceIdWords",
       desc:    "Number of 32bit words in the Device ID.",
       type:    "int"
@@ -557,7 +563,33 @@
         }
       ]
     }
-
+    //////////////////////////////////
+    // Vendor Specific OTP Settings //
+    //////////////////////////////////
+    { name: "OTP_TEST_CTRL",
+      desc: '''
+      Test/vendor-specific settings for the OTP macro wrapper.
+      These values are only active during RAW, TEST_* and RMA life cycle states.
+      In all other states, these values will be gated to zero before sending
+      them to the OTP macro wrapper - even if this register is programmed to a non-zero value.
+      ''',
+      swaccess: "rw",
+      hwaccess: "hrw",
+      hwqe:     "true",
+      hwext:    "true",
+      regwen:   "TRANSITION_REGWEN",
+      tags: [ // To update this register, SW needs to claim the associated hardware mutex via
+              // CLAIM_TRANSITION_IF, so can not auto predict its value.
+              "excl:CsrNonInitTests:CsrExclCheck"],
+      fields: [
+        { bits: "CsrOtpTestCtrlWidth-1:0",
+          name: "VAL",
+          desc: '''
+          Settings defined by vendor.
+          '''
+        }
+      ]
+    }
     //////////////////
     // LC State CSR //
     //////////////////

--- a/hw/ip/lc_ctrl/doc/_index.md
+++ b/hw/ip/lc_ctrl/doc/_index.md
@@ -587,7 +587,7 @@ To arbitrate between the two, a hardware mutex needs to be obtained before eithe
 The hardware mutex internally acts as a mux to block off the unselected path and all accesses to the request interface are blocked until it is claimed.
 If two requests arrive simultaneously, the TAP interface is given priority.
 
-The request interface consists of 4 registers:
+The request interface consists of 5 registers:
 
 1. {{< regref "TRANSITION_TARGET" >}}: Specifies the target state to which the agent wants to transition.
 2. {{< regref "TRANSITION_TOKEN_*" >}}: Any necessary token for conditional transitions.
@@ -605,6 +605,13 @@ If the value is not read back, then the requesting interface should wait and try
 
 When an agent is done with the mutex, it releases the mutex by explicitly writing a 0 to the claim register.
 This resets the mux to select no one and also holds the request interface in reset.
+
+#### Vendor-specific Test Control Register
+
+Certain OTP macros require special configuration bits to be set during the test phases.
+Hence, the life cycle CSRs include register {{< regref "OTP_TEST_CTRL" >}}, which is reserved for vendor-specific test control bits.
+Its value is only forwarded to the OTP macro in RAW, TEST_* and RMA life cycle states.
+In all other life cycle states, a value of 0 will be sent to the OTP macro.
 
 ### TAP Construction and Isolation
 

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -19,6 +19,9 @@ module tb;
   wire devmode;
   wire [LcPwrIfWidth-1:0] pwr_lc;
 
+  // TODO: need to connect this properly
+  wire [OtpTestCtrlWidth-1:0] otp_test_ctrl;
+
   // interfaces
   clk_rst_if   clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if      #(1) devmode_if(devmode);
@@ -93,7 +96,7 @@ module tb;
     .pwr_lc_i                   (pwr_lc[LcPwrInitReq]),
     .pwr_lc_o                   (pwr_lc[LcPwrDoneRsp:LcPwrIdleRsp]),
 
-    .lc_otp_program_o           ({otp_prog_if.req, otp_prog_if.h_data}),
+    .lc_otp_program_o           ({otp_prog_if.req, otp_prog_if.h_data, otp_test_ctrl}),
     .lc_otp_program_i           ({otp_prog_if.d_data, otp_prog_if.ack}),
 
     .kmac_data_i                (kmac_data_in),

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
@@ -58,6 +58,8 @@ module lc_ctrl_fsm
   output logic                  flash_rma_error_o,
   output logic                  otp_prog_error_o,
   output logic                  state_invalid_error_o,
+  // Local life cycle signal
+  output lc_tx_t                lc_test_or_rma_o,
   // Life cycle broadcast outputs.
   output lc_tx_t                lc_dft_en_o,
   output lc_tx_t                lc_nvm_debug_en_o,
@@ -507,6 +509,7 @@ module lc_ctrl_fsm
     .lc_id_state_i      ( lc_id_state_q    ),
     .fsm_state_i        ( fsm_state_q      ),
     .esc_wipe_secrets_i,
+    .lc_test_or_rma_o,
     .lc_dft_en_o,
     .lc_nvm_debug_en_o,
     .lc_hw_debug_en_o,

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
@@ -11,6 +11,7 @@ package lc_ctrl_reg_pkg;
   parameter int CsrLcStateWidth = 4;
   parameter int CsrLcCountWidth = 5;
   parameter int CsrLcIdStateWidth = 2;
+  parameter int CsrOtpTestCtrlWidth = 8;
   parameter int NumDeviceIdWords = 8;
   parameter int NumAlerts = 2;
 
@@ -51,6 +52,11 @@ package lc_ctrl_reg_pkg;
     logic [3:0]  q;
     logic        qe;
   } lc_ctrl_reg2hw_transition_target_reg_t;
+
+  typedef struct packed {
+    logic [7:0]  q;
+    logic        qe;
+  } lc_ctrl_reg2hw_otp_test_ctrl_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -99,6 +105,10 @@ package lc_ctrl_reg_pkg;
   } lc_ctrl_hw2reg_transition_target_reg_t;
 
   typedef struct packed {
+    logic [7:0]  d;
+  } lc_ctrl_hw2reg_otp_test_ctrl_reg_t;
+
+  typedef struct packed {
     logic [3:0]  d;
   } lc_ctrl_hw2reg_lc_state_reg_t;
 
@@ -116,20 +126,22 @@ package lc_ctrl_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    lc_ctrl_reg2hw_alert_test_reg_t alert_test; // [151:148]
-    lc_ctrl_reg2hw_claim_transition_if_reg_t claim_transition_if; // [147:139]
-    lc_ctrl_reg2hw_transition_cmd_reg_t transition_cmd; // [138:137]
-    lc_ctrl_reg2hw_transition_token_mreg_t [3:0] transition_token; // [136:5]
-    lc_ctrl_reg2hw_transition_target_reg_t transition_target; // [4:0]
+    lc_ctrl_reg2hw_alert_test_reg_t alert_test; // [160:157]
+    lc_ctrl_reg2hw_claim_transition_if_reg_t claim_transition_if; // [156:148]
+    lc_ctrl_reg2hw_transition_cmd_reg_t transition_cmd; // [147:146]
+    lc_ctrl_reg2hw_transition_token_mreg_t [3:0] transition_token; // [145:14]
+    lc_ctrl_reg2hw_transition_target_reg_t transition_target; // [13:9]
+    lc_ctrl_reg2hw_otp_test_ctrl_reg_t otp_test_ctrl; // [8:0]
   } lc_ctrl_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    lc_ctrl_hw2reg_status_reg_t status; // [416:408]
-    lc_ctrl_hw2reg_claim_transition_if_reg_t claim_transition_if; // [407:400]
-    lc_ctrl_hw2reg_transition_regwen_reg_t transition_regwen; // [399:399]
-    lc_ctrl_hw2reg_transition_token_mreg_t [3:0] transition_token; // [398:271]
-    lc_ctrl_hw2reg_transition_target_reg_t transition_target; // [270:267]
+    lc_ctrl_hw2reg_status_reg_t status; // [424:416]
+    lc_ctrl_hw2reg_claim_transition_if_reg_t claim_transition_if; // [415:408]
+    lc_ctrl_hw2reg_transition_regwen_reg_t transition_regwen; // [407:407]
+    lc_ctrl_hw2reg_transition_token_mreg_t [3:0] transition_token; // [406:279]
+    lc_ctrl_hw2reg_transition_target_reg_t transition_target; // [278:275]
+    lc_ctrl_hw2reg_otp_test_ctrl_reg_t otp_test_ctrl; // [274:267]
     lc_ctrl_hw2reg_lc_state_reg_t lc_state; // [266:263]
     lc_ctrl_hw2reg_lc_transition_cnt_reg_t lc_transition_cnt; // [262:258]
     lc_ctrl_hw2reg_lc_id_state_reg_t lc_id_state; // [257:256]
@@ -147,17 +159,18 @@ package lc_ctrl_reg_pkg;
   parameter logic [BlockAw-1:0] LC_CTRL_TRANSITION_TOKEN_2_OFFSET = 7'h 1c;
   parameter logic [BlockAw-1:0] LC_CTRL_TRANSITION_TOKEN_3_OFFSET = 7'h 20;
   parameter logic [BlockAw-1:0] LC_CTRL_TRANSITION_TARGET_OFFSET = 7'h 24;
-  parameter logic [BlockAw-1:0] LC_CTRL_LC_STATE_OFFSET = 7'h 28;
-  parameter logic [BlockAw-1:0] LC_CTRL_LC_TRANSITION_CNT_OFFSET = 7'h 2c;
-  parameter logic [BlockAw-1:0] LC_CTRL_LC_ID_STATE_OFFSET = 7'h 30;
-  parameter logic [BlockAw-1:0] LC_CTRL_DEVICE_ID_0_OFFSET = 7'h 34;
-  parameter logic [BlockAw-1:0] LC_CTRL_DEVICE_ID_1_OFFSET = 7'h 38;
-  parameter logic [BlockAw-1:0] LC_CTRL_DEVICE_ID_2_OFFSET = 7'h 3c;
-  parameter logic [BlockAw-1:0] LC_CTRL_DEVICE_ID_3_OFFSET = 7'h 40;
-  parameter logic [BlockAw-1:0] LC_CTRL_DEVICE_ID_4_OFFSET = 7'h 44;
-  parameter logic [BlockAw-1:0] LC_CTRL_DEVICE_ID_5_OFFSET = 7'h 48;
-  parameter logic [BlockAw-1:0] LC_CTRL_DEVICE_ID_6_OFFSET = 7'h 4c;
-  parameter logic [BlockAw-1:0] LC_CTRL_DEVICE_ID_7_OFFSET = 7'h 50;
+  parameter logic [BlockAw-1:0] LC_CTRL_OTP_TEST_CTRL_OFFSET = 7'h 28;
+  parameter logic [BlockAw-1:0] LC_CTRL_LC_STATE_OFFSET = 7'h 2c;
+  parameter logic [BlockAw-1:0] LC_CTRL_LC_TRANSITION_CNT_OFFSET = 7'h 30;
+  parameter logic [BlockAw-1:0] LC_CTRL_LC_ID_STATE_OFFSET = 7'h 34;
+  parameter logic [BlockAw-1:0] LC_CTRL_DEVICE_ID_0_OFFSET = 7'h 38;
+  parameter logic [BlockAw-1:0] LC_CTRL_DEVICE_ID_1_OFFSET = 7'h 3c;
+  parameter logic [BlockAw-1:0] LC_CTRL_DEVICE_ID_2_OFFSET = 7'h 40;
+  parameter logic [BlockAw-1:0] LC_CTRL_DEVICE_ID_3_OFFSET = 7'h 44;
+  parameter logic [BlockAw-1:0] LC_CTRL_DEVICE_ID_4_OFFSET = 7'h 48;
+  parameter logic [BlockAw-1:0] LC_CTRL_DEVICE_ID_5_OFFSET = 7'h 4c;
+  parameter logic [BlockAw-1:0] LC_CTRL_DEVICE_ID_6_OFFSET = 7'h 50;
+  parameter logic [BlockAw-1:0] LC_CTRL_DEVICE_ID_7_OFFSET = 7'h 54;
 
   // Reset values for hwext registers and their fields
   parameter logic [1:0] LC_CTRL_ALERT_TEST_RESVAL = 2'h 0;
@@ -173,6 +186,7 @@ package lc_ctrl_reg_pkg;
   parameter logic [31:0] LC_CTRL_TRANSITION_TOKEN_2_RESVAL = 32'h 0;
   parameter logic [31:0] LC_CTRL_TRANSITION_TOKEN_3_RESVAL = 32'h 0;
   parameter logic [3:0] LC_CTRL_TRANSITION_TARGET_RESVAL = 4'h 0;
+  parameter logic [7:0] LC_CTRL_OTP_TEST_CTRL_RESVAL = 8'h 0;
   parameter logic [3:0] LC_CTRL_LC_STATE_RESVAL = 4'h 0;
   parameter logic [4:0] LC_CTRL_LC_TRANSITION_CNT_RESVAL = 5'h 0;
   parameter logic [1:0] LC_CTRL_LC_ID_STATE_RESVAL = 2'h 0;
@@ -197,6 +211,7 @@ package lc_ctrl_reg_pkg;
     LC_CTRL_TRANSITION_TOKEN_2,
     LC_CTRL_TRANSITION_TOKEN_3,
     LC_CTRL_TRANSITION_TARGET,
+    LC_CTRL_OTP_TEST_CTRL,
     LC_CTRL_LC_STATE,
     LC_CTRL_LC_TRANSITION_CNT,
     LC_CTRL_LC_ID_STATE,
@@ -211,7 +226,7 @@ package lc_ctrl_reg_pkg;
   } lc_ctrl_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] LC_CTRL_PERMIT [21] = '{
+  parameter logic [3:0] LC_CTRL_PERMIT [22] = '{
     4'b 0001, // index[ 0] LC_CTRL_ALERT_TEST
     4'b 0011, // index[ 1] LC_CTRL_STATUS
     4'b 0001, // index[ 2] LC_CTRL_CLAIM_TRANSITION_IF
@@ -222,17 +237,18 @@ package lc_ctrl_reg_pkg;
     4'b 1111, // index[ 7] LC_CTRL_TRANSITION_TOKEN_2
     4'b 1111, // index[ 8] LC_CTRL_TRANSITION_TOKEN_3
     4'b 0001, // index[ 9] LC_CTRL_TRANSITION_TARGET
-    4'b 0001, // index[10] LC_CTRL_LC_STATE
-    4'b 0001, // index[11] LC_CTRL_LC_TRANSITION_CNT
-    4'b 0001, // index[12] LC_CTRL_LC_ID_STATE
-    4'b 1111, // index[13] LC_CTRL_DEVICE_ID_0
-    4'b 1111, // index[14] LC_CTRL_DEVICE_ID_1
-    4'b 1111, // index[15] LC_CTRL_DEVICE_ID_2
-    4'b 1111, // index[16] LC_CTRL_DEVICE_ID_3
-    4'b 1111, // index[17] LC_CTRL_DEVICE_ID_4
-    4'b 1111, // index[18] LC_CTRL_DEVICE_ID_5
-    4'b 1111, // index[19] LC_CTRL_DEVICE_ID_6
-    4'b 1111  // index[20] LC_CTRL_DEVICE_ID_7
+    4'b 0001, // index[10] LC_CTRL_OTP_TEST_CTRL
+    4'b 0001, // index[11] LC_CTRL_LC_STATE
+    4'b 0001, // index[12] LC_CTRL_LC_TRANSITION_CNT
+    4'b 0001, // index[13] LC_CTRL_LC_ID_STATE
+    4'b 1111, // index[14] LC_CTRL_DEVICE_ID_0
+    4'b 1111, // index[15] LC_CTRL_DEVICE_ID_1
+    4'b 1111, // index[16] LC_CTRL_DEVICE_ID_2
+    4'b 1111, // index[17] LC_CTRL_DEVICE_ID_3
+    4'b 1111, // index[18] LC_CTRL_DEVICE_ID_4
+    4'b 1111, // index[19] LC_CTRL_DEVICE_ID_5
+    4'b 1111, // index[20] LC_CTRL_DEVICE_ID_6
+    4'b 1111  // index[21] LC_CTRL_DEVICE_ID_7
   };
 
 endpackage

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
@@ -154,6 +154,10 @@ module lc_ctrl_reg_top (
   logic [3:0] transition_target_wd;
   logic transition_target_we;
   logic transition_target_re;
+  logic [7:0] otp_test_ctrl_qs;
+  logic [7:0] otp_test_ctrl_wd;
+  logic otp_test_ctrl_we;
+  logic otp_test_ctrl_re;
   logic [3:0] lc_state_qs;
   logic lc_state_re;
   logic [4:0] lc_transition_cnt_qs;
@@ -483,6 +487,23 @@ module lc_ctrl_reg_top (
   );
 
 
+  // R[otp_test_ctrl]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (8)
+  ) u_otp_test_ctrl (
+    .re     (otp_test_ctrl_re),
+    // qualified with register enable
+    .we     (otp_test_ctrl_we & transition_regwen_qs),
+    .wd     (otp_test_ctrl_wd),
+    .d      (hw2reg.otp_test_ctrl.d),
+    .qre    (),
+    .qe     (reg2hw.otp_test_ctrl.qe),
+    .q      (reg2hw.otp_test_ctrl.q ),
+    .qs     (otp_test_ctrl_qs)
+  );
+
+
   // R[lc_state]: V(True)
 
   prim_subreg_ext #(
@@ -663,7 +684,7 @@ module lc_ctrl_reg_top (
 
 
 
-  logic [20:0] addr_hit;
+  logic [21:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == LC_CTRL_ALERT_TEST_OFFSET);
@@ -676,17 +697,18 @@ module lc_ctrl_reg_top (
     addr_hit[ 7] = (reg_addr == LC_CTRL_TRANSITION_TOKEN_2_OFFSET);
     addr_hit[ 8] = (reg_addr == LC_CTRL_TRANSITION_TOKEN_3_OFFSET);
     addr_hit[ 9] = (reg_addr == LC_CTRL_TRANSITION_TARGET_OFFSET);
-    addr_hit[10] = (reg_addr == LC_CTRL_LC_STATE_OFFSET);
-    addr_hit[11] = (reg_addr == LC_CTRL_LC_TRANSITION_CNT_OFFSET);
-    addr_hit[12] = (reg_addr == LC_CTRL_LC_ID_STATE_OFFSET);
-    addr_hit[13] = (reg_addr == LC_CTRL_DEVICE_ID_0_OFFSET);
-    addr_hit[14] = (reg_addr == LC_CTRL_DEVICE_ID_1_OFFSET);
-    addr_hit[15] = (reg_addr == LC_CTRL_DEVICE_ID_2_OFFSET);
-    addr_hit[16] = (reg_addr == LC_CTRL_DEVICE_ID_3_OFFSET);
-    addr_hit[17] = (reg_addr == LC_CTRL_DEVICE_ID_4_OFFSET);
-    addr_hit[18] = (reg_addr == LC_CTRL_DEVICE_ID_5_OFFSET);
-    addr_hit[19] = (reg_addr == LC_CTRL_DEVICE_ID_6_OFFSET);
-    addr_hit[20] = (reg_addr == LC_CTRL_DEVICE_ID_7_OFFSET);
+    addr_hit[10] = (reg_addr == LC_CTRL_OTP_TEST_CTRL_OFFSET);
+    addr_hit[11] = (reg_addr == LC_CTRL_LC_STATE_OFFSET);
+    addr_hit[12] = (reg_addr == LC_CTRL_LC_TRANSITION_CNT_OFFSET);
+    addr_hit[13] = (reg_addr == LC_CTRL_LC_ID_STATE_OFFSET);
+    addr_hit[14] = (reg_addr == LC_CTRL_DEVICE_ID_0_OFFSET);
+    addr_hit[15] = (reg_addr == LC_CTRL_DEVICE_ID_1_OFFSET);
+    addr_hit[16] = (reg_addr == LC_CTRL_DEVICE_ID_2_OFFSET);
+    addr_hit[17] = (reg_addr == LC_CTRL_DEVICE_ID_3_OFFSET);
+    addr_hit[18] = (reg_addr == LC_CTRL_DEVICE_ID_4_OFFSET);
+    addr_hit[19] = (reg_addr == LC_CTRL_DEVICE_ID_5_OFFSET);
+    addr_hit[20] = (reg_addr == LC_CTRL_DEVICE_ID_6_OFFSET);
+    addr_hit[21] = (reg_addr == LC_CTRL_DEVICE_ID_7_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -714,7 +736,8 @@ module lc_ctrl_reg_top (
                (addr_hit[17] & (|(LC_CTRL_PERMIT[17] & ~reg_be))) |
                (addr_hit[18] & (|(LC_CTRL_PERMIT[18] & ~reg_be))) |
                (addr_hit[19] & (|(LC_CTRL_PERMIT[19] & ~reg_be))) |
-               (addr_hit[20] & (|(LC_CTRL_PERMIT[20] & ~reg_be)))));
+               (addr_hit[20] & (|(LC_CTRL_PERMIT[20] & ~reg_be))) |
+               (addr_hit[21] & (|(LC_CTRL_PERMIT[21] & ~reg_be)))));
   end
 
   assign alert_test_fatal_prog_error_we = addr_hit[0] & reg_we & !reg_error;
@@ -770,27 +793,31 @@ module lc_ctrl_reg_top (
   assign transition_target_wd = reg_wdata[3:0];
   assign transition_target_re = addr_hit[9] & reg_re & !reg_error;
 
-  assign lc_state_re = addr_hit[10] & reg_re & !reg_error;
+  assign otp_test_ctrl_we = addr_hit[10] & reg_we & !reg_error;
+  assign otp_test_ctrl_wd = reg_wdata[7:0];
+  assign otp_test_ctrl_re = addr_hit[10] & reg_re & !reg_error;
 
-  assign lc_transition_cnt_re = addr_hit[11] & reg_re & !reg_error;
+  assign lc_state_re = addr_hit[11] & reg_re & !reg_error;
 
-  assign lc_id_state_re = addr_hit[12] & reg_re & !reg_error;
+  assign lc_transition_cnt_re = addr_hit[12] & reg_re & !reg_error;
 
-  assign device_id_0_re = addr_hit[13] & reg_re & !reg_error;
+  assign lc_id_state_re = addr_hit[13] & reg_re & !reg_error;
 
-  assign device_id_1_re = addr_hit[14] & reg_re & !reg_error;
+  assign device_id_0_re = addr_hit[14] & reg_re & !reg_error;
 
-  assign device_id_2_re = addr_hit[15] & reg_re & !reg_error;
+  assign device_id_1_re = addr_hit[15] & reg_re & !reg_error;
 
-  assign device_id_3_re = addr_hit[16] & reg_re & !reg_error;
+  assign device_id_2_re = addr_hit[16] & reg_re & !reg_error;
 
-  assign device_id_4_re = addr_hit[17] & reg_re & !reg_error;
+  assign device_id_3_re = addr_hit[17] & reg_re & !reg_error;
 
-  assign device_id_5_re = addr_hit[18] & reg_re & !reg_error;
+  assign device_id_4_re = addr_hit[18] & reg_re & !reg_error;
 
-  assign device_id_6_re = addr_hit[19] & reg_re & !reg_error;
+  assign device_id_5_re = addr_hit[19] & reg_re & !reg_error;
 
-  assign device_id_7_re = addr_hit[20] & reg_re & !reg_error;
+  assign device_id_6_re = addr_hit[20] & reg_re & !reg_error;
+
+  assign device_id_7_re = addr_hit[21] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin
@@ -846,46 +873,50 @@ module lc_ctrl_reg_top (
       end
 
       addr_hit[10]: begin
-        reg_rdata_next[3:0] = lc_state_qs;
+        reg_rdata_next[7:0] = otp_test_ctrl_qs;
       end
 
       addr_hit[11]: begin
-        reg_rdata_next[4:0] = lc_transition_cnt_qs;
+        reg_rdata_next[3:0] = lc_state_qs;
       end
 
       addr_hit[12]: begin
-        reg_rdata_next[1:0] = lc_id_state_qs;
+        reg_rdata_next[4:0] = lc_transition_cnt_qs;
       end
 
       addr_hit[13]: begin
-        reg_rdata_next[31:0] = device_id_0_qs;
+        reg_rdata_next[1:0] = lc_id_state_qs;
       end
 
       addr_hit[14]: begin
-        reg_rdata_next[31:0] = device_id_1_qs;
+        reg_rdata_next[31:0] = device_id_0_qs;
       end
 
       addr_hit[15]: begin
-        reg_rdata_next[31:0] = device_id_2_qs;
+        reg_rdata_next[31:0] = device_id_1_qs;
       end
 
       addr_hit[16]: begin
-        reg_rdata_next[31:0] = device_id_3_qs;
+        reg_rdata_next[31:0] = device_id_2_qs;
       end
 
       addr_hit[17]: begin
-        reg_rdata_next[31:0] = device_id_4_qs;
+        reg_rdata_next[31:0] = device_id_3_qs;
       end
 
       addr_hit[18]: begin
-        reg_rdata_next[31:0] = device_id_5_qs;
+        reg_rdata_next[31:0] = device_id_4_qs;
       end
 
       addr_hit[19]: begin
-        reg_rdata_next[31:0] = device_id_6_qs;
+        reg_rdata_next[31:0] = device_id_5_qs;
       end
 
       addr_hit[20]: begin
+        reg_rdata_next[31:0] = device_id_6_qs;
+      end
+
+      addr_hit[21]: begin
         reg_rdata_next[31:0] = device_id_7_qs;
       end
 

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -23,6 +23,9 @@ module tb;
   wire otp_ctrl_pkg::sram_otp_key_req_t[NumSramKeyReqSlots-1:0] sram_req;
   wire otp_ctrl_pkg::sram_otp_key_rsp_t[NumSramKeyReqSlots-1:0] sram_rsp;
 
+  // TODO: need to connect this properly
+  wire [otp_ctrl_pkg::OtpTestCtrlWidth-1:0] otp_test_ctrl;
+
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
   wire intr_otp_operation_done, intr_otp_error;
 
@@ -88,7 +91,7 @@ module tb;
     .pwr_otp_i                  (otp_ctrl_if.pwr_otp_init_i),
     .pwr_otp_o                  ({otp_ctrl_if.pwr_otp_done_o, otp_ctrl_if.pwr_otp_idle_o}),
     // lc
-    .lc_otp_program_i           ({lc_prog_if.req, lc_prog_if.h_data}),
+    .lc_otp_program_i           ({lc_prog_if.req, lc_prog_if.h_data, otp_test_ctrl}),
     .lc_otp_program_o           ({lc_prog_if.d_data, lc_prog_if.ack}),
     .lc_creator_seed_sw_rw_en_i (otp_ctrl_if.lc_creator_seed_sw_rw_en_i),
     .lc_seed_hw_rd_en_i         (otp_ctrl_if.lc_seed_hw_rd_en_i),

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -625,11 +625,11 @@ module otp_ctrl
     .ready_i ( otp_arb_ready       )
   );
 
-  prim_otp_pkg::err_e    part_otp_err;
-  logic [OtpIfWidth-1:0] part_otp_rdata;
-  logic                  otp_rvalid;
-  tlul_pkg::tl_h2d_t     tl_win_h2d_gated;
-  tlul_pkg::tl_d2h_t     tl_win_d2h_gated;
+  prim_otp_pkg::err_e          part_otp_err;
+  logic [OtpIfWidth-1:0]       part_otp_rdata;
+  logic                        otp_rvalid;
+  tlul_pkg::tl_h2d_t           tl_win_h2d_gated;
+  tlul_pkg::tl_d2h_t           tl_win_d2h_gated;
 
   // Life cycle qualification of TL-UL test interface.
   assign tl_win_h2d_gated              = (lc_dft_en[0] == lc_ctrl_pkg::On) ?
@@ -637,43 +637,42 @@ module otp_ctrl
   assign tl_win_d2h[$high(tl_win_h2d)] = (lc_dft_en[1] == lc_ctrl_pkg::On) ?
                                          tl_win_d2h_gated : '0;
 
-  // TODO: correctly connect this to life cycle
-  logic ext_voltage_en;
-  assign ext_voltage_en = 1'b0;
-
   prim_otp #(
-    .Width       ( OtpWidth            ),
-    .Depth       ( OtpDepth            ),
-    .SizeWidth   ( OtpSizeWidth        ),
-    .PwrSeqWidth ( OtpPwrSeqWidth      ),
-    .TlDepth     ( NumDebugWindowWords ),
-    .MemInitFile ( MemInitFile         )
+    .Width         ( OtpWidth            ),
+    .Depth         ( OtpDepth            ),
+    .SizeWidth     ( OtpSizeWidth        ),
+    .PwrSeqWidth   ( OtpPwrSeqWidth      ),
+    .TlDepth       ( NumDebugWindowWords ),
+    .TestCtrlWidth ( OtpTestCtrlWidth    ),
+    .MemInitFile   ( MemInitFile         )
   ) u_otp (
     .clk_i,
     .rst_ni,
     // Power sequencing signals to/from AST
-    .pwr_seq_o   ( otp_ast_pwr_seq_o.pwr_seq     ),
-    .pwr_seq_h_i ( otp_ast_pwr_seq_h_i.pwr_seq_h ),
+    .pwr_seq_o        ( otp_ast_pwr_seq_o.pwr_seq      ),
+    .pwr_seq_h_i      ( otp_ast_pwr_seq_h_i.pwr_seq_h  ),
+    .ext_voltage_io   ( otp_ext_voltage_h_io           ),
     // Test interface
-    .test_tl_i   ( tl_win_h2d_gated              ),
-    .test_tl_o   ( tl_win_d2h_gated              ),
-    // Read / Write command interface
-    .ready_o     ( otp_arb_ready                 ),
-    .valid_i     ( otp_arb_valid                 ),
-    .cmd_i       ( otp_arb_bundle.cmd            ),
-    .size_i      ( otp_arb_bundle.size           ),
-    .addr_i      ( otp_arb_bundle.addr           ),
-    .wdata_i     ( otp_arb_bundle.wdata          ),
-    // Read data out
-    .valid_o     ( otp_rvalid                    ),
-    .rdata_o     ( part_otp_rdata                ),
-    .err_o       ( part_otp_err                  ),
-    .ext_voltage_io   ( otp_ext_voltage_h_io     ),
-    .ext_voltage_en_i ( ext_voltage_en           ),
-    .otp_alert_src_o  ( otp_alert_o              ),
+    .test_ctrl_i      ( lc_otp_program_i.otp_test_ctrl ),
+    .test_tl_i        ( tl_win_h2d_gated               ),
+    .test_tl_o        ( tl_win_d2h_gated               ),
+    // Other DFT signals
     .scan_en_i,
     .scan_rst_ni,
-    .scanmode_i
+    .scanmode_i,
+    // Alerts
+    .otp_alert_src_o  ( otp_alert_o          ),
+    // Read / Write command interface
+    .ready_o          ( otp_arb_ready        ),
+    .valid_i          ( otp_arb_valid        ),
+    .cmd_i            ( otp_arb_bundle.cmd   ),
+    .size_i           ( otp_arb_bundle.size  ),
+    .addr_i           ( otp_arb_bundle.addr  ),
+    .wdata_i          ( otp_arb_bundle.wdata ),
+    // Read data out
+    .valid_o          ( otp_rvalid           ),
+    .rdata_o          ( part_otp_rdata       ),
+    .err_o            ( part_otp_err         )
   );
 
   logic otp_fifo_valid;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -12,6 +12,10 @@ package otp_ctrl_pkg;
   // General Parameters //
   ////////////////////////
 
+  // Number of vendor-specific test CSR bits coming from
+  // the life cycle TAP registers.
+  parameter int OtpTestCtrlWidth = 8;
+
   // Width of entropy input
   parameter int EdnDataWidth = 64;
 
@@ -132,6 +136,7 @@ package otp_ctrl_pkg;
     logic req;
     lc_ctrl_state_pkg::lc_state_e state;
     lc_ctrl_state_pkg::lc_cnt_e   count;
+    logic [OtpTestCtrlWidth-1:0]  otp_test_ctrl;
   } lc_otp_program_req_t;
 
   typedef struct packed {


### PR DESCRIPTION
This adds another register to the LC TAP which is called `OTP_TEST_CTRL`, and its value is forwarded to the OTP wrapper during DFT enabled states (`TEST_*`, and `RMA`). Otherwise its value will be gated to 0.

This allows to steer certain test-related, vendor-specific mechanisms through the LC TAP when we are in DFT-enabled states - in our case the external VPP selection.

It is meant to make the VPP selection a bit more flexible than what we had discussed (i.e., instead of tying this to a specific `TEST_LOCKED*` state, it can be specified through this LC TAP register in any `RAW`, `TEST_*` or `RMA` state).

@zi-v @cdgori @moidx: Let me know whether you have any concerns from a security perspective. 
Note that this external VPP selection can already be performed via the OTP TL-UL test interface in `TEST_UNLOCKED*` and `RMA` states - so what this is basically adding is a way to make this selection `TEST_LOCKED*` and `RAW` states as well (via the LC TAP).