### PR TITLE
[sw/silicon_creator] Switch otp to sec_mmio

### DIFF
--- a/sw/device/silicon_creator/lib/base/mock_sec_mmio.h
+++ b/sw/device/silicon_creator/lib/base/mock_sec_mmio.h
@@ -65,7 +65,7 @@ void sec_mmio_init(sec_mmio_shutdown_handler callee) {
 }
 
 uint32_t sec_mmio_read32(uint32_t addr) {
-  MockSecMmio::Instance().Read32(addr);
+  return MockSecMmio::Instance().Read32(addr);
 }
 
 void sec_mmio_write32(uint32_t addr, uint32_t value) {

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -173,7 +173,7 @@ sw_silicon_creator_lib_driver_otp = declare_dependency(
       'otp.c',
     ],
     dependencies: [
-      sw_lib_mmio,
+      sw_silicon_creator_lib_base_sec_mmio,
     ],
   ),
 )
@@ -187,12 +187,10 @@ test('sw_silicon_creator_lib_driver_otp_unittest', executable(
     ],
     dependencies: [
       sw_vendor_gtest,
-      sw_lib_base_testing_mock_mmio,
+      sw_silicon_creator_lib_base_mock_sec_mmio,
     ],
     native: true,
-    c_args: ['-DMOCK_MMIO'],
-    cpp_args: ['-DMOCK_MMIO'],
-    ),
+  ),
   suite: 'mask_rom',
 )
 

--- a/sw/device/silicon_creator/lib/drivers/otp.h
+++ b/sw/device/silicon_creator/lib/drivers/otp.h
@@ -8,50 +8,47 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "sw/device/lib/base/mmio.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef struct otp {
-  /**
-   * The base address for the OTP hardware registers.
-   */
-  mmio_region_t base_addr;
-} otp_t;
+#define OTP_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 
 /**
  * Perform a blocking 32-bit read from the memory mapped software config
  * partitions.
  *
- * @param otp The handle to the otp_ctrl device.
  * @param address The address to read from offset from the start of OTP memory.
  * @return The 32-bit value from OTP.
  */
-uint32_t otp_read32(const otp_t *otp, uint32_t address);
+OTP_WARN_UNUSED_RESULT
+uint32_t otp_read32(uint32_t address);
 
 /**
  * Perform a blocking 64-bit read from the memory mapped software config
  * partitions.
  *
- * @param otp The handle to the otp_ctrl device.
  * @param address The address to read from offset from the start of OTP memory.
  * @return The 64-bit value from OTP.
  */
-uint64_t otp_read64(const otp_t *otp, uint32_t address);
+OTP_WARN_UNUSED_RESULT
+uint64_t otp_read64(uint32_t address);
 
 /**
  * Perform a blocking read of `len` bytes from the memory mapped software config
- * partitions.
+ * partitions. It is required that both `address` and `address` + `len` be
+ * word-aligned.
  *
- * @param otp The handle to the otp_ctrl device.
  * @param address The address to read from offset from the start of OTP memory.
  * @param data The output buffer of at least length `len`.
  * @param len The number of bytes to read from OTP.
+ * @return `kErrorOtpBadAlignment` if `address` or `address` + `len` are
+ * misaligned, `kErrorOk` otherwise.
  */
-void otp_read(const otp_t *otp, uint32_t address, void *data, size_t len);
+OTP_WARN_UNUSED_RESULT
+rom_error_t otp_read(uint32_t address, void *data, size_t len);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -33,6 +33,7 @@ enum module_ {
   kModuleRomextimage = 0x4552,   // ASCII "RE".
   kModuleInterrupt = 0x5249,     // ASCII "IR".
   kModuleEpmp = 0x5045,          // ASCII "EP",
+  kModuleOtp = 0x504f,           // ASCII "OP".
 };
 
 /**
@@ -79,6 +80,7 @@ enum module_ {
   /* The high-byte of kErrorInterrupt is modified with the interrupt cause */ \
   X(kErrorInterrupt,                  ERROR_(0, kModuleInterrupt, kUnknown)), \
   X(kErrorEpmpBadCheck,               ERROR_(1, kModuleEpmp, kInternal)), \
+  X(kErrorOtpBadAlignment,            ERROR_(1, kModuleOtp, kInvalidArgument)), \
   X(kErrorUnknown, 0xFFFFFFFF)
 // clang-format on
 


### PR DESCRIPTION
Moves the OTP mask_rom driver over to sec_mmio.