### PR TITLE
[rom_ctrl] Use a plus for XOR in the block diagram

### DIFF
--- a/hw/ip/rom_ctrl/doc/rom_ctrl_blockdiag.svg
+++ b/hw/ip/rom_ctrl/doc/rom_ctrl_blockdiag.svg
@@ -720,9 +720,9 @@
      inkscape:window-height="1043"
      id="namedview2851"
      showgrid="false"
-     inkscape:zoom="0.89639071"
-     inkscape:cx="612.09568"
-     inkscape:cy="437.0582"
+     inkscape:zoom="1.7927814"
+     inkscape:cx="1069.3263"
+     inkscape:cy="296.72112"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
@@ -820,7 +820,7 @@
        y="-39.999992" /></text>
   <g
      id="g914"
-     transform="translate(719.99996,40.000008)"
+     transform="rotate(-45,978.28426,-679.11683)"
      style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#cff1b6;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1">
     <circle
        style="color:#000000;font-variation-settings:normal;overflow:visible;vector-effect:none;fill:#cff1b6;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"


### PR DESCRIPTION
Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>