### PR TITLE
[rom_ctrl] Pass through data integrity properly from ROM to bus

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -58,7 +58,7 @@ module rom_ctrl
   logic [RomIndexWidth-1:0] bus_rom_index;
   logic                     bus_rom_req;
   logic                     bus_rom_gnt;
-  logic [39:0]              bus_rom_rdata;
+  logic [38:0]              bus_rom_rdata;
   logic                     bus_rom_rvalid;
 
   logic [RomIndexWidth-1:0] checker_rom_index;
@@ -117,7 +117,7 @@ module rom_ctrl
     .ByteAccess(0),
     .ErrOnWrite(1),
     .EnableRspIntgGen(1),
-    .EnableDataIntgGen(1) // TODO: Needs to be updated for integrity passthrough
+    .EnableDataIntgPt(1)
   ) u_tl_adapter_rom (
     .clk_i        (clk_i),
     .rst_ni       (rst_ni),
@@ -133,7 +133,7 @@ module rom_ctrl
     .wdata_o      (),
     .wmask_o      (),
     .intg_error_o (rom_integrity_error),
-    .rdata_i      (bus_rom_rdata[31:0]),
+    .rdata_i      (bus_rom_rdata),
     .rvalid_i     (bus_rom_rvalid),
     // TODO: Send an error on access when locked
     .rerror_i     (2'b00)
@@ -183,13 +183,6 @@ module rom_ctrl
     .clr_rdata_o (rom_clr_rdata),
     .cfg_i       (rom_cfg_i)
   );
-
-  // TODO: The ROM has been expanded to 40 bits wide to allow us to add 9 ECC check bits. At the
-  //       moment, however, we're actually generating the ECC data in u_tl_adapter_rom. That should
-  //       go away soonish but, until then, waive the fact that we're not looking at the top bits of
-  //       rom_rdata.
-  logic unused_bus_rom_rdata_top;
-  assign unused_bus_rom_rdata_top = &{1'b0, bus_rom_rdata[39:32]};
 
   // Zero expand checker rdata to pass to KMAC
   assign kmac_rom_data = {24'd0, checker_rom_rdata};

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_mux.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_mux.sv
@@ -19,7 +19,7 @@ module rom_ctrl_mux #(
   input logic [AW-1:0]  bus_addr_i,
   input logic           bus_req_i,
   output logic          bus_gnt_o,
-  output logic [39:0]   bus_rdata_o,
+  output logic [38:0]   bus_rdata_o,
   output logic          bus_rvalid_o,
 
   // Interface for ROM checker
@@ -54,7 +54,7 @@ module rom_ctrl_mux #(
 
   // The bus can have access every cycle, once the select signal is zero.
   assign bus_gnt_o    = ~sel_i;
-  assign bus_rdata_o  = rom_clr_rdata_i;
+  assign bus_rdata_o  = rom_clr_rdata_i[38:0];
   // A high rom_rvalid_i is a response to a bus request if sel_i was zero on the previous cycle.
   assign bus_rvalid_o = ~sel_q & rom_rvalid_i;
 
@@ -62,5 +62,12 @@ module rom_ctrl_mux #(
 
   assign rom_addr_o = sel_i ? chk_addr_i : bus_addr_i;
   assign rom_req_o  = sel_i ? chk_req_i  : bus_req_i;
+
+  // We use a Hsiao (39,32) ECC scheme for data integrity, but have expanded the ROM to 40 bits
+  // rather than 39 bits (it's no more expensive with many macro libraries, and it's slightly nicer
+  // for scrambling, because 40 is a whole number of 4-bit sboxes). Of course, this means that we
+  // never actually pass the top bit through to the bus. Waive that here.
+  logic unused_bus_rdata_top;
+  assign unused_bus_rdata_top = rom_clr_rdata_i[39];
 
 endmodule


### PR DESCRIPTION
Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>