### PR TITLE
Otbn scramble

### DIFF
--- a/hw/dv/verilator/cpp/ecc32_mem_area.cc
+++ b/hw/dv/verilator/cpp/ecc32_mem_area.cc
@@ -31,7 +31,7 @@ void Ecc32MemArea::LoadVmem(const std::string &path) const {
 
 void Ecc32MemArea::WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
                                const std::vector<uint8_t> &data,
-                               size_t start_idx) const {
+                               size_t start_idx, uint32_t dst_word) const {
   int log_width_32 = width_byte_ / 4;
   int phy_width_bits = 39 * log_width_32;
   int phy_width_bytes = (phy_width_bits + 7) / 8;
@@ -116,7 +116,8 @@ void Ecc32MemArea::WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
 }
 
 void Ecc32MemArea::ReadBuffer(std::vector<uint8_t> &data,
-                              const uint8_t buf[SV_MEM_WIDTH_BYTES]) const {
+                              const uint8_t buf[SV_MEM_WIDTH_BYTES],
+                              uint32_t src_word) const {
   for (int i = 0; i < width_byte_; ++i) {
     int in_word = i / 4;
 

--- a/hw/dv/verilator/cpp/ecc32_mem_area.h
+++ b/hw/dv/verilator/cpp/ecc32_mem_area.h
@@ -24,13 +24,14 @@ class Ecc32MemArea : public MemArea {
 
   void LoadVmem(const std::string &path) const override;
 
- private:
+ protected:
   void WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
-                   const std::vector<uint8_t> &data,
-                   size_t start_idx) const override;
+                   const std::vector<uint8_t> &data, size_t start_idx,
+                   uint32_t dst_word) const override;
 
   void ReadBuffer(std::vector<uint8_t> &data,
-                  const uint8_t buf[SV_MEM_WIDTH_BYTES]) const override;
+                  const uint8_t buf[SV_MEM_WIDTH_BYTES],
+                  uint32_t src_word) const override;
 };
 
 #endif  // OPENTITAN_HW_DV_VERILATOR_CPP_ECC32_MEM_AREA_H_

