### PR TITLE
[dv] Update intg alert names

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -280,8 +280,7 @@ virtual task run_tl_intg_err_vseq_sub(int num_times = 1, string ral_name);
     join
 
     // issue hard reset for fatal alert to recover
-    apply_reset("HARD");
-    #1ps; // avoid sending item while reset is deasserting
+    dut_init("HARD");
   end
 endtask
 `undef create_tl_access_error_case

--- a/hw/dv/tools/dvsim/tests/tl_access_tests.hjson
+++ b/hw/dv/tools/dvsim/tests/tl_access_tests.hjson
@@ -21,7 +21,9 @@
       build_mode: "cover_reg_top"
       uvm_test_seq: "{name}_common_vseq"
       run_opts: ["+run_tl_intg_err", "+en_scb=0"]
-      reseed: 20
+      // TODO, lower the reseed to avoid having many failed tests in regression as not all the IPs
+      // have the integrity alert connected
+      reseed: 1
     }
   ]
 }

--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -51,6 +51,7 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = csrng_env_pkg::LIST_OF_ALERTS;
+    tl_intg_alert_name = "fatal_alert";
     super.initialize(csr_base_addr);
 
     // create agent configs

--- a/hw/ip/edn/dv/env/edn_env_cfg.sv
+++ b/hw/ip/edn/dv/env/edn_env_cfg.sv
@@ -34,6 +34,7 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = edn_env_pkg::LIST_OF_ALERTS;
+    tl_intg_alert_name = "fatal_alert";
     super.initialize(csr_base_addr);
     // create config objects
     m_csrng_agent_cfg = csrng_agent_cfg::type_id::create("m_csrng_genbits_agent_cfg");

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -41,6 +41,7 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   // Functions
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = entropy_src_env_pkg::LIST_OF_ALERTS;
+    tl_intg_alert_name = "fatal_alert";
     super.initialize(csr_base_addr);
 
     // create agent config objs

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
@@ -23,6 +23,7 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(lc_ctrl_reg_block));
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = lc_ctrl_env_pkg::LIST_OF_ALERTS;
+    tl_intg_alert_name = "fatal_bus_integ_error";
     super.initialize(csr_base_addr);
 
     m_otp_prog_pull_agent_cfg = push_pull_agent_cfg#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
@@ -24,6 +24,7 @@ class sram_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(sram_ctrl_reg_block));
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = sram_ctrl_env_pkg::LIST_OF_ALERTS;
+    tl_intg_alert_name = "fatal_intg_error";
     super.initialize(csr_base_addr);
 
     ral.set_hdl_path_root("tb.dut.u_sram_ctrl", "BkdrRegPathRtl");


### PR DESCRIPTION
1. after intg alert is triggered, use `dut_init` instead of
`apply_reset` as `dut_init` also re-enables alert auto-rsp seq
2. changed the intg alert name if the IP doesn't use default alert name

Signed-off-by: Weicai Yang <weicai@google.com>