### PR TITLE
[dv, flash_ctrl] Fix the smoke test

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_mem_addr_attrs.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_mem_addr_attrs.sv
@@ -5,34 +5,28 @@
 // Provides abstraction for mapping a flash memory address in flash organization.
 class flash_mem_addr_attrs;
 
-    bit [TL_AW-1:0] addr;               // Input addr (this is aligned to the bus word)
-    bit [TL_AW-1:0] bank_addr;          // Addr within the bank.
-    bit [TL_AW-1:0] full64_addr;        // Input full word addr (this is aligned to 64bits word)
-    bit [TL_AW-1:0] full64_bank_addr;   // Full word addr within the bank.
+    bit [TL_AW-1:0] addr;               // Input addr, bus-word aligned.
+    bit [TL_AW-1:0] bank_addr;          // Addr within the bank, bus-word aligned.
+    bit [TL_AW-1:0] word_addr;          // Addr within the bank, flash word aligned.
+    int             offset;             // Byte offset within the flash word.
 
-    bit [TL_AW-1:0] bank_start_addr;    // Start addr of the bank.
+    bit [TL_AW-1:0] bank_start_addr;    // Start addr of the bank (bus word aligned).
     bit [TL_AW-1:0] page_start_addr;    // Start addr of the page within the bank.
 
     uint            bank;               // The bank the address belongs to.
     uint            page;               // The page within the bank.
     uint            line;               // The word line within the page.
-
-    bit             is_start_addr_msb;  // Tells whether the start address of this addr_attr is
-                                        //  the 32 MSBs of some 64 bits word or the 32 LSBs.
+    uint            byte_offset;        // Byte offset within the flash word.
 
   function new(bit [TL_AW-1:0] addr = 0);
-    is_start_addr_msb = addr[flash_ctrl_pkg::BusByteWidth];
     set_attrs(addr);
   endfunction
 
   // Set attributes from a sample input addr.
   function void set_attrs(bit [TL_AW-1:0] addr);
-
     this.addr = {addr[TL_AW-1:TL_SZW], {TL_SZW{1'b0}}};
     bank_addr = this.addr[FlashMemAddrPageMsbBit : 0];
-    full64_addr = {addr[TL_AW-1:flash_ctrl_env_pkg::FlashDataByteWidth],
-                 {flash_ctrl_env_pkg::FlashDataByteWidth{1'b0}}};
-    full64_bank_addr = full64_addr[FlashMemAddrPageMsbBit : 0];
+    word_addr = {bank_addr[TL_AW-1:FlashDataByteWidth], {FlashDataByteWidth{1'b0}}};
 
     bank_start_addr = {addr[TL_AW-1 : FlashMemAddrPageMsbBit+1], {FlashMemAddrPageMsbBit+1{1'b0}}};
     page_start_addr = {addr[FlashMemAddrPageMsbBit : FlashMemAddrLineMsbBit+1],
@@ -41,6 +35,7 @@ class flash_mem_addr_attrs;
     bank = addr[FlashMemAddrBankMsbBit : FlashMemAddrPageMsbBit+1];
     page = addr[FlashMemAddrPageMsbBit : FlashMemAddrLineMsbBit+1];
     line = addr[FlashMemAddrLineMsbBit : FlashMemAddrWordMsbBit+1];
+    byte_offset = addr[FlashDataByteWidth-1 : 0];
   endfunction
 
   function void incr(bit [TL_AW-1:0] offset);
@@ -49,11 +44,11 @@ class flash_mem_addr_attrs;
   endfunction
 
   function string sprint();
-    return $sformatf({{"addr_attrs: addr = 0x%0h, bank_addr = 0x%0h "},
+    return $sformatf({{"addr_attrs: addr = 0x%0h, word_addr = 0x%0h, bank_addr = 0x%0h "},
                       {"bank_start_addr = 0x%0h, page_start_addr = 0x%0h "},
-                      {"bank = %0d, page = %0d, line = %0d"}},
-                     addr, bank_addr, bank_start_addr, page_start_addr,
-                     bank, page, line);
+                      {"bank = %0d, page = %0d, line = %0d, byte_offset = %0d"}},
+                     addr, word_addr, bank_addr, bank_start_addr, page_start_addr,
+                     bank, page, line, byte_offset);
   endfunction
 
 endclass


### PR DESCRIPTION
The smoke test writes and reads back a random chunk of memory within
the flash. The start address and the randomized number of words is bus-aligned
(i.e. 32 bits) and not flash word aligned (64-bits). Between each randomized 
configuration, the flash mem is invalidated. This means if we write to a flash
mem half word, while leaving the other half word as Xs, that causes an X 
problem on reads, because flash ctrl reads in the whole word, not just the 
half word. This commit fixes that problem.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>