### PR TITLE
[aon_timer] General register cleanup

### DIFF
--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -72,9 +72,7 @@
     { name: "WKUP_CTRL",
       desc: "Wakeup Timer Control register",
       swaccess: "rw",
-      hwaccess: "hrw",
-      hwext: "true",
-      hwqe: "true",
+      hwaccess: "hro",
       fields: [
         { bits: "0",
           name: "enable",
@@ -85,41 +83,30 @@
           desc: "Pre-scaler value for wakeup timer count",
         }
       ],
-      tags: [// register implemented in clk_aon domain and does not update according to
-             // normal timing
-        "excl:CsrAllTests:CsrExclWriteCheck"],
     },
     { name: "WKUP_THOLD",
       desc: "Wakeup Timer Threshold Register",
       swaccess: "rw",
-      hwaccess: "hrw",
-      hwext: "true",
-      hwqe: "true",
+      hwaccess: "hro",
       fields: [
         { bits: "31:0",
           name: "threshold",
           desc: "The count at which a wakeup interrupt should be generated",
         }
       ],
-      tags: [// register implemented in clk_aon domain and does not update according to
-             // normal timing
-        "excl:CsrAllTests:CsrExclWriteCheck"],
     },
     { name: "WKUP_COUNT",
       desc: "Wakeup Timer Count Register",
       swaccess: "rw",
       hwaccess: "hrw",
-      hwext: "true",
-      hwqe: "true",
       fields: [
         { bits: "31:0",
           name: "count",
           desc: "The current wakeup counter value",
         }
       ],
-      tags: [// register implemented in clk_aon domain and does not update according to
-             // normal timing
-        "excl:CsrAllTests:CsrExclWriteCheck"],
+      tags: [// this could be updated by HW
+        "excl:CsrNonInitTests:CsrExclWriteCheck"],
     },
     { name: "WDOG_REGWEN",
       desc: "Watchdog Timer Write Enable Register",
@@ -136,9 +123,7 @@
     { name: "WDOG_CTRL",
       desc: "Watchdog Timer Control register",
       swaccess: "rw",
-      hwaccess: "hrw",
-      hwext: "true",
-      hwqe: "true",
+      hwaccess: "hro",
       regwen: "WDOG_REGWEN",
       fields: [
         { bits: "0",
@@ -150,16 +135,11 @@
           desc: "When set to 1, the watchdog timer will not count during sleep",
         }
       ],
-      tags: [// register implemented in clk_aon domain and does not update according to
-             // normal timing
-        "excl:CsrAllTests:CsrExclWriteCheck"],
     },
     { name: "WDOG_BARK_THOLD",
       desc: "Watchdog Timer Bark Threshold Register",
       swaccess: "rw",
-      hwaccess: "hrw",
-      hwext: "true",
-      hwqe: "true",
+      hwaccess: "hro",
       regwen: "WDOG_REGWEN",
       fields: [
         { bits: "31:0",
@@ -167,16 +147,11 @@
           desc: "The count at which a watchdog bark interrupt should be generated",
         }
       ],
-      tags: [// register implemented in clk_aon domain and does not update according to
-             // normal timing
-        "excl:CsrAllTests:CsrExclWriteCheck"],
     },
     { name: "WDOG_BITE_THOLD",
       desc: "Watchdog Timer Bite Threshold Register",
       swaccess: "rw",
-      hwaccess: "hrw",
-      hwext: "true",
-      hwqe: "true",
+      hwaccess: "hro",
       regwen: "WDOG_REGWEN",
       fields: [
         { bits: "31:0",
@@ -184,25 +159,19 @@
           desc: "The count at which a watchdog bite reset should be generated",
         }
       ],
-      tags: [// register implemented in clk_aon domain and does not update according to
-             // normal timing
-        "excl:CsrAllTests:CsrExclWriteCheck"],
     },
     { name: "WDOG_COUNT",
       desc: "Watchdog Timer Count Register",
       swaccess: "rw",
       hwaccess: "hrw",
-      hwext: "true",
-      hwqe: "true",
       fields: [
         { bits: "31:0",
           name: "count",
           desc: "The current watchdog counter value",
         }
       ],
-      tags: [// register implemented in clk_aon domain and does not update according to
-             // normal timing
-        "excl:CsrAllTests:CsrExclWriteCheck"],
+      tags: [// this could be updated by HW
+        "excl:CsrNonInitTests:CsrExclWriteCheck"],
     },
     { name: "INTR_STATE",
       desc: "Interrupt State Register",
@@ -242,8 +211,6 @@
       desc: "Wakeup request status",
       swaccess: "rw0c",
       hwaccess: "hrw",
-      hwext: "true",
-      hwqe: "true",
       fields: [
         { bits: "0",
           name: "cause",

--- a/hw/ip/aon_timer/dv/env/aon_timer_env.core
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env.core
@@ -10,7 +10,6 @@ filesets:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
     files:
-      - aon_timer_core_if.sv
       - aon_timer_env_pkg.sv
       - aon_timer_env_cfg.sv: {is_include_file: true}
       - aon_timer_env_cov.sv: {is_include_file: true}

--- a/hw/ip/aon_timer/dv/env/aon_timer_env.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env.sv
@@ -32,10 +32,6 @@ class aon_timer_env extends cip_base_env #(
         get(this, "", "sleep_vif", cfg.sleep_vif)) begin
       `uvm_fatal(`gfn, "failed to get sleep_vif from uvm_config_db")
     end
-    if (!uvm_config_db#(virtual aon_timer_core_if)::
-        get(this, "", "core_vif", cfg.core_vif)) begin
-      `uvm_fatal(`gfn, "failed to get core_vif from uvm_config_db")
-    end
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/aon_timer/dv/env/aon_timer_env_cfg.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env_cfg.sv
@@ -8,7 +8,6 @@ class aon_timer_env_cfg extends cip_base_env_cfg #(.RAL_T(aon_timer_reg_block));
   virtual pins_if #(1)      lc_escalate_en_vif;
   virtual pins_if #(2)      aon_intr_vif;
   virtual pins_if #(1)      sleep_vif;
-  virtual aon_timer_core_if core_vif;
 
   // ext component cfgs
 

--- a/hw/ip/aon_timer/dv/tb.sv
+++ b/hw/ip/aon_timer/dv/tb.sv
@@ -59,8 +59,6 @@ module tb;
     .sleep_mode_i              (sleep)
   );
 