--- a/hw/dv/verilator/cpp/mem_area.cc
+++ b/hw/dv/verilator/cpp/mem_area.cc
@@ -27,10 +27,6 @@ MemArea::MemArea(const std::string &scope, uint32_t num_words,
 
 void MemArea::Write(uint32_t word_offset,
                     const std::vector<uint8_t> &data) const {
-  // If this fails to set scope, it will throw an error which should
-  // be caught at this function's callsite.
-  SVScoped scoped(scope_);
-
   // This "mini buffer" is used to transfer each write to SystemVerilog.
   // `simutil_set_mem` takes a fixed SV_MEM_WIDTH_BITS-bit vector but it will
   // only use the bits required for the RAM width. As an example, for a 32-bit
@@ -47,8 +43,17 @@ void MemArea::Write(uint32_t word_offset,
 
   for (uint32_t i = 0; i < data_words; ++i) {
     uint32_t dst_word = word_offset + i;
-    WriteBuffer(minibuf, data, i * width_byte_);
-    if (!simutil_set_mem(dst_word, (svBitVecVal *)minibuf)) {
+    uint32_t phys_addr = ToPhysAddr(dst_word);
+
+    WriteBuffer(minibuf, data, i * width_byte_, dst_word);
+
+    // Both ToPhysAddr and WriteBuffer might set the scope with `SVScoped` so
+    // only construct `SVScoped` once they've both been called so they don't
+    // interact causing incorrect relative path behaviour. If this fails to set
+    // scope, it will throw an error which should be caught at this function's
+    // callsite.
+    SVScoped scoped(scope_);
+    if (!simutil_set_mem(phys_addr, (svBitVecVal *)minibuf)) {
       std::ostringstream oss;
       oss << "Could not set memory at byte offset 0x" << std::hex
           << dst_word * width_byte_ << ".";
@@ -64,8 +69,6 @@ std::vector<uint8_t> MemArea::Read(uint32_t word_offset,
   uint32_t num_bytes = width_byte_ * num_words;
   assert(num_words <= num_bytes);
 
-  SVScoped scoped(scope_);
-
   // See Write for an explanation for this buffer.
   uint8_t minibuf[SV_MEM_WIDTH_BYTES];
   memset(minibuf, 0, sizeof minibuf);
@@ -76,13 +79,24 @@ std::vector<uint8_t> MemArea::Read(uint32_t word_offset,
 
   for (uint32_t i = 0; i < num_words; ++i) {
     uint32_t src_word = word_offset + i;
-    if (!simutil_get_mem(src_word, (svBitVecVal *)minibuf)) {
-      std::ostringstream oss;
-      oss << "Could not read memory at byte offset 0x" << std::hex
-          << src_word * width_byte_ << ".";
-      throw std::runtime_error(oss.str());
+    uint32_t phys_addr = ToPhysAddr(src_word);
+
+    {
+      // Both ToPhysAddr and ReadBuffer might set the scope with `SVScoped`.
+      // Keep the `SVScoped` here confined to an inner scope so they don't
+      // interact causing incorrect relative path behaviour. If this fails to
+      // set scope, it will throw an error which should be caught at this
+      // function's callsite.
+      SVScoped scoped(scope_);
+      if (!simutil_get_mem(phys_addr, (svBitVecVal *)minibuf)) {
+        std::ostringstream oss;
+        oss << "Could not read memory at byte offset 0x" << std::hex
+            << src_word * width_byte_ << ".";
+        throw std::runtime_error(oss.str());
+      }
     }
-    ReadBuffer(ret, minibuf);
+
+    ReadBuffer(ret, minibuf, src_word);
   }
 
   return ret;
@@ -95,8 +109,8 @@ void MemArea::LoadVmem(const std::string &path) const {
 }
 
 void MemArea::WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
-                          const std::vector<uint8_t> &data,
-                          size_t start_idx) const {
+                          const std::vector<uint8_t> &data, size_t start_idx,
+                          uint32_t dst_word) const {
   size_t words_left = data.size() - start_idx;
   size_t to_copy = std::min(words_left, (size_t)width_byte_);
   if (to_copy < width_byte_) {
@@ -106,7 +120,8 @@ void MemArea::WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
 }
 
 void MemArea::ReadBuffer(std::vector<uint8_t> &data,
-                         const uint8_t buf[SV_MEM_WIDTH_BYTES]) const {
+                         const uint8_t buf[SV_MEM_WIDTH_BYTES],
+                         uint32_t src_word) const {
   // Append the first width_byte_ bytes of buf to data.
   std::copy_n(reinterpret_cast<const char *>(buf), width_byte_,
               std::back_inserter(data));

--- a/hw/dv/verilator/cpp/mem_area.h
+++ b/hw/dv/verilator/cpp/mem_area.h
@@ -92,10 +92,11 @@ class MemArea {
    * @param buf       Destination buffer
    * @param data      A large buffer that contains the data to be written
    * @param start_idx An offset into \p data for the start of the memory word
+   * @param dst_word  Logical address of the location being written
    */
   virtual void WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
-                           const std::vector<uint8_t> &data,
-                           size_t start_idx) const;
+                           const std::vector<uint8_t> &data, size_t start_idx,
+                           uint32_t dst_word) const;
 
   /** Extract the logical memory contents corresponding to the physical
    * memory contents in \p buf and append them to \p data.
@@ -104,13 +105,26 @@ class MemArea {
    * across. Other implementations might undo scrambling, remove ECC bits or
    * similar.
    *
-   * @param data The target, onto which the extracted memory contents should be
-   *             appended.
+   * @param data     The target, onto which the extracted memory contents should
+   * be appended.
    *
-   * @param buf  Source buffer (physical memory bits)
+   * @param buf      Source buffer (physical memory bits)
+   * @param src_word Logical address of the location being read
    */
   virtual void ReadBuffer(std::vector<uint8_t> &data,
-                          const uint8_t buf[SV_MEM_WIDTH_BYTES]) const;
+                          const uint8_t buf[SV_MEM_WIDTH_BYTES],
+                          uint32_t src_word) const;
+
+  /** Convert a logical address to physical address
+   *
+   * Some memories may have a mapping between the address supplied on the
+   * request and the physical address used to access the memory array (for
+   * example scrambled memories). By default logical and physical address are
+   * the same.
+   */
+  virtual uint32_t ToPhysAddr(uint32_t logical_addr) const {
+    return logical_addr;
+  }
 };
 
 #endif  // OPENTITAN_HW_DV_VERILATOR_CPP_MEM_AREA_H_

--- a/hw/dv/verilator/cpp/scrambled_ecc32_mem_area.cc
+++ b/hw/dv/verilator/cpp/scrambled_ecc32_mem_area.cc
@@ -1,0 +1,185 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "scrambled_ecc32_mem_area.h"
+#include "scramble_model.h"
+
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <sstream>
+
+#include "sv_scoped.h"
+
+// This is the maximum width of a nonce that's supported by the code in
+// prim_util_get_scramble_key_nonce.svh
+static const uint32_t kScrMaxNonceWidth = 320;
+static const uint32_t kScrMaxNonceWidthByte = (kScrMaxNonceWidth + 7) / 8;
+
+// Functions to convert from integer address to/from a little-endian vector of
+// bytes, addr_width is given in bits
+static std::vector<uint8_t> AddrIntToBytes(uint32_t addr, uint32_t addr_width) {
+  uint32_t addr_width_bytes = (addr_width + 7) / 8;
+  std::vector<uint8_t> addr_bytes(addr_width_bytes);
+
+  for (int i = 0; i < addr_width_bytes; ++i) {
+    addr_bytes[i] = addr & 0xff;
+    addr >>= 8;
+  }
+
+  return addr_bytes;
+}
+
+static uint32_t AddrBytesToInt(const std::vector<uint8_t> &addr) {
+  assert(addr.size() <= 4);
+
+  uint32_t addr_out = 0;
+  int cur_shift = 0;
+
+  for (int i = 0; i < addr.size(); ++i) {
+    addr_out |= (addr[i] << cur_shift);
+    cur_shift += 8;
+  }
+
+  return addr_out;
+}
+
+// Converts svBitVecVal (bit[m:n] SV type) into a byte vector
+static std::vector<uint8_t> ByteVecFromSV(svBitVecVal sv_val[],
+                                          uint32_t bytes) {
+  int shift = 0;
+  std::vector<uint8_t> vec(bytes);
+  for (int i = 0; i < bytes; ++i) {
+    vec[i] = (sv_val[i / 4] >> shift) & 0xff;
+
+    shift += 8;
+    if (shift == 32) {
+      shift = 0;
+    }
+  }
+
+  return vec;
+}
+
+// Analogous to the vbits SystemVerilog function from prim_util_pkg.sv. It
+// calculates the number of bits needed to address size items.
+static uint32_t vbits(uint32_t size) {
+  assert(size > 0);
+
+  if (size == 1) {
+    return 1;
+  }
+
+  size -= 1;
+  uint32_t width = 0;
+  while (size) {
+    width++;
+    size /= 2;
+  }
+
+  return width;
+}
+
+extern "C" {
+int simutil_get_scramble_key(svBitVecVal *key);
+int simutil_get_scramble_nonce(svBitVecVal *nonce);
+}
+
+std::vector<uint8_t> ScrambledEcc32MemArea::GetScrambleKey() const {
+  SVScoped scoped(scr_scope_);
+  svBitVecVal key_minibuf[((kPrinceWidthByte * 2) + 3) / 4];
+
+  if (!simutil_get_scramble_key(key_minibuf)) {
+    std::ostringstream oss;
+    oss << "Could not read key at scope " << scr_scope_;
+    throw std::runtime_error(oss.str());
+  }
+
+  return ByteVecFromSV(key_minibuf, kPrinceWidthByte * 2);
+}
+
+std::vector<uint8_t> ScrambledEcc32MemArea::GetScrambleNonce() const {
+  assert(GetNonceWidthByte() <= kScrMaxNonceWidthByte);
+
+  SVScoped scoped(scr_scope_);
+  svBitVecVal nonce_minibuf[(kScrMaxNonceWidthByte + 3) / 4];
+
+  if (!simutil_get_scramble_nonce((svBitVecVal *)nonce_minibuf)) {
+    std::ostringstream oss;
+    oss << "Could not read nonce at scope " << scr_scope_;
+    throw std::runtime_error(oss.str());
+  }
+
+  return ByteVecFromSV(nonce_minibuf, GetNonceWidthByte());
+}
+
+ScrambledEcc32MemArea::ScrambledEcc32MemArea(const std::string &scope,
+                                             uint32_t size, uint32_t width_32)
+    : Ecc32MemArea(
+          SVScoped::join_sv_scopes(
+              scope, "u_prim_ram_1p_adv.u_mem.gen_generic.u_impl_generic"),
+          size, width_32),
+      scr_scope_(scope) {
+  addr_width_ = vbits(size);
+}
+
+uint32_t ScrambledEcc32MemArea::GetPhysWidth() const {
+  return (GetWidthByte() / 4) * 39;
+}
+
+uint32_t ScrambledEcc32MemArea::GetPhysWidthByte() const {
+  return (GetPhysWidth() + 7) / 8;
+}
+
+uint32_t ScrambledEcc32MemArea::GetPrinceReplications() const {
+  return (GetPhysWidthByte() + 7) / 8;
+}
+
+uint32_t ScrambledEcc32MemArea::GetNonceWidth() const {
+  return GetPrinceReplications() * 64;
+}
+
+uint32_t ScrambledEcc32MemArea::GetNonceWidthByte() const {
+  return GetPrinceReplications() * 8;
+}
+
+void ScrambledEcc32MemArea::WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
+                                        const std::vector<uint8_t> &data,
+                                        size_t start_idx,
+                                        uint32_t dst_word) const {
+  // Compute integrity
+  Ecc32MemArea::WriteBuffer(buf, data, start_idx, dst_word);
+
+  std::vector<uint8_t> scramble_buf =
+      std::vector<uint8_t>(buf, buf + GetPhysWidthByte());
+
+  // Scramble data with integrity
+  scramble_buf = scramble_encrypt_data(
+      scramble_buf, GetPhysWidth(), 39, AddrIntToBytes(dst_word, addr_width_),
+      addr_width_, GetScrambleNonce(), GetScrambleKey());
+
+  // Copy scrambled data to write buffer
+  std::copy(scramble_buf.begin(), scramble_buf.end(), &buf[0]);
+}
+
+void ScrambledEcc32MemArea::ReadBuffer(std::vector<uint8_t> &data,
+                                       const uint8_t buf[SV_MEM_WIDTH_BYTES],
+                                       uint32_t src_word) const {
+  // Unscramble data from read buffer
+  std::vector<uint8_t> scrambled_data =
+      std::vector<uint8_t>(buf, buf + GetPhysWidthByte());
+  std::vector<uint8_t> unscrambled_data = scramble_decrypt_data(
+      scrambled_data, GetPhysWidth(), 39, AddrIntToBytes(src_word, addr_width_),
+      addr_width_, GetScrambleNonce(), GetScrambleKey());
+
+  // Strip integrity to give final result
+  Ecc32MemArea::ReadBuffer(data, &unscrambled_data[0], src_word);
+}
+
+uint32_t ScrambledEcc32MemArea::ToPhysAddr(uint32_t logical_addr) const {
+  // Scramble logical address to get physical address
+  return AddrBytesToInt(scramble_addr(AddrIntToBytes(logical_addr, addr_width_),
+                                      addr_width_, GetScrambleNonce(),
+                                      GetNonceWidth()));
+}

--- a/hw/dv/verilator/cpp/scrambled_ecc32_mem_area.h
+++ b/hw/dv/verilator/cpp/scrambled_ecc32_mem_area.h
@@ -1,0 +1,54 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_HW_DV_VERILATOR_CPP_SCRAMBLED_ECC32_MEM_AREA_H_
+#define OPENTITAN_HW_DV_VERILATOR_CPP_SCRAMBLED_ECC32_MEM_AREA_H_
+
+#include "ecc32_mem_area.h"
+
+#include <vector>
+
+/**
+ * A memory that implements scrambling over a 32-bit ECC integrity protection
+ * scheme storing 39 = 32 + 7 bits of physical data for each 32 bits of logical
+ * data.
+ */
+class ScrambledEcc32MemArea : public Ecc32MemArea {
+ public:
+  /**
+   * Constructor
+   *
+   * Create an ScrambledEcc32MemArea that will connect to a SystemVerilog memory
+   * at scope. It is size words long. Each memory word is 4 * width_32 bytes
+   * wide in the address space and 39 * width_32 bits wide in the physical
+   * memory.
+   */
+  ScrambledEcc32MemArea(const std::string &scope, uint32_t size,
+                        uint32_t width_32);
+
+ private:
+  void WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
+                   const std::vector<uint8_t> &data, size_t start_idx,
+                   uint32_t dst_word) const override;
+
+  void ReadBuffer(std::vector<uint8_t> &data,
+                  const uint8_t buf[SV_MEM_WIDTH_BYTES],
+                  uint32_t src_word) const override;
+
+  uint32_t ToPhysAddr(uint32_t logical_addr) const override;
+
+  uint32_t GetPhysWidth() const;
+  uint32_t GetPhysWidthByte() const;
+  uint32_t GetPrinceReplications() const;
+  uint32_t GetNonceWidth() const;
+  uint32_t GetNonceWidthByte() const;
+
+  std::vector<uint8_t> GetScrambleKey() const;
+  std::vector<uint8_t> GetScrambleNonce() const;
+
+  std::string scr_scope_;
+  uint32_t addr_width_;
+};
+
+#endif  // OPENTITAN_HW_DV_VERILATOR_CPP_SCRAMBLED_ECC32_MEM_AREA_H_

--- a/hw/dv/verilator/cpp/sv_scoped.cc
+++ b/hw/dv/verilator/cpp/sv_scoped.cc
@@ -93,3 +93,12 @@ SVScoped::Error::Error(const std::string &scope_name)
   oss << "No such SystemVerilog scope: `" << scope_name << "'.";
   msg_ = oss.str();
 }
+
+std::string SVScoped::join_sv_scopes(const std::string &a,
+                                     const std::string &b) {
+  assert(a.size() && b.size());
+  // If a = ".." and b = "foo.bar", we want "..foo.bar". Otherwise, a
+  // = "..foo" and b = "bar.baz", so we want "..foo.bar.baz"
+  // (inserting a "." between the two)
+  return (a.back() == '.') ? a + b : a + "." + b;
+}

--- a/hw/dv/verilator/cpp/sv_scoped.h
+++ b/hw/dv/verilator/cpp/sv_scoped.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_HW_DV_VERILATOR_CPP_SV_SCOPED_H_
 #define OPENTITAN_HW_DV_VERILATOR_CPP_SV_SCOPED_H_
 
+#include <cassert>
 #include <stdexcept>
 #include <string>
 #include <svdpi.h>
@@ -43,6 +44,9 @@ class SVScoped {
    private:
     std::string msg_;
   };
+
+  // helper function to join two, possibly relative, scopes correctly.
+  static std::string join_sv_scopes(const std::string &a, const std::string &b);
 
  private:
   svScope prev_scope_;

--- a/hw/dv/verilator/memutil_dpi.core
+++ b/hw/dv/verilator/memutil_dpi.core
@@ -9,11 +9,14 @@ filesets:
   files_cpp:
     depend:
       - lowrisc:dv:secded_enc
+      - lowrisc:dv:scramble_model
     files:
       - cpp/dpi_memutil.cc
       - cpp/dpi_memutil.h: { is_include_file: true }
       - cpp/ecc32_mem_area.cc
       - cpp/ecc32_mem_area.h: { is_include_file: true }
+      - cpp/scrambled_ecc32_mem_area.cc
+      - cpp/scrambled_ecc32_mem_area.h: { is_include_file: true }
       - cpp/mem_area.cc
       - cpp/mem_area.h: { is_include_file: true }
       - cpp/ranged_map.h: { is_include_file: true }

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
@@ -23,6 +23,8 @@
   // Import additional common sim cfg files.
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
+                // Config files to get the correct flags for crypto_dpi_prince
+                "{proj_root}/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_dpi_prince_sim_opts.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
@@ -30,6 +32,8 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"],
+
+  en_build_modes: ["{tool}_crypto_dpi_prince_build_opts"]
 
   // Flash references pwrmgr directly, need to reference the top version
   overrides: [

--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -4,12 +4,14 @@
 { name: "otbn"
   clock_primary: "clk_i"
   other_clock_list: [
-    "clk_edn_i"
+    "clk_edn_i",
+    "clk_otp_i"
   ],
   reset_primary: "rst_ni",
   other_reset_list: [
-    "rst_edn_ni"
-  ]
+    "rst_edn_ni",
+    "rst_otp_ni"
+  ],
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }
   ],
@@ -44,6 +46,22 @@
       randcount: "64",
       randtype:  "perm"
     },
+    { name: "RndCnstOtbnKey",
+      type: "otp_ctrl_pkg::otbn_key_t",
+      desc: '''
+        Compile-time random reset value for IMem/DMem scrambling key.
+      '''
+      randcount: "128",
+      randtype: "data"
+    },
+    { name: "RndCnstOtbnNonce",
+      type: "otp_ctrl_pkg::otbn_nonce_t",
+      desc: '''
+        Compile-time random reset value for IMem/DMem scrambling nonce.
+      '''
+      randcount: "256",
+      randtype: "data"
+    },
   ]
   interrupt_list: [
     { name: "done"
@@ -60,6 +78,14 @@
   ]
 
   inter_signal_list: [
+    // Key request to OTP
+    { struct:  "otbn_otp_key"
+      type:    "req_rsp"
+      name:    "otbn_otp_key"
+      act:     "req"
+      default: "'0"
+      package: "otp_ctrl_pkg"
+    },
     // EDN interface for RND
     { struct:  "edn"
       type:    "req_rsp"

--- a/hw/ip/otbn/dv/memutil/otbn_memutil.cc
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil.cc
@@ -13,21 +13,13 @@
 #include <stdexcept>
 
 #include "ecc32_mem_area.h"
-
-// join two, possibly relative, scopes correctly.
-static std::string join_scopes(const std::string &a, const std::string &b) {
-  assert(a.size() && b.size());
-  // If a = ".." and b = "foo.bar", we want "..foo.bar". Otherwise, a
-  // = "..foo" and b = "bar.baz", so we want "..foo.bar.baz"
-  // (inserting a "." between the two)
-  return (a.back() == '.') ? a + b : a + "." + b;
-}
+#include "sv_scoped.h"
 
 OtbnMemUtil::OtbnMemUtil(const std::string &top_scope)
-    : imem_(join_scopes(top_scope, "u_imem.u_mem.gen_generic.u_impl_generic"),
-            4096 / 4, 4 / 4),
-      dmem_(join_scopes(top_scope, "u_dmem.u_mem.gen_generic.u_impl_generic"),
-            4096 / 32, 32 / 4),
+    : imem_(SVScoped::join_sv_scopes(top_scope,
+          "u_imem.u_mem.gen_generic.u_impl_generic"), 4096 / 4, 4 / 4),
+      dmem_(SVScoped::join_sv_scopes(top_scope,
+            "u_dmem.u_mem.gen_generic.u_impl_generic"), 4096 / 32, 32 / 4),
       expected_end_addr_(-1) {
   RegisterMemoryArea("imem", 0x4000, &imem_);
   RegisterMemoryArea("dmem", 0x8000, &dmem_);

--- a/hw/ip/otbn/dv/memutil/otbn_memutil.cc
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil.cc
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "otbn_memutil.h"
+#include "scrambled_ecc32_mem_area.h"
 
 #include <cassert>
 #include <cstring>
@@ -10,16 +11,14 @@
 #include <iostream>
 #include <libelf.h>
 #include <limits>
+#include <sstream>
 #include <stdexcept>
 
-#include "ecc32_mem_area.h"
 #include "sv_scoped.h"
 
 OtbnMemUtil::OtbnMemUtil(const std::string &top_scope)
-    : imem_(SVScoped::join_sv_scopes(top_scope,
-          "u_imem.u_mem.gen_generic.u_impl_generic"), 4096 / 4, 4 / 4),
-      dmem_(SVScoped::join_sv_scopes(top_scope,
-            "u_dmem.u_mem.gen_generic.u_impl_generic"), 4096 / 32, 32 / 4),
+    : imem_(SVScoped::join_sv_scopes(top_scope, "u_imem"), 4096 / 4, 4 / 4),
+      dmem_(SVScoped::join_sv_scopes(top_scope, "u_dmem"), 4096 / 32, 32 / 4),
       expected_end_addr_(-1) {
   RegisterMemoryArea("imem", 0x4000, &imem_);
   RegisterMemoryArea("dmem", 0x8000, &dmem_);

--- a/hw/ip/otbn/dv/memutil/otbn_memutil.h
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil.h
@@ -5,9 +5,10 @@
 #define OPENTITAN_HW_IP_OTBN_DV_MEMUTIL_OTBN_MEMUTIL_H_
 
 #include <svdpi.h>
+#include <vector>
 
 #include "dpi_memutil.h"
-#include "ecc32_mem_area.h"
+#include "scrambled_ecc32_mem_area.h"
 
 class OtbnMemUtil : public DpiMemUtil {
  public:
@@ -35,7 +36,7 @@ class OtbnMemUtil : public DpiMemUtil {
  private:
   void OnElfLoaded(Elf *elf_file) override;
 
-  Ecc32MemArea imem_, dmem_;
+  ScrambledEcc32MemArea imem_, dmem_;
   int expected_end_addr_;
 };
 

--- a/hw/ip/otbn/dv/memutil/otbn_memutil_sim_opts.hjson
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil_sim_opts.hjson
@@ -14,12 +14,21 @@
   otbn_memutil_core: "lowrisc:dv:otbn_memutil:0"
   otbn_memutil_src_dir: "{eval_cmd} echo \"{otbn_memutil_core}\" | tr ':' '_'"
 
+  scramble_model_core: "lowrisc:dv:scramble_model:0"
+  scramble_model_dir: "{eval_cmd} echo \"{scramble_model_core}\" | tr ':' '_'"
+
+  prince_ref_core: "lowrisc:dv:crypto_prince_ref:0.1"
+  prince_ref_src_dir: "{eval_cmd} echo \"{prince_ref_core}\" | tr ':' '_'"
+
+
   build_modes: [
     {
       name: vcs_otbn_memutil_build_opts
       build_opts: ["-CFLAGS -I{build_dir}/src/{memutil_dpi_src_dir}/cpp",
                    "-CFLAGS -I{build_dir}/src/{otbn_memutil_src_dir}",
                    "-CFLAGS -I{build_dir}/src/{secded_enc_src_dir}",
+                   "-CFLAGS -I{build_dir}/src/{scramble_model_dir}",
+                   "-CFLAGS -I{build_dir}/src/{prince_ref_src_dir}",
                    "-lelf"]
     }
 
@@ -27,7 +36,8 @@
       name: xcelium_otbn_memutil_build_opts
       build_opts: ["-I{build_dir}/src/{memutil_dpi_src_dir}/cpp",
                    "-I{build_dir}/src/{otbn_memutil_src_dir}",
-                   "-I{build_dir}/src/{secded_enc_src_dir}",
+                   "-I{build_dir}/src/{prince_ref_src_dir}",
+                   "-I{build_dir}/src/{scramble_model_dir}",
                    "-lelf"]
     }
   ]

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -41,14 +41,16 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:prim:assert
       - lowrisc:prim:util
-      - lowrisc:prim:ram_1p_adv
+      - lowrisc:prim:ram_1p_scr
       - lowrisc:ip:edn_pkg
       - lowrisc:prim:edn_req
       - lowrisc:ip:otbn_pkg
+      - lowrisc:ip:otp_ctrl_pkg
       - lowrisc:dv:otbn_model
     files:
       - rtl/otbn_reg_pkg.sv
       - rtl/otbn_reg_top.sv
+      - rtl/otbn_scramble_ctrl.sv
       - rtl/otbn.sv
     file_type: systemVerilogSource
 

--- a/hw/ip/otbn/otbn_pkg.core
+++ b/hw/ip/otbn/otbn_pkg.core
@@ -9,6 +9,7 @@ filesets:
   files_pkg:
     depend:
       - lowrisc:prim:assert
+      - lowrisc:ip:otp_ctrl_pkg
     files:
       - rtl/otbn_pkg.sv
     file_type: systemVerilogSource

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -389,4 +389,8 @@ package otbn_pkg;
     256'h86c701ecc39d9d483bdcacb5a15340b0988e2336e955ddd0dc01ab17e173726e
   };
 
+  parameter otp_ctrl_pkg::otbn_key_t RndCnstOtbnKeyDefault =
+    128'h14e8cecae3040d5e12286bb3cc113298;
+  parameter otp_ctrl_pkg::otbn_nonce_t RndCnstOtbnNonceDefault =
+    256'hf79780bc735f38434f47570613cabf6490f795a48be7a10d930e0fdd326df627;
 endpackage

--- a/hw/ip/otbn/rtl/otbn_scramble_ctrl.sv
+++ b/hw/ip/otbn/rtl/otbn_scramble_ctrl.sv
@@ -1,0 +1,189 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Scramble control for OTBN
+ *
+ * This provides a key and nonce for scrambling the OTBN IMem and DMem. The OTP
+ * key interface is used to request a new key and nonce when they are requested.
+ */
+module otbn_scramble_ctrl
+#(
+  // Default seed and nonce for scrambling
+  parameter otp_ctrl_pkg::otbn_key_t   RndCnstOtbnKey   = otbn_pkg::RndCnstOtbnKeyDefault,
+  parameter otp_ctrl_pkg::otbn_nonce_t RndCnstOtbnNonce = otbn_pkg::RndCnstOtbnNonceDefault
+) (
+  // OTBN clock
+  input clk_i,
+  input rst_ni,
+
+  // OTP Clock (for key interface)
+  input clk_otp_i,
+  input rst_otp_ni,
+
+  // OTP key interface
+  output otp_ctrl_pkg::otbn_otp_key_req_t otbn_otp_key_o,
+  input  otp_ctrl_pkg::otbn_otp_key_rsp_t otbn_otp_key_i,
+
+  output otp_ctrl_pkg::otbn_key_t   otbn_dmem_scramble_key_o,
+  output otp_ctrl_pkg::otbn_nonce_t otbn_dmem_scramble_nonce_o,
+  output logic                      otbn_dmem_scramble_valid_o,
+  output logic                      otbn_dmem_scramble_key_seed_valid_o,
+
+  output otp_ctrl_pkg::otbn_key_t   otbn_imem_scramble_key_o,
+  output otp_ctrl_pkg::otbn_nonce_t otbn_imem_scramble_nonce_o,
+  output logic                      otbn_imem_scramble_valid_o,
+  output logic                      otbn_imem_scramble_key_seed_valid_o,
+
+  input  logic otbn_dmem_scramble_new_req_i,
+  input  logic otbn_imem_scramble_new_req_i
+);
+  typedef enum logic [1:0] {
+    ScrambleCtrlIdle,
+    ScrambleCtrlDmemReq,
+    ScrambleCtrlImemReq
+  } scramble_ctrl_state_t;
+
+  scramble_ctrl_state_t state_q, state_d;
+
+  logic dmem_key_valid_q, dmem_key_valid_d;
+  logic imem_key_valid_q, imem_key_valid_d;
+
+  logic dmem_key_seed_valid_q, dmem_key_seed_valid_d;
+  logic imem_key_seed_valid_q, imem_key_seed_valid_d;
+
+  logic dmem_scramble_req_pending_q, dmem_scramble_req_pending_d;
+  logic imem_scramble_req_pending_q, imem_scramble_req_pending_d;
+
+  logic dmem_key_nonce_en;
+  logic imem_key_nonce_en;
+
+  otp_ctrl_pkg::otbn_key_t   dmem_key_q;
+  otp_ctrl_pkg::otbn_key_t   imem_key_q;
+
+  otp_ctrl_pkg::otbn_nonce_t dmem_nonce_q, dmem_nonce_d;
+  otp_ctrl_pkg::otbn_nonce_t imem_nonce_q, imem_nonce_d;
+
+  logic                      otp_key_req, otp_key_ack;
+  otp_ctrl_pkg::otbn_key_t   otp_key;
+  otp_ctrl_pkg::otbn_nonce_t otp_nonce;
+  logic                      otp_key_seed_valid;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      dmem_key_q   <= RndCnstOtbnKey;
+      dmem_nonce_q <= RndCnstOtbnNonce;
+    end else if (dmem_key_nonce_en) begin
+      dmem_key_q   <= otp_key;
+      dmem_nonce_q <= otp_nonce;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      imem_key_q   <= RndCnstOtbnKey;
+      imem_nonce_q <= RndCnstOtbnNonce;
+    end else if (imem_key_nonce_en) begin
+      imem_key_q   <= otp_key;
+      imem_nonce_q <= otp_nonce;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      // Initial key and nonce are taken from defaults so on reset a valid key
+      // is available.
+      dmem_key_valid_q            <= 1'b1;
+      imem_key_valid_q            <= 1'b1;
+      dmem_key_seed_valid_q       <= 1'b0;
+      imem_key_seed_valid_q       <= 1'b0;
+      dmem_scramble_req_pending_q <= 1'b0;
+      imem_scramble_req_pending_q <= 1'b0;
+      state_q                     <= ScrambleCtrlIdle;
+    end else begin
+      dmem_key_valid_q            <= dmem_key_valid_d;
+      imem_key_valid_q            <= imem_key_valid_d;
+      dmem_key_seed_valid_q       <= dmem_key_seed_valid_d;
+      imem_key_seed_valid_q       <= imem_key_seed_valid_d;
+      dmem_scramble_req_pending_q <= dmem_scramble_req_pending_d;
+      imem_scramble_req_pending_q <= imem_scramble_req_pending_d;
+      state_q                     <= state_d;
+    end
+  end
+
+  always_comb begin
+    dmem_key_valid_d            = dmem_key_valid_q;
+    imem_key_valid_d            = imem_key_valid_q;
+    dmem_key_seed_valid_d       = dmem_key_seed_valid_q;
+    imem_key_seed_valid_d       = imem_key_seed_valid_q;
+    dmem_key_nonce_en           = 1'b0;
+    imem_key_nonce_en           = 1'b0;
+    dmem_scramble_req_pending_d = dmem_scramble_req_pending_q | otbn_dmem_scramble_new_req_i;
+    imem_scramble_req_pending_d = imem_scramble_req_pending_q | otbn_imem_scramble_new_req_i;
+    state_d                     = state_q;
+    otp_key_req                 = 1'b0;
+
+    case (state_q)
+      ScrambleCtrlIdle: begin
+        if (dmem_scramble_req_pending_q) begin
+          otp_key_req      = 1'b1;
+          dmem_key_valid_d = 1'b0;
+          state_d          = ScrambleCtrlDmemReq;
+        end else if (imem_scramble_req_pending_q) begin
+          otp_key_req      = 1'b1;
+          imem_key_valid_d = 1'b0;
+          state_d          = ScrambleCtrlImemReq;
+        end
+      end
+      ScrambleCtrlDmemReq: begin
+        if (otp_key_ack) begin
+          state_d                     = ScrambleCtrlIdle;
+          dmem_scramble_req_pending_d = 1'b0;
+          dmem_key_nonce_en           = 1'b1;
+          dmem_key_valid_d            = 1'b1;
+          dmem_key_seed_valid_d       = otp_key_seed_valid;
+        end
+      end ScrambleCtrlImemReq: begin
+        if (otp_key_ack) begin
+          state_d                     = ScrambleCtrlIdle;
+          imem_scramble_req_pending_d = 1'b0;
+          imem_key_nonce_en           = 1'b1;
+          imem_key_valid_d            = 1'b1;
+          imem_key_seed_valid_d       = otp_key_seed_valid;
+        end
+      end
+      default: ;
+    endcase
+  end
+
+  prim_sync_reqack_data #(
+    .Width($bits(otp_ctrl_pkg::otbn_otp_key_rsp_t)-1),
+    .DataSrc2Dst(1'b0)
+  ) u_otp_key_req_sync (
+    .clk_src_i (clk_i),
+    .rst_src_ni(rst_ni),
+    .clk_dst_i (clk_otp_i),
+    .rst_dst_ni(rst_otp_ni),
+    .src_req_i (otp_key_req),
+    .src_ack_o (otp_key_ack),
+    .dst_req_o (otbn_otp_key_o.req),
+    .dst_ack_i (otbn_otp_key_i.ack),
+    .data_i    ({otbn_otp_key_i.key,
+                 otbn_otp_key_i.nonce,
+                 otbn_otp_key_i.seed_valid}),
+    .data_o    ({otp_key,
+                 otp_nonce,
+                 otp_key_seed_valid})
+  );
+
+  assign otbn_dmem_scramble_key_o            = dmem_key_q;
+  assign otbn_dmem_scramble_nonce_o          = dmem_nonce_q;
+  assign otbn_dmem_scramble_valid_o          = dmem_key_valid_q;
+  assign otbn_dmem_scramble_key_seed_valid_o = dmem_key_seed_valid_q;
+
+  assign otbn_imem_scramble_key_o            = imem_key_q;
+  assign otbn_imem_scramble_nonce_o          = imem_nonce_q;
+  assign otbn_imem_scramble_valid_o          = imem_key_valid_q;
+  assign otbn_imem_scramble_key_seed_valid_o = imem_key_seed_valid_q;
+endmodule

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -26,6 +26,8 @@
   // Import additional common sim cfg files.
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
+                // Config files to get the correct flags for crypto_dpi_prince
+                "{proj_root}/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_dpi_prince_sim_opts.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
@@ -33,6 +35,8 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
+
+  en_build_modes: ["{tool}_crypto_dpi_prince_build_opts"]
 
   // Add additional tops for simulation.
   sim_tops: ["otp_ctrl_bind", "otp_ctrl_cov_bind"]

--- a/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_dpi_prince.core
+++ b/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_dpi_prince.core
@@ -3,11 +3,12 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:dv:crypto_dpi_prince:0.1"
-description: "PRINCE block cipher reference C implementation from Sebastien Riou"
+description: "PRINCE block cipher reference C implementation DPI interface"
 filesets:
   files_dv:
+    depend:
+      - lowrisc:dv:crypto_prince_ref
     files:
-      - prince_ref.h: {file_type: cSource, is_include_file: true}
       - crypto_dpi_prince.c: {file_type: cSource}
       - crypto_dpi_prince_pkg.sv: {file_type: systemVerilogSource}
 

--- a/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_dpi_prince_sim_opts.hjson
+++ b/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_dpi_prince_sim_opts.hjson
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Additional build-time options needed to compile C++ sources in
+  // simulators such as VCS and Xcelium for anything that uses
+  // otbn_memutil.
+  crypto_prince_ref_core: "lowrisc:dv:crypto_prince_ref:0.1"
+  crypto_prince_ref_src_dir: "{eval_cmd} echo \"{crypto_prince_ref_core}\" | tr ':' '_'"
+
+  build_modes: [
+    {
+      name: vcs_crypto_dpi_prince_build_opts
+      build_opts: ["-CFLAGS -I{build_dir}/src/{crypto_prince_ref_src_dir}"]
+    }
+
+    {
+      name: xcelium_crypto_dpi_prince_build_opts
+      build_opts: ["-I{build_dir}/src/{crypto_prince_ref_src_dir}"]
+    }
+  ]
+}

--- a/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_prince_ref.core
+++ b/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_prince_ref.core
@@ -1,0 +1,15 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:crypto_prince_ref:0.1"
+description: "PRINCE block cipher reference C implementation from Sebastien Riou"
+filesets:
+  files_dv:
+    files:
+      - prince_ref.h: {file_type: cSource, is_include_file: true}
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson
@@ -18,7 +18,11 @@
   fusesoc_core: lowrisc:dv:prim_prince_sim:0.1
 
   // Import additional common sim cfg files.
-  import_cfgs: ["{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson"]
+  import_cfgs: ["{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
+                // Config files to get the correct flags for crypto_dpi_prince
+                "{proj_root}/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_dpi_prince_sim_opts.hjson"]
+
+  en_build_modes: ["{tool}_crypto_dpi_prince_build_opts"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/prim/dv/prim_ram_scr/cpp/scramble_model.cc
+++ b/hw/ip/prim/dv/prim_ram_scr/cpp/scramble_model.cc
@@ -1,0 +1,351 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "scramble_model.h"
+#include <algorithm>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <stdint.h>
+#include <vector>
+#include "prince_ref.h"
+
+uint8_t PRESENT_SBOX4[] = {0xc, 0x5, 0x6, 0xb, 0x9, 0x0, 0xa, 0xd,
+                           0x3, 0xe, 0xf, 0x8, 0x4, 0x7, 0x1, 0x2};
+
+uint8_t PRESENT_SBOX4_INV[] = {0x5, 0xe, 0xf, 0x8, 0xc, 0x1, 0x2, 0xd,
+                               0xb, 0x4, 0x6, 0x3, 0x0, 0x7, 0x9, 0xa};
+
+static const uint32_t kNumAddrSubstPermRounds = 2;
+static const uint32_t kNumDataSubstPermRounds = 2;
+static const uint32_t kNumPrinceHalfRounds = 2;
+
+static std::vector<uint8_t> byte_reverse_vector(
+    const std::vector<uint8_t> &vec_in) {
+  std::vector<uint8_t> vec_out(vec_in.size());
+
+  std::reverse_copy(std::begin(vec_in), std::end(vec_in), std::begin(vec_out));
+
+  return vec_out;
+}
+
+static uint8_t read_vector_bit(const std::vector<uint8_t> &vec,
+                               uint32_t bit_pos) {
+  assert(bit_pos / 8 < vec.size());
+
+  return (vec[bit_pos / 8] >> (bit_pos % 8)) & 1;
+}
+
+static void or_vector_bit(std::vector<uint8_t> &vec, uint32_t bit_pos,
+                          uint8_t bit) {
+  assert(bit_pos / 8 < vec.size());
+
+  vec[bit_pos / 8] |= bit << (bit_pos % 8);
+}
+
+static std::vector<uint8_t> xor_vectors(const std::vector<uint8_t> &vec_a,
+                                        const std::vector<uint8_t> &vec_b) {
+  assert(vec_a.size() == vec_b.size());
+
+  std::vector<uint8_t> vec_out(vec_a.size());
+
+  std::transform(vec_a.begin(), vec_a.end(), vec_b.begin(), vec_out.begin(),
+                 std::bit_xor<uint8_t>{});
+
+  return vec_out;
+}
+
+// Run each 4-bit chunk of bytes from `in` through the SBOX. Where `bit_width`
+// isn't a multiple of 4 the remaining bits are just copied straight through.
+// `invert` choose whether to use the inverted SBOX or not.
+static std::vector<uint8_t> scramble_sbox_layer(const std::vector<uint8_t> &in,
+                                                uint32_t bit_width,
+                                                uint8_t sbox[16]) {
+  assert(in.size() == ((bit_width + 7) / 8));
+  std::vector<uint8_t> out(in.size(), 0);
+
+  // Iterate through each 4 bit chunk of the data and apply the appropriate SBOX
+  for (int i = 0; i < bit_width / 4; ++i) {
+    uint8_t sbox_in, sbox_out;
+
+    sbox_in = in[i / 2];
+
+    int shift = (i % 2) ? 4 : 0;
+    sbox_in = (sbox_in >> shift) & 0xf;
+
+    sbox_out = sbox[sbox_in];
+
+    out[i / 2] |= sbox_out << shift;
+  }
+
+  // Where bit_width is not a multiple of 4 copy over the remaining bits
+  if (bit_width % 4) {
+    int shift = ((bit_width % 8) >= 4) ? 4 : 0;
+    uint8_t nibble = (in[bit_width / 8] >> shift) & 0xf;
+    out[bit_width / 8] |= nibble << shift;
+  }
+
+  return out;
+}
+
+// Reverse bits from incoming byte vector
+static std::vector<uint8_t> scramble_flip_layer(const std::vector<uint8_t> &in,
+                                                uint32_t bit_width) {
+  assert(in.size() == ((bit_width + 7) / 8));
+  std::vector<uint8_t> out(in.size(), 0);
+
+  for (int i = 0; i < bit_width; ++i) {
+    or_vector_bit(out, bit_width - i - 1, read_vector_bit(in, i));
+  }
+
+  return out;
+}
+
+// Apply butterfly to incoming byte vector. Even bits are placed in the lower
+// half of the output, odd bits are placed in the upper half of the output.
+static std::vector<uint8_t> scramble_perm_layer(const std::vector<uint8_t> &in,
+                                                uint32_t bit_width,
+                                                bool invert) {
+  assert(in.size() == ((bit_width + 7) / 8));
+  std::vector<uint8_t> out(in.size(), 0);
+
+  for (int i = 0; i < bit_width / 2; ++i) {
+    if (invert) {
+      or_vector_bit(out, i * 2, read_vector_bit(in, i));
+      or_vector_bit(out, i * 2 + 1, read_vector_bit(in, i + (bit_width / 2)));
+    } else {
+      or_vector_bit(out, i, read_vector_bit(in, i * 2));
+      or_vector_bit(out, i + (bit_width / 2), read_vector_bit(in, i * 2 + 1));
+    }
+  }
+
+  if (bit_width % 2) {
+    // Where bit_width isn't even, the final bit is copied across to the same
+    // position
+    or_vector_bit(out, bit_width - 1, read_vector_bit(in, bit_width - 1));
+  }
+
+  return out;
+}
+
+// Apply a full set of subsitution/permutation rounds for encrypt to the
+// incoming byte vector
+static std::vector<uint8_t> scramble_subst_perm_enc(
+    const std::vector<uint8_t> &in, const std::vector<uint8_t> &key,
+    uint32_t bit_width, uint32_t num_rounds) {
+  assert(in.size() == ((bit_width + 7) / 8));
+  assert(key.size() == ((bit_width + 7) / 8));
+
+  std::vector<uint8_t> state(in);
+
+  for (int i = 0; i < num_rounds; ++i) {
+    state = xor_vectors(state, key);
+
+    state = scramble_sbox_layer(state, bit_width, PRESENT_SBOX4);
+    state = scramble_flip_layer(state, bit_width);
+    state = scramble_perm_layer(state, bit_width, false);
+  }
+
+  state = xor_vectors(state, key);
+
+  return state;
+}
+
+// Apply a full set of substitution/permutation rounds for decrypt to the
+// incoming byte vector
+static std::vector<uint8_t> scramble_subst_perm_dec(
+    const std::vector<uint8_t> &in, const std::vector<uint8_t> &key,
+    uint32_t bit_width, uint32_t num_rounds) {
+  assert(in.size() == ((bit_width + 7) / 8));
+  assert(key.size() == ((bit_width + 7) / 8));
+
+  std::vector<uint8_t> state(in);
+
+  for (int i = 0; i < num_rounds; ++i) {
+    state = xor_vectors(state, key);
+
+    state = scramble_perm_layer(state, bit_width, true);
+    state = scramble_flip_layer(state, bit_width);
+    state = scramble_sbox_layer(state, bit_width, PRESENT_SBOX4_INV);
+  }
+
+  state = xor_vectors(state, key);
+
+  return state;
+}
+
+// Generate a keystream for XORing with data using PRINCE. Multiple PRINCE
+// instantiations are used when the keystream is greater than a single PRINCE
+// width (64-bit).
+static std::vector<uint8_t> scramble_gen_keystream(
+    const std::vector<uint8_t> &addr, uint32_t addr_width,
+    const std::vector<uint8_t> &nonce, const std::vector<uint8_t> &key,
+    uint32_t keystream_width, uint32_t num_half_rounds) {
+  assert(key.size() == (kPrinceWidthByte * 2));
+
+  // Determine how many PRINCE replications are required
+  uint32_t num_princes = (keystream_width + kPrinceWidth - 1) / kPrinceWidth;
+
+  std::vector<uint8_t> keystream;
+
+  for (int i = 0; i < num_princes; ++i) {
+    // Initial vector is data for PRINCE to encrypt. Formed from nonce and data
+    // address
+    std::vector<uint8_t> iv(8, 0);
+
+    for (int j = 0; j < kPrinceWidth; ++j) {
+      if (j < addr_width) {
+        // Bottom addr_width bits of IV are address
+        or_vector_bit(iv, j, read_vector_bit(addr, j));
+      } else {
+        // Other bits are taken from nonce. Each PRINCE instantiation will use
+        // different nonce bits.
+        int nonce_bit = (j - addr_width) + i * (kPrinceWidth - addr_width);
+        or_vector_bit(iv, j, read_vector_bit(nonce, nonce_bit));
+      }
+    }
+
+    // PRINCE C reference model works on big-endian byte order
+    iv = byte_reverse_vector(iv);
+    auto key_be = byte_reverse_vector(key);
+
+    // Apply PRINCE to IV to produce keystream
+    std::vector<uint8_t> keystream_block(kPrinceWidthByte);
+    prince_enc_dec(&iv[0], &key_be[0], &keystream_block[0], 0, num_half_rounds,
+                   0);
+
+    // Flip keystream into little endian order and add to keystream vector
+    keystream_block = byte_reverse_vector(keystream_block);
+    keystream.insert(keystream.end(), keystream_block.begin(),
+                     keystream_block.end());
+  }
+
+  // Total keystream bits generated are some multiple of kPrinceWidth. This can
+  // result in unused keystream bits. Remove the unused bytes from the keystream
+  // vector and zero out top unused bits in the final byte if required.
+  uint32_t keystream_bytes = (keystream_width + 7) / 8;
+  uint32_t keystream_bytes_to_erase = keystream.size() - keystream_bytes;
+  if (keystream_bytes_to_erase) {
+    keystream.erase(keystream.end() - keystream_bytes_to_erase,
+                    keystream.end());
+  }
+
+  if (keystream_width % 8) {
+    keystream[keystream.size() - 1] &= (1 << (keystream_width % 8)) - 1;
+  }
+
+  return keystream;
+}
+
+// Split incoming data into subst_perm_width chunks and individually apply the
+// substitution/permutation layer to each
+static std::vector<uint8_t> scramble_subst_perm_full_width(
+    const std::vector<uint8_t> &in, uint32_t bit_width,
+    uint32_t subst_perm_width, bool enc) {
+  assert(in.size() == ((bit_width + 7) / 8));
+
+  // Determine how many bytes each subst_perm_width chunk is and how many
+  // chunks are needed to cover the full bit_width.
+  uint32_t subst_perm_bytes = (subst_perm_width + 7) / 8;
+  uint32_t subst_perm_blocks =
+      (bit_width + subst_perm_width - 1) / subst_perm_width;
+
+  std::vector<uint8_t> out(in.size(), 0);
+  std::vector<uint8_t> zero_key(subst_perm_bytes, 0);
+
+  auto sp_scrambler = enc ? scramble_subst_perm_enc : scramble_subst_perm_dec;
+
+  for (int i = 0; i < subst_perm_blocks; ++i) {
+    // Where bit_width does not evenly divide into subst_perm_width the
+    // final block is smaller.
+    uint32_t bits_so_far = subst_perm_width * i;
+    uint32_t block_width = std::min(subst_perm_width, bit_width - bits_so_far);
+
+    std::vector<uint8_t> subst_perm_data(subst_perm_bytes, 0);
+
+    // Extract bits from in for this chunk
+    for (int j = 0; j < block_width; ++j) {
+      or_vector_bit(subst_perm_data, j,
+                    read_vector_bit(in, j + i * subst_perm_width));
+    }
+
+    // Apply the substitution/permutation layer to the chunk
+    auto subst_perm_out = sp_scrambler(subst_perm_data, zero_key, block_width,
+                                       kNumDataSubstPermRounds);
+
+    // Write the result to the `out` vector
+    for (int j = 0; j < block_width; ++j) {
+      or_vector_bit(out, j + i * subst_perm_width,
+                    read_vector_bit(subst_perm_out, j));
+    }
+  }
+
+  return out;
+}
+
+std::vector<uint8_t> scramble_addr(const std::vector<uint8_t> &addr_in,
+                                   uint32_t addr_width,
+                                   const std::vector<uint8_t> &nonce,
+                                   uint32_t nonce_width) {
+  assert(addr_in.size() == ((addr_width + 7) / 8));
+
+  std::vector<uint8_t> addr_enc_nonce(addr_in.size(), 0);
+
+  // Address is scrambled by using substitution/permutation layer with the nonce
+  // used as a key.
+  // Extract relevant nonce bits for key
+  for (int i = 0; i < addr_width; ++i) {
+    or_vector_bit(addr_enc_nonce, i,
+                  read_vector_bit(nonce, nonce_width - addr_width + i));
+  }
+
+  // Apply substitution/permutation layer
+  return scramble_subst_perm_enc(addr_in, addr_enc_nonce, addr_width,
+                                 kNumAddrSubstPermRounds);
+}
+
+std::vector<uint8_t> scramble_encrypt_data(const std::vector<uint8_t> &data_in,
+                                           uint32_t data_width,
+                                           uint32_t subst_perm_width,
+                                           const std::vector<uint8_t> &addr,
+                                           uint32_t addr_width,
+                                           const std::vector<uint8_t> &nonce,
+                                           const std::vector<uint8_t> &key) {
+  assert(data_in.size() == ((data_width + 7) / 8));
+  assert(addr.size() == ((addr_width + 7) / 8));
+
+  // Data is encrypted by XORing with keystream then applying
+  // substitution/permutation layer
+
+  auto keystream = scramble_gen_keystream(addr, addr_width, nonce, key,
+                                          data_width, kNumPrinceHalfRounds);
+
+  auto data_enc = xor_vectors(data_in, keystream);
+
+  return scramble_subst_perm_full_width(data_enc, data_width, subst_perm_width,
+                                        true);
+}
+
+std::vector<uint8_t> scramble_decrypt_data(const std::vector<uint8_t> &data_in,
+                                           uint32_t data_width,
+                                           uint32_t subst_perm_width,
+                                           const std::vector<uint8_t> &addr,
+                                           uint32_t addr_width,
+                                           const std::vector<uint8_t> &nonce,
+                                           const std::vector<uint8_t> &key) {
+  assert(data_in.size() == ((data_width + 7) / 8));
+  assert(addr.size() == ((addr_width + 7) / 8));
+
+  // Data is decrypted by reversing substitution/permutation layer then XORing
+  // with keystream
+  auto data_sp_out = scramble_subst_perm_full_width(data_in, data_width,
+                                                    subst_perm_width, false);
+
+  auto keystream = scramble_gen_keystream(addr, addr_width, nonce, key,
+                                          data_width, kNumPrinceHalfRounds);
+
+  auto data_dec = xor_vectors(data_sp_out, keystream);
+
+  return data_dec;
+}

--- a/hw/ip/prim/dv/prim_ram_scr/cpp/scramble_model.core
+++ b/hw/ip/prim/dv/prim_ram_scr/cpp/scramble_model.core
@@ -1,0 +1,20 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:dv:scramble_model"
+description: "Memory scrambling C++ model"
+filesets:
+  files_cpp:
+    depend:
+      - lowrisc:dv:crypto_prince_ref
+    files:
+      - scramble_model.cc
+      - scramble_model.h: { is_include_file: true }
+    file_type: cppSource
+
+targets:
+  default:
+    filesets:
+      - files_cpp

--- a/hw/ip/prim/dv/prim_ram_scr/cpp/scramble_model.h
+++ b/hw/ip/prim/dv/prim_ram_scr/cpp/scramble_model.h
@@ -1,0 +1,69 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_HW_IP_PRIM_DV_PRIM_RAM_SCR_CPP_SCRAMBLE_MODEL_H_
+#define OPENTITAN_HW_IP_PRIM_DV_PRIM_RAM_SCR_CPP_SCRAMBLE_MODEL_H_
+
+#include <stdint.h>
+#include <vector>
+
+const uint32_t kPrinceWidth = 64;
+const uint32_t kPrinceWidthByte = kPrinceWidth / 8;
+
+// C++ model of memory scrambling. All byte vectors are in little endian byte
+// order (least significant byte at index 0).
+
+/** Scramble an address to give the physical address used to access the
+ * scrambled memory. Return vector of scrambled address bytes
+ *
+ * @param addr_in      Byte vector of address
+ * @param addr_width   Width of the address in bits
+ * @param nonce        Byte vector of scrambling nonce
+ * @param nonce_width  Width of scramble nonce in bits
+ * @return Byte vector with scrambled address
+ */
+std::vector<uint8_t> scramble_addr(const std::vector<uint8_t> &addr_in,
+                                   uint32_t addr_width,
+                                   const std::vector<uint8_t> &nonce,
+                                   uint32_t nonce_width);
+
+/** Decrypt scrambled data
+ * @param data_in          Byte vector of data to decrypt
+ * @param data_width       Width of data in bits
+ * @param subst_perm_width Width over which the substitution/permutation network
+ *                         is applied (DiffWidth parameter on prim_ram_1p_scr)
+ * @param addr             Byte vector of data address
+ * @param addr_width       Width of the address in bits
+ * @param nonce            Byte vector of scrambling nonce
+ * @param key              Byte vector of scrambling key
+ * @return Byte vector with decrypted data
+ */
+std::vector<uint8_t> scramble_decrypt_data(const std::vector<uint8_t> &data_in,
+                                           uint32_t data_width,
+                                           uint32_t subst_perm_width,
+                                           const std::vector<uint8_t> &addr,
+                                           uint32_t addr_width,
+                                           const std::vector<uint8_t> &nonce,
+                                           const std::vector<uint8_t> &key);
+
+/** Encrypt scrambled data
+ * @param data_in          Byte vector of data to encrypt
+ * @param data_width       Width of data in bits
+ * @param subst_perm_width Width over which the substitution/permutation network
+ *                         is applied (DiffWidth parameter on prim_ram_1p_scr)
+ * @param addr             Byte vector of data address
+ * @param addr_width       Width of the address in bits
+ * @param nonce            Byte vector of scrambling nonce
+ * @param key              Byte vector of scrambling key
+ * @return Byte vector with encrypted data
+ */
+std::vector<uint8_t> scramble_encrypt_data(const std::vector<uint8_t> &data_in,
+                                           uint32_t data_width,
+                                           uint32_t subst_perm_width,
+                                           const std::vector<uint8_t> &addr,
+                                           uint32_t addr_width,
+                                           const std::vector<uint8_t> &nonce,
+                                           const std::vector<uint8_t> &key);
+
+#endif  // OPENTITAN_HW_IP_PRIM_DV_PRIM_RAM_SCR_CPP_SCRAMBLE_MODEL_H_

--- a/hw/ip/prim/lint/prim_ram_1p_scr.vlt
+++ b/hw/ip/prim/lint/prim_ram_1p_scr.vlt
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`verilator_config
+
+// prim_ram_1p_scr
+// waive warnings on comparing 'addr_cnt_q' with 32 bit parameters
+lint_off -rule WIDTH -file "*/rtl/prim_ram_1p_scr.sv" -match "Operator * expects 32 bits on the LHS, but LHS's VARREF 'addr_cnt_q' generates * bits."

--- a/hw/ip/prim/prim_ram_1p_scr.core
+++ b/hw/ip/prim/prim_ram_1p_scr.core
@@ -18,7 +18,16 @@ filesets:
       - rtl/prim_ram_1p_scr.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_ram_1p_scr.vlt
+    file_type: vlt
+
 targets:
   default:
     filesets:
+      - tool_verilator ? (files_verilator_waiver)
       - files_rtl

--- a/hw/ip/prim/prim_ram_1p_scr.core
+++ b/hw/ip/prim/prim_ram_1p_scr.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:prim:ram_1p_adv
       - lowrisc:prim:lfsr
       - lowrisc:prim:all
+      - lowrisc:prim:util_get_scramble_params
     files:
       - rtl/prim_ram_1p_scr.sv
     file_type: systemVerilogSource

--- a/hw/ip/prim/prim_util_get_scramble_params.core
+++ b/hw/ip/prim/prim_util_get_scramble_params.core
@@ -1,0 +1,17 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:util_get_scramble_params"
+description: "DPI functions to snoop scramble key and nonce for simulation"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_util_get_scramble_params.svh: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/ip/prim/rtl/prim_ram_1p_scr.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_scr.sv
@@ -516,4 +516,6 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
     .cfg_i
   );
 
+  `include "prim_util_get_scramble_params.svh"
+
 endmodule : prim_ram_1p_scr

--- a/hw/ip/prim/rtl/prim_util_get_scramble_params.svh
+++ b/hw/ip/prim/rtl/prim_util_get_scramble_params.svh
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`ifndef SYNTHESIS
+  export "DPI-C" function simutil_get_scramble_key;
+
+  function int simutil_get_scramble_key(output bit [127:0] val);
+    if (!key_valid_i) begin
+      return 0;
+    end
+
+    if (DataKeyWidth != 128) begin
+      return 0;
+    end
+
+    val = key_i;
+    return 1;
+  endfunction
+
+  export "DPI-C" function simutil_get_scramble_nonce;
+
+  function int simutil_get_scramble_nonce(output bit [319:0] nonce);
+    if (!key_valid_i) begin
+      return 0;
+    end
+
+    if (NonceWidth > 320) begin
+      return 0;
+    end
+
+    nonce = 0;
+    nonce[NonceWidth-1:0] = nonce_i;
+    return 1;
+  endfunction
+`endif

--- a/hw/ip/rom_ctrl/dv/rom_ctrl_sim_cfg.hjson
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_sim_cfg.hjson
@@ -27,12 +27,16 @@
   // TODO: remove imported cfgs that do not apply.
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
+                // Config files to get the correct flags for crypto_dpi_prince
+                "{proj_root}/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_dpi_prince_sim_opts.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
+
+  en_build_modes: ["{tool}_crypto_dpi_prince_build_opts"]
 
   // Add additional tops for simulation.
   sim_tops: ["rom_ctrl_bind", "rom_ctrl_cov_bind"]

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -27,12 +27,16 @@
   // TODO: remove imported cfgs that do not apply.
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
+                // Config files to get the correct flags for crypto_dpi_prince
+                "{proj_root}/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_dpi_prince_sim_opts.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
+
+  en_build_modes: ["{tool}_crypto_dpi_prince_build_opts"]
 
   // Add additional tops for simulation.
   sim_tops: ["sram_ctrl_bind"]

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -106,6 +106,7 @@
           clk_main_hmac: main
           clk_main_kmac: main
           clk_main_otbn: main
+          clk_io_div4_otbn: io_div4
         }
       }
       {
@@ -1484,6 +1485,8 @@
           width: 1
           default: "'0"
           inst_name: otp_ctrl
+          end_idx: -1
+          top_signame: otp_ctrl_otbn_otp_key
           index: -1
         }
         {
@@ -2641,12 +2644,12 @@
           struct: logic
           type: uni
           act: rcv
-          width: 4
+          width: 5
           inst_name: clkmgr_aon
           default: ""
           package: ""
-          end_idx: -1
-          top_type: one-to-N
+          end_idx: 4
+          top_type: partial-one-to-N
           top_signame: clkmgr_aon_idle
           index: -1
         }
@@ -5087,17 +5090,20 @@
       {
         clk_i: main
         clk_edn_i: main
+        clk_otp_i: io_div4
       }
       clock_group: trans
       reset_connections:
       {
         rst_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
         rst_edn_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
+        rst_otp_ni: rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_otbn
         clk_edn_i: clkmgr_aon_clocks.clk_main_otbn
+        clk_otp_i: clkmgr_aon_clocks.clk_io_div4_otbn
       }
       domain: "0"
       param_list:
@@ -5138,9 +5144,41 @@
           default: 0xc12f0e2b9ea5a371fd0f691ca53bf257b7531e119cef75b206a2ca62f4d02ee4a4029144fe8521d5f36637ee6805c7a
           randwidth: 384
         }
+        {
+          name: RndCnstOtbnKey
+          desc: Compile-time random reset value for IMem/DMem scrambling key.
+          type: otp_ctrl_pkg::otbn_key_t
+          randcount: 128
+          randtype: data
+          name_top: RndCnstOtbnOtbnKey
+          default: 0x2fb69c3aab936b415a0d6e7185eaa2e0
+          randwidth: 128
+        }
+        {
+          name: RndCnstOtbnNonce
+          desc: Compile-time random reset value for IMem/DMem scrambling nonce.
+          type: otp_ctrl_pkg::otbn_nonce_t
+          randcount: 256
+          randtype: data
+          name_top: RndCnstOtbnOtbnNonce
+          default: 0xe58a331208f189de6265edc8fde06db0ce44cbff5e09e6dd3ae54e9e45da6e66
+          randwidth: 256
+        }
       ]
       inter_signal_list:
       [
+        {
+          name: otbn_otp_key
+          struct: otbn_otp_key
+          package: otp_ctrl_pkg
+          type: req_rsp
+          act: req
+          width: 1
+          default: "'0"
+          inst_name: otbn
+          top_signame: otp_ctrl_otbn_otp_key
+          index: -1
+        }
         {
           name: edn_rnd
           struct: edn
@@ -5247,7 +5285,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRomCtrlScrNonce
-          default: 0x5a0d6e7185eaa2e0
+          default: 0xf678e7d227881bcf
           randwidth: 64
         }
         {
@@ -5257,7 +5295,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRomCtrlScrKey
-          default: 0x3ae54e9e45da6e662fb69c3aab936b41
+          default: 0xd38bd8674f4b542dfcc581b66ae11d33
           randwidth: 128
         }
       ]
