### PR TITLE
[lc_ctrl/dif] Add get/set functions for OTP test register

### DIFF
--- a/sw/device/lib/dif/dif_lc_ctrl.c
+++ b/sw/device/lib/dif/dif_lc_ctrl.c
@@ -314,3 +314,35 @@ dif_lc_ctrl_mutex_result_t dif_lc_ctrl_transition(
                       1);
   return kDifLcCtrlMutexOk;
 }
+
+dif_lc_ctrl_mutex_result_t dif_lc_ctrl_set_otp_test_reg(const dif_lc_ctrl_t *lc,
+                                                        uint32_t settings) {
+  if (lc == NULL) {
+    return kDifLcCtrlMutexBadArg;
+  }
+
+  uint32_t busy = mmio_region_read32(lc->params.base_addr,
+                                     LC_CTRL_TRANSITION_REGWEN_REG_OFFSET);
+  if (busy == 0) {
+    return kDifLcCtrlMutexAlreadyTaken;
+  }
+
+  mmio_region_write32(lc->params.base_addr, LC_CTRL_OTP_TEST_CTRL_REG_OFFSET,
+                      settings);
+
+  return kDifLcCtrlMutexOk;
+}
+
+dif_lc_ctrl_result_t dif_lc_ctrl_get_otp_test_reg(const dif_lc_ctrl_t *lc,
+                                                  uint32_t *settings) {
+  if (lc == NULL || settings == NULL) {
+    return kDifLcCtrlBadArg;
+  }
+
+  uint32_t reg = mmio_region_read32(lc->params.base_addr,
+                                    LC_CTRL_OTP_TEST_CTRL_REG_OFFSET);
+
+  *settings = bitfield_field32_read(reg, LC_CTRL_OTP_TEST_CTRL_VAL_FIELD);
+
+  return kDifLcCtrlOk;
+}

--- a/sw/device/lib/dif/dif_lc_ctrl.h
+++ b/sw/device/lib/dif/dif_lc_ctrl.h
@@ -425,6 +425,28 @@ dif_lc_ctrl_mutex_result_t dif_lc_ctrl_transition(
     const dif_lc_ctrl_t *lc, dif_lc_ctrl_state_t state,
     const dif_lc_ctrl_token_t *token);
 
+/**
+ * Writes settings to the vendor-specific OTP test control register.
+ *
+ * @param lc A lifecycle handle.
+ * @param settings The settings to write to the register.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_lc_ctrl_mutex_result_t dif_lc_ctrl_set_otp_test_reg(const dif_lc_ctrl_t *lc,
+                                                        uint32_t settings);
+
+/**
+ * Reads settings from the vendor-specific OTP test control register.
+ *
+ * @param lc A lifecycle handle.
+ * @param settings Output parameter for the settings.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_lc_ctrl_result_t dif_lc_ctrl_get_otp_test_reg(const dif_lc_ctrl_t *lc,
+                                                  uint32_t *settings);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/dif_lc_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_lc_ctrl_unittest.cc
@@ -226,5 +226,20 @@ TEST_F(TransitionTest, NullArgs) {
   EXPECT_EQ(dif_lc_ctrl_transition(nullptr, kDifLcCtrlStateProd, &token),
             kDifLcCtrlMutexBadArg);
 }
+
+class OtpTestRegTest : public LcTest {};
+
+TEST_F(OtpTestRegTest, Read) {
+  uint32_t settings_read = 0;
+  EXPECT_READ32(LC_CTRL_OTP_TEST_CTRL_REG_OFFSET, 0x5A);
+  EXPECT_EQ(dif_lc_ctrl_get_otp_test_reg(&lc_, &settings_read), kDifLcCtrlOk);
+  EXPECT_EQ(settings_read, 0x5A);
+}
+
+TEST_F(OtpTestRegTest, Write) {
+  EXPECT_READ32(LC_CTRL_TRANSITION_REGWEN_REG_OFFSET, true);
+  EXPECT_WRITE32(LC_CTRL_OTP_TEST_CTRL_REG_OFFSET, 0xA5);
+  EXPECT_EQ(dif_lc_ctrl_set_otp_test_reg(&lc_, 0xA5), kDifLcCtrlMutexOk);
+}
 }  // namespace
 }  // namespace dif_lc_ctrl_unittest


### PR DESCRIPTION
We've recently added an additional CSR to the life cycle controller for vendor-specific OTP config bits.
This adds set/get methods for this register.
The individual bits are not defined in the open-source docs.

Let me know if you think this could be handler in a better way.

Signed-off-by: Michael Schaffner <msf@opentitan.org>