-  bind aon_timer_core aon_timer_core_if core_if (.*);
-
   initial begin
     // Configure interfaces
     fast_clk_rst_if.set_active();
@@ -79,8 +77,6 @@ module tb;
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", fast_intr_if);
     uvm_config_db#(virtual pins_if #(2))::set(null, "*.env", "aon_intr_vif", aon_intr_if);
     uvm_config_db#(virtual pins_if #(1))::set(null, "*.env", "sleep_vif", sleep_if);
-
-    uvm_config_db#(virtual aon_timer_core_if)::set(null, "*.env", "core_vif", dut.u_core.core_if);
 
     $timeformat(-12, 0, " ps", 12);
     run_test();

--- a/hw/ip/aon_timer/rtl/aon_timer.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer.sv
@@ -39,36 +39,13 @@ module aon_timer (
   // Register structs
   aon_timer_reg2hw_t         aon_reg2hw;
   aon_timer_hw2reg_t         aon_hw2reg;
-  // Register read signals
-  logic                      wkup_enable;
-  logic [11:0]               wkup_prescaler;
-  logic [31:0]               wkup_thold;
-  logic [31:0]               wkup_count;
-  logic                      wdog_enable;
-  logic                      wdog_pause;
-  logic [31:0]               wdog_bark_thold;
-  logic [31:0]               wdog_bite_thold;
-  logic [31:0]               wdog_count;
   // Register write signals
-  logic                      wkup_ctrl_reg_wr;
-  logic [12:0]               wkup_ctrl_wr_data;
-  logic                      wkup_thold_reg_wr;
-  logic [31:0]               wkup_thold_wr_data;
   logic                      wkup_count_reg_wr;
   logic [31:0]               wkup_count_wr_data;
-  logic                      wdog_ctrl_reg_wr;
-  logic [1:0]                wdog_ctrl_wr_data;
-  logic                      wdog_bark_thold_reg_wr;
-  logic [31:0]               wdog_bark_thold_wr_data;
-  logic                      wdog_bite_thold_reg_wr;
-  logic [31:0]               wdog_bite_thold_wr_data;
   logic                      wdog_count_reg_wr;
   logic [31:0]               wdog_count_wr_data;
   // Other sync signals
   lc_ctrl_pkg::lc_tx_t [2:0] lc_escalate_en;
-  // Wakeup signals
-  logic                      aon_wkup_req_d, aon_wkup_req_q;
-  logic                      aon_wkup_ack;
   // Interrupt signals
   logic                      aon_wkup_intr_set;
   logic                      aon_wdog_intr_set;
@@ -82,53 +59,14 @@ module aon_timer (
   logic                      aon_rst_req_set;
   logic                      aon_rst_req_d, aon_rst_req_q;
 
-  ////////////////////////////
-  // Register Read Sampling //
-  ////////////////////////////
-
-  assign aon_hw2reg.wkup_ctrl.enable.d         = wkup_enable;
-  assign aon_hw2reg.wkup_ctrl.prescaler.d      = wkup_prescaler;
-  assign aon_hw2reg.wkup_thold.d               = wkup_thold;
-  assign aon_hw2reg.wkup_count.d               = wkup_count;
-  assign aon_hw2reg.wdog_ctrl.enable.d         = wdog_enable;
-  assign aon_hw2reg.wdog_ctrl.pause_in_sleep.d = wdog_pause;
-  assign aon_hw2reg.wdog_bark_thold.d          = wdog_bark_thold;
-  assign aon_hw2reg.wdog_bite_thold.d          = wdog_bite_thold;
-  assign aon_hw2reg.wdog_count.d               = wdog_count;
-  assign aon_hw2reg.wkup_cause.d               = aon_wkup_req_q;
-
   //////////////////////////////
   // Register Write Interface //
   //////////////////////////////
 
-  // wkup_ctrl
-  assign wkup_ctrl_reg_wr  = aon_reg2hw.wkup_ctrl.prescaler.qe | aon_reg2hw.wkup_ctrl.enable.qe;
-  assign wkup_ctrl_wr_data = {aon_reg2hw.wkup_ctrl.prescaler.q, aon_reg2hw.wkup_ctrl.enable.q};
-
-  // wkup_thold
-  assign wkup_thold_reg_wr  = aon_reg2hw.wkup_thold.qe;
-  assign wkup_thold_wr_data = aon_reg2hw.wkup_thold.q;
-
-  // wkup_count
-  assign wkup_count_reg_wr  = aon_reg2hw.wkup_count.qe;
-  assign wkup_count_wr_data = aon_reg2hw.wkup_count.q;
-
-  // wdog_ctrl
-  assign wdog_ctrl_reg_wr  = aon_reg2hw.wdog_ctrl.pause_in_sleep.qe |
-                             aon_reg2hw.wdog_ctrl.enable.qe;
-  assign wdog_ctrl_wr_data = {aon_reg2hw.wdog_ctrl.pause_in_sleep.q, aon_reg2hw.wdog_ctrl.enable.q};
-
-  // wdog_bark_thold
-  assign wdog_bark_thold_reg_wr  = aon_reg2hw.wdog_bark_thold.qe;
-  assign wdog_bark_thold_wr_data = aon_reg2hw.wdog_bark_thold.q;
-
-  // wdog_bite_thold
-  assign wdog_bite_thold_reg_wr  = aon_reg2hw.wdog_bite_thold.qe;
-  assign wdog_bite_thold_wr_data = aon_reg2hw.wdog_bite_thold.q;
-
-  // wdog_count
-  assign wdog_count_reg_wr  = aon_reg2hw.wdog_count.qe;
-  assign wdog_count_wr_data = aon_reg2hw.wdog_count.q;
+  assign aon_hw2reg.wkup_count.de = wkup_count_reg_wr;
+  assign aon_hw2reg.wkup_count.d  = wkup_count_wr_data;
+  assign aon_hw2reg.wdog_count.de = wdog_count_reg_wr;
+  assign aon_hw2reg.wdog_count.d  = wdog_count_wr_data;
 
   // registers instantiation
   aon_timer_reg_top u_reg (
@@ -192,29 +130,11 @@ module aon_timer (
     .rst_aon_ni,
     .sleep_mode_i              (sleep_mode),
     .lc_escalate_en_i          (lc_escalate_en),
-    .wkup_enable_o             (wkup_enable),
-    .wkup_prescaler_o          (wkup_prescaler),
-    .wkup_thold_o              (wkup_thold),
-    .wkup_count_o              (wkup_count),
-    .wdog_enable_o             (wdog_enable),
-    .wdog_pause_o              (wdog_pause),
-    .wdog_bark_thold_o         (wdog_bark_thold),
-    .wdog_bite_thold_o         (wdog_bite_thold),
-    .wdog_count_o              (wdog_count),
-    .wkup_ctrl_reg_wr_i        (wkup_ctrl_reg_wr),
-    .wkup_ctrl_wr_data_i       (wkup_ctrl_wr_data),
-    .wkup_thold_reg_wr_i       (wkup_thold_reg_wr),
-    .wkup_thold_wr_data_i      (wkup_thold_wr_data),
-    .wkup_count_reg_wr_i       (wkup_count_reg_wr),
-    .wkup_count_wr_data_i      (wkup_count_wr_data),
-    .wdog_ctrl_reg_wr_i        (wdog_ctrl_reg_wr),
-    .wdog_ctrl_wr_data_i       (wdog_ctrl_wr_data),
-    .wdog_bark_thold_reg_wr_i  (wdog_bark_thold_reg_wr),
-    .wdog_bark_thold_wr_data_i (wdog_bark_thold_wr_data),
-    .wdog_bite_thold_reg_wr_i  (wdog_bite_thold_reg_wr),
-    .wdog_bite_thold_wr_data_i (wdog_bite_thold_wr_data),
-    .wdog_count_reg_wr_i       (wdog_count_reg_wr),
-    .wdog_count_wr_data_i      (wdog_count_wr_data),
+    .reg2hw_i                  (aon_reg2hw),
+    .wkup_count_reg_wr_o       (wkup_count_reg_wr),
+    .wkup_count_wr_data_o      (wkup_count_wr_data),
+    .wdog_count_reg_wr_o       (wdog_count_reg_wr),
+    .wdog_count_wr_data_o      (wdog_count_wr_data),
     .wkup_intr_o               (aon_wkup_intr_set),
     .wdog_intr_o               (aon_wdog_intr_set),
     .wdog_reset_req_o          (aon_rst_req_set)
@@ -224,21 +144,11 @@ module aon_timer (
   // Wakeup Signals //
   ////////////////////
 
-  // Wakeup signal remains high until acked by software
-  assign aon_wkup_req_d = aon_wkup_intr_set | aon_wdog_intr_set | (aon_wkup_req_q & ~aon_wkup_ack);
+  // Wakeup request is set by HW and cleared by SW
+  assign aon_hw2reg.wkup_cause.de = (aon_wkup_intr_set | aon_wdog_intr_set) & sleep_mode;
+  assign aon_hw2reg.wkup_cause.d  = 1'b1;
 
-  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
-    if (!rst_aon_ni) begin
-      aon_wkup_req_q <= 1'b0;
-    end else begin
-      aon_wkup_req_q <= aon_wkup_req_d;
-    end
-  end
-
-  // Wakeup request is cleared by SW writing zero
-  assign aon_wkup_ack = aon_reg2hw.wkup_cause.qe & ~aon_reg2hw.wkup_cause.q;
-
-  assign aon_timer_wkup_req_o = aon_wkup_req_q;
+  assign aon_timer_wkup_req_o = aon_reg2hw.wkup_cause.q;
 
   ////////////////////////
   // Interrupt Handling //

--- a/hw/ip/aon_timer/rtl/aon_timer_core.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_core.sv
@@ -3,98 +3,40 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-module aon_timer_core (
+module aon_timer_core import aon_timer_reg_pkg::*; (
   input  logic                      clk_aon_i,
   input  logic                      rst_aon_ni,
 
   input  lc_ctrl_pkg::lc_tx_t [2:0] lc_escalate_en_i,
   input  logic                      sleep_mode_i,
 
-  // Register read outputs
-  output logic                      wkup_enable_o,
-  output logic [11:0]               wkup_prescaler_o,
-  output logic [31:0]               wkup_thold_o,
-  output logic [31:0]               wkup_count_o,
-  output logic                      wdog_enable_o,
-  output logic                      wdog_pause_o,
-  output logic [31:0]               wdog_bark_thold_o,
-  output logic [31:0]               wdog_bite_thold_o,
-  output logic [31:0]               wdog_count_o,
-
-  // Register write inputs
-  input  logic                      wkup_ctrl_reg_wr_i,
-  input  logic [12:0]               wkup_ctrl_wr_data_i,
-  input  logic                      wkup_thold_reg_wr_i,
-  input  logic [31:0]               wkup_thold_wr_data_i,
-  input  logic                      wkup_count_reg_wr_i,
-  input  logic [31:0]               wkup_count_wr_data_i,
-  input  logic                      wdog_ctrl_reg_wr_i,
-  input  logic [1:0]                wdog_ctrl_wr_data_i,
-  input  logic                      wdog_bark_thold_reg_wr_i,
-  input  logic [31:0]               wdog_bark_thold_wr_data_i,
-  input  logic                      wdog_bite_thold_reg_wr_i,
-  input  logic [31:0]               wdog_bite_thold_wr_data_i,
-  input  logic                      wdog_count_reg_wr_i,
-  input  logic [31:0]               wdog_count_wr_data_i,
+  // Register interface
+  input  aon_timer_reg2hw_t         reg2hw_i,
+  output logic                      wkup_count_reg_wr_o,
+  output logic [31:0]               wkup_count_wr_data_o,
+  output logic                      wdog_count_reg_wr_o,
+  output logic [31:0]               wdog_count_wr_data_o,
 
   output logic                      wkup_intr_o,
   output logic                      wdog_intr_o,
   output logic                      wdog_reset_req_o
 );
 
+  logic        unused_reg2hw;
   // Wakeup signals
-  logic        wkup_enable_d, wkup_enable_q;
-  logic [11:0] wkup_prescaler_d, wkup_prescaler_q;
-  logic [31:0] wkup_thold_d, wkup_thold_q;
   logic [11:0] prescale_count_d, prescale_count_q;
   logic        prescale_en;
-  logic        wkup_incr, wkup_count_en;
-  logic [31:0] wkup_count_d, wkup_count_q;
+  logic        wkup_incr;
   // Watchdog signals
-  logic        wdog_enable_d, wdog_enable_q;
-  logic        wdog_pause_d, wdog_pause_q;
-  logic [31:0] wdog_bark_thold_d, wdog_bark_thold_q;
-  logic [31:0] wdog_bite_thold_d, wdog_bite_thold_q;
-  logic        wdog_incr, wdog_count_en;
-  logic [31:0] wdog_count_d, wdog_count_q;
+  logic        wdog_incr;
 
   //////////////////
   // Wakeup Timer //
   //////////////////
 
-  // Wakeup control register
-  assign wkup_prescaler_d = wkup_ctrl_wr_data_i[12:1];
-  assign wkup_enable_d    = wkup_ctrl_wr_data_i[0];
-
-  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
-    if (!rst_aon_ni) begin
-      wkup_prescaler_q <= 12'h000;
-      wkup_enable_q    <= 1'b0;
-    end else if (wkup_ctrl_reg_wr_i) begin
-      wkup_prescaler_q <= wkup_prescaler_d;
-      wkup_enable_q    <= wkup_enable_d;
-    end
-  end
-
-  assign wkup_enable_o    = wkup_enable_q;
-  assign wkup_prescaler_o = wkup_prescaler_q;
-
-  // Wakeup threshold register
-  assign wkup_thold_d = wkup_thold_wr_data_i;
-
-  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
-    if (!rst_aon_ni) begin
-      wkup_thold_q <= 32'd0;
-    end else if (wkup_thold_reg_wr_i) begin
-      wkup_thold_q <= wkup_thold_d;
-    end
-  end
-
-  assign wkup_thold_o = wkup_thold_q;
-
   // Prescaler counter
   assign prescale_count_d = wkup_incr ? 12'h000 : (prescale_count_q + 12'h001);
-  assign prescale_en      = wkup_enable_q & (lc_escalate_en_i[0] == lc_ctrl_pkg::Off);
+  assign prescale_en      = reg2hw_i.wkup_ctrl.enable.q & (lc_escalate_en_i[0] == lc_ctrl_pkg::Off);
 
   always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
     if (!rst_aon_ni) begin
@@ -105,92 +47,31 @@ module aon_timer_core (
   end
 
   // Wakeup timer count
-  assign wkup_incr     = (lc_escalate_en_i[1] == lc_ctrl_pkg::Off) & wkup_enable_q &
-                         (prescale_count_q == wkup_prescaler_q);
-  assign wkup_count_d  = wkup_count_reg_wr_i ? wkup_count_wr_data_i :
-                                               (wkup_count_q + 32'd1);
-  assign wkup_count_en = wkup_incr | wkup_count_reg_wr_i;
+  assign wkup_incr = (lc_escalate_en_i[1] == lc_ctrl_pkg::Off) & reg2hw_i.wkup_ctrl.enable.q &
+                     (prescale_count_q == reg2hw_i.wkup_ctrl.prescaler.q);
 
-  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
-    if (!rst_aon_ni) begin
-      wkup_count_q <= 32'd0;
-    end else if (wkup_count_en) begin
-      wkup_count_q <= wkup_count_d;
-    end
-  end
-
-  assign wkup_count_o = wkup_count_q;
+  assign wkup_count_reg_wr_o  = wkup_incr;
+  assign wkup_count_wr_data_o = (reg2hw_i.wkup_count.q + 32'd1);
 
   // Timer interrupt
-  assign wkup_intr_o = wkup_incr & (wkup_count_q == wkup_thold_q);
+  assign wkup_intr_o = wkup_incr & (reg2hw_i.wkup_count.q == reg2hw_i.wkup_thold.q);
 
   ////////////////////
   // Watchdog Timer //
   ////////////////////
 
-  // Watchdog control register
-  assign wdog_pause_d  = wdog_ctrl_wr_data_i[1];
-  assign wdog_enable_d = wdog_ctrl_wr_data_i[0];
-
-  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
-    if (!rst_aon_ni) begin
-      wdog_pause_q  <= 1'b0;
-      wdog_enable_q <= 1'b0;
-    end else if (wdog_ctrl_reg_wr_i) begin
-      wdog_pause_q  <= wdog_pause_d;
-      wdog_enable_q <= wdog_enable_d;
-    end
-  end
-
-  assign wdog_enable_o = wdog_enable_q;
-  assign wdog_pause_o  = wdog_pause_q;
-
-  // Watchdog bark threshold register
-  assign wdog_bark_thold_d = wdog_bark_thold_wr_data_i;
-
-  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
-    if (!rst_aon_ni) begin
-      wdog_bark_thold_q <= 32'd0;
-    end else if (wdog_bark_thold_reg_wr_i) begin
-      wdog_bark_thold_q <= wdog_bark_thold_d;
-    end
-  end
-
-  assign wdog_bark_thold_o = wdog_bark_thold_q;
-
-  // Watchdog bite threshold register
-  assign wdog_bite_thold_d = wdog_bite_thold_wr_data_i;
-
-  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
-    if (!rst_aon_ni) begin
-      wdog_bite_thold_q <= 32'd0;
-    end else if (wdog_bite_thold_reg_wr_i) begin
-      wdog_bite_thold_q <= wdog_bite_thold_d;
-    end
-  end
-
-  assign wdog_bite_thold_o = wdog_bite_thold_q;
-
   // Watchdog timer count
-  assign wdog_incr     = wdog_enable_q & (lc_escalate_en_i[2] == lc_ctrl_pkg::Off) &
-                         ~(sleep_mode_i & wdog_pause_q);
-  assign wdog_count_d  = wdog_count_reg_wr_i ? wdog_count_wr_data_i :
-                                               (wdog_count_q + 32'd1);
-  assign wdog_count_en = wdog_incr | wdog_count_reg_wr_i;
+  assign wdog_incr = reg2hw_i.wdog_ctrl.enable.q & (lc_escalate_en_i[2] == lc_ctrl_pkg::Off) &
+                     ~(sleep_mode_i & reg2hw_i.wdog_ctrl.pause_in_sleep.q);
 
-  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
-    if (!rst_aon_ni) begin
-      wdog_count_q <= 32'd0;
-    end else if (wdog_count_en) begin
-      wdog_count_q <= wdog_count_d;
-    end
-  end
-
-  assign wdog_count_o = wdog_count_q;
+  assign wdog_count_reg_wr_o  = wdog_incr;
+  assign wdog_count_wr_data_o = (reg2hw_i.wdog_count.q + 32'd1);
 
   // Timer interrupt
-  assign wdog_intr_o = wdog_incr & (wdog_count_q == wdog_bark_thold_q);
+  assign wdog_intr_o = wdog_incr & (reg2hw_i.wdog_count.q == reg2hw_i.wdog_bark_thold.q);
   // Timer reset
-  assign wdog_reset_req_o = wdog_incr & (wdog_count_q == wdog_bite_thold_q);
+  assign wdog_reset_req_o = wdog_incr & (reg2hw_i.wdog_count.q == reg2hw_i.wdog_bite_thold.q);
+
+  assign unused_reg2hw = |{reg2hw_i.intr_state, reg2hw_i.intr_test, reg2hw_i.wkup_cause};
 
 endmodule

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv
@@ -16,48 +16,39 @@ package aon_timer_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
-      logic        qe;
     } enable;
     struct packed {
       logic [11:0] q;
-      logic        qe;
     } prescaler;
   } aon_timer_reg2hw_wkup_ctrl_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
-    logic        qe;
   } aon_timer_reg2hw_wkup_thold_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
-    logic        qe;
   } aon_timer_reg2hw_wkup_count_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
-      logic        qe;
     } enable;
     struct packed {
       logic        q;
-      logic        qe;
     } pause_in_sleep;
   } aon_timer_reg2hw_wdog_ctrl_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
-    logic        qe;
   } aon_timer_reg2hw_wdog_bark_thold_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
-    logic        qe;
   } aon_timer_reg2hw_wdog_bite_thold_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
-    logic        qe;
   } aon_timer_reg2hw_wdog_count_reg_t;
 
   typedef struct packed {
@@ -82,45 +73,16 @@ package aon_timer_reg_pkg;
 
   typedef struct packed {
     logic        q;
-    logic        qe;
   } aon_timer_reg2hw_wkup_cause_reg_t;
 
   typedef struct packed {
-    struct packed {
-      logic        d;
-    } enable;
-    struct packed {
-      logic [11:0] d;
-    } prescaler;
-  } aon_timer_hw2reg_wkup_ctrl_reg_t;
-
-  typedef struct packed {
     logic [31:0] d;
-  } aon_timer_hw2reg_wkup_thold_reg_t;
-
-  typedef struct packed {
-    logic [31:0] d;
+    logic        de;
   } aon_timer_hw2reg_wkup_count_reg_t;
 
   typedef struct packed {
-    struct packed {
-      logic        d;
-    } enable;
-    struct packed {
-      logic        d;
-    } pause_in_sleep;
-  } aon_timer_hw2reg_wdog_ctrl_reg_t;
-
-  typedef struct packed {
     logic [31:0] d;
-  } aon_timer_hw2reg_wdog_bark_thold_reg_t;
-
-  typedef struct packed {
-    logic [31:0] d;
-  } aon_timer_hw2reg_wdog_bite_thold_reg_t;
-
-  typedef struct packed {
-    logic [31:0] d;
+    logic        de;
   } aon_timer_hw2reg_wdog_count_reg_t;
 
   typedef struct packed {
@@ -136,33 +98,29 @@ package aon_timer_reg_pkg;
 
   typedef struct packed {
     logic        d;
+    logic        de;
   } aon_timer_hw2reg_wkup_cause_reg_t;
 
   // Register -> HW type
   typedef struct packed {
-    aon_timer_reg2hw_wkup_ctrl_reg_t wkup_ctrl; // [191:177]
-    aon_timer_reg2hw_wkup_thold_reg_t wkup_thold; // [176:144]
-    aon_timer_reg2hw_wkup_count_reg_t wkup_count; // [143:111]
-    aon_timer_reg2hw_wdog_ctrl_reg_t wdog_ctrl; // [110:107]
-    aon_timer_reg2hw_wdog_bark_thold_reg_t wdog_bark_thold; // [106:74]
-    aon_timer_reg2hw_wdog_bite_thold_reg_t wdog_bite_thold; // [73:41]
-    aon_timer_reg2hw_wdog_count_reg_t wdog_count; // [40:8]
-    aon_timer_reg2hw_intr_state_reg_t intr_state; // [7:6]
-    aon_timer_reg2hw_intr_test_reg_t intr_test; // [5:2]
-    aon_timer_reg2hw_wkup_cause_reg_t wkup_cause; // [1:0]
+    aon_timer_reg2hw_wkup_ctrl_reg_t wkup_ctrl; // [181:169]
+    aon_timer_reg2hw_wkup_thold_reg_t wkup_thold; // [168:137]
+    aon_timer_reg2hw_wkup_count_reg_t wkup_count; // [136:105]
+    aon_timer_reg2hw_wdog_ctrl_reg_t wdog_ctrl; // [104:103]
+    aon_timer_reg2hw_wdog_bark_thold_reg_t wdog_bark_thold; // [102:71]
+    aon_timer_reg2hw_wdog_bite_thold_reg_t wdog_bite_thold; // [70:39]
+    aon_timer_reg2hw_wdog_count_reg_t wdog_count; // [38:7]
+    aon_timer_reg2hw_intr_state_reg_t intr_state; // [6:5]
+    aon_timer_reg2hw_intr_test_reg_t intr_test; // [4:1]
+    aon_timer_reg2hw_wkup_cause_reg_t wkup_cause; // [0:0]
   } aon_timer_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    aon_timer_hw2reg_wkup_ctrl_reg_t wkup_ctrl; // [179:167]
-    aon_timer_hw2reg_wkup_thold_reg_t wkup_thold; // [166:135]
-    aon_timer_hw2reg_wkup_count_reg_t wkup_count; // [134:103]
-    aon_timer_hw2reg_wdog_ctrl_reg_t wdog_ctrl; // [102:101]
-    aon_timer_hw2reg_wdog_bark_thold_reg_t wdog_bark_thold; // [100:69]
-    aon_timer_hw2reg_wdog_bite_thold_reg_t wdog_bite_thold; // [68:37]
-    aon_timer_hw2reg_wdog_count_reg_t wdog_count; // [36:5]
-    aon_timer_hw2reg_intr_state_reg_t intr_state; // [4:1]
-    aon_timer_hw2reg_wkup_cause_reg_t wkup_cause; // [0:0]
+    aon_timer_hw2reg_wkup_count_reg_t wkup_count; // [71:39]
+    aon_timer_hw2reg_wdog_count_reg_t wdog_count; // [38:6]
+    aon_timer_hw2reg_intr_state_reg_t intr_state; // [5:2]
+    aon_timer_hw2reg_wkup_cause_reg_t wkup_cause; // [1:0]
   } aon_timer_hw2reg_t;
 
   // Register offsets
@@ -179,15 +137,7 @@ package aon_timer_reg_pkg;
   parameter logic [BlockAw-1:0] AON_TIMER_WKUP_CAUSE_OFFSET = 6'h 28;
 
   // Reset values for hwext registers and their fields
-  parameter logic [12:0] AON_TIMER_WKUP_CTRL_RESVAL = 13'h 0;
-  parameter logic [31:0] AON_TIMER_WKUP_THOLD_RESVAL = 32'h 0;
-  parameter logic [31:0] AON_TIMER_WKUP_COUNT_RESVAL = 32'h 0;
-  parameter logic [1:0] AON_TIMER_WDOG_CTRL_RESVAL = 2'h 0;
-  parameter logic [31:0] AON_TIMER_WDOG_BARK_THOLD_RESVAL = 32'h 0;
-  parameter logic [31:0] AON_TIMER_WDOG_BITE_THOLD_RESVAL = 32'h 0;
-  parameter logic [31:0] AON_TIMER_WDOG_COUNT_RESVAL = 32'h 0;
   parameter logic [1:0] AON_TIMER_INTR_TEST_RESVAL = 2'h 0;
-  parameter logic [0:0] AON_TIMER_WKUP_CAUSE_RESVAL = 1'h 0;
 
   // Register index
   typedef enum int {

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
@@ -107,42 +107,33 @@ module aon_timer_reg_top (
   logic wkup_ctrl_enable_qs;
   logic wkup_ctrl_enable_wd;
   logic wkup_ctrl_enable_we;
-  logic wkup_ctrl_enable_re;
   logic [11:0] wkup_ctrl_prescaler_qs;
   logic [11:0] wkup_ctrl_prescaler_wd;
   logic wkup_ctrl_prescaler_we;
-  logic wkup_ctrl_prescaler_re;
   logic [31:0] wkup_thold_qs;
   logic [31:0] wkup_thold_wd;
   logic wkup_thold_we;
-  logic wkup_thold_re;
   logic [31:0] wkup_count_qs;
   logic [31:0] wkup_count_wd;
   logic wkup_count_we;
-  logic wkup_count_re;
   logic wdog_regwen_qs;
   logic wdog_regwen_wd;
   logic wdog_regwen_we;
   logic wdog_ctrl_enable_qs;
   logic wdog_ctrl_enable_wd;
   logic wdog_ctrl_enable_we;
-  logic wdog_ctrl_enable_re;
   logic wdog_ctrl_pause_in_sleep_qs;
   logic wdog_ctrl_pause_in_sleep_wd;
   logic wdog_ctrl_pause_in_sleep_we;
-  logic wdog_ctrl_pause_in_sleep_re;
   logic [31:0] wdog_bark_thold_qs;
   logic [31:0] wdog_bark_thold_wd;
   logic wdog_bark_thold_we;
-  logic wdog_bark_thold_re;
   logic [31:0] wdog_bite_thold_qs;
   logic [31:0] wdog_bite_thold_wd;
   logic wdog_bite_thold_we;
-  logic wdog_bite_thold_re;
   logic [31:0] wdog_count_qs;
   logic [31:0] wdog_count_wd;
   logic wdog_count_we;
-  logic wdog_count_re;
   logic intr_state_wkup_timer_expired_qs;
   logic intr_state_wkup_timer_expired_wd;
   logic intr_state_wkup_timer_expired_we;
@@ -156,69 +147,112 @@ module aon_timer_reg_top (
   logic wkup_cause_qs;
   logic wkup_cause_wd;
   logic wkup_cause_we;
-  logic wkup_cause_re;
 
   // Register instances
-  // R[wkup_ctrl]: V(True)
+  // R[wkup_ctrl]: V(False)
 
   //   F[enable]: 0:0
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
   ) u_wkup_ctrl_enable (
-    .re     (wkup_ctrl_enable_re),
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
     .we     (wkup_ctrl_enable_we),
     .wd     (wkup_ctrl_enable_wd),
-    .d      (hw2reg.wkup_ctrl.enable.d),
-    .qre    (),
-    .qe     (reg2hw.wkup_ctrl.enable.qe),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.wkup_ctrl.enable.q),
+
+    // to register interface (read)
     .qs     (wkup_ctrl_enable_qs)
   );
 
 
   //   F[prescaler]: 12:1
-  prim_subreg_ext #(
-    .DW    (12)
+  prim_subreg #(
+    .DW      (12),
+    .SWACCESS("RW"),
+    .RESVAL  (12'h0)
   ) u_wkup_ctrl_prescaler (
-    .re     (wkup_ctrl_prescaler_re),
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
     .we     (wkup_ctrl_prescaler_we),
     .wd     (wkup_ctrl_prescaler_wd),
-    .d      (hw2reg.wkup_ctrl.prescaler.d),
-    .qre    (),
-    .qe     (reg2hw.wkup_ctrl.prescaler.qe),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.wkup_ctrl.prescaler.q),
+
+    // to register interface (read)
     .qs     (wkup_ctrl_prescaler_qs)
   );
 
 
-  // R[wkup_thold]: V(True)
+  // R[wkup_thold]: V(False)
 
-  prim_subreg_ext #(
-    .DW    (32)
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
   ) u_wkup_thold (
-    .re     (wkup_thold_re),
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
     .we     (wkup_thold_we),
     .wd     (wkup_thold_wd),
-    .d      (hw2reg.wkup_thold.d),
-    .qre    (),
-    .qe     (reg2hw.wkup_thold.qe),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.wkup_thold.q),
+
+    // to register interface (read)
     .qs     (wkup_thold_qs)
   );
 
 
