### PR TITLE
[csrng/dv] aes model, csrng monitor

### DIFF
--- a/hw/dv/sv/csrng_agent/csrng_agent.sv
+++ b/hw/dv/sv/csrng_agent/csrng_agent.sv
@@ -64,6 +64,8 @@ class csrng_agent extends dv_base_agent #(
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
 
+    m_cmd_push_agent.monitor.analysis_port.connect(monitor.csrng_cmd_fifo.analysis_export);
+
     if (cfg.is_active) begin
       if (cfg.if_mode == dv_utils_pkg::Device) begin
         monitor.req_analysis_port.connect(sequencer.req_analysis_fifo.analysis_export);

--- a/hw/dv/sv/csrng_agent/csrng_item.sv
+++ b/hw/dv/sv/csrng_agent/csrng_item.sv
@@ -13,23 +13,22 @@ class csrng_item extends uvm_sequence_item;
   acmd_e       acmd;
   bit [3:0]    clen, flags;
   bit [18:0]   glen;
-  bit [31:0]   cmd_data[$];
+  bit [31:0]   cmd_data_q[$];
 
   virtual function string convert2string();
     string str = "";
     str = {str, "\n"};
-    str = {str,  $sformatf("\n\t |********** csrng_item **********| \t")             };
-    str = {str,  $sformatf("\n\t |* acmd   :   %4s              *| \t", acmd.name()) };
-    str = {str,  $sformatf("\n\t |* clen   :   %4h              *| \t", clen)        };
-    str = {str,  $sformatf("\n\t |* flags  :   %4h              *| \t", flags)       };
-    str = {str,  $sformatf("\n\t |* glen   :   %19h             *| \t", glen)        };
-    if (cmd_data.size()) begin
-      do begin
-        str = {str,  $sformatf("\n\t |* cmd_data[%0d]   :   %0h             *| \t", cmd_data.size(), cmd_data.pop_front())        };
+    str = {str,  $sformatf("\n\t |*********** csrng_item ************| \t")                   };
+    str = {str,  $sformatf("\n\t |* acmd           :   %4s         *| \t", acmd.name())       };
+    str = {str,  $sformatf("\n\t |* clen           :   0x%0h          *| \t", clen)           };
+    str = {str,  $sformatf("\n\t |* flags          :   0x%0h          *| \t", flags)          };
+    str = {str,  $sformatf("\n\t |* glen           :   0x%5h      *| \t", glen)               };
+    if (cmd_data_q.size()) begin
+      for (int i = 0; i < cmd_data_q.size(); i++) begin
+        str = {str,  $sformatf("\n\t |* cmd_data_q[%2d] :   0x%0h   *| \t", i, cmd_data_q[i]) };
       end
-      while (cmd_data.size());
     end
-    str = {str,  $sformatf("\n\t |********************************| \t")             };
+    str = {str,  $sformatf("\n\t |***********************************| \t")                   };
     str = {str, "\n"};
     return str;
   endfunction

--- a/hw/dv/sv/csrng_agent/csrng_monitor.sv
+++ b/hw/dv/sv/csrng_agent/csrng_monitor.sv
@@ -14,15 +14,24 @@ class csrng_monitor extends dv_base_monitor #(
   // csrng_agent_cov: cov
   // uvm_analysis_port #(csrng_item): analysis_port
 
