### PR TITLE
[mask_rom, pinmux] Add Pin Multiplexer driver for mask ROM

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -285,3 +285,35 @@ mask_rom_tests += {
     'library': sw_silicon_creator_lib_driver_alert_functest,
   }
 }
+
+# Mask ROM pinmux driver
+sw_silicon_creator_lib_driver_pinmux = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_lib_driver_pinmux',
+    sources: [
+      hw_top_earlgrey_pinmux_reg_h,
+      'pinmux.c',
+    ],
+    dependencies: [
+      sw_silicon_creator_lib_base_abs_mmio,
+    ],
+  ),
+)
+
+test('sw_silicon_creator_lib_driver_pinmux_unittest', executable(
+    'sw_silicon_creator_lib_driver_pinmux_unittest',
+    sources: [
+      'pinmux_unittest.cc',
+      hw_top_earlgrey_pinmux_reg_h,
+      'pinmux.c',
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_silicon_creator_lib_base_mock_abs_mmio,
+    ],
+    native: true,
+    c_args: ['-DMOCK_ABS_MMIO'],
+    cpp_args: ['-DMOCK_ABS_MMIO'],
+  ),
+  suite: 'mask_rom',
+)

--- a/sw/device/silicon_creator/lib/drivers/pinmux.c
+++ b/sw/device/silicon_creator/lib/drivers/pinmux.c
@@ -1,0 +1,69 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/pinmux.h"
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/base/abs_mmio.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "pinmux_regs.h"  // Generated.
+
+/**
+ * A peripheral input and MIO pad to link it to.
+ */
+typedef struct pinmux_input {
+  top_earlgrey_pinmux_peripheral_in_t periph;
+  top_earlgrey_pinmux_insel_t pad;
+} pinmux_input_t;
+
+/**
+ * Peripheral input to MIO pad mappings.
+ */
+static const pinmux_input_t kPinmuxInputs[] = {
+    /**
+     * UART
+     */
+    {.periph = kTopEarlgreyPinmuxPeripheralInUart0Rx,
+     .pad = kTopEarlgreyPinmuxInselIoc10},
+};
+
+/**
+ * An MIO pad and a peripheral output to link it to.
+ */
+typedef struct pinmux_output {
+  top_earlgrey_pinmux_mio_out_t pad;
+  top_earlgrey_pinmux_outsel_t periph;
+} pinmux_output_t;
+
+/**
+ * MIO pad to peripheral output mappings.
+ */
+static const pinmux_output_t kPinmuxOutputs[] = {
+    /**
+     * UART
+     */
+    {.pad = kTopEarlgreyPinmuxMioOutIoc11,
+     .periph = kTopEarlgreyPinmuxOutselUart0Tx},
+};
+
+void pinmux_init(void) {
+  // Set the input pad for each specified peripheral input.
+  const uint32_t kInputBase =
+      TOP_EARLGREY_PINMUX_AON_BASE_ADDR + PINMUX_MIO_PERIPH_INSEL_0_REG_OFFSET;
+  for (uint32_t i = 0; i < ARRAYSIZE(kPinmuxInputs); ++i) {
+    uint32_t reg = kPinmuxInputs[i].periph * sizeof(uint32_t);
+    uint32_t val = kPinmuxInputs[i].pad;
+    abs_mmio_write32(kInputBase + reg, val);
+  }
+
+  // Set the peripheral output for each specified output pad.
+  const uint32_t kOutputBase =
+      TOP_EARLGREY_PINMUX_AON_BASE_ADDR + PINMUX_MIO_OUTSEL_0_REG_OFFSET;
+  for (uint32_t i = 0; i < ARRAYSIZE(kPinmuxOutputs); ++i) {
+    uint32_t reg = kPinmuxOutputs[i].pad * sizeof(uint32_t);
+    uint32_t val = kPinmuxOutputs[i].periph;
+    abs_mmio_write32(kOutputBase + reg, val);
+  }
+}

--- a/sw/device/silicon_creator/lib/drivers/pinmux.h
+++ b/sw/device/silicon_creator/lib/drivers/pinmux.h
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_PINMUX_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_PINMUX_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Driver for the Pin Multiplexer (pinmux).
+ *
+ * The pinmux connects peripheral input and output signals to the Padring
+ * MIO pad input and output signals.
+ */
+
+/**
+ * Initialize the pinmux with the configuration required for the mask ROM.
+ */
+void pinmux_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_PINMUX_H_

