### PR TITLE
[entropy/doc] hw interface descriptions updated

### DIFF
--- a/hw/ip/csrng/doc/_index.md
+++ b/hw/ip/csrng/doc/_index.md
@@ -129,6 +129,7 @@ The specific state information held in the instance is documented below.
 If the command was a `generate` command, the genbits data word will be returned to the requesting `cmd_stage` block.
 Finally, an `ack` response and status will be returned to the application interface once the command has been completely processed.
 
+
 ## Block Diagram
 
 ![CSRNG Block Diagram](csrng_blk_diag.svg)
@@ -136,6 +137,19 @@ Finally, an `ack` response and status will be returned to the application interf
 ## Hardware Interfaces
 
  {{< incGenFromIpDesc "../data/csrng.hjson" "hwcfg" >}}
+
+The table below lists other CSRNG signals.
+
+Signal                       | Direction        | Type                        | Description
+-----------------------------|------------------|-----------------------------|---------------
+`otp_en_csrng_sw_app_read_i` | `input `         | `otp_en_t `                 | An efuse that will enable firmware to access the NIST ctr_drbg internal state through registers.
+`lc_hw_debug_en_i`           | `input`          | `lc_tx_t `                  | A life-cycle that will allow disabling of the AES encryption block, to be used for debug only.
+`entropy_src_hw_if_o`        | `output`         | `entropy_src_hw_if_req_t`   | Seed request made to the Entropy_src module.
+`entropy_src_hw_if_i`        | `input`          | `entropy_src_hw_if_rsp_t`   | Seed response from the Entropy_src module. 
+`cs_aes_halt_i`              | `input`          | `cs_aes_halt_req_t`         | Request to CSRNG from Entropy_Src to halt requests to the AES block for power leveling purposes.
+`cs_aes_halt_o`              | `output`         | `cs_aes_halt_rsp_t`         | Response from CSRNG to Entropy_Src that all requests to AES block are halted.
+`csrng_cmd_i`                | `input`          | `csrng_req_t`               | Application interface request to CSRNG from an EDN block.
+`csrng_cmd_o`                | `output`         | `csrng_rsp_t`               | Application interface response from CSRNG to an EDN block.
 
 ## Design Details
 

--- a/hw/ip/entropy_src/doc/_index.md
+++ b/hw/ip/entropy_src/doc/_index.md
@@ -175,7 +175,13 @@ This drop point will save on conditioner power, and still preserve `esfinal` FIF
 
 The above process will be repeated for as long as entropy bits are to be collected and processed.
 
-At any time, the `ENABLE` field can be cleared to halt the entropy generation (and health check testing) immediately.
+At any time, the `ENABLE` field can be cleared to halt the entropy generation (and health check testing) within a few clocks cycles after the register write.
+The reason for the delay is that there is a power spike feature where a handshake exists between ENTROPY_SRC and CSRNG modules.
+The power spike feature prevents the cryptographic block in ENTROPY_SRC to run at the same time as the one in CSRNG.
+A handshake exists that is made up of a simple request/acknowledge interface.
+The ENTROPY_SRC block will make a request to CSRNG.
+The CSRNG block will acknowledge after any current block encrpytion request has completed.
+At that point, the ENTROPY_SRC block will recieve the acknowledge and continue processing entropy bits, running them through the SHA3 conditioner.
 
 ## Block Diagram
 
@@ -184,6 +190,23 @@ At any time, the `ENABLE` field can be cleared to halt the entropy generation (a
 ## Hardware Interfaces
 
 {{< incGenFromIpDesc "../data/entropy_src.hjson" "hwcfg" >}}
+
+The table below lists other ENTROPY_SRC signals.
+
+Signal                         | Direction        | Type                        | Description
+-------------------------------|------------------|-----------------------------|---------------
+`otp_en_entropy_src_fw_read_i` | `input `         | `otp_en_t `                 | An efuse that will enable firmware to access final entropy through a register.
+`otp_en_entropy_src_fw_over_i` | `input `         | `otp_en_t `                 | An efuse that will enable firmware to access post-health check raw entropy through a register FIFO.
+`rng_fips_o`                   | `output`         | `logic `                    | Output that indicates to the RNG AST block that Entropy_src block is generating fips level entropy.
+`entropy_src_hw_if_i`          | `input`          | `entropy_src_hw_if_req_t`   | Seed request made to the Entropy_src module.
+`entropy_src_hw_if_o`          | `output`         | `entropy_src_hw_if_rsp_t`   | Seed response from the Entropy_src module. 
+`entropy_src_rng_i`            | `input`          | `entropy_src_hw_if_req_t`   | Request made from RNG AST to the Entropy_src module to provide raw noise bits.
+`entropy_src_rng_o`            | `output`         | `entropy_src_rng_rsp_t`     | Response to RNG AST from the Entropy_src module that raw noise bits were received.
+`cs_aes_halt_o`                | `output`         | `cs_aes_halt_req_t`         | Request from Entropy_Src tp CSRNG that all requests to AES block are halted.
+`cs_aes_halt_i`                | `input`          | `cs_aes_halt_rsp_t`         | Response from CSRNG from Entropy_Src that the AES block is halted for power leveling purposes.
+`entropy_src_xht_o`            | `output`         | `entropy_src_xht_req_t`     | Request from Entropy_Src to an external health test block, which is optional.
+`entropy_src_xht_i`            | `input`          | `entropy_src_xht_rsp_t`     | Response to Entropy_Src from an external health test block, which is optional.
+
 
 ## Design Details
 


### PR DESCRIPTION
A complete list of hardware interface updates have been made for entropy_src and csrng documention files.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>