### PR TITLE
[doc,checklist] Make FPGA_TIMING item more descriptive

### DIFF
--- a/doc/project/checklist.md
+++ b/doc/project/checklist.md
@@ -112,7 +112,7 @@ CDC run set up. No must fix errors, waiver file created.
 
 ### FPGA_TIMING
 
-FPGA synthesis timing meet (Fmax-10%) target or better
+Block is synthesized as part of continuous integration checks and meets timing there.
 
 ### CDC_SYNCMACRO
 


### PR DESCRIPTION
We don't really have a definition of "Fmax-10%" and, in practice,
everything passes this by being synthesized at chip-level as part of
CI checks. Amend the text to reflect this.

Closes #6935.