### PR TITLE
[dv, mem_bkdr_util] Address #6850 comments

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
@@ -22,11 +22,12 @@ class mem_bkdr_util extends uvm_object;
   // The width of the memory.
   protected uint32_t width;
 
-  // Indicates whether the memory implements parity protection per byte.
-  protected bit parity;
+  // Indicates the error detection scheme implemented for this memory.
+  protected err_detection_e err_detection_scheme = ErrDetectionNone;
 
-  // Indicates whether the memory implements ECC protection.
-  protected prim_secded_pkg::prim_secded_e ecc = prim_secded_pkg::SecdedNone;
+  // Convenience macro to check if ECC / parity is enabled.
+  `define HAS_ECC (!(err_detection_scheme inside {ErrDetectionNone, ParityEven, ParityOdd}))
+  `define HAS_PARITY (err_detection_scheme inside {ParityEven, ParityOdd})
 
   // TODO: Indicates whether the memory implements scrambling.
 
@@ -63,49 +64,47 @@ class mem_bkdr_util extends uvm_object;
 
   // Initialize the class instance.
   function new(string name = "", string path, int unsigned depth,
-               longint unsigned n_bits, bit parity, prim_secded_pkg::prim_secded_e ecc);
+               longint unsigned n_bits, err_detection_e err_detection_scheme);
 
     bit res;
     super.new(name);
-    `DV_CHECK_FATAL(!(parity && (ecc != SecdedNone)), "Cannot enable both parity & ecc.")
     `DV_CHECK_FATAL(!(n_bits % depth), "n_bits must be divisible by depth.")
     res = uvm_hdl_check_path(path);
     `DV_CHECK_EQ_FATAL(res, 1, $sformatf("Hierarchical path %0s appears to be invalid.", path))
 
-    this.path   = path;
-    this.depth  = depth;
-    this.width  = n_bits / depth;
-    this.parity = parity;
-    this.ecc    = ecc;
-    data_width  = (ecc == prim_secded_pkg::SecdedNone) ? width :
-                                                         prim_secded_pkg::get_ecc_data_width(ecc);
-    byte_width      = parity ? 9 : 8;
-    bytes_per_word  = data_width / byte_width;
+    this.path  = path;
+    this.depth = depth;
+    this.width = n_bits / depth;
+    this.err_detection_scheme = err_detection_scheme;
+
+    data_width = `HAS_ECC ? prim_secded_pkg::get_ecc_data_width(
+        prim_secded_pkg::prim_secded_e'(err_detection_scheme)) : width;
+    byte_width = `HAS_PARITY ? 9 : 8;
+    bytes_per_word = data_width / byte_width;
     `DV_CHECK_LE_FATAL(bytes_per_word, 16, "data width > 16 bytes is not supported")
-    size_bytes      = depth * bytes_per_word;
-    addr_lsb        = $clog2(bytes_per_word);
-    addr_width      = $clog2(depth);
+    size_bytes = depth * bytes_per_word;
+    addr_lsb   = $clog2(bytes_per_word);
+    addr_width = $clog2(depth);
     byte_addr_width = addr_width + addr_lsb;
-    max_errors      = width;
+    max_errors = width;
     if (name == "") set_name({path, "::mem_bkdr_util"});
     `uvm_info(`gfn, this.convert2string(), UVM_MEDIUM)
   endfunction
 
   virtual function string convert2string();
     return {"\n",
-            $sformatf("path             = %0s\n", path),
-            $sformatf("depth            = %0d\n", depth),
-            $sformatf("width            = %0d\n", width),
-            $sformatf("parity           = %0b\n", parity),
-            $sformatf("ecc              = %0s\n", ecc.name),
-            $sformatf("data_width       = %0d\n", data_width),
-            $sformatf("byte_width       = %0d\n", byte_width),
-            $sformatf("bytes_per_word   = %0d\n", bytes_per_word),
-            $sformatf("size_bytes       = 0x%0h\n", size_bytes),
-            $sformatf("addr_lsb         = %0d\n", addr_lsb),
-            $sformatf("addr_width       = %0d\n", addr_width),
-            $sformatf("byte_addr_width  = %0d\n", byte_addr_width),
-            $sformatf("max_errors       = %0d\n", max_errors)};
+            $sformatf("path = %0s\n", path),
+            $sformatf("depth = %0d\n", depth),
+            $sformatf("width = %0d\n", width),
+            $sformatf("err_detection_scheme = %0s\n", err_detection_scheme.name),
+            $sformatf("data_width = %0d\n", data_width),
+            $sformatf("byte_width = %0d\n", byte_width),
+            $sformatf("bytes_per_word = %0d\n", bytes_per_word),
+            $sformatf("size_bytes = 0x%0h\n", size_bytes),
+            $sformatf("addr_lsb = %0d\n", addr_lsb),
+            $sformatf("addr_width = %0d\n", addr_width),
+            $sformatf("byte_addr_width = %0d\n", byte_addr_width),
+            $sformatf("max_errors = %0d\n", max_errors)};
   endfunction
 
   function string get_path();
