### PR TITLE
[opentitantool] Add skeleton of opentitanlib

### DIFF
--- a/sw/host/opentitanlib/Cargo.toml
+++ b/sw/host/opentitanlib/Cargo.toml
@@ -1,0 +1,17 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "opentitanlib"
+version = "0.1.0"
+authors = ["lowRISC contributors"]
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+lazy_static = "1.4.0"
+regex = "1"
+nix = "0.17.0"
+bitflags = "1.0"
+log = "0.4"

--- a/sw/host/opentitanlib/src/io/gpio.rs
+++ b/sw/host/opentitanlib/src/io/gpio.rs
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+
+/// A trait which represents a GPIO interface.
+pub trait Gpio {
+    /// Reads the value of the the GPIO pin `id`.
+    fn read(&self, id: u32) -> Result<bool>;
+
+    /// Sets the value of the GPIO pin `id` to `value`.
+    fn write(&self, id: u32, value: bool) -> Result<()>;
+}

--- a/sw/host/opentitanlib/src/io/mod.rs
+++ b/sw/host/opentitanlib/src/io/mod.rs
@@ -1,0 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod gpio;
+pub mod spi;
+pub mod uart;

--- a/sw/host/opentitanlib/src/io/spi.rs
+++ b/sw/host/opentitanlib/src/io/spi.rs
@@ -1,0 +1,50 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+
+/// Represents the SPI transfer mode.
+/// See https://en.wikipedia.org/wiki/Serial_Peripheral_Interface#Clock_polarity_and_phase
+/// for details about SPI transfer modes.
+pub enum TransferMode {
+    /// `Mode0` is CPOL=0, CPHA=0.
+    Mode0,
+    /// `Mode1` is CPOL=0, CPHA=1.
+    Mode1,
+    /// `Mode2` is CPOL=1, CPHA=0.
+    Mode2,
+    /// `Mode3` is CPOL=1, CPHA=1.
+    Mode3,
+}
+
+/// Represents a SPI transfer.
+pub enum Transfer<'rd, 'wr> {
+    Read(&'rd mut [u8]),
+    Write(&'wr [u8]),
+    Both(&'rd mut [u8], &'wr [u8]),
+}
+
+/// A trait which represents a SPI Target.
+pub trait Target {
+    /// Gets the current SPI transfer mode.
+    fn get_transfer_mode(&self) -> Result<TransferMode>;
+    /// Sets the current SPI transfer mode.
+    fn set_transfer_mode(&mut self, mode: TransferMode) -> Result<()>;
+
+    /// Gets the current number of bits per word.
+    fn get_bits_per_word(&self) -> Result<u32>;
+    /// Sets the current number of bits per word.
+    fn set_bits_per_word(&mut self, bits_per_word: u32) -> Result<()>;
+
+    /// Gets the maximum allowed speed of the SPI bus.
+    fn get_max_speed(&self) -> Result<u32>;
+    /// Sets the maximum allowed speed of the SPI bus.
+    fn set_max_speed(&mut self, max_speed: u32) -> Result<()>;
+
+    /// Returns the maximum number of transfers allowed in a single transaction.
+    fn get_max_transfer_count(&self) -> usize;
+
+    /// Runs a SPI transaction composed from the slice of [`Transfer`] objects.
+    fn run_transaction(&self, transaction: &[Transfer]) -> Result<()>;
+}

--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use std::io::{Read, Write};
+use std::time::Duration;
+
+/// A trait which represents a UART.
+pub trait Uart: Read + Write {
+    /// Returns the UART baudrate.  May return zero for virtual UARTs.
+    fn get_baudrate(&self) -> u32;
+
+    /// Sets the UART baudrate.  May do nothing for virtual UARTs.
+    fn set_baudrate(&mut self, baudrate: u32) -> Result<()>;
+
+    /// Reads UART recieve data into `buf`, returning the number of bytes read.
+    /// The `timeout` may be used to specify a duration to wait for data.
+    fn read_timeout(&mut self, buf: &mut [u8], timeout: Duration) -> Result<usize>;
+}

--- a/sw/host/opentitanlib/src/lib.rs
+++ b/sw/host/opentitanlib/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod io;
+pub mod util;

--- a/sw/host/opentitanlib/src/util/file.rs
+++ b/sw/host/opentitanlib/src/util/file.rs
@@ -1,0 +1,80 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use nix::libc::c_int;
+use nix::poll;
+use std::convert::TryInto;
+use std::io;
+use std::os::unix::io::AsRawFd;
+use std::time::Duration;
+
+/// Waits for an event on `fd` or for `timeout` to expire.
+pub fn wait_timeout(fd: &impl AsRawFd, events: poll::PollFlags, timeout: Duration) -> Result<()> {
+    let timeout = timeout.as_millis().try_into().unwrap_or(c_int::MAX);
+    let mut pfd = [poll::PollFd::new(fd.as_raw_fd(), events)];
+    match poll::poll(&mut pfd, timeout)? {
+        0 => Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "timed out waiting for fd to be ready",
+        )
+        .into()),
+        _ => Ok(()),
+    }
+}
+
+/// Waits for `fd` to become ready to read or `timeout` to expire.
+pub fn wait_read_timeout(fd: &impl AsRawFd, timeout: Duration) -> Result<()> {
+    wait_timeout(fd, poll::PollFlags::POLLIN, timeout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::bail;
+    use nix::sys::socket::{socketpair, AddressFamily, SockFlag, SockType};
+    use nix::unistd::{read, write};
+
+    #[test]
+    fn test_data_ready() -> Result<()> {
+        let (snd, rcv) = socketpair(
+            AddressFamily::Unix,
+            SockType::Stream,
+            None,
+            SockFlag::empty(),
+        )?;
+
+        // Send the test data into the socket.
+        let sndbuf = b"abc123";
+        assert_eq!(write(snd, sndbuf)?, sndbuf.len());
+
+        // Wait for it to be ready.
+        wait_read_timeout(&rcv, Duration::from_millis(10))?;
+
+        // Receive the test data and compare.
+        let mut rcvbuf = [0u8; 6];
+        assert_eq!(read(rcv, &mut rcvbuf)?, sndbuf.len());
+        assert_eq!(sndbuf, &rcvbuf);
+        Ok(())
+    }
+
+    #[test]
+    fn test_timeout() -> Result<()> {
+        let (_snd, rcv) = socketpair(
+            AddressFamily::Unix,
+            SockType::Stream,
+            None,
+            SockFlag::empty(),
+        )?;
+        // Expect to timeout since there is no data ready on the socket.
+        let result = wait_read_timeout(&rcv, Duration::from_millis(10));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        match err.downcast_ref::<io::Error>() {
+            Some(e) => assert_eq!(io::ErrorKind::TimedOut, e.kind()),
+            _ => bail!("Unexpected error result {:?}", err),
+        }
+        Ok(())
+    }
+}

--- a/sw/host/opentitanlib/src/util/mod.rs
+++ b/sw/host/opentitanlib/src/util/mod.rs
@@ -1,0 +1,5 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod file;


### PR DESCRIPTION
1. Create traits for basic IO interfaces: GPIOs, SPI and UART.
2. Add utility functions for waiting on a filedescriptor.

Signed-off-by: Chris Frantz <cfrantz@google.com>