### PR TITLE
[dv] Add TL integrity error test for CSR

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_pkg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_pkg.sv
@@ -31,6 +31,13 @@ package cip_base_pkg;
     err_storage
   } shadow_reg_alert_e;
 
+  typedef enum bit [1:0] {
+    TlIntgErrNone,
+    TlIntgErrCmd,
+    TlIntgErrData,
+    TlIntgErrBoth // have both payload and data intg errors
+  } tl_intg_err_e;
+
   typedef class cip_tl_seq_item;
 
   // functions

--- a/hw/dv/sv/cip_lib/cip_base_test.sv
+++ b/hw/dv/sv/cip_lib/cip_base_test.sv
@@ -8,5 +8,12 @@ class cip_base_test #(type CFG_T = cip_base_env_cfg,
 
   `uvm_component_new
 
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+
+    // use cip_tl_seq_item to create tl_seq_item with correct integrity values and obtain integrity
+    // related functions
+    tl_seq_item::type_id::set_type_override(cip_tl_seq_item::get_type());
+  endfunction
 endclass : cip_base_test
 

--- a/hw/dv/sv/cip_lib/seq_lib/cip_tl_host_single_seq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_tl_host_single_seq.sv
@@ -12,10 +12,12 @@ class cip_tl_host_single_seq extends tl_host_single_seq #(cip_tl_seq_item);
   `uvm_object_new
 
   tlul_pkg::tl_type_e tl_type = DataType;
+  tl_intg_err_e       tl_intg_err_type = TlIntgErrNone;
 
   virtual function void randomize_req(REQ req, int idx);
     super.randomize_req(req, idx);
     req.tl_type = tl_type;
+    req.tl_intg_err_type = tl_intg_err_type;
   endfunction
 
 endclass

