### PR TITLE
[dv/otp_ctrl] write_blank_err [PART4]

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -423,7 +423,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
 
   virtual task req_lc_transition(bit check_intr = 0,
                                  bit blocking = default_req_blocking,
-                                 bit wr_blank_err = 0);
+                                 bit wr_blank_err = !collect_used_addr);
     if (cfg.m_lc_prog_pull_agent_cfg.vif.req === 1'b1) return;
 
     if (blocking) begin
@@ -439,7 +439,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     end
   endtask
 
-  virtual task req_lc_transition_sub(bit check_intr = 0, bit wr_blank_err = 0);
+  virtual task req_lc_transition_sub(bit check_intr = 0, bit wr_blank_err = !collect_used_addr);
     lc_ctrl_state_pkg::lc_cnt_e       next_lc_cnt;
     lc_ctrl_state_pkg::dec_lc_state_e next_lc_state, lc_state_dec;
     bit [TL_DW-1:0]                   intr_val;

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
@@ -9,11 +9,22 @@
 class otp_ctrl_dai_errs_vseq extends otp_ctrl_dai_lock_vseq;
   `uvm_object_utils(otp_ctrl_dai_errs_vseq)
 
+  bit[31:0] exp_status;
   `uvm_object_new
 
   constraint num_trans_c {
-    num_trans  inside {[1:5]};
+    num_trans  == 1;
     num_dai_op inside {[100:500]};
+  }
+
+  constraint regwens_c {
+    check_trigger_regwen_val == 0;
+  }
+
+  constraint rd_check_after_wr_c {
+    rand_wr == rand_rd;
+    // TODO: enable this sw read
+    rd_sw_tlul_rd == 0;
   }
 
   function void pre_randomize();
@@ -24,4 +35,16 @@ class otp_ctrl_dai_errs_vseq extends otp_ctrl_dai_lock_vseq;
     collect_used_addr = 0;
   endfunction
 
+  task body();
+    do_apply_reset = 0;
+    super.body();
+  endtask
+
+  virtual task post_start();
+    apply_reset();
+    // delay to avoid race condition when sending item and checking no item after reset occur
+    // at the same time
+    #1ps;
+    super.post_start();
+  endtask
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_stress_all_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_stress_all_vseq.sv
@@ -8,6 +8,8 @@
 //            - macro_errs_vseq and check_fail_vseq: require to write back to OTP once fatal
 //              error is triggered, thus does not handle random reset
 //            - partition_walk_vseq: assume OTP initial value is 0
+//            - dai_errs_vseq: write_blank_err will cause otp_init to fail, and requires to wipe
+//              out otp memory.
 class otp_ctrl_stress_all_vseq extends otp_ctrl_base_vseq;
   `uvm_object_utils(otp_ctrl_stress_all_vseq)
 
@@ -31,7 +33,6 @@ class otp_ctrl_stress_all_vseq extends otp_ctrl_base_vseq;
 
   task body();
     string seq_names[] = {"otp_ctrl_common_vseq",
-                          "otp_ctrl_dai_errs_vseq",
                           "otp_ctrl_dai_lock_vseq",
                           "otp_ctrl_smoke_vseq",
                           "otp_ctrl_test_access_vseq",
@@ -63,7 +64,6 @@ class otp_ctrl_stress_all_vseq extends otp_ctrl_base_vseq;
       end
 
       // Pass local variables to next sequence due to randomly issued reset.
-      otp_ctrl_vseq.collect_used_addr = 0;
       otp_ctrl_vseq.is_valid_dai_op = 0;
       otp_ctrl_vseq.lc_prog_blocking = this.lc_prog_blocking;
       otp_ctrl_vseq.digest_calculated = this.digest_calculated;


### PR DESCRIPTION
This PR fixes the OTP_CTRL_dai_errors. The write-blank error will
trigger OTP ECC errors. So in this PR, we modify the sequence:
1. Will always read out the memory after write.
2. Will not do any background check or otp_init because ECC
uncorrectable error.
3. Will create lc_program request write-blank error.

On scb side, we will use backdoor read to read out ECC and memory after
a write-blank-error.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>