### PR TITLE
[dv/edn_reset] Fix apply_reset to concurrently deassert resets

### DIFF
--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_base_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_base_vseq.sv
@@ -30,11 +30,17 @@ class adc_ctrl_base_vseq extends cip_base_vseq #(
     `uvm_info(`gfn, "Initializating adc_ctrl, nothing to do at the moment", UVM_MEDIUM)
   endtask  // adc_ctrl_init
 
-  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
+  virtual task apply_reset(string kind = "HARD");
     if (kind == "HARD") begin
       cfg.clk_aon_rst_vif.apply_reset();
     end
-    super.apply_reset(kind, concurrent_deassert_resets);
+    super.apply_reset(kind);
   endtask  // apply_reset
+
+  virtual task apply_resets_concurrently();
+    cfg.clk_aon_rst_vif.drive_rst_pin(0);
+    super.apply_resets_concurrently();
+    cfg.clk_aon_rst_vif.drive_rst_pin(1);
+  endtask
 
 endclass : adc_ctrl_base_vseq

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
@@ -44,7 +44,7 @@ class aon_timer_base_vseq extends cip_base_vseq #(
     `uvm_info(`gfn, "Initializating aon timer, nothing to do at the moment", UVM_MEDIUM)
   endtask
 
-  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
+  virtual task apply_reset(string kind = "HARD");
     cfg.lc_escalate_en_vif.drive(initial_lc_escalate_en);
     cfg.sleep_vif.drive(initial_sleep_mode);
 
@@ -52,13 +52,18 @@ class aon_timer_base_vseq extends cip_base_vseq #(
     // because the AON clock is much slower so will always come up second.
     if (kind == "HARD" && reset_aon_first) begin
       cfg.aon_clk_rst_vif.apply_reset();
-      super.apply_reset(kind, concurrent_deassert_resets);
+      super.apply_reset(kind);
     end else begin
       fork
         if (kind == "HARD") cfg.aon_clk_rst_vif.apply_reset();
-        super.apply_reset(kind, concurrent_deassert_resets);
+        super.apply_reset(kind);
       join
     end
   endtask // apply_reset
 
+  virtual task apply_resets_concurrently();
+    cfg.aon_clk_rst_vif.drive_rst_pin(0);
+    super.apply_resets_concurrently();
+    cfg.aon_clk_rst_vif.drive_rst_pin(1);
+  endtask
 endclass : aon_timer_base_vseq

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -56,9 +56,9 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     cfg.aon_clk_rst_vif.drive_rst_pin(1'b0);
   endtask
 
-  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
+  virtual task apply_reset(string kind = "HARD");
     fork
-      super.apply_reset(kind, concurrent_deassert_resets);
+      super.apply_reset(kind);
       if (kind == "HARD") fork
         cfg.main_clk_rst_vif.apply_reset();
         cfg.io_clk_rst_vif.apply_reset();
@@ -68,6 +68,18 @@ class clkmgr_base_vseq extends cip_base_vseq #(
         start_aon_clk();
       join
     join
+  endtask
+
+  virtual task apply_resets_concurrently();
+    cfg.main_clk_rst_vif.drive_rst_pin(0);
+    cfg.io_clk_rst_vif.drive_rst_pin(0);
+    cfg.usb_clk_rst_vif.drive_rst_pin(0);
+
+    super.apply_resets_concurrently();
+
+    cfg.main_clk_rst_vif.drive_rst_pin(1);
+    cfg.io_clk_rst_vif.drive_rst_pin(1);
+    cfg.usb_clk_rst_vif.drive_rst_pin(1);
   endtask
 
   // setup basic clkmgr features

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -23,10 +23,10 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     // TODO
   endtask
 
-  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
+  virtual task apply_reset(string kind = "HARD");
     uvm_reg_data_t data;
     bit init_busy;
-    super.apply_reset(kind, concurrent_deassert_resets);
+    super.apply_reset(kind);
     if (kind == "HARD") begin
       cfg.clk_rst_vif.wait_clks(cfg.post_reset_delay_clks);
     end

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -47,8 +47,8 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   endtask
 
   // Cfg errors are cleared after reset
-  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
-    super.apply_reset(kind, concurrent_deassert_resets);
+  virtual task apply_reset(string kind = "HARD");
+    super.apply_reset(kind);
     cfg.ecc_err = OtpNoEccErr;
   endtask
 

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_base_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_base_vseq.sv
@@ -44,16 +44,22 @@ class pwm_base_vseq extends cip_base_vseq #(
   endtask : body
 
   // override apply_reset to handle core_reset domain
-  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
+  virtual task apply_reset(string kind = "HARD");
     fork
       if (kind == "HARD" || kind == "TL_IF") begin
-        super.apply_reset("HARD", concurrent_deassert_resets);
+        super.apply_reset("HARD");
       end
       if (kind == "HARD" || kind == "CORE_IF") begin
         cfg.clk_rst_core_vif.apply_reset();
       end
     join
   endtask : apply_reset
+
+  virtual task apply_resets_concurrently();
+    cfg.clk_rst_core_vif.drive_rst_pin(0);
+    super.apply_resets_concurrently();
+    cfg.clk_rst_core_vif.drive_rst_pin(1);
+  endtask
 
   // phase alignment for resets signal of core and bus domain
   virtual task do_phase_align_reset(bit do_phase_align = 1'b0);

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -157,15 +157,21 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
     // TODO
   endtask
 
-  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0));
+  virtual task apply_reset(string kind = "HARD");
     fork
