### PR TITLE
[dv/otp_ctrl] align write_blank_err [PART1]

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_dv_pkg.core
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_dv_pkg.core
@@ -1,0 +1,18 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:lc_ctrl_dv_utils:0.1"
+description: "LC_CTRL DV utilities package"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:cip_lib
+    files:
+      - lc_ctrl_dv_utils_pkg.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_dv_utils_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_dv_utils_pkg.sv
@@ -1,0 +1,98 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package lc_ctrl_dv_utils_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import top_pkg::*;
+  import dv_utils_pkg::*;
+  import dv_lib_pkg::*;
+  import lc_ctrl_pkg::*;
+  import lc_ctrl_state_pkg::*;
+  import otp_ctrl_pkg::*;
+
+  // associative array cannot declare parameter here, so we used const instead
+  const dec_lc_state_e VALID_NEXT_STATES [dec_lc_state_e][$] = '{
+    DecLcStRma:     {DecLcStScrap},
+    DecLcStProdEnd: {DecLcStScrap},
+    DecLcStProd:    {DecLcStScrap, DecLcStRma},
+    DecLcStDev:     {DecLcStScrap, DecLcStRma},
+    DecLcStTestUnlocked3: {DecLcStScrap, DecLcStRma, DecLcStProdEnd, DecLcStProd, DecLcStDev},
+    DecLcStTestUnlocked2: {DecLcStScrap, DecLcStProdEnd, DecLcStProd, DecLcStDev,
+                           DecLcStTestLocked2},
+    DecLcStTestUnlocked1: {DecLcStScrap, DecLcStRma, DecLcStProdEnd, DecLcStProd, DecLcStDev,
+                           DecLcStTestLocked2, DecLcStTestLocked1},
+    DecLcStTestUnlocked0: {DecLcStScrap, DecLcStRma, DecLcStProdEnd, DecLcStProd, DecLcStDev,
+                           DecLcStTestLocked2, DecLcStTestLocked1, DecLcStTestLocked0},
+    DecLcStTestLocked2: {DecLcStScrap, DecLcStProdEnd, DecLcStProd,
+                         DecLcStDev, DecLcStTestUnlocked3},
+    DecLcStTestLocked1: {DecLcStScrap, DecLcStProdEnd, DecLcStProd, DecLcStDev,
+                         DecLcStTestUnlocked3, DecLcStTestUnlocked2},
+    DecLcStTestLocked0: {DecLcStScrap, DecLcStProdEnd, DecLcStProd, DecLcStDev,
+                         DecLcStTestUnlocked3, DecLcStTestUnlocked2, DecLcStTestUnlocked1},
+    DecLcStRaw: {DecLcStScrap, DecLcStTestUnlocked2, DecLcStTestUnlocked1, DecLcStTestUnlocked0}
+  };
+
+  function automatic dec_lc_state_e dec_lc_state(lc_state_e curr_state);
+    case (curr_state)
+      LcStRaw:           return DecLcStRaw;
+      LcStTestUnlocked0: return DecLcStTestUnlocked0;
+      LcStTestLocked0:   return DecLcStTestLocked0;
+      LcStTestUnlocked1: return DecLcStTestUnlocked1;
+      LcStTestLocked1:   return DecLcStTestLocked1;
+      LcStTestUnlocked2: return DecLcStTestUnlocked2;
+      LcStTestLocked2:   return DecLcStTestLocked2;
+      LcStTestUnlocked3: return DecLcStTestUnlocked3;
+      LcStDev:           return DecLcStDev;
+      LcStProd:          return DecLcStProd;
+      LcStProdEnd:       return DecLcStProdEnd;
+      LcStRma:           return DecLcStRma;
+      LcStScrap:         return DecLcStScrap;
+      default: `uvm_fatal("lc_env_pkg", $sformatf("unknown lc_state 0x%0h", curr_state))
+    endcase
+  endfunction
+
+  function automatic lc_state_e encode_lc_state(dec_lc_state_e curr_state);
+    case (curr_state)
+      DecLcStRaw:           return LcStRaw;
+      DecLcStTestUnlocked0: return LcStTestUnlocked0;
+      DecLcStTestLocked0:   return LcStTestLocked0;
+      DecLcStTestUnlocked1: return LcStTestUnlocked1;
+      DecLcStTestLocked1:   return LcStTestLocked1;
+      DecLcStTestUnlocked2: return LcStTestUnlocked2;
+      DecLcStTestLocked2:   return LcStTestLocked2;
+      DecLcStTestUnlocked3: return LcStTestUnlocked3;
+      DecLcStDev:           return LcStDev;
+      DecLcStProd:          return LcStProd;
+      DecLcStProdEnd:       return LcStProdEnd;
+      DecLcStRma:           return LcStRma;
+      DecLcStScrap:         return LcStScrap;
+      default: `uvm_fatal("lc_env_pkg", $sformatf("unknown lc_state 0x%0h", curr_state))
+    endcase
+  endfunction
+
+  function automatic int dec_lc_cnt(lc_cnt_e curr_cnt);
+    case (curr_cnt)
+      LcCnt0  : return 0;
+      LcCnt1  : return 1;
+      LcCnt2  : return 2;
+      LcCnt3  : return 3;
+      LcCnt4  : return 4;
+      LcCnt5  : return 5;
+      LcCnt6  : return 6;
+      LcCnt7  : return 7;
+      LcCnt8  : return 8;
+      LcCnt9  : return 9;
+      LcCnt10 : return 10;
+      LcCnt11 : return 11;
+      LcCnt12 : return 12;
+      LcCnt13 : return 13;
+      LcCnt14 : return 14;
+      LcCnt15 : return 15;
+      LcCnt16 : return 16;
+      default: `uvm_fatal("lc_env_pkg", $sformatf("unknown lc_cnt 0x%0h", curr_cnt))
+    endcase
+  endfunction
+
+endpackage

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
@@ -10,6 +10,7 @@ filesets:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
       - lowrisc:dv:jtag_riscv_agent
+      - lowrisc:dv:lc_ctrl_dv_utils
     files:
       - lc_ctrl_env_pkg.sv
       - lc_ctrl_if.sv

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
@@ -18,6 +18,7 @@ package lc_ctrl_env_pkg;
   import push_pull_agent_pkg::*;
   import alert_esc_agent_pkg::*;
   import jtag_riscv_agent_pkg::*;
+  import lc_ctrl_dv_utils_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -85,28 +86,6 @@ package lc_ctrl_env_pkg;
     {Off, Off, Off, Off, Off, Off, Off, Off, Off, Off, On}
   };
 
-  // associative array cannot declare parameter here, so we used const instead
-  const dec_lc_state_e VALID_NEXT_STATES [dec_lc_state_e][$] = '{
-    DecLcStRma:     {DecLcStScrap},
-    DecLcStProdEnd: {DecLcStScrap},
-    DecLcStProd:    {DecLcStScrap, DecLcStRma},
-    DecLcStDev:     {DecLcStScrap, DecLcStRma},
-    DecLcStTestUnlocked3: {DecLcStScrap, DecLcStRma, DecLcStProdEnd, DecLcStProd, DecLcStDev},
-    DecLcStTestUnlocked2: {DecLcStScrap, DecLcStProdEnd, DecLcStProd, DecLcStDev,
-                           DecLcStTestLocked2},
-    DecLcStTestUnlocked1: {DecLcStScrap, DecLcStRma, DecLcStProdEnd, DecLcStProd, DecLcStDev,
-                           DecLcStTestLocked2, DecLcStTestLocked1},
-    DecLcStTestUnlocked0: {DecLcStScrap, DecLcStRma, DecLcStProdEnd, DecLcStProd, DecLcStDev,
-                           DecLcStTestLocked2, DecLcStTestLocked1, DecLcStTestLocked0},
-    DecLcStTestLocked2: {DecLcStScrap, DecLcStProdEnd, DecLcStProd,
-                         DecLcStDev, DecLcStTestUnlocked3},
-    DecLcStTestLocked1: {DecLcStScrap, DecLcStProdEnd, DecLcStProd, DecLcStDev,
-                         DecLcStTestUnlocked3, DecLcStTestUnlocked2},
-    DecLcStTestLocked0: {DecLcStScrap, DecLcStProdEnd, DecLcStProd, DecLcStDev,
-                         DecLcStTestUnlocked3, DecLcStTestUnlocked2, DecLcStTestUnlocked1},
-    DecLcStRaw: {DecLcStScrap, DecLcStTestUnlocked2, DecLcStTestUnlocked1, DecLcStTestUnlocked0}
-  };
-
   // types
   typedef enum bit [1:0] {
     LcPwrInitReq,
@@ -126,48 +105,6 @@ package lc_ctrl_env_pkg;
                            LcStTestLocked2, LcStTestLocked1, LcStTestLocked0, LcStRaw}) begin
       valid_state_for_trans = 1;
     end
-  endfunction
-
-  function automatic dec_lc_state_e dec_lc_state(lc_state_e curr_state);
-    case (curr_state)
-      LcStRaw:           return DecLcStRaw;
-      LcStTestUnlocked0: return DecLcStTestUnlocked0;
-      LcStTestLocked0:   return DecLcStTestLocked0;
-      LcStTestUnlocked1: return DecLcStTestUnlocked1;
-      LcStTestLocked1:   return DecLcStTestLocked1;
-      LcStTestUnlocked2: return DecLcStTestUnlocked2;
-      LcStTestLocked2:   return DecLcStTestLocked2;
-      LcStTestUnlocked3: return DecLcStTestUnlocked3;
-      LcStDev:           return DecLcStDev;
-      LcStProd:          return DecLcStProd;
-      LcStProdEnd:       return DecLcStProdEnd;
-      LcStRma:           return DecLcStRma;
-      LcStScrap:         return DecLcStScrap;
-      default: `uvm_fatal("lc_env_pkg", $sformatf("unknown lc_state 0x%0h", curr_state))
-    endcase
-  endfunction
-
-  function automatic int dec_lc_cnt(lc_cnt_e curr_cnt);
-    case (curr_cnt)
-      LcCnt0  : return 0;
-      LcCnt1  : return 1;
-      LcCnt2  : return 2;
-      LcCnt3  : return 3;
-      LcCnt4  : return 4;
-      LcCnt5  : return 5;
-      LcCnt6  : return 6;
-      LcCnt7  : return 7;
-      LcCnt8  : return 8;
-      LcCnt9  : return 9;
-      LcCnt10 : return 10;
-      LcCnt11 : return 11;
-      LcCnt12 : return 12;
-      LcCnt13 : return 13;
-      LcCnt14 : return 14;
-      LcCnt15 : return 15;
-      LcCnt16 : return 16;
-      default: `uvm_fatal("lc_env_pkg", $sformatf("unknown lc_cnt 0x%0h", curr_cnt))
-    endcase
   endfunction
 
   function automatic lc_ctrl_pkg::token_idx_e get_exp_token(dec_lc_state_e curr_state,

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:dv:cip_lib
       - lowrisc:dv:mem_bkdr_if
       - lowrisc:dv:crypto_dpi_present
+      - lowrisc:dv:lc_ctrl_dv_utils
     files:
       - otp_ctrl_env_pkg.sv
       - otp_ctrl_if.sv

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -19,6 +19,7 @@ package otp_ctrl_env_pkg;
   import otp_ctrl_part_pkg::*;
   import lc_ctrl_pkg::*;
   import lc_ctrl_state_pkg::*;
+  import lc_ctrl_dv_utils_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -27,6 +27,11 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   bit default_req_blocking = 1;
   bit lc_prog_blocking     = 1;
 
+  // Collect current lc_state and lc_cnt. This is used to create next lc_state and lc_cnt without
+  // error.
+  lc_ctrl_state_pkg::lc_state_e lc_state;
+  lc_ctrl_state_pkg::lc_cnt_e   lc_cnt;
+
   `uvm_object_new
 
   virtual task dut_init(string reset_kind = "HARD");
