### PR TITLE
[dv/hmac] reduce smoke test runtime

### DIFF
--- a/hw/ip/hmac/dv/env/seq_lib/hmac_smoke_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_smoke_vseq.sv
@@ -7,7 +7,7 @@ class hmac_smoke_vseq extends hmac_base_vseq;
   `uvm_object_new
 
   constraint num_trans_c {
-    num_trans inside {[1:100]};
+    num_trans inside {[1:50]};
   }
 
   rand bit        hmac_en;


### PR DESCRIPTION
This PR reduces smoke test runtime by running fewer iterations.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>