@@ -5961,6 +5999,10 @@
       edn1.edn:
       [
         otbn.edn_rnd
+      ]
+      otp_ctrl.otbn_otp_key:
+      [
+        otbn.otbn_otp_key
       ]
       otp_ctrl.otp_keymgr_key:
       [
@@ -12599,6 +12641,8 @@
         width: 1
         default: "'0"
         inst_name: otp_ctrl
+        end_idx: -1
+        top_signame: otp_ctrl_otbn_otp_key
         index: -1
       }
       {
@@ -13536,12 +13580,12 @@
         struct: logic
         type: uni
         act: rcv
-        width: 4
+        width: 5
         inst_name: clkmgr_aon
         default: ""
         package: ""
-        end_idx: -1
-        top_type: one-to-N
+        end_idx: 4
+        top_type: partial-one-to-N
         top_signame: clkmgr_aon_idle
         index: -1
       }
@@ -14960,6 +15004,18 @@
         default: ""
         end_idx: -1
         top_signame: sram_ctrl_main_tl
+        index: -1
+      }
+      {
+        name: otbn_otp_key
+        struct: otbn_otp_key
+        package: otp_ctrl_pkg
+        type: req_rsp
+        act: req
+        width: 1
+        default: "'0"
+        inst_name: otbn
+        top_signame: otp_ctrl_otbn_otp_key
         index: -1
       }
       {
@@ -17245,6 +17301,28 @@
       }
       {
         package: otp_ctrl_pkg
+        struct: otbn_otp_key_req
+        signame: otp_ctrl_otbn_otp_key_req
+        width: 1
+        type: req_rsp
+        end_idx: -1
+        act: rsp
+        suffix: req
+        default: "'0"
+      }
+      {
+        package: otp_ctrl_pkg
+        struct: otbn_otp_key_rsp
+        signame: otp_ctrl_otbn_otp_key_rsp
+        width: 1
+        type: req_rsp
+        end_idx: -1
+        act: rsp
+        suffix: rsp
+        default: ""
+      }
+      {
+        package: otp_ctrl_pkg
         struct: otp_keymgr_key
         signame: otp_ctrl_otp_keymgr_key
         width: 1
@@ -17291,9 +17369,9 @@
         package: ""
         struct: logic
         signame: clkmgr_aon_idle
-        width: 4
+        width: 5
         type: uni
-        end_idx: -1
+        end_idx: 4
         act: rcv
         suffix: ""
         default: "'0"

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -585,9 +585,9 @@
     },
     { name: "otbn",
       type: "otbn",
-      clock_srcs: {clk_i: "main", clk_edn_i: "main"},
+      clock_srcs: {clk_i: "main", clk_edn_i: "main", clk_otp_i: "io_div4"},
       clock_group: "trans",
-      reset_connections: {rst_ni: "sys", rst_edn_ni: "sys"},
+      reset_connections: {rst_ni: "sys", rst_edn_ni: "sys", rst_otp_ni: "lc_io_div4"},
       base_addr: "0x411D0000",
     },
     { name: "rom_ctrl",
@@ -896,6 +896,9 @@
       'edn0.edn'              : ['keymgr.edn', 'otp_ctrl.edn', 'ast.edn', 'kmac.entropy',
                                  'alert_handler.edn', 'aes.edn', 'otbn.edn_urnd'],
       'edn1.edn'              : ['otbn.edn_rnd'],
+
+      // OTBN OTP scramble key
+      'otp_ctrl.otbn_otp_key' : ['otbn.otbn_otp_key'],
 
       // KeyMgr Sideload & KDF function
       'otp_ctrl.otp_keymgr_key' : ['keymgr.otp_key'],

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -135,7 +135,7 @@
       name:    "idle",
       act:     "rcv",
       package: "",
-      width:   "4"
+      width:   "5"
     },
   ],
 
