### PR TITLE
[dv/mem_bkdr_if,otp_ctrl] replace mem_bkdr_if functionality from inte…

### DIFF
--- a/hw/dv/sv/mem_bkdr_if/gen_mem_base_if.sv
+++ b/hw/dv/sv/mem_bkdr_if/gen_mem_base_if.sv
@@ -1,0 +1,44 @@
+// this interface class is a catalog of general memory functions that the programmer
+// must implement according to each memory type they choose to use
+interface class gen_mem_base_if;
+    pure virtual function automatic logic [7:0] read8(input bit [bus_params_pkg::BUS_AW-1:0] addr);
+
+    pure virtual function automatic logic [15:0] read16(input bit [bus_params_pkg::BUS_AW-1:0] addr);
+
+    pure virtual function automatic logic [31:0] read32(input bit [bus_params_pkg::BUS_AW-1:0] addr);
+
+    pure virtual function automatic logic [63:0] read64(input bit [bus_params_pkg::BUS_AW-1:0] addr);
+
+    pure virtual function automatic void write8(input bit [bus_params_pkg::BUS_AW-1:0] addr,
+                                                input bit [7:0] data,
+                                                input int inject_num_errors = 0);
+
+    pure virtual function automatic void write16(input bit [bus_params_pkg::BUS_AW-1:0] addr,
+                                                input bit [15:0] data,
+                                                input int inject_num_errors = 0);
+
+    pure virtual function automatic void write32(input bit [bus_params_pkg::BUS_AW-1:0] addr,
+                                                input bit [31:0] data,
+                                                input int inject_num_errors = 0);
+
+    pure virtual function automatic void write64(input bit [bus_params_pkg::BUS_AW-1:0] addr,
+                                                input bit [63:0] data,
+                                                input int inject_num_errors = 0);
+
+    // iniatialize paramaters of the interface if needed
+    pure virtual function automatic void init();
+
+    pure virtual function automatic bit is_addr_valid(input bit [bus_params_pkg::BUS_AW-1:0] addr);
+    
+    pure virtual function automatic void clear_mem();
+
+    pure virtual function automatic void set_mem();
+
+    pure virtual function automatic void load_mem_from_file(string file);
+
+    pure virtual function automatic void write_mem_to_file(string file);
+
+    pure virtual function automatic void randomize_mem();
+
+    pure virtual function automatic void invalidate_mem();
+endclass : gen_mem_base_if

--- a/hw/dv/sv/mem_bkdr_if/mem_bkdr_if.core
+++ b/hw/dv/sv/mem_bkdr_if/mem_bkdr_if.core
@@ -15,7 +15,11 @@ filesets:
       - lowrisc:prim:secded:0.1
     files:
       - sram_scrambler_pkg.sv
+      - mem_bkdr_pkg.sv
       - mem_bkdr_if.sv
