### PR TITLE
[otbn/sw] Introduce otbn_dump_dmem()

### DIFF
--- a/sw/device/lib/runtime/meson.build
+++ b/sw/device/lib/runtime/meson.build
@@ -85,6 +85,7 @@ sw_lib_runtime_otbn = declare_dependency(
       sw_lib_dif_otbn,
       sw_lib_mmio,
       sw_lib_runtime_hart,
+      sw_lib_runtime_log,
     ]
   )
 )

--- a/sw/device/lib/runtime/otbn.h
+++ b/sw/device/lib/runtime/otbn.h
@@ -259,4 +259,14 @@ otbn_result_t otbn_func_ptr_to_imem_addr(const otbn_t *ctx, otbn_ptr_t ptr,
 otbn_result_t otbn_data_ptr_to_dmem_addr(const otbn_t *ctx, otbn_ptr_t ptr,
                                          uint32_t *dmem_addr_otbn);
 
+/**
+ * Writes a LOG_INFO message with the contents of each 256b DMEM word.
+ *
+ * @param ctx The context object.
+ * @param max_addr The highest address to dump. Set to 0 to output the whole
+ *                 DMEM. Must be a multiple of WLEN.
+ * @return The result of the operation.
+ */
+otbn_result_t otbn_dump_dmem(const otbn_t *ctx, uint32_t max_addr);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_RUNTIME_OTBN_H_


### PR DESCRIPTION
A development helper function to dump (a subset of) OTBN's data memory.