-  // R[wkup_count]: V(True)
+  // R[wkup_count]: V(False)
 
-  prim_subreg_ext #(
-    .DW    (32)
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
   ) u_wkup_count (
-    .re     (wkup_count_re),
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
     .we     (wkup_count_we),
     .wd     (wkup_count_wd),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_count.de),
     .d      (hw2reg.wkup_count.d),
-    .qre    (),
-    .qe     (reg2hw.wkup_count.qe),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.wkup_count.q),
+
+    // to register interface (read)
     .qs     (wkup_count_qs)
   );
 
@@ -250,82 +284,137 @@ module aon_timer_reg_top (
   );
 
 
-  // R[wdog_ctrl]: V(True)
+  // R[wdog_ctrl]: V(False)
 
   //   F[enable]: 0:0
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
   ) u_wdog_ctrl_enable (
-    .re     (wdog_ctrl_enable_re),
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
     .we     (wdog_ctrl_enable_we & wdog_regwen_qs),
     .wd     (wdog_ctrl_enable_wd),
-    .d      (hw2reg.wdog_ctrl.enable.d),
-    .qre    (),
-    .qe     (reg2hw.wdog_ctrl.enable.qe),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.wdog_ctrl.enable.q),
+
+    // to register interface (read)
     .qs     (wdog_ctrl_enable_qs)
   );
 
 
   //   F[pause_in_sleep]: 1:1
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
   ) u_wdog_ctrl_pause_in_sleep (
-    .re     (wdog_ctrl_pause_in_sleep_re),
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
     .we     (wdog_ctrl_pause_in_sleep_we & wdog_regwen_qs),
     .wd     (wdog_ctrl_pause_in_sleep_wd),
-    .d      (hw2reg.wdog_ctrl.pause_in_sleep.d),
-    .qre    (),
-    .qe     (reg2hw.wdog_ctrl.pause_in_sleep.qe),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.wdog_ctrl.pause_in_sleep.q),
+
+    // to register interface (read)
     .qs     (wdog_ctrl_pause_in_sleep_qs)
   );
 
 
