### PR TITLE
[otbn,dv] Add cover points for the call stack and flag writes

### DIFF
--- a/hw/ip/otbn/doc/dv/index.md
+++ b/hw/ip/otbn/doc/dv/index.md
@@ -134,6 +134,11 @@ Important events for it are tracked at those instructions, rather than separatel
 Each flag in each flag group should be set to one from zero by some instruction.
 Similarly, each flag in each flag group should be cleared to zero from one by some instruction.
 
+> These events are tracked in `flag_write_cg`.
+> This is called from `on_insn()` once for each flag group that is being written.
+> The covergroup contains eight coverpoints (for each flag set and cleared).
+> These are then crossed with the flag group.
+
 ### Instruction-based coverage
 
 As a processor, much of OTBN's coverage points are described in terms of instructions being executed.

--- a/hw/ip/otbn/doc/dv/index.md
+++ b/hw/ip/otbn/doc/dv/index.md
@@ -119,6 +119,11 @@ We expect to see the following events:
 
 All four of these events should be crossed with the three states of the call stack: empty, partially full, and full.
 
+> Coverage for these points is tracked in the `call_stack_cg` covergroup.
+> We track all possible combinations of push/pop flags (8 possibilities) in `flags_cp`.
+> The 3 different fullness states are tracked as `fullness_cp`.
+> These are then crossed to give `flags_fullness_cross`.
+
 #### Loop stack
 
 The [loop stack]({{< relref ".#loop-stack" >}}) is accessed by executing `LOOP` and `LOOPI` instructions.

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -19,6 +19,7 @@ filesets:
       - otbn_loop_if.sv
       - otbn_alu_bignum_if.sv
       - otbn_mac_bignum_if.sv
+      - otbn_rf_base_if.sv
       - otbn_trace_item.sv: {is_include_file: true}
       - otbn_trace_monitor.sv: {is_include_file: true}
       - otbn_env_cfg.sv: {is_include_file: true}

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.sv
@@ -33,11 +33,15 @@ class otbn_env extends cip_base_env #(
     end
     if (!uvm_config_db#(virtual otbn_alu_bignum_if)::get(this, "", "alu_bignum_vif",
                                                          cfg.alu_bignum_vif)) begin
-      `uvm_fatal(`gfn, "failed to get otbn_bignum_if handle from uvm_config_db")
+      `uvm_fatal(`gfn, "failed to get otbn_alu_bignum_if handle from uvm_config_db")
     end
     if (!uvm_config_db#(virtual otbn_mac_bignum_if)::get(this, "", "mac_bignum_vif",
                                                          cfg.mac_bignum_vif)) begin
-      `uvm_fatal(`gfn, "failed to get otbn_bignum_if handle from uvm_config_db")
+      `uvm_fatal(`gfn, "failed to get otbn_mac_bignum_if handle from uvm_config_db")
+    end
+    if (!uvm_config_db#(virtual otbn_rf_base_if)::get(this, "", "rf_base_vif",
+                                                      cfg.rf_base_vif)) begin
+      `uvm_fatal(`gfn, "failed to get otbn_rf_base_if handle from uvm_config_db")
     end
 
     trace_monitor = otbn_trace_monitor::type_id::create("trace_monitor", this);

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -17,6 +17,7 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
   virtual otbn_loop_if       loop_vif;
   virtual otbn_alu_bignum_if alu_bignum_vif;
   virtual otbn_mac_bignum_if mac_bignum_vif;
