### PR TITLE
[rom_ctrl,lint] Fix AscentLint error about unused bits

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_scrambled_rom.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_scrambled_rom.sv
@@ -98,7 +98,7 @@ module rom_ctrl_scrambled_rom
   if (Width < 64) begin : gen_unread_keystream
     // Ignore top bits of keystream: we just use the bottom Width bits.
     logic unused_top_keystream;
-    assign unused_top_keystream = &{1'b0, keystream[63:Width]};
+    assign unused_top_keystream = ^keystream[63:Width];
   end
 
   // The physical ROM ==========================================================


### PR DESCRIPTION
The "&{1'b0, ...}" construct doesn't work with AscentLint because it
checks for unused bits after constant propagation has thrown
everything away.
