### PR TITLE
[dv, util] Make poll_for_stop() opt-in

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_test.sv
+++ b/hw/dv/sv/dv_lib/dv_base_test.sv
@@ -14,7 +14,7 @@ class dv_base_test #(type CFG_T = dv_base_env_cfg,
   uint   max_quit_count  = 1;
   uint64 test_timeout_ns = 200_000_000; // 200ms
   uint   drain_time_ns   = 2_000;  // 2us
-  bit    poll_for_stop   = 1'b1;
+  bit    poll_for_stop   = 1'b0;
   uint   poll_for_stop_interval_ns = 1000;
 
   `uvm_component_new

--- a/hw/dv/sv/dv_utils/dv_utils_pkg.sv
+++ b/hw/dv/sv/dv_utils/dv_utils_pkg.sv
@@ -189,7 +189,7 @@ package dv_utils_pkg;
 
   // Periodically check for the existence of a magic file (dv.stop). Exit if it exists. This
   // provides a mechanism to gracefully kill a simulation without direct access to the process.
-  task automatic poll_for_stop(uint interval_ns = 1000, string filename = "dv.stop");
+  task automatic poll_for_stop(uint interval_ns = 10_000, string filename = "dv.stop");
     fork
       while (1) begin
         #(interval_ns * 1ns);


### PR DESCRIPTION
The `poll_for_stop()` method in `dv_utils_pkg` provides a mechanism to
kill the simulation more gracefully on hangs. It looks for the presence
of a file called `dv.stop` every 1us in the rundir which the user can
'touch' if they want it killed.

This mechanism was added because historically, it was not always
reliable to kill a sim by hitting `CTRL-C`, especially, waves 
would get corrupt on `CTRL-C`. The other reason was to be able to kill
specific sims if they are deemed broken already while allowing others to
continue to run.

In any case, allowing that logic to run by default introduces a pretty big
bottleneck - it consumes a whopping **54%** of simulation runtime,
especially for UART which has periods of idle due to slowness of the
baud rate. In this commit, the logic by default is turned off. If this
feature is needed, it can be turned on by passing `--run-opts
"+poll_for_stop=1"` on the command line.

The other change increases the polling interval to 10us.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>