### PR TITLE
[dv/otp_ctrl] OTP write_blank_error support [PART6]

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -77,6 +77,13 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
     check_lc_err();
   endtask
 
+  // Used for stress_all sequence to clear OTP internal memory before going to next test.
+  // This can avoid unexpected ECC injection errors or write_blank errors.
+  virtual task post_start();
+    super.post_start();
+    clear_otp_memory();
+  endtask
+
   virtual task check_lc_err();
     fork
       forever begin


### PR DESCRIPTION
This PR cleans up the stress_all and stress_all_with_rand_reset
sequences to support write_blank_error.
To avoid previous sequence dai_wr affects next sequence, this PR wipes
the OTP memory after one sequence finishes running.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>