### PR TITLE
[rom_ctrl] Mark block as D1

### DIFF
--- a/hw/ip/rom_ctrl/data/rom_ctrl.prj.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl.prj.hjson
@@ -11,7 +11,7 @@
         {
             version:            "0.1",
             life_stage:         "L1",
-            design_stage:       "D0",
+            design_stage:       "D1",
             verification_stage: "V0",
         },
     ]

--- a/hw/ip/rom_ctrl/doc/checklist.md
+++ b/hw/ip/rom_ctrl/doc/checklist.md
@@ -19,7 +19,7 @@ RTL           | [IP_INSTANTIABLE][]            | Done        |
 RTL           | [PHYSICAL_MACROS_DEFINED_80][] | N/A         |
 RTL           | [FUNC_IMPLEMENTED][]           | Done        |
 RTL           | [ASSERT_KNOWN_ADDED][]         | Done        |
-Code Quality  | [LINT_SETUP][]                 | Not started |
+Code Quality  | [LINT_SETUP][]                 | Done        |
 
 [SPEC_COMPLETE]:              {{<relref "/doc/project/checklist.md#spec_complete" >}}
 [CSR_DEFINED]:                {{<relref "/doc/project/checklist.md#csr_defined" >}}


### PR DESCRIPTION
This has been D1-ready for a while now. Explicitly bump the
development stage.
