### PR TITLE
[dv/clkmgr] Add test for extclk feature

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr_testplan.hjson
+++ b/hw/ip/clkmgr/data/clkmgr_testplan.hjson
@@ -80,22 +80,22 @@
       desc: '''
             Tests the functionality of enabling external clocks.
 
-            - External clocks can be enabled writing `lc_ctrl_pkg::On` to CSR
-              `extclk_sel`.
-            - Writes to CSR `extclk_sel` are ignored unless the value of CSR
-              `extclk_sel_regwen` is 1.
-            - Regardless of the `extclk_sel` contents, external clocks won't
-              be enabled unless `lc_dtl_en_i == lc_ctrl_pkg::On`.
-            - External clocks can also be enabled if the input
-             `lc_clk_byp_req_i == lc_ctrl_pkg::On`.
+            - External clock is enabled if the `lc_clk_byp_req_i` input from
+              `lc_ctrl` is `lc_ctrl_pkg::On`.
+            - External clock is also be enabled when CSR `extclk_sel` is set to
+              `lc_ctrl_pkg::On` and the `lc_dtl_en_i` input from `lc_ctrl` is
+              `lc_ctrl_pkg::On`.
+            - Notice writes to the `extclk_sel` register are ignored unless the
+              CSR `extclk_sel_regwen` is 1.
             - A successful switch to external clocks will cause the clkmgr
-              to undo a divide by 2 for io_div4 and io_div2 clocks unless in
-              scan mode `(scanmode_i == lc_ctrl_pkg::On)`.
+              to undo a divide by 2 for io_div4 and io_div2 clocks except when
+              `(scanmode_i == lc_ctrl_pkg::On)`.
 
             **Stimulus**:
             - CSR writes to `extclk_sel` and `extclk_sel_regwen`.
             - Setting `lc_dft_en_i`, `lc_clk_byp_req_i`, and the handshake to
               ast via `ast_clk_byp_req_o` and `ast_clk_byp_ack_i`.
+            - Setting `scanmode_i`.
 
             **Checks**:
             - SVA assertions:
@@ -108,7 +108,7 @@
                 clocks to ramp up unless `scanmode_i == lc_ctrl_pkg::On`.
             '''
       milestone: V2
-      tests: []
+      tests: ["clkmgr_extclk"]
     }
   ]
   covergroups: [

--- a/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -57,6 +57,10 @@
       uvm_test_seq: clkmgr_smoke_vseq
     }
     {
+      name: clkmgr_extclk
+      uvm_test_seq: clkmgr_extclk_vseq
+    }
+    {
       name: clkmgr_peri
       uvm_test_seq: clkmgr_peri_vseq
     }

--- a/hw/ip/clkmgr/dv/env/clkmgr_env.core
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env.core
@@ -19,6 +19,7 @@ filesets:
       - seq_lib/clkmgr_vseq_list.sv: {is_include_file: true}
       - seq_lib/clkmgr_base_vseq.sv: {is_include_file: true}
       - seq_lib/clkmgr_common_vseq.sv: {is_include_file: true}
+      - seq_lib/clkmgr_extclk_vseq.sv: {is_include_file: true}
       - seq_lib/clkmgr_peri_vseq.sv: {is_include_file: true}
       - seq_lib/clkmgr_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/clkmgr_trans_vseq.sv: {is_include_file: true}

--- a/hw/ip/clkmgr/dv/env/clkmgr_env_cov.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env_cov.sv
@@ -45,7 +45,7 @@ class clkmgr_trans_cg_wrap;
     trans_cg = new(name);
   endfunction
 
