### PR TITLE
[alert_handler] Wire up integrity alert

### DIFF
--- a/hw/ip/alert_handler/data/alert_handler.hjson
+++ b/hw/ip/alert_handler/data/alert_handler.hjson
@@ -82,7 +82,7 @@
     { name: "N_LOC_ALERT",
       desc: "Number of local alerts phases",
       type: "int",
-      default: "4",
+      default: "5",
       local: "true"
     },
     { name: "PING_CNT_DW",
@@ -312,7 +312,7 @@
 # local alerts
     { multireg: { name:     "LOC_ALERT_REGWEN",
                   desc:     "Register write enable for alert enable bits.",
-                  count:    "NAlerts",
+                  count:    "N_LOC_ALERT",
                   compact:  "false",
                   swaccess: "rw0c",
                   hwaccess: "none",
@@ -334,7 +334,7 @@
     },
     { multireg: { name:     "LOC_ALERT_EN",
                   desc:     '''Enable register for the aggregated local alerts "alert
-                  pingfail" (0), "escalation pingfail" (1), "alert integfail" (2) and "escalation integfail" (3).
+                  pingfail" (0), "escalation pingfail" (1), "alert integfail" (2), "escalation integfail" (3), and "bus integrity failure (4)".
                   ''',
                   count:    "N_LOC_ALERT",
                   compact:  "false",
@@ -358,7 +358,7 @@
     },
     { multireg: { name:     "LOC_ALERT_CLASS",
                   desc:     '''Class assignment of local alerts. "alert
-                  pingfail" (0), "escalation pingfail" (1), "alert integfail" (2) and "escalation integfail" (3).
+                  pingfail" (0), "escalation pingfail" (1), "alert integfail" (2), "escalation integfail" (3), and "bus integrity failure (4)".
                   ''',
                   count:    "N_LOC_ALERT",
                   compact:  "false",
@@ -386,7 +386,7 @@
     { multireg: {
       name: "LOC_ALERT_CAUSE",
       desc: '''Alert Cause Register for Local Alerts. "alert
-      pingfail" (0), "escalation pingfail" (1), "alert integfail" (2) and "escalation integfail" (3).
+      pingfail" (0), "escalation pingfail" (1), "alert integfail" (2), "escalation integfail" (3), and "bus integrity failure (4)".
       ''',
       count: "N_LOC_ALERT",
       compact:  "false",

--- a/hw/ip/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip/alert_handler/data/alert_handler.hjson.tpl
@@ -86,7 +86,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     { name: "N_LOC_ALERT",
       desc: "Number of local alerts phases",
       type: "int",
-      default: "4",
+      default: "5",
       local: "true"
     },
     { name: "PING_CNT_DW",
@@ -306,7 +306,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
 # local alerts
     { multireg: { name:     "LOC_ALERT_REGWEN",
                   desc:     "Register write enable for alert enable bits.",
-                  count:    "NAlerts",
+                  count:    "N_LOC_ALERT",
                   compact:  "false",
                   swaccess: "rw0c",
                   hwaccess: "none",
@@ -328,7 +328,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     },
     { multireg: { name:     "LOC_ALERT_EN",
                   desc:     '''Enable register for the aggregated local alerts "alert
-                  pingfail" (0), "escalation pingfail" (1), "alert integfail" (2) and "escalation integfail" (3).
+                  pingfail" (0), "escalation pingfail" (1), "alert integfail" (2), "escalation integfail" (3), and "bus integrity failure (4)".
                   ''',
                   count:    "N_LOC_ALERT",
                   compact:  "false",
@@ -352,7 +352,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     },
     { multireg: { name:     "LOC_ALERT_CLASS",
                   desc:     '''Class assignment of local alerts. "alert
-                  pingfail" (0), "escalation pingfail" (1), "alert integfail" (2) and "escalation integfail" (3).
+                  pingfail" (0), "escalation pingfail" (1), "alert integfail" (2), "escalation integfail" (3), and "bus integrity failure (4)".
                   ''',
                   count:    "N_LOC_ALERT",
                   compact:  "false",
@@ -379,7 +379,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     { multireg: {
       name: "LOC_ALERT_CAUSE",
       desc: '''Alert Cause Register for Local Alerts. "alert
-      pingfail" (0), "escalation pingfail" (1), "alert integfail" (2) and "escalation integfail" (3).
+      pingfail" (0), "escalation pingfail" (1), "alert integfail" (2), "escalation integfail" (3), and "bus integrity failure (4)".
       ''',
       count: "N_LOC_ALERT",
       compact:  "false",

--- a/hw/ip/alert_handler/rtl/alert_handler.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler.sv
@@ -48,11 +48,11 @@ module alert_handler
   // Regfile Breakout and Mapping //
   //////////////////////////////////
 
+  logic [N_LOC_ALERT-1:0] loc_alert_trig;
   logic [N_CLASSES-1:0] irq;
   hw2reg_wrap_t hw2reg_wrap;
   reg2hw_wrap_t reg2hw_wrap;
 
-  // TODO: make this fully parametric at some point
   assign {intr_classd_o,
           intr_classc_o,
           intr_classb_o,
@@ -66,14 +66,14 @@ module alert_handler
     .irq_o ( irq ),
     .crashdump_o,
     .hw2reg_wrap,
-    .reg2hw_wrap
+    .reg2hw_wrap,
+    .fatal_integ_alert_o(loc_alert_trig[4])
   );
 
   ////////////////
   // Ping Timer //
   ////////////////
 
-  logic [N_LOC_ALERT-1:0] loc_alert_trig;
 
   logic [NAlerts-1:0]   alert_ping_req;
   logic [NAlerts-1:0]   alert_ping_ok;

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_pkg.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_pkg.sv
@@ -14,7 +14,7 @@ package alert_handler_reg_pkg;
   parameter int N_CLASSES = 4;
   parameter int N_ESC_SEV = 4;
   parameter int N_PHASES = 4;
-  parameter int N_LOC_ALERT = 4;
+  parameter int N_LOC_ALERT = 5;
   parameter int PING_CNT_DW = 24;
   parameter int PHASE_DW = 2;
   parameter int CLASS_DW = 2;
@@ -458,18 +458,18 @@ package alert_handler_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    alert_handler_reg2hw_intr_state_reg_t intr_state; // [844:841]
-    alert_handler_reg2hw_intr_enable_reg_t intr_enable; // [840:837]
-    alert_handler_reg2hw_intr_test_reg_t intr_test; // [836:829]
-    alert_handler_reg2hw_ping_timeout_cyc_reg_t ping_timeout_cyc; // [828:805]
-    alert_handler_reg2hw_ping_timer_en_reg_t ping_timer_en; // [804:804]
-    alert_handler_reg2hw_alert_regwen_mreg_t [3:0] alert_regwen; // [803:800]
-    alert_handler_reg2hw_alert_en_mreg_t [3:0] alert_en; // [799:796]
-    alert_handler_reg2hw_alert_class_mreg_t [3:0] alert_class; // [795:788]
-    alert_handler_reg2hw_alert_cause_mreg_t [3:0] alert_cause; // [787:784]
-    alert_handler_reg2hw_loc_alert_en_mreg_t [3:0] loc_alert_en; // [783:780]
-    alert_handler_reg2hw_loc_alert_class_mreg_t [3:0] loc_alert_class; // [779:772]
-    alert_handler_reg2hw_loc_alert_cause_mreg_t [3:0] loc_alert_cause; // [771:768]
+    alert_handler_reg2hw_intr_state_reg_t intr_state; // [848:845]
+    alert_handler_reg2hw_intr_enable_reg_t intr_enable; // [844:841]
+    alert_handler_reg2hw_intr_test_reg_t intr_test; // [840:833]
+    alert_handler_reg2hw_ping_timeout_cyc_reg_t ping_timeout_cyc; // [832:809]
+    alert_handler_reg2hw_ping_timer_en_reg_t ping_timer_en; // [808:808]
+    alert_handler_reg2hw_alert_regwen_mreg_t [3:0] alert_regwen; // [807:804]
+    alert_handler_reg2hw_alert_en_mreg_t [3:0] alert_en; // [803:800]
+    alert_handler_reg2hw_alert_class_mreg_t [3:0] alert_class; // [799:792]
+    alert_handler_reg2hw_alert_cause_mreg_t [3:0] alert_cause; // [791:788]
+    alert_handler_reg2hw_loc_alert_en_mreg_t [4:0] loc_alert_en; // [787:783]
+    alert_handler_reg2hw_loc_alert_class_mreg_t [4:0] loc_alert_class; // [782:773]
+    alert_handler_reg2hw_loc_alert_cause_mreg_t [4:0] loc_alert_cause; // [772:768]
     alert_handler_reg2hw_classa_ctrl_reg_t classa_ctrl; // [767:754]
     alert_handler_reg2hw_classa_clr_reg_t classa_clr; // [753:752]
     alert_handler_reg2hw_classa_accum_thresh_reg_t classa_accum_thresh; // [751:736]
@@ -506,9 +506,9 @@ package alert_handler_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    alert_handler_hw2reg_intr_state_reg_t intr_state; // [235:228]
-    alert_handler_hw2reg_alert_cause_mreg_t [3:0] alert_cause; // [227:220]
-    alert_handler_hw2reg_loc_alert_cause_mreg_t [3:0] loc_alert_cause; // [219:212]
+    alert_handler_hw2reg_intr_state_reg_t intr_state; // [237:230]
+    alert_handler_hw2reg_alert_cause_mreg_t [3:0] alert_cause; // [229:222]
+    alert_handler_hw2reg_loc_alert_cause_mreg_t [4:0] loc_alert_cause; // [221:212]
     alert_handler_hw2reg_classa_clr_regwen_reg_t classa_clr_regwen; // [211:210]
     alert_handler_hw2reg_classa_accum_cnt_reg_t classa_accum_cnt; // [209:194]
     alert_handler_hw2reg_classa_esc_cnt_reg_t classa_esc_cnt; // [193:162]
@@ -554,70 +554,74 @@ package alert_handler_reg_pkg;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_1_OFFSET = 9'h 5c;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_2_OFFSET = 9'h 60;
   parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_3_OFFSET = 9'h 64;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_EN_0_OFFSET = 9'h 68;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_EN_1_OFFSET = 9'h 6c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_EN_2_OFFSET = 9'h 70;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_EN_3_OFFSET = 9'h 74;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_0_OFFSET = 9'h 78;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_1_OFFSET = 9'h 7c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_2_OFFSET = 9'h 80;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_3_OFFSET = 9'h 84;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_0_OFFSET = 9'h 88;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_1_OFFSET = 9'h 8c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_2_OFFSET = 9'h 90;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_3_OFFSET = 9'h 94;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_REGWEN_OFFSET = 9'h 98;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_CTRL_OFFSET = 9'h 9c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_CLR_REGWEN_OFFSET = 9'h a0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_CLR_OFFSET = 9'h a4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_ACCUM_CNT_OFFSET = 9'h a8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_ACCUM_THRESH_OFFSET = 9'h ac;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_TIMEOUT_CYC_OFFSET = 9'h b0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_PHASE0_CYC_OFFSET = 9'h b4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_PHASE1_CYC_OFFSET = 9'h b8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_PHASE2_CYC_OFFSET = 9'h bc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_PHASE3_CYC_OFFSET = 9'h c0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_ESC_CNT_OFFSET = 9'h c4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_STATE_OFFSET = 9'h c8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_REGWEN_OFFSET = 9'h cc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_CTRL_OFFSET = 9'h d0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_CLR_REGWEN_OFFSET = 9'h d4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_CLR_OFFSET = 9'h d8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_ACCUM_CNT_OFFSET = 9'h dc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_ACCUM_THRESH_OFFSET = 9'h e0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_TIMEOUT_CYC_OFFSET = 9'h e4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_PHASE0_CYC_OFFSET = 9'h e8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_PHASE1_CYC_OFFSET = 9'h ec;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_PHASE2_CYC_OFFSET = 9'h f0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_PHASE3_CYC_OFFSET = 9'h f4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_ESC_CNT_OFFSET = 9'h f8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_STATE_OFFSET = 9'h fc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_REGWEN_OFFSET = 9'h 100;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_CTRL_OFFSET = 9'h 104;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_CLR_REGWEN_OFFSET = 9'h 108;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_CLR_OFFSET = 9'h 10c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_ACCUM_CNT_OFFSET = 9'h 110;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_ACCUM_THRESH_OFFSET = 9'h 114;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_TIMEOUT_CYC_OFFSET = 9'h 118;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_PHASE0_CYC_OFFSET = 9'h 11c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_PHASE1_CYC_OFFSET = 9'h 120;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_PHASE2_CYC_OFFSET = 9'h 124;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_PHASE3_CYC_OFFSET = 9'h 128;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_ESC_CNT_OFFSET = 9'h 12c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_STATE_OFFSET = 9'h 130;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_REGWEN_OFFSET = 9'h 134;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_CTRL_OFFSET = 9'h 138;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_CLR_REGWEN_OFFSET = 9'h 13c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_CLR_OFFSET = 9'h 140;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_ACCUM_CNT_OFFSET = 9'h 144;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_ACCUM_THRESH_OFFSET = 9'h 148;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_TIMEOUT_CYC_OFFSET = 9'h 14c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_PHASE0_CYC_OFFSET = 9'h 150;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_PHASE1_CYC_OFFSET = 9'h 154;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_PHASE2_CYC_OFFSET = 9'h 158;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_PHASE3_CYC_OFFSET = 9'h 15c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_ESC_CNT_OFFSET = 9'h 160;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_STATE_OFFSET = 9'h 164;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_4_OFFSET = 9'h 68;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_EN_0_OFFSET = 9'h 6c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_EN_1_OFFSET = 9'h 70;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_EN_2_OFFSET = 9'h 74;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_EN_3_OFFSET = 9'h 78;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_EN_4_OFFSET = 9'h 7c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_0_OFFSET = 9'h 80;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_1_OFFSET = 9'h 84;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_2_OFFSET = 9'h 88;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_3_OFFSET = 9'h 8c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_4_OFFSET = 9'h 90;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_0_OFFSET = 9'h 94;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_1_OFFSET = 9'h 98;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_2_OFFSET = 9'h 9c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_3_OFFSET = 9'h a0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_4_OFFSET = 9'h a4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_REGWEN_OFFSET = 9'h a8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_CTRL_OFFSET = 9'h ac;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_CLR_REGWEN_OFFSET = 9'h b0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_CLR_OFFSET = 9'h b4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_ACCUM_CNT_OFFSET = 9'h b8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_ACCUM_THRESH_OFFSET = 9'h bc;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_TIMEOUT_CYC_OFFSET = 9'h c0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_PHASE0_CYC_OFFSET = 9'h c4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_PHASE1_CYC_OFFSET = 9'h c8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_PHASE2_CYC_OFFSET = 9'h cc;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_PHASE3_CYC_OFFSET = 9'h d0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_ESC_CNT_OFFSET = 9'h d4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_STATE_OFFSET = 9'h d8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_REGWEN_OFFSET = 9'h dc;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_CTRL_OFFSET = 9'h e0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_CLR_REGWEN_OFFSET = 9'h e4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_CLR_OFFSET = 9'h e8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_ACCUM_CNT_OFFSET = 9'h ec;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_ACCUM_THRESH_OFFSET = 9'h f0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_TIMEOUT_CYC_OFFSET = 9'h f4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_PHASE0_CYC_OFFSET = 9'h f8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_PHASE1_CYC_OFFSET = 9'h fc;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_PHASE2_CYC_OFFSET = 9'h 100;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_PHASE3_CYC_OFFSET = 9'h 104;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_ESC_CNT_OFFSET = 9'h 108;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_STATE_OFFSET = 9'h 10c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_REGWEN_OFFSET = 9'h 110;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_CTRL_OFFSET = 9'h 114;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_CLR_REGWEN_OFFSET = 9'h 118;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_CLR_OFFSET = 9'h 11c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_ACCUM_CNT_OFFSET = 9'h 120;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_ACCUM_THRESH_OFFSET = 9'h 124;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_TIMEOUT_CYC_OFFSET = 9'h 128;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_PHASE0_CYC_OFFSET = 9'h 12c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_PHASE1_CYC_OFFSET = 9'h 130;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_PHASE2_CYC_OFFSET = 9'h 134;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_PHASE3_CYC_OFFSET = 9'h 138;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_ESC_CNT_OFFSET = 9'h 13c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_STATE_OFFSET = 9'h 140;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_REGWEN_OFFSET = 9'h 144;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_CTRL_OFFSET = 9'h 148;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_CLR_REGWEN_OFFSET = 9'h 14c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_CLR_OFFSET = 9'h 150;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_ACCUM_CNT_OFFSET = 9'h 154;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_ACCUM_THRESH_OFFSET = 9'h 158;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_TIMEOUT_CYC_OFFSET = 9'h 15c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_PHASE0_CYC_OFFSET = 9'h 160;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_PHASE1_CYC_OFFSET = 9'h 164;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_PHASE2_CYC_OFFSET = 9'h 168;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_PHASE3_CYC_OFFSET = 9'h 16c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_ESC_CNT_OFFSET = 9'h 170;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_STATE_OFFSET = 9'h 174;
 
   // Reset values for hwext registers and their fields
   parameter logic [3:0] ALERT_HANDLER_INTR_TEST_RESVAL = 4'h 0;
@@ -666,18 +670,22 @@ package alert_handler_reg_pkg;
     ALERT_HANDLER_LOC_ALERT_REGWEN_1,
     ALERT_HANDLER_LOC_ALERT_REGWEN_2,
     ALERT_HANDLER_LOC_ALERT_REGWEN_3,
+    ALERT_HANDLER_LOC_ALERT_REGWEN_4,
     ALERT_HANDLER_LOC_ALERT_EN_0,
     ALERT_HANDLER_LOC_ALERT_EN_1,
     ALERT_HANDLER_LOC_ALERT_EN_2,
     ALERT_HANDLER_LOC_ALERT_EN_3,
+    ALERT_HANDLER_LOC_ALERT_EN_4,
     ALERT_HANDLER_LOC_ALERT_CLASS_0,
     ALERT_HANDLER_LOC_ALERT_CLASS_1,
     ALERT_HANDLER_LOC_ALERT_CLASS_2,
     ALERT_HANDLER_LOC_ALERT_CLASS_3,
+    ALERT_HANDLER_LOC_ALERT_CLASS_4,
     ALERT_HANDLER_LOC_ALERT_CAUSE_0,
     ALERT_HANDLER_LOC_ALERT_CAUSE_1,
     ALERT_HANDLER_LOC_ALERT_CAUSE_2,
     ALERT_HANDLER_LOC_ALERT_CAUSE_3,
+    ALERT_HANDLER_LOC_ALERT_CAUSE_4,
     ALERT_HANDLER_CLASSA_REGWEN,
     ALERT_HANDLER_CLASSA_CTRL,
     ALERT_HANDLER_CLASSA_CLR_REGWEN,
@@ -733,7 +741,7 @@ package alert_handler_reg_pkg;
   } alert_handler_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] ALERT_HANDLER_PERMIT [90] = '{
+  parameter logic [3:0] ALERT_HANDLER_PERMIT [94] = '{
     4'b 0001, // index[ 0] ALERT_HANDLER_INTR_STATE
     4'b 0001, // index[ 1] ALERT_HANDLER_INTR_ENABLE
     4'b 0001, // index[ 2] ALERT_HANDLER_INTR_TEST
@@ -760,70 +768,74 @@ package alert_handler_reg_pkg;
     4'b 0001, // index[23] ALERT_HANDLER_LOC_ALERT_REGWEN_1
     4'b 0001, // index[24] ALERT_HANDLER_LOC_ALERT_REGWEN_2
     4'b 0001, // index[25] ALERT_HANDLER_LOC_ALERT_REGWEN_3
-    4'b 0001, // index[26] ALERT_HANDLER_LOC_ALERT_EN_0
-    4'b 0001, // index[27] ALERT_HANDLER_LOC_ALERT_EN_1
-    4'b 0001, // index[28] ALERT_HANDLER_LOC_ALERT_EN_2
-    4'b 0001, // index[29] ALERT_HANDLER_LOC_ALERT_EN_3
-    4'b 0001, // index[30] ALERT_HANDLER_LOC_ALERT_CLASS_0
-    4'b 0001, // index[31] ALERT_HANDLER_LOC_ALERT_CLASS_1
-    4'b 0001, // index[32] ALERT_HANDLER_LOC_ALERT_CLASS_2
-    4'b 0001, // index[33] ALERT_HANDLER_LOC_ALERT_CLASS_3
-    4'b 0001, // index[34] ALERT_HANDLER_LOC_ALERT_CAUSE_0
-    4'b 0001, // index[35] ALERT_HANDLER_LOC_ALERT_CAUSE_1
-    4'b 0001, // index[36] ALERT_HANDLER_LOC_ALERT_CAUSE_2
-    4'b 0001, // index[37] ALERT_HANDLER_LOC_ALERT_CAUSE_3
-    4'b 0001, // index[38] ALERT_HANDLER_CLASSA_REGWEN
-    4'b 0011, // index[39] ALERT_HANDLER_CLASSA_CTRL
-    4'b 0001, // index[40] ALERT_HANDLER_CLASSA_CLR_REGWEN
-    4'b 0001, // index[41] ALERT_HANDLER_CLASSA_CLR
-    4'b 0011, // index[42] ALERT_HANDLER_CLASSA_ACCUM_CNT
-    4'b 0011, // index[43] ALERT_HANDLER_CLASSA_ACCUM_THRESH
-    4'b 1111, // index[44] ALERT_HANDLER_CLASSA_TIMEOUT_CYC
-    4'b 1111, // index[45] ALERT_HANDLER_CLASSA_PHASE0_CYC
-    4'b 1111, // index[46] ALERT_HANDLER_CLASSA_PHASE1_CYC
-    4'b 1111, // index[47] ALERT_HANDLER_CLASSA_PHASE2_CYC
-    4'b 1111, // index[48] ALERT_HANDLER_CLASSA_PHASE3_CYC
-    4'b 1111, // index[49] ALERT_HANDLER_CLASSA_ESC_CNT
-    4'b 0001, // index[50] ALERT_HANDLER_CLASSA_STATE
-    4'b 0001, // index[51] ALERT_HANDLER_CLASSB_REGWEN
-    4'b 0011, // index[52] ALERT_HANDLER_CLASSB_CTRL
-    4'b 0001, // index[53] ALERT_HANDLER_CLASSB_CLR_REGWEN
-    4'b 0001, // index[54] ALERT_HANDLER_CLASSB_CLR
-    4'b 0011, // index[55] ALERT_HANDLER_CLASSB_ACCUM_CNT
-    4'b 0011, // index[56] ALERT_HANDLER_CLASSB_ACCUM_THRESH
-    4'b 1111, // index[57] ALERT_HANDLER_CLASSB_TIMEOUT_CYC
-    4'b 1111, // index[58] ALERT_HANDLER_CLASSB_PHASE0_CYC
-    4'b 1111, // index[59] ALERT_HANDLER_CLASSB_PHASE1_CYC
-    4'b 1111, // index[60] ALERT_HANDLER_CLASSB_PHASE2_CYC
-    4'b 1111, // index[61] ALERT_HANDLER_CLASSB_PHASE3_CYC
-    4'b 1111, // index[62] ALERT_HANDLER_CLASSB_ESC_CNT
-    4'b 0001, // index[63] ALERT_HANDLER_CLASSB_STATE
-    4'b 0001, // index[64] ALERT_HANDLER_CLASSC_REGWEN
-    4'b 0011, // index[65] ALERT_HANDLER_CLASSC_CTRL
-    4'b 0001, // index[66] ALERT_HANDLER_CLASSC_CLR_REGWEN
-    4'b 0001, // index[67] ALERT_HANDLER_CLASSC_CLR
-    4'b 0011, // index[68] ALERT_HANDLER_CLASSC_ACCUM_CNT
-    4'b 0011, // index[69] ALERT_HANDLER_CLASSC_ACCUM_THRESH
-    4'b 1111, // index[70] ALERT_HANDLER_CLASSC_TIMEOUT_CYC
-    4'b 1111, // index[71] ALERT_HANDLER_CLASSC_PHASE0_CYC
-    4'b 1111, // index[72] ALERT_HANDLER_CLASSC_PHASE1_CYC
-    4'b 1111, // index[73] ALERT_HANDLER_CLASSC_PHASE2_CYC
-    4'b 1111, // index[74] ALERT_HANDLER_CLASSC_PHASE3_CYC
-    4'b 1111, // index[75] ALERT_HANDLER_CLASSC_ESC_CNT
-    4'b 0001, // index[76] ALERT_HANDLER_CLASSC_STATE
-    4'b 0001, // index[77] ALERT_HANDLER_CLASSD_REGWEN
-    4'b 0011, // index[78] ALERT_HANDLER_CLASSD_CTRL
-    4'b 0001, // index[79] ALERT_HANDLER_CLASSD_CLR_REGWEN
-    4'b 0001, // index[80] ALERT_HANDLER_CLASSD_CLR
-    4'b 0011, // index[81] ALERT_HANDLER_CLASSD_ACCUM_CNT
-    4'b 0011, // index[82] ALERT_HANDLER_CLASSD_ACCUM_THRESH
-    4'b 1111, // index[83] ALERT_HANDLER_CLASSD_TIMEOUT_CYC
-    4'b 1111, // index[84] ALERT_HANDLER_CLASSD_PHASE0_CYC
-    4'b 1111, // index[85] ALERT_HANDLER_CLASSD_PHASE1_CYC
-    4'b 1111, // index[86] ALERT_HANDLER_CLASSD_PHASE2_CYC
-    4'b 1111, // index[87] ALERT_HANDLER_CLASSD_PHASE3_CYC
-    4'b 1111, // index[88] ALERT_HANDLER_CLASSD_ESC_CNT
-    4'b 0001  // index[89] ALERT_HANDLER_CLASSD_STATE
+    4'b 0001, // index[26] ALERT_HANDLER_LOC_ALERT_REGWEN_4
+    4'b 0001, // index[27] ALERT_HANDLER_LOC_ALERT_EN_0
+    4'b 0001, // index[28] ALERT_HANDLER_LOC_ALERT_EN_1
+    4'b 0001, // index[29] ALERT_HANDLER_LOC_ALERT_EN_2
+    4'b 0001, // index[30] ALERT_HANDLER_LOC_ALERT_EN_3
+    4'b 0001, // index[31] ALERT_HANDLER_LOC_ALERT_EN_4
+    4'b 0001, // index[32] ALERT_HANDLER_LOC_ALERT_CLASS_0
+    4'b 0001, // index[33] ALERT_HANDLER_LOC_ALERT_CLASS_1
+    4'b 0001, // index[34] ALERT_HANDLER_LOC_ALERT_CLASS_2
+    4'b 0001, // index[35] ALERT_HANDLER_LOC_ALERT_CLASS_3
+    4'b 0001, // index[36] ALERT_HANDLER_LOC_ALERT_CLASS_4
+    4'b 0001, // index[37] ALERT_HANDLER_LOC_ALERT_CAUSE_0
+    4'b 0001, // index[38] ALERT_HANDLER_LOC_ALERT_CAUSE_1
+    4'b 0001, // index[39] ALERT_HANDLER_LOC_ALERT_CAUSE_2
+    4'b 0001, // index[40] ALERT_HANDLER_LOC_ALERT_CAUSE_3
+    4'b 0001, // index[41] ALERT_HANDLER_LOC_ALERT_CAUSE_4
+    4'b 0001, // index[42] ALERT_HANDLER_CLASSA_REGWEN
+    4'b 0011, // index[43] ALERT_HANDLER_CLASSA_CTRL
+    4'b 0001, // index[44] ALERT_HANDLER_CLASSA_CLR_REGWEN
+    4'b 0001, // index[45] ALERT_HANDLER_CLASSA_CLR
+    4'b 0011, // index[46] ALERT_HANDLER_CLASSA_ACCUM_CNT
+    4'b 0011, // index[47] ALERT_HANDLER_CLASSA_ACCUM_THRESH
+    4'b 1111, // index[48] ALERT_HANDLER_CLASSA_TIMEOUT_CYC
+    4'b 1111, // index[49] ALERT_HANDLER_CLASSA_PHASE0_CYC
+    4'b 1111, // index[50] ALERT_HANDLER_CLASSA_PHASE1_CYC
+    4'b 1111, // index[51] ALERT_HANDLER_CLASSA_PHASE2_CYC
+    4'b 1111, // index[52] ALERT_HANDLER_CLASSA_PHASE3_CYC
+    4'b 1111, // index[53] ALERT_HANDLER_CLASSA_ESC_CNT
+    4'b 0001, // index[54] ALERT_HANDLER_CLASSA_STATE
+    4'b 0001, // index[55] ALERT_HANDLER_CLASSB_REGWEN
+    4'b 0011, // index[56] ALERT_HANDLER_CLASSB_CTRL
+    4'b 0001, // index[57] ALERT_HANDLER_CLASSB_CLR_REGWEN
+    4'b 0001, // index[58] ALERT_HANDLER_CLASSB_CLR
+    4'b 0011, // index[59] ALERT_HANDLER_CLASSB_ACCUM_CNT
+    4'b 0011, // index[60] ALERT_HANDLER_CLASSB_ACCUM_THRESH
+    4'b 1111, // index[61] ALERT_HANDLER_CLASSB_TIMEOUT_CYC
+    4'b 1111, // index[62] ALERT_HANDLER_CLASSB_PHASE0_CYC
+    4'b 1111, // index[63] ALERT_HANDLER_CLASSB_PHASE1_CYC
+    4'b 1111, // index[64] ALERT_HANDLER_CLASSB_PHASE2_CYC
+    4'b 1111, // index[65] ALERT_HANDLER_CLASSB_PHASE3_CYC
+    4'b 1111, // index[66] ALERT_HANDLER_CLASSB_ESC_CNT
+    4'b 0001, // index[67] ALERT_HANDLER_CLASSB_STATE
+    4'b 0001, // index[68] ALERT_HANDLER_CLASSC_REGWEN
+    4'b 0011, // index[69] ALERT_HANDLER_CLASSC_CTRL
+    4'b 0001, // index[70] ALERT_HANDLER_CLASSC_CLR_REGWEN
+    4'b 0001, // index[71] ALERT_HANDLER_CLASSC_CLR
+    4'b 0011, // index[72] ALERT_HANDLER_CLASSC_ACCUM_CNT
+    4'b 0011, // index[73] ALERT_HANDLER_CLASSC_ACCUM_THRESH
+    4'b 1111, // index[74] ALERT_HANDLER_CLASSC_TIMEOUT_CYC
+    4'b 1111, // index[75] ALERT_HANDLER_CLASSC_PHASE0_CYC
+    4'b 1111, // index[76] ALERT_HANDLER_CLASSC_PHASE1_CYC
+    4'b 1111, // index[77] ALERT_HANDLER_CLASSC_PHASE2_CYC
+    4'b 1111, // index[78] ALERT_HANDLER_CLASSC_PHASE3_CYC
+    4'b 1111, // index[79] ALERT_HANDLER_CLASSC_ESC_CNT
+    4'b 0001, // index[80] ALERT_HANDLER_CLASSC_STATE
+    4'b 0001, // index[81] ALERT_HANDLER_CLASSD_REGWEN
+    4'b 0011, // index[82] ALERT_HANDLER_CLASSD_CTRL
+    4'b 0001, // index[83] ALERT_HANDLER_CLASSD_CLR_REGWEN
+    4'b 0001, // index[84] ALERT_HANDLER_CLASSD_CLR
+    4'b 0011, // index[85] ALERT_HANDLER_CLASSD_ACCUM_CNT
+    4'b 0011, // index[86] ALERT_HANDLER_CLASSD_ACCUM_THRESH
+    4'b 1111, // index[87] ALERT_HANDLER_CLASSD_TIMEOUT_CYC
+    4'b 1111, // index[88] ALERT_HANDLER_CLASSD_PHASE0_CYC
+    4'b 1111, // index[89] ALERT_HANDLER_CLASSD_PHASE1_CYC
+    4'b 1111, // index[90] ALERT_HANDLER_CLASSD_PHASE2_CYC
+    4'b 1111, // index[91] ALERT_HANDLER_CLASSD_PHASE3_CYC
+    4'b 1111, // index[92] ALERT_HANDLER_CLASSD_ESC_CNT
+    4'b 0001  // index[93] ALERT_HANDLER_CLASSD_STATE
   };
 
 endpackage

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_top.sv
@@ -205,6 +205,9 @@ module alert_handler_reg_top (
   logic loc_alert_regwen_3_qs;
   logic loc_alert_regwen_3_wd;
   logic loc_alert_regwen_3_we;
+  logic loc_alert_regwen_4_qs;
+  logic loc_alert_regwen_4_wd;
+  logic loc_alert_regwen_4_we;
   logic loc_alert_en_0_qs;
   logic loc_alert_en_0_wd;
   logic loc_alert_en_0_we;
@@ -217,6 +220,9 @@ module alert_handler_reg_top (
   logic loc_alert_en_3_qs;
   logic loc_alert_en_3_wd;
   logic loc_alert_en_3_we;
+  logic loc_alert_en_4_qs;
+  logic loc_alert_en_4_wd;
+  logic loc_alert_en_4_we;
   logic [1:0] loc_alert_class_0_qs;
   logic [1:0] loc_alert_class_0_wd;
   logic loc_alert_class_0_we;
@@ -229,6 +235,9 @@ module alert_handler_reg_top (
   logic [1:0] loc_alert_class_3_qs;
   logic [1:0] loc_alert_class_3_wd;
   logic loc_alert_class_3_we;
+  logic [1:0] loc_alert_class_4_qs;
+  logic [1:0] loc_alert_class_4_wd;
+  logic loc_alert_class_4_we;
   logic loc_alert_cause_0_qs;
   logic loc_alert_cause_0_wd;
   logic loc_alert_cause_0_we;
@@ -241,6 +250,9 @@ module alert_handler_reg_top (
   logic loc_alert_cause_3_qs;
   logic loc_alert_cause_3_wd;
   logic loc_alert_cause_3_we;
+  logic loc_alert_cause_4_qs;
+  logic loc_alert_cause_4_wd;
+  logic loc_alert_cause_4_we;
   logic classa_regwen_qs;
   logic classa_regwen_wd;
   logic classa_regwen_we;
@@ -1395,6 +1407,33 @@ module alert_handler_reg_top (
     .qs     (loc_alert_regwen_3_qs)
   );
 
+  // Subregister 4 of Multireg loc_alert_regwen
+  // R[loc_alert_regwen_4]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W0C"),
+    .RESVAL  (1'h1)
+  ) u_loc_alert_regwen_4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (loc_alert_regwen_4_we),
+    .wd     (loc_alert_regwen_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (loc_alert_regwen_4_qs)
+  );
+
 
 
   // Subregister 0 of Multireg loc_alert_en
@@ -1503,6 +1542,33 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (loc_alert_en_3_qs)
+  );
+
+  // Subregister 4 of Multireg loc_alert_en
+  // R[loc_alert_en_4]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_loc_alert_en_4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (loc_alert_en_4_we & loc_alert_regwen_4_qs),
+    .wd     (loc_alert_en_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.loc_alert_en[4].q),
+
+    // to register interface (read)
+    .qs     (loc_alert_en_4_qs)
   );
 
 
@@ -1615,6 +1681,33 @@ module alert_handler_reg_top (
     .qs     (loc_alert_class_3_qs)
   );
 
+  // Subregister 4 of Multireg loc_alert_class
+  // R[loc_alert_class_4]: V(False)
+
+  prim_subreg #(
+    .DW      (2),
+    .SWACCESS("RW"),
+    .RESVAL  (2'h0)
+  ) u_loc_alert_class_4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (loc_alert_class_4_we & loc_alert_regwen_4_qs),
+    .wd     (loc_alert_class_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.loc_alert_class[4].q),
+
+    // to register interface (read)
+    .qs     (loc_alert_class_4_qs)
+  );
+
 
 
   // Subregister 0 of Multireg loc_alert_cause
@@ -1723,6 +1816,33 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (loc_alert_cause_3_qs)
+  );
+
+  // Subregister 4 of Multireg loc_alert_cause
+  // R[loc_alert_cause_4]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_loc_alert_cause_4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (loc_alert_cause_4_we),
+    .wd     (loc_alert_cause_4_wd),
+
+    // from internal hardware
+    .de     (hw2reg.loc_alert_cause[4].de),
+    .d      (hw2reg.loc_alert_cause[4].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.loc_alert_cause[4].q),
+
+    // to register interface (read)
+    .qs     (loc_alert_cause_4_qs)
   );
 
 
@@ -3940,7 +4060,7 @@ module alert_handler_reg_top (
 
 
 
-  logic [89:0] addr_hit;
+  logic [93:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == ALERT_HANDLER_INTR_STATE_OFFSET);
@@ -3969,70 +4089,74 @@ module alert_handler_reg_top (
     addr_hit[23] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_1_OFFSET);
     addr_hit[24] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_2_OFFSET);
     addr_hit[25] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_3_OFFSET);
-    addr_hit[26] = (reg_addr == ALERT_HANDLER_LOC_ALERT_EN_0_OFFSET);
-    addr_hit[27] = (reg_addr == ALERT_HANDLER_LOC_ALERT_EN_1_OFFSET);
-    addr_hit[28] = (reg_addr == ALERT_HANDLER_LOC_ALERT_EN_2_OFFSET);
-    addr_hit[29] = (reg_addr == ALERT_HANDLER_LOC_ALERT_EN_3_OFFSET);
-    addr_hit[30] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_0_OFFSET);
-    addr_hit[31] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_1_OFFSET);
-    addr_hit[32] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_2_OFFSET);
-    addr_hit[33] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_3_OFFSET);
-    addr_hit[34] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_0_OFFSET);
-    addr_hit[35] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_1_OFFSET);
-    addr_hit[36] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_2_OFFSET);
-    addr_hit[37] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_3_OFFSET);
-    addr_hit[38] = (reg_addr == ALERT_HANDLER_CLASSA_REGWEN_OFFSET);
-    addr_hit[39] = (reg_addr == ALERT_HANDLER_CLASSA_CTRL_OFFSET);
-    addr_hit[40] = (reg_addr == ALERT_HANDLER_CLASSA_CLR_REGWEN_OFFSET);
-    addr_hit[41] = (reg_addr == ALERT_HANDLER_CLASSA_CLR_OFFSET);
-    addr_hit[42] = (reg_addr == ALERT_HANDLER_CLASSA_ACCUM_CNT_OFFSET);
-    addr_hit[43] = (reg_addr == ALERT_HANDLER_CLASSA_ACCUM_THRESH_OFFSET);
-    addr_hit[44] = (reg_addr == ALERT_HANDLER_CLASSA_TIMEOUT_CYC_OFFSET);
-    addr_hit[45] = (reg_addr == ALERT_HANDLER_CLASSA_PHASE0_CYC_OFFSET);
-    addr_hit[46] = (reg_addr == ALERT_HANDLER_CLASSA_PHASE1_CYC_OFFSET);
-    addr_hit[47] = (reg_addr == ALERT_HANDLER_CLASSA_PHASE2_CYC_OFFSET);
-    addr_hit[48] = (reg_addr == ALERT_HANDLER_CLASSA_PHASE3_CYC_OFFSET);
-    addr_hit[49] = (reg_addr == ALERT_HANDLER_CLASSA_ESC_CNT_OFFSET);
-    addr_hit[50] = (reg_addr == ALERT_HANDLER_CLASSA_STATE_OFFSET);
-    addr_hit[51] = (reg_addr == ALERT_HANDLER_CLASSB_REGWEN_OFFSET);
-    addr_hit[52] = (reg_addr == ALERT_HANDLER_CLASSB_CTRL_OFFSET);
-    addr_hit[53] = (reg_addr == ALERT_HANDLER_CLASSB_CLR_REGWEN_OFFSET);
-    addr_hit[54] = (reg_addr == ALERT_HANDLER_CLASSB_CLR_OFFSET);
-    addr_hit[55] = (reg_addr == ALERT_HANDLER_CLASSB_ACCUM_CNT_OFFSET);
-    addr_hit[56] = (reg_addr == ALERT_HANDLER_CLASSB_ACCUM_THRESH_OFFSET);
-    addr_hit[57] = (reg_addr == ALERT_HANDLER_CLASSB_TIMEOUT_CYC_OFFSET);
-    addr_hit[58] = (reg_addr == ALERT_HANDLER_CLASSB_PHASE0_CYC_OFFSET);
-    addr_hit[59] = (reg_addr == ALERT_HANDLER_CLASSB_PHASE1_CYC_OFFSET);
-    addr_hit[60] = (reg_addr == ALERT_HANDLER_CLASSB_PHASE2_CYC_OFFSET);
-    addr_hit[61] = (reg_addr == ALERT_HANDLER_CLASSB_PHASE3_CYC_OFFSET);
-    addr_hit[62] = (reg_addr == ALERT_HANDLER_CLASSB_ESC_CNT_OFFSET);
-    addr_hit[63] = (reg_addr == ALERT_HANDLER_CLASSB_STATE_OFFSET);
-    addr_hit[64] = (reg_addr == ALERT_HANDLER_CLASSC_REGWEN_OFFSET);
-    addr_hit[65] = (reg_addr == ALERT_HANDLER_CLASSC_CTRL_OFFSET);
-    addr_hit[66] = (reg_addr == ALERT_HANDLER_CLASSC_CLR_REGWEN_OFFSET);
-    addr_hit[67] = (reg_addr == ALERT_HANDLER_CLASSC_CLR_OFFSET);
-    addr_hit[68] = (reg_addr == ALERT_HANDLER_CLASSC_ACCUM_CNT_OFFSET);
-    addr_hit[69] = (reg_addr == ALERT_HANDLER_CLASSC_ACCUM_THRESH_OFFSET);
-    addr_hit[70] = (reg_addr == ALERT_HANDLER_CLASSC_TIMEOUT_CYC_OFFSET);
-    addr_hit[71] = (reg_addr == ALERT_HANDLER_CLASSC_PHASE0_CYC_OFFSET);
-    addr_hit[72] = (reg_addr == ALERT_HANDLER_CLASSC_PHASE1_CYC_OFFSET);
-    addr_hit[73] = (reg_addr == ALERT_HANDLER_CLASSC_PHASE2_CYC_OFFSET);
-    addr_hit[74] = (reg_addr == ALERT_HANDLER_CLASSC_PHASE3_CYC_OFFSET);
-    addr_hit[75] = (reg_addr == ALERT_HANDLER_CLASSC_ESC_CNT_OFFSET);
-    addr_hit[76] = (reg_addr == ALERT_HANDLER_CLASSC_STATE_OFFSET);
-    addr_hit[77] = (reg_addr == ALERT_HANDLER_CLASSD_REGWEN_OFFSET);
-    addr_hit[78] = (reg_addr == ALERT_HANDLER_CLASSD_CTRL_OFFSET);
-    addr_hit[79] = (reg_addr == ALERT_HANDLER_CLASSD_CLR_REGWEN_OFFSET);
-    addr_hit[80] = (reg_addr == ALERT_HANDLER_CLASSD_CLR_OFFSET);
-    addr_hit[81] = (reg_addr == ALERT_HANDLER_CLASSD_ACCUM_CNT_OFFSET);
-    addr_hit[82] = (reg_addr == ALERT_HANDLER_CLASSD_ACCUM_THRESH_OFFSET);
-    addr_hit[83] = (reg_addr == ALERT_HANDLER_CLASSD_TIMEOUT_CYC_OFFSET);
-    addr_hit[84] = (reg_addr == ALERT_HANDLER_CLASSD_PHASE0_CYC_OFFSET);
-    addr_hit[85] = (reg_addr == ALERT_HANDLER_CLASSD_PHASE1_CYC_OFFSET);
-    addr_hit[86] = (reg_addr == ALERT_HANDLER_CLASSD_PHASE2_CYC_OFFSET);
-    addr_hit[87] = (reg_addr == ALERT_HANDLER_CLASSD_PHASE3_CYC_OFFSET);
-    addr_hit[88] = (reg_addr == ALERT_HANDLER_CLASSD_ESC_CNT_OFFSET);
-    addr_hit[89] = (reg_addr == ALERT_HANDLER_CLASSD_STATE_OFFSET);
+    addr_hit[26] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_4_OFFSET);
+    addr_hit[27] = (reg_addr == ALERT_HANDLER_LOC_ALERT_EN_0_OFFSET);
+    addr_hit[28] = (reg_addr == ALERT_HANDLER_LOC_ALERT_EN_1_OFFSET);
+    addr_hit[29] = (reg_addr == ALERT_HANDLER_LOC_ALERT_EN_2_OFFSET);
+    addr_hit[30] = (reg_addr == ALERT_HANDLER_LOC_ALERT_EN_3_OFFSET);
+    addr_hit[31] = (reg_addr == ALERT_HANDLER_LOC_ALERT_EN_4_OFFSET);
+    addr_hit[32] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_0_OFFSET);
+    addr_hit[33] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_1_OFFSET);
+    addr_hit[34] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_2_OFFSET);
+    addr_hit[35] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_3_OFFSET);
+    addr_hit[36] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_4_OFFSET);
+    addr_hit[37] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_0_OFFSET);
+    addr_hit[38] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_1_OFFSET);
+    addr_hit[39] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_2_OFFSET);
+    addr_hit[40] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_3_OFFSET);
+    addr_hit[41] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_4_OFFSET);
+    addr_hit[42] = (reg_addr == ALERT_HANDLER_CLASSA_REGWEN_OFFSET);
+    addr_hit[43] = (reg_addr == ALERT_HANDLER_CLASSA_CTRL_OFFSET);
+    addr_hit[44] = (reg_addr == ALERT_HANDLER_CLASSA_CLR_REGWEN_OFFSET);
+    addr_hit[45] = (reg_addr == ALERT_HANDLER_CLASSA_CLR_OFFSET);
+    addr_hit[46] = (reg_addr == ALERT_HANDLER_CLASSA_ACCUM_CNT_OFFSET);
+    addr_hit[47] = (reg_addr == ALERT_HANDLER_CLASSA_ACCUM_THRESH_OFFSET);
+    addr_hit[48] = (reg_addr == ALERT_HANDLER_CLASSA_TIMEOUT_CYC_OFFSET);
+    addr_hit[49] = (reg_addr == ALERT_HANDLER_CLASSA_PHASE0_CYC_OFFSET);
+    addr_hit[50] = (reg_addr == ALERT_HANDLER_CLASSA_PHASE1_CYC_OFFSET);
+    addr_hit[51] = (reg_addr == ALERT_HANDLER_CLASSA_PHASE2_CYC_OFFSET);
+    addr_hit[52] = (reg_addr == ALERT_HANDLER_CLASSA_PHASE3_CYC_OFFSET);
+    addr_hit[53] = (reg_addr == ALERT_HANDLER_CLASSA_ESC_CNT_OFFSET);
+    addr_hit[54] = (reg_addr == ALERT_HANDLER_CLASSA_STATE_OFFSET);
+    addr_hit[55] = (reg_addr == ALERT_HANDLER_CLASSB_REGWEN_OFFSET);
+    addr_hit[56] = (reg_addr == ALERT_HANDLER_CLASSB_CTRL_OFFSET);
+    addr_hit[57] = (reg_addr == ALERT_HANDLER_CLASSB_CLR_REGWEN_OFFSET);
+    addr_hit[58] = (reg_addr == ALERT_HANDLER_CLASSB_CLR_OFFSET);
+    addr_hit[59] = (reg_addr == ALERT_HANDLER_CLASSB_ACCUM_CNT_OFFSET);
+    addr_hit[60] = (reg_addr == ALERT_HANDLER_CLASSB_ACCUM_THRESH_OFFSET);
+    addr_hit[61] = (reg_addr == ALERT_HANDLER_CLASSB_TIMEOUT_CYC_OFFSET);
+    addr_hit[62] = (reg_addr == ALERT_HANDLER_CLASSB_PHASE0_CYC_OFFSET);
+    addr_hit[63] = (reg_addr == ALERT_HANDLER_CLASSB_PHASE1_CYC_OFFSET);
+    addr_hit[64] = (reg_addr == ALERT_HANDLER_CLASSB_PHASE2_CYC_OFFSET);
+    addr_hit[65] = (reg_addr == ALERT_HANDLER_CLASSB_PHASE3_CYC_OFFSET);
+    addr_hit[66] = (reg_addr == ALERT_HANDLER_CLASSB_ESC_CNT_OFFSET);
+    addr_hit[67] = (reg_addr == ALERT_HANDLER_CLASSB_STATE_OFFSET);
+    addr_hit[68] = (reg_addr == ALERT_HANDLER_CLASSC_REGWEN_OFFSET);
+    addr_hit[69] = (reg_addr == ALERT_HANDLER_CLASSC_CTRL_OFFSET);
+    addr_hit[70] = (reg_addr == ALERT_HANDLER_CLASSC_CLR_REGWEN_OFFSET);
+    addr_hit[71] = (reg_addr == ALERT_HANDLER_CLASSC_CLR_OFFSET);
+    addr_hit[72] = (reg_addr == ALERT_HANDLER_CLASSC_ACCUM_CNT_OFFSET);
+    addr_hit[73] = (reg_addr == ALERT_HANDLER_CLASSC_ACCUM_THRESH_OFFSET);
+    addr_hit[74] = (reg_addr == ALERT_HANDLER_CLASSC_TIMEOUT_CYC_OFFSET);
+    addr_hit[75] = (reg_addr == ALERT_HANDLER_CLASSC_PHASE0_CYC_OFFSET);
+    addr_hit[76] = (reg_addr == ALERT_HANDLER_CLASSC_PHASE1_CYC_OFFSET);
+    addr_hit[77] = (reg_addr == ALERT_HANDLER_CLASSC_PHASE2_CYC_OFFSET);
+    addr_hit[78] = (reg_addr == ALERT_HANDLER_CLASSC_PHASE3_CYC_OFFSET);
+    addr_hit[79] = (reg_addr == ALERT_HANDLER_CLASSC_ESC_CNT_OFFSET);
+    addr_hit[80] = (reg_addr == ALERT_HANDLER_CLASSC_STATE_OFFSET);
+    addr_hit[81] = (reg_addr == ALERT_HANDLER_CLASSD_REGWEN_OFFSET);
+    addr_hit[82] = (reg_addr == ALERT_HANDLER_CLASSD_CTRL_OFFSET);
+    addr_hit[83] = (reg_addr == ALERT_HANDLER_CLASSD_CLR_REGWEN_OFFSET);
+    addr_hit[84] = (reg_addr == ALERT_HANDLER_CLASSD_CLR_OFFSET);
+    addr_hit[85] = (reg_addr == ALERT_HANDLER_CLASSD_ACCUM_CNT_OFFSET);
+    addr_hit[86] = (reg_addr == ALERT_HANDLER_CLASSD_ACCUM_THRESH_OFFSET);
+    addr_hit[87] = (reg_addr == ALERT_HANDLER_CLASSD_TIMEOUT_CYC_OFFSET);
+    addr_hit[88] = (reg_addr == ALERT_HANDLER_CLASSD_PHASE0_CYC_OFFSET);
+    addr_hit[89] = (reg_addr == ALERT_HANDLER_CLASSD_PHASE1_CYC_OFFSET);
+    addr_hit[90] = (reg_addr == ALERT_HANDLER_CLASSD_PHASE2_CYC_OFFSET);
+    addr_hit[91] = (reg_addr == ALERT_HANDLER_CLASSD_PHASE3_CYC_OFFSET);
+    addr_hit[92] = (reg_addr == ALERT_HANDLER_CLASSD_ESC_CNT_OFFSET);
+    addr_hit[93] = (reg_addr == ALERT_HANDLER_CLASSD_STATE_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -4129,7 +4253,11 @@ module alert_handler_reg_top (
                (addr_hit[86] & (|(ALERT_HANDLER_PERMIT[86] & ~reg_be))) |
                (addr_hit[87] & (|(ALERT_HANDLER_PERMIT[87] & ~reg_be))) |
                (addr_hit[88] & (|(ALERT_HANDLER_PERMIT[88] & ~reg_be))) |
-               (addr_hit[89] & (|(ALERT_HANDLER_PERMIT[89] & ~reg_be)))));
+               (addr_hit[89] & (|(ALERT_HANDLER_PERMIT[89] & ~reg_be))) |
+               (addr_hit[90] & (|(ALERT_HANDLER_PERMIT[90] & ~reg_be))) |
+               (addr_hit[91] & (|(ALERT_HANDLER_PERMIT[91] & ~reg_be))) |
+               (addr_hit[92] & (|(ALERT_HANDLER_PERMIT[92] & ~reg_be))) |
+               (addr_hit[93] & (|(ALERT_HANDLER_PERMIT[93] & ~reg_be)))));
   end
 
   assign intr_state_classa_we = addr_hit[0] & reg_we & !reg_error;