@@ -120,12 +119,8 @@ class mem_bkdr_util extends uvm_object;
     return width;
   endfunction
 
-  function bit get_parity();
-    return parity;
-  endfunction
-
-  function prim_secded_pkg::prim_secded_e get_ecc();
-    return ecc;
+  function err_detection_e get_err_detection_scheme();
+    return err_detection_scheme;
   endfunction
 
   function uint32_t get_data_width();
@@ -192,6 +187,11 @@ class mem_bkdr_util extends uvm_object;
     return data;
   endfunction
 
+  // Convenience macro to check the addr and data width for each flavor of read and write functions.
+  `define _ADDR_DW_CHECKS(_ADDR, _DW) \
+    `DV_CHECK_GE_FATAL(data_width, _DW, $sformatf("data_width %0d is < ``_DW``!", data_width)) \
+    `DV_CHECK_EQ_FATAL(_ADDR % (_DW / 8), 0, $sformatf("addr 0x%0h not ``_DW``-bit aligned", _ADDR))
+
   // Read a single byte at specified address.
   //
   // The data returned does not include the parity bits.
@@ -202,26 +202,22 @@ class mem_bkdr_util extends uvm_object;
   endfunction
 
   virtual function logic [15:0] read16(bit [bus_params_pkg::BUS_AW-1:0] addr);
-    `DV_CHECK_EQ_FATAL(addr[0], 0, $sformatf("addr 0x%0h not 16-bit aligned", addr))
-    `DV_CHECK_GE_FATAL(data_width, 16, $sformatf("data_width %0d is < 16!", data_width))
+    `_ADDR_DW_CHECKS(addr, 16)
     return {read8(addr + 1), read8(addr)};
   endfunction
 
   virtual function logic [31:0] read32(bit [bus_params_pkg::BUS_AW-1:0] addr);
-    `DV_CHECK_EQ_FATAL(addr[1:0], '0, $sformatf("addr 0x%0h not 32-bit aligned", addr), path)
-    `DV_CHECK_GE_FATAL(data_width, 32, $sformatf("data_width %0d is < 32!", data_width))
+    `_ADDR_DW_CHECKS(addr, 32)
     return {read16(addr + 2), read16(addr)};
   endfunction
 
   virtual function logic [63:0] read64(bit [bus_params_pkg::BUS_AW-1:0] addr);
-    `DV_CHECK_EQ_FATAL(addr[2:0], '0, $sformatf("addr 0x%0h not 64-bit aligned", addr), path)
-    `DV_CHECK_GE_FATAL(data_width, 64, $sformatf("data_width %0d is < 64!", data_width))
+    `_ADDR_DW_CHECKS(addr, 64)
     return {read32(addr + 4), read32(addr)};
   endfunction
 
   virtual function logic [127:0] read128(bit [bus_params_pkg::BUS_AW-1:0] addr);
-    `DV_CHECK_EQ_FATAL(addr[3:0], '0, $sformatf("addr 0x%0h not 128-bit aligned", addr), path)
-    `DV_CHECK_GE_FATAL(data_width, 128, $sformatf("data_width %0d is < 128!", data_width))
+    `_ADDR_DW_CHECKS(addr, 128)
     return {read64(addr + 8), read64(addr)};
   endfunction
 
@@ -258,8 +254,9 @@ class mem_bkdr_util extends uvm_object;
     word_idx = addr >> addr_lsb;
     byte_idx = addr - (word_idx << addr_lsb);
 
-    if (parity) begin
-      bit [8:0] lane = {~(^data), data};
+    if (`HAS_PARITY) begin
+      bit parity = (err_detection_scheme == ParityOdd) ? ~(^data) : (^data);
+      bit [8:0] lane = {parity, data};
       if (inject_num_errors) begin
         lane ^= (1 << $urandom_range(0, byte_width - 1));
       end
