### PR TITLE
[dv/otp_ctrl] Clean up write-blank-errors in overflowed addresses [PART3]

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
@@ -6,9 +6,6 @@
 // - A writeblank error will be triggered if write to a non-empty address
 // - An access error will be triggered if write to lc partition via DAI interface, or if DAI write
 //   to digest addrs for non-sw partitions
-`define PART_ADDR_RANGE(i) \
-    {[PartInfo[``i``].offset : (PartInfo[``i``].offset + PartInfo[``i``].size - 1)]}
-
 class otp_ctrl_dai_errs_vseq extends otp_ctrl_dai_lock_vseq;
   `uvm_object_utils(otp_ctrl_dai_errs_vseq)
 
@@ -19,26 +16,12 @@ class otp_ctrl_dai_errs_vseq extends otp_ctrl_dai_lock_vseq;
     num_dai_op inside {[100:500]};
   }
 
-  constraint partition_index_c {part_idx inside {[CreatorSwCfgIdx:LifeCycleIdx]};}
-
-  constraint dai_wr_legal_addr_c {
-    if (part_idx == CreatorSwCfgIdx) dai_addr inside `PART_ADDR_RANGE(CreatorSwCfgIdx);
-    if (part_idx == OwnerSwCfgIdx)   dai_addr inside `PART_ADDR_RANGE(OwnerSwCfgIdx);
-    if (part_idx == HwCfgIdx)        dai_addr inside `PART_ADDR_RANGE(HwCfgIdx);
-    if (part_idx == Secret0Idx)      dai_addr inside `PART_ADDR_RANGE(Secret0Idx);
-    if (part_idx == Secret1Idx)      dai_addr inside `PART_ADDR_RANGE(Secret1Idx);
-    if (part_idx == Secret2Idx)      dai_addr inside `PART_ADDR_RANGE(Secret2Idx);
-    if (part_idx == LifeCycleIdx)    dai_addr inside `PART_ADDR_RANGE(LifeCycleIdx);
-    solve part_idx before dai_addr;
-  }
-
   function void pre_randomize();
     this.dai_wr_blank_addr_c.constraint_mode(0);
     this.no_access_err_c.constraint_mode(0);
     this.num_iterations_up_to_num_valid_addr_c.constraint_mode(0);
+    this.dai_wr_digests_c.constraint_mode(0);
     collect_used_addr = 0;
   endfunction
 
 endclass
-
-`undef PART_ADDR_RANGE

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
@@ -4,6 +4,12 @@
 
 // otp_ctrl_dai_lock_vseq is developed to read/write lock DAI interface by partitions, and request
 // read/write access to check if correct status and error code is triggered
+
+// Partitoin's legal range covers offset to digest addresses, dai_rd/dai_wr function will
+// randomize the address based on the granularity.
+`define PART_ADDR_RANGE(i) \
+    {[PartInfo[``i``].offset : (PartInfo[``i``].offset + PartInfo[``i``].size - 8)]}
+
 class otp_ctrl_dai_lock_vseq extends otp_ctrl_smoke_vseq;
   `uvm_object_utils(otp_ctrl_dai_lock_vseq)
 
@@ -22,11 +28,31 @@ class otp_ctrl_dai_lock_vseq extends otp_ctrl_smoke_vseq;
     num_dai_op inside {[1:50]};
   }
 
+  constraint partition_index_c {part_idx inside {[CreatorSwCfgIdx:LifeCycleIdx]};}
+
   constraint dai_wr_legal_addr_c {
+    if (part_idx == CreatorSwCfgIdx) dai_addr inside `PART_ADDR_RANGE(CreatorSwCfgIdx);
+    if (part_idx == OwnerSwCfgIdx)   dai_addr inside `PART_ADDR_RANGE(OwnerSwCfgIdx);
+    if (part_idx == HwCfgIdx)        dai_addr inside `PART_ADDR_RANGE(HwCfgIdx);
+    if (part_idx == Secret0Idx)      dai_addr inside `PART_ADDR_RANGE(Secret0Idx);
+    if (part_idx == Secret1Idx)      dai_addr inside `PART_ADDR_RANGE(Secret1Idx);
+    if (part_idx == Secret2Idx)      dai_addr inside `PART_ADDR_RANGE(Secret2Idx);
+    if (part_idx == LifeCycleIdx && collect_used_addr) {
+      if (collect_used_addr) {
+        // Dai address input is only 11 bits wide.
+        dai_addr inside {[PartInfo[LifeCycleIdx].offset : {11{1'b1}}]};
+      } else {
+        dai_addr inside {[PartInfo[LifeCycleIdx].offset : '1]};
+      }
+    }
+    solve part_idx before dai_addr;
+  }
+
+  constraint dai_wr_digests_c {
     {dai_addr[TL_AW-1:2], 2'b0} dist {
       {CreatorSwCfgDigestOffset, OwnerSwCfgDigestOffset,HwCfgDigestOffset, Secret0DigestOffset,
        Secret1DigestOffset, Secret2DigestOffset} :/ 1,
-      [CreatorSwCfgOffset : (LifeCycleOffset + LifeCycleSize)] :/ 9
+      [CreatorSwCfgOffset : '1] :/ 9
     };
   }
 
@@ -41,3 +67,5 @@ class otp_ctrl_dai_lock_vseq extends otp_ctrl_smoke_vseq;
   endtask;
 
 endclass
+
+`undef PART_ADDR_RANGE

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -13,7 +13,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
   rand bit                           do_req_keys, do_lc_trans;
   rand bit                           access_locked_parts;
-  rand bit [TL_AW-1:0]               dai_addr;
+  rand bit [TL_DW-1:0]               dai_addr;
   rand bit [TL_DW-1:0]               wdata0, wdata1;
   rand int                           num_dai_op;
   rand otp_ctrl_part_pkg::part_idx_e part_idx;


### PR DESCRIPTION
This PR cleans up the write-blank-errors in dai_lock_vseq. We want to
use a separate test to check write-blank-errors as previously mentioned
- it will cause fatal alert.

CSR dai address is 32 bits wide but design only take 11 bits. Address
values larger than 11'b1 could cause write-blank-error.
This PR tries to solve this issue.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>