+      - otp_mem_base_if.sv: {is_include_file: true}
+      - gen_mem_base_if.sv: {is_include_file: true}
+      - otp_bkdr_base_if.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/sv/mem_bkdr_if/mem_bkdr_pkg.sv
+++ b/hw/dv/sv/mem_bkdr_if/mem_bkdr_pkg.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package mem_bkdr_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import sram_scrambler_pkg::*;
+  import bus_params_pkg::BUS_AW;
+  import prim_secded_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+  
+  localparam int MAX_WIDTH = 64;
+
+  // the interface classes
+  `include "otp_mem_base_if.sv"
+  `include "gen_mem_base_if.sv"
+
+  // the base classes implementing the interface classes
+  `include "otp_bkdr_base_if.sv"
+
+endpackage

--- a/hw/dv/sv/mem_bkdr_if/otp_bkdr_base_if.sv
+++ b/hw/dv/sv/mem_bkdr_if/otp_bkdr_base_if.sv
@@ -1,0 +1,126 @@
+//  Class: mem_bkdr_base_if
+// 
+// this class is not a pure virtual class, but doesn't actually implement anything
+// concrete implementation is left for the vendor/PRIM_GENERIC implementation in
+// the classes inside the implementation-specific interface
+class otp_bkdr_base_if extends uvm_component implements gen_mem_base_if, otp_mem_base_if;
+    `uvm_component_utils(otp_bkdr_base_if);
+
+               
+    ////////////////////////////////////////////////////////////////////
+    ///////////////////  gen_mem_base_if implementations  //////////////
+    ////////////////////////////////////////////////////////////////////
+    function new(string name = "otp_bkdr_base_if", uvm_component parent);
+        super.new(name, parent);
+    endfunction: new
+                                          
+    virtual function automatic void init();
+        `uvm_error(get_full_name(), "init is not implemented!")
+    endfunction
+
+    virtual function automatic bit is_addr_valid(input bit [bus_params_pkg::BUS_AW-1:0] addr);
+        `uvm_error(get_full_name(), "is_addr_valid is not implemented!")
+    endfunction
+
+    virtual function automatic logic [7:0] read8(input bit [bus_params_pkg::BUS_AW-1:0] addr);
+        `uvm_error(get_full_name(), "read8 is not implemented!")
+    endfunction 
+
+    virtual function automatic logic [15:0] read16(input bit [bus_params_pkg::BUS_AW-1:0] addr);
+        `uvm_error(get_full_name(), "read16 is not implemented!")
+    endfunction 
+
+    virtual function automatic logic [31:0] read32(input bit [bus_params_pkg::BUS_AW-1:0] addr);
+        `uvm_error(get_full_name(), "read32 is not implemented!")
+    endfunction 
+
+    virtual function automatic logic [63:0] read64(input bit [bus_params_pkg::BUS_AW-1:0] addr);
+        `uvm_error(get_full_name(), "read64 is not implemented!")
+    endfunction 
+
+    virtual function automatic void write8(  input bit [bus_params_pkg::BUS_AW-1:0] addr,
+                                                    input bit [7:0] data,
+                                                    input int inject_num_errors = 0);
+        `uvm_error(get_full_name(), "write8 is not implemented!")
+    endfunction 
+
+    virtual function automatic void write16(input bit [bus_params_pkg::BUS_AW-1:0] addr,
+                                                    input bit [15:0] data,
+                                                    input int inject_num_errors = 0);
+        `uvm_error(get_full_name(), "write16 is not implemented!")
+    endfunction 
+
+    virtual function automatic void write32(input bit [bus_params_pkg::BUS_AW-1:0] addr,
+                                                    input bit [31:0] data,
+                                                    input int inject_num_errors = 0);
+        `uvm_error(get_full_name(), "write32 is not implemented!")
+    endfunction 
+
+    virtual function automatic void write64(input bit [bus_params_pkg::BUS_AW-1:0] addr,
+                                                    input bit [63:0] data,
+                                                    input int inject_num_errors = 0);
+        `uvm_error(get_full_name(), "write64 is not implemented!")
+    endfunction 
+   
+    // check if input file is read/writable
+    virtual function automatic void check_file(string file, bit wr);
+        `uvm_error(get_full_name(), "check_file is not implemented!")
+    endfunction
+
+    // load mem from file
+    virtual function automatic void load_mem_from_file(string file);
+        `uvm_error(get_full_name(), "load_mem_from_file is not implemented!")
+    endfunction
+
+    // save mem contents to file
+    virtual function automatic void write_mem_to_file(string file);
+        `uvm_error(get_full_name(), "write_mem_to_file is not implemented!")
+    endfunction
+
+    // print mem
+    virtual function automatic void print_mem();
+        `uvm_error(get_full_name(), "print_mem is not implemented!")
+    endfunction
+
+    // clear or set memory
+    virtual function automatic void clear_mem();
+        `uvm_error(get_full_name(), "clear_mem is not implemented!")
+    endfunction // clr_mem
+
+    virtual function automatic void set_mem();
+        `uvm_error(get_full_name(), "set_mem is not implemented!")
+    endfunction
+
+    // randomize the memory
+    virtual function automatic void randomize_mem();
+        `uvm_error(get_full_name(), "randomize_mem is not implemented!")
+    endfunction
+
+    // invalidate the memory.
+    virtual function automatic void invalidate_mem();
+        `uvm_error(get_full_name(), "invalidate_mem is not implemented!")
+    endfunction
+
+    ////////////////////////////////////////////////////////////////////
+    ///////////////////  otp_mem_base_if implementations  //////////////
+    ////////////////////////////////////////////////////////////////////
+    virtual function automatic secded_22_16_t ecc_read16(input bit [bus_params_pkg::BUS_AW-1:0] addr);
+        `uvm_error(get_full_name(), "ecc_read16 is not implemented!")
+    endfunction
+
+    // Intended for use with memories which have data width of 32 bits and 7 ECC bits.
+    virtual function automatic secded_39_32_t ecc_read32(input bit [bus_params_pkg::BUS_AW-1:0] addr);
+        `uvm_error(get_full_name(), "ecc_read32 is not implemented!")
+    endfunction
+
+    // Intended for use with memories which have data width of 64 bits and 8 ECC bits.
+    virtual function automatic secded_72_64_t ecc_read64(input bit [bus_params_pkg::BUS_AW-1:0] addr);
+        `uvm_error(get_full_name(), "ecc_read64 is not implemented!")
+    endfunction
+
+    virtual function automatic bit [MAX_WIDTH-1:0] inject_errors(bit [MAX_WIDTH-1:0] data, int inject_num_errors);
+        `uvm_error(get_full_name(), "inject_errors is not implemented!")
+    endfunction
+
+        
+endclass: otp_bkdr_base_if