@@ -294,6 +294,15 @@
             1 CLK_MAIN_OTBN is enabled.
           '''
         }
+        {
+          bits: "4",
+          name: "CLK_IO_DIV4_OTBN_HINT",
+          resval: 1,
+          desc: '''
+            0 CLK_IO_DIV4_OTBN can be disabled.
+            1 CLK_IO_DIV4_OTBN is enabled.
+          '''
+        }
       ]
       // the CLK_HINT register cannot be written, otherwise there is the potential clocks could be
       // disabled and the system will hang
@@ -343,6 +352,15 @@
           desc: '''
             0 CLK_MAIN_OTBN is disabled.
             1 CLK_MAIN_OTBN is enabled.
+          '''
+        }
+        {
+          bits: "4",
+          name: "CLK_IO_DIV4_OTBN_VAL",
+          resval: 1,
+          desc: '''
+            0 CLK_IO_DIV4_OTBN is disabled.
+            1 CLK_IO_DIV4_OTBN is enabled.
           '''
         }
       ]

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -33,6 +33,7 @@ package clkmgr_pkg;
     logic clk_main_hmac;
     logic clk_main_kmac;
     logic clk_main_otbn;
+    logic clk_io_div4_otbn;
     logic clk_main_infra;
     logic clk_io_div4_infra;
     logic clk_io_div4_secure;
@@ -60,11 +61,11 @@ package clkmgr_pkg;
   } clkmgr_ast_out_t;
 
   typedef struct packed {
-    logic [4-1:0] idle;
+    logic [5-1:0] idle;
   } clk_hint_status_t;
 
   parameter clk_hint_status_t CLK_HINT_STATUS_DEFAULT = '{
-    idle: {4{1'b1}}
+    idle: {5{1'b1}}
   };
 
 endpackage // clkmgr_pkg

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
@@ -52,6 +52,9 @@ package clkmgr_reg_pkg;
     struct packed {
       logic        q;
     } clk_main_otbn_hint;
+    struct packed {
+      logic        q;
+    } clk_io_div4_otbn_hint;
   } clkmgr_reg2hw_clk_hints_reg_t;
 
   typedef struct packed {
@@ -71,19 +74,23 @@ package clkmgr_reg_pkg;
       logic        d;
       logic        de;
     } clk_main_otbn_val;
+    struct packed {
+      logic        d;
+      logic        de;
+    } clk_io_div4_otbn_val;
   } clkmgr_hw2reg_clk_hints_status_reg_t;
 
   // Register -> HW type
   typedef struct packed {
-    clkmgr_reg2hw_extclk_sel_reg_t extclk_sel; // [12:9]
-    clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [8:8]
-    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [7:4]
-    clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [3:0]
+    clkmgr_reg2hw_extclk_sel_reg_t extclk_sel; // [13:10]
+    clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [9:9]
+    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [8:5]
+    clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [4:0]
   } clkmgr_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    clkmgr_hw2reg_clk_hints_status_reg_t clk_hints_status; // [7:0]
+    clkmgr_hw2reg_clk_hints_status_reg_t clk_hints_status; // [9:0]
   } clkmgr_hw2reg_t;
 
   // Register offsets

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -131,10 +131,13 @@ module clkmgr_reg_top (
   logic clk_hints_clk_main_kmac_hint_wd;
   logic clk_hints_clk_main_otbn_hint_qs;
   logic clk_hints_clk_main_otbn_hint_wd;
+  logic clk_hints_clk_io_div4_otbn_hint_qs;
+  logic clk_hints_clk_io_div4_otbn_hint_wd;
   logic clk_hints_status_clk_main_aes_val_qs;
   logic clk_hints_status_clk_main_hmac_val_qs;
   logic clk_hints_status_clk_main_kmac_val_qs;
   logic clk_hints_status_clk_main_otbn_val_qs;
+  logic clk_hints_status_clk_io_div4_otbn_val_qs;
 
   // Register instances
   // R[extclk_sel_regwen]: V(False)
@@ -430,6 +433,32 @@ module clkmgr_reg_top (
   );
 
 
+  //   F[clk_io_div4_otbn_hint]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h1)
+  ) u_clk_hints_clk_io_div4_otbn_hint (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (clk_hints_we),
+    .wd     (clk_hints_clk_io_div4_otbn_hint_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.clk_hints.clk_io_div4_otbn_hint.q),
+
+    // to register interface (read)
+    .qs     (clk_hints_clk_io_div4_otbn_hint_qs)
+  );
+
+
   // R[clk_hints_status]: V(False)
 
   //   F[clk_main_aes_val]: 0:0
@@ -536,6 +565,32 @@ module clkmgr_reg_top (
   );
 
 
+  //   F[clk_io_div4_otbn_val]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h1)
+  ) u_clk_hints_status_clk_io_div4_otbn_val (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.clk_hints_status.clk_io_div4_otbn_val.de),
+    .d      (hw2reg.clk_hints_status.clk_io_div4_otbn_val.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (clk_hints_status_clk_io_div4_otbn_val_qs)
+  );
+
+
 
 
   logic [5:0] addr_hit;
@@ -589,6 +644,8 @@ module clkmgr_reg_top (
 
   assign clk_hints_clk_main_otbn_hint_wd = reg_wdata[3];
 
+  assign clk_hints_clk_io_div4_otbn_hint_wd = reg_wdata[4];
+
   // Read data return
   always_comb begin
     reg_rdata_next = '0;
@@ -617,6 +674,7 @@ module clkmgr_reg_top (
         reg_rdata_next[1] = clk_hints_clk_main_hmac_hint_qs;
         reg_rdata_next[2] = clk_hints_clk_main_kmac_hint_qs;
         reg_rdata_next[3] = clk_hints_clk_main_otbn_hint_qs;
+        reg_rdata_next[4] = clk_hints_clk_io_div4_otbn_hint_qs;
       end
 
       addr_hit[5]: begin
@@ -624,6 +682,7 @@ module clkmgr_reg_top (
         reg_rdata_next[1] = clk_hints_status_clk_main_hmac_val_qs;
         reg_rdata_next[2] = clk_hints_status_clk_main_kmac_val_qs;
         reg_rdata_next[3] = clk_hints_status_clk_main_otbn_val_qs;
+        reg_rdata_next[4] = clk_hints_status_clk_io_div4_otbn_val_qs;
       end
 
       default: begin

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -509,11 +509,13 @@ module top_earlgrey #(
   edn_pkg::edn_rsp_t [6:0] edn0_edn_rsp;
   edn_pkg::edn_req_t [6:0] edn1_edn_req;
   edn_pkg::edn_rsp_t [6:0] edn1_edn_rsp;
+  otp_ctrl_pkg::otbn_otp_key_req_t       otp_ctrl_otbn_otp_key_req;
+  otp_ctrl_pkg::otbn_otp_key_rsp_t       otp_ctrl_otbn_otp_key_rsp;
   otp_ctrl_pkg::otp_keymgr_key_t       otp_ctrl_otp_keymgr_key;
   keymgr_pkg::hw_key_req_t       keymgr_kmac_key;
   kmac_pkg::app_req_t [2:0] kmac_app_req;
   kmac_pkg::app_rsp_t [2:0] kmac_app_rsp;
-  logic [3:0] clkmgr_aon_idle;
+  logic [4:0] clkmgr_aon_idle;
   jtag_pkg::jtag_req_t       pinmux_aon_lc_jtag_req;
   jtag_pkg::jtag_rsp_t       pinmux_aon_lc_jtag_rsp;
   jtag_pkg::jtag_req_t       pinmux_aon_rv_jtag_req;
@@ -1614,8 +1616,8 @@ module top_earlgrey #(
       .flash_otp_key_o(flash_ctrl_otp_rsp),
       .sram_otp_key_i(otp_ctrl_sram_otp_key_req),
       .sram_otp_key_o(otp_ctrl_sram_otp_key_rsp),
-      .otbn_otp_key_i('0),
-      .otbn_otp_key_o(),
+      .otbn_otp_key_i(otp_ctrl_otbn_otp_key_req),
+      .otbn_otp_key_o(otp_ctrl_otbn_otp_key_rsp),
       .otp_hw_cfg_o(otp_ctrl_otp_hw_cfg),
       .tl_i(otp_ctrl_tl_req),
       .tl_o(otp_ctrl_tl_rsp),
@@ -2415,7 +2417,9 @@ module top_earlgrey #(
     .Stub(OtbnStub),
     .RegFile(OtbnRegFile),
     .RndCnstUrndLfsrSeed(RndCnstOtbnUrndLfsrSeed),
-    .RndCnstUrndChunkLfsrPerm(RndCnstOtbnUrndChunkLfsrPerm)
+    .RndCnstUrndChunkLfsrPerm(RndCnstOtbnUrndChunkLfsrPerm),
+    .RndCnstOtbnKey(RndCnstOtbnOtbnKey),
+    .RndCnstOtbnNonce(RndCnstOtbnOtbnNonce)
   ) u_otbn (
 
       // Interrupt
@@ -2426,6 +2430,8 @@ module top_earlgrey #(
       .alert_rx_i  ( alert_rx[53:52] ),
 
       // Inter-module signals
+      .otbn_otp_key_o(otp_ctrl_otbn_otp_key_req),
+      .otbn_otp_key_i(otp_ctrl_otbn_otp_key_rsp),
       .edn_rnd_o(edn1_edn_req[0]),
       .edn_rnd_i(edn1_edn_rsp[0]),
       .edn_urnd_o(edn0_edn_req[6]),
@@ -2438,8 +2444,10 @@ module top_earlgrey #(
       // Clock and reset connections
       .clk_i (clkmgr_aon_clocks.clk_main_otbn),
       .clk_edn_i (clkmgr_aon_clocks.clk_main_otbn),
+      .clk_otp_i (clkmgr_aon_clocks.clk_io_div4_otbn),
       .rst_ni (rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
-      .rst_edn_ni (rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel])
+      .rst_edn_ni (rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
+      .rst_otp_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel])
   );
 
   rom_ctrl #(

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -243,17 +243,27 @@ package top_earlgrey_rnd_cnst_pkg;
     256'h7B7531E119CEF75B206A2CA62F4D02EE4A4029144FE8521D5F36637EE6805C7A
   };
 
+  // Compile-time random reset value for IMem/DMem scrambling key.
+  parameter otp_ctrl_pkg::otbn_key_t RndCnstOtbnOtbnKey = {
+    128'h2FB69C3AAB936B415A0D6E7185EAA2E0
+  };
+
+  // Compile-time random reset value for IMem/DMem scrambling nonce.
+  parameter otp_ctrl_pkg::otbn_nonce_t RndCnstOtbnOtbnNonce = {
+    256'hE58A331208F189DE6265EDC8FDE06DB0CE44CBFF5E09E6DD3AE54E9E45DA6E66
+  };
+
   ////////////////////////////////////////////
   // rom_ctrl
   ////////////////////////////////////////////
   // Fixed nonce used for address / data scrambling
   parameter bit [63:0] RndCnstRomCtrlScrNonce = {
-    64'h5A0D6E7185EAA2E0
+    64'hF678E7D227881BCF
   };
 
   // Randomised constant used as a scrambling key for ROM data
   parameter bit [127:0] RndCnstRomCtrlScrKey = {
-    128'h3AE54E9E45DA6E662FB69C3AAB936B41
+    128'hD38BD8674F4B542DFCC581B66AE11D33
   };
 
 endpackage : top_earlgrey_rnd_cnst_pkg

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -1520,7 +1520,8 @@ typedef enum top_earlgrey_hintable_clocks {
   kTopEarlgreyHintableClocksMainHmac = 1, /**< Clock clk_main_hmac in group trans */
   kTopEarlgreyHintableClocksMainKmac = 2, /**< Clock clk_main_kmac in group trans */
   kTopEarlgreyHintableClocksMainOtbn = 3, /**< Clock clk_main_otbn in group trans */
-  kTopEarlgreyHintableClocksLast = 3, /**< \internal Last Valid Hintable Clock */
+  kTopEarlgreyHintableClocksIoDiv4Otbn = 4, /**< Clock clk_io_div4_otbn in group trans */
+  kTopEarlgreyHintableClocksLast = 4, /**< \internal Last Valid Hintable Clock */
 } top_earlgrey_hintable_clocks_t;
 
 // Header Extern Guard


### PR DESCRIPTION
I've marked this as a draft as to make it work I had to place OTBN in the 'secure' clock group from the 'trans' one and I don't think this is the correct thing to do, it's just it's a workaround for what looks like a topgen bug (see https://github.com/lowRISC/opentitan/issues/6813).

Initially I had planned to implement the register interface to request new scrambling key and nonce but I'm keen to get this reviewed so haven't fully implemented this. The `otbn_scramble_ctrl.sv` file has the functionality to do it but it's not been tested.