-  function sample(bit hint, bit ip_clk_en, bit scanmode, bit idle);
+  function void sample(bit hint, bit ip_clk_en, bit scanmode, bit idle);
     trans_cg.sample(hint, ip_clk_en, scanmode, idle);
   endfunction
 endclass

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_extclk_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_extclk_vseq.sv
@@ -1,0 +1,113 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// The extclk vseq causes the external clock selection to be triggered. More details
+// in the clkmgr_testplan.hjson file.
+class clkmgr_extclk_vseq extends clkmgr_base_vseq;
+  `uvm_object_utils(clkmgr_extclk_vseq)
+
+  `uvm_object_new
+
+  // If the extclk_sel_regwen is clear, it is not possible to select external clocks.
+  // This is tested in regular csr_rw, so here this register is simply set to 1.
+
+  // lc_dft_en is set according to sel_lc_dft_en, which is randomized with weights.
+  lc_tx_t            lc_dft_en;
+  rand lc_tx_t       lc_dft_en_other;
+  rand lc_tx_t_sel_e sel_lc_dft_en;
+
+  constraint lc_dft_en_c {
+    sel_lc_dft_en dist {LcTxTSelOn := 8, LcTxTSelOff := 2, LcTxTSelOther := 2};
+    !(lc_dft_en_other inside {On, Off});
+  }
+
+  // lc_clk_byp_req is set according to sel_lc_clk_byp_req, which is randomized with weights.
+  lc_tx_t            lc_clk_byp_req;
+  rand lc_tx_t       lc_clk_byp_req_other;
+  rand lc_tx_t_sel_e sel_lc_clk_byp_req;
+
+  constraint lc_clk_byp_req_c {
+    sel_lc_clk_byp_req dist {LcTxTSelOn := 8, LcTxTSelOff := 2, LcTxTSelOther := 2};
+    !(lc_clk_byp_req_other inside {On, Off});
+  }
+
+  // This randomizes the time when the extclk_sel CSR write and the lc_clk_byp_req
+  // input is asserted for good measure. Of course, there is a good chance only a single
+  // one of these trigger a request, so they are also independently tested.
+  rand int cycles_before_extclk_sel;
+  rand int cycles_before_lc_clk_byp_req;
+  rand int cycles_before_lc_clk_byp_ack;
+  rand int cycles_before_ast_clk_byp_ack;
+  rand int cycles_before_next_trans;
+
+  constraint trans_large_c { num_trans == 16; }
+  constraint cycles_to_stim_c {
+    cycles_before_extclk_sel      inside {[4:20]};
+    cycles_before_lc_clk_byp_req  inside {[4:20]};
+    cycles_before_lc_clk_byp_ack  inside {[4:20]};
+    cycles_before_ast_clk_byp_ack inside {[3:11]};
+    cycles_before_next_trans      inside {[15:25]};
+  }
+
+  function void post_randomize();
+    super.post_randomize();
+    lc_dft_en = get_lc_tx_t_from_sel(sel_lc_dft_en, lc_dft_en_other);
+    lc_clk_byp_req = get_lc_tx_t_from_sel(sel_lc_clk_byp_req, lc_clk_byp_req_other);
+  endfunction
+
+  task body();
+    update_csrs_with_reset_values();
+    set_scanmode_on_low_weight();
+    csr_wr(.ptr(ral.extclk_sel_regwen), .value(1));
+    fork
+      forever @cfg.clkmgr_vif.ast_clk_byp_req begin : ast_clk_byp_ack
+        if (cfg.clkmgr_vif.ast_clk_byp_req == lc_ctrl_pkg::On) begin
+          `uvm_info(`gfn, "Got ast_clk_byp_req on", UVM_MEDIUM)
+          cfg.clk_rst_vif.wait_clks(cycles_before_ast_clk_byp_ack);
+          cfg.clkmgr_vif.update_ast_clk_byp_ack(lc_ctrl_pkg::On);
+        end else begin
+          `uvm_info(`gfn, "Got ast_clk_byp_req off", UVM_MEDIUM)
+          cfg.clk_rst_vif.wait_clks(cycles_before_ast_clk_byp_ack);
+          cfg.clkmgr_vif.update_ast_clk_byp_ack(lc_ctrl_pkg::Off);
+        end
+      end
+      forever @cfg.clkmgr_vif.lc_clk_byp_ack begin : lc_clk_byp_ack
+        if (cfg.clkmgr_vif.lc_clk_byp_ack == lc_ctrl_pkg::On) begin
+          `uvm_info(`gfn, "Got lc_clk_byp_ack on", UVM_MEDIUM)
+        end else begin
+          `uvm_info(`gfn, "Got lc_clk_byp_req off", UVM_MEDIUM)
+          cfg.clk_rst_vif.wait_clks(cycles_before_lc_clk_byp_ack);
+          cfg.clkmgr_vif.update_lc_clk_byp_req(lc_ctrl_pkg::Off);
+        end
+      end
+    join_none
+    for (int i = 0; i < num_trans; ++i) begin
+      logic [TL_DW-1:0] value;
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      // Init needs to be synchronous.
+      @cfg.clk_rst_vif.cb begin
+        cfg.clkmgr_vif.init(.idle(idle), .ip_clk_en(ip_clk_en), .scanmode(scanmode),
+                            .lc_dft_en(lc_dft_en));
+      end
+      fork
+        begin
+          cfg.clk_rst_vif.wait_clks(cycles_before_extclk_sel);
+          csr_wr(.ptr(ral.extclk_sel), .value(extclk_sel));
+        end
+        begin
+          cfg.clk_rst_vif.wait_clks(cycles_before_lc_clk_byp_req);
+          cfg.clkmgr_vif.update_lc_clk_byp_req(lc_clk_byp_req);
+        end
+      join
+      `uvm_info(`gfn,
+                $sformatf("extclk_sel=0x%0x, lc_clk_byp_req=0x%0x, lc_dft_en=0x%0x, scanmode=0x%0x",
+                          extclk_sel, lc_clk_byp_req, lc_dft_en, scanmode),
+                UVM_MEDIUM)
+      csr_rd_check(.ptr(ral.extclk_sel), .compare_value(extclk_sel));
+      cfg.io_clk_rst_vif.wait_clks(cycles_before_next_trans);
+    end
+    disable fork;
+  endtask
+
+endclass

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
@@ -23,6 +23,7 @@ class clkmgr_trans_vseq extends clkmgr_base_vseq;
 
       `DV_CHECK_RANDOMIZE_FATAL(this)
       cfg.clkmgr_vif.init(.idle(idle), .ip_clk_en(ip_clk_en), .scanmode(scanmode));
+
       cfg.clk_rst_vif.wait_clks(10);
       `uvm_info(`gfn, $sformatf("Updating hints to 0x%0x", initial_hints), UVM_MEDIUM)
       csr_wr(.ptr(ral.clk_hints), .value(initial_hints));

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_vseq_list.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_vseq_list.sv
@@ -4,6 +4,7 @@
 
 `include "clkmgr_base_vseq.sv"
 `include "clkmgr_common_vseq.sv"
+`include "clkmgr_extclk_vseq.sv"
 `include "clkmgr_peri_vseq.sv"
 `include "clkmgr_smoke_vseq.sv"
 `include "clkmgr_trans_vseq.sv"


### PR DESCRIPTION
Add randomized test for the external clock clkmgr feature.
Check the ast request/response handshake.
Check that the clock divisors get ramped up unless in scan mode.

Signed-off-by: Guillermo Maturana <maturana@google.com>