### PR TITLE
Minor tweaks for bleeding-edge mypy

### DIFF
--- a/hw/ip/otbn/util/shared/yaml_parse_helpers.py
+++ b/hw/ip/otbn/util/shared/yaml_parse_helpers.py
@@ -6,11 +6,11 @@
 
 from typing import Callable, Dict, List, Optional, Sequence, TypeVar
 
-import yaml
+import yaml  # type: ignore
 try:
     from yaml import CSafeLoader as YamlLoader
 except ImportError:
-    from yaml import SafeLoader as YamlLoader  # type: ignore
+    from yaml import SafeLoader as YamlLoader
 
 
 T = TypeVar('T')

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -31,6 +31,10 @@ pyyaml
 tabulate
 yapf
 
+# Type stubs for mypy checking. types-dataclasses is only needed for Python <= 3.6.
+types-dataclasses
+types-tabulate
+
 # Development version with OT-specific changes
 git+https://github.com/lowRISC/fusesoc.git@ot#egg=fusesoc >= 1.11.0
 


### PR DESCRIPTION
In CI, we track the latest releases of all our Python dependencies.
Mypy just got a new release that gets downloaded by pip3 (version
0.901). Looking at the release log at http://mypy-lang.org/, it looks
like they no longer bundle quite as many type stubs as part of the
package.

In particular, the types for the tabulate package have been split out
into a "types-tabulate" package. Depending on that in
python-requirements should sort that out. Similarly, the dataclasses
module (a transient dependency of libcst for Python < 3.7) needs a
types-dataclasses package to avoid some seriously mysterious error
messages.

There also seems to be a small change to where the magic "ignore" line
needs to live when importing pyyaml. Meh, ok...
