### PR TITLE
[tlul] Drop the "quick fail" path from tlul_adapter_sram.sv

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -166,7 +166,7 @@ module tlul_adapter_sram import tlul_pkg::*; #(
       d_user   : '{default: '1, data_intg: d_valid ? rspfifo_rdata.data_intg : '1},
       d_error  : d_valid && d_error,
 
-      a_ready  : (gnt_i | error_internal) & reqfifo_wready & sramreqfifo_wready
+      a_ready  : gnt_i & reqfifo_wready & sramreqfifo_wready
   };
 
 
@@ -182,9 +182,8 @@ module tlul_adapter_sram import tlul_pkg::*; #(
   // assemble response, including read response, write response, and error for unsupported stuff
 
   // Output to SRAM:
-  //    Generate request only when no internal error occurs. If error occurs, the request should be
-  //    dropped and returned error response to the host. So, error to be pushed to reqfifo.
-  //    In this case, it is assumed the request is granted (may cause ordering issue later?)
+  //    Generate request only when no internal error occurs. If there's an error, we squash the
+  //    outgoing request (so as not to propagate rubbish to the rest of the block).
   assign req_o      = tl_i.a_valid & reqfifo_wready & ~error_internal;
   assign req_type_o = tl_i.a_user.tl_type;
   assign we_o       = tl_i.a_valid & (tl_i.a_opcode inside {PutFullData, PutPartialData});


### PR DESCRIPTION
Before this change, the adapter responded immediately on the A channel
if the request would cause an internal error (assuming there was space
in the request FIFO). The logic is that there's no need to wait for a
grant from the SRAM side since we're not sending anything to the SRAM
anyway.

This patch removes that logic so now the TL interface is stalled
unconditionally if !gnt_i. This might shorten some timing paths a
bit (since we no longer have the combinatorial path from request to
response, unless there's one on the SRAM side). However, my actual
motivation is to be able to assert things like "if gnt_i is false, the
TL side will stall" without having to add special handling for the
error case.

There will be a small observable slow-down for responses that should
generate an error, but this doesn't seem like a big deal (it's an
error! We probably don't care how quickly it's reported!). Indeed,
making that sort of thing more uniform seems like a more secure
approach anyway since it might eliminate some timing channel.

@cdgori, @tjaychen: I'd be interested in any comments you guys have about the system level security implications of this change. I *think* it's a net win, but it's totally possible I've missed something!