### PR TITLE
[otp_ctrl] Refine escalation behavior in life cycle partition

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -1023,7 +1023,7 @@ module otp_ctrl
         .cnsty_chk_ack_o   ( cnsty_chk_ack[k]                ),
         .escalate_en_i     ( lc_escalate_en[k]               ),
         // Only supported by life cycle partition (see further below).
-        .check_byp_en_i ( lc_ctrl_pkg::Off                ),
+        .check_byp_en_i    ( lc_ctrl_pkg::Off                ),
         .error_o           ( part_error[k]                   ),
         .access_i          ( part_access_csrs[k]             ),
         .access_o          ( part_access_dai[k]              ),
@@ -1070,7 +1070,13 @@ module otp_ctrl
         .integ_chk_ack_o   ( integ_chk_ack[k]                ),
         .cnsty_chk_req_i   ( cnsty_chk_req[k]                ),
         .cnsty_chk_ack_o   ( cnsty_chk_ack[k]                ),
-        .escalate_en_i     ( lc_escalate_en[k]               ),
+        // This is the only partition that does not support external escalation.
+        // The reason for this is that the "life cycle scrap" escalation action is 1) implemented
+        // directly inside the life cycle controller, and 2) this action may follow a different
+        // escalation protocol timing than the "wipe secrets" action activated via escalate_en_i.
+        // Note that glitch errors within this partition still lead to immediate invalidation
+        // of the life cycle vector.
+        .escalate_en_i     ( lc_ctrl_pkg::Off                ),
         // This is only supported by the life cycle partition. We need to prevent this partition
         // from escalating once the life cycle state in memory is being updated (and hence not
         // consistent with the values in the buffer regs anymore).
@@ -1119,6 +1125,9 @@ module otp_ctrl
       assign unused_part_scrmbl_sigs = ^{part_scrmbl_mtx_gnt[k],
                                          part_scrmbl_req_ready[k],
                                          part_scrmbl_rsp_valid[k]};
+
+      logic unused_escalate_en_sig;
+      assign unused_escalate_en_sig = ^lc_escalate_en[k];
 
     end else begin : gen_invalid
       // This is invalid and should break elaboration


### PR DESCRIPTION
Previously, all OTP partitions could be moved into escalation mode externally via `escalate_en_i`.
This can cause issues with the escalation action sequencing, since "wipe secrets" (`escalate_en_i`) is usually triggered a couple of cycles before triggering the "life cycle state scrap" action to allow for
clearing of local state. If the OTP life cycle partition can be moved into escalation state via `escalate_en_i`, this separation is no longer possible, since this action would immediately scrap the life cycle state as well.
Therefore, the `escalate_en_i` signal is disconnected from the OTP life cycle partition.

This should not have any major impact on security, since

1) glitching of that partition can still be detected immediately, and the partition responds by scrapping the life cycle state.

2) the "life cycle state scrap" escalation action implemented inside the life cycle controller takes care of invalidating the life cycle state and all life cycle signal outputs as part of the escalation protocol.

Signed-off-by: Michael Schaffner <msf@opentitan.org>