### PR TITLE
[dv/otp_ctrl] connected scanmode to Off and otp_ast_pwr_seq internally

### DIFF
--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -86,7 +86,7 @@ module tb;
     .alert_tx_o                 (alert_tx   ),
     // ast
     .otp_ast_pwr_seq_o          (ast_req),
-    .otp_ast_pwr_seq_h_i        (otp_ctrl_if.otp_ast_pwr_seq_h_i),
+    .otp_ast_pwr_seq_h_i        (ast_req),
     .otp_alert_o                (otp_ctrl_if.otp_alert_o),
     // pwrmgr
     .pwr_otp_i                  (otp_ctrl_if.pwr_otp_init_i),
@@ -118,7 +118,7 @@ module tb;
     //scan
     .scan_en_i                  (otp_ctrl_if.scan_en_i),
     .scan_rst_ni                (otp_ctrl_if.scan_rst_ni),
-    .scanmode_i                 (otp_ctrl_if.scanmode_i)
+    .scanmode_i                 (lc_ctrl_pkg::Off)
   );
 
   for (genvar i = 0; i < NumSramKeyReqSlots; i++) begin : gen_sram_pull_if


### PR DESCRIPTION
Signed-off-by: Sharon Topaz <sharon.topaz@nuvoton.com>
Connected tb scanmode_i to Off and otp_ast_pwr_seq_h_i to otp_ast_pwr_seq_o for IP level DV