### PR TITLE
[csrng/rtl] diversification value for prod mode

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -7,6 +7,20 @@
     { protocol: "tlul", direction: "device" }
   ],
   param_list: [
+    // Random netlist constants
+    { name:      "RndCnstCsKeymgrDivNonProduction",
+      desc:      "Compile-time random bits for csrng state group diversification value",
+      type:      "csrng_pkg::cs_keymgr_div_t",
+      randcount: "384",
+      randtype:  "data",
+    }
+    { name:      "RndCnstCsKeymgrDivProduction",
+      desc:      "Compile-time random bits for csrng state group diversification value",
+      type:      "csrng_pkg::cs_keymgr_div_t",
+      randcount: "384",
+      randtype:  "data",
+    }
+    // Regular parameters
     { name: "SBoxImpl",
       type: "aes_pkg::sbox_impl_e",
       default: "aes_pkg::SBoxImplCanright",

--- a/hw/ip/csrng/rtl/csrng.sv
+++ b/hw/ip/csrng/rtl/csrng.sv
@@ -12,7 +12,9 @@ module csrng
 #(
   parameter aes_pkg::sbox_impl_e SBoxImpl = aes_pkg::SBoxImplCanright,
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
-  parameter int NHwApps = 2
+  parameter int NHwApps = 2,
+  parameter cs_keymgr_div_t RndCnstCsKeymgrDivNonProduction = CsKeymgrDivWidth'(0),
+  parameter cs_keymgr_div_t RndCnstCsKeymgrDivProduction = CsKeymgrDivWidth'(0)
 ) (
   input logic         clk_i,
   input logic         rst_ni,
@@ -76,7 +78,9 @@ module csrng
 
   csrng_core #(
     .SBoxImpl(SBoxImpl),
-    .NHwApps(NHwApps)
+    .NHwApps(NHwApps),
+    .RndCnstCsKeymgrDivNonProduction(RndCnstCsKeymgrDivNonProduction),
+    .RndCnstCsKeymgrDivProduction(RndCnstCsKeymgrDivProduction)
   ) u_csrng_core (
     .clk_i,
     .rst_ni,

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -8,7 +8,9 @@
 
 module csrng_core import csrng_pkg::*; #(
   parameter aes_pkg::sbox_impl_e SBoxImpl = aes_pkg::SBoxImplLut,
-  parameter int NHwApps = 2
+  parameter int NHwApps = 2,
+  parameter cs_keymgr_div_t RndCnstCsKeymgrDivNonProduction = CsKeymgrDivWidth'(0),
+  parameter cs_keymgr_div_t RndCnstCsKeymgrDivProduction = CsKeymgrDivWidth'(0)
 ) (
   input logic        clk_i,
   input logic        rst_ni,
@@ -89,6 +91,7 @@ module csrng_core import csrng_pkg::*; #(
   logic [AppCmdWidth-1:0] acmd_bus;
 
   logic [SeedLen-1:0]     packer_adata;
+  logic [SeedLen-1:0]     seed_diversification;
 
   logic                   cmd_entropy_req;
   logic                   cmd_entropy_avail;
@@ -327,8 +330,6 @@ module csrng_core import csrng_pkg::*; #(
   logic        flag0_q, flag0_d;
   logic        statedb_wr_select_q, statedb_wr_select_d;
   logic        genbits_stage_fips_sw_q, genbits_stage_fips_sw_d;
-  logic        lc_hw_debug_not_on_q, lc_hw_debug_not_on_d;
-  logic        lc_hw_debug_on_q, lc_hw_debug_on_d;
   logic        cmd_req_dly_q, cmd_req_dly_d;
   logic [Cmd-1:0] cmd_req_ccmd_dly_q, cmd_req_ccmd_dly_d;
   logic           cs_aes_halt_q, cs_aes_halt_d;
@@ -344,8 +345,6 @@ module csrng_core import csrng_pkg::*; #(
       flag0_q <= '0;
       statedb_wr_select_q <= '0;
       genbits_stage_fips_sw_q <= '0;
-      lc_hw_debug_not_on_q <= '0;
-      lc_hw_debug_on_q <= '0;
       cmd_req_dly_q <= '0;
       cmd_req_ccmd_dly_q <= '0;
       cs_aes_halt_q <= '0;
@@ -359,8 +358,6 @@ module csrng_core import csrng_pkg::*; #(
       flag0_q <= flag0_d;
       statedb_wr_select_q <= statedb_wr_select_d;
       genbits_stage_fips_sw_q <= genbits_stage_fips_sw_d;
-      lc_hw_debug_not_on_q <= lc_hw_debug_not_on_d;
-      lc_hw_debug_on_q <= lc_hw_debug_on_d;
       cmd_req_dly_q <= cmd_req_dly_d;
       cmd_req_ccmd_dly_q <= cmd_req_ccmd_dly_d;
       cs_aes_halt_q <= cs_aes_halt_d;
@@ -963,7 +960,7 @@ module csrng_core import csrng_pkg::*; #(
     .state_db_wr_res_ctr_i(state_db_wr_rc),
     .state_db_wr_sts_i(state_db_wr_sts),
 
-    .state_db_lc_en_i(lc_hw_debug_on_q),
+    .state_db_lc_en_i(lc_hw_debug_on),
     .state_db_reg_rd_sel_i(state_db_reg_rd_sel),
     .state_db_reg_rd_id_pulse_i(state_db_reg_rd_id_pulse),
     .state_db_reg_rd_val_o(state_db_reg_rd_val),
@@ -1002,10 +999,14 @@ module csrng_core import csrng_pkg::*; #(
   assign entropy_src_hw_if_o.es_req = cs_enable &&
          cmd_entropy_req;
 
+
+  assign seed_diversification = lc_hw_debug_on ? RndCnstCsKeymgrDivNonProduction :
+                                                 RndCnstCsKeymgrDivProduction;
+
   // Capture entropy from entropy_src
   assign entropy_src_seed_d =
          (cmd_entropy_avail && flag0_q) ? '0 : // special case where zero is used
-         cmd_entropy_avail ? entropy_src_hw_if_i.es_bits :
+         cmd_entropy_avail ? (entropy_src_hw_if_i.es_bits ^ seed_diversification) :
          entropy_src_seed_q;
   assign entropy_src_fips_d =
          (cmd_entropy_avail && flag0_q) ? '0 : // special case where zero is used
@@ -1228,14 +1229,6 @@ module csrng_core import csrng_pkg::*; #(
   assign      lc_hw_debug_not_on = (lc_hw_debug_en_out[0] != lc_ctrl_pkg::On);
   assign      lc_hw_debug_on = (lc_hw_debug_en_out[1] == lc_ctrl_pkg::On);
 
-  // flop for better timing
-  assign      lc_hw_debug_not_on_d =
-              (!cs_enable) ? '0 :
-              lc_hw_debug_not_on;
-
-  assign      lc_hw_debug_on_d =
-              (!cs_enable) ? '0 :
-              lc_hw_debug_on;
 
   //-------------------------------------
   // csrng_block_encrypt instantiation
@@ -1258,7 +1251,7 @@ module csrng_core import csrng_pkg::*; #(
     .rst_ni(rst_ni),
     .block_encrypt_bypass_i(!aes_cipher_enable),
     .block_encrypt_enable_i(cs_enable),
-    .block_encrypt_lc_hw_debug_not_on_i(lc_hw_debug_not_on_q),
+    .block_encrypt_lc_hw_debug_not_on_i(lc_hw_debug_not_on),
     .block_encrypt_req_i(benblk_arb_vld),
     .block_encrypt_rdy_o(benblk_arb_rdy),
     .block_encrypt_key_i(benblk_arb_key),

--- a/hw/ip/csrng/rtl/csrng_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_pkg.sv
@@ -44,4 +44,7 @@ package csrng_pkg;
     GENU = 3'h7
   } acmd_e;
 
+  parameter int CsKeymgrDivWidth = 384;
+  typedef logic [CsKeymgrDivWidth-1:0] cs_keymgr_div_t;
+
 endpackage : csrng_pkg

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -4496,6 +4496,26 @@
       param_list:
       [
         {
+          name: RndCnstCsKeymgrDivNonProduction
+          desc: Compile-time random bits for csrng state group diversification value
+          type: csrng_pkg::cs_keymgr_div_t
+          randcount: 384
+          randtype: data
+          name_top: RndCnstCsrngCsKeymgrDivNonProduction
+          default: 0x3a1955e3d4549f3608232d03f93eed0fe9d1b1f891dcab64f5a52883a710b72b92e47f6e0845f450ead8f3095ff32c32
+          randwidth: 384
+        }
+        {
+          name: RndCnstCsKeymgrDivProduction
+          desc: Compile-time random bits for csrng state group diversification value
+          type: csrng_pkg::cs_keymgr_div_t
+          randcount: 384
+          randtype: data
+          name_top: RndCnstCsrngCsKeymgrDivProduction
+          default: 0x220e25ba7743095f2c1194fb74487a86b6fee0311af608b7123f603c251a36ab2e658548c5420be549da272d96ae771b
+          randwidth: 384
+        }
+        {
           name: SBoxImpl
           desc: Selection of the S-Box implementation. See aes_pkg.sv.
           type: aes_pkg::sbox_impl_e
@@ -4907,7 +4927,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramKey
-          default: 0x92e47f6e0845f450ead8f3095ff32c32
+          default: 0xfe8c330ca072829f9970f91074501568
           randwidth: 128
         }
         {
@@ -4917,7 +4937,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramNonce
-          default: 0xe9d1b1f891dcab64f5a52883a710b72b
+          default: 0xcb942155264f8c121b7387a0a07db44
           randwidth: 128
         }
         {
@@ -4927,7 +4947,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstSramCtrlMainSramLfsrPerm
-          default: 0x33d0bedd4d8c36cb029c0cfd5cb87f2170991f42
+          default: 0x2bc503fee4ec68862f5c4db196cc15df82a1c8ce
           randwidth: 160
         }
         {
@@ -5105,7 +5125,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstOtbnUrndLfsrSeed
-          default: 0x1102be301eb1a8d04814ac33b45de425069e5959df06d42254a25afae52a5963
+          default: 0x44c7bd9e98eb2847fa1a35f74a8586d23e3bd765866c6f6363a02ed345973cf
           randwidth: 256
         }
         {
@@ -5115,7 +5135,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstOtbnUrndChunkLfsrPerm
-          default: 0x96c27a70b8a45cfd2d3b52b1f040db79a46ed80e5942bc02513fbdfd5a98a66805bc17dded6ccd3271a3e37a08c92847
+          default: 0xc12f0e2b9ea5a371fd0f691ca53bf257b7531e119cef75b206a2ca62f4d02ee4a4029144fe8521d5f36637ee6805c7a
           randwidth: 384
         }
       ]
@@ -5227,7 +5247,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRomCtrlScrNonce
-          default: 0xfc00de9d9734c3fe
+          default: 0x5a0d6e7185eaa2e0
           randwidth: 64
         }
         {
@@ -5237,7 +5257,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRomCtrlScrKey
-          default: 0x23c074e020fd502869582e71443c8be0
+          default: 0x3ae54e9e45da6e662fb69c3aab936b41
           randwidth: 128
         }
       ]

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -2249,6 +2249,8 @@ module top_earlgrey #(
 
   csrng #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[42:42]),