@@ -64,6 +69,8 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     cfg.mem_bkdr_vif.clear_mem();
     cfg.backdoor_clear_mem = 1;
     used_dai_addr_q.delete();
+    lc_state = 0;
+    lc_cnt   = 0;
   endtask
 
   // some registers won't set to default value until otp_init is done
@@ -426,15 +433,17 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     `uvm_send(flash_data_pull_seq)
   endtask
 
-  virtual task req_lc_transition(bit check_intr = 0, bit blocking = default_req_blocking);
+  virtual task req_lc_transition(bit check_intr = 0,
+                                 bit blocking = default_req_blocking,
+                                 bit wr_blank_err = 0);
     if (cfg.m_lc_prog_pull_agent_cfg.vif.req === 1'b1) return;
 
     if (blocking) begin
-      req_lc_transition_sub(check_intr);
+      req_lc_transition_sub(check_intr, wr_blank_err);
     end else begin
       fork
         begin
-          req_lc_transition_sub(check_intr);
+          req_lc_transition_sub(check_intr, wr_blank_err);
         end
       join_none;
       // Add #0 to ensure that this thread starts executing before any subsequent call
@@ -442,22 +451,29 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     end
   endtask
 
-  virtual task req_lc_transition_sub(bit check_intr = 0);
-    lc_ctrl_state_pkg::lc_state_e lc_state;
-    lc_ctrl_state_pkg::lc_cnt_e   lc_cnt;
+  virtual task req_lc_transition_sub(bit check_intr = 0, bit wr_blank_err = 0);
+    lc_ctrl_state_pkg::lc_cnt_e       next_lc_cnt;
+    lc_ctrl_state_pkg::dec_lc_state_e next_lc_state, lc_state_dec;
     bit [TL_DW-1:0]               intr_val;
     push_pull_host_seq#(.HostDataWidth(LC_PROG_DATA_SIZE), .DeviceDataWidth(1))
                         lc_prog_pull_seq;
     wait(cfg.under_reset == 0);
     `uvm_create_on(lc_prog_pull_seq, p_sequencer.lc_prog_pull_sequencer_h);
 
