### PR TITLE
[uart/dv] reduce sim time for smoke test

### DIFF
--- a/hw/ip/uart/dv/env/seq_lib/uart_smoke_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_smoke_vseq.sv
@@ -8,7 +8,7 @@ class uart_smoke_vseq extends uart_tx_rx_vseq;
   `uvm_object_utils(uart_smoke_vseq)
 
   constraint num_trans_c {
-    num_trans == 10;
+    num_trans == 2;
   }
 
   constraint num_tx_bytes_c {


### PR DESCRIPTION
reduce itaration to 2, which should bring sim time to < 10s even with
lowest uart clock

Signed-off-by: Weicai Yang <weicai@google.com>