### PR TITLE
[rom_ctrl] Remove an outdated TODO comment

### DIFF
--- a/hw/ip/rom_ctrl/util/scramble_image.py
+++ b/hw/ip/rom_ctrl/util/scramble_image.py
@@ -236,8 +236,6 @@ def prince(data: int, key: int, num_rounds_half: int) -> int:
     assert 0 <= key < (1 << 128)
     assert 0 <= num_rounds_half <= 5
 
-    # TODO: This matches the RTL in prim_prince.sv, but seems to be the other
-    #       way around in the original paper.
     k1 = key & ((1 << 64) - 1)
     k0 = key >> 64
 


### PR DESCRIPTION
When I was bringing this code up, the RTL didn't quite match the
original paper. Michael fixed the RTL in the meantime and I presumably
switched the Python around without removing the todo comment: oops!
