### PR TITLE
[dv/top_level] Fix a dif test typo

### DIFF
--- a/hw/top_earlgrey/dv/chip_dif_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_dif_tests.hjson
@@ -76,7 +76,7 @@
     {
       name: chip_dif_otp_ctrl_smoketest
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["sw/device/tests/dif_otbn_smoketest:1"]
+      sw_images: ["sw/device/tests/dif_otp_ctrl_smoketest:1"]
       en_run_modes: ["sw_test_mode"]
     }
     {


### PR DESCRIPTION
This PR fixes a small typo from chip_dif_tests.hjson file.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>