### PR TITLE
[dv/otp_ctrl] Fix new changes in mem_bkdr_utils

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -72,4 +72,14 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
     m_tl_agent_cfg.max_outstanding_req = 1;
   endfunction
 
+  // OTP memory width is 16 bits while OTP word is 32 bits.
+  virtual function void backdoor_write32(bit [TL_DW-1:0] addr, bit [31:0] val);
+    mem_bkdr_util_h.write16(addr,     val[15:0]);
+    mem_bkdr_util_h.write16(addr + 2, val[31:16]);
+  endfunction
+
+  virtual function bit[31:0] backdoor_read32(bit [TL_DW-1:0] addr);
+    return {mem_bkdr_util_h.read16(addr + 2), mem_bkdr_util_h.read16(addr)};
+  endfunction
+
 endclass

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -113,8 +113,8 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
 
             if (dai_digest_ip != LifeCycleIdx) begin
               bit [TL_DW-1:0] otp_addr = PART_OTP_DIGEST_ADDRS[dai_digest_ip];
-              otp_a[otp_addr]   = cfg.mem_bkdr_util_h.read32(otp_addr << 2);
-              otp_a[otp_addr+1] = cfg.mem_bkdr_util_h.read32((otp_addr << 2) + 4);
+              otp_a[otp_addr]   = cfg.backdoor_read32(otp_addr << 2);
+              otp_a[otp_addr+1] = cfg.backdoor_read32((otp_addr << 2) + 4);
               dai_digest_ip = LifeCycleIdx;
             end
             predict_digest_csrs();
@@ -222,7 +222,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
       #1ps;
       if (cfg.otp_ctrl_vif.rst_ni == 0) begin
         for (int i = 0; i < LC_PROG_DATA_SIZE/32; i++) begin
-          otp_lc_data[i*32+:32] = cfg.mem_bkdr_util_h.read32(LifeCycleOffset+i*4);
+          otp_lc_data[i*32+:32] = cfg.backdoor_read32(LifeCycleOffset + i * 4);
         end
       end
     end
@@ -1167,4 +1167,5 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
     exp_alert = alert_name == "fatal_check_error" ? OtpCheckAlert : OtpMacroAlert;
     super.set_exp_alert(alert_name, is_fatal, max_delay);
   endfunction
+
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -148,7 +148,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     // If has ecc_err, backdoor write back original value
     // TODO: remove this once we can detect ECC error from men_bkdr_if
     if (backdoor_wr) begin
-      cfg.mem_bkdr_util_h.write32({addr[TL_DW-3:2], 2'b00}, backdoor_rd_val);
+      cfg.backdoor_write32({addr[TL_DW-3:2], 2'b00}, backdoor_rd_val);
     end
   endtask : dai_rd
 
@@ -243,7 +243,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     bit [TL_DW-1:0] val;
     prim_secded_pkg::secded_22_16_t out;
     addr = {addr[TL_DW-1:2], 2'b00};
-    val = cfg.mem_bkdr_util_h.read32(addr);
+    val = {cfg.mem_bkdr_util_h.read16(addr+2), cfg.mem_bkdr_util_h.read16(addr)};
     if (ecc_err == OtpNoEccErr || addr >= (LifeCycleOffset + LifeCycleSize)) return val;
 
     // Backdoor read and write back with error bits
@@ -278,7 +278,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     if (wait_done && val) csr_spinwait(ral.status.check_pending, 0);
 
     if (ecc_err != OtpNoEccErr) begin
-      cfg.mem_bkdr_util_h.write32(addr, backdoor_rd_val);
+      cfg.backdoor_write32(addr, backdoor_rd_val);
       cfg.ecc_chk_err = '{default: OtpNoEccErr};
     end
   endtask


### PR DESCRIPTION
Mem_bkdr_utils only can read up to the memory line width. For example,
OTP memory is 16 bits width, so we can only call read16 but not read32,
similarly only write16 not write32 directly.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>