+  virtual otbn_rf_base_if    rf_base_vif;
 
   // The directory in which to look for ELF files (set by the test in build_phase; controlled by the
   // +otbn_elf_dir plusarg).

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
@@ -53,10 +53,16 @@ package otbn_env_pkg;
   } otbn_loaded_word;
 
   typedef enum {
-    LoopStackEmpty,
-    LoopStackPartial,
-    LoopStackFull
-  } loop_stack_fullness_e;
+    StackEmpty,
+    StackPartial,
+    StackFull
+  } stack_fullness_e;
+
+  typedef struct packed {
+    logic pop_a;
+    logic pop_b;
+    logic push;
+  } call_stack_flags_t;
 
   // package sources
   `include "otbn_env_cfg.sv"

--- a/hw/ip/otbn/dv/uvm/env/otbn_loop_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_loop_if.sv
@@ -17,14 +17,14 @@ interface otbn_loop_if (
   input logic [31:0] current_loop_end
 );
 
-  function automatic otbn_env_pkg::loop_stack_fullness_e get_fullness();
+  function automatic otbn_env_pkg::stack_fullness_e get_fullness();
     if (loop_stack_full) begin
-      return otbn_env_pkg::LoopStackFull;
+      return otbn_env_pkg::StackFull;
     end
     if (loop_active_q) begin
-      return otbn_env_pkg::LoopStackPartial;
+      return otbn_env_pkg::StackPartial;
     end
-    return otbn_env_pkg::LoopStackEmpty;
+    return otbn_env_pkg::StackEmpty;
   endfunction
 
 endinterface

--- a/hw/ip/otbn/dv/uvm/env/otbn_rf_base_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_rf_base_if.sv
@@ -1,0 +1,38 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bound into the otbn_rf_base and used to help collect call stack information for coverage.
+
+interface otbn_rf_base_if (
+  input       clk_i,
+  input       rst_ni,
+
+  // Signal names from the otbn_rf_base module (where we are bound)
+  input logic pop_stack_a, 
+  input logic pop_stack_b,
+  input logic pop_stack,
+  input logic push_stack,
+  input logic stack_full,
+  input logic stack_data_valid 
+);
+
+  function automatic otbn_env_pkg::call_stack_flags_t get_call_stack_flags();
+    return '{
+              pop_a: pop_stack && pop_stack_a,
+              pop_b: pop_stack && pop_stack_b,
+              push: push_stack
+            };
+  endfunction
+
+  function automatic otbn_env_pkg::stack_fullness_e get_call_stack_fullness();
+    if (stack_full) begin
+      return otbn_env_pkg::StackFull;
+    end
+    if (stack_data_valid) begin
+      return otbn_env_pkg::StackPartial;
+    end
+    return otbn_env_pkg::StackEmpty;
+  endfunction
+
+endinterface

--- a/hw/ip/otbn/dv/uvm/env/otbn_trace_item.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_trace_item.sv
@@ -23,11 +23,15 @@ class otbn_trace_item extends uvm_sequence_item;
   logic [31:0]  gpr_write_data;
   logic [255:0] wdr_write_data;
 
-  // Enum value that shows how full the loop stack is
-  loop_stack_fullness_e loop_stack_fullness;
+  // Flags showing call stack pushes and pops
+  call_stack_flags_t call_stack_flags;
+
+  // Enum values that show how full the loop and call stacks are
+  stack_fullness_e loop_stack_fullness;
+  stack_fullness_e call_stack_fullness;
 
   // The address of the last instruction of the innermost loop. Only valid if loop_stack_fullness is
-  // not LoopStackEmpty.
+  // not StackEmpty.
   logic [31:0] current_loop_end;
 
   // Flag which is true if the current instruction is at the end of the innermost loop. This will
@@ -51,9 +55,11 @@ class otbn_trace_item extends uvm_sequence_item;
     `uvm_field_sarray_int (flags_write_data,         UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (gpr_write_data,           UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (wdr_write_data,           UVM_DEFAULT | UVM_HEX)
+    `uvm_field_int        (call_stack_flags,         UVM_DEFAULT)
+    `uvm_field_int        (loop_stack_fullness,      UVM_DEFAULT)
+    `uvm_field_int        (call_stack_fullness,      UVM_DEFAULT)
     `uvm_field_int        (current_loop_end,         UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (at_current_loop_end_insn, UVM_DEFAULT)
-    `uvm_field_int        (loop_stack_fullness,      UVM_DEFAULT)
     `uvm_field_int        (mod,                      UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (new_acc_extended,         UVM_DEFAULT | UVM_HEX)
   `uvm_object_utils_end

--- a/hw/ip/otbn/dv/uvm/env/otbn_trace_item.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_trace_item.sv
@@ -15,8 +15,9 @@ class otbn_trace_item extends uvm_sequence_item;
   logic [255:0] wdr_operand_a;
   logic [255:0] wdr_operand_b;
 
-  // Flag output data
+  // Flag read/write data
   otbn_pkg::flags_t flags_read_data [2];
+  logic [1:0]       flags_write_valid;
   otbn_pkg::flags_t flags_write_data [2];
 
   // GPR and WDR write data
@@ -52,6 +53,7 @@ class otbn_trace_item extends uvm_sequence_item;
     `uvm_field_int        (wdr_operand_a,            UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (wdr_operand_b,            UVM_DEFAULT | UVM_HEX)
     `uvm_field_sarray_int (flags_read_data,          UVM_DEFAULT | UVM_HEX)
+    `uvm_field_int        (flags_write_valid,        UVM_DEFAULT | UVM_BIN)
     `uvm_field_sarray_int (flags_write_data,         UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (gpr_write_data,           UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (wdr_write_data,           UVM_DEFAULT | UVM_HEX)

--- a/hw/ip/otbn/dv/uvm/env/otbn_trace_monitor.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_trace_monitor.sv
@@ -36,6 +36,7 @@ class otbn_trace_monitor extends dv_base_monitor #(
           item.wdr_operand_a = cfg.trace_vif.rf_bignum_rd_data_a;
           item.wdr_operand_b = cfg.trace_vif.rf_bignum_rd_data_b;
           item.flags_read_data = cfg.trace_vif.flags_read_data;
+          item.flags_write_valid = cfg.trace_vif.flags_write;
           item.flags_write_data = cfg.trace_vif.flags_write_data;
           item.gpr_write_data = cfg.trace_vif.rf_base_wr_data;
           item.wdr_write_data = cfg.trace_vif.rf_bignum_wr_data;

--- a/hw/ip/otbn/dv/uvm/env/otbn_trace_monitor.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_trace_monitor.sv
@@ -39,7 +39,9 @@ class otbn_trace_monitor extends dv_base_monitor #(
           item.flags_write_data = cfg.trace_vif.flags_write_data;
           item.gpr_write_data = cfg.trace_vif.rf_base_wr_data;
           item.wdr_write_data = cfg.trace_vif.rf_bignum_wr_data;
+          item.call_stack_flags = cfg.rf_base_vif.get_call_stack_flags();
           item.loop_stack_fullness = cfg.loop_vif.get_fullness();
+          item.call_stack_fullness = cfg.rf_base_vif.get_call_stack_fullness();
           item.current_loop_end = cfg.loop_vif.current_loop_end;
           item.at_current_loop_end_insn = cfg.loop_vif.at_current_loop_end_insn;
           item.mod = cfg.alu_bignum_vif.mod_q;

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -102,6 +102,7 @@ module tb;
 
   bind dut.u_otbn_core.u_otbn_alu_bignum otbn_alu_bignum_if i_otbn_alu_bignum_if (.*);
   bind dut.u_otbn_core.u_otbn_mac_bignum otbn_mac_bignum_if i_otbn_mac_bignum_if (.*);
+  bind dut.u_otbn_core.u_otbn_rf_base otbn_rf_base_if i_otbn_rf_base_if (.*);
 
   // OTBN model, wrapping an ISS.
   //
@@ -160,6 +161,9 @@ module tb;
     uvm_config_db#(virtual otbn_mac_bignum_if)::set(
       null, "*.env", "mac_bignum_vif",
       dut.u_otbn_core.u_otbn_mac_bignum.i_otbn_mac_bignum_if);
+    uvm_config_db#(virtual otbn_rf_base_if)::set(
+      null, "*.env", "rf_base_vif",
+      dut.u_otbn_core.u_otbn_rf_base.i_otbn_rf_base_if);
 
     $timeformat(-12, 0, " ps", 12);
     run_test();


### PR DESCRIPTION
Add cover points for the coverage we had planned for `x1` and writes to the two flag groups.