### PR TITLE
[dv/otp_ctrl] Fix regression issues

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -83,6 +83,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
                       bit [TL_DW-1:0] wdata0,
                       bit [TL_DW-1:0] wdata1 = 0);
     bit [TL_DW-1:0] val;
+    if (collect_used_addr)  used_dai_addr_q.push_back(addr);
     addr = randomize_dai_addr(addr);
     csr_wr(ral.direct_access_address, addr);
     csr_wr(ral.direct_access_wdata_0, wdata0);
@@ -114,6 +115,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
                       output bit [TL_DW-1:0] rdata1);
     bit [TL_DW-1:0] val, backdoor_rd_val;
     bit backdoor_wr;
+    if (collect_used_addr) used_dai_addr_q.push_back(addr);
     addr = randomize_dai_addr(addr);
 
     // Here we won't backdoor write to corrupt ECC bits if:

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
@@ -142,6 +142,8 @@ class otp_ctrl_init_fail_vseq extends otp_ctrl_smoke_vseq;
 
         // Create LC check failure.
         `uvm_info(`gfn, "OTP_init LC failure", UVM_LOW)
+        // Clear backdoor injected errors.
+        cfg.mem_bkdr_util_h.clear_mem();
         exp_status[OtpDaiIdleIdx] = 0;
         cfg.otp_ctrl_vif.lc_check_byp_en = 0;
         req_lc_transition(1);

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_base_vseq.sv
@@ -13,11 +13,6 @@ class otp_ctrl_parallel_base_vseq extends otp_ctrl_dai_lock_vseq;
 
   `uvm_object_new
 
-  constraint num_trans_c {
-    num_trans  inside {[1:5]};
-    num_dai_op inside {[1:500]};
-  }
-
   virtual task body();
     bit base_vseq_done;
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -139,7 +139,6 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
         // OTP write via DAI
         if (rand_wr && !digest_calculated[part_idx]) begin
           dai_wr(dai_addr, wdata0, wdata1);
-          if (collect_used_addr) used_dai_addr_q.push_back(dai_addr);
           if (cfg.otp_ctrl_vif.lc_prog_req == 0) csr_rd(.ptr(ral.err_code), .value(tlul_val));
         end
 


### PR DESCRIPTION
This PR fixes wirte_blank_errors change related regression issue:
1). Move collect used address in `wr_dai` task.
2). Wipe memories after ECC backdoor injections in otp_init_fail test.
3). Mark DAI access to HW digest as invalid operation in
otp_partition_walk.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>