### PR TITLE
[otbn,dv] Add coverage tracking for big number instructions

### DIFF
--- a/hw/ip/otbn/doc/dv/index.md
+++ b/hw/ip/otbn/doc/dv/index.md
@@ -338,17 +338,17 @@ This instruction uses the `I` encoding schema, with covergroup `enc_i_cg`.
 The instruction-specific covergroup is `insn_xw_cg` (shared with `SW`).
 
 - Load from a valid address, where `<grs1>` is above the top of memory and a negative `<offset>` brings the load address in range. 
-  Tracked as `oob_base_neg_off_cp`.
+  Tracked as `oob_base_neg_off_cross`.
 - Load from a valid address, where `<grs1>` is negative and a positive `<offset>` brings the load address in range.
-  Tracked as `neg_base_pos_off_cp`.
+  Tracked as `neg_base_pos_off_cross`.
 - Load from address zero.
-  Tracked as `addr0_cp`.
+  Tracked as `addr0_cross`.
 - Load from the top word of memory
-  Tracked as `top_addr_cp`.
+  Tracked as `top_addr_cross`.
 - Load from an invalid address (aligned but above the top of memory)
-  Tracked as `oob_addr_cp`.
+  Tracked as `oob_addr_cross`.
 - Load from a "barely invalid" address (aligned but overlapping the top of memory)
-  Tracked as `barely_oob_addr_cp`.
+  Tracked as `barely_oob_addr_cross`.
 - Misaligned address tracking.
   Track loads from addresses that are in range for the size of the memory.
   Cross the different values modulo 4 for `grs1` and `offset`.
@@ -360,17 +360,17 @@ This instruction uses the `I` encoding schema, with covergroup `enc_s_cg`.
 The instruction-specific covergroup is `insn_xw_cg` (shared with `LW`).
 
 - Store to a valid address, where `<grs1>` is above the top of memory and a negative `<offset>` brings the load address in range.
-  Tracked as `oob_base_neg_off_cp`.
+  Tracked as `oob_base_neg_off_cross`.
 - Store to a valid address, where `<grs1>` is negative and a positive `<offset>` brings the load address in range.
-  Tracked as `neg_base_pos_off_cp`.
+  Tracked as `neg_base_pos_off_cross`.
 - Store to address zero
-  Tracked as `addr0_cp`.
+  Tracked as `addr0_cross`.
 - Store to the top word of memory
-  Tracked as `top_addr_cp`.
+  Tracked as `top_addr_cross`.
 - Store to an invalid address (aligned but above the top of memory)
-  Tracked as `oob_addr_cp`.
+  Tracked as `oob_addr_cross`.
 - Store to a "barely invalid" address (aligned but overlapping the top of memory)
-  Tracked as `barely_oob_addr_cp`.
+  Tracked as `barely_oob_addr_cross`.
 - Misaligned address tracking.
   Track stores from addresses that are in range for the size of the memory.
   Cross the different values modulo 4 for `grs1` and `offset`.
@@ -530,202 +530,303 @@ The instruction-specific covergroup is `insn_loopi_cg`.
 
 #### BN.ADD
 
-This instruction uses the `bnaf` encoding schema, with covergroup `enc_bna_cg`.
+This instruction uses the `bnaf` encoding schema, with covergroup `enc_bnaf_cg`.
+There is no instruction-specific covergroup.
 
-- Extremal values of shift for both directions where the shifted value is nonzero
+- Extremal values of shift for both directions where the shifted value is nonzero.
+  This is tracked in `enc_bnaf_cg` as `st_sb_nz_shifted_cross`.
 - A nonzero right shift with a value in `wrs2` whose top bit is set
+  This is tracked in `enc_bnaf_cg` as `srl_cross`.
 
 #### BN.ADDC
 
-This instruction uses the `bnaf` encoding schema, with covergroup `enc_bna_cg`.
+This instruction uses the `bnaf` encoding schema, with covergroup `enc_bnaf_cg`.
+The instruction-specific covergroup is `insn_bn_addc_cg`.
 
 - Extremal values of shift for both directions where the shifted value is nonzero
