### PR TITLE
[sw/silicon_creator] Update manifest fields

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 
+#include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/base/abs_mmio.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -74,8 +75,8 @@ rom_error_t keymgr_init(uint16_t entropy_reseed_interval) {
   return kErrorOk;
 }
 
-rom_error_t keymgr_state_advance_to_creator(const uint32_t binding_value[8],
-                                            uint32_t max_key_ver) {
+rom_error_t keymgr_state_advance_to_creator(
+    const keymgr_binding_value_t *binding_value, uint32_t max_key_ver) {
   RETURN_IF_ERROR(
       check_expected_state(KEYMGR_WORKING_STATE_STATE_VALUE_INIT,
                            KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS));
@@ -83,10 +84,10 @@ rom_error_t keymgr_state_advance_to_creator(const uint32_t binding_value[8],
   // Write and lock (rw0c) the software binding value. This register is unlocked
   // by hardware upon a successful state transition.
   // FIXME: Consider using sec_mmio module for the following register writes.
-  for (size_t i = 0; i < 8; ++i) {
+  for (size_t i = 0; i < ARRAYSIZE(binding_value->data); ++i) {
     abs_mmio_write32(
         kBase + KEYMGR_SW_BINDING_0_REG_OFFSET + i * sizeof(uint32_t),
-        binding_value[i]);
+        binding_value->data[i]);
   }
   abs_mmio_write32(kBase + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 0);
 

--- a/sw/device/silicon_creator/lib/drivers/keymgr.h
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/keymgr_binding_value.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,9 +44,8 @@ rom_error_t keymgr_init(uint16_t entropy_reseed_interval);
  * manifest.
  * @return The result of the operation.
  */
-// TODO: Switch binding_value to a wrapped struct parameter.
-rom_error_t keymgr_state_advance_to_creator(const uint32_t binding_value[8],
-                                            uint32_t max_key_version);
+rom_error_t keymgr_state_advance_to_creator(
+    const keymgr_binding_value_t *binding_value, uint32_t max_key_version);
 
 /**
  * Checks the state of the key manager.

--- a/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
@@ -16,12 +16,10 @@
 
 namespace keymgr_unittest {
 namespace {
-using ::testing::ElementsAreArray;
-using ::testing::Test;
 
 struct SwBindingCfg {
   uint32_t max_key_ver;
-  uint32_t sw_binding_value[8];
+  keymgr_binding_value_t binding_value;
 };
 
 class KeymgrTest : public mask_rom_test::MaskRomTest {
@@ -39,7 +37,7 @@ class KeymgrTest : public mask_rom_test::MaskRomTest {
   uint32_t base_ = TOP_EARLGREY_KEYMGR_BASE_ADDR;
   SwBindingCfg cfg_ = {
       .max_key_ver = 0xA5A5A5A5,
-      .sw_binding_value = {0, 1, 2, 3, 4, 6, 7, 8},
+      .binding_value = {0, 1, 2, 3, 4, 6, 7, 8},
   };
   mask_rom_test::MockAbsMmio mmio_;
 };
@@ -77,21 +75,21 @@ TEST_F(KeymgrTest, StateAdvanceToCreator) {
                     /*err_code=*/0u);
 
   EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_SW_BINDING_0_REG_OFFSET,
-                     cfg_.sw_binding_value[0]);
+                     cfg_.binding_value.data[0]);
   EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_SW_BINDING_1_REG_OFFSET,
-                     cfg_.sw_binding_value[1]);
+                     cfg_.binding_value.data[1]);
   EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_SW_BINDING_2_REG_OFFSET,
-                     cfg_.sw_binding_value[2]);
+                     cfg_.binding_value.data[2]);
   EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_SW_BINDING_3_REG_OFFSET,
-                     cfg_.sw_binding_value[3]);
+                     cfg_.binding_value.data[3]);
   EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_SW_BINDING_4_REG_OFFSET,
-                     cfg_.sw_binding_value[4]);
+                     cfg_.binding_value.data[4]);
   EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_SW_BINDING_5_REG_OFFSET,
-                     cfg_.sw_binding_value[5]);
+                     cfg_.binding_value.data[5]);
   EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_SW_BINDING_6_REG_OFFSET,
-                     cfg_.sw_binding_value[6]);
+                     cfg_.binding_value.data[6]);
   EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_SW_BINDING_7_REG_OFFSET,