@@ -4237,293 +4365,305 @@ module alert_handler_reg_top (
   assign loc_alert_regwen_3_we = addr_hit[25] & reg_we & !reg_error;
   assign loc_alert_regwen_3_wd = reg_wdata[0];
 
-  assign loc_alert_en_0_we = addr_hit[26] & reg_we & !reg_error;
+  assign loc_alert_regwen_4_we = addr_hit[26] & reg_we & !reg_error;
+  assign loc_alert_regwen_4_wd = reg_wdata[0];
+
+  assign loc_alert_en_0_we = addr_hit[27] & reg_we & !reg_error;
   assign loc_alert_en_0_wd = reg_wdata[0];
 
-  assign loc_alert_en_1_we = addr_hit[27] & reg_we & !reg_error;
+  assign loc_alert_en_1_we = addr_hit[28] & reg_we & !reg_error;
   assign loc_alert_en_1_wd = reg_wdata[0];
 
-  assign loc_alert_en_2_we = addr_hit[28] & reg_we & !reg_error;
+  assign loc_alert_en_2_we = addr_hit[29] & reg_we & !reg_error;
   assign loc_alert_en_2_wd = reg_wdata[0];
 
-  assign loc_alert_en_3_we = addr_hit[29] & reg_we & !reg_error;
+  assign loc_alert_en_3_we = addr_hit[30] & reg_we & !reg_error;
   assign loc_alert_en_3_wd = reg_wdata[0];
 
-  assign loc_alert_class_0_we = addr_hit[30] & reg_we & !reg_error;
+  assign loc_alert_en_4_we = addr_hit[31] & reg_we & !reg_error;
+  assign loc_alert_en_4_wd = reg_wdata[0];
+
+  assign loc_alert_class_0_we = addr_hit[32] & reg_we & !reg_error;
   assign loc_alert_class_0_wd = reg_wdata[1:0];
 
-  assign loc_alert_class_1_we = addr_hit[31] & reg_we & !reg_error;
+  assign loc_alert_class_1_we = addr_hit[33] & reg_we & !reg_error;
   assign loc_alert_class_1_wd = reg_wdata[1:0];
 
-  assign loc_alert_class_2_we = addr_hit[32] & reg_we & !reg_error;
+  assign loc_alert_class_2_we = addr_hit[34] & reg_we & !reg_error;
   assign loc_alert_class_2_wd = reg_wdata[1:0];
 
-  assign loc_alert_class_3_we = addr_hit[33] & reg_we & !reg_error;
+  assign loc_alert_class_3_we = addr_hit[35] & reg_we & !reg_error;
   assign loc_alert_class_3_wd = reg_wdata[1:0];
 
-  assign loc_alert_cause_0_we = addr_hit[34] & reg_we & !reg_error;
+  assign loc_alert_class_4_we = addr_hit[36] & reg_we & !reg_error;
+  assign loc_alert_class_4_wd = reg_wdata[1:0];
+
+  assign loc_alert_cause_0_we = addr_hit[37] & reg_we & !reg_error;
   assign loc_alert_cause_0_wd = reg_wdata[0];
 
-  assign loc_alert_cause_1_we = addr_hit[35] & reg_we & !reg_error;
+  assign loc_alert_cause_1_we = addr_hit[38] & reg_we & !reg_error;
   assign loc_alert_cause_1_wd = reg_wdata[0];
 
-  assign loc_alert_cause_2_we = addr_hit[36] & reg_we & !reg_error;
+  assign loc_alert_cause_2_we = addr_hit[39] & reg_we & !reg_error;
   assign loc_alert_cause_2_wd = reg_wdata[0];
 
-  assign loc_alert_cause_3_we = addr_hit[37] & reg_we & !reg_error;
+  assign loc_alert_cause_3_we = addr_hit[40] & reg_we & !reg_error;
   assign loc_alert_cause_3_wd = reg_wdata[0];
 
-  assign classa_regwen_we = addr_hit[38] & reg_we & !reg_error;
+  assign loc_alert_cause_4_we = addr_hit[41] & reg_we & !reg_error;
+  assign loc_alert_cause_4_wd = reg_wdata[0];
+
+  assign classa_regwen_we = addr_hit[42] & reg_we & !reg_error;
   assign classa_regwen_wd = reg_wdata[0];
 
-  assign classa_ctrl_en_we = addr_hit[39] & reg_we & !reg_error;
+  assign classa_ctrl_en_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_en_wd = reg_wdata[0];
 
-  assign classa_ctrl_lock_we = addr_hit[39] & reg_we & !reg_error;
+  assign classa_ctrl_lock_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_lock_wd = reg_wdata[1];
 
-  assign classa_ctrl_en_e0_we = addr_hit[39] & reg_we & !reg_error;
+  assign classa_ctrl_en_e0_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classa_ctrl_en_e1_we = addr_hit[39] & reg_we & !reg_error;
+  assign classa_ctrl_en_e1_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classa_ctrl_en_e2_we = addr_hit[39] & reg_we & !reg_error;
+  assign classa_ctrl_en_e2_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classa_ctrl_en_e3_we = addr_hit[39] & reg_we & !reg_error;
+  assign classa_ctrl_en_e3_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classa_ctrl_map_e0_we = addr_hit[39] & reg_we & !reg_error;
+  assign classa_ctrl_map_e0_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classa_ctrl_map_e1_we = addr_hit[39] & reg_we & !reg_error;
+  assign classa_ctrl_map_e1_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classa_ctrl_map_e2_we = addr_hit[39] & reg_we & !reg_error;
+  assign classa_ctrl_map_e2_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classa_ctrl_map_e3_we = addr_hit[39] & reg_we & !reg_error;
+  assign classa_ctrl_map_e3_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classa_clr_regwen_we = addr_hit[40] & reg_we & !reg_error;
+  assign classa_clr_regwen_we = addr_hit[44] & reg_we & !reg_error;
   assign classa_clr_regwen_wd = reg_wdata[0];
 
-  assign classa_clr_we = addr_hit[41] & reg_we & !reg_error;
+  assign classa_clr_we = addr_hit[45] & reg_we & !reg_error;
   assign classa_clr_wd = reg_wdata[0];
 
-  assign classa_accum_cnt_re = addr_hit[42] & reg_re & !reg_error;
+  assign classa_accum_cnt_re = addr_hit[46] & reg_re & !reg_error;
 
-  assign classa_accum_thresh_we = addr_hit[43] & reg_we & !reg_error;
+  assign classa_accum_thresh_we = addr_hit[47] & reg_we & !reg_error;
   assign classa_accum_thresh_wd = reg_wdata[15:0];
 
-  assign classa_timeout_cyc_we = addr_hit[44] & reg_we & !reg_error;
+  assign classa_timeout_cyc_we = addr_hit[48] & reg_we & !reg_error;
   assign classa_timeout_cyc_wd = reg_wdata[31:0];
 
-  assign classa_phase0_cyc_we = addr_hit[45] & reg_we & !reg_error;
+  assign classa_phase0_cyc_we = addr_hit[49] & reg_we & !reg_error;
   assign classa_phase0_cyc_wd = reg_wdata[31:0];
 
-  assign classa_phase1_cyc_we = addr_hit[46] & reg_we & !reg_error;
+  assign classa_phase1_cyc_we = addr_hit[50] & reg_we & !reg_error;
   assign classa_phase1_cyc_wd = reg_wdata[31:0];
 
-  assign classa_phase2_cyc_we = addr_hit[47] & reg_we & !reg_error;
+  assign classa_phase2_cyc_we = addr_hit[51] & reg_we & !reg_error;
   assign classa_phase2_cyc_wd = reg_wdata[31:0];
 
-  assign classa_phase3_cyc_we = addr_hit[48] & reg_we & !reg_error;
+  assign classa_phase3_cyc_we = addr_hit[52] & reg_we & !reg_error;
   assign classa_phase3_cyc_wd = reg_wdata[31:0];
 
-  assign classa_esc_cnt_re = addr_hit[49] & reg_re & !reg_error;
+  assign classa_esc_cnt_re = addr_hit[53] & reg_re & !reg_error;
 
-  assign classa_state_re = addr_hit[50] & reg_re & !reg_error;
+  assign classa_state_re = addr_hit[54] & reg_re & !reg_error;
 
-  assign classb_regwen_we = addr_hit[51] & reg_we & !reg_error;
+  assign classb_regwen_we = addr_hit[55] & reg_we & !reg_error;
   assign classb_regwen_wd = reg_wdata[0];
 
-  assign classb_ctrl_en_we = addr_hit[52] & reg_we & !reg_error;
+  assign classb_ctrl_en_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_en_wd = reg_wdata[0];
 
-  assign classb_ctrl_lock_we = addr_hit[52] & reg_we & !reg_error;
+  assign classb_ctrl_lock_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_lock_wd = reg_wdata[1];
 
-  assign classb_ctrl_en_e0_we = addr_hit[52] & reg_we & !reg_error;
+  assign classb_ctrl_en_e0_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classb_ctrl_en_e1_we = addr_hit[52] & reg_we & !reg_error;
+  assign classb_ctrl_en_e1_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classb_ctrl_en_e2_we = addr_hit[52] & reg_we & !reg_error;
+  assign classb_ctrl_en_e2_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classb_ctrl_en_e3_we = addr_hit[52] & reg_we & !reg_error;
+  assign classb_ctrl_en_e3_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classb_ctrl_map_e0_we = addr_hit[52] & reg_we & !reg_error;
+  assign classb_ctrl_map_e0_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classb_ctrl_map_e1_we = addr_hit[52] & reg_we & !reg_error;
+  assign classb_ctrl_map_e1_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classb_ctrl_map_e2_we = addr_hit[52] & reg_we & !reg_error;
+  assign classb_ctrl_map_e2_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classb_ctrl_map_e3_we = addr_hit[52] & reg_we & !reg_error;
+  assign classb_ctrl_map_e3_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classb_clr_regwen_we = addr_hit[53] & reg_we & !reg_error;
+  assign classb_clr_regwen_we = addr_hit[57] & reg_we & !reg_error;
   assign classb_clr_regwen_wd = reg_wdata[0];
 
-  assign classb_clr_we = addr_hit[54] & reg_we & !reg_error;
+  assign classb_clr_we = addr_hit[58] & reg_we & !reg_error;
   assign classb_clr_wd = reg_wdata[0];
 
-  assign classb_accum_cnt_re = addr_hit[55] & reg_re & !reg_error;
+  assign classb_accum_cnt_re = addr_hit[59] & reg_re & !reg_error;
 
-  assign classb_accum_thresh_we = addr_hit[56] & reg_we & !reg_error;
+  assign classb_accum_thresh_we = addr_hit[60] & reg_we & !reg_error;
   assign classb_accum_thresh_wd = reg_wdata[15:0];
 
-  assign classb_timeout_cyc_we = addr_hit[57] & reg_we & !reg_error;
+  assign classb_timeout_cyc_we = addr_hit[61] & reg_we & !reg_error;
   assign classb_timeout_cyc_wd = reg_wdata[31:0];
 
-  assign classb_phase0_cyc_we = addr_hit[58] & reg_we & !reg_error;
+  assign classb_phase0_cyc_we = addr_hit[62] & reg_we & !reg_error;
   assign classb_phase0_cyc_wd = reg_wdata[31:0];
 
-  assign classb_phase1_cyc_we = addr_hit[59] & reg_we & !reg_error;
+  assign classb_phase1_cyc_we = addr_hit[63] & reg_we & !reg_error;
   assign classb_phase1_cyc_wd = reg_wdata[31:0];
 
-  assign classb_phase2_cyc_we = addr_hit[60] & reg_we & !reg_error;
+  assign classb_phase2_cyc_we = addr_hit[64] & reg_we & !reg_error;
   assign classb_phase2_cyc_wd = reg_wdata[31:0];
 
-  assign classb_phase3_cyc_we = addr_hit[61] & reg_we & !reg_error;
+  assign classb_phase3_cyc_we = addr_hit[65] & reg_we & !reg_error;
   assign classb_phase3_cyc_wd = reg_wdata[31:0];
 
-  assign classb_esc_cnt_re = addr_hit[62] & reg_re & !reg_error;
+  assign classb_esc_cnt_re = addr_hit[66] & reg_re & !reg_error;
 
-  assign classb_state_re = addr_hit[63] & reg_re & !reg_error;
+  assign classb_state_re = addr_hit[67] & reg_re & !reg_error;
 
-  assign classc_regwen_we = addr_hit[64] & reg_we & !reg_error;
+  assign classc_regwen_we = addr_hit[68] & reg_we & !reg_error;
   assign classc_regwen_wd = reg_wdata[0];
 
-  assign classc_ctrl_en_we = addr_hit[65] & reg_we & !reg_error;
+  assign classc_ctrl_en_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_en_wd = reg_wdata[0];
 
-  assign classc_ctrl_lock_we = addr_hit[65] & reg_we & !reg_error;
+  assign classc_ctrl_lock_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_lock_wd = reg_wdata[1];
 
-  assign classc_ctrl_en_e0_we = addr_hit[65] & reg_we & !reg_error;
+  assign classc_ctrl_en_e0_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classc_ctrl_en_e1_we = addr_hit[65] & reg_we & !reg_error;
+  assign classc_ctrl_en_e1_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classc_ctrl_en_e2_we = addr_hit[65] & reg_we & !reg_error;
+  assign classc_ctrl_en_e2_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classc_ctrl_en_e3_we = addr_hit[65] & reg_we & !reg_error;
+  assign classc_ctrl_en_e3_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classc_ctrl_map_e0_we = addr_hit[65] & reg_we & !reg_error;
+  assign classc_ctrl_map_e0_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classc_ctrl_map_e1_we = addr_hit[65] & reg_we & !reg_error;
+  assign classc_ctrl_map_e1_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classc_ctrl_map_e2_we = addr_hit[65] & reg_we & !reg_error;
+  assign classc_ctrl_map_e2_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classc_ctrl_map_e3_we = addr_hit[65] & reg_we & !reg_error;
+  assign classc_ctrl_map_e3_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classc_clr_regwen_we = addr_hit[66] & reg_we & !reg_error;
+  assign classc_clr_regwen_we = addr_hit[70] & reg_we & !reg_error;
   assign classc_clr_regwen_wd = reg_wdata[0];
 
-  assign classc_clr_we = addr_hit[67] & reg_we & !reg_error;
+  assign classc_clr_we = addr_hit[71] & reg_we & !reg_error;
   assign classc_clr_wd = reg_wdata[0];
 
-  assign classc_accum_cnt_re = addr_hit[68] & reg_re & !reg_error;
+  assign classc_accum_cnt_re = addr_hit[72] & reg_re & !reg_error;
 
-  assign classc_accum_thresh_we = addr_hit[69] & reg_we & !reg_error;
+  assign classc_accum_thresh_we = addr_hit[73] & reg_we & !reg_error;
   assign classc_accum_thresh_wd = reg_wdata[15:0];
 
-  assign classc_timeout_cyc_we = addr_hit[70] & reg_we & !reg_error;
+  assign classc_timeout_cyc_we = addr_hit[74] & reg_we & !reg_error;
   assign classc_timeout_cyc_wd = reg_wdata[31:0];
 
-  assign classc_phase0_cyc_we = addr_hit[71] & reg_we & !reg_error;
+  assign classc_phase0_cyc_we = addr_hit[75] & reg_we & !reg_error;
   assign classc_phase0_cyc_wd = reg_wdata[31:0];
 
-  assign classc_phase1_cyc_we = addr_hit[72] & reg_we & !reg_error;
+  assign classc_phase1_cyc_we = addr_hit[76] & reg_we & !reg_error;
   assign classc_phase1_cyc_wd = reg_wdata[31:0];
 
-  assign classc_phase2_cyc_we = addr_hit[73] & reg_we & !reg_error;
+  assign classc_phase2_cyc_we = addr_hit[77] & reg_we & !reg_error;
   assign classc_phase2_cyc_wd = reg_wdata[31:0];
 
-  assign classc_phase3_cyc_we = addr_hit[74] & reg_we & !reg_error;
+  assign classc_phase3_cyc_we = addr_hit[78] & reg_we & !reg_error;
   assign classc_phase3_cyc_wd = reg_wdata[31:0];
 
-  assign classc_esc_cnt_re = addr_hit[75] & reg_re & !reg_error;
+  assign classc_esc_cnt_re = addr_hit[79] & reg_re & !reg_error;
 
-  assign classc_state_re = addr_hit[76] & reg_re & !reg_error;
+  assign classc_state_re = addr_hit[80] & reg_re & !reg_error;
 
-  assign classd_regwen_we = addr_hit[77] & reg_we & !reg_error;
+  assign classd_regwen_we = addr_hit[81] & reg_we & !reg_error;
   assign classd_regwen_wd = reg_wdata[0];
 
-  assign classd_ctrl_en_we = addr_hit[78] & reg_we & !reg_error;
+  assign classd_ctrl_en_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_en_wd = reg_wdata[0];
 
-  assign classd_ctrl_lock_we = addr_hit[78] & reg_we & !reg_error;
+  assign classd_ctrl_lock_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_lock_wd = reg_wdata[1];
 
-  assign classd_ctrl_en_e0_we = addr_hit[78] & reg_we & !reg_error;
+  assign classd_ctrl_en_e0_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classd_ctrl_en_e1_we = addr_hit[78] & reg_we & !reg_error;
+  assign classd_ctrl_en_e1_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classd_ctrl_en_e2_we = addr_hit[78] & reg_we & !reg_error;
+  assign classd_ctrl_en_e2_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classd_ctrl_en_e3_we = addr_hit[78] & reg_we & !reg_error;
+  assign classd_ctrl_en_e3_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classd_ctrl_map_e0_we = addr_hit[78] & reg_we & !reg_error;
+  assign classd_ctrl_map_e0_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classd_ctrl_map_e1_we = addr_hit[78] & reg_we & !reg_error;
+  assign classd_ctrl_map_e1_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classd_ctrl_map_e2_we = addr_hit[78] & reg_we & !reg_error;
+  assign classd_ctrl_map_e2_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classd_ctrl_map_e3_we = addr_hit[78] & reg_we & !reg_error;
+  assign classd_ctrl_map_e3_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classd_clr_regwen_we = addr_hit[79] & reg_we & !reg_error;
+  assign classd_clr_regwen_we = addr_hit[83] & reg_we & !reg_error;
   assign classd_clr_regwen_wd = reg_wdata[0];
 
-  assign classd_clr_we = addr_hit[80] & reg_we & !reg_error;
+  assign classd_clr_we = addr_hit[84] & reg_we & !reg_error;
   assign classd_clr_wd = reg_wdata[0];
 
-  assign classd_accum_cnt_re = addr_hit[81] & reg_re & !reg_error;
+  assign classd_accum_cnt_re = addr_hit[85] & reg_re & !reg_error;
 
-  assign classd_accum_thresh_we = addr_hit[82] & reg_we & !reg_error;
+  assign classd_accum_thresh_we = addr_hit[86] & reg_we & !reg_error;
   assign classd_accum_thresh_wd = reg_wdata[15:0];
 
-  assign classd_timeout_cyc_we = addr_hit[83] & reg_we & !reg_error;
+  assign classd_timeout_cyc_we = addr_hit[87] & reg_we & !reg_error;
   assign classd_timeout_cyc_wd = reg_wdata[31:0];
 
-  assign classd_phase0_cyc_we = addr_hit[84] & reg_we & !reg_error;
+  assign classd_phase0_cyc_we = addr_hit[88] & reg_we & !reg_error;
   assign classd_phase0_cyc_wd = reg_wdata[31:0];
 
-  assign classd_phase1_cyc_we = addr_hit[85] & reg_we & !reg_error;
+  assign classd_phase1_cyc_we = addr_hit[89] & reg_we & !reg_error;
   assign classd_phase1_cyc_wd = reg_wdata[31:0];
 
-  assign classd_phase2_cyc_we = addr_hit[86] & reg_we & !reg_error;
+  assign classd_phase2_cyc_we = addr_hit[90] & reg_we & !reg_error;
   assign classd_phase2_cyc_wd = reg_wdata[31:0];
 
-  assign classd_phase3_cyc_we = addr_hit[87] & reg_we & !reg_error;
+  assign classd_phase3_cyc_we = addr_hit[91] & reg_we & !reg_error;
   assign classd_phase3_cyc_wd = reg_wdata[31:0];
 
-  assign classd_esc_cnt_re = addr_hit[88] & reg_re & !reg_error;
+  assign classd_esc_cnt_re = addr_hit[92] & reg_re & !reg_error;
 
-  assign classd_state_re = addr_hit[89] & reg_re & !reg_error;
+  assign classd_state_re = addr_hit[93] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin
@@ -4643,58 +4783,74 @@ module alert_handler_reg_top (
       end
 
       addr_hit[26]: begin
-        reg_rdata_next[0] = loc_alert_en_0_qs;
+        reg_rdata_next[0] = loc_alert_regwen_4_qs;
       end
 
       addr_hit[27]: begin
-        reg_rdata_next[0] = loc_alert_en_1_qs;
+        reg_rdata_next[0] = loc_alert_en_0_qs;
       end
 
       addr_hit[28]: begin
-        reg_rdata_next[0] = loc_alert_en_2_qs;
+        reg_rdata_next[0] = loc_alert_en_1_qs;
       end
 
       addr_hit[29]: begin
-        reg_rdata_next[0] = loc_alert_en_3_qs;
+        reg_rdata_next[0] = loc_alert_en_2_qs;
       end
 
       addr_hit[30]: begin
-        reg_rdata_next[1:0] = loc_alert_class_0_qs;
+        reg_rdata_next[0] = loc_alert_en_3_qs;
       end
 
       addr_hit[31]: begin
-        reg_rdata_next[1:0] = loc_alert_class_1_qs;
+        reg_rdata_next[0] = loc_alert_en_4_qs;
       end
 
       addr_hit[32]: begin
-        reg_rdata_next[1:0] = loc_alert_class_2_qs;
+        reg_rdata_next[1:0] = loc_alert_class_0_qs;
       end
 
       addr_hit[33]: begin
-        reg_rdata_next[1:0] = loc_alert_class_3_qs;
+        reg_rdata_next[1:0] = loc_alert_class_1_qs;
       end
 
       addr_hit[34]: begin
-        reg_rdata_next[0] = loc_alert_cause_0_qs;
+        reg_rdata_next[1:0] = loc_alert_class_2_qs;
       end
 
       addr_hit[35]: begin
-        reg_rdata_next[0] = loc_alert_cause_1_qs;
+        reg_rdata_next[1:0] = loc_alert_class_3_qs;
       end
 
       addr_hit[36]: begin
-        reg_rdata_next[0] = loc_alert_cause_2_qs;
+        reg_rdata_next[1:0] = loc_alert_class_4_qs;
       end
 
       addr_hit[37]: begin
-        reg_rdata_next[0] = loc_alert_cause_3_qs;
+        reg_rdata_next[0] = loc_alert_cause_0_qs;
       end
 
       addr_hit[38]: begin
-        reg_rdata_next[0] = classa_regwen_qs;
+        reg_rdata_next[0] = loc_alert_cause_1_qs;
       end
 
       addr_hit[39]: begin
+        reg_rdata_next[0] = loc_alert_cause_2_qs;
+      end
+
+      addr_hit[40]: begin
+        reg_rdata_next[0] = loc_alert_cause_3_qs;
+      end
+
+      addr_hit[41]: begin
+        reg_rdata_next[0] = loc_alert_cause_4_qs;
+      end
+
+      addr_hit[42]: begin
+        reg_rdata_next[0] = classa_regwen_qs;
+      end
+
+      addr_hit[43]: begin
         reg_rdata_next[0] = classa_ctrl_en_qs;
         reg_rdata_next[1] = classa_ctrl_lock_qs;
         reg_rdata_next[2] = classa_ctrl_en_e0_qs;
@@ -4707,55 +4863,55 @@ module alert_handler_reg_top (
         reg_rdata_next[13:12] = classa_ctrl_map_e3_qs;
       end
 
-      addr_hit[40]: begin
+      addr_hit[44]: begin
         reg_rdata_next[0] = classa_clr_regwen_qs;
       end
 
-      addr_hit[41]: begin
+      addr_hit[45]: begin
         reg_rdata_next[0] = '0;
       end
 
-      addr_hit[42]: begin
+      addr_hit[46]: begin
         reg_rdata_next[15:0] = classa_accum_cnt_qs;
       end
 
-      addr_hit[43]: begin
+      addr_hit[47]: begin
         reg_rdata_next[15:0] = classa_accum_thresh_qs;
       end
 
-      addr_hit[44]: begin
+      addr_hit[48]: begin
         reg_rdata_next[31:0] = classa_timeout_cyc_qs;
       end
 
-      addr_hit[45]: begin
+      addr_hit[49]: begin
         reg_rdata_next[31:0] = classa_phase0_cyc_qs;
       end
 
-      addr_hit[46]: begin
+      addr_hit[50]: begin
         reg_rdata_next[31:0] = classa_phase1_cyc_qs;
       end
 
-      addr_hit[47]: begin
+      addr_hit[51]: begin
         reg_rdata_next[31:0] = classa_phase2_cyc_qs;
       end
 
-      addr_hit[48]: begin
+      addr_hit[52]: begin
         reg_rdata_next[31:0] = classa_phase3_cyc_qs;
       end
 
-      addr_hit[49]: begin
+      addr_hit[53]: begin
         reg_rdata_next[31:0] = classa_esc_cnt_qs;
       end
 
-      addr_hit[50]: begin
+      addr_hit[54]: begin
         reg_rdata_next[2:0] = classa_state_qs;
       end
 
-      addr_hit[51]: begin
+      addr_hit[55]: begin
         reg_rdata_next[0] = classb_regwen_qs;
       end
 
-      addr_hit[52]: begin
+      addr_hit[56]: begin
         reg_rdata_next[0] = classb_ctrl_en_qs;
         reg_rdata_next[1] = classb_ctrl_lock_qs;
         reg_rdata_next[2] = classb_ctrl_en_e0_qs;
@@ -4768,55 +4924,55 @@ module alert_handler_reg_top (
         reg_rdata_next[13:12] = classb_ctrl_map_e3_qs;
       end
 
-      addr_hit[53]: begin
+      addr_hit[57]: begin
         reg_rdata_next[0] = classb_clr_regwen_qs;
       end
 
-      addr_hit[54]: begin
+      addr_hit[58]: begin
         reg_rdata_next[0] = '0;
       end
 
-      addr_hit[55]: begin
+      addr_hit[59]: begin
         reg_rdata_next[15:0] = classb_accum_cnt_qs;
       end
 
-      addr_hit[56]: begin
+      addr_hit[60]: begin
         reg_rdata_next[15:0] = classb_accum_thresh_qs;
       end
 
-      addr_hit[57]: begin
+      addr_hit[61]: begin
         reg_rdata_next[31:0] = classb_timeout_cyc_qs;
       end
 
-      addr_hit[58]: begin
+      addr_hit[62]: begin
         reg_rdata_next[31:0] = classb_phase0_cyc_qs;
       end
 
-      addr_hit[59]: begin
+      addr_hit[63]: begin
         reg_rdata_next[31:0] = classb_phase1_cyc_qs;
       end
 
-      addr_hit[60]: begin
+      addr_hit[64]: begin
         reg_rdata_next[31:0] = classb_phase2_cyc_qs;
       end
 
-      addr_hit[61]: begin
+      addr_hit[65]: begin
         reg_rdata_next[31:0] = classb_phase3_cyc_qs;
       end
 
-      addr_hit[62]: begin
+      addr_hit[66]: begin
         reg_rdata_next[31:0] = classb_esc_cnt_qs;
       end
 
-      addr_hit[63]: begin
+      addr_hit[67]: begin
         reg_rdata_next[2:0] = classb_state_qs;
       end
 
-      addr_hit[64]: begin
+      addr_hit[68]: begin
         reg_rdata_next[0] = classc_regwen_qs;
       end
 
-      addr_hit[65]: begin
+      addr_hit[69]: begin
         reg_rdata_next[0] = classc_ctrl_en_qs;
         reg_rdata_next[1] = classc_ctrl_lock_qs;
         reg_rdata_next[2] = classc_ctrl_en_e0_qs;
@@ -4829,55 +4985,55 @@ module alert_handler_reg_top (
         reg_rdata_next[13:12] = classc_ctrl_map_e3_qs;
       end
 
-      addr_hit[66]: begin
+      addr_hit[70]: begin
         reg_rdata_next[0] = classc_clr_regwen_qs;
       end
 
-      addr_hit[67]: begin
+      addr_hit[71]: begin
         reg_rdata_next[0] = '0;
       end
 
-      addr_hit[68]: begin
+      addr_hit[72]: begin
         reg_rdata_next[15:0] = classc_accum_cnt_qs;
       end
 
-      addr_hit[69]: begin
+      addr_hit[73]: begin
         reg_rdata_next[15:0] = classc_accum_thresh_qs;
       end
 
-      addr_hit[70]: begin
+      addr_hit[74]: begin
         reg_rdata_next[31:0] = classc_timeout_cyc_qs;
       end
 
-      addr_hit[71]: begin
+      addr_hit[75]: begin
         reg_rdata_next[31:0] = classc_phase0_cyc_qs;
       end
 
-      addr_hit[72]: begin
+      addr_hit[76]: begin
         reg_rdata_next[31:0] = classc_phase1_cyc_qs;
       end
 
-      addr_hit[73]: begin
+      addr_hit[77]: begin
         reg_rdata_next[31:0] = classc_phase2_cyc_qs;
       end
 
-      addr_hit[74]: begin
+      addr_hit[78]: begin
         reg_rdata_next[31:0] = classc_phase3_cyc_qs;
       end
 
-      addr_hit[75]: begin
+      addr_hit[79]: begin
         reg_rdata_next[31:0] = classc_esc_cnt_qs;
       end
 
-      addr_hit[76]: begin
+      addr_hit[80]: begin
         reg_rdata_next[2:0] = classc_state_qs;
       end
 
-      addr_hit[77]: begin
+      addr_hit[81]: begin
         reg_rdata_next[0] = classd_regwen_qs;
       end
 
-      addr_hit[78]: begin
+      addr_hit[82]: begin
         reg_rdata_next[0] = classd_ctrl_en_qs;
         reg_rdata_next[1] = classd_ctrl_lock_qs;
         reg_rdata_next[2] = classd_ctrl_en_e0_qs;
@@ -4890,47 +5046,47 @@ module alert_handler_reg_top (
         reg_rdata_next[13:12] = classd_ctrl_map_e3_qs;
       end
 
-      addr_hit[79]: begin
+      addr_hit[83]: begin
         reg_rdata_next[0] = classd_clr_regwen_qs;
       end
 
-      addr_hit[80]: begin
+      addr_hit[84]: begin
         reg_rdata_next[0] = '0;
       end
 
-      addr_hit[81]: begin
+      addr_hit[85]: begin
         reg_rdata_next[15:0] = classd_accum_cnt_qs;
       end
 
-      addr_hit[82]: begin
+      addr_hit[86]: begin
         reg_rdata_next[15:0] = classd_accum_thresh_qs;
       end
 
-      addr_hit[83]: begin
+      addr_hit[87]: begin
         reg_rdata_next[31:0] = classd_timeout_cyc_qs;
       end
 
-      addr_hit[84]: begin
+      addr_hit[88]: begin
         reg_rdata_next[31:0] = classd_phase0_cyc_qs;
       end
 
-      addr_hit[85]: begin
+      addr_hit[89]: begin
         reg_rdata_next[31:0] = classd_phase1_cyc_qs;
       end
 
-      addr_hit[86]: begin
+      addr_hit[90]: begin
         reg_rdata_next[31:0] = classd_phase2_cyc_qs;
       end
 
-      addr_hit[87]: begin
+      addr_hit[91]: begin
         reg_rdata_next[31:0] = classd_phase3_cyc_qs;
       end
 
-      addr_hit[88]: begin
+      addr_hit[92]: begin
         reg_rdata_next[31:0] = classd_esc_cnt_qs;
       end
 
-      addr_hit[89]: begin
+      addr_hit[93]: begin
         reg_rdata_next[2:0] = classd_state_qs;
       end
 

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_wrap.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_wrap.sv
@@ -17,7 +17,9 @@ module alert_handler_reg_wrap import alert_pkg::*; (
   // hw2reg
   input  hw2reg_wrap_t         hw2reg_wrap,
   // reg2hw
-  output reg2hw_wrap_t         reg2hw_wrap
+  output reg2hw_wrap_t         reg2hw_wrap,
+  // bus integrity alert
+  output logic                 fatal_integ_alert_o
 );
 
 
@@ -36,7 +38,7 @@ module alert_handler_reg_wrap import alert_pkg::*; (
     .tl_o,
     .reg2hw,
     .hw2reg,
-    .intg_err_o(),
+    .intg_err_o(fatal_integ_alert_o),
     .devmode_i(1'b1)
   );
 

--- a/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
@@ -90,7 +90,7 @@
     { name: "N_LOC_ALERT",
       desc: "Number of local alerts phases",
       type: "int",
-      default: "4",
+      default: "5",
       local: "true"
     },
     { name: "PING_CNT_DW",
@@ -320,7 +320,7 @@
 # local alerts
     { multireg: { name:     "LOC_ALERT_REGWEN",
                   desc:     "Register write enable for alert enable bits.",
-                  count:    "NAlerts",
+                  count:    "N_LOC_ALERT",
                   compact:  "false",
                   swaccess: "rw0c",
                   hwaccess: "none",
@@ -342,7 +342,7 @@
     },
     { multireg: { name:     "LOC_ALERT_EN",
                   desc:     '''Enable register for the aggregated local alerts "alert
-                  pingfail" (0), "escalation pingfail" (1), "alert integfail" (2) and "escalation integfail" (3).
+                  pingfail" (0), "escalation pingfail" (1), "alert integfail" (2), "escalation integfail" (3), and "bus integrity failure (4)".
                   ''',
                   count:    "N_LOC_ALERT",
                   compact:  "false",
@@ -366,7 +366,7 @@
     },
     { multireg: { name:     "LOC_ALERT_CLASS",
                   desc:     '''Class assignment of local alerts. "alert
-                  pingfail" (0), "escalation pingfail" (1), "alert integfail" (2) and "escalation integfail" (3).
+                  pingfail" (0), "escalation pingfail" (1), "alert integfail" (2), "escalation integfail" (3), and "bus integrity failure (4)".
                   ''',
                   count:    "N_LOC_ALERT",
                   compact:  "false",
@@ -394,7 +394,7 @@
     { multireg: {
       name: "LOC_ALERT_CAUSE",
       desc: '''Alert Cause Register for Local Alerts. "alert
-      pingfail" (0), "escalation pingfail" (1), "alert integfail" (2) and "escalation integfail" (3).
+      pingfail" (0), "escalation pingfail" (1), "alert integfail" (2), "escalation integfail" (3), and "bus integrity failure (4)".
       ''',
       count: "N_LOC_ALERT",
       compact:  "false",

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
@@ -14,13 +14,13 @@ package alert_handler_reg_pkg;
   parameter int N_CLASSES = 4;
   parameter int N_ESC_SEV = 4;
   parameter int N_PHASES = 4;
-  parameter int N_LOC_ALERT = 4;
+  parameter int N_LOC_ALERT = 5;
   parameter int PING_CNT_DW = 24;
   parameter int PHASE_DW = 2;
   parameter int CLASS_DW = 2;
 
   // Address widths within the block
-  parameter int BlockAw = 11;
+  parameter int BlockAw = 10;
 
   ////////////////////////////
   // Typedefs for registers //
@@ -458,18 +458,18 @@ package alert_handler_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    alert_handler_reg2hw_intr_state_reg_t intr_state; // [1024:1021]
-    alert_handler_reg2hw_intr_enable_reg_t intr_enable; // [1020:1017]
-    alert_handler_reg2hw_intr_test_reg_t intr_test; // [1016:1009]
-    alert_handler_reg2hw_ping_timeout_cyc_reg_t ping_timeout_cyc; // [1008:985]
-    alert_handler_reg2hw_ping_timer_en_reg_t ping_timer_en; // [984:984]
-    alert_handler_reg2hw_alert_regwen_mreg_t [39:0] alert_regwen; // [983:944]
-    alert_handler_reg2hw_alert_en_mreg_t [39:0] alert_en; // [943:904]
-    alert_handler_reg2hw_alert_class_mreg_t [39:0] alert_class; // [903:824]
-    alert_handler_reg2hw_alert_cause_mreg_t [39:0] alert_cause; // [823:784]
-    alert_handler_reg2hw_loc_alert_en_mreg_t [3:0] loc_alert_en; // [783:780]
-    alert_handler_reg2hw_loc_alert_class_mreg_t [3:0] loc_alert_class; // [779:772]
-    alert_handler_reg2hw_loc_alert_cause_mreg_t [3:0] loc_alert_cause; // [771:768]
+    alert_handler_reg2hw_intr_state_reg_t intr_state; // [1028:1025]
+    alert_handler_reg2hw_intr_enable_reg_t intr_enable; // [1024:1021]
+    alert_handler_reg2hw_intr_test_reg_t intr_test; // [1020:1013]
+    alert_handler_reg2hw_ping_timeout_cyc_reg_t ping_timeout_cyc; // [1012:989]
+    alert_handler_reg2hw_ping_timer_en_reg_t ping_timer_en; // [988:988]
+    alert_handler_reg2hw_alert_regwen_mreg_t [39:0] alert_regwen; // [987:948]
+    alert_handler_reg2hw_alert_en_mreg_t [39:0] alert_en; // [947:908]
+    alert_handler_reg2hw_alert_class_mreg_t [39:0] alert_class; // [907:828]
+    alert_handler_reg2hw_alert_cause_mreg_t [39:0] alert_cause; // [827:788]
+    alert_handler_reg2hw_loc_alert_en_mreg_t [4:0] loc_alert_en; // [787:783]
+    alert_handler_reg2hw_loc_alert_class_mreg_t [4:0] loc_alert_class; // [782:773]
+    alert_handler_reg2hw_loc_alert_cause_mreg_t [4:0] loc_alert_cause; // [772:768]
     alert_handler_reg2hw_classa_ctrl_reg_t classa_ctrl; // [767:754]
     alert_handler_reg2hw_classa_clr_reg_t classa_clr; // [753:752]
     alert_handler_reg2hw_classa_accum_thresh_reg_t classa_accum_thresh; // [751:736]
@@ -506,9 +506,9 @@ package alert_handler_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    alert_handler_hw2reg_intr_state_reg_t intr_state; // [307:300]
-    alert_handler_hw2reg_alert_cause_mreg_t [39:0] alert_cause; // [299:220]
-    alert_handler_hw2reg_loc_alert_cause_mreg_t [3:0] loc_alert_cause; // [219:212]
+    alert_handler_hw2reg_intr_state_reg_t intr_state; // [309:302]
+    alert_handler_hw2reg_alert_cause_mreg_t [39:0] alert_cause; // [301:222]
+    alert_handler_hw2reg_loc_alert_cause_mreg_t [4:0] loc_alert_cause; // [221:212]
     alert_handler_hw2reg_classa_clr_regwen_reg_t classa_clr_regwen; // [211:210]
     alert_handler_hw2reg_classa_accum_cnt_reg_t classa_accum_cnt; // [209:194]
     alert_handler_hw2reg_classa_esc_cnt_reg_t classa_esc_cnt; // [193:162]
@@ -528,276 +528,244 @@ package alert_handler_reg_pkg;
   } alert_handler_hw2reg_t;
 
   // Register offsets
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_INTR_STATE_OFFSET = 11'h 0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_INTR_ENABLE_OFFSET = 11'h 4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_INTR_TEST_OFFSET = 11'h 8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_PING_TIMER_REGWEN_OFFSET = 11'h c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_PING_TIMEOUT_CYC_OFFSET = 11'h 10;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_PING_TIMER_EN_OFFSET = 11'h 14;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_0_OFFSET = 11'h 18;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_1_OFFSET = 11'h 1c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_2_OFFSET = 11'h 20;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_3_OFFSET = 11'h 24;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_4_OFFSET = 11'h 28;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_5_OFFSET = 11'h 2c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_6_OFFSET = 11'h 30;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_7_OFFSET = 11'h 34;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_8_OFFSET = 11'h 38;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_9_OFFSET = 11'h 3c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_10_OFFSET = 11'h 40;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_11_OFFSET = 11'h 44;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_12_OFFSET = 11'h 48;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_13_OFFSET = 11'h 4c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_14_OFFSET = 11'h 50;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_15_OFFSET = 11'h 54;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_16_OFFSET = 11'h 58;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_17_OFFSET = 11'h 5c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_18_OFFSET = 11'h 60;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_19_OFFSET = 11'h 64;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_20_OFFSET = 11'h 68;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_21_OFFSET = 11'h 6c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_22_OFFSET = 11'h 70;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_23_OFFSET = 11'h 74;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_24_OFFSET = 11'h 78;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_25_OFFSET = 11'h 7c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_26_OFFSET = 11'h 80;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_27_OFFSET = 11'h 84;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_28_OFFSET = 11'h 88;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_29_OFFSET = 11'h 8c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_30_OFFSET = 11'h 90;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_31_OFFSET = 11'h 94;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_32_OFFSET = 11'h 98;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_33_OFFSET = 11'h 9c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_34_OFFSET = 11'h a0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_35_OFFSET = 11'h a4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_36_OFFSET = 11'h a8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_37_OFFSET = 11'h ac;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_38_OFFSET = 11'h b0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_39_OFFSET = 11'h b4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_0_OFFSET = 11'h b8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_1_OFFSET = 11'h bc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_2_OFFSET = 11'h c0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_3_OFFSET = 11'h c4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_4_OFFSET = 11'h c8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_5_OFFSET = 11'h cc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_6_OFFSET = 11'h d0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_7_OFFSET = 11'h d4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_8_OFFSET = 11'h d8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_9_OFFSET = 11'h dc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_10_OFFSET = 11'h e0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_11_OFFSET = 11'h e4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_12_OFFSET = 11'h e8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_13_OFFSET = 11'h ec;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_14_OFFSET = 11'h f0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_15_OFFSET = 11'h f4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_16_OFFSET = 11'h f8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_17_OFFSET = 11'h fc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_18_OFFSET = 11'h 100;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_19_OFFSET = 11'h 104;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_20_OFFSET = 11'h 108;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_21_OFFSET = 11'h 10c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_22_OFFSET = 11'h 110;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_23_OFFSET = 11'h 114;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_24_OFFSET = 11'h 118;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_25_OFFSET = 11'h 11c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_26_OFFSET = 11'h 120;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_27_OFFSET = 11'h 124;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_28_OFFSET = 11'h 128;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_29_OFFSET = 11'h 12c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_30_OFFSET = 11'h 130;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_31_OFFSET = 11'h 134;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_32_OFFSET = 11'h 138;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_33_OFFSET = 11'h 13c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_34_OFFSET = 11'h 140;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_35_OFFSET = 11'h 144;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_36_OFFSET = 11'h 148;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_37_OFFSET = 11'h 14c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_38_OFFSET = 11'h 150;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_39_OFFSET = 11'h 154;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_0_OFFSET = 11'h 158;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_1_OFFSET = 11'h 15c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_2_OFFSET = 11'h 160;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_3_OFFSET = 11'h 164;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_4_OFFSET = 11'h 168;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_5_OFFSET = 11'h 16c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_6_OFFSET = 11'h 170;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_7_OFFSET = 11'h 174;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_8_OFFSET = 11'h 178;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_9_OFFSET = 11'h 17c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_10_OFFSET = 11'h 180;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_11_OFFSET = 11'h 184;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_12_OFFSET = 11'h 188;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_13_OFFSET = 11'h 18c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_14_OFFSET = 11'h 190;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_15_OFFSET = 11'h 194;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_16_OFFSET = 11'h 198;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_17_OFFSET = 11'h 19c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_18_OFFSET = 11'h 1a0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_19_OFFSET = 11'h 1a4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_20_OFFSET = 11'h 1a8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_21_OFFSET = 11'h 1ac;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_22_OFFSET = 11'h 1b0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_23_OFFSET = 11'h 1b4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_24_OFFSET = 11'h 1b8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_25_OFFSET = 11'h 1bc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_26_OFFSET = 11'h 1c0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_27_OFFSET = 11'h 1c4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_28_OFFSET = 11'h 1c8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_29_OFFSET = 11'h 1cc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_30_OFFSET = 11'h 1d0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_31_OFFSET = 11'h 1d4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_32_OFFSET = 11'h 1d8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_33_OFFSET = 11'h 1dc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_34_OFFSET = 11'h 1e0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_35_OFFSET = 11'h 1e4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_36_OFFSET = 11'h 1e8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_37_OFFSET = 11'h 1ec;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_38_OFFSET = 11'h 1f0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_39_OFFSET = 11'h 1f4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_0_OFFSET = 11'h 1f8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_1_OFFSET = 11'h 1fc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_2_OFFSET = 11'h 200;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_3_OFFSET = 11'h 204;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_4_OFFSET = 11'h 208;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_5_OFFSET = 11'h 20c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_6_OFFSET = 11'h 210;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_7_OFFSET = 11'h 214;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_8_OFFSET = 11'h 218;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_9_OFFSET = 11'h 21c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_10_OFFSET = 11'h 220;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_11_OFFSET = 11'h 224;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_12_OFFSET = 11'h 228;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_13_OFFSET = 11'h 22c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_14_OFFSET = 11'h 230;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_15_OFFSET = 11'h 234;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_16_OFFSET = 11'h 238;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_17_OFFSET = 11'h 23c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_18_OFFSET = 11'h 240;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_19_OFFSET = 11'h 244;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_20_OFFSET = 11'h 248;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_21_OFFSET = 11'h 24c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_22_OFFSET = 11'h 250;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_23_OFFSET = 11'h 254;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_24_OFFSET = 11'h 258;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_25_OFFSET = 11'h 25c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_26_OFFSET = 11'h 260;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_27_OFFSET = 11'h 264;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_28_OFFSET = 11'h 268;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_29_OFFSET = 11'h 26c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_30_OFFSET = 11'h 270;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_31_OFFSET = 11'h 274;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_32_OFFSET = 11'h 278;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_33_OFFSET = 11'h 27c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_34_OFFSET = 11'h 280;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_35_OFFSET = 11'h 284;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_36_OFFSET = 11'h 288;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_37_OFFSET = 11'h 28c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_38_OFFSET = 11'h 290;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_39_OFFSET = 11'h 294;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_0_OFFSET = 11'h 298;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_1_OFFSET = 11'h 29c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_2_OFFSET = 11'h 2a0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_3_OFFSET = 11'h 2a4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_4_OFFSET = 11'h 2a8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_5_OFFSET = 11'h 2ac;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_6_OFFSET = 11'h 2b0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_7_OFFSET = 11'h 2b4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_8_OFFSET = 11'h 2b8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_9_OFFSET = 11'h 2bc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_10_OFFSET = 11'h 2c0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_11_OFFSET = 11'h 2c4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_12_OFFSET = 11'h 2c8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_13_OFFSET = 11'h 2cc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_14_OFFSET = 11'h 2d0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_15_OFFSET = 11'h 2d4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_16_OFFSET = 11'h 2d8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_17_OFFSET = 11'h 2dc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_18_OFFSET = 11'h 2e0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_19_OFFSET = 11'h 2e4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_20_OFFSET = 11'h 2e8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_21_OFFSET = 11'h 2ec;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_22_OFFSET = 11'h 2f0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_23_OFFSET = 11'h 2f4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_24_OFFSET = 11'h 2f8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_25_OFFSET = 11'h 2fc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_26_OFFSET = 11'h 300;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_27_OFFSET = 11'h 304;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_28_OFFSET = 11'h 308;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_29_OFFSET = 11'h 30c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_30_OFFSET = 11'h 310;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_31_OFFSET = 11'h 314;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_32_OFFSET = 11'h 318;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_33_OFFSET = 11'h 31c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_34_OFFSET = 11'h 320;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_35_OFFSET = 11'h 324;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_36_OFFSET = 11'h 328;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_37_OFFSET = 11'h 32c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_38_OFFSET = 11'h 330;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_39_OFFSET = 11'h 334;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_EN_0_OFFSET = 11'h 338;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_EN_1_OFFSET = 11'h 33c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_EN_2_OFFSET = 11'h 340;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_EN_3_OFFSET = 11'h 344;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_0_OFFSET = 11'h 348;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_1_OFFSET = 11'h 34c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_2_OFFSET = 11'h 350;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_3_OFFSET = 11'h 354;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_0_OFFSET = 11'h 358;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_1_OFFSET = 11'h 35c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_2_OFFSET = 11'h 360;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_3_OFFSET = 11'h 364;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_REGWEN_OFFSET = 11'h 368;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_CTRL_OFFSET = 11'h 36c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_CLR_REGWEN_OFFSET = 11'h 370;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_CLR_OFFSET = 11'h 374;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_ACCUM_CNT_OFFSET = 11'h 378;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_ACCUM_THRESH_OFFSET = 11'h 37c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_TIMEOUT_CYC_OFFSET = 11'h 380;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_PHASE0_CYC_OFFSET = 11'h 384;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_PHASE1_CYC_OFFSET = 11'h 388;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_PHASE2_CYC_OFFSET = 11'h 38c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_PHASE3_CYC_OFFSET = 11'h 390;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_ESC_CNT_OFFSET = 11'h 394;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_STATE_OFFSET = 11'h 398;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_REGWEN_OFFSET = 11'h 39c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_CTRL_OFFSET = 11'h 3a0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_CLR_REGWEN_OFFSET = 11'h 3a4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_CLR_OFFSET = 11'h 3a8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_ACCUM_CNT_OFFSET = 11'h 3ac;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_ACCUM_THRESH_OFFSET = 11'h 3b0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_TIMEOUT_CYC_OFFSET = 11'h 3b4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_PHASE0_CYC_OFFSET = 11'h 3b8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_PHASE1_CYC_OFFSET = 11'h 3bc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_PHASE2_CYC_OFFSET = 11'h 3c0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_PHASE3_CYC_OFFSET = 11'h 3c4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_ESC_CNT_OFFSET = 11'h 3c8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_STATE_OFFSET = 11'h 3cc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_REGWEN_OFFSET = 11'h 3d0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_CTRL_OFFSET = 11'h 3d4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_CLR_REGWEN_OFFSET = 11'h 3d8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_CLR_OFFSET = 11'h 3dc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_ACCUM_CNT_OFFSET = 11'h 3e0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_ACCUM_THRESH_OFFSET = 11'h 3e4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_TIMEOUT_CYC_OFFSET = 11'h 3e8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_PHASE0_CYC_OFFSET = 11'h 3ec;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_PHASE1_CYC_OFFSET = 11'h 3f0;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_PHASE2_CYC_OFFSET = 11'h 3f4;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_PHASE3_CYC_OFFSET = 11'h 3f8;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_ESC_CNT_OFFSET = 11'h 3fc;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_STATE_OFFSET = 11'h 400;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_REGWEN_OFFSET = 11'h 404;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_CTRL_OFFSET = 11'h 408;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_CLR_REGWEN_OFFSET = 11'h 40c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_CLR_OFFSET = 11'h 410;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_ACCUM_CNT_OFFSET = 11'h 414;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_ACCUM_THRESH_OFFSET = 11'h 418;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_TIMEOUT_CYC_OFFSET = 11'h 41c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_PHASE0_CYC_OFFSET = 11'h 420;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_PHASE1_CYC_OFFSET = 11'h 424;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_PHASE2_CYC_OFFSET = 11'h 428;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_PHASE3_CYC_OFFSET = 11'h 42c;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_ESC_CNT_OFFSET = 11'h 430;
-  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_STATE_OFFSET = 11'h 434;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_INTR_STATE_OFFSET = 10'h 0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_INTR_ENABLE_OFFSET = 10'h 4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_INTR_TEST_OFFSET = 10'h 8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_PING_TIMER_REGWEN_OFFSET = 10'h c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_PING_TIMEOUT_CYC_OFFSET = 10'h 10;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_PING_TIMER_EN_OFFSET = 10'h 14;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_0_OFFSET = 10'h 18;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_1_OFFSET = 10'h 1c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_2_OFFSET = 10'h 20;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_3_OFFSET = 10'h 24;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_4_OFFSET = 10'h 28;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_5_OFFSET = 10'h 2c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_6_OFFSET = 10'h 30;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_7_OFFSET = 10'h 34;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_8_OFFSET = 10'h 38;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_9_OFFSET = 10'h 3c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_10_OFFSET = 10'h 40;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_11_OFFSET = 10'h 44;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_12_OFFSET = 10'h 48;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_13_OFFSET = 10'h 4c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_14_OFFSET = 10'h 50;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_15_OFFSET = 10'h 54;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_16_OFFSET = 10'h 58;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_17_OFFSET = 10'h 5c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_18_OFFSET = 10'h 60;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_19_OFFSET = 10'h 64;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_20_OFFSET = 10'h 68;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_21_OFFSET = 10'h 6c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_22_OFFSET = 10'h 70;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_23_OFFSET = 10'h 74;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_24_OFFSET = 10'h 78;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_25_OFFSET = 10'h 7c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_26_OFFSET = 10'h 80;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_27_OFFSET = 10'h 84;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_28_OFFSET = 10'h 88;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_29_OFFSET = 10'h 8c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_30_OFFSET = 10'h 90;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_31_OFFSET = 10'h 94;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_32_OFFSET = 10'h 98;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_33_OFFSET = 10'h 9c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_34_OFFSET = 10'h a0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_35_OFFSET = 10'h a4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_36_OFFSET = 10'h a8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_37_OFFSET = 10'h ac;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_38_OFFSET = 10'h b0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_REGWEN_39_OFFSET = 10'h b4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_0_OFFSET = 10'h b8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_1_OFFSET = 10'h bc;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_2_OFFSET = 10'h c0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_3_OFFSET = 10'h c4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_4_OFFSET = 10'h c8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_5_OFFSET = 10'h cc;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_6_OFFSET = 10'h d0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_7_OFFSET = 10'h d4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_8_OFFSET = 10'h d8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_9_OFFSET = 10'h dc;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_10_OFFSET = 10'h e0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_11_OFFSET = 10'h e4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_12_OFFSET = 10'h e8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_13_OFFSET = 10'h ec;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_14_OFFSET = 10'h f0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_15_OFFSET = 10'h f4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_16_OFFSET = 10'h f8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_17_OFFSET = 10'h fc;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_18_OFFSET = 10'h 100;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_19_OFFSET = 10'h 104;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_20_OFFSET = 10'h 108;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_21_OFFSET = 10'h 10c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_22_OFFSET = 10'h 110;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_23_OFFSET = 10'h 114;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_24_OFFSET = 10'h 118;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_25_OFFSET = 10'h 11c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_26_OFFSET = 10'h 120;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_27_OFFSET = 10'h 124;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_28_OFFSET = 10'h 128;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_29_OFFSET = 10'h 12c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_30_OFFSET = 10'h 130;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_31_OFFSET = 10'h 134;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_32_OFFSET = 10'h 138;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_33_OFFSET = 10'h 13c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_34_OFFSET = 10'h 140;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_35_OFFSET = 10'h 144;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_36_OFFSET = 10'h 148;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_37_OFFSET = 10'h 14c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_38_OFFSET = 10'h 150;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_EN_39_OFFSET = 10'h 154;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_0_OFFSET = 10'h 158;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_1_OFFSET = 10'h 15c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_2_OFFSET = 10'h 160;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_3_OFFSET = 10'h 164;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_4_OFFSET = 10'h 168;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_5_OFFSET = 10'h 16c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_6_OFFSET = 10'h 170;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_7_OFFSET = 10'h 174;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_8_OFFSET = 10'h 178;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_9_OFFSET = 10'h 17c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_10_OFFSET = 10'h 180;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_11_OFFSET = 10'h 184;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_12_OFFSET = 10'h 188;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_13_OFFSET = 10'h 18c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_14_OFFSET = 10'h 190;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_15_OFFSET = 10'h 194;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_16_OFFSET = 10'h 198;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_17_OFFSET = 10'h 19c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_18_OFFSET = 10'h 1a0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_19_OFFSET = 10'h 1a4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_20_OFFSET = 10'h 1a8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_21_OFFSET = 10'h 1ac;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_22_OFFSET = 10'h 1b0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_23_OFFSET = 10'h 1b4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_24_OFFSET = 10'h 1b8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_25_OFFSET = 10'h 1bc;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_26_OFFSET = 10'h 1c0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_27_OFFSET = 10'h 1c4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_28_OFFSET = 10'h 1c8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_29_OFFSET = 10'h 1cc;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_30_OFFSET = 10'h 1d0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_31_OFFSET = 10'h 1d4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_32_OFFSET = 10'h 1d8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_33_OFFSET = 10'h 1dc;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_34_OFFSET = 10'h 1e0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_35_OFFSET = 10'h 1e4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_36_OFFSET = 10'h 1e8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_37_OFFSET = 10'h 1ec;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_38_OFFSET = 10'h 1f0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CLASS_39_OFFSET = 10'h 1f4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_0_OFFSET = 10'h 1f8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_1_OFFSET = 10'h 1fc;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_2_OFFSET = 10'h 200;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_3_OFFSET = 10'h 204;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_4_OFFSET = 10'h 208;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_5_OFFSET = 10'h 20c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_6_OFFSET = 10'h 210;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_7_OFFSET = 10'h 214;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_8_OFFSET = 10'h 218;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_9_OFFSET = 10'h 21c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_10_OFFSET = 10'h 220;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_11_OFFSET = 10'h 224;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_12_OFFSET = 10'h 228;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_13_OFFSET = 10'h 22c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_14_OFFSET = 10'h 230;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_15_OFFSET = 10'h 234;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_16_OFFSET = 10'h 238;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_17_OFFSET = 10'h 23c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_18_OFFSET = 10'h 240;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_19_OFFSET = 10'h 244;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_20_OFFSET = 10'h 248;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_21_OFFSET = 10'h 24c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_22_OFFSET = 10'h 250;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_23_OFFSET = 10'h 254;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_24_OFFSET = 10'h 258;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_25_OFFSET = 10'h 25c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_26_OFFSET = 10'h 260;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_27_OFFSET = 10'h 264;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_28_OFFSET = 10'h 268;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_29_OFFSET = 10'h 26c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_30_OFFSET = 10'h 270;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_31_OFFSET = 10'h 274;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_32_OFFSET = 10'h 278;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_33_OFFSET = 10'h 27c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_34_OFFSET = 10'h 280;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_35_OFFSET = 10'h 284;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_36_OFFSET = 10'h 288;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_37_OFFSET = 10'h 28c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_38_OFFSET = 10'h 290;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_ALERT_CAUSE_39_OFFSET = 10'h 294;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_0_OFFSET = 10'h 298;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_1_OFFSET = 10'h 29c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_2_OFFSET = 10'h 2a0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_3_OFFSET = 10'h 2a4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_REGWEN_4_OFFSET = 10'h 2a8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_EN_0_OFFSET = 10'h 2ac;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_EN_1_OFFSET = 10'h 2b0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_EN_2_OFFSET = 10'h 2b4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_EN_3_OFFSET = 10'h 2b8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_EN_4_OFFSET = 10'h 2bc;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_0_OFFSET = 10'h 2c0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_1_OFFSET = 10'h 2c4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_2_OFFSET = 10'h 2c8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_3_OFFSET = 10'h 2cc;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CLASS_4_OFFSET = 10'h 2d0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_0_OFFSET = 10'h 2d4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_1_OFFSET = 10'h 2d8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_2_OFFSET = 10'h 2dc;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_3_OFFSET = 10'h 2e0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_LOC_ALERT_CAUSE_4_OFFSET = 10'h 2e4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_REGWEN_OFFSET = 10'h 2e8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_CTRL_OFFSET = 10'h 2ec;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_CLR_REGWEN_OFFSET = 10'h 2f0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_CLR_OFFSET = 10'h 2f4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_ACCUM_CNT_OFFSET = 10'h 2f8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_ACCUM_THRESH_OFFSET = 10'h 2fc;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_TIMEOUT_CYC_OFFSET = 10'h 300;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_PHASE0_CYC_OFFSET = 10'h 304;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_PHASE1_CYC_OFFSET = 10'h 308;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_PHASE2_CYC_OFFSET = 10'h 30c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_PHASE3_CYC_OFFSET = 10'h 310;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_ESC_CNT_OFFSET = 10'h 314;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSA_STATE_OFFSET = 10'h 318;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_REGWEN_OFFSET = 10'h 31c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_CTRL_OFFSET = 10'h 320;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_CLR_REGWEN_OFFSET = 10'h 324;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_CLR_OFFSET = 10'h 328;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_ACCUM_CNT_OFFSET = 10'h 32c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_ACCUM_THRESH_OFFSET = 10'h 330;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_TIMEOUT_CYC_OFFSET = 10'h 334;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_PHASE0_CYC_OFFSET = 10'h 338;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_PHASE1_CYC_OFFSET = 10'h 33c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_PHASE2_CYC_OFFSET = 10'h 340;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_PHASE3_CYC_OFFSET = 10'h 344;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_ESC_CNT_OFFSET = 10'h 348;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSB_STATE_OFFSET = 10'h 34c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_REGWEN_OFFSET = 10'h 350;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_CTRL_OFFSET = 10'h 354;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_CLR_REGWEN_OFFSET = 10'h 358;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_CLR_OFFSET = 10'h 35c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_ACCUM_CNT_OFFSET = 10'h 360;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_ACCUM_THRESH_OFFSET = 10'h 364;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_TIMEOUT_CYC_OFFSET = 10'h 368;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_PHASE0_CYC_OFFSET = 10'h 36c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_PHASE1_CYC_OFFSET = 10'h 370;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_PHASE2_CYC_OFFSET = 10'h 374;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_PHASE3_CYC_OFFSET = 10'h 378;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_ESC_CNT_OFFSET = 10'h 37c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSC_STATE_OFFSET = 10'h 380;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_REGWEN_OFFSET = 10'h 384;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_CTRL_OFFSET = 10'h 388;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_CLR_REGWEN_OFFSET = 10'h 38c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_CLR_OFFSET = 10'h 390;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_ACCUM_CNT_OFFSET = 10'h 394;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_ACCUM_THRESH_OFFSET = 10'h 398;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_TIMEOUT_CYC_OFFSET = 10'h 39c;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_PHASE0_CYC_OFFSET = 10'h 3a0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_PHASE1_CYC_OFFSET = 10'h 3a4;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_PHASE2_CYC_OFFSET = 10'h 3a8;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_PHASE3_CYC_OFFSET = 10'h 3ac;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_ESC_CNT_OFFSET = 10'h 3b0;
+  parameter logic [BlockAw-1:0] ALERT_HANDLER_CLASSD_STATE_OFFSET = 10'h 3b4;
 
   // Reset values for hwext registers and their fields
   parameter logic [3:0] ALERT_HANDLER_INTR_TEST_RESVAL = 4'h 0;
@@ -991,53 +959,21 @@ package alert_handler_reg_pkg;
     ALERT_HANDLER_LOC_ALERT_REGWEN_2,
     ALERT_HANDLER_LOC_ALERT_REGWEN_3,
     ALERT_HANDLER_LOC_ALERT_REGWEN_4,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_5,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_6,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_7,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_8,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_9,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_10,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_11,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_12,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_13,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_14,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_15,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_16,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_17,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_18,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_19,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_20,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_21,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_22,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_23,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_24,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_25,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_26,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_27,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_28,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_29,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_30,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_31,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_32,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_33,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_34,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_35,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_36,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_37,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_38,
-    ALERT_HANDLER_LOC_ALERT_REGWEN_39,
     ALERT_HANDLER_LOC_ALERT_EN_0,
     ALERT_HANDLER_LOC_ALERT_EN_1,
     ALERT_HANDLER_LOC_ALERT_EN_2,
     ALERT_HANDLER_LOC_ALERT_EN_3,
+    ALERT_HANDLER_LOC_ALERT_EN_4,
     ALERT_HANDLER_LOC_ALERT_CLASS_0,
     ALERT_HANDLER_LOC_ALERT_CLASS_1,
     ALERT_HANDLER_LOC_ALERT_CLASS_2,
     ALERT_HANDLER_LOC_ALERT_CLASS_3,
+    ALERT_HANDLER_LOC_ALERT_CLASS_4,
     ALERT_HANDLER_LOC_ALERT_CAUSE_0,
     ALERT_HANDLER_LOC_ALERT_CAUSE_1,
     ALERT_HANDLER_LOC_ALERT_CAUSE_2,
     ALERT_HANDLER_LOC_ALERT_CAUSE_3,
+    ALERT_HANDLER_LOC_ALERT_CAUSE_4,
     ALERT_HANDLER_CLASSA_REGWEN,
     ALERT_HANDLER_CLASSA_CTRL,
     ALERT_HANDLER_CLASSA_CLR_REGWEN,
@@ -1093,7 +1029,7 @@ package alert_handler_reg_pkg;
   } alert_handler_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] ALERT_HANDLER_PERMIT [270] = '{
+  parameter logic [3:0] ALERT_HANDLER_PERMIT [238] = '{
     4'b 0001, // index[  0] ALERT_HANDLER_INTR_STATE
     4'b 0001, // index[  1] ALERT_HANDLER_INTR_ENABLE
     4'b 0001, // index[  2] ALERT_HANDLER_INTR_TEST
@@ -1265,105 +1201,73 @@ package alert_handler_reg_pkg;
     4'b 0001, // index[168] ALERT_HANDLER_LOC_ALERT_REGWEN_2
     4'b 0001, // index[169] ALERT_HANDLER_LOC_ALERT_REGWEN_3
     4'b 0001, // index[170] ALERT_HANDLER_LOC_ALERT_REGWEN_4
-    4'b 0001, // index[171] ALERT_HANDLER_LOC_ALERT_REGWEN_5
-    4'b 0001, // index[172] ALERT_HANDLER_LOC_ALERT_REGWEN_6
-    4'b 0001, // index[173] ALERT_HANDLER_LOC_ALERT_REGWEN_7
-    4'b 0001, // index[174] ALERT_HANDLER_LOC_ALERT_REGWEN_8
-    4'b 0001, // index[175] ALERT_HANDLER_LOC_ALERT_REGWEN_9
-    4'b 0001, // index[176] ALERT_HANDLER_LOC_ALERT_REGWEN_10
-    4'b 0001, // index[177] ALERT_HANDLER_LOC_ALERT_REGWEN_11
-    4'b 0001, // index[178] ALERT_HANDLER_LOC_ALERT_REGWEN_12
-    4'b 0001, // index[179] ALERT_HANDLER_LOC_ALERT_REGWEN_13
-    4'b 0001, // index[180] ALERT_HANDLER_LOC_ALERT_REGWEN_14
-    4'b 0001, // index[181] ALERT_HANDLER_LOC_ALERT_REGWEN_15
-    4'b 0001, // index[182] ALERT_HANDLER_LOC_ALERT_REGWEN_16
-    4'b 0001, // index[183] ALERT_HANDLER_LOC_ALERT_REGWEN_17
-    4'b 0001, // index[184] ALERT_HANDLER_LOC_ALERT_REGWEN_18
-    4'b 0001, // index[185] ALERT_HANDLER_LOC_ALERT_REGWEN_19
-    4'b 0001, // index[186] ALERT_HANDLER_LOC_ALERT_REGWEN_20
-    4'b 0001, // index[187] ALERT_HANDLER_LOC_ALERT_REGWEN_21
-    4'b 0001, // index[188] ALERT_HANDLER_LOC_ALERT_REGWEN_22
-    4'b 0001, // index[189] ALERT_HANDLER_LOC_ALERT_REGWEN_23
-    4'b 0001, // index[190] ALERT_HANDLER_LOC_ALERT_REGWEN_24
-    4'b 0001, // index[191] ALERT_HANDLER_LOC_ALERT_REGWEN_25
-    4'b 0001, // index[192] ALERT_HANDLER_LOC_ALERT_REGWEN_26
-    4'b 0001, // index[193] ALERT_HANDLER_LOC_ALERT_REGWEN_27
-    4'b 0001, // index[194] ALERT_HANDLER_LOC_ALERT_REGWEN_28
-    4'b 0001, // index[195] ALERT_HANDLER_LOC_ALERT_REGWEN_29
-    4'b 0001, // index[196] ALERT_HANDLER_LOC_ALERT_REGWEN_30
-    4'b 0001, // index[197] ALERT_HANDLER_LOC_ALERT_REGWEN_31
-    4'b 0001, // index[198] ALERT_HANDLER_LOC_ALERT_REGWEN_32
-    4'b 0001, // index[199] ALERT_HANDLER_LOC_ALERT_REGWEN_33
-    4'b 0001, // index[200] ALERT_HANDLER_LOC_ALERT_REGWEN_34
-    4'b 0001, // index[201] ALERT_HANDLER_LOC_ALERT_REGWEN_35
-    4'b 0001, // index[202] ALERT_HANDLER_LOC_ALERT_REGWEN_36
-    4'b 0001, // index[203] ALERT_HANDLER_LOC_ALERT_REGWEN_37
-    4'b 0001, // index[204] ALERT_HANDLER_LOC_ALERT_REGWEN_38
-    4'b 0001, // index[205] ALERT_HANDLER_LOC_ALERT_REGWEN_39
-    4'b 0001, // index[206] ALERT_HANDLER_LOC_ALERT_EN_0
-    4'b 0001, // index[207] ALERT_HANDLER_LOC_ALERT_EN_1
-    4'b 0001, // index[208] ALERT_HANDLER_LOC_ALERT_EN_2
-    4'b 0001, // index[209] ALERT_HANDLER_LOC_ALERT_EN_3
-    4'b 0001, // index[210] ALERT_HANDLER_LOC_ALERT_CLASS_0
-    4'b 0001, // index[211] ALERT_HANDLER_LOC_ALERT_CLASS_1
-    4'b 0001, // index[212] ALERT_HANDLER_LOC_ALERT_CLASS_2
-    4'b 0001, // index[213] ALERT_HANDLER_LOC_ALERT_CLASS_3
-    4'b 0001, // index[214] ALERT_HANDLER_LOC_ALERT_CAUSE_0
-    4'b 0001, // index[215] ALERT_HANDLER_LOC_ALERT_CAUSE_1
-    4'b 0001, // index[216] ALERT_HANDLER_LOC_ALERT_CAUSE_2
-    4'b 0001, // index[217] ALERT_HANDLER_LOC_ALERT_CAUSE_3
-    4'b 0001, // index[218] ALERT_HANDLER_CLASSA_REGWEN
-    4'b 0011, // index[219] ALERT_HANDLER_CLASSA_CTRL
-    4'b 0001, // index[220] ALERT_HANDLER_CLASSA_CLR_REGWEN
-    4'b 0001, // index[221] ALERT_HANDLER_CLASSA_CLR
-    4'b 0011, // index[222] ALERT_HANDLER_CLASSA_ACCUM_CNT
-    4'b 0011, // index[223] ALERT_HANDLER_CLASSA_ACCUM_THRESH
-    4'b 1111, // index[224] ALERT_HANDLER_CLASSA_TIMEOUT_CYC
-    4'b 1111, // index[225] ALERT_HANDLER_CLASSA_PHASE0_CYC
-    4'b 1111, // index[226] ALERT_HANDLER_CLASSA_PHASE1_CYC
-    4'b 1111, // index[227] ALERT_HANDLER_CLASSA_PHASE2_CYC
-    4'b 1111, // index[228] ALERT_HANDLER_CLASSA_PHASE3_CYC
-    4'b 1111, // index[229] ALERT_HANDLER_CLASSA_ESC_CNT
-    4'b 0001, // index[230] ALERT_HANDLER_CLASSA_STATE
-    4'b 0001, // index[231] ALERT_HANDLER_CLASSB_REGWEN
-    4'b 0011, // index[232] ALERT_HANDLER_CLASSB_CTRL
-    4'b 0001, // index[233] ALERT_HANDLER_CLASSB_CLR_REGWEN
-    4'b 0001, // index[234] ALERT_HANDLER_CLASSB_CLR
-    4'b 0011, // index[235] ALERT_HANDLER_CLASSB_ACCUM_CNT
-    4'b 0011, // index[236] ALERT_HANDLER_CLASSB_ACCUM_THRESH
-    4'b 1111, // index[237] ALERT_HANDLER_CLASSB_TIMEOUT_CYC
-    4'b 1111, // index[238] ALERT_HANDLER_CLASSB_PHASE0_CYC
-    4'b 1111, // index[239] ALERT_HANDLER_CLASSB_PHASE1_CYC
-    4'b 1111, // index[240] ALERT_HANDLER_CLASSB_PHASE2_CYC
-    4'b 1111, // index[241] ALERT_HANDLER_CLASSB_PHASE3_CYC
-    4'b 1111, // index[242] ALERT_HANDLER_CLASSB_ESC_CNT
-    4'b 0001, // index[243] ALERT_HANDLER_CLASSB_STATE
-    4'b 0001, // index[244] ALERT_HANDLER_CLASSC_REGWEN
-    4'b 0011, // index[245] ALERT_HANDLER_CLASSC_CTRL
-    4'b 0001, // index[246] ALERT_HANDLER_CLASSC_CLR_REGWEN
-    4'b 0001, // index[247] ALERT_HANDLER_CLASSC_CLR
-    4'b 0011, // index[248] ALERT_HANDLER_CLASSC_ACCUM_CNT
-    4'b 0011, // index[249] ALERT_HANDLER_CLASSC_ACCUM_THRESH
-    4'b 1111, // index[250] ALERT_HANDLER_CLASSC_TIMEOUT_CYC
-    4'b 1111, // index[251] ALERT_HANDLER_CLASSC_PHASE0_CYC
-    4'b 1111, // index[252] ALERT_HANDLER_CLASSC_PHASE1_CYC
-    4'b 1111, // index[253] ALERT_HANDLER_CLASSC_PHASE2_CYC
-    4'b 1111, // index[254] ALERT_HANDLER_CLASSC_PHASE3_CYC
-    4'b 1111, // index[255] ALERT_HANDLER_CLASSC_ESC_CNT
-    4'b 0001, // index[256] ALERT_HANDLER_CLASSC_STATE
-    4'b 0001, // index[257] ALERT_HANDLER_CLASSD_REGWEN
-    4'b 0011, // index[258] ALERT_HANDLER_CLASSD_CTRL
-    4'b 0001, // index[259] ALERT_HANDLER_CLASSD_CLR_REGWEN
-    4'b 0001, // index[260] ALERT_HANDLER_CLASSD_CLR
-    4'b 0011, // index[261] ALERT_HANDLER_CLASSD_ACCUM_CNT
-    4'b 0011, // index[262] ALERT_HANDLER_CLASSD_ACCUM_THRESH
-    4'b 1111, // index[263] ALERT_HANDLER_CLASSD_TIMEOUT_CYC
-    4'b 1111, // index[264] ALERT_HANDLER_CLASSD_PHASE0_CYC
-    4'b 1111, // index[265] ALERT_HANDLER_CLASSD_PHASE1_CYC
-    4'b 1111, // index[266] ALERT_HANDLER_CLASSD_PHASE2_CYC
-    4'b 1111, // index[267] ALERT_HANDLER_CLASSD_PHASE3_CYC
-    4'b 1111, // index[268] ALERT_HANDLER_CLASSD_ESC_CNT
-    4'b 0001  // index[269] ALERT_HANDLER_CLASSD_STATE
+    4'b 0001, // index[171] ALERT_HANDLER_LOC_ALERT_EN_0
+    4'b 0001, // index[172] ALERT_HANDLER_LOC_ALERT_EN_1
+    4'b 0001, // index[173] ALERT_HANDLER_LOC_ALERT_EN_2
+    4'b 0001, // index[174] ALERT_HANDLER_LOC_ALERT_EN_3
+    4'b 0001, // index[175] ALERT_HANDLER_LOC_ALERT_EN_4
+    4'b 0001, // index[176] ALERT_HANDLER_LOC_ALERT_CLASS_0
+    4'b 0001, // index[177] ALERT_HANDLER_LOC_ALERT_CLASS_1
+    4'b 0001, // index[178] ALERT_HANDLER_LOC_ALERT_CLASS_2
+    4'b 0001, // index[179] ALERT_HANDLER_LOC_ALERT_CLASS_3
+    4'b 0001, // index[180] ALERT_HANDLER_LOC_ALERT_CLASS_4
+    4'b 0001, // index[181] ALERT_HANDLER_LOC_ALERT_CAUSE_0
+    4'b 0001, // index[182] ALERT_HANDLER_LOC_ALERT_CAUSE_1
+    4'b 0001, // index[183] ALERT_HANDLER_LOC_ALERT_CAUSE_2
+    4'b 0001, // index[184] ALERT_HANDLER_LOC_ALERT_CAUSE_3
+    4'b 0001, // index[185] ALERT_HANDLER_LOC_ALERT_CAUSE_4
+    4'b 0001, // index[186] ALERT_HANDLER_CLASSA_REGWEN
+    4'b 0011, // index[187] ALERT_HANDLER_CLASSA_CTRL
+    4'b 0001, // index[188] ALERT_HANDLER_CLASSA_CLR_REGWEN
+    4'b 0001, // index[189] ALERT_HANDLER_CLASSA_CLR
+    4'b 0011, // index[190] ALERT_HANDLER_CLASSA_ACCUM_CNT
+    4'b 0011, // index[191] ALERT_HANDLER_CLASSA_ACCUM_THRESH
+    4'b 1111, // index[192] ALERT_HANDLER_CLASSA_TIMEOUT_CYC
+    4'b 1111, // index[193] ALERT_HANDLER_CLASSA_PHASE0_CYC
+    4'b 1111, // index[194] ALERT_HANDLER_CLASSA_PHASE1_CYC
+    4'b 1111, // index[195] ALERT_HANDLER_CLASSA_PHASE2_CYC
+    4'b 1111, // index[196] ALERT_HANDLER_CLASSA_PHASE3_CYC
+    4'b 1111, // index[197] ALERT_HANDLER_CLASSA_ESC_CNT
+    4'b 0001, // index[198] ALERT_HANDLER_CLASSA_STATE
+    4'b 0001, // index[199] ALERT_HANDLER_CLASSB_REGWEN
+    4'b 0011, // index[200] ALERT_HANDLER_CLASSB_CTRL
+    4'b 0001, // index[201] ALERT_HANDLER_CLASSB_CLR_REGWEN
+    4'b 0001, // index[202] ALERT_HANDLER_CLASSB_CLR
+    4'b 0011, // index[203] ALERT_HANDLER_CLASSB_ACCUM_CNT
+    4'b 0011, // index[204] ALERT_HANDLER_CLASSB_ACCUM_THRESH
+    4'b 1111, // index[205] ALERT_HANDLER_CLASSB_TIMEOUT_CYC
+    4'b 1111, // index[206] ALERT_HANDLER_CLASSB_PHASE0_CYC
+    4'b 1111, // index[207] ALERT_HANDLER_CLASSB_PHASE1_CYC
+    4'b 1111, // index[208] ALERT_HANDLER_CLASSB_PHASE2_CYC
+    4'b 1111, // index[209] ALERT_HANDLER_CLASSB_PHASE3_CYC
+    4'b 1111, // index[210] ALERT_HANDLER_CLASSB_ESC_CNT
+    4'b 0001, // index[211] ALERT_HANDLER_CLASSB_STATE
+    4'b 0001, // index[212] ALERT_HANDLER_CLASSC_REGWEN
+    4'b 0011, // index[213] ALERT_HANDLER_CLASSC_CTRL
+    4'b 0001, // index[214] ALERT_HANDLER_CLASSC_CLR_REGWEN
+    4'b 0001, // index[215] ALERT_HANDLER_CLASSC_CLR
+    4'b 0011, // index[216] ALERT_HANDLER_CLASSC_ACCUM_CNT
+    4'b 0011, // index[217] ALERT_HANDLER_CLASSC_ACCUM_THRESH
+    4'b 1111, // index[218] ALERT_HANDLER_CLASSC_TIMEOUT_CYC
+    4'b 1111, // index[219] ALERT_HANDLER_CLASSC_PHASE0_CYC
+    4'b 1111, // index[220] ALERT_HANDLER_CLASSC_PHASE1_CYC
+    4'b 1111, // index[221] ALERT_HANDLER_CLASSC_PHASE2_CYC
+    4'b 1111, // index[222] ALERT_HANDLER_CLASSC_PHASE3_CYC
+    4'b 1111, // index[223] ALERT_HANDLER_CLASSC_ESC_CNT
+    4'b 0001, // index[224] ALERT_HANDLER_CLASSC_STATE
+    4'b 0001, // index[225] ALERT_HANDLER_CLASSD_REGWEN
+    4'b 0011, // index[226] ALERT_HANDLER_CLASSD_CTRL
+    4'b 0001, // index[227] ALERT_HANDLER_CLASSD_CLR_REGWEN
+    4'b 0001, // index[228] ALERT_HANDLER_CLASSD_CLR
+    4'b 0011, // index[229] ALERT_HANDLER_CLASSD_ACCUM_CNT
+    4'b 0011, // index[230] ALERT_HANDLER_CLASSD_ACCUM_THRESH
+    4'b 1111, // index[231] ALERT_HANDLER_CLASSD_TIMEOUT_CYC
+    4'b 1111, // index[232] ALERT_HANDLER_CLASSD_PHASE0_CYC
+    4'b 1111, // index[233] ALERT_HANDLER_CLASSD_PHASE1_CYC
+    4'b 1111, // index[234] ALERT_HANDLER_CLASSD_PHASE2_CYC
+    4'b 1111, // index[235] ALERT_HANDLER_CLASSD_PHASE3_CYC
+    4'b 1111, // index[236] ALERT_HANDLER_CLASSD_ESC_CNT
+    4'b 0001  // index[237] ALERT_HANDLER_CLASSD_STATE
   };
 
 endpackage

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
@@ -25,7 +25,7 @@ module alert_handler_reg_top (
 
   import alert_handler_reg_pkg::* ;
 
-  localparam int AW = 11;
+  localparam int AW = 10;
   localparam int DW = 32;
   localparam int DBW = DW/8;                    // Byte Width
 
@@ -640,111 +640,6 @@ module alert_handler_reg_top (
   logic loc_alert_regwen_4_qs;
   logic loc_alert_regwen_4_wd;
   logic loc_alert_regwen_4_we;
-  logic loc_alert_regwen_5_qs;
-  logic loc_alert_regwen_5_wd;
-  logic loc_alert_regwen_5_we;
-  logic loc_alert_regwen_6_qs;
-  logic loc_alert_regwen_6_wd;
-  logic loc_alert_regwen_6_we;
-  logic loc_alert_regwen_7_qs;
-  logic loc_alert_regwen_7_wd;
-  logic loc_alert_regwen_7_we;
-  logic loc_alert_regwen_8_qs;
-  logic loc_alert_regwen_8_wd;
-  logic loc_alert_regwen_8_we;
-  logic loc_alert_regwen_9_qs;
-  logic loc_alert_regwen_9_wd;
-  logic loc_alert_regwen_9_we;
-  logic loc_alert_regwen_10_qs;
-  logic loc_alert_regwen_10_wd;
-  logic loc_alert_regwen_10_we;
-  logic loc_alert_regwen_11_qs;
-  logic loc_alert_regwen_11_wd;
-  logic loc_alert_regwen_11_we;
-  logic loc_alert_regwen_12_qs;
-  logic loc_alert_regwen_12_wd;
-  logic loc_alert_regwen_12_we;
-  logic loc_alert_regwen_13_qs;
-  logic loc_alert_regwen_13_wd;
-  logic loc_alert_regwen_13_we;
-  logic loc_alert_regwen_14_qs;
-  logic loc_alert_regwen_14_wd;
-  logic loc_alert_regwen_14_we;
-  logic loc_alert_regwen_15_qs;
-  logic loc_alert_regwen_15_wd;
-  logic loc_alert_regwen_15_we;
-  logic loc_alert_regwen_16_qs;
-  logic loc_alert_regwen_16_wd;
-  logic loc_alert_regwen_16_we;
-  logic loc_alert_regwen_17_qs;
-  logic loc_alert_regwen_17_wd;
-  logic loc_alert_regwen_17_we;
-  logic loc_alert_regwen_18_qs;
-  logic loc_alert_regwen_18_wd;
-  logic loc_alert_regwen_18_we;
-  logic loc_alert_regwen_19_qs;
-  logic loc_alert_regwen_19_wd;
-  logic loc_alert_regwen_19_we;
-  logic loc_alert_regwen_20_qs;
-  logic loc_alert_regwen_20_wd;
-  logic loc_alert_regwen_20_we;
-  logic loc_alert_regwen_21_qs;
-  logic loc_alert_regwen_21_wd;
-  logic loc_alert_regwen_21_we;
-  logic loc_alert_regwen_22_qs;
-  logic loc_alert_regwen_22_wd;
-  logic loc_alert_regwen_22_we;
-  logic loc_alert_regwen_23_qs;
-  logic loc_alert_regwen_23_wd;
-  logic loc_alert_regwen_23_we;
-  logic loc_alert_regwen_24_qs;
-  logic loc_alert_regwen_24_wd;
-  logic loc_alert_regwen_24_we;
-  logic loc_alert_regwen_25_qs;
-  logic loc_alert_regwen_25_wd;
-  logic loc_alert_regwen_25_we;
-  logic loc_alert_regwen_26_qs;
-  logic loc_alert_regwen_26_wd;
-  logic loc_alert_regwen_26_we;
-  logic loc_alert_regwen_27_qs;
-  logic loc_alert_regwen_27_wd;
-  logic loc_alert_regwen_27_we;
-  logic loc_alert_regwen_28_qs;
-  logic loc_alert_regwen_28_wd;
-  logic loc_alert_regwen_28_we;
-  logic loc_alert_regwen_29_qs;
-  logic loc_alert_regwen_29_wd;
-  logic loc_alert_regwen_29_we;
-  logic loc_alert_regwen_30_qs;
-  logic loc_alert_regwen_30_wd;
-  logic loc_alert_regwen_30_we;
-  logic loc_alert_regwen_31_qs;
-  logic loc_alert_regwen_31_wd;
-  logic loc_alert_regwen_31_we;
-  logic loc_alert_regwen_32_qs;
-  logic loc_alert_regwen_32_wd;
-  logic loc_alert_regwen_32_we;
-  logic loc_alert_regwen_33_qs;
-  logic loc_alert_regwen_33_wd;
-  logic loc_alert_regwen_33_we;
-  logic loc_alert_regwen_34_qs;
-  logic loc_alert_regwen_34_wd;
-  logic loc_alert_regwen_34_we;
-  logic loc_alert_regwen_35_qs;
-  logic loc_alert_regwen_35_wd;
-  logic loc_alert_regwen_35_we;
-  logic loc_alert_regwen_36_qs;
-  logic loc_alert_regwen_36_wd;
-  logic loc_alert_regwen_36_we;
-  logic loc_alert_regwen_37_qs;
-  logic loc_alert_regwen_37_wd;
-  logic loc_alert_regwen_37_we;
-  logic loc_alert_regwen_38_qs;
-  logic loc_alert_regwen_38_wd;
-  logic loc_alert_regwen_38_we;
-  logic loc_alert_regwen_39_qs;
-  logic loc_alert_regwen_39_wd;
-  logic loc_alert_regwen_39_we;
   logic loc_alert_en_0_qs;
   logic loc_alert_en_0_wd;
   logic loc_alert_en_0_we;
@@ -757,6 +652,9 @@ module alert_handler_reg_top (
   logic loc_alert_en_3_qs;
   logic loc_alert_en_3_wd;
   logic loc_alert_en_3_we;
+  logic loc_alert_en_4_qs;
+  logic loc_alert_en_4_wd;
+  logic loc_alert_en_4_we;
   logic [1:0] loc_alert_class_0_qs;
   logic [1:0] loc_alert_class_0_wd;
   logic loc_alert_class_0_we;
@@ -769,6 +667,9 @@ module alert_handler_reg_top (
   logic [1:0] loc_alert_class_3_qs;
   logic [1:0] loc_alert_class_3_wd;
   logic loc_alert_class_3_we;
+  logic [1:0] loc_alert_class_4_qs;
+  logic [1:0] loc_alert_class_4_wd;
+  logic loc_alert_class_4_we;
   logic loc_alert_cause_0_qs;
   logic loc_alert_cause_0_wd;
   logic loc_alert_cause_0_we;
@@ -781,6 +682,9 @@ module alert_handler_reg_top (
   logic loc_alert_cause_3_qs;
   logic loc_alert_cause_3_wd;
   logic loc_alert_cause_3_we;
+  logic loc_alert_cause_4_qs;
+  logic loc_alert_cause_4_wd;
+  logic loc_alert_cause_4_we;
   logic classa_regwen_qs;
   logic classa_regwen_wd;
   logic classa_regwen_we;
@@ -5850,951 +5754,6 @@ module alert_handler_reg_top (
     .qs     (loc_alert_regwen_4_qs)
   );
 
-  // Subregister 5 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_5]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_5 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_5_we),
-    .wd     (loc_alert_regwen_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_5_qs)
-  );
-
-  // Subregister 6 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_6]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_6 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_6_we),
-    .wd     (loc_alert_regwen_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_6_qs)
-  );
-
-  // Subregister 7 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_7]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_7 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_7_we),
-    .wd     (loc_alert_regwen_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_7_qs)
-  );
-
-  // Subregister 8 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_8]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_8 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_8_we),
-    .wd     (loc_alert_regwen_8_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_8_qs)
-  );
-
-  // Subregister 9 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_9]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_9 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_9_we),
-    .wd     (loc_alert_regwen_9_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_9_qs)
-  );
-
-  // Subregister 10 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_10]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_10 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_10_we),
-    .wd     (loc_alert_regwen_10_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_10_qs)
-  );
-
-  // Subregister 11 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_11]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_11 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_11_we),
-    .wd     (loc_alert_regwen_11_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_11_qs)
-  );
-
-  // Subregister 12 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_12]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_12 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_12_we),
-    .wd     (loc_alert_regwen_12_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_12_qs)
-  );
-
-  // Subregister 13 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_13]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_13 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_13_we),
-    .wd     (loc_alert_regwen_13_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_13_qs)
-  );
-
-  // Subregister 14 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_14]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_14 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_14_we),
-    .wd     (loc_alert_regwen_14_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_14_qs)
-  );
-
-  // Subregister 15 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_15]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_15 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_15_we),
-    .wd     (loc_alert_regwen_15_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_15_qs)
-  );
-
-  // Subregister 16 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_16]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_16 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_16_we),
-    .wd     (loc_alert_regwen_16_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_16_qs)
-  );
-
-  // Subregister 17 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_17]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_17 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_17_we),
-    .wd     (loc_alert_regwen_17_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_17_qs)
-  );
-
-  // Subregister 18 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_18]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_18 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_18_we),
-    .wd     (loc_alert_regwen_18_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_18_qs)
-  );
-
-  // Subregister 19 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_19]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_19 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_19_we),
-    .wd     (loc_alert_regwen_19_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_19_qs)
-  );
-
-  // Subregister 20 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_20]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_20 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_20_we),
-    .wd     (loc_alert_regwen_20_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_20_qs)
-  );
-
-  // Subregister 21 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_21]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_21 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_21_we),
-    .wd     (loc_alert_regwen_21_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_21_qs)
-  );
-
-  // Subregister 22 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_22]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_22 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_22_we),
-    .wd     (loc_alert_regwen_22_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_22_qs)
-  );
-
-  // Subregister 23 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_23]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_23 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_23_we),
-    .wd     (loc_alert_regwen_23_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_23_qs)
-  );
-
-  // Subregister 24 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_24]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_24 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_24_we),
-    .wd     (loc_alert_regwen_24_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_24_qs)
-  );
-
-  // Subregister 25 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_25]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_25 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_25_we),
-    .wd     (loc_alert_regwen_25_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_25_qs)
-  );
-
-  // Subregister 26 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_26]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_26 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_26_we),
-    .wd     (loc_alert_regwen_26_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_26_qs)
-  );
-
-  // Subregister 27 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_27]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_27 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_27_we),
-    .wd     (loc_alert_regwen_27_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_27_qs)
-  );
-
-  // Subregister 28 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_28]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_28 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_28_we),
-    .wd     (loc_alert_regwen_28_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_28_qs)
-  );
-
-  // Subregister 29 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_29]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_29 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_29_we),
-    .wd     (loc_alert_regwen_29_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_29_qs)
-  );
-
-  // Subregister 30 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_30]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_30 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_30_we),
-    .wd     (loc_alert_regwen_30_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_30_qs)
-  );
-
-  // Subregister 31 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_31]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_31 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_31_we),
-    .wd     (loc_alert_regwen_31_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_31_qs)
-  );
-
-  // Subregister 32 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_32]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_32 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_32_we),
-    .wd     (loc_alert_regwen_32_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_32_qs)
-  );
-
-  // Subregister 33 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_33]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_33 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_33_we),
-    .wd     (loc_alert_regwen_33_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_33_qs)
-  );
-
-  // Subregister 34 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_34]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_34 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_34_we),
-    .wd     (loc_alert_regwen_34_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_34_qs)
-  );
-
-  // Subregister 35 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_35]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_35 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_35_we),
-    .wd     (loc_alert_regwen_35_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_35_qs)
-  );
-
-  // Subregister 36 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_36]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_36 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_36_we),
-    .wd     (loc_alert_regwen_36_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_36_qs)
-  );
-
-  // Subregister 37 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_37]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_37 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_37_we),
-    .wd     (loc_alert_regwen_37_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_37_qs)
-  );
-
-  // Subregister 38 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_38]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_38 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_38_we),
-    .wd     (loc_alert_regwen_38_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_38_qs)
-  );
-
-  // Subregister 39 of Multireg loc_alert_regwen
-  // R[loc_alert_regwen_39]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_loc_alert_regwen_39 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (loc_alert_regwen_39_we),
-    .wd     (loc_alert_regwen_39_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (loc_alert_regwen_39_qs)
-  );
-
 
 
   // Subregister 0 of Multireg loc_alert_en