+  This is tracked in `enc_bnaf_cg` as `st_sb_nz_shifted_cross`.
 - A nonzero right shift with a value in `wrs2` whose top bit is set
+  This is tracked in `enc_bnaf_cg` as `srl_cross`.
 - Execute with both values of the carry flag for both flag groups (to make sure things are wired through properly)
+  Tracked as `carry_cross`.
 
 #### BN.ADDI
 
 This instruction uses the `bnai` encoding schema, with covergroup `enc_bnai_cg`.
+There is no instruction-specific covergroup.
 
 No special coverage.
 
 #### BN.ADDM
 
 This instruction uses the `bnam` encoding schema, with covergroup `enc_bnam_cg`.
+The instruction-specific covergroup is `insn_bn_addm_cg`.
 
 - Execute with the two extreme values of `MOD` (zero and all ones)
-- Perform a subtraction (because the sum is at least `MOD`) when `MOD` is nonzero.
+  Tracked as `mod_cp`.
 - Don't perform a subtraction (because the sum is less than `MOD`) when `MOD` is nonzero.
-- Perform a subtraction where the sum is at least twice a nonzero value of `MOD`.
+  Tracked as `sum_lt_cp`.
 - A calculation where the sum exactly equals a nonzero `MOD`
+  Tracked as `sum_eq_cp`.
+- A calculation where the sum is greater than a nonzero `MOD`.
+  Tracked as `sum_gt_cp`.
+- Perform a subtraction where the sum is at least twice a nonzero value of `MOD`.
+  Tracked as `sum_gt2_cp`.
 - A calculation where the intermediate sum is greater than `2^256-1`, crossed with whether the subtraction of `MOD` results in a value that will wrap.
+  Tracked as `overflow_wrap_cross`.
 
 #### BN.MULQACC
 
 This instruction uses the `bnaq` encoding schema, with covergroup `enc_bnaq_cg`.
+The instruction-specific covergroup is `insn_bn_mulqaccx_cg` (shared with the other `BN.MULQACC*` instructions).
 
 - Cross `wrs1_qwsel` with `wrs2_qwsel` to make sure they are applied to the right inputs
+  This is tracked in `enc_bnaq_cg` as `qwsel_cross`.
 - See the accumulator overflow
+  This is tracked in `insn_bnmulqaccx_cg` as `overflow_cross`.
 
 #### BN.MULQACC.WO
 
 This instruction uses the `bnaq` encoding schema, with an extra field not present in `bn.mulqacc`.
 Encoding-level coverpoints are tracked in covergroup `enc_bnaqw_cg`.
+The instruction-specific covergroup is `insn_bn_mulqaccx_cg` (shared with the other `BN.MULQACC*` instructions).
 
 - Cross `wrs1_qwsel` with `wrs2_qwsel` to make sure they are applied to the right inputs
+  This is tracked in `enc_bnaqw_cg` as `qwsel_cross`.
 - See the accumulator overflow
+  This is tracked in `insn_bnmulqaccx_cg` as `overflow_cross`.
 
 #### BN.MULQACC.SO
 
 This instruction uses the `bnaq` encoding schema, with an extra field not present in `bn.mulqacc`.
 Encoding-level coverpoints are tracked in covergroup `enc_bnaqs_cg`.
+The instruction-specific covergroup is `insn_bn_mulqaccx_cg` (shared with the other `BN.MULQACC*` instructions).
 
 - Cross `wrs1_qwsel` with `wrs2_qwsel` to make sure they are applied to the right inputs
+  This is tracked in `enc_bnaqs_cg` as `qwsel_cross`.
 - See the accumulator overflow
+  This is tracked in `insn_bnmulqaccx_cg` as `overflow_cross`.
 - Cross the generic flag updates with `wrd_hwsel`, since the flag changes are different in the two modes.
+  This is tracked in `enc_bnaqs_cg` as `flags_01_cross`, `flags_10_cross` and `flags_11_cross`.
 
 #### BN.SUB
 
