### PR TITLE
[otbn] Update block diagram for RND/URND

### DIFF
--- a/hw/ip/otbn/doc/otbn_blockarch.svg
+++ b/hw/ip/otbn/doc/otbn_blockarch.svg
@@ -8,13 +8,13 @@
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
-   viewBox="0 0 868.50442 679.38984"
+   viewBox="0 0 868.50442 767.90681"
    stroke-miterlimit="10"
    id="svg2383"
    sodipodi:docname="otbn_blockarch.svg"
    inkscape:version="0.92.3 (2405546, 2018-03-11)"
    width="868.50439"
-   height="679.38983"
+   height="767.9068"
    style="fill:none;stroke:none;stroke-linecap:square;stroke-miterlimit:10">
   <metadata
      id="metadata2389">
@@ -457,6 +457,66 @@
          style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
          transform="matrix(-0.4,0,0,-0.4,-4,0)" />
     </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1702-2-1-88-6"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1700-6-2-8-4"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1702-2-1-88-9"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1700-6-2-8-6"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1702-2-1-88-0"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1700-6-2-8-1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1702-2-1-88-6-7"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1700-6-2-8-4-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
   </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -471,23 +531,24 @@
      inkscape:window-height="1416"
      id="namedview2385"
      showgrid="true"
-     inkscape:zoom="2.8284271"
-     inkscape:cx="214.7736"
-     inkscape:cy="428.03851"
+     inkscape:zoom="4"
+     inkscape:cx="408.20287"
+     inkscape:cy="192.10798"
      inkscape:window-x="1920"
      inkscape:window-y="0"
      inkscape:window-maximized="0"
-     inkscape:current-layer="g2772"
+     inkscape:current-layer="svg2383"
      showguides="false"
      fit-margin-top="15"
      fit-margin-left="15"
      fit-margin-bottom="15"
-     fit-margin-right="15">
+     fit-margin-right="15"
+     showborder="true">
     <inkscape:grid
        type="xygrid"
        id="grid3683"
-       originx="-14.674988"
-       originy="57.166619" />
+       originx="-14.674989"
+       originy="145.6836" />
   </sodipodi:namedview>
   <path
      style="fill:none;stroke:#008000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1"
@@ -496,7 +557,7 @@
      inkscape:connector-curvature="0" />
   <path
      style="fill:none;stroke:#0000ff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 173.5,87.223213 h -63.17499 v 0"
+     d="m 173.5,87.223215 h -63.17499 v 0"
      id="path3437"
      inkscape:connector-curvature="0" />
   <text
@@ -517,13 +578,13 @@
      sodipodi:nodetypes="cccc" />
   <path
      style="fill:none;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 463.94475,60.383367 0.0496,-30 H 109.78577"
+     d="m 463.94475,60.383369 0.0496,-30 H 109.78577"
      id="path3851"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccc" />
   <path
      style="fill:none;stroke:#800080;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 551.9943,218.13582 c 12.83333,0 30.49738,0 43.33071,0 3.80014,-2.5622 7.71829,-3.61393 13,0 l 20.66929,0"
+     d="m 551.9943,218.13582 c 12.83333,0 30.49738,0 43.33071,0 3.80014,-2.5622 7.71829,-3.61393 13,0 h 20.66929"
      id="path2004"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cccc" />
@@ -562,7 +623,7 @@
      sodipodi:nodetypes="cccc" />
   <path
      style="fill:none;stroke:#008000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 370.32501,418.70621 197.04429,0 c 3.35971,-3.27939 6.59137,-3.34182 9.6875,0 h 4.9375 v -39 h 46"
+     d="M 370.32501,418.70621 H 567.3693 c 3.35971,-3.27939 6.59137,-3.34182 9.6875,0 h 4.9375 v -39 h 46"
      id="path2274"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cccccc" />
@@ -649,7 +710,7 @@
      inkscape:connector-curvature="0" />
   <path
      style="fill:#ff0000;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 290.32501,87.396433 h 55.01576 v 0"
+     d="m 290.32501,87.396435 h 55.01576 v 0"
      id="path3786"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccc" />
@@ -657,17 +718,17 @@
      style="fill:#9fc5e8;fill-opacity:0.98431373;fill-rule:evenodd;stroke:#000000;stroke-opacity:1"
      inkscape:connector-curvature="0"
      id="path1669-5"
