### PR TITLE
Add Michael and Mark to committers list

### DIFF
--- a/COMMITTERS
+++ b/COMMITTERS
@@ -7,6 +7,7 @@ Committers are listed alphabetically by surname in the format:
 
 Committer list:
 * Alex Bradbury (asb)
+* Mark Branstad (mwbranstad)
 * Greg Chadwick (gregac)
 * Cindy Chen (cindychip)
 * Timothy Chen (tjaychen)
@@ -17,6 +18,7 @@ Committer list:
 * Martin Lueker-Boden (martin-lueker)
 * Rasmus Madsen (rasmus-madsen)
 * Felix Miller (felixmiller)
+* Michael Munday (mundaym)
 * Miguel Osorio (moidx)
 * Dominic Rizzo (domrizz0)
 * Tom Roberts (tomroberts-lowrisc)


### PR DESCRIPTION
The OpenTitan Technical Committee is happy to announce that Mark
Branstad and Michael Munday are now committers!

Thanks for your great work on OpenTitan so far, we're looking forward to
more of it!