-This instruction uses the `bnaf` encoding schema, with covergroup `enc_bna_cg`.
+This instruction uses the `bnaf` encoding schema, with covergroup `enc_bnaf_cg`.
+There is no instruction-specific covergroup.
 
 - Extremal values of shift for both directions where the shifted value is nonzero
+  This is tracked in `enc_bnaf_cg` as `st_sb_nz_shifted_cross`.
 - A nonzero right shift with a value in `wrs2` whose top bit is set
+  This is tracked in `enc_bnaf_cg` as `srl_cross`.
 
 #### BN.SUBB
 
-This instruction uses the `bnaf` encoding schema, with covergroup `enc_bna_cg`.
+This instruction uses the `bnaf` encoding schema, with covergroup `enc_bnaf_cg`.
+The instruction-specific covergroup is `insn_bn_subcmpb_cg`.
 
 - Extremal values of shift for both directions where the shifted value is nonzero
+  This is tracked in `enc_bnaf_cg` as `st_sb_nz_shifted_cross`.
 - A nonzero right shift with a value in `wrs2` whose top bit is set
+  This is tracked in `enc_bnaf_cg` as `srl_cross`.
 - Execute with both values of the carry flag for both flag groups (to make sure things are wired through properly)
+  Tracked as `fg_carry_flag_cross`.
 
 #### BN.SUBI
 
 This instruction uses the `bnai` encoding schema, with covergroup `enc_bnai_cg`.
+There is no instruction-specific covergroup.
 
 No special coverage.
 
 #### BN.SUBM
 
 This instruction uses the `bnam` encoding schema, with covergroup `enc_bnam_cg`.
+The instruction-specific covergroup is `insn_bn_subm_cg`.
 
 - Execute with the two extreme values of `MOD` (zero and all ones)
+  Tracked as `mod_cp`.
 - A non-negative intermediate result with a nonzero `MOD` (so `MOD` is not added).
-- A negative intermediate result with a nonzero `MOD` (so `MOD` is added).
-- A very negative intermediate result with a nonzero `MOD` (so `MOD` is added, but the top bit is still set)
+  Tracked as `diff_nonneg_cp`.
 - An intermediate result that exactly equals a nonzero `-MOD`.
+  Tracked as `diff_minus_mod_cp`.
+- A negative intermediate result with a nonzero `MOD`, so `MOD` is added and the result is positive.
+  Tracked as `diff_neg_cp`.
+- A very negative intermediate result with a nonzero `MOD` (so `MOD` is added, but the top bit is still set)
+  Tracked as `diff_neg2_cp`.
 
 #### BN.AND
 
 This instruction uses the `bna` encoding schema, with covergroup `enc_bna_cg`.
+There is no instruction-specific covergroup.
 
 - Extremal values of shift for both directions where the shifted value is nonzero
+  Tracked in `enc_bna_cg` as `st_sb_nz_shifted_cross`.
 - Toggle coverage of the output result (to ensure we're not just AND'ing things with zero)
+  Tracked in `enc_bna_cg` as `wrd_XXXXXXXX_cross`, where `XXXXXXXX` is the base-2 representation of the bit being checked.
 
 #### BN.OR
 
 This instruction uses the `bna` encoding schema, with covergroup `enc_bna_cg`.
+There is no instruction-specific covergroup.
 
 - Extremal values of shift for both directions where the shifted value is nonzero
+  Tracked in `enc_bna_cg` as `st_sb_nz_shifted_cross`.
 - Toggle coverage of the output result (to ensure we're not just OR'ing things with zero)
+  Tracked in `enc_bna_cg` as `wrd_XXXXXXXX_cross`, where `XXXXXXXX` is the base-2 representation of the bit being checked.
 
 #### BN.NOT
 
 This instruction uses the `bnan` encoding schema, with covergroup `enc_bnan_cg`.
+There is no instruction-specific covergroup.
 
 - Extremal values of shift for both directions where the shifted value is nonzero
