### PR TITLE
[rom_ctrl,util] Add a collision check to scramble_image.py

### DIFF
--- a/hw/ip/rom_ctrl/util/mem.py
+++ b/hw/ip/rom_ctrl/util/mem.py
@@ -363,3 +363,25 @@ class MemFile:
         for chunk in self.chunks:
             chunk.add_ecc32()
         self.width = 39
+
+    def collisions(self) -> List[Tuple[int, int]]:
+        '''Find "collisions" in the scrambled memory
+
+        This looks at all pairs of words in the memory, looking for addresses
+        where the words are equal. Returns a list of pairs (addr0, addr1) of
+        such addresses where addr0 < addr1 and in ascending order of addr0.
+
+        '''
+        ret = []
+        for idx0, chunk0 in enumerate(self.chunks):
+            for off0, word0 in enumerate(chunk0.words):
+                for diff_idx, chunk1 in enumerate(self.chunks[idx0:]):
+                    first_off1 = 0 if diff_idx else off0 + 1
+                    for diff_off, word1 in enumerate(chunk1.words[first_off1:]):
+                        off1 = first_off1 + diff_off
+
+                        if word0 == word1:
+                            addr0 = chunk0.base_addr + off0
+                            addr1 = chunk1.base_addr + off1
+                            ret.append((addr0, addr1))
+        return ret


### PR DESCRIPTION
It matters if we get one of these collisions because
it (theoretically) might allow an attacker to glitch address lines to
hide a modification he or she had made to a duplicated word in ROM.

This is a kind of random process: we pick the `RndCnstScrNonce` and
`RndCnstScrKey` arbitrarily and they *might* just happen to cause a
collision. A back-of-the-envelope computation suggests this happens
<1% of the time, but that's still too frequent to fail the SW build
for. For now, we just complain very noisily if it has happened. Maybe
we'll add a "--be-very-careful" flag later that's used for final
builds (there are probably other similar checks that need to hide
behind something similar).

@msfschaffner: Is there a plan for how to handle this "meh, fine for now, but catastrophic in the final image" sort of check?