### PR TITLE
[sw] Pass on native C/C++ compiler to Mundane build

### DIFF
--- a/sw/host/rom_ext_image_tools/signer/meson.build
+++ b/sw/host/rom_ext_image_tools/signer/meson.build
@@ -31,9 +31,20 @@ rust_flags = ''
 # The cargo invocation script.
 cargo_invoke_cmd = meson.source_root() / 'util/invoke_cargo.sh'
 
+# Get the command lines for the native C and C++ compilers to pass on to other
+# build systems.
+# The Mundane rust library uses CMake to build BoringSSL, which needs a native
+# C/C++ compiler. Ensure that this build step uses the same native compiler as
+# all other parts of the build.
+prog_c_native = ' '.join(meson.get_compiler('c', native: true).cmd_array())
+prog_cxx_native = ' '.join(meson.get_compiler('cpp', native: true).cmd_array())
+
 rom_ext_signer = custom_target(
   'rom_ext_signer',
   command: [
+    prog_env,
+    'CC=@0@'.format(prog_c_native),
+    'CXX=@0@'.format(prog_cxx_native),
     cargo_invoke_cmd,
     cargo,
     cargo_flags,


### PR DESCRIPTION
In systems with more than one compiler users can choose the native (x86)
C/C++ compiler to use e.g. with the following command:

```
CC_FOR_BUILD=gcc-10 CXX_FOR_BUILD=g++-10 ./meson_init.sh -f
```

This compiler is then tested and used for native builds triggerd from
within Meson. Additionally, we also spawn out to other build systems,
and they need to know which compiler to use as well.

In particular, we build the Mundane Rust crate, which itself calls CMake
to build BoringSSL ("native", i.e. for the build machine).

With this change, we pass on the native compiler in a way that Mundane
gets ultimately built with the same native compiler as the rest of our
x86 ("native") software.

(This came up when trying to switch to an older GCC version due to
Mundane being unable to build with GCC 11, see
https://github.com/lowRISC/opentitan/issues/6978.)