### PR TITLE
[sw/silicon_creator] Add entry_point, code_start, and code_end fields to the manifest

### DIFF
--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -54,6 +54,8 @@ enum module_ {
   X(kErrorSigverifyBadExponent,       ERROR_(2, kModuleSigverify, kInvalidArgument)), \
   X(kErrorKeymgrInternal,             ERROR_(1, kModuleKeymgr, kInternal)), \
   X(kErrorManifestInternal,           ERROR_(1, kModuleManifest, kInternal)), \
+  X(kErrorManifestBadEntryPoint,      ERROR_(2, kModuleManifest, kInternal)), \
+  X(kErrorManifestBadCodeRegion,      ERROR_(3, kModuleManifest, kInternal)), \
   X(kErrorRomextimageInvalidArgument, ERROR_(1, kModuleRomextimage, kInvalidArgument)), \
   X(kErrorRomextimageInternal,        ERROR_(2, kModuleRomextimage, kInternal)), \
   X(kErrorAlertBadIndex,              ERROR_(1, kModuleAlertHandler, kInvalidArgument)), \

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -53,7 +53,7 @@ enum module_ {
   X(kErrorSigverifyBadEncodedMessage, ERROR_(1, kModuleSigverify, kInvalidArgument)), \
   X(kErrorSigverifyBadExponent,       ERROR_(2, kModuleSigverify, kInvalidArgument)), \
   X(kErrorKeymgrInternal,             ERROR_(1, kModuleKeymgr, kInternal)), \
-  X(kErrorManifestInternal,           ERROR_(1, kModuleManifest, kInternal)), \
+  X(kErrorManifestBadLength,          ERROR_(1, kModuleManifest, kInternal)), \
   X(kErrorManifestBadEntryPoint,      ERROR_(2, kModuleManifest, kInternal)), \
   X(kErrorManifestBadCodeRegion,      ERROR_(3, kModuleManifest, kInternal)), \
   X(kErrorRomextimageInvalidArgument, ERROR_(1, kModuleRomextimage, kInvalidArgument)), \

--- a/sw/device/silicon_creator/lib/manifest.c
+++ b/sw/device/silicon_creator/lib/manifest.c
@@ -7,4 +7,7 @@
 // Extern declarations for the inline functions in the manifest header.
 extern rom_error_t manifest_signed_region_get(
     const manifest_t *manifest, manifest_signed_region_t *signed_region);
-extern uintptr_t manifest_entry_point_address_get(const manifest_t *manifest);
+extern rom_error_t manifest_code_region_get(const manifest_t *manifest,
+                                            epmp_region_t *code_region);
+extern rom_error_t manifest_entry_point_get(const manifest_t *manifest,
+                                            uintptr_t *entry_point);

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -21,14 +21,15 @@ extern "C" {
 /**
  * Manifest for boot stage images stored in flash.
  *
- * OpenTitan secure boot, at a minimum, consists of four boot stages: ROM,
- * ROM_EXT, BL0, and Kernel. ROM is stored in the read-only Mask ROM while
- * remaining stages are stored in flash. This structure must be placed at the
- * start of ROM_EXT and BL0 images so that ROM and ROM_EXT can verify the
- * integrity and authenticity of the next stage and configure peripherals as
- * needed before handing over execution.
+ * OpenTitan secure boot, at a minimum, consists of three boot stages: ROM,
+ * ROM_EXT, and the first owner boot stage, e.g. BL0. ROM is stored in the
+ * read-only Mask ROM while remaining stages are stored in flash. This structure
+ * must be placed at the start of ROM_EXT and first owner boot stage images so
+ * that ROM and ROM_EXT can verify the integrity and authenticity of the next
+ * stage and configure peripherals as needed before handing over execution.
  *
- * Use of this struct for stages following BL0 is optional.
+ * Use of this struct for stages following the first owner boot stage is
+ * optional.
  *
  * Note: The definitions in
  * sw/host/rom_ext_image_tools/signer/image/src/manifest.rs must be updated if

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -22,9 +22,10 @@ extern "C" {
  *
  * OpenTitan secure boot, at a minimum, consists of four boot stages: ROM,
  * ROM_EXT, BL0, and Kernel. ROM is stored in the read-only Mask ROM while
- * remaning stages are stored in flash. This structure must be placed at the
- * beginning of ROM_EXT and BL0 images so that ROM and ROM_EXT can verify
- * integrity and authenticity of the next stage before handing over execution.
+ * remaining stages are stored in flash. This structure must be placed at the
+ * start of ROM_EXT and BL0 images so that ROM and ROM_EXT can verify the
+ * integrity and authenticity of the next stage and configure peripherals as
+ * needed before handing over execution.
  *
  * Use of this struct for stages following BL0 is optional.
  *
@@ -81,6 +82,25 @@ typedef struct manifest {
    * Modulus of the signer's RSA public key.
    */
   sigverify_rsa_buffer_t modulus;
+  /**
+   * Offset of the start of the executable region of the image from the start
+   * of the manifest in bytes.
+   */
+  uint32_t code_start;
+  /**
+   * Offset of the end of the executable region (exclusive) of the image from
+   * the start of the manifest in bytes.
+   */
+  uint32_t code_end;
+  /**
+   * Offset of the first instruction to execute in the image from the start of
+   * the manifest in bytes.
+   */
+  uint32_t entry_point;
+  /**
+   * Trailing padding (due to image_timestamp and the size of the struct).
+   */
+  uint32_t padding;
 } manifest_t;
 
 OT_ASSERT_MEMBER_OFFSET(manifest_t, identifier, 0);
@@ -93,6 +113,10 @@ OT_ASSERT_MEMBER_OFFSET(manifest_t, exponent, 408);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, binding_value, 412);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, max_key_version, 444);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, modulus, 448);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, code_start, 832);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, code_end, 836);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, entry_point, 840);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, padding, 844);
 OT_ASSERT_SIZE(manifest_t, MANIFEST_SIZE);
 
 /**

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -157,7 +157,7 @@ inline rom_error_t manifest_signed_region_get(
     const manifest_t *manifest, manifest_signed_region_t *signed_region) {
   if (manifest->image_length < kManifestImageLengthMin ||
       manifest->image_length > kManifestImageLengthMax) {
-    return kErrorManifestInternal;
+    return kErrorManifestBadLength;
   }
   *signed_region = (manifest_signed_region_t){
       .start = &manifest->image_length,

--- a/sw/device/silicon_creator/lib/manifest_size.h
+++ b/sw/device/silicon_creator/lib/manifest_size.h
@@ -8,6 +8,6 @@
 /**
  * Manifest size for boot stages stored in flash (in bytes).
  */
