### PR TITLE
Revert "python-requirements.txt: Bump the supported version of meson"

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -13,7 +13,7 @@ isort
 libcst
 livereload
 mako
-meson >= 0.53.0, <= 0.56 # minimum matches version in meson.build
+meson >= 0.53.0, <= 0.54 # minimum matches version in meson.build
 mistletoe>=0.7.2
 mypy
 # Premailer 3.9.0 broke the API by introducing an allow_loading_external_files


### PR DESCRIPTION
Reverts lowRISC/opentitan#6767

This reverts commit 54da889 because it causes all SW unit tests to be skipped in CI and freshly built containers.

Fixes #6794

Signed-off-by: Alphan Ulusoy <alphan@google.com>