### PR TITLE
[dvsim] Do not assume the build failed if "ERROR" is printed

### DIFF
--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -21,7 +21,9 @@
 
   // pass and fail patterns
   build_pass_patterns: []
-  build_fail_patterns: ["^ERROR:.*$"] // fusesoc build error
+  // TODO: Add back FuseSoC fail pattern after
+  // https://github.com/lowRISC/opentitan/issues/7348 is resolved.
+  build_fail_patterns: []
   run_pass_patterns:   ["^TEST PASSED (UVM_)?CHECKS$"]
   run_fail_patterns:   ["^UVM_ERROR\\s[^:].*$",
                         "^UVM_FATAL\\s[^:].*$",


### PR DESCRIPTION
During a hardware build with FuseSoC, other tools are called and their
output is sometimes printed to stdout/stderr. What these tools output
isn't something FuseSoC can control (other than silencing it all).
Dvsim tries to parse the output of FuseSoC and extract errors out of it
to aggregate them at the end. It also assumes that the build failed if
error messages are found, even if FuseSoC returned a 0 exit code. This
behavior isn't matched with how FuseSoC operates.

FuseSoC does return a non-zero exit code if a build failed and assumes
the stdout/stderr contents to be human readable and not meant for parsing
(like most tools, actually).

This patch stops dvsim from treating lines starting with "ERROR:" in the
FuseSoC output as failure condition.

The change is triggered by a scenario reported by Sharon Topasz:

* FuseSoC calls a generator called primgen.py to produce target-specific
  primitives.
* primgen.py tries to call Verible for some of its work.
* The Verible call fails, and Verible prints the string "ERROR: Unknown
  command line flag -export_json". This string is displayed as-is during
  the FuseSoC run.
* primgen.py knows how to deal with this problem and uses a fallback
  path. The build succeeds, FuseSoC returns a zero exit code.
* dvsim picks up the "ERROR" line from FuseSoC's stdout/stderr and
  assumes the build failed.