-#define MANIFEST_SIZE 832
+#define MANIFEST_SIZE 848
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MANIFEST_SIZE_H_

--- a/sw/device/silicon_creator/lib/manifest_unittest.cc
+++ b/sw/device/silicon_creator/lib/manifest_unittest.cc
@@ -28,11 +28,13 @@ TEST(Manifest, SignedRegionGetBadLength) {
 
   manifest.image_length = kManifestImageLengthMax + 1;
   EXPECT_EQ(manifest_signed_region_get(&manifest, &signed_region),
-            kErrorManifestInternal);
+            kErrorManifestBadLength);
 
   manifest.image_length = kManifestImageLengthMin - 1;
   EXPECT_EQ(manifest_signed_region_get(&manifest, &signed_region),
-            kErrorManifestInternal);
+            kErrorManifestBadLength);
+}
+
 TEST(Manifest, CodeRegionGet) {
   manifest_t manifest{};
   manifest.image_length = 0x1000;

--- a/sw/device/silicon_creator/lib/manifest_unittest.cc
+++ b/sw/device/silicon_creator/lib/manifest_unittest.cc
@@ -5,6 +5,7 @@
 #include "sw/device/silicon_creator/lib/manifest.h"
 
 #include "gtest/gtest.h"
+#include "sw/device/lib/runtime/epmp.h"
 
 namespace manifest_unittest {
 namespace {
@@ -32,14 +33,69 @@ TEST(Manifest, SignedRegionGetBadLength) {
   manifest.image_length = kManifestImageLengthMin - 1;
   EXPECT_EQ(manifest_signed_region_get(&manifest, &signed_region),
             kErrorManifestInternal);
+TEST(Manifest, CodeRegionGet) {
+  manifest_t manifest{};
+  manifest.image_length = 0x1000;
+  manifest.code_start = 0x400;
+  manifest.code_end = 0x800;
+  epmp_region_t code_region;
+
+  EXPECT_EQ(manifest_code_region_get(&manifest, &code_region), kErrorOk);
+  EXPECT_EQ(code_region.start,
+            reinterpret_cast<uintptr_t>(&manifest) + manifest.code_start);
+  EXPECT_EQ(code_region.end,
+            reinterpret_cast<uintptr_t>(&manifest) + manifest.code_end);
+  // Code region cannot be empty.
+  manifest.code_start = manifest.code_end;
+  EXPECT_EQ(manifest_code_region_get(&manifest, &code_region),
+            kErrorManifestBadCodeRegion);
+  // Code region must be after the manifest.
+  manifest.code_start = sizeof(manifest_t) - 1;
+  EXPECT_EQ(manifest_code_region_get(&manifest, &code_region),
+            kErrorManifestBadCodeRegion);
+  // Code region must be inside the image.
+  manifest.code_start = 0x400;
+  manifest.code_end = manifest.image_length + 1;
+  EXPECT_EQ(manifest_code_region_get(&manifest, &code_region),
+            kErrorManifestBadCodeRegion);
+  // Start and end offsets must be word aligned.
+  manifest.code_start = 0x401;
+  manifest.code_end = 0x800;
+  EXPECT_EQ(manifest_code_region_get(&manifest, &code_region),
+            kErrorManifestBadCodeRegion);
+  manifest.code_start = 0x400;
+  manifest.code_end = 0x801;
+  EXPECT_EQ(manifest_code_region_get(&manifest, &code_region),
+            kErrorManifestBadCodeRegion);
 }
 
 TEST(Manifest, EntryPointGet) {
   manifest_t manifest{};
+  manifest.image_length = 0x1000;
+  manifest.code_start = 0x400;
+  manifest.entry_point = 0x500;
+  manifest.code_end = 0x800;
+  uintptr_t entry_point;
 
-  // FIXME: Update after `entry_point` field is added.
-  EXPECT_EQ(manifest_entry_point_address_get(&manifest),
-            reinterpret_cast<uintptr_t>(&manifest) + 1152);
+  EXPECT_EQ(manifest_entry_point_get(&manifest, &entry_point), kErrorOk);
+  EXPECT_EQ(entry_point,
+            reinterpret_cast<uintptr_t>(&manifest) + manifest.entry_point);
+  // entry_point must be at or after code_start.
+  manifest.entry_point = manifest.code_start - 1;
+  EXPECT_EQ(manifest_entry_point_get(&manifest, &entry_point),
+            kErrorManifestBadEntryPoint);
+  // entry_point must be before code_end.
+  manifest.entry_point = manifest.code_end;
+  EXPECT_EQ(manifest_entry_point_get(&manifest, &entry_point),
+            kErrorManifestBadEntryPoint);
+  // entry_point must be before the end of the image.
+  manifest.entry_point = manifest.image_length;
+  EXPECT_EQ(manifest_entry_point_get(&manifest, &entry_point),
+            kErrorManifestBadEntryPoint);
+  // entry_point must be word aligned.
+  manifest.entry_point = 0x501;
+  EXPECT_EQ(manifest_entry_point_get(&manifest, &entry_point),
+            kErrorManifestBadEntryPoint);
 }
 
 }  // namespace

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -162,11 +162,13 @@ void mask_rom_boot(void) {
     // if (!final_jump_to_rom_ext(current_rom_ext_manifest)) { // Hardened Jump
     // Module
     if (true) {
+      uintptr_t entry_point;
+      if (manifest_entry_point_get(manifest, &entry_point) != kErrorOk) {
+        break;
+      }
       // Jump to ROM_EXT entry point.
-      romextimage_entry_point *entry_point =
-          (romextimage_entry_point *)manifest_entry_point_address_get(manifest);
       base_printf("rom_ext_entry: %p\r\n", entry_point);
-      entry_point();
+      ((romextimage_entry_point *)entry_point)();
       // NOTE: never expecting a return, but if something were to go wrong
       // in the real `jump` implementation, we need to enter a failure case.
 

--- a/sw/device/silicon_creator/rom_exts/rom_ext_common.ld
+++ b/sw/device/silicon_creator/rom_exts/rom_ext_common.ld
@@ -21,10 +21,9 @@ __DYNAMIC = 0;
 _dv_log_offset = 0x10000;
 
 /**
- * Marking the entrypoint correctly for the ELF file. In reality, we will end up
- * using a hard-coded offset from the slot start, as we don't have the ELF info
- * around once we have the image, and the entry offset is static in the image
- * format.
+ * Marking the entry point correctly for the ELF file. The signer tool will
+ * transfer this value to the `entry_point` field of the manifest, which will
+ * then be used by `mask_rom_boot` to handover execution to ROM_EXT.
  */
 ENTRY(_rom_ext_start_boot)
 

--- a/sw/device/silicon_creator/rom_exts/rom_ext_start.S
+++ b/sw/device/silicon_creator/rom_exts/rom_ext_start.S
@@ -21,15 +21,8 @@
 /**
  * `_rom_ext_interrupt_vector` is an ibex-compatible interrupt vector.
  *
- * Interrupt vectors in Ibex have 32 entries for 32 possible interrupts. The
+ * Interrupt vectors in Ibex have 32 4-byte entries for 32 possible interrupts. The
  * vector must be 256-byte aligned, as Ibex's vectoring mechanism requires that.
- *
- * The ROM_EXT uses the address directly after the first possible interrupt
- * vector when starting execution after Mask ROM, which we choose to make look
- * like an extra entry. This is designed to match how Ibex chooses to implement
- * its initial execution address after boot.
- *
- * Thus this vector has exactly 33 4-byte entries.
  *
  * Only the following will be used by Ibex:
  * - Exception Handler (Entry 0)
@@ -37,7 +30,6 @@
  * - Machine Timer Interrupt Handler (Entry 7)
  * - Machine External Interrupt Handler (Entry 11)
  * - Vendor Interrupt Handlers (Entries 16-31)
- * - Reset Handler (Entry 32)
  *
  * More information about Ibex's interrupts can be found here:
  *   https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
@@ -84,23 +76,13 @@ _rom_ext_interrupt_vector:
 
   // Vendor Interrupt Handlers:
 
-  // On Ibex interrupt ids 30-16 are for "fast" interrupts.
+  // On Ibex interrupt ids 16-30 are for "fast" interrupts.
   .rept 15
   unimp
   .endr
 
   // On Ibex interrupt id 31 is for non-maskable interrupts.
   unimp
-
-  /**
-   * ROM_EXT entry point.
-   *
-   * ROM_EXT is the second boot stage, which means that
-   * this entry will be hit as a result of the jump from the Mask ROM, and
-   * not the power-on. This indirection insures that Mask ROM has a well
-   * defined address to jump to.
-   */
-  j _rom_ext_start_boot
 
   // Set size so this vector can be disassembled.
   .size _rom_ext_interrupt_vector, .-_rom_ext_interrupt_vector
@@ -130,9 +112,8 @@ _rom_ext_interrupt_vector:
 /**
  * Entry point.
  *
- * This symbol is jumped to from `_rom_ext_interrupt_vector + (32 * 4)`, and
- * is part of a two jump Mask ROM execution handover to ROM_EXT (`mask_rom_boot`
- * -> `_rom_ext_interrupt_vector + (32 * 4)` -> `_rom_ext_start_boot`).
+ * This symbol is jumped to from `mask_rom_boot` using the `entry_point` field
+ * of the manifest.
  */
   .globl _rom_ext_start_boot
   .type _rom_ext_start_boot, @function

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -281,6 +281,7 @@ foreach sw_test_name, sw_test_info : sw_rom_ext_tests
           rom_ext_signer_export.full_path(),
           '@INPUT@',
           key_info['path'],
+          sw_test_elf.full_path(),
           '@OUTPUT@',
         ],
         depends: rom_ext_signer_export,

--- a/sw/host/rom_ext_image_tools/signer/Cargo.lock
+++ b/sw/host/rom_ext_image_tools/signer/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +33,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "crc32fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "goblin"
 version = "0.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,13 +71,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+
+[[package]]
 name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memoffset"
@@ -56,12 +101,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg",
+]
+
+[[package]]
 name = "mundane"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e0fa854bb6ab697baa4b14bf0ea911a9eeb95b2f3dc98192df9ea4fc79d097c"
 dependencies = [
  "goblin",
+]
+
+[[package]]
+name = "object"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
+dependencies = [
+ "flate2",
+ "memchr",
 ]
 
 [[package]]
@@ -121,6 +186,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "mundane",
+ "object",
  "rom_ext_image",
  "zerocopy",
 ]

--- a/sw/host/rom_ext_image_tools/signer/Cargo.toml
+++ b/sw/host/rom_ext_image_tools/signer/Cargo.toml
@@ -25,6 +25,7 @@ debug = true
 
 [dependencies]
 anyhow = "1.0.40"
+object = "0.25.3"
 rom_ext_image = { path = "image" }
 zerocopy = "0.5.0"
 

--- a/sw/host/rom_ext_image_tools/signer/image/src/manifest.rs
+++ b/sw/host/rom_ext_image_tools/signer/image/src/manifest.rs
@@ -26,7 +26,7 @@ use zerocopy::FromBytes;
 //      sw/device/silicon_creator/lib/manifest.h \
 //      -- -I./ -Isw/device/lib/base/freestanding
 
-pub const MANIFEST_SIZE: u32 = 832;
+pub const MANIFEST_SIZE: u32 = 848;
 
 /// Manifest for boot stage images stored in flash.
 #[repr(C)]
@@ -42,6 +42,10 @@ pub struct Manifest {
     pub binding_value: KeymgrBindingValue,
     pub max_key_version: u32,
     pub modulus: SigverifyRsaBuffer,
+    pub code_start: u32,
+    pub code_end: u32,
+    pub entry_point: u32,
+    pub padding: u32,
 }
 
 /// A type that holds 96 32-bit words for RSA-3072.
@@ -60,7 +64,7 @@ impl Default for SigverifyRsaBuffer {
 #[repr(C)]
 #[derive(FromBytes, AsBytes, Debug, Default)]
 pub struct KeymgrBindingValue {
-        pub data: [u32; 8usize],
+    pub data: [u32; 8usize],
 }
 
 /// Checks the layout of the manifest struct.
@@ -79,5 +83,9 @@ pub fn check_manifest_layout() {
     assert_eq!(offset_of!(Manifest, binding_value), 412);
     assert_eq!(offset_of!(Manifest, max_key_version), 444);
     assert_eq!(offset_of!(Manifest, modulus), 448);
+    assert_eq!(offset_of!(Manifest, code_start), 832);
+    assert_eq!(offset_of!(Manifest, code_end), 836);
+    assert_eq!(offset_of!(Manifest, entry_point), 840);
+    assert_eq!(offset_of!(Manifest, padding), 844);
     assert_eq!(size_of::<Manifest>(), MANIFEST_SIZE as usize);
 }

--- a/sw/host/rom_ext_image_tools/signer/src/main.rs
+++ b/sw/host/rom_ext_image_tools/signer/src/main.rs
@@ -30,6 +30,10 @@ use rom_ext_image::image::ManifestBuffer;
 use rom_ext_image::manifest;
 use rom_ext_image::manifest::Manifest;
 
+use object::read::elf::ElfFile32;
+use object::read::ObjectSection;
+use object::Object;
+
 // Type aliases for convenience.
 type ImageSignature =
     mundane::public::rsa::RsaSignature<B3072, RsaPkcs1v15, Sha256>;
@@ -37,21 +41,23 @@ type PrivateKey = mundane::public::rsa::RsaPrivKey<B3072>;
 
 // TODO: Remove this struct when this functionality is integrated into `opentitantool`.
 struct Args {
-    input: PathBuf,
+    input_image: PathBuf,
     priv_key: PathBuf,
-    output: PathBuf,
+    elf_file: PathBuf,
+    output_image: PathBuf,
 }
 
 impl Args {
     pub fn new(args: env::ArgsOs) -> Result<Args> {
         let args = args.skip(1).collect::<Vec<_>>();
         match args.as_slice() {
-            [input, priv_key, output] => Ok(Args {
-                    input: PathBuf::from(input),
+            [input_image, priv_key, elf_file, output_image] => Ok(Args {
+                    input_image: PathBuf::from(input_image),
                     priv_key: PathBuf::from(priv_key),
-                    output: PathBuf::from(output),
+                    elf_file: PathBuf::from(elf_file),
+                    output_image: PathBuf::from(output_image),
                 }),
-            args => bail!("Expected exactly 3 positional arguments: input, private key, and output, got: {}.", args.len()),
+            args => bail!("Expected exactly 4 positional arguments: input image, private key, elf file, and output image, got: {}.", args.len()),
         }
     }
 }
@@ -76,10 +82,43 @@ fn _parse_hex_str(hex_str: &str) -> Result<Vec<u8>> {
 
 /// Updates the manifest of an image.
 // TODO: This function must use a public key.
-fn update_image_manifest(image: &mut Image, key: &PrivateKey) -> Result<()> {
+fn update_image_manifest(
+    image: &mut Image,
+    key: &PrivateKey,
+    elf: &ElfFile32,
+) -> Result<()> {
+    let manifest_addr = u32::try_from(
+        elf.section_by_name(".manifest")
+            .context("Could not find the `.manifest` section.")?
+            .address(),
+    )?;
+
     *image.manifest = Manifest {
         identifier: 0x4552544f,
         image_length: u32::try_from(image.bytes().len())?,
+        entry_point: {
+            let addr = u32::try_from(elf.entry())?;
+            addr.checked_sub(manifest_addr).context("Overflow")?
+        },
+        code_start: {
+            let addr = u32::try_from(
+                elf.section_by_name(".vectors")
+                    .context("Could not find the `.vectors` section.")?
+                    .address(),
+            )?;
+            addr.checked_sub(manifest_addr).context("Overflow")?
+        },
+        code_end: {
+            let text = elf
+                .section_by_name(".text")
+                .context("Could not find the `.text` section.")?;
+            let addr = u32::try_from(
+                text.address()
+                    .checked_add(text.size())
+                    .context("Overflow")?,
+            )?;
+            addr.checked_sub(manifest_addr).context("Overflow")?
+        },
         ..Default::default()
     };
 
@@ -134,9 +173,9 @@ fn main() -> Result<()> {
     // We use a separate buffer for manifest because it must have the same alignment as `Manifest`
     // to be able to use `LayoutVerified::new()` and the approach we use to ensure this requires
     // its size to be known at compile time.
-    let payload = &fs::read(&args.input)
-        .with_context(|| format!("Failed to read {}", args.input.display()))?
-        [size_of::<Manifest>()..];
+    let payload = &fs::read(&args.input_image).with_context(|| {
+        format!("Failed to read {}", args.input_image.display())
+    })?[size_of::<Manifest>()..];
     let mut manifest_buffer = ManifestBuffer::new();
     let mut image = Image::new(&mut manifest_buffer, payload)?;
 
@@ -145,13 +184,19 @@ fn main() -> Result<()> {
     })?;
     let key =
         PrivateKey::parse_from_der(&key).context("Failed to parse the key.")?;
-    update_image_manifest(&mut image, &key)?;
 
+    let elf = fs::read(&args.elf_file)?;
+    let elf = ElfFile32::parse(elf.as_slice())?;
+
+    update_image_manifest(&mut image, &key, &elf)?;
     let sig = calculate_image_signature(&image, &key)?;
     update_image_signature(&mut image, sig)?;
 
-    fs::write(&args.output, image.bytes()).with_context(|| {
-        format!("Failed to write the image to {}", args.output.display())
+    fs::write(&args.output_image, image.bytes()).with_context(|| {
+        format!(
+            "Failed to write the image to {}",
+            args.output_image.display()
+        )
     })?;
     Ok(())
 }


### PR DESCRIPTION
This change
- Adds entry_point, code_start, and code_end to the manifest along with getters and unit tests,
- Updates the signer tool to set these fields by parsing ELF files, and
- Removes the extra entry in ROM_EXT interrupt vector since it is no longer needed.

This change also adds a new rust dependency (`object` crate) for parsing ELF files.