### PR TITLE
[otbn,dv] Teach the RIG to dump an expected end address and check it in simulation

### DIFF
--- a/hw/dv/verilator/cpp/dpi_memutil.cc
+++ b/hw/dv/verilator/cpp/dpi_memutil.cc
@@ -458,6 +458,9 @@ void DpiMemUtil::StageElf(bool verbose, const std::string &path) {
 
   ElfFile elf(path);
 
+  // Allow subclasses to get at the loaded ELF data if they need it
+  OnElfLoaded(elf.ptr_);
+
   size_t file_size;
   const char *file_data = elf_rawfile(elf.ptr_, &file_size);
   assert(file_data);

--- a/hw/dv/verilator/cpp/dpi_memutil.h
+++ b/hw/dv/verilator/cpp/dpi_memutil.h
@@ -13,6 +13,9 @@
 #include "mem_area.h"
 #include "ranged_map.h"
 
+// Forward declaration for the Elf type from libelf.
+struct Elf;
+
 enum MemImageType {
   kMemImageUnknown = 0,
   kMemImageElf,
@@ -59,6 +62,8 @@ class StagedMem {
  */
 class DpiMemUtil {
  public:
+  virtual ~DpiMemUtil() {}
+
   /**
    * Register a memory as instantiated by generic ram
    *
@@ -127,6 +132,14 @@ class DpiMemUtil {
    * Get the contents of the staging area by memory name
    */
   const StagedMem &GetMemoryData(const std::string &mem_name) const;
+
+ protected:
+  /**
+   * A hook for subclasses to do extra computations with loaded ELF data. This
+   * runs as part of StageElf: after loading the ELF file, but before reading
+   * in the segments.
+   */
+  virtual void OnElfLoaded(Elf *elf_file) {}
 
  private:
   // Memory area registry. The maps give indices pointing into the vectors

--- a/hw/ip/otbn/dv/memutil/otbn_memutil_pkg.sv
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil_pkg.sv
@@ -24,5 +24,7 @@ package otbn_memutil_pkg;
   import "DPI-C" function bit OtbnMemUtilGetSegData(chandle mem_util, bit is_imem, int word_off,
                                                     output bit [31:0] data_value);
 
+  import "DPI-C" function int OtbnMemUtilGetExpEndAddr(chandle mem_util);
+
 endpackage
 `endif // SYNTHESIS

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -55,7 +55,15 @@ struct ISSWrapper {
   //
   // err_bits is zero unless the simulation just came to a halt, in which case
   // it's the value of the ERR_BITS register.
-  std::pair<int, uint32_t> step(bool gen_trace);
+  int step(bool gen_trace);
+
+  // Get the err_bits from a run that's just finished. This should be
+  // called just after step() returns 1.
+  uint32_t get_err_bits() const { return err_bits_; }
+
+  // Get the final PC from a run that's just finished. This should be
+  // called just after step() returns 1.
+  uint32_t get_stop_pc() const { return stop_pc_; }
 
   // Read contents of the register file
   void get_regs(std::array<uint32_t, 32> *gprs, std::array<u256_t, 32> *wdrs);
@@ -84,6 +92,10 @@ struct ISSWrapper {
 
   // A temporary directory for communicating with the child process
   std::unique_ptr<TmpDir> tmpdir;
+
+  // ERR_BITS and STOP_PC values from a run that's just finished.
+  uint32_t err_bits_;
+  uint32_t stop_pc_;
 };
 
 #endif  // OPENTITAN_HW_IP_OTBN_DV_MODEL_ISS_WRAPPER_H_

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -193,7 +193,14 @@ class OTBNState:
         # STATUS is a status register. Bit 0 (being cleared) is the 'busy' flag
         self.ext_regs.clear_bits('STATUS', 1 << 0)
 
+        # Make any error bits visible
         self.ext_regs.write('ERR_BITS', self._err_bits, True)
+
+        # Make the final PC visible. This isn't currently in the RTL, but is
+        # useful in simulations that want to track whether we stopped where we
+        # expected to stop.
+        self.ext_regs.write('STOP_PC', self.pc, True)
+
         self.running = False
 
     def set_flags(self, fg: int, flags: FlagReg) -> None:

--- a/hw/ip/otbn/dv/otbnsim/standalone.py
+++ b/hw/ip/otbn/dv/otbnsim/standalone.py
@@ -42,13 +42,20 @@ def main() -> int:
     collect_stats = args.dump_stats is not None
 
     sim = OTBNSim()
-    load_elf(sim, args.elf)
+    exp_end_addr = load_elf(sim, args.elf)
 
     sim.state.ext_regs.write('START_ADDR', 0, False)
     sim.state.ext_regs.commit()
 
     sim.start()
     sim.run(verbose=args.verbose, collect_stats=collect_stats)
+
+    if exp_end_addr is not None:
+        if sim.state.pc != exp_end_addr:
+            print('Run stopped at PC {:#x}, but _expected_end_addr was {:#x}.'
+                  .format(sim.state.pc, exp_end_addr),
+                  file=sys.stderr)
+            return 1
 
     if args.dump_dmem is not None:
         args.dump_dmem.write(sim.dump_data())

--- a/hw/ip/otbn/dv/rig/otbn-rig
+++ b/hw/ip/otbn/dv/rig/otbn-rig
@@ -59,10 +59,10 @@ def gen_main(args: argparse.Namespace) -> int:
 
     # Run the generator
     try:
-        init_data, snippet = gen_program(config,
-                                         args.start_addr,
-                                         args.size,
-                                         insns_file)
+        init_data, snippet, end_addr = gen_program(config,
+                                                   args.start_addr,
+                                                   args.size,
+                                                   insns_file)
     except RuntimeError as err:
         print(err, file=sys.stderr)
         return 1
@@ -70,7 +70,7 @@ def gen_main(args: argparse.Namespace) -> int:
     # Write out the data and snippets to a JSON file
     ser_data = init_data.as_json()
     ser_snippet = snippet.to_json()
-    ser = [ser_data, ser_snippet]
+    ser = [ser_data, ser_snippet, end_addr]
     json.dump(ser, sys.stdout)
     # Add a newline at end of output: json.dump doesn't, and it makes a
     # bit of a mess of some consoles.
@@ -97,12 +97,15 @@ def asm_main(args: argparse.Namespace) -> int:
 
     # Parse these to proper init data and snippet objects.
     try:
-        if not (isinstance(json_data, list) and len(json_data) == 2):
-            raise ValueError('Top-level structure should be a length 2 list.')
+        if not (isinstance(json_data, list) and len(json_data) == 3):
+            raise ValueError('Top-level structure should be a length 3 list.')
 
-        json_init_data, json_snippet = json_data
+        json_init_data, json_snippet, json_end_addr = json_data
         init_data = InitData.read(json_init_data)
         snippet = Snippet.from_json(insns_file, [], json_snippet)
+        if not isinstance(json_end_addr, int) or json_end_addr < 0:
+            raise ValueError('end_addr should be an integer.')
+        end_addr = json_end_addr
     except ValueError as err:
         print('Failed to parse snippets from {!r}: {}'
               .format(args.snippets.name, err),
@@ -130,7 +133,7 @@ def asm_main(args: argparse.Namespace) -> int:
         try:
             ld_path = args.output + '.ld'
             with open(ld_path, 'w') as out_file:
-                program.dump_linker_script(out_file, dsegs)
+                program.dump_linker_script(out_file, dsegs, end_addr)
         except OSError as err:
             print('Failed to open ld script output file {!r}: {}.'
                   .format(ld_path, err),

--- a/hw/ip/otbn/dv/rig/rig/gens/branch.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/branch.py
@@ -131,7 +131,7 @@ class Branch(SnippetGen):
             psnip.insert_into_program(program)
             model.update_for_insn(branch_insn)
             model.pc += 4
-            return (psnip, model)
+            return (psnip, False, model)
 
         # Decide how much of our remaining fuel to give the code below the
         # branch. Each side gets the same amount because only one side appears
@@ -248,4 +248,4 @@ class Branch(SnippetGen):
 
         snippet = BranchSnippet(model.pc, branch_insn, snippet0, snippet1)
         snippet.insert_into_program(program)
-        return (snippet, model0)
+        return (snippet, False, model0)

--- a/hw/ip/otbn/dv/rig/rig/gens/ecall.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/ecall.py
@@ -46,7 +46,7 @@ class ECall(SnippetGen):
             cont: GenCont,
             model: Model,
             program: Program) -> Optional[GenRet]:
-        return (self.gen_at(model.pc, program), None)
+        return (self.gen_at(model.pc, program), True, model)
 
     def pick_weight(self,
                     model: Model,

--- a/hw/ip/otbn/dv/rig/rig/gens/jump.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/jump.py
@@ -11,8 +11,8 @@ from shared.operand import ImmOperandType, RegOperandType
 from ..config import Config
 from ..program import ProgInsn, Program
 from ..model import Model
-from ..snippet import ProgSnippet, Snippet
-from ..snippet_gen import GenCont, GenRet, SnippetGen
+from ..snippet import ProgSnippet
+from ..snippet_gen import GenCont, GenRet, SimpleGenRet, SnippetGen
 
 
 class Jump(SnippetGen):
@@ -65,12 +65,12 @@ class Jump(SnippetGen):
             cont: GenCont,
             model: Model,
             program: Program) -> Optional[GenRet]:
-        return self.gen_tgt(model, program, None)
+        return SnippetGen._unsimple_genret(self.gen_tgt(model, program, None))
 
     def gen_tgt(self,
                 model: Model,
                 program: Program,
-                tgt_addr: Optional[int]) -> Optional[Tuple[Snippet, Model]]:
+                tgt_addr: Optional[int]) -> Optional[SimpleGenRet]:
 
         # Decide whether to generate JALR or JAL. If we try to generate a JALR
         # and fail, try to generate a JAL instead: in practice that might well
@@ -159,7 +159,7 @@ class Jump(SnippetGen):
                      link_reg_idx: int,
                      new_pc: int,
                      model: Model,
-                     program: Program) -> GenRet:
+                     program: Program) -> SimpleGenRet:
         '''Generate a 1-instruction snippet for prog_insn; finish generation'''
         # Generate our one-instruction snippet and add it to the program
         snippet = ProgSnippet(model.pc, [prog_insn])
@@ -186,7 +186,7 @@ class Jump(SnippetGen):
     def gen_jal(self,
                 model: Model,
                 program: Program,
-                tgt_addr: Optional[int]) -> Optional[GenRet]:
+                tgt_addr: Optional[int]) -> Optional[SimpleGenRet]:
         '''Generate a random JAL instruction'''
         assert len(self.jal.operands) == 2
         offset_optype = self.jal.operands[1].op_type
@@ -204,7 +204,7 @@ class Jump(SnippetGen):
     def gen_jalr(self,
                  model: Model,
                  program: Program,
-                 tgt_addr: Optional[int]) -> Optional[GenRet]:
+                 tgt_addr: Optional[int]) -> Optional[SimpleGenRet]:
         '''Generate a random JALR instruction'''
 
         assert len(self.jalr.operands) == 3

--- a/hw/ip/otbn/dv/rig/rig/gens/loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/loop.py
@@ -14,7 +14,7 @@ from ..config import Config
 from ..program import ProgInsn, Program
 from ..model import Model
 from ..snippet import LoopSnippet, Snippet
-from ..snippet_gen import GenCont, GenRet, SnippetGen
+from ..snippet_gen import GenCont, GenRet, SimpleGenRet, SnippetGen
 
 
 class Loop(SnippetGen):
@@ -193,7 +193,7 @@ class Loop(SnippetGen):
                   bogus_insn: ProgInsn,
                   cont: GenCont,
                   model: Model,
-                  program: Program) -> Optional[Tuple[Snippet, Model]]:
+                  program: Program) -> Optional[SimpleGenRet]:
         '''Generate the body of a loop
 
         The model is currently sitting at the start of the loop body.
@@ -451,4 +451,4 @@ class Loop(SnippetGen):
             # we computed before.
             model.fuel = fuel_afterwards
 
-        return (snippet, model)
+        return (snippet, False, model)

--- a/hw/ip/otbn/dv/rig/rig/gens/straight_line_insn.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/straight_line_insn.py
@@ -13,7 +13,7 @@ from ..config import Config
 from ..program import ProgInsn, Program
 from ..model import Model
 from ..snippet import ProgSnippet, Snippet
-from ..snippet_gen import GenCont, GenRet, SnippetGen
+from ..snippet_gen import GenCont, GenRet, SimpleGenRet, SnippetGen
 
 
 class StraightLineInsn(SnippetGen):
@@ -64,12 +64,12 @@ class StraightLineInsn(SnippetGen):
             cont: GenCont,
             model: Model,
             program: Program) -> Optional[GenRet]:
-        return self._gen(model, program)
+        return SnippetGen._unsimple_genret(self._gen(model, program))
 
     def gen_some(self,
                  count: int,
                  model: Model,
-                 program: Program) -> Optional[Tuple[Snippet, Model]]:
+                 program: Program) -> Optional[SimpleGenRet]:
         '''Generate a block of count straight-line instructions'''
         assert 0 < count
 
@@ -89,7 +89,7 @@ class StraightLineInsn(SnippetGen):
 
     def _gen(self,
              model: Model,
-             program: Program) -> Optional[Tuple[Snippet, Model]]:
+             program: Program) -> Optional[SimpleGenRet]:
         # Return None if this is the last instruction in the current gap
         # because we need to either jump or do an ECALL to avoid getting stuck.
         #

--- a/hw/ip/otbn/dv/rig/rig/program.py
+++ b/hw/ip/otbn/dv/rig/rig/program.py
@@ -283,12 +283,15 @@ class Program:
 
     def dump_linker_script(self,
                            out_file: TextIO,
-                           dsegs: Dict[int, List[int]]) -> None:
+                           dsegs: Dict[int, List[int]],
+                           end_addr: int) -> None:
         '''Write a linker script to link the program
 
         This lays out the sections generated in dump_asm().
 
         '''
+        assert end_addr >= 0
+
         seg_descs = []
         for idx, (addr, values) in enumerate(sorted(dsegs.items())):
             seg_descs.append(('dseg{:04}'.format(idx),
@@ -309,6 +312,8 @@ class Program:
         for seg, vma, lma, sec, comment in seg_descs:
             out_file.write('    {} PT_LOAD AT ( {:#x} );\n'.format(seg, lma))
         out_file.write('}\n\n')
+
+        out_file.write('_expected_end_addr = {:#x};\n\n'.format(end_addr))
 
         out_file.write('SECTIONS\n'
                        '{\n')

--- a/hw/ip/otbn/dv/rig/rig/rig.py
+++ b/hw/ip/otbn/dv/rig/rig/rig.py
@@ -18,17 +18,17 @@ from .snippet import Snippet
 def gen_program(config: Config,
                 start_addr: int,
                 fuel: int,
-                insns_file: InsnsFile) -> Tuple[InitData, Snippet]:
+                insns_file: InsnsFile) -> Tuple[InitData, Snippet, int]:
     '''Generate a random program for OTBN
 
     start_addr is the reset address (the value that should be programmed into
     the START_ADDR register). fuel gives a rough upper bound for the number of
     instructions that will be executed by the generated program.
 
-    Returns (init_data, snippets, program). init_data is a dict mapping (4-byte
+    Returns (init_data, snippet, end_addr). init_data is a dict mapping (4-byte
     aligned) address to u32s that should be loaded into data memory before
-    starting the program. snippets is a list of instruction snippets. program
-    is the generated program (from flattening them both).
+    starting the program. snippets is a tree of instruction snippets. end_addr
+    is the expected end address.
 
     '''
 
@@ -58,5 +58,5 @@ def gen_program(config: Config,
         raise RuntimeError('Failed to initialise snippet generators: {}'
                            .format(err)) from None
 
-    snippet = gens.gen_rest(model, program)
-    return init_data, snippet
+    snippet, end_addr = gens.gen_rest(model, program)
+    return init_data, snippet, end_addr

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -101,6 +101,7 @@ class otbn_base_vseq extends cip_base_vseq #(
 
   // Start OTBN and then wait until done
   protected task run_otbn();
+    int exp_end_addr;
     uvm_reg_data_t cmd_val;
 
     // Set the "start" bit in cmd_val and write it to the "cmd" register to start OTBN.
@@ -115,6 +116,14 @@ class otbn_base_vseq extends cip_base_vseq #(
     csr_utils_pkg::csr_spinwait(.ptr(ral.status.busy), .exp_data(1'b0));
 
     `uvm_info(`gfn, $sformatf("\n\t ----| OTBN finished"), UVM_MEDIUM)
+
+    // If there was an expected end address, compare it with the model. This isn't really a test of
+    // the RTL, but it's handy to make sure that the RIG really is generating the control flow that
+    // it expects.
+    exp_end_addr = OtbnMemUtilGetExpEndAddr(cfg.mem_util);
+    if (exp_end_addr >= 0) begin
+      `DV_CHECK_EQ_FATAL(exp_end_addr, cfg.model_agent_cfg.vif.stop_pc)
+    end
    endtask
 
   virtual protected function string pick_elf_path();

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -12,11 +12,14 @@ interface otbn_model_if #(
   input logic rst_ni
 );
 
+  // Inputs to DUT
   logic                     start;        // Start the operation
   logic [ImemAddrWidth-1:0] start_addr;   // Start byte address in IMEM
 
+  // Outputs from DUT
   bit                       done;         // Operation done
   bit                       err;          // Something went wrong
+  bit [31:0]                stop_pc;      // PC at end of operation
 
   // Wait until done goes high. Stops early on reset
   task automatic wait_done();

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -139,6 +139,9 @@ module tb;
     .edn_urnd_data_valid_i (edn_urnd_data_valid)
   );
 
+  // Pull the final PC out of the DUT
+  assign model_if.stop_pc = u_model.stop_pc_q;
+
   initial begin
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
@@ -14,6 +14,7 @@
 #include "otbn_memutil.h"
 #include "otbn_trace_checker.h"
 #include "otbn_trace_source.h"
+#include "sv_scoped.h"
 #include "verilated_toplevel.h"
 #include "verilator_memutil.h"
 #include "verilator_sim_ctrl.h"
@@ -177,6 +178,18 @@ int main(int argc, char **argv) {
 
     std::cout << std::setw(8) << std::setfill('0') << otbn_bignum_reg_get(i, 0)
               << std::endl;
+  }
+
+  int exp_stop_pc = otbn_memutil.GetExpEndAddr();
+  if (exp_stop_pc >= 0) {
+    SVScoped core_scope("TOP.otbn_top_sim.u_otbn_core_model");
+    int act_stop_pc = otbn_core_get_stop_pc();
+    if (exp_stop_pc != act_stop_pc) {
+      std::cerr << "ERROR: Expected stop PC from ELF file was 0x" << std::hex
+                << exp_stop_pc << ", but simulation actually stopped at 0x"
+                << act_stop_pc << ".\n";
+      return 1;
+    }
   }
 
   return 0;


### PR DESCRIPTION
This is a sort of "belt and braces" check to make it easier to develop the RIG. As we start teaching the RIG to generate (architecturally defined) erroring instruction sequences, it becomes harder to tell whether an instruction stream that triggered an OTBN error did so on purpose or not. A bug in the RIG that causes this to come unstuck wouldn't endanger the quality of our verification, but it might make test generation much less efficient (e.g. if we never get to the error case we think we're generating).

The first patch in this series teaches the RIG to export its expected end address as a symbol in the ELF files it generates. The second patch teaches the `otbn_memutil` code to read this symbol in (if defined) and store it away somewhere helpful. The third patch works from "the other end", exposing the address where the model stopped to the SystemVerilog ISS wrapper. Finally, the last three patches teach the three different flavours of OTBN simulation that we run how to compare things properly.

Note: You might wonder why we can't just do the end address check in the Python code every time. The problem is that RTL simulations actually load up the ELF file themselves and then initialise some memories with the imem/dmem segments. Later, the OTBN model wrapper reads these memories to initialise the ISS memory with their contents before the ISS starts running. There's not really a clean way to pass the expected end address through this chain, so we are doing it the other way: the level of the test that understands that there's an ELF file involved is the thing that's in charge of checking that everything matches.