### PR TITLE
[rom_ctrl] Remove a bogus TODO comment

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -135,7 +135,6 @@ module rom_ctrl
     .intg_error_o (rom_integrity_error),
     .rdata_i      (bus_rom_rdata[31:0]),
     .rvalid_i     (bus_rom_rvalid),
-    // TODO: Send an error on access when locked
     .rerror_i     (2'b00)
   );
 


### PR DESCRIPTION
When I wrote this, I imagined that a bus access when the ROM checker
was running should result in an error response. What we've ended up
with is that the bus access will just stall until the checker is done,
which seems like a perfectly reasonable behaviour. Let's just keep
that!

@cdgori: Just a ping to check that you agree about this. I suspect this will only ever happen if someone manages to reset the rom_ctrl block without resetting the power manager (otherwise, there aren't any bus hosts that are going to be trying to read the ROM). In that case, things are looking bad but I think the best response is probably to have KMAC and/or keymgr spot an unexpected request and explode that way. In normal operation, this should never happen (because Ibex doesn't come out of reset until after the check is finished).