-      super.apply_reset(kind, concurrent_deassert_resets);
+      super.apply_reset(kind);
       if (kind == "HARD") begin
         // A short slow clock reset should suffice.
         cfg.slow_clk_rst_vif.apply_reset(.pre_reset_dly_clks(0),
                                          .reset_width_clks(5));
       end
     join
+  endtask
+
+  virtual task apply_resets_concurrently();
+    cfg.slow_clk_rst_vif.drive_rst_pin(0);
+    super.apply_resets_concurrently();
+    cfg.slow_clk_rst_vif.drive_rst_pin(1);
   endtask
 
   // setup basic pwrmgr features

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
@@ -26,8 +26,8 @@ class rom_ctrl_base_vseq extends cip_base_vseq #(
     // TODO
   endtask
 
-  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
-    super.apply_reset(kind, concurrent_deassert_resets);
+  virtual task apply_reset(string kind = "HARD");
+    super.apply_reset(kind);
     // Initialize memory
     rom_ctrl_mem_init();
   endtask

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -81,8 +81,8 @@ class spi_device_base_vseq extends cip_base_vseq #(
 
   `uvm_object_new
 
-  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
-    super.apply_reset(kind, concurrent_deassert_resets);
+  virtual task apply_reset(string kind = "HARD");
+    super.apply_reset(kind);
     cfg.clk_rst_vif.wait_clks(1);
   endtask
 

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
@@ -204,15 +204,21 @@ class spi_host_base_vseq extends cip_base_vseq #(
   endtask : process_interrupts
 
   // override apply_reset to handle core_reset domain
-  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
+  virtual task apply_reset(string kind = "HARD");
     fork
       if (kind == "HARD" || kind == "TL_IF") begin
-        super.apply_reset("HARD", concurrent_deassert_resets);
+        super.apply_reset("HARD");
       end
       if (kind == "HARD" || kind == "CORE_IF") begin
         cfg.clk_rst_core_vif.apply_reset();
       end
     join
+  endtask
+
+  virtual task apply_resets_concurrently();
+    cfg.clk_rst_core_vif.drive_rst_pin(0);
+    super.apply_resets_concurrently();
+    cfg.clk_rst_core_vif.drive_rst_pin(1);
   endtask
 
   // override wait_for_reset to to handle core_reset domain

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
@@ -21,13 +21,19 @@ class sram_ctrl_base_vseq extends cip_base_vseq #(
     if (do_sram_ctrl_init) sram_ctrl_init();
   endtask
 
-  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
-    super.apply_reset(kind, concurrent_deassert_resets);
+  virtual task apply_reset(string kind = "HARD");
+    super.apply_reset(kind);
     cfg.lc_vif.init();
     cfg.exec_vif.init();
     if (kind == "HARD") begin
       cfg.otp_clk_rst_vif.apply_reset();
     end
+  endtask
+
+  virtual task apply_resets_concurrently();
+    cfg.otp_clk_rst_vif.drive_rst_pin(0);
+    super.apply_resets_concurrently();
+    cfg.otp_clk_rst_vif.drive_rst_pin(1);
   endtask
 
   virtual task dut_shutdown();

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -19,16 +19,22 @@ class usbdev_base_vseq extends cip_base_vseq #(
   `uvm_object_new
 
   // Override apply_reset to cater to usb domain as well.
