### PR TITLE
[mask_rom] Add alert handler test automation.

### DIFF
--- a/hw/top_earlgrey/dv/verilator_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/verilator_sim_cfg.hjson
@@ -201,6 +201,10 @@
       name: sw_silicon_creator_lib_driver_uart_functest
       sw_images: ["sw/device/silicon_creator/testing/sw_silicon_creator_lib_driver_uart_functest:1"]
     }
+    {
+      name: sw_silicon_creator_lib_driver_alert_functest
+      sw_images: ["sw/device/silicon_creator/testing/sw_silicon_creator_lib_driver_alert_functest:1"]
+    }
   ]
 
   // List of regressions.

--- a/test/systemtest/config.py
+++ b/test/systemtest/config.py
@@ -126,4 +126,12 @@ TEST_APPS_SELFCHECKING = [
         "name": "sw_silicon_creator_lib_driver_uart_functest",
         "test_dir": "sw/device/silicon_creator/testing",
     },
+    {
+        "name": "sw_silicon_creator_lib_driver_alert_functest",
+        "test_dir": "sw/device/silicon_creator/testing",
+        # TODO(lowRISC/opentitan#6965) This test resets the chip and appears to
+        # cause a test failure on FPGA boards.  Restrict this test to
+        # verilator for now.
+        "targets": ["sim_verilator"],
+    },
 ]


### PR DESCRIPTION
1. Add the alert handler's functest to systemtest and dvsim.

Signed-off-by: Chris Frantz <cfrantz@google.com>