### PR TITLE
[topgen,clkmgr] De-duplicate clock hint names

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr_pkg.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr_pkg.sv.tpl
@@ -13,8 +13,8 @@ num_hints = len(hint_clks)
 package clkmgr_pkg;
 
   typedef enum int {
-% for hint, v in hint_clks.items():
-    ${v['name'].capitalize()} = ${loop.index}${"," if not loop.last else ""}
+% for idx, blk_name in list(enumerate(hint_blocks)):
+    ${blk_name.capitalize()} = ${idx}${"," if not loop.last else ""}
 % endfor
   } hint_names_e;
 

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -483,6 +483,10 @@ def generate_clkmgr(top, cfg_path, out_path):
     hint_clks = {clk: {'name': clk.rsplit('_', 1)[-1], 'src': src}
                  for clk, src in hints.items()}
 
+    # The names of blocks that use one or more sw hint clocks (clkmgr has an
+    # "idle" feedback signal from each), in ascending order.
+    hint_blocks = sorted(set([v['name'] for v in hint_clks.values()]))
+
     # Define a canonical ordering for rg_srcs
     rg_srcs = sorted(rg_srcs_set)
 
@@ -498,7 +502,8 @@ def generate_clkmgr(top, cfg_path, out_path):
                                  rg_clks=rg_clks,
                                  sw_clks=sw_clks,
                                  export_clks=top['exported_clks'],
-                                 hint_clks=hint_clks)
+                                 hint_clks=hint_clks,
+                                 hint_blocks=hint_blocks)
             except:  # noqa: E722
                 log.error(exceptions.text_error_template().render())
 


### PR DESCRIPTION
Fixes #6813.

@GregAC: The problem you were seeing is caused by the fact that the topgen code implicitly assumed that each block's idle signal would feed back to at most one clock. Fortunately, it's a pretty simple fix!