-                     cfg_.sw_binding_value[7]);
+                     cfg_.binding_value.data[7]);
   EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 0);
 
   EXPECT_ABS_WRITE32(mmio_, base_ + KEYMGR_MAX_CREATOR_KEY_VER_REG_OFFSET,
@@ -109,7 +107,7 @@ TEST_F(KeymgrTest, StateAdvanceToCreator) {
       });
 
   EXPECT_EQ(
-      keymgr_state_advance_to_creator(cfg_.sw_binding_value, cfg_.max_key_ver),
+      keymgr_state_advance_to_creator(&cfg_.binding_value, cfg_.max_key_ver),
       kErrorOk);
 }
 
@@ -119,7 +117,7 @@ TEST_F(KeymgrTest, StateAdvanceToCreatorInvalid) {
                     KEYMGR_WORKING_STATE_STATE_VALUE_RESET,
                     /*err_code=*/0u);
   EXPECT_EQ(
-      keymgr_state_advance_to_creator(cfg_.sw_binding_value, cfg_.max_key_ver),
+      keymgr_state_advance_to_creator(&cfg_.binding_value, cfg_.max_key_ver),
       kErrorKeymgrInternal);
 
   // Any non-idle status is expected to fail.
@@ -127,7 +125,7 @@ TEST_F(KeymgrTest, StateAdvanceToCreatorInvalid) {
                     KEYMGR_WORKING_STATE_STATE_VALUE_INIT,
                     /*err_code=*/0u);
   EXPECT_EQ(
-      keymgr_state_advance_to_creator(cfg_.sw_binding_value, cfg_.max_key_ver),
+      keymgr_state_advance_to_creator(&cfg_.binding_value, cfg_.max_key_ver),
       kErrorKeymgrInternal);
 }
 

--- a/sw/device/silicon_creator/lib/keymgr_binding_value.h
+++ b/sw/device/silicon_creator/lib/keymgr_binding_value.h
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_KEYMGR_BINDING_VALUE_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_KEYMGR_BINDING_VALUE_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Binding value used by key manager to derive secret values.
+ *
+ * A change in this value changes the secret value of key manager, and
+ * consequently, the versioned keys and identity seeds generated at subsequent
+ * boot stages.
+ *
+ * Note: The size of this value is an implementation detail of the key manager
+ * hardware.
+ */
+typedef struct keymgr_binding_value {
+  uint32_t data[8];
+} keymgr_binding_value_t;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_KEYMGR_BINDING_VALUE_H_

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -38,10 +38,6 @@ typedef struct manifest {
    */
   uint32_t identifier;
   /**
-   * FIXME: remove this field.
-   */
-  uint32_t reserved0;
-  /**
    * Image signature.
    *
    * The signed region of an image starts at `image_length` and ends at the
@@ -54,9 +50,13 @@ typedef struct manifest {
    */
   uint32_t image_length;
   /**
-   * FIXME: Replace with max_version, min_version.
+   * Image major version.
    */
-  uint32_t image_version;
+  uint32_t image_major_version;
+  /**
+   * Image minor version.
+   */
+  uint32_t image_minor_version;
   /**
    * Image timestamp.
    */
@@ -66,51 +66,33 @@ typedef struct manifest {
    */
   uint32_t exponent;
   /**
-   * FIXME: remove this field.
+   * Binding value used by key manager to derive secret values.
+   *
+   * A change in this value changes the secret value of key manager, and
+   * consequently, the versioned keys and identity seeds generated at subsequent
+   * boot stages.
    */
-  uint32_t reserved1;
+  uint32_t binding_value[8];
   /**
-   * FIXME: Replace these with binding_tag and max_key_version.
+   * Maximum allowed version for keys generated at the next boot stage.
    */
-  uint32_t usage_constraints[8];
-  uint32_t lockdown_info[4];
+  uint32_t max_key_version;
   /**
    * Modulus of the signer's RSA public key.
    */
   sigverify_rsa_buffer_t modulus;
-  /**
-   * Extension fields.
-   * FIXME: Remove these until we have a clear use-case.
-   */
-  uint32_t extension0_offset;
-  uint32_t extension0_checksum;
-  uint32_t extension1_offset;
-  uint32_t extension1_checksum;
-  uint32_t extension2_offset;
-  uint32_t extension2_checksum;
-  uint32_t extension3_offset;
-  uint32_t extension3_checksum;
 } manifest_t;
 
 OT_ASSERT_MEMBER_OFFSET(manifest_t, identifier, 0);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, reserved0, 4);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, signature, 8);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, image_length, 392);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, image_version, 396);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, signature, 4);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, image_length, 388);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, image_major_version, 392);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, image_minor_version, 396);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, image_timestamp, 400);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, exponent, 408);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, reserved1, 412);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, usage_constraints, 416);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, lockdown_info, 448);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, modulus, 464);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, extension0_offset, 848);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, extension0_checksum, 852);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, extension1_offset, 856);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, extension1_checksum, 860);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, extension2_offset, 864);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, extension2_checksum, 868);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, extension3_offset, 872);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, extension3_checksum, 876);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, binding_value, 412);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, max_key_version, 444);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, modulus, 448);
 OT_ASSERT_SIZE(manifest_t, MANIFEST_SIZE);
 
 /**

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -9,6 +9,7 @@
 
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/keymgr_binding_value.h"
 #include "sw/device/silicon_creator/lib/manifest_size.h"
 // FIXME: Move sigverify to sw/device/silicon_creator/lib
 #include "sw/device/silicon_creator/mask_rom/sig_verify_keys.h"
@@ -72,7 +73,7 @@ typedef struct manifest {
    * consequently, the versioned keys and identity seeds generated at subsequent
    * boot stages.
    */
