### PR TITLE
[sw] Fix compilation errors on GCC11

### DIFF
--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -311,11 +311,10 @@ dif_plic_result_t dif_plic_irq_claim(const dif_plic_t *plic,
   return kDifPlicOk;
 }
 
-dif_plic_result_t dif_plic_irq_complete(
-    const dif_plic_t *plic, dif_plic_target_t target,
-    const dif_plic_irq_id_t *complete_data) {
-  if (plic == NULL || target >= RV_PLIC_PARAM_NUM_TARGET ||
-      complete_data == NULL) {
+dif_plic_result_t dif_plic_irq_complete(const dif_plic_t *plic,
+                                        dif_plic_target_t target,
+                                        dif_plic_irq_id_t complete_data) {
+  if (plic == NULL || target >= RV_PLIC_PARAM_NUM_TARGET) {
     return kDifPlicBadArg;
   }
 
@@ -323,7 +322,7 @@ dif_plic_result_t dif_plic_irq_complete(
   // to notify the PLIC of the IRQ completion.
   ptrdiff_t claim_complete_reg = plic_claim_complete_base_for_target(target);
   mmio_region_write32(plic->params.base_addr, claim_complete_reg,
-                      *complete_data);
+                      complete_data);
 
   return kDifPlicOk;
 }

--- a/sw/device/lib/dif/dif_plic.h
+++ b/sw/device/lib/dif/dif_plic.h
@@ -287,14 +287,14 @@ dif_plic_result_t dif_plic_irq_claim(const dif_plic_t *plic,
  *
  * @param plic A PLIC handle.
  * @param target Target that claimed the IRQ.
- * @param[out] complete_data Previously claimed IRQ data that is used to signal
- * PLIC of the IRQ servicing completion.
+ * @param complete_data Previously claimed IRQ data that is used to signal
+ *        PLIC of the IRQ servicing completion.
  * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
 dif_plic_result_t dif_plic_irq_complete(const dif_plic_t *plic,
                                         dif_plic_target_t target,
-                                        const dif_plic_irq_id_t *complete_data);
+                                        dif_plic_irq_id_t complete_data);
 
 /**
  * Forces the software interrupt for a particular target.

--- a/sw/device/lib/dif/dif_plic_unittest.cc
+++ b/sw/device/lib/dif/dif_plic_unittest.cc
@@ -341,12 +341,7 @@ class IrqCompleteTest : public PlicTest {
 };
 
 TEST_F(IrqCompleteTest, NullArgs) {
-  dif_plic_irq_id_t data;
-  EXPECT_EQ(dif_plic_irq_complete(nullptr, kTarget0, &data), kDifPlicBadArg);
-
-  EXPECT_EQ(dif_plic_irq_complete(&plic_, kTarget0, nullptr), kDifPlicBadArg);
-
-  EXPECT_EQ(dif_plic_irq_complete(nullptr, kTarget0, nullptr), kDifPlicBadArg);
+  EXPECT_EQ(dif_plic_irq_complete(nullptr, kTarget0, 0), kDifPlicBadArg);
 }
 
 TEST_F(IrqCompleteTest, Target0Success) {
@@ -357,8 +352,7 @@ TEST_F(IrqCompleteTest, Target0Success) {
 
   // Complete all of the IRQs.
   for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
-    dif_plic_irq_id_t data = i;
-    EXPECT_EQ(dif_plic_irq_complete(&plic_, kTarget0, &data), kDifPlicOk);
+    EXPECT_EQ(dif_plic_irq_complete(&plic_, kTarget0, i), kDifPlicOk);
   }
 }
 

--- a/sw/device/lib/dif/dif_pwrmgr.c
+++ b/sw/device/lib/dif/dif_pwrmgr.c
@@ -585,12 +585,12 @@ dif_pwrmgr_result_t dif_pwrmgr_irq_disable_all(
 }
 
 dif_pwrmgr_result_t dif_pwrmgr_irq_restore_all(
-    const dif_pwrmgr_t *pwrmgr, const dif_pwrmgr_irq_snapshot_t *snapshot) {
-  if (pwrmgr == NULL || snapshot == NULL) {
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_irq_snapshot_t snapshot) {
+  if (pwrmgr == NULL) {
     return kDifPwrmgrBadArg;
   }
 
   mmio_region_write32(pwrmgr->params.base_addr, PWRMGR_INTR_ENABLE_REG_OFFSET,
-                      *snapshot);
+                      snapshot);
   return kDifPwrmgrOk;
 }

--- a/sw/device/lib/dif/dif_pwrmgr.h
+++ b/sw/device/lib/dif/dif_pwrmgr.h
@@ -563,7 +563,7 @@ dif_pwrmgr_result_t dif_pwrmgr_irq_disable_all(
  */
 DIF_WARN_UNUSED_RESULT
 dif_pwrmgr_result_t dif_pwrmgr_irq_restore_all(
-    const dif_pwrmgr_t *pwrmgr, const dif_pwrmgr_irq_snapshot_t *snapshot);
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_irq_snapshot_t snapshot);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/dif_pwrmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_pwrmgr_unittest.cc
@@ -883,11 +883,7 @@ TEST_F(IrqTest, DisableAll) {
 }
 
 TEST_F(IrqTest, RestoreAllBadArgs) {
-  dif_pwrmgr_irq_snapshot_t snapshot;
-
-  EXPECT_EQ(dif_pwrmgr_irq_restore_all(nullptr, &snapshot), kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_restore_all(&pwrmgr_, nullptr), kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_restore_all(nullptr, nullptr), kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_restore_all(nullptr, 0), kDifPwrmgrBadArg);
 }
 
 TEST_F(IrqTest, RestoreAll) {
@@ -895,7 +891,7 @@ TEST_F(IrqTest, RestoreAll) {
 
   EXPECT_WRITE32(PWRMGR_INTR_ENABLE_REG_OFFSET, snapshot);
 
-  EXPECT_EQ(dif_pwrmgr_irq_restore_all(&pwrmgr_, &snapshot), kDifPwrmgrOk);
+  EXPECT_EQ(dif_pwrmgr_irq_restore_all(&pwrmgr_, snapshot), kDifPwrmgrOk);
 }
 
 }  // namespace

--- a/sw/device/silicon_creator/lib/sigverify_mod_exp_ibex_unittest.cc
+++ b/sw/device/silicon_creator/lib/sigverify_mod_exp_ibex_unittest.cc
@@ -195,7 +195,7 @@ TEST_P(ModExp, EncMsg) {
 TEST(ModExp, BadExp) {
   // Exponent = 0
   constexpr sigverify_rsa_key_t bad_key{};
-  sigverify_rsa_buffer_t empty;
+  sigverify_rsa_buffer_t empty{};
 
   EXPECT_EQ(sigverify_mod_exp_ibex(&bad_key, &empty, &empty),
             kErrorSigverifyBadExponent);

--- a/sw/device/tests/dif/dif_plic_smoketest.c
+++ b/sw/device/tests/dif/dif_plic_smoketest.c
@@ -86,7 +86,7 @@ void handler_irq_external(void) {
 
   // Complete the IRQ by writing the IRQ source to the Ibex specific CC
   // register.
-  CHECK(dif_plic_irq_complete(&plic0, kPlicTarget, &interrupt_id) == kDifPlicOk,
+  CHECK(dif_plic_irq_complete(&plic0, kPlicTarget, interrupt_id) == kDifPlicOk,
         "Unable to complete the IRQ request!");
 }
 

--- a/sw/device/tests/sim_dv/gpio_test.c
+++ b/sw/device/tests/sim_dv/gpio_test.c
@@ -268,7 +268,7 @@ void handler_irq_external(void) {
 
   // Complete the IRQ at PLIC.
   CHECK(dif_plic_irq_complete(&plic, kTopEarlgreyPlicTargetIbex0,
-                              &plic_irq_id) == kDifPlicOk,
+                              plic_irq_id) == kDifPlicOk,
         "dif_plic_irq_complete failed");
 }
 

--- a/sw/device/tests/sim_dv/spi_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/spi_tx_rx_test.c
@@ -130,7 +130,7 @@ void handler_irq_external(void) {
 
   // Complete the IRQ at PLIC.
   CHECK(dif_plic_irq_complete(&plic0, kTopEarlgreyPlicTargetIbex0,
-                              &plic_irq_id) == kDifPlicOk,
+                              plic_irq_id) == kDifPlicOk,
         "dif_plic_irq_complete failed");
 }
 

--- a/sw/device/tests/sim_dv/uart_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/uart_tx_rx_test.c
@@ -155,7 +155,7 @@ void handler_irq_external(void) {
 
   // Complete the IRQ at PLIC.
   CHECK(dif_plic_irq_complete(&plic, kTopEarlgreyPlicTargetIbex0,
-                              &plic_irq_id) == kDifPlicOk,
+                              plic_irq_id) == kDifPlicOk,
         "dif_plic_irq_complete failed");
 }
 


### PR DESCRIPTION
GCC 11 (11.1.1 at least) issues a maybe-uninitialized warning in some of our code; see the individual commit messages for details.

(Edited to reflect the increased scope.)