@@ -269,28 +266,28 @@ class mem_bkdr_util extends uvm_object;
     end
 
     rw_data[byte_idx * 8 +: 8] = data;
-    case (ecc)
-      prim_secded_pkg::SecdedNone: ;
-      prim_secded_pkg::Secded_22_16: begin
+    case (err_detection_scheme)
+      ErrDetectionNone: ;
+      Ecc_22_16: begin
         rw_data = prim_secded_pkg::prim_secded_22_16_enc(rw_data[15:0]);
       end
-      prim_secded_pkg::SecdedHamming_22_16: begin
+      EccHamming_22_16: begin
         rw_data = prim_secded_pkg::prim_secded_hamming_22_16_enc(rw_data[15:0]);
       end
-      prim_secded_pkg::Secded_39_32: begin
+      Ecc_39_32: begin
         rw_data = prim_secded_pkg::prim_secded_39_32_enc(rw_data[31:0]);
       end
-      prim_secded_pkg::SecdedHamming_39_32: begin
+      EccHamming_39_32: begin
         rw_data = prim_secded_pkg::prim_secded_hamming_39_32_enc(rw_data[31:0]);
       end
-      prim_secded_pkg::Secded_72_64: begin
+      Ecc_72_64: begin
         rw_data = prim_secded_pkg::prim_secded_72_64_enc(rw_data[63:0]);
       end
-      prim_secded_pkg::SecdedHamming_72_64: begin
+      EccHamming_72_64: begin
         rw_data = prim_secded_pkg::prim_secded_hamming_72_64_enc(rw_data[63:0]);
       end
       default: begin
-        `uvm_error(`gfn, $sformatf("ECC scheme %0s is unsupported.", ecc))
+        `uvm_error(`gfn, $sformatf("ECC scheme %0s is unsupported.", err_detection_scheme))
       end
     endcase
     if (inject_num_errors) rw_data = inject_errors(rw_data, inject_num_errors);
@@ -300,8 +297,7 @@ class mem_bkdr_util extends uvm_object;
   virtual function void write16(bit [bus_params_pkg::BUS_AW-1:0] addr, logic [15:0] data,
                                 uint32_t inject_num_errors = 0);
     int_pair_t inject_num_errors_split;
