### PR TITLE
[alert_handler] Escalation Receiver Ping Timeout Feature

### DIFF
--- a/hw/ip/alert_handler/alert_handler_component.core
+++ b/hw/ip/alert_handler/alert_handler_component.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:all
+      - lowrisc:prim:esc
       - lowrisc:prim:lfsr
       - lowrisc:prim:edn_req
       - lowrisc:prim:buf

--- a/hw/ip/alert_handler/data/alert_handler.hjson
+++ b/hw/ip/alert_handler/data/alert_handler.hjson
@@ -88,7 +88,7 @@
     { name: "PING_CNT_DW",
       desc: "Width of ping counter",
       type: "int",
-      default: "24",
+      default: "16",
       local: "true"
     },
     { name: "PHASE_DW",
@@ -533,7 +533,7 @@
       hwaccess: "hwo",
       hwext:    "true",
       fields: [
-        { bits: "15:0" }
+        { bits: "AccuCntDw-1:0" }
       ],
       tags: [// The value of this register is determined by how many alerts have been triggered
              // Cannot be auto-predicted so it is excluded from read check
@@ -547,7 +547,7 @@
       hwaccess: "hro",
       regwen:   "CLASSA_REGWEN",
       fields: [
-        { bits: "15:0",
+        { bits: "AccuCntDw-1:0",
           desc: '''Once the accumulation value register is equal to the threshold escalation will
           be triggered on the next alert occurrence within this class A begins. Note that this
           register can not be modified if !!CLASSA_REGWEN is false.
@@ -563,7 +563,7 @@
       hwaccess: "hro",
       regwen:   "CLASSA_REGWEN",
       fields: [
-        { bits: "31:0",
+        { bits: "EscCntDw-1:0",
           desc: '''If the interrupt corresponding to this class is not
           handled within the specified amount of cycles, escalation will be triggered.
           Set to a positive value to enable the interrupt timeout for Class A. The timeout is set to zero
@@ -581,7 +581,7 @@
       hwaccess: "hro",
       regwen:   "CLASSA_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSA_REGWEN is false.'''
         }
@@ -595,7 +595,7 @@
       hwaccess: "hro",
       regwen:   "CLASSA_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSA_REGWEN is false.'''
         }
@@ -609,7 +609,7 @@
       hwaccess: "hro",
       regwen:   "CLASSA_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSA_REGWEN is false.'''
         }
@@ -623,7 +623,7 @@
       hwaccess: "hro",
       regwen:   "CLASSA_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSA_REGWEN is false.'''
         }
@@ -637,7 +637,7 @@
       hwaccess: "hwo",
       hwext:    "true",
       fields: [
-        { bits: "31:0",
+        { bits: "EscCntDw-1:0",
           desc: '''Returns the current timeout or escalation count (depending on !!CLASSA_STATE).
           This register can not be directly cleared. However, SW can indirectly clear as follows.
 
@@ -808,7 +808,7 @@
       hwaccess: "hwo",
       hwext:    "true",
       fields: [
-        { bits: "15:0" }
+        { bits: "AccuCntDw-1:0" }
       ],
       tags: [// The value of this register is determined by how many alerts have been triggered
              // Cannot be auto-predicted so it is excluded from read check
@@ -822,7 +822,7 @@
       hwaccess: "hro",
       regwen:   "CLASSB_REGWEN",
       fields: [
-        { bits: "15:0",
+        { bits: "AccuCntDw-1:0",
           desc: '''Once the accumulation value register is equal to the threshold escalation will
           be triggered on the next alert occurrence within this class B begins. Note that this
           register can not be modified if !!CLASSB_REGWEN is false.
@@ -838,7 +838,7 @@
       hwaccess: "hro",
       regwen:   "CLASSB_REGWEN",
       fields: [
-        { bits: "31:0",
+        { bits: "EscCntDw-1:0",
           desc: '''If the interrupt corresponding to this class is not
           handled within the specified amount of cycles, escalation will be triggered.
           Set to a positive value to enable the interrupt timeout for Class B. The timeout is set to zero
@@ -856,7 +856,7 @@
       hwaccess: "hro",
       regwen:   "CLASSB_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSB_REGWEN is false.'''
         }
@@ -870,7 +870,7 @@
       hwaccess: "hro",
       regwen:   "CLASSB_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSB_REGWEN is false.'''
         }
@@ -884,7 +884,7 @@
       hwaccess: "hro",
       regwen:   "CLASSB_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSB_REGWEN is false.'''
         }
@@ -898,7 +898,7 @@
       hwaccess: "hro",
       regwen:   "CLASSB_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSB_REGWEN is false.'''
         }
@@ -912,7 +912,7 @@
       hwaccess: "hwo",
       hwext:    "true",
       fields: [
-        { bits: "31:0",
+        { bits: "EscCntDw-1:0",
           desc: '''Returns the current timeout or escalation count (depending on !!CLASSB_STATE).
           This register can not be directly cleared. However, SW can indirectly clear as follows.
 
@@ -1083,7 +1083,7 @@
       hwaccess: "hwo",
       hwext:    "true",
       fields: [
-        { bits: "15:0" }
+        { bits: "AccuCntDw-1:0" }
       ],
       tags: [// The value of this register is determined by how many alerts have been triggered
              // Cannot be auto-predicted so it is excluded from read check
@@ -1097,7 +1097,7 @@
       hwaccess: "hro",
       regwen:   "CLASSC_REGWEN",
       fields: [
-        { bits: "15:0",
+        { bits: "AccuCntDw-1:0",
           desc: '''Once the accumulation value register is equal to the threshold escalation will
           be triggered on the next alert occurrence within this class C begins. Note that this
           register can not be modified if !!CLASSC_REGWEN is false.
@@ -1113,7 +1113,7 @@
       hwaccess: "hro",
       regwen:   "CLASSC_REGWEN",
       fields: [
-        { bits: "31:0",
+        { bits: "EscCntDw-1:0",
           desc: '''If the interrupt corresponding to this class is not
           handled within the specified amount of cycles, escalation will be triggered.
           Set to a positive value to enable the interrupt timeout for Class C. The timeout is set to zero
@@ -1131,7 +1131,7 @@
       hwaccess: "hro",
       regwen:   "CLASSC_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSC_REGWEN is false.'''
         }
@@ -1145,7 +1145,7 @@
       hwaccess: "hro",
       regwen:   "CLASSC_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSC_REGWEN is false.'''
         }
@@ -1159,7 +1159,7 @@
       hwaccess: "hro",
       regwen:   "CLASSC_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSC_REGWEN is false.'''
         }
@@ -1173,7 +1173,7 @@
       hwaccess: "hro",
       regwen:   "CLASSC_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSC_REGWEN is false.'''
         }
@@ -1187,7 +1187,7 @@
       hwaccess: "hwo",
       hwext:    "true",
       fields: [
-        { bits: "31:0",
+        { bits: "EscCntDw-1:0",
           desc: '''Returns the current timeout or escalation count (depending on !!CLASSC_STATE).
           This register can not be directly cleared. However, SW can indirectly clear as follows.
 
@@ -1358,7 +1358,7 @@
       hwaccess: "hwo",
       hwext:    "true",
       fields: [
-        { bits: "15:0" }
+        { bits: "AccuCntDw-1:0" }
       ],
       tags: [// The value of this register is determined by how many alerts have been triggered
              // Cannot be auto-predicted so it is excluded from read check
@@ -1372,7 +1372,7 @@
       hwaccess: "hro",
       regwen:   "CLASSD_REGWEN",
       fields: [
-        { bits: "15:0",
+        { bits: "AccuCntDw-1:0",
           desc: '''Once the accumulation value register is equal to the threshold escalation will
           be triggered on the next alert occurrence within this class D begins. Note that this
           register can not be modified if !!CLASSD_REGWEN is false.
@@ -1388,7 +1388,7 @@
       hwaccess: "hro",
       regwen:   "CLASSD_REGWEN",
       fields: [
-        { bits: "31:0",
+        { bits: "EscCntDw-1:0",
           desc: '''If the interrupt corresponding to this class is not
           handled within the specified amount of cycles, escalation will be triggered.
           Set to a positive value to enable the interrupt timeout for Class D. The timeout is set to zero
@@ -1406,7 +1406,7 @@
       hwaccess: "hro",
       regwen:   "CLASSD_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSD_REGWEN is false.'''
         }
@@ -1420,7 +1420,7 @@
       hwaccess: "hro",
       regwen:   "CLASSD_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSD_REGWEN is false.'''
         }
@@ -1434,7 +1434,7 @@
       hwaccess: "hro",
       regwen:   "CLASSD_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSD_REGWEN is false.'''
         }
@@ -1448,7 +1448,7 @@
       hwaccess: "hro",
       regwen:   "CLASSD_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSD_REGWEN is false.'''
         }
@@ -1462,7 +1462,7 @@
       hwaccess: "hwo",
       hwext:    "true",
       fields: [
-        { bits: "31:0",
+        { bits: "EscCntDw-1:0",
           desc: '''Returns the current timeout or escalation count (depending on !!CLASSD_STATE).
           This register can not be directly cleared. However, SW can indirectly clear as follows.
 

--- a/hw/ip/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip/alert_handler/data/alert_handler.hjson.tpl
@@ -92,7 +92,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     { name: "PING_CNT_DW",
       desc: "Width of ping counter",
       type: "int",
-      default: "24",
+      default: "16",
       local: "true"
     },
     { name: "PHASE_DW",
@@ -528,7 +528,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       hwaccess: "hwo",
       hwext:    "true",
       fields: [
-        { bits: "${accu_cnt_dw - 1}:0" }
+        { bits: "AccuCntDw-1:0" }
       ],
       tags: [// The value of this register is determined by how many alerts have been triggered
              // Cannot be auto-predicted so it is excluded from read check
@@ -542,7 +542,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       hwaccess: "hro",
       regwen:   "CLASS${chars[i]}_REGWEN",
       fields: [
-        { bits: "${accu_cnt_dw - 1}:0",
+        { bits: "AccuCntDw-1:0",
           desc: '''Once the accumulation value register is equal to the threshold escalation will
           be triggered on the next alert occurrence within this class ${chars[i]} begins. Note that this
           register can not be modified if !!CLASS${chars[i]}_REGWEN is false.
@@ -558,7 +558,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       hwaccess: "hro",
       regwen:   "CLASS${chars[i]}_REGWEN",
       fields: [
-        { bits: "${esc_cnt_dw - 1}:0",
+        { bits: "EscCntDw-1:0",
           desc: '''If the interrupt corresponding to this class is not
           handled within the specified amount of cycles, escalation will be triggered.
           Set to a positive value to enable the interrupt timeout for Class ${chars[i]}. The timeout is set to zero
@@ -577,7 +577,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       hwaccess: "hro",
       regwen:   "CLASS${chars[i]}_REGWEN",
       fields: [
-        { bits: "${esc_cnt_dw - 1}:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASS${chars[i]}_REGWEN is false.'''
         }
@@ -592,7 +592,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       hwaccess: "hwo",
       hwext:    "true",
       fields: [
-        { bits: "${esc_cnt_dw - 1}:0",
+        { bits: "EscCntDw-1:0",
           desc: '''Returns the current timeout or escalation count (depending on !!CLASS${chars[i]}_STATE).
           This register can not be directly cleared. However, SW can indirectly clear as follows.
 

--- a/hw/ip/alert_handler/fpv/vip/alert_handler_ping_timer_assert_fpv.sv
+++ b/hw/ip/alert_handler/fpv/vip/alert_handler_ping_timer_assert_fpv.sv
@@ -25,7 +25,8 @@ module alert_handler_ping_timer_assert_fpv import alert_pkg::*; (
   input                   esc_ping_fail_o
 );
 
-  logic [N_ESC_SEV+NAlerts-1:0] ping_en_vector, ping_en_mask, ping_ok_vector;
+  localparam int unsigned PingEnDw = N_ESC_SEV + NAlerts;
+  logic [PingEnDw-1:0] ping_en_vector, ping_en_mask, ping_ok_vector;
 
   assign ping_en_vector = {esc_ping_req_o, alert_ping_req_o};
   assign ping_en_mask   = {N_ESC_SEV'('1), alert_ping_en_i};
@@ -35,19 +36,24 @@ module alert_handler_ping_timer_assert_fpv import alert_pkg::*; (
   // Assumptions //
   /////////////////
 
-  // symbolic variable. we want to assess all valid indices
-  int unsigned ping_en_sel;
-  `ASSUME_FPV(PingEnSelRange_M, ping_en_sel >= 0 && ping_en_sel < (N_ESC_SEV+NAlerts))
+  localparam int MaxWaitCntDw = 3;
+
+  // symbolic variables. we want to assess all valid indices
+  logic [$clog2(PingEnDw)-1:0] ping_en_sel;
+  logic [$clog2(N_ESC_SEV)-1:0] esc_idx;
+  `ASSUME_FPV(PingEnSelRange_M, ping_en_sel < PingEnDw)
   `ASSUME_FPV(PingEnSelStable_M, ##1 $stable(ping_en_sel))
+  `ASSUME_FPV(EscIdxRange_M, esc_idx < N_ESC_SEV)
+  `ASSUME_FPV(EscIdxStable_M, ##1 $stable(esc_idx))
   // assume that the alert enable configuration is locked once en_i is high
   // this is ensured by the CSR regfile on the outside
-  `ASSUME_FPV(ConfigLocked0_M, en_i |-> ($stable(alert_ping_en_i) [*]))
-  `ASSUME_FPV(ConfigLocked1_M, en_i |-> ($stable(ping_timeout_cyc_i) [*]))
+  `ASSUME_FPV(ConfigLocked0_M, en_i |-> $stable(alert_ping_en_i))
+  `ASSUME_FPV(ConfigLocked1_M, en_i |-> $stable(ping_timeout_cyc_i))
   // enable stays high forever, once it has been asserted
-  // this can be enabled in DV as well
-  `ASSUME(ConfigLocked2_M, en_i |-> (##1 en_i) [*])
+  `ASSUME(ConfigLocked2_M, en_i |=> en_i)
   // reduce state space by reducing length of wait period
-  `ASSUME_FPV(WaitPeriod_M, wait_cyc_mask_i == 7)
+  `ASSUME_FPV(WaitPeriod0_M, wait_cyc_mask_i == {MaxWaitCntDw{1'b1}})
+  `ASSUME_FPV(WaitPeriod1_M, ping_timeout_cyc_i <= {MaxWaitCntDw{1'b1}})
 
   ////////////////////////
   // Forward Assertions //
@@ -73,6 +79,24 @@ module alert_handler_ping_timer_assert_fpv import alert_pkg::*; (
   // response must be one hot
   `ASSERT(SpuriousPingsDetected2_A, en_i && !$onehot0(ping_ok_vector) |->
       esc_ping_fail_o || alert_ping_fail_o)
+
+  // ensure that the number of cycles between pings on a specific escalation channel
+  // are within bounds. we try to prove this property with a margin of 2x here, whereas
+  // the ping receivers actually work with a margin of 4x to stay on the safe side.
+  localparam int MarginFactor = 2;
+  localparam int NumWaitCounts = 2;
+  localparam int NumTimeoutCounts = 2;
+  localparam int PingPeriodBound = MarginFactor *        // margin to apply
+                                   N_ESC_SEV *           // number of escalation channels to ping
+                                   (NumWaitCounts +      // 1 alert and 1 esc wait count
+                                    NumTimeoutCounts) *  // 1 alert and 1 esc timeout count
+                                   2**MaxWaitCntDw;      // maximum counter value
+
+  `ASSERT(EscalationPingPeriodWithinBounds_A,
+      $rose(esc_ping_req_o[esc_idx])
+      |->
+      ##[1 : PingPeriodBound]
+      $rose(esc_ping_req_o[esc_idx]))
 
   /////////////////////////
   // Backward Assertions //

--- a/hw/ip/alert_handler/rtl/alert_handler.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler.sv
@@ -106,21 +106,21 @@ module alert_handler
   ) u_ping_timer (
     .clk_i,
     .rst_ni,
-    .edn_req_o          ( edn_req                      ),
-    .edn_ack_i          ( edn_ack                      ),
-    .edn_data_i         ( edn_data                     ),
-    .en_i               ( reg2hw_wrap.ping_enable      ),
-    .alert_ping_en_i    ( reg2hw_wrap.alert_ping_en    ),
-    .ping_timeout_cyc_i ( reg2hw_wrap.ping_timeout_cyc ),
-    // this determines the range of the randomly generated
-    // wait period between ping. maximum mask width is PING_CNT_DW.
-    .wait_cyc_mask_i    ( PING_CNT_DW'(16'hFFFFFF)     ),
-    .alert_ping_req_o   ( alert_ping_req               ),
-    .esc_ping_req_o     ( esc_ping_req                 ),
-    .alert_ping_ok_i    ( alert_ping_ok                ),
-    .esc_ping_ok_i      ( esc_ping_ok                  ),
-    .alert_ping_fail_o  ( loc_alert_trig[0]            ),
-    .esc_ping_fail_o    ( loc_alert_trig[1]            )
+    .edn_req_o          ( edn_req                        ),
+    .edn_ack_i          ( edn_ack                        ),
+    .edn_data_i         ( edn_data                       ),
+    .en_i               ( reg2hw_wrap.ping_enable        ),
+    .alert_ping_en_i    ( reg2hw_wrap.alert_ping_en      ),
+    .ping_timeout_cyc_i ( reg2hw_wrap.ping_timeout_cyc   ),
+    // set this to the maximum width in the design.
+    // can be overridden in DV and FPV to shorten the wait periods.
+    .wait_cyc_mask_i    ( {PING_CNT_DW{1'b1}}            ),
+    .alert_ping_req_o   ( alert_ping_req                 ),
+    .esc_ping_req_o     ( esc_ping_req                   ),
+    .alert_ping_ok_i    ( alert_ping_ok                  ),
+    .esc_ping_ok_i      ( esc_ping_ok                    ),
+    .alert_ping_fail_o  ( loc_alert_trig[0]              ),
+    .esc_ping_fail_o    ( loc_alert_trig[1]              )
   );
 
   /////////////////////

--- a/hw/ip/alert_handler/rtl/alert_handler.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler.sv
@@ -114,7 +114,7 @@ module alert_handler
     .ping_timeout_cyc_i ( reg2hw_wrap.ping_timeout_cyc ),
     // this determines the range of the randomly generated
     // wait period between ping. maximum mask width is PING_CNT_DW.
-    .wait_cyc_mask_i    ( PING_CNT_DW'(24'hFFFFFF)     ),
+    .wait_cyc_mask_i    ( PING_CNT_DW'(16'hFFFFFF)     ),
     .alert_ping_req_o   ( alert_ping_req               ),
     .esc_ping_req_o     ( esc_ping_req                 ),
     .alert_ping_ok_i    ( alert_ping_ok                ),

--- a/hw/ip/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -40,7 +40,7 @@ module alert_handler_ping_timer import alert_pkg::*; #(
   input                            en_i,               // enable ping testing
   input        [NAlerts-1:0]       alert_ping_en_i,    // determines which alerts to ping
   input        [PING_CNT_DW-1:0]   ping_timeout_cyc_i, // timeout in cycles
-  input        [PING_CNT_DW-1:0]   wait_cyc_mask_i,    // wait cycles mask
+  input        [PING_CNT_DW-1:0]   wait_cyc_mask_i,    // mask to shorten the counters in DV / FPV
   output logic [NAlerts-1:0]       alert_ping_req_o,   // request to alert receivers
   output logic [N_ESC_SEV-1:0]     esc_ping_req_o,     // enable to esc senders
   input        [NAlerts-1:0]       alert_ping_ok_i,    // response from alert receivers
@@ -49,19 +49,35 @@ module alert_handler_ping_timer import alert_pkg::*; #(
   output logic                     esc_ping_fail_o     // any of the esc senders failed
 );
 
-  localparam int unsigned NModsToPing = NAlerts + N_ESC_SEV;
-  localparam int unsigned IdDw        = $clog2(NModsToPing);
+  localparam int unsigned IdDw = $clog2(NAlerts);
+
+  // Entropy reseeding is triggered every time this counter expires.
+  // The expected wait time between pings is 2**(PING_CNT_DW-1) on average.
+  // We do not need to reseed the LFSR very often, and the constant below is chosen
+  // such that on average the LFSR is reseeded every 16th ping.
+  localparam int unsigned ReseedLfsrExtraBits = 3;
+  localparam int unsigned ReseedLfsrWidth = PING_CNT_DW + ReseedLfsrExtraBits;
 
   ////////////////////
   // Reseed counter //
   ////////////////////
 
-  // TODO: update this to account for escalation reverse ping.
   logic reseed_en;
-  logic unused_edn_ack;
-  assign edn_req_o = 1'b0;
-  assign reseed_en = 1'b0;
-  assign unused_edn_ack = edn_ack_i;
+  logic [ReseedLfsrWidth-1:0] reseed_timer_d, reseed_timer_q;
+
+  assign reseed_timer_d = (reseed_timer_q > '0) ? reseed_timer_q - 1'b1        :
+                          (reseed_en)           ? {wait_cyc_mask_i,
+                                                  {ReseedLfsrExtraBits{1'b1}}} : '0;
+  assign edn_req_o = (reseed_timer_q == '0);
+  assign reseed_en = edn_req_o & edn_ack_i;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
+    if (!rst_ni) begin
+      reseed_timer_q <= '0;
+    end else begin
+      reseed_timer_q <= reseed_timer_d;
+    end
+  end
 
   ///////////////////////////
   // Tandem LFSR Instances //
@@ -71,7 +87,7 @@ module alert_handler_ping_timer import alert_pkg::*; #(
   logic [LfsrWidth-1:0] entropy_unbuf;
   logic [1:0][LfsrWidth-1:0] lfsr_state;
 
-  assign lfsr_en_unbuf = reseed_en || lfsr_en;
+  assign lfsr_en_unbuf = reseed_en | lfsr_en;
   assign entropy_unbuf = (reseed_en) ? edn_data_i[LfsrWidth-1:0] : '0;
 
   // We employ two redundant LFSRs to guard against FI attacks.
@@ -124,38 +140,78 @@ module alert_handler_ping_timer import alert_pkg::*; #(
   end
 
   logic [IdDw-1:0] id_to_ping;
-  logic [PING_CNT_DW-1:0] wait_cyc;
   assign id_to_ping = lfsr_state[0][PING_CNT_DW +: IdDw];
 
-  // to avoid lint warnings
-  logic unused_lfsr_state;
-  assign unused_lfsr_state = ^{lfsr_state[0][LfsrWidth - 1 : PING_CNT_DW + IdDw],
-                               lfsr_state[0][2]}; // [2] is masked due to the constant offset below.
-
-  // the constant offset ensures a minimum cycle spacing between pings.
-  assign wait_cyc = (lfsr_state[0][0 +: PING_CNT_DW] | PING_CNT_DW'(3'b100)) & wait_cyc_mask_i;
-
+  // align the enable mask with powers of two for the indexing operation below.
   logic [2**IdDw-1:0] enable_mask;
-  always_comb begin : p_enable_mask
-    enable_mask                        = '0;              // tie off unused
-    enable_mask[NAlerts-1:0]           = alert_ping_en_i; // alerts
-    enable_mask[NModsToPing-1:NAlerts] = '1;              // escalation senders are always enabled
+  assign enable_mask = (2**IdDw)'(alert_ping_en_i);
+
+  // check if the randomly drawn alert ID is actually valid and the alert is enabled
+  logic id_vld;
+  assign id_vld = enable_mask[id_to_ping];
+
+  //////////////////////////////////
+  // Escalation Counter Instances //
+  //////////////////////////////////
+
+  // As opposed to the alert ID, the escalation sender ID to be pinged is not drawn at random.
+  // Rather, we cycle through the escalation senders one by one in a deterministic fashion.
+  // This allows us to provide guarantees needed for the ping timeout / auto escalation feature
+  // implemented at the escalation receiver side.
+  //
+  // In particular, with N_ESC_SEV escalation senders in the design, we can guarantee
+  // that each escalation channel will be pinged at least once every
+  //
+  // N_ESC_SEV x (NUM_WAIT_COUNT + NUM_TIMEOUT_COUNT) x 2**PING_CNT_DW
+  //
+  // cycles - independently of the reseeding operation.
+  //
+  // - N_ESC_SEV: # escalation channels to ping.
+  // - NUM_WAIT_COUNT: # wait counts between subsequent escalation channel pings.
+  // - NUM_TIMEOUT_COUNT: # timeout counts between subsequent escalation channel pings.
+  // - 2**PING_CNT_DW: # maximum counter value.
+  //
+  // This guarantee is used inside the escalation receivers to monitor the pings sent out by the
+  // alert handler. I.e., once the alert handler has started to send out pings, each escalation
+  // receiver employs a timeout window within which it expects the next ping to arrive. If
+  // escalation pings cease to arrive at an escalation receiver for any reason, this will
+  // automatically trigger the associated escalation countermeasure.
+  //
+  // In order to have enough margin, the escalation receiver timeout counters use a threshold that
+  // is 4x higher than the value calculated above. With N_ESC_SEV = 4, PING_CNT_DW = 16 and
+  // NUM_WAIT_COUNT = NUM_TIMEOUT_COUNT = 2 this amounts to a 22bit timeout threshold.
+
+  logic esc_cnt_en;
+  logic [1:0][PING_CNT_DW-1:0] esc_cnt_q;
+
+  // We employ two redundant counters to guard against FI attacks.
+  // If any of the two is glitched and the two counter states do not agree,
+  // the FSM below is moved into a terminal error state and all ping alerts
+  // are permanently asserted.
+  for (genvar k = 0; k < 2; k++) begin : gen_double_esc_cnt
+
+    logic [PING_CNT_DW-1:0] esc_cnt_d;
+    assign esc_cnt_d = (esc_cnt_q[k] >= PING_CNT_DW'(N_ESC_SEV-1)) ? '0 : (esc_cnt_q[k] + 1'b1);
+
+    prim_flop_en #(
+      .Width(PING_CNT_DW)
+    ) u_prim_flop_en (
+      .clk_i,
+      .rst_ni,
+      .en_i  ( esc_cnt_en   ),
+      .d_i   ( esc_cnt_d    ),
+      .q_o   ( esc_cnt_q[k] )
+    );
   end
 
-  logic id_vld;
-  // check if the randomly drawn ID is actually valid and the alert is enabled
-  assign id_vld  = enable_mask[id_to_ping];
-
-  //////////////////////////////
-  // Tandem Counter Instances //
-  //////////////////////////////
+  /////////////////////////////
+  // Timer Counter Instances //
+  /////////////////////////////
 
   logic [1:0][PING_CNT_DW-1:0] cnt_q;
-  logic cnt_en, cnt_clr;
-  logic wait_ge, timeout_ge;
-
-  assign wait_ge    = (cnt_q[0] >= wait_cyc);
-  assign timeout_ge = (cnt_q[0] >= ping_timeout_cyc_i);
+  logic wait_cnt_load, timeout_cnt_load, timer_expired;
+  assign timer_expired = (cnt_q[0] == '0);
+  assign lfsr_en = wait_cnt_load || timeout_cnt_load;
 
   // We employ two redundant counters to guard against FI attacks.
   // If any of the two is glitched and the two counter states do not agree,
@@ -163,17 +219,23 @@ module alert_handler_ping_timer import alert_pkg::*; #(
   // are permanently asserted.
   for (genvar k = 0; k < 2; k++) begin : gen_double_cnt
 
-    logic [PING_CNT_DW-1:0] cnt_d;
-    assign cnt_d = cnt_q[k] + 1'b1;
+    // the constant offset ensures a minimum cycle spacing between pings.
+    logic [PING_CNT_DW-1:0] wait_cyc;
+    assign wait_cyc = (lfsr_state[k][PING_CNT_DW-1:0] | PING_CNT_DW'(3'b100));
 
-    prim_flop_en #(
+    // note that the masks are used for DV/FPV only in order to reduce the state space.
+    logic [PING_CNT_DW-1:0] cnt_d;
+    assign cnt_d = (wait_cnt_load)    ? (wait_cyc & wait_cyc_mask_i) :
+                   (timeout_cnt_load) ? (ping_timeout_cyc_i)         :
+                   (cnt_q[k] > '0)    ? cnt_q[k] - 1'b1              : '0;
+
+    prim_flop #(
       .Width(PING_CNT_DW)
-    ) u_prim_flop_en (
+    ) u_prim_flop (
       .clk_i,
       .rst_ni,
-      .en_i  ( cnt_clr | cnt_en                ),
-      .d_i   ( cnt_d & {PING_CNT_DW{~cnt_clr}} ),
-      .q_o   ( cnt_q[k]                        )
+      .d_i   ( cnt_d    ),
+      .q_o   ( cnt_q[k] )
     );
   end
 
@@ -181,35 +243,29 @@ module alert_handler_ping_timer import alert_pkg::*; #(
   // Ping and Timeout Logic //
   ////////////////////////////
 
-  logic ping_en, ping_ok;
-  logic [NModsToPing-1:0] ping_sel;
-  logic [NModsToPing-1:0] spurious_ping;
+  logic alert_ping_en, esc_ping_en;
   logic spurious_alert_ping, spurious_esc_ping;
 
   // generate ping enable vector
-  assign ping_sel         = NModsToPing'(ping_en) << id_to_ping;
-  assign alert_ping_req_o = ping_sel[NAlerts-1:0];
-  assign esc_ping_req_o   = ping_sel[NModsToPing-1:NAlerts];
+  assign alert_ping_req_o = NAlerts'(alert_ping_en) << id_to_ping;
+  assign esc_ping_req_o   = N_ESC_SEV'(esc_ping_en) << esc_cnt_q[0];
 
-  // mask out response
-  assign ping_ok             = |({esc_ping_ok_i, alert_ping_ok_i} & ping_sel);
-  assign spurious_ping       = ({esc_ping_ok_i, alert_ping_ok_i} & ~ping_sel);
   // under normal operation, these signals should never be asserted.
   // we place hand instantiated buffers here such that these signals are not
   // optimized away during synthesis (these buffers will receive a keep or size_only
   // attribute in our Vivado and DC synthesis flows).
   prim_buf u_prim_buf_spurious_alert_ping (
-    .in_i(|spurious_ping[NAlerts-1:0]),
+    .in_i(|(alert_ping_ok_i & ~alert_ping_req_o)),
     .out_o(spurious_alert_ping)
   );
   prim_buf u_prim_buf_spurious_esc_ping (
-    .in_i(|spurious_ping[NModsToPing-1:NAlerts]),
+    .in_i(|(esc_ping_ok_i & ~esc_ping_req_o)),
     .out_o(spurious_esc_ping)
   );
 
   // Encoding generated with:
-  // $ ./util/design/sparse-fsm-encode.py -d 5 -m 4 -n 8 \
-  //      -s 97540418 --language=sv
+  // $ ./util/design/sparse-fsm-encode.py -d 5 -m 6 -n 9 \
+  //      -s 728582219 --language=sv
   //
   // Hamming distance histogram:
   //
@@ -218,34 +274,38 @@ module alert_handler_ping_timer import alert_pkg::*; #(
   //  2: --
   //  3: --
   //  4: --
-  //  5: |||||||||||||||||||| (66.67%)
-  //  6: |||||||||| (33.33%)
+  //  5: |||||||||||||||||||| (60.00%)
+  //  6: ||||||||||||| (40.00%)
   //  7: --
   //  8: --
+  //  9: --
   //
   // Minimum Hamming distance: 5
   // Maximum Hamming distance: 6
   // Minimum Hamming weight: 2
-  // Maximum Hamming weight: 5
+  // Maximum Hamming weight: 6
   //
-  localparam int StateWidth = 8;
+  localparam int StateWidth = 9;
   typedef enum logic [StateWidth-1:0] {
-    InitSt     = 8'b11111000,
-    RespWaitSt = 8'b11000110,
-    DoPingSt   = 8'b00100001,
-    FsmErrorSt = 8'b00011111
+    InitSt      = 9'b000101100,
+    AlertWaitSt = 9'b011001011,
+    AlertPingSt = 9'b110000000,
+    EscWaitSt   = 9'b101110001,
+    EscPingSt   = 9'b011110110,
+    FsmErrorSt  = 9'b100011111
   } state_e;
 
   state_e state_d, state_q;
 
   always_comb begin : p_fsm
     // default
-    state_d = state_q;
-    cnt_en  = 1'b0;
-    cnt_clr = 1'b0;
-    lfsr_en = 1'b0;
-    ping_en = 1'b0;
-    // this captures spurious
+    state_d          = state_q;
+    wait_cnt_load    = 1'b0;
+    timeout_cnt_load = 1'b0;
+    esc_cnt_en       = 1'b0;
+    alert_ping_en    = 1'b0;
+    esc_ping_en      = 1'b0;
+    // this captures spurious ping responses
     alert_ping_fail_o = spurious_alert_ping;
     esc_ping_fail_o   = spurious_esc_ping;
 
@@ -254,40 +314,49 @@ module alert_handler_ping_timer import alert_pkg::*; #(
       // we never return to this state
       // once activated!
       InitSt: begin
-        cnt_clr = 1'b1;
         if (en_i) begin
-          state_d = RespWaitSt;
+          state_d = AlertWaitSt;
+          wait_cnt_load = 1'b1;
         end
       end
       // wait for random amount of cycles
-      // draw another ID/wait count if the
-      // peripheral ID is not valid
-      RespWaitSt: begin
-        if (!id_vld) begin
-          lfsr_en = 1'b1;
-          cnt_clr = 1'b1;
-        end else if (wait_ge) begin
-          state_d = DoPingSt;
-          cnt_clr = 1'b1;
-        end else begin
-          cnt_en = 1'b1;
+      AlertWaitSt: begin
+        if (timer_expired) begin
+          state_d = AlertPingSt;
+          timeout_cnt_load = 1'b1;
         end
       end
-      // send out ping request and wait for a ping
+      // send out an alert ping request and wait for a ping
+      // response or a ping timeout (whatever comes first).
+      // if the alert ID is not valid, we drop the request and
+      // proceed to the next ping.
+      AlertPingSt: begin
+        alert_ping_en = id_vld;
+        if (timer_expired || |(alert_ping_ok_i & alert_ping_req_o) || !id_vld) begin
+          state_d           = EscWaitSt;
+          wait_cnt_load     = 1'b1;
+          if (timer_expired) begin
+            alert_ping_fail_o = 1'b1;
+          end
+        end
+      end
+      // wait for random amount of cycles
+      EscWaitSt: begin
+        if (timer_expired) begin
+          state_d          = EscPingSt;
+          timeout_cnt_load = 1'b1;
+        end
+      end
+      // send out an escalation ping request and wait for a ping
       // response or a ping timeout (whatever comes first)
-      DoPingSt: begin
-        cnt_en  = 1'b1;
-        ping_en = 1'b1;
-        if (timeout_ge || ping_ok) begin
-          state_d = RespWaitSt;
-          lfsr_en = 1'b1;
-          cnt_clr = 1'b1;
-          if (timeout_ge) begin
-            if (id_to_ping < IdDw'(NAlerts)) begin
-              alert_ping_fail_o = 1'b1;
-            end else begin
-              esc_ping_fail_o   = 1'b1;
-            end
+      EscPingSt: begin
+        esc_ping_en = 1'b1;
+        if (timer_expired || |(esc_ping_ok_i & esc_ping_req_o)) begin
+          state_d         = AlertWaitSt;
+          wait_cnt_load   = 1'b1;
+          esc_cnt_en      = 1'b1;
+          if (timer_expired) begin
+            esc_ping_fail_o = 1'b1;
           end
         end
       end
@@ -306,7 +375,8 @@ module alert_handler_ping_timer import alert_pkg::*; #(
     // if the two LFSR or counter states do not agree,
     // we move into the terminal state.
     if (lfsr_state[0] != lfsr_state[1] ||
-        cnt_q[0] != cnt_q[1]) begin
+        cnt_q[0]      != cnt_q[1]      ||
+        esc_cnt_q[0]  != esc_cnt_q[1]) begin
        state_d = FsmErrorSt;
     end
   end
@@ -334,13 +404,14 @@ module alert_handler_ping_timer import alert_pkg::*; #(
   // Assertions //
   ////////////////
 
-  // make sure the ID width is within bounds
+  // make sure the ID width is within bounds.
   `ASSERT_INIT(MaxIdDw_A, IdDw <= (LfsrWidth - PING_CNT_DW))
 
-  // internals
-  `ASSERT(PingOH0_A, $onehot0(ping_sel))
-  // we should never get into the ping state without knowing
-  // which module to ping
-  `ASSERT(PingOH_A, ping_en |-> $onehot(ping_sel))
+  // only one module is pinged at a time.
+  `ASSERT(PingOH0_A, $onehot0({alert_ping_req_o, esc_ping_req_o}))
+
+  // we should never get into the ping state without knowing which module to ping.
+  `ASSERT(AlertPingOH_A, alert_ping_en |-> $onehot(alert_ping_req_o))
+  `ASSERT(EscPingOH_A, esc_ping_en |-> $onehot(esc_ping_req_o))
 
 endmodule : alert_handler_ping_timer

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_pkg.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_pkg.sv
@@ -15,7 +15,7 @@ package alert_handler_reg_pkg;
   parameter int N_ESC_SEV = 4;
   parameter int N_PHASES = 4;
   parameter int N_LOC_ALERT = 5;
-  parameter int PING_CNT_DW = 24;
+  parameter int PING_CNT_DW = 16;
   parameter int PHASE_DW = 2;
   parameter int CLASS_DW = 2;
 
@@ -76,7 +76,7 @@ package alert_handler_reg_pkg;
   } alert_handler_reg2hw_intr_test_reg_t;
 
   typedef struct packed {
-    logic [23:0] q;
+    logic [15:0] q;
   } alert_handler_reg2hw_ping_timeout_cyc_reg_t;
 
   typedef struct packed {
@@ -458,10 +458,10 @@ package alert_handler_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    alert_handler_reg2hw_intr_state_reg_t intr_state; // [848:845]
-    alert_handler_reg2hw_intr_enable_reg_t intr_enable; // [844:841]
-    alert_handler_reg2hw_intr_test_reg_t intr_test; // [840:833]
-    alert_handler_reg2hw_ping_timeout_cyc_reg_t ping_timeout_cyc; // [832:809]
+    alert_handler_reg2hw_intr_state_reg_t intr_state; // [840:837]
+    alert_handler_reg2hw_intr_enable_reg_t intr_enable; // [836:833]
+    alert_handler_reg2hw_intr_test_reg_t intr_test; // [832:825]
+    alert_handler_reg2hw_ping_timeout_cyc_reg_t ping_timeout_cyc; // [824:809]
     alert_handler_reg2hw_ping_timer_en_reg_t ping_timer_en; // [808:808]
     alert_handler_reg2hw_alert_regwen_mreg_t [3:0] alert_regwen; // [807:804]
     alert_handler_reg2hw_alert_en_mreg_t [3:0] alert_en; // [803:800]
@@ -746,7 +746,7 @@ package alert_handler_reg_pkg;
     4'b 0001, // index[ 1] ALERT_HANDLER_INTR_ENABLE
     4'b 0001, // index[ 2] ALERT_HANDLER_INTR_TEST
     4'b 0001, // index[ 3] ALERT_HANDLER_PING_TIMER_REGWEN
-    4'b 0111, // index[ 4] ALERT_HANDLER_PING_TIMEOUT_CYC
+    4'b 0011, // index[ 4] ALERT_HANDLER_PING_TIMEOUT_CYC
     4'b 0001, // index[ 5] ALERT_HANDLER_PING_TIMER_EN
     4'b 0001, // index[ 6] ALERT_HANDLER_ALERT_REGWEN_0
     4'b 0001, // index[ 7] ALERT_HANDLER_ALERT_REGWEN_1

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_top.sv
@@ -139,8 +139,8 @@ module alert_handler_reg_top (
   logic ping_timer_regwen_qs;
   logic ping_timer_regwen_wd;
   logic ping_timer_regwen_we;
-  logic [23:0] ping_timeout_cyc_qs;
-  logic [23:0] ping_timeout_cyc_wd;
+  logic [15:0] ping_timeout_cyc_qs;
+  logic [15:0] ping_timeout_cyc_wd;
   logic ping_timeout_cyc_we;
   logic ping_timer_en_qs;
   logic ping_timer_en_wd;
@@ -807,9 +807,9 @@ module alert_handler_reg_top (
   // R[ping_timeout_cyc]: V(False)
 
   prim_subreg #(
-    .DW      (24),
+    .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (24'h20)
+    .RESVAL  (16'h20)
   ) u_ping_timeout_cyc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4300,7 +4300,7 @@ module alert_handler_reg_top (
   assign ping_timer_regwen_wd = reg_wdata[0];
 
   assign ping_timeout_cyc_we = addr_hit[4] & reg_we & !reg_error;
-  assign ping_timeout_cyc_wd = reg_wdata[23:0];
+  assign ping_timeout_cyc_wd = reg_wdata[15:0];
 
   assign ping_timer_en_we = addr_hit[5] & reg_we & !reg_error;
   assign ping_timer_en_wd = reg_wdata[0];
@@ -4695,7 +4695,7 @@ module alert_handler_reg_top (
       end
 
       addr_hit[4]: begin
-        reg_rdata_next[23:0] = ping_timeout_cyc_qs;
+        reg_rdata_next[15:0] = ping_timeout_cyc_qs;
       end
 
       addr_hit[5]: begin

--- a/hw/ip/lc_ctrl/lc_ctrl.core
+++ b/hw/ip/lc_ctrl/lc_ctrl.core
@@ -9,6 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:all
+      - lowrisc:prim:esc
       - lowrisc:prim:clock_mux2
       - lowrisc:prim:lc_sync
       - lowrisc:prim:lc_sender

--- a/hw/ip/prim/fpv/prim_alert_rxtx_async_fatal_fpv.core
+++ b/hw/ip/prim/fpv/prim_alert_rxtx_async_fatal_fpv.core
@@ -8,6 +8,7 @@ filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
+      - lowrisc:prim:alert
     files:
       - vip/prim_alert_rxtx_async_assert_fpv.sv
       - tb/prim_alert_rxtx_async_fatal_fpv.sv

--- a/hw/ip/prim/fpv/prim_alert_rxtx_async_fpv.core
+++ b/hw/ip/prim/fpv/prim_alert_rxtx_async_fpv.core
@@ -8,6 +8,7 @@ filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
+      - lowrisc:prim:alert
     files:
       - vip/prim_alert_rxtx_async_assert_fpv.sv
       - tb/prim_alert_rxtx_async_fpv.sv

--- a/hw/ip/prim/fpv/prim_alert_rxtx_fatal_fpv.core
+++ b/hw/ip/prim/fpv/prim_alert_rxtx_fatal_fpv.core
@@ -8,6 +8,7 @@ filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
+      - lowrisc:prim:alert
     files:
       - vip/prim_alert_rxtx_assert_fpv.sv
       - tb/prim_alert_rxtx_fatal_fpv.sv

--- a/hw/ip/prim/fpv/prim_alert_rxtx_fpv.core
+++ b/hw/ip/prim/fpv/prim_alert_rxtx_fpv.core
@@ -8,6 +8,7 @@ filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
+      - lowrisc:prim:alert
     files:
       - vip/prim_alert_rxtx_assert_fpv.sv
       - tb/prim_alert_rxtx_fpv.sv

--- a/hw/ip/prim/fpv/prim_esc_rxtx_fpv.core
+++ b/hw/ip/prim/fpv/prim_esc_rxtx_fpv.core
@@ -8,6 +8,7 @@ filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
+      - lowrisc:prim:esc
     files:
       - vip/prim_esc_rxtx_assert_fpv.sv
       - tb/prim_esc_rxtx_bind_fpv.sv

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_fatal_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_fatal_fpv.sv
@@ -7,7 +7,6 @@
 
 module prim_alert_rxtx_async_fatal_fpv
   import prim_alert_pkg::*;
-  import prim_esc_pkg::*;
 (
   input        clk_i,
   input        rst_ni,

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_fpv.sv
@@ -7,7 +7,6 @@
 
 module prim_alert_rxtx_async_fpv
   import prim_alert_pkg::*;
-  import prim_esc_pkg::*;
 (
   input        clk_i,
   input        rst_ni,

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_fatal_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_fatal_fpv.sv
@@ -7,7 +7,6 @@
 
 module prim_alert_rxtx_fatal_fpv
   import prim_alert_pkg::*;
-  import prim_esc_pkg::*;
 (
   input        clk_i,
   input        rst_ni,

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_fpv.sv
@@ -7,7 +7,6 @@
 
 module prim_alert_rxtx_fpv
   import prim_alert_pkg::*;
-  import prim_esc_pkg::*;
 (
   input        clk_i,
   input        rst_ni,

--- a/hw/ip/prim/fpv/tb/prim_esc_rxtx_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_esc_rxtx_fpv.sv
@@ -6,7 +6,6 @@
 // a formal tool.
 
 module prim_esc_rxtx_fpv
-  import prim_alert_pkg::*;
   import prim_esc_pkg::*;
 (
   input        clk_i,
@@ -32,7 +31,7 @@ module prim_esc_rxtx_fpv
   assign esc_tx_in.esc_p  = esc_tx_out.esc_p  ^ esc_err_pi;
   assign esc_tx_in.esc_n  = esc_tx_out.esc_n  ^ esc_err_ni;
 
-  prim_esc_sender i_prim_esc_sender (
+  prim_esc_sender u_prim_esc_sender (
     .clk_i        ,
     .rst_ni       ,
     .ping_req_i   ,
@@ -43,7 +42,11 @@ module prim_esc_rxtx_fpv
     .esc_tx_o     ( esc_tx_out )
   );
 
-  prim_esc_receiver i_prim_esc_receiver (
+  prim_esc_receiver #(
+    // This reduces the state space for this counter
+    // from 2**24 to 2**6 to speed up convergence.
+    .TimeoutCntDw(6)
+  ) u_prim_esc_receiver (
     .clk_i    ,
     .rst_ni   ,
     .esc_en_o ,

--- a/hw/ip/prim/fpv/vip/prim_esc_rxtx_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_esc_rxtx_assert_fpv.sv
@@ -24,47 +24,147 @@ module prim_esc_rxtx_assert_fpv (
 );
 
   logic error_present;
-  assign error_present = resp_err_pi | resp_err_ni |
-                         esc_err_pi  | esc_err_ni;
+  assign error_present = resp_err_pi ||
+                         resp_err_ni ||
+                         esc_err_pi  ||
+                         esc_err_ni;
+
+  // tracks whether any error has been injected so far
+  logic error_d, error_q;
+  assign error_d = error_q || error_present;
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_error_reg
+    if (!rst_ni) begin
+      error_q <= 1'b0;
+    end else begin
+      error_q <= error_d;
+    end
+  end
+
+  // tracks whether escalation has been triggered so far
+  logic esc_d, esc_q;
+  assign esc_d = esc_q || esc_req_i;
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_esc_reg
+    if (!rst_ni) begin
+      esc_q <= 1'b0;
+    end else begin
+      esc_q <= esc_d;
+    end
+  end
 
   // ping will stay high until ping ok received, then it must be deasserted
-  // TODO: this escludes the case where no ping ok will be returned due to an error
-  `ASSUME_FPV(PingDeassert_M, ping_req_i && ping_ok_o |=> ping_req_i, clk_i, !rst_ni)
-  `ASSUME_FPV(PingEnStaysAsserted0_M, ping_req_i |=>
-      (ping_req_i && !ping_ok_o) or (ping_req_i && ping_ok_o ##1 $fell(ping_req_i)),
-      clk_i, !rst_ni || error_present)
+  `ASSUME_FPV(PingReqDeassert_M,
+      ping_req_i &&
+      ping_ok_o
+      |=>
+      !ping_req_i)
+  `ASSUME_FPV(PingReqStaysAsserted0_M,
+      ping_req_i &&
+      !ping_ok_o
+      |=>
+      ping_req_i)
+  // this timing is guaranteed by the lfsr ping timer.
+  `ASSUME_FPV(PingReqStaysLowFor3Cycles_M,
+      $fell(ping_req_i)
+      |->
+      !ping_req_i [*3])
 
-  // assume that the ping enable and escalation enable signals will eventually be deasserted (and
-  // esc will stay low for more than 2 cycles)
-  `ASSUME_FPV(FiniteEsc_M, esc_req_i |-> strong(##[1:$] !esc_req_i [*2]))
-  `ASSUME_FPV(FinitePing_M, ping_req_i |-> strong(##[1:$] !ping_req_i))
 
-  // ping response mus occur within 4 cycles (given that no
-  // error occured within the previous cycles)
-  `ASSERT(PingRespCheck_A, !error_present [*4] ##1 $rose(ping_req_i) |->
-      ##[0:4] ping_ok_o, clk_i, !rst_ni || error_present)
+  // assume that escalation enable signal will eventually be deasserted
+  // for more than 3 cycles (this assumption is needed such that the FSM liveness
+  // assertion below can be proven).
+  `ASSUME_FPV(FiniteEsc_M,
+      esc_req_i
+      |->
+      strong(##[1:$] !esc_req_i [*3]))
 
-  // be more specific (i.e. use throughout)
-  `ASSERT(EscRespCheck_A, ##1 esc_req_i |-> ##[0:1] prim_esc_rxtx_fpv.esc_rx_out.resp_p ##1
-      !prim_esc_rxtx_fpv.esc_rx_out.resp_p, clk_i, !rst_ni || error_present)
+  // check that ping response time is bounded if no error has occurred so far, and
+  // no escalation is being requested.
+  `ASSERT(PingRespCheck_A,
+      $rose(ping_req_i) &&
+      !esc_req_i
+      |->
+      ##[0:4] ping_ok_o,
+      clk_i,
+      !rst_ni ||
+      error_d ||
+      esc_req_i)
+
+  // check escalation response toggles.
+  `ASSERT(EscRespCheck_A,
+      ##1 esc_req_i
+      |->
+      ##[0:1] prim_esc_rxtx_fpv.esc_rx_out.resp_p
+      ##1 !prim_esc_rxtx_fpv.esc_rx_out.resp_p,
+      clk_i,
+      !rst_ni ||
+      error_present)
 
   // check correct transmission of escalation within 0-1 cycles
-  `ASSERT(EscCheck_A, ##1 esc_req_i |-> ##[0:1] esc_en_o, clk_i, !rst_ni || error_present)
+  `ASSERT(EscCheck_A,
+      ##1 esc_req_i
+      |->
+      ##[0:1] esc_en_o,
+      clk_i,
+      !rst_ni ||
+      error_present)
 
   // check that a single error on the diffpairs is detected
-  `ASSERT(SingleSigIntDetected0_A, {esc_err_pi, esc_err_ni} == '0 ##1
-      $onehot({resp_err_pi, resp_err_ni}) |-> integ_fail_o)
-  `ASSERT(SingleSigIntDetected1_A, $onehot({esc_err_pi, esc_err_ni}) ##1
-      {resp_err_pi, resp_err_ni} == '0 |-> integ_fail_o)
+  `ASSERT(SingleSigIntDetected0_A,
+      {esc_err_pi, esc_err_ni} == '0 ##1
+      $onehot({resp_err_pi, resp_err_ni})
+      |->
+      integ_fail_o)
+  `ASSERT(SingleSigIntDetected1_A,
+      $onehot({esc_err_pi, esc_err_ni}) ##1
+      {resp_err_pi, resp_err_ni} == '0
+      |->
+      integ_fail_o)
 
-  // basic liveness of FSMs in case no errors are present
-  `ASSERT(FsmLivenessSender_A, (prim_esc_rxtx_fpv.i_prim_esc_sender.state_q !=
-      prim_esc_rxtx_fpv.i_prim_esc_sender.Idle) |->
-      strong(##[1:$] (prim_esc_rxtx_fpv.i_prim_esc_sender.state_q
-      == prim_esc_rxtx_fpv.i_prim_esc_sender.Idle)), clk_i, !rst_ni || error_present)
-  `ASSERT(FsmLivenessReceiver_A, (prim_esc_rxtx_fpv.i_prim_esc_receiver.state_q !=
-      prim_esc_rxtx_fpv.i_prim_esc_receiver.Idle) |->
-      strong(##[1:$] (prim_esc_rxtx_fpv.i_prim_esc_receiver.state_q
-      == prim_esc_rxtx_fpv.i_prim_esc_receiver.Idle)), clk_i, !rst_ni || error_present)
+  // basic liveness of sender FSM
+  `ASSERT(FsmLivenessSender_A,
+      (prim_esc_rxtx_fpv.u_prim_esc_sender.state_q !=
+      prim_esc_rxtx_fpv.u_prim_esc_sender.Idle)
+      |->
+      strong(##[1:$] (prim_esc_rxtx_fpv.u_prim_esc_sender.state_q
+      == prim_esc_rxtx_fpv.u_prim_esc_sender.Idle)))
+  // basic liveness of sender FSM (can only be guaranteed if no error is present)
+  `ASSERT(FsmLivenessReceiver_A,
+      (prim_esc_rxtx_fpv.u_prim_esc_receiver.state_q !=
+      prim_esc_rxtx_fpv.u_prim_esc_receiver.Idle)
+      |->
+      strong(##[1:$] (prim_esc_rxtx_fpv.u_prim_esc_receiver.state_q
+      == prim_esc_rxtx_fpv.u_prim_esc_receiver.Idle)),
+      clk_i,
+      rst_ni ||
+      error_present)
+
+  // check that auto escalation timeout does not trigger prematurely.
+  // this requires that no errors have been present so far.
+  `ASSERT(AutoEscalation0_A,
+      ping_req_i &&
+      ping_ok_o &&
+      !esc_en_o ##1
+      !ping_req_i [*0 : 2**prim_esc_rxtx_fpv.u_prim_esc_receiver.TimeoutCntDw - 4]
+      |->
+      !esc_en_o,
+      clk_i,
+      !rst_ni ||
+      error_d ||
+      esc_d)
+
+  // check that auto escalation timeout kicks in if pings are absent for too long.
+  // this requires that no errors have been present so far.
+  `ASSERT(AutoEscalation1_A,
+      ping_req_i &&
+      ping_ok_o &&
+      !esc_en_o ##1
+      !ping_req_i [* 2**prim_esc_rxtx_fpv.u_prim_esc_receiver.TimeoutCntDw - 3 : $]
+      |->
+      esc_en_o,
+      clk_i,
+      !rst_ni ||
+      error_d ||
+      esc_d)
+
 
 endmodule : prim_esc_rxtx_assert_fpv

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -22,14 +22,12 @@ filesets:
       - lowrisc:prim:arbiter
       - lowrisc:prim:fifo
       - lowrisc:prim:alert
+      - lowrisc:prim:esc
       - lowrisc:prim:subreg
       - lowrisc:prim:cipher
       - lowrisc:prim:xor2
     files:
       - rtl/prim_clock_gating_sync.sv
-      - rtl/prim_esc_pkg.sv
-      - rtl/prim_esc_receiver.sv
-      - rtl/prim_esc_sender.sv
       - rtl/prim_sram_arbiter.sv
       - rtl/prim_slicer.sv
       - rtl/prim_sync_reqack.sv

--- a/hw/ip/prim/prim_esc.core
+++ b/hw/ip/prim/prim_esc.core
@@ -1,0 +1,43 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:esc"
+description: "Escalation send and receive"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+      - lowrisc:prim:diff_decode
+      - lowrisc:prim:buf
+      - lowrisc:prim:flop
+      - lowrisc:ip:alert_handler_reg
+    files:
+      - rtl/prim_esc_pkg.sv
+      - rtl/prim_esc_receiver.sv
+      - rtl/prim_esc_sender.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/rstmgr/rstmgr.core
+++ b/hw/ip/rstmgr/rstmgr.core
@@ -9,6 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:tlul
+      - lowrisc:prim:esc
       - lowrisc:prim:clock_mux2
       - lowrisc:prim:lc_sync
       - "fileset_ip     ? (lowrisc:ip:rstmgr_pkg)"

--- a/hw/ip/rv_core_ibex/rv_core_ibex.core
+++ b/hw/ip/rv_core_ibex/rv_core_ibex.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:ibex:ibex_top
       - lowrisc:prim:all
+      - lowrisc:prim:esc
       - lowrisc:prim:clock_gating
       - lowrisc:ip:tlul
       - lowrisc:tlul:adapter_host

--- a/hw/ip/tlul/headers.core
+++ b/hw/ip/tlul/headers.core
@@ -9,6 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:constants:top_pkg
+      - lowrisc:prim:secded
     files:
       - rtl/tlul_pkg.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
@@ -96,7 +96,7 @@
     { name: "PING_CNT_DW",
       desc: "Width of ping counter",
       type: "int",
-      default: "24",
+      default: "16",
       local: "true"
     },
     { name: "PHASE_DW",
@@ -541,7 +541,7 @@
       hwaccess: "hwo",
       hwext:    "true",
       fields: [
-        { bits: "15:0" }
+        { bits: "AccuCntDw-1:0" }
       ],
       tags: [// The value of this register is determined by how many alerts have been triggered
              // Cannot be auto-predicted so it is excluded from read check
@@ -555,7 +555,7 @@
       hwaccess: "hro",
       regwen:   "CLASSA_REGWEN",
       fields: [
-        { bits: "15:0",
+        { bits: "AccuCntDw-1:0",
           desc: '''Once the accumulation value register is equal to the threshold escalation will
           be triggered on the next alert occurrence within this class A begins. Note that this
           register can not be modified if !!CLASSA_REGWEN is false.
@@ -571,7 +571,7 @@
       hwaccess: "hro",
       regwen:   "CLASSA_REGWEN",
       fields: [
-        { bits: "31:0",
+        { bits: "EscCntDw-1:0",
           desc: '''If the interrupt corresponding to this class is not
           handled within the specified amount of cycles, escalation will be triggered.
           Set to a positive value to enable the interrupt timeout for Class A. The timeout is set to zero
@@ -589,7 +589,7 @@
       hwaccess: "hro",
       regwen:   "CLASSA_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSA_REGWEN is false.'''
         }
@@ -603,7 +603,7 @@
       hwaccess: "hro",
       regwen:   "CLASSA_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSA_REGWEN is false.'''
         }
@@ -617,7 +617,7 @@
       hwaccess: "hro",
       regwen:   "CLASSA_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSA_REGWEN is false.'''
         }
@@ -631,7 +631,7 @@
       hwaccess: "hro",
       regwen:   "CLASSA_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSA_REGWEN is false.'''
         }
@@ -645,7 +645,7 @@
       hwaccess: "hwo",
       hwext:    "true",
       fields: [
-        { bits: "31:0",
+        { bits: "EscCntDw-1:0",
           desc: '''Returns the current timeout or escalation count (depending on !!CLASSA_STATE).
           This register can not be directly cleared. However, SW can indirectly clear as follows.
 
@@ -816,7 +816,7 @@
       hwaccess: "hwo",
       hwext:    "true",
       fields: [
-        { bits: "15:0" }
+        { bits: "AccuCntDw-1:0" }
       ],
       tags: [// The value of this register is determined by how many alerts have been triggered
              // Cannot be auto-predicted so it is excluded from read check
@@ -830,7 +830,7 @@
       hwaccess: "hro",
       regwen:   "CLASSB_REGWEN",
       fields: [
-        { bits: "15:0",
+        { bits: "AccuCntDw-1:0",
           desc: '''Once the accumulation value register is equal to the threshold escalation will
           be triggered on the next alert occurrence within this class B begins. Note that this
           register can not be modified if !!CLASSB_REGWEN is false.
@@ -846,7 +846,7 @@
       hwaccess: "hro",
       regwen:   "CLASSB_REGWEN",
       fields: [
-        { bits: "31:0",
+        { bits: "EscCntDw-1:0",
           desc: '''If the interrupt corresponding to this class is not
           handled within the specified amount of cycles, escalation will be triggered.
           Set to a positive value to enable the interrupt timeout for Class B. The timeout is set to zero
@@ -864,7 +864,7 @@
       hwaccess: "hro",
       regwen:   "CLASSB_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSB_REGWEN is false.'''
         }
@@ -878,7 +878,7 @@
       hwaccess: "hro",
       regwen:   "CLASSB_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSB_REGWEN is false.'''
         }
@@ -892,7 +892,7 @@
       hwaccess: "hro",
       regwen:   "CLASSB_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSB_REGWEN is false.'''
         }
@@ -906,7 +906,7 @@
       hwaccess: "hro",
       regwen:   "CLASSB_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSB_REGWEN is false.'''
         }
@@ -920,7 +920,7 @@
       hwaccess: "hwo",
       hwext:    "true",
       fields: [
-        { bits: "31:0",
+        { bits: "EscCntDw-1:0",
           desc: '''Returns the current timeout or escalation count (depending on !!CLASSB_STATE).
           This register can not be directly cleared. However, SW can indirectly clear as follows.
 
@@ -1091,7 +1091,7 @@
       hwaccess: "hwo",
       hwext:    "true",
       fields: [
-        { bits: "15:0" }
+        { bits: "AccuCntDw-1:0" }
       ],
       tags: [// The value of this register is determined by how many alerts have been triggered
              // Cannot be auto-predicted so it is excluded from read check
@@ -1105,7 +1105,7 @@
       hwaccess: "hro",
       regwen:   "CLASSC_REGWEN",
       fields: [
-        { bits: "15:0",
+        { bits: "AccuCntDw-1:0",
           desc: '''Once the accumulation value register is equal to the threshold escalation will
           be triggered on the next alert occurrence within this class C begins. Note that this
           register can not be modified if !!CLASSC_REGWEN is false.
@@ -1121,7 +1121,7 @@
       hwaccess: "hro",
       regwen:   "CLASSC_REGWEN",
       fields: [
-        { bits: "31:0",
+        { bits: "EscCntDw-1:0",
           desc: '''If the interrupt corresponding to this class is not
           handled within the specified amount of cycles, escalation will be triggered.
           Set to a positive value to enable the interrupt timeout for Class C. The timeout is set to zero
@@ -1139,7 +1139,7 @@
       hwaccess: "hro",
       regwen:   "CLASSC_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSC_REGWEN is false.'''
         }
@@ -1153,7 +1153,7 @@
       hwaccess: "hro",
       regwen:   "CLASSC_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSC_REGWEN is false.'''
         }
@@ -1167,7 +1167,7 @@
       hwaccess: "hro",
       regwen:   "CLASSC_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSC_REGWEN is false.'''
         }
@@ -1181,7 +1181,7 @@
       hwaccess: "hro",
       regwen:   "CLASSC_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSC_REGWEN is false.'''
         }
@@ -1195,7 +1195,7 @@
       hwaccess: "hwo",
       hwext:    "true",
       fields: [
-        { bits: "31:0",
+        { bits: "EscCntDw-1:0",
           desc: '''Returns the current timeout or escalation count (depending on !!CLASSC_STATE).
           This register can not be directly cleared. However, SW can indirectly clear as follows.
 
@@ -1366,7 +1366,7 @@
       hwaccess: "hwo",
       hwext:    "true",
       fields: [
-        { bits: "15:0" }
+        { bits: "AccuCntDw-1:0" }
       ],
       tags: [// The value of this register is determined by how many alerts have been triggered
              // Cannot be auto-predicted so it is excluded from read check
@@ -1380,7 +1380,7 @@
       hwaccess: "hro",
       regwen:   "CLASSD_REGWEN",
       fields: [
-        { bits: "15:0",
+        { bits: "AccuCntDw-1:0",
           desc: '''Once the accumulation value register is equal to the threshold escalation will
           be triggered on the next alert occurrence within this class D begins. Note that this
           register can not be modified if !!CLASSD_REGWEN is false.
@@ -1396,7 +1396,7 @@
       hwaccess: "hro",
       regwen:   "CLASSD_REGWEN",
       fields: [
-        { bits: "31:0",
+        { bits: "EscCntDw-1:0",
           desc: '''If the interrupt corresponding to this class is not
           handled within the specified amount of cycles, escalation will be triggered.
           Set to a positive value to enable the interrupt timeout for Class D. The timeout is set to zero
@@ -1414,7 +1414,7 @@
       hwaccess: "hro",
       regwen:   "CLASSD_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSD_REGWEN is false.'''
         }
@@ -1428,7 +1428,7 @@
       hwaccess: "hro",
       regwen:   "CLASSD_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSD_REGWEN is false.'''
         }
@@ -1442,7 +1442,7 @@
       hwaccess: "hro",
       regwen:   "CLASSD_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSD_REGWEN is false.'''
         }
@@ -1456,7 +1456,7 @@
       hwaccess: "hro",
       regwen:   "CLASSD_REGWEN",
       fields: [
-        { bits: "31:0" ,
+        { bits: "EscCntDw-1:0" ,
           desc: '''Escalation phase duration in cycles. Note that this register can not be
           modified if !!CLASSD_REGWEN is false.'''
         }
@@ -1470,7 +1470,7 @@
       hwaccess: "hwo",
       hwext:    "true",
       fields: [
-        { bits: "31:0",
+        { bits: "EscCntDw-1:0",
           desc: '''Returns the current timeout or escalation count (depending on !!CLASSD_STATE).
           This register can not be directly cleared. However, SW can indirectly clear as follows.
 

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
@@ -15,7 +15,7 @@ package alert_handler_reg_pkg;
   parameter int N_ESC_SEV = 4;
   parameter int N_PHASES = 4;
   parameter int N_LOC_ALERT = 5;
-  parameter int PING_CNT_DW = 24;
+  parameter int PING_CNT_DW = 16;
   parameter int PHASE_DW = 2;
   parameter int CLASS_DW = 2;
 
@@ -76,7 +76,7 @@ package alert_handler_reg_pkg;
   } alert_handler_reg2hw_intr_test_reg_t;
 
   typedef struct packed {
-    logic [23:0] q;
+    logic [15:0] q;
   } alert_handler_reg2hw_ping_timeout_cyc_reg_t;
 
   typedef struct packed {
@@ -458,10 +458,10 @@ package alert_handler_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    alert_handler_reg2hw_intr_state_reg_t intr_state; // [1103:1100]
-    alert_handler_reg2hw_intr_enable_reg_t intr_enable; // [1099:1096]
-    alert_handler_reg2hw_intr_test_reg_t intr_test; // [1095:1088]
-    alert_handler_reg2hw_ping_timeout_cyc_reg_t ping_timeout_cyc; // [1087:1064]
+    alert_handler_reg2hw_intr_state_reg_t intr_state; // [1095:1092]
+    alert_handler_reg2hw_intr_enable_reg_t intr_enable; // [1091:1088]
+    alert_handler_reg2hw_intr_test_reg_t intr_test; // [1087:1080]
+    alert_handler_reg2hw_ping_timeout_cyc_reg_t ping_timeout_cyc; // [1079:1064]
     alert_handler_reg2hw_ping_timer_en_reg_t ping_timer_en; // [1063:1063]
     alert_handler_reg2hw_alert_regwen_mreg_t [54:0] alert_regwen; // [1062:1008]
     alert_handler_reg2hw_alert_en_mreg_t [54:0] alert_en; // [1007:953]
@@ -1154,7 +1154,7 @@ package alert_handler_reg_pkg;
     4'b 0001, // index[  1] ALERT_HANDLER_INTR_ENABLE
     4'b 0001, // index[  2] ALERT_HANDLER_INTR_TEST
     4'b 0001, // index[  3] ALERT_HANDLER_PING_TIMER_REGWEN
-    4'b 0111, // index[  4] ALERT_HANDLER_PING_TIMEOUT_CYC
+    4'b 0011, // index[  4] ALERT_HANDLER_PING_TIMEOUT_CYC
     4'b 0001, // index[  5] ALERT_HANDLER_PING_TIMER_EN
     4'b 0001, // index[  6] ALERT_HANDLER_ALERT_REGWEN_0
     4'b 0001, // index[  7] ALERT_HANDLER_ALERT_REGWEN_1

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
@@ -139,8 +139,8 @@ module alert_handler_reg_top (
   logic ping_timer_regwen_qs;
   logic ping_timer_regwen_wd;
   logic ping_timer_regwen_we;
-  logic [23:0] ping_timeout_cyc_qs;
-  logic [23:0] ping_timeout_cyc_wd;
+  logic [15:0] ping_timeout_cyc_qs;
+  logic [15:0] ping_timeout_cyc_wd;
   logic ping_timeout_cyc_we;
   logic ping_timer_en_qs;
   logic ping_timer_en_wd;
@@ -1419,9 +1419,9 @@ module alert_handler_reg_top (
   // R[ping_timeout_cyc]: V(False)
 
   prim_subreg #(
-    .DW      (24),
+    .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (24'h20)
+    .RESVAL  (16'h20)
   ) u_ping_timeout_cyc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10828,7 +10828,7 @@ module alert_handler_reg_top (
   assign ping_timer_regwen_wd = reg_wdata[0];
 
   assign ping_timeout_cyc_we = addr_hit[4] & reg_we & !reg_error;
-  assign ping_timeout_cyc_wd = reg_wdata[23:0];
+  assign ping_timeout_cyc_wd = reg_wdata[15:0];
 
   assign ping_timer_en_we = addr_hit[5] & reg_we & !reg_error;
   assign ping_timer_en_wd = reg_wdata[0];
@@ -11835,7 +11835,7 @@ module alert_handler_reg_top (
       end
 
       addr_hit[4]: begin
-        reg_rdata_next[23:0] = ping_timeout_cyc_qs;
+        reg_rdata_next[15:0] = ping_timeout_cyc_qs;
       end
 
       addr_hit[5]: begin


### PR DESCRIPTION
This addresses https://github.com/lowRISC/opentitan/issues/2049 and adds monitoring counters to the escalation receivers that get kicked off once the first ping arrives. After that, these counters act like watchdog counters on the escalation receiver side which will trigger the corresponding escalation action if the alert handler ceases to send out pings.

~~Note that this PR is dependent on https://github.com/lowRISC/opentitan/pull/6839.~~ (has been merged)