-     d="M 177.33166,73.853133 H 284.9537 V 100.93975 H 177.33166 Z" />
+     d="M 177.33166,73.853135 H 284.9537 V 100.93975 H 177.33166 Z" />
   <path
      style="fill:#3d85c6;fill-rule:evenodd;stroke:#000000;stroke-opacity:1"
      inkscape:connector-curvature="0"
      id="path2115-6"
-     d="m 173.64786,91.569663 v -8.34645 h 6.67715 l 1.66932,4.17322 -1.66932,4.17323 z" />
+     d="m 173.64786,91.569665 v -8.34645 h 6.67715 l 1.66932,4.17322 -1.66932,4.17323 z" />
   <path
      style="fill:#3d85c6;fill-rule:evenodd;stroke:#000000;stroke-opacity:1"
      inkscape:connector-curvature="0"
      id="path2115-6-5"
-     d="m 281.97854,91.569663 v -8.34645 h 6.67715 l 1.66932,4.17322 -1.66932,4.17323 z" />
+     d="m 281.97854,91.569665 v -8.34645 h 6.67715 l 1.66932,4.17322 -1.66932,4.17323 z" />
   <text
      xml:space="preserve"
      style="font-style:normal;font-weight:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
@@ -1310,7 +1371,7 @@
      sodipodi:nodetypes="ccc" />
   <path
      style="fill:none;stroke:#800080;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 361.9943,263.70621 c 44.5,0 188.83071,0 233.33071,0 4,-3.77825 9.10262,-3.73287 13,0 l 20.66929,0"
+     d="m 361.9943,263.70621 c 44.5,0 188.83071,0 233.33071,0 4,-3.77825 9.10262,-3.73287 13,0 h 20.66929"
      id="path2292"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cccc" />
@@ -1528,41 +1589,6 @@
          sodipodi:role="line">(4kB)</tspan></text>
   </g>
   <g
-     id="g2894"
-     transform="translate(-13.005696,762.70621)">
-    <g
-       transform="translate(-6.625)"
-       id="g2714">
-      <rect
-         style="fill:#b6d7a8;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="rect2490"
-         width="145.25316"
-         height="30.003155"
-         x="409.99844"
-         y="-189.00159" />
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-weight:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-         x="467.60873"
-         y="-169.13997"
-         id="text2494"><tspan
-           sodipodi:role="line"
-           id="tspan2492"
-           x="467.60873"
-           y="-169.13997">RND</tspan></text>
-      <path
-         style="fill:#6aa84f;fill-rule:evenodd;stroke:#000000;stroke-opacity:1"
-         inkscape:connector-curvature="0"
-         id="path2145-7-04-5-8-5"
-         d="m 429.17321,-185.65355 -8.34645,-2e-5 2e-5,-6.67718 L 425,-194 l 4.17323,1.66927 z" />
-      <path
-         style="fill:#6aa84f;fill-rule:evenodd;stroke:#000000;stroke-opacity:1"
-         inkscape:connector-curvature="0"
-         id="path2145-7-04-5-8-5-6"
-         d="m 545.79821,-185.65355 -8.34645,-2e-5 2e-5,-6.67718 4.17322,-1.66925 4.17323,1.66927 z" />
-    </g>
-  </g>
-  <g
      id="g2707"
      transform="translate(-13.005696,762.70621)">
     <path
@@ -1669,7 +1695,7 @@
      inkscape:connector-curvature="0" />
   <g
      id="g2973"
-     transform="translate(165.88436,762.70621)">
+     transform="translate(165.88437,851.2232)">
     <path
        inkscape:connector-curvature="0"
        id="path2896"
@@ -1736,4 +1762,233 @@
      d="M 386.875,477.22321 H 370.32501 V 359.38983"
      id="path1141"
      inkscape:connector-curvature="0" />
