### PR TITLE
[ci] Avoid a spurious warning from grep in the non-ASCII check

### DIFF
--- a/ci/jobs/quick-lint.sh
+++ b/ci/jobs/quick-lint.sh
@@ -36,7 +36,7 @@ ci/scripts/check-licence-headers.sh $tgt_branch
 echo -e "\n### Check executable bits"
 ci/scripts/exec-check.sh
 
-echo -e "\n### Check executable bits"
+echo -e "\n### Check for non-ASCII characters in source code"
 ci/scripts/check-ascii.sh
 
 echo -e "\n### Run Python lint (flake8)"

--- a/ci/scripts/check-ascii.sh
+++ b/ci/scripts/check-ascii.sh
@@ -62,7 +62,7 @@ trap 'rm -f "$TMPFILE"' EXIT
 git ls-files | \
     grep -v "${excl_re}" | \
     grep -v "${suff_re}" | \
-    env LC_ALL=C xargs grep -P '[^\0-\x7f]' >"$TMPFILE" || true
+    env LC_ALL=C xargs grep -d skip -P '[^\0-\x7f]' >"$TMPFILE" || true
 if [ -s "$TMPFILE" ]; then
     echo -n "##vso[task.logissue type=error]"
     echo "One or more files have unexpected non-ASCII text:"


### PR DESCRIPTION
We've got a symlink to a directory checked in to the repository (it's
hw/ip/aes/pre_syn/python). This appears in the "git ls-files" list,
but grep then gets a bit confused about being asked to search through
a directory. Use "-d skip" to tell it to silently ignore the target of
the symlink.

Also, fix the message in quick-lint.sh: apparently, I was too eager
with my copy+paste!
