### PR TITLE
[otbn,dv] Add coverage tracking for loop stack

### DIFF
--- a/hw/ip/otbn/doc/dv/index.md
+++ b/hw/ip/otbn/doc/dv/index.md
@@ -129,16 +129,25 @@ All four of these events should be crossed with the three states of the call sta
 The [loop stack]({{< relref ".#loop-stack" >}}) is accessed by executing `LOOP` and `LOOPI` instructions.
 Events concerning the start of loops are tracked at those instructions, but we can't track things like loop completion there.
 
+> Coverage for these points is tracked with cover properties in the `otbn_loop_if` interface.
+
 We expect to:
 - Complete a loop.
+  Tracked as `LoopEnd_C`.
 - Complete the last loop on the stack (emptying it) after the stack has been full.
+  Tracked as `FullToEmpty_C`.
 - Complete a loop with one instruction and an iteration count of one.
+  Tracked as `ShortestLoop_C`.
 - Complete a loop with the maximal number of iterations.
   Obviously, this isn't a reasonable thing to do for real in a test (there's a 32-bit iteration counter!).
   The testbench will have to force a signal to skip past some iterations.
+  Tracked as `MaxIterLoop_C`.
 - Run through a "badly nested" loop, where the body contains the final instruction from an outer loop (checking that we don't wrongly skip back).
+  Tracked as `BadNestingEnd_C` and `BadNestingMiddle_C`.
 - Jump into a loop body from outside.
+  Tracked as `JumpIntoLoop_C`.
 - Jump/branch to the final instruction of a loop
+  Tracked as `JumpToLoopEnd_C`.
 
 #### Flags
 

--- a/hw/ip/otbn/dv/uvm/env/otbn_loop_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_loop_if.sv
@@ -4,6 +4,8 @@
 //
 // Bound into the otbn_loop_controller and used to help collect loop information for coverage.
 
+`include "prim_assert.sv"
+
 interface otbn_loop_if (
   input              clk_i,
   input              rst_ni,
@@ -13,8 +15,16 @@ interface otbn_loop_if (
   input logic        at_current_loop_end_insn,
   input logic        loop_active_q,
   input logic        loop_stack_full,
+  input logic        current_loop_finish,
+  input logic        next_loop_valid,
+  input logic        loop_start_req_i,
+  input logic        loop_start_commit_i,
+  input logic [31:0] loop_iterations_i,
+  input logic        otbn_stall_i,
 
-  input logic [31:0] current_loop_end
+  input logic [31:0] current_loop_start,
+  input logic [31:0] current_loop_end,
+  input logic [31:0] next_loop_end
 );
 
   function automatic otbn_env_pkg::stack_fullness_e get_fullness();
@@ -26,5 +36,66 @@ interface otbn_loop_if (
     end
     return otbn_env_pkg::StackEmpty;
   endfunction
+
+  // Track completing some loop. This is implied by the next item, but much easier to hit so maybe
+  // worth covering separately.
+  `COVER(LoopEnd_C, current_loop_finish)
+
+  // A property that tracks us popping the last loop after we've filled the loop stack. Since we're
+  // just using this for coverage, we use first_match on the antecedent to avoid multiple threads if
+  // we spend several cycles full.
+  `COVER(FullToEmpty_C,
+         first_match(loop_stack_full) ##[1:$]
+         (current_loop_finish && !next_loop_valid))
+
+  // A property that tracks us completing a one-instruction loop with an iteration count of one (the
+  // point being that this is the quickest "in and out"). To spot this happening, we just look for a
+  // loop start and then a loop finish on the following cycle.
+  `COVER(ShortestLoop_C, (loop_start_req_i && loop_start_commit_i) ##1 current_loop_finish)
+
+  // A property that tracks us running a loop to completion with the maximal number of iterations.
+  // (To hit this, we're going to need to force some signals!) This sequence is actually slightly
+  // more specific: it asks that this maximal number of iterations should also occur in the
+  // innermost loop. This is much easier to track and, in practice, it's going to be the easiest way
+  // to try to hit things too.
+  `COVER(MaximalLoop_C,
+         (loop_start_req_i && loop_start_commit_i && (loop_iterations_i == '1)) ##1
+         !(loop_start_req_i && loop_start_commit_i) [*0:$] ##1
+         current_loop_finish)
+
+  // Try to see loops with "bad nesting", where the final instruction address for the innermost loop
+  // matches the final instruction address for the next one out. This property will trigger on the
+  // final instruction of the inner loop for the last time (to make sure we actually get there,
+  // where a bug would cause the fireworks).
+  `COVER(BadNestingEnd_C,
+         loop_active_q && next_loop_valid &&
+         current_loop_finish && (current_loop_end == next_loop_end))
+
+  // Try to see loops with "bad nesting", where the final instruction for an outer loop occurs in
+  // the middle of the innermost loop. This property triggers when we execute the instruction at the
+  // end of the outer loop (and hopefully nothing exciting happens). We condition this on not
+  // stalling (because loop-based redirects only happen when the instruction isn't stalled) but
+  // don't condition on next_loop.loop_iterations: even if there are several more iterations left,
+  // we'd expect to see a back edge on a spurious match, so it shouldn't matter.
+  `COVER(BadNestingMiddle_C,
+         loop_active_q && next_loop_valid &&
+         (insn_addr_i != current_loop_end) &&
+         (insn_addr_i == next_loop_end) &&
+         !otbn_stall_i)
+
+  // Jump into a loop body from outside. We don't bother checking that this is a jump: since the
+  // code sequence is fixed, we know we can't get here through a straight line instruction because
+  // we check that !loop_start_req_i.
+  `COVER(JumpIntoLoop_C,
+         (!loop_start_req_i && loop_active_q &&
+          !((current_loop_start <= insn_addr_i) && (insn_addr_i <= current_loop_end))) ##1
+         ((current_loop_start <= insn_addr_i) && (insn_addr_i <= current_loop_end)))
+
+  // Jump to the last instruction of a loop body from outside. This is a stronger version of
+  // JumpIntoLoop_C.
+  `COVER(JumpToLoopEnd_C,
+         (!loop_start_req_i && loop_active_q &&
+          !((current_loop_start <= insn_addr_i) && (insn_addr_i <= current_loop_end))) ##1
+         (insn_addr_i == current_loop_end))
 
 endinterface

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -94,10 +94,18 @@ module tb;
       .at_current_loop_end_insn,
       .loop_active_q,
       .loop_stack_full,
-      // As with insn_addr_i, we expand this to 32 bits. Also, current_loop_q has a type that's not
-      // exposed outside of the loop controller module so we need to extract the loop_end field
-      // here.
-      .current_loop_end (32'(current_loop_q.loop_end))
+      .current_loop_finish,
+      .next_loop_valid,
+      .loop_start_req_i,
+      .loop_start_commit_i,
+      .loop_iterations_i,
+      .otbn_stall_i,
+      // These addresses are start/end addresses for entries in the loop stack. As with insn_addr_i,
+      // we expand them to 32 bits. Also the loop stack entries have a type that's not exposed
+      // outside of the loop controller module so we need to extract the fields here.
+      .current_loop_start (32'(current_loop_q.loop_start)),
+      .current_loop_end   (32'(current_loop_q.loop_end)),
+      .next_loop_end      (32'(next_loop.loop_end))
     );
 
   bind dut.u_otbn_core.u_otbn_alu_bignum otbn_alu_bignum_if i_otbn_alu_bignum_if (.*);


### PR DESCRIPTION
This uses the \`COVER macro in the bound-in `otbn_loop_if` rather than
pushing everything all the way to the `otbn_env_cov` class. We want to
use sequences for the temporal logic ("see this, then that") and it
seems simpler to do it this way, rather than plumb absolutely
everything through sequence items.

@GregAC: Would you mind checking this to make sure I've understood the internal signals correctly? I *think* I understand, but it seems like a good idea for the designer check it too!