### PR TITLE
[reggen] Minor updates for shadowed multiregs

### DIFF
--- a/util/reggen/reg_pkg.sv.tpl
+++ b/util/reggen/reg_pkg.sv.tpl
@@ -169,8 +169,14 @@ packbit = 0
     msb = nbits - packbit - 1
     lsb = msb - struct_width + 1
     packbit += struct_width
+    name_and_comment = f'{r0.name.lower()}; // [{msb}:{lsb}]'
 %>\
-    ${struct_type} ${r0.name.lower()}; // [${msb}:${lsb}]
+  % if 4 + len(struct_type) + 1 + len(name_and_comment) <= 100:
+    ${struct_type} ${name_and_comment}
+  % else:
+    ${struct_type}
+        ${name_and_comment}
+  % endif
   % endif
 % endfor
   } ${gen_rtl.get_iface_tx_type(block, iface_name, False)};
@@ -199,8 +205,14 @@ packbit = 0
     msb = nbits - packbit - 1
     lsb = msb - struct_width + 1
     packbit += struct_width
+    name_and_comment = f'{r0.name.lower()}; // [{msb}:{lsb}]'
 %>\
-    ${struct_type} ${r0.name.lower()}; // [${msb}:${lsb}]
+  % if 4 + len(struct_type) + 1 + len(name_and_comment) <= 100:
+    ${struct_type} ${name_and_comment}
+  % else:
+    ${struct_type}
+        ${name_and_comment}
+  % endif
   % endif
 % endfor
   } ${gen_rtl.get_iface_tx_type(block, iface_name, True)};

--- a/util/reggen/register.py
+++ b/util/reggen/register.py
@@ -11,6 +11,8 @@ from .lib import (check_keys, check_str, check_name, check_bool,
 from .params import ReggenParams
 from .reg_base import RegBase
 
+import re
+
 REQUIRED_FIELDS = {
     'name': ['s', "name of the register"],
     'desc': ['t', "description of the register"],
@@ -122,7 +124,8 @@ class Register(RegBase):
         self.tags = tags
 
         self.shadowed = shadowed
-        sounds_shadowy = self.name.lower().endswith('_shadowed')
+        pattern = r'^[a-z0-9_]+_shadowed(?:_[0-9]+)?'
+        sounds_shadowy = re.match(pattern, self.name.lower())
         if self.shadowed and not sounds_shadowy:
             raise ValueError("Register {} has the shadowed flag but its name "
                              "doesn't end with the _shadowed suffix."


### PR DESCRIPTION
Two minor reggen updates:
- update name checking rule such that multiregs can be declared `SHADOWED` as well
- such multiregs tend to produce long struct type definitions in `reg_pkg`, hence in certain cases where a line would become longer than 100 chars the template now breaks the definition onto two lines.

Signed-off-by: Michael Schaffner <msf@opentitan.org>