### PR TITLE
[rom_ctrl/dv] Build second TLUL agent automatically

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -128,7 +128,8 @@ virtual task tl_write_mem_less_than_word(string ral_name);
         addr[1:0] == 0; // word aligned
         (addr & csr_addr_mask[ral_name]) inside
             {[loc_mem_ranges[mem_idx].start_addr : loc_mem_ranges[mem_idx].end_addr]};
-        mask != '1 || size < 2;
+        mask != '1 || size < 2;, ,
+        p_sequencer.tl_sequencer_hs[ral_name]
         )
   end
 endtask
@@ -147,7 +148,8 @@ virtual task tl_read_mem_err(string ral_name);
         opcode == tlul_pkg::Get;
         (addr & csr_addr_mask[ral_name]) inside
             {[loc_mem_ranges[mem_idx].start_addr :
-              loc_mem_ranges[mem_idx].end_addr]};
+              loc_mem_ranges[mem_idx].end_addr]};, ,
+        p_sequencer.tl_sequencer_hs[ral_name]
         )
   end
 endtask

--- a/hw/ip/rom_ctrl/data/rom_ctrl_testplan.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl_testplan.hjson
@@ -5,6 +5,7 @@
   name: "rom_ctrl"
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
   testpoints: [
     {

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.sv
@@ -12,8 +12,6 @@ class rom_ctrl_env extends cip_base_env #(
 
   `uvm_component_new
 
-  // TL agent for the rom interface
-  tl_agent m_rom_tl_agent;
   // KMAC interface agent
   kmac_app_agent m_kmac_agent;
 
@@ -29,11 +27,6 @@ class rom_ctrl_env extends cip_base_env #(
       `uvm_fatal(`gfn, "failed to get rom_ctrl_vif from uvm_config_db")
     end
 
-    // Build the rom TLUL agent (the regs agent is built in the CIP base class)
-    m_rom_tl_agent  = tl_agent::type_id::create("m_rom_tl_agent", this);
-    uvm_config_db#(tl_agent_cfg)::set(this, "m_rom_tl_agent", "cfg", cfg.m_rom_tl_cfg);
-    cfg.m_rom_tl_cfg.en_cov  = cfg.en_cov;
-
     // Build the KMAC agent
     m_kmac_agent = kmac_app_agent::type_id::create("m_kmac_agent", this);
     uvm_config_db#(kmac_app_agent_cfg)::set(this, "m_kmac_agent", "cfg", cfg.m_kmac_agent_cfg);
@@ -46,11 +39,7 @@ class rom_ctrl_env extends cip_base_env #(
     m_kmac_agent.monitor.analysis_port.connect(scoreboard.kmac_rsp_fifo.analysis_export);
     m_kmac_agent.monitor.req_analysis_port.connect(scoreboard.kmac_req_fifo.analysis_export);
 
-    m_rom_tl_agent.monitor.a_chan_port.connect(scoreboard.rom_tl_a_chan_fifo.analysis_export);
-    m_rom_tl_agent.monitor.d_chan_port.connect(scoreboard.rom_tl_d_chan_fifo.analysis_export);
-
-    virtual_sequencer.kmac_sequencer_h   = m_kmac_agent.sequencer;
-    virtual_sequencer.rom_tl_sequencer_h = m_rom_tl_agent.sequencer;
+    virtual_sequencer.kmac_sequencer_h = m_kmac_agent.sequencer;
 
   endfunction
 

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -5,7 +5,6 @@
 class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block));
 
   // ext component cfgs
-  rand tl_agent_cfg m_rom_tl_cfg;
   kmac_app_agent_cfg m_kmac_agent_cfg;
 
   // Memory backdoor util instance for ROM.
@@ -21,15 +20,13 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = rom_ctrl_env_pkg::LIST_OF_ALERTS;
+    ral_model_names.push_back("rom_ctrl_rom_reg_block");
     super.initialize(csr_base_addr);
     num_interrupts = 0;
 
     m_kmac_agent_cfg = kmac_app_agent_cfg::type_id::create("m_kmac_agent_cfg");
     m_kmac_agent_cfg.if_mode = dv_utils_pkg::Device;
     m_kmac_agent_cfg.start_default_device_seq = 1'b1;
-
-    m_rom_tl_cfg = tl_agent_cfg::type_id::create("m_rom_tl_cfg");
-    m_rom_tl_cfg.if_mode = dv_utils_pkg::Host;
 
   endfunction
 

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_virtual_sequencer.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_virtual_sequencer.sv
@@ -8,7 +8,6 @@ class rom_ctrl_virtual_sequencer extends cip_base_virtual_sequencer #(
   );
   `uvm_component_utils(rom_ctrl_virtual_sequencer)
 
-  tl_sequencer rom_tl_sequencer_h;
   kmac_app_sequencer kmac_sequencer_h;
 
   `uvm_component_new

--- a/hw/ip/rom_ctrl/dv/tb.sv
+++ b/hw/ip/rom_ctrl/dv/tb.sv
@@ -23,6 +23,7 @@ module tb;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
+  clk_rst_if rom_clk_rst_if(.clk(), .rst_n()); // dummy clk_rst_vif for second RAL
   pins_if #(1) devmode_if(devmode);
   tl_if tl_rom_if(.clk(clk), .rst_n(rst_n));
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
@@ -76,10 +77,15 @@ module tb;
 
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();
+    rom_clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
+    uvm_config_db#(virtual clk_rst_if)::set(null,
+        "*.env", "clk_rst_vif_rom_ctrl_rom_reg_block", rom_clk_rst_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
-    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_rom_tl_agent*", "vif", tl_rom_if);
-    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
+    uvm_config_db#(virtual tl_if)::set(null,
+        "*.env.m_tl_agent_rom_ctrl_rom_reg_block*", "vif", tl_rom_if);
+    uvm_config_db#(virtual tl_if)::set(null,
+        "*.env.m_tl_agent_rom_ctrl_regs_reg_block*", "vif", tl_if);
     uvm_config_db#(mem_bkdr_util)::set(null, "*.env", "mem_bkdr_util", m_mem_bkdr_util);
     uvm_config_db#(virtual kmac_app_intf)::set(null, "*.env.m_kmac_agent*", "vif", kmac_app_if);
     uvm_config_db#(rom_ctrl_vif)::set(null, "*.env", "rom_ctrl_vif", rom_ctrl_if);


### PR DESCRIPTION
This change switches the rom_ctrl testbench to build the second TLUL agent automatically, based on the auto-generated RAL. It is currently DRAFT due to a couple of issues:
- Constraint solving issues around unmapped addresses noted in #6594 
- _As-yet undiagnosed issues around unmapped addresses being generated in tl_errors sequences which don't result in protocol errors_

EDIT: tracked down unmapped address issue (missing RAL specifier in the sequence) and fixed as part of this PR. This still needs #6626 to go in first to fix constraint issues in `tl_write_csr_word_unaligned_addr` and address calculation in `tl_access_unmapped_addr`
EDIT: Now ready to go in since #6626 has been merged