### PR TITLE
[reggen] Simplify reg_top ports if there's exactly one window

### DIFF
--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -35,8 +35,8 @@ module hmac
   hmac_reg2hw_t reg2hw;
   hmac_hw2reg_t hw2reg;
 
-  tlul_pkg::tl_h2d_t  tl_win_h2d[1];
-  tlul_pkg::tl_d2h_t  tl_win_d2h[1];
+  tlul_pkg::tl_h2d_t  tl_win_h2d;
+  tlul_pkg::tl_d2h_t  tl_win_d2h;
 
   logic [255:0] secret_key;
 
@@ -298,8 +298,8 @@ module hmac
   ) u_tlul_adapter (
     .clk_i,
     .rst_ni,
-    .tl_i        (tl_win_h2d[0]),
-    .tl_o        (tl_win_d2h[0]),
+    .tl_i        (tl_win_h2d),
+    .tl_o        (tl_win_d2h),
     .en_ifetch_i (tlul_pkg::InstrDis),
     .req_o       (msg_fifo_req   ),
     .req_type_o  (               ),

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -14,8 +14,8 @@ module hmac_reg_top (
   output tlul_pkg::tl_d2h_t tl_o,
 
   // Output port for window
-  output tlul_pkg::tl_h2d_t tl_win_o  [1],
-  input  tlul_pkg::tl_d2h_t tl_win_i  [1],
+  output tlul_pkg::tl_h2d_t tl_win_o,
+  input  tlul_pkg::tl_d2h_t tl_win_i,
 
   // To HW
   output hmac_reg_pkg::hmac_reg2hw_t reg2hw, // Write
@@ -89,8 +89,8 @@ module hmac_reg_top (
   assign tl_reg_h2d = tl_socket_h2d[1];
   assign tl_socket_d2h[1] = tl_reg_d2h;
 
-  assign tl_win_o[0] = tl_socket_h2d[0];
-  assign tl_socket_d2h[0] = tl_win_i[0];
+  assign tl_win_o = tl_socket_h2d[0];
+  assign tl_socket_d2h[0] = tl_win_i;
 
   // Create Socket_1n
   tlul_socket_1n #(

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -87,8 +87,8 @@ module rom_ctrl
 
   // TL interface ==============================================================
 
-  tlul_pkg::tl_h2d_t tl_rom_h2d [1];
-  tlul_pkg::tl_d2h_t tl_rom_d2h [1];
+  tlul_pkg::tl_h2d_t tl_rom_h2d;
+  tlul_pkg::tl_d2h_t tl_rom_d2h;
 
   logic  rom_reg_integrity_error;
 
@@ -121,8 +121,8 @@ module rom_ctrl
     .clk_i        (clk_i),
     .rst_ni       (rst_ni),
 
-    .tl_i         (tl_rom_h2d[0]),
-    .tl_o         (tl_rom_d2h[0]),
+    .tl_i         (tl_rom_h2d),
+    .tl_o         (tl_rom_d2h),
     .en_ifetch_i  (tlul_pkg::InstrEn),
     .req_o        (bus_rom_req),
     .req_type_o   (),

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_rom_reg_top.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_rom_reg_top.sv
@@ -14,8 +14,8 @@ module rom_ctrl_rom_reg_top (
   output tlul_pkg::tl_d2h_t tl_o,
 
   // Output port for window
-  output tlul_pkg::tl_h2d_t tl_win_o  [1],
-  input  tlul_pkg::tl_d2h_t tl_win_i  [1],
+  output tlul_pkg::tl_h2d_t tl_win_o,
+  input  tlul_pkg::tl_d2h_t tl_win_i,
 
   // To HW
 
@@ -59,8 +59,8 @@ module rom_ctrl_rom_reg_top (
     .tl_o
   );
 
-  assign tl_win_o[0] = tl_i;
-  assign tl_o_pre    = tl_win_i[0];
+  assign tl_win_o = tl_i;
+  assign tl_o_pre = tl_win_i;
 
   // Unused signal tieoff
   // devmode_i is not used if there are no registers

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -66,8 +66,8 @@ module spi_device
   spi_device_reg2hw_t reg2hw;
   spi_device_hw2reg_t hw2reg;
 
-  tlul_pkg::tl_h2d_t tl_sram_h2d [1];
-  tlul_pkg::tl_d2h_t tl_sram_d2h [1];
+  tlul_pkg::tl_h2d_t tl_sram_h2d;
+  tlul_pkg::tl_d2h_t tl_sram_d2h;
 
   // Dual-port SRAM Interface: Refer prim_ram_2p_wrapper.sv
   logic              sram_clk;
@@ -899,8 +899,8 @@ module spi_device
     .clk_i,
     .rst_ni,
 
-    .tl_i        (tl_sram_h2d [0]),
-    .tl_o        (tl_sram_d2h [0]),
+    .tl_i        (tl_sram_h2d),
+    .tl_o        (tl_sram_d2h),
     .en_ifetch_i (tlul_pkg::InstrDis),
     .req_o       (mem_a_req),
     .req_type_o  (),

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -14,8 +14,8 @@ module spi_device_reg_top (
   output tlul_pkg::tl_d2h_t tl_o,
 
   // Output port for window
-  output tlul_pkg::tl_h2d_t tl_win_o  [1],
-  input  tlul_pkg::tl_d2h_t tl_win_i  [1],
+  output tlul_pkg::tl_h2d_t tl_win_o,
+  input  tlul_pkg::tl_d2h_t tl_win_i,
 
   // To HW
   output spi_device_reg_pkg::spi_device_reg2hw_t reg2hw, // Write
@@ -89,8 +89,8 @@ module spi_device_reg_top (
   assign tl_reg_h2d = tl_socket_h2d[1];
   assign tl_socket_d2h[1] = tl_reg_d2h;
 
-  assign tl_win_o[0] = tl_socket_h2d[0];
-  assign tl_socket_d2h[0] = tl_win_i[0];
+  assign tl_win_o = tl_socket_h2d[0];
+  assign tl_socket_d2h[0] = tl_win_i;
 
   // Create Socket_1n
   tlul_socket_1n #(

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -50,8 +50,8 @@ module spi_host
   spi_host_reg2hw_t reg2hw;
   spi_host_hw2reg_t hw2reg;
 
-  tlul_pkg::tl_h2d_t fifo_win_h2d [1];
-  tlul_pkg::tl_d2h_t fifo_win_d2h [1];
+  tlul_pkg::tl_h2d_t fifo_win_h2d;
+  tlul_pkg::tl_d2h_t fifo_win_d2h;
 
   // Register module
   logic [NumAlerts-1:0] alert_test, alerts;
@@ -303,8 +303,8 @@ module spi_host
   spi_host_window u_window (
     .clk_i,
     .rst_ni,
-    .win_i      (fifo_win_h2d[0]),
-    .win_o      (fifo_win_d2h[0]),
+    .win_i      (fifo_win_h2d),
+    .win_o      (fifo_win_d2h),
     .tx_data_o  (tx_data),
     .tx_be_o    (tx_be),
     .tx_valid_o (tx_valid),

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -14,8 +14,8 @@ module spi_host_reg_top (
   output tlul_pkg::tl_d2h_t tl_o,
 
   // Output port for window
-  output tlul_pkg::tl_h2d_t tl_win_o  [1],
-  input  tlul_pkg::tl_d2h_t tl_win_i  [1],
+  output tlul_pkg::tl_h2d_t tl_win_o,
+  input  tlul_pkg::tl_d2h_t tl_win_i,
 
   // To HW
   output spi_host_reg_pkg::spi_host_reg2hw_t reg2hw, // Write
@@ -89,8 +89,8 @@ module spi_host_reg_top (
   assign tl_reg_h2d = tl_socket_h2d[1];
   assign tl_socket_d2h[1] = tl_reg_d2h;
 
-  assign tl_win_o[0] = tl_socket_h2d[0];
-  assign tl_socket_d2h[0] = tl_win_i[0];
+  assign tl_win_o = tl_socket_h2d[0];
+  assign tl_socket_d2h[0] = tl_win_i;
 
   // Create Socket_1n
   tlul_socket_1n #(

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -107,8 +107,8 @@ module usbdev import usbdev_pkg::*; (
   usbdev_reg2hw_t reg2hw;
   usbdev_hw2reg_t hw2reg;
 
-  tlul_pkg::tl_h2d_t tl_sram_h2d [1];
-  tlul_pkg::tl_d2h_t tl_sram_d2h [1];
+  tlul_pkg::tl_h2d_t tl_sram_h2d;
+  tlul_pkg::tl_d2h_t tl_sram_d2h;
 
   // Dual-port SRAM Interface: Refer prim_ram_2p_async_adv.sv
   logic              mem_a_req;
@@ -673,8 +673,8 @@ module usbdev import usbdev_pkg::*; (
     .clk_i       (clk_i),
     .rst_ni      (rst_ni),
 
-    .tl_i        (tl_sram_h2d [0]),
-    .tl_o        (tl_sram_d2h [0]),
+    .tl_i        (tl_sram_h2d),
+    .tl_o        (tl_sram_d2h),
     .en_ifetch_i (tlul_pkg::InstrDis),
     .req_o       (mem_a_req),
     .req_type_o  (),

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -14,8 +14,8 @@ module usbdev_reg_top (
   output tlul_pkg::tl_d2h_t tl_o,
 
   // Output port for window
-  output tlul_pkg::tl_h2d_t tl_win_o  [1],
-  input  tlul_pkg::tl_d2h_t tl_win_i  [1],
+  output tlul_pkg::tl_h2d_t tl_win_o,
+  input  tlul_pkg::tl_d2h_t tl_win_i,
 
   // To HW
   output usbdev_reg_pkg::usbdev_reg2hw_t reg2hw, // Write
@@ -89,8 +89,8 @@ module usbdev_reg_top (
   assign tl_reg_h2d = tl_socket_h2d[1];
   assign tl_socket_d2h[1] = tl_reg_d2h;
 
-  assign tl_win_o[0] = tl_socket_h2d[0];
-  assign tl_socket_d2h[0] = tl_win_i[0];
+  assign tl_win_o = tl_socket_h2d[0];
+  assign tl_socket_d2h[0] = tl_win_i;
 
   // Create Socket_1n
   tlul_socket_1n #(


### PR DESCRIPTION
Expose `tl_win_o` and `tl_win_i` as a single `tl_h2d_t` / `tl_d2h_t`,
respectively, rather than as unpacked arrays with one entry each. No
big deal, but it makes the code that instantiates the reg_top module a
bit cleaner.
