### PR TITLE
[dv/otp_ctrl] Minor improvement on OTP_CTRL testbench

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -99,6 +99,8 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
         end
         `uvm_info(`gfn, "clear internal memory and digest", UVM_HIGH)
         cfg.backdoor_clear_mem = 0;
+        dai_wr_ip = 0;
+        dai_digest_ip = LifeCycleIdx;
       end
     end
   endtask

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -80,12 +80,9 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   endfunction
 
   // Overide this task for otp_ctrl_common_vseq and otp_ctrl_stress_all_with_rand_reset_vseq
-  // 1). Some registers won't set to default value until otp_init is done
-  // 2). Clear memory for next sequence to run. This can avoid ECC injection error and
-  //     write_blank error
+  // because some registers won't set to default value until otp_init is done.
   virtual task read_and_check_all_csrs_after_reset();
     cfg.otp_ctrl_vif.drive_lc_escalate_en(lc_ctrl_pkg::Off);
-    clear_otp_memory();
     otp_pwr_init();
     super.read_and_check_all_csrs_after_reset();
   endtask

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
@@ -12,6 +12,8 @@ class otp_ctrl_dai_errs_vseq extends otp_ctrl_dai_lock_vseq;
   bit[31:0] exp_status;
   `uvm_object_new
 
+  // Only run one transition to avoid dut_init in the sequence. Because write-blank-error can cause
+  // otp_init failure.
   constraint num_trans_c {
     num_trans  == 1;
     num_dai_op inside {[100:500]};
@@ -36,6 +38,9 @@ class otp_ctrl_dai_errs_vseq extends otp_ctrl_dai_lock_vseq;
 
   task body();
     do_apply_reset = 0;
+    if (do_lc_trans && !cfg.otp_ctrl_vif.alert_reqs) begin
+      req_lc_transition(do_lc_trans, lc_prog_blocking);
+    end
     super.body();
   endtask
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -76,13 +76,6 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
     check_lc_err();
   endtask
 
-  // Used for stress_all sequence to clear OTP internal memory before going to next test.
-  // This can avoid unexpected ECC injection errors or write_blank errors.
-  virtual task post_start();
-    super.post_start();
-    clear_otp_memory();
-  endtask
-
   virtual task check_lc_err();
     fork
       forever begin


### PR DESCRIPTION
1. Remove redundant clear_otp_memory: with static queue and associative
array to store used address, we can remove clear_otp_memory in
stress_all_with_rand_reset test.

2. Add a lc_transition req before running dai_error_test to add more
possibility for lc program write-blank-error.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>