### PR TITLE
[i2c, dv] Fix csr_* and smoke test for I2C

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -94,6 +94,8 @@
                 Enable I2C line loopback test
                 If line loopback is enabled, the internal design sees ACQ and RX data as "1"
                 '''
+          tags: [// Exclude from write-checks: writing 1'b1 to this bit causes interrupts unexpectedly asserted
+                "excl:CsrAllTests:CsrExclWrite"]
         }
       ]
     }

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -226,6 +226,7 @@ class i2c_base_vseq extends cip_base_vseq #(
     if (mode == Host) begin
       ral.ctrl.enablehost.set(1'b1);
       ral.ctrl.enabletarget.set(1'b0);
+      ral.ctrl.llpbk.set(1'b0);
       csr_update(ral.ctrl);
       // diable override
       ral.ovrd.txovrden.set(1'b0);
@@ -233,6 +234,7 @@ class i2c_base_vseq extends cip_base_vseq #(
     end else begin
       ral.ctrl.enablehost.set(1'b0);
       ral.ctrl.enabletarget.set(1'b1);
+      ral.ctrl.llpbk.set(1'b0);
       csr_update(ral.ctrl);
       // TODO: more initialization for the host running Target mode
     end


### PR DESCRIPTION
This PR fixed csr_* and smoke test for I2C by disabling write to the loopback bit which causes interrupts unexpectedly asserted

Signed-off-by: Tung Hoang <hoang.tung@wdc.com>