### PR TITLE
[dv, chip] Remove USB clk driver

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -50,10 +50,10 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   rand clk_freq_mhz_e clk_freqs_mhz[string];
 
   `uvm_object_param_utils_begin(dv_base_env_cfg #(RAL_T))
-    `uvm_field_int   (is_active,                    UVM_DEFAULT)
-    `uvm_field_int   (en_scb,                       UVM_DEFAULT)
-    `uvm_field_int   (en_cov,                       UVM_DEFAULT)
-    `uvm_field_int   (zero_delays,                  UVM_DEFAULT)
+    `uvm_field_int   (is_active,   UVM_DEFAULT)
+    `uvm_field_int   (en_scb,      UVM_DEFAULT)
+    `uvm_field_int   (en_cov,      UVM_DEFAULT)
+    `uvm_field_int   (zero_delays, UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -20,11 +20,6 @@ class chip_env extends cip_base_env #(
     super.build_phase(phase);
     // configure the cpu d tl agent
     // get the vifs from config db
-    if (!uvm_config_db#(virtual clk_rst_if)::get(this, "", "usb_clk_rst_vif",
-        cfg.usb_clk_rst_vif)) begin
-      `uvm_fatal(`gfn, "failed to get usb_clk_rst_vif from uvm_config_db")
-    end
-
     if (!uvm_config_db#(gpio_vif)::get(this, "", "gpio_vif", cfg.gpio_vif)) begin
       `uvm_fatal(`gfn, "failed to get gpio_vif from uvm_config_db")
     end

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -18,7 +18,6 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
   bit                 use_spi_load_bootstrap = 0;
 
   // chip top interfaces
-  virtual clk_rst_if  usb_clk_rst_vif;
   gpio_vif            gpio_vif;
   virtual pins_if#(2) tap_straps_vif;
   virtual pins_if#(2) dft_straps_vif;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -43,8 +43,6 @@ class chip_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task dut_init(string reset_kind = "HARD");
-    // Set default frequencies.
-    cfg.usb_clk_rst_vif.set_freq_mhz(dv_utils_pkg::ClkFreq48Mhz);
     // Initialize gpio pin default states
     cfg.gpio_vif.set_pulldown_en({chip_env_pkg::NUM_GPIOS{1'b1}});
     // Initialize flash seeds

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -19,8 +19,6 @@ module tb;
   `include "chip_hier_macros.svh"
 
   wire clk, rst_n;
-  wire usb_clk, usb_rst_n;
-
   wire [NUM_GPIOS-1:0] gpio_pins;
 
   wire jtag_tck;
@@ -55,7 +53,6 @@ module tb;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk, .rst_n);
-  clk_rst_if usb_clk_rst_if(.clk(usb_clk), .rst_n(usb_rst_n));
   alert_esc_if alert_if[NUM_ALERTS](.clk(alert_handler_clk), .rst_n(rst_n));
   pins_if #(NUM_GPIOS) gpio_if(.pins(gpio_pins));
   pins_if #(1) srst_n_if(.pins(srst_n));
@@ -245,14 +242,9 @@ module tb;
   end : gen_connect_alerts_pins
 
   initial begin
-    // Set clk_rst_vifs
-    // drive rst_n from clk_if
-    // clk_rst_if references internal clock created by ast
+    // Set clk_rst_vifs.
     clk_rst_if.set_active();
-    usb_clk_rst_if.set_active(.drive_clk_val(1'b1), .drive_rst_n_val(1'b0));
-    // clk_rst_if will be gotten by env and env.scoreboard (for xbar)
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env*", "clk_rst_vif", clk_rst_if);
-    uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "usb_clk_rst_vif", usb_clk_rst_if);
 
     // IO Interfaces
     uvm_config_db#(virtual pins_if #(NUM_GPIOS))::set(null, "*.env", "gpio_vif", gpio_if);


### PR DESCRIPTION
Removes the `clk_rst_if` instance associated with USB clock at the chip
level which is not used.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>