+  Tracked in `enc_bnan_cg` as `st_sb_nz_shifted_cross`.
 - Toggle coverage of the output result (to ensure nothing gets clamped)
+  Tracked in `enc_bnan_cg` as `wrd_XXXXXXXX_cp`, where `XXXXXXXX` is the base-2 representation of the bit being checked.
 
 #### BN.XOR
 
 This instruction uses the `bna` encoding schema, with covergroup `enc_bna_cg`.
+There is no instruction-specific covergroup.
 
 - Extremal values of shift for both directions where the shifted value is nonzero
+  Tracked in `enc_bna_cg` as `st_sb_nz_shifted_cross`.
 - Toggle coverage of the output result (to ensure we're not just XOR'ing things with zero)
+  Tracked in `enc_bna_cg` as `wrd_XXXXXXXX_cross`, where `XXXXXXXX` is the base-2 representation of the bit being checked.
 
 #### BN.RSHI
 
 This instruction uses the `bnr` encoding schema, with covergroup `enc_bnr_cg`.
+There is no instruction-specific covergroup.
 
 No special coverage.
 
 #### BN.SEL
 
 This instruction uses the `bns` encoding schema, with covergroup `enc_bns_cg`.
+There is no instruction-specific covergroup.
 
 - Cross flag group, flag and flag value (2 times 4 times 2 points)
+  Tracked in `enc_bns_cg` as `flag_cross`.
 
 #### BN.CMP
 
 This instruction uses the `bnc` encoding schema, with covergroup `enc_bnc_cg`.
+There is no instruction-specific covergroup.
 
 - Extremal values of shift for both directions where the shifted value is nonzero
+  Tracked in `enc_bnc_cg` as `st_sb_nz_shifted_cross`.
 - A nonzero right shift with a value in `wrs2` whose top bit is set
+  Tracked in `enc_bnc_cg` as `srl_cross`.
 
 #### BN.CMPB
 
 This instruction uses the `bnc` encoding schema, with covergroup `enc_bnc_cg`.
+The instruction-specific covergroup is `insn_bn_subcmpb_cg`.
 
 - Extremal values of shift for both directions where the shifted value is nonzero
+  Tracked in `enc_bnc_cg` as `st_sb_nz_shifted_cross`.
 - A nonzero right shift with a value in `wrs2` whose top bit is set
+  Tracked in `enc_bnc_cg` as `srl_cross`.
 - Execute with both values of the carry flag for both flag groups (to make sure things are wired through properly)
+  Tracked as `fg_carry_flag_cross`.
 
 #### BN.LID
 
 This instruction uses the `bnxid` encoding schema, with covergroup `enc_bnxid_cg`.
+The instruction-specific covergroup is `insn_bn_xid_cg` (shared with `BN.SID`).
 
 - Load from a valid address, where `grs1` is above the top of memory and a negative `offset` brings the load address in range.
+  Tracked as `oob_base_neg_off_cross`.
 - Load from a valid address, where `grs1` is negative and a positive `offset` brings the load address in range.
+  Tracked as `neg_base_pos_off_cross`.
 - Load from address zero
+  Tracked as `addr0_cross`.
 - Load from the top word of memory
+  Tracked as `top_addr_cross`.
 - Load from an invalid address (aligned but above the top of memory)
-- Load from a misaligned address
+  Tracked as `oob_addr_cross`.
+- Misaligned address tracking.
+  Track loads from addresses that are in range for the size of the memory.
+  Crossing the possible misalignments for operand_a and offset would give a big cross (`32^2 = 1024`).
+  Instead, we split those alignments into 3 bins: 0, 1-30 and 31.
+  Crossing them gives 9 combinations, tracked as `part_align_cross`.
+  We also track all possible alignments of the sum as `addr_align_cross`.
 - See an invalid instruction with both increments specified
+  Tracked in `enc_bnxid_cg` as a bin of `incd_inc1_cross`.
 - See `grd` greater than 31, giving an illegal instruction error
+  Tracked as `bigb_cross`.
 - Cross the three types of GPR for `grd` with `grd_inc`
