### PR TITLE
[mask_rom] Add the lifecycle controller driver.

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/lifecycle.c
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.c
@@ -1,0 +1,70 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+
+#include <assert.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/base/abs_mmio.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "lc_ctrl_regs.h"
+
+const char *const lifecycle_state_name[] = {
+    // clang-format off
+    "RAW",
+    "TEST_UNLOCKED0",
+    "TEST_LOCKED0",
+    "TEST_UNLOCKED1",
+    "TEST_LOCKED1",
+    "TEST_UNLOCKED2",
+    "TEST_LOCKED2",
+    "TEST_UNLOCKED3",
+    "DEV",
+    "PROD",
+    "PROD_END",
+    "RMA",
+    "SCRAP",
+    "POST_TRANSITION",
+    "ESCALATE",
+    "INVALID",
+    // clang-format on
+};
+
+static_assert(ARRAYSIZE(lifecycle_state_name) == kLcStateNumStates,
+              "length of the lifecycle_state_name array doesn't match the "
+              "number of states.");
+
+#define LC_ASSERT(a, b) static_assert(a == b, "Bad value for " #a)
+LC_ASSERT(kLcStateRaw, LC_CTRL_LC_STATE_STATE_VALUE_RAW);
+LC_ASSERT(kLcStateTestUnlocked0, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED0);
+LC_ASSERT(kLcStateTestLocked0, LC_CTRL_LC_STATE_STATE_VALUE_TEST_LOCKED0);
+LC_ASSERT(kLcStateTestUnlocked1, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED1);
+LC_ASSERT(kLcStateTestLocked1, LC_CTRL_LC_STATE_STATE_VALUE_TEST_LOCKED1);
+LC_ASSERT(kLcStateTestUnlocked2, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED2);
+LC_ASSERT(kLcStateTestLocked2, LC_CTRL_LC_STATE_STATE_VALUE_TEST_LOCKED2);
+LC_ASSERT(kLcStateTestUnlocked3, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED3);
+LC_ASSERT(kLcStateDev, LC_CTRL_LC_STATE_STATE_VALUE_DEV);
+LC_ASSERT(kLcStateProd, LC_CTRL_LC_STATE_STATE_VALUE_PROD);
+LC_ASSERT(kLcStateProdEnd, LC_CTRL_LC_STATE_STATE_VALUE_PROD_END);
+LC_ASSERT(kLcStateRma, LC_CTRL_LC_STATE_STATE_VALUE_RMA);
+LC_ASSERT(kLcStateScrap, LC_CTRL_LC_STATE_STATE_VALUE_SCRAP);
+LC_ASSERT(kLcStatePostTransition, LC_CTRL_LC_STATE_STATE_VALUE_POST_TRANSITION);
+LC_ASSERT(kLcStateEscalate, LC_CTRL_LC_STATE_STATE_VALUE_ESCALATE);
+LC_ASSERT(kLcStateInvalid, LC_CTRL_LC_STATE_STATE_VALUE_INVALID);
+
+enum {
+  kBase = TOP_EARLGREY_LC_CTRL_BASE_ADDR,
+};
+
+lifecycle_state_t lifecycle_state_get(void) {
+  // TODO(lowRISC/opentitan#7026): Convert to use sec_mmio.
+  uint32_t value = bitfield_field32_read(
+      abs_mmio_read32(kBase + LC_CTRL_LC_STATE_REG_OFFSET),
+      LC_CTRL_LC_STATE_STATE_FIELD);
+  return (lifecycle_state_t)value;
+}

--- a/sw/device/silicon_creator/lib/drivers/lifecycle.h
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.h
@@ -1,0 +1,101 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_LIFECYCLE_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_LIFECYCLE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Lifecycle States.
+ */
+typedef enum LcState {
+  /**
+   * Raw life cycle state after fabrication where all functions are disabled.
+   */
+  kLcStateRaw,
+  /**
+   * Unlocked test state where debug functions are enabled.
+   */
+  kLcStateTestUnlocked0,
+  /**
+   * Locked test state where where all functions are disabled.
+   */
+  kLcStateTestLocked0,
+  /**
+   * Unlocked test state where debug functions are enabled.
+   */
+  kLcStateTestUnlocked1,
+  /**
+   * Locked test state where where all functions are disabled.
+   */
+  kLcStateTestLocked1,
+  /**
+   * Unlocked test state where debug functions are enabled.
+   */
+  kLcStateTestUnlocked2,
+  /**
+   * Locked test state where debug all functions are disabled.
+   */
+  kLcStateTestLocked2,
+  /**
+   * Unlocked test state where debug functions are enabled.
+   */
+  kLcStateTestUnlocked3,
+  /**
+   * Development life cycle state where limited debug functionality is
+   * available.
+   */
+  kLcStateDev,
+  /**
+   * Production life cycle state.
+   */
+  kLcStateProd,
+  /**
+   * Same as PROD, but transition into RMA is not possible from this state.
+   */
+  kLcStateProdEnd,
+  /**
+   * RMA life cycle state.
+   */
+  kLcStateRma,
+  /**
+   * SCRAP life cycle state where all functions are disabled.
+   */
+  kLcStateScrap,
+  /**
+   * This state is temporary and behaves the same way as SCRAP.
+   */
+  kLcStatePostTransition,
+  /**
+   * This state is temporary and behaves the same way as SCRAP.
+   */
+  kLcStateEscalate,
+  /**
+   * This state is reported when the life cycle state encoding is invalid.
+   * This state is temporary and behaves the same way as SCRAP.
+   */
+  kLcStateInvalid,
+  /**
+   * This is not a state - it is the total number of states.
+   */
+  kLcStateNumStates,
+} lifecycle_state_t;
+
+/*
+ * An array of human-readable lifecycle state names.
+ */
+extern const char *const lifecycle_state_name[];
+
+/**
+ * Get the lifecycle state.
+ */
+lifecycle_state_t lifecycle_state_get(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_LIFECYCLE_H_

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -246,3 +246,18 @@ mask_rom_tests += {
     'library': sw_silicon_creator_lib_driver_alert_functest,
   }
 }
+
+# Mask ROM lifecycle driver
+sw_silicon_creator_lib_driver_lifecycle = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_lib_driver_lifecycle',
+    sources: [
+      hw_ip_lc_ctrl_reg_h,
+      'lifecycle.c',
+    ],
+    dependencies: [
+      sw_silicon_creator_lib_base_abs_mmio,
+      sw_lib_bitfield,
+    ],
+  ),
+)


### PR DESCRIPTION
1. Read the current lifecycle state from the lifecycle controller.
2. Provide a translation table between states and human readable
strings.

Signed-off-by: Chris Frantz <cfrantz@google.com>