### PR TITLE
[dv/otp_ctrl] Change used_addr from a queue to an associative array

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -65,6 +65,8 @@ package otp_ctrl_env_pkg;
   parameter uint OTP_ARRAY_SIZE = (CreatorSwCfgSize + OwnerSwCfgSize + HwCfgSize + Secret0Size +
                                    Secret1Size + Secret2Size) / (TL_DW / 8);
 
+  parameter int OTP_ADDR_WIDTH = 11;
+
   // Total num of valid dai address, secret partitions have a granularity of 8, the rest have
   // a granularity of 4. Subtract 8 for each digest.
   parameter uint DAI_ADDR_SIZE =

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
@@ -30,9 +30,8 @@ class otp_ctrl_dai_errs_vseq extends otp_ctrl_dai_lock_vseq;
   function void pre_randomize();
     this.dai_wr_blank_addr_c.constraint_mode(0);
     this.no_access_err_c.constraint_mode(0);
-    this.num_iterations_up_to_num_valid_addr_c.constraint_mode(0);
     this.dai_wr_digests_c.constraint_mode(0);
-    collect_used_addr = 0;
+    write_unused_addr = 0;
   endfunction
 
   task body();

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
@@ -18,11 +18,6 @@ class otp_ctrl_dai_lock_vseq extends otp_ctrl_smoke_vseq;
   // enable access_err for each cycle
   constraint no_access_err_c {access_locked_parts == 1;}
 
-  // access locked means no memory clear, constraint to ensure there are enough dai address
-  constraint num_iterations_up_to_num_valid_addr_c {
-    collect_used_addr -> num_trans * num_dai_op <= DAI_ADDR_SIZE;
-  }
-
   constraint num_trans_c {
     num_trans  inside {[1:10]};
     num_dai_op inside {[1:50]};
@@ -37,8 +32,8 @@ class otp_ctrl_dai_lock_vseq extends otp_ctrl_smoke_vseq;
     if (part_idx == Secret0Idx)      dai_addr inside `PART_ADDR_RANGE(Secret0Idx);
     if (part_idx == Secret1Idx)      dai_addr inside `PART_ADDR_RANGE(Secret1Idx);
     if (part_idx == Secret2Idx)      dai_addr inside `PART_ADDR_RANGE(Secret2Idx);
-    if (part_idx == LifeCycleIdx && collect_used_addr) {
-      if (collect_used_addr) {
+    if (part_idx == LifeCycleIdx && write_unused_addr) {
+      if (write_unused_addr) {
         // Dai address input is only 11 bits wide.
         dai_addr inside {[PartInfo[LifeCycleIdx].offset : {11{1'b1}}]};
       } else {

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
@@ -58,7 +58,6 @@ class otp_ctrl_init_fail_vseq extends otp_ctrl_smoke_vseq;
 
       // OTP write via DAI
       dai_wr(dai_addr, wdata0, wdata1);
-      used_dai_addr_q.push_back(dai_addr);
 
       if (i > num_to_lock_digests && part_idx inside {[HwCfgIdx: Secret2Idx]}) begin
         init_chk_err[part_idx] = 1;

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_invalid_cmd_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_invalid_cmd_vseq.sv
@@ -63,7 +63,6 @@ class otp_ctrl_macro_invalid_cmd_vseq extends otp_ctrl_smoke_vseq;
         end
 
       dai_wr(dai_addr, wdata0, wdata1);
-      used_dai_addr_q.push_back(dai_addr);
 
       // OTP read via DAI, check data in scb
       dai_rd(dai_addr, 0, wdata0, wdata1);

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_partition_walk_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_partition_walk_vseq.sv
@@ -10,7 +10,7 @@ class otp_ctrl_partition_walk_vseq extends otp_ctrl_base_vseq;
 
   virtual task pre_start();
     super.pre_start();
-    collect_used_addr = 0;
+    write_unused_addr = 0;
   endtask
 
   virtual task body();

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -40,7 +40,6 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
   }
 
   constraint dai_wr_blank_addr_c {
-    dai_addr inside {used_dai_addr_q} == 0;
     dai_addr % 4 == 0;
     if (part_idx inside {[Secret0Idx:Secret2Idx]}) dai_addr % 8 == 0;
   }


### PR DESCRIPTION
As Matute suggested (in PR #6885 ), I changed the data structure to collect used
addresses. Now we are using an associative array to collect written
addresses.

This PR also improves the sequence randomization. The old way is to try
randomize addresses and avoid write used address, now we will randomize
any address, but `dai_wr` task will skip the write if it is the address
is already written.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>