-  // R[wdog_bark_thold]: V(True)
+  // R[wdog_bark_thold]: V(False)
 
-  prim_subreg_ext #(
-    .DW    (32)
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
   ) u_wdog_bark_thold (
-    .re     (wdog_bark_thold_re),
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
     .we     (wdog_bark_thold_we & wdog_regwen_qs),
     .wd     (wdog_bark_thold_wd),
-    .d      (hw2reg.wdog_bark_thold.d),
-    .qre    (),
-    .qe     (reg2hw.wdog_bark_thold.qe),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.wdog_bark_thold.q),
+
+    // to register interface (read)
     .qs     (wdog_bark_thold_qs)
   );
 
 
-  // R[wdog_bite_thold]: V(True)
+  // R[wdog_bite_thold]: V(False)
 
-  prim_subreg_ext #(
-    .DW    (32)
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
   ) u_wdog_bite_thold (
-    .re     (wdog_bite_thold_re),
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
     .we     (wdog_bite_thold_we & wdog_regwen_qs),
     .wd     (wdog_bite_thold_wd),
-    .d      (hw2reg.wdog_bite_thold.d),
-    .qre    (),
-    .qe     (reg2hw.wdog_bite_thold.qe),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.wdog_bite_thold.q),
+
+    // to register interface (read)
     .qs     (wdog_bite_thold_qs)
   );
 
 