-  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
+  virtual task apply_reset(string kind = "HARD");
     fork
       if (kind == "HARD" || kind == "BUS_IF") begin
-        super.apply_reset("HARD", concurrent_deassert_resets);
+        super.apply_reset("HARD");
       end
       if (kind == "HARD" || kind == "USB_IF") begin
         cfg.usb_clk_rst_vif.apply_reset();
       end
     join
     do_apply_post_reset_delays_for_sync();
+  endtask
+
+  virtual task apply_resets_concurrently();
+    cfg.usb_clk_rst_vif.drive_rst_pin(0);
+    super.apply_resets_concurrently();
+    cfg.usb_clk_rst_vif.drive_rst_pin(1);
   endtask
 
   // Apply additional delays at the dut_init stage when either apply_reset or

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -27,7 +27,7 @@ class chip_base_vseq extends cip_base_vseq #(
     super.post_start();
   endtask
 
-  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
+  virtual task apply_reset(string kind = "HARD");
     // Note: The JTAG reset does not have a dedicated pad and is muxed with other chip IOs.
     // These IOs have pad attributes that are driven from registers, and as long as
     // the reset line of those registers is X, the registers and hence the pad outputs
@@ -39,7 +39,7 @@ class chip_base_vseq extends cip_base_vseq #(
     // resets de-assert at different times. If the main rst_n de-asserts before others,
     // the CPU starts executing right away which can cause breakages.
     cfg.m_jtag_agent_cfg.do_trst_n();
-    super.apply_reset(kind, concurrent_deassert_resets);
+    super.apply_reset(kind);
   endtask
 
   virtual task dut_init(string reset_kind = "HARD");

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -10,7 +10,7 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
   }
   `uvm_object_new
 
-  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
+  virtual task apply_reset(string kind = "HARD");
     // The CSR tests (handled by this class) need to wait until the rom_ctrl block has finished
     // running KMAC before they can start issuing reads and writes. Otherwise, they might write to a
     // KMAC register while KMAC is in operation. This would have no effect and a subsequent read
@@ -22,7 +22,7 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
     // will go low. When the operation is finished, it will go high again. Wait until then.
     int unsigned rc_phase = 0;
 
-    super.apply_reset(kind, concurrent_deassert_resets);
+    super.apply_reset(kind);
 
     `uvm_info(`gfn, "waiting for rom_ctrl after reset", UVM_MEDIUM)
     while (rc_phase < 2) begin

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
@@ -31,8 +31,8 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
     apply_reset();
   endtask
 
-  virtual task apply_reset(string kind = "HARD", bit concurrent_deassert_resets = 0);
-    super.apply_reset(kind, concurrent_deassert_resets);
+  virtual task apply_reset(string kind = "HARD");
+    super.apply_reset(kind);
     // Backdoor load the OTP image.
     cfg.mem_bkdr_util_h[Otp].load_mem_from_file({cfg.sw_images[SwTypeOtp], ".vmem"});
     wait (cfg.rst_n_mon_vif.pins[0] === 1);


### PR DESCRIPTION
Previous commit only take care of deassert all resets if we have edn
reset, this PR fix it to deasserts all dut resets if we do not have edn
reset.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>