@@ -6903,6 +5862,33 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (loc_alert_en_3_qs)
+  );
+
+  // Subregister 4 of Multireg loc_alert_en
+  // R[loc_alert_en_4]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_loc_alert_en_4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (loc_alert_en_4_we & loc_alert_regwen_4_qs),
+    .wd     (loc_alert_en_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.loc_alert_en[4].q),
+
+    // to register interface (read)
+    .qs     (loc_alert_en_4_qs)
   );
 
 
@@ -7015,6 +6001,33 @@ module alert_handler_reg_top (
     .qs     (loc_alert_class_3_qs)
   );
 
+  // Subregister 4 of Multireg loc_alert_class
+  // R[loc_alert_class_4]: V(False)
+
+  prim_subreg #(
+    .DW      (2),
+    .SWACCESS("RW"),
+    .RESVAL  (2'h0)
+  ) u_loc_alert_class_4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (loc_alert_class_4_we & loc_alert_regwen_4_qs),
+    .wd     (loc_alert_class_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.loc_alert_class[4].q),
+
+    // to register interface (read)
+    .qs     (loc_alert_class_4_qs)
+  );
+
 
 
   // Subregister 0 of Multireg loc_alert_cause
@@ -7123,6 +6136,33 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (loc_alert_cause_3_qs)
+  );
+
+  // Subregister 4 of Multireg loc_alert_cause
+  // R[loc_alert_cause_4]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_loc_alert_cause_4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (loc_alert_cause_4_we),
+    .wd     (loc_alert_cause_4_wd),
+
+    // from internal hardware
+    .de     (hw2reg.loc_alert_cause[4].de),
+    .d      (hw2reg.loc_alert_cause[4].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.loc_alert_cause[4].q),
+
+    // to register interface (read)
+    .qs     (loc_alert_cause_4_qs)
   );
 
 
