### PR TITLE
[dv/dv_base_scoreboard] remove duplicated code

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_scoreboard.sv
+++ b/hw/dv/sv/dv_lib/dv_base_scoreboard.sv
@@ -34,12 +34,10 @@ class dv_base_scoreboard #(type RAL_T = dv_base_reg_block,
       if (!cfg.clk_rst_vif.rst_n) begin
         `uvm_info(`gfn, "reset occurred", UVM_HIGH)
         cfg.reset_asserted();
-        csr_utils_pkg::reset_asserted();
         @(posedge cfg.clk_rst_vif.rst_n);
         reset();
         cfg.reset_deasserted();
         csr_utils_pkg::clear_outstanding_access();
-        csr_utils_pkg::reset_deasserted();
         `uvm_info(`gfn, "out of reset", UVM_HIGH)
       end
       else begin


### PR DESCRIPTION
This PR removes duplicated call `csr_util_pkg::reset_assert` and
`csr_util_pkg::reset_deassert`. These two tasks are called in
`cfg.reset_asserted` and `cfg.reset_deasserted`.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>