### PR TITLE
[dv] check alert after tl intg error occurs

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -11,6 +11,9 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   tl_agent_cfg        m_tl_agent_cfg;
   rand tl_agent_cfg   m_tl_agent_cfgs[string];
 
+  // Override this alert name at `initialize` if it's not as below
+  string              tl_intg_alert_name = "fatal_fault";
+
   alert_esc_agent_cfg m_alert_agent_cfg[string];
   push_pull_agent_cfg#(.DeviceDataWidth(EDN_DATA_WIDTH)) m_edn_pull_agent_cfg;
 

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -461,10 +461,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
                   begin
                     // if previous alert_handler just finish, there is a max of two clock_cycle
                     // pause in between
-                    `DV_SPINWAIT_EXIT(while (!cfg.m_alert_agent_cfg[alert_name].vif.get_alert())
-                                      cfg.clk_rst_vif.wait_clks(1);,
-                                      cfg.clk_rst_vif.wait_clks(2);,
-                                      $sformatf("expect alert_%0d:%0s to fire", index, alert_name))
+                    wait_alert_trigger(alert_name, .max_wait_cycle(2));
 
                     // write alert_test during alert handshake will be ignored
                     if ($urandom_range(1, 10) == 10) begin
@@ -510,6 +507,17 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
                        $sformatf("expect alert:%0s to stay low", cfg.list_of_alerts[i]))
         end
       end // end repeat
+    end
+  endtask
+
+  virtual task wait_alert_trigger(string alert_name, int max_wait_cycle = 2, bit wait_complete = 0);
+    `DV_SPINWAIT_EXIT(while (!cfg.m_alert_agent_cfg[alert_name].vif.get_alert())
+                      cfg.clk_rst_vif.wait_clks(1);,
+                      cfg.clk_rst_vif.wait_clks(max_wait_cycle);,
+                      $sformatf("expect alert:%0s to fire", alert_name))
+    if (wait_complete) begin
+      `DV_SPINWAIT(cfg.m_alert_agent_cfg[alert_name].vif.wait_ack_complete();,
+                   $sformatf("timeout wait for alert handshake:%0s", alert_name))
     end
   endtask
 

--- a/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
@@ -16,6 +16,7 @@ class keymgr_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_reg_block));
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = keymgr_env_pkg::LIST_OF_ALERTS;
+    tl_intg_alert_name = "fatal_fault_err";
     has_edn = 1;
     super.initialize(csr_base_addr);
 


### PR DESCRIPTION
Once we get the tl intg_err, check the corresponding alert for a few
times as it should be a fatal alert which keeps sending until reset
then, issue a reset and restart the iteration

For blocks which don't use `fatal_fault` as intg_err alert, need to provide the alert name