-    `DV_CHECK_EQ_FATAL(addr[0], '0, $sformatf("addr 0x%0h not 16-bit aligned", addr), path)
-    `DV_CHECK_GE_FATAL(data_width, 16, $sformatf("data_width %0d is < 16!", data_width))
+    `_ADDR_DW_CHECKS(addr, 16)
     if (!check_addr_valid(addr)) return;
     // Split the number of errors into different sub-byte write.
     inject_num_errors_split = rand_split(inject_num_errors);
@@ -312,8 +308,7 @@ class mem_bkdr_util extends uvm_object;
   virtual function void write32(bit [bus_params_pkg::BUS_AW-1:0] addr, logic [31:0] data,
                                 uint32_t inject_num_errors = 0);
     int_pair_t inject_num_errors_split;
-    `DV_CHECK_EQ_FATAL(addr[1:0], '0, $sformatf("addr 0x%0h not 32-bit aligned", addr), path)
-    `DV_CHECK_GE_FATAL(data_width, 32, $sformatf("data_width %0d is < 32!", data_width))
+    `_ADDR_DW_CHECKS(addr, 32)
     if (!check_addr_valid(addr)) return;
     // Split the number of errors into different sub-byte write.
     inject_num_errors_split = rand_split(inject_num_errors);
@@ -324,8 +319,7 @@ class mem_bkdr_util extends uvm_object;
   virtual function void write64(bit [bus_params_pkg::BUS_AW-1:0] addr, logic [63:0] data,
                                 uint32_t inject_num_errors = 0);
     int_pair_t inject_num_errors_split;
-    `DV_CHECK_EQ_FATAL(addr[2:0], '0, $sformatf("addr 0x%0h not 64-bit aligned", addr), path)
-    `DV_CHECK_GE_FATAL(data_width, 64, $sformatf("data_width %0d is < 64!", data_width))
+    `_ADDR_DW_CHECKS(addr, 64)
     if (!check_addr_valid(addr)) return;
     // Split the number of errors into different sub-byte write.
     inject_num_errors_split = rand_split(inject_num_errors);
@@ -336,14 +330,15 @@ class mem_bkdr_util extends uvm_object;
   virtual function void write128(bit [bus_params_pkg::BUS_AW-1:0] addr, logic [127:0] data,
                                  uint32_t inject_num_errors = 0);
     int_pair_t inject_num_errors_split;
-    `DV_CHECK_EQ_FATAL(addr[3:0], '0, $sformatf("addr 0x%0h not 128-bit aligned", addr), path)
-    `DV_CHECK_GE_FATAL(data_width, 128, $sformatf("data_width %0d is < 128!", data_width))
+    `_ADDR_DW_CHECKS(addr, 128)
     if (!check_addr_valid(addr)) return;
     // Split the number of errors into different sub-byte write.
     inject_num_errors_split = rand_split(inject_num_errors);
     write64(addr, data[63:0], inject_num_errors_split.x);
     write64(addr + 4, data[127:63], inject_num_errors_split.y);
   endfunction
+
+  `undef _ADDR_DW_CHECKS
 
   /////////////////////////////////////////////////////////
   // Wrapper functions for memory reads with ECC enabled //
@@ -357,11 +352,11 @@ class mem_bkdr_util extends uvm_object;
     uvm_hdl_data_t data;
     if (!check_addr_valid(addr)) return 'x;
     data = read(addr);
-    case (ecc)
-      prim_secded_pkg::Secded_22_16: begin
+    case (err_detection_scheme)
+      Ecc_22_16: begin
         return prim_secded_pkg::prim_secded_22_16_dec(data);
       end
-      prim_secded_pkg::SecdedHamming_22_16: begin
+      EccHamming_22_16: begin
         return prim_secded_pkg::prim_secded_hamming_22_16_dec(data);
       end
       default: return 'x;
@@ -373,11 +368,11 @@ class mem_bkdr_util extends uvm_object;
     uvm_hdl_data_t data;
     if (!check_addr_valid(addr)) return 'x;
     data = read(addr);
-    case (ecc)
-      prim_secded_pkg::Secded_39_32: begin
+    case (err_detection_scheme)
+      Ecc_39_32: begin
         return prim_secded_pkg::prim_secded_39_32_dec(data);
       end
-      prim_secded_pkg::SecdedHamming_39_32: begin
+      EccHamming_39_32: begin
         return prim_secded_pkg::prim_secded_hamming_39_32_dec(data);
       end
       default: return 'x;
@@ -389,11 +384,11 @@ class mem_bkdr_util extends uvm_object;
     uvm_hdl_data_t data;
     if (!check_addr_valid(addr)) return 'x;
     data = read(addr);
-    case (ecc)
-      prim_secded_pkg::Secded_72_64: begin
+    case (err_detection_scheme)
+      Ecc_72_64: begin
         return prim_secded_pkg::prim_secded_72_64_dec(data);
       end
-      prim_secded_pkg::SecdedHamming_72_64: begin
+      EccHamming_72_64: begin
         return prim_secded_pkg::prim_secded_hamming_72_64_dec(data);
       end
       default: return 'x;
@@ -874,6 +869,9 @@ class mem_bkdr_util extends uvm_object;
                                        (err_mask >> width) == '0;)
     return data ^ err_mask;
   endfunction
+
+  `undef HAS_ECC
+  `undef HAS_PARITY
 
 endclass
 

--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util_pkg.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util_pkg.sv
@@ -10,11 +10,20 @@ package mem_bkdr_util_pkg;
   import sram_scrambler_pkg::*;
   import uvm_pkg::*;
 
-  typedef enum {
-    MemParityNone,
-    MemParityOdd,
-    MemParityEven
-  } mem_parity_e;
+  // Represents the various forms of error detection / correction supported.
+  typedef enum int {
+    ErrDetectionNone = prim_secded_pkg::SecdedNone,
+    Ecc_22_16        = prim_secded_pkg::Secded_22_16,
+    Ecc_28_22        = prim_secded_pkg::Secded_28_22,
+    Ecc_39_32        = prim_secded_pkg::Secded_39_32,
+    Ecc_64_57        = prim_secded_pkg::Secded_64_57,
+    Ecc_72_64        = prim_secded_pkg::Secded_72_64,
+    EccHamming_22_16 = prim_secded_pkg::SecdedHamming_22_16,
+    EccHamming_39_32 = prim_secded_pkg::SecdedHamming_39_32,
+    EccHamming_72_64 = prim_secded_pkg::SecdedHamming_72_64,
+    ParityEven,
+    ParityOdd
+  } err_detection_e;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -137,8 +137,7 @@ module tb;
                               .path  (`FLASH_DATA_MEM_HIER_STR(i)),
                               .depth ($size(`FLASH_DATA_MEM_HIER(i))),
                               .n_bits($bits(`FLASH_DATA_MEM_HIER(i))),
-                              .parity(1'b0),
-                              .ecc   (prim_secded_pkg::SecdedNone));
+                              .err_detection_scheme(mem_bkdr_util_pkg::ErrDetectionNone));
         uvm_config_db#(mem_bkdr_util)::set(null, "*.env", m_mem_bkdr_util.get_name(),
                                            m_mem_bkdr_util);
         part = part.next();