--- a/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
@@ -1,0 +1,74 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/pinmux.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/silicon_creator/lib/base/mock_abs_mmio.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "pinmux_regs.h"  // Generated.
+
+namespace pinmux_unittest {
+namespace {
+class PinmuxTest : public mask_rom_test::MaskRomTest {
+ protected:
+  uint32_t base_ = TOP_EARLGREY_PINMUX_AON_BASE_ADDR;
+  mask_rom_test::MockAbsMmio mmio_;
+};
+
+class InitTest : public PinmuxTest {
+ protected:
+  /**
+   * Set to track which peripheral inputs have already been configured.
+   */
+  std::set<top_earlgrey_pinmux_peripheral_in_t> configured_in_;
+
+  /**
+   * Register the configuration of the input peripheral in the tracking
+   * set and return its computed address.
+   *
+   * Triggers a test failure if the input has already been registered.
+   */
+  uint32_t RegIn(top_earlgrey_pinmux_peripheral_in_t index) {
+    EXPECT_TRUE(index >= 0 && index < kTopEarlgreyPinmuxPeripheralInLast);
+    EXPECT_TRUE(configured_in_.insert(index).second);
+    return base_ + PINMUX_MIO_PERIPH_INSEL_0_REG_OFFSET +
+           static_cast<uint32_t>(index) * sizeof(uint32_t);
+  }
+
+  /**
+   * Set to track which MIO outputs have already been configured.
+   */
+  std::set<top_earlgrey_pinmux_mio_out_t> configured_out_;
+
+  /**
+   * Register the configuration of the MIO output in the tracking
+   * set and return its computed address.
+   *
+   * Triggers a test failure if the input has already been registered.
+   */
+  uint32_t RegOut(top_earlgrey_pinmux_mio_out_t index) {
+    EXPECT_TRUE(index >= 0 && index < kTopEarlgreyPinmuxMioOutLast);
+    EXPECT_TRUE(configured_out_.insert(index).second);
+    return base_ + PINMUX_MIO_OUTSEL_0_REG_OFFSET +
+           static_cast<uint32_t>(index) * sizeof(uint32_t);
+  };
+};
+
+TEST_F(InitTest, Initialize) {
+  // The inputs that will be configured.
+  EXPECT_ABS_WRITE32(mmio_, RegIn(kTopEarlgreyPinmuxPeripheralInUart0Rx),
+                     kTopEarlgreyPinmuxInselIoc10);
+
+  // The outputs that will be configured.
+  EXPECT_ABS_WRITE32(mmio_, RegOut(kTopEarlgreyPinmuxMioOutIoc11),
+                     kTopEarlgreyPinmuxOutselUart0Tx);
+
+  pinmux_init();
+}
+
+}  // namespace
+}  // namespace pinmux_unittest

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -163,6 +163,7 @@ mask_rom_lib = declare_dependency(
       sw_silicon_creator_lib_driver_hmac,
       sw_silicon_creator_lib_driver_keymgr,
       sw_silicon_creator_lib_driver_lifecycle,
+      sw_silicon_creator_lib_driver_pinmux,
       sw_silicon_creator_lib_driver_uart,
       sw_silicon_creator_lib_fake_deps,
       sw_silicon_creator_lib_manifest,
@@ -171,7 +172,6 @@ mask_rom_lib = declare_dependency(
       sw_silicon_creator_mask_rom_sigverify,
       sw_silicon_creator_mask_rom_romextimage,
       sw_lib_crt,
-      sw_lib_pinmux,
       sw_lib_runtime_print,
     ],
     link_with: static_library(


### PR DESCRIPTION
Add a simple pinmux driver for the mask ROM to use. Uses the
`abs_mmio` library for register accesses.

Right now the mask ROM is only using two pins: one for the UART RX
and one for the UART TX. The number of pins the mask ROM needs to
configure will grow however so the library has been designed to
make it trivial to add new pin mappings. The configuration the mask
ROM needs is static so we do all of the work in a single function:
`pinmux_init`. Pad attributes may need to be set dynamically so
those will be handled later.

The driver itself is table driven which makes it easy to see which
pins are mapped to which peripheral inputs and outputs. In the
future we may want to revisit this decision to reduce code size.