### PR TITLE
[flah_ctrl/dv] Two small fixes regarding flash back-door access

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
@@ -31,17 +31,14 @@ class flash_ctrl_env #(type CFG_T = flash_ctrl_env_cfg,
       cfg.m_eflash_tl_agent_cfg.d_ready_delay_max = 0;
     end
 
-    // Retrieve the mem backdoor util instances when using open-source generic flash model.
-    // TODO: this perhaps works for the closed source model as well?
-    if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin
-      for (int i = 0, flash_dv_part_e part = part.first(); i < part.num();
-           i++, part = part.next()) begin
-        foreach (cfg.mem_bkdr_util_h[, bank]) begin
-          string name = $sformatf("mem_bkdr_util[%0s][%0d]", part.name(), bank);
-          if (!uvm_config_db#(mem_bkdr_util)::get(this, "", name,
-                                                  cfg.mem_bkdr_util_h[part][bank])) begin
-            `uvm_fatal(`gfn, $sformatf("failed to get %s from uvm_config_db", name))
-          end
+    // Retrieve the mem backdoor util instances.
+    for (int i = 0, flash_dv_part_e part = part.first(); i < part.num();
+         i++, part = part.next()) begin
+      foreach (cfg.mem_bkdr_util_h[, bank]) begin
+        string name = $sformatf("mem_bkdr_util[%0s][%0d]", part.name(), bank);
+        if (!uvm_config_db#(mem_bkdr_util)::get(this, "", name,
+                                                cfg.mem_bkdr_util_h[part][bank])) begin
+          `uvm_fatal(`gfn, $sformatf("failed to get %s from uvm_config_db", name))
         end
       end
     end

--- a/hw/ip/flash_ctrl/dv/env/flash_mem_addr_attrs.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_mem_addr_attrs.sv
@@ -4,24 +4,35 @@
 
 // Provides abstraction for mapping a flash memory address in flash organization.
 class flash_mem_addr_attrs;
-    bit [TL_AW-1:0] addr;             // Input addr (this is aligned to the bus word)
-    bit [TL_AW-1:0] bank_addr;        // Addr within the bank.
 
-    bit [TL_AW-1:0] bank_start_addr;  // Start addr of the bank.
-    bit [TL_AW-1:0] page_start_addr;  // Start addr of the page within the bank.
+    bit [TL_AW-1:0] addr;               // Input addr (this is aligned to the bus word)
+    bit [TL_AW-1:0] bank_addr;          // Addr within the bank.
+    bit [TL_AW-1:0] full64_addr;        // Input full word addr (this is aligned to 64bits word)
+    bit [TL_AW-1:0] full64_bank_addr;   // Full word addr within the bank.
 
-    uint            bank;             // The bank the address belongs to.
-    uint            page;             // The page within the bank.
-    uint            line;             // The word line within the page.
+    bit [TL_AW-1:0] bank_start_addr;    // Start addr of the bank.
+    bit [TL_AW-1:0] page_start_addr;    // Start addr of the page within the bank.
+
+    uint            bank;               // The bank the address belongs to.
+    uint            page;               // The page within the bank.
+    uint            line;               // The word line within the page.
+
+    bit             is_start_addr_msb;  // Tells whether the start address of this addr_attr is
+                                        //  the 32 MSBs of some 64 bits word or the 32 LSBs.
 
   function new(bit [TL_AW-1:0] addr = 0);
+    is_start_addr_msb = addr[flash_ctrl_pkg::BusByteWidth];
     set_attrs(addr);
   endfunction
 
   // Set attributes from a sample input addr.
   function void set_attrs(bit [TL_AW-1:0] addr);
+
     this.addr = {addr[TL_AW-1:TL_SZW], {TL_SZW{1'b0}}};
     bank_addr = this.addr[FlashMemAddrPageMsbBit : 0];
+    full64_addr = {addr[TL_AW-1:flash_ctrl_env_pkg::FlashDataByteWidth],
+                 {flash_ctrl_env_pkg::FlashDataByteWidth{1'b0}}};
+    full64_bank_addr = full64_addr[FlashMemAddrPageMsbBit : 0];
 
     bank_start_addr = {addr[TL_AW-1 : FlashMemAddrPageMsbBit+1], {FlashMemAddrPageMsbBit+1{1'b0}}};
     page_start_addr = {addr[FlashMemAddrPageMsbBit : FlashMemAddrLineMsbBit+1],


### PR DESCRIPTION
Hi,
Two fixes featured in this PR:
1. Made the env config_db::set of mem_bkdr_util to be independent of implementation. Work well for partner env too.
2. Following Michael's response on closed PR #6770, made sure the simulation will do full words (64 bits) initializations even though the flash_ctrl transactions are in fact of 32 bits only.



Signed-off-by: Eitan Shapira <eitan.shapira@nuvoton.com>