@@ -9340,7 +8380,7 @@ module alert_handler_reg_top (
 
 
 
-  logic [269:0] addr_hit;
+  logic [237:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[  0] = (reg_addr == ALERT_HANDLER_INTR_STATE_OFFSET);
@@ -9514,105 +8554,73 @@ module alert_handler_reg_top (
     addr_hit[168] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_2_OFFSET);
     addr_hit[169] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_3_OFFSET);
     addr_hit[170] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_4_OFFSET);
-    addr_hit[171] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_5_OFFSET);
-    addr_hit[172] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_6_OFFSET);
-    addr_hit[173] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_7_OFFSET);
-    addr_hit[174] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_8_OFFSET);
-    addr_hit[175] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_9_OFFSET);
-    addr_hit[176] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_10_OFFSET);
-    addr_hit[177] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_11_OFFSET);
-    addr_hit[178] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_12_OFFSET);
-    addr_hit[179] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_13_OFFSET);
-    addr_hit[180] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_14_OFFSET);
-    addr_hit[181] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_15_OFFSET);
-    addr_hit[182] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_16_OFFSET);
-    addr_hit[183] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_17_OFFSET);
-    addr_hit[184] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_18_OFFSET);
-    addr_hit[185] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_19_OFFSET);
-    addr_hit[186] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_20_OFFSET);
-    addr_hit[187] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_21_OFFSET);
-    addr_hit[188] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_22_OFFSET);
-    addr_hit[189] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_23_OFFSET);
-    addr_hit[190] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_24_OFFSET);
-    addr_hit[191] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_25_OFFSET);
-    addr_hit[192] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_26_OFFSET);
-    addr_hit[193] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_27_OFFSET);
-    addr_hit[194] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_28_OFFSET);
-    addr_hit[195] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_29_OFFSET);
-    addr_hit[196] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_30_OFFSET);
-    addr_hit[197] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_31_OFFSET);
-    addr_hit[198] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_32_OFFSET);
-    addr_hit[199] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_33_OFFSET);
-    addr_hit[200] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_34_OFFSET);
-    addr_hit[201] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_35_OFFSET);
-    addr_hit[202] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_36_OFFSET);
-    addr_hit[203] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_37_OFFSET);
-    addr_hit[204] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_38_OFFSET);
-    addr_hit[205] = (reg_addr == ALERT_HANDLER_LOC_ALERT_REGWEN_39_OFFSET);
-    addr_hit[206] = (reg_addr == ALERT_HANDLER_LOC_ALERT_EN_0_OFFSET);
-    addr_hit[207] = (reg_addr == ALERT_HANDLER_LOC_ALERT_EN_1_OFFSET);
-    addr_hit[208] = (reg_addr == ALERT_HANDLER_LOC_ALERT_EN_2_OFFSET);
-    addr_hit[209] = (reg_addr == ALERT_HANDLER_LOC_ALERT_EN_3_OFFSET);
-    addr_hit[210] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_0_OFFSET);
-    addr_hit[211] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_1_OFFSET);
-    addr_hit[212] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_2_OFFSET);
-    addr_hit[213] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_3_OFFSET);
-    addr_hit[214] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_0_OFFSET);
-    addr_hit[215] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_1_OFFSET);
-    addr_hit[216] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_2_OFFSET);
-    addr_hit[217] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_3_OFFSET);
-    addr_hit[218] = (reg_addr == ALERT_HANDLER_CLASSA_REGWEN_OFFSET);
-    addr_hit[219] = (reg_addr == ALERT_HANDLER_CLASSA_CTRL_OFFSET);
-    addr_hit[220] = (reg_addr == ALERT_HANDLER_CLASSA_CLR_REGWEN_OFFSET);
-    addr_hit[221] = (reg_addr == ALERT_HANDLER_CLASSA_CLR_OFFSET);
-    addr_hit[222] = (reg_addr == ALERT_HANDLER_CLASSA_ACCUM_CNT_OFFSET);
-    addr_hit[223] = (reg_addr == ALERT_HANDLER_CLASSA_ACCUM_THRESH_OFFSET);
-    addr_hit[224] = (reg_addr == ALERT_HANDLER_CLASSA_TIMEOUT_CYC_OFFSET);
-    addr_hit[225] = (reg_addr == ALERT_HANDLER_CLASSA_PHASE0_CYC_OFFSET);
-    addr_hit[226] = (reg_addr == ALERT_HANDLER_CLASSA_PHASE1_CYC_OFFSET);
-    addr_hit[227] = (reg_addr == ALERT_HANDLER_CLASSA_PHASE2_CYC_OFFSET);
-    addr_hit[228] = (reg_addr == ALERT_HANDLER_CLASSA_PHASE3_CYC_OFFSET);
-    addr_hit[229] = (reg_addr == ALERT_HANDLER_CLASSA_ESC_CNT_OFFSET);
-    addr_hit[230] = (reg_addr == ALERT_HANDLER_CLASSA_STATE_OFFSET);
-    addr_hit[231] = (reg_addr == ALERT_HANDLER_CLASSB_REGWEN_OFFSET);
-    addr_hit[232] = (reg_addr == ALERT_HANDLER_CLASSB_CTRL_OFFSET);
-    addr_hit[233] = (reg_addr == ALERT_HANDLER_CLASSB_CLR_REGWEN_OFFSET);
-    addr_hit[234] = (reg_addr == ALERT_HANDLER_CLASSB_CLR_OFFSET);
-    addr_hit[235] = (reg_addr == ALERT_HANDLER_CLASSB_ACCUM_CNT_OFFSET);
-    addr_hit[236] = (reg_addr == ALERT_HANDLER_CLASSB_ACCUM_THRESH_OFFSET);
-    addr_hit[237] = (reg_addr == ALERT_HANDLER_CLASSB_TIMEOUT_CYC_OFFSET);
-    addr_hit[238] = (reg_addr == ALERT_HANDLER_CLASSB_PHASE0_CYC_OFFSET);
-    addr_hit[239] = (reg_addr == ALERT_HANDLER_CLASSB_PHASE1_CYC_OFFSET);
-    addr_hit[240] = (reg_addr == ALERT_HANDLER_CLASSB_PHASE2_CYC_OFFSET);
-    addr_hit[241] = (reg_addr == ALERT_HANDLER_CLASSB_PHASE3_CYC_OFFSET);
-    addr_hit[242] = (reg_addr == ALERT_HANDLER_CLASSB_ESC_CNT_OFFSET);
-    addr_hit[243] = (reg_addr == ALERT_HANDLER_CLASSB_STATE_OFFSET);
-    addr_hit[244] = (reg_addr == ALERT_HANDLER_CLASSC_REGWEN_OFFSET);
-    addr_hit[245] = (reg_addr == ALERT_HANDLER_CLASSC_CTRL_OFFSET);
-    addr_hit[246] = (reg_addr == ALERT_HANDLER_CLASSC_CLR_REGWEN_OFFSET);
-    addr_hit[247] = (reg_addr == ALERT_HANDLER_CLASSC_CLR_OFFSET);
-    addr_hit[248] = (reg_addr == ALERT_HANDLER_CLASSC_ACCUM_CNT_OFFSET);
-    addr_hit[249] = (reg_addr == ALERT_HANDLER_CLASSC_ACCUM_THRESH_OFFSET);
-    addr_hit[250] = (reg_addr == ALERT_HANDLER_CLASSC_TIMEOUT_CYC_OFFSET);
-    addr_hit[251] = (reg_addr == ALERT_HANDLER_CLASSC_PHASE0_CYC_OFFSET);
-    addr_hit[252] = (reg_addr == ALERT_HANDLER_CLASSC_PHASE1_CYC_OFFSET);
-    addr_hit[253] = (reg_addr == ALERT_HANDLER_CLASSC_PHASE2_CYC_OFFSET);
-    addr_hit[254] = (reg_addr == ALERT_HANDLER_CLASSC_PHASE3_CYC_OFFSET);
-    addr_hit[255] = (reg_addr == ALERT_HANDLER_CLASSC_ESC_CNT_OFFSET);
-    addr_hit[256] = (reg_addr == ALERT_HANDLER_CLASSC_STATE_OFFSET);
-    addr_hit[257] = (reg_addr == ALERT_HANDLER_CLASSD_REGWEN_OFFSET);
-    addr_hit[258] = (reg_addr == ALERT_HANDLER_CLASSD_CTRL_OFFSET);
-    addr_hit[259] = (reg_addr == ALERT_HANDLER_CLASSD_CLR_REGWEN_OFFSET);
-    addr_hit[260] = (reg_addr == ALERT_HANDLER_CLASSD_CLR_OFFSET);
-    addr_hit[261] = (reg_addr == ALERT_HANDLER_CLASSD_ACCUM_CNT_OFFSET);
-    addr_hit[262] = (reg_addr == ALERT_HANDLER_CLASSD_ACCUM_THRESH_OFFSET);
-    addr_hit[263] = (reg_addr == ALERT_HANDLER_CLASSD_TIMEOUT_CYC_OFFSET);
-    addr_hit[264] = (reg_addr == ALERT_HANDLER_CLASSD_PHASE0_CYC_OFFSET);
-    addr_hit[265] = (reg_addr == ALERT_HANDLER_CLASSD_PHASE1_CYC_OFFSET);
-    addr_hit[266] = (reg_addr == ALERT_HANDLER_CLASSD_PHASE2_CYC_OFFSET);
-    addr_hit[267] = (reg_addr == ALERT_HANDLER_CLASSD_PHASE3_CYC_OFFSET);
-    addr_hit[268] = (reg_addr == ALERT_HANDLER_CLASSD_ESC_CNT_OFFSET);
-    addr_hit[269] = (reg_addr == ALERT_HANDLER_CLASSD_STATE_OFFSET);
+    addr_hit[171] = (reg_addr == ALERT_HANDLER_LOC_ALERT_EN_0_OFFSET);
+    addr_hit[172] = (reg_addr == ALERT_HANDLER_LOC_ALERT_EN_1_OFFSET);
+    addr_hit[173] = (reg_addr == ALERT_HANDLER_LOC_ALERT_EN_2_OFFSET);
+    addr_hit[174] = (reg_addr == ALERT_HANDLER_LOC_ALERT_EN_3_OFFSET);
+    addr_hit[175] = (reg_addr == ALERT_HANDLER_LOC_ALERT_EN_4_OFFSET);
+    addr_hit[176] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_0_OFFSET);
+    addr_hit[177] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_1_OFFSET);
+    addr_hit[178] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_2_OFFSET);
+    addr_hit[179] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_3_OFFSET);
+    addr_hit[180] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CLASS_4_OFFSET);
+    addr_hit[181] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_0_OFFSET);
+    addr_hit[182] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_1_OFFSET);
+    addr_hit[183] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_2_OFFSET);
+    addr_hit[184] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_3_OFFSET);
+    addr_hit[185] = (reg_addr == ALERT_HANDLER_LOC_ALERT_CAUSE_4_OFFSET);
+    addr_hit[186] = (reg_addr == ALERT_HANDLER_CLASSA_REGWEN_OFFSET);
+    addr_hit[187] = (reg_addr == ALERT_HANDLER_CLASSA_CTRL_OFFSET);
+    addr_hit[188] = (reg_addr == ALERT_HANDLER_CLASSA_CLR_REGWEN_OFFSET);
+    addr_hit[189] = (reg_addr == ALERT_HANDLER_CLASSA_CLR_OFFSET);
+    addr_hit[190] = (reg_addr == ALERT_HANDLER_CLASSA_ACCUM_CNT_OFFSET);
+    addr_hit[191] = (reg_addr == ALERT_HANDLER_CLASSA_ACCUM_THRESH_OFFSET);
+    addr_hit[192] = (reg_addr == ALERT_HANDLER_CLASSA_TIMEOUT_CYC_OFFSET);
+    addr_hit[193] = (reg_addr == ALERT_HANDLER_CLASSA_PHASE0_CYC_OFFSET);
+    addr_hit[194] = (reg_addr == ALERT_HANDLER_CLASSA_PHASE1_CYC_OFFSET);
+    addr_hit[195] = (reg_addr == ALERT_HANDLER_CLASSA_PHASE2_CYC_OFFSET);
+    addr_hit[196] = (reg_addr == ALERT_HANDLER_CLASSA_PHASE3_CYC_OFFSET);
+    addr_hit[197] = (reg_addr == ALERT_HANDLER_CLASSA_ESC_CNT_OFFSET);
+    addr_hit[198] = (reg_addr == ALERT_HANDLER_CLASSA_STATE_OFFSET);
+    addr_hit[199] = (reg_addr == ALERT_HANDLER_CLASSB_REGWEN_OFFSET);
+    addr_hit[200] = (reg_addr == ALERT_HANDLER_CLASSB_CTRL_OFFSET);
+    addr_hit[201] = (reg_addr == ALERT_HANDLER_CLASSB_CLR_REGWEN_OFFSET);
+    addr_hit[202] = (reg_addr == ALERT_HANDLER_CLASSB_CLR_OFFSET);
+    addr_hit[203] = (reg_addr == ALERT_HANDLER_CLASSB_ACCUM_CNT_OFFSET);
+    addr_hit[204] = (reg_addr == ALERT_HANDLER_CLASSB_ACCUM_THRESH_OFFSET);
+    addr_hit[205] = (reg_addr == ALERT_HANDLER_CLASSB_TIMEOUT_CYC_OFFSET);
+    addr_hit[206] = (reg_addr == ALERT_HANDLER_CLASSB_PHASE0_CYC_OFFSET);
+    addr_hit[207] = (reg_addr == ALERT_HANDLER_CLASSB_PHASE1_CYC_OFFSET);
+    addr_hit[208] = (reg_addr == ALERT_HANDLER_CLASSB_PHASE2_CYC_OFFSET);
+    addr_hit[209] = (reg_addr == ALERT_HANDLER_CLASSB_PHASE3_CYC_OFFSET);
+    addr_hit[210] = (reg_addr == ALERT_HANDLER_CLASSB_ESC_CNT_OFFSET);
+    addr_hit[211] = (reg_addr == ALERT_HANDLER_CLASSB_STATE_OFFSET);
+    addr_hit[212] = (reg_addr == ALERT_HANDLER_CLASSC_REGWEN_OFFSET);
+    addr_hit[213] = (reg_addr == ALERT_HANDLER_CLASSC_CTRL_OFFSET);
+    addr_hit[214] = (reg_addr == ALERT_HANDLER_CLASSC_CLR_REGWEN_OFFSET);
+    addr_hit[215] = (reg_addr == ALERT_HANDLER_CLASSC_CLR_OFFSET);
+    addr_hit[216] = (reg_addr == ALERT_HANDLER_CLASSC_ACCUM_CNT_OFFSET);
+    addr_hit[217] = (reg_addr == ALERT_HANDLER_CLASSC_ACCUM_THRESH_OFFSET);
+    addr_hit[218] = (reg_addr == ALERT_HANDLER_CLASSC_TIMEOUT_CYC_OFFSET);
+    addr_hit[219] = (reg_addr == ALERT_HANDLER_CLASSC_PHASE0_CYC_OFFSET);
+    addr_hit[220] = (reg_addr == ALERT_HANDLER_CLASSC_PHASE1_CYC_OFFSET);
+    addr_hit[221] = (reg_addr == ALERT_HANDLER_CLASSC_PHASE2_CYC_OFFSET);
+    addr_hit[222] = (reg_addr == ALERT_HANDLER_CLASSC_PHASE3_CYC_OFFSET);
+    addr_hit[223] = (reg_addr == ALERT_HANDLER_CLASSC_ESC_CNT_OFFSET);
+    addr_hit[224] = (reg_addr == ALERT_HANDLER_CLASSC_STATE_OFFSET);
+    addr_hit[225] = (reg_addr == ALERT_HANDLER_CLASSD_REGWEN_OFFSET);
+    addr_hit[226] = (reg_addr == ALERT_HANDLER_CLASSD_CTRL_OFFSET);
+    addr_hit[227] = (reg_addr == ALERT_HANDLER_CLASSD_CLR_REGWEN_OFFSET);
+    addr_hit[228] = (reg_addr == ALERT_HANDLER_CLASSD_CLR_OFFSET);
+    addr_hit[229] = (reg_addr == ALERT_HANDLER_CLASSD_ACCUM_CNT_OFFSET);
+    addr_hit[230] = (reg_addr == ALERT_HANDLER_CLASSD_ACCUM_THRESH_OFFSET);
+    addr_hit[231] = (reg_addr == ALERT_HANDLER_CLASSD_TIMEOUT_CYC_OFFSET);
+    addr_hit[232] = (reg_addr == ALERT_HANDLER_CLASSD_PHASE0_CYC_OFFSET);
+    addr_hit[233] = (reg_addr == ALERT_HANDLER_CLASSD_PHASE1_CYC_OFFSET);
+    addr_hit[234] = (reg_addr == ALERT_HANDLER_CLASSD_PHASE2_CYC_OFFSET);
+    addr_hit[235] = (reg_addr == ALERT_HANDLER_CLASSD_PHASE3_CYC_OFFSET);
+    addr_hit[236] = (reg_addr == ALERT_HANDLER_CLASSD_ESC_CNT_OFFSET);
+    addr_hit[237] = (reg_addr == ALERT_HANDLER_CLASSD_STATE_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -9857,39 +8865,7 @@ module alert_handler_reg_top (
                (addr_hit[234] & (|(ALERT_HANDLER_PERMIT[234] & ~reg_be))) |
                (addr_hit[235] & (|(ALERT_HANDLER_PERMIT[235] & ~reg_be))) |
                (addr_hit[236] & (|(ALERT_HANDLER_PERMIT[236] & ~reg_be))) |
-               (addr_hit[237] & (|(ALERT_HANDLER_PERMIT[237] & ~reg_be))) |
-               (addr_hit[238] & (|(ALERT_HANDLER_PERMIT[238] & ~reg_be))) |
-               (addr_hit[239] & (|(ALERT_HANDLER_PERMIT[239] & ~reg_be))) |
-               (addr_hit[240] & (|(ALERT_HANDLER_PERMIT[240] & ~reg_be))) |
-               (addr_hit[241] & (|(ALERT_HANDLER_PERMIT[241] & ~reg_be))) |
-               (addr_hit[242] & (|(ALERT_HANDLER_PERMIT[242] & ~reg_be))) |
-               (addr_hit[243] & (|(ALERT_HANDLER_PERMIT[243] & ~reg_be))) |
-               (addr_hit[244] & (|(ALERT_HANDLER_PERMIT[244] & ~reg_be))) |
-               (addr_hit[245] & (|(ALERT_HANDLER_PERMIT[245] & ~reg_be))) |
-               (addr_hit[246] & (|(ALERT_HANDLER_PERMIT[246] & ~reg_be))) |
-               (addr_hit[247] & (|(ALERT_HANDLER_PERMIT[247] & ~reg_be))) |
-               (addr_hit[248] & (|(ALERT_HANDLER_PERMIT[248] & ~reg_be))) |
-               (addr_hit[249] & (|(ALERT_HANDLER_PERMIT[249] & ~reg_be))) |
-               (addr_hit[250] & (|(ALERT_HANDLER_PERMIT[250] & ~reg_be))) |
-               (addr_hit[251] & (|(ALERT_HANDLER_PERMIT[251] & ~reg_be))) |
-               (addr_hit[252] & (|(ALERT_HANDLER_PERMIT[252] & ~reg_be))) |
-               (addr_hit[253] & (|(ALERT_HANDLER_PERMIT[253] & ~reg_be))) |
-               (addr_hit[254] & (|(ALERT_HANDLER_PERMIT[254] & ~reg_be))) |
-               (addr_hit[255] & (|(ALERT_HANDLER_PERMIT[255] & ~reg_be))) |
-               (addr_hit[256] & (|(ALERT_HANDLER_PERMIT[256] & ~reg_be))) |
-               (addr_hit[257] & (|(ALERT_HANDLER_PERMIT[257] & ~reg_be))) |
-               (addr_hit[258] & (|(ALERT_HANDLER_PERMIT[258] & ~reg_be))) |
-               (addr_hit[259] & (|(ALERT_HANDLER_PERMIT[259] & ~reg_be))) |
-               (addr_hit[260] & (|(ALERT_HANDLER_PERMIT[260] & ~reg_be))) |
-               (addr_hit[261] & (|(ALERT_HANDLER_PERMIT[261] & ~reg_be))) |
-               (addr_hit[262] & (|(ALERT_HANDLER_PERMIT[262] & ~reg_be))) |
-               (addr_hit[263] & (|(ALERT_HANDLER_PERMIT[263] & ~reg_be))) |
-               (addr_hit[264] & (|(ALERT_HANDLER_PERMIT[264] & ~reg_be))) |
-               (addr_hit[265] & (|(ALERT_HANDLER_PERMIT[265] & ~reg_be))) |
-               (addr_hit[266] & (|(ALERT_HANDLER_PERMIT[266] & ~reg_be))) |
-               (addr_hit[267] & (|(ALERT_HANDLER_PERMIT[267] & ~reg_be))) |
-               (addr_hit[268] & (|(ALERT_HANDLER_PERMIT[268] & ~reg_be))) |
-               (addr_hit[269] & (|(ALERT_HANDLER_PERMIT[269] & ~reg_be)))));
+               (addr_hit[237] & (|(ALERT_HANDLER_PERMIT[237] & ~reg_be)))));
   end
 
   assign intr_state_classa_we = addr_hit[0] & reg_we & !reg_error;