+  Tracked in `enc_bnxid_cg` as `grx_incd_cross`.
 - Cross the three types of GPR for `grs1` with `grd_inc`
+  Tracked in `enc_bnxid_cg` as `grs1_inc1_cross`.
 
 #### BN.SID
 
 This instruction uses the `bnxid` encoding schema, with covergroup `enc_bnxid_cg`.
+The instruction-specific covergroup is `insn_bn_xid_cg` (shared with `BN.LID`).
 
 - Store to a valid address, where `grs1` is above the top of memory and a negative `offset` brings the load address in range.
+  Tracked as `oob_base_neg_off_cross`.
 - Store to a valid address, where `grs1` is negative and a positive `offset` brings the load address in range.
+  Tracked as `neg_base_pos_off_cross`.
 - Store to address zero
+  Tracked as `addr0_cross`.
 - Store to the top word of memory
+  Tracked as `top_addr_cross`.
 - Store to an invalid address (aligned but above the top of memory)
-- Store to a misaligned address
+  Tracked as `oob_addr_cross`.
+- Misaligned address tracking.
+  Track stores to addresses that are in range for the size of the memory.
+  Crossing the possible misalignments for operand_a and offset would give a big cross (`32^2 = 1024`).
+  Instead, we split those alignments into 3 bins: 0, 1-30 and 31.
+  Crossing them gives 9 combinations, tracked as `part_align_cross`.
+  We also track all possible alignments of the sum as `addr_align_cross`.
 - See an invalid instruction with both increments specified
+  Tracked in `enc_bnxid_cg` as a bin of `incd_inc1_cross`.
 - See `grd` greater than 31, giving an illegal instruction error
+  Tracked as `bigb_cross`.
 - Cross the three types of GPR for `grs2` with `grs2_inc`
+  Tracked in `enc_bnxid_cg` as `grx_incd_cross`.
 - Cross the three types of GPR for `grs1` with `grd_inc`
+  Tracked in `enc_bnxid_cg` as `grs1_inc1_cross`.
 
 #### BN.MOV
 
 This instruction uses the `bnmov` encoding schema, with covergroup `enc_bnmov_cg`.
+There is no instruction-specific covergroup.
 
 No special coverage otherwise.
 
 #### BN.MOVR
 
 This instruction uses the `bnmovr` encoding schema, with covergroup `enc_bnmovr_cg`.
+There is no instruction-specific covergroup.
 
 - See an invalid instruction with both increments specified
+  Tracked in `enc_bnmovr_cg` as a bin of `incd_inc1_cross`.
 - Since MOVR signals an error if either of its source registers has a value greater than 31, cross whether the input register value at `grd` is greater than 31 with whether the register value at `grs` is greater than 31
+  Tracked in `enc_bnmovr_cg` as `big_gpr_cross`.
 
 #### BN.WSRR
 
 This instruction uses the `bnwcsr` encoding schema, with covergroup `enc_wcsr_cg`.
+There is no instruction-specific covergroup.
 
 - Read from each valid WSR
 - Read from an invalid WSR
 
+These points are tracked with `wsr_cross` in `enc_wcsr_cg`.
+
 #### BN.WSRW
 
 This instruction uses the `bnwcsr` encoding schema, with covergroup `enc_wcsr_cg`.
+There is no instruction-specific covergroup.
 
 - Write to each valid WSR, including read-only WSRs.
 - Write to an invalid WSR
+
+These points are tracked with `wsr_cross` in `enc_wcsr_cg`.
 
 ## Self-checking strategy
 ### Scoreboard

--- a/hw/ip/otbn/dv/uvm/env/otbn_alu_bignum_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_alu_bignum_if.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bound into the otbn_alu_bignum and used to help collect ISPR information for coverage.
+
+interface otbn_alu_bignum_if (
+  input         clk_i,
+  input         rst_ni,
+
+  // Signal names from the otbn_alu_bignum module (where we are bound)
+  input [255:0] mod_q
+);
+
+endinterface

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -17,6 +17,8 @@ filesets:
     files:
       - otbn_env_pkg.sv
       - otbn_loop_if.sv
