### PR TITLE
[dv/otp_ctrl] Fix two typo

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
@@ -56,12 +56,13 @@ class otp_ctrl_init_fail_vseq extends otp_ctrl_smoke_vseq;
       `uvm_info(`gfn, $sformatf("starting dai access seq %0d/%0d with addr %0h in partition %0d",
                 i, num_dai_op, dai_addr, part_idx), UVM_MEDIUM)
 
-      // OTP write via DAI
-      dai_wr(dai_addr, wdata0, wdata1);
-
-      if (i > num_to_lock_digests && part_idx inside {[HwCfgIdx: Secret2Idx]}) begin
+      if (i > num_to_lock_digests && part_idx inside {[HwCfgIdx: Secret2Idx]} &&
+          !used_dai_addrs.exists(dai_addr)) begin
         init_chk_err[part_idx] = 1;
       end
+
+      // OTP write via DAI
+      dai_wr(dai_addr, wdata0, wdata1);
 
       // OTP read via DAI, check data in scb
       dai_rd(dai_addr, 0, wdata0, wdata1);

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_invalid_cmd_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_invalid_cmd_vseq.sv
@@ -98,8 +98,8 @@ class otp_ctrl_macro_invalid_cmd_vseq extends otp_ctrl_smoke_vseq;
     string alert_name = "fatal_macro_error";
     int max_wait_cycles = (cfg.m_alert_agent_cfg[alert_name].ack_delay_max +
                            cfg.m_alert_agent_cfg[alert_name].ack_stable_max) *
-                          ($ceil(cfg.clk_rst_vif.clk_freq_mhz) /
-                           cfg.m_alert_agent_cfg[alert_name].vif.clk_rst_async_if.clk_freq_mhz);
+                          ($ceil(cfg.clk_rst_vif.clk_freq_mhz /
+                           cfg.m_alert_agent_cfg[alert_name].vif.clk_rst_async_if.clk_freq_mhz));
 
     `DV_SPINWAIT_EXIT(wait(cfg.m_alert_agent_cfg[alert_name].vif.alert_tx_final.alert_p);,
         cfg.clk_rst_vif.wait_clks(max_wait_cycles);,


### PR DESCRIPTION
Two typos found in regression:
1. A `)` was placed in wrong place, that ceil function does not work.
2. With the new wr_dai, otp_init should collect check if wr_data is
actually executed.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>