@@ -151,8 +150,7 @@ module tb;
                                 .path  (`FLASH_INFO_MEM_HIER_STR(i, j)),
                                 .depth ($size(`FLASH_INFO_MEM_HIER(i, j))),
                                 .n_bits($bits(`FLASH_INFO_MEM_HIER(i, j))),
-                                .parity(1'b0),
-                                .ecc   (prim_secded_pkg::SecdedNone));
+                                .err_detection_scheme(mem_bkdr_util_pkg::ErrDetectionNone));
           uvm_config_db#(mem_bkdr_util)::set(null, "*.env", m_mem_bkdr_util.get_name(),
                                              m_mem_bkdr_util);
           part = part.next();

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -153,8 +153,7 @@ module tb;
                           .path  (`DV_STRINGIFY(`OTP_CTRL_MEM_HIER)),
                           .depth ($size(`OTP_CTRL_MEM_HIER)),
                           .n_bits($bits(`OTP_CTRL_MEM_HIER)),
-                          .parity(1'b0),
-                          .ecc   (prim_secded_pkg::SecdedHamming_22_16));
+                          .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_22_16));
 
     // These SVA checks the lc_escalate_en is either Off or On, we will use more than these
     // 2 values.

--- a/hw/ip/rom_ctrl/dv/tb.sv
+++ b/hw/ip/rom_ctrl/dv/tb.sv
@@ -72,8 +72,7 @@ module tb;
                           .path  (`DV_STRINGIFY(`ROM_CTRL_MEM_HIER)),
                           .depth ($size(`ROM_CTRL_MEM_HIER)),
                           .n_bits($bits(`ROM_CTRL_MEM_HIER)),
-                          .parity(1'b0),
-                          .ecc   (prim_secded_pkg::Secded_39_32));
+                          .err_detection_scheme(mem_bkdr_util_pkg::Ecc_39_32));
 
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();

--- a/hw/ip/sram_ctrl/dv/tb.sv
+++ b/hw/ip/sram_ctrl/dv/tb.sv
@@ -117,8 +117,7 @@ module tb;
                           .path  (`DV_STRINGIFY(`SRAM_CTRL_MEM_HIER)),
                           .depth ($size(`SRAM_CTRL_MEM_HIER)),
                           .n_bits($bits(`SRAM_CTRL_MEM_HIER)),
-                          .parity(1'b1),
-                          .ecc   (prim_secded_pkg::SecdedNone));
+                          .err_detection_scheme(mem_bkdr_util_pkg::ParityOdd));
 
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -285,68 +285,64 @@ module tb;
     initial begin
       mem_bkdr_util m_mem_bkdr_util[chip_mem_e];
 
-      m_mem_bkdr_util[FlashBank0Data] = new(.name  ("mem_bkdr_util[FlashBank0Data]"),
-                                            .path  (`DV_STRINGIFY(`FLASH0_DATA_MEM_HIER)),
-                                            .depth ($size(`FLASH0_DATA_MEM_HIER)),
-                                            .n_bits($bits(`FLASH0_DATA_MEM_HIER)),
-                                            .parity(1'b0),
-                                            .ecc   (prim_secded_pkg::SecdedNone));
+      m_mem_bkdr_util[FlashBank0Data] = new(
+          .name  ("mem_bkdr_util[FlashBank0Data]"),
+          .path  (`DV_STRINGIFY(`FLASH0_DATA_MEM_HIER)),
+          .depth ($size(`FLASH0_DATA_MEM_HIER)),
+          .n_bits($bits(`FLASH0_DATA_MEM_HIER)),
+          .err_detection_scheme(mem_bkdr_util_pkg::ErrDetectionNone));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[FlashBank0Data], `FLASH0_DATA_MEM_HIER)
 
-      m_mem_bkdr_util[FlashBank0Info] = new(.name  ("mem_bkdr_util[FlashBank0Info]"),
-                                            .path  (`DV_STRINGIFY(`FLASH0_INFO_MEM_HIER)),
-                                            .depth ($size(`FLASH0_INFO_MEM_HIER)),
-                                            .n_bits($bits(`FLASH0_INFO_MEM_HIER)),
-                                            .parity(1'b0),
-                                            .ecc   (prim_secded_pkg::SecdedNone));
+      m_mem_bkdr_util[FlashBank0Info] = new(
+          .name  ("mem_bkdr_util[FlashBank0Info]"),
+          .path  (`DV_STRINGIFY(`FLASH0_INFO_MEM_HIER)),
+          .depth ($size(`FLASH0_INFO_MEM_HIER)),
+          .n_bits($bits(`FLASH0_INFO_MEM_HIER)),
+          .err_detection_scheme(mem_bkdr_util_pkg::ErrDetectionNone));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[FlashBank0Info], `FLASH0_INFO_MEM_HIER)
 
-      m_mem_bkdr_util[FlashBank1Data] = new(.name  ("mem_bkdr_util[FlashBank1Data]"),
-                                            .path  (`DV_STRINGIFY(`FLASH1_DATA_MEM_HIER)),
-                                            .depth ($size(`FLASH1_DATA_MEM_HIER)),
-                                            .n_bits($bits(`FLASH1_DATA_MEM_HIER)),
-                                            .parity(1'b0),
-                                            .ecc   (prim_secded_pkg::SecdedNone));
+      m_mem_bkdr_util[FlashBank1Data] = new(
+          .name  ("mem_bkdr_util[FlashBank1Data]"),
+          .path  (`DV_STRINGIFY(`FLASH1_DATA_MEM_HIER)),
+          .depth ($size(`FLASH1_DATA_MEM_HIER)),
+          .n_bits($bits(`FLASH1_DATA_MEM_HIER)),
+          .err_detection_scheme(mem_bkdr_util_pkg::ErrDetectionNone));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[FlashBank1Data], `FLASH0_DATA_MEM_HIER)
 
-      m_mem_bkdr_util[FlashBank1Info] = new(.name  ("mem_bkdr_util[FlashBank1Info]"),
-                                            .path  (`DV_STRINGIFY(`FLASH1_INFO_MEM_HIER)),
-                                            .depth ($size(`FLASH1_INFO_MEM_HIER)),
-                                            .n_bits($bits(`FLASH1_INFO_MEM_HIER)),
-                                            .parity(1'b0),
-                                            .ecc   (prim_secded_pkg::SecdedNone));
+      m_mem_bkdr_util[FlashBank1Info] = new(
+          .name  ("mem_bkdr_util[FlashBank1Info]"),
+          .path  (`DV_STRINGIFY(`FLASH1_INFO_MEM_HIER)),
+          .depth ($size(`FLASH1_INFO_MEM_HIER)),
+          .n_bits($bits(`FLASH1_INFO_MEM_HIER)),
+          .err_detection_scheme(mem_bkdr_util_pkg::ErrDetectionNone));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[FlashBank1Info], `FLASH1_INFO_MEM_HIER)
 
       m_mem_bkdr_util[Otp] = new(.name  ("mem_bkdr_util[Otp]"),
                                  .path  (`DV_STRINGIFY(`OTP_MEM_HIER)),
                                  .depth ($size(`OTP_MEM_HIER)),
                                  .n_bits($bits(`OTP_MEM_HIER)),
-                                 .parity(1'b0),
-                                 .ecc   (prim_secded_pkg::SecdedHamming_22_16));
+                                 .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_22_16));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[Otp], `OTP_MEM_HIER)
 
       m_mem_bkdr_util[RamMain] = new(.name  ("mem_bkdr_util[RamMain]"),
                                      .path  (`DV_STRINGIFY(`RAM_MAIN_MEM_HIER)),
                                      .depth ($size(`RAM_MAIN_MEM_HIER)),
                                      .n_bits($bits(`RAM_MAIN_MEM_HIER)),
-                                     .parity(1'b1),
-                                     .ecc   (prim_secded_pkg::SecdedNone));
+                                     .err_detection_scheme(mem_bkdr_util_pkg::ParityOdd));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[RamMain], `RAM_MAIN_MEM_HIER)
 
       m_mem_bkdr_util[RamRet] = new(.name  ("mem_bkdr_util[RamRet]"),
                                     .path  (`DV_STRINGIFY(`RAM_RET_MEM_HIER)),
                                     .depth ($size(`RAM_RET_MEM_HIER)),
                                     .n_bits($bits(`RAM_RET_MEM_HIER)),
-                                    .parity(1'b0),
-                                    .ecc   (prim_secded_pkg::SecdedNone));
+                                    .err_detection_scheme(mem_bkdr_util_pkg::ParityOdd));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[RamRet], `RAM_RET_MEM_HIER)
 
       m_mem_bkdr_util[Rom] = new(.name  ("mem_bkdr_util[Rom]"),
                                  .path  (`DV_STRINGIFY(`ROM_MEM_HIER)),
                                  .depth ($size(`ROM_MEM_HIER)),
                                  .n_bits($bits(`ROM_MEM_HIER)),
-                                 .parity(1'b0),
-                                 .ecc   (prim_secded_pkg::Secded_39_32));
+                                 .err_detection_scheme(mem_bkdr_util_pkg::Ecc_39_32));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[Rom], `ROM_MEM_HIER)
 
       for (chip_mem_e mem = mem.first(), int i = 0; i < mem.num(); mem = mem.next(), i++) begin


### PR DESCRIPTION
This commit address 2 comments:
- Add enum that encompasses `prim_secded_e` and adds parity and none to
it, so that we can set the error detection scheme as a single enum var.
- Macrofy the repeated addr and data width checks

Signed-off-by: Srikrishna Iyer <sriyer@google.com>