### PR TITLE
[dv, chip] Enable UNR flow

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -66,6 +66,11 @@
       name: cover_reg_top_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/top_earlgrey/dv/cov/chip_cover_reg_top.cfg"
     }
+    // Used by the UNR flow.
+    {
+      name: vcs_unr_cfg_file
+      value: "{proj_root}/hw/top_earlgrey/dv/cov/unr.cfg"
+    }
 
     // This defaults to 'ip' in `hw/data/common_project_cfg.hjson`.
     {

--- a/hw/top_earlgrey/dv/cov/unr.cfg
+++ b/hw/top_earlgrey/dv/cov/unr.cfg
@@ -1,0 +1,21 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+-covInput $SCRATCH_PATH/cov_merge/merged.vdb
+-covDUT $dut_instance
+
+# Provide the clock specification.
+-clock IOC6 100
+
+# Provide the reset specification: signal_name, active_value, num clk cycles reset to be active.
+-reset POR_N 0 20
+
+# Black box some of the modules
+# -blackBoxes -type design *
+
+# Name of the generated exclusion file
+-save_exclusion $SCRATCH_PATH/cov_unr/unr_exclude.el
+
+# Enables verbose reporting in addition to summary reporting.
+-verboseReport


### PR DESCRIPTION
This sets up the UNR flow for the chip. Though, it does not work due to
errors thrown by the UNR tool. I am working with SNPS to resolve that.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>