+      - otbn_alu_bignum_if.sv
+      - otbn_mac_bignum_if.sv
       - otbn_trace_item.sv: {is_include_file: true}
       - otbn_trace_monitor.sv: {is_include_file: true}
       - otbn_env_cfg.sv: {is_include_file: true}

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.sv
@@ -31,6 +31,14 @@ class otbn_env extends cip_base_env #(
     if (!uvm_config_db#(virtual otbn_loop_if)::get(this, "", "loop_vif", cfg.loop_vif)) begin
       `uvm_fatal(`gfn, "failed to get otbn_loop_if handle from uvm_config_db")
     end
+    if (!uvm_config_db#(virtual otbn_alu_bignum_if)::get(this, "", "alu_bignum_vif",
+                                                         cfg.alu_bignum_vif)) begin
+      `uvm_fatal(`gfn, "failed to get otbn_bignum_if handle from uvm_config_db")
+    end
+    if (!uvm_config_db#(virtual otbn_mac_bignum_if)::get(this, "", "mac_bignum_vif",
+                                                         cfg.mac_bignum_vif)) begin
+      `uvm_fatal(`gfn, "failed to get otbn_bignum_if handle from uvm_config_db")
+    end
 
     trace_monitor = otbn_trace_monitor::type_id::create("trace_monitor", this);
     trace_monitor.cfg = cfg;

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -13,8 +13,10 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
   `uvm_object_new
 
   // Handles used by otbn_trace_monitor
-  virtual otbn_trace_if trace_vif;
-  virtual otbn_loop_if  loop_vif;
+  virtual otbn_trace_if      trace_vif;
+  virtual otbn_loop_if       loop_vif;
+  virtual otbn_alu_bignum_if alu_bignum_vif;
+  virtual otbn_mac_bignum_if mac_bignum_vif;
 
   // The directory in which to look for ELF files (set by the test in build_phase; controlled by the
   // +otbn_elf_dir plusarg).

--- a/hw/ip/otbn/dv/uvm/env/otbn_mac_bignum_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_mac_bignum_if.sv
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bound into the otbn_mac_bignum and used to help collect ISPR information for coverage.
+
+interface otbn_mac_bignum_if (
+  input         clk_i,
+  input         rst_ni,
+
+  // Signal names from the otbn_mac_bignum module (where we are bound)
+  input logic [255:0] adder_op_a,
+  input logic [255:0] adder_op_b
+);
+
+  // Return the intermediate sum (the value of ACC before it gets truncated back down to 256 bits).
+  function automatic logic [256:0] get_sum_value();
+    return {1'b0, adder_op_a} + {1'b0, adder_op_b};
+  endfunction
+
+endinterface

--- a/hw/ip/otbn/dv/uvm/env/otbn_trace_item.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_trace_item.sv
@@ -16,10 +16,12 @@ class otbn_trace_item extends uvm_sequence_item;
   logic [255:0] wdr_operand_b;
 
   // Flag output data
+  otbn_pkg::flags_t flags_read_data [2];
   otbn_pkg::flags_t flags_write_data [2];
 
-  // GPR write data
-  logic [31:0] gpr_write_data;
+  // GPR and WDR write data
+  logic [31:0]  gpr_write_data;
+  logic [255:0] wdr_write_data;
 
   // Enum value that shows how full the loop stack is
   loop_stack_fullness_e loop_stack_fullness;
@@ -32,6 +34,12 @@ class otbn_trace_item extends uvm_sequence_item;
   // cause an if it's a jump, branch or another loop/loopi.
   logic        at_current_loop_end_insn;
 
+  // MOD ispr
+  logic [255:0] mod;
+
+  // Intermediate value for MULQACC instructions
+  logic [256:0] new_acc_extended;
+
   `uvm_object_utils_begin(otbn_trace_item)
     `uvm_field_int        (insn_addr,                UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (insn_data,                UVM_DEFAULT | UVM_HEX)
@@ -39,11 +47,15 @@ class otbn_trace_item extends uvm_sequence_item;
     `uvm_field_int        (gpr_operand_b,            UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (wdr_operand_a,            UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (wdr_operand_b,            UVM_DEFAULT | UVM_HEX)
+    `uvm_field_sarray_int (flags_read_data,          UVM_DEFAULT | UVM_HEX)
     `uvm_field_sarray_int (flags_write_data,         UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (gpr_write_data,           UVM_DEFAULT | UVM_HEX)
+    `uvm_field_int        (wdr_write_data,           UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (current_loop_end,         UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (at_current_loop_end_insn, UVM_DEFAULT)
     `uvm_field_int        (loop_stack_fullness,      UVM_DEFAULT)
+    `uvm_field_int        (mod,                      UVM_DEFAULT | UVM_HEX)
+    `uvm_field_int        (new_acc_extended,         UVM_DEFAULT | UVM_HEX)
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/hw/ip/otbn/dv/uvm/env/otbn_trace_monitor.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_trace_monitor.sv
@@ -35,11 +35,15 @@ class otbn_trace_monitor extends dv_base_monitor #(
           item.gpr_operand_b = cfg.trace_vif.rf_base_rd_data_b;
           item.wdr_operand_a = cfg.trace_vif.rf_bignum_rd_data_a;
           item.wdr_operand_b = cfg.trace_vif.rf_bignum_rd_data_b;
+          item.flags_read_data = cfg.trace_vif.flags_read_data;
           item.flags_write_data = cfg.trace_vif.flags_write_data;
           item.gpr_write_data = cfg.trace_vif.rf_base_wr_data;
+          item.wdr_write_data = cfg.trace_vif.rf_bignum_wr_data;
           item.loop_stack_fullness = cfg.loop_vif.get_fullness();
           item.current_loop_end = cfg.loop_vif.current_loop_end;
           item.at_current_loop_end_insn = cfg.loop_vif.at_current_loop_end_insn;
+          item.mod = cfg.alu_bignum_vif.mod_q;
+          item.new_acc_extended = cfg.mac_bignum_vif.get_sum_value();
 
           `uvm_info(`gfn, $sformatf("saw trace item:\n%0s", item.sprint()), UVM_HIGH)
           analysis_port.write(item);

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -100,6 +100,9 @@ module tb;
       .current_loop_end (32'(current_loop_q.loop_end))
     );
 
+  bind dut.u_otbn_core.u_otbn_alu_bignum otbn_alu_bignum_if i_otbn_alu_bignum_if (.*);
+  bind dut.u_otbn_core.u_otbn_mac_bignum otbn_mac_bignum_if i_otbn_mac_bignum_if (.*);
+
   // OTBN model, wrapping an ISS.
   //
   // Note that we pull the "start" signal out of the DUT. This is because it's much more difficult
@@ -151,6 +154,12 @@ module tb;
     uvm_config_db#(virtual otbn_loop_if)::set(
       null, "*.env", "loop_vif",
       dut.u_otbn_core.u_otbn_controller.u_otbn_loop_controller.i_otbn_loop_if);
+    uvm_config_db#(virtual otbn_alu_bignum_if)::set(
+      null, "*.env", "alu_bignum_vif",
+      dut.u_otbn_core.u_otbn_alu_bignum.i_otbn_alu_bignum_if);
+    uvm_config_db#(virtual otbn_mac_bignum_if)::set(
+      null, "*.env", "mac_bignum_vif",
+      dut.u_otbn_core.u_otbn_mac_bignum.i_otbn_mac_bignum_if);
 
     $timeformat(-12, 0, " ps", 12);
     run_test();


### PR DESCRIPTION
This is mostly pretty routine, just inspecting the various bits of
data in our trace to make sure everything matches.

We also need two new interfaces bound in, to get hold of some more
internal signals. The target modules don't have an "insn_addr" or
"insn_data" signal that would let us do a check to make sure things
are in sync, but I've manually looked at a log and everything seems to
line up.

Fixes #6565.