-  uint32_t binding_value[8];
+  keymgr_binding_value_t binding_value;
   /**
    * Maximum allowed version for keys generated at the next boot stage.
    */

--- a/sw/device/silicon_creator/lib/manifest_size.h
+++ b/sw/device/silicon_creator/lib/manifest_size.h
@@ -8,6 +8,6 @@
 /**
  * Manifest size for boot stages stored in flash (in bytes).
  */
-#define MANIFEST_SIZE 880
+#define MANIFEST_SIZE 832
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MANIFEST_SIZE_H_

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -133,9 +133,9 @@ void mask_rom_boot(void) {
     //   the current ROM_EXT.
     // TODO(#5955): Switch to manifest in C struct format update this code to
     // use the sw binding and max key version fields from the manifest.
-    uint32_t binding_value[8] = {0};
+    keymgr_binding_value_t binding_value = {0};
     uint32_t max_key_version = 0x1;
-    if (keymgr_state_advance_to_creator(binding_value, max_key_version) !=
+    if (keymgr_state_advance_to_creator(&binding_value, max_key_version) !=
         kErrorOk) {
       break;
     }

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -131,12 +131,8 @@ void mask_rom_boot(void) {
     // CreatorRootKey (2.c.iv)
     // - This is only allowed to be done if we have verified the signature on
     //   the current ROM_EXT.
-    // TODO(#5955): Switch to manifest in C struct format update this code to
-    // use the sw binding and max key version fields from the manifest.
-    keymgr_binding_value_t binding_value = {0};
-    uint32_t max_key_version = 0x1;
-    if (keymgr_state_advance_to_creator(&binding_value, max_key_version) !=
-        kErrorOk) {
+    if (keymgr_state_advance_to_creator(
+            &manifest->binding_value, manifest->max_key_version) != kErrorOk) {
       break;
     }
 

--- a/sw/device/silicon_creator/mask_rom/romextimage_unittest.cc
+++ b/sw/device/silicon_creator/mask_rom/romextimage_unittest.cc
@@ -16,7 +16,7 @@ using ::testing::Return;
 class RomExtImage : public mask_rom_test::MaskRomTest {
  protected:
   mask_rom_test::MockRomextimagePtrs romextimage_ptrs_;
-  manifest_t manifest_;
+  manifest_t manifest_{};
 };
 
 TEST_F(RomExtImage, ManifestGet) {

--- a/sw/host/rom_ext_image_tools/signer/image/src/manifest.rs
+++ b/sw/host/rom_ext_image_tools/signer/image/src/manifest.rs
@@ -26,31 +26,22 @@ use zerocopy::FromBytes;
 //      sw/device/silicon_creator/lib/manifest.h \
 //      -- -I./ -Isw/device/lib/base/freestanding
 
-pub const MANIFEST_SIZE: u32 = 880;
+pub const MANIFEST_SIZE: u32 = 832;
 
 /// Manifest for boot stage images stored in flash.
 #[repr(C)]
 #[derive(FromBytes, AsBytes, Debug, Default)]
 pub struct Manifest {
     pub identifier: u32,
-    pub reserved0: u32,
     pub signature: SigverifyRsaBuffer,
     pub image_length: u32,
-    pub image_version: u32,
+    pub image_major_version: u32,
+    pub image_minor_version: u32,
     pub image_timestamp: u64,
     pub exponent: u32,
-    pub reserved1: u32,
-    pub usage_constraints: [u32; 8usize],
-    pub lockdown_info: [u32; 4usize],
+    pub binding_value: [u32; 8usize],
+    pub max_key_version: u32,
     pub modulus: SigverifyRsaBuffer,
-    pub extension0_offset: u32,
-    pub extension0_checksum: u32,
-    pub extension1_offset: u32,
-    pub extension1_checksum: u32,
-    pub extension2_offset: u32,
-    pub extension2_checksum: u32,
-    pub extension3_offset: u32,
-    pub extension3_checksum: u32,
 }
 
 /// A type that holds 96 32-bit words for RSA-3072.
@@ -73,22 +64,14 @@ impl Default for SigverifyRsaBuffer {
 /// TODO(#6915): Convert this to a unit test after we start running rust tests during our builds.
 pub fn check_manifest_layout() {
     assert_eq!(offset_of!(Manifest, identifier), 0);
-    assert_eq!(offset_of!(Manifest, reserved0), 4);
-    assert_eq!(offset_of!(Manifest, signature), 8);
-    assert_eq!(offset_of!(Manifest, image_length), 392);
-    assert_eq!(offset_of!(Manifest, image_version), 396);
+    assert_eq!(offset_of!(Manifest, signature), 4);
+    assert_eq!(offset_of!(Manifest, image_length), 388);
+    assert_eq!(offset_of!(Manifest, image_major_version), 392);
+    assert_eq!(offset_of!(Manifest, image_minor_version), 396);
     assert_eq!(offset_of!(Manifest, image_timestamp), 400);
     assert_eq!(offset_of!(Manifest, exponent), 408);
-    assert_eq!(offset_of!(Manifest, reserved1), 412);
-    assert_eq!(offset_of!(Manifest, usage_constraints), 416);
-    assert_eq!(offset_of!(Manifest, lockdown_info), 448);
-    assert_eq!(offset_of!(Manifest, modulus), 464);
-    assert_eq!(offset_of!(Manifest, extension0_offset), 848);
-    assert_eq!(offset_of!(Manifest, extension0_checksum), 852);
-    assert_eq!(offset_of!(Manifest, extension1_offset), 856);
-    assert_eq!(offset_of!(Manifest, extension1_checksum), 860);
-    assert_eq!(offset_of!(Manifest, extension2_offset), 864);
-    assert_eq!(offset_of!(Manifest, extension2_checksum), 868);
-    assert_eq!(offset_of!(Manifest, extension3_offset), 872);
+    assert_eq!(offset_of!(Manifest, binding_value), 412);
+    assert_eq!(offset_of!(Manifest, max_key_version), 444);
+    assert_eq!(offset_of!(Manifest, modulus), 448);
     assert_eq!(size_of::<Manifest>(), MANIFEST_SIZE as usize);
 }

--- a/sw/host/rom_ext_image_tools/signer/image/src/manifest.rs
+++ b/sw/host/rom_ext_image_tools/signer/image/src/manifest.rs
@@ -39,7 +39,7 @@ pub struct Manifest {
     pub image_minor_version: u32,
     pub image_timestamp: u64,
     pub exponent: u32,
-    pub binding_value: [u32; 8usize],
+    pub binding_value: KeymgrBindingValue,
     pub max_key_version: u32,
     pub modulus: SigverifyRsaBuffer,
 }
@@ -55,6 +55,12 @@ impl Default for SigverifyRsaBuffer {
     fn default() -> Self {
         Self { data: [0; 96usize] }
     }
+}
+
+#[repr(C)]
+#[derive(FromBytes, AsBytes, Debug, Default)]
+pub struct KeymgrBindingValue {
+        pub data: [u32; 8usize],
 }
 
 /// Checks the layout of the manifest struct.


### PR DESCRIPTION
This change:
- Removes `extension_*`, `reserved*`, `usage_constraints`, `lockdown_info`, `image_version`,
- Adds a struct for key manager binding value (`keymgr_binding_value_t`), and
- Adds `image_major_version`, `image_minor_version`, `binding_value`, and `max_key_version` fields.

@moidx I saw #5956 but the last time we met the final format that we came up with did not include `usage_constraints`. Please let me know if you would like me to keep it.