-    // Even though OTP does not check input lc_state or lc_cnt is valid enum,
-    // this sequence will have 90% chance that the input data is correctly encoded
-    if (!$urandom_range(0, 9)) begin
-      `DV_CHECK_STD_RANDOMIZE_FATAL(lc_state)
-      `DV_CHECK_STD_RANDOMIZE_FATAL(lc_cnt)
-      cfg.m_lc_prog_pull_agent_cfg.add_h_user_data({lc_state, lc_cnt});
+    if (!wr_blank_err) begin
+      // Find valid next state and next cnt using lc_ctrl_dv_utils_pkg.
+      // If terminal state or max LcCnt reaches, will not program any new data.
+      if ((lc_state != LcStScrap) && (lc_cnt != LcCnt16)) begin
+        lc_state_dec = lc_ctrl_dv_utils_pkg::dec_lc_state(lc_state);
+        `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(next_lc_state,
+                                           next_lc_state inside {VALID_NEXT_STATES[lc_state_dec]};)
+        `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(next_lc_cnt, next_lc_cnt > lc_cnt;)
+        lc_state = lc_ctrl_dv_utils_pkg::encode_lc_state(next_lc_state);
+        lc_cnt   = next_lc_cnt;
+      end
+      cfg.m_lc_prog_pull_agent_cfg.add_h_user_data({lc_cnt, lc_state});
     end
+
     `DV_CHECK_RANDOMIZE_FATAL(lc_prog_pull_seq)
     `uvm_send(lc_prog_pull_seq)
 


### PR DESCRIPTION
The new write_blank_error will write to OTP memory until the
write_blank_error is triggered. This partially written OTP memories can
trigger check failures or init failure.
This PR cleans up otp_dai_lock_vseq and avoid write_blank_err in these
tests.

For lc_program to issue valid values, this PR reuses the function from
lc_ctrl dv environment. To avoid duplicated code, this PR moves the
common pkg functions to a separate file, and packed it with a separate
core file.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>