--- a/hw/dv/sv/cip_lib/seq_lib/cip_tl_seq_item.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_tl_seq_item.sv
@@ -11,33 +11,35 @@ class cip_tl_seq_item extends tl_seq_item;
   `uvm_object_new
 
   tlul_pkg::tl_type_e tl_type = DataType;
+  tl_intg_err_e       tl_intg_err_type = TlIntgErrNone;
+  // the max errors that we can detect
+  int                 max_ecc_errors = 3;
 
   function void post_randomize();
-    a_user = get_a_user_val();
-    d_user = get_d_user_val();
+    update_a_chan_intg_val(tl_intg_err_type);
   endfunction
 
   // calculate ecc value for a_user
   virtual function tl_a_user_t get_a_user_val();
     tl_a_user_t user;
     tl_h2d_cmd_intg_t cmd_intg_payload;
-    logic [H2DCmdFullWidth - 1 : 0] payload_intg;
-    logic [D2HRspFullWidth - 1 : 0] data_intg;
+    logic [H2DCmdFullWidth - 1 : 0] cmd_with_intg;
+    logic [D2HRspFullWidth - 1 : 0] data_with_intg;
 
     // construct command integrity
     cmd_intg_payload.tl_type = tl_type;
     cmd_intg_payload.addr = a_addr;
     cmd_intg_payload.opcode = tl_a_op_e'(a_opcode);
     cmd_intg_payload.mask = a_mask;
-    payload_intg = prim_secded_pkg::prim_secded_64_57_enc(H2DCmdMaxWidth'(cmd_intg_payload));
+    cmd_with_intg = prim_secded_pkg::prim_secded_64_57_enc(H2DCmdMaxWidth'(cmd_intg_payload));
 
     // construct data integrity
-    data_intg = prim_secded_pkg::prim_secded_64_57_enc(DataMaxWidth'(a_data));
+    data_with_intg = prim_secded_pkg::prim_secded_64_57_enc(DataMaxWidth'(a_data));
 
     user.rsvd = '0;
     user.tl_type = tl_type;
-    user.cmd_intg = payload_intg[H2DCmdFullWidth -1 -: H2DCmdIntgWidth];
-    user.data_intg = data_intg[DataFullWidth -1 -: DataIntgWidth];;
+    user.cmd_intg = cmd_with_intg[H2DCmdFullWidth -1 -: H2DCmdIntgWidth];
+    user.data_intg = data_with_intg[DataFullWidth -1 -: DataIntgWidth];;
     return user;
   endfunction // get_a_user_val
 
@@ -45,21 +47,147 @@ class cip_tl_seq_item extends tl_seq_item;
   virtual function tl_d_user_t get_d_user_val();
     tl_d_user_t user;
     tl_d2h_rsp_intg_t rsp_intg_payload;
-    logic [D2HRspFullWidth - 1:0] payload_intg;
-    logic [D2HRspFullWidth - 1:0] data_intg;
+    logic [D2HRspFullWidth - 1:0] rsp_with_intg;
+    logic [D2HRspFullWidth - 1:0] data_with_intg;
 
     // construct response integrity
     rsp_intg_payload.opcode = tl_d_op_e'(d_opcode);
     rsp_intg_payload.size = d_size;
     rsp_intg_payload.error = d_error;
-    payload_intg = prim_secded_pkg::prim_secded_64_57_enc(D2HRspMaxWidth'(rsp_intg_payload));
+    rsp_with_intg = prim_secded_pkg::prim_secded_64_57_enc(D2HRspMaxWidth'(rsp_intg_payload));
 
     // construct data integrity
-    data_intg = prim_secded_pkg::prim_secded_64_57_enc(DataMaxWidth'(d_data));
+    data_with_intg = prim_secded_pkg::prim_secded_64_57_enc(DataMaxWidth'(d_data));
 
-    user.rsp_intg = payload_intg[D2HRspFullWidth -1 -: D2HRspIntgWidth];
-    user.data_intg = data_intg[DataFullWidth -1 -: DataIntgWidth];
+    user.rsp_intg = rsp_with_intg[D2HRspFullWidth -1 -: D2HRspIntgWidth];
+    user.data_intg = data_with_intg[DataFullWidth -1 -: DataIntgWidth];
     return user;
   endfunction // get_d_user_val
+
+  // update data and ecc value for a channel
+  virtual function void update_a_chan_intg_val(tl_intg_err_e tl_intg_err_type = TlIntgErrNone);
+    tl_a_user_t cur_user = get_a_user_val();
+    tl_a_user_t final_user;
+    cip_tl_seq_item cur_item;
+    bit [DataIntgWidth + $bits(tl_h2d_cmd_intg_t) - 1 : 0] cmd_and_intg_err_mask;
+    bit [DataIntgWidth + BUS_DW - 1 : 0]                   data_and_intg_err_mask;
+
+    `downcast(cur_item, this.clone())
+
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(cmd_and_intg_err_mask,
+        if (tl_intg_err_type inside {TlIntgErrCmd, TlIntgErrBoth}) {
+          $countones(cmd_and_intg_err_mask) inside {[1 : max_ecc_errors]};
+        } else {
+          cmd_and_intg_err_mask == '0;
+        })
+    {a_addr, a_opcode, a_mask, final_user.tl_type, final_user.cmd_intg} = {
+        cur_item.a_addr,
+        cur_item.a_opcode,
+        cur_item.a_mask,
+        cur_user.tl_type,
+        cur_user.cmd_intg} ^ cmd_and_intg_err_mask;
+
+    if (cmd_and_intg_err_mask != '0) begin
+      string str = "TL cmd or integrity bits have been flipped, see the changes as below:\n";
+      str = $sformatf("%s\t a_addr: 0x%0x -> 0x%0x\n", str, cur_item.a_addr, a_addr);
+      str = $sformatf("%s\t a_opcode: 0x%0x -> 0x%0x\n", str, cur_item.a_opcode, a_opcode);
+      str = $sformatf("%s\t a_mask: 0x%0x -> 0x%0x\n", str, cur_item.a_mask, a_mask);
+      str = $sformatf("%s\t tl_type: 0x%0x -> 0x%0x\n", str, cur_user.tl_type, final_user.tl_type);
+      str = $sformatf("%s\t cmd_intg: 0x%0x -> 0x%0x\n", str, cur_user.cmd_intg,
+                      final_user.cmd_intg);
+      `uvm_info(`gfn, str, UVM_LOW)
+    end
+
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(data_and_intg_err_mask,
+        if (tl_intg_err_type inside {TlIntgErrData, TlIntgErrBoth}) {
+          $countones(data_and_intg_err_mask) inside {[1 : max_ecc_errors]};
+        } else {
+          data_and_intg_err_mask == '0;
+        })
+    {a_data, final_user.data_intg} = {cur_item.a_data, final_user.data_intg} ^
+                                     data_and_intg_err_mask;
+
+    if (cmd_and_intg_err_mask != '0) begin
+      string str = "TL data or integrity bits have been flipped, see the changes as below: \n";
+      str = $sformatf("%s\t a_data: 0x%0x -> 0x%0x\n", str, cur_item.a_data, a_data);
+      str = $sformatf("%s\t data_intg: 0x%0x -> 0x%0x\n", str, cur_user.data_intg,
+                      final_user.data_intg);
+      `uvm_info(`gfn, str, UVM_LOW)
+    end
+
+    a_user = final_user;
+  endfunction // update_a_chan_intg_val
+
+  // update data and ecc value for d channel
+  virtual function void update_d_chan_intg_val(tl_intg_err_e tl_intg_err_type = TlIntgErrNone);
+    tl_d_user_t cur_user = get_d_user_val();
+    tl_d_user_t final_user;
+    cip_tl_seq_item cur_item;
+    bit [DataIntgWidth + $bits(tl_d2h_rsp_intg_t) - 1 : 0] rsp_and_intg_err_mask;
+    bit [DataIntgWidth + BUS_DW - 1 : 0]                   data_and_intg_err_mask;
+
+    `downcast(cur_item, this.clone())
+
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(rsp_and_intg_err_mask,
+        if (tl_intg_err_type inside {TlIntgErrCmd, TlIntgErrBoth}) {
+          $countones(rsp_and_intg_err_mask) inside {[1 : max_ecc_errors]};
+        } else {
+          rsp_and_intg_err_mask == '0;
+        })
+    {d_opcode, d_size, d_error, final_user.rsp_intg} = {
+        cur_item.d_opcode,
+        cur_item.d_size,
+        cur_item.d_error,
+        cur_user.rsp_intg} ^ rsp_and_intg_err_mask;
+
+    if (rsp_and_intg_err_mask != '0) begin
+      string str = "TL cmd or integrity bits have been flipped, see the changes as below:\n";
+      str = $sformatf("%s\t d_opcode: 0x%0x -> 0x%0x\n", str, cur_item.d_opcode, d_opcode);
+      str = $sformatf("%s\t d_size: 0x%0x -> 0x%0x\n", str, cur_item.d_size, d_size);
+      str = $sformatf("%s\t d_error: 0x%0x -> 0x%0x\n", str, cur_item.d_error, d_error);
+      str = $sformatf("%s\t rsp_intg: 0x%0x -> 0x%0x\n", str, cur_user.rsp_intg,
+                      final_user.rsp_intg);
+      `uvm_info(`gfn, str, UVM_LOW)
+    end
+
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(data_and_intg_err_mask,
+        if (tl_intg_err_type inside {TlIntgErrData, TlIntgErrBoth}) {
+          $countones(data_and_intg_err_mask) inside {[1 : max_ecc_errors]};
+        } else {
+          data_and_intg_err_mask == '0;
+        })
+    {a_data, final_user.data_intg} = {cur_item.a_data, final_user.data_intg} ^
+                                     data_and_intg_err_mask;
+
+    if (rsp_and_intg_err_mask != '0) begin
+      string str = "TL data or integrity bits have been flipped, see the changes as below: \n";
+      str = $sformatf("%s\t a_data: 0x%0x -> 0x%0x\n", str, cur_item.a_data, a_data);
+      str = $sformatf("%s\t data_intg: 0x%0x -> 0x%0x\n", str, cur_user.data_intg,
+                      final_user.data_intg);
+      `uvm_info(`gfn, str, UVM_LOW)
+    end
+
+    d_user = final_user;
+  endfunction // update_d_chan_intg_val
+
+  virtual function bit is_a_user_ok(bit throw_error = 1'b1);
+    tl_a_user_t exp_user = get_a_user_val();
+    tl_a_user_t act_user = tl_a_user_t'(a_user);
+
+    // TODO, #6887, dat_intg isn't implemented in design
+    // is_a_user_ok = (act_user.cmd_intg == exp_user.cmd_intg) &&
+    //                (act_user.data_intg == exp_user.data_intg);
+    is_a_user_ok = (act_user.cmd_intg == exp_user.cmd_intg);
+
+    if (!is_a_user_ok) begin
+      `uvm_info(`gfn, $sformatf(
+                "cmd_intg act (0x%0x) != exp (0x%0x), data_intg act (0x%0x) != exp (0x%0x)",
+                act_user.cmd_intg, exp_user.cmd_intg, act_user.data_intg, exp_user.data_intg),
+                UVM_LOW)
+    end
+    if (!is_a_user_ok && throw_error) begin
+      `uvm_error(`gfn, "a_user integrity check fails")
+    end
+  endfunction // is_a_user_ok
 
 endclass

--- a/hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson
@@ -54,13 +54,13 @@
               "{name}_same_csr_outstanding"]
     }
     {
-      name: tl_integrity_check
+      name: tl_intg_err
       desc: ''' Verify that the data integrity check violation generates an alert.
 
             Randomly inject errors on the control, data, or the ECC bits during CSR accesses.
             Verify that triggers the correct fatal alert.'''
       milestone: V3
-      tests: []
+      tests: ["{name}_tl_intg_err"]
     }
   ]
 }

--- a/hw/dv/tools/dvsim/tests/tl_access_tests.hjson
+++ b/hw/dv/tools/dvsim/tests/tl_access_tests.hjson
@@ -16,5 +16,12 @@
       run_opts: ["+run_tl_errors"]
       reseed: 20
     }
+    {
+      name: "{name}_tl_intg_err"
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "{name}_common_vseq"
+      run_opts: ["+run_tl_intg_err", "+en_scb=0"]
+      reseed: 20
+    }
   ]
 }

--- a/hw/ip/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/ip/gpio/dv/gpio_sim_cfg.hjson
@@ -140,6 +140,12 @@
       name: gpio_csr_mem_rw_with_rand_reset
       run_opts: ["+do_clear_all_interrupts=0"]
     }
+
+    {
+      name: gpio_tl_intg_err
+      run_opts: ["+do_clear_all_interrupts=0"]
+    }
+
   ]
 
   // List of regressions.

--- a/hw/ip/otbn/dv/uvm/tests/otbn_base_test.sv
+++ b/hw/ip/otbn/dv/uvm/tests/otbn_base_test.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class otbn_base_test extends dv_base_test #(
+class otbn_base_test extends cip_base_test #(
     .CFG_T(otbn_env_cfg),
     .ENV_T(otbn_env)
   );

--- a/hw/ip/otbn/dv/uvm/tests/otbn_test_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/tests/otbn_test_pkg.sv
@@ -5,7 +5,7 @@
 package otbn_test_pkg;
   // dep packages
   import uvm_pkg::*;
-  import dv_lib_pkg::*;
+  import cip_base_pkg::*;
   import otbn_env_pkg::*;
   import otbn_memutil_pkg::*;
 


### PR DESCRIPTION
Create 2 threads. In one thread, call csr_rw to do normal TL access. In
the other, wait for some delay and issue a TL access with integrity
error

Signed-off-by: Weicai Yang <weicai@google.com>