### PR TITLE
[doc/pwrmgr] Fix pwrmgr and rstmgr doc typos

### DIFF
--- a/hw/ip/pwrmgr/data/pwrmgr.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson
@@ -165,7 +165,7 @@
           desc: '''
             The low power hint to power manager.
             The hint is an indication for how the manager should treat the next WFI.
-            Once the power manager begins a low power transition, or if a valid reset request is registerd,
+            Once the power manager begins a low power transition, or if a valid reset request is registered,
             this bit is automatically cleared by HW.
             '''
           resval: "0"
@@ -275,15 +275,13 @@
             { value: "0",
               name: "Power down",
               desc: '''
-                Main power domain is powered down during low power state.
-                Note this signal is active low.
+                Main power domain is powered down during low power state
                 '''
             },
             { value: "1",
               name: "Power up",
               desc: '''
                 Main power domain is kept powered during low power state
-                Note this signal is active low.
                 '''
             },
           ]
@@ -313,7 +311,7 @@
             the sync completes, this bit then self clears.
 
             Software should write this bit to 1, wait for it to clear, before assuming the slow clock
-            domain has assumed the programmaed values.
+            domain has assumed the programmed values.
           ''',
           resval: "0",
         },
@@ -324,7 +322,7 @@
     },
 
     { name: "WAKEUP_EN_REGWEN",
-      desc: "Configuration enable for wakeup register",
+      desc: "Configuration enable for wakeup_en register",
       swaccess: "rw0c",
       hwaccess: "none",
       fields: [
@@ -332,8 +330,8 @@
           resval: "1"
           name: "EN",
           desc: '''
-            When 1, WAKEUP register can be configured.
-            When 0, WAKEUP register cannot be configured.
+            When 1, WAKEUP_EN register can be configured.
+            When 0, WAKEUP_EN register cannot be configured.
           ''',
         },
       ]
@@ -382,7 +380,7 @@
     },
 
     { name: "RESET_EN_REGWEN",
-      desc: "Configuration enable for reset register",
+      desc: "Configuration enable for reset_en register",
       swaccess: "rw0c",
       hwaccess: "none",
       fields: [
@@ -390,8 +388,8 @@
           resval: "1"
           name: "EN",
           desc: '''
-            When 1, RESET register can be configured.
-            When 0, RESET register cannot be configured.
+            When 1, RESET_EN register can be configured.
+            When 0, RESET_EN register cannot be configured.
           ''',
         },
       ]

--- a/hw/ip/pwrmgr/doc/_index.md
+++ b/hw/ip/pwrmgr/doc/_index.md
@@ -94,11 +94,11 @@ Once these steps are complete, the slow FSM transitions to a low power state and
 The fast clock domain FSM (referred to as fast FSM from here on) resets to `Low Power` state and waits for a power-up request from the slow FSM.
 
 Once received, the fast FSM releases the life cycle reset stage (see [reset controller](https://docs.google.com/document/d/1oprdDwbm-_opDwMuu-kmmaFVwt4-f1EGqCf0nkO8VpM/edit?usp=sharing) for more details).
-This allows the [OTP]() to begin sensing.
+This allows the [OTP]({{< relref "hw/ip/otp_ctrl/doc" >}}) to begin sensing.
 Once OTP sensing completes , the life cycle controller is initialized.
-The initialization of the life cycle controller puts the device into its allowed operating state (see [life cycle controller](https://docs.google.com/document/d/1H6jHtX2xYgy3nmkWKeHMkYcP0vsPq9duyUtLu5imX2E/edit?usp=sharing) for more details).
+The initialization of the life cycle controller puts the device into its allowed operating state (see [life cycle controller]({{< relref "hw/ip/lc_ctrl/doc" >}}) for more details).
 
-Once life cycle initialization is done, the fast FSM enables all second level clock gating (see [clock controller](https://docs.google.com/document/d/1j8H9ikPO2TKTRQvRFItjE5myiba1825PD-Yhy-yaLt0/edit?usp=sharing) for more details) and initiates strap sampling.
+Once life cycle initialization is done, the fast FSM enables all second level clock gating (see [clock controller]({{< relref "hw/ip/clkmgr/doc" >}}) for more details) and initiates strap sampling.
 For more details on what exactly the strap samples, please see [here](https://docs.google.com/spreadsheets/d/1pH8T1MhQ7TXtP_bFNT85T9jSVIHlxHAfbMnPbsMdjc0/edit?usp=sharing).
 
 Once strap sampling is complete, the system is ready to begin normal operations (note flash initialization is explicitly not done here, please see [sections below](#Flash-Handling) for more details).

--- a/hw/ip/rstmgr/data/rstmgr.hjson
+++ b/hw/ip/rstmgr/data/rstmgr.hjson
@@ -221,7 +221,7 @@
         cname: "RSTMGR_SW_RST",
         name:  "SW_RST_REGEN",
         desc:  '''
-          Register write enable for software controllabe resets.
+          Register write enable for software controllable resets.
           When a particular bit value is 0, the corresponding value in !SW_RST_CTRL can no longer be changed.
           When a particular bit value is 1, the corresponding value in !SW_RST_CTRL can be changed.
         ''',
@@ -245,7 +245,7 @@
         cname: "RSTMGR_SW_RST",
         name:  "SW_RST_CTRL_N",
         desc:  '''
-          Software controllabe resets.
+          Software controllable resets.
           When a particular bit value is 0, the corresponding module is held in reset.
           When a particular bit value is 1, the corresponding module is not held in reset.
         ''',

--- a/hw/ip/rstmgr/data/rstmgr.hjson.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.hjson.tpl
@@ -244,7 +244,7 @@
         cname: "RSTMGR_SW_RST",
         name:  "SW_RST_REGEN",
         desc:  '''
-          Register write enable for software controllabe resets.
+          Register write enable for software controllable resets.
           When a particular bit value is 0, the corresponding value in !SW_RST_CTRL can no longer be changed.
           When a particular bit value is 1, the corresponding value in !SW_RST_CTRL can be changed.
         ''',
@@ -268,7 +268,7 @@
         cname: "RSTMGR_SW_RST",
         name:  "SW_RST_CTRL_N",
         desc:  '''
-          Software controllabe resets.
+          Software controllable resets.
           When a particular bit value is 0, the corresponding module is held in reset.
           When a particular bit value is 1, the corresponding module is not held in reset.
         ''',

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -329,7 +329,7 @@
         cname: "RSTMGR_SW_RST",
         name:  "SW_RST_REGEN",
         desc:  '''
-          Register write enable for software controllabe resets.
+          Register write enable for software controllable resets.
           When a particular bit value is 0, the corresponding value in !SW_RST_CTRL can no longer be changed.
           When a particular bit value is 1, the corresponding value in !SW_RST_CTRL can be changed.
         ''',
@@ -353,7 +353,7 @@
         cname: "RSTMGR_SW_RST",
         name:  "SW_RST_CTRL_N",
         desc:  '''
-          Software controllabe resets.
+          Software controllable resets.
           When a particular bit value is 0, the corresponding module is held in reset.
           When a particular bit value is 1, the corresponding module is not held in reset.
         ''',


### PR DESCRIPTION
The non-typo change is to remove a redundant mention that the
power_down bit in the control register is active low, since the
values clearly show that.

Signed-off-by: Guillermo Maturana <maturana@google.com>