### PR TITLE
[dv] Update VCS cov merge opts

### DIFF
--- a/doc/project/checklist.md
+++ b/doc/project/checklist.md
@@ -377,7 +377,7 @@ Code coverage requirements: line, toggle, fsm (state & transition), branch, asse
 
 ### SIM_FUNCTIONAL_COVERAGE_V2
 
-Functional coverage requirements: coverpoints: 100%, crosses: 75%
+Functional coverage requirements: 70%
 
 ### FPV_CODE_COVERAGE_V2
 
@@ -450,7 +450,7 @@ Code coverage requirements: line, toggle, fsm (state & transition), branch, asse
 
 ### SIM_FUNCTIONAL_COVERAGE_AT_100
 
-Functional coverage requirements: coverpoints: 100%, crosses: 100%
+Functional coverage requirements: 100%
 
 ### FPV_CODE_COVERAGE_AT_100
 

--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -125,31 +125,45 @@
   cov_merge_dir:    "{scratch_path}/cov_merge"
   cov_merge_db_dir: "{cov_merge_dir}/merged.vdb"
   cov_merge_cmd:    "{job_prefix} urg"
-  cov_merge_opts:   ["-full64",
-                     "+urg+lic+wait",
-                     "-nocheck",
+  cov_merge_opts:   ["-lca",
+                     "-full64",
+                     // No need of generating report when merging coverage.
                      "-noreport",
-                     "-flex_merge drop",
-                     "-group merge_across_scopes",
+                     // Merge results from tests in parallel.
                      "-parallel",
                      "-parallel_split 20",
+                     "-parallel_temproot {cov_merge_dir}",
+                     "+urg+lic+wait",
+                     // Merge same assert instances found in different VDBs.
+                     "-merge_across_libs",
+                     // Enable union mode of flexible merging for covergroups.
+                     "-flex_merge union",
                      // Use cov_db_dirs var for dir args; append -dir in front of each
                      "{eval_cmd} echo {cov_db_dirs} | sed -E 's/(\\S+)/-dir \\1/g'",
                      "-dbname {cov_merge_db_dir}"]
 
   // Generate coverage reports in text as well as html.
-  cov_report_dir:       "{scratch_path}/cov_report"
-  cov_report_cmd:       "{job_prefix} urg"
-  cov_report_opts:      ["-full64",
-                        "+urg+lic+wait",
-                        "-dir {cov_merge_db_dir}",
-                        "-group instcov_for_score",
-                        "-line nocasedef",
-                        "-format both",
-                        "-elfile {vcs_cov_excl_files}",
-                        "-report {cov_report_dir}"]
-  cov_report_txt:       "{cov_report_dir}/dashboard.txt"
-  cov_report_page:      "dashboard.html"
+  cov_report_dir:   "{scratch_path}/cov_report"
+  cov_report_cmd:   "{job_prefix} urg"
+  cov_report_opts:  ["-lca",
+                     "-full64",
+                     "+urg+lic+wait",
+                     // Lists all the tests that covered a given object.
+                     "-show tests",
+                     // Enable test grading.
+                     "-grade index",
+                     // Use simple ratio of total covered bins over total bins across cps & crs,
+                     "-group ratio",
+                     // Compute overall coverage for per-instance covergroups individually rather
+                     // than cumulatively.
+                     "-group instcov_for_score",
+                     "-dir {cov_merge_db_dir}",
+                     "-line nocasedef",
+                     "-format both",
+                     "-elfile {vcs_cov_excl_files}",
+                     "-report {cov_report_dir}"]
+  cov_report_txt:   "{cov_report_dir}/dashboard.txt"
+  cov_report_page:  "dashboard.html"
 
   // UNR related.
   // All code coverage, assert isn't supported


### PR DESCRIPTION
- Enable tests to be shown in coverage reports, with grading data
showing the % improvement contributed by each test - useful to look at
and prune the regression footprint.
- Enable merging of assertion coverage across VDBs
- Enable merging of covergroups across VDBs in union mode.
- Enable LCA features (does not require extra license)

Signed-off-by: Srikrishna Iyer <sriyer@google.com>