### PR TITLE
[otbn] Add DIF for reading OTBN instruction count

### DIFF
--- a/sw/device/lib/dif/dif_otbn.c
+++ b/sw/device/lib/dif/dif_otbn.c
@@ -248,6 +248,16 @@ dif_otbn_result_t dif_otbn_get_err_bits(const dif_otbn_t *otbn,
   return kDifOtbnOk;
 }
 
+dif_otbn_result_t dif_otbn_get_insn_cnt(const dif_otbn_t *otbn,
+                                        uint32_t *insn_cnt) {
+  if (otbn == NULL || insn_cnt == NULL) {
+    return kDifOtbnBadArg;
+  }
+
+  *insn_cnt = mmio_region_read32(otbn->base_addr, OTBN_INSN_CNT_REG_OFFSET);
+  return kDifOtbnOk;
+}
+
 dif_otbn_result_t dif_otbn_imem_write(const dif_otbn_t *otbn,
                                       uint32_t offset_bytes, const void *src,
                                       size_t len_bytes) {

--- a/sw/device/lib/dif/dif_otbn.h
+++ b/sw/device/lib/dif/dif_otbn.h
@@ -12,6 +12,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+
 #include "sw/device/lib/base/mmio.h"
 
 #ifdef __cplusplus
@@ -254,6 +255,21 @@ dif_otbn_result_t dif_otbn_is_busy(const dif_otbn_t *otbn, bool *busy);
  */
 dif_otbn_result_t dif_otbn_get_err_bits(const dif_otbn_t *otbn,
                                         dif_otbn_err_bits_t *err_bits);
+
+/**
+ * Gets the number of executed OTBN instructions.
+ *
+ * Gets the number of instructions executed so far in the current OTBN run if
+ * there is one. Otherwise, gets the number executed in total in the previous
+ * OTBN run.
+ *
+ * @param otbn OTBN instance
+ * @param[out] insn_cnt The number of instructions executed by OTBN.
+ * @return `kDifOtbnBadArg` if `otbn` or `insn_cnt` is `NULL`,
+ *         `kDifOtbnOk` otherwise.
+ */
+dif_otbn_result_t dif_otbn_get_insn_cnt(const dif_otbn_t *otbn,
+                                        uint32_t *insn_cnt);
 
 /**
  * Write an OTBN application into its instruction memory (IMEM)

--- a/sw/device/lib/dif/dif_otbn_unittest.cc
+++ b/sw/device/lib/dif/dif_otbn_unittest.cc
@@ -321,6 +321,26 @@ TEST_F(GetErrBitsTest, Success) {
   EXPECT_EQ(err_bits, kDifOtbnErrBitsIllegalInsn | kDifOtbnErrBitsFatalReg);
 }
 
+class GetInsnCntTest : public OtbnTest {};
+
+TEST_F(GetInsnCntTest, NullArgs) {
+  EXPECT_EQ(dif_otbn_get_insn_cnt(nullptr, nullptr), kDifOtbnBadArg);
+
+  EXPECT_EQ(dif_otbn_get_insn_cnt(&dif_otbn_, nullptr), kDifOtbnBadArg);
+
+  uint32_t insn_cnt = 55;
+  EXPECT_EQ(dif_otbn_get_insn_cnt(nullptr, &insn_cnt), kDifOtbnBadArg);
+  EXPECT_EQ(insn_cnt, 55);
+}
+
+TEST_F(GetInsnCntTest, Success) {
+  EXPECT_READ32(OTBN_INSN_CNT_REG_OFFSET, 55);
+
+  uint32_t insn_cnt;
+  EXPECT_EQ(dif_otbn_get_insn_cnt(&dif_otbn_, &insn_cnt), kDifOtbnOk);
+  EXPECT_EQ(insn_cnt, 55);
+}
+
 class ImemWriteTest : public OtbnTest {};
 
 TEST_F(ImemWriteTest, NullArgs) {

--- a/sw/device/lib/dif/dif_otbn_unittest.cc
+++ b/sw/device/lib/dif/dif_otbn_unittest.cc
@@ -41,54 +41,44 @@ class OtbnTest : public Test, public MmioTest {
 class InitTest : public OtbnTest {};
 
 TEST_F(InitTest, NullArgs) {
-  dif_otbn_result_t result;
+  EXPECT_EQ(dif_otbn_init(nullptr, nullptr), kDifOtbnBadArg);
 
-  result = dif_otbn_init(nullptr, nullptr);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_init(nullptr, &dif_otbn_), kDifOtbnBadArg);
 
-  result = dif_otbn_init(nullptr, &dif_otbn_);
-  EXPECT_EQ(result, kDifOtbnBadArg);
-
-  result = dif_otbn_init(&dif_otbn_config_, nullptr);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_init(&dif_otbn_config_, nullptr), kDifOtbnBadArg);
 }
 
 TEST_F(InitTest, Default) {
   ExpectDeviceReset();
 
-  dif_otbn_result_t result = dif_otbn_init(&dif_otbn_config_, &dif_otbn_);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_init(&dif_otbn_config_, &dif_otbn_), kDifOtbnOk);
 }
 
 class ResetTest : public OtbnTest {};
 
 TEST_F(ResetTest, NullArgs) {
-  dif_otbn_result_t result;
-  result = dif_otbn_reset(nullptr);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_reset(nullptr), kDifOtbnBadArg);
 }
 
 TEST_F(ResetTest, Default) {
   ExpectDeviceReset();
 
-  dif_otbn_result_t result = dif_otbn_reset(&dif_otbn_);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_reset(&dif_otbn_), kDifOtbnOk);
 }
 
 class IrqStateGetTest : public OtbnTest {};
 
 TEST_F(IrqStateGetTest, NullArgs) {
-  dif_otbn_result_t result;
   dif_otbn_enable_t state;
 
-  result = dif_otbn_irq_state_get(nullptr, kDifOtbnInterruptDone, nullptr);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_irq_state_get(nullptr, kDifOtbnInterruptDone, nullptr),
+            kDifOtbnBadArg);
 
-  result = dif_otbn_irq_state_get(nullptr, kDifOtbnInterruptDone, &state);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_irq_state_get(nullptr, kDifOtbnInterruptDone, &state),
+            kDifOtbnBadArg);
 
-  result = dif_otbn_irq_state_get(&dif_otbn_, kDifOtbnInterruptDone, nullptr);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_irq_state_get(&dif_otbn_, kDifOtbnInterruptDone, nullptr),
+            kDifOtbnBadArg);
 }
 
 TEST_F(IrqStateGetTest, Success) {
@@ -96,47 +86,42 @@ TEST_F(IrqStateGetTest, Success) {
   EXPECT_READ32(OTBN_INTR_STATE_REG_OFFSET, {{OTBN_INTR_STATE_DONE_BIT, true}});
 
   dif_otbn_enable_t done_state = kDifOtbnDisable;
-  dif_otbn_result_t result =
-      dif_otbn_irq_state_get(&dif_otbn_, kDifOtbnInterruptDone, &done_state);
-  EXPECT_EQ(result, kDifOtbnOk);
+
+  EXPECT_EQ(
+      dif_otbn_irq_state_get(&dif_otbn_, kDifOtbnInterruptDone, &done_state),
+      kDifOtbnOk);
   EXPECT_EQ(done_state, kDifOtbnEnable);
 }
 
 class IrqStateClearTest : public OtbnTest {};
 
 TEST_F(IrqStateClearTest, NullArgs) {
-  dif_otbn_result_t result =
-      dif_otbn_irq_state_clear(nullptr, kDifOtbnInterruptDone);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_irq_state_clear(nullptr, kDifOtbnInterruptDone),
+            kDifOtbnBadArg);
 }
 
 TEST_F(IrqStateClearTest, Success) {
   // Clear the (only) IRQ state.
   EXPECT_WRITE32(OTBN_INTR_STATE_REG_OFFSET, {{OTBN_INTR_STATE_DONE_BIT, 1}});
 
-  dif_otbn_result_t result =
-      dif_otbn_irq_state_clear(&dif_otbn_, kDifOtbnInterruptDone);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_irq_state_clear(&dif_otbn_, kDifOtbnInterruptDone),
+            kDifOtbnOk);
 }
 
 class IrqsDisableTest : public OtbnTest {};
 
 TEST_F(IrqsDisableTest, NullArgs) {
   uint32_t state;
-  dif_otbn_result_t result;
 
-  result = dif_otbn_irqs_disable(nullptr, nullptr);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_irqs_disable(nullptr, nullptr), kDifOtbnBadArg);
 
-  result = dif_otbn_irqs_disable(nullptr, &state);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_irqs_disable(nullptr, &state), kDifOtbnBadArg);
 }
 
 TEST_F(IrqsDisableTest, SuccessNoStateReturned) {
   EXPECT_WRITE32(OTBN_INTR_ENABLE_REG_OFFSET, 0);
 
-  dif_otbn_result_t result = dif_otbn_irqs_disable(&dif_otbn_, nullptr);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_irqs_disable(&dif_otbn_, nullptr), kDifOtbnOk);
 }
 
 TEST_F(IrqsDisableTest, AllDisabled) {
@@ -145,8 +130,7 @@ TEST_F(IrqsDisableTest, AllDisabled) {
   EXPECT_WRITE32(OTBN_INTR_ENABLE_REG_OFFSET, 0);
 
   uint32_t state = std::numeric_limits<uint32_t>::max();
-  dif_otbn_result_t result = dif_otbn_irqs_disable(&dif_otbn_, &state);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_irqs_disable(&dif_otbn_, &state), kDifOtbnOk);
   EXPECT_EQ(state, 0);
 }
 
@@ -157,41 +141,38 @@ TEST_F(IrqsDisableTest, AllEnabled) {
   EXPECT_WRITE32(OTBN_INTR_ENABLE_REG_OFFSET, 0);
 
   uint32_t state = 0;
-  dif_otbn_result_t result = dif_otbn_irqs_disable(&dif_otbn_, &state);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_irqs_disable(&dif_otbn_, &state), kDifOtbnOk);
   EXPECT_EQ(state, std::numeric_limits<uint32_t>::max());
 }
 
 class IrqsRestoreTest : public OtbnTest {};
 
 TEST_F(IrqsRestoreTest, NullArgs) {
-  dif_otbn_result_t result =
-      dif_otbn_irqs_restore(nullptr, std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(
+      dif_otbn_irqs_restore(nullptr, std::numeric_limits<uint32_t>::max()),
+      kDifOtbnBadArg);
 }
 
 TEST_F(IrqsRestoreTest, AllEnabled) {
   uint32_t state = std::numeric_limits<uint32_t>::max();
   EXPECT_WRITE32(OTBN_INTR_ENABLE_REG_OFFSET, state);
 
-  dif_otbn_result_t result = dif_otbn_irqs_restore(&dif_otbn_, state);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_irqs_restore(&dif_otbn_, state), kDifOtbnOk);
 }
 
 TEST_F(IrqsRestoreTest, NoneEnabled) {
   uint32_t state = 0;
   EXPECT_WRITE32(OTBN_INTR_ENABLE_REG_OFFSET, state);
 
-  dif_otbn_result_t result = dif_otbn_irqs_restore(&dif_otbn_, state);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_irqs_restore(&dif_otbn_, state), kDifOtbnOk);
 }
 
 class IrqControlTest : public OtbnTest {};
 
 TEST_F(IrqControlTest, NullArgs) {
-  dif_otbn_result_t result =
-      dif_otbn_irq_control(nullptr, kDifOtbnInterruptDone, kDifOtbnEnable);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(
+      dif_otbn_irq_control(nullptr, kDifOtbnInterruptDone, kDifOtbnEnable),
+      kDifOtbnBadArg);
 }
 
 TEST_F(IrqControlTest, Success) {
@@ -199,16 +180,15 @@ TEST_F(IrqControlTest, Success) {
   EXPECT_MASK32(OTBN_INTR_ENABLE_REG_OFFSET,
                 {{OTBN_INTR_ENABLE_DONE_BIT, 0x1, true}});
 
-  dif_otbn_result_t result =
-      dif_otbn_irq_control(&dif_otbn_, kDifOtbnInterruptDone, kDifOtbnEnable);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(
+      dif_otbn_irq_control(&dif_otbn_, kDifOtbnInterruptDone, kDifOtbnEnable),
+      kDifOtbnOk);
 }
 
 class IrqForceTest : public OtbnTest {};
 
 TEST_F(IrqForceTest, NullArgs) {
-  dif_otbn_result_t result = dif_otbn_irq_force(nullptr, kDifOtbnInterruptDone);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_irq_force(nullptr, kDifOtbnInterruptDone), kDifOtbnBadArg);
 }
 
 TEST_F(IrqForceTest, Success) {
@@ -216,34 +196,26 @@ TEST_F(IrqForceTest, Success) {
   EXPECT_MASK32(OTBN_INTR_TEST_REG_OFFSET,
                 {{OTBN_INTR_TEST_DONE_BIT, 0x1, true}});
 
-  dif_otbn_result_t result =
-      dif_otbn_irq_force(&dif_otbn_, kDifOtbnInterruptDone);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_irq_force(&dif_otbn_, kDifOtbnInterruptDone), kDifOtbnOk);
 }
 
 class StartTest : public OtbnTest {};
 
 TEST_F(StartTest, NullArgs) {
-  dif_otbn_result_t result = dif_otbn_start(nullptr, 0);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_start(nullptr, 0), kDifOtbnBadArg);
 }
 
 TEST_F(StartTest, BadStartAddress) {
-  dif_otbn_result_t result;
-
   // Must be 4-byte aligned.
-  result = dif_otbn_start(&dif_otbn_, 1);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_start(&dif_otbn_, 1), kDifOtbnBadArg);
 
-  result = dif_otbn_start(&dif_otbn_, 2);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_start(&dif_otbn_, 2), kDifOtbnBadArg);
 
   // Valid addresses (ignoring alignment): 0 .. (OTBN_IMEM_SIZE_BYTES - 1)
-  result = dif_otbn_start(&dif_otbn_, OTBN_IMEM_SIZE_BYTES);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_start(&dif_otbn_, OTBN_IMEM_SIZE_BYTES), kDifOtbnBadArg);
 
-  result = dif_otbn_start(&dif_otbn_, OTBN_IMEM_SIZE_BYTES + 32);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_start(&dif_otbn_, OTBN_IMEM_SIZE_BYTES + 32),
+            kDifOtbnBadArg);
 }
 
 TEST_F(StartTest, Success) {
@@ -256,31 +228,25 @@ TEST_F(StartTest, Success) {
   // Set start command bit.
   EXPECT_WRITE32(OTBN_CMD_REG_OFFSET, {{OTBN_CMD_START_BIT, 1}});
 
-  dif_otbn_result_t result = dif_otbn_start(&dif_otbn_, 4);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_start(&dif_otbn_, 4), kDifOtbnOk);
 }
 
 class IsBusyTest : public OtbnTest {};
 
 TEST_F(IsBusyTest, NullArgs) {
-  dif_otbn_result_t result;
   bool busy;
 
-  result = dif_otbn_is_busy(nullptr, nullptr);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_is_busy(nullptr, nullptr), kDifOtbnBadArg);
 
-  result = dif_otbn_is_busy(&dif_otbn_, nullptr);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_is_busy(&dif_otbn_, nullptr), kDifOtbnBadArg);
 
   // Also check for freedom from side effects in `busy`.
   busy = false;
-  result = dif_otbn_is_busy(nullptr, &busy);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_is_busy(nullptr, &busy), kDifOtbnBadArg);
   EXPECT_EQ(busy, false);
 
   busy = true;
-  result = dif_otbn_is_busy(nullptr, &busy);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_is_busy(nullptr, &busy), kDifOtbnBadArg);
   EXPECT_EQ(busy, true);
 }
 
@@ -288,26 +254,21 @@ TEST_F(IsBusyTest, Success) {
   EXPECT_READ32(OTBN_STATUS_REG_OFFSET, {{OTBN_STATUS_BUSY_BIT, true}});
 
   bool busy = false;
-  dif_otbn_result_t result = dif_otbn_is_busy(&dif_otbn_, &busy);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_is_busy(&dif_otbn_, &busy), kDifOtbnOk);
   EXPECT_EQ(busy, true);
 }
 
 class GetErrBitsTest : public OtbnTest {};
 
 TEST_F(GetErrBitsTest, NullArgs) {
-  dif_otbn_result_t result;
   dif_otbn_err_bits_t err_bits;
 
-  result = dif_otbn_get_err_bits(nullptr, nullptr);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_get_err_bits(nullptr, nullptr), kDifOtbnBadArg);
 
-  result = dif_otbn_get_err_bits(&dif_otbn_, nullptr);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_get_err_bits(&dif_otbn_, nullptr), kDifOtbnBadArg);
 
   err_bits = kDifOtbnErrBitsBadDataAddr;
-  result = dif_otbn_get_err_bits(nullptr, &err_bits);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_get_err_bits(nullptr, &err_bits), kDifOtbnBadArg);
   EXPECT_EQ(err_bits, kDifOtbnErrBitsBadDataAddr);
 }
 
@@ -316,8 +277,7 @@ TEST_F(GetErrBitsTest, Success) {
                 kDifOtbnErrBitsIllegalInsn | kDifOtbnErrBitsFatalReg);
 
   dif_otbn_err_bits_t err_bits;
-  dif_otbn_result_t result = dif_otbn_get_err_bits(&dif_otbn_, &err_bits);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_get_err_bits(&dif_otbn_, &err_bits), kDifOtbnOk);
   EXPECT_EQ(err_bits, kDifOtbnErrBitsIllegalInsn | kDifOtbnErrBitsFatalReg);
 }
 
@@ -344,57 +304,45 @@ TEST_F(GetInsnCntTest, Success) {
 class ImemWriteTest : public OtbnTest {};
 
 TEST_F(ImemWriteTest, NullArgs) {
-  dif_otbn_result_t result;
   uint32_t test_data[] = {0};
 
-  result = dif_otbn_imem_write(nullptr, 0, nullptr, 4);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_imem_write(nullptr, 0, nullptr, 4), kDifOtbnBadArg);
 
-  result = dif_otbn_imem_write(nullptr, 0, test_data, 4);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_imem_write(nullptr, 0, test_data, 4), kDifOtbnBadArg);
 
-  result = dif_otbn_imem_write(&dif_otbn_, 0, nullptr, 4);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_imem_write(&dif_otbn_, 0, nullptr, 4), kDifOtbnBadArg);
 }
 
 TEST_F(ImemWriteTest, BadLenBytes) {
-  dif_otbn_result_t result;
   uint32_t test_data[] = {0};
 
   // `len_bytes` must be a multiple of 4 bytes.
-  result = dif_otbn_imem_write(&dif_otbn_, 0, test_data, 1);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_imem_write(&dif_otbn_, 0, test_data, 1), kDifOtbnBadArg);
 
-  result = dif_otbn_imem_write(&dif_otbn_, 0, test_data, 2);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_imem_write(&dif_otbn_, 0, test_data, 2), kDifOtbnBadArg);
 }
 
 TEST_F(ImemWriteTest, BadOffset) {
-  dif_otbn_result_t result;
   uint32_t test_data[] = {0};
 
   // `offset` must be 32b-aligned.
-  result = dif_otbn_imem_write(&dif_otbn_, 1, test_data, 4);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_imem_write(&dif_otbn_, 1, test_data, 4), kDifOtbnBadArg);
 
-  result = dif_otbn_imem_write(&dif_otbn_, 2, test_data, 4);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_imem_write(&dif_otbn_, 2, test_data, 4), kDifOtbnBadArg);
 }
 
 TEST_F(ImemWriteTest, BadAddressBeyondMemorySize) {
-  dif_otbn_result_t result;
   uint32_t test_data[] = {0};
 
-  result = dif_otbn_imem_write(&dif_otbn_, OTBN_IMEM_SIZE_BYTES, test_data, 4);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_imem_write(&dif_otbn_, OTBN_IMEM_SIZE_BYTES, test_data, 4),
+            kDifOtbnBadArg);
 }
 
 TEST_F(ImemWriteTest, BadAddressIntegerOverflow) {
-  dif_otbn_result_t result;
   uint32_t test_data[4] = {0};
 
-  result = dif_otbn_imem_write(&dif_otbn_, 0xFFFFFFFC, test_data, 16);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_imem_write(&dif_otbn_, 0xFFFFFFFC, test_data, 16),
+            kDifOtbnBadArg);
 }
 
 TEST_F(ImemWriteTest, SuccessWithoutOffset) {
@@ -406,8 +354,7 @@ TEST_F(ImemWriteTest, SuccessWithoutOffset) {
   EXPECT_WRITE32(OTBN_IMEM_REG_OFFSET, test_data[0]);
   EXPECT_WRITE32(OTBN_IMEM_REG_OFFSET + 4, test_data[1]);
 
-  dif_otbn_result_t result = dif_otbn_imem_write(&dif_otbn_, 0, test_data, 8);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_imem_write(&dif_otbn_, 0, test_data, 8), kDifOtbnOk);
 }
 
 TEST_F(ImemWriteTest, SuccessWithOffset) {
@@ -419,24 +366,22 @@ TEST_F(ImemWriteTest, SuccessWithOffset) {
   EXPECT_WRITE32(OTBN_IMEM_REG_OFFSET + 4, test_data[0]);
   EXPECT_WRITE32(OTBN_IMEM_REG_OFFSET + 8, test_data[1]);
 
-  dif_otbn_result_t result = dif_otbn_imem_write(&dif_otbn_, 4, test_data, 8);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_imem_write(&dif_otbn_, 4, test_data, 8), kDifOtbnOk);
 }
 
 class ImemReadTest : public OtbnTest {};
 
 TEST_F(ImemReadTest, NullArgs) {
-  dif_otbn_result_t result;
   uint32_t test_data[2] = {0x12345678, 0xabcdef01};
 
-  result = dif_otbn_imem_read(nullptr, 0, nullptr, sizeof(test_data));
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_imem_read(nullptr, 0, nullptr, sizeof(test_data)),
+            kDifOtbnBadArg);
 
-  result = dif_otbn_imem_read(nullptr, 0, test_data, sizeof(test_data));
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_imem_read(nullptr, 0, test_data, sizeof(test_data)),
+            kDifOtbnBadArg);
 
-  result = dif_otbn_imem_read(&dif_otbn_, 0, nullptr, sizeof(test_data));
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_imem_read(&dif_otbn_, 0, nullptr, sizeof(test_data)),
+            kDifOtbnBadArg);
 
   // No side effects are expected.
   EXPECT_EQ(test_data[0], 0x12345678);
@@ -444,27 +389,23 @@ TEST_F(ImemReadTest, NullArgs) {
 }
 
 TEST_F(ImemReadTest, BadLenBytes) {
-  dif_otbn_result_t result;
   uint32_t test_data[2] = {0};
 
   // `len_bytes` must be a multiple of 4 bytes.
-  result = dif_otbn_imem_read(&dif_otbn_, 0, test_data, 1);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_imem_read(&dif_otbn_, 0, test_data, 1), kDifOtbnBadArg);
 
-  result = dif_otbn_imem_read(&dif_otbn_, 0, test_data, 2);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_imem_read(&dif_otbn_, 0, test_data, 2), kDifOtbnBadArg);
 }
 
 TEST_F(ImemReadTest, BadOffset) {
-  dif_otbn_result_t result;
   uint32_t test_data[2] = {0};
 
   // `offset` must be 32b-aligned.
-  result = dif_otbn_imem_read(&dif_otbn_, 1, test_data, sizeof(test_data));
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_imem_read(&dif_otbn_, 1, test_data, sizeof(test_data)),
+            kDifOtbnBadArg);
 
-  result = dif_otbn_imem_read(&dif_otbn_, 2, test_data, sizeof(test_data));
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_imem_read(&dif_otbn_, 2, test_data, sizeof(test_data)),
+            kDifOtbnBadArg);
 }
 
 TEST_F(ImemReadTest, SuccessWithoutOffset) {
@@ -476,8 +417,7 @@ TEST_F(ImemReadTest, SuccessWithoutOffset) {
   EXPECT_READ32(OTBN_IMEM_REG_OFFSET, 0x12345678);
   EXPECT_READ32(OTBN_IMEM_REG_OFFSET + 4, 0xabcdef01);
 
-  dif_otbn_result_t result = dif_otbn_imem_read(&dif_otbn_, 0, test_data, 8);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_imem_read(&dif_otbn_, 0, test_data, 8), kDifOtbnOk);
   EXPECT_EQ(test_data[0], 0x12345678);
   EXPECT_EQ(test_data[1], 0xabcdef01);
 }
@@ -491,8 +431,7 @@ TEST_F(ImemReadTest, SuccessWithOffset) {
   EXPECT_READ32(OTBN_IMEM_REG_OFFSET + 4, 0x12345678);
   EXPECT_READ32(OTBN_IMEM_REG_OFFSET + 8, 0xabcdef01);
 
-  dif_otbn_result_t result = dif_otbn_imem_read(&dif_otbn_, 4, test_data, 8);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_imem_read(&dif_otbn_, 4, test_data, 8), kDifOtbnOk);
   EXPECT_EQ(test_data[0], 0x12345678);
   EXPECT_EQ(test_data[1], 0xabcdef01);
 }
@@ -500,41 +439,31 @@ TEST_F(ImemReadTest, SuccessWithOffset) {
 class DmemWriteTest : public OtbnTest {};
 
 TEST_F(DmemWriteTest, NullArgs) {
-  dif_otbn_result_t result;
   uint32_t test_data[1] = {0};
 
-  result = dif_otbn_dmem_write(nullptr, 0, nullptr, 4);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_dmem_write(nullptr, 0, nullptr, 4), kDifOtbnBadArg);
 
-  result = dif_otbn_dmem_write(nullptr, 0, test_data, 4);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_dmem_write(nullptr, 0, test_data, 4), kDifOtbnBadArg);
 
-  result = dif_otbn_dmem_write(&dif_otbn_, 0, nullptr, 4);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_dmem_write(&dif_otbn_, 0, nullptr, 4), kDifOtbnBadArg);
 }
 
 TEST_F(DmemWriteTest, BadLenBytes) {
-  dif_otbn_result_t result;
   uint32_t test_data[1] = {0};
 
   // `len_bytes` must be a multiple of 4 bytes.
-  result = dif_otbn_dmem_write(&dif_otbn_, 0, test_data, 1);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_dmem_write(&dif_otbn_, 0, test_data, 1), kDifOtbnBadArg);
 
-  result = dif_otbn_dmem_write(&dif_otbn_, 0, test_data, 2);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_dmem_write(&dif_otbn_, 0, test_data, 2), kDifOtbnBadArg);
 }
 
 TEST_F(DmemWriteTest, BadOffset) {
-  dif_otbn_result_t result;
   uint32_t test_data[1] = {0};
 
   // `offset` must be 32b-aligned.
-  result = dif_otbn_dmem_write(&dif_otbn_, 1, test_data, 4);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_dmem_write(&dif_otbn_, 1, test_data, 4), kDifOtbnBadArg);
 
-  result = dif_otbn_dmem_write(&dif_otbn_, 2, test_data, 4);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_dmem_write(&dif_otbn_, 2, test_data, 4), kDifOtbnBadArg);
 }
 
 TEST_F(DmemWriteTest, SuccessWithoutOffset) {
@@ -546,8 +475,7 @@ TEST_F(DmemWriteTest, SuccessWithoutOffset) {
   EXPECT_WRITE32(OTBN_DMEM_REG_OFFSET, test_data[0]);
   EXPECT_WRITE32(OTBN_DMEM_REG_OFFSET + 4, test_data[1]);
 
-  dif_otbn_result_t result = dif_otbn_dmem_write(&dif_otbn_, 0, test_data, 8);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_dmem_write(&dif_otbn_, 0, test_data, 8), kDifOtbnOk);
 }
 
 TEST_F(DmemWriteTest, SuccessWithOffset) {
@@ -559,24 +487,22 @@ TEST_F(DmemWriteTest, SuccessWithOffset) {
   EXPECT_WRITE32(OTBN_DMEM_REG_OFFSET + 4, test_data[0]);
   EXPECT_WRITE32(OTBN_DMEM_REG_OFFSET + 8, test_data[1]);
 
-  dif_otbn_result_t result = dif_otbn_dmem_write(&dif_otbn_, 4, test_data, 8);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_dmem_write(&dif_otbn_, 4, test_data, 8), kDifOtbnOk);
 }
 
 class DmemReadTest : public OtbnTest {};
 
 TEST_F(DmemReadTest, NullArgs) {
-  dif_otbn_result_t result;
   uint32_t test_data[2] = {0x12345678, 0xabcdef01};
 
-  result = dif_otbn_dmem_read(nullptr, 0, nullptr, sizeof(test_data));
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_dmem_read(nullptr, 0, nullptr, sizeof(test_data)),
+            kDifOtbnBadArg);
 
-  result = dif_otbn_dmem_read(nullptr, 0, test_data, sizeof(test_data));
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_dmem_read(nullptr, 0, test_data, sizeof(test_data)),
+            kDifOtbnBadArg);
 
-  result = dif_otbn_dmem_read(&dif_otbn_, 0, nullptr, sizeof(test_data));
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_dmem_read(&dif_otbn_, 0, nullptr, sizeof(test_data)),
+            kDifOtbnBadArg);
 
   // No side effects are expected.
   EXPECT_EQ(test_data[0], 0x12345678);
@@ -584,27 +510,23 @@ TEST_F(DmemReadTest, NullArgs) {
 }
 
 TEST_F(DmemReadTest, BadLenBytes) {
-  dif_otbn_result_t result;
   uint32_t test_data[2] = {0};
 
   // `len_bytes` must be a multiple of 4 bytes.
-  result = dif_otbn_dmem_read(&dif_otbn_, 0, test_data, 1);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_dmem_read(&dif_otbn_, 0, test_data, 1), kDifOtbnBadArg);
 
-  result = dif_otbn_dmem_read(&dif_otbn_, 0, test_data, 2);
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_dmem_read(&dif_otbn_, 0, test_data, 2), kDifOtbnBadArg);
 }
 
 TEST_F(DmemReadTest, BadOffset) {
-  dif_otbn_result_t result;
   uint32_t test_data[2] = {0};
 
   // `offset` must be 32b-aligned.
-  result = dif_otbn_dmem_read(&dif_otbn_, 1, test_data, sizeof(test_data));
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_dmem_read(&dif_otbn_, 1, test_data, sizeof(test_data)),
+            kDifOtbnBadArg);
 
-  result = dif_otbn_dmem_read(&dif_otbn_, 2, test_data, sizeof(test_data));
-  EXPECT_EQ(result, kDifOtbnBadArg);
+  EXPECT_EQ(dif_otbn_dmem_read(&dif_otbn_, 2, test_data, sizeof(test_data)),
+            kDifOtbnBadArg);
 }
 
 TEST_F(DmemReadTest, SuccessWithoutOffset) {
@@ -616,8 +538,7 @@ TEST_F(DmemReadTest, SuccessWithoutOffset) {
   EXPECT_READ32(OTBN_DMEM_REG_OFFSET, 0x12345678);
   EXPECT_READ32(OTBN_DMEM_REG_OFFSET + 4, 0xabcdef01);
 
-  dif_otbn_result_t result = dif_otbn_dmem_read(&dif_otbn_, 0, test_data, 8);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_dmem_read(&dif_otbn_, 0, test_data, 8), kDifOtbnOk);
   EXPECT_EQ(test_data[0], 0x12345678);
   EXPECT_EQ(test_data[1], 0xabcdef01);
 }
@@ -631,8 +552,7 @@ TEST_F(DmemReadTest, SuccessWithOffset) {
   EXPECT_READ32(OTBN_DMEM_REG_OFFSET + 4, 0x12345678);
   EXPECT_READ32(OTBN_DMEM_REG_OFFSET + 8, 0xabcdef01);
 
-  dif_otbn_result_t result = dif_otbn_dmem_read(&dif_otbn_, 4, test_data, 8);
-  EXPECT_EQ(result, kDifOtbnOk);
+  EXPECT_EQ(dif_otbn_dmem_read(&dif_otbn_, 4, test_data, 8), kDifOtbnOk);
   EXPECT_EQ(test_data[0], 0x12345678);
   EXPECT_EQ(test_data[1], 0xabcdef01);
 }

--- a/sw/device/tests/dif/dif_otbn_smoketest.c
+++ b/sw/device/tests/dif/dif_otbn_smoketest.c
@@ -57,6 +57,17 @@ static void check_otbn_err_bits(otbn_t *otbn_ctx,
 }
 
 /**
+ * Gets the OTBN instruction count, checks that it matches expectations.
+ */
+static void check_otbn_insn_cnt(otbn_t *otbn_ctx, uint32_t expected_insn_cnt) {
+  uint32_t insn_cnt;
+  CHECK(dif_otbn_get_insn_cnt(&otbn_ctx->dif, &insn_cnt) == kDifOtbnOk);
+  CHECK(insn_cnt == expected_insn_cnt,
+        "Expected to execute %d instructions, but got %d.", expected_insn_cnt,
+        insn_cnt);
+}
+
+/**
  * Run a 384-bit Barrett Multiplication on OTBN and check its result.
  *
  * This test is not aiming to exhaustively test the Barrett multiplication
@@ -124,6 +135,8 @@ static void test_barrett384(otbn_t *otbn_ctx) {
           "Unexpected result c at byte %d: 0x%x (actual) != 0x%x (expected)", i,
           c[i], c_expected[i]);
   }
+
+  check_otbn_insn_cnt(otbn_ctx, 161);
 }
 
 /**
@@ -143,6 +156,8 @@ static void test_err_test(otbn_t *otbn_ctx) {
   CHECK(otbn_busy_wait_for_done(otbn_ctx) == kOtbnExecutionFailed);
 
   check_otbn_err_bits(otbn_ctx, kDifOtbnErrBitsBadDataAddr);
+
+  check_otbn_insn_cnt(otbn_ctx, 1);
 }
 
 bool test_main() {


### PR DESCRIPTION
[otbn] Add DIF for reading OTBN instruction count.
Update OTBN smoke test to check for instruction count.