### PR TITLE
[dv/kmac/sram] reduce iterations of smoke test

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -17,7 +17,7 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   // useful to keep the runtime down especially in time-sensitive runs such as CI, which is meant
   // to check the code health and not find design bugs. It is set via plusarg and retrieved in
   // `dv_base_test`.
-  bit smoke_test        = 0;
+  bit smoke_test = 0;
 
   // bit to configure all uvcs with zero delays to create high bw test
   rand bit zero_delays;

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -15,10 +15,13 @@ class kmac_smoke_vseq extends kmac_base_vseq;
 
   rand kmac_app_e app_mode;
 
-  // TODO: 200 is chosen as upper bound due to large configuration space for KMAC.
-  //       If this large range causes noticeable simulation slowdown, reduce it.
   constraint num_trans_c {
     num_trans inside {[1:200]};
+    if (cfg.smoke_test) {
+      num_trans == 10;
+    } else {
+      num_trans inside {[1:200]};
+    }
   }
 
   // If in KMAC mode, the function name has to be "KMAC" string

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
@@ -27,15 +27,17 @@ class sram_ctrl_smoke_vseq extends sram_ctrl_base_vseq;
     num_trans == 1;
   }
 
-  // TODO: 10_000 iterations takes roughly 150s CPU time during simulation.
-  //       If this is too much, modify the constraint.
   constraint num_ops_c {
-    num_ops dist {
-      [1    : 999 ] :/ 1,
-      [1000 : 4999] :/ 3,
-      [5000 : 9999] :/ 5,
-      10_000        :/ 1
-    };
+    if (cfg.smoke_test) {
+      num_ops == 100;
+    } else {
+      num_ops dist {
+        [1    : 999 ] :/ 1,
+        [1000 : 4999] :/ 3,
+        [5000 : 9999] :/ 5,
+        10_000        :/ 1
+      };
+    }
   }
 
   // This can be much smaller than `num_ops`, as we only perform some memory accesses


### PR DESCRIPTION
This PR drastically reduces the runtime of the smoke test in private CI
to remove some performance bottlenecks.

Applies to both the KMAC and SRAM modules.

Signed-off-by: Udi Jonnalagadda <udij@google.com>