--- a/hw/dv/sv/mem_bkdr_if/otp_mem_base_if.sv
+++ b/hw/dv/sv/mem_bkdr_if/otp_mem_base_if.sv
@@ -1,0 +1,8 @@
+// this interface class is a catalog of OTP specific functions that the programmer
+// must implement
+interface class otp_mem_base_if;
+    pure virtual function automatic secded_22_16_t ecc_read16(input bit [bus_params_pkg::BUS_AW-1:0] addr);
+    pure virtual function automatic secded_39_32_t ecc_read32(input bit [bus_params_pkg::BUS_AW-1:0] addr);
+    pure virtual function automatic secded_72_64_t ecc_read64(input bit [bus_params_pkg::BUS_AW-1:0] addr);
+    pure virtual function automatic bit [MAX_WIDTH-1:0] inject_errors(bit [MAX_WIDTH-1:0] data, int inject_num_errors);
+endclass

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
@@ -53,7 +53,7 @@ class otp_ctrl_env extends cip_base_env #(
         set(this, "m_lc_prog_pull_agent", "cfg", cfg.m_lc_prog_pull_agent_cfg);
 
     // config mem virtual interface
-    if (!uvm_config_db#(mem_bkdr_vif)::get(this, "", "mem_bkdr_vif", cfg.mem_bkdr_vif)) begin
+    if (!uvm_config_db#(otp_bkdr_base_if)::get(this, "", "mem_bkdr_vif", cfg.mem_bkdr_vif)) begin
       `uvm_fatal(`gfn, "failed to get mem_bkdr_vif from uvm_config_db")
     end
 

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -14,7 +14,7 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
       m_lc_prog_pull_agent_cfg;
 
   // ext interfaces
-  mem_bkdr_vif mem_bkdr_vif;
+  otp_bkdr_base_if mem_bkdr_vif;
   otp_ctrl_vif otp_ctrl_vif;
 
   bit backdoor_clear_mem;

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -19,6 +19,7 @@ package otp_ctrl_env_pkg;
   import otp_ctrl_part_pkg::*;
   import lc_ctrl_pkg::*;
   import lc_ctrl_state_pkg::*;
+  import mem_bkdr_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -9,6 +9,7 @@ module tb;
   import otp_ctrl_env_pkg::*;
   import otp_ctrl_test_pkg::*;
   import otp_ctrl_reg_pkg::*;
+  import mem_bkdr_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -189,8 +190,8 @@ module tb;
 
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
-    uvm_config_db#(mem_bkdr_vif)::set(null, "*.env", "mem_bkdr_vif",
-                                      `OTP_CTRL_MEM_HIER.mem_bkdr_if);
+    uvm_config_db#(otp_bkdr_base_if)::set(null, "*.env", "mem_bkdr_vif",
+                                      `OTP_CTRL_MEM_HIER.mem_bkdr_if.getInst());
 
     uvm_config_db#(virtual otp_ctrl_if)::set(null, "*.env", "otp_ctrl_vif", otp_ctrl_if);
     $timeformat(-12, 0, " ps", 12);


### PR DESCRIPTION
…rface-based to class-based

Signed-off-by: Sharon Topaz <sharon.topaz@nuvoton.com>

Hi,
This is a PR draft suggesting to implement an OTP backdoor memory functionality via classes instead of interface which will allow better flexibility and extensibility for different OTP implementations.

The main idea is to have a handle to a base class instead of the virtual interface inside the otp_ctrl_env_cfg, which will allow to override the backdoor functionality easier.

The base class (otp_bkdr_base_if.sv) doesn't have any backdoor implementation, and the concrete behavior is implemented in the child classes (otp_prim_generic_bkdr_if in mem_bkdr_if.sv) that are declared and instantiated inside interfaces, which allow them to access RTL signals.

Each different implementation will have to provide an implementation-specific functionality that is dictated by the list of functions in the base class (otp_bkdr_base_if.sv), and also to provide its own interface connecting to the correct path in the RTL implementation.