+    .RndCnstCsKeymgrDivNonProduction(RndCnstCsrngCsKeymgrDivNonProduction),
+    .RndCnstCsKeymgrDivProduction(RndCnstCsrngCsKeymgrDivProduction),
     .SBoxImpl(CsrngSBoxImpl)
   ) u_csrng (
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -197,21 +197,36 @@ package top_earlgrey_rnd_cnst_pkg;
   };
 
   ////////////////////////////////////////////
+  // csrng
+  ////////////////////////////////////////////
+  // Compile-time random bits for csrng state group diversification value
+  parameter csrng_pkg::cs_keymgr_div_t RndCnstCsrngCsKeymgrDivNonProduction = {
+    128'h3A1955E3D4549F3608232D03F93EED0F,
+    256'hE9D1B1F891DCAB64F5A52883A710B72B92E47F6E0845F450EAD8F3095FF32C32
+  };
+
+  // Compile-time random bits for csrng state group diversification value
+  parameter csrng_pkg::cs_keymgr_div_t RndCnstCsrngCsKeymgrDivProduction = {
+    128'h220E25BA7743095F2C1194FB74487A86,
+    256'hB6FEE0311AF608B7123F603C251A36AB2E658548C5420BE549DA272D96AE771B
+  };
+
+  ////////////////////////////////////////////
   // sram_ctrl_main
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlMainSramKey = {
-    128'h92E47F6E0845F450EAD8F3095FF32C32
+    128'hFE8C330CA072829F9970F91074501568
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlMainSramNonce = {
-    128'hE9D1B1F891DCAB64F5A52883A710B72B
+    128'h0CB942155264F8C121B7387A0A07DB44
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlMainSramLfsrPerm = {
-    160'h33D0BEDD4D8C36CB029C0CFD5CB87F2170991F42
+    160'h2BC503FEE4EC68862F5C4DB196CC15DF82A1C8CE
   };
 
   ////////////////////////////////////////////
@@ -219,13 +234,13 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for URND.
   parameter otbn_pkg::urnd_lfsr_seed_t RndCnstOtbnUrndLfsrSeed = {
-    256'h1102BE301EB1A8D04814AC33B45DE425069E5959DF06D42254A25AFAE52A5963
+    256'h044C7BD9E98EB2847FA1A35F74A8586D23E3BD765866C6F6363A02ED345973CF
   };
 
   // Permutation applied to the LFSR chunks of the PRNG used for URND.
   parameter otbn_pkg::urnd_chunk_lfsr_perm_t RndCnstOtbnUrndChunkLfsrPerm = {
-    128'h96C27A70B8A45CFD2D3B52B1F040DB79,
-    256'hA46ED80E5942BC02513FBDFD5A98A66805BC17DDED6CCD3271A3E37A08C92847
+    128'h0C12F0E2B9EA5A371FD0F691CA53BF25,
+    256'h7B7531E119CEF75B206A2CA62F4D02EE4A4029144FE8521D5F36637EE6805C7A
   };
 
   ////////////////////////////////////////////
@@ -233,12 +248,12 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Fixed nonce used for address / data scrambling
   parameter bit [63:0] RndCnstRomCtrlScrNonce = {
-    64'hFC00DE9D9734C3FE
+    64'h5A0D6E7185EAA2E0
   };
 
   // Randomised constant used as a scrambling key for ROM data
   parameter bit [127:0] RndCnstRomCtrlScrKey = {
-    128'h23C074E020FD502869582E71443C8BE0
+    128'h3AE54E9E45DA6E662FB69C3AAB936B41
   };
 
 endpackage : top_earlgrey_rnd_cnst_pkg


### PR DESCRIPTION
A new random string constant is being passed to be xor'ed with the input seed.
This will make the production mode look different than debug or other modes.
Fixes #4603.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>