-  // R[wdog_count]: V(True)
+  // R[wdog_count]: V(False)
 
-  prim_subreg_ext #(
-    .DW    (32)
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
   ) u_wdog_count (
-    .re     (wdog_count_re),
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
     .we     (wdog_count_we),
     .wd     (wdog_count_wd),
+
+    // from internal hardware
+    .de     (hw2reg.wdog_count.de),
     .d      (hw2reg.wdog_count.d),
-    .qre    (),
-    .qe     (reg2hw.wdog_count.qe),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.wdog_count.q),
+
+    // to register interface (read)
     .qs     (wdog_count_qs)
   );
 
@@ -416,18 +505,29 @@ module aon_timer_reg_top (
   );
 
 
-  // R[wkup_cause]: V(True)
+  // R[wkup_cause]: V(False)
 
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W0C"),
+    .RESVAL  (1'h0)
   ) u_wkup_cause (
-    .re     (wkup_cause_re),
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
     .we     (wkup_cause_we),
     .wd     (wkup_cause_wd),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_cause.de),
     .d      (hw2reg.wkup_cause.d),
-    .qre    (),
-    .qe     (reg2hw.wkup_cause.qe),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.wkup_cause.q),
+
+    // to register interface (read)
     .qs     (wkup_cause_qs)
   );
 
