### PR TITLE
[sw/silicon_creator] Remove unused `using` statements from tests

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/alert_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/alert_unittest.cc
@@ -13,9 +13,6 @@
 
 namespace alert_unittest {
 namespace {
-using testing::Each;
-using testing::Eq;
-using testing::Test;
 
 class AlertTest : public mask_rom_test::MaskRomTest {
  protected:

--- a/sw/device/silicon_creator/lib/drivers/hmac_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/hmac_unittest.cc
@@ -18,7 +18,6 @@
 namespace hmac_unittest {
 namespace {
 using ::testing::ElementsAreArray;
-using ::testing::Test;
 
 class HmacTest : public mask_rom_test::MaskRomTest {
  protected:

--- a/sw/device/silicon_creator/lib/drivers/uart_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/uart_unittest.cc
@@ -13,9 +13,6 @@
 
 namespace uart_unittest {
 namespace {
-using testing::Each;
-using testing::Eq;
-using testing::Test;
 
 const std::vector<uint8_t> kBytesArray = {
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a',


### PR DESCRIPTION
A minor cleanup prompted by an @mcy comment on #6930.