### PR TITLE
[reggen,dv] Remove swaccess and hwaccess from Register objects

### DIFF
--- a/util/reggen/access.py
+++ b/util/reggen/access.py
@@ -87,13 +87,10 @@ class SWAccess:
                              .format(self.key, where)) from None
 
     def dv_rights(self) -> str:
-        if self.key in ['none', 'ro', 'rc']:
-            return "RO"
-        elif self.key in ['rw', 'r0w1c', 'rw1s', 'rw1c', 'rw0c']:
-            return "RW"
-        else:
-            assert self.key == 'wo'
-            return "WO"
+        '''Return a UVM access string as used by uvm_field::set_access().'''
+        if self.key == 'r0w1c':
+            return 'W1C'
+        return self.value[1].name
 
     def swrd(self) -> SwRdAccess:
         return self.value[3]

--- a/util/reggen/field.py
+++ b/util/reggen/field.py
@@ -275,3 +275,9 @@ class Field:
         if self.enum is not None:
             rd['enum'] = self.enum
         return rd
+
+    def sw_readable(self) -> bool:
+        return self.swaccess.key not in ['wo', 'r0w1c']
+
+    def sw_writable(self) -> bool:
+        return self.swaccess.key != 'ro'

--- a/util/reggen/fpv_csr.sv.tpl
+++ b/util/reggen/fpv_csr.sv.tpl
@@ -38,7 +38,7 @@ module ${mod_base}_csr_assert_fpv import tlul_pkg::*;
 <%
   addr_width = rb.get_addr_width()
   addr_msb  = addr_width - 1
-  hro_regs_list = [r for r in rb.flat_regs if not r.hwaccess.allows_write()]
+  hro_regs_list = [r for r in rb.flat_regs if not r.is_hw_writable()]
   num_hro_regs = len(hro_regs_list)
   hro_map = {r.offset: (idx, r) for idx, r in enumerate(hro_regs_list)}
 %>\

--- a/util/reggen/reg_block.py
+++ b/util/reggen/reg_block.py
@@ -267,30 +267,7 @@ class RegBlock:
                                  'write-enable, but there is no such register.'
                                  .format(wenname))
 
-            # If the REGWEN bit is SW controlled, check that the register
-            # defaults to enabled. If this bit is read-only by SW and hence
-            # hardware controlled, we do not enforce this requirement.
-            if wen_reg.swaccess.key != "ro" and not wen_reg.resval:
-                raise ValueError('One or more registers use {} as a '
-                                 'write-enable. Since it is SW-controlled '
-                                 'it should have a nonzero reset value.'
-                                 .format(wenname))
-
-            if wen_reg.swaccess.key == "rw0c":
-                # The register is software managed: all good!
-                continue
-
-            if wen_reg.swaccess.key == "ro" and wen_reg.hwaccess.key == "hwo":
-                # The register is hardware managed: that's fine too.
-                continue
-
-            raise ValueError('One or more registers use {} as a write-enable. '
-                             'However, it has invalid access permissions '
-                             '({} / {}). It should either have swaccess=RW0C '
-                             'or have swaccess=RO and hwaccess=HWO.'
-                             .format(wenname,
-                                     wen_reg.swaccess.key,
-                                     wen_reg.hwaccess.key))
+            wen_reg.check_valid_regwen()
 
     def get_n_bits(self, bittype: List[str] = ["q"]) -> int:
         '''Returns number of bits in registers in this block.
@@ -357,8 +334,6 @@ class RegBlock:
         reg = Register(self.offset,
                        reg_name,
                        reg_desc,
-                       swaccess_obj,
-                       hwaccess_obj,
                        hwext=is_testreg,
                        hwqe=is_testreg,
                        hwre=False,

--- a/util/reggen/uvm_reg_base.sv.tpl
+++ b/util/reggen/uvm_reg_base.sv.tpl
@@ -85,7 +85,6 @@ ${make_ral_pkg_window_class(dv_base_prefix, esc_if_name, window)}
 %   for r in rb.flat_regs:
 <%
       reg_name = r.name.lower()
-      reg_right = r.dv_rights()
       reg_offset = "{}'h{:x}".format(reg_width, r.offset)
       reg_tags = r.tags
       reg_shadowed = r.shadowed
@@ -97,8 +96,7 @@ ${make_ral_pkg_window_class(dv_base_prefix, esc_if_name, window)}
       ${reg_name}.configure(.blk_parent(this));
       ${reg_name}.build(csr_excl);
       default_map.add_reg(.rg(${reg_name}),
-                          .offset(${reg_offset}),
-                          .rights("${reg_right}"));
+                          .offset(${reg_offset}));
 %     if reg_shadowed:
       ${reg_name}.set_is_shadowed();
 %     endif

--- a/util/reggen/uvm_reg_base.sv.tpl
+++ b/util/reggen/uvm_reg_base.sv.tpl
@@ -301,10 +301,7 @@ ${_create_reg_field(dv_base_prefix, reg_width, reg_block_path, reg.shadowed, reg
 <%def name="_create_reg_field(dv_base_prefix, reg_width, reg_block_path, shadowed, hwext, reg_field_name, field)">\
 <%
   field_size = field.bits.width()
-  if field.swaccess.key == "r0w1c":
-    field_access = "W1C"
-  else:
-    field_access = field.swaccess.value[1].name
+  field_access = field.swaccess.dv_rights()
 
   if not field.hwaccess.allows_write():
     field_volatile = 0


### PR DESCRIPTION
This PR has two commits. The first removes an unneeded computation when adding registers to the RAL memory map: I think the original code was wrong and this is simpler, to boot!

The second is the more interesting commit, with the following commit message:

> In the hjson format, you can specify `swaccess` and `hwaccess` for a
> register. This is just a handy shortcut to avoid having to specify it
> for all the constituent fields. It's not supposed to mean anything
> further. Remove `swaccess` and `hwaccess` from the Register class to make
> sure no-one is (mis)using them.
> 
> Some knock-on effects are:
> 
>   - The REGWEN checks in `RegBlock.validate()` are now a bit stronger,
>     checking that there's exactly one field in a REGWEN register,
>     covering bit 0. (And then using that field for the access checks
>     that existed before)
> 
>   - The checks for sensible access types for hwext registers now get
>     applied to the fields, rather than the register itself.
>
>   - The list of registers that aren't HW-writable that we collect for
>     FPV (`hro_regs_list` in `fpv_csr.sv.tpl`) now makes sure not to
>     include any registers where some (but not all) fields are HW
>     writable.
> 
> I've checked, and this patch has no effect on the generated RAL
> model (with `topgen.py -t`).
> 