+  <g
+     id="g1800"
+     transform="translate(-1.6727884,-9.1924959)" />
+  <g
+     id="g2102"
+     transform="translate(-4.2927932e-7,1.5707207e-6)">
+    <rect
+       y="573.70465"
+       x="370.32501"
+       height="68.518585"
+       width="164.99998"
+       id="rect2490"
+       style="fill:#b6d7a8;fill-opacity:1;stroke:#000000;stroke-width:1.61064446;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <text
+       id="text2494"
+       y="598.06622"
+       x="375.47803"
+       style="font-style:normal;font-weight:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       xml:space="preserve"><tspan
+         y="598.06622"
+         x="375.47803"
+         id="tspan2492"
+         sodipodi:role="line">RND</tspan></text>
+    <path
+       d="m 409.54251,577.05266 -8.34645,-2e-5 2e-5,-6.67718 4.17322,-1.66925 4.17323,1.66927 z"
+       id="path2145-7-04-5-8-5"
+       inkscape:connector-curvature="0"
+       style="fill:#6aa84f;fill-rule:evenodd;stroke:#000000;stroke-opacity:1" />
+    <path
+       d="m 526.16751,577.05266 -8.34645,-2e-5 2e-5,-6.67718 4.17322,-1.66925 4.17323,1.66927 z"
+       id="path2145-7-04-5-8-5-6"
+       inkscape:connector-curvature="0"
+       style="fill:#6aa84f;fill-rule:evenodd;stroke:#000000;stroke-opacity:1" />
+    <text
+       id="text2494-4"
+       y="622.30713"
+       x="376.37897"
+       style="font-style:normal;font-weight:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-linecap:square;stroke-miterlimit:10"
+       xml:space="preserve"><tspan
+         y="622.30713"
+         x="376.37897"
+         id="tspan2492-7"
+         sodipodi:role="line">URND</tspan></text>
+    <g
+       transform="translate(284.68208,966.17873)"
+       id="g1385-2"
+       style="fill:none;stroke:none;stroke-linecap:square;stroke-miterlimit:10">
+      <g
+         transform="translate(-263.4931,-49.999997)"
+         id="g1926">
+        <g
+           id="g1983">
+          <path
+             style="fill:#d9ead3;fill-rule:evenodd;stroke:#000000;stroke-width:0.95;stroke-opacity:1;stroke-miterlimit:10;stroke-dasharray:none"
+             inkscape:connector-curvature="0"
+             id="path1887-3-1-3-6"
+             d="m 399,-309 h 56 v 23.06121 h -56 z" />
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-weight:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+             x="410.23892"
+             y="-292.61588"
+             id="text1376-0"><tspan
+               sodipodi:role="line"
+               id="tspan1374-6"
+               x="410.23892"
+               y="-292.61588">LFSR</tspan></text>
+        </g>
+      </g>
+    </g>
+    <path
+       d="m 452.3622,633.90041 -8.34645,-2e-5 2e-5,-6.67718 4.17322,-1.66925 4.17323,1.66927 z"
+       id="path2145-7-04-5-8-5-8"
+       inkscape:connector-curvature="0"
+       style="fill:#6aa84f;fill-rule:evenodd;stroke:#000000;stroke-linecap:square;stroke-miterlimit:10;stroke-opacity:1" />
+    <path
+       style="fill:#ff0000;stroke:#ff0000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:3, 1;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#marker1702-2-1-88-0)"
+       d="m 462.9995,561.55395 0.006,8"
+       id="path1420-4-8-6-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="m 458.82109,568.87677 h 8.34645 v 6.67718 l -4.17322,1.66926 -4.17323,-1.66926 z"
+       id="path2145-7-04-5-8-1"
+       inkscape:connector-curvature="0"
+       style="fill:#6aa84f;fill-rule:evenodd;stroke:#000000;stroke-linecap:square;stroke-miterlimit:10;stroke-opacity:1" />
+    <g
+       transform="translate(348.81811,936.17873)"
+       id="g1385-2-7"
+       style="fill:none;stroke:none;stroke-linecap:square;stroke-miterlimit:10" />
+    <g
+       transform="translate(223.81811,919.23994)"
+       id="g1385-2-0"
+       style="fill:none;stroke:none;stroke-linecap:square;stroke-miterlimit:10">
+      <g
+         transform="translate(-263.4931,-49.999997)"
+         id="g1926-2">
+        <g
+           id="g1983-9"
+           transform="translate(61.000002,21.98327)">
+          <path
+             style="fill:#d9ead3;fill-rule:evenodd;stroke:#000000;stroke-width:0.94965053;stroke-opacity:1"
+             inkscape:connector-curvature="0"
+             id="path1887-3-1-3-6-0"
+             d="m 399,-309 h 110 v 23.06121 H 399 Z" />
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-weight:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+             x="409.88217"
+             y="-292.49869"
+             id="text1376-0-9"><tspan
+               sodipodi:role="line"
+               id="tspan1374-6-9"
+               x="409.88217"
+               y="-292.49869">EDN Prefetch</tspan></text>
+        </g>
+      </g>
+    </g>
+    <path
+       d="m 508.67146,610.77541 -8.34645,-2e-5 2e-5,-6.67718 4.17322,-1.66925 4.17323,1.66927 z"
+       id="path2145-7-04-5-8-5-8-4"
+       inkscape:connector-curvature="0"
+       style="fill:#6aa84f;fill-rule:evenodd;stroke:#000000;stroke-linecap:square;stroke-miterlimit:10;stroke-opacity:1" />
+  </g>
+  <path
+     style="fill:none;stroke:#008000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:10;stroke-dasharray:none"
+     d="m 448.32501,634.22321 0.15386,25.99999"
+     id="path2181"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:none;stroke:#008000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:10;stroke-dasharray:none"
+     d="M 504.49823,660.55391 V 611.2232"
+     id="path2220"
+     inkscape:connector-curvature="0" />
+  <g
+     id="g2190"
+     transform="translate(0.68839157,-21.834395)">
+    <g
+       id="g1978">
+      <g
+         transform="translate(2.0296248,-21.105431)"
+         id="g1547">
+        <rect
+           style="fill:#f3f3f3;fill-opacity:1;stroke:#000000;stroke-width:1.15913177;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect1793"
+           width="46.559811"
+           height="34.241882"
+           x="408.04718"
+           y="707.92114"
+           ry="3.4241903" />
+        <path
+           style="fill:#cccccc;fill-rule:evenodd;stroke:#000000;stroke-linecap:square;stroke-miterlimit:10;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path1827-3-0"
+           d="m 441.61307,711.05759 h 8.34644 v -6.67717 l -4.17322,-1.66929 -4.17322,1.66929 z" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-linecap:square;stroke-miterlimit:10"
+           x="431.11874"
+           y="729.89557"
+           id="text2409-3"><tspan
+             sodipodi:role="line"
+             x="431.11874"
+             y="729.89557"
+             id="tspan2415-4">EDN0</tspan></text>
+        <path
+           style="fill:#ff0000;stroke:#ff0000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:3, 1;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#marker1702-2-1-88-6)"
+           d="m 465.42498,725.02699 -7.99999,0.01"
+           id="path1420-4-8-6-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           d="m 459.59832,720.68059 0.0383,8.3464 -6.67711,0.0306 -1.68839,-4.1656 1.65009,-4.1808 z"
+           id="path2145-7-04-5-8-2"
+           inkscape:connector-curvature="0"
+           style="fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-linecap:square;stroke-miterlimit:10;stroke-opacity:1" />
+      </g>
+      <g
+         transform="translate(86.677109,-20.918301)"
+         id="g1547-8"
+         style="fill:none;stroke:none;stroke-linecap:square;stroke-miterlimit:10">
+        <rect
+           style="fill:#f3f3f3;fill-opacity:1;stroke:#000000;stroke-width:1.15913177;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect1793-2"
+           width="46.559811"
+           height="34.241882"
+           x="408.04718"
+           y="707.92114"
+           ry="3.4241903" />
+        <path
+           style="fill:#cccccc;fill-rule:evenodd;stroke:#000000;stroke-linecap:square;stroke-miterlimit:10;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path1827-3-0-9"
+           d="m 413.43377,710.87046 h 8.34644 v -6.67717 l -4.17322,-1.66929 -4.17322,1.66929 z" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-linecap:square;stroke-miterlimit:10"
+           x="431.11874"
+           y="729.89557"
+           id="text2409-3-9"><tspan
+             sodipodi:role="line"
+             x="431.11874"
+             y="729.89557"
+             id="tspan2415-4-6">EDN1</tspan></text>
+        <path
+           style="fill:#ff0000;stroke:#ff0000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:3, 1;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#marker1702-2-1-88-6-7)"
+           d="m 465.42498,725.02699 -7.99999,0.01"
+           id="path1420-4-8-6-6-0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           d="m 459.59832,720.68059 0.0383,8.3464 -6.67711,0.0306 -1.68839,-4.1656 1.65009,-4.1808 z"
+           id="path2145-7-04-5-8-2-2"
+           inkscape:connector-curvature="0"
+           style="fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-linecap:square;stroke-miterlimit:10;stroke-opacity:1" />
+      </g>
+      <text
+         id="text1590"
+         y="677.30762"
+         x="412.63663"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+         xml:space="preserve"><tspan
+           y="677.30762"
+           x="412.63663"
+           id="tspan1588"
+           sodipodi:role="line">Seed</tspan></text>
+    </g>
+  </g>
 </svg>


### PR DESCRIPTION
Fixes #6458

Direct link to new SVG: https://github.com/GregAC/opentitan/blob/ebd50f28ba075796b665eaa951f137dee74ab595/hw/ip/otbn/doc/otbn_blockarch.svg