### PR TITLE
[util/fpga] Add "save to eeprom" feature

### DIFF
--- a/util/fpga/cw310_loader.py
+++ b/util/fpga/cw310_loader.py
@@ -32,6 +32,11 @@ def main():
                         help='Path to the software .bin file to load',
                         default=None)
 
+    parser.add_argument('--set-pll-defaults',
+                        action='store_true',
+                        help='Program on-board PLL with defaults',
+                        default=False)
+
     args = parser.parse_args()
 
     print("CW310 Loader: Attemping to find CW310 FPGA Board:")
@@ -41,17 +46,21 @@ def main():
         print("    No bitstream specified")
     target = cw.target(None, CW310, bsfile=args.bitstream, slurp=False)
 
-    print("Board found, setting PLL2 to 100 MHz")
+    print("CW310 Board Found:")
 
-    target.pll.pll_enable_set(True)
-    target.pll.pll_outenable_set(False, 0)
-    # Note: 1 and 2 seem to be reversed.
-    target.pll.pll_outenable_set(True, 1)
-    target.pll.pll_outenable_set(False, 2)
+    if args.set_pll_defaults:
+        print("Configuring PLL, setting as default")
+        target.pll.pll_enable_set(True)
+        target.pll.pll_outenable_set(False, 0)
+        # Note: 1 and 2 seem to be reversed.
+        target.pll.pll_outenable_set(True, 1)
+        target.pll.pll_outenable_set(False, 2)
 
-    # Note: both 1 and 2 need to be set, even if only 1 is enabled.
-    target.pll.pll_outfreq_set(100E6, 1)
-    target.pll.pll_outfreq_set(100E6, 2)
+        # Note: both 1 and 2 need to be set, even if only 1 is enabled.
+        target.pll.pll_outfreq_set(100E6, 1)
+        target.pll.pll_outfreq_set(100E6, 2)
+        
+        target.pll.pll_writedefaults()
 
     if args.firmware:
         print("INFO: Programming firmware file: {}".format(args.firmware))


### PR DESCRIPTION
This is a workaround for #6878 which allows saving the PLL with default settings that will be used on power-on.

Signed-off-by: Colin O'Flynn <coflynn@newae.com>