@@ -10432,398 +9408,302 @@ module alert_handler_reg_top (
   assign loc_alert_regwen_4_we = addr_hit[170] & reg_we & !reg_error;
   assign loc_alert_regwen_4_wd = reg_wdata[0];
 
-  assign loc_alert_regwen_5_we = addr_hit[171] & reg_we & !reg_error;
-  assign loc_alert_regwen_5_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_6_we = addr_hit[172] & reg_we & !reg_error;
-  assign loc_alert_regwen_6_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_7_we = addr_hit[173] & reg_we & !reg_error;
-  assign loc_alert_regwen_7_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_8_we = addr_hit[174] & reg_we & !reg_error;
-  assign loc_alert_regwen_8_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_9_we = addr_hit[175] & reg_we & !reg_error;
-  assign loc_alert_regwen_9_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_10_we = addr_hit[176] & reg_we & !reg_error;
-  assign loc_alert_regwen_10_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_11_we = addr_hit[177] & reg_we & !reg_error;
-  assign loc_alert_regwen_11_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_12_we = addr_hit[178] & reg_we & !reg_error;
-  assign loc_alert_regwen_12_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_13_we = addr_hit[179] & reg_we & !reg_error;
-  assign loc_alert_regwen_13_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_14_we = addr_hit[180] & reg_we & !reg_error;
-  assign loc_alert_regwen_14_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_15_we = addr_hit[181] & reg_we & !reg_error;
-  assign loc_alert_regwen_15_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_16_we = addr_hit[182] & reg_we & !reg_error;
-  assign loc_alert_regwen_16_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_17_we = addr_hit[183] & reg_we & !reg_error;
-  assign loc_alert_regwen_17_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_18_we = addr_hit[184] & reg_we & !reg_error;
-  assign loc_alert_regwen_18_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_19_we = addr_hit[185] & reg_we & !reg_error;
-  assign loc_alert_regwen_19_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_20_we = addr_hit[186] & reg_we & !reg_error;
-  assign loc_alert_regwen_20_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_21_we = addr_hit[187] & reg_we & !reg_error;
-  assign loc_alert_regwen_21_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_22_we = addr_hit[188] & reg_we & !reg_error;
-  assign loc_alert_regwen_22_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_23_we = addr_hit[189] & reg_we & !reg_error;
-  assign loc_alert_regwen_23_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_24_we = addr_hit[190] & reg_we & !reg_error;
-  assign loc_alert_regwen_24_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_25_we = addr_hit[191] & reg_we & !reg_error;
-  assign loc_alert_regwen_25_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_26_we = addr_hit[192] & reg_we & !reg_error;
-  assign loc_alert_regwen_26_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_27_we = addr_hit[193] & reg_we & !reg_error;
-  assign loc_alert_regwen_27_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_28_we = addr_hit[194] & reg_we & !reg_error;
-  assign loc_alert_regwen_28_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_29_we = addr_hit[195] & reg_we & !reg_error;
-  assign loc_alert_regwen_29_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_30_we = addr_hit[196] & reg_we & !reg_error;
-  assign loc_alert_regwen_30_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_31_we = addr_hit[197] & reg_we & !reg_error;
-  assign loc_alert_regwen_31_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_32_we = addr_hit[198] & reg_we & !reg_error;
-  assign loc_alert_regwen_32_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_33_we = addr_hit[199] & reg_we & !reg_error;
-  assign loc_alert_regwen_33_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_34_we = addr_hit[200] & reg_we & !reg_error;
-  assign loc_alert_regwen_34_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_35_we = addr_hit[201] & reg_we & !reg_error;
-  assign loc_alert_regwen_35_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_36_we = addr_hit[202] & reg_we & !reg_error;
-  assign loc_alert_regwen_36_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_37_we = addr_hit[203] & reg_we & !reg_error;
-  assign loc_alert_regwen_37_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_38_we = addr_hit[204] & reg_we & !reg_error;
-  assign loc_alert_regwen_38_wd = reg_wdata[0];
-
-  assign loc_alert_regwen_39_we = addr_hit[205] & reg_we & !reg_error;
-  assign loc_alert_regwen_39_wd = reg_wdata[0];
-
-  assign loc_alert_en_0_we = addr_hit[206] & reg_we & !reg_error;
+  assign loc_alert_en_0_we = addr_hit[171] & reg_we & !reg_error;
   assign loc_alert_en_0_wd = reg_wdata[0];
 
-  assign loc_alert_en_1_we = addr_hit[207] & reg_we & !reg_error;
+  assign loc_alert_en_1_we = addr_hit[172] & reg_we & !reg_error;
   assign loc_alert_en_1_wd = reg_wdata[0];
 
-  assign loc_alert_en_2_we = addr_hit[208] & reg_we & !reg_error;
+  assign loc_alert_en_2_we = addr_hit[173] & reg_we & !reg_error;
   assign loc_alert_en_2_wd = reg_wdata[0];
 
-  assign loc_alert_en_3_we = addr_hit[209] & reg_we & !reg_error;
+  assign loc_alert_en_3_we = addr_hit[174] & reg_we & !reg_error;
   assign loc_alert_en_3_wd = reg_wdata[0];
 
-  assign loc_alert_class_0_we = addr_hit[210] & reg_we & !reg_error;
+  assign loc_alert_en_4_we = addr_hit[175] & reg_we & !reg_error;
+  assign loc_alert_en_4_wd = reg_wdata[0];
+
+  assign loc_alert_class_0_we = addr_hit[176] & reg_we & !reg_error;
   assign loc_alert_class_0_wd = reg_wdata[1:0];
 
-  assign loc_alert_class_1_we = addr_hit[211] & reg_we & !reg_error;
+  assign loc_alert_class_1_we = addr_hit[177] & reg_we & !reg_error;
   assign loc_alert_class_1_wd = reg_wdata[1:0];
 
-  assign loc_alert_class_2_we = addr_hit[212] & reg_we & !reg_error;
+  assign loc_alert_class_2_we = addr_hit[178] & reg_we & !reg_error;
   assign loc_alert_class_2_wd = reg_wdata[1:0];
 
-  assign loc_alert_class_3_we = addr_hit[213] & reg_we & !reg_error;
+  assign loc_alert_class_3_we = addr_hit[179] & reg_we & !reg_error;
   assign loc_alert_class_3_wd = reg_wdata[1:0];
 
-  assign loc_alert_cause_0_we = addr_hit[214] & reg_we & !reg_error;
+  assign loc_alert_class_4_we = addr_hit[180] & reg_we & !reg_error;
+  assign loc_alert_class_4_wd = reg_wdata[1:0];
+
+  assign loc_alert_cause_0_we = addr_hit[181] & reg_we & !reg_error;
   assign loc_alert_cause_0_wd = reg_wdata[0];
 
-  assign loc_alert_cause_1_we = addr_hit[215] & reg_we & !reg_error;
+  assign loc_alert_cause_1_we = addr_hit[182] & reg_we & !reg_error;
   assign loc_alert_cause_1_wd = reg_wdata[0];
 
-  assign loc_alert_cause_2_we = addr_hit[216] & reg_we & !reg_error;
+  assign loc_alert_cause_2_we = addr_hit[183] & reg_we & !reg_error;
   assign loc_alert_cause_2_wd = reg_wdata[0];
 
-  assign loc_alert_cause_3_we = addr_hit[217] & reg_we & !reg_error;
+  assign loc_alert_cause_3_we = addr_hit[184] & reg_we & !reg_error;
   assign loc_alert_cause_3_wd = reg_wdata[0];
 
-  assign classa_regwen_we = addr_hit[218] & reg_we & !reg_error;
+  assign loc_alert_cause_4_we = addr_hit[185] & reg_we & !reg_error;
+  assign loc_alert_cause_4_wd = reg_wdata[0];
+
+  assign classa_regwen_we = addr_hit[186] & reg_we & !reg_error;
   assign classa_regwen_wd = reg_wdata[0];
 
-  assign classa_ctrl_en_we = addr_hit[219] & reg_we & !reg_error;
+  assign classa_ctrl_en_we = addr_hit[187] & reg_we & !reg_error;
   assign classa_ctrl_en_wd = reg_wdata[0];
 
-  assign classa_ctrl_lock_we = addr_hit[219] & reg_we & !reg_error;
+  assign classa_ctrl_lock_we = addr_hit[187] & reg_we & !reg_error;
   assign classa_ctrl_lock_wd = reg_wdata[1];
 
-  assign classa_ctrl_en_e0_we = addr_hit[219] & reg_we & !reg_error;
+  assign classa_ctrl_en_e0_we = addr_hit[187] & reg_we & !reg_error;
   assign classa_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classa_ctrl_en_e1_we = addr_hit[219] & reg_we & !reg_error;
+  assign classa_ctrl_en_e1_we = addr_hit[187] & reg_we & !reg_error;
   assign classa_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classa_ctrl_en_e2_we = addr_hit[219] & reg_we & !reg_error;
+  assign classa_ctrl_en_e2_we = addr_hit[187] & reg_we & !reg_error;
   assign classa_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classa_ctrl_en_e3_we = addr_hit[219] & reg_we & !reg_error;
+  assign classa_ctrl_en_e3_we = addr_hit[187] & reg_we & !reg_error;
   assign classa_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classa_ctrl_map_e0_we = addr_hit[219] & reg_we & !reg_error;
+  assign classa_ctrl_map_e0_we = addr_hit[187] & reg_we & !reg_error;
   assign classa_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classa_ctrl_map_e1_we = addr_hit[219] & reg_we & !reg_error;
+  assign classa_ctrl_map_e1_we = addr_hit[187] & reg_we & !reg_error;
   assign classa_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classa_ctrl_map_e2_we = addr_hit[219] & reg_we & !reg_error;
+  assign classa_ctrl_map_e2_we = addr_hit[187] & reg_we & !reg_error;
   assign classa_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classa_ctrl_map_e3_we = addr_hit[219] & reg_we & !reg_error;
+  assign classa_ctrl_map_e3_we = addr_hit[187] & reg_we & !reg_error;
   assign classa_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classa_clr_regwen_we = addr_hit[220] & reg_we & !reg_error;
+  assign classa_clr_regwen_we = addr_hit[188] & reg_we & !reg_error;
   assign classa_clr_regwen_wd = reg_wdata[0];
 
-  assign classa_clr_we = addr_hit[221] & reg_we & !reg_error;
+  assign classa_clr_we = addr_hit[189] & reg_we & !reg_error;
   assign classa_clr_wd = reg_wdata[0];
 
-  assign classa_accum_cnt_re = addr_hit[222] & reg_re & !reg_error;
+  assign classa_accum_cnt_re = addr_hit[190] & reg_re & !reg_error;
 
-  assign classa_accum_thresh_we = addr_hit[223] & reg_we & !reg_error;
+  assign classa_accum_thresh_we = addr_hit[191] & reg_we & !reg_error;
   assign classa_accum_thresh_wd = reg_wdata[15:0];
 
-  assign classa_timeout_cyc_we = addr_hit[224] & reg_we & !reg_error;
+  assign classa_timeout_cyc_we = addr_hit[192] & reg_we & !reg_error;
   assign classa_timeout_cyc_wd = reg_wdata[31:0];
 
-  assign classa_phase0_cyc_we = addr_hit[225] & reg_we & !reg_error;
+  assign classa_phase0_cyc_we = addr_hit[193] & reg_we & !reg_error;
   assign classa_phase0_cyc_wd = reg_wdata[31:0];
 
-  assign classa_phase1_cyc_we = addr_hit[226] & reg_we & !reg_error;
+  assign classa_phase1_cyc_we = addr_hit[194] & reg_we & !reg_error;
   assign classa_phase1_cyc_wd = reg_wdata[31:0];
 
-  assign classa_phase2_cyc_we = addr_hit[227] & reg_we & !reg_error;
+  assign classa_phase2_cyc_we = addr_hit[195] & reg_we & !reg_error;
   assign classa_phase2_cyc_wd = reg_wdata[31:0];
 
-  assign classa_phase3_cyc_we = addr_hit[228] & reg_we & !reg_error;
+  assign classa_phase3_cyc_we = addr_hit[196] & reg_we & !reg_error;
   assign classa_phase3_cyc_wd = reg_wdata[31:0];
 
-  assign classa_esc_cnt_re = addr_hit[229] & reg_re & !reg_error;
+  assign classa_esc_cnt_re = addr_hit[197] & reg_re & !reg_error;
 
-  assign classa_state_re = addr_hit[230] & reg_re & !reg_error;
+  assign classa_state_re = addr_hit[198] & reg_re & !reg_error;
 
-  assign classb_regwen_we = addr_hit[231] & reg_we & !reg_error;
+  assign classb_regwen_we = addr_hit[199] & reg_we & !reg_error;
   assign classb_regwen_wd = reg_wdata[0];
 
-  assign classb_ctrl_en_we = addr_hit[232] & reg_we & !reg_error;
+  assign classb_ctrl_en_we = addr_hit[200] & reg_we & !reg_error;
   assign classb_ctrl_en_wd = reg_wdata[0];
 
-  assign classb_ctrl_lock_we = addr_hit[232] & reg_we & !reg_error;
+  assign classb_ctrl_lock_we = addr_hit[200] & reg_we & !reg_error;
   assign classb_ctrl_lock_wd = reg_wdata[1];
 
-  assign classb_ctrl_en_e0_we = addr_hit[232] & reg_we & !reg_error;
+  assign classb_ctrl_en_e0_we = addr_hit[200] & reg_we & !reg_error;
   assign classb_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classb_ctrl_en_e1_we = addr_hit[232] & reg_we & !reg_error;
+  assign classb_ctrl_en_e1_we = addr_hit[200] & reg_we & !reg_error;
   assign classb_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classb_ctrl_en_e2_we = addr_hit[232] & reg_we & !reg_error;
+  assign classb_ctrl_en_e2_we = addr_hit[200] & reg_we & !reg_error;
   assign classb_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classb_ctrl_en_e3_we = addr_hit[232] & reg_we & !reg_error;
+  assign classb_ctrl_en_e3_we = addr_hit[200] & reg_we & !reg_error;
   assign classb_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classb_ctrl_map_e0_we = addr_hit[232] & reg_we & !reg_error;
+  assign classb_ctrl_map_e0_we = addr_hit[200] & reg_we & !reg_error;
   assign classb_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classb_ctrl_map_e1_we = addr_hit[232] & reg_we & !reg_error;
+  assign classb_ctrl_map_e1_we = addr_hit[200] & reg_we & !reg_error;
   assign classb_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classb_ctrl_map_e2_we = addr_hit[232] & reg_we & !reg_error;
+  assign classb_ctrl_map_e2_we = addr_hit[200] & reg_we & !reg_error;
   assign classb_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classb_ctrl_map_e3_we = addr_hit[232] & reg_we & !reg_error;
+  assign classb_ctrl_map_e3_we = addr_hit[200] & reg_we & !reg_error;
   assign classb_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classb_clr_regwen_we = addr_hit[233] & reg_we & !reg_error;
+  assign classb_clr_regwen_we = addr_hit[201] & reg_we & !reg_error;
   assign classb_clr_regwen_wd = reg_wdata[0];
 
-  assign classb_clr_we = addr_hit[234] & reg_we & !reg_error;
+  assign classb_clr_we = addr_hit[202] & reg_we & !reg_error;
   assign classb_clr_wd = reg_wdata[0];
 
-  assign classb_accum_cnt_re = addr_hit[235] & reg_re & !reg_error;
+  assign classb_accum_cnt_re = addr_hit[203] & reg_re & !reg_error;
 
-  assign classb_accum_thresh_we = addr_hit[236] & reg_we & !reg_error;
+  assign classb_accum_thresh_we = addr_hit[204] & reg_we & !reg_error;
   assign classb_accum_thresh_wd = reg_wdata[15:0];
 
-  assign classb_timeout_cyc_we = addr_hit[237] & reg_we & !reg_error;
+  assign classb_timeout_cyc_we = addr_hit[205] & reg_we & !reg_error;
   assign classb_timeout_cyc_wd = reg_wdata[31:0];
 
-  assign classb_phase0_cyc_we = addr_hit[238] & reg_we & !reg_error;
+  assign classb_phase0_cyc_we = addr_hit[206] & reg_we & !reg_error;
   assign classb_phase0_cyc_wd = reg_wdata[31:0];
 
-  assign classb_phase1_cyc_we = addr_hit[239] & reg_we & !reg_error;
+  assign classb_phase1_cyc_we = addr_hit[207] & reg_we & !reg_error;
   assign classb_phase1_cyc_wd = reg_wdata[31:0];
 
-  assign classb_phase2_cyc_we = addr_hit[240] & reg_we & !reg_error;
+  assign classb_phase2_cyc_we = addr_hit[208] & reg_we & !reg_error;
   assign classb_phase2_cyc_wd = reg_wdata[31:0];
 
-  assign classb_phase3_cyc_we = addr_hit[241] & reg_we & !reg_error;
+  assign classb_phase3_cyc_we = addr_hit[209] & reg_we & !reg_error;
   assign classb_phase3_cyc_wd = reg_wdata[31:0];
 
-  assign classb_esc_cnt_re = addr_hit[242] & reg_re & !reg_error;
+  assign classb_esc_cnt_re = addr_hit[210] & reg_re & !reg_error;
 
-  assign classb_state_re = addr_hit[243] & reg_re & !reg_error;
+  assign classb_state_re = addr_hit[211] & reg_re & !reg_error;
 
-  assign classc_regwen_we = addr_hit[244] & reg_we & !reg_error;
+  assign classc_regwen_we = addr_hit[212] & reg_we & !reg_error;
   assign classc_regwen_wd = reg_wdata[0];
 
-  assign classc_ctrl_en_we = addr_hit[245] & reg_we & !reg_error;
+  assign classc_ctrl_en_we = addr_hit[213] & reg_we & !reg_error;
   assign classc_ctrl_en_wd = reg_wdata[0];
 
-  assign classc_ctrl_lock_we = addr_hit[245] & reg_we & !reg_error;
+  assign classc_ctrl_lock_we = addr_hit[213] & reg_we & !reg_error;
   assign classc_ctrl_lock_wd = reg_wdata[1];
 
-  assign classc_ctrl_en_e0_we = addr_hit[245] & reg_we & !reg_error;
+  assign classc_ctrl_en_e0_we = addr_hit[213] & reg_we & !reg_error;
   assign classc_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classc_ctrl_en_e1_we = addr_hit[245] & reg_we & !reg_error;
+  assign classc_ctrl_en_e1_we = addr_hit[213] & reg_we & !reg_error;
   assign classc_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classc_ctrl_en_e2_we = addr_hit[245] & reg_we & !reg_error;
+  assign classc_ctrl_en_e2_we = addr_hit[213] & reg_we & !reg_error;
   assign classc_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classc_ctrl_en_e3_we = addr_hit[245] & reg_we & !reg_error;
+  assign classc_ctrl_en_e3_we = addr_hit[213] & reg_we & !reg_error;
   assign classc_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classc_ctrl_map_e0_we = addr_hit[245] & reg_we & !reg_error;
+  assign classc_ctrl_map_e0_we = addr_hit[213] & reg_we & !reg_error;
   assign classc_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classc_ctrl_map_e1_we = addr_hit[245] & reg_we & !reg_error;
+  assign classc_ctrl_map_e1_we = addr_hit[213] & reg_we & !reg_error;
   assign classc_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classc_ctrl_map_e2_we = addr_hit[245] & reg_we & !reg_error;
+  assign classc_ctrl_map_e2_we = addr_hit[213] & reg_we & !reg_error;
   assign classc_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classc_ctrl_map_e3_we = addr_hit[245] & reg_we & !reg_error;
+  assign classc_ctrl_map_e3_we = addr_hit[213] & reg_we & !reg_error;
   assign classc_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classc_clr_regwen_we = addr_hit[246] & reg_we & !reg_error;
+  assign classc_clr_regwen_we = addr_hit[214] & reg_we & !reg_error;
   assign classc_clr_regwen_wd = reg_wdata[0];
 
-  assign classc_clr_we = addr_hit[247] & reg_we & !reg_error;
+  assign classc_clr_we = addr_hit[215] & reg_we & !reg_error;
   assign classc_clr_wd = reg_wdata[0];
 
-  assign classc_accum_cnt_re = addr_hit[248] & reg_re & !reg_error;
+  assign classc_accum_cnt_re = addr_hit[216] & reg_re & !reg_error;
 
-  assign classc_accum_thresh_we = addr_hit[249] & reg_we & !reg_error;
+  assign classc_accum_thresh_we = addr_hit[217] & reg_we & !reg_error;
   assign classc_accum_thresh_wd = reg_wdata[15:0];
 
-  assign classc_timeout_cyc_we = addr_hit[250] & reg_we & !reg_error;
+  assign classc_timeout_cyc_we = addr_hit[218] & reg_we & !reg_error;
   assign classc_timeout_cyc_wd = reg_wdata[31:0];
 
-  assign classc_phase0_cyc_we = addr_hit[251] & reg_we & !reg_error;
+  assign classc_phase0_cyc_we = addr_hit[219] & reg_we & !reg_error;
   assign classc_phase0_cyc_wd = reg_wdata[31:0];
 
-  assign classc_phase1_cyc_we = addr_hit[252] & reg_we & !reg_error;
+  assign classc_phase1_cyc_we = addr_hit[220] & reg_we & !reg_error;
   assign classc_phase1_cyc_wd = reg_wdata[31:0];
 
-  assign classc_phase2_cyc_we = addr_hit[253] & reg_we & !reg_error;
+  assign classc_phase2_cyc_we = addr_hit[221] & reg_we & !reg_error;
   assign classc_phase2_cyc_wd = reg_wdata[31:0];
 
-  assign classc_phase3_cyc_we = addr_hit[254] & reg_we & !reg_error;
+  assign classc_phase3_cyc_we = addr_hit[222] & reg_we & !reg_error;
   assign classc_phase3_cyc_wd = reg_wdata[31:0];
 
-  assign classc_esc_cnt_re = addr_hit[255] & reg_re & !reg_error;
+  assign classc_esc_cnt_re = addr_hit[223] & reg_re & !reg_error;
 
-  assign classc_state_re = addr_hit[256] & reg_re & !reg_error;
+  assign classc_state_re = addr_hit[224] & reg_re & !reg_error;
 
-  assign classd_regwen_we = addr_hit[257] & reg_we & !reg_error;
+  assign classd_regwen_we = addr_hit[225] & reg_we & !reg_error;
   assign classd_regwen_wd = reg_wdata[0];
 
-  assign classd_ctrl_en_we = addr_hit[258] & reg_we & !reg_error;
+  assign classd_ctrl_en_we = addr_hit[226] & reg_we & !reg_error;
   assign classd_ctrl_en_wd = reg_wdata[0];
 
-  assign classd_ctrl_lock_we = addr_hit[258] & reg_we & !reg_error;
+  assign classd_ctrl_lock_we = addr_hit[226] & reg_we & !reg_error;
   assign classd_ctrl_lock_wd = reg_wdata[1];
 
-  assign classd_ctrl_en_e0_we = addr_hit[258] & reg_we & !reg_error;
+  assign classd_ctrl_en_e0_we = addr_hit[226] & reg_we & !reg_error;
   assign classd_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classd_ctrl_en_e1_we = addr_hit[258] & reg_we & !reg_error;
+  assign classd_ctrl_en_e1_we = addr_hit[226] & reg_we & !reg_error;
   assign classd_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classd_ctrl_en_e2_we = addr_hit[258] & reg_we & !reg_error;
+  assign classd_ctrl_en_e2_we = addr_hit[226] & reg_we & !reg_error;
   assign classd_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classd_ctrl_en_e3_we = addr_hit[258] & reg_we & !reg_error;
+  assign classd_ctrl_en_e3_we = addr_hit[226] & reg_we & !reg_error;
   assign classd_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classd_ctrl_map_e0_we = addr_hit[258] & reg_we & !reg_error;
+  assign classd_ctrl_map_e0_we = addr_hit[226] & reg_we & !reg_error;
   assign classd_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classd_ctrl_map_e1_we = addr_hit[258] & reg_we & !reg_error;
+  assign classd_ctrl_map_e1_we = addr_hit[226] & reg_we & !reg_error;
   assign classd_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classd_ctrl_map_e2_we = addr_hit[258] & reg_we & !reg_error;
+  assign classd_ctrl_map_e2_we = addr_hit[226] & reg_we & !reg_error;
   assign classd_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classd_ctrl_map_e3_we = addr_hit[258] & reg_we & !reg_error;
+  assign classd_ctrl_map_e3_we = addr_hit[226] & reg_we & !reg_error;
   assign classd_ctrl_map_e3_wd = reg_wdata[13:12];
 
-  assign classd_clr_regwen_we = addr_hit[259] & reg_we & !reg_error;
+  assign classd_clr_regwen_we = addr_hit[227] & reg_we & !reg_error;
   assign classd_clr_regwen_wd = reg_wdata[0];
 
-  assign classd_clr_we = addr_hit[260] & reg_we & !reg_error;
+  assign classd_clr_we = addr_hit[228] & reg_we & !reg_error;
   assign classd_clr_wd = reg_wdata[0];
 
-  assign classd_accum_cnt_re = addr_hit[261] & reg_re & !reg_error;
+  assign classd_accum_cnt_re = addr_hit[229] & reg_re & !reg_error;
 
-  assign classd_accum_thresh_we = addr_hit[262] & reg_we & !reg_error;
+  assign classd_accum_thresh_we = addr_hit[230] & reg_we & !reg_error;
   assign classd_accum_thresh_wd = reg_wdata[15:0];
 
-  assign classd_timeout_cyc_we = addr_hit[263] & reg_we & !reg_error;
+  assign classd_timeout_cyc_we = addr_hit[231] & reg_we & !reg_error;
   assign classd_timeout_cyc_wd = reg_wdata[31:0];
 
-  assign classd_phase0_cyc_we = addr_hit[264] & reg_we & !reg_error;
+  assign classd_phase0_cyc_we = addr_hit[232] & reg_we & !reg_error;
   assign classd_phase0_cyc_wd = reg_wdata[31:0];
 
-  assign classd_phase1_cyc_we = addr_hit[265] & reg_we & !reg_error;
+  assign classd_phase1_cyc_we = addr_hit[233] & reg_we & !reg_error;
   assign classd_phase1_cyc_wd = reg_wdata[31:0];
 
-  assign classd_phase2_cyc_we = addr_hit[266] & reg_we & !reg_error;
+  assign classd_phase2_cyc_we = addr_hit[234] & reg_we & !reg_error;
   assign classd_phase2_cyc_wd = reg_wdata[31:0];
 
-  assign classd_phase3_cyc_we = addr_hit[267] & reg_we & !reg_error;
+  assign classd_phase3_cyc_we = addr_hit[235] & reg_we & !reg_error;
   assign classd_phase3_cyc_wd = reg_wdata[31:0];
 
-  assign classd_esc_cnt_re = addr_hit[268] & reg_re & !reg_error;
+  assign classd_esc_cnt_re = addr_hit[236] & reg_re & !reg_error;
 
-  assign classd_state_re = addr_hit[269] & reg_re & !reg_error;
+  assign classd_state_re = addr_hit[237] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin
@@ -11523,198 +10403,70 @@ module alert_handler_reg_top (
       end
 
       addr_hit[171]: begin
-        reg_rdata_next[0] = loc_alert_regwen_5_qs;
-      end
-
-      addr_hit[172]: begin
-        reg_rdata_next[0] = loc_alert_regwen_6_qs;
-      end
-
-      addr_hit[173]: begin
-        reg_rdata_next[0] = loc_alert_regwen_7_qs;
-      end
-
-      addr_hit[174]: begin
-        reg_rdata_next[0] = loc_alert_regwen_8_qs;
-      end
-
-      addr_hit[175]: begin
-        reg_rdata_next[0] = loc_alert_regwen_9_qs;
-      end
-
-      addr_hit[176]: begin
-        reg_rdata_next[0] = loc_alert_regwen_10_qs;
-      end
-
-      addr_hit[177]: begin
-        reg_rdata_next[0] = loc_alert_regwen_11_qs;
-      end
-
-      addr_hit[178]: begin
-        reg_rdata_next[0] = loc_alert_regwen_12_qs;
-      end
-
-      addr_hit[179]: begin
-        reg_rdata_next[0] = loc_alert_regwen_13_qs;
-      end
-
-      addr_hit[180]: begin
-        reg_rdata_next[0] = loc_alert_regwen_14_qs;
-      end
-
-      addr_hit[181]: begin
-        reg_rdata_next[0] = loc_alert_regwen_15_qs;
-      end
-
-      addr_hit[182]: begin
-        reg_rdata_next[0] = loc_alert_regwen_16_qs;
-      end
-
-      addr_hit[183]: begin
-        reg_rdata_next[0] = loc_alert_regwen_17_qs;
-      end
-
-      addr_hit[184]: begin
-        reg_rdata_next[0] = loc_alert_regwen_18_qs;
-      end
-
-      addr_hit[185]: begin
-        reg_rdata_next[0] = loc_alert_regwen_19_qs;
-      end
-
-      addr_hit[186]: begin
-        reg_rdata_next[0] = loc_alert_regwen_20_qs;
-      end
-
-      addr_hit[187]: begin
-        reg_rdata_next[0] = loc_alert_regwen_21_qs;
-      end
-
-      addr_hit[188]: begin
-        reg_rdata_next[0] = loc_alert_regwen_22_qs;
-      end
-
-      addr_hit[189]: begin
-        reg_rdata_next[0] = loc_alert_regwen_23_qs;
-      end
-
-      addr_hit[190]: begin
-        reg_rdata_next[0] = loc_alert_regwen_24_qs;
-      end
-
-      addr_hit[191]: begin
-        reg_rdata_next[0] = loc_alert_regwen_25_qs;
-      end
-
-      addr_hit[192]: begin
-        reg_rdata_next[0] = loc_alert_regwen_26_qs;
-      end
-
-      addr_hit[193]: begin
-        reg_rdata_next[0] = loc_alert_regwen_27_qs;
-      end
-
-      addr_hit[194]: begin
-        reg_rdata_next[0] = loc_alert_regwen_28_qs;
-      end
-
-      addr_hit[195]: begin
-        reg_rdata_next[0] = loc_alert_regwen_29_qs;
-      end
-
-      addr_hit[196]: begin
-        reg_rdata_next[0] = loc_alert_regwen_30_qs;
-      end
-
-      addr_hit[197]: begin
-        reg_rdata_next[0] = loc_alert_regwen_31_qs;
-      end
-
-      addr_hit[198]: begin
-        reg_rdata_next[0] = loc_alert_regwen_32_qs;
-      end
-
-      addr_hit[199]: begin
-        reg_rdata_next[0] = loc_alert_regwen_33_qs;
-      end
-
-      addr_hit[200]: begin
-        reg_rdata_next[0] = loc_alert_regwen_34_qs;
-      end
-
-      addr_hit[201]: begin
-        reg_rdata_next[0] = loc_alert_regwen_35_qs;
-      end
-
-      addr_hit[202]: begin
-        reg_rdata_next[0] = loc_alert_regwen_36_qs;
-      end
-
-      addr_hit[203]: begin
-        reg_rdata_next[0] = loc_alert_regwen_37_qs;
-      end
-
-      addr_hit[204]: begin
-        reg_rdata_next[0] = loc_alert_regwen_38_qs;
-      end
-
-      addr_hit[205]: begin
-        reg_rdata_next[0] = loc_alert_regwen_39_qs;
-      end
-
-      addr_hit[206]: begin
         reg_rdata_next[0] = loc_alert_en_0_qs;
       end
 
-      addr_hit[207]: begin
+      addr_hit[172]: begin
         reg_rdata_next[0] = loc_alert_en_1_qs;
       end
 
-      addr_hit[208]: begin
+      addr_hit[173]: begin
         reg_rdata_next[0] = loc_alert_en_2_qs;
       end
 
-      addr_hit[209]: begin
+      addr_hit[174]: begin
         reg_rdata_next[0] = loc_alert_en_3_qs;
       end
 
-      addr_hit[210]: begin
+      addr_hit[175]: begin
+        reg_rdata_next[0] = loc_alert_en_4_qs;
+      end
+
+      addr_hit[176]: begin
         reg_rdata_next[1:0] = loc_alert_class_0_qs;
       end
 
-      addr_hit[211]: begin
+      addr_hit[177]: begin
         reg_rdata_next[1:0] = loc_alert_class_1_qs;
       end
 
-      addr_hit[212]: begin
+      addr_hit[178]: begin
         reg_rdata_next[1:0] = loc_alert_class_2_qs;
       end
 
-      addr_hit[213]: begin
+      addr_hit[179]: begin
         reg_rdata_next[1:0] = loc_alert_class_3_qs;
       end
 
-      addr_hit[214]: begin
+      addr_hit[180]: begin
+        reg_rdata_next[1:0] = loc_alert_class_4_qs;
+      end
+
+      addr_hit[181]: begin
         reg_rdata_next[0] = loc_alert_cause_0_qs;
       end
 
-      addr_hit[215]: begin
+      addr_hit[182]: begin
         reg_rdata_next[0] = loc_alert_cause_1_qs;
       end
 
-      addr_hit[216]: begin
+      addr_hit[183]: begin
         reg_rdata_next[0] = loc_alert_cause_2_qs;
       end
 
-      addr_hit[217]: begin
+      addr_hit[184]: begin
         reg_rdata_next[0] = loc_alert_cause_3_qs;
       end
 
-      addr_hit[218]: begin
+      addr_hit[185]: begin
+        reg_rdata_next[0] = loc_alert_cause_4_qs;
+      end
+
+      addr_hit[186]: begin
         reg_rdata_next[0] = classa_regwen_qs;
       end
 
-      addr_hit[219]: begin
+      addr_hit[187]: begin
         reg_rdata_next[0] = classa_ctrl_en_qs;
         reg_rdata_next[1] = classa_ctrl_lock_qs;
         reg_rdata_next[2] = classa_ctrl_en_e0_qs;
@@ -11727,55 +10479,55 @@ module alert_handler_reg_top (
         reg_rdata_next[13:12] = classa_ctrl_map_e3_qs;
       end
 
-      addr_hit[220]: begin
+      addr_hit[188]: begin
         reg_rdata_next[0] = classa_clr_regwen_qs;
       end
 
-      addr_hit[221]: begin
+      addr_hit[189]: begin
         reg_rdata_next[0] = '0;
       end
 
-      addr_hit[222]: begin
+      addr_hit[190]: begin
         reg_rdata_next[15:0] = classa_accum_cnt_qs;
       end
 
-      addr_hit[223]: begin
+      addr_hit[191]: begin
         reg_rdata_next[15:0] = classa_accum_thresh_qs;
       end
 
-      addr_hit[224]: begin
+      addr_hit[192]: begin
         reg_rdata_next[31:0] = classa_timeout_cyc_qs;
       end
 
-      addr_hit[225]: begin
+      addr_hit[193]: begin
         reg_rdata_next[31:0] = classa_phase0_cyc_qs;
       end
 
-      addr_hit[226]: begin
+      addr_hit[194]: begin
         reg_rdata_next[31:0] = classa_phase1_cyc_qs;
       end
 
-      addr_hit[227]: begin
+      addr_hit[195]: begin
         reg_rdata_next[31:0] = classa_phase2_cyc_qs;
       end
 
-      addr_hit[228]: begin
+      addr_hit[196]: begin
         reg_rdata_next[31:0] = classa_phase3_cyc_qs;
       end
 
-      addr_hit[229]: begin
+      addr_hit[197]: begin
         reg_rdata_next[31:0] = classa_esc_cnt_qs;
       end
 
-      addr_hit[230]: begin
+      addr_hit[198]: begin
         reg_rdata_next[2:0] = classa_state_qs;
       end
 
-      addr_hit[231]: begin
+      addr_hit[199]: begin
         reg_rdata_next[0] = classb_regwen_qs;
       end
 
-      addr_hit[232]: begin
+      addr_hit[200]: begin
         reg_rdata_next[0] = classb_ctrl_en_qs;
         reg_rdata_next[1] = classb_ctrl_lock_qs;
         reg_rdata_next[2] = classb_ctrl_en_e0_qs;
@@ -11788,55 +10540,55 @@ module alert_handler_reg_top (
         reg_rdata_next[13:12] = classb_ctrl_map_e3_qs;
       end
 
-      addr_hit[233]: begin
+      addr_hit[201]: begin
         reg_rdata_next[0] = classb_clr_regwen_qs;
       end
 
-      addr_hit[234]: begin
+      addr_hit[202]: begin
         reg_rdata_next[0] = '0;
       end
 
-      addr_hit[235]: begin
+      addr_hit[203]: begin
         reg_rdata_next[15:0] = classb_accum_cnt_qs;
       end
 
-      addr_hit[236]: begin
+      addr_hit[204]: begin
         reg_rdata_next[15:0] = classb_accum_thresh_qs;
       end
 
-      addr_hit[237]: begin
+      addr_hit[205]: begin
         reg_rdata_next[31:0] = classb_timeout_cyc_qs;
       end
 
-      addr_hit[238]: begin
+      addr_hit[206]: begin
         reg_rdata_next[31:0] = classb_phase0_cyc_qs;
       end
 
-      addr_hit[239]: begin
+      addr_hit[207]: begin
         reg_rdata_next[31:0] = classb_phase1_cyc_qs;
       end
 
-      addr_hit[240]: begin
+      addr_hit[208]: begin
         reg_rdata_next[31:0] = classb_phase2_cyc_qs;
       end
 
-      addr_hit[241]: begin
+      addr_hit[209]: begin
         reg_rdata_next[31:0] = classb_phase3_cyc_qs;
       end
 
-      addr_hit[242]: begin
+      addr_hit[210]: begin
         reg_rdata_next[31:0] = classb_esc_cnt_qs;
       end
 
-      addr_hit[243]: begin
+      addr_hit[211]: begin
         reg_rdata_next[2:0] = classb_state_qs;
       end
 
-      addr_hit[244]: begin
+      addr_hit[212]: begin
         reg_rdata_next[0] = classc_regwen_qs;
       end
 
-      addr_hit[245]: begin
+      addr_hit[213]: begin
         reg_rdata_next[0] = classc_ctrl_en_qs;
         reg_rdata_next[1] = classc_ctrl_lock_qs;
         reg_rdata_next[2] = classc_ctrl_en_e0_qs;
@@ -11849,55 +10601,55 @@ module alert_handler_reg_top (
         reg_rdata_next[13:12] = classc_ctrl_map_e3_qs;
       end
 
-      addr_hit[246]: begin
+      addr_hit[214]: begin
         reg_rdata_next[0] = classc_clr_regwen_qs;
       end
 
-      addr_hit[247]: begin
+      addr_hit[215]: begin
         reg_rdata_next[0] = '0;
       end
 
-      addr_hit[248]: begin
+      addr_hit[216]: begin
         reg_rdata_next[15:0] = classc_accum_cnt_qs;
       end
 
-      addr_hit[249]: begin
+      addr_hit[217]: begin
         reg_rdata_next[15:0] = classc_accum_thresh_qs;
       end
 
-      addr_hit[250]: begin
+      addr_hit[218]: begin
         reg_rdata_next[31:0] = classc_timeout_cyc_qs;
       end
 
-      addr_hit[251]: begin
+      addr_hit[219]: begin
         reg_rdata_next[31:0] = classc_phase0_cyc_qs;
       end
 
-      addr_hit[252]: begin
+      addr_hit[220]: begin
         reg_rdata_next[31:0] = classc_phase1_cyc_qs;
       end
 
-      addr_hit[253]: begin
+      addr_hit[221]: begin
         reg_rdata_next[31:0] = classc_phase2_cyc_qs;
       end
 
-      addr_hit[254]: begin
+      addr_hit[222]: begin
         reg_rdata_next[31:0] = classc_phase3_cyc_qs;
       end
 
-      addr_hit[255]: begin
+      addr_hit[223]: begin
         reg_rdata_next[31:0] = classc_esc_cnt_qs;
       end
 
-      addr_hit[256]: begin
+      addr_hit[224]: begin
         reg_rdata_next[2:0] = classc_state_qs;
       end
 
-      addr_hit[257]: begin
+      addr_hit[225]: begin
         reg_rdata_next[0] = classd_regwen_qs;
       end
 
-      addr_hit[258]: begin
+      addr_hit[226]: begin
         reg_rdata_next[0] = classd_ctrl_en_qs;
         reg_rdata_next[1] = classd_ctrl_lock_qs;
         reg_rdata_next[2] = classd_ctrl_en_e0_qs;
@@ -11910,47 +10662,47 @@ module alert_handler_reg_top (
         reg_rdata_next[13:12] = classd_ctrl_map_e3_qs;
       end
 
-      addr_hit[259]: begin
+      addr_hit[227]: begin
         reg_rdata_next[0] = classd_clr_regwen_qs;
       end
 
-      addr_hit[260]: begin
+      addr_hit[228]: begin
         reg_rdata_next[0] = '0;
       end
 
-      addr_hit[261]: begin
+      addr_hit[229]: begin
         reg_rdata_next[15:0] = classd_accum_cnt_qs;
       end
 
-      addr_hit[262]: begin
+      addr_hit[230]: begin
         reg_rdata_next[15:0] = classd_accum_thresh_qs;
       end
 
-      addr_hit[263]: begin
+      addr_hit[231]: begin
         reg_rdata_next[31:0] = classd_timeout_cyc_qs;
       end
 
-      addr_hit[264]: begin
+      addr_hit[232]: begin
         reg_rdata_next[31:0] = classd_phase0_cyc_qs;
       end
 
-      addr_hit[265]: begin
+      addr_hit[233]: begin
         reg_rdata_next[31:0] = classd_phase1_cyc_qs;
       end
 
-      addr_hit[266]: begin
+      addr_hit[234]: begin
         reg_rdata_next[31:0] = classd_phase2_cyc_qs;
       end
 
-      addr_hit[267]: begin
+      addr_hit[235]: begin
         reg_rdata_next[31:0] = classd_phase3_cyc_qs;
       end
 
-      addr_hit[268]: begin
+      addr_hit[236]: begin
         reg_rdata_next[31:0] = classd_esc_cnt_qs;
       end
 
-      addr_hit[269]: begin
+      addr_hit[237]: begin
         reg_rdata_next[2:0] = classd_state_qs;
       end
 


### PR DESCRIPTION
This wires up the bus integrity alert in the alert handler by exposing it as another "internal alert" (similar to ping failures, etc.).

As a side note: we will likely get some more internal alerts when introducing mechanisms like shadow registers.

CC @cfrantz @mcy 

Signed-off-by: Michael Schaffner <msf@opentitan.org>