@@ -470,42 +570,33 @@ module aon_timer_reg_top (
 
   assign wkup_ctrl_enable_we = addr_hit[0] & reg_we & !reg_error;
   assign wkup_ctrl_enable_wd = reg_wdata[0];
-  assign wkup_ctrl_enable_re = addr_hit[0] & reg_re & !reg_error;
 
   assign wkup_ctrl_prescaler_we = addr_hit[0] & reg_we & !reg_error;
   assign wkup_ctrl_prescaler_wd = reg_wdata[12:1];
-  assign wkup_ctrl_prescaler_re = addr_hit[0] & reg_re & !reg_error;
 
   assign wkup_thold_we = addr_hit[1] & reg_we & !reg_error;
   assign wkup_thold_wd = reg_wdata[31:0];
-  assign wkup_thold_re = addr_hit[1] & reg_re & !reg_error;
 
   assign wkup_count_we = addr_hit[2] & reg_we & !reg_error;
   assign wkup_count_wd = reg_wdata[31:0];
-  assign wkup_count_re = addr_hit[2] & reg_re & !reg_error;
 
   assign wdog_regwen_we = addr_hit[3] & reg_we & !reg_error;
   assign wdog_regwen_wd = reg_wdata[0];
 
   assign wdog_ctrl_enable_we = addr_hit[4] & reg_we & !reg_error;
   assign wdog_ctrl_enable_wd = reg_wdata[0];
-  assign wdog_ctrl_enable_re = addr_hit[4] & reg_re & !reg_error;
 
   assign wdog_ctrl_pause_in_sleep_we = addr_hit[4] & reg_we & !reg_error;
   assign wdog_ctrl_pause_in_sleep_wd = reg_wdata[1];
-  assign wdog_ctrl_pause_in_sleep_re = addr_hit[4] & reg_re & !reg_error;
 
   assign wdog_bark_thold_we = addr_hit[5] & reg_we & !reg_error;
   assign wdog_bark_thold_wd = reg_wdata[31:0];
-  assign wdog_bark_thold_re = addr_hit[5] & reg_re & !reg_error;
 
   assign wdog_bite_thold_we = addr_hit[6] & reg_we & !reg_error;
   assign wdog_bite_thold_wd = reg_wdata[31:0];
-  assign wdog_bite_thold_re = addr_hit[6] & reg_re & !reg_error;
 
   assign wdog_count_we = addr_hit[7] & reg_we & !reg_error;
   assign wdog_count_wd = reg_wdata[31:0];
-  assign wdog_count_re = addr_hit[7] & reg_re & !reg_error;
 
   assign intr_state_wkup_timer_expired_we = addr_hit[8] & reg_we & !reg_error;
   assign intr_state_wkup_timer_expired_wd = reg_wdata[0];
@@ -521,7 +612,6 @@ module aon_timer_reg_top (
 
   assign wkup_cause_we = addr_hit[10] & reg_we & !reg_error;
   assign wkup_cause_wd = reg_wdata[0];
-  assign wkup_cause_re = addr_hit[10] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin


### PR DESCRIPTION
NOTE: No functional changes intended just tidy-up

Now that the register file itself is clocked on the AON domain, all of
the registers that were instantiated externally can be moved back into
the autogenerated files.

DV exclusions that were applied due to the propagation delays on
register reads and writes have also been removed.

The "core_if" in the aon_timer testbench has also been removed as there
isn't really anything left for it to bind on to.

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>