### PR TITLE
[reggen] Optionally expose register interface in reg2hw signal

### DIFF
--- a/util/reggen/ip_block.py
+++ b/util/reggen/ip_block.py
@@ -34,6 +34,7 @@ OPTIONAL_FIELDS = {
     'available_inout_list': ['lnw', "list of available peripheral inouts"],
     'available_input_list': ['lnw', "list of available peripheral inputs"],
     'available_output_list': ['lnw', "list of available peripheral outputs"],
+    'expose_reg_if': ['pb', 'if set, expose reg interface in reg2hw signal'],
     'hier_path': [
         None,
         'additional hierarchy path before the reg block instance'
@@ -92,6 +93,7 @@ class IpBlock:
                               Sequence[Signal]],
                  wakeups: Sequence[Signal],
                  reset_requests: Sequence[Signal],
+                 expose_reg_if: bool,
                  scan_reset: bool,
                  scan_en: bool):
         assert reg_blocks
@@ -123,6 +125,7 @@ class IpBlock:
         self.xputs = xputs
         self.wakeups = wakeups
         self.reset_requests = reset_requests
+        self.expose_reg_if = expose_reg_if
         self.scan_reset = scan_reset
         self.scan_en = scan_en
 
@@ -249,6 +252,9 @@ class IpBlock:
         rst_reqs = Signal.from_raw_list('reset_request_list for block ' + name,
                                         rd.get('reset_request_list', []))
 
+        expose_reg_if = check_bool(rd.get('expose_reg_if', False),
+                                   'expose_reg_if field of ' + what)
+
         scan_reset = check_bool(rd.get('scan_reset', False),
                                 'scan_reset field of ' + what)
 
@@ -272,7 +278,7 @@ class IpBlock:
                        interrupts, no_auto_intr, alerts, no_auto_alert,
                        scan, inter_signals, bus_interfaces,
                        hier_path, clock_signals, reset_signals, xputs,
-                       wakeups, rst_reqs, scan_reset, scan_en)
+                       wakeups, rst_reqs, expose_reg_if, scan_reset, scan_en)
 
     @staticmethod
     def from_text(txt: str,

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -241,6 +241,14 @@ module ${mod_name} (
     .error_i (reg_error)
   );
 
+  % if block.expose_reg_if:
+  assign reg2hw.reg_if.reg_we    = reg_we;
+  assign reg2hw.reg_if.reg_re    = reg_re;
+  assign reg2hw.reg_if.reg_addr  = reg_addr;
+  assign reg2hw.reg_if.reg_wdata = reg_wdata;
+  assign reg2hw.reg_if.reg_be    = reg_be;
+
+  % endif
   assign reg_rdata = reg_rdata_next ;
   assign reg_error = (devmode_i & addrmiss) | wr_err | intg_err;
 


### PR DESCRIPTION
If a block sets expose_reg_if in the hjson, the generated reg2hw
structure will contain an extra field called "reg_if", which has the
register interface signals. This could be useful for things like
checksumming writes over the interface. For example, OTBN is
considering a register that checksums all the writes from Ibex, in
order to beef up data integrity checking between Ibex and OTBN (see
issue #6175). This could also be used for more elaborate things like
port knocking schemes.

This exposes all the signals that come from the TLUL interface:
reg_we, reg_re, reg_addr, reg_wdata and reg_be. It doesn't expose
reg_rdata and reg_error because we don't really have a use for that at
the moment and it causes lint problems (where it looks like a
combinatorial loop between reg2hw and hw2reg).

@Jacob-Levy: I think this should do what you need: could you give it a try?

Fixes #6793.