### PR TITLE
[reggen] Disallow non-hwext shadow registers

### DIFF
--- a/util/reggen/reg_pkg.sv.tpl
+++ b/util/reggen/reg_pkg.sv.tpl
@@ -61,10 +61,6 @@ ${hdr}
       % if r0.hwre or (r0.shadowed and r0.hwext):
     logic        re;
       % endif
-      % if r0.shadowed and not r0.hwext:
-    logic        err_update;
-    logic        err_storage;
-      % endif
     % else:
       ## We are inhomogeneous, which means there is more than one different
       ## field. Generate a reg2hw typedef that packs together all the fields of
@@ -85,10 +81,6 @@ ${hdr}
           % endif
           % if r0.hwre or (r0.shadowed and r0.hwext):
       logic        re;
-          % endif
-          % if r0.shadowed and not r0.hwext:
-      logic        err_update;
-      logic        err_storage;
           % endif
     } ${struct_name};
         %endif

--- a/util/reggen/register.py
+++ b/util/reggen/register.py
@@ -135,6 +135,11 @@ class Register(RegBase):
                              "the shadowed flag is not set."
                              .format(self.name))
 
+        # Shadowed registers must be hwext
+        if self.shadowed and not self.hwext:
+            raise ValueError('Register {} is shadowed but not hwext.'
+                             .format(self.name))
+
         # Take a copy of fields and then sort by bit index
         assert fields
         self.fields = fields.copy()


### PR DESCRIPTION
We don't use them in the design, so there's a good chance they are
either broken now or will bit-rot. Rip out the support for now, at
least: we can always add it back in the future if needed.

@vogelpi: Looking at the commit history, I think the original AES shadow register code used this, but now uses hwext registers. Is that right?