-  `uvm_component_new
+  uvm_tlm_analysis_fifo#(push_pull_item#(.HostDataWidth(csrng_pkg::CSRNG_CMD_WIDTH)))
+      csrng_cmd_fifo;
+
   bit in_reset;
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+
+    csrng_cmd_fifo = new("csrng_cmd_fifo", this);
+  endfunction
 
   task run_phase(uvm_phase phase);
     @(posedge cfg.vif.rst_n);
     fork
       handle_reset();
-      // TODO: implement function
-      // collect_valid_trans();
+      collect_valid_trans();
       // We only need to monitor incoming requests if the agent is configured
       // in device mode.
       if (cfg.if_mode == dv_utils_pkg::Device) begin
@@ -38,6 +47,31 @@ class csrng_monitor extends dv_base_monitor #(
       // TODO: sample any reset-related covergroups
       @(posedge cfg.vif.rst_n);
       in_reset = 0;
+    end
+  endtask
+
+  virtual task collect_valid_trans();
+    push_pull_item#(.HostDataWidth(csrng_pkg::CSRNG_CMD_WIDTH))  item;
+    csrng_item   cs_item;
+
+    cs_item = csrng_item::type_id::create("cs_item");
+
+    forever begin
+      for (int i = 0; i <= cs_item.clen; i++) begin
+        csrng_cmd_fifo.get(item);
+	if (i == 0) begin
+          cs_item.acmd  = item.h_data[3:0];
+          cs_item.clen  = item.h_data[7:4];
+          cs_item.flags = item.h_data[11:8];
+          cs_item.glen  = item.h_data[30:12];
+        end
+        else begin
+          cs_item.cmd_data_q.push_back(item.h_data);
+        end
+      end
+      @(posedge cfg.vif.mon_cb.cmd_rsp.csrng_rsp_ack);
+      `uvm_info(`gfn, $sformatf("Captured item: %s", cs_item.convert2string()), UVM_HIGH)
+      analysis_port.write(cs_item);
     end
   endtask
 
@@ -66,7 +100,4 @@ class csrng_monitor extends dv_base_monitor #(
        end
     end
   endtask
-
-  // TODO: collect_trans
-
 endclass

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi_pkg.sv
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi_pkg.sv
@@ -72,10 +72,12 @@ package aes_model_dpi_pkg;
     output bit [3:0][31:0] data_o);
 
     bit [3:0][3:0][7:0] iv_in, data_in, data_out;
-    data_in = aes_transpose(data_i);
+    data_in = aes_transpose({<<8{data_i}});
     iv_in   = aes_transpose(iv_i);
+    key_i   = {<<8{key_i}};
     c_dpi_aes_crypt_block(impl_i, op_i, mode_i, iv_in, key_len_i, key_i, data_in, data_out);
     data_o  = aes_transpose(data_out);
+    data_o  = {<<8{data_o}};
     return;
   endfunction // sv_dpi_aes_crypt_block
 endpackage

--- a/hw/ip/csrng/dv/csrng_sim_cfg.hjson
+++ b/hw/ip/csrng/dv/csrng_sim_cfg.hjson
@@ -27,6 +27,8 @@
   // TODO: remove imported cfgs that do not apply.
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
+                // Enable C compilation of AES model for DPI-C
+                "{proj_root}/hw/ip/aes/model/aes_model_sim_opts.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
@@ -39,6 +41,9 @@
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
+
+  // Update all builds to add options specific to AES C model compilation.
+  en_build_modes: ["{tool}_aes_model_build_opts"]
 
   // Default UVM test and seq class name.
   uvm_test: csrng_base_test

--- a/hw/ip/csrng/dv/env/csrng_env.core
+++ b/hw/ip/csrng/dv/env/csrng_env.core
@@ -5,12 +5,17 @@ CAPI=2:
 name: "lowrisc:dv:csrng_env:0.1"
 description: "CSRNG DV UVM environment"
 filesets:
+  files_rtl:
+    depend:
+      - lowrisc:ip:aes:0.6
   files_dv:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
       - lowrisc:dv:push_pull_agent
       - lowrisc:dv:csrng_agent
+      - lowrisc:dv:csr_utils
+      - lowrisc:dv:aes_model_dpi
     files:
       - csrng_env_pkg.sv
       - csrng_env_cfg.sv: {is_include_file: true}

--- a/hw/ip/csrng/dv/env/csrng_env.sv
+++ b/hw/ip/csrng/dv/env/csrng_env.sv
@@ -42,6 +42,7 @@ class csrng_env extends cip_base_env #(
     super.connect_phase(phase);
     if (cfg.en_scb) begin
       m_entropy_src_agent.monitor.analysis_port.connect(scoreboard.entropy_src_fifo.analysis_export);
+      m_edn_agent.monitor.analysis_port.connect(scoreboard.csrng_cmd_fifo.analysis_export);
     end
     if (cfg.is_active) begin
       if (cfg.m_entropy_src_agent_cfg.is_active)

--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -18,8 +18,15 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   virtual pins_if  efuse_sw_app_enable_vif;
 
   // Knobs & Weights
-  uint       efuse_sw_app_enable_pct, aes_cipher_disable_pct;
-  rand bit   efuse_sw_app_enable, aes_cipher_disable;
+  uint             efuse_sw_app_enable_pct, aes_cipher_disable_pct,
+                   cmd_length_0_pct, cmd_flags_0_pct, chk_int_state_pct;
+  rand bit         efuse_sw_app_enable, aes_cipher_disable, chk_int_state;
+  rand bit [3:0]   cmd_length, cmd_flags;
+
+  // Variables
+  bit [csrng_env_pkg::KEY_LEN-1:0]       key;
+  bit [csrng_env_pkg::BLOCK_LEN-1:0]     v;
+  bit [csrng_env_pkg::RSD_CTR_LEN-1:0]   reseed_counter;
 
   // Constraints
   constraint c_efuse_sw_app_enable {efuse_sw_app_enable dist { 1 :/ efuse_sw_app_enable_pct,
@@ -29,6 +36,18 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   constraint c_aes_cipher_disable {aes_cipher_disable dist { 1 :/ aes_cipher_disable_pct,
                                                              0 :/ (100 - aes_cipher_disable_pct)
                                                            };}
+
+  constraint c_chk_int_state {chk_int_state dist { 1 :/ chk_int_state_pct,
+                                                   0 :/ (100 - chk_int_state_pct)
+                                                 };}
+
+  constraint c_cmd_length_0 {cmd_length dist { 0      :/ cmd_length_0_pct,
+                                               [1:12] :/ (100 - cmd_length_0_pct)
+                                             };}
+
+  constraint c_cmd_flags_0 {cmd_flags dist { 0 :/ cmd_flags_0_pct,
+                                             1 :/ (100 - cmd_flags_0_pct)
+                                           };}
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = csrng_env_pkg::LIST_OF_ALERTS;
@@ -52,13 +71,19 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   virtual function string convert2string();
     string str = "";
     str = {str, "\n"};
-    str = {str,  $sformatf("\n\t |********** csrng_env_cfg ***********************| \t")                  };
-    str = {str,  $sformatf("\n\t |***** efuse_sw_app_enable     : %10d *****| \t", efuse_sw_app_enable)   };
-    str = {str,  $sformatf("\n\t |***** aes_cipher_disable      : %10d *****| \t", aes_cipher_disable)    };
-    str = {str,  $sformatf("\n\t |---------- knobs -------------------------------| \t")                  };
-    str = {str,  $sformatf("\n\t |***** efuse_sw_app_enable_pct : %10d *****| \t", efuse_sw_app_enable_pct)};
-    str = {str,  $sformatf("\n\t |***** aes_cipher_disable_pct  : %10d *****| \t", aes_cipher_disable_pct) };
-    str = {str,  $sformatf("\n\t |************************************************| \t")                  };
+    str = {str,  $sformatf("\n\t |********** csrng_env_cfg ***********************| \t")                    };
+    str = {str,  $sformatf("\n\t |***** efuse_sw_app_enable     : %10d *****| \t", efuse_sw_app_enable)     };
+    str = {str,  $sformatf("\n\t |***** aes_cipher_disable      : %10d *****| \t", aes_cipher_disable)      };
+    str = {str,  $sformatf("\n\t |***** chk_int_state           : %10d *****| \t", chk_int_state)           };
+    str = {str,  $sformatf("\n\t |***** cmd_length              : %10d *****| \t", cmd_length)              };
+    str = {str,  $sformatf("\n\t |***** cmd_flags               : %10d *****| \t", cmd_flags)               };
+    str = {str,  $sformatf("\n\t |---------- knobs -------------------------------| \t")                    };
+    str = {str,  $sformatf("\n\t |***** efuse_sw_app_enable_pct : %10d *****| \t", efuse_sw_app_enable_pct) };
+    str = {str,  $sformatf("\n\t |***** aes_cipher_disable_pct  : %10d *****| \t", aes_cipher_disable_pct)  };
+    str = {str,  $sformatf("\n\t |***** chk_int_state_pct       : %10d *****| \t", chk_int_state_pct)       };
+    str = {str,  $sformatf("\n\t |***** cmd_length_0_pct        : %10d *****| \t", cmd_length_0_pct)        };
+    str = {str,  $sformatf("\n\t |***** cmd_flags_0_pct         : %10d *****| \t", cmd_flags_0_pct)         };
+    str = {str,  $sformatf("\n\t |************************************************| \t")                    };
     str = {str, "\n"};
     return str;
   endfunction

--- a/hw/ip/csrng/dv/env/csrng_env_pkg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_pkg.sv
@@ -14,18 +14,20 @@ package csrng_env_pkg;
   import cip_base_pkg::*;
   import csr_utils_pkg::*;
   import csrng_ral_pkg::*;
+  import aes_model_dpi_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
   // parameters
-  parameter uint     NUM_HW_APPS = 1;
+  parameter uint     NUM_HW_APPS      = 1;
   parameter string   LIST_OF_ALERTS[] = {"fatal_alert"};
-  parameter uint     NUM_ALERTS = 1;
-  parameter uint     KEY_LEN    = 256;
-  parameter uint     BLOCK_LEN  = 128;
-  parameter uint     CTR_LEN    = 32;
+  parameter uint     NUM_ALERTS       = 1;
+  parameter uint     KEY_LEN          = 256;
+  parameter uint     BLOCK_LEN        = 128;
+  parameter uint     CTR_LEN          = 32;
+  parameter uint     RSD_CTR_LEN      = 32;
 
   parameter bit [TL_DW-1:0] [3:0] ZERO_SEED_GENBITS = {32'h0,
                                                        32'h0,

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -10,10 +10,17 @@ class csrng_scoreboard extends cip_base_scoreboard #(
   `uvm_component_utils(csrng_scoreboard)
 
   // local variables
+  csrng_item              cs_item;
+  bit [TL_DW-1:0]         rdata;
+  bit [RSD_CTR_LEN-1:0]   reseed_counter;
+  bit [BLOCK_LEN-1:0]     v;
+  bit [KEY_LEN-1:0]       key;
+
 
   // TLM agent fifos
   uvm_tlm_analysis_fifo#(push_pull_item#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)))
       entropy_src_fifo;
+  uvm_tlm_analysis_fifo#(csrng_item)   csrng_cmd_fifo;
 
   // local queues to hold incoming packets pending comparison
   push_pull_item#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))
@@ -23,7 +30,9 @@ class csrng_scoreboard extends cip_base_scoreboard #(
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
+
     entropy_src_fifo = new("entropy_src_fifo", this);
+    csrng_cmd_fifo   = new("csrng_cmd_fifo", this);
   endfunction
 
   function void connect_phase(uvm_phase phase);
@@ -32,16 +41,18 @@ class csrng_scoreboard extends cip_base_scoreboard #(
 
   task run_phase(uvm_phase phase);
     super.run_phase(phase);
+
     fork
-      process_push_pull_fifo();
+      process_entropy_src_fifo();
+      process_csrng_cmd_fifo();
     join_none
   endtask
 
-  virtual task process_push_pull_fifo();
+  virtual task process_entropy_src_fifo();
     push_pull_item#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))  item;
     forever begin
       entropy_src_fifo.get(item);
-      `uvm_info(`gfn, $sformatf("received item:\n%0s", item.sprint()), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("received entropy_src item:\n%0s", item.sprint()), UVM_HIGH)
     end
   endtask
 
@@ -102,6 +113,11 @@ class csrng_scoreboard extends cip_base_scoreboard #(
       "genbits": begin
         do_read_check = 1'b0;
       end
+      "int_state_val": begin
+        do_read_check = 1'b0;
+      end
+      "int_state_num": begin
+      end
       "hw_exc_sts": begin
       end
       "err_code": begin
@@ -130,5 +146,120 @@ class csrng_scoreboard extends cip_base_scoreboard #(
     super.check_phase(phase);
     // post test checks - ensure that all local fifos and queues are empty
   endfunction
+
+    // Compare internal state
+  task check_int_state();
+// TODO: Halt main state machine and poll first
+// TODO: Check FIPs and instantiated too
+    csr_wr(.ptr(ral.int_state_num), .value(1'b0));
+    for (int i = 0; i < RSD_CTR_LEN/TL_DW; i++) begin
+      csr_rd(.ptr(ral.int_state_val), .value(rdata));
+      reseed_counter = (rdata<<TL_DW*i) + reseed_counter;
+    end
+    `DV_CHECK_EQ_FATAL(reseed_counter, cfg.reseed_counter)
+    for (int i = 0; i < BLOCK_LEN/TL_DW; i++) begin
+      csr_rd(.ptr(ral.int_state_val), .value(rdata));
+      v = (rdata<<TL_DW*i) + v;
+    end
+    `DV_CHECK_EQ_FATAL(v, cfg.v)
+    for (int i = 0; i < KEY_LEN/TL_DW; i++) begin
+      csr_rd(.ptr(ral.int_state_val), .value(rdata));
+      key = (rdata<<TL_DW*i) + key;
+    end
+    `DV_CHECK_EQ_FATAL(key, cfg.key)
+  endtask
+
+  // From NIST.SP.800-90Ar1
+  function bit [csrng_env_pkg::BLOCK_LEN-1:0] block_encrypt(bit [csrng_env_pkg::KEY_LEN-1:0] key,
+      bit [csrng_env_pkg::BLOCK_LEN-1:0] input_block);
+
+    bit [csrng_env_pkg::BLOCK_LEN-1:0]   output_block;
+
+    if (cfg.aes_cipher_disable)
+      output_block = input_block;
+    else begin
+      sv_dpi_aes_crypt_block(.impl_i(1'b0), .op_i(1'b0), .mode_i(6'b00_0001), .key_len_i(3'b100),
+                             .iv_i('h0),
+                             .key_i(key),
+                             .data_i(input_block),
+                             .data_o(output_block));
+    end
+    return output_block;
+  endfunction
+
+  function void ctr_drbg_update(bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0] provided_data,
+                                ref bit [csrng_env_pkg::KEY_LEN-1:0]       key,
+                                ref bit [csrng_env_pkg::BLOCK_LEN-1:0]     v);
+
+    bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0]   temp;
+    bit [csrng_env_pkg::CTR_LEN-1:0]             inc;
+    bit [csrng_env_pkg::BLOCK_LEN-1:0]           output_block;
+    bit [63:0]                                   mod_val;
+
+    for (int i = 0; i < (entropy_src_pkg::CSRNG_BUS_WIDTH/csrng_env_pkg::BLOCK_LEN); i++) begin
+      if (csrng_env_pkg::CTR_LEN < csrng_env_pkg::BLOCK_LEN) begin
+        inc = (v[csrng_env_pkg::CTR_LEN-1:0] + 1);
+        mod_val = 2**csrng_env_pkg::CTR_LEN;
+        inc = inc % mod_val;
+        v = {v[csrng_env_pkg::BLOCK_LEN - 1:csrng_env_pkg::CTR_LEN], inc};
+      end
+      else begin
+        v += 1;
+        mod_val = 2**csrng_env_pkg::BLOCK_LEN;
+        v = v % mod_val;
+      end
+
+      output_block = block_encrypt(key, v);
+      temp = {temp, output_block};
+    end
+
+    temp = temp ^ provided_data;
+    key  = temp[entropy_src_pkg::CSRNG_BUS_WIDTH-1:(entropy_src_pkg::CSRNG_BUS_WIDTH -
+           csrng_env_pkg::KEY_LEN)];
+    v    = temp[csrng_env_pkg::BLOCK_LEN-1:0];
+  endfunction
+
+  function void ctr_drbg_instantiate(bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0] entropy_input,
+                                     bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0]
+                                         personalization_string = 'h0);
+
+    bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0]   seed_material;
+
+    seed_material = entropy_input ^ personalization_string;
+    cfg.key = 'h0;
+    cfg.v = 'h0;
+    ctr_drbg_update(seed_material, cfg.key, cfg.v);
+    cfg.reseed_counter = 1'b1;
+  endfunction
+
+  function void ctr_drbg_reseed(bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0] entropy_input,
+                                bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0]
+                                    additional_input = 'h0);
+
+    bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0]   seed_material;
+
+    seed_material = entropy_input ^ additional_input;
+    ctr_drbg_update(seed_material, cfg.key, cfg.v);
+    cfg.reseed_counter = 1'b1;
+  endfunction
+
+  virtual task process_csrng_cmd_fifo();
+    bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0]   seed;
+
+    forever begin
+      csrng_cmd_fifo.get(cs_item);
+      for (int i = 0; i < cs_item.cmd_data_q.size(); i++) begin
+        seed = (cs_item.cmd_data_q[i] << i * 32) + seed;
+      end
+
+      case (cs_item.acmd)
+        csrng_pkg::INS: begin
+          ctr_drbg_instantiate(seed);
+        end
+      endcase
+
+      check_int_state();
+    end
+  endtask
 
 endclass

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
@@ -10,10 +10,7 @@ class csrng_base_vseq extends cip_base_vseq #(
   );
   `uvm_object_utils(csrng_base_vseq)
 
-  bit [csrng_env_pkg::KEY_LEN-1:0]         key;
-  bit [csrng_env_pkg::BLOCK_LEN-1:0]       v;
-  bit [csrng_pkg::CSRNG_CMD_WIDTH-1:0]     cmd_data_q[$];
-  uint                                     reseed_counter;
+  bit [csrng_pkg::CSRNG_CMD_WIDTH-1:0]   cmd_data_q[$];
 
   // various knobs to enable certain routines
   bit do_csrng_init = 1'b1;
@@ -45,11 +42,11 @@ class csrng_base_vseq extends cip_base_vseq #(
   endtask
 
   // send csrng command request
+  // TODO: make csrng_item-based
   virtual task send_cmd_req(bit[3:0] acmd, bit[3:0] clen, bit[3:0] flags, bit[18:0] glen,
                             bit[31:0] data_q[$] = '{});
     // Gen cmd_req
     cfg.m_edn_agent_cfg.m_cmd_push_agent_cfg.add_h_user_data({glen, flags, clen, acmd});
-//    `DV_CHECK_FATAL(clen == data_q.size())
       m_edn_push_seq.num_trans = 1 + clen;
       for (int i = 0; i < clen; i++)
         cfg.m_edn_agent_cfg.m_cmd_push_agent_cfg.add_h_user_data(data_q.pop_front());
@@ -58,109 +55,5 @@ class csrng_base_vseq extends cip_base_vseq #(
     // Wait for cmd_ack
     cfg.m_edn_agent_cfg.vif.wait_cmd_ack();
   endtask // send_cmd_req
-
-  // TODO: Move NIST functions to scoreboard, autochecking
-
-  // From NIST.SP.800-90Ar1
-  function bit [csrng_env_pkg::BLOCK_LEN-1:0] block_encrypt(bit [csrng_env_pkg::KEY_LEN-1:0] key,
-     bit [csrng_env_pkg::BLOCK_LEN-1:0] input_block);
-
-    if (cfg.aes_cipher_disable)
-      return input_block;
-    // else
-  endfunction
-
-  function void ctr_drbg_update(bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0] provided_data,
-                                ref bit [csrng_env_pkg::KEY_LEN-1:0]       key,
-                                ref bit [csrng_env_pkg::BLOCK_LEN-1:0] v);
-
-    bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0]   temp;
-    bit [csrng_env_pkg::CTR_LEN-1:0]             inc;
-    bit [csrng_env_pkg::BLOCK_LEN-1:0]           output_block;
-    bit [63:0]                                   mod_val;
-
-    for (int i = 0; i < (entropy_src_pkg::CSRNG_BUS_WIDTH/csrng_env_pkg::BLOCK_LEN); i++) begin
-      if (csrng_env_pkg::CTR_LEN < csrng_env_pkg::BLOCK_LEN) begin
-        inc = (v[csrng_env_pkg::CTR_LEN-1:0] + 1);
-        mod_val = 2**csrng_env_pkg::CTR_LEN;
-        inc = inc % mod_val;
-        v = {v[csrng_env_pkg::BLOCK_LEN - 1:csrng_env_pkg::CTR_LEN], inc};
-      end
-      else begin
-        v += 1;
-        mod_val = 2**csrng_env_pkg::BLOCK_LEN;
-        v = v % mod_val;
-      end
-
-      output_block = block_encrypt(key, v);
-      temp = {temp, output_block};
-    end
-
-    temp = temp ^ provided_data;
-    key  = temp[entropy_src_pkg::CSRNG_BUS_WIDTH-1:(entropy_src_pkg::CSRNG_BUS_WIDTH -
-           csrng_env_pkg::KEY_LEN)];
-    v    = temp[csrng_env_pkg::BLOCK_LEN-1:0];
-  endfunction
-
-  function ctr_drbg_instantiate(bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0] entropy_input,
-                                bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0]
-                                    personalization_string = 'h0);
-
-    bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0]   seed_material;
-
-    seed_material = entropy_input ^ personalization_string;
-    key = 'h0;
-    v = 'h0;
-    ctr_drbg_update(seed_material, key, v);
-    reseed_counter = 1;
-  endfunction
-
-  function ctr_drbg_reseed(bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0] entropy_input,
-                           bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0]
-                               additional_input = 'h0);
-
-    bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0]   seed_material;
-
-    seed_material = entropy_input ^ additional_input;
-    ctr_drbg_update(seed_material, key, v);
-    reseed_counter = 1;
-  endfunction
-
-  function csrng_update(bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0] entropy_input);
-    ctr_drbg_update(entropy_input, key, v);
-  endfunction
-
-  function bit [csrng_pkg::GENBITS_BUS_WIDTH-1:0] ctr_drbg_generate(
-           uint number_of_blocks_requested = 1,
-           bit [entropy_src_pkg::CSRNG_BUS_WIDTH-1:0] additional_input = 'h0);
-
-    bit [csrng_env_pkg::BLOCK_LEN-1:0]           temp;
-    bit [csrng_env_pkg::CTR_LEN-1:0]             inc;
-    bit [csrng_env_pkg::BLOCK_LEN-1:0]           output_block;
-    bit [csrng_pkg::GENBITS_BUS_WIDTH-1:0]       returned_bits;
-    bit [63:0]                                   mod_val;
-
-    for (int i = 0; i < number_of_blocks_requested; i++) begin
-      if (csrng_env_pkg::CTR_LEN < csrng_env_pkg::BLOCK_LEN) begin
-        inc = (v[csrng_env_pkg::CTR_LEN-1:0] + 1);
-        mod_val = 2**csrng_env_pkg::CTR_LEN;
-        inc = inc % mod_val;
-        v = {v[csrng_env_pkg::BLOCK_LEN - 1:csrng_env_pkg::CTR_LEN], inc};
-      end
-      else begin
-        mod_val = 2**csrng_env_pkg::BLOCK_LEN;
-        v = (v + 1) % mod_val;
-      end
-
-      output_block = block_encrypt(key, v);
-      temp = output_block;
-    end
-
-    returned_bits = temp;
-    ctr_drbg_update(additional_input, key, v);
-    reseed_counter+=1;
-
-    return returned_bits;
-  endfunction
 
 endclass : csrng_base_vseq

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_cmds_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_cmds_vseq.sv
@@ -9,6 +9,7 @@ class csrng_cmds_vseq extends csrng_base_vseq;
   `uvm_object_new
 
   rand bit [entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH-1:0]   entropy_val;
+  csrng_item                                             cs_item;
   bit [csrng_pkg::CSRNG_CMD_WIDTH-1:0]                   cmd_data, cmd_data_q[$];
   bit [csrng_pkg::GENBITS_BUS_WIDTH-1:0]                 genbits;
 
@@ -29,6 +30,8 @@ class csrng_cmds_vseq extends csrng_base_vseq;
     // Create csrng_cmd host sequence
     m_edn_push_seq = push_pull_host_seq#(csrng_pkg::CSRNG_CMD_WIDTH)::type_id::create("m_edn_push_seq");
 
+    cs_item = csrng_item::type_id::create("cs_item");
+
     fork
       begin
 //      for (int i = 0; i < num_trans; i++) begin
@@ -37,6 +40,7 @@ class csrng_cmds_vseq extends csrng_base_vseq;
           // TODO: Not always 0, maybe leave randomized
 //        entropy_val[entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH] = 1'b0;
 //          entropy_val = ;
+          // TODO: randomize entropy
           cfg.m_entropy_src_agent_cfg.add_d_user_data(384'hdeadbeef);
           cfg.m_entropy_src_agent_cfg.add_d_user_data(384'hbeefdead);
 //      end
@@ -45,26 +49,25 @@ class csrng_cmds_vseq extends csrng_base_vseq;
 
       begin
         //instantiate cmd
-//        for (int i = 0; i < 1; i++)
-//          cmd_data_q.push_back(32'hdeadbeef);
-//        send_cmd_req(.acmd(csrng_pkg::INS), .clen(4'h1), .flags(4'h1), .glen(19'h0), .data_q(cmd_data_q));
-        send_cmd_req(.acmd(csrng_pkg::INS), .clen(4'h0), .flags(4'h0), .glen(19'h0));
-        ctr_drbg_instantiate(384'hdeadbeef);
+        for (int i = 0; i < cfg.cmd_length; i++)
+          cmd_data_q.push_back(32'hdeadbeef);
+        send_cmd_req(.acmd(csrng_pkg::INS), .clen(cfg.cmd_length), .flags(cfg.cmd_flags), .glen(19'h0), .data_q(cmd_data_q));
 
-        //generate cmd
-        send_cmd_req(.acmd(csrng_pkg::GEN), .clen(4'h0), .flags(4'h0), .glen(19'h1));
-        genbits = ctr_drbg_generate();
+	// TODO: add other commands
+        // //generate cmd
+        // send_cmd_req(.acmd(csrng_pkg::GEN), .clen(4'h0), .flags(4'h0), .glen(19'h1));
+        // genbits = ctr_drbg_generate();
 
-        //reseed cmd
-        send_cmd_req(.acmd(csrng_pkg::RES), .clen(4'h0), .flags(4'h0), .glen(19'h0));
-        ctr_drbg_reseed(384'hbeefdead);
+        // //reseed cmd
+        // send_cmd_req(.acmd(csrng_pkg::RES), .clen(4'h0), .flags(4'h0), .glen(19'h0));
+        // ctr_drbg_reseed(384'hbeefdead);
 
-        //update cmd
-        cmd_data_q.push_back(32'hdeadbeef);
-        send_cmd_req(.acmd(csrng_pkg::UPD), .clen(4'h1), .flags(4'h0), .glen(19'h0), .data_q(cmd_data_q));
-        csrng_update(384'hdeadbeef);
+        // //update cmd
+        // cmd_data_q.push_back(32'hdeadbeef);
+        // send_cmd_req(.acmd(csrng_pkg::UPD), .clen(4'h1), .flags(4'h0), .glen(19'h0), .data_q(cmd_data_q));
+        // csrng_update(384'hdeadbeef);
 
-        send_cmd_req(.acmd(csrng_pkg::UNI), .clen(4'h0), .flags(4'h0), .glen(19'h0));
+        // send_cmd_req(.acmd(csrng_pkg::UNI), .clen(4'h0), .flags(4'h0), .glen(19'h0));
       end
     join_none
 

--- a/hw/ip/csrng/dv/tests/csrng_base_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_base_test.sv
@@ -25,6 +25,10 @@ class csrng_base_test extends cip_base_test #(
 
   virtual function void configure_env();
     cfg.efuse_sw_app_enable_pct = 100;
+    cfg.chk_int_state_pct       = 100;
+    cfg.aes_cipher_disable_pct  = 0;
+    cfg.cmd_length_0_pct        = 0;
+    cfg.cmd_flags_0_pct         = 0;
   endfunction
 
 endclass : csrng_base_test

--- a/hw/ip/csrng/dv/tests/csrng_cmds_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_cmds_test.sv
@@ -11,7 +11,6 @@ class csrng_cmds_test extends csrng_base_test;
     super.configure_env();
 
     // TODO: Modify cfg_knob randomization
-    cfg.aes_cipher_disable_pct = 100;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
     `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)


### PR DESCRIPTION
Integrated AES encryption model, moved internal state generation/compare from sequences to scoreboard, convert push_pull monitor/item to csrng command in csrng monitor.

Signed-off-by: Steve Nelson <steve.nelson@wdc.com>