### PR TITLE
[topgen] Fix hex chunking code

### DIFF
--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -61,7 +61,7 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlRetAonSramKey = {
-    128'h738F30D9006289A1D7D9D0CE1DD7D7C
+    128'h0738F30D9006289A1D7D9D0CE1DD7D7C
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
@@ -89,7 +89,7 @@ package top_earlgrey_rnd_cnst_pkg;
 
   // Compile-time random bits for initial LFSR seed
   parameter flash_ctrl_pkg::lfsr_seed_t RndCnstFlashCtrlLfsrSeed = {
-    32'h96F534D
+    32'h096F534D
   };
 
   // Compile-time random permutation for LFSR output
@@ -183,7 +183,7 @@ package top_earlgrey_rnd_cnst_pkg;
 
   // Compile-time random bits for generation seed when hmac destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrHmacSeed = {
-    256'hBC5F1A8862845852761603352213B7A034816103A781D0A4F5A0A911C1BCAFE
+    256'h0BC5F1A8862845852761603352213B7A034816103A781D0A4F5A0A911C1BCAFE
   };
 
   // Compile-time random bits for generation seed when kmac destination selected

--- a/util/topgen/templates/toplevel_rnd_cnst_pkg.sv.tpl
+++ b/util/topgen/templates/toplevel_rnd_cnst_pkg.sv.tpl
@@ -4,24 +4,28 @@
 ${gencmd}
 <%
   def make_blocked_sv_literal(hexstr, randwidth):
-    """This chops the random hexstring into manageable blocks of 64 chars such that the
-    lines do not get too long.
-    """
-    # Make all-caps and drop '0x' preamble
-    hexstr = str(hexstr[2:]).upper()
-    # Block width in hex chars
-    blockwidth = 64
-    remainder = randwidth % (4*blockwidth)
-    numbits = remainder if remainder else 4*blockwidth
-    idx = 0
-    hexblocks = []
-    while randwidth > 0:
-      hexstr = hexstr[idx:]
-      randwidth -= numbits
-      idx = (numbits + 3) // 4
-      hexblocks.append(str(numbits) + "'h" + hexstr[0:idx])
-      numbits = 4*blockwidth
-    return hexblocks
+    """Chop a hex string into blocks of <= 64 digits"""
+    # Convert hexstr to an actual number
+    num = int(hexstr, 16)
+    assert 0 <= num < (1 << randwidth)
+
+    mask = (1 << 256) - 1
+
+    bits_left = randwidth
+    acc = []
+    while bits_left > 0:
+      word = num & mask
+      width = min(256, bits_left)
+
+      acc.append("{nbits}'h{word:0{num_nibbles}X}"
+                 .format(word=word,
+                         nbits=width,
+                         num_nibbles=(width + 3) // 4))
+      bits_left -= width
+      num >>= width
+
+    acc.reverse()
+    return acc
 %>
 package top_${top["name"]}_rnd_cnst_pkg;
 


### PR DESCRIPTION
The previous version didn't work correctly if a block happened to
start with a leading zero. The rewrite works with integers internally
instead of hex strings, which makes things rather simpler (and fixes
the bug).
