### PR TITLE
AON Timer clock domain changes

### DIFF
--- a/hw/ip/aon_timer/doc/_index.md
+++ b/hw/ip/aon_timer/doc/_index.md
@@ -78,9 +78,9 @@ The always-on timer will run on a ~200KHz clock.
 The timers themselves are 32b wide, giving a maximum timeout window of roughly ~6 hours.
 For the wakeup timer, the pre-scaler extends the maximum timeout to ~1000 days.
 
-Since the timer core runs on a slow clock, register values are sampled into the main clock domain to ensure register read / writes do not incur large latencies.
-The synchronization between clocks means that there is a delay between a register write completing and the underlying hardware taking the new value.
-Software can read back register values to know if/when updates have taken effect.
+Register reads via the TLUL interface are synchronized to the slow clock via a single asynchronous fifo.
+This synchronization guarantees that updates have propagated into the underlying registers on completion of a write.
+Note that as a consequence of this, reads and writes to the AON Timer peripheral will cause the CPU to stall.
 
 # Programmers Guide
 

--- a/hw/ip/tlul/rtl/tlul_fifo_async.sv
+++ b/hw/ip/tlul/rtl/tlul_fifo_async.sv
@@ -87,9 +87,4 @@ module tlul_fifo_async #(
     .rdepth_o      ()
   );
 
-  ////////////////
-  // Assertions //
-  ////////////////
-  `ASSERT_INIT(DepthGTE3_A, ReqDepth >= 3 && RspDepth >= 3)
-
 endmodule

--- a/hw/top_earlgrey/dv/chip_dif_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_dif_tests.hjson
@@ -90,7 +90,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/dif_pwrmgr_smoketest:1"]
       en_run_modes: ["sw_test_mode"]
-      run_opts: ["+sw_test_timeout_ns=2000000"]
+      run_opts: ["+sw_test_timeout_ns=3000000"]
     }
     {
       name: chip_dif_rv_timer_smoketest


### PR DESCRIPTION
As discussed in #5805, we planned to trial a different approach for the AON Timer (and potentially other blocks) where registers from different clock domains have their own dedicated TLUL interface. I have implemented that here, but found that all the registers are in-fact in the AON domain, so there is still only a single TLUL interface needed.

These changes mean that the core stalls more while setting up the aon timer and so I had to extend the timeout for the dif_pwrmgr_smoke test.

Note, there are some more things that can be cleaned up in this module if we go with this approach (moving hwext registers back into the main register file) but I am leaving that for a future PR.