### PR TITLE
[otbn] Use a hwext register for INSN_CNT

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -256,6 +256,7 @@
     } // register : fatal_alert_cause
     { name: "INSN_CNT",
       desc: "Instruction Counter",
+      hwext: "true",
       swaccess: "ro",
       hwaccess: "hwo",
       fields: [

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -523,7 +523,6 @@ module otbn
   // INSN_CNT register
   logic [31:0] insn_cnt;
   assign hw2reg.insn_cnt.d = insn_cnt;
-  assign hw2reg.insn_cnt.de = 1'b1;
 
   // Alerts ====================================================================
 

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -114,7 +114,6 @@ package otbn_reg_pkg;
 
   typedef struct packed {
     logic [31:0] d;
-    logic        de;
   } otbn_hw2reg_insn_cnt_reg_t;
 
   // Register -> HW type
@@ -129,11 +128,11 @@ package otbn_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    otbn_hw2reg_intr_state_reg_t intr_state; // [59:58]
-    otbn_hw2reg_status_reg_t status; // [57:57]
-    otbn_hw2reg_err_bits_reg_t err_bits; // [56:41]
-    otbn_hw2reg_fatal_alert_cause_reg_t fatal_alert_cause; // [40:33]
-    otbn_hw2reg_insn_cnt_reg_t insn_cnt; // [32:0]
+    otbn_hw2reg_intr_state_reg_t intr_state; // [58:57]
+    otbn_hw2reg_status_reg_t status; // [56:56]
+    otbn_hw2reg_err_bits_reg_t err_bits; // [55:40]
+    otbn_hw2reg_fatal_alert_cause_reg_t fatal_alert_cause; // [39:32]
+    otbn_hw2reg_insn_cnt_reg_t insn_cnt; // [31:0]
   } otbn_hw2reg_t;
 
   // Register offsets
@@ -156,6 +155,7 @@ package otbn_reg_pkg;
   parameter logic [0:0] OTBN_ALERT_TEST_RECOV_RESVAL = 1'h 0;
   parameter logic [0:0] OTBN_CMD_RESVAL = 1'h 0;
   parameter logic [0:0] OTBN_STATUS_RESVAL = 1'h 0;
+  parameter logic [31:0] OTBN_INSN_CNT_RESVAL = 32'h 0;
 
   // Window parameters
   parameter logic [BlockAw-1:0] OTBN_IMEM_OFFSET = 16'h 4000;

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -188,6 +188,7 @@ module otbn_reg_top (
   logic fatal_alert_cause_dmem_error_qs;
   logic fatal_alert_cause_reg_error_qs;
   logic [31:0] insn_cnt_qs;
+  logic insn_cnt_re;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -667,29 +668,18 @@ module otbn_reg_top (
   );
 
 
-  // R[insn_cnt]: V(False)
+  // R[insn_cnt]: V(True)
 
-  prim_subreg #(
-    .DW      (32),
-    .SWACCESS("RO"),
-    .RESVAL  (32'h0)
+  prim_subreg_ext #(
+    .DW    (32)
   ) u_insn_cnt (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
+    .re     (insn_cnt_re),
     .we     (1'b0),
     .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.insn_cnt.de),
     .d      (hw2reg.insn_cnt.d),
-
-    // to internal hardware
+    .qre    (),
     .qe     (),
     .q      (),
-
-    // to register interface (read)
     .qs     (insn_cnt_qs)
   );
 
@@ -750,6 +740,8 @@ module otbn_reg_top (
 
   assign start_addr_we = addr_hit[7] & reg_we & !reg_error;
   assign start_addr_wd = reg_wdata[31:0];
+
+  assign insn_cnt_re = addr_hit[9] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin


### PR DESCRIPTION
There's no need to duplicate the flop in otbn_reg_top.