### PR TITLE
[dv/otp_ctrl] Align with fatal alert LC partition status update

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -90,8 +90,9 @@ package otp_ctrl_env_pkg;
 
   parameter uint CHK_TIMEOUT_CYC = 40;
 
-  // When fatal alert triggered, all partitions go to error state and status will be 1.
-  parameter bit [8:0] FATAL_EXP_STATUS = 9'b1_1111_1111;
+  // When fatal alert triggered, all partitions go to error state and status will be
+  // set to 1, except LC partition index.
+  parameter bit [8:0] FATAL_EXP_STATUS = 9'b1_1011_1111;
 
   // lc does not have dai access
   parameter int PART_BASE_ADDRS [NumPart-1] = {

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -202,9 +202,11 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
       end
 
       // Update status bits.
-      for (int i = 0; i < OtpTimeoutErrIdx; i++) begin
-        predict_err(.status_err_idx(otp_status_e'(i)), .err_code(OtpFsmStateError),
-                    .update_esc_err(1));
+      foreach (FATAL_EXP_STATUS[i]) begin
+        if (FATAL_EXP_STATUS[i]) begin
+          predict_err(.status_err_idx(otp_status_e'(i)), .err_code(OtpFsmStateError),
+                      .update_esc_err(1));
+        end
       end
 
       // Update digest values and direct_access_regwen.


### PR DESCRIPTION
This PR aligns with design change PR #6889. This design change ensures
that OTP_CTRL's internal alerts won't directly trigger a LC escalation.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>