### PR TITLE
[dv/otp_ctrl] align write_blank_error[PART2]

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_background_chks_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_background_chks_vseq.sv
@@ -4,7 +4,7 @@
 
 // This simple sequence checks if the background check can be triggered once the period is set.
 
-class otp_ctrl_background_chks_vseq extends otp_ctrl_dai_errs_vseq;
+class otp_ctrl_background_chks_vseq extends otp_ctrl_dai_lock_vseq;
   `uvm_object_utils(otp_ctrl_background_chks_vseq)
 
   `uvm_object_new

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_check_fail_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_check_fail_vseq.sv
@@ -6,7 +6,7 @@
 // 1. Check timeout
 // 2. Correctable ECC check error
 // 3. TODO: add when support
-class otp_ctrl_check_fail_vseq extends otp_ctrl_dai_errs_vseq;
+class otp_ctrl_check_fail_vseq extends otp_ctrl_dai_lock_vseq;
   `uvm_object_utils(otp_ctrl_check_fail_vseq)
 
   `uvm_object_new

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_errs_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_errs_vseq.sv
@@ -5,7 +5,7 @@
 // otp_ctrl_marco_errs_vseq is create OTP macro errors including:
 // - ECC correctable errors
 // - ECC uncorrectable errors
-class otp_ctrl_macro_errs_vseq extends otp_ctrl_dai_errs_vseq;
+class otp_ctrl_macro_errs_vseq extends otp_ctrl_dai_lock_vseq;
   `uvm_object_utils(otp_ctrl_macro_errs_vseq)
 
   `uvm_object_new

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_base_vseq.sv
@@ -8,7 +8,7 @@
 // 2. Another sequence is an empty task that needs to be override, this could be: key_request
 //    sequences or lc_request sequences.
 
-class otp_ctrl_parallel_base_vseq extends otp_ctrl_dai_errs_vseq;
+class otp_ctrl_parallel_base_vseq extends otp_ctrl_dai_lock_vseq;
   `uvm_object_utils(otp_ctrl_parallel_base_vseq)
 
   `uvm_object_new

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
@@ -6,7 +6,7 @@
 // After lc_escalate_en is On, this sequence will continue run base sequence to check if all state
 // machines are locked to `ErrorSt`.
 
-class otp_ctrl_parallel_lc_esc_vseq extends otp_ctrl_dai_errs_vseq;
+class otp_ctrl_parallel_lc_esc_vseq extends otp_ctrl_dai_lock_vseq;
   `uvm_object_utils(otp_ctrl_parallel_lc_esc_vseq)
 
   `uvm_object_new
@@ -59,9 +59,9 @@ class otp_ctrl_parallel_lc_esc_vseq extends otp_ctrl_dai_errs_vseq;
     // Wait 5 clock cycles until async lc_escalate_en propogate to each state machine.
     cfg.clk_rst_vif.wait_clks(5);
 
-    // After LC_escalate is On, we trigger the dai_errs_vseq to check interfaces will return
+    // After LC_escalate is On, we trigger the dai_lock_vseq to check interfaces will return
     // default values and the design won't hang.
-    otp_ctrl_dai_errs_vseq::body();
+    otp_ctrl_dai_lock_vseq::body();
   endtask
 
   virtual task post_start();

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_partition_walk_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_partition_walk_vseq.sv
@@ -15,9 +15,9 @@ class otp_ctrl_partition_walk_vseq extends otp_ctrl_base_vseq;
 
       // granularity of 64 bits
       if (is_secret(dai_addr) || is_digest(dai_addr)) begin
-        if (dai_addr % 2 || !is_sw_digest(dai_addr)) continue;
+        if (addr % 2) continue;
         dai_wr(dai_addr, dai_addr, dai_addr + 1);
-        dai_rd_check(dai_addr, dai_addr, dai_addr + 1);
+        if (!is_digest(dai_addr)) dai_rd_check(dai_addr, dai_addr, dai_addr + 1);
 
       // granularity of 32 bits
       end else begin

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_test_access_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_test_access_vseq.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class otp_ctrl_test_access_vseq extends otp_ctrl_dai_errs_vseq;
+class otp_ctrl_test_access_vseq extends otp_ctrl_dai_lock_vseq;
   `uvm_object_utils(otp_ctrl_test_access_vseq)
 
   `uvm_object_new


### PR DESCRIPTION
This PR moves the base tests for all extended sequence from
`otp_ctrl_dai_errs` to `otp_ctrl_dai_lock`.
This is because the new `otp_ctrl_write_blank_err` can trigger fatal
alert, and entire otp_ctrl will go to terminal state. So we do not use
that for base class anymore.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>