### PR TITLE
[prim_alert*/prim_esc*] Rework placement of size_only bufs/flops

### DIFF
--- a/hw/ip/prim/prim_alert.core
+++ b/hw/ip/prim/prim_alert.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:prim:diff_decode
       - lowrisc:prim:buf
+      - lowrisc:prim:flop
     files:
       - rtl/prim_alert_pkg.sv
       - rtl/prim_alert_receiver.sv

--- a/hw/ip/prim/rtl/prim_esc_sender.sv
+++ b/hw/ip/prim/rtl/prim_esc_sender.sv
@@ -43,15 +43,25 @@ module prim_esc_sender
   // decode differential signals //
   /////////////////////////////////
 
-  logic resp, sigint_detected;
+  logic resp, resp_n, resp_p, sigint_detected;
+
+  // This prevents further tool optimizations of the differential signal.
+  prim_buf #(
+    .Width(2)
+  ) u_prim_buf_resp (
+    .in_i({esc_rx_i.resp_n,
+           esc_rx_i.resp_p}),
+    .out_o({resp_n,
+            resp_p})
+  );
 
   prim_diff_decode #(
     .AsyncOn(1'b0)
-  ) i_decode_resp (
+  ) u_decode_resp (
     .clk_i,
     .rst_ni,
-    .diff_pi  ( esc_rx_i.resp_p ),
-    .diff_ni  ( esc_rx_i.resp_n ),
+    .diff_pi  ( resp_p          ),
+    .diff_ni  ( resp_n          ),
     .level_o  ( resp            ),
     .rise_o   (                 ),
     .fall_o   (                 ),
@@ -75,13 +85,13 @@ module prim_esc_sender
   assign esc_p = esc_req_i | esc_req_q | (ping_req_d & ~ping_req_q);
 
   // This prevents further tool optimizations of the differential signal.
-  prim_buf u_prim_buf_p (
-    .in_i(esc_p),
-    .out_o(esc_tx_o.esc_p)
-  );
-  prim_buf u_prim_buf_n (
-    .in_i(~esc_p),
-    .out_o(esc_tx_o.esc_n)
+  prim_buf #(
+    .Width(2)
+  ) u_prim_buf_esc (
+    .in_i({~esc_p,
+           esc_p}),
+    .out_o({esc_tx_o.esc_n,
+            esc_tx_o.esc_p})
   );
 
   //////////////


### PR DESCRIPTION
This slightly reworks the placement of `size_only` bufs and flops.
In particular, all diff input and outputs should now either go through a
`size_only` flop or a `size_only` buf to prevent logical optimization of diff pairs.

Signed-off-by: Michael Schaffner <msf@opentitan.org>