### PR TITLE
[dv/edn_reset] Fix stress_all_with_rand_reset error 

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -127,7 +127,11 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
             super.apply_reset(kind);
           join_any
           disable fork;
-          cfg.clk_rst_vif.drive_rst_pin(1);
+          if (cfg.clk_rst_vifs.size > 0) begin
+            foreach (cfg.clk_rst_vifs[i]) cfg.clk_rst_vifs[i].drive_rst_pin(1);
+          end else begin
+            cfg.clk_rst_vif.drive_rst_pin(1);
+          end
           cfg.edn_clk_rst_vif.drive_rst_pin(1);
         end join
       end

--- a/hw/dv/sv/dv_lib/dv_base_vseq.sv
+++ b/hw/dv/sv/dv_lib/dv_base_vseq.sv
@@ -100,7 +100,7 @@ class dv_base_vseq #(type RAL_T               = dv_base_reg_block,
             if (concurrent_deassert_resets) begin
               wait(one_reset_deasserted);
               disable fork;
-              foreach(cfg.clk_rst_vifs[i]) cfg.clk_rst_vifs[ral_name].drive_rst_pin(1);
+              foreach (cfg.clk_rst_vifs[i]) cfg.clk_rst_vifs[i].drive_rst_pin(1);
             end else begin
               wait fork;
             end

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_base_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_base_vseq.sv
@@ -30,11 +30,11 @@ class adc_ctrl_base_vseq extends cip_base_vseq #(
     `uvm_info(`gfn, "Initializating adc_ctrl, nothing to do at the moment", UVM_MEDIUM)
   endtask  // adc_ctrl_init
 
-  virtual task apply_reset(string kind = "HARD");
+  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
     if (kind == "HARD") begin
       cfg.clk_aon_rst_vif.apply_reset();
     end
-    super.apply_reset(kind);
+    super.apply_reset(kind, concurrent_deassert_resets);
   endtask  // apply_reset
 
 endclass : adc_ctrl_base_vseq

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
@@ -44,7 +44,7 @@ class aon_timer_base_vseq extends cip_base_vseq #(
     `uvm_info(`gfn, "Initializating aon timer, nothing to do at the moment", UVM_MEDIUM)
   endtask
 
-  virtual task apply_reset(string kind = "HARD");
+  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
     cfg.lc_escalate_en_vif.drive(initial_lc_escalate_en);
     cfg.sleep_vif.drive(initial_sleep_mode);
 
@@ -52,11 +52,11 @@ class aon_timer_base_vseq extends cip_base_vseq #(
     // because the AON clock is much slower so will always come up second.
     if (kind == "HARD" && reset_aon_first) begin
       cfg.aon_clk_rst_vif.apply_reset();
-      super.apply_reset(kind);
+      super.apply_reset(kind, concurrent_deassert_resets);
     end else begin
       fork
         if (kind == "HARD") cfg.aon_clk_rst_vif.apply_reset();
-        super.apply_reset(kind);
+        super.apply_reset(kind, concurrent_deassert_resets);
       join
     end
   endtask // apply_reset

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -56,9 +56,9 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     cfg.aon_clk_rst_vif.drive_rst_pin(1'b0);
   endtask
 
-  virtual task apply_reset(string kind = "HARD");
+  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
     fork
-      super.apply_reset(kind);
+      super.apply_reset(kind, concurrent_deassert_resets);
       if (kind == "HARD") fork
         cfg.main_clk_rst_vif.apply_reset();
         cfg.io_clk_rst_vif.apply_reset();

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -23,10 +23,10 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     // TODO
   endtask
 
-  virtual task apply_reset(string kind = "HARD");
+  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
     uvm_reg_data_t data;
     bit init_busy;
-    super.apply_reset(kind);
+    super.apply_reset(kind, concurrent_deassert_resets);
     if (kind == "HARD") begin
       cfg.clk_rst_vif.wait_clks(cfg.post_reset_delay_clks);
     end

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -44,8 +44,8 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   endtask
 
   // Cfg errors are cleared after reset
-  virtual task apply_reset(string kind = "HARD");
-    super.apply_reset(kind);
+  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
+    super.apply_reset(kind, concurrent_deassert_resets);
     cfg.ecc_err = OtpNoEccErr;
   endtask
 

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_base_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_base_vseq.sv
@@ -44,10 +44,10 @@ class pwm_base_vseq extends cip_base_vseq #(
   endtask : body
 
   // override apply_reset to handle core_reset domain
-  virtual task apply_reset(string kind = "HARD");
+  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
     fork
       if (kind == "HARD" || kind == "TL_IF") begin
-        super.apply_reset("HARD");
+        super.apply_reset("HARD", concurrent_deassert_resets);
       end
       if (kind == "HARD" || kind == "CORE_IF") begin
         cfg.clk_rst_core_vif.apply_reset();

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -157,9 +157,9 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
     // TODO
   endtask
 
-  virtual task apply_reset(string kind = "HARD");
+  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0));
     fork
-      super.apply_reset(kind);
+      super.apply_reset(kind, concurrent_deassert_resets);
       if (kind == "HARD") begin
         // A short slow clock reset should suffice.
         cfg.slow_clk_rst_vif.apply_reset(.pre_reset_dly_clks(0),

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
@@ -26,8 +26,8 @@ class rom_ctrl_base_vseq extends cip_base_vseq #(
     // TODO
   endtask
 
-  virtual task apply_reset(string kind = "HARD");
-    super.apply_reset();
+  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
+    super.apply_reset(kind, concurrent_deassert_resets);
     // Initialize memory
     rom_ctrl_mem_init();
   endtask

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -81,8 +81,8 @@ class spi_device_base_vseq extends cip_base_vseq #(
 
   `uvm_object_new
 
-  virtual task apply_reset(string kind = "HARD");
-    super.apply_reset(kind);
+  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
+    super.apply_reset(kind, concurrent_deassert_resets);
     cfg.clk_rst_vif.wait_clks(1);
   endtask
 

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
@@ -204,10 +204,10 @@ class spi_host_base_vseq extends cip_base_vseq #(
   endtask : process_interrupts
 
   // override apply_reset to handle core_reset domain
-  virtual task apply_reset(string kind = "HARD");
+  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
     fork
       if (kind == "HARD" || kind == "TL_IF") begin
-        super.apply_reset("HARD");
+        super.apply_reset("HARD", concurrent_deassert_resets);
       end
       if (kind == "HARD" || kind == "CORE_IF") begin
         cfg.clk_rst_core_vif.apply_reset();

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
@@ -21,8 +21,8 @@ class sram_ctrl_base_vseq extends cip_base_vseq #(
     if (do_sram_ctrl_init) sram_ctrl_init();
   endtask
 
-  virtual task apply_reset(string kind = "HARD");
-    super.apply_reset();
+  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
+    super.apply_reset(kind, concurrent_deassert_resets);
     cfg.lc_vif.init();
     cfg.exec_vif.init();
     if (kind == "HARD") begin

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -19,10 +19,10 @@ class usbdev_base_vseq extends cip_base_vseq #(
   `uvm_object_new
 
   // Override apply_reset to cater to usb domain as well.
-  virtual task apply_reset(string kind = "HARD");
+  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
     fork
       if (kind == "HARD" || kind == "BUS_IF") begin
-        super.apply_reset("HARD");
+        super.apply_reset("HARD", concurrent_deassert_resets);
       end
       if (kind == "HARD" || kind == "USB_IF") begin
         cfg.usb_clk_rst_vif.apply_reset();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -27,7 +27,7 @@ class chip_base_vseq extends cip_base_vseq #(
     super.post_start();
   endtask
 
-  virtual task apply_reset(string kind = "HARD");
+  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
     // Note: The JTAG reset does not have a dedicated pad and is muxed with other chip IOs.
     // These IOs have pad attributes that are driven from registers, and as long as
     // the reset line of those registers is X, the registers and hence the pad outputs
@@ -39,7 +39,7 @@ class chip_base_vseq extends cip_base_vseq #(
     // resets de-assert at different times. If the main rst_n de-asserts before others,
     // the CPU starts executing right away which can cause breakages.
     cfg.m_jtag_agent_cfg.do_trst_n();
-    super.apply_reset(kind);
+    super.apply_reset(kind, concurrent_deassert_resets);
   endtask
 
   virtual task dut_init(string reset_kind = "HARD");

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -10,7 +10,7 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
   }
   `uvm_object_new
 
-  virtual task apply_reset(string kind = "HARD");
+  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
     // The CSR tests (handled by this class) need to wait until the rom_ctrl block has finished
     // running KMAC before they can start issuing reads and writes. Otherwise, they might write to a
     // KMAC register while KMAC is in operation. This would have no effect and a subsequent read
@@ -22,7 +22,7 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
     // will go low. When the operation is finished, it will go high again. Wait until then.
     int unsigned rc_phase = 0;
 
-    super.apply_reset(kind);
+    super.apply_reset(kind, concurrent_deassert_resets);
 
     `uvm_info(`gfn, "waiting for rom_ctrl after reset", UVM_MEDIUM)
     while (rc_phase < 2) begin

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
@@ -31,8 +31,8 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
     apply_reset();
   endtask
 
-  virtual task apply_reset(string kind = "HARD");
-    super.apply_reset(kind);
+  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
+    super.apply_reset(kind, concurrent_deassert_resets);
     // Backdoor load the OTP image.
     cfg.mem_bkdr_util_h[Otp].load_mem_from_file({cfg.sw_images[SwTypeOtp], ".vmem"});
     wait (cfg.rst_n_mon_vif.pins[0] === 1);


### PR DESCRIPTION
There are two commits under this PR:
1. This commit fixes some error when `apply_reset()` task deasserts edn_reset and
dut_reset at different times.
The issue is: stress_all_with_rand_reset sequence tries to kill child
thread as soon as dut_reset is deasserted. If we deasserts edn_reset
later then dut_reset, then child thread might execute some tl_sequence,
and eventually causes some uvm_error when kill the child